### PR TITLE
Oil Cracker/Large Chemical Reactor structure

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeChemicalReactor.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeChemicalReactor.java
@@ -45,8 +45,8 @@ public class GT_MetaTileEntity_LargeChemicalReactor extends GT_MetaTileEntity_Mu
 				"Size(WxHxD): 3x3x3",
 				"3x3x3 of Chemically Inert Machine Casings (hollow, min 8!)",
 				"Controller (Front centered)",
-				"1x Cupronickel Coil Block (Bottom centered)",
 				"1x PTFE Pipe Machine Casing (inside the hollow casings)",
+				"1x Cupronickel Coil Block (next to PTFE Pipe Machine Casing)",
 				"1x Input Bus/Hatch (Any inert casing)",
 				"1x Output Bus/Hatch (Any inert casing)",
 				"1x Maintenance Hatch (Any inert casing)",
@@ -151,20 +151,37 @@ public class GT_MetaTileEntity_LargeChemicalReactor extends GT_MetaTileEntity_Mu
 		int xDir = ForgeDirection.getOrientation(aBaseMetaTileEntity.getBackFacing()).offsetX;
 		int zDir = ForgeDirection.getOrientation(aBaseMetaTileEntity.getBackFacing()).offsetZ;
 		int casingAmount = 0;
+		boolean hasHeatingCoil = false;
 		// x=width, z=depth, y=height
 		for (int x = -1 + xDir; x <= xDir + 1; x++) {
 			for (int z = -1 + zDir; z <= zDir + 1; z++) {
 				for (int y = -1; y <= 1; y++) {
+					if (x == 0 && y == 0 && z == 0) {
+						continue;
+					}
 					IGregTechTileEntity tileEntity = aBaseMetaTileEntity.getIGregTechTileEntityOffset(x, y, z);
 					Block block = aBaseMetaTileEntity.getBlockOffset(x, y, z);
-					if (x == xDir && z == zDir && y <= 0) {
-						if ((y == -1)
-								&& (block != GregTech_API.sBlockCasings5 || aBaseMetaTileEntity.getMetaIDOffset(x, y, z) != 0)) {
-							return false;
-						} else if (y == 0 && (block != GregTech_API.sBlockCasings8 || aBaseMetaTileEntity.getMetaIDOffset(x, y, z) != 1)) {
+					int centerCoords = 0;
+					if (x == xDir) {
+						centerCoords++;
+					}
+					if (y == 0) {
+						centerCoords++;
+					}
+					if (z == zDir) {
+						centerCoords++;
+					}
+					if (centerCoords == 3) {
+						if (block == GregTech_API.sBlockCasings8 && aBaseMetaTileEntity.getMetaIDOffset(x, y, z) == 1) {
+							continue;
+						} else {
 							return false;
 						}
-					} else if (x != 0 || y != 0 || z != 0) {
+					}
+					if (centerCoords == 2 && block == GregTech_API.sBlockCasings5 && aBaseMetaTileEntity.getMetaIDOffset(x, y, z) == 0) {
+						hasHeatingCoil = true;
+						continue;
+					}
 						if (!addInputToMachineList(tileEntity, CASING_INDEX) && !addOutputToMachineList(tileEntity, CASING_INDEX)
 								&& !addMaintenanceToMachineList(tileEntity, CASING_INDEX)
 								&& !addEnergyInputToMachineList(tileEntity, CASING_INDEX)) {
@@ -174,13 +191,12 @@ public class GT_MetaTileEntity_LargeChemicalReactor extends GT_MetaTileEntity_Mu
 								return false;
 							}
 						}
-					}
 
 				}
 			}
 
 		}
-		return casingAmount >= 8;
+		return casingAmount >= 8 && hasHeatingCoil;
 	}
 
 	@Override

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_OilCracker.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_OilCracker.java
@@ -38,12 +38,13 @@ public class GT_MetaTileEntity_OilCracker extends GT_MetaTileEntity_MultiBlockBa
                 "Thermally cracks heavy hydrocarbons into lighter fractions",
                 "Size(WxHxD): 5x3x3 (Hollow), Controller (Front center)",
                 "Ring of 8 Cupronickel Coils (Each side of Controller)",
-                "1x Hydrocarbon Input Bus/Hatch (Any left side casing)",
+                "1x Hydrocarbon Input Bus/Hatch (Any left/right side casing)",
                 "1x Steam/Hydrogen Input Hatch (Any middle ring casing)",
