### PR TITLE
Debug/dd broken debug

### DIFF
--- a/src/main/java/gregtech/GT_Mod.java
+++ b/src/main/java/gregtech/GT_Mod.java
@@ -190,7 +190,9 @@ public class GT_Mod implements IGT_Mod {
         GT_Values.D2 = tMainConfig.get(aTextGeneral, "Debug2", false).getBoolean(false);
         GT_Values.debugCleanroom = tMainConfig.get(aTextGeneral, "debugCleanroom", false).getBoolean(false);
 		GT_Values.debugWorldGen = tMainConfig.get(aTextGeneral, "debugWorldGen", false).getBoolean(false);
-		GT_Values.oreveinPercentage = tMainConfig.get(aTextGeneral, "oreveinPercentage_100",100).getInt(100);
+		GT_Values.debugOrevein = tMainConfig.get(aTextGeneral, "debugOrevein", false).getBoolean(false);
+		GT_Values.oreveinPercentage = tMainConfig.get(aTextGeneral, "oreveinPercentage_75",75).getInt(75);
+		GT_Values.oreveinAttempts = tMainConfig.get(aTextGeneral, "oreveinAttempts_64",64).getInt(64);
 
         GregTech_API.TICKS_FOR_LAG_AVERAGING = tMainConfig.get(aTextGeneral, "TicksForLagAveragingWithScanner", 25).getInt(25);
         GregTech_API.MILLISECOND_THRESHOLD_UNTIL_LAG_WARNING = tMainConfig.get(aTextGeneral, "MillisecondsPassedInGTTileEntityUntilLagWarning", 100).getInt(100);

--- a/src/main/java/gregtech/GT_Mod.java
+++ b/src/main/java/gregtech/GT_Mod.java
@@ -189,6 +189,8 @@ public class GT_Mod implements IGT_Mod {
         GT_Values.D1 = tMainConfig.get(aTextGeneral, "Debug", false).getBoolean(false);
         GT_Values.D2 = tMainConfig.get(aTextGeneral, "Debug2", false).getBoolean(false);
         GT_Values.debugCleanroom = tMainConfig.get(aTextGeneral, "debugCleanroom", false).getBoolean(false);
+		GT_Values.debugWorldGen = tMainConfig.get(aTextGeneral, "debugWorldGen", false).getBoolean(false);
+		GT_Values.oreveinPercentage = tMainConfig.get(aTextGeneral, "oreveinPercentage_100",100).getInt(100);
 
         GregTech_API.TICKS_FOR_LAG_AVERAGING = tMainConfig.get(aTextGeneral, "TicksForLagAveragingWithScanner", 25).getInt(25);
         GregTech_API.MILLISECOND_THRESHOLD_UNTIL_LAG_WARNING = tMainConfig.get(aTextGeneral, "MillisecondsPassedInGTTileEntityUntilLagWarning", 100).getInt(100);

--- a/src/main/java/gregtech/api/enums/GT_Values.java
+++ b/src/main/java/gregtech/api/enums/GT_Values.java
@@ -118,15 +118,23 @@ public class GT_Values {
      */
     public static IGT_NetworkHandler NW;
     /**
-     * Debug parameter for cleanroom testing.
-     */
-    public static boolean debugCleanroom = false;	
-    /**
      * Not really Constants, but they set using the Config and therefore should be constant (those are for the Debug Mode)
      */
     public static boolean D1 = false, D2 = false;
+	/**
+	 * Debug parameter for cleanroom testing.
+	 */
+	public static boolean debugCleanroom = false;
+	/**
+	 * Debug parameter for world generation. Tracks chunks added/removed from run queue.
+	 */
+	public static boolean debugWorldGen = false;
     /**
      * If you have to give something a World Parameter but there is no World... (Dummy World)
      */
     public static World DW;
+	/**
+	 * Control percentage of filled 3x3 chunks. Lower number means less oreveins spawn
+	 */
+	public static int oreveinPercentage;
 }

--- a/src/main/java/gregtech/api/enums/GT_Values.java
+++ b/src/main/java/gregtech/api/enums/GT_Values.java
@@ -117,24 +117,32 @@ public class GT_Values {
      * For Internal Usage (Network)
      */
     public static IGT_NetworkHandler NW;
-    /**
+	/**
+	 * Control percentage of filled 3x3 chunks. Lower number means less oreveins spawn
+	 */
+	public static int oreveinPercentage;
+	/**
+	 * Control number of attempts to find a valid orevein. Lower numbers is slightly faster chunkgen, but more empty chunks with thin stone height.
+	 */
+	public static int oreveinAttempts;
+	/**
      * Not really Constants, but they set using the Config and therefore should be constant (those are for the Debug Mode)
      */
     public static boolean D1 = false, D2 = false;
 	/**
 	 * Debug parameter for cleanroom testing.
-	 */
+	 */	 
 	public static boolean debugCleanroom = false;
 	/**
 	 * Debug parameter for world generation. Tracks chunks added/removed from run queue.
 	 */
 	public static boolean debugWorldGen = false;
+	/**
+	 * Debug parameter for orevein generation.
+	 */
+	public static boolean debugOrevein = false;
     /**
      * If you have to give something a World Parameter but there is no World... (Dummy World)
      */
     public static World DW;
-	/**
-	 * Control percentage of filled 3x3 chunks. Lower number means less oreveins spawn
-	 */
-	public static int oreveinPercentage;
 }

--- a/src/main/java/gregtech/common/GT_Worldgen_GT_Ore_Layer.java
+++ b/src/main/java/gregtech/common/GT_Worldgen_GT_Ore_Layer.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.Random;
 
 import static gregtech.api.enums.GT_Values.debugOrevein;
+import static gregtech.api.enums.GT_Values.debugWorldGen;
 
 public class GT_Worldgen_GT_Ore_Layer
         extends GT_Worldgen {
@@ -51,7 +52,15 @@ public class GT_Worldgen_GT_Ore_Layer
         //this.mMars = GregTech_API.sWorldgenFile.get(aTextWorldgen + this.mWorldGenName, "Mars", aMars);
         //this.mAsteroid = GregTech_API.sWorldgenFile.get(aTextWorldgen + this.mWorldGenName, "Asteroid", aAsteroid);
         this.mMinY = ((short) GregTech_API.sWorldgenFile.get(aTextWorldgen + this.mWorldGenName, "MinHeight", aMinY));
-        this.mMaxY = ((short) Math.max(this.mMinY + 5, GregTech_API.sWorldgenFile.get(aTextWorldgen + this.mWorldGenName, "MaxHeight", aMaxY)));
+        short mMaxY = ((short) GregTech_API.sWorldgenFile.get(aTextWorldgen + this.mWorldGenName, "MaxHeight", aMaxY));
+		if (mMaxY < (this.mMinY + 7))	{
+			GT_Log.out.println(
+					"Oremix " + this.mWorldGenName +
+				    " has invalid Min/Max heights!"
+				);
+			mMaxY = (short) (this.mMinY + 7);
+		}
+		this.mMaxY = mMaxY;
         this.mWeight = ((short) GregTech_API.sWorldgenFile.get(aTextWorldgen + this.mWorldGenName, "RandomWeight", aWeight));
         this.mDensity = ((short) GregTech_API.sWorldgenFile.get(aTextWorldgen + this.mWorldGenName, "Density", aDensity));
         this.mSize = ((short) Math.max(1, GregTech_API.sWorldgenFile.get(aTextWorldgen + this.mWorldGenName, "Size", aSize)));
@@ -130,6 +139,7 @@ public class GT_Worldgen_GT_Ore_Layer
                             " chunkX="+aChunkX+
                             " chunkZ="+aChunkZ+
                             " chunkY="+tMinY+
+                            " Density=" + this.mDensity +
                             " Secondary="+placeCount[1]+" "+new ItemStack(GregTech_API.sBlockOres1,1,mSecondaryMeta).getDisplayName()+
                             " Between="+placeCount[2]+" "+new ItemStack(GregTech_API.sBlockOres1,1,mBetweenMeta).getDisplayName()+
                             " Primary="+placeCount[0]+" "+new ItemStack(GregTech_API.sBlockOres1,1,mPrimaryMeta).getDisplayName()+

--- a/src/main/java/gregtech/common/GT_Worldgen_GT_Ore_Layer.java
+++ b/src/main/java/gregtech/common/GT_Worldgen_GT_Ore_Layer.java
@@ -108,7 +108,6 @@ public class GT_Worldgen_GT_Ore_Layer
                 if ((this.mBetweenMeta > 0) && ((aRandom.nextInt(Math.max(1, Math.max(MathHelper.abs_int(cZ - tZ), MathHelper.abs_int(eZ - tZ)) / this.mDensity)) == 0) || (aRandom.nextInt(Math.max(1, Math.max(MathHelper.abs_int(cX - tX), MathHelper.abs_int(eX - tX)) / this.mDensity)) == 0))) {
                     if (GT_TileEntity_Ores.setOreBlock(aWorld, tX, tMinY + 2 + aRandom.nextInt(2), tZ, this.mBetweenMeta, false))
 						placeCount[2]++;
-                    execCount[2]++;
                 }
                 if (this.mPrimaryMeta > 0) {
                     for (int i = tMinY + 3; i < tMinY + 6; i++) {
@@ -127,7 +126,6 @@ public class GT_Worldgen_GT_Ore_Layer
         if (D1) {
             GT_Log.out.println(
                             "Generated Orevein:" + this.mWorldGenName +
-                            " @ dim="+aDimensionType+
                             " chunkX="+aChunkX+
                             " chunkZ="+aChunkZ+
                             " chunkY="+tMinY+

--- a/src/main/java/gregtech/common/GT_Worldgen_GT_Ore_Layer.java
+++ b/src/main/java/gregtech/common/GT_Worldgen_GT_Ore_Layer.java
@@ -140,6 +140,10 @@ public class GT_Worldgen_GT_Ore_Layer
                             " Sporadic="+execCount[3]+","+placeCount[3]+" "+new ItemStack(GregTech_API.sBlockOres1,1,mSporadicMeta).getDisplayName()
             );
         }
-        return true;
+		// Didn't place anything, return false
+		if( (placeCount[0] + placeCount[1] + placeCount[2] + placeCount[3]) == 0 )
+			return false;
+		else 
+        	return true;
     }
 }

--- a/src/main/java/gregtech/common/GT_Worldgen_GT_Ore_Layer.java
+++ b/src/main/java/gregtech/common/GT_Worldgen_GT_Ore_Layer.java
@@ -15,7 +15,7 @@ import net.minecraft.world.chunk.IChunkProvider;
 import java.util.ArrayList;
 import java.util.Random;
 
-import static gregtech.api.enums.GT_Values.D1;
+import static gregtech.api.enums.GT_Values.debugOrevein;
 
 public class GT_Worldgen_GT_Ore_Layer
         extends GT_Worldgen {
@@ -123,7 +123,8 @@ public class GT_Worldgen_GT_Ore_Layer
                 }
             }
         }
-        if (D1) {
+        if (debugOrevein) {
+			String tDimensionName = aWorld.provider.getDimensionName();
             GT_Log.out.println(
                             "Generated Orevein:" + this.mWorldGenName +
                             " chunkX="+aChunkX+
@@ -132,7 +133,8 @@ public class GT_Worldgen_GT_Ore_Layer
                             " Secondary="+placeCount[1]+" "+new ItemStack(GregTech_API.sBlockOres1,1,mSecondaryMeta).getDisplayName()+
                             " Between="+placeCount[2]+" "+new ItemStack(GregTech_API.sBlockOres1,1,mBetweenMeta).getDisplayName()+
                             " Primary="+placeCount[0]+" "+new ItemStack(GregTech_API.sBlockOres1,1,mPrimaryMeta).getDisplayName()+
-                            " Sporadic="+placeCount[3]+" "+new ItemStack(GregTech_API.sBlockOres1,1,mSporadicMeta).getDisplayName()
+                            " Sporadic="+placeCount[3]+" "+new ItemStack(GregTech_API.sBlockOres1,1,mSporadicMeta).getDisplayName() +
+                            " Dimension=" + tDimensionName
             );
         }
 		// Didn't place anything, return false

--- a/src/main/java/gregtech/common/GT_Worldgen_GT_Ore_Layer.java
+++ b/src/main/java/gregtech/common/GT_Worldgen_GT_Ore_Layer.java
@@ -92,7 +92,6 @@ public class GT_Worldgen_GT_Ore_Layer
         int cX = aChunkX - aRandom.nextInt(this.mSize);
         int eX = aChunkX + 16 + aRandom.nextInt(this.mSize);
 
-        int[] execCount=new int[4];
 		int[] placeCount=new int[4];
         for (int tX = cX; tX <= eX; tX++) {
             int cZ = aChunkZ - aRandom.nextInt(this.mSize);
@@ -103,7 +102,6 @@ public class GT_Worldgen_GT_Ore_Layer
                         if ((aRandom.nextInt(Math.max(1, Math.max(MathHelper.abs_int(cZ - tZ), MathHelper.abs_int(eZ - tZ)) / this.mDensity)) == 0) || (aRandom.nextInt(Math.max(1, Math.max(MathHelper.abs_int(cX - tX), MathHelper.abs_int(eX - tX)) / this.mDensity)) == 0)) {
                             if (GT_TileEntity_Ores.setOreBlock(aWorld, tX, i, tZ, this.mSecondaryMeta, false))
 								placeCount[1]++;
-                            execCount[1]++;
                         }
                     }
                 }
@@ -117,14 +115,12 @@ public class GT_Worldgen_GT_Ore_Layer
                         if ((aRandom.nextInt(Math.max(1, Math.max(MathHelper.abs_int(cZ - tZ), MathHelper.abs_int(eZ - tZ)) / this.mDensity)) == 0) || (aRandom.nextInt(Math.max(1, Math.max(MathHelper.abs_int(cX - tX), MathHelper.abs_int(eX - tX)) / this.mDensity)) == 0)) {
                             if (GT_TileEntity_Ores.setOreBlock(aWorld, tX, i, tZ, this.mPrimaryMeta, false))
 								placeCount[0]++;
-                            execCount[0]++;
                         }
                     }
                 }
                 if ((this.mSporadicMeta > 0) && ((aRandom.nextInt(Math.max(1, Math.max(MathHelper.abs_int(cZ - tZ), MathHelper.abs_int(eZ - tZ)) / this.mDensity)) == 0) || (aRandom.nextInt(Math.max(1, Math.max(MathHelper.abs_int(cX - tX), MathHelper.abs_int(eX - tX)) / this.mDensity)) == 0))) {
                     if (GT_TileEntity_Ores.setOreBlock(aWorld, tX, tMinY - 1 + aRandom.nextInt(7), tZ, this.mSporadicMeta, false))
 						placeCount[3]++;
-                    execCount[3]++;
                 }
             }
         }
