### PR TITLE
1909: Fix oregen issue with empty chunks. Problem was caused by not u…

### DIFF
--- a/src/main/java/gregtech/common/GT_Worldgen_GT_Ore_Layer.java
+++ b/src/main/java/gregtech/common/GT_Worldgen_GT_Ore_Layer.java
@@ -93,6 +93,7 @@ public class GT_Worldgen_GT_Ore_Layer
         int eX = aChunkX + 16 + aRandom.nextInt(this.mSize);
 
         int[] execCount=new int[4];
+		int[] placeCount=new int[4];
         for (int tX = cX; tX <= eX; tX++) {
             int cZ = aChunkZ - aRandom.nextInt(this.mSize);
             int eZ = aChunkZ + 16 + aRandom.nextInt(this.mSize);
@@ -100,25 +101,29 @@ public class GT_Worldgen_GT_Ore_Layer
                 if (this.mSecondaryMeta > 0) {
                     for (int i = tMinY - 1; i < tMinY + 2; i++) {
                         if ((aRandom.nextInt(Math.max(1, Math.max(MathHelper.abs_int(cZ - tZ), MathHelper.abs_int(eZ - tZ)) / this.mDensity)) == 0) || (aRandom.nextInt(Math.max(1, Math.max(MathHelper.abs_int(cX - tX), MathHelper.abs_int(eX - tX)) / this.mDensity)) == 0)) {
-                            GT_TileEntity_Ores.setOreBlock(aWorld, tX, i, tZ, this.mSecondaryMeta, false);
+                            if (GT_TileEntity_Ores.setOreBlock(aWorld, tX, i, tZ, this.mSecondaryMeta, false))
+								placeCount[1]++;
                             execCount[1]++;
                         }
                     }
                 }
                 if ((this.mBetweenMeta > 0) && ((aRandom.nextInt(Math.max(1, Math.max(MathHelper.abs_int(cZ - tZ), MathHelper.abs_int(eZ - tZ)) / this.mDensity)) == 0) || (aRandom.nextInt(Math.max(1, Math.max(MathHelper.abs_int(cX - tX), MathHelper.abs_int(eX - tX)) / this.mDensity)) == 0))) {
-                    GT_TileEntity_Ores.setOreBlock(aWorld, tX, tMinY + 2 + aRandom.nextInt(2), tZ, this.mBetweenMeta, false);
+                    if (GT_TileEntity_Ores.setOreBlock(aWorld, tX, tMinY + 2 + aRandom.nextInt(2), tZ, this.mBetweenMeta, false))
+						placeCount[2]++;
                     execCount[2]++;
                 }
                 if (this.mPrimaryMeta > 0) {
                     for (int i = tMinY + 3; i < tMinY + 6; i++) {
                         if ((aRandom.nextInt(Math.max(1, Math.max(MathHelper.abs_int(cZ - tZ), MathHelper.abs_int(eZ - tZ)) / this.mDensity)) == 0) || (aRandom.nextInt(Math.max(1, Math.max(MathHelper.abs_int(cX - tX), MathHelper.abs_int(eX - tX)) / this.mDensity)) == 0)) {
-                            GT_TileEntity_Ores.setOreBlock(aWorld, tX, i, tZ, this.mPrimaryMeta, false);
+                            if (GT_TileEntity_Ores.setOreBlock(aWorld, tX, i, tZ, this.mPrimaryMeta, false))
+								placeCount[0]++;
                             execCount[0]++;
                         }
                     }
                 }
                 if ((this.mSporadicMeta > 0) && ((aRandom.nextInt(Math.max(1, Math.max(MathHelper.abs_int(cZ - tZ), MathHelper.abs_int(eZ - tZ)) / this.mDensity)) == 0) || (aRandom.nextInt(Math.max(1, Math.max(MathHelper.abs_int(cX - tX), MathHelper.abs_int(eX - tX)) / this.mDensity)) == 0))) {
-                    GT_TileEntity_Ores.setOreBlock(aWorld, tX, tMinY - 1 + aRandom.nextInt(7), tZ, this.mSporadicMeta, false);
+                    if (GT_TileEntity_Ores.setOreBlock(aWorld, tX, tMinY - 1 + aRandom.nextInt(7), tZ, this.mSporadicMeta, false))
+						placeCount[3]++;
                     execCount[3]++;
                 }
             }
@@ -129,10 +134,10 @@ public class GT_Worldgen_GT_Ore_Layer
                             " @ dim="+aDimensionType+
                             " chunkX="+aChunkX+
                             " chunkZ="+aChunkZ+
-                            " Secondary="+execCount[1]+" "+new ItemStack(GregTech_API.sBlockOres1,1,mPrimaryMeta).getDisplayName()+
-                            " Between="+execCount[2]+" "+new ItemStack(GregTech_API.sBlockOres1,1,mPrimaryMeta).getDisplayName()+
-                            " Primary="+execCount[0]+" "+new ItemStack(GregTech_API.sBlockOres1,1,mPrimaryMeta).getDisplayName()+
-                            " Sporadic="+execCount[3]+" "+new ItemStack(GregTech_API.sBlockOres1,1,mPrimaryMeta).getDisplayName()
+                            " Secondary="+execCount[1]+","+placeCount[1]+" "+new ItemStack(GregTech_API.sBlockOres1,1,mSecondaryMeta).getDisplayName()+
+                            " Between="+execCount[2]+","+placeCount[2]+" "+new ItemStack(GregTech_API.sBlockOres1,1,mBetweenMeta).getDisplayName()+
+                            " Primary="+execCount[0]+","+placeCount[0]+" "+new ItemStack(GregTech_API.sBlockOres1,1,mPrimaryMeta).getDisplayName()+
+                            " Sporadic="+execCount[3]+","+placeCount[3]+" "+new ItemStack(GregTech_API.sBlockOres1,1,mSporadicMeta).getDisplayName()
             );
         }
         return true;


### PR DESCRIPTION
…sing threadsafe techiniques on ArrayList. Also add and fix some more debug messages, including messages to show a vein being genererated in the air, and if an orevein failed to be chosen after 256 tries.

Fixes issue with Oregen leaving completely blank chunks with no GT oregen. Problem was worse on potato computers. See issue #1909 for details.

Thanks to bigbass and mitch for contributing.