### PR TITLE
Debug/chestbuffer

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
@@ -277,7 +277,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
         }
 
         mRunningThroughTick = true;
-        long tTime = System.currentTimeMillis();
+        long tTime = System.nanoTime();
         int tCode = 0;
         boolean aSideServer = isServerSide();
         boolean aSideClient = isClientSide();
@@ -573,11 +573,11 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
         }
 
         if (aSideServer && hasValidMetaTileEntity()) {
-            tTime = System.currentTimeMillis() - tTime;
+            tTime = System.nanoTime() - tTime;
             if (mTimeStatistics.length > 0)
                 mTimeStatistics[mTimeStatisticsIndex = (mTimeStatisticsIndex + 1) % mTimeStatistics.length] = (int) tTime;
-            if (tTime > 0 && tTime > GregTech_API.MILLISECOND_THRESHOLD_UNTIL_LAG_WARNING && mTickTimer > 1000 && getMetaTileEntity().doTickProfilingMessageDuringThisTick() && mLagWarningCount++ < 10)
-                System.out.println("WARNING: Possible Lag Source at [" + xCoord + ", " + yCoord + ", " + zCoord + "] in Dimension " + worldObj.provider.dimensionId + " with " + tTime + "ms caused by an instance of " + getMetaTileEntity().getClass());
+            if (tTime > 0 && tTime > (GregTech_API.MILLISECOND_THRESHOLD_UNTIL_LAG_WARNING*1000000) && mTickTimer > 1000 && getMetaTileEntity().doTickProfilingMessageDuringThisTick() && mLagWarningCount++ < 10)
+                System.out.println("WARNING: Possible Lag Source at [" + xCoord + ", " + yCoord + ", " + zCoord + "] in Dimension " + worldObj.provider.dimensionId + " with " + tTime + "ns caused by an instance of " + getMetaTileEntity().getClass());
         }
 
         mWorkUpdate = mInventoryChanged = mRunningThroughTick = false;
@@ -706,8 +706,14 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
         if (aLogLevel > 1) {
             if (mTimeStatistics.length > 0) {
                 double tAverageTime = 0;
-                for (int tTime : mTimeStatistics) tAverageTime += tTime;
-                tList.add("Average CPU-load of ~" + (tAverageTime / mTimeStatistics.length) + "ms since " + mTimeStatistics.length + " ticks.");
+                double tWorstTime = 0;
+                for (int tTime : mTimeStatistics) {
+                    tAverageTime += tTime;
+                    if (tTime > tWorstTime) {
+                        tWorstTime = tTime;
+                    }
+                }
+                tList.add("Average CPU-load of ~" + (tAverageTime / mTimeStatistics.length) + "ns since " + mTimeStatistics.length + " ticks with worst time of " + tWorstTime + "ns.");
             }
             if (mLagWarningCount > 0) {
                 tList.add("Caused " + (mLagWarningCount >= 10 ? "more than 10" : mLagWarningCount) + " Lag Spike Warnings (anything taking longer than " + GregTech_API.MILLISECOND_THRESHOLD_UNTIL_LAG_WARNING + "ms) on the Server.");

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
@@ -712,8 +712,10 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
                     if (tTime > tWorstTime) {
                         tWorstTime = tTime;
                     }
+                    // Uncomment this line to print out tick-by-tick times.
+                    //tList.add("tTime " + tTime);
                 }
-                tList.add("Average CPU-load of ~" + (tAverageTime / mTimeStatistics.length) + "ns since " + mTimeStatistics.length + " ticks with worst time of " + tWorstTime + "ns.");
+                tList.add("Average CPU-load of ~" + (tAverageTime / mTimeStatistics.length) + "ns over " + mTimeStatistics.length + " ticks with worst time of " + tWorstTime + "ns.");
             }
             if (mLagWarningCount > 0) {
                 tList.add("Caused " + (mLagWarningCount >= 10 ? "more than 10" : mLagWarningCount) + " Lag Spike Warnings (anything taking longer than " + GregTech_API.MILLISECOND_THRESHOLD_UNTIL_LAG_WARNING + "ms) on the Server.");

--- a/src/main/java/gregtech/common/tileentities/automation/GT_MetaTileEntity_ChestBuffer.java
+++ b/src/main/java/gregtech/common/tileentities/automation/GT_MetaTileEntity_ChestBuffer.java
@@ -49,17 +49,39 @@ public class GT_MetaTileEntity_ChestBuffer
     }
 
     protected void moveItems(IGregTechTileEntity aBaseMetaTileEntity, long aTimer) {
-        fillStacksIntoFirstSlots();
+        if(aBaseMetaTileEntity.hasInventoryBeenModified())
+        {
+            fillStacksIntoFirstSlots();
+        }
         super.moveItems(aBaseMetaTileEntity, aTimer);
-        fillStacksIntoFirstSlots();
+        if(mSuccess == 50) {
+            fillStacksIntoFirstSlots();
+        }
     }
 
     protected void fillStacksIntoFirstSlots() {
         for (int i = 0; i < this.mInventory.length - 1; i++) {
             for (int j = i + 1; j < this.mInventory.length - 1; j++) {
-                if ((this.mInventory[j] != null) && ((this.mInventory[i] == null) || (GT_Utility.areStacksEqual(this.mInventory[i], this.mInventory[j])))) {
+//                if ((this.mInventory[j] != null) && ((this.mInventory[i] == null) || (GT_Utility.areStacksEqual(this.mInventory[i], this.mInventory[j])))) {
+                if ((this.mInventory[j] != null) && ((GT_Utility.areStacksEqual(this.mInventory[i], this.mInventory[j])))) {
                     GT_Utility.moveStackFromSlotAToSlotB(getBaseMetaTileEntity(), getBaseMetaTileEntity(), j, i, (byte) 64, (byte) 1, (byte) 64, (byte) 1);
                 }
+            }
+        }
+        // Find first non-null item from the tail
+        int lastValid;
+        for( lastValid = this.mInventory.length-1; lastValid >0; lastValid-- ) {
+            if(this.mInventory[lastValid] == null) {
+                continue;
+                }
+            break;
+        }
+        // Go back to the start of the array, swapping any nulls with the last valid item and move last valid item down 1
+        for (int i = lastValid; i >= 0; i-- ) {
+            if(this.mInventory[i] == null) {
+                //Swap the current null with the last valid item
+                GT_Utility.moveStackFromSlotAToSlotB(getBaseMetaTileEntity(), getBaseMetaTileEntity(), lastValid, i, (byte) 64, (byte) 1, (byte) 64, (byte) 1);
+                lastValid --;
             }
         }
     }


### PR DESCRIPTION
Adds better lag tracking debug output.  Lag is now tracked by ns. Output worst time as well as average time. 

Resolve https://github.com/GTNewHorizons/NewHorizons/issues/3006 with a change to using Java's Array.sort algorithm, and by throttling the block differently.  Pushes for 6 ticks after a success, then every 5 ticks for 50 ticks, old way was pushing for 50 ticks. Block can now be fully filled with 256 items without crushing server, about 450us average per block if fully filled and adding/emptying every tick. 

Does not dive deeper into NBT for sorting, may cause issues if items with different NBT are added, but shouldn't be too bad since insertion code will try to match an existing item first anyways.