@@ -134,10 +130,11 @@ public class GT_Worldgen_GT_Ore_Layer
                             " @ dim="+aDimensionType+
                             " chunkX="+aChunkX+
                             " chunkZ="+aChunkZ+
-                            " Secondary="+execCount[1]+","+placeCount[1]+" "+new ItemStack(GregTech_API.sBlockOres1,1,mSecondaryMeta).getDisplayName()+
-                            " Between="+execCount[2]+","+placeCount[2]+" "+new ItemStack(GregTech_API.sBlockOres1,1,mBetweenMeta).getDisplayName()+
-                            " Primary="+execCount[0]+","+placeCount[0]+" "+new ItemStack(GregTech_API.sBlockOres1,1,mPrimaryMeta).getDisplayName()+
-                            " Sporadic="+execCount[3]+","+placeCount[3]+" "+new ItemStack(GregTech_API.sBlockOres1,1,mSporadicMeta).getDisplayName()
+                            " chunkY="+tMinY+
+                            " Secondary="+placeCount[1]+" "+new ItemStack(GregTech_API.sBlockOres1,1,mSecondaryMeta).getDisplayName()+
+                            " Between="+placeCount[2]+" "+new ItemStack(GregTech_API.sBlockOres1,1,mBetweenMeta).getDisplayName()+
+                            " Primary="+placeCount[0]+" "+new ItemStack(GregTech_API.sBlockOres1,1,mPrimaryMeta).getDisplayName()+
+                            " Sporadic="+placeCount[3]+" "+new ItemStack(GregTech_API.sBlockOres1,1,mSporadicMeta).getDisplayName()
             );
         }
 		// Didn't place anything, return false