-                "1x Cracked Hydrocarbon Output Hatch (Any right side casing)",
-                "1x Maintenance Hatch (Any middle ring casing)",
-                "1x Energy Hatch (Any middle ring casing)",
-                "Clean Stainless Steel Machine Casings for the rest (18 at least!)"};
+                "1x Cracked Hydrocarbon Output Hatch (Any left/right side casing)",
+                "1x Maintenance Hatch (Any casing)",
+                "1x Energy Hatch (Any casing)",
+                "Clean Stainless Steel Machine Casings for the rest (18 at least!)",
+                "Input/output Hatches must be on opposite sides"};
     }
 
     public ITexture[] getTexture(IGregTechTileEntity aBaseMetaTileEntity, byte aSide, byte aFacing, byte aColorIndex, boolean aActive, boolean aRedstone) {
@@ -95,6 +96,7 @@ public class GT_MetaTileEntity_OilCracker extends GT_MetaTileEntity_MultiBlockBa
         int zDir = this.orientation.offsetZ;
         int amount = 0;
         replaceDeprecatedCoils(aBaseMetaTileEntity);
+        boolean negSideInput = false, negSideOutput = false, posSideInput = false, posSideOutput = false;
         if (xDir != 0) {
             for (int i = -1; i < 2; i++) {// xDirection
                 for (int j = -1; j < 2; j++) {// height
@@ -110,8 +112,19 @@ public class GT_MetaTileEntity_OilCracker extends GT_MetaTileEntity_MultiBlockBa
                             }
                             if (h == 2 || h == -2) {
                                 IGregTechTileEntity tTileEntity = aBaseMetaTileEntity.getIGregTechTileEntityOffset(xDir + i, j, h + zDir);
-                                boolean tSide = ((aBaseMetaTileEntity.getBackFacing() == 4 && 2 == h) || (aBaseMetaTileEntity.getBackFacing() == 5 && -2 == h));
-                                if (tSide ? !addInputToMachineList(tTileEntity, 49) : !addOutputToMachineList(tTileEntity, 49)) {
+                                if (addInputToMachineList(tTileEntity, 49)) {
+                                	if (h == -2) {
+                                		negSideInput = true;
+                                	} else {
+                                		posSideInput = true;
+                                	}
+                                } else if (addOutputToMachineList(tTileEntity, 49)) {
+                                	if (h == -2) {
+                                		negSideOutput = true;
+                                	} else {
+                                		posSideOutput = true;
+                                	}                                	
+                                } else if (!addEnergyInputToMachineList(tTileEntity, 49) && !addMaintenanceToMachineList(tTileEntity, 49)){
                                     if (aBaseMetaTileEntity.getBlockOffset(xDir + i, j, h + zDir) != GregTech_API.sBlockCasings4) {
                                         return false;
                                     }
@@ -156,8 +169,19 @@ public class GT_MetaTileEntity_OilCracker extends GT_MetaTileEntity_MultiBlockBa
                             }
                             if (h == 2 || h == -2) {
                                 IGregTechTileEntity tTileEntity = aBaseMetaTileEntity.getIGregTechTileEntityOffset(xDir + h, j, i + zDir);
-                                boolean tSide = (aBaseMetaTileEntity.getBackFacing() == h || (aBaseMetaTileEntity.getBackFacing() == 3 && -2 == h));
-                                if (tSide ? !addOutputToMachineList(tTileEntity, 49) : !addInputToMachineList(tTileEntity, 49)) {
+                                if (addInputToMachineList(tTileEntity, 49)) {
+                                	if (h == -2) {
+                                		negSideInput = true;
+                                	} else {
+                                		posSideInput = true;
+                                	}
+                                } else if (addOutputToMachineList(tTileEntity, 49)) {
+                                	if (h == -2) {
+                                		negSideOutput = true;
+                                	} else {
+                                		posSideOutput = true;
+                                	}                                	
+                                } else if (!addEnergyInputToMachineList(tTileEntity, 49) && !addMaintenanceToMachineList(tTileEntity, 49)){
                                     if (aBaseMetaTileEntity.getBlockOffset(xDir + h, j, i + zDir) != GregTech_API.sBlockCasings4) {
                                         return false;
                                     }
@@ -187,6 +211,10 @@ public class GT_MetaTileEntity_OilCracker extends GT_MetaTileEntity_MultiBlockBa
                     }
                 }
             }
+        }
+        if ((negSideInput && negSideOutput) || (posSideInput && posSideOutput) 
+        		|| (negSideInput && posSideInput) || (negSideOutput && posSideOutput)) {
+        	return false;
         }
         if (amount < 18) return false;
         return true;

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_OilCracker.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_OilCracker.java
@@ -44,7 +44,7 @@ public class GT_MetaTileEntity_OilCracker extends GT_MetaTileEntity_MultiBlockBa
                 "1x Maintenance Hatch (Any casing)",
                 "1x Energy Hatch (Any casing)",
                 "Clean Stainless Steel Machine Casings for the rest (18 at least!)",
-                "Input/output Hatches must be on opposite sides"};
+                "Input/Output Hatches must be on opposite sides"};
     }
 
     public ITexture[] getTexture(IGregTechTileEntity aBaseMetaTileEntity, byte aSide, byte aFacing, byte aColorIndex, boolean aActive, boolean aRedstone) {


### PR DESCRIPTION
I recently made the structure checks for the Oil Cracker and the Large Chemical Reactor more flexible.
These changes could not be merged automatically, and as such Dreammaster has requested my assistance.
This PR merges my changes into GTNH.
I have **not** tested these changes in a GTNH environment since I only have a testing environment set up for regular GT5U.