### PR TITLE
Possible fix for cables disconnecting on chunk unload & load

### DIFF
--- a/src/main/java/gregtech/api/interfaces/tileentity/IEnergyConnected.java
+++ b/src/main/java/gregtech/api/interfaces/tileentity/IEnergyConnected.java
@@ -42,6 +42,11 @@ public interface IEnergyConnected extends IColoredTileEntity, IHasWorldObjectAnd
     public boolean outputsEnergyTo(byte aSide);
 
     /**
+     * Are we ready for energy state?
+     */
+    public boolean energyStateReady();
+    
+    /**
      * Utility for the Network
      */
     public static class Util {

--- a/src/main/java/gregtech/api/interfaces/tileentity/IEnergyConnected.java
+++ b/src/main/java/gregtech/api/interfaces/tileentity/IEnergyConnected.java
@@ -35,16 +35,13 @@ public interface IEnergyConnected extends IColoredTileEntity, IHasWorldObjectAnd
      * Sided Energy Input
      */
     public boolean inputEnergyFrom(byte aSide);
+    public boolean isEnergyInputSide(byte aSide);
 
     /**
      * Sided Energy Output
      */
     public boolean outputsEnergyTo(byte aSide);
-
-    /**
-     * Are we ready for energy state?
-     */
-    public boolean energyStateReady();
+    public boolean isEnergyOutputSide(byte aSide);
     
     /**
      * Utility for the Network

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
@@ -629,6 +629,11 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
     }
 
     @Override
+    public boolean energyStateReady() {
+    	return true;
+    }
+    
+    @Override
     public boolean inputEnergyFrom(byte aSide) {
         return false;
     }

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
@@ -629,20 +629,26 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
     }
 
     @Override
-    public boolean energyStateReady() {
-    	return true;
-    }
-    
-    @Override
     public boolean inputEnergyFrom(byte aSide) {
         return false;
     }
+
+    @Override
+    public boolean isEnergyInputSide(byte aSide) {
+    	return false;
+    }
+    
 
     @Override
     public boolean outputsEnergyTo(byte aSide) {
         return false;
     }
 
+    @Override
+    public boolean isEnergyOutputSide(byte aSide) {
+    	return false;
+    }
+    
     @Override
     public long getOutputAmperage() {
         return 0;

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
@@ -56,6 +56,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
     protected int mAverageEUInputIndex = 0, mAverageEUOutputIndex = 0;
     protected boolean mReleaseEnergy = false;
     protected int[] mAverageEUInput = new int[]{0, 0, 0, 0, 0}, mAverageEUOutput = new int[]{0, 0, 0, 0, 0};
+    private boolean mEnergyStateReady = false;
     private boolean[] mActiveEUInputs = new boolean[]{false, false, false, false, false, false}, mActiveEUOutputs = new boolean[]{false, false, false, false, false, false};
     private byte[] mSidedRedstone = new byte[]{15, 15, 15, 15, 15, 15};
     private int[] mCoverSides = new int[]{0, 0, 0, 0, 0, 0}, mCoverData = new int[]{0, 0, 0, 0, 0, 0}, mTimeStatistics = new int[GregTech_API.TICKS_FOR_LAG_AVERAGING];
@@ -391,6 +392,12 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
                                         dropCover(i, i, true);
                             issueBlockUpdate();
                         }
+
+                        if (mTickTimer > 20) {
+                            // We're ready to tell about our energy state - Only used server side
+                            mEnergyStateReady = true;
+                        }
+
 
                         if (mTickTimer > 20 && mMetaTileEntity.isElectric()) {
                             mAcceptedAmperes = 0;
@@ -968,6 +975,12 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
         return false;
     }
 
+    @Override
+    public boolean energyStateReady() {
+    	if (!isServerSide()) return true;
+    	else return mEnergyStateReady;
+    }
+    
     @Override
     public boolean inputEnergyFrom(byte aSide) {
         if (aSide == 6) return true;

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
@@ -56,7 +56,6 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
     protected int mAverageEUInputIndex = 0, mAverageEUOutputIndex = 0;
     protected boolean mReleaseEnergy = false;
     protected int[] mAverageEUInput = new int[]{0, 0, 0, 0, 0}, mAverageEUOutput = new int[]{0, 0, 0, 0, 0};
-    private boolean mEnergyStateReady = false;
     private boolean[] mActiveEUInputs = new boolean[]{false, false, false, false, false, false}, mActiveEUOutputs = new boolean[]{false, false, false, false, false, false};
     private byte[] mSidedRedstone = new byte[]{15, 15, 15, 15, 15, 15};
     private int[] mCoverSides = new int[]{0, 0, 0, 0, 0, 0}, mCoverData = new int[]{0, 0, 0, 0, 0, 0}, mTimeStatistics = new int[GregTech_API.TICKS_FOR_LAG_AVERAGING];
@@ -73,7 +72,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
     {
         Field f = null;
 
-        try {
+        try { 
             f = EntityItem.class.getDeclaredField("field_70291_e");
             f.setAccessible(true);
         } catch (Exception e1) {
@@ -392,12 +391,6 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
                                         dropCover(i, i, true);
                             issueBlockUpdate();
                         }
-
-                        if (mTickTimer > 20) {
-                            // We're ready to tell about our energy state - Only used server side
-                            mEnergyStateReady = true;
-                        }
-
 
                         if (mTickTimer > 20 && mMetaTileEntity.isElectric()) {
                             mAcceptedAmperes = 0;
@@ -976,12 +969,6 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
     }
 
     @Override
-    public boolean energyStateReady() {
-    	if (!isServerSide()) return true;
-    	else return mEnergyStateReady;
-    }
-    
-    @Override
     public boolean inputEnergyFrom(byte aSide) {
         if (aSide == 6) return true;
         if (isServerSide()) return (aSide >= 0 && aSide < 6 ? mActiveEUInputs[aSide] : false) && !mReleaseEnergy;
@@ -1085,7 +1072,8 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
         return Textures.BlockIcons.ERROR_RENDERING;
     }
 
-    private boolean isEnergyInputSide(byte aSide) {
+    @Override
+    public boolean isEnergyInputSide(byte aSide) {
         if (aSide >= 0 && aSide < 6) {
             if (!getCoverBehaviorAtSide(aSide).letsEnergyIn(aSide, getCoverIDAtSide(aSide), getCoverDataAtSide(aSide), this))
                 return false;
@@ -1096,7 +1084,8 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
         return false;
     }
 
-    private boolean isEnergyOutputSide(byte aSide) {
+    @Override
+    public boolean isEnergyOutputSide(byte aSide) {
         if (aSide >= 0 && aSide < 6) {
             if (!getCoverBehaviorAtSide(aSide).letsEnergyOut(aSide, getCoverIDAtSide(aSide), getCoverDataAtSide(aSide), this))
                 return false;

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Cable.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Cable.java
@@ -1,5 +1,6 @@
 package gregtech.api.metatileentity.implementations;
 
+import static gregtech.api.enums.GT_Values.D1;
 import cofh.api.energy.IEnergyReceiver;
 import gregtech.GT_Mod;
 import gregtech.api.GregTech_API;
@@ -14,8 +15,10 @@ import gregtech.api.interfaces.tileentity.IColoredTileEntity;
 import gregtech.api.interfaces.tileentity.IEnergyConnected;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.BaseMetaPipeEntity;
+import gregtech.api.metatileentity.BaseMetaTileEntity;
 import gregtech.api.metatileentity.MetaPipeEntity;
 import gregtech.api.objects.GT_RenderedTexture;
+import gregtech.api.util.GT_Log;
 import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_Utility;
 import gregtech.common.GT_Client;
@@ -297,7 +300,11 @@ public class GT_MetaPipeEntity_Cable extends MetaPipeEntity implements IMetaTile
                     if ((mCheckConnections || isConnectedAtSide(tSide)
                     			|| aBaseMetaTileEntity.getCoverBehaviorAtSide(tSide).alwaysLookConnected(tSide, aBaseMetaTileEntity.getCoverIDAtSide(tSide), aBaseMetaTileEntity.getCoverDataAtSide(tSide), aBaseMetaTileEntity)
                     			|| (tBaseMetaTileEntity != null && tBaseMetaTileEntity.getCoverBehaviorAtSide(uSide).alwaysLookConnected(uSide, tBaseMetaTileEntity.getCoverIDAtSide(uSide), tBaseMetaTileEntity.getCoverDataAtSide(uSide), tBaseMetaTileEntity)))
-                    		&& connect(tSide) == 0) {
+                    		&& connect(tSide) == 0) 
+                    {
+                    	if(D1 && isConnectedAtSide(tSide)) {
+                    		GT_Log.out.println("Was connected - Now disconnecting.  CheckConnections: " + mCheckConnections);
+                    	}
                     	disconnect(tSide);
                     }
                 }
@@ -340,30 +347,77 @@ public class GT_MetaPipeEntity_Cable extends MetaPipeEntity implements IMetaTile
 		byte tSide = GT_Utility.getOppositeSide(aSide);
 		TileEntity tTileEntity = getBaseMetaTileEntity().getTileEntityAtSide(aSide);
 		if (tTileEntity != null) {
-			if (getBaseMetaTileEntity().getCoverBehaviorAtSide(aSide).alwaysLookConnected(aSide, getBaseMetaTileEntity().getCoverIDAtSide(aSide), getBaseMetaTileEntity().getCoverDataAtSide(aSide), getBaseMetaTileEntity())
-					|| getBaseMetaTileEntity().getCoverBehaviorAtSide(aSide).letsEnergyIn(aSide, getBaseMetaTileEntity().getCoverIDAtSide(aSide), getBaseMetaTileEntity().getCoverDataAtSide(aSide), getBaseMetaTileEntity())
-					|| getBaseMetaTileEntity().getCoverBehaviorAtSide(aSide).letsEnergyOut(aSide, getBaseMetaTileEntity().getCoverIDAtSide(aSide), getBaseMetaTileEntity().getCoverDataAtSide(aSide), getBaseMetaTileEntity())) {
+			boolean sAlwaysLookConnected = getBaseMetaTileEntity().getCoverBehaviorAtSide(aSide).alwaysLookConnected(aSide, getBaseMetaTileEntity()
+					.getCoverIDAtSide(aSide), getBaseMetaTileEntity().getCoverDataAtSide(aSide), getBaseMetaTileEntity());
+			boolean sLetEnergyIn = getBaseMetaTileEntity().getCoverBehaviorAtSide(aSide).letsEnergyIn(aSide, getBaseMetaTileEntity()
+					.getCoverIDAtSide(aSide), getBaseMetaTileEntity().getCoverDataAtSide(aSide), getBaseMetaTileEntity());
+			boolean sLetEnergyOut = getBaseMetaTileEntity().getCoverBehaviorAtSide(aSide).letsEnergyOut(aSide, getBaseMetaTileEntity()
+					.getCoverIDAtSide(aSide), getBaseMetaTileEntity().getCoverDataAtSide(aSide), getBaseMetaTileEntity());
+
+			if (sAlwaysLookConnected || sLetEnergyIn || sLetEnergyOut) {
 	            if (tTileEntity instanceof IColoredTileEntity) {
 	                if (getBaseMetaTileEntity().getColorization() >= 0) {
 	                    byte tColor = ((IColoredTileEntity) tTileEntity).getColorization();
-	                    if (tColor >= 0 && tColor != getBaseMetaTileEntity().getColorization())
+	                    if (tColor >= 0 && tColor != getBaseMetaTileEntity().getColorization()) {
+	                    	if(D1) GT_Log.out.println("returning rConnect because of Color? " + rConnect);
 	                    	return rConnect;
+	                    }
 	                }
 	            }
-	            if ((tTileEntity instanceof IEnergyConnected && (((IEnergyConnected) tTileEntity).inputEnergyFrom(tSide) || ((IEnergyConnected) tTileEntity).outputsEnergyTo(tSide)))
-	            		|| (tTileEntity instanceof IGregTechTileEntity && ((IGregTechTileEntity) tTileEntity).getMetaTileEntity() instanceof IMetaTileEntityCable
-	                    		&& (((IGregTechTileEntity) tTileEntity).getCoverBehaviorAtSide(tSide).alwaysLookConnected(tSide, ((IGregTechTileEntity) tTileEntity).getCoverIDAtSide(tSide), ((IGregTechTileEntity) tTileEntity).getCoverDataAtSide(tSide), ((IGregTechTileEntity) tTileEntity))
-	                    				|| ((IGregTechTileEntity) tTileEntity).getCoverBehaviorAtSide(tSide).letsEnergyIn(tSide, ((IGregTechTileEntity) tTileEntity).getCoverIDAtSide(tSide), ((IGregTechTileEntity) tTileEntity).getCoverDataAtSide(tSide), ((IGregTechTileEntity) tTileEntity))
-	                    				|| ((IGregTechTileEntity) tTileEntity).getCoverBehaviorAtSide(tSide).letsEnergyOut(tSide, ((IGregTechTileEntity) tTileEntity).getCoverIDAtSide(tSide), ((IGregTechTileEntity) tTileEntity).getCoverDataAtSide(tSide), ((IGregTechTileEntity) tTileEntity))))
-	            		|| (tTileEntity instanceof IEnergySink && ((IEnergySink) tTileEntity).acceptsEnergyFrom((TileEntity) getBaseMetaTileEntity(), ForgeDirection.getOrientation(tSide)))
-	            		|| (GregTech_API.mOutputRF && tTileEntity instanceof IEnergyReceiver && ((IEnergyReceiver) tTileEntity).canConnectEnergy(ForgeDirection.getOrientation(tSide)))
-	            		/*|| (tTileEntity instanceof IEnergyEmitter && ((IEnergyEmitter)tTileEntity).emitsEnergyTo((TileEntity)getBaseMetaTileEntity(), ForgeDirection.getOrientation(tSide)))*/) {
+	            
+	            boolean tEnergyIsConnected = tTileEntity instanceof IEnergyConnected;
+	            if (tEnergyIsConnected && GT_Mod.gregtechproxy.gt6Cable && !((IEnergyConnected )tTileEntity).energyStateReady()) {
+	            	// Server side EnergyConnected tile entities aren't ready to report their energy states for about 20 ticks
+	            	// the old GT5 style cables would always keep trying to reconnect, but the GT6 style cables only try when
+	            	// placed, forced, or when reloaded (once).  Return -1 (and don't disconnect) until the tile entity
+	            	// is ready to report it's state
+	            	rConnect = -1;
+	            }
+	            boolean tEnergyInOrOut = (((IEnergyConnected) tTileEntity).inputEnergyFrom(tSide) || ((IEnergyConnected) tTileEntity).outputsEnergyTo(tSide));
+	            
+	            boolean tIsTileEntity = tTileEntity instanceof IGregTechTileEntity;
+	            boolean tIsTileEntityCable = tIsTileEntity && ((IGregTechTileEntity) tTileEntity).getMetaTileEntity() instanceof IMetaTileEntityCable; 
+	            boolean tAlwaysLookConnected = tIsTileEntity && ((IGregTechTileEntity) tTileEntity).getCoverBehaviorAtSide(tSide).alwaysLookConnected(tSide, ((IGregTechTileEntity) tTileEntity)
+	            		.getCoverIDAtSide(tSide), ((IGregTechTileEntity) tTileEntity).getCoverDataAtSide(tSide), ((IGregTechTileEntity) tTileEntity));
+	            boolean tLetEnergyIn = tIsTileEntity && ((IGregTechTileEntity) tTileEntity).getCoverBehaviorAtSide(tSide).letsEnergyIn(tSide, ((IGregTechTileEntity) tTileEntity)
+	            		.getCoverIDAtSide(tSide),  ((IGregTechTileEntity) tTileEntity).getCoverDataAtSide(tSide), ((IGregTechTileEntity) tTileEntity));
+	            boolean tLetEnergyOut = tIsTileEntity && ((IGregTechTileEntity) tTileEntity).getCoverBehaviorAtSide(tSide).letsEnergyOut(tSide, ((IGregTechTileEntity) tTileEntity)
+	            		.getCoverIDAtSide(tSide), ((IGregTechTileEntity) tTileEntity).getCoverDataAtSide(tSide), ((IGregTechTileEntity) tTileEntity));
+	            
+	            boolean tIsEnergySink = tTileEntity instanceof IEnergySink;
+	            boolean tSinkAcceptsEnergyFromSide = tIsEnergySink && ((IEnergySink) tTileEntity).acceptsEnergyFrom((TileEntity) getBaseMetaTileEntity(), ForgeDirection.getOrientation(tSide));
+	            
+	            boolean tIsEnergyReceiver = tTileEntity instanceof IEnergyReceiver;
+	            boolean tEnergyReceiverCanAcceptFromSide = tIsEnergyReceiver && ((IEnergyReceiver) tTileEntity).canConnectEnergy(ForgeDirection.getOrientation(tSide));
+
+	            if (   (tEnergyIsConnected && tEnergyInOrOut)
+            		|| (tIsTileEntity && tIsTileEntityCable && (tAlwaysLookConnected || tLetEnergyIn || tLetEnergyOut) )
+            		|| (tIsEnergySink && tSinkAcceptsEnergyFromSide)
+            		|| (GregTech_API.mOutputRF && tIsEnergyReceiver && tEnergyReceiverCanAcceptFromSide)
+	            		/*|| (tTileEntity instanceof IEnergyEmitter && ((IEnergyEmitter)tTileEntity).emitsEnergyTo((TileEntity)getBaseMetaTileEntity(), ForgeDirection.getOrientation(tSide)))*/) 
+	            {
 	                rConnect = 1;
 	            }
+
+	            if(D1 && rConnect == 0) {
+					GT_Log.out.println("Tile Debug: tEnergyConnected:" + tEnergyIsConnected + " tEnergyInOrOut:" +tEnergyInOrOut);
+					GT_Log.out.println("\t tIsTileEntity:" + tIsTileEntity + " tIsTileEntityCable:" + tIsTileEntityCable + 
+							" AlwaysLookConnected:" + tAlwaysLookConnected + " LetEnergyIn:" + tLetEnergyIn + " LetEnergyOut:" + tLetEnergyOut);
+					GT_Log.out.println("\t tIsEnergySink:" + tIsEnergySink + " tSinkAcceptsEnergyFromSide:" + tSinkAcceptsEnergyFromSide );
+					GT_Log.out.println("\t tIsEnergyReceiver:" + tIsEnergyReceiver + " tEnergyReceiverCanAcceptFromSide:" + tEnergyReceiverCanAcceptFromSide );
+				}
+
 	        }