--- a/src/main/java/gregtech/common/GT_Worldgen_GT_Ore_SmallPieces.java
+++ b/src/main/java/gregtech/common/GT_Worldgen_GT_Ore_SmallPieces.java
@@ -12,6 +12,7 @@ import net.minecraft.world.chunk.IChunkProvider;
 import java.util.Random;
 
 import static gregtech.api.enums.GT_Values.D1;
+import static gregtech.api.enums.GT_Values.D2;
 
 public class GT_Worldgen_GT_Ore_SmallPieces
         extends GT_Worldgen {
@@ -53,7 +54,7 @@ public class GT_Worldgen_GT_Ore_SmallPieces
                 count++;
             }
         }
-        if(D1){
+        if(D2){
             GT_Log.out.println(
                     "Small Ore:" + this.mWorldGenName +
                             " @ dim="+aDimensionType+

--- a/src/main/java/gregtech/common/GT_Worldgenerator.java
+++ b/src/main/java/gregtech/common/GT_Worldgenerator.java
@@ -112,10 +112,12 @@ public class GT_Worldgenerator
         }
 
         public void run() {
+			String tDimensionName = this.mWorld.provider.getDimensionName();
             if ((Math.abs(this.mX / 16) % 3 == 1) && (Math.abs(this.mZ / 16) % 3 == 1)) {
 				int oreveinRNG = this.mRandom.nextInt(100);
                 if (( oreveinRNG < oreveinPercentage) && (GT_Worldgen_GT_Ore_Layer.sWeight > 0) && (GT_Worldgen_GT_Ore_Layer.sList.size() > 0)) {
                     boolean temp = true;
+
                     int tRandomWeight;
 					int i;
                     for (i = 0; (i < 256) && (temp); i++) {
@@ -139,12 +141,15 @@ public class GT_Worldgenerator
 										"No orevein selected!" +
 										" @ dim="+ this.mDimensionType+
 										" chunkX="+ this.mX +
-										" chunkZ="+ this.mZ
+										" chunkZ="+ this.mZ + 
+										" dimensionName=" + tDimensionName
 						);
 					} else if (D1)
 					{
 						GT_Log.out.println(
-										"Orevein took " + i + " attempts to find"
+										"Orevein took " + i + 
+										" attempts to find" + 
+										" dimensionName=" + tDimensionName
 						);
 					}
 						
@@ -158,7 +163,8 @@ public class GT_Worldgenerator
 										" chunkX="+ this.mX +
 										" chunkZ="+ this.mZ +
 										" RNG=" + oreveinRNG +
-										" %=" + oreveinPercentage
+										" %=" + oreveinPercentage+ 
+										" dimensionName=" + tDimensionName
 						);
                 	}
                 }
@@ -190,7 +196,8 @@ public class GT_Worldgenerator
 									"Skipped chunk, not 3x3 center" +
 									" @ dim="+this.mDimensionType+
 									" chunkX="+this.mX+
-									" chunkZ="+this.mZ
+									" chunkZ="+this.mZ+ 
+									" dimensionName=" + tDimensionName
 					);
 				}
 			}

