### PR TITLE
Chunky oregen rebase2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,10 +71,6 @@ repositories {
         url "http://jenkins.usrv.de:8082/nexus/content/repositories/releases/"
     }
     ivy {
-        name "BuildCraft"
-        artifactPattern "http://www.mod-buildcraft.com/releases/BuildCraft/[revision]/[module]-[revision]-[classifier].[ext]"
-    }
-    ivy {
         name 'CoFHLib'
         artifactPattern "http://addons-origin.cursecdn.com/files/${config.cofhlib.cf}/[module]-[revision].[ext]"
     }
@@ -116,7 +112,6 @@ dependencies {
     provided ("com.enderio:EnderIO:${config.enderio.version}:dev") {
         transitive = false
     }
-    provided name: 'buildcraft', version: config.buildcraft.version, classifier: "dev", ext: 'jar'
     provided name: 'CoFHLib', version: config.cofhlib.version, ext: 'jar'
     provided name: 'CoFHCore', version: config.cofhcore.version, ext: 'jar'
     provided name: 'Railcraft', version: config.railcraft.version, ext: 'jar'

--- a/src/main/java/gregtech/GT_Mod.java
+++ b/src/main/java/gregtech/GT_Mod.java
@@ -194,6 +194,8 @@ public class GT_Mod implements IGT_Mod {
 		GT_Values.debugSmallOres = tMainConfig.get(aTextGeneral, "debugSmallOres", false).getBoolean(false);
 		GT_Values.oreveinPercentage = tMainConfig.get(aTextGeneral, "oreveinPercentage_75",75).getInt(75);
 		GT_Values.oreveinAttempts = tMainConfig.get(aTextGeneral, "oreveinAttempts_64",64).getInt(64);
+		GT_Values.oreveinMaxPlacementAttempts = tMainConfig.get(aTextGeneral, "oreveinMaxPlacementAttempts_8",8).getInt(8);
+		GT_Values.oreveinMaxSize = tMainConfig.get(aTextGeneral, "oreveinMaxSize_64",64).getInt(64);
 
         GregTech_API.TICKS_FOR_LAG_AVERAGING = tMainConfig.get(aTextGeneral, "TicksForLagAveragingWithScanner", 25).getInt(25);
         GregTech_API.MILLISECOND_THRESHOLD_UNTIL_LAG_WARNING = tMainConfig.get(aTextGeneral, "MillisecondsPassedInGTTileEntityUntilLagWarning", 100).getInt(100);

--- a/src/main/java/gregtech/GT_Mod.java
+++ b/src/main/java/gregtech/GT_Mod.java
@@ -192,6 +192,7 @@ public class GT_Mod implements IGT_Mod {
 		GT_Values.debugWorldGen = tMainConfig.get(aTextGeneral, "debugWorldGen", false).getBoolean(false);
 		GT_Values.debugOrevein = tMainConfig.get(aTextGeneral, "debugOrevein", false).getBoolean(false);
 		GT_Values.debugSmallOres = tMainConfig.get(aTextGeneral, "debugSmallOres", false).getBoolean(false);
+		GT_Values.debugStones = tMainConfig.get(aTextGeneral, "debugStones", false).getBoolean(false);
 		GT_Values.oreveinPercentage = tMainConfig.get(aTextGeneral, "oreveinPercentage_75",75).getInt(75);
 		GT_Values.oreveinAttempts = tMainConfig.get(aTextGeneral, "oreveinAttempts_64",64).getInt(64);
 		GT_Values.oreveinMaxPlacementAttempts = tMainConfig.get(aTextGeneral, "oreveinMaxPlacementAttempts_8",8).getInt(8);

--- a/src/main/java/gregtech/GT_Mod.java
+++ b/src/main/java/gregtech/GT_Mod.java
@@ -189,14 +189,14 @@ public class GT_Mod implements IGT_Mod {
         GT_Values.D1 = tMainConfig.get(aTextGeneral, "Debug", false).getBoolean(false);
         GT_Values.D2 = tMainConfig.get(aTextGeneral, "Debug2", false).getBoolean(false);
         GT_Values.debugCleanroom = tMainConfig.get(aTextGeneral, "debugCleanroom", false).getBoolean(false);
-		GT_Values.debugWorldGen = tMainConfig.get(aTextGeneral, "debugWorldGen", false).getBoolean(false);
-		GT_Values.debugOrevein = tMainConfig.get(aTextGeneral, "debugOrevein", false).getBoolean(false);
-		GT_Values.debugSmallOres = tMainConfig.get(aTextGeneral, "debugSmallOres", false).getBoolean(false);
-		GT_Values.debugStones = tMainConfig.get(aTextGeneral, "debugStones", false).getBoolean(false);
-		GT_Values.oreveinPercentage = tMainConfig.get(aTextGeneral, "oreveinPercentage_75",75).getInt(75);
-		GT_Values.oreveinAttempts = tMainConfig.get(aTextGeneral, "oreveinAttempts_64",64).getInt(64);
-		GT_Values.oreveinMaxPlacementAttempts = tMainConfig.get(aTextGeneral, "oreveinMaxPlacementAttempts_8",8).getInt(8);
-		GT_Values.oreveinMaxSize = tMainConfig.get(aTextGeneral, "oreveinMaxSize_64",64).getInt(64);
+        GT_Values.debugWorldGen = tMainConfig.get(aTextGeneral, "debugWorldGen", false).getBoolean(false);
+        GT_Values.debugOrevein = tMainConfig.get(aTextGeneral, "debugOrevein", false).getBoolean(false);
+        GT_Values.debugSmallOres = tMainConfig.get(aTextGeneral, "debugSmallOres", false).getBoolean(false);
+        GT_Values.debugStones = tMainConfig.get(aTextGeneral, "debugStones", false).getBoolean(false);
+        GT_Values.oreveinPercentage = tMainConfig.get(aTextGeneral, "oreveinPercentage_75",75).getInt(75);
+        GT_Values.oreveinAttempts = tMainConfig.get(aTextGeneral, "oreveinAttempts_64",64).getInt(64);
+        GT_Values.oreveinMaxPlacementAttempts = tMainConfig.get(aTextGeneral, "oreveinMaxPlacementAttempts_8",8).getInt(8);
+        //GT_Values.oreveinMaxSize = tMainConfig.get(aTextGeneral, "oreveinMaxSize_64",64).getInt(64);
 
         GregTech_API.TICKS_FOR_LAG_AVERAGING = tMainConfig.get(aTextGeneral, "TicksForLagAveragingWithScanner", 25).getInt(25);
         GregTech_API.MILLISECOND_THRESHOLD_UNTIL_LAG_WARNING = tMainConfig.get(aTextGeneral, "MillisecondsPassedInGTTileEntityUntilLagWarning", 100).getInt(100);

--- a/src/main/java/gregtech/api/enums/GT_Values.java
+++ b/src/main/java/gregtech/api/enums/GT_Values.java
@@ -131,8 +131,9 @@ public class GT_Values {
     public static int oreveinMaxPlacementAttempts;
     /**
      * How wide to look for oreveins that affect a requested chunk. Trying to use oreveins larger than this will not work correctly. Increasing the size will cause additional worldgenerator lag.
+     * Disabled for now, using 64 in Deep Dark, 32 elsewhere
      */
-    public static int oreveinMaxSize; 
+    // public static int oreveinMaxSize; 
     /**
      * Not really Constants, but they set using the Config and therefore should be constant (those are for the Debug Mode)
      */

--- a/src/main/java/gregtech/api/enums/GT_Values.java
+++ b/src/main/java/gregtech/api/enums/GT_Values.java
@@ -117,47 +117,47 @@ public class GT_Values {
      * For Internal Usage (Network)
      */
     public static IGT_NetworkHandler NW;
-	/**
-	 * Control percentage of filled 3x3 chunks. Lower number means less oreveins spawn
-	 */
-	public static int oreveinPercentage;
-	/**
-	 * Control number of attempts to find a valid orevein. Generally this maximum limit isn't hit, selecting a vein is cheap
-	 */
-	public static int oreveinAttempts;
-	/**
-	 * Control number of attempts to place a valid orevein.  If a vein wasn't placed due to height restrictions, completely in the water, etc, another attempt is tried.
-	 */
-	public static int oreveinMaxPlacementAttempts;
-	/**
-	 * How wide to look for oreveins that affect a requested chunk. Trying to use oreveins larger than this will not work correctly. Increasing the size will cause additional worldgenerator lag.
-	 */
-	public static int oreveinMaxSize; 
-	/**
+    /**
+     * Control percentage of filled 3x3 chunks. Lower number means less oreveins spawn
+     */
+    public static int oreveinPercentage;
+    /**
+     * Control number of attempts to find a valid orevein. Generally this maximum limit isn't hit, selecting a vein is cheap
+     */
+    public static int oreveinAttempts;
+    /**
+     * Control number of attempts to place a valid orevein.  If a vein wasn't placed due to height restrictions, completely in the water, etc, another attempt is tried.
+     */
+    public static int oreveinMaxPlacementAttempts;
+    /**
+     * How wide to look for oreveins that affect a requested chunk. Trying to use oreveins larger than this will not work correctly. Increasing the size will cause additional worldgenerator lag.
+     */
+    public static int oreveinMaxSize; 
+    /**
      * Not really Constants, but they set using the Config and therefore should be constant (those are for the Debug Mode)
      */
     public static boolean D1 = false, D2 = false;
-	/**
-	 * Debug parameter for cleanroom testing.
-	 */	 
-	public static boolean debugCleanroom = false;
-	/**
-	 * Debug parameter for world generation. Tracks chunks added/removed from run queue.
-	 */
-	public static boolean debugWorldGen = false;
-	/**
-	 * Debug parameter for orevein generation.
-	 */
-	public static boolean debugOrevein = false;
-	/**
-	 * Debug parameter for small ore generation.
-	 */
-	public static boolean debugSmallOres = false;
-	/**
-	 * Debug parameter for stones generation.
-	 */
-	public static boolean debugStones = false;
-	/**
+    /**
+     * Debug parameter for cleanroom testing.
+     */     
+    public static boolean debugCleanroom = false;
+    /**
+     * Debug parameter for world generation. Tracks chunks added/removed from run queue.
+     */
+    public static boolean debugWorldGen = false;
+    /**
+     * Debug parameter for orevein generation.
+     */
+    public static boolean debugOrevein = false;
+    /**
+     * Debug parameter for small ore generation.
+     */
+    public static boolean debugSmallOres = false;
+    /**
+     * Debug parameter for stones generation.
+     */
+    public static boolean debugStones = false;
+    /**
      * If you have to give something a World Parameter but there is no World... (Dummy World)
      */
     public static World DW;

--- a/src/main/java/gregtech/api/enums/GT_Values.java
+++ b/src/main/java/gregtech/api/enums/GT_Values.java
@@ -122,9 +122,17 @@ public class GT_Values {
 	 */
 	public static int oreveinPercentage;
 	/**
-	 * Control number of attempts to find a valid orevein. Lower numbers is slightly faster chunkgen, but more empty chunks with thin stone height.
+	 * Control number of attempts to find a valid orevein. Generally this maximum limit isn't hit, selecting a vein is cheap
 	 */
 	public static int oreveinAttempts;
+	/**
+	 * Control number of attempts to place a valid orevein.  If a vein wasn't placed due to height restrictions, completely in the water, etc, another attempt is tried.
+	 */
+	public static int oreveinMaxPlacementAttempts;
+	/**
+	 * How wide to look for oreveins that affect a requested chunk. Trying to use oreveins larger than this will not work correctly. Increasing the size will cause additional worldgenerator lag.
+	 */
+	public static int oreveinMaxSize; 
 	/**
      * Not really Constants, but they set using the Config and therefore should be constant (those are for the Debug Mode)
      */

--- a/src/main/java/gregtech/api/enums/GT_Values.java
+++ b/src/main/java/gregtech/api/enums/GT_Values.java
@@ -153,7 +153,11 @@ public class GT_Values {
 	 * Debug parameter for small ore generation.
 	 */
 	public static boolean debugSmallOres = false;
-    /**
+	/**
+	 * Debug parameter for stones generation.
+	 */
+	public static boolean debugStones = false;
+	/**
      * If you have to give something a World Parameter but there is no World... (Dummy World)
      */
     public static World DW;

--- a/src/main/java/gregtech/api/world/GT_Worldgen.java
+++ b/src/main/java/gregtech/api/world/GT_Worldgen.java
@@ -35,7 +35,7 @@ public abstract class GT_Worldgen {
     }
 
     public int executeWorldgenChunkified(World aWorld, Random aRandom, String aBiome, int aDimensionType, int aChunkX, int aChunkZ, int seedX, int seedZ, IChunkProvider aChunkGenerator, IChunkProvider aChunkProvider) {
-        return 0;
+        return 4; // This is for the empryOrevein 
     }
 
     /**

--- a/src/main/java/gregtech/api/world/GT_Worldgen.java
+++ b/src/main/java/gregtech/api/world/GT_Worldgen.java
@@ -34,6 +34,10 @@ public abstract class GT_Worldgen {
         return false;
     }
 
+    public int executeWorldgenChunkified(World aWorld, Random aRandom, String aBiome, int aDimensionType, int aChunkX, int aChunkZ, int seedX, int seedZ, IChunkProvider aChunkGenerator, IChunkProvider aChunkProvider) {
+        return 0;
+    }
+
     /**
      * @param aWorld         The World Object
      * @param aRandom        The Random Generator to use

--- a/src/main/java/gregtech/api/world/GT_Worldgen.java
+++ b/src/main/java/gregtech/api/world/GT_Worldgen.java
@@ -35,7 +35,7 @@ public abstract class GT_Worldgen {
     }
 
     public int executeWorldgenChunkified(World aWorld, Random aRandom, String aBiome, int aDimensionType, int aChunkX, int aChunkZ, int seedX, int seedZ, IChunkProvider aChunkGenerator, IChunkProvider aChunkProvider) {
-        return 4; // This is for the empryOrevein 
+        return 4; // This is for the empty Orevein 
     }
 
     /**

--- a/src/main/java/gregtech/common/GT_Worldgen_GT_Ore_Layer.java
+++ b/src/main/java/gregtech/common/GT_Worldgen_GT_Ore_Layer.java
@@ -102,10 +102,8 @@ public class GT_Worldgen_GT_Ore_Layer
             // This is a special empty orevein
             return ORE_PLACED;
         }
-            
-        //if (!isGenerationAllowed(aWorld, aDimensionType, ((aDimensionType == -1) && (this.mNether)) || ((aDimensionType == 0) && (this.mOverworld)) || ((aDimensionType == 1) && (this.mEnd)) || ((aWorld.provider.getDimensionName().equals("Moon")) && (this.mMoon)) || ((aWorld.provider.getDimensionName().equals("Mars")) && (this.mMars)) ? aDimensionType : aDimensionType ^ 0xFFFFFFFF)) {
         if (!isGenerationAllowed(aWorld, aDimensionType, ((aDimensionType == -1) && (this.mNether)) || ((aDimensionType == 0) && (this.mOverworld)) || ((aDimensionType == 1) && (this.mEnd)) ? aDimensionType : aDimensionType ^ 0xFFFFFFFF)) {
-            /*
+            /* // Debug code, but spams log
             if (debugOrevein) {
                 GT_Log.out.println(
                     "Wrong dimension"
@@ -115,13 +113,10 @@ public class GT_Worldgen_GT_Ore_Layer
             return WRONG_DIMENSION;
         }
         if (!this.mRestrictBiome.equals("None") && !(this.mRestrictBiome.equals(aBiome))) {
-            return WRONG_BIOME; //Not the correct biome for ore mix
+            return WRONG_BIOME;
         }
         int[] placeCount=new int[4];
 
-        // Need to "reseed" RNG with values based on the orevein constants so that two oreveins at this same chunk don't end up trying the same sizes and offsets.
-        aRandom.nextInt( this.mPrimaryMeta + this.mSecondaryMeta + this.mSporadicMeta + this.mBetweenMeta + Math.abs(aChunkX + aChunkZ));
-        
         int tMinY = mMinY + aRandom.nextInt(mMaxY - mMinY - 5);
         // Determine West/East ends of orevein
         int wXVein = aSeedX - aRandom.nextInt(mSize);        // West side

--- a/src/main/java/gregtech/common/GT_Worldgen_GT_Ore_Layer.java
+++ b/src/main/java/gregtech/common/GT_Worldgen_GT_Ore_Layer.java
@@ -97,9 +97,11 @@ public class GT_Worldgen_GT_Ore_Layer
 
     public int executeWorldgenChunkified(World aWorld, Random aRandom, String aBiome, int aDimensionType, int aChunkX, int aChunkZ, int aSeedX, int aSeedZ, IChunkProvider aChunkGenerator, IChunkProvider aChunkProvider) {
 		if( mWorldGenName.equals("NoOresInVein") ) {
+			/*
 			if (debugOrevein) GT_Log.out.println(
                             " NoOresInVein, skipping"
             );
+            */
 			// This is a special empty orevein
 			return ORE_PLACED;
 		}
@@ -121,8 +123,8 @@ public class GT_Worldgen_GT_Ore_Layer
 		int wXVein = aSeedX - aRandom.nextInt(mSize);        // West side
 		int eXVein = aSeedX + 16 + aRandom.nextInt(mSize);
 		// Limit Orevein to only blocks present in current chunk
-		int wX = Math.max( wXVein, aChunkX + 1);
-		int eX = Math.min( eXVein, aChunkX + 15);
+		int wX = Math.max( wXVein, aChunkX);
+		int eX = Math.min( eXVein, aChunkX + 16);
 		if (wX >= eX) {  //No overlap between orevein and this chunk exists in X
 /*
 			if (debugOrevein) {
@@ -137,8 +139,8 @@ public class GT_Worldgen_GT_Ore_Layer
 		int nZVein = aSeedZ - aRandom.nextInt(mSize);
 		int sZVein = aSeedZ + 16 + aRandom.nextInt(mSize);
 		
-		int nZ = Math.max(nZVein, aChunkZ + 1);
-		int sZ = Math.min(sZVein, aChunkZ + 15);
+		int nZ = Math.max(nZVein, aChunkZ);
+		int sZ = Math.min(sZVein, aChunkZ + 16);
 		if (nZ >= sZ) { //No overlap between orevein and this chunk exists in Z
 /*
 			if (debugOrevein) {
@@ -149,19 +151,16 @@ public class GT_Worldgen_GT_Ore_Layer
 */
 			return NO_OVERLAP;
 		}
-		if (debugOrevein) GT_Log.out.println(
-        	 "wX=" + wX +
-        	" eX=" + eX +
-        	" nZ=" + nZ +
-        	" sZ=" + sZ
-        );
+		// Adjust the density down the more chunks we are away from the oreseed.  The 5 chunks surrounding the seed should always be max density due to truncation of Math.sqrt().
+		int localDensity = Math.max(1, this.mDensity / ((int)Math.sqrt(2 + Math.pow(aChunkX/16 - aSeedX/16, 2) + Math.pow(aChunkZ/16 - aSeedZ/16, 2))) );
+
  		// To allow for early exit due to no ore placed in the bottom layer (probably because we are in the sky), unroll 1 pass through the loop
 		// Now we do bottom-level-first oregen, and work our way upwards.
 		int level = tMinY - 1; //Dunno why, but the first layer is actually played one below tMinY.  Go figure.
 			for (int tX = wX; tX < eX; tX++) {
-				int placeX = Math.max(1, Math.max(MathHelper.abs_int(wX - tX), MathHelper.abs_int(eX - tX))/mDensity);
+				int placeX = Math.max(1, Math.max(MathHelper.abs_int(wXVein - tX), MathHelper.abs_int(eXVein - tX))/localDensity);
 				for (int tZ = nZ; tZ < sZ; tZ++) {
-					int placeZ = Math.max(1, Math.max(MathHelper.abs_int(sZ - tZ), MathHelper.abs_int(nZ - tZ))/mDensity);
+					int placeZ = Math.max(1, Math.max(MathHelper.abs_int(sZVein - tZ), MathHelper.abs_int(nZVein - tZ))/localDensity);
 					if ( ((aRandom.nextInt(placeZ) == 0) || (aRandom.nextInt(placeX) == 0)) && (this.mSecondaryMeta > 0) ) {
 						if (GT_TileEntity_Ores.setOreBlock(aWorld, tX, level, tZ, this.mSecondaryMeta, false, false)) {
 							placeCount[1]++;
@@ -184,9 +183,9 @@ public class GT_Worldgen_GT_Ore_Layer
 		}
 		for (level = tMinY; level < (tMinY-1+3); level++) {
 			for (int tX = wX; tX < eX; tX++) {
-				int placeX = Math.max(1, Math.max(MathHelper.abs_int(wX - tX), MathHelper.abs_int(eX - tX))/mDensity);
+				int placeX = Math.max(1, Math.max(MathHelper.abs_int(wXVein - tX), MathHelper.abs_int(eXVein - tX))/localDensity);
 				for (int tZ = nZ; tZ < sZ; tZ++) {
-					int placeZ = Math.max(1, Math.max(MathHelper.abs_int(sZ - tZ), MathHelper.abs_int(nZ - tZ))/mDensity);
+					int placeZ = Math.max(1, Math.max(MathHelper.abs_int(sZVein - tZ), MathHelper.abs_int(nZVein - tZ))/localDensity);
 					if ( ((aRandom.nextInt(placeZ) == 0) || (aRandom.nextInt(placeX) == 0)) && (this.mSecondaryMeta > 0) ) {
 						if (GT_TileEntity_Ores.setOreBlock(aWorld, tX, level, tZ, this.mSecondaryMeta, false, false)) {
 							placeCount[1]++;
@@ -202,9 +201,9 @@ public class GT_Worldgen_GT_Ore_Layer
 		// Low Middle layer is between + sporadic
 		// level should be = tMinY-1+3 from end of for loop
 			for (int tX = wX; tX < eX; tX++) {
-				int placeX = Math.max(1, Math.max(MathHelper.abs_int(wX - tX), MathHelper.abs_int(eX - tX))/mDensity);
+				int placeX = Math.max(1, Math.max(MathHelper.abs_int(wXVein - tX), MathHelper.abs_int(eXVein - tX))/localDensity);
 				for (int tZ = nZ; tZ < sZ; tZ++) {
-					int placeZ = Math.max(1, Math.max(MathHelper.abs_int(sZ - tZ), MathHelper.abs_int(nZ - tZ))/mDensity);
+					int placeZ = Math.max(1, Math.max(MathHelper.abs_int(sZVein - tZ), MathHelper.abs_int(nZVein - tZ))/localDensity);
 					if ((aRandom.nextInt(2) == 0) && ((aRandom.nextInt(placeZ) == 0) || (aRandom.nextInt(placeX) == 0)) && (this.mBetweenMeta > 0) ) {  // Between are only 1 per vertical column, reduce by 1/2 to compensate
 						if (GT_TileEntity_Ores.setOreBlock(aWorld, tX, level, tZ, this.mBetweenMeta, false, false)) {
 							placeCount[2]++;
@@ -219,9 +218,9 @@ public class GT_Worldgen_GT_Ore_Layer
 		// High Middle layer is between + primary + sporadic
 		level++; // Increment level to next layer
 			for (int tX = wX; tX < eX; tX++) {
-				int placeX = Math.max(1, Math.max(MathHelper.abs_int(wX - tX), MathHelper.abs_int(eX - tX))/mDensity);
+				int placeX = Math.max(1, Math.max(MathHelper.abs_int(wXVein - tX), MathHelper.abs_int(eXVein - tX))/localDensity);
 				for (int tZ = nZ; tZ < sZ; tZ++) {
-					int placeZ = Math.max(1, Math.max(MathHelper.abs_int(sZ - tZ), MathHelper.abs_int(nZ - tZ))/mDensity);
+					int placeZ = Math.max(1, Math.max(MathHelper.abs_int(sZVein - tZ), MathHelper.abs_int(nZVein - tZ))/localDensity);
 					if ((aRandom.nextInt(2) == 0) && ((aRandom.nextInt(placeZ) == 0) || (aRandom.nextInt(placeX) == 0)) && (this.mBetweenMeta > 0) ) {  // Between are only 1 per vertical column, reduce by 1/2 to compensate
 						if (GT_TileEntity_Ores.setOreBlock(aWorld, tX, level, tZ, this.mBetweenMeta, false, false)) {
 							placeCount[2]++;
@@ -242,9 +241,9 @@ public class GT_Worldgen_GT_Ore_Layer
 		level++; // Increment level to next layer
 		for( ; level < (tMinY + 6); level++){ // should do two layers
 			for (int tX = wX; tX < eX; tX++) {
-				int placeX = Math.max(1, Math.max(MathHelper.abs_int(wX - tX), MathHelper.abs_int(eX - tX))/mDensity);
+				int placeX = Math.max(1, Math.max(MathHelper.abs_int(wXVein - tX), MathHelper.abs_int(eXVein - tX))/localDensity);
 				for (int tZ = nZ; tZ < sZ; tZ++) {
-					int placeZ = Math.max(1, Math.max(MathHelper.abs_int(sZ - tZ), MathHelper.abs_int(nZ - tZ))/mDensity);
+					int placeZ = Math.max(1, Math.max(MathHelper.abs_int(sZVein - tZ), MathHelper.abs_int(nZVein - tZ))/localDensity);
 					if ( ((aRandom.nextInt(placeZ) == 0) || (aRandom.nextInt(placeX) == 0)) && (this.mPrimaryMeta > 0) ) {
 						if (GT_TileEntity_Ores.setOreBlock(aWorld, tX, level, tZ, this.mPrimaryMeta, false, false)) {
 							placeCount[0]++;
@@ -267,6 +266,7 @@ public class GT_Worldgen_GT_Ore_Layer
                             " oreseedX="+ aSeedX/16 +
 							" oreseedZ="+ aSeedZ/16 +
                             " cY="+tMinY+
+                            " locDen=" + localDensity +
                             " Den=" + this.mDensity +
                             " Sec="+placeCount[1]+
                             " Spo="+placeCount[3]+

--- a/src/main/java/gregtech/common/GT_Worldgen_GT_Ore_Layer.java
+++ b/src/main/java/gregtech/common/GT_Worldgen_GT_Ore_Layer.java
@@ -37,6 +37,13 @@ public class GT_Worldgen_GT_Ore_Layer
     public final boolean mNether;
     public final boolean mEnd;
     public final boolean mEndAsteroid;
+	public static final int WRONG_BIOME=0;
+	public static final int WRONG_DIMENSION=1;
+	public static final int NO_ORE_IN_BOTTOM_LAYER=2;
+	public static final int NO_OVERLAP=3;
+	public static final int ORE_PLACED=4;
+
+	
     //public final boolean mMoon;
     //public final boolean mMars;
     //public final boolean mAsteroid;
@@ -88,69 +95,173 @@ public class GT_Worldgen_GT_Ore_Layer
         }
     }
 
-    public boolean executeWorldgen(World aWorld, Random aRandom, String aBiome, int aDimensionType, int aChunkX, int aChunkZ, IChunkProvider aChunkGenerator, IChunkProvider aChunkProvider) {
-        if (!this.mRestrictBiome.equals("None") && !(this.mRestrictBiome.equals(aBiome))) {
-            return false; //Not the correct biome for ore mix
-        }
+    public int executeWorldgenChunkified(World aWorld, Random aRandom, String aBiome, int aDimensionType, int aChunkX, int aChunkZ, int aSeedX, int aSeedZ, IChunkProvider aChunkGenerator, IChunkProvider aChunkProvider) {
 		//if (!isGenerationAllowed(aWorld, aDimensionType, ((aDimensionType == -1) && (this.mNether)) || ((aDimensionType == 0) && (this.mOverworld)) || ((aDimensionType == 1) && (this.mEnd)) || ((aWorld.provider.getDimensionName().equals("Moon")) && (this.mMoon)) || ((aWorld.provider.getDimensionName().equals("Mars")) && (this.mMars)) ? aDimensionType : aDimensionType ^ 0xFFFFFFFF)) {
         if (!isGenerationAllowed(aWorld, aDimensionType, ((aDimensionType == -1) && (this.mNether)) || ((aDimensionType == 0) && (this.mOverworld)) || ((aDimensionType == 1) && (this.mEnd)) ? aDimensionType : aDimensionType ^ 0xFFFFFFFF)) {
-            return false;
+            return WRONG_DIMENSION;
         }
-        int tMinY = this.mMinY + aRandom.nextInt(this.mMaxY - this.mMinY - 5);
-
-        int cX = aChunkX - aRandom.nextInt(this.mSize);
-        int eX = aChunkX + 16 + aRandom.nextInt(this.mSize);
-
+        if (!this.mRestrictBiome.equals("None") && !(this.mRestrictBiome.equals(aBiome))) {
+            return WRONG_BIOME; //Not the correct biome for ore mix
+        }
 		int[] placeCount=new int[4];
-        for (int tX = cX; tX <= eX; tX++) {
-            int cZ = aChunkZ - aRandom.nextInt(this.mSize);
-            int eZ = aChunkZ + 16 + aRandom.nextInt(this.mSize);
-            for (int tZ = cZ; tZ <= eZ; tZ++) {
-                if (this.mSecondaryMeta > 0) {
-                    for (int i = tMinY - 1; i < tMinY + 2; i++) {
-                        if ((aRandom.nextInt(Math.max(1, Math.max(MathHelper.abs_int(cZ - tZ), MathHelper.abs_int(eZ - tZ)) / this.mDensity)) == 0) || (aRandom.nextInt(Math.max(1, Math.max(MathHelper.abs_int(cX - tX), MathHelper.abs_int(eX - tX)) / this.mDensity)) == 0)) {
-                            if (GT_TileEntity_Ores.setOreBlock(aWorld, tX, i, tZ, this.mSecondaryMeta, false))
-								placeCount[1]++;
-                        }
-                    }
-                }
-                if ((this.mBetweenMeta > 0) && ((aRandom.nextInt(Math.max(1, Math.max(MathHelper.abs_int(cZ - tZ), MathHelper.abs_int(eZ - tZ)) / this.mDensity)) == 0) || (aRandom.nextInt(Math.max(1, Math.max(MathHelper.abs_int(cX - tX), MathHelper.abs_int(eX - tX)) / this.mDensity)) == 0))) {
-                    if (GT_TileEntity_Ores.setOreBlock(aWorld, tX, tMinY + 2 + aRandom.nextInt(2), tZ, this.mBetweenMeta, false))
-						placeCount[2]++;
-                }
-                if (this.mPrimaryMeta > 0) {
-                    for (int i = tMinY + 3; i < tMinY + 6; i++) {
-                        if ((aRandom.nextInt(Math.max(1, Math.max(MathHelper.abs_int(cZ - tZ), MathHelper.abs_int(eZ - tZ)) / this.mDensity)) == 0) || (aRandom.nextInt(Math.max(1, Math.max(MathHelper.abs_int(cX - tX), MathHelper.abs_int(eX - tX)) / this.mDensity)) == 0)) {
-                            if (GT_TileEntity_Ores.setOreBlock(aWorld, tX, i, tZ, this.mPrimaryMeta, false))
-								placeCount[0]++;
-                        }
-                    }
-                }
-                if ((this.mSporadicMeta > 0) && ((aRandom.nextInt(Math.max(1, Math.max(MathHelper.abs_int(cZ - tZ), MathHelper.abs_int(eZ - tZ)) / this.mDensity)) == 0) || (aRandom.nextInt(Math.max(1, Math.max(MathHelper.abs_int(cX - tX), MathHelper.abs_int(eX - tX)) / this.mDensity)) == 0))) {
-                    if (GT_TileEntity_Ores.setOreBlock(aWorld, tX, tMinY - 1 + aRandom.nextInt(7), tZ, this.mSporadicMeta, false))
-						placeCount[3]++;
-                }
-            }
-        }
+
+		// Need to "reseed" RNG with values based on the orevein constants so that two oreveins at this same chunk don't end up trying the same sizes and offsets.
+		aRandom.nextInt( this.mPrimaryMeta + this.mSecondaryMeta + this.mSporadicMeta + this.mBetweenMeta);
+		
+		int tMinY = mMinY + aRandom.nextInt(mMaxY - mMinY - 5);
+		// Determine West/East ends of orevein
+		int wXVein = aSeedX - aRandom.nextInt(mSize);        // West side
+		int eXVein = aSeedX + 16 + aRandom.nextInt(mSize);
+		// Limit Orevein to only blocks present in current chunk
+		int wX = Math.max( wXVein, aChunkX);
+		int eX = Math.min( eXVein, aChunkX + 16);
+		if (wX >= eX) {  //No overlap between orevein and this chunk exists in X
+/*
+			if (debugOrevein) {
+				System.out.println(
+					"No overlap in X dim!"
+				);
+			}
+*/
+			return NO_OVERLAP;
+		}
+		// Determine North/Sound ends of orevein
+		int nZVein = aSeedZ - aRandom.nextInt(mSize);
+		int sZVein = aSeedZ + 16 + aRandom.nextInt(mSize);
+		
+		int nZ = Math.max(nZVein, aChunkZ);
+		int sZ = Math.min(sZVein, aChunkZ+16);
+		if (nZ >= sZ) { //No overlap between orevein and this chunk exists in Z
+/*
+			if (debugOrevein) {
+				System.out.println(
+					"No overlap in Z dim!"
+				);
+			}
+*/
+			return NO_OVERLAP;
+		}
+		// Need to "reseed" RNG with values based on the chunkX/Z location so that filled chunks don't repeat the same RNG values
+		aRandom.nextInt( aChunkX + aChunkZ );
+		
+		// To allow for early exit due to no ore placed in the bottom layer (probably because we are in the sky), unroll 1 pass through the loop
+		// Now we do bottom-level-first oregen, and work our way upwards.
+		int level = tMinY - 1; //Dunno why, but the first layer is actually played one below tMinY.  Go figure.
+			for (int tX = wX; tX < eX; tX++) {
+				int placeX = Math.max(1, Math.max(MathHelper.abs_int(wX - tX), MathHelper.abs_int(eX - tX)));
+				for (int tZ = nZ; tZ < sZ; tZ++) {
+					int placeZ = Math.max(1, Math.max(MathHelper.abs_int(sZ - tZ), MathHelper.abs_int(nZ - tZ)));
+					if ( ((aRandom.nextInt(placeZ/mDensity) == 0) || (aRandom.nextInt(placeX/mDensity) == 0)) && (this.mSecondaryMeta > 0) ) {
+						if (GT_TileEntity_Ores.setOreBlock(aWorld, tX, level, tZ, this.mSecondaryMeta, false, false)) {
+							placeCount[1]++;
+						}
+					}
+					else if ((aRandom.nextInt(7) == 0) && ((aRandom.nextInt(placeZ/mDensity) == 0) || (aRandom.nextInt(placeX/mDensity) == 0)) && (this.mSporadicMeta > 0) ) {  // Sporadics are only 1 per vertical column normally, reduce by 1/7 to compensate
+						if (GT_TileEntity_Ores.setOreBlock(aWorld, tX, level, tZ, this.mSporadicMeta, false, false))
+							placeCount[3]++;
+					}
+				}
+			}
+		if ((placeCount[1]+placeCount[3])==0) {
+/*
+			GT_Log.out.println(
+                            "Generated Orevein:" + this.mWorldGenName +
+                            " did not place any ores in bottom layer, skipping"
+            );
+*/
+			return NO_ORE_IN_BOTTOM_LAYER;  // Exit early, didn't place anything in the bottom layer
+		}
+		for (level = tMinY; level < (tMinY-1+3); level++) {
+			for (int tX = wX; tX < eX; tX++) {
+				int placeX = Math.max(1, Math.max(MathHelper.abs_int(wX - tX), MathHelper.abs_int(eX - tX)));
+				for (int tZ = nZ; tZ < sZ; tZ++) {
+					int placeZ = Math.max(1, Math.max(MathHelper.abs_int(sZ - tZ), MathHelper.abs_int(nZ - tZ)));
+					if ( ((aRandom.nextInt(placeZ/mDensity) == 0) || (aRandom.nextInt(placeX/mDensity) == 0)) && (this.mSecondaryMeta > 0) ) {
+						if (GT_TileEntity_Ores.setOreBlock(aWorld, tX, level, tZ, this.mSecondaryMeta, false, false)) {
+							placeCount[1]++;
+						}
+					}
+					else if ((aRandom.nextInt(7) == 0) && ((aRandom.nextInt(placeZ/mDensity) == 0) || (aRandom.nextInt(placeX/mDensity) == 0)) && (this.mSporadicMeta > 0) ) {  // Sporadics are only 1 per vertical column normally, reduce by 1/7 to compensate
+						if (GT_TileEntity_Ores.setOreBlock(aWorld, tX, level, tZ, this.mSporadicMeta, false, false))
+							placeCount[3]++;
+					}
+				}
+			}
+		}
+		// Low Middle layer is between + sporadic
+		// level should be = tMinY-1+3 from end of for loop
+			for (int tX = wX; tX < eX; tX++) {
+				int placeX = Math.max(1, Math.max(MathHelper.abs_int(wX - tX), MathHelper.abs_int(eX - tX)));
+				for (int tZ = nZ; tZ < sZ; tZ++) {
+					int placeZ = Math.max(1, Math.max(MathHelper.abs_int(sZ - tZ), MathHelper.abs_int(nZ - tZ)));
+					if ((aRandom.nextInt(2) == 0) && ((aRandom.nextInt(placeZ/mDensity) == 0) || (aRandom.nextInt(placeX/mDensity) == 0)) && (this.mBetweenMeta > 0) ) {  // Between are only 1 per vertical column, reduce by 1/2 to compensate
+						if (GT_TileEntity_Ores.setOreBlock(aWorld, tX, level, tZ, this.mBetweenMeta, false, false)) {
+							placeCount[2]++;
+						}
+					}
+					else if ((aRandom.nextInt(7) == 0) && ((aRandom.nextInt(placeZ/mDensity) == 0) || (aRandom.nextInt(placeX/mDensity) == 0)) && (this.mSporadicMeta > 0) ) {  // Sporadics are only 1 per vertical column normally, reduce by 1/7 to compensate
+						if (GT_TileEntity_Ores.setOreBlock(aWorld, tX, level, tZ, this.mSporadicMeta, false, false))
+							placeCount[3]++;
+					}
+				}
+			}
+		// High Middle layer is between + primary + sporadic
+		level++; // Increment level to next layer
+			for (int tX = wX; tX < eX; tX++) {
+				int placeX = Math.max(1, Math.max(MathHelper.abs_int(wX - tX), MathHelper.abs_int(eX - tX)));
+				for (int tZ = nZ; tZ < sZ; tZ++) {
+					int placeZ = Math.max(1, Math.max(MathHelper.abs_int(sZ - tZ), MathHelper.abs_int(nZ - tZ)));
+					if ((aRandom.nextInt(2) == 0) && ((aRandom.nextInt(placeZ/mDensity) == 0) || (aRandom.nextInt(placeX/mDensity) == 0)) && (this.mBetweenMeta > 0) ) {  // Between are only 1 per vertical column, reduce by 1/2 to compensate
+						if (GT_TileEntity_Ores.setOreBlock(aWorld, tX, level, tZ, this.mBetweenMeta, false, false)) {
+							placeCount[2]++;
+						}
+					}
+					else if ( ((aRandom.nextInt(placeZ/mDensity) == 0) || (aRandom.nextInt(placeX/mDensity) == 0)) && (this.mPrimaryMeta > 0) ) {
+						if (GT_TileEntity_Ores.setOreBlock(aWorld, tX, level, tZ, this.mPrimaryMeta, false, false)) {
+							placeCount[0]++;
+						}
+					}
+					else if ((aRandom.nextInt(7) == 0) && ((aRandom.nextInt(placeZ/mDensity) == 0) || (aRandom.nextInt(placeX/mDensity) == 0)) && (this.mSporadicMeta > 0) ) {  // Sporadics are only 1 per vertical column normally, reduce by 1/7 to compensate
+						if (GT_TileEntity_Ores.setOreBlock(aWorld, tX, level, tZ, this.mSporadicMeta, false, false))
+							placeCount[3]++;
+					}
+				}
+			}
+		// Top two layers are primary + sporadic
+		level++; // Increment level to next layer
+		for( ; level < (tMinY + 6); level++){ // should do two layers
+			for (int tX = wX; tX < eX; tX++) {
+				int placeX = Math.max(1, Math.max(MathHelper.abs_int(wX - tX), MathHelper.abs_int(eX - tX)));
+				for (int tZ = nZ; tZ < sZ; tZ++) {
+					int placeZ = Math.max(1, Math.max(MathHelper.abs_int(sZ - tZ), MathHelper.abs_int(nZ - tZ)));
+					if ( ((aRandom.nextInt(placeZ/mDensity) == 0) || (aRandom.nextInt(placeX/mDensity) == 0)) && (this.mPrimaryMeta > 0) ) {
+						if (GT_TileEntity_Ores.setOreBlock(aWorld, tX, level, tZ, this.mPrimaryMeta, false, false)) {
+							placeCount[0]++;
+						}
+					}
+					else if ((aRandom.nextInt(7) == 0) && ((aRandom.nextInt(placeZ/mDensity) == 0) || (aRandom.nextInt(placeX/mDensity) == 0)) && (this.mSporadicMeta > 0) ) {  // Sporadics are only 1 per vertical column normally, reduce by 1/7 to compensate
+						if (GT_TileEntity_Ores.setOreBlock(aWorld, tX, level, tZ, this.mSporadicMeta, false, false))
+							placeCount[3]++;
+					}
+				}
+			}
+		}	
         if (debugOrevein) {
 			String tDimensionName = aWorld.provider.getDimensionName();
             GT_Log.out.println(
                             "Generated Orevein:" + this.mWorldGenName +
-                            " chunkX="+aChunkX+
-                            " chunkZ="+aChunkZ+
-                            " chunkY="+tMinY+
-                            " Density=" + this.mDensity +
-                            " Secondary="+placeCount[1]+" "+new ItemStack(GregTech_API.sBlockOres1,1,mSecondaryMeta).getDisplayName()+
-                            " Between="+placeCount[2]+" "+new ItemStack(GregTech_API.sBlockOres1,1,mBetweenMeta).getDisplayName()+
-                            " Primary="+placeCount[0]+" "+new ItemStack(GregTech_API.sBlockOres1,1,mPrimaryMeta).getDisplayName()+
-                            " Sporadic="+placeCount[3]+" "+new ItemStack(GregTech_API.sBlockOres1,1,mSporadicMeta).getDisplayName() +
-                            " Dimension=" + tDimensionName
+                            " Dimension=" + tDimensionName +
+							" cX="+aChunkX+
+                            " cZ="+aChunkZ+
+                            " cY="+tMinY+
+                            " Den=" + this.mDensity +
+                            " Sec="+placeCount[1]+
+                            " Spo="+placeCount[3]+
+                            " Bet="+placeCount[2]+
+                            " Pri="+placeCount[0]
             );
-        }
-		// Didn't place anything, return false
-		if( (placeCount[0] + placeCount[1] + placeCount[2] + placeCount[3]) == 0 )
-			return false;
-		else 
-        	return true;
+		}
+		// Something (at least the bottom layer must have 1 block) must have been placed, return true
+       	return ORE_PLACED;
     }
 }

--- a/src/main/java/gregtech/common/GT_Worldgen_GT_Ore_Layer.java
+++ b/src/main/java/gregtech/common/GT_Worldgen_GT_Ore_Layer.java
@@ -105,6 +105,13 @@ public class GT_Worldgen_GT_Ore_Layer
             
         //if (!isGenerationAllowed(aWorld, aDimensionType, ((aDimensionType == -1) && (this.mNether)) || ((aDimensionType == 0) && (this.mOverworld)) || ((aDimensionType == 1) && (this.mEnd)) || ((aWorld.provider.getDimensionName().equals("Moon")) && (this.mMoon)) || ((aWorld.provider.getDimensionName().equals("Mars")) && (this.mMars)) ? aDimensionType : aDimensionType ^ 0xFFFFFFFF)) {
         if (!isGenerationAllowed(aWorld, aDimensionType, ((aDimensionType == -1) && (this.mNether)) || ((aDimensionType == 0) && (this.mOverworld)) || ((aDimensionType == 1) && (this.mEnd)) ? aDimensionType : aDimensionType ^ 0xFFFFFFFF)) {
+            /*
+            if (debugOrevein) {
+                GT_Log.out.println(
+                    "Wrong dimension"
+                );
+            }
+            */
             return WRONG_DIMENSION;
         }
         if (!this.mRestrictBiome.equals("None") && !(this.mRestrictBiome.equals(aBiome))) {
@@ -123,11 +130,13 @@ public class GT_Worldgen_GT_Ore_Layer
         int wX = Math.max( wXVein, aChunkX + 2);  // Bias placement by 2 blocks to prevent worldgen cascade.
         int eX = Math.min( eXVein, aChunkX + 2 + 16);
         if (wX >= eX) {  //No overlap between orevein and this chunk exists in X
+            /*
             if (debugOrevein) {
                 GT_Log.out.println(
                     "No X overlap"
                 );
             }
+            */
             return NO_OVERLAP;
         }
         // Determine North/Sound ends of orevein
@@ -137,11 +146,13 @@ public class GT_Worldgen_GT_Ore_Layer
         int nZ = Math.max(nZVein, aChunkZ + 2);  // Bias placement by 2 blocks to prevent worldgen cascade.
         int sZ = Math.min(sZVein, aChunkZ + 2 + 16);
         if (nZ >= sZ) { //No overlap between orevein and this chunk exists in Z
+            /*
             if (debugOrevein) {
                 GT_Log.out.println(
                     "No Z overlap"
                 );
             }
+            */
             return NO_OVERLAP;
         }
         // Adjust the density down the more chunks we are away from the oreseed.  The 5 chunks surrounding the seed should always be max density due to truncation of Math.sqrt().
@@ -256,6 +267,10 @@ public class GT_Worldgen_GT_Ore_Layer
                             " oreseedX="+ aSeedX/16 +
                             " oreseedZ="+ aSeedZ/16 +
                             " cY="+tMinY+
+                            " wXVein" + wXVein +
+                            " eXVein" + eXVein +
+                            " nZVein" + nZVein +
+                            " sZVein" + sZVein +
                             " locDen=" + localDensity +
                             " Den=" + this.mDensity +
                             " Sec="+placeCount[1]+
@@ -265,6 +280,6 @@ public class GT_Worldgen_GT_Ore_Layer
             );
         }
         // Something (at least the bottom layer must have 1 block) must have been placed, return true
-           return ORE_PLACED;
+        return ORE_PLACED;
     }
 }

--- a/src/main/java/gregtech/common/GT_Worldgen_GT_Ore_Layer.java
+++ b/src/main/java/gregtech/common/GT_Worldgen_GT_Ore_Layer.java
@@ -16,7 +16,6 @@ import java.util.ArrayList;
 import java.util.Random;
 
 import static gregtech.api.enums.GT_Values.debugOrevein;
-import static gregtech.api.enums.GT_Values.debugWorldGen;
 
 public class GT_Worldgen_GT_Ore_Layer
         extends GT_Worldgen {
@@ -97,11 +96,9 @@ public class GT_Worldgen_GT_Ore_Layer
 
     public int executeWorldgenChunkified(World aWorld, Random aRandom, String aBiome, int aDimensionType, int aChunkX, int aChunkZ, int aSeedX, int aSeedZ, IChunkProvider aChunkGenerator, IChunkProvider aChunkProvider) {
 		if( mWorldGenName.equals("NoOresInVein") ) {
-			/*
 			if (debugOrevein) GT_Log.out.println(
-                            " NoOresInVein, skipping"
+                            " NoOresInVein"
             );
-            */
 			// This is a special empty orevein
 			return ORE_PLACED;
 		}
@@ -116,39 +113,35 @@ public class GT_Worldgen_GT_Ore_Layer
 		int[] placeCount=new int[4];
 
 		// Need to "reseed" RNG with values based on the orevein constants so that two oreveins at this same chunk don't end up trying the same sizes and offsets.
-		aRandom.nextInt( this.mPrimaryMeta + this.mSecondaryMeta + this.mSporadicMeta + this.mBetweenMeta + aChunkX + aChunkZ);
+		aRandom.nextInt( this.mPrimaryMeta + this.mSecondaryMeta + this.mSporadicMeta + this.mBetweenMeta + Math.abs(aChunkX + aChunkZ));
 		
 		int tMinY = mMinY + aRandom.nextInt(mMaxY - mMinY - 5);
 		// Determine West/East ends of orevein
 		int wXVein = aSeedX - aRandom.nextInt(mSize);        // West side
 		int eXVein = aSeedX + 16 + aRandom.nextInt(mSize);
 		// Limit Orevein to only blocks present in current chunk
-		int wX = Math.max( wXVein, aChunkX);
-		int eX = Math.min( eXVein, aChunkX + 16);
+		int wX = Math.max( wXVein, aChunkX + 2);  // Bias placement by 2 blocks to prevent worldgen cascade.
+		int eX = Math.min( eXVein, aChunkX + 2 + 16);
 		if (wX >= eX) {  //No overlap between orevein and this chunk exists in X
-/*
 			if (debugOrevein) {
-				System.out.println(
-					"No overlap in X dim!"
+				GT_Log.out.println(
+					"No X overlap"
 				);
 			}
-*/
 			return NO_OVERLAP;
 		}
 		// Determine North/Sound ends of orevein
 		int nZVein = aSeedZ - aRandom.nextInt(mSize);
 		int sZVein = aSeedZ + 16 + aRandom.nextInt(mSize);
 		
-		int nZ = Math.max(nZVein, aChunkZ);
-		int sZ = Math.min(sZVein, aChunkZ + 16);
+		int nZ = Math.max(nZVein, aChunkZ + 2);  // Bias placement by 2 blocks to prevent worldgen cascade.
+		int sZ = Math.min(sZVein, aChunkZ + 2 + 16);
 		if (nZ >= sZ) { //No overlap between orevein and this chunk exists in Z
-/*
 			if (debugOrevein) {
-				System.out.println(
-					"No overlap in Z dim!"
+				GT_Log.out.println(
+					"No Z overlap"
 				);
 			}
-*/
 			return NO_OVERLAP;
 		}
 		// Adjust the density down the more chunks we are away from the oreseed.  The 5 chunks surrounding the seed should always be max density due to truncation of Math.sqrt().
@@ -173,12 +166,9 @@ public class GT_Worldgen_GT_Ore_Layer
 				}
 			}
 		if ((placeCount[1]+placeCount[3])==0) {
-/*
-			GT_Log.out.println(
-                            "Generated Orevein:" + this.mWorldGenName +
-                            " did not place any ores in bottom layer, skipping"
+			if (debugOrevein) GT_Log.out.println(
+	            " No ore in bottom layer"
             );
-*/
 			return NO_ORE_IN_BOTTOM_LAYER;  // Exit early, didn't place anything in the bottom layer
 		}
 		for (level = tMinY; level < (tMinY-1+3); level++) {

--- a/src/main/java/gregtech/common/GT_Worldgen_GT_Ore_Layer.java
+++ b/src/main/java/gregtech/common/GT_Worldgen_GT_Ore_Layer.java
@@ -36,13 +36,13 @@ public class GT_Worldgen_GT_Ore_Layer
     public final boolean mNether;
     public final boolean mEnd;
     public final boolean mEndAsteroid;
-	public static final int WRONG_BIOME=0;
-	public static final int WRONG_DIMENSION=1;
-	public static final int NO_ORE_IN_BOTTOM_LAYER=2;
-	public static final int NO_OVERLAP=3;
-	public static final int ORE_PLACED=4;
+    public static final int WRONG_BIOME=0;
+    public static final int WRONG_DIMENSION=1;
+    public static final int NO_ORE_IN_BOTTOM_LAYER=2;
+    public static final int NO_OVERLAP=3;
+    public static final int ORE_PLACED=4;
 
-	
+    
     //public final boolean mMoon;
     //public final boolean mMars;
     //public final boolean mAsteroid;
@@ -59,14 +59,14 @@ public class GT_Worldgen_GT_Ore_Layer
         //this.mAsteroid = GregTech_API.sWorldgenFile.get(aTextWorldgen + this.mWorldGenName, "Asteroid", aAsteroid);
         this.mMinY = ((short) GregTech_API.sWorldgenFile.get(aTextWorldgen + this.mWorldGenName, "MinHeight", aMinY));
         short mMaxY = ((short) GregTech_API.sWorldgenFile.get(aTextWorldgen + this.mWorldGenName, "MaxHeight", aMaxY));
-		if (mMaxY < (this.mMinY + 7))	{
-			GT_Log.out.println(
-					"Oremix " + this.mWorldGenName +
-				    " has invalid Min/Max heights!"
-				);
-			mMaxY = (short) (this.mMinY + 7);
-		}
-		this.mMaxY = mMaxY;
+        if (mMaxY < (this.mMinY + 7))    {
+            GT_Log.out.println(
+                    "Oremix " + this.mWorldGenName +
+                    " has invalid Min/Max heights!"
+                );
+            mMaxY = (short) (this.mMinY + 7);
+        }
+        this.mMaxY = mMaxY;
         this.mWeight = ((short) GregTech_API.sWorldgenFile.get(aTextWorldgen + this.mWorldGenName, "RandomWeight", aWeight));
         this.mDensity = ((short) GregTech_API.sWorldgenFile.get(aTextWorldgen + this.mWorldGenName, "Density", aDensity));
         this.mSize = ((short) Math.max(1, GregTech_API.sWorldgenFile.get(aTextWorldgen + this.mWorldGenName, "Size", aSize)));
@@ -88,173 +88,173 @@ public class GT_Worldgen_GT_Ore_Layer
             GT_Achievements.registerOre(GregTech_API.sGeneratedMaterials[(mSporadicMeta % 1000)], aMinY, aMaxY, aWeight, aOverworld, aNether, aEnd);
             sWeight += this.mWeight;
             if(GregTech_API.mImmersiveEngineering && GT_Mod.gregtechproxy.mImmersiveEngineeringRecipes){
-            	blusunrize.immersiveengineering.api.tool.ExcavatorHandler.addMineral(aName.substring(8, 9).toUpperCase()+aName.substring(9), aWeight, 0.2f, new String[]{"ore"+aPrimary.mName,"ore"+aSecondary.mName,"ore"+aBetween.mName,"ore"+aSporadic.mName}, new float[]{.4f,.4f,.15f,.05f});
+                blusunrize.immersiveengineering.api.tool.ExcavatorHandler.addMineral(aName.substring(8, 9).toUpperCase()+aName.substring(9), aWeight, 0.2f, new String[]{"ore"+aPrimary.mName,"ore"+aSecondary.mName,"ore"+aBetween.mName,"ore"+aSporadic.mName}, new float[]{.4f,.4f,.15f,.05f});
             }
             
         }
     }
 
     public int executeWorldgenChunkified(World aWorld, Random aRandom, String aBiome, int aDimensionType, int aChunkX, int aChunkZ, int aSeedX, int aSeedZ, IChunkProvider aChunkGenerator, IChunkProvider aChunkProvider) {
-		if( mWorldGenName.equals("NoOresInVein") ) {
-			if (debugOrevein) GT_Log.out.println(
+        if( mWorldGenName.equals("NoOresInVein") ) {
+            if (debugOrevein) GT_Log.out.println(
                             " NoOresInVein"
             );
-			// This is a special empty orevein
-			return ORE_PLACED;
-		}
-			
-		//if (!isGenerationAllowed(aWorld, aDimensionType, ((aDimensionType == -1) && (this.mNether)) || ((aDimensionType == 0) && (this.mOverworld)) || ((aDimensionType == 1) && (this.mEnd)) || ((aWorld.provider.getDimensionName().equals("Moon")) && (this.mMoon)) || ((aWorld.provider.getDimensionName().equals("Mars")) && (this.mMars)) ? aDimensionType : aDimensionType ^ 0xFFFFFFFF)) {
+            // This is a special empty orevein
+            return ORE_PLACED;
+        }
+            
+        //if (!isGenerationAllowed(aWorld, aDimensionType, ((aDimensionType == -1) && (this.mNether)) || ((aDimensionType == 0) && (this.mOverworld)) || ((aDimensionType == 1) && (this.mEnd)) || ((aWorld.provider.getDimensionName().equals("Moon")) && (this.mMoon)) || ((aWorld.provider.getDimensionName().equals("Mars")) && (this.mMars)) ? aDimensionType : aDimensionType ^ 0xFFFFFFFF)) {
         if (!isGenerationAllowed(aWorld, aDimensionType, ((aDimensionType == -1) && (this.mNether)) || ((aDimensionType == 0) && (this.mOverworld)) || ((aDimensionType == 1) && (this.mEnd)) ? aDimensionType : aDimensionType ^ 0xFFFFFFFF)) {
             return WRONG_DIMENSION;
         }
         if (!this.mRestrictBiome.equals("None") && !(this.mRestrictBiome.equals(aBiome))) {
             return WRONG_BIOME; //Not the correct biome for ore mix
         }
-		int[] placeCount=new int[4];
+        int[] placeCount=new int[4];
 
-		// Need to "reseed" RNG with values based on the orevein constants so that two oreveins at this same chunk don't end up trying the same sizes and offsets.
-		aRandom.nextInt( this.mPrimaryMeta + this.mSecondaryMeta + this.mSporadicMeta + this.mBetweenMeta + Math.abs(aChunkX + aChunkZ));
-		
-		int tMinY = mMinY + aRandom.nextInt(mMaxY - mMinY - 5);
-		// Determine West/East ends of orevein
-		int wXVein = aSeedX - aRandom.nextInt(mSize);        // West side
-		int eXVein = aSeedX + 16 + aRandom.nextInt(mSize);
-		// Limit Orevein to only blocks present in current chunk
-		int wX = Math.max( wXVein, aChunkX + 2);  // Bias placement by 2 blocks to prevent worldgen cascade.
-		int eX = Math.min( eXVein, aChunkX + 2 + 16);
-		if (wX >= eX) {  //No overlap between orevein and this chunk exists in X
-			if (debugOrevein) {
-				GT_Log.out.println(
-					"No X overlap"
-				);
-			}
-			return NO_OVERLAP;
-		}
-		// Determine North/Sound ends of orevein
-		int nZVein = aSeedZ - aRandom.nextInt(mSize);
-		int sZVein = aSeedZ + 16 + aRandom.nextInt(mSize);
-		
-		int nZ = Math.max(nZVein, aChunkZ + 2);  // Bias placement by 2 blocks to prevent worldgen cascade.
-		int sZ = Math.min(sZVein, aChunkZ + 2 + 16);
-		if (nZ >= sZ) { //No overlap between orevein and this chunk exists in Z
-			if (debugOrevein) {
-				GT_Log.out.println(
-					"No Z overlap"
-				);
-			}
-			return NO_OVERLAP;
-		}
-		// Adjust the density down the more chunks we are away from the oreseed.  The 5 chunks surrounding the seed should always be max density due to truncation of Math.sqrt().
-		int localDensity = Math.max(1, this.mDensity / ((int)Math.sqrt(2 + Math.pow(aChunkX/16 - aSeedX/16, 2) + Math.pow(aChunkZ/16 - aSeedZ/16, 2))) );
+        // Need to "reseed" RNG with values based on the orevein constants so that two oreveins at this same chunk don't end up trying the same sizes and offsets.
+        aRandom.nextInt( this.mPrimaryMeta + this.mSecondaryMeta + this.mSporadicMeta + this.mBetweenMeta + Math.abs(aChunkX + aChunkZ));
+        
+        int tMinY = mMinY + aRandom.nextInt(mMaxY - mMinY - 5);
+        // Determine West/East ends of orevein
+        int wXVein = aSeedX - aRandom.nextInt(mSize);        // West side
+        int eXVein = aSeedX + 16 + aRandom.nextInt(mSize);
+        // Limit Orevein to only blocks present in current chunk
+        int wX = Math.max( wXVein, aChunkX + 2);  // Bias placement by 2 blocks to prevent worldgen cascade.
+        int eX = Math.min( eXVein, aChunkX + 2 + 16);
+        if (wX >= eX) {  //No overlap between orevein and this chunk exists in X
+            if (debugOrevein) {
+                GT_Log.out.println(
+                    "No X overlap"
+                );
+            }
+            return NO_OVERLAP;
+        }
+        // Determine North/Sound ends of orevein
+        int nZVein = aSeedZ - aRandom.nextInt(mSize);
+        int sZVein = aSeedZ + 16 + aRandom.nextInt(mSize);
+        
+        int nZ = Math.max(nZVein, aChunkZ + 2);  // Bias placement by 2 blocks to prevent worldgen cascade.
+        int sZ = Math.min(sZVein, aChunkZ + 2 + 16);
+        if (nZ >= sZ) { //No overlap between orevein and this chunk exists in Z
+            if (debugOrevein) {
+                GT_Log.out.println(
+                    "No Z overlap"
+                );
+            }
+            return NO_OVERLAP;
+        }
+        // Adjust the density down the more chunks we are away from the oreseed.  The 5 chunks surrounding the seed should always be max density due to truncation of Math.sqrt().
+        int localDensity = Math.max(1, this.mDensity / ((int)Math.sqrt(2 + Math.pow(aChunkX/16 - aSeedX/16, 2) + Math.pow(aChunkZ/16 - aSeedZ/16, 2))) );
 
- 		// To allow for early exit due to no ore placed in the bottom layer (probably because we are in the sky), unroll 1 pass through the loop
-		// Now we do bottom-level-first oregen, and work our way upwards.
-		int level = tMinY - 1; //Dunno why, but the first layer is actually played one below tMinY.  Go figure.
-			for (int tX = wX; tX < eX; tX++) {
-				int placeX = Math.max(1, Math.max(MathHelper.abs_int(wXVein - tX), MathHelper.abs_int(eXVein - tX))/localDensity);
-				for (int tZ = nZ; tZ < sZ; tZ++) {
-					int placeZ = Math.max(1, Math.max(MathHelper.abs_int(sZVein - tZ), MathHelper.abs_int(nZVein - tZ))/localDensity);
-					if ( ((aRandom.nextInt(placeZ) == 0) || (aRandom.nextInt(placeX) == 0)) && (this.mSecondaryMeta > 0) ) {
-						if (GT_TileEntity_Ores.setOreBlock(aWorld, tX, level, tZ, this.mSecondaryMeta, false, false)) {
-							placeCount[1]++;
-						}
-					}
-					else if ((aRandom.nextInt(7) == 0) && ((aRandom.nextInt(placeZ) == 0) || (aRandom.nextInt(placeX) == 0)) && (this.mSporadicMeta > 0) ) {  // Sporadics are only 1 per vertical column normally, reduce by 1/7 to compensate
-						if (GT_TileEntity_Ores.setOreBlock(aWorld, tX, level, tZ, this.mSporadicMeta, false, false))
-							placeCount[3]++;
-					}
-				}
-			}
-		if ((placeCount[1]+placeCount[3])==0) {
-			if (debugOrevein) GT_Log.out.println(
-	            " No ore in bottom layer"
+         // To allow for early exit due to no ore placed in the bottom layer (probably because we are in the sky), unroll 1 pass through the loop
+        // Now we do bottom-level-first oregen, and work our way upwards.
+        int level = tMinY - 1; //Dunno why, but the first layer is actually played one below tMinY.  Go figure.
+            for (int tX = wX; tX < eX; tX++) {
+                int placeX = Math.max(1, Math.max(MathHelper.abs_int(wXVein - tX), MathHelper.abs_int(eXVein - tX))/localDensity);
+                for (int tZ = nZ; tZ < sZ; tZ++) {
+                    int placeZ = Math.max(1, Math.max(MathHelper.abs_int(sZVein - tZ), MathHelper.abs_int(nZVein - tZ))/localDensity);
+                    if ( ((aRandom.nextInt(placeZ) == 0) || (aRandom.nextInt(placeX) == 0)) && (this.mSecondaryMeta > 0) ) {
+                        if (GT_TileEntity_Ores.setOreBlock(aWorld, tX, level, tZ, this.mSecondaryMeta, false, false)) {
+                            placeCount[1]++;
+                        }
+                    }
+                    else if ((aRandom.nextInt(7) == 0) && ((aRandom.nextInt(placeZ) == 0) || (aRandom.nextInt(placeX) == 0)) && (this.mSporadicMeta > 0) ) {  // Sporadics are only 1 per vertical column normally, reduce by 1/7 to compensate
+                        if (GT_TileEntity_Ores.setOreBlock(aWorld, tX, level, tZ, this.mSporadicMeta, false, false))
+                            placeCount[3]++;
+                    }
+                }
+            }
+        if ((placeCount[1]+placeCount[3])==0) {
+            if (debugOrevein) GT_Log.out.println(
+                " No ore in bottom layer"
             );
-			return NO_ORE_IN_BOTTOM_LAYER;  // Exit early, didn't place anything in the bottom layer
-		}
-		for (level = tMinY; level < (tMinY-1+3); level++) {
-			for (int tX = wX; tX < eX; tX++) {
-				int placeX = Math.max(1, Math.max(MathHelper.abs_int(wXVein - tX), MathHelper.abs_int(eXVein - tX))/localDensity);
-				for (int tZ = nZ; tZ < sZ; tZ++) {
-					int placeZ = Math.max(1, Math.max(MathHelper.abs_int(sZVein - tZ), MathHelper.abs_int(nZVein - tZ))/localDensity);
-					if ( ((aRandom.nextInt(placeZ) == 0) || (aRandom.nextInt(placeX) == 0)) && (this.mSecondaryMeta > 0) ) {
-						if (GT_TileEntity_Ores.setOreBlock(aWorld, tX, level, tZ, this.mSecondaryMeta, false, false)) {
-							placeCount[1]++;
-						}
-					}
-					else if ((aRandom.nextInt(7) == 0) && ((aRandom.nextInt(placeZ) == 0) || (aRandom.nextInt(placeX) == 0)) && (this.mSporadicMeta > 0) ) {  // Sporadics are only 1 per vertical column normally, reduce by 1/7 to compensate
-						if (GT_TileEntity_Ores.setOreBlock(aWorld, tX, level, tZ, this.mSporadicMeta, false, false))
-							placeCount[3]++;
-					}
-				}
-			}
-		}
-		// Low Middle layer is between + sporadic
-		// level should be = tMinY-1+3 from end of for loop
-			for (int tX = wX; tX < eX; tX++) {
-				int placeX = Math.max(1, Math.max(MathHelper.abs_int(wXVein - tX), MathHelper.abs_int(eXVein - tX))/localDensity);
-				for (int tZ = nZ; tZ < sZ; tZ++) {
-					int placeZ = Math.max(1, Math.max(MathHelper.abs_int(sZVein - tZ), MathHelper.abs_int(nZVein - tZ))/localDensity);
-					if ((aRandom.nextInt(2) == 0) && ((aRandom.nextInt(placeZ) == 0) || (aRandom.nextInt(placeX) == 0)) && (this.mBetweenMeta > 0) ) {  // Between are only 1 per vertical column, reduce by 1/2 to compensate
-						if (GT_TileEntity_Ores.setOreBlock(aWorld, tX, level, tZ, this.mBetweenMeta, false, false)) {
-							placeCount[2]++;
-						}
-					}
-					else if ((aRandom.nextInt(7) == 0) && ((aRandom.nextInt(placeZ) == 0) || (aRandom.nextInt(placeX) == 0)) && (this.mSporadicMeta > 0) ) {  // Sporadics are only 1 per vertical column normally, reduce by 1/7 to compensate
-						if (GT_TileEntity_Ores.setOreBlock(aWorld, tX, level, tZ, this.mSporadicMeta, false, false))
-							placeCount[3]++;
-					}
-				}
-			}
-		// High Middle layer is between + primary + sporadic
-		level++; // Increment level to next layer
-			for (int tX = wX; tX < eX; tX++) {
-				int placeX = Math.max(1, Math.max(MathHelper.abs_int(wXVein - tX), MathHelper.abs_int(eXVein - tX))/localDensity);
-				for (int tZ = nZ; tZ < sZ; tZ++) {
-					int placeZ = Math.max(1, Math.max(MathHelper.abs_int(sZVein - tZ), MathHelper.abs_int(nZVein - tZ))/localDensity);
-					if ((aRandom.nextInt(2) == 0) && ((aRandom.nextInt(placeZ) == 0) || (aRandom.nextInt(placeX) == 0)) && (this.mBetweenMeta > 0) ) {  // Between are only 1 per vertical column, reduce by 1/2 to compensate
-						if (GT_TileEntity_Ores.setOreBlock(aWorld, tX, level, tZ, this.mBetweenMeta, false, false)) {
-							placeCount[2]++;
-						}
-					}
-					else if ( ((aRandom.nextInt(placeZ) == 0) || (aRandom.nextInt(placeX) == 0)) && (this.mPrimaryMeta > 0) ) {
-						if (GT_TileEntity_Ores.setOreBlock(aWorld, tX, level, tZ, this.mPrimaryMeta, false, false)) {
-							placeCount[0]++;
-						}
-					}
-					else if ((aRandom.nextInt(7) == 0) && ((aRandom.nextInt(placeZ) == 0) || (aRandom.nextInt(placeX) == 0)) && (this.mSporadicMeta > 0) ) {  // Sporadics are only 1 per vertical column normally, reduce by 1/7 to compensate
-						if (GT_TileEntity_Ores.setOreBlock(aWorld, tX, level, tZ, this.mSporadicMeta, false, false))
-							placeCount[3]++;
-					}
-				}
-			}
-		// Top two layers are primary + sporadic
-		level++; // Increment level to next layer
-		for( ; level < (tMinY + 6); level++){ // should do two layers
-			for (int tX = wX; tX < eX; tX++) {
-				int placeX = Math.max(1, Math.max(MathHelper.abs_int(wXVein - tX), MathHelper.abs_int(eXVein - tX))/localDensity);
-				for (int tZ = nZ; tZ < sZ; tZ++) {
-					int placeZ = Math.max(1, Math.max(MathHelper.abs_int(sZVein - tZ), MathHelper.abs_int(nZVein - tZ))/localDensity);
-					if ( ((aRandom.nextInt(placeZ) == 0) || (aRandom.nextInt(placeX) == 0)) && (this.mPrimaryMeta > 0) ) {
-						if (GT_TileEntity_Ores.setOreBlock(aWorld, tX, level, tZ, this.mPrimaryMeta, false, false)) {
-							placeCount[0]++;
-						}
-					}
-					else if ((aRandom.nextInt(7) == 0) && ((aRandom.nextInt(placeZ) == 0) || (aRandom.nextInt(placeX) == 0)) && (this.mSporadicMeta > 0) ) {  // Sporadics are only 1 per vertical column normally, reduce by 1/7 to compensate
-						if (GT_TileEntity_Ores.setOreBlock(aWorld, tX, level, tZ, this.mSporadicMeta, false, false))
-							placeCount[3]++;
-					}
-				}
-			}
-		}	
+            return NO_ORE_IN_BOTTOM_LAYER;  // Exit early, didn't place anything in the bottom layer
+        }
+        for (level = tMinY; level < (tMinY-1+3); level++) {
+            for (int tX = wX; tX < eX; tX++) {
+                int placeX = Math.max(1, Math.max(MathHelper.abs_int(wXVein - tX), MathHelper.abs_int(eXVein - tX))/localDensity);
+                for (int tZ = nZ; tZ < sZ; tZ++) {
+                    int placeZ = Math.max(1, Math.max(MathHelper.abs_int(sZVein - tZ), MathHelper.abs_int(nZVein - tZ))/localDensity);
+                    if ( ((aRandom.nextInt(placeZ) == 0) || (aRandom.nextInt(placeX) == 0)) && (this.mSecondaryMeta > 0) ) {
+                        if (GT_TileEntity_Ores.setOreBlock(aWorld, tX, level, tZ, this.mSecondaryMeta, false, false)) {
+                            placeCount[1]++;
+                        }
+                    }
+                    else if ((aRandom.nextInt(7) == 0) && ((aRandom.nextInt(placeZ) == 0) || (aRandom.nextInt(placeX) == 0)) && (this.mSporadicMeta > 0) ) {  // Sporadics are only 1 per vertical column normally, reduce by 1/7 to compensate
+                        if (GT_TileEntity_Ores.setOreBlock(aWorld, tX, level, tZ, this.mSporadicMeta, false, false))
+                            placeCount[3]++;
+                    }
+                }
+            }
+        }
+        // Low Middle layer is between + sporadic
+        // level should be = tMinY-1+3 from end of for loop
+            for (int tX = wX; tX < eX; tX++) {
+                int placeX = Math.max(1, Math.max(MathHelper.abs_int(wXVein - tX), MathHelper.abs_int(eXVein - tX))/localDensity);
+                for (int tZ = nZ; tZ < sZ; tZ++) {
+                    int placeZ = Math.max(1, Math.max(MathHelper.abs_int(sZVein - tZ), MathHelper.abs_int(nZVein - tZ))/localDensity);
+                    if ((aRandom.nextInt(2) == 0) && ((aRandom.nextInt(placeZ) == 0) || (aRandom.nextInt(placeX) == 0)) && (this.mBetweenMeta > 0) ) {  // Between are only 1 per vertical column, reduce by 1/2 to compensate
+                        if (GT_TileEntity_Ores.setOreBlock(aWorld, tX, level, tZ, this.mBetweenMeta, false, false)) {
+                            placeCount[2]++;
+                        }
+                    }
+                    else if ((aRandom.nextInt(7) == 0) && ((aRandom.nextInt(placeZ) == 0) || (aRandom.nextInt(placeX) == 0)) && (this.mSporadicMeta > 0) ) {  // Sporadics are only 1 per vertical column normally, reduce by 1/7 to compensate
+                        if (GT_TileEntity_Ores.setOreBlock(aWorld, tX, level, tZ, this.mSporadicMeta, false, false))
+                            placeCount[3]++;
+                    }
+                }
+            }
+        // High Middle layer is between + primary + sporadic
+        level++; // Increment level to next layer
+            for (int tX = wX; tX < eX; tX++) {
+                int placeX = Math.max(1, Math.max(MathHelper.abs_int(wXVein - tX), MathHelper.abs_int(eXVein - tX))/localDensity);
+                for (int tZ = nZ; tZ < sZ; tZ++) {
+                    int placeZ = Math.max(1, Math.max(MathHelper.abs_int(sZVein - tZ), MathHelper.abs_int(nZVein - tZ))/localDensity);
+                    if ((aRandom.nextInt(2) == 0) && ((aRandom.nextInt(placeZ) == 0) || (aRandom.nextInt(placeX) == 0)) && (this.mBetweenMeta > 0) ) {  // Between are only 1 per vertical column, reduce by 1/2 to compensate
+                        if (GT_TileEntity_Ores.setOreBlock(aWorld, tX, level, tZ, this.mBetweenMeta, false, false)) {
+                            placeCount[2]++;
+                        }
+                    }
+                    else if ( ((aRandom.nextInt(placeZ) == 0) || (aRandom.nextInt(placeX) == 0)) && (this.mPrimaryMeta > 0) ) {
+                        if (GT_TileEntity_Ores.setOreBlock(aWorld, tX, level, tZ, this.mPrimaryMeta, false, false)) {
+                            placeCount[0]++;
+                        }
+                    }
+                    else if ((aRandom.nextInt(7) == 0) && ((aRandom.nextInt(placeZ) == 0) || (aRandom.nextInt(placeX) == 0)) && (this.mSporadicMeta > 0) ) {  // Sporadics are only 1 per vertical column normally, reduce by 1/7 to compensate
+                        if (GT_TileEntity_Ores.setOreBlock(aWorld, tX, level, tZ, this.mSporadicMeta, false, false))
+                            placeCount[3]++;
+                    }
+                }
+            }
+        // Top two layers are primary + sporadic
+        level++; // Increment level to next layer
+        for( ; level < (tMinY + 6); level++){ // should do two layers
+            for (int tX = wX; tX < eX; tX++) {
+                int placeX = Math.max(1, Math.max(MathHelper.abs_int(wXVein - tX), MathHelper.abs_int(eXVein - tX))/localDensity);
+                for (int tZ = nZ; tZ < sZ; tZ++) {
+                    int placeZ = Math.max(1, Math.max(MathHelper.abs_int(sZVein - tZ), MathHelper.abs_int(nZVein - tZ))/localDensity);
+                    if ( ((aRandom.nextInt(placeZ) == 0) || (aRandom.nextInt(placeX) == 0)) && (this.mPrimaryMeta > 0) ) {
+                        if (GT_TileEntity_Ores.setOreBlock(aWorld, tX, level, tZ, this.mPrimaryMeta, false, false)) {
+                            placeCount[0]++;
+                        }
+                    }
+                    else if ((aRandom.nextInt(7) == 0) && ((aRandom.nextInt(placeZ) == 0) || (aRandom.nextInt(placeX) == 0)) && (this.mSporadicMeta > 0) ) {  // Sporadics are only 1 per vertical column normally, reduce by 1/7 to compensate
+                        if (GT_TileEntity_Ores.setOreBlock(aWorld, tX, level, tZ, this.mSporadicMeta, false, false))
+                            placeCount[3]++;
+                    }
+                }
+            }
+        }    
         if (debugOrevein) {
-			String tDimensionName = aWorld.provider.getDimensionName();
+            String tDimensionName = aWorld.provider.getDimensionName();
             GT_Log.out.println(
                             "Generated Orevein:" + this.mWorldGenName +
                             " Dimension=" + tDimensionName +
-							" mX="+aChunkX/16+
+                            " mX="+aChunkX/16+
                             " mZ="+aChunkZ/16+
                             " oreseedX="+ aSeedX/16 +
-							" oreseedZ="+ aSeedZ/16 +
+                            " oreseedZ="+ aSeedZ/16 +
                             " cY="+tMinY+
                             " locDen=" + localDensity +
                             " Den=" + this.mDensity +
@@ -263,8 +263,8 @@ public class GT_Worldgen_GT_Ore_Layer
                             " Bet="+placeCount[2]+
                             " Pri="+placeCount[0]
             );
-		}
-		// Something (at least the bottom layer must have 1 block) must have been placed, return true
-       	return ORE_PLACED;
+        }
+        // Something (at least the bottom layer must have 1 block) must have been placed, return true
+           return ORE_PLACED;
     }
 }

--- a/src/main/java/gregtech/common/GT_Worldgen_GT_Ore_SmallPieces.java
+++ b/src/main/java/gregtech/common/GT_Worldgen_GT_Ore_SmallPieces.java
@@ -47,9 +47,9 @@ public class GT_Worldgen_GT_Ore_SmallPieces
             return false;
         }
         int count=0;
-	
+    
         if (this.mMeta > 0) {
-			int j = Math.max(1, this.mAmount / 2 + aRandom.nextInt(this.mAmount) / 2);
+            int j = Math.max(1, this.mAmount / 2 + aRandom.nextInt(this.mAmount) / 2);
             for ( int i = 0; i < j; i++) {
                 GT_TileEntity_Ores.setOreBlock(aWorld, aChunkX + 8 + aRandom.nextInt(16), this.mMinY + aRandom.nextInt(Math.max(1, this.mMaxY - this.mMinY)), aChunkZ + 8 + aRandom.nextInt(16), this.mMeta, true);
                 count++;
@@ -59,8 +59,8 @@ public class GT_Worldgen_GT_Ore_SmallPieces
             GT_Log.out.println(
                     "Small Ore:" + this.mWorldGenName +
                             " @ dim="+aDimensionType+
-							" mX="+aChunkX/16+
-							" mZ="+aChunkZ/16+
+                            " mX="+aChunkX/16+
+                            " mZ="+aChunkZ/16+
                             " ore="+count
             );
         }

--- a/src/main/java/gregtech/common/GT_Worldgen_GT_Ore_SmallPieces.java
+++ b/src/main/java/gregtech/common/GT_Worldgen_GT_Ore_SmallPieces.java
@@ -47,10 +47,11 @@ public class GT_Worldgen_GT_Ore_SmallPieces
             return false;
         }
         int count=0;
+	
         if (this.mMeta > 0) {
-            int i = 0;
-            for (int j = Math.max(1, this.mAmount / 2 + aRandom.nextInt(this.mAmount) / 2); i < j; i++) {
-                GT_TileEntity_Ores.setOreBlock(aWorld, aChunkX + aRandom.nextInt(16), this.mMinY + aRandom.nextInt(Math.max(1, this.mMaxY - this.mMinY)), aChunkZ + aRandom.nextInt(16), this.mMeta, true);
+			int j = Math.max(1, this.mAmount / 2 + aRandom.nextInt(this.mAmount) / 2);
+            for ( int i = 0; i < j; i++) {
+                GT_TileEntity_Ores.setOreBlock(aWorld, aChunkX + 8 + aRandom.nextInt(16), this.mMinY + aRandom.nextInt(Math.max(1, this.mMaxY - this.mMinY)), aChunkZ + 8 + aRandom.nextInt(16), this.mMeta, true);
                 count++;
             }
         }
@@ -58,9 +59,9 @@ public class GT_Worldgen_GT_Ore_SmallPieces
             GT_Log.out.println(
                     "Small Ore:" + this.mWorldGenName +
                             " @ dim="+aDimensionType+
-                            " chunkX="+aChunkX+
-                            " chunkZ="+aChunkZ+
-                            " ore="+count+" "+new ItemStack(GregTech_API.sBlockOres1,1,mMeta).getDisplayName()
+							" mX="+aChunkX/16+
+							" mZ="+aChunkZ/16+
+                            " ore="+count
             );
         }
         return true;

--- a/src/main/java/gregtech/common/GT_Worldgen_Stone.java
+++ b/src/main/java/gregtech/common/GT_Worldgen_Stone.java
@@ -1,6 +1,8 @@
 package gregtech.common;
 
 import gregtech.api.GregTech_API;
+import gregtech.api.objects.XSTR;
+import gregtech.api.util.GT_Log;
 import gregtech.api.world.GT_Worldgen_Ore;
 import gregtech.common.blocks.GT_Block_Ores_Abstract;
 import gregtech.common.blocks.GT_TileEntity_Ores;
@@ -13,37 +15,116 @@ import net.minecraft.world.chunk.IChunkProvider;
 
 import java.util.Collection;
 import java.util.Random;
+import java.util.Hashtable;
+import java.util.ArrayList;
+
+import static gregtech.api.enums.GT_Values.debugStones;
 
 public class GT_Worldgen_Stone
         extends GT_Worldgen_Ore {
+
+	public Hashtable<Long, StoneSeeds> validStoneSeeds = new Hashtable(1024);
+
+	class StoneSeeds {
+		public boolean mExists;
+
+		StoneSeeds( boolean exists ) {
+			mExists = exists;
+		}
+	};
+
+	class ValidSeeds {
+		public int mX;
+		public int mZ;
+		ValidSeeds( int x, int z) {
+			this.mX = x;
+			this.mZ = z;
+		}
+	};
     public GT_Worldgen_Stone(String aName, boolean aDefault, Block aBlock, int aBlockMeta, int aDimensionType, int aAmount, int aSize, int aProbability, int aMinY, int aMaxY, Collection<String> aBiomeList, boolean aAllowToGenerateinVoid) {
         super(aName, aDefault, aBlock, aBlockMeta, aDimensionType, aAmount, aSize, aProbability, aMinY, aMaxY, aBiomeList, aAllowToGenerateinVoid);
     }
 
     public boolean executeWorldgen(World aWorld, Random aRandom, String aBiome, int aDimensionType, int aChunkX, int aChunkZ, IChunkProvider aChunkGenerator, IChunkProvider aChunkProvider) {
-        if ((isGenerationAllowed(aWorld, aDimensionType, this.mDimensionType)) && ((this.mBiomeList.isEmpty()) || (this.mBiomeList.contains(aBiome))) && ((this.mProbability <= 1) || (aRandom.nextInt(this.mProbability) == 0))) {
+		XSTR stoneRNG = new XSTR();
+		ArrayList<ValidSeeds> stones = new ArrayList();
+		
+        if ( !isGenerationAllowed(aWorld, aDimensionType, this.mDimensionType)) {
+			return false;
+        }
+		if ( !(this.mBiomeList.isEmpty() || this.mBiomeList.contains(aBiome)) ) {
+			return false;
+		}
+		int windowWidth = (mSize/8)/16 + 1; // Width of chunks to check for a potential stoneseed (I think the real size of the balls is mSize/8, but the code below is difficult to understand)
+		// Check stone seeds to see if they have been added
+		for( int x = aChunkX/16 - windowWidth; x < (aChunkX/16 + windowWidth + 1); x++ ) {
+			for( int z = aChunkZ/16 - windowWidth; z < (aChunkZ/16 + windowWidth + 1); z++ ) {
+				long hash = (( (long)x << 32) | ( (long)z & 0x00000000ffffffffL ));
+				if( !validStoneSeeds.containsKey(hash) ) {
+					// Determine if RNG says to add stone at this chunk
+					stoneRNG.setSeed((long)aWorld.getSeed() ^  hash);
+					if ( (this.mProbability <= 1) || (aRandom.nextInt(this.mProbability) == 0) ) {
+						// Add stone at this chunk
+						validStoneSeeds.put( hash, new StoneSeeds(true) );
+						// Add to generation list
+						stones.add( new ValidSeeds(x,z) );
+						if (debugStones) GT_Log.out.println(
+							"New stoneseed x="+x+
+							" z="+z+
+							" mSize="+mSize
+						);
+					} else {
+						validStoneSeeds.put( hash, new StoneSeeds(false) );
+					}
+				} else {
+					// This chunk has already been checked, check to see if a boulder exists here
+					if( validStoneSeeds.get(hash).mExists ) {
+						// Add to generation list
+						stones.add( new ValidSeeds(x,z) );
+					}
+				}
+			}
+		}
+
+		boolean result = true;
+		if (stones.size() == 0) {
+			result = false;
+		}
+		// Now process each oreseed vs this requested chunk
+		for( ; stones.size() != 0; stones.remove(0) ) {
+			int x = stones.get(0).mX*16;
+			int z = stones.get(0).mZ*16;
+			
+			stoneRNG.setSeed((long)aWorld.getSeed() ^  (( (long)x << 32) | ( (long)z & 0x00000000ffffffffL )));
+
             for (int i = 0; i < this.mAmount; i++) {
-                int tX = aChunkX + aRandom.nextInt(16);
-                int tY = this.mMinY + aRandom.nextInt(this.mMaxY - this.mMinY);
-                int tZ = aChunkZ + aRandom.nextInt(16);
-                if ((this.mAllowToGenerateinVoid) || (!aWorld.getBlock(tX, tY, tZ).isAir(aWorld, tX, tY, tZ))) {
+                int tX = x + stoneRNG.nextInt(16);
+                int tY = this.mMinY + stoneRNG.nextInt(this.mMaxY - this.mMinY);
+                int tZ = z + stoneRNG.nextInt(16);
+                if ((this.mAllowToGenerateinVoid) || (!aWorld.getBlock(tX, tY, tZ).isAir(aWorld, tX, tY, tZ))) { // Causes slight amount of worldgen cascade since it may load a chunk that is far away.
                     float math_pi = 3.141593F;//FB: CNT - CNT_ROUGH_CONSTANT_VALUE
-                    float var6 = aRandom.nextFloat() * math_pi;
-                    float var1d = this.mSize / 8.0F;int var2d = tX + 8;int var3d = tZ + 8;int var4d = tY - 2;
-                    float mh_s_0 = MathHelper.sin(var6) * var1d;float mh_c_0 = MathHelper.cos(var6) * var1d;
+                    float var6 = stoneRNG.nextFloat() * math_pi;
+                    float var1d = this.mSize / 8.0F;
+					int var2d = tX + 8;
+					int var3d = tZ + 8;
+					int var4d = tY - 2;
+                    float mh_s_0 = MathHelper.sin(var6) * var1d;
+					float mh_c_0 = MathHelper.cos(var6) * var1d;
                     float var7 = var2d + mh_s_0;
                     float var11 = var3d + mh_c_0;
-                    int var15r = aRandom.nextInt(3);int var17r = aRandom.nextInt(3);
+                    int var15r = stoneRNG.nextInt(3);
+					int var17r = stoneRNG.nextInt(3);
                     int var15 = var4d + var15r;
                     int mh_n_4=var17r - var15r;
-                    float mh_n_0 = -2*mh_s_0;float mh_n_1 = -2*mh_c_0;
+                    float mh_n_0 = -2*mh_s_0;
+					float mh_n_1 = -2*mh_c_0;
                     for (int var19 = 0; var19 <= this.mSize; var19++) {
                         float var5d = var19 / this.mSize;
                         float var20 = var7 + mh_n_0 * var5d;
                         float var22 = var15 + mh_n_4 * var5d;
                         float var24 = var11 + mh_n_1 * var5d;
                         float var6d = var19 * math_pi / this.mSize;
-                        float var26 = aRandom.nextFloat() * this.mSize / 16.0F;
+                        float var26 = stoneRNG.nextFloat() * this.mSize / 16.0F;
                         float var28 = ((MathHelper.sin(var6d) + 1.0F) * var26 + 1.0F) / 2.0F;
                         int tMinX = MathHelper.floor_float(var20 - var28);
                         int tMinY = MathHelper.floor_float(var22 - var28);
@@ -51,28 +132,35 @@ public class GT_Worldgen_Stone
                         int tMaxX = MathHelper.floor_float(var20 + var28);
                         int tMaxY = MathHelper.floor_float(var22 + var28);
                         int tMaxZ = MathHelper.floor_float(var24 + var28);
-                        for (int eX = tMinX; eX <= tMaxX; eX++) {
-                            float var39 = (eX + 0.5F - var20) / (var28);
+
+						int wX = Math.max( tMinX, aChunkX + 8);
+						int eX = Math.min( tMaxX, aChunkX + 8 + 16 );
+
+						int sZ = Math.max( tMinZ, aChunkZ + 8);
+						int nZ = Math.min( tMaxZ, aChunkZ + 8 + 16 );
+		
+                        for (int iX = wX; iX < eX; iX++) {
+                            float var39 = (iX + 0.5F - var20) / (var28);
                             float var10d = var39 * var39;
                             if (var10d < 1.0F) {
-                                for (int eY = tMinY; eY <= tMaxY; eY++) {
-                                    float var42 = (eY + 0.5F - var22) / (var28);
+                                for (int iY = tMinY; iY <= tMaxY; iY++) {
+                                    float var42 = (iY + 0.5F - var22) / (var28);
                                     float var12d = var10d + var42 * var42;
                                     if (var12d < 1.0F) {
-                                        for (int eZ = tMinZ; eZ <= tMaxZ; eZ++) {
-                                            float var45 = (eZ + 0.5F - var24) / (var28);
+                                        for (int iZ = sZ; iZ < nZ; iZ++) {
+                                            float var45 = (iZ + 0.5F - var24) / (var28);
                                             if (var12d + var45 * var45 < 1.0F) {
-                                                Block tTargetedBlock = aWorld.getBlock(eX, eY, eZ);
+                                                Block tTargetedBlock = aWorld.getBlock(iX, iY, iZ);
                                                 if (tTargetedBlock instanceof GT_Block_Ores_Abstract) {
-                                                    TileEntity tTileEntity = aWorld.getTileEntity(eX, eY, eZ);
+                                                    TileEntity tTileEntity = aWorld.getTileEntity(iX, iY, iZ);
                                                     if ((tTileEntity instanceof GT_TileEntity_Ores)) {
                                                         if (tTargetedBlock != GregTech_API.sBlockOres1) {
-                                                            ((GT_TileEntity_Ores) tTileEntity).convertOreBlock(aWorld, eX, eY, eZ);
+                                                            ((GT_TileEntity_Ores) tTileEntity).convertOreBlock(aWorld, iX, iY, iZ);
                                                         }
                                                         ((GT_TileEntity_Ores)tTileEntity).overrideOreBlockMaterial(this.mBlock, (byte) this.mBlockMeta);
                                                     }
-                                                } else if (((this.mAllowToGenerateinVoid) && (aWorld.getBlock(eX, eY, eZ).isAir(aWorld, eX, eY, eZ))) || ((tTargetedBlock != null) && ((tTargetedBlock.isReplaceableOreGen(aWorld, eX, eY, eZ, Blocks.stone)) || (tTargetedBlock.isReplaceableOreGen(aWorld, eX, eY, eZ, Blocks.end_stone)) || (tTargetedBlock.isReplaceableOreGen(aWorld, eX, eY, eZ, Blocks.netherrack)) || (tTargetedBlock.isReplaceableOreGen(aWorld, eX, eY, eZ, GregTech_API.sBlockGranites)) || (tTargetedBlock.isReplaceableOreGen(aWorld, eX, eY, eZ, GregTech_API.sBlockStones))))) {
-                                                    aWorld.setBlock(eX, eY, eZ, this.mBlock, this.mBlockMeta, 0);
+                                                } else if (((this.mAllowToGenerateinVoid) && (aWorld.getBlock(iX, iY, iZ).isAir(aWorld, iX, iY, iZ))) || ((tTargetedBlock != null) && ((tTargetedBlock.isReplaceableOreGen(aWorld, iX, iY, iZ, Blocks.stone)) || (tTargetedBlock.isReplaceableOreGen(aWorld, iX, iY, iZ, Blocks.end_stone)) || (tTargetedBlock.isReplaceableOreGen(aWorld, iX, iY, iZ, Blocks.netherrack)) || (tTargetedBlock.isReplaceableOreGen(aWorld, iX, iY, iZ, GregTech_API.sBlockGranites)) || (tTargetedBlock.isReplaceableOreGen(aWorld, iX, iY, iZ, GregTech_API.sBlockStones))))) {
+                                                    aWorld.setBlock(iX, iY, iZ, this.mBlock, this.mBlockMeta, 0);
                                                 }
                                             }
                                         }
@@ -83,8 +171,7 @@ public class GT_Worldgen_Stone
                     }
                 }
             }
-            return true;
         }
-        return false;
+        return result;
     }
 }

--- a/src/main/java/gregtech/common/GT_Worldgen_Stone.java
+++ b/src/main/java/gregtech/common/GT_Worldgen_Stone.java
@@ -23,81 +23,175 @@ import static gregtech.api.enums.GT_Values.debugStones;
 public class GT_Worldgen_Stone
         extends GT_Worldgen_Ore {
 
-	public Hashtable<Long, StoneSeeds> validStoneSeeds = new Hashtable(1024);
+    static final double sizeConversion[] = { 1, 1, 1.333333, 1.333333, 2, 2, 2, 2, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4 }; // Bias the sizes towards skinnier boulders, ie more "shafts" than dikes or sills. 
 
-	class StoneSeeds {
-		public boolean mExists;
+    public Hashtable<Long, StoneSeeds> validStoneSeeds = new Hashtable(1024);
 
-		StoneSeeds( boolean exists ) {
-			mExists = exists;
-		}
-	};
+    class StoneSeeds {
+        public boolean mExists;
 
-	class ValidSeeds {
-		public int mX;
-		public int mZ;
-		ValidSeeds( int x, int z) {
-			this.mX = x;
-			this.mZ = z;
-		}
-	};
+        StoneSeeds( boolean exists ) {
+            mExists = exists;
+        }
+    };
+
+    class ValidSeeds {
+        public int mX;
+        public int mZ;
+        ValidSeeds( int x, int z) {
+            this.mX = x;
+            this.mZ = z;
+        }
+    };
     public GT_Worldgen_Stone(String aName, boolean aDefault, Block aBlock, int aBlockMeta, int aDimensionType, int aAmount, int aSize, int aProbability, int aMinY, int aMaxY, Collection<String> aBiomeList, boolean aAllowToGenerateinVoid) {
         super(aName, aDefault, aBlock, aBlockMeta, aDimensionType, aAmount, aSize, aProbability, aMinY, aMaxY, aBiomeList, aAllowToGenerateinVoid);
     }
 
     public boolean executeWorldgen(World aWorld, Random aRandom, String aBiome, int aDimensionType, int aChunkX, int aChunkZ, IChunkProvider aChunkGenerator, IChunkProvider aChunkProvider) {
-		XSTR stoneRNG = new XSTR();
-		ArrayList<ValidSeeds> stones = new ArrayList();
-		
+        XSTR stoneRNG = new XSTR();
+        ArrayList<ValidSeeds> stones = new ArrayList();
+        
         if ( !isGenerationAllowed(aWorld, aDimensionType, this.mDimensionType)) {
-			return false;
+            return false;
         }
-		if ( !(this.mBiomeList.isEmpty() || this.mBiomeList.contains(aBiome)) ) {
-			return false;
-		}
-		int windowWidth = (mSize/8)/16 + 1; // Width of chunks to check for a potential stoneseed (I think the real size of the balls is mSize/8, but the code below is difficult to understand)
-		// Check stone seeds to see if they have been added
-		for( int x = aChunkX/16 - windowWidth; x < (aChunkX/16 + windowWidth + 1); x++ ) {
-			for( int z = aChunkZ/16 - windowWidth; z < (aChunkZ/16 + windowWidth + 1); z++ ) {
-				long hash = (( (long)x << 32) | ( (long)z & 0x00000000ffffffffL ));
-				if( !validStoneSeeds.containsKey(hash) ) {
-					// Determine if RNG says to add stone at this chunk
-					stoneRNG.setSeed((long)aWorld.getSeed() ^  hash);
-					if ( (this.mProbability <= 1) || (aRandom.nextInt(this.mProbability) == 0) ) {
-						// Add stone at this chunk
-						validStoneSeeds.put( hash, new StoneSeeds(true) );
-						// Add to generation list
-						stones.add( new ValidSeeds(x,z) );
-						if (debugStones) GT_Log.out.println(
-							"New stoneseed x="+x+
-							" z="+z+
-							" mSize="+mSize
-						);
-					} else {
-						validStoneSeeds.put( hash, new StoneSeeds(false) );
-					}
-				} else {
-					// This chunk has already been checked, check to see if a boulder exists here
-					if( validStoneSeeds.get(hash).mExists ) {
-						// Add to generation list
-						stones.add( new ValidSeeds(x,z) );
-					}
-				}
-			}
-		}
+        if ( !(this.mBiomeList.isEmpty() || this.mBiomeList.contains(aBiome)) ) {
+            return false;
+        }
+        // I think the real size of the balls is mSize/8, but the original code was difficult to understand. 
+        // Overall there will be less GT stones since they aren't spheres any more. /16 since this code uses it as a radius.
+        double realSize = mSize/16;
+        int windowWidth = ((int)realSize)/16 + 1; // Width of chunks to check for a potential stoneseed
+        // Check stone seeds to see if they have been added
+        for( int x = aChunkX/16 - windowWidth; x < (aChunkX/16 + windowWidth + 1); x++ ) {
+            for( int z = aChunkZ/16 - windowWidth; z < (aChunkZ/16 + windowWidth + 1); z++ ) {
+                long hash = ((long)((aWorld.provider.dimensionId & 0xffL)<<56) |( ((long)x & 0x000000000fffffffL) << 28) | ( (long)z & 0x000000000fffffffL ));
+                if( !validStoneSeeds.containsKey(hash) ) {
+                    // Determine if RNG says to add stone at this chunk
+                    stoneRNG.setSeed((long)aWorld.getSeed() ^  hash + Math.abs(mBlockMeta) + Math.abs(mSize) + Math.abs(mProbability) + ((GregTech_API.sBlockGranites==mBlock)?(1000):(0)));  //Don't judge me. Want different values for different block types
+                    if ( (this.mProbability <= 1) || (stoneRNG.nextInt(this.mProbability*3/2) == 0) ) { // Decreased probability of stones by factor of 66%.
+                        // Add stone at this chunk
+                        validStoneSeeds.put( hash, new StoneSeeds(true) );
+                        // Add to generation list
+                        stones.add( new ValidSeeds(x,z) );
+                        if (debugStones) GT_Log.out.println(
+                            "New stoneseed="+mWorldGenName+
+                            " x="+x+
+                            " z="+z+
+                            " realSize="+realSize
+                        );
+                    } else {
+                        validStoneSeeds.put( hash, new StoneSeeds(false) );
+                    }
+                } else {
+                    // This chunk has already been checked, check to see if a boulder exists here
+                    if( validStoneSeeds.get(hash).mExists ) {
+                        // Add to generation list
+                        stones.add( new ValidSeeds(x,z) );
+                    }
+                }
+            }
+        }
 
-		boolean result = true;
-		if (stones.size() == 0) {
-			result = false;
-		}
-		// Now process each oreseed vs this requested chunk
-		for( ; stones.size() != 0; stones.remove(0) ) {
-			int x = stones.get(0).mX*16;
-			int z = stones.get(0).mZ*16;
-			
-			stoneRNG.setSeed((long)aWorld.getSeed() ^  (( (long)x << 32) | ( (long)z & 0x00000000ffffffffL )));
+        boolean result = true;
+        if (stones.size() == 0) {
+            result = false;
+        }
+        // Now process each oreseed vs this requested chunk
+        for( ; stones.size() != 0; stones.remove(0) ) {
+            int x = stones.get(0).mX*16;
+            int z = stones.get(0).mZ*16;
+            
+            stoneRNG.setSeed((long)aWorld.getSeed() ^  ((long)((aWorld.provider.dimensionId & 0xffL)<<60) |( ((long)x & 0x000000000fffffffL)<< 28) | ( (long)z & 0x000000000fffffffL )) + Math.abs(mBlockMeta) + Math.abs(mSize) + Math.abs(mProbability) + ((GregTech_API.sBlockGranites==mBlock)?(1000):(0)));  //Don't judge me
+            for (int i = 0; i < this.mAmount; i++) { // Not sure why you would want more than one in a chunk! Left alone though.
+                // Locate the stoneseed XYZ. Original code would request an isAir at the seed location, causing a chunk generation request.
+                // To reduce potential worldgen cascade, we just always try to place a ball and use the check inside the for loop to prevent
+                // placement instead.
+                int tX = x + stoneRNG.nextInt(16);
+                int tY = mMinY + stoneRNG.nextInt(mMaxY - mMinY);
+                int tZ = z + stoneRNG.nextInt(16);
+                //Determine the XYZ sizes of the stoneseed
+                double xSize = sizeConversion[stoneRNG.nextInt(sizeConversion.length)];
+                double ySize = sizeConversion[stoneRNG.nextInt(sizeConversion.length)/2];  // Skew the ySize towards the larger sizes, more long skinny pipes
+                double zSize = sizeConversion[stoneRNG.nextInt(sizeConversion.length)];
+                
+                //Equation for an ellipsoid centered around 0,0,0
+                // Sx, Sy, and Sz are size controls (size = 1/S_)
+                // 1 = full size, 1.333 = 75%, 2 = 50%, 4 = 25%
+                // (x * Sx)^2 + (y * Sy)^2 + (z * sZ)^2 <= (mSize)^2
+                
+                //So, we setup the intial boundaries to be the size of the boulder plus a block in each direction
+                int tMinX = tX-(int)(realSize/xSize-1.0); 
+                int tMaxX = tX+(int)(realSize/xSize+2.0);
+                int tMinY = tY-(int)(realSize/ySize-1.0);
+                int tMaxY = tY+(int)(realSize/ySize+2.0);
+                int tMinZ = tZ-(int)(realSize/zSize-1.0);
+                int tMaxZ = tZ+(int)(realSize/zSize+2.0);
+                
+                //Chop the boundaries by the parts that intersect with the current chunk
+                int wX = Math.max( tMinX, aChunkX + 8);
+                int eX = Math.min( tMaxX, aChunkX + 8 + 16 );
+                
+                int sZ = Math.max( tMinZ, aChunkZ + 8);
+                int nZ = Math.min( tMaxZ, aChunkZ + 8 + 16 );
+                
+                if (debugStones) GT_Log.out.println(
+                    mWorldGenName +
+                    " tX=" + tX +
+                    " tY=" + tY +
+                    " tZ=" + tZ +
+                    " realSize=" + realSize +
+                    " xSize=" + realSize/xSize +
+                    " ySize=" + realSize/ySize +
+                    " zSize=" + realSize/zSize +
+                    " wX=" + wX +
+                    " eX=" + eX +
+                    " tMinY=" + tMinY +
+                    " tMaxY=" + tMaxY +
+                    " sZ=" + sZ +
+                    " nZ=" + nZ
+                );
+                
+                double rightHandSide = realSize*realSize + 1;  //Precalc the right hand side 
+                for( int iY = tMinY; iY < tMaxY; iY++) {  // Do placement from the bottom up layer up.  Maybe better on cache usage?
+                    double yCalc = ( (double)(iY-tY)*ySize );
+                    yCalc = yCalc * yCalc; // (y*Sy)^2
+                    double leftHandSize = yCalc;
+                    if( leftHandSize > rightHandSide ) {
+                        continue; // If Y alone is larger than the RHS, skip the rest of the loops
+                    }
+                    for( int iX = wX; iX < eX; iX++) {
+                        double xCalc = ( (double)(iX-tX)*xSize );
+                        xCalc = xCalc * xCalc;
+                        leftHandSize = yCalc + xCalc;
+                        if( leftHandSize > rightHandSide ) { // Again, if X and Y is larger than the RHS, skip to the next value
+                            continue;
+                        }
+                        for( int iZ = sZ; iZ < nZ; iZ++ ) {
+                            double zCalc = ( (double)(iZ-tZ)*zSize );
+                            zCalc = zCalc * zCalc;
+                            leftHandSize = zCalc + xCalc + yCalc;
+                            if( leftHandSize > rightHandSide ) {
+                                continue;
+                            } else {
+                                // Yay! We can actually place a block now. (this part copied from original code)
+                                Block tTargetedBlock = aWorld.getBlock(iX, iY, iZ);
+                                if (tTargetedBlock instanceof GT_Block_Ores_Abstract) {
+                                    TileEntity tTileEntity = aWorld.getTileEntity(iX, iY, iZ);
+                                    if ((tTileEntity instanceof GT_TileEntity_Ores)) {
+                                        if (tTargetedBlock != GregTech_API.sBlockOres1) {
+                                            ((GT_TileEntity_Ores) tTileEntity).convertOreBlock(aWorld, iX, iY, iZ);
+                                        }
+                                        ((GT_TileEntity_Ores)tTileEntity).overrideOreBlockMaterial(this.mBlock, (byte) this.mBlockMeta);
+                                    }
+                                } else if (((this.mAllowToGenerateinVoid) && (aWorld.getBlock(iX, iY, iZ).isAir(aWorld, iX, iY, iZ))) || ((tTargetedBlock != null) && ((tTargetedBlock.isReplaceableOreGen(aWorld, iX, iY, iZ, Blocks.stone)) || (tTargetedBlock.isReplaceableOreGen(aWorld, iX, iY, iZ, Blocks.end_stone)) || (tTargetedBlock.isReplaceableOreGen(aWorld, iX, iY, iZ, Blocks.netherrack)) || (tTargetedBlock.isReplaceableOreGen(aWorld, iX, iY, iZ, GregTech_API.sBlockGranites)) || (tTargetedBlock.isReplaceableOreGen(aWorld, iX, iY, iZ, GregTech_API.sBlockStones))))) {
+                                    aWorld.setBlock(iX, iY, iZ, this.mBlock, this.mBlockMeta, 0);
+                                }
+                            }
+                        }
+                    }
+                }
 
-            for (int i = 0; i < this.mAmount; i++) {
+/* Old stone code
                 int tX = x + stoneRNG.nextInt(16);
                 int tY = this.mMinY + stoneRNG.nextInt(this.mMaxY - this.mMinY);
                 int tZ = z + stoneRNG.nextInt(16);
@@ -105,19 +199,19 @@ public class GT_Worldgen_Stone
                     float math_pi = 3.141593F;//FB: CNT - CNT_ROUGH_CONSTANT_VALUE
                     float var6 = stoneRNG.nextFloat() * math_pi;
                     float var1d = this.mSize / 8.0F;
-					int var2d = tX + 8;
-					int var3d = tZ + 8;
-					int var4d = tY - 2;
+                    int var2d = tX + 8;
+                    int var3d = tZ + 8;
+                    int var4d = tY - 2;
                     float mh_s_0 = MathHelper.sin(var6) * var1d;
-					float mh_c_0 = MathHelper.cos(var6) * var1d;
+                    float mh_c_0 = MathHelper.cos(var6) * var1d;
                     float var7 = var2d + mh_s_0;
                     float var11 = var3d + mh_c_0;
                     int var15r = stoneRNG.nextInt(3);
-					int var17r = stoneRNG.nextInt(3);
+                    int var17r = stoneRNG.nextInt(3);
                     int var15 = var4d + var15r;
                     int mh_n_4=var17r - var15r;
                     float mh_n_0 = -2*mh_s_0;
-					float mh_n_1 = -2*mh_c_0;
+                    float mh_n_1 = -2*mh_c_0;
                     for (int var19 = 0; var19 <= this.mSize; var19++) {
                         float var5d = var19 / this.mSize;
                         float var20 = var7 + mh_n_0 * var5d;
@@ -133,12 +227,12 @@ public class GT_Worldgen_Stone
                         int tMaxY = MathHelper.floor_float(var22 + var28);
                         int tMaxZ = MathHelper.floor_float(var24 + var28);
 
-						int wX = Math.max( tMinX, aChunkX + 8);
-						int eX = Math.min( tMaxX, aChunkX + 8 + 16 );
+                        int wX = Math.max( tMinX, aChunkX + 8);
+                        int eX = Math.min( tMaxX, aChunkX + 8 + 16 );
 
-						int sZ = Math.max( tMinZ, aChunkZ + 8);
-						int nZ = Math.min( tMaxZ, aChunkZ + 8 + 16 );
-		
+                        int sZ = Math.max( tMinZ, aChunkZ + 8);
+                        int nZ = Math.min( tMaxZ, aChunkZ + 8 + 16 );
+        
                         for (int iX = wX; iX < eX; iX++) {
                             float var39 = (iX + 0.5F - var20) / (var28);
                             float var10d = var39 * var39;
@@ -170,6 +264,14 @@ public class GT_Worldgen_Stone
                         }
                     }
                 }
+*/
+
+
+
+
+
+
+
             }
         }
         return result;

--- a/src/main/java/gregtech/common/GT_Worldgen_Stone.java
+++ b/src/main/java/gregtech/common/GT_Worldgen_Stone.java
@@ -109,11 +109,12 @@ public class GT_Worldgen_Stone
                 int tX = x + stoneRNG.nextInt(16);
                 int tY = mMinY + stoneRNG.nextInt(mMaxY - mMinY);
                 int tZ = z + stoneRNG.nextInt(16);
+
                 //Determine the XYZ sizes of the stoneseed
                 double xSize = sizeConversion[stoneRNG.nextInt(sizeConversion.length)];
                 double ySize = sizeConversion[stoneRNG.nextInt(sizeConversion.length)/2];  // Skew the ySize towards the larger sizes, more long skinny pipes
                 double zSize = sizeConversion[stoneRNG.nextInt(sizeConversion.length)];
-                
+
                 //Equation for an ellipsoid centered around 0,0,0
                 // Sx, Sy, and Sz are size controls (size = 1/S_)
                 // 1 = full size, 1.333 = 75%, 2 = 50%, 4 = 25%
@@ -126,7 +127,27 @@ public class GT_Worldgen_Stone
                 int tMaxY = tY+(int)(realSize/ySize+2.0);
                 int tMinZ = tZ-(int)(realSize/zSize-1.0);
                 int tMaxZ = tZ+(int)(realSize/zSize+2.0);
-                
+
+                // If the (tY-ySize) of the stoneseed is air in the current chunk, mark the seed empty and move on.
+                if(aWorld.getBlock(aChunkX + 8, tMinY, aChunkZ + 8).isAir(aWorld, aChunkX + 8, tMinY, aChunkZ + 8)) {
+                    if (debugStones) GT_Log.out.println(
+                        mWorldGenName +
+                        " tX=" + tX +
+                        " tY=" + tY +
+                        " tZ=" + tZ +
+                        " realSize=" + realSize +
+                        " xSize=" + realSize/xSize +
+                        " ySize=" + realSize/ySize +
+                        " zSize=" + realSize/zSize +
+                        " tMinY=" + tMinY +
+                        " tMaxY=" + tMaxY +
+                        " - Skipped because first requesting chunk would not contain this stone"
+                    );
+                    long hash = ((long)((aWorld.provider.dimensionId & 0xffL)<<56) |( ((long)x & 0x000000000fffffffL) << 28) | ( (long)z & 0x000000000fffffffL ));
+                    validStoneSeeds.remove(hash);
+                    validStoneSeeds.put( hash, new StoneSeeds(false) );
+                }
+
                 //Chop the boundaries by the parts that intersect with the current chunk
                 int wX = Math.max( tMinX, aChunkX + 8);
                 int eX = Math.min( tMaxX, aChunkX + 8 + 16 );

--- a/src/main/java/gregtech/common/GT_Worldgen_Stone.java
+++ b/src/main/java/gregtech/common/GT_Worldgen_Stone.java
@@ -67,8 +67,8 @@ public class GT_Worldgen_Stone
                 long hash = ((long)((aWorld.provider.dimensionId & 0xffL)<<56) |( ((long)x & 0x000000000fffffffL) << 28) | ( (long)z & 0x000000000fffffffL ));
                 if( !validStoneSeeds.containsKey(hash) ) {
                     // Determine if RNG says to add stone at this chunk
-                    stoneRNG.setSeed((long)aWorld.getSeed() ^  hash + Math.abs(mBlockMeta) + Math.abs(mSize) + Math.abs(mProbability) + ((GregTech_API.sBlockGranites==mBlock)?(1000):(0)));  //Don't judge me. Want different values for different block types
-                    if ( (this.mProbability <= 1) || (stoneRNG.nextInt(this.mProbability*3/2) == 0) ) { // Decreased probability of stones by factor of 66%.
+                    stoneRNG.setSeed((long)aWorld.getSeed() ^  hash + Math.abs(mBlockMeta) + Math.abs(mSize) + ((GregTech_API.sBlockGranites==mBlock)?(32768):(0)));  //Don't judge me. Want different values for different block types
+                    if ( (this.mProbability <= 1) || (stoneRNG.nextInt(this.mProbability*2) == 0) ) { // Decreased probability of stones by factor of 2
                         // Add stone at this chunk
                         validStoneSeeds.put( hash, new StoneSeeds(true) );
                         // Add to generation list
@@ -101,7 +101,7 @@ public class GT_Worldgen_Stone
             int x = stones.get(0).mX*16;
             int z = stones.get(0).mZ*16;
             
-            stoneRNG.setSeed((long)aWorld.getSeed() ^  ((long)((aWorld.provider.dimensionId & 0xffL)<<60) |( ((long)x & 0x000000000fffffffL)<< 28) | ( (long)z & 0x000000000fffffffL )) + Math.abs(mBlockMeta) + Math.abs(mSize) + Math.abs(mProbability) + ((GregTech_API.sBlockGranites==mBlock)?(1000):(0)));  //Don't judge me
+            stoneRNG.setSeed((long)aWorld.getSeed() ^  ((long)((aWorld.provider.dimensionId & 0xffL)<<56) |( ((long)x & 0x000000000fffffffL)<< 28) | ( (long)z & 0x000000000fffffffL )) + Math.abs(mBlockMeta) + Math.abs(mSize) + ((GregTech_API.sBlockGranites==mBlock)?(32768):(0)));  //Don't judge me
             for (int i = 0; i < this.mAmount; i++) { // Not sure why you would want more than one in a chunk! Left alone though.
                 // Locate the stoneseed XYZ. Original code would request an isAir at the seed location, causing a chunk generation request.
                 // To reduce potential worldgen cascade, we just always try to place a ball and use the check inside the for loop to prevent
@@ -190,88 +190,6 @@ public class GT_Worldgen_Stone
                         }
                     }
                 }
-
-/* Old stone code
-                int tX = x + stoneRNG.nextInt(16);
-                int tY = this.mMinY + stoneRNG.nextInt(this.mMaxY - this.mMinY);
-                int tZ = z + stoneRNG.nextInt(16);
-                if ((this.mAllowToGenerateinVoid) || (!aWorld.getBlock(tX, tY, tZ).isAir(aWorld, tX, tY, tZ))) { // Causes slight amount of worldgen cascade since it may load a chunk that is far away.
-                    float math_pi = 3.141593F;//FB: CNT - CNT_ROUGH_CONSTANT_VALUE
-                    float var6 = stoneRNG.nextFloat() * math_pi;
-                    float var1d = this.mSize / 8.0F;
-                    int var2d = tX + 8;
-                    int var3d = tZ + 8;
-                    int var4d = tY - 2;
-                    float mh_s_0 = MathHelper.sin(var6) * var1d;
-                    float mh_c_0 = MathHelper.cos(var6) * var1d;
-                    float var7 = var2d + mh_s_0;
-                    float var11 = var3d + mh_c_0;
-                    int var15r = stoneRNG.nextInt(3);
-                    int var17r = stoneRNG.nextInt(3);
-                    int var15 = var4d + var15r;
-                    int mh_n_4=var17r - var15r;
-                    float mh_n_0 = -2*mh_s_0;
-                    float mh_n_1 = -2*mh_c_0;
-                    for (int var19 = 0; var19 <= this.mSize; var19++) {
-                        float var5d = var19 / this.mSize;
-                        float var20 = var7 + mh_n_0 * var5d;
-                        float var22 = var15 + mh_n_4 * var5d;
-                        float var24 = var11 + mh_n_1 * var5d;
-                        float var6d = var19 * math_pi / this.mSize;
-                        float var26 = stoneRNG.nextFloat() * this.mSize / 16.0F;
-                        float var28 = ((MathHelper.sin(var6d) + 1.0F) * var26 + 1.0F) / 2.0F;
-                        int tMinX = MathHelper.floor_float(var20 - var28);
-                        int tMinY = MathHelper.floor_float(var22 - var28);
-                        int tMinZ = MathHelper.floor_float(var24 - var28);
-                        int tMaxX = MathHelper.floor_float(var20 + var28);
-                        int tMaxY = MathHelper.floor_float(var22 + var28);
-                        int tMaxZ = MathHelper.floor_float(var24 + var28);
-
-                        int wX = Math.max( tMinX, aChunkX + 8);
-                        int eX = Math.min( tMaxX, aChunkX + 8 + 16 );
-
-                        int sZ = Math.max( tMinZ, aChunkZ + 8);
-                        int nZ = Math.min( tMaxZ, aChunkZ + 8 + 16 );
-        
-                        for (int iX = wX; iX < eX; iX++) {
-                            float var39 = (iX + 0.5F - var20) / (var28);
-                            float var10d = var39 * var39;
-                            if (var10d < 1.0F) {
-                                for (int iY = tMinY; iY <= tMaxY; iY++) {
-                                    float var42 = (iY + 0.5F - var22) / (var28);
-                                    float var12d = var10d + var42 * var42;
-                                    if (var12d < 1.0F) {
-                                        for (int iZ = sZ; iZ < nZ; iZ++) {
-                                            float var45 = (iZ + 0.5F - var24) / (var28);
-                                            if (var12d + var45 * var45 < 1.0F) {
-                                                Block tTargetedBlock = aWorld.getBlock(iX, iY, iZ);
-                                                if (tTargetedBlock instanceof GT_Block_Ores_Abstract) {
-                                                    TileEntity tTileEntity = aWorld.getTileEntity(iX, iY, iZ);
-                                                    if ((tTileEntity instanceof GT_TileEntity_Ores)) {
-                                                        if (tTargetedBlock != GregTech_API.sBlockOres1) {
-                                                            ((GT_TileEntity_Ores) tTileEntity).convertOreBlock(aWorld, iX, iY, iZ);
-                                                        }
-                                                        ((GT_TileEntity_Ores)tTileEntity).overrideOreBlockMaterial(this.mBlock, (byte) this.mBlockMeta);
-                                                    }
-                                                } else if (((this.mAllowToGenerateinVoid) && (aWorld.getBlock(iX, iY, iZ).isAir(aWorld, iX, iY, iZ))) || ((tTargetedBlock != null) && ((tTargetedBlock.isReplaceableOreGen(aWorld, iX, iY, iZ, Blocks.stone)) || (tTargetedBlock.isReplaceableOreGen(aWorld, iX, iY, iZ, Blocks.end_stone)) || (tTargetedBlock.isReplaceableOreGen(aWorld, iX, iY, iZ, Blocks.netherrack)) || (tTargetedBlock.isReplaceableOreGen(aWorld, iX, iY, iZ, GregTech_API.sBlockGranites)) || (tTargetedBlock.isReplaceableOreGen(aWorld, iX, iY, iZ, GregTech_API.sBlockStones))))) {
-                                                    aWorld.setBlock(iX, iY, iZ, this.mBlock, this.mBlockMeta, 0);
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-*/
-
-
-
-
-
-
-
             }
         }
         return result;

--- a/src/main/java/gregtech/common/GT_Worldgenerator.java
+++ b/src/main/java/gregtech/common/GT_Worldgenerator.java
@@ -147,13 +147,15 @@ implements IWorldGenerator {
 			int noOrePlacedCount=0;
 			String tDimensionName = "";
 			if (debugOrevein) { tDimensionName = this.mWorld.provider.getDimensionName(); }
+			/*
 			if (debugOrevein) GT_Log.out.println(
 				" Finding oreveins for oreveinSeed="+ oreveinSeed +
 				" mX="+ this.mX +
 				" mZ="+ this.mZ + 
 				" oreseedX="+ oreseedX +
 				" oreseedZ="+ oreseedZ									
-			);	
+			);
+			*/
 
 			// Search for a valid orevein for this dimension
 			if( !validOreveins.containsKey(oreveinSeed) ) {
@@ -171,22 +173,21 @@ implements IWorldGenerator {
 									int placementResult = tWorldGen.executeWorldgenChunkified(this.mWorld, new XSTR( oreveinSeed ), this.mBiome, this.mDimensionType, this.mX*16, this.mZ*16, oreseedX*16, oreseedZ*16, this.mChunkGenerator, this.mChunkProvider);
 									switch(placementResult) {
 										case GT_Worldgen_GT_Ore_Layer.ORE_PLACED:
-											if (debugOrevein) GT_Log.out.println(
-												" Adding orevein to hash table. oreveinSeed=" + oreveinSeed + 
+											if (debugWorldGen) GT_Log.out.println(
+												" Added oreveinSeed=" + oreveinSeed + 
 												" mX="+ this.mX +
 												" mZ="+ this.mZ + 
 												" oreseedX="+ oreseedX +
 												" oreseedZ="+ oreseedZ +
-												" Orevein took " + (i-1) + 
-												" attempts to find" + 
-												" and " + placementAttempts +
-												" tries to place " +
-												" in dimensionName=" + tDimensionName
+												" tries at oremix=" + i +
+												" placementAttempts=" + placementAttempts +
+												" dimensionName=" + tDimensionName
 											);
 											validOreveins.put(oreveinSeed, tWorldGen);
 											oreveinFound = true;
 											break;
 										case GT_Worldgen_GT_Ore_Layer.NO_ORE_IN_BOTTOM_LAYER:
+											placementAttempts++;
 											// SHould do retry in this case until out of chances
 											break;
 										case GT_Worldgen_GT_Ore_Layer.NO_OVERLAP:
@@ -195,7 +196,7 @@ implements IWorldGenerator {
 									}
 	                                break; // Try the next orevein
 	                            } catch (Throwable e) {
-	                            	if (debugOrevein) GT_Log.out.println(
+	                            	if (debugWorldGen) GT_Log.out.println(
 										"Exception occurred on oreVein" + tWorldGen +
 										" oreveinSeed="+ oreveinSeed +
 										" mX="+ this.mX +
@@ -210,23 +211,21 @@ implements IWorldGenerator {
 					}
 					// Only add an empty orevein if are unable to place a vein at the oreseed chunk.
 					if ((!oreveinFound) && (this.mX == oreseedX) && (this.mZ == oreseedZ)){
-						if (debugOrevein) GT_Log.out.println(
-							" Adding empty orevein to hash table. Could not find/place valid orevein" +
-							" oreveinSeed="+ oreveinSeed +
+						if (debugWorldGen) GT_Log.out.println(
+							" Empty oreveinSeed="+ oreveinSeed +
 							" mX="+ this.mX +
 							" mZ="+ this.mZ + 
 							" oreseedX="+ oreseedX +
 							" oreseedZ="+ oreseedZ + 
 							" tries at oremix=" + i +
 							" placementAttempts=" + placementAttempts +
-							" in dimensionName=" + tDimensionName
+							" dimensionName=" + tDimensionName
 						);
 						validOreveins.put(oreveinSeed, noOresInVein );
 					}
 				} else if(oreveinPercentageRoll >= oreveinPercentage) {
-					if (debugOrevein) GT_Log.out.println(
-						" Skipped orevein in this 3x3 chunk!" +
-						" oreveinSeed="+ oreveinSeed +
+					if (debugWorldGen) GT_Log.out.println(
+						" Skipped oreveinSeed="+ oreveinSeed +
 						" mX="+ this.mX +
 						" mZ="+ this.mZ +
 						" oreseedX=" + oreseedX +
@@ -239,15 +238,9 @@ implements IWorldGenerator {
 	        	}
 			}else {
 				// oreseed is located in the previously processed table
-				if (debugOrevein) GT_Log.out.println(
-					" Valid orevein found in hash table" +
-					" oreveinSeed="+ oreveinSeed +					
-					" validOreveins.size()=" + validOreveins.size() +
-					" mX="+ this.mX +
-					" mZ="+ this.mZ + 
-					" oreseedX="+ oreseedX +
-					" oreseedZ="+ oreseedZ + 
-					" in dimensionName=" + tDimensionName
+				if (debugWorldGen) GT_Log.out.print(
+					" Valid oreveinSeed="+ oreveinSeed +					
+					" validOreveins.size()=" + validOreveins.size() + " "
 				);
 				GT_Worldgen tWorldGen = validOreveins.get(oreveinSeed);
 				oreveinRNG.setSeed(oreveinSeed);  // reset seed for RNG to only be based on oreseed X/Z
@@ -276,15 +269,12 @@ implements IWorldGenerator {
 
 			// Now process each oreseed vs this requested chunk
 			for( ; seedList.size() != 0; ) {
-				
 				worldGenFindVein( seedList.get(0).mX, seedList.get(0).mZ );
 				seedList.remove(0);
 			}
 
 			// Do leftover worldgen for this chunk (GT_Stones and GT_small_ores)
 
-/////RAH Disable these for now
-/*
 			try {
 				for (GT_Worldgen tWorldGen : GregTech_API.sWorldgenList) {
 					tWorldGen.executeWorldgen(this.mWorld, this.mRandom, this.mBiome, this.mDimensionType, this.mX*16, this.mZ*16, this.mChunkGenerator, this.mChunkProvider);
@@ -292,8 +282,8 @@ implements IWorldGenerator {
 			} catch (Throwable e) {
 				e.printStackTrace(GT_Log.err);
 			}
-*/		
-	/*		
+/*		
+			// Old non-chunkified oregen	
             if ((Math.abs(this.mX / 16) % 3 == 1) && (Math.abs(this.mZ / 16) % 3 == 1)) {
 				int oreveinRNG = this.mRandom.nextInt(100);
                 if (( oreveinRNG < oreveinPercentage) && (GT_Worldgen_GT_Ore_Layer.sWeight > 0) && (GT_Worldgen_GT_Ore_Layer.sList.size() > 0)) {

--- a/src/main/java/gregtech/common/GT_Worldgenerator.java
+++ b/src/main/java/gregtech/common/GT_Worldgenerator.java
@@ -273,7 +273,6 @@ implements IWorldGenerator {
 			}
 
 			// Do leftover worldgen for this chunk (GT_Stones and GT_small_ores)
-
 			try {
 				for (GT_Worldgen tWorldGen : GregTech_API.sWorldgenList) {
 					/*
@@ -286,105 +285,6 @@ implements IWorldGenerator {
 			} catch (Throwable e) {
 				e.printStackTrace(GT_Log.err);
 			}
-/*		
-			// Old non-chunkified oregen	
-            if ((Math.abs(this.mX / 16) % 3 == 1) && (Math.abs(this.mZ / 16) % 3 == 1)) {
-				int oreveinRNG = this.mRandom.nextInt(100);
-                if (( oreveinRNG < oreveinPercentage) && (GT_Worldgen_GT_Ore_Layer.sWeight > 0) && (GT_Worldgen_GT_Ore_Layer.sList.size() > 0)) {
-                    boolean temp = true;
-
-                    int tRandomWeight;
-					int i;
-					int placementAttempts=0;
-                    for (i = 0; (i < oreveinAttempts) && (temp) && (placementAttempts<oreveinMaxPlacementAttempts); i++) {
-                        tRandomWeight = this.mRandom.nextInt(GT_Worldgen_GT_Ore_Layer.sWeight);
-                        for (GT_Worldgen tWorldGen : GT_Worldgen_GT_Ore_Layer.sList) {
-                            tRandomWeight -= ((GT_Worldgen_GT_Ore_Layer) tWorldGen).mWeight;
-                            if (tRandomWeight <= 0) {
-                                try {
-									int genResult = tWorldGen.executeWorldgenInt(this.mWorld, this.mRandom, this.mBiome, this.mDimensionType, this.mX, this.mZ, this.mChunkGenerator, this.mChunkProvider);
-                                    if (genResult == GT_Worldgen_GT_Ore_Layer.ORE_PLACED) { // Successful ore placement
-                                        temp = false;
-                                    } else if (genResult == GT_Worldgen_GT_Ore_Layer.NO_ORE_IN_BOTTOM_LAYER) { // Ore vein allowed, but could not place any
-										placementAttempts++;
-                                    }
-                                    break;
-                                } catch (Throwable e) {
-                                    e.printStackTrace(GT_Log.err);
-                                }
-                            }
-                        }
-                    }
-					if (debugOrevein & temp) {
-						GT_Log.out.println(
-										" Could not find/place valid orevein" +
-										" chunkX="+ this.mX +
-										" chunkZ="+ this.mZ + 
-										" tries at oremix=" + i +
-										" placementAttempts=" + placementAttempts +
-										" oreveinMaxPlacementAttempts=" + oreveinMaxPlacementAttempts +
-										"in dimensionName=" + tDimensionName
-						);
-					} else if (debugOrevein)
-					{
-						GT_Log.out.println(
-										" Orevein took " + (i-1) + 
-										" attempts to find" + 
-										" and " + placementAttempts +
-										" tries to place " +
-										" in dimensionName=" + tDimensionName
-						);
-					}
-						
-                }else
-                {
-                	if((oreveinRNG >= oreveinPercentage) && (debugOrevein))
-                	{
-						GT_Log.out.println(
-										" Skipped orevein in this 3x3 chunk!" +
-										" chunkX="+ this.mX +
-										" chunkZ="+ this.mZ +
-										" RNG=" + oreveinRNG +
-										" %=" + oreveinPercentage+ 
-										" dimensionName=" + tDimensionName
-						);
-                	}
-                }
-				
-                int i = 0;
-                for (int tX = this.mX - 16; i < 3; tX += 16) {
-                    int j = 0;
-                    for (int tZ = this.mZ - 16; j < 3; tZ += 16) {
-                        String tBiome = this.mWorld.getBiomeGenForCoords(tX + 8, tZ + 8).biomeName;
-                        //if (tBiome == null) {//TODO NEEDED?
-                        //    tBiome = BiomeGenBase.plains.biomeName;
-                        //}
-                        try {
-                            for (GT_Worldgen tWorldGen : GregTech_API.sWorldgenList) {
-                                tWorldGen.executeWorldgen(this.mWorld, this.mRandom, this.mBiome, this.mDimensionType, tX, tZ, this.mChunkGenerator, this.mChunkProvider);
-                            }
-                        } catch (Throwable e) {
-                            e.printStackTrace(GT_Log.err);
-                        }
-                        j++;
-                    }
-                    i++;
-                }
-            }
-			else
-			{
-				if (debugOrevein) {
-					GT_Log.out.println(
-									" Skipped chunk, not 3x3 center" +
-									" @ dim="+this.mDimensionType+
-									" chunkX="+this.mX+
-									" chunkZ="+this.mZ+ 
-									" dimensionName=" + tDimensionName
-					);
-				}
-			}
-
-*/
 			
             //Asteroid Worldgen
             int tDimensionType = this.mWorld.provider.dimensionId;

--- a/src/main/java/gregtech/common/GT_Worldgenerator.java
+++ b/src/main/java/gregtech/common/GT_Worldgenerator.java
@@ -173,7 +173,7 @@ implements IWorldGenerator {
 									int placementResult = tWorldGen.executeWorldgenChunkified(this.mWorld, new XSTR( oreveinSeed ), this.mBiome, this.mDimensionType, this.mX*16, this.mZ*16, oreseedX*16, oreseedZ*16, this.mChunkGenerator, this.mChunkProvider);
 									switch(placementResult) {
 										case GT_Worldgen_GT_Ore_Layer.ORE_PLACED:
-											if (debugWorldGen) GT_Log.out.println(
+											if (debugOrevein) GT_Log.out.println(
 												" Added oreveinSeed=" + oreveinSeed + 
 												" mX="+ this.mX +
 												" mZ="+ this.mZ + 
@@ -196,7 +196,7 @@ implements IWorldGenerator {
 									}
 	                                break; // Try the next orevein
 	                            } catch (Throwable e) {
-	                            	if (debugWorldGen) GT_Log.out.println(
+	                            	if (debugOrevein) GT_Log.out.println(
 										"Exception occurred on oreVein" + tWorldGen +
 										" oreveinSeed="+ oreveinSeed +
 										" mX="+ this.mX +
@@ -211,7 +211,7 @@ implements IWorldGenerator {
 					}
 					// Only add an empty orevein if are unable to place a vein at the oreseed chunk.
 					if ((!oreveinFound) && (this.mX == oreseedX) && (this.mZ == oreseedZ)){
-						if (debugWorldGen) GT_Log.out.println(
+						if (debugOrevein) GT_Log.out.println(
 							" Empty oreveinSeed="+ oreveinSeed +
 							" mX="+ this.mX +
 							" mZ="+ this.mZ + 
@@ -224,7 +224,7 @@ implements IWorldGenerator {
 						validOreveins.put(oreveinSeed, noOresInVein );
 					}
 				} else if(oreveinPercentageRoll >= oreveinPercentage) {
-					if (debugWorldGen) GT_Log.out.println(
+					if (debugOrevein) GT_Log.out.println(
 						" Skipped oreveinSeed="+ oreveinSeed +
 						" mX="+ this.mX +
 						" mZ="+ this.mZ +
@@ -238,7 +238,7 @@ implements IWorldGenerator {
 	        	}
 			}else {
 				// oreseed is located in the previously processed table
-				if (debugWorldGen) GT_Log.out.print(
+				if (debugOrevein) GT_Log.out.print(
 					" Valid oreveinSeed="+ oreveinSeed +					
 					" validOreveins.size()=" + validOreveins.size() + " "
 				);
@@ -268,15 +268,19 @@ implements IWorldGenerator {
 			}
 
 			// Now process each oreseed vs this requested chunk
-			for( ; seedList.size() != 0; ) {
+			for( ; seedList.size() != 0; seedList.remove(0) ) {
 				worldGenFindVein( seedList.get(0).mX, seedList.get(0).mZ );
-				seedList.remove(0);
 			}
 
 			// Do leftover worldgen for this chunk (GT_Stones and GT_small_ores)
 
 			try {
 				for (GT_Worldgen tWorldGen : GregTech_API.sWorldgenList) {
+					/*
+					if (debugWorldGen) GT_Log.out.println(
+						"tWorldGen.mWorldGenName="+tWorldGen.mWorldGenName
+					);
+					*/
 					tWorldGen.executeWorldgen(this.mWorld, this.mRandom, this.mBiome, this.mDimensionType, this.mX*16, this.mZ*16, this.mChunkGenerator, this.mChunkProvider);
 				}
 			} catch (Throwable e) {

--- a/src/main/java/gregtech/common/GT_Worldgenerator.java
+++ b/src/main/java/gregtech/common/GT_Worldgenerator.java
@@ -45,12 +45,12 @@ implements IWorldGenerator {
     //private static int gcMaxSize = 400;
     private static boolean endAsteroids = true;
     public static List<Runnable> mList = new ArrayList();
-	public static HashSet<Long> ProcChunks = new HashSet<Long>();
-	// This is probably not going to work.  Trying to create a fake orevein to put into hashtable when there will be no ores in a vein.
-	public static GT_Worldgen_GT_Ore_Layer noOresInVein = new GT_Worldgen_GT_Ore_Layer( "NoOresInVein", false, 0, 255, 0, 255, 16,  false, false, false, false, false, false, Materials.Aluminium, Materials.Aluminium, Materials.Aluminium, Materials.Aluminium);
-	public static Hashtable<Long, GT_Worldgen> validOreveins = new Hashtable(1024);
+    public static HashSet<Long> ProcChunks = new HashSet<Long>();
+    // This is probably not going to work.  Trying to create a fake orevein to put into hashtable when there will be no ores in a vein.
+    public static GT_Worldgen_GT_Ore_Layer noOresInVein = new GT_Worldgen_GT_Ore_Layer( "NoOresInVein", false, 0, 255, 0, 255, 16,  false, false, false, false, false, false, Materials.Aluminium, Materials.Aluminium, Materials.Aluminium, Materials.Aluminium);
+    public static Hashtable<Long, GT_Worldgen> validOreveins = new Hashtable(1024);
     public boolean mIsGenerating = false;
-	public static final Object listLock = new Object();
+    public static final Object listLock = new Object();
     //private static boolean gcAsteroids = true;
 
 
@@ -64,23 +64,23 @@ implements IWorldGenerator {
         //gcMaxSize = GregTech_API.sWorldgenFile.get("gcasteroids", "GCAsteroidMaxSize", 400);
         //mGCAsteroidProbability = GregTech_API.sWorldgenFile.get("gcasteroids", "GCAsteroidProbability", 300);
         GameRegistry.registerWorldGenerator(this, 1073741823);
-		if (debugWorldGen) {
-			GT_Log.out.println(
-							"GT_Worldgenerator created"
-			);
-		}
+        if (debugWorldGen) {
+            GT_Log.out.println(
+                            "GT_Worldgenerator created"
+            );
+        }
     }
 
     public void generate(Random aRandom, int aX, int aZ, World aWorld, IChunkProvider aChunkGenerator, IChunkProvider aChunkProvider) {
         synchronized (listLock)
-		{
-			if (!this.ProcChunks.contains( ((long)aX << 32) | ((long)(aZ) & 0x00000000ffffffffL)) ) {
-				this.ProcChunks.add( ((long)aX << 32) | ((long)(aZ) & 0x00000000ffffffffL));
-				this.mList.add(new WorldGenContainer(new XSTR(aRandom.nextInt()), aX, aZ, ((aChunkGenerator instanceof ChunkProviderEnd)) || (aWorld.getBiomeGenForCoords(aX * 16 + 8, aZ * 16 + 8) == BiomeGenBase.sky) ? 1 : ((aChunkGenerator instanceof ChunkProviderHell)) || (aWorld.getBiomeGenForCoords(aX * 16 + 8, aZ * 16 + 8) == BiomeGenBase.hell) ? -1 : 0, aWorld, aChunkGenerator, aChunkProvider, aWorld.getBiomeGenForCoords(aX * 16 + 8, aZ * 16 + 8).biomeName));
-				if (debugWorldGen) {GT_Log.out.println("ADD WorldGen chunk x:" + aX + " z:" + aZ + " SIZE: " + this.mList.size());}
-			} else {
-				if (debugWorldGen) {GT_Log.out.println("DUP WorldGen chunk x:" + aX + " z:" + aZ + " SIZE: " + this.mList.size() + " ProcChunks.size(): " + ProcChunks.size() ); }
-			}
+        {
+            if (!this.ProcChunks.contains( ((long)aX << 32) | ((long)(aZ) & 0x00000000ffffffffL)) ) {
+                this.ProcChunks.add( ((long)aX << 32) | ((long)(aZ) & 0x00000000ffffffffL));
+                this.mList.add(new WorldGenContainer(new XSTR(aRandom.nextInt()), aX, aZ, ((aChunkGenerator instanceof ChunkProviderEnd)) || (aWorld.getBiomeGenForCoords(aX * 16 + 8, aZ * 16 + 8) == BiomeGenBase.sky) ? 1 : ((aChunkGenerator instanceof ChunkProviderHell)) || (aWorld.getBiomeGenForCoords(aX * 16 + 8, aZ * 16 + 8) == BiomeGenBase.hell) ? -1 : 0, aWorld, aChunkGenerator, aChunkProvider, aWorld.getBiomeGenForCoords(aX * 16 + 8, aZ * 16 + 8).biomeName));
+                if (debugWorldGen) {GT_Log.out.println("ADD WorldGen chunk x:" + aX + " z:" + aZ + " SIZE: " + this.mList.size());}
+            } else {
+                if (debugWorldGen) {GT_Log.out.println("DUP WorldGen chunk x:" + aX + " z:" + aZ + " SIZE: " + this.mList.size() + " ProcChunks.size(): " + ProcChunks.size() ); }
+            }
         }
         if (!this.mIsGenerating) {
             this.mIsGenerating = true;
@@ -88,7 +88,7 @@ implements IWorldGenerator {
             for (int i = 0; i < mList_sS; i++) {
                 WorldGenContainer toRun = (WorldGenContainer) this.mList.get(0);
                 if (debugWorldGen) {GT_Log.out.println("RUN WorldGen chunk x:" + toRun.mX + " z:" + toRun.mZ + " SIZE: " + this.mList.size() + " i: " + i );}
-				this.ProcChunks.remove( ((long)(toRun.mX) << 32) | ((long)(toRun.mZ) & 0x00000000ffffffffL));
+                this.ProcChunks.remove( ((long)(toRun.mX) << 32) | ((long)(toRun.mZ) & 0x00000000ffffffffL));
                 synchronized (listLock)
                 {
                     this.mList.remove(0);
@@ -117,18 +117,18 @@ implements IWorldGenerator {
         public final IChunkProvider mChunkGenerator;
         public final IChunkProvider mChunkProvider;
         public final String mBiome;
-		// Local class to track which orevein seeds must be checked when doing chunkified worldgen
-		class NearbySeeds {
-			public int mX;
-			public int mZ;
-			NearbySeeds( int x, int z) {
-				this.mX = x;
-				this.mZ = z;
-			}
-		};
-		public static ArrayList<NearbySeeds> seedList = new ArrayList();
+        // Local class to track which orevein seeds must be checked when doing chunkified worldgen
+        class NearbySeeds {
+            public int mX;
+            public int mZ;
+            NearbySeeds( int x, int z) {
+                this.mX = x;
+                this.mZ = z;
+            }
+        };
+        public static ArrayList<NearbySeeds> seedList = new ArrayList();
 
-		// aX and aZ are now the by-chunk X and Z for the chunk of interest
+        // aX and aZ are now the by-chunk X and Z for the chunk of interest
         public WorldGenContainer(Random aRandom, int aX, int aZ, int aDimensionType, World aWorld, IChunkProvider aChunkGenerator, IChunkProvider aChunkProvider, String aBiome) {
             this.mRandom = aRandom;
             this.mX = aX;
@@ -140,152 +140,152 @@ implements IWorldGenerator {
             this.mBiome = aBiome;
         }
 
-		public void worldGenFindVein( int oreseedX, int oreseedZ) {
-			long oreveinSeed = (long)this.mWorld.getSeed() ^  (( (long)oreseedX << 32) | ( (long)oreseedZ & 0x00000000ffffffffL )); // Use an RNG that is identical every time it is called for this oreseed
-			XSTR oreveinRNG = new XSTR( oreveinSeed );  
-			int oreveinPercentageRoll = oreveinRNG.nextInt(100); // Roll the dice, see if we get an orevein here at all
-			int noOrePlacedCount=0;
-			String tDimensionName = "";
-			if (debugOrevein) { tDimensionName = this.mWorld.provider.getDimensionName(); }
-			/*
-			if (debugOrevein) GT_Log.out.println(
-				" Finding oreveins for oreveinSeed="+ oreveinSeed +
-				" mX="+ this.mX +
-				" mZ="+ this.mZ + 
-				" oreseedX="+ oreseedX +
-				" oreseedZ="+ oreseedZ									
-			);
-			*/
+        public void worldGenFindVein( int oreseedX, int oreseedZ) {
+            long oreveinSeed = (long)this.mWorld.getSeed() ^  (( (long)oreseedX << 32) | ( (long)oreseedZ & 0x00000000ffffffffL )); // Use an RNG that is identical every time it is called for this oreseed
+            XSTR oreveinRNG = new XSTR( oreveinSeed );  
+            int oreveinPercentageRoll = oreveinRNG.nextInt(100); // Roll the dice, see if we get an orevein here at all
+            int noOrePlacedCount=0;
+            String tDimensionName = "";
+            if (debugOrevein) { tDimensionName = this.mWorld.provider.getDimensionName(); }
+            /*
+            if (debugOrevein) GT_Log.out.println(
+                " Finding oreveins for oreveinSeed="+ oreveinSeed +
+                " mX="+ this.mX +
+                " mZ="+ this.mZ + 
+                " oreseedX="+ oreseedX +
+                " oreseedZ="+ oreseedZ                                    
+            );
+            */
 
-			// Search for a valid orevein for this dimension
-			if( !validOreveins.containsKey(oreveinSeed) ) {
-				if ( (oreveinPercentageRoll<oreveinPercentage) && (GT_Worldgen_GT_Ore_Layer.sWeight > 0) && (GT_Worldgen_GT_Ore_Layer.sList.size() > 0)) {
-					int placementAttempts = 0;
-					boolean oreveinFound = false;
-					int i;
-					
-					for( i = 0; (i < oreveinAttempts) && (!oreveinFound) && (placementAttempts<oreveinMaxPlacementAttempts); i++ ) {
-	                    int tRandomWeight = oreveinRNG.nextInt(GT_Worldgen_GT_Ore_Layer.sWeight);
-	                    for (GT_Worldgen tWorldGen : GT_Worldgen_GT_Ore_Layer.sList) {
-	                        tRandomWeight -= ((GT_Worldgen_GT_Ore_Layer) tWorldGen).mWeight;
-	                        if (tRandomWeight <= 0) {
-	                            try { 
-									int placementResult = tWorldGen.executeWorldgenChunkified(this.mWorld, new XSTR( oreveinSeed ), this.mBiome, this.mDimensionType, this.mX*16, this.mZ*16, oreseedX*16, oreseedZ*16, this.mChunkGenerator, this.mChunkProvider);
-									switch(placementResult) {
-										case GT_Worldgen_GT_Ore_Layer.ORE_PLACED:
-											if (debugOrevein) GT_Log.out.println(
-												" Added oreveinSeed=" + oreveinSeed + 
-												" mX="+ this.mX +
-												" mZ="+ this.mZ + 
-												" oreseedX="+ oreseedX +
-												" oreseedZ="+ oreseedZ +
-												" tries at oremix=" + i +
-												" placementAttempts=" + placementAttempts +
-												" dimensionName=" + tDimensionName
-											);
-											validOreveins.put(oreveinSeed, tWorldGen);
-											oreveinFound = true;
-											break;
-										case GT_Worldgen_GT_Ore_Layer.NO_ORE_IN_BOTTOM_LAYER:
-											placementAttempts++;
-											// SHould do retry in this case until out of chances
-											break;
-										case GT_Worldgen_GT_Ore_Layer.NO_OVERLAP:
-											// Orevein didn't reach this chunk, can't add it yet to the hash
-											break;
-									}
-	                                break; // Try the next orevein
-	                            } catch (Throwable e) {
-	                            	if (debugOrevein) GT_Log.out.println(
-										"Exception occurred on oreVein" + tWorldGen +
-										" oreveinSeed="+ oreveinSeed +
-										" mX="+ this.mX +
-										" mZ="+ this.mZ + 
-										" oreseedX="+ oreseedX +
-										" oreseedZ="+ oreseedZ									
-									);	
-	                                e.printStackTrace(GT_Log.err);
-	                            }
-	                        }
-	                    }
-					}
-					// Only add an empty orevein if are unable to place a vein at the oreseed chunk.
-					if ((!oreveinFound) && (this.mX == oreseedX) && (this.mZ == oreseedZ)){
-						if (debugOrevein) GT_Log.out.println(
-							" Empty oreveinSeed="+ oreveinSeed +
-							" mX="+ this.mX +
-							" mZ="+ this.mZ + 
-							" oreseedX="+ oreseedX +
-							" oreseedZ="+ oreseedZ + 
-							" tries at oremix=" + i +
-							" placementAttempts=" + placementAttempts +
-							" dimensionName=" + tDimensionName
-						);
-						validOreveins.put(oreveinSeed, noOresInVein );
-					}
-				} else if(oreveinPercentageRoll >= oreveinPercentage) {
-					if (debugOrevein) GT_Log.out.println(
-						" Skipped oreveinSeed="+ oreveinSeed +
-						" mX="+ this.mX +
-						" mZ="+ this.mZ +
-						" oreseedX=" + oreseedX +
-						" oreseedZ="+ oreseedZ + 
-						" RNG=" + oreveinPercentageRoll +
-						" %=" + oreveinPercentage+ 
-						" dimensionName=" + tDimensionName
-					);
-					validOreveins.put(oreveinSeed, noOresInVein);
-	        	}
-			}else {
-				// oreseed is located in the previously processed table
-				if (debugOrevein) GT_Log.out.print(
-					" Valid oreveinSeed="+ oreveinSeed +					
-					" validOreveins.size()=" + validOreveins.size() + " "
-				);
-				GT_Worldgen tWorldGen = validOreveins.get(oreveinSeed);
-				oreveinRNG.setSeed(oreveinSeed);  // reset seed for RNG to only be based on oreseed X/Z
-				tWorldGen.executeWorldgenChunkified(this.mWorld, oreveinRNG, this.mBiome, this.mDimensionType, this.mX*16, this.mZ*16, oreseedX*16, oreseedZ*16, this.mChunkGenerator, this.mChunkProvider);
-			}
-		}
-			
+            // Search for a valid orevein for this dimension
+            if( !validOreveins.containsKey(oreveinSeed) ) {
+                if ( (oreveinPercentageRoll<oreveinPercentage) && (GT_Worldgen_GT_Ore_Layer.sWeight > 0) && (GT_Worldgen_GT_Ore_Layer.sList.size() > 0)) {
+                    int placementAttempts = 0;
+                    boolean oreveinFound = false;
+                    int i;
+                    
+                    for( i = 0; (i < oreveinAttempts) && (!oreveinFound) && (placementAttempts<oreveinMaxPlacementAttempts); i++ ) {
+                        int tRandomWeight = oreveinRNG.nextInt(GT_Worldgen_GT_Ore_Layer.sWeight);
+                        for (GT_Worldgen tWorldGen : GT_Worldgen_GT_Ore_Layer.sList) {
+                            tRandomWeight -= ((GT_Worldgen_GT_Ore_Layer) tWorldGen).mWeight;
+                            if (tRandomWeight <= 0) {
+                                try { 
+                                    int placementResult = tWorldGen.executeWorldgenChunkified(this.mWorld, new XSTR( oreveinSeed ), this.mBiome, this.mDimensionType, this.mX*16, this.mZ*16, oreseedX*16, oreseedZ*16, this.mChunkGenerator, this.mChunkProvider);
+                                    switch(placementResult) {
+                                        case GT_Worldgen_GT_Ore_Layer.ORE_PLACED:
+                                            if (debugOrevein) GT_Log.out.println(
+                                                " Added oreveinSeed=" + oreveinSeed + 
+                                                " mX="+ this.mX +
+                                                " mZ="+ this.mZ + 
+                                                " oreseedX="+ oreseedX +
+                                                " oreseedZ="+ oreseedZ +
+                                                " tries at oremix=" + i +
+                                                " placementAttempts=" + placementAttempts +
+                                                " dimensionName=" + tDimensionName
+                                            );
+                                            validOreveins.put(oreveinSeed, tWorldGen);
+                                            oreveinFound = true;
+                                            break;
+                                        case GT_Worldgen_GT_Ore_Layer.NO_ORE_IN_BOTTOM_LAYER:
+                                            placementAttempts++;
+                                            // SHould do retry in this case until out of chances
+                                            break;
+                                        case GT_Worldgen_GT_Ore_Layer.NO_OVERLAP:
+                                            // Orevein didn't reach this chunk, can't add it yet to the hash
+                                            break;
+                                    }
+                                    break; // Try the next orevein
+                                } catch (Throwable e) {
+                                    if (debugOrevein) GT_Log.out.println(
+                                        "Exception occurred on oreVein" + tWorldGen +
+                                        " oreveinSeed="+ oreveinSeed +
+                                        " mX="+ this.mX +
+                                        " mZ="+ this.mZ + 
+                                        " oreseedX="+ oreseedX +
+                                        " oreseedZ="+ oreseedZ                                    
+                                    );    
+                                    e.printStackTrace(GT_Log.err);
+                                }
+                            }
+                        }
+                    }
+                    // Only add an empty orevein if are unable to place a vein at the oreseed chunk.
+                    if ((!oreveinFound) && (this.mX == oreseedX) && (this.mZ == oreseedZ)){
+                        if (debugOrevein) GT_Log.out.println(
+                            " Empty oreveinSeed="+ oreveinSeed +
+                            " mX="+ this.mX +
+                            " mZ="+ this.mZ + 
+                            " oreseedX="+ oreseedX +
+                            " oreseedZ="+ oreseedZ + 
+                            " tries at oremix=" + i +
+                            " placementAttempts=" + placementAttempts +
+                            " dimensionName=" + tDimensionName
+                        );
+                        validOreveins.put(oreveinSeed, noOresInVein );
+                    }
+                } else if(oreveinPercentageRoll >= oreveinPercentage) {
+                    if (debugOrevein) GT_Log.out.println(
+                        " Skipped oreveinSeed="+ oreveinSeed +
+                        " mX="+ this.mX +
+                        " mZ="+ this.mZ +
+                        " oreseedX=" + oreseedX +
+                        " oreseedZ="+ oreseedZ + 
+                        " RNG=" + oreveinPercentageRoll +
+                        " %=" + oreveinPercentage+ 
+                        " dimensionName=" + tDimensionName
+                    );
+                    validOreveins.put(oreveinSeed, noOresInVein);
+                }
+            }else {
+                // oreseed is located in the previously processed table
+                if (debugOrevein) GT_Log.out.print(
+                    " Valid oreveinSeed="+ oreveinSeed +                    
+                    " validOreveins.size()=" + validOreveins.size() + " "
+                );
+                GT_Worldgen tWorldGen = validOreveins.get(oreveinSeed);
+                oreveinRNG.setSeed(oreveinSeed);  // reset seed for RNG to only be based on oreseed X/Z
+                tWorldGen.executeWorldgenChunkified(this.mWorld, oreveinRNG, this.mBiome, this.mDimensionType, this.mX*16, this.mZ*16, oreseedX*16, oreseedZ*16, this.mChunkGenerator, this.mChunkProvider);
+            }
+        }
+            
         public void run() {
-			long startTime = System.nanoTime();
+            long startTime = System.nanoTime();
 
-			// Determine bounding box on how far out to check for oreveins affecting this chunk
-			int wXbox = this.mX - (oreveinMaxSize/16);
-			int eXbox = this.mX + (oreveinMaxSize/16 + 1); // Need to add 1 since it is compared using a <
-			int nZbox = this.mZ - (oreveinMaxSize/16);
-			int sZbox = this.mZ + (oreveinMaxSize/16 + 1);
+            // Determine bounding box on how far out to check for oreveins affecting this chunk
+            int wXbox = this.mX - (oreveinMaxSize/16);
+            int eXbox = this.mX + (oreveinMaxSize/16 + 1); // Need to add 1 since it is compared using a <
+            int nZbox = this.mZ - (oreveinMaxSize/16);
+            int sZbox = this.mZ + (oreveinMaxSize/16 + 1);
 
-			// Search for orevein seeds and add to the list;
-			for( int x = wXbox; x < eXbox; x++ ) {
-				for( int z = nZbox; z < sZbox; z++ ) {
-					// Determine if this X/Z is an orevein seed
-					if ( ( (Math.abs(x)%3) == 1) && ( (Math.abs(z)%3) == 1 ) ) {
-						seedList.add( new NearbySeeds(x,z) );
-					}
-				}
-			}
+            // Search for orevein seeds and add to the list;
+            for( int x = wXbox; x < eXbox; x++ ) {
+                for( int z = nZbox; z < sZbox; z++ ) {
+                    // Determine if this X/Z is an orevein seed
+                    if ( ( (Math.abs(x)%3) == 1) && ( (Math.abs(z)%3) == 1 ) ) {
+                        seedList.add( new NearbySeeds(x,z) );
+                    }
+                }
+            }
 
-			// Now process each oreseed vs this requested chunk
-			for( ; seedList.size() != 0; seedList.remove(0) ) {
-				worldGenFindVein( seedList.get(0).mX, seedList.get(0).mZ );
-			}
+            // Now process each oreseed vs this requested chunk
+            for( ; seedList.size() != 0; seedList.remove(0) ) {
+                worldGenFindVein( seedList.get(0).mX, seedList.get(0).mZ );
+            }
 
-			// Do leftover worldgen for this chunk (GT_Stones and GT_small_ores)
-			try {
-				for (GT_Worldgen tWorldGen : GregTech_API.sWorldgenList) {
-					/*
-					if (debugWorldGen) GT_Log.out.println(
-						"tWorldGen.mWorldGenName="+tWorldGen.mWorldGenName
-					);
-					*/
-					tWorldGen.executeWorldgen(this.mWorld, this.mRandom, this.mBiome, this.mDimensionType, this.mX*16, this.mZ*16, this.mChunkGenerator, this.mChunkProvider);
-				}
-			} catch (Throwable e) {
-				e.printStackTrace(GT_Log.err);
-			}
-			
+            // Do leftover worldgen for this chunk (GT_Stones and GT_small_ores)
+            try {
+                for (GT_Worldgen tWorldGen : GregTech_API.sWorldgenList) {
+                    /*
+                    if (debugWorldGen) GT_Log.out.println(
+                        "tWorldGen.mWorldGenName="+tWorldGen.mWorldGenName
+                    );
+                    */
+                    tWorldGen.executeWorldgen(this.mWorld, this.mRandom, this.mBiome, this.mDimensionType, this.mX*16, this.mZ*16, this.mChunkGenerator, this.mChunkProvider);
+                }
+            } catch (Throwable e) {
+                e.printStackTrace(GT_Log.err);
+            }
+            
             //Asteroid Worldgen
             int tDimensionType = this.mWorld.provider.dimensionId;
             //String tDimensionName = this.mWorld.provider.getDimensionName();
@@ -397,14 +397,14 @@ implements IWorldGenerator {
             if (tChunk != null) {
                 tChunk.isModified = true;
             }
-			long endTime = System.nanoTime();
-			long duration = (endTime - startTime);
-			if (debugWorldGen) {
-				GT_Log.out.println(
-					" Oregen took " + duration + 
-					" nanoseconds"
-					);
-			}
+            long endTime = System.nanoTime();
+            long duration = (endTime - startTime);
+            if (debugWorldGen) {
+                GT_Log.out.println(
+                    " Oregen took " + duration + 
+                    " nanoseconds"
+                    );
+            }
         }
     }
 }

--- a/src/main/java/gregtech/common/GT_Worldgenerator.java
+++ b/src/main/java/gregtech/common/GT_Worldgenerator.java
@@ -48,7 +48,7 @@ implements IWorldGenerator {
     public static HashSet<Long> ProcChunks = new HashSet<Long>();
     // This is probably not going to work.  Trying to create a fake orevein to put into hashtable when there will be no ores in a vein.
     public static GT_Worldgen_GT_Ore_Layer noOresInVein = new GT_Worldgen_GT_Ore_Layer( "NoOresInVein", false, 0, 255, 0, 255, 16,  false, false, false, false, false, false, Materials.Aluminium, Materials.Aluminium, Materials.Aluminium, Materials.Aluminium);
-    public static Hashtable<Long, GT_Worldgen> validOreveins = new Hashtable(1024);
+    public static Hashtable<Long, GT_Worldgen_GT_Ore_Layer> validOreveins = new Hashtable(1024);
     public boolean mIsGenerating = false;
     public static final Object listLock = new Object();
     //private static boolean gcAsteroids = true;
@@ -197,7 +197,7 @@ implements IWorldGenerator {
                                 try { 
                                     // Adjust the seed so that this layer has a series of unique random numbers.  Otherwise multiple attempts at this same oreseed will get the same offset and X/Z values. If an orevein failed, any orevein with the 
                                     // same minimum heights would fail as well.  This prevents that, giving each orevein a unique height each pass through here.
-                                    int placementResult = tWorldGen.executeWorldgenChunkified(this.mWorld, new XSTR( oreveinSeed + tWorldGen.mPrimaryMeta), this.mBiome, this.mDimensionType, this.mX*16, this.mZ*16, oreseedX*16, oreseedZ*16, this.mChunkGenerator, this.mChunkProvider);
+                                    int placementResult = tWorldGen.executeWorldgenChunkified(this.mWorld, new XSTR( oreveinSeed ^ (tWorldGen.mPrimaryMeta)), this.mBiome, this.mDimensionType, this.mX*16, this.mZ*16, oreseedX*16, oreseedZ*16, this.mChunkGenerator, this.mChunkProvider);
                                     switch(placementResult) {
                                         case GT_Worldgen_GT_Ore_Layer.ORE_PLACED:
                                             if (debugOrevein) GT_Log.out.println(
@@ -265,8 +265,8 @@ implements IWorldGenerator {
                     " Valid oreveinSeed="+ oreveinSeed +                    
                     " validOreveins.size()=" + validOreveins.size() + " "
                 );
-                GT_Worldgen tWorldGen = validOreveins.get(oreveinSeed);
-                oreveinRNG.setSeed(oreveinSeed);  // Reset RNG to only be based on oreseed X/Z
+                GT_Worldgen_GT_Ore_Layer tWorldGen = validOreveins.get(oreveinSeed);
+                oreveinRNG.setSeed(oreveinSeed ^ (tWorldGen.mPrimaryMeta));  // Reset RNG to only be based on oreseed X/Z and type of vein
                 int placementResult = tWorldGen.executeWorldgenChunkified(this.mWorld, oreveinRNG, this.mBiome, this.mDimensionType, this.mX*16, this.mZ*16, oreseedX*16, oreseedZ*16, this.mChunkGenerator, this.mChunkProvider);
                 switch( placementResult )
                 {

--- a/src/main/java/gregtech/common/blocks/GT_TileEntity_Ores.java
+++ b/src/main/java/gregtech/common/blocks/GT_TileEntity_Ores.java
@@ -31,7 +31,7 @@ public class GT_TileEntity_Ores extends TileEntity implements ITexturedTileEntit
     public static byte getHarvestData(short aMetaData, int aBaseBlockHarvestLevel) {
         Materials aMaterial = GregTech_API.sGeneratedMaterials[(aMetaData % 1000)];
         byte tByte = aMaterial == null ? 0 : (byte) Math.max(aBaseBlockHarvestLevel, Math.min(7, aMaterial.mToolQuality - (aMetaData < 16000 ? 0 : 1)));
-        if(GT_Mod.gregtechproxy.mChangeHarvestLevels ){
+        if(GT_Mod.gregtechproxy.mChangeHarvestLevels ) {
             tByte = aMaterial == null ? 0 : (byte) Math.max(aBaseBlockHarvestLevel, Math.min(GT_Mod.gregtechproxy.mMaxHarvestLevel, GT_Mod.gregtechproxy.mHarvestLevel[aMaterial.mMetaItemSubID] - (aMetaData < 16000 ? 0 : 1)));
         }
         return tByte;
@@ -51,38 +51,9 @@ public class GT_TileEntity_Ores extends TileEntity implements ITexturedTileEntit
         String BlockName = tBlock.getUnlocalizedName();
         aMetaData += isSmallOre ? 16000 : 0;
         if ((aMetaData > 0) && ((tBlock != Blocks.air) || air)) {
-            if (BlockName.equals("tile.igneousStone")) {
-                if (GregTech_API.sBlockOresUb1 != null) {
-                    tOreBlock = GregTech_API.sBlockOresUb1;
-                    aMetaData += (BlockMeta * 1000);
-                    //System.out.println("Block changed to UB1");
-                }
-            } else if (BlockName.equals("tile.metamorphicStone")) {
-                if (GregTech_API.sBlockOresUb2 != null) {
-                    tOreBlock = GregTech_API.sBlockOresUb2;
-                    aMetaData += (BlockMeta * 1000);
-                    //System.out.println("Block changed to UB2");
-                }
-            } else if (BlockName.equals("tile.sedimentaryStone")) {
-                if (GregTech_API.sBlockOresUb3 != null) {
-                    tOreBlock = GregTech_API.sBlockOresUb3;
-                    aMetaData += (BlockMeta * 1000);
-                    //System.out.println("Block changed to UB3");
-                }
-            //} else if (BlockName.equals("tile.moonBlock") && (BlockMeta == 3 || BlockMeta == 4)) {
-            //    if (GregTech_API.sBlockOresGC != null) {
-            //        switch (BlockMeta) {
-            //            case 3: tOreBlock = GregTech_API.sBlockOresGC; break;
-            //            case 4: aMetaData += 1000; tOreBlock = GregTech_API.sBlockOresGC; break;
-            //        }
-            //    }
-            //} else if (BlockName.equals("tile.mars") && (BlockMeta == 6 || BlockMeta == 9)) {
-            //    if (GregTech_API.sBlockOresGC != null) {
-            //        switch (BlockMeta) {
-            //            case 6: aMetaData += 2000; tOreBlock = GregTech_API.sBlockOresGC; break;
-            //            case 9: aMetaData += 3000; tOreBlock = GregTech_API.sBlockOresGC; break;
-            //        }
-            //    }
+			if (tBlock.isReplaceableOreGen(aWorld, aX, aY, aZ, Blocks.stone)) {
+				//Do nothing, stone background is default background.
+				//Do this comparison first since stone is most common
             } else if (tBlock.isReplaceableOreGen(aWorld, aX, aY, aZ, Blocks.netherrack)) {
                 aMetaData += 1000;
             } else if (tBlock.isReplaceableOreGen(aWorld, aX, aY, aZ, Blocks.end_stone)) {
@@ -107,7 +78,25 @@ public class GT_TileEntity_Ores extends TileEntity implements ITexturedTileEntit
                 } else {
                     aMetaData += 5000;
                 }
-            } else if (!tBlock.isReplaceableOreGen(aWorld, aX, aY, aZ, Blocks.stone)) {
+			} else if (BlockName.equals("tile.igneousStone")) {
+                if (GregTech_API.sBlockOresUb1 != null) {
+                    tOreBlock = GregTech_API.sBlockOresUb1;
+                    aMetaData += (BlockMeta * 1000);
+                    //System.out.println("Block changed to UB1");
+                }
+            } else if (BlockName.equals("tile.metamorphicStone")) {
+                if (GregTech_API.sBlockOresUb2 != null) {
+                    tOreBlock = GregTech_API.sBlockOresUb2;
+                    aMetaData += (BlockMeta * 1000);
+                    //System.out.println("Block changed to UB2");
+                }
+            } else if (BlockName.equals("tile.sedimentaryStone")) {
+                if (GregTech_API.sBlockOresUb3 != null) {
+                    tOreBlock = GregTech_API.sBlockOresUb3;
+                    aMetaData += (BlockMeta * 1000);
+                    //System.out.println("Block changed to UB3");
+                }
+            } else {
                 return false;
             }
             //System.out.println(tOreBlock);

--- a/src/main/java/gregtech/common/blocks/GT_TileEntity_Ores.java
+++ b/src/main/java/gregtech/common/blocks/GT_TileEntity_Ores.java
@@ -51,9 +51,9 @@ public class GT_TileEntity_Ores extends TileEntity implements ITexturedTileEntit
         String BlockName = tBlock.getUnlocalizedName();
         aMetaData += isSmallOre ? 16000 : 0;
         if ((aMetaData > 0) && ((tBlock != Blocks.air) || air)) {
-			if (tBlock.isReplaceableOreGen(aWorld, aX, aY, aZ, Blocks.stone)) {
-				//Do nothing, stone background is default background.
-				//Do this comparison first since stone is most common
+            if (tBlock.isReplaceableOreGen(aWorld, aX, aY, aZ, Blocks.stone)) {
+                //Do nothing, stone background is default background.
+                //Do this comparison first since stone is most common
             } else if (tBlock.isReplaceableOreGen(aWorld, aX, aY, aZ, Blocks.netherrack)) {
                 aMetaData += 1000;
             } else if (tBlock.isReplaceableOreGen(aWorld, aX, aY, aZ, Blocks.end_stone)) {
@@ -78,7 +78,7 @@ public class GT_TileEntity_Ores extends TileEntity implements ITexturedTileEntit
                 } else {
                     aMetaData += 5000;
                 }
-			} else if (BlockName.equals("tile.igneousStone")) {
+            } else if (BlockName.equals("tile.igneousStone")) {
                 if (GregTech_API.sBlockOresUb1 != null) {
                     tOreBlock = GregTech_API.sBlockOresUb1;
                     aMetaData += (BlockMeta * 1000);


### PR DESCRIPTION
Chunkify oregen to reduce worldgen cascade and improve performance.
Orevein placement optimization - give up if bottom layer has 0 ores placed, do not place ores in the same block twice.
Remove old confusing and complex stone gen code, replace with nicely commented code that has variations in stone sizes and does not double-place stones.
Re-allow deep dark double orevein generation. (oreveins still limited to 32 for performance).
https://github.com/GTNewHorizons/GT5-Unofficial/issues/52