+			if(D1 && rConnect == 0) GT_Log.out.println("Self - AlwaysLookConnected:" + sAlwaysLookConnected + " LetEnergyIn:" + sLetEnergyIn + " LetEnergyOut:" + sLetEnergyOut);
+
+			
 		} else if (getBaseMetaTileEntity().getOffsetX(aSide, 1) >> 4 != getBaseMetaTileEntity().getXCoord() >> 4 
-    			|| getBaseMetaTileEntity().getOffsetZ(aSide, 1) >> 4 != getBaseMetaTileEntity().getZCoord() >> 4) { // if chunk unloaded
+    			|| getBaseMetaTileEntity().getOffsetZ(aSide, 1) >> 4 != getBaseMetaTileEntity().getZCoord() >> 4) 
+		{ 
+			// if chunk unloaded
     		rConnect = -1;
+		} else if(D1) {
+			GT_Log.out.println("tile entity NULL");
 		}
         if (rConnect > 0) {
         	super.connect(aSide);
@@ -405,8 +459,10 @@ public class GT_MetaPipeEntity_Cable extends MetaPipeEntity implements IMetaTile
     @Override
     public void loadNBTData(NBTTagCompound aNBT) {
         if (GT_Mod.gregtechproxy.gt6Cable) {
-        	if (!aNBT.hasKey("mConnections"))
+        	if (!aNBT.hasKey("mConnections")) {
+        		if(D1) GT_Log.out.println("Loading a cable - No connections found, so checking them.");
         		mCheckConnections = true;
+        	}
         	mConnections = aNBT.getByte("mConnections");
         }
     }

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Cable.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Cable.java
@@ -366,14 +366,7 @@ public class GT_MetaPipeEntity_Cable extends MetaPipeEntity implements IMetaTile
 	            }
 	            
 	            boolean tEnergyIsConnected = tTileEntity instanceof IEnergyConnected;