--- a/src/main/java/gregtech/common/GT_Worldgenerator.java
+++ b/src/main/java/gregtech/common/GT_Worldgenerator.java
@@ -63,33 +63,26 @@ public class GT_Worldgenerator
 		}
     }
 
+
     public void generate(Random aRandom, int aX, int aZ, World aWorld, IChunkProvider aChunkGenerator, IChunkProvider aChunkProvider) {
-        synchronized (listLock)
-		{
-			if (!this.ProcChunks.contains( ((long)aX << 32) | ((long)(aZ) & 0x00000000ffffffffL)) ) {
-				this.ProcChunks.add( ((long)aX << 32) | ((long)(aZ) & 0x00000000ffffffffL));
-				this.mList.add(new WorldGenContainer(new XSTR(aRandom.nextInt()), aX * 16, aZ * 16, ((aChunkGenerator instanceof ChunkProviderEnd)) || (aWorld.getBiomeGenForCoords(aX * 16 + 8, aZ * 16 + 8) == BiomeGenBase.sky) ? 1 : ((aChunkGenerator instanceof ChunkProviderHell)) || (aWorld.getBiomeGenForCoords(aX * 16 + 8, aZ * 16 + 8) == BiomeGenBase.hell) ? -1 : 0, aWorld, aChunkGenerator, aChunkProvider, aWorld.getBiomeGenForCoords(aX * 16 + 8, aZ * 16 + 8).biomeName));
-				if (debugWorldGen) {GT_Log.out.println("ADD WorldGen chunk x:" + aX + " z:" + aZ + " SIZE: " + this.mList.size());}
-			} else {
-				if (debugWorldGen) {GT_Log.out.println("DUP WorldGen chunk x:" + aX + " z:" + aZ + " SIZE: " + this.mList.size() + " ProcChunks.size(): " + ProcChunks.size() ); }
-			}
-        }
+        this.mList.add(new WorldGenContainer(new XSTR(aRandom.nextInt()), aX * 16, aZ * 16, ((aChunkGenerator instanceof ChunkProviderEnd)) || (aWorld.getBiomeGenForCoords(aX * 16 + 8, aZ * 16 + 8) == BiomeGenBase.sky) ? 1 : ((aChunkGenerator instanceof ChunkProviderHell)) || (aWorld.getBiomeGenForCoords(aX * 16 + 8, aZ * 16 + 8) == BiomeGenBase.hell) ? -1 : 0, aWorld, aChunkGenerator, aChunkProvider, aWorld.getBiomeGenForCoords(aX * 16 + 8, aZ * 16 + 8).biomeName));
         if (!this.mIsGenerating) {
             this.mIsGenerating = true;
             int mList_sS=this.mList.size();
             for (int i = 0; i < mList_sS; i++) {
-                WorldGenContainer toRun = (WorldGenContainer) this.mList.get(0);
-                if (debugWorldGen) {GT_Log.out.println("RUN WorldGen chunk x:" + toRun.mX/16 + " z:" + toRun.mZ/16 + " SIZE: " + this.mList.size() + " i: " + i );}
-				this.ProcChunks.remove( ((long)(toRun.mX/16) << 32) | ((long)(toRun.mZ/16) & 0x00000000ffffffffL));
-                synchronized (listLock)
-                {
-                    this.mList.remove(0);
-                }
-                toRun.run();
+                ((Runnable) this.mList.get(i)).run();
             }
+			if (debugWorldGen) {
+				GT_Log.out.println(
+								"Tossing " + (this.mList.size() - mList_sS) + 
+								" chunks!"
+				);
+			}
+            this.mList.clear();
             this.mIsGenerating = false;
         }
     }
