### PR TITLE
Fix transformers not exploding when receiving overvoltage through P2P-EU tunnels

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Transformer.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Transformer.java
@@ -1,5 +1,6 @@
 package gregtech.api.metatileentity.implementations;
 
+import appeng.api.parts.IPartHost;
 import cofh.api.energy.IEnergyProvider;
 import cofh.api.energy.IEnergyStorage;
 import crazypants.enderio.machine.capbank.TileCapBank;
@@ -150,7 +151,7 @@ public class GT_MetaTileEntity_Transformer extends GT_MetaTileEntity_TieredMachi
                     if (tTileEntity instanceof IReactorChamber) {
                         tTileEntity = (TileEntity) ((IReactorChamber) tTileEntity).getReactor();
                     }
-                    if (tTileEntity instanceof IEnergySource && ((IEnergySource) tTileEntity).emitsEnergyTo((TileEntity) aBaseMetaTileEntity, ForgeDirection.getOrientation(GT_Utility.getOppositeSide(i)))) {
+                    if (tTileEntity instanceof IEnergySource && !(tTileEntity instanceof IPartHost) && ((IEnergySource) tTileEntity).emitsEnergyTo((TileEntity) aBaseMetaTileEntity, ForgeDirection.getOrientation(GT_Utility.getOppositeSide(i)))) {
                         long tEU = Math.min(maxEUInput(), (long) ((IEnergySource) tTileEntity).getOfferedEnergy());
                         ((IEnergySource) tTileEntity).drawEnergy(tEU);
                         aBaseMetaTileEntity.injectEnergyUnits((byte) 6, tEU, 1);


### PR DESCRIPTION
Transformers were using the IC2 compat to draw IC2 energy from the tunnel before the tunnel got a chance to push GT energy into the transformer. Because this uses up the transformer's max amperage, the tunnel never gets a chance to push the GT energy into it.

This change makes sure the IC2 compat is not activated for P2P-EU tunnels.