-	            if (tEnergyIsConnected && GT_Mod.gregtechproxy.gt6Cable && !((IEnergyConnected )tTileEntity).energyStateReady()) {
-	            	// Server side EnergyConnected tile entities aren't ready to report their energy states for about 20 ticks
-	            	// the old GT5 style cables would always keep trying to reconnect, but the GT6 style cables only try when
-	            	// placed, forced, or when reloaded (once).  Return -1 (and don't disconnect) until the tile entity
-	            	// is ready to report it's state
-	            	rConnect = -1;
-	            }
-	            boolean tEnergyInOrOut = (((IEnergyConnected) tTileEntity).inputEnergyFrom(tSide) || ((IEnergyConnected) tTileEntity).outputsEnergyTo(tSide));
+	            boolean tEnergyInOrOut = (((IEnergyConnected) tTileEntity).isEnergyInputSide(tSide) || ((IEnergyConnected) tTileEntity).isEnergyOutputSide(tSide));
 	            
 	            boolean tIsTileEntity = tTileEntity instanceof IGregTechTileEntity;
 	            boolean tIsTileEntityCable = tIsTileEntity && ((IGregTechTileEntity) tTileEntity).getMetaTileEntity() instanceof IMetaTileEntityCable; 
@@ -408,17 +401,17 @@ public class GT_MetaPipeEntity_Cable extends MetaPipeEntity implements IMetaTile
 				}
 
 	        }