+
 
     //public synchronized void generate(Random aRandom, int aX, int aZ, World aWorld, IChunkProvider aChunkGenerator, IChunkProvider aChunkProvider) {//TODO CHECK???
     //    int tempDimensionId = aWorld.provider.dimensionId;

--- a/src/main/java/gregtech/common/GT_Worldgenerator.java
+++ b/src/main/java/gregtech/common/GT_Worldgenerator.java
@@ -18,6 +18,8 @@ import net.minecraft.world.gen.ChunkProviderHell;
 import static gregtech.api.enums.GT_Values.D1;
 import static gregtech.api.enums.GT_Values.oreveinPercentage;
 import static gregtech.api.enums.GT_Values.debugWorldGen;
+import static gregtech.api.enums.GT_Values.debugOrevein;
+import static gregtech.api.enums.GT_Values.oreveinAttempts;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -120,7 +122,7 @@ public class GT_Worldgenerator
 
                     int tRandomWeight;
 					int i;
-                    for (i = 0; (i < 256) && (temp); i++) {
+                    for (i = 0; (i < oreveinAttempts) && (temp); i++) {
                         tRandomWeight = this.mRandom.nextInt(GT_Worldgen_GT_Ore_Layer.sWeight);
                         for (GT_Worldgen tWorldGen : GT_Worldgen_GT_Ore_Layer.sList) {
                             tRandomWeight -= ((GT_Worldgen_GT_Ore_Layer) tWorldGen).mWeight;
@@ -136,15 +138,15 @@ public class GT_Worldgenerator
                             }
                         }
                     }
