### PR TITLE
Debug/ore ratios

### DIFF
--- a/src/main/java/gregtech/common/GT_Worldgen_GT_Ore_Layer.java
+++ b/src/main/java/gregtech/common/GT_Worldgen_GT_Ore_Layer.java
@@ -7,6 +7,8 @@ import gregtech.api.util.GT_Log;
 import gregtech.api.world.GT_Worldgen;
 import gregtech.common.blocks.GT_TileEntity_Ores;
 import gregtech.loaders.misc.GT_Achievements;
+import net.minecraft.block.Block;
+import net.minecraft.init.Blocks;
 import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.IChunkProvider;
@@ -40,7 +42,7 @@ public class GT_Worldgen_GT_Ore_Layer
     public static final int NO_ORE_IN_BOTTOM_LAYER=2;
     public static final int NO_OVERLAP=3;
     public static final int ORE_PLACED=4;
-
+    public static final int NO_OVERLAP_AIR_BLOCK=5;
     
     //public final boolean mMoon;
     //public final boolean mMars;
@@ -124,14 +126,18 @@ public class GT_Worldgen_GT_Ore_Layer
         int wX = Math.max( wXVein, aChunkX + 2);  // Bias placement by 2 blocks to prevent worldgen cascade.
         int eX = Math.min( eXVein, aChunkX + 2 + 16);
         if (wX >= eX) {  //No overlap between orevein and this chunk exists in X
-            /*
-            if (debugOrevein) {
-                GT_Log.out.println(
-                    "No X overlap"
-                );
+            Block tBlock = aWorld.getBlock(aChunkX + 8, tMinY, aChunkZ + 8);
+            if (tBlock.isReplaceableOreGen(aWorld, aChunkX+8, tMinY, aChunkZ + 8, Blocks.stone) ||
+                tBlock.isReplaceableOreGen(aWorld, aChunkX+8, tMinY, aChunkZ + 8, Blocks.netherrack) ||
+                tBlock.isReplaceableOreGen(aWorld, aChunkX+8, tMinY, aChunkZ + 8, Blocks.end_stone) ||
+                tBlock.isReplaceableOreGen(aWorld, aChunkX+8, tMinY, aChunkZ + 8, GregTech_API.sBlockGranites) ||
+                tBlock.isReplaceableOreGen(aWorld, aChunkX+8, tMinY, aChunkZ + 8, GregTech_API.sBlockStones) ) {
+                // Didn't reach, but could have placed. Save orevein for future use.
+                return NO_OVERLAP;
+            } else {
+                // Didn't reach, but couldn't place in test spot anywys, try for another orevein
+                return NO_OVERLAP_AIR_BLOCK;
             }
-            */
-            return NO_OVERLAP;
         }
         // Determine North/Sound ends of orevein
         int nZVein = aSeedZ - aRandom.nextInt(mSize);
@@ -140,14 +146,31 @@ public class GT_Worldgen_GT_Ore_Layer
         int nZ = Math.max(nZVein, aChunkZ + 2);  // Bias placement by 2 blocks to prevent worldgen cascade.
         int sZ = Math.min(sZVein, aChunkZ + 2 + 16);
         if (nZ >= sZ) { //No overlap between orevein and this chunk exists in Z
-            /*
-            if (debugOrevein) {
-                GT_Log.out.println(
-                    "No Z overlap"
-                );
+            Block tBlock = aWorld.getBlock(aChunkX + 8, tMinY, aChunkZ + 8);
+            if (tBlock.isReplaceableOreGen(aWorld, aChunkX+8, tMinY, aChunkZ + 8, Blocks.stone) ||
+                tBlock.isReplaceableOreGen(aWorld, aChunkX+8, tMinY, aChunkZ + 8, Blocks.netherrack) ||
+                tBlock.isReplaceableOreGen(aWorld, aChunkX+8, tMinY, aChunkZ + 8, Blocks.end_stone) ||
+                tBlock.isReplaceableOreGen(aWorld, aChunkX+8, tMinY, aChunkZ + 8, GregTech_API.sBlockGranites) ||
+                tBlock.isReplaceableOreGen(aWorld, aChunkX+8, tMinY, aChunkZ + 8, GregTech_API.sBlockStones) ) {
+                // Didn't reach, but could have placed. Save orevein for future use.
+                return NO_OVERLAP;
+            } else {
+                // Didn't reach, but couldn't place in test spot anywys, try for another orevein
+                return NO_OVERLAP_AIR_BLOCK;
             }
-            */
-            return NO_OVERLAP;
+        }
+
+        if (debugOrevein) {
+            String tDimensionName = aWorld.provider.getDimensionName();
+            GT_Log.out.print(
+                            "Trying Orevein:" + this.mWorldGenName +
+                            " Dimension=" + tDimensionName +
+                            " mX="+aChunkX/16+
+                            " mZ="+aChunkZ/16+
+                            " oreseedX="+ aSeedX/16 +
+                            " oreseedZ="+ aSeedZ/16 +
+                            " cY="+tMinY
+                            );
         }
         // Adjust the density down the more chunks we are away from the oreseed.  The 5 chunks surrounding the seed should always be max density due to truncation of Math.sqrt().
         int localDensity = Math.max(1, this.mDensity / ((int)Math.sqrt(2 + Math.pow(aChunkX/16 - aSeedX/16, 2) + Math.pow(aChunkZ/16 - aSeedZ/16, 2))) );
