### PR TITLE
Upstream texture changes

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch.java
@@ -76,6 +76,14 @@ public abstract class GT_MetaTileEntity_Hatch extends GT_MetaTileEntity_BasicTan
         mMachineBlock=actualTexture;
     }
 
+    /**
+     * 
+     * @param textureIndex
+     * Index between 0-127.
+     * Add 128 per page, if texture index is not on first page.
+     * 
+     */
+    
     public final void updateTexture(int textureIndex){
         onValueUpdate((byte) textureIndex);
         onTexturePageUpdate((byte) (textureIndex>>7));

--- a/src/main/java/gregtech/api/util/GT_Utility.java
+++ b/src/main/java/gregtech/api/util/GT_Utility.java
@@ -9,9 +9,11 @@ import gregtech.api.enchants.Enchantment_Radioactivity;
 import gregtech.api.enums.GT_Values;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.SubTag;
+import gregtech.api.enums.Textures;
 import gregtech.api.events.BlockScanningEvent;
 import gregtech.api.interfaces.IDebugableBlock;
 import gregtech.api.interfaces.IProjectileItem;
+import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.tileentity.*;
 import gregtech.api.items.GT_EnergyArmor_Item;
 import gregtech.api.items.GT_Generic_Item;
@@ -1123,6 +1125,17 @@ public class GT_Utility {
             if (tStack != null && (tStack.stackSize == 0 || tStack.getItem() == null))
                 aInventory.setInventorySlotContents(i, null);
         }
+    }
+
+    /**
+     * Initializes a new texture page.
+     */
+    public static boolean addTexturePage(byte page){
+        if(Textures.BlockIcons.casingTexturePages[page]==null){
+            Textures.BlockIcons.casingTexturePages[page]=new ITexture[128];
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/gregtech/common/blocks/GT_Block_Casings1.java
+++ b/src/main/java/gregtech/common/blocks/GT_Block_Casings1.java
@@ -10,12 +10,28 @@ import net.minecraft.world.IBlockAccess;
 
 public class GT_Block_Casings1
         extends GT_Block_Casings_Abstract {
+	
+	/**
+	 * Texture Index Information
+	 * Textures.BlockIcons.casingTexturePages[0][0-63] - Gregtech
+	 * Textures.BlockIcons.casingTexturePages[0][64-127] - GT++
+	 * Textures.BlockIcons.casingTexturePages[1][0-127] - Gregtech
+	 * Textures.BlockIcons.casingTexturePages[2][0-127] - Free
+	 * Textures.BlockIcons.casingTexturePages[3][0-127] - Free
+	 * Textures.BlockIcons.casingTexturePages[4][0-127] - Free
+	 * Textures.BlockIcons.casingTexturePages[5][0-127] - Free
+	 * Textures.BlockIcons.casingTexturePages[6][0-127] - Free
+	 * Textures.BlockIcons.casingTexturePages[7][0-127] - Free
+	 * Textures.BlockIcons.casingTexturePages[8][0-127] - TecTech	  
+	 */
+	
+	
     public GT_Block_Casings1() {
         super(GT_Item_Casings1.class, "gt.blockcasings", GT_Material_Casings.INSTANCE);
         for (byte i = 0; i < 16; i = (byte) (i + 1)) {
             Textures.BlockIcons.CASING_BLOCKS[i] = new GT_CopiedBlockTexture(this, 6, i);
         }
-        Textures.BlockIcons.CASING_BLOCKS[111] = new GT_CopiedBlockTexture(this, 6, 0);
+
         GT_LanguageManager.addStringLocalization(getUnlocalizedName() + ".0.name", "ULV Machine Casing");
         GT_LanguageManager.addStringLocalization(getUnlocalizedName() + ".1.name", "LV Machine Casing");
         GT_LanguageManager.addStringLocalization(getUnlocalizedName() + ".2.name", "MV Machine Casing");

--- a/src/main/java/gregtech/common/blocks/GT_Block_Casings2.java
+++ b/src/main/java/gregtech/common/blocks/GT_Block_Casings2.java
@@ -1,9 +1,11 @@
 package gregtech.common.blocks;
 
+import gregtech.api.enums.Dyes;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Textures;
 import gregtech.api.objects.GT_CopiedBlockTexture;
 import gregtech.api.util.GT_LanguageManager;
+import net.minecraft.block.Block;
 import net.minecraft.entity.Entity;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
@@ -15,8 +17,11 @@ public class GT_Block_Casings2
     public GT_Block_Casings2() {
         super(GT_Item_Casings2.class, "gt.blockcasings2", GT_Material_Casings.INSTANCE);
         for (byte i = 0; i < 16; i = (byte) (i + 1)) {
-            Textures.BlockIcons.CASING_BLOCKS[(i + 16)] = new GT_CopiedBlockTexture(this, 6, i);
-        }
+        	if (i != 6){
+        		Textures.BlockIcons.CASING_BLOCKS[(i + 16)] = new GT_CopiedBlockTexture(this, 6, i);
+        	}
+         }
+        
         GT_LanguageManager.addStringLocalization(getUnlocalizedName() + ".0.name", "Solid Steel Machine Casing");
         GT_LanguageManager.addStringLocalization(getUnlocalizedName() + ".1.name", "Frost Proof Machine Casing");
         GT_LanguageManager.addStringLocalization(getUnlocalizedName() + ".2.name", "Bronze Gear Box Casing");
@@ -49,6 +54,9 @@ public class GT_Block_Casings2
         ItemList.Casing_Pipe_Steel.set(new ItemStack(this, 1, 13));
         ItemList.Casing_Pipe_Titanium.set(new ItemStack(this, 1, 14));
         ItemList.Casing_Pipe_TungstenSteel.set(new ItemStack(this, 1, 15));
+        
+        //Special handler for Pyrolyse Oven Casing
+        Textures.BlockIcons.CASING_BLOCKS[22] = new GT_CopiedBlockTexture(Block.getBlockFromItem(ItemList.Casing_ULV.get(1).getItem()), 6, 0,Dyes.MACHINE_METAL.mRGBa);
     }
 
     public IIcon getIcon(int aSide, int aMeta) {

--- a/src/main/java/gregtech/common/blocks/GT_Block_Casings5.java
+++ b/src/main/java/gregtech/common/blocks/GT_Block_Casings5.java
@@ -6,6 +6,7 @@ import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Textures;
 import gregtech.api.objects.GT_CopiedBlockTexture;
 import gregtech.api.util.GT_LanguageManager;
+import gregtech.api.util.GT_Utility;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
 
@@ -13,8 +14,9 @@ public class GT_Block_Casings5
         extends GT_Block_Casings_Abstract {
     public GT_Block_Casings5() {
         super(GT_Item_Casings5.class, "gt.blockcasings5", GT_Material_Casings.INSTANCE);
+        GT_Utility.addTexturePage((byte) 1);
         for (byte i = 0; i < 16; i = (byte) (i + 1)) {
-            Textures.BlockIcons.CASING_BLOCKS[(i + 64)] = new GT_CopiedBlockTexture(this, 6, i);
+            Textures.BlockIcons.casingTexturePages[1][i] = new GT_CopiedBlockTexture(this, 6, i);
         }
         GT_LanguageManager.addStringLocalization(getUnlocalizedName() + ".0.name", "Cupronickel Coil Block");
         GT_LanguageManager.addStringLocalization(getUnlocalizedName() + ".1.name", "Kanthal Coil Block");

--- a/src/main/java/gregtech/common/blocks/GT_Block_Casings8.java
+++ b/src/main/java/gregtech/common/blocks/GT_Block_Casings8.java
@@ -15,8 +15,8 @@ public class GT_Block_Casings8
     //WATCH OUT FOR TEXTURE ID's
     public GT_Block_Casings8() {
         super(GT_Item_Casings8.class, "gt.blockcasings8", GT_Material_Casings.INSTANCE);
-        for (int i = 0; i < 2/*16*/; i = (i + 1)) {
-            Textures.BlockIcons.CASING_BLOCKS[(i + 64 + 14)] = new GT_CopiedBlockTexture(this, 6, i);
+        for (int i = 0; i < 1; i = (i + 1)) {
+            Textures.BlockIcons.casingTexturePages[1][i+48] = new GT_CopiedBlockTexture(this, 6, i);
         }
         GT_LanguageManager.addStringLocalization(getUnlocalizedName() + ".0.name", "Chemically Inert Machine Casing");
         GT_LanguageManager.addStringLocalization(getUnlocalizedName() + ".1.name", "PTFE Pipe Casing");

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeChemicalReactor.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeChemicalReactor.java
@@ -20,7 +20,7 @@ import java.util.ArrayList;
 
 public class GT_MetaTileEntity_LargeChemicalReactor extends GT_MetaTileEntity_MultiBlockBase {
 
-	private static final int CASING_INDEX = 64+14/*112*/;
+	private final int CASING_INDEX = 176;
 
 	public GT_MetaTileEntity_LargeChemicalReactor(int aID, String aName, String aNameRegional) {
 		super(aID, aName, aNameRegional);
@@ -58,11 +58,11 @@ public class GT_MetaTileEntity_LargeChemicalReactor extends GT_MetaTileEntity_Mu
 			boolean aRedstone) {
 		if (aSide == aFacing) {
 			return new ITexture[] {
-					Textures.BlockIcons.CASING_BLOCKS[CASING_INDEX],
+					Textures.BlockIcons.casingTexturePages[1][48],
 					new GT_RenderedTexture(aActive ? Textures.BlockIcons.OVERLAY_FRONT_LARGE_CHEMICAL_REACTOR_ACTIVE
 							: Textures.BlockIcons.OVERLAY_FRONT_LARGE_CHEMICAL_REACTOR) };
 		}
-		return new ITexture[] { Textures.BlockIcons.CASING_BLOCKS[CASING_INDEX] };
+		return new ITexture[] { Textures.BlockIcons.casingTexturePages[1][48] };
 	}
 	
 	@Override

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_PyrolyseOven.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_PyrolyseOven.java
@@ -172,13 +172,8 @@ public class GT_MetaTileEntity_PyrolyseOven extends GT_MetaTileEntity_MultiBlock
                             	}
                             }
                         } else if (h == 3) {// innen decke (ulv casings + input + muffler)
-<<<<<<< HEAD
-                            if ((!addInputToMachineList(tTileEntity, 111)) && (!addMufflerToMachineList(tTileEntity, 111))) {
-                                if (aBaseMetaTileEntity.getBlockOffset(xDir + i, h, zDir + j) != CasingBlock) {
-=======
                             if ((!addInputToMachineList(tTileEntity, 22)) && (!addMufflerToMachineList(tTileEntity, 22))) {
-                                if (aBaseMetaTileEntity.getBlockOffset(xDir + i, h, zDir + j) != GregTech_API.sBlockCasings1) {
->>>>>>> f70c7d40... Added documentation to updateTexture in GT_MetaTileEntity_Hatch.
+                                if (aBaseMetaTileEntity.getBlockOffset(xDir + i, h, zDir + j) != CasingBlock) {
                                     return false;
                                 }
                                 if (aBaseMetaTileEntity.getMetaIDOffset(xDir + i, h, zDir + j) != CasingMeta) {
@@ -190,15 +185,9 @@ public class GT_MetaTileEntity_PyrolyseOven extends GT_MetaTileEntity_MultiBlock
                                 return false;
                             }
                         }
-<<<<<<< HEAD
-                    } else {// Au�erer 5x5 ohne h�he
-                        if (h == 0) {// au�en boden (controller, output, energy, maintainance, rest ulv casings)
-                            if ((!addMaintenanceToMachineList(tTileEntity, 111)) && (!addOutputToMachineList(tTileEntity, 111)) && (!addEnergyInputToMachineList(tTileEntity, 111))) {
-=======
                     } else {// Aeusserer 5x5 ohne hoehe
                         if (h == 0) {// aussen boden (controller, output, energy, maintainance, rest ulv casings)
                             if ((!addMaintenanceToMachineList(tTileEntity, 22)) && (!addOutputToMachineList(tTileEntity, 22)) && (!addEnergyInputToMachineList(tTileEntity, 22))) {
->>>>>>> f70c7d40... Added documentation to updateTexture in GT_MetaTileEntity_Hatch.
                                 if ((xDir + i != 0) || (zDir + j != 0)) {//no controller
                                     if (aBaseMetaTileEntity.getBlockOffset(xDir + i, h, zDir + j) != CasingBlock) {
                                         return false;

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_PyrolyseOven.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_PyrolyseOven.java
@@ -3,12 +3,15 @@ package gregtech.common.tileentities.machines.multi;
 import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.registry.GameRegistry;
 import gregtech.api.GregTech_API;
+import gregtech.api.enums.Dyes;
+import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Textures;
 import gregtech.api.gui.GT_GUIContainer_MultiMachine;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_MultiBlockBase;
+import gregtech.api.objects.GT_CopiedBlockTexture;
 import gregtech.api.objects.GT_RenderedTexture;
 import gregtech.api.util.GT_Recipe;
 import gregtech.api.util.GT_Utility;
@@ -26,6 +29,9 @@ import java.util.Arrays;
 public class GT_MetaTileEntity_PyrolyseOven extends GT_MetaTileEntity_MultiBlockBase {
 	
 	private int coilMetaID;
+	public static GT_CopiedBlockTexture mTextureULV = new GT_CopiedBlockTexture(Block.getBlockFromItem(ItemList.Casing_ULV.get(1).getItem()), 6, 0,Dyes.MACHINE_METAL.mRGBa);
+	
+	//private final int CASING_INDEX = 22;
 
     public GT_MetaTileEntity_PyrolyseOven(int aID, String aName, String aNameRegional) {
         super(aID, aName, aNameRegional);
@@ -55,10 +61,9 @@ public class GT_MetaTileEntity_PyrolyseOven extends GT_MetaTileEntity_MultiBlock
 
     public ITexture[] getTexture(IGregTechTileEntity aBaseMetaTileEntity, byte aSide, byte aFacing, byte aColorIndex, boolean aActive, boolean aRedstone) {
         if (aSide == aFacing) {
-            return new ITexture[]{new GT_RenderedTexture(Textures.BlockIcons.MACHINE_8V_SIDE),
-                    new GT_RenderedTexture(aActive ? Textures.BlockIcons.OVERLAY_FRONT_PYROLYSE_OVEN_ACTIVE : Textures.BlockIcons.OVERLAY_FRONT_PYROLYSE_OVEN)};
+            return new ITexture[]{mTextureULV, new GT_RenderedTexture(aActive ? Textures.BlockIcons.OVERLAY_FRONT_PYROLYSE_OVEN_ACTIVE : Textures.BlockIcons.OVERLAY_FRONT_PYROLYSE_OVEN)};
         }
-        return new ITexture[]{new GT_RenderedTexture(Textures.BlockIcons.MACHINE_8V_SIDE)};
+        return new ITexture[]{mTextureULV};
     }
 
     public Object getClientGUI(int aID, InventoryPlayer aPlayerInventory, IGregTechTileEntity aBaseMetaTileEntity) {
@@ -167,8 +172,13 @@ public class GT_MetaTileEntity_PyrolyseOven extends GT_MetaTileEntity_MultiBlock
                             	}
                             }
                         } else if (h == 3) {// innen decke (ulv casings + input + muffler)
+<<<<<<< HEAD
                             if ((!addInputToMachineList(tTileEntity, 111)) && (!addMufflerToMachineList(tTileEntity, 111))) {
                                 if (aBaseMetaTileEntity.getBlockOffset(xDir + i, h, zDir + j) != CasingBlock) {
+=======
+                            if ((!addInputToMachineList(tTileEntity, 22)) && (!addMufflerToMachineList(tTileEntity, 22))) {
+                                if (aBaseMetaTileEntity.getBlockOffset(xDir + i, h, zDir + j) != GregTech_API.sBlockCasings1) {
+>>>>>>> f70c7d40... Added documentation to updateTexture in GT_MetaTileEntity_Hatch.
                                     return false;
                                 }
                                 if (aBaseMetaTileEntity.getMetaIDOffset(xDir + i, h, zDir + j) != CasingMeta) {
@@ -180,9 +190,15 @@ public class GT_MetaTileEntity_PyrolyseOven extends GT_MetaTileEntity_MultiBlock
                                 return false;
                             }
                         }
+<<<<<<< HEAD
                     } else {// Au�erer 5x5 ohne h�he
                         if (h == 0) {// au�en boden (controller, output, energy, maintainance, rest ulv casings)
                             if ((!addMaintenanceToMachineList(tTileEntity, 111)) && (!addOutputToMachineList(tTileEntity, 111)) && (!addEnergyInputToMachineList(tTileEntity, 111))) {
+=======
+                    } else {// Aeusserer 5x5 ohne hoehe
+                        if (h == 0) {// aussen boden (controller, output, energy, maintainance, rest ulv casings)
+                            if ((!addMaintenanceToMachineList(tTileEntity, 22)) && (!addOutputToMachineList(tTileEntity, 22)) && (!addEnergyInputToMachineList(tTileEntity, 22))) {
+>>>>>>> f70c7d40... Added documentation to updateTexture in GT_MetaTileEntity_Hatch.
                                 if ((xDir + i != 0) || (zDir + j != 0)) {//no controller
                                     if (aBaseMetaTileEntity.getBlockOffset(xDir + i, h, zDir + j) != CasingBlock) {
                                         return false;


### PR DESCRIPTION
Running the latest pre-release of GT++ and there were some texture issues on LCR & Pyrolyse, this commit was pointed out by codewarrior0/draknyte1 as missing from the GTNH fork.

Compiled & ran locally with no obvious issues & textures worked.