-					if (D1 & temp) {
+					if (debugOrevein & temp) {
 						GT_Log.out.println(
 										"No orevein selected!" +
-										" @ dim="+ this.mDimensionType+
 										" chunkX="+ this.mX +
 										" chunkZ="+ this.mZ + 
+										" oreveinAttemps=" + oreveinAttempts +
 										" dimensionName=" + tDimensionName
 						);
-					} else if (D1)
+					} else if (debugOrevein)
 					{
 						GT_Log.out.println(
 										"Orevein took " + i + 
@@ -155,11 +157,10 @@ public class GT_Worldgenerator
 						
                 }else
                 {
-                	if((oreveinRNG >= oreveinPercentage) && (D1))
+                	if((oreveinRNG >= oreveinPercentage) && (debugOrevein))
                 	{
 						GT_Log.out.println(
 										"Skipped orevein in this 3x3 chunk!" +
-										" @ dim="+ this.mDimensionType+
 										" chunkX="+ this.mX +
 										" chunkZ="+ this.mZ +
 										" RNG=" + oreveinRNG +
@@ -191,7 +192,7 @@ public class GT_Worldgenerator
             }
 			else
 			{
-				if (D1) {
+				if (debugOrevein) {
 					GT_Log.out.println(
 									"Skipped chunk, not 3x3 center" +
 									" @ dim="+this.mDimensionType+
@@ -214,7 +215,7 @@ public class GT_Worldgenerator
                 if ((GT_Worldgen_GT_Ore_Layer.sWeight > 0) && (GT_Worldgen_GT_Ore_Layer.sList.size() > 0)) {
                     boolean temp = true;
                     int tRandomWeight;
-                    for (int i = 0; (i < 256) && (temp); i++) {
+                    for (int i = 0; (i < oreveinAttempts) && (temp); i++) {
                         tRandomWeight = aRandom.nextInt(GT_Worldgen_GT_Ore_Layer.sWeight);
                         for (GT_Worldgen_GT_Ore_Layer tWorldGen : GT_Worldgen_GT_Ore_Layer.sList) {
                             tRandomWeight -= ((GT_Worldgen_GT_Ore_Layer) tWorldGen).mWeight;


### PR DESCRIPTION
Rolls back threadsafe version of oregen. This version will cause ore, including small ores, in chunks to be lost. 

Includes orevein fill percentage control (Default 75%)  - 25% of valid chunks will be empty due to this.

Will try up to 64 attempts to find valid orevein for height available.