### PR TITLE
Debug/deepdark ores

### DIFF
--- a/src/main/java/gregtech/GT_Mod.java
+++ b/src/main/java/gregtech/GT_Mod.java
@@ -191,6 +191,7 @@ public class GT_Mod implements IGT_Mod {
         GT_Values.debugCleanroom = tMainConfig.get(aTextGeneral, "debugCleanroom", false).getBoolean(false);
 		GT_Values.debugWorldGen = tMainConfig.get(aTextGeneral, "debugWorldGen", false).getBoolean(false);
 		GT_Values.debugOrevein = tMainConfig.get(aTextGeneral, "debugOrevein", false).getBoolean(false);
+		GT_Values.debugSmallOres = tMainConfig.get(aTextGeneral, "debugSmallOres", false).getBoolean(false);
 		GT_Values.oreveinPercentage = tMainConfig.get(aTextGeneral, "oreveinPercentage_75",75).getInt(75);
 		GT_Values.oreveinAttempts = tMainConfig.get(aTextGeneral, "oreveinAttempts_64",64).getInt(64);
 

--- a/src/main/java/gregtech/api/enums/GT_Values.java
+++ b/src/main/java/gregtech/api/enums/GT_Values.java
@@ -141,6 +141,10 @@ public class GT_Values {
 	 * Debug parameter for orevein generation.
 	 */
 	public static boolean debugOrevein = false;
+	/**
+	 * Debug parameter for small ore generation.
+	 */
+	public static boolean debugSmallOres = false;
     /**
      * If you have to give something a World Parameter but there is no World... (Dummy World)
      */

--- a/src/main/java/gregtech/common/GT_Worldgen_GT_Ore_SmallPieces.java
+++ b/src/main/java/gregtech/common/GT_Worldgen_GT_Ore_SmallPieces.java
@@ -12,7 +12,7 @@ import net.minecraft.world.chunk.IChunkProvider;
 import java.util.Random;
 
 import static gregtech.api.enums.GT_Values.D1;
-import static gregtech.api.enums.GT_Values.D2;
+import static gregtech.api.enums.GT_Values.debugSmallOres;
 
 public class GT_Worldgen_GT_Ore_SmallPieces
         extends GT_Worldgen {
@@ -54,7 +54,7 @@ public class GT_Worldgen_GT_Ore_SmallPieces
                 count++;
             }
         }
-        if(D2){
+        if(debugSmallOres){
             GT_Log.out.println(
                     "Small Ore:" + this.mWorldGenName +
                             " @ dim="+aDimensionType+

--- a/src/main/java/gregtech/common/blocks/GT_TileEntity_Ores.java
+++ b/src/main/java/gregtech/common/blocks/GT_TileEntity_Ores.java
@@ -38,7 +38,7 @@ public class GT_TileEntity_Ores extends TileEntity implements ITexturedTileEntit
     }
 
     public static boolean setOreBlock(World aWorld, int aX, int aY, int aZ, int aMetaData, boolean isSmallOre) {
-        return setOreBlock(aWorld, aX, aY, aZ, aMetaData, isSmallOre, false);
+        return setOreBlock(aWorld, aX, aY, aZ, aMetaData, isSmallOre, true);
     }
 
     public static boolean setOreBlock(World aWorld, int aX, int aY, int aZ, int aMetaData, boolean isSmallOre, boolean air) {


### PR DESCRIPTION
Setting air=true will allow for Deep dark oregen above Y=128. Should not have side-effects on nether. As long as other dimensions don't put stone where oregen is not wanted, we should be OK.