### PR TITLE
Added option for disabling machinemetal tinting.

### DIFF
--- a/src/main/java/gregtech/GT_Mod.java
+++ b/src/main/java/gregtech/GT_Mod.java
@@ -220,6 +220,7 @@ public class GT_Mod implements IGT_Mod {
         GregTech_API.sMachineThunderExplosions = tMainConfig.get("machines", "lightning_causes_explosions", true).getBoolean(false);
         GregTech_API.sConstantEnergy = tMainConfig.get("machines", "constant_need_of_energy", true).getBoolean(false);
         GregTech_API.sColoredGUI = tMainConfig.get("machines", "colored_guis_when_painted", true).getBoolean(false);
+        GregTech_API.sUseMachineMetal = tMainConfig.get("machines", "use_machine_metal_tint", true).getBoolean(true);
 
         GregTech_API.sTimber = tMainConfig.get(aTextGeneral, "timber_axe", true).getBoolean(true);
         GregTech_API.sDrinksAlwaysDrinkable = tMainConfig.get(aTextGeneral, "drinks_always_drinkable", false).getBoolean(false);

--- a/src/main/java/gregtech/api/GregTech_API.java
+++ b/src/main/java/gregtech/api/GregTech_API.java
@@ -199,6 +199,12 @@ public class GregTech_API {
     public static boolean mTranslocator = false;
     public static boolean mTConstruct = false;
 
+    /**
+     * Option to not use MACHINE_METAL mixing into colors
+     */
+    public static boolean  sUseMachineMetal = false;
+    
+
     public static boolean mUseOnlyGoodSolderingMaterials = false;
 
     private static final String aTextIC2Lower = MOD_ID_IC2.toLowerCase(Locale.ENGLISH);

--- a/src/main/java/gregtech/api/enums/Textures.java
+++ b/src/main/java/gregtech/api/enums/Textures.java
@@ -703,7 +703,7 @@ public class Textures {
         static {
             for (byte i = 0; i < MACHINE_CASINGS.length; i++)
                 for (byte j = 0; j < MACHINE_CASINGS[i].length; j++)
-                    MACHINE_CASINGS[i][j] = new GT_SidedTexture(MACHINECASINGS_BOTTOM[i], MACHINECASINGS_TOP[i], MACHINECASINGS_SIDE[i], Dyes.getModulation(j - 1, Dyes.MACHINE_METAL.mRGBa));
+                    MACHINE_CASINGS[i][j] = new GT_SidedTexture(MACHINECASINGS_BOTTOM[i], MACHINECASINGS_TOP[i], MACHINECASINGS_SIDE[i], Dyes.getModulation(j - 1, (GregTech_API.sUseMachineMetal) ? Dyes.MACHINE_METAL.mRGBa : Dyes.dyeWhite.mRGBa));
             casingTexturePages[0]=CASING_BLOCKS;
             if(casingTexturePages[8]==null)
                 casingTexturePages[8]=new ITexture[128];

--- a/src/main/java/gregtech/api/gui/GT_GUIContainerMetaTile_Machine.java
+++ b/src/main/java/gregtech/api/gui/GT_GUIContainerMetaTile_Machine.java
@@ -31,7 +31,7 @@ public class GT_GUIContainerMetaTile_Machine extends GT_GUIContainer {
             byte colorByte=mContainer.mTileEntity.getColorization();
             Dyes color;
             if(colorByte != -1) color= Dyes.get(colorByte);
-            else color=Dyes.MACHINE_METAL;
+            else color=(GregTech_API.sUseMachineMetal) ? Dyes.MACHINE_METAL : Dyes.dyeWhite; // Maybe not use white here?
             GL11.glColor3ub((byte)color.mRGBa[0], (byte)color.mRGBa[1], (byte)color.mRGBa[2]);
         } else GL11.glColor3ub((byte)255,(byte)255,(byte)255);
     }

--- a/src/main/java/gregtech/common/blocks/GT_Block_Casings1.java
+++ b/src/main/java/gregtech/common/blocks/GT_Block_Casings1.java
@@ -1,5 +1,6 @@
 package gregtech.common.blocks;
 
+import gregtech.api.GregTech_API;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Textures;
 import gregtech.api.objects.GT_CopiedBlockTexture;
@@ -94,6 +95,10 @@ public class GT_Block_Casings1
     }
 
     public int colorMultiplier(IBlockAccess aWorld, int aX, int aY, int aZ) {
-        return aWorld.getBlockMetadata(aX, aY, aZ) > 9 ? super.colorMultiplier(aWorld, aX, aY, aZ) : gregtech.api.enums.Dyes.MACHINE_METAL.mRGBa[0] << 16 | gregtech.api.enums.Dyes.MACHINE_METAL.mRGBa[1] << 8 | gregtech.api.enums.Dyes.MACHINE_METAL.mRGBa[2];
+        if (GregTech_API.sUseMachineMetal) {
+            return aWorld.getBlockMetadata(aX, aY, aZ) > 9 ? super.colorMultiplier(aWorld, aX, aY, aZ) : gregtech.api.enums.Dyes.MACHINE_METAL.mRGBa[0] << 16 | gregtech.api.enums.Dyes.MACHINE_METAL.mRGBa[1] << 8 | gregtech.api.enums.Dyes.MACHINE_METAL.mRGBa[2];
+        } else {
+            return aWorld.getBlockMetadata(aX, aY, aZ) > 9 ? super.colorMultiplier(aWorld, aX, aY, aZ) : gregtech.api.enums.Dyes.dyeWhite.mRGBa[0] << 16 | gregtech.api.enums.Dyes.dyeWhite.mRGBa[1] << 8 | gregtech.api.enums.Dyes.dyeWhite.mRGBa[2];
+        }
     }
 }

--- a/src/main/java/gregtech/common/blocks/GT_Block_Casings2.java
+++ b/src/main/java/gregtech/common/blocks/GT_Block_Casings2.java
@@ -1,5 +1,6 @@
 package gregtech.common.blocks;
 
+import gregtech.api.GregTech_API;
 import gregtech.api.enums.Dyes;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Textures;
@@ -56,8 +57,12 @@ public class GT_Block_Casings2
         ItemList.Casing_Pipe_TungstenSteel.set(new ItemStack(this, 1, 15));
         
         //Special handler for Pyrolyse Oven Casing
-        Textures.BlockIcons.CASING_BLOCKS[22] = new GT_CopiedBlockTexture(Block.getBlockFromItem(ItemList.Casing_ULV.get(1).getItem()), 6, 0,Dyes.MACHINE_METAL.mRGBa);
-    }
+        if (GregTech_API.sUseMachineMetal) {
+            Textures.BlockIcons.CASING_BLOCKS[22] = new GT_CopiedBlockTexture(Block.getBlockFromItem(ItemList.Casing_ULV.get(1).getItem()), 6, 0,Dyes.MACHINE_METAL.mRGBa);
+        } else {
+            Textures.BlockIcons.CASING_BLOCKS[22] = new GT_CopiedBlockTexture(Block.getBlockFromItem(ItemList.Casing_ULV.get(1).getItem()), 6, 0,Dyes.dyeWhite.mRGBa);
+        }
+}
 
     public IIcon getIcon(int aSide, int aMeta) {
         switch (aMeta) {

--- a/src/main/java/gregtech/common/blocks/GT_Block_Casings6.java
+++ b/src/main/java/gregtech/common/blocks/GT_Block_Casings6.java
@@ -2,6 +2,7 @@ package gregtech.common.blocks;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import gregtech.api.GregTech_API;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Textures;
 import gregtech.api.objects.GT_CopiedBlockTexture;
@@ -98,6 +99,10 @@ public class GT_Block_Casings6
     }
 
     public int colorMultiplier(IBlockAccess aWorld, int aX, int aY, int aZ) {
-        return gregtech.api.enums.Dyes.MACHINE_METAL.mRGBa[0] << 16 | gregtech.api.enums.Dyes.MACHINE_METAL.mRGBa[1] << 8 | gregtech.api.enums.Dyes.MACHINE_METAL.mRGBa[2];
+        if(GregTech_API.sUseMachineMetal) {
+            return gregtech.api.enums.Dyes.MACHINE_METAL.mRGBa[0] << 16 | gregtech.api.enums.Dyes.MACHINE_METAL.mRGBa[1] << 8 | gregtech.api.enums.Dyes.MACHINE_METAL.mRGBa[2];
+        } else {
+            return gregtech.api.enums.Dyes.dyeWhite.mRGBa[0] << 16 | gregtech.api.enums.Dyes.dyeWhite.mRGBa[1] << 8 | gregtech.api.enums.Dyes.dyeWhite.mRGBa[2];
+        }
     }
 }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_PyrolyseOven.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_PyrolyseOven.java
@@ -29,7 +29,7 @@ import java.util.Arrays;
 public class GT_MetaTileEntity_PyrolyseOven extends GT_MetaTileEntity_MultiBlockBase {
 	
 	private int coilMetaID;
-	public static GT_CopiedBlockTexture mTextureULV = new GT_CopiedBlockTexture(Block.getBlockFromItem(ItemList.Casing_ULV.get(1).getItem()), 6, 0,Dyes.MACHINE_METAL.mRGBa);
+	public static GT_CopiedBlockTexture mTextureULV = new GT_CopiedBlockTexture(Block.getBlockFromItem(ItemList.Casing_ULV.get(1).getItem()), 6, 0,(GregTech_API.sUseMachineMetal)? Dyes.MACHINE_METAL.mRGBa : Dyes.dyeWhite.mRGBa);
 	
 	//private final int CASING_INDEX = 22;
 


### PR DESCRIPTION
https://github.com/GTNewHorizons/NewHorizons/issues/3032
https://github.com/GTNewHorizons/NewHorizons/issues/3031

Create config option to enable/disable machine metal tint on machines.  Need to test on servers.  Default is on. New default option will use dyeWhite instead, so no bias on textures.

Washing off dyes still isn't supported, but at least you can use a white spraycan to get back to white default.