@@ -254,13 +277,6 @@ public class GT_Worldgen_GT_Ore_Layer
         if (debugOrevein) {
             String tDimensionName = aWorld.provider.getDimensionName();
             GT_Log.out.println(
-                            "Generated Orevein:" + this.mWorldGenName +
-                            " Dimension=" + tDimensionName +
-                            " mX="+aChunkX/16+
-                            " mZ="+aChunkZ/16+
-                            " oreseedX="+ aSeedX/16 +
-                            " oreseedZ="+ aSeedZ/16 +
-                            " cY="+tMinY+
                             " wXVein" + wXVein +
                             " eXVein" + eXVein +
                             " nZVein" + nZVein +

--- a/src/main/java/gregtech/common/GT_Worldgen_GT_Ore_Layer.java
+++ b/src/main/java/gregtech/common/GT_Worldgen_GT_Ore_Layer.java
@@ -126,12 +126,12 @@ public class GT_Worldgen_GT_Ore_Layer
         int wX = Math.max( wXVein, aChunkX + 2);  // Bias placement by 2 blocks to prevent worldgen cascade.
         int eX = Math.min( eXVein, aChunkX + 2 + 16);
         if (wX >= eX) {  //No overlap between orevein and this chunk exists in X
-            Block tBlock = aWorld.getBlock(aChunkX + 8, tMinY, aChunkZ + 8);
-            if (tBlock.isReplaceableOreGen(aWorld, aChunkX+8, tMinY, aChunkZ + 8, Blocks.stone) ||
-                tBlock.isReplaceableOreGen(aWorld, aChunkX+8, tMinY, aChunkZ + 8, Blocks.netherrack) ||
-                tBlock.isReplaceableOreGen(aWorld, aChunkX+8, tMinY, aChunkZ + 8, Blocks.end_stone) ||
-                tBlock.isReplaceableOreGen(aWorld, aChunkX+8, tMinY, aChunkZ + 8, GregTech_API.sBlockGranites) ||
-                tBlock.isReplaceableOreGen(aWorld, aChunkX+8, tMinY, aChunkZ + 8, GregTech_API.sBlockStones) ) {
+            Block tBlock = aWorld.getBlock(aChunkX + 7, tMinY, aChunkZ + 9);
+            if (tBlock.isReplaceableOreGen(aWorld, aChunkX+7, tMinY, aChunkZ + 9, Blocks.stone) ||
+                tBlock.isReplaceableOreGen(aWorld, aChunkX+7, tMinY, aChunkZ + 9, Blocks.netherrack) ||
+                tBlock.isReplaceableOreGen(aWorld, aChunkX+7, tMinY, aChunkZ + 9, Blocks.end_stone) ||
+                tBlock.isReplaceableOreGen(aWorld, aChunkX+7, tMinY, aChunkZ + 9, GregTech_API.sBlockGranites) ||
+                tBlock.isReplaceableOreGen(aWorld, aChunkX+7, tMinY, aChunkZ + 9, GregTech_API.sBlockStones) ) {
                 // Didn't reach, but could have placed. Save orevein for future use.
                 return NO_OVERLAP;
             } else {
@@ -146,12 +146,12 @@ public class GT_Worldgen_GT_Ore_Layer
         int nZ = Math.max(nZVein, aChunkZ + 2);  // Bias placement by 2 blocks to prevent worldgen cascade.
         int sZ = Math.min(sZVein, aChunkZ + 2 + 16);
         if (nZ >= sZ) { //No overlap between orevein and this chunk exists in Z
-            Block tBlock = aWorld.getBlock(aChunkX + 8, tMinY, aChunkZ + 8);
-            if (tBlock.isReplaceableOreGen(aWorld, aChunkX+8, tMinY, aChunkZ + 8, Blocks.stone) ||
-                tBlock.isReplaceableOreGen(aWorld, aChunkX+8, tMinY, aChunkZ + 8, Blocks.netherrack) ||
-                tBlock.isReplaceableOreGen(aWorld, aChunkX+8, tMinY, aChunkZ + 8, Blocks.end_stone) ||
-                tBlock.isReplaceableOreGen(aWorld, aChunkX+8, tMinY, aChunkZ + 8, GregTech_API.sBlockGranites) ||
-                tBlock.isReplaceableOreGen(aWorld, aChunkX+8, tMinY, aChunkZ + 8, GregTech_API.sBlockStones) ) {
+            Block tBlock = aWorld.getBlock(aChunkX + 7, tMinY, aChunkZ + 9);
+            if (tBlock.isReplaceableOreGen(aWorld, aChunkX+7, tMinY, aChunkZ + 9, Blocks.stone) ||
+                tBlock.isReplaceableOreGen(aWorld, aChunkX+7, tMinY, aChunkZ + 9, Blocks.netherrack) ||
+                tBlock.isReplaceableOreGen(aWorld, aChunkX+7, tMinY, aChunkZ + 9, Blocks.end_stone) ||
+                tBlock.isReplaceableOreGen(aWorld, aChunkX+7, tMinY, aChunkZ + 9, GregTech_API.sBlockGranites) ||
+                tBlock.isReplaceableOreGen(aWorld, aChunkX+7, tMinY, aChunkZ + 9, GregTech_API.sBlockStones) ) {
                 // Didn't reach, but could have placed. Save orevein for future use.
                 return NO_OVERLAP;
             } else {

--- a/src/main/java/gregtech/common/GT_Worldgenerator.java
+++ b/src/main/java/gregtech/common/GT_Worldgenerator.java
@@ -108,7 +108,13 @@ implements IWorldGenerator {
         public final IChunkProvider mChunkGenerator;
         public final IChunkProvider mChunkProvider;
         public final String mBiome;
+        // Used for outputting orevein weights and bins
+        //        static int test=0;
+
+
         // Local class to track which orevein seeds must be checked when doing chunkified worldgen
+
+
         class NearbySeeds {
             public int mX;
             public int mZ;
@@ -131,6 +137,12 @@ implements IWorldGenerator {
             this.mBiome = aBiome;
         }
 
+
+        // How to evaluate oregen distribution
+        // 
+
+
+        
         public void worldGenFindVein( int oreseedX, int oreseedZ) {
             // Explanation of oreveinseed implementation.
             // (long)this.mWorld.getSeed()<<16)    Deep Dark does two oregen passes, one with getSeed set to +1 the original world seed.  This pushes that +1 off the low bits of oreseedZ, so that the hashes are far apart for the two passes.
@@ -159,6 +171,22 @@ implements IWorldGenerator {
                     int placementAttempts = 0;
                     boolean oreveinFound = false;
                     int i;
+
+                    // Used for outputting orevein weights and bins
+                    /*
+                    if( test==0 )
+                        {
+                        test = 1;
+                        GT_Log.out.println(
+                            "sWeight = " + GT_Worldgen_GT_Ore_Layer.sWeight 
+                            );
+                        for (GT_Worldgen_GT_Ore_Layer tWorldGen : GT_Worldgen_GT_Ore_Layer.sList) {
+                            GT_Log.out.println(
+                                ( tWorldGen).mWorldGenName + " mWeight = " + ( tWorldGen).mWeight + " mSize = " + (tWorldGen).mSize
+                                );
+                            }
+                        }
+                    */
                     for( i = 0; (i < oreveinAttempts) && (!oreveinFound) && (placementAttempts<oreveinMaxPlacementAttempts); i++ ) {
                         int tRandomWeight = oreveinRNG.nextInt(GT_Worldgen_GT_Ore_Layer.sWeight);
                         for (GT_Worldgen_GT_Ore_Layer tWorldGen : GT_Worldgen_GT_Ore_Layer.sList) {
@@ -171,7 +199,8 @@ implements IWorldGenerator {
                                     switch(placementResult) {
                                         case GT_Worldgen_GT_Ore_Layer.ORE_PLACED:
                                             if (debugOrevein) GT_Log.out.println(
-                                                " Added oreveinSeed=" + oreveinSeed + 
+                                                " Added near oreveinSeed=" + oreveinSeed + " " +
+                                                ( tWorldGen).mWorldGenName +
                                                 " tries at oremix=" + i +
                                                 " placementAttempts=" + placementAttempts +
                                                 " dimensionName=" + tDimensionName
@@ -184,7 +213,26 @@ implements IWorldGenerator {
                                             // SHould do retry in this case until out of chances
                                             break;
                                         case GT_Worldgen_GT_Ore_Layer.NO_OVERLAP:
-                                            // Orevein didn't reach this chunk, can't add it yet to the hash
+                                            if (debugOrevein) GT_Log.out.println(
+                                                " Added far oreveinSeed=" + oreveinSeed + " " +
+                                                ( tWorldGen).mWorldGenName +
+                                                " tries at oremix=" + i +
+                                                " placementAttempts=" + placementAttempts +
+                                                " dimensionName=" + tDimensionName
+                                            );
+                                            validOreveins.put(oreveinSeed, tWorldGen);
+                                            oreveinFound = true;
+                                            break;
+                                        case GT_Worldgen_GT_Ore_Layer.NO_OVERLAP_AIR_BLOCK:
+                                            if (debugOrevein) GT_Log.out.println(
+                                                " No overlap and air block in test spot=" + oreveinSeed + " " +
+                                                ( tWorldGen).mWorldGenName +
+                                                " tries at oremix=" + i +
+                                                " placementAttempts=" + placementAttempts +
+                                                " dimensionName=" + tDimensionName
+                                            );
+                                            // SHould do retry in this case until out of chances
+                                            placementAttempts++;
                                             break;
                                     }
                                     break; // Try the next orevein
@@ -195,14 +243,14 @@ implements IWorldGenerator {
                                         " mX="+ this.mX +
                                         " mZ="+ this.mZ + 
                                         " oreseedX="+ oreseedX +
-                                        " oreseedZ="+ oreseedZ                                    
-                                    );    
+                                        " oreseedZ="+ oreseedZ
+                                    );
                                     e.printStackTrace(GT_Log.err);
                                 }
                             }
                         }
                     }
-                    // Only add an empty orevein if are unable to place a vein at the oreseed chunk.
+                    // Only add an empty orevein if unable to place a vein at the oreseed chunk.
                     if ((!oreveinFound) && (this.mX == oreseedX) && (this.mZ == oreseedZ)){
                         if (debugOrevein) GT_Log.out.println(
                             " Empty oreveinSeed="+ oreveinSeed +

--- a/src/main/java/gregtech/common/GT_Worldgenerator.java
+++ b/src/main/java/gregtech/common/GT_Worldgenerator.java
@@ -137,12 +137,30 @@ implements IWorldGenerator {
             this.mBiome = aBiome;
         }
 
-
         // How to evaluate oregen distribution
-        // 
+        // - Enable debugOreveins
+        // - Fly around for a while, or teleport jumping ~320 blocks at a time, with 
+        //   a 15-30s pause for worldgen to catch up
+        // - Do this across a large area, at least 2000x2000 blocks for good numbers
+        // - Open logs\gregtech.log
+        // - Using notepad++, do a Search | Find  - enter "Added" for the search term
+        // - Select Find All In Current Document
+        // - In the Search window, right-click and Select All
+        // - Copy and paste to a new file
+        // - Delete extraneous stuff at top, and blank line at bottom.  Line count is 
+        //   # of total oreveins
+        // - For simple spot checks, use Find All in Current Document for specific 
+        //   oremixes, ie ore.mix.diamond, to check how many appear in the list.
+        // - For more complex work, import file into Excel, and sort based on oremix 
+        //   column.  Drag select the oremix names, in the bottom right will be how many 
+        //   entries to add in a seperate tab to calculate %ages.
+        //
+        // When using the ore weights, discount or remove the high altitude veins since
+        // their high weight are offset by their rareness. I usually just use zero for them.
+        // Actual spawn rates will vary based upon the average height of the stone layers
+        // in the dimension. For example veins that range above and below the average height 
+        // will be less, and veins that are completely above the average height will be much less.
 
-
-        
         public void worldGenFindVein( int oreseedX, int oreseedZ) {
             // Explanation of oreveinseed implementation.
             // (long)this.mWorld.getSeed()<<16)    Deep Dark does two oregen passes, one with getSeed set to +1 the original world seed.  This pushes that +1 off the low bits of oreseedZ, so that the hashes are far apart for the two passes.


### PR DESCRIPTION
This fixes the problem with ore ratios skewing due to larger oreveins being more likely to reach the generating chunk and be placed. 

If an orevein doesn't reach the chunk, but the chunk had a replaceable block at 7,9, then the orevein is saved anyways to the list of valid veins.