-			if(D1 && rConnect == 0) GT_Log.out.println("Self - AlwaysLookConnected:" + sAlwaysLookConnected + " LetEnergyIn:" + sLetEnergyIn + " LetEnergyOut:" + sLetEnergyOut);
-
-			
-		} else if (getBaseMetaTileEntity().getOffsetX(aSide, 1) >> 4 != getBaseMetaTileEntity().getXCoord() >> 4 
-    			|| getBaseMetaTileEntity().getOffsetZ(aSide, 1) >> 4 != getBaseMetaTileEntity().getZCoord() >> 4) 
+			if(D1 && rConnect == 0) GT_Log.out.println("Self - AlwaysLookConnected:" + sAlwaysLookConnected + " LetEnergyIn:" + sLetEnergyIn + " LetEnergyOut:" + sLetEnergyOut);			
+		} 
+		
+		if (rConnect == 0 && (getBaseMetaTileEntity().getOffsetX(aSide, 1) >> 4 != getBaseMetaTileEntity().getXCoord() >> 4 
+    			|| getBaseMetaTileEntity().getOffsetZ(aSide, 1) >> 4 != getBaseMetaTileEntity().getZCoord() >> 4)) 
 		{ 
 			// if chunk unloaded
     		rConnect = -1;
-		} else if(D1) {
-			GT_Log.out.println("tile entity NULL");
+    		if(D1)  GT_Log.out.println("Cable - Chunk not loaded, deferring (dis)connection");
 		}
+		
         if (rConnect > 0) {
         	super.connect(aSide);
         }


### PR DESCRIPTION
Server side EnergyConnected tile entities aren't ready to report their energy states for about 20 ticks, and would end up disconnecting on chunk load.  The old GT5 style cables would always keep trying to reconnect so it didn't matter, they'd end up reconnecting 20 ticks later.  The GT6 style cables only try to connect when placed, forced, or when reloaded (once).  Added a little more state tracking to server side tile entities and had them defer disconnect until the tile entity is ready to report it's state.