### PR TITLE
Pipe/Cable overhaul & Add filter output on fluid filters

### DIFF
--- a/src/main/java/gregtech/api/interfaces/tileentity/IEnergyConnected.java
+++ b/src/main/java/gregtech/api/interfaces/tileentity/IEnergyConnected.java
@@ -35,17 +35,14 @@ public interface IEnergyConnected extends IColoredTileEntity, IHasWorldObjectAnd
      * Sided Energy Input
      */
     public boolean inputEnergyFrom(byte aSide);
+    public boolean inputEnergyFrom(byte aSide, boolean waitForActive);
 
     /**
      * Sided Energy Output
      */
     public boolean outputsEnergyTo(byte aSide);
+    public boolean outputsEnergyTo(byte aSide, boolean waitForActive);
 
-    /**
-     * Are we ready for energy state?
-     */
-    public boolean energyStateReady();
-    
     /**
      * Utility for the Network
      */

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
@@ -645,7 +645,17 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
     }
 
     @Override
+    public boolean inputEnergyFrom(byte aSide, boolean waitForActive) {
+        return false;
+    }
+
+    @Override
     public boolean outputsEnergyTo(byte aSide) {
+        return false;
+    }
+
+    @Override
+    public boolean outputsEnergyTo(byte aSide, boolean waitForActive) {
         return false;
     }
 
@@ -1362,9 +1372,4 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
     public void onEntityCollidedWithBlock(World aWorld, int aX, int aY, int aZ, Entity collider) {
         mMetaTileEntity.onEntityCollidedWithBlock(aWorld, aX, aY, aZ, collider);
     }
-
-	@Override
-	public boolean energyStateReady() {
-		return true;
-	}
 }

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Cable.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Cable.java
@@ -12,6 +12,7 @@ import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntityCable;
 import gregtech.api.interfaces.tileentity.IColoredTileEntity;
+import gregtech.api.interfaces.tileentity.ICoverable;
 import gregtech.api.interfaces.tileentity.IEnergyConnected;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.BaseMetaPipeEntity;
@@ -24,6 +25,7 @@ import gregtech.api.util.GT_Utility;
 import gregtech.common.GT_Client;
 import gregtech.common.covers.GT_Cover_SolarPanel;
 import gregtech.loaders.postload.PartP2PGTPower;
+import ic2.api.energy.tile.IEnergyEmitter;
 import ic2.api.energy.tile.IEnergySink;
 import ic2.api.energy.tile.IEnergySource;
 import net.minecraft.entity.Entity;
@@ -55,7 +57,6 @@ public class GT_MetaPipeEntity_Cable extends MetaPipeEntity implements IMetaTile
     public long mRestRF;
     public int mOverheat;
     public static short mMaxOverheat=(short) (GT_Mod.gregtechproxy.mWireHeatingTicks * 100);
-    private boolean mCheckConnections = !GT_Mod.gregtechproxy.gt6Cable;
 
     private int[] lastAmperage;
     private long lastWorldTick;
@@ -162,8 +163,8 @@ public class GT_MetaPipeEntity_Cable extends MetaPipeEntity implements IMetaTile
 
     @Override
     public long transferElectricity(byte aSide, long aVoltage, long aAmperage, ArrayList<TileEntity> aAlreadyPassedTileEntityList) {
-    	if (!isConnectedAtSide(aSide) && aSide != 6)
-    		return 0;
+        if (!isConnectedAtSide(aSide) && aSide != 6)
+            return 0;
         long rUsedAmperes = 0;
         aVoltage -= mCableLossPerMeter;
         if (aVoltage > 0) for (byte i = 0; i < 6 && aAmperage > rUsedAmperes; i++)
@@ -182,11 +183,6 @@ public class GT_MetaPipeEntity_Cable extends MetaPipeEntity implements IMetaTile
                         } else {
                             rUsedAmperes += ((IEnergyConnected) tTileEntity).injectEnergyUnits(GT_Utility.getOppositeSide(i), aVoltage, aAmperage - rUsedAmperes);
                         }
-//        		} else if (tTileEntity instanceof IEnergySink) {
-//            		ForgeDirection tDirection = ForgeDirection.getOrientation(i).getOpposite();
-//            		if (((IEnergySink)tTileEntity).acceptsEnergyFrom((TileEntity)getBaseMetaTileEntity(), tDirection)) {
-//            			if (((IEnergySink)tTileEntity).demandedEnergyUnits() > 0 && ((IEnergySink)tTileEntity).injectEnergyUnits(tDirection, aVoltage) < aVoltage) rUsedAmperes++;
-//            		}
                     } else if (tTileEntity instanceof IEnergySink) {
                         ForgeDirection tDirection = ForgeDirection.getOrientation(i).getOpposite();
                         if (((IEnergySink) tTileEntity).acceptsEnergyFrom((TileEntity) getBaseMetaTileEntity(), tDirection)) {
@@ -196,7 +192,7 @@ public class GT_MetaPipeEntity_Cable extends MetaPipeEntity implements IMetaTile
                     } else if (GregTech_API.mOutputRF && tTileEntity instanceof IEnergyReceiver) {
                         ForgeDirection tDirection = ForgeDirection.getOrientation(i).getOpposite();
                         long rfOUT = aVoltage * GregTech_API.mEUtoRF / 100;
-                        int  rfOut = rfOUT>Integer.MAX_VALUE ? Integer.MAX_VALUE : (int)rfOUT;
+                        int rfOut = rfOUT > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) rfOUT;
                         if (((IEnergyReceiver) tTileEntity).receiveEnergy(tDirection, rfOut, true) == rfOut) {
                             ((IEnergyReceiver) tTileEntity).receiveEnergy(tDirection, rfOut, false);
                             rUsedAmperes++;
@@ -216,12 +212,12 @@ public class GT_MetaPipeEntity_Cable extends MetaPipeEntity implements IMetaTile
                     }
                 }
             }
-        mTransferredVoltage=Math.max(mTransferredVoltage,aVoltage);
+        mTransferredVoltage = Math.max(mTransferredVoltage, aVoltage);
         mTransferredAmperage += rUsedAmperes;
         mTransferredVoltageLast20 = Math.max(mTransferredVoltageLast20, aVoltage);
         mTransferredAmperageLast20 = Math.max(mTransferredAmperageLast20, mTransferredAmperage);
-        if (aVoltage > mVoltage){
-            mOverheat+=Math.max(100,100*GT_Utility.getTier(aVoltage)-GT_Utility.getTier(mVoltage));
+        if (aVoltage > mVoltage) {
+            mOverheat += Math.max(100, 100 * GT_Utility.getTier(aVoltage) - GT_Utility.getTier(mVoltage));
         }
         if (mTransferredAmperage > mAmperage) return aAmperage;
         return rUsedAmperes;
@@ -299,19 +295,9 @@ public class GT_MetaPipeEntity_Cable extends MetaPipeEntity implements IMetaTile
                 mTransferredVoltageLast20 = 0;
                 mTransferredAmperageLast20OK=mTransferredAmperageLast20;
                 mTransferredAmperageLast20 = 0;
-                for (byte tSide = 0; tSide < 6; tSide++) {
-                	IGregTechTileEntity tBaseMetaTileEntity = aBaseMetaTileEntity.getIGregTechTileEntityAtSide(tSide);
-                	byte uSide = GT_Utility.getOppositeSide(tSide);
-                    if ((mCheckConnections || isConnectedAtSide(tSide)
-                    			|| aBaseMetaTileEntity.getCoverBehaviorAtSide(tSide).alwaysLookConnected(tSide, aBaseMetaTileEntity.getCoverIDAtSide(tSide), aBaseMetaTileEntity.getCoverDataAtSide(tSide), aBaseMetaTileEntity)
-                    			|| (tBaseMetaTileEntity != null && tBaseMetaTileEntity.getCoverBehaviorAtSide(uSide).alwaysLookConnected(uSide, tBaseMetaTileEntity.getCoverIDAtSide(uSide), tBaseMetaTileEntity.getCoverDataAtSide(uSide), tBaseMetaTileEntity)))
-                    		&& connect(tSide) == 0) {
-                    	disconnect(tSide);
-                    }
-                }
-                if (GT_Mod.gregtechproxy.gt6Cable) mCheckConnections = false;
+                if (!GT_Mod.gregtechproxy.gt6Cable) checkConnections();
             }
-        }else if(aBaseMetaTileEntity.isClientSide() && GT_Client.changeDetected==4) aBaseMetaTileEntity.issueTextureUpdate();
+        } else if(aBaseMetaTileEntity.isClientSide() && GT_Client.changeDetected==4) aBaseMetaTileEntity.issueTextureUpdate();
     }
 
     @Override
@@ -343,86 +329,62 @@ public class GT_MetaPipeEntity_Cable extends MetaPipeEntity implements IMetaTile
         return false;
     }
 
-	@Override
-	public int connect(byte aSide) {
-		int rConnect = 0;
-		if (aSide >= 6) return rConnect;
-		byte tSide = GT_Utility.getOppositeSide(aSide);
-		TileEntity tTileEntity = getBaseMetaTileEntity().getTileEntityAtSide(aSide);
-		GT_CoverBehavior coverBehavior = getBaseMetaTileEntity().getCoverBehaviorAtSide(aSide);
-		int coverId = getBaseMetaTileEntity().getCoverIDAtSide(aSide), coverData = getBaseMetaTileEntity().getCoverDataAtSide(aSide);
-		
-		boolean sAlwaysLookConnected = coverBehavior.alwaysLookConnected(aSide, coverId, coverData, getBaseMetaTileEntity());
-		boolean sLetEnergyIn = coverBehavior.letsEnergyIn(aSide, coverId, coverData, getBaseMetaTileEntity());
-		boolean sLetEnergyOut = coverBehavior.letsEnergyOut(aSide, coverId, coverData, getBaseMetaTileEntity()); 
+    @Override
+    public boolean letsIn(GT_CoverBehavior coverBehavior, byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity) {
+        return coverBehavior.letsEnergyIn(aSide, aCoverID, aCoverVariable, aTileEntity);
+    }
 
-        if (sAlwaysLookConnected || sLetEnergyIn || sLetEnergyOut) {
-            if (tTileEntity instanceof IColoredTileEntity) {
-                if (getBaseMetaTileEntity().getColorization() >= 0) {
-                    byte tColor = ((IColoredTileEntity) tTileEntity).getColorization();
-                    if (tColor >= 0 && tColor != getBaseMetaTileEntity().getColorization()) {
-                    	return rConnect;
-                    }
-                }
+    @Override
+    public boolean letsOut(GT_CoverBehavior coverBehavior, byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity) {
+        return coverBehavior.letsEnergyOut(aSide, aCoverID, aCoverVariable, aTileEntity);
+    }
+
+
+    @Override
+    public boolean canConnect(byte aSide, TileEntity tTileEntity) {
+        final IGregTechTileEntity gTileEntity = (tTileEntity instanceof IGregTechTileEntity) ? (IGregTechTileEntity) tTileEntity : null;
+        final GT_CoverBehavior coverBehavior = getBaseMetaTileEntity().getCoverBehaviorAtSide(aSide);
+        final byte tSide = GT_Utility.getOppositeSide(aSide);
+        final ForgeDirection tDir = ForgeDirection.getOrientation(tSide);
+
+        if (tTileEntity instanceof IColoredTileEntity) {
+            if (getBaseMetaTileEntity().getColorization() >= 0) {
+                byte tColor = ((IColoredTileEntity) tTileEntity).getColorization();
+                if (tColor >= 0 && tColor != getBaseMetaTileEntity().getColorization()) return false;
             }
-            
-            boolean sHasSolarPanel = coverBehavior instanceof GT_Cover_SolarPanel;
-            
-            boolean tIsEnergyIsConnected = tTileEntity instanceof IEnergyConnected;
-            boolean tEnergyInOrOut = (tIsEnergyIsConnected && (((IEnergyConnected) tTileEntity).inputEnergyFrom(tSide) || ((IEnergyConnected) tTileEntity).outputsEnergyTo(tSide)));
-            
-            boolean tIsGregTechTileEntity = tTileEntity instanceof IGregTechTileEntity;
-            boolean tIsTileEntityCable = tIsGregTechTileEntity && ((IGregTechTileEntity) tTileEntity).getMetaTileEntity() instanceof IMetaTileEntityCable; 
-            boolean tAlwaysLookConnected = tIsGregTechTileEntity && ((IGregTechTileEntity) tTileEntity).getCoverBehaviorAtSide(tSide).alwaysLookConnected(tSide, ((IGregTechTileEntity) tTileEntity).getCoverIDAtSide(tSide), ((IGregTechTileEntity) tTileEntity).getCoverDataAtSide(tSide), ((IGregTechTileEntity) tTileEntity));
-            boolean tLetEnergyIn = tIsGregTechTileEntity && ((IGregTechTileEntity) tTileEntity).getCoverBehaviorAtSide(tSide).letsEnergyIn(tSide, ((IGregTechTileEntity) tTileEntity).getCoverIDAtSide(tSide), ((IGregTechTileEntity) tTileEntity).getCoverDataAtSide(tSide), ((IGregTechTileEntity) tTileEntity));
-            boolean tLetEnergyOut = tIsGregTechTileEntity && ((IGregTechTileEntity) tTileEntity).getCoverBehaviorAtSide(tSide).letsEnergyOut(tSide, ((IGregTechTileEntity) tTileEntity).getCoverIDAtSide(tSide), ((IGregTechTileEntity) tTileEntity).getCoverDataAtSide(tSide), ((IGregTechTileEntity) tTileEntity));
-
-            boolean tIsEnergySink = tTileEntity instanceof IEnergySink;
-            boolean tSinkAcceptsEnergyFromSide = tIsEnergySink && ((IEnergySink) tTileEntity).acceptsEnergyFrom((TileEntity) getBaseMetaTileEntity(), ForgeDirection.getOrientation(tSide));
-            
-            boolean tIsGTp2pProvider = (GT_Mod.gregtechproxy.mAE2Integration && tTileEntity instanceof IEnergySource 
-            		&& tTileEntity instanceof IPartHost && ((IPartHost)tTileEntity).getPart(ForgeDirection.getOrientation(tSide)) instanceof PartP2PGTPower);
-            boolean tGTp2pProvidesEnergyToSide = tIsGTp2pProvider && ((IEnergySource) tTileEntity).emitsEnergyTo((TileEntity) getBaseMetaTileEntity(), ForgeDirection.getOrientation(tSide));
-
-            boolean tIsEnergyReceiver = tTileEntity instanceof IEnergyReceiver;
-            boolean tEnergyReceiverCanAcceptFromSide = tIsEnergyReceiver && ((IEnergyReceiver) tTileEntity).canConnectEnergy(ForgeDirection.getOrientation(tSide));
-
-            if (   (tIsEnergyIsConnected && tEnergyInOrOut)
-                || sHasSolarPanel
-                || ((tIsGregTechTileEntity && tIsTileEntityCable) && (tAlwaysLookConnected || tLetEnergyIn || tLetEnergyOut) )
-                || (tIsEnergySink && tSinkAcceptsEnergyFromSide)
-                || (tIsGTp2pProvider && tGTp2pProvidesEnergyToSide)
-        		|| (GregTech_API.mOutputRF && tIsEnergyReceiver && tEnergyReceiverCanAcceptFromSide)
-            		/*|| (tTileEntity instanceof IEnergyEmitter && ((IEnergyEmitter)tTileEntity).emitsEnergyTo((TileEntity)getBaseMetaTileEntity(), ForgeDirection.getOrientation(tSide)))*/) 
-			{
-                rConnect = 1;
-            }
-
-            if(D1 && rConnect == 0) {
-            	GT_Log.out.println("Gt6StyleCable - Debug: ");
-            	GT_Log.out.println("\t AlwaysLookConnected:" + sAlwaysLookConnected + " LetEnergyIn:" + sLetEnergyIn + " LetEnergyOut:" + sLetEnergyOut);
-            	GT_Log.out.println("\t sHasSolarPanel:" + sHasSolarPanel);
-            	GT_Log.out.println("\t tIsEnergyIsConnected:" + tIsEnergyIsConnected + " tEnergyInOrOut:" +tEnergyInOrOut);
-            	GT_Log.out.println("\t tIsGregTechTileEntity:" + tIsGregTechTileEntity + " tIsTileEntityCable:" + tIsTileEntityCable);
-            	GT_Log.out.println("\t tIsEnergySink:" + tIsEnergySink + " tSinkAcceptsEnergyFromSide:" + tSinkAcceptsEnergyFromSide );
-            	GT_Log.out.println("\t tIsGTp2pProvider:" + tIsGTp2pProvider + " tGTp2pProvidesEnergyToSide:" + tGTp2pProvidesEnergyToSide );
-            	GT_Log.out.println("\t tIsEnergyReceiver:" + tIsEnergyReceiver + " tEnergyReceiverCanAcceptFromSide:" + tEnergyReceiverCanAcceptFromSide );
-            }
-
         }
-		if (rConnect == 0) {
-			if ((!getBaseMetaTileEntity().getWorld().getChunkProvider().chunkExists(getBaseMetaTileEntity().getOffsetX(aSide, 1) >> 4, getBaseMetaTileEntity().getOffsetZ(aSide, 1) >> 4)) // if chunk unloaded
-					|| (tTileEntity instanceof IEnergyConnected && !((IEnergyConnected) tTileEntity).energyStateReady())) //Energy state not ready 
-			{ 
-				rConnect = -1;
-    			if(D1)  GT_Log.out.println("Gt6StyleCable - Deferring (dis)connection");
-    		}
-		}
-        if (rConnect > 0) {
-        	super.connect(aSide);
-        }
-        return rConnect;
-	}
+
+        // GT Machine handling
+        if ((tTileEntity instanceof IEnergyConnected) &&
+            (((IEnergyConnected) tTileEntity).inputEnergyFrom(tSide, false) || ((IEnergyConnected) tTileEntity).outputsEnergyTo(tSide, false)))
+            return true;
+
+        // Solar Panel Compat
+        if (coverBehavior instanceof GT_Cover_SolarPanel) return true;
+
+        // ((tIsGregTechTileEntity && tIsTileEntityCable) && (tAlwaysLookConnected || tLetEnergyIn || tLetEnergyOut) ) --> Not needed
+
+        // IC2 Compat
+        if ((tTileEntity instanceof IEnergySink) && ((IEnergySink) tTileEntity).acceptsEnergyFrom((TileEntity) getBaseMetaTileEntity(), tDir))
+            return true;
+
+        // AE2-p2p Compat
+        if (GT_Mod.gregtechproxy.mAE2Integration && tTileEntity instanceof IEnergySource &&
+            tTileEntity instanceof IPartHost && ((IPartHost)tTileEntity).getPart(tDir) instanceof PartP2PGTPower &&
+            ((IEnergySource) tTileEntity).emitsEnergyTo((TileEntity) getBaseMetaTileEntity(), tDir))
+            return true;
+
+        // RF Output Compat
+        if (GregTech_API.mOutputRF && tTileEntity instanceof IEnergyReceiver && ((IEnergyReceiver) tTileEntity).canConnectEnergy(tDir))
+            return true;
+
+        // RF Input Compat
+        if (GregTech_API.mInputRF && (tTileEntity instanceof IEnergyEmitter && ((IEnergyEmitter) tTileEntity).emitsEnergyTo((TileEntity)getBaseMetaTileEntity(), tDir)))
+            return true;
+
+
+        return false;
+    }
 
     @Override
     public boolean allowPullStack(IGregTechTileEntity aBaseMetaTileEntity, int aIndex, byte aSide, ItemStack aStack) {
@@ -458,8 +420,6 @@ public class GT_MetaPipeEntity_Cable extends MetaPipeEntity implements IMetaTile
     @Override
     public void loadNBTData(NBTTagCompound aNBT) {
         if (GT_Mod.gregtechproxy.gt6Cable) {
-        	if (!aNBT.hasKey("mConnections"))
-        		mCheckConnections = true;
         	mConnections = aNBT.getByte("mConnections");
         }
     }

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Fluid.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Fluid.java
@@ -10,14 +10,18 @@ import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.BaseMetaPipeEntity;
 import gregtech.api.metatileentity.MetaPipeEntity;
 import gregtech.api.objects.GT_RenderedTexture;
+import gregtech.api.util.GT_CoverBehavior;
 import gregtech.api.util.GT_Log;
 import gregtech.api.util.GT_Utility;
 import gregtech.common.GT_Client;
+import gregtech.common.covers.GT_Cover_Drain;
+import gregtech.common.covers.GT_Cover_FluidRegulator;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.world.World;
@@ -25,11 +29,10 @@ import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTankInfo;
 import net.minecraftforge.fluids.IFluidHandler;
+import org.apache.commons.lang3.tuple.MutableTriple;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map.Entry;
-import java.util.concurrent.ConcurrentHashMap;
 
 import static gregtech.api.enums.GT_Values.D1;
 import static gregtech.api.objects.XSTR.XSTR_INSTANCE;
@@ -41,7 +44,6 @@ public class GT_MetaPipeEntity_Fluid extends MetaPipeEntity {
     public final boolean mGasProof;
     public final FluidStack[] mFluids;
     public byte mLastReceivedFrom = 0, oLastReceivedFrom = 0;
-    private boolean mCheckConnections = !GT_Mod.gregtechproxy.gt6Pipe;
     /**
      * Bitmask for whether disable fluid input form each side.
      */
@@ -196,8 +198,6 @@ public class GT_MetaPipeEntity_Fluid extends MetaPipeEntity {
     		mFluids[i] = FluidStack.loadFluidStackFromNBT(aNBT.getCompoundTag("mFluid"+(i==0?"":i)));
         mLastReceivedFrom = aNBT.getByte("mLastReceivedFrom");
         if (GT_Mod.gregtechproxy.gt6Pipe) {
-        	if (!aNBT.hasKey("mConnections"))
-        		mCheckConnections = false;
         	mConnections = aNBT.getByte("mConnections");
         	mDisableInput = aNBT.getByte("mDisableInput");
         }
@@ -227,98 +227,114 @@ public class GT_MetaPipeEntity_Fluid extends MetaPipeEntity {
                 mLastReceivedFrom = 0;
             }
 
-            for (FluidStack tFluid : mFluids) {
-            	if (tFluid != null && tFluid.amount > 0) {
-                    int tTemperature = tFluid.getFluid().getTemperature(tFluid);
-                    if (tTemperature > mHeatResistance) {
-                        if (aBaseMetaTileEntity.getRandomNumber(100) == 0) {
-                            aBaseMetaTileEntity.setToFire();
-                            return;
-                        }
-                        aBaseMetaTileEntity.setOnFire();
-                    }
-                    if (!mGasProof && tFluid.getFluid().isGaseous(tFluid)) {
-                        tFluid.amount -= 5;
-                        sendSound((byte) 9);
-                        if (tTemperature > 320) {
-                            try {
-                                for (EntityLivingBase tLiving : (ArrayList<EntityLivingBase>) getBaseMetaTileEntity().getWorld().getEntitiesWithinAABB(EntityLivingBase.class, AxisAlignedBB.getBoundingBox(getBaseMetaTileEntity().getXCoord() - 2, getBaseMetaTileEntity().getYCoord() - 2, getBaseMetaTileEntity().getZCoord() - 2, getBaseMetaTileEntity().getXCoord() + 3, getBaseMetaTileEntity().getYCoord() + 3, getBaseMetaTileEntity().getZCoord() + 3))) {
-                                    GT_Utility.applyHeatDamage(tLiving, (tTemperature - 300) / 25.0F);
-                                }
-                            } catch (Throwable e) {
-                                if (D1) e.printStackTrace(GT_Log.err);
-                            }
-                        } else if (tTemperature < 260) {
-                            try {
-                                for (EntityLivingBase tLiving : (ArrayList<EntityLivingBase>) getBaseMetaTileEntity().getWorld().getEntitiesWithinAABB(EntityLivingBase.class, AxisAlignedBB.getBoundingBox(getBaseMetaTileEntity().getXCoord() - 2, getBaseMetaTileEntity().getYCoord() - 2, getBaseMetaTileEntity().getZCoord() - 2, getBaseMetaTileEntity().getXCoord() + 3, getBaseMetaTileEntity().getYCoord() + 3, getBaseMetaTileEntity().getZCoord() + 3))) {
-                                    GT_Utility.applyFrostDamage(tLiving, (270 - tTemperature) / 12.5F);
-                                }
-                            } catch (Throwable e) {
-                                if (D1) e.printStackTrace(GT_Log.err);
-                            }
-                        }
-                        if (tFluid.amount <= 0) tFluid = null;
-                    }
+            if (!GT_Mod.gregtechproxy.gt6Pipe) checkConnections();
+
+            boolean shouldDistribute = (oLastReceivedFrom == mLastReceivedFrom);
+            for (int i = 0, j = aBaseMetaTileEntity.getRandomNumber(mPipeAmount); i < mPipeAmount; i++) {
+                int index = (i + j) % mPipeAmount;
+                if (mFluids[index] != null && mFluids[index].amount <= 0) mFluids[index] = null;
+                if (mFluids[index] == null) continue;
+
+                if (checkEnvironment(index, aBaseMetaTileEntity)) return;
+
+                if (shouldDistribute) {
+                    distributeFluid(index, aBaseMetaTileEntity);
+                    mLastReceivedFrom = 0;
                 }
-            }
-
-            if (mLastReceivedFrom == oLastReceivedFrom) {
-                ConcurrentHashMap<IFluidHandler, ForgeDirection> tTanks = new ConcurrentHashMap<IFluidHandler, ForgeDirection>();
-                
-                for (byte tSide = 0, uSide = 0, i = 0, j = (byte) aBaseMetaTileEntity.getRandomNumber(6); i < 6; i++) {
-                	tSide = (byte) ((i + j) % 6);
-                	uSide = GT_Utility.getOppositeSide(tSide);
-                	IFluidHandler tTank = aBaseMetaTileEntity.getITankContainerAtSide(tSide);
-                	ICoverable tBaseMetaTileEntity = tTank instanceof ICoverable ? (ICoverable) tTank : null;
-                	if (mCheckConnections || isConnectedAtSide(tSide)
-                			|| aBaseMetaTileEntity.getCoverBehaviorAtSide(tSide).alwaysLookConnected(tSide, aBaseMetaTileEntity.getCoverIDAtSide(tSide), aBaseMetaTileEntity.getCoverDataAtSide(tSide), aBaseMetaTileEntity)
-                			|| (tBaseMetaTileEntity != null && tBaseMetaTileEntity.getCoverBehaviorAtSide(uSide).alwaysLookConnected(uSide, tBaseMetaTileEntity.getCoverIDAtSide(uSide), tBaseMetaTileEntity.getCoverDataAtSide(uSide), tBaseMetaTileEntity))) {
-                		switch (connect(tSide)) {
-                		case 0:
-                			disconnect(tSide); break;
-                		case 2:
-                			if ((mLastReceivedFrom & (1 << tSide)) == 0)
-                				tTanks.put(tTank, ForgeDirection.getOrientation(tSide).getOpposite()); break;
-                		}
-                	}
-                }
-                if (GT_Mod.gregtechproxy.gt6Pipe) mCheckConnections = false;
-                
-                for (int i = 0, j = aBaseMetaTileEntity.getRandomNumber(mPipeAmount); i < mPipeAmount; i++) {
-                	int index = (i + j) % mPipeAmount;
-                	if (mFluids[index] != null && mFluids[index].amount > 0) {
-                        int tAmount = Math.max(1, Math.min(mCapacity * 10, mFluids[index].amount / 2)), tSuccessfulTankAmount = 0;
-
-                        for (Entry<IFluidHandler, ForgeDirection> tEntry : tTanks.entrySet())
-                            if (tEntry.getKey().fill(tEntry.getValue(), drainFromIndex(tAmount, false, index), false) > 0)
-                                tSuccessfulTankAmount++;
-
-                        if (tSuccessfulTankAmount > 0) {
-                            if (tAmount >= tSuccessfulTankAmount) {
-                                tAmount /= tSuccessfulTankAmount;
-                                for (Entry<IFluidHandler, ForgeDirection> tTileEntity : tTanks.entrySet()) {
-                                    if (mFluids[index] == null || mFluids[index].amount <= 0) break;
-                                    int tFilledAmount = tTileEntity.getKey().fill(tTileEntity.getValue(), drainFromIndex(tAmount, false, index), false);
-                                    if (tFilledAmount > 0)
-                                        tTileEntity.getKey().fill(tTileEntity.getValue(), drainFromIndex(tFilledAmount, true, index), true);
-                                }
-                            } else {
-                                for (Entry<IFluidHandler, ForgeDirection> tTileEntity : tTanks.entrySet()) {
-                                    if (mFluids[index] == null || mFluids[index].amount <= 0) break;
-                                    int tFilledAmount = tTileEntity.getKey().fill(tTileEntity.getValue(), drainFromIndex(mFluids[index].amount, false, index), false);
-                                    if (tFilledAmount > 0)
-                                        tTileEntity.getKey().fill(tTileEntity.getValue(), drainFromIndex(tFilledAmount, true, index), true);
-                                }
-                            }
-                        }
-                    }
-                }
-
-                mLastReceivedFrom = 0;
             }
 
             oLastReceivedFrom = mLastReceivedFrom;
-        }else if(aBaseMetaTileEntity.isClientSide() && GT_Client.changeDetected==4) aBaseMetaTileEntity.issueTextureUpdate();
+
+        } else if(aBaseMetaTileEntity.isClientSide() && GT_Client.changeDetected==4) aBaseMetaTileEntity.issueTextureUpdate();
+    }
+
+    private boolean checkEnvironment(int index, IGregTechTileEntity aBaseMetaTileEntity) {
+        // Check for hot liquids that melt the pipe or gasses that escape and burn/freeze people
+        final FluidStack tFluid = mFluids[index];
+
+        if (tFluid != null && tFluid.amount > 0) {
+            int tTemperature = tFluid.getFluid().getTemperature(tFluid);
+            if (tTemperature > mHeatResistance) {
+                if (aBaseMetaTileEntity.getRandomNumber(100) == 0) {
+                    // Poof
+                    aBaseMetaTileEntity.setToFire();
+                    return true;
+                }
+                // Mmhmm, Fire
+                aBaseMetaTileEntity.setOnFire();
+            }
+            if (!mGasProof && tFluid.getFluid().isGaseous(tFluid)) {
+                tFluid.amount -= 5;
+                sendSound((byte) 9);
+                if (tTemperature > 320) {
+                    try {
+                        for (EntityLivingBase tLiving : (ArrayList<EntityLivingBase>) getBaseMetaTileEntity().getWorld().getEntitiesWithinAABB(EntityLivingBase.class, AxisAlignedBB.getBoundingBox(getBaseMetaTileEntity().getXCoord() - 2, getBaseMetaTileEntity().getYCoord() - 2, getBaseMetaTileEntity().getZCoord() - 2, getBaseMetaTileEntity().getXCoord() + 3, getBaseMetaTileEntity().getYCoord() + 3, getBaseMetaTileEntity().getZCoord() + 3))) {
+                            GT_Utility.applyHeatDamage(tLiving, (tTemperature - 300) / 25.0F);
+                        }
+                    } catch (Throwable e) {
+                        if (D1) e.printStackTrace(GT_Log.err);
+                    }
+                } else if (tTemperature < 260) {
+                    try {
+                        for (EntityLivingBase tLiving : (ArrayList<EntityLivingBase>) getBaseMetaTileEntity().getWorld().getEntitiesWithinAABB(EntityLivingBase.class, AxisAlignedBB.getBoundingBox(getBaseMetaTileEntity().getXCoord() - 2, getBaseMetaTileEntity().getYCoord() - 2, getBaseMetaTileEntity().getZCoord() - 2, getBaseMetaTileEntity().getXCoord() + 3, getBaseMetaTileEntity().getYCoord() + 3, getBaseMetaTileEntity().getZCoord() + 3))) {
+                            GT_Utility.applyFrostDamage(tLiving, (270 - tTemperature) / 12.5F);
+                        }
+                    } catch (Throwable e) {
+                        if (D1) e.printStackTrace(GT_Log.err);
+                    }
+                }
+            }
+            if (tFluid.amount <= 0) mFluids[index] = null;
+        }
+        return false;
+    }
+
+    private void distributeFluid(int index, IGregTechTileEntity aBaseMetaTileEntity) {
+        final FluidStack tFluid = mFluids[index];
+        if (tFluid == null) return;
+
+        // Tank, From, Amount to receive
+        List<MutableTriple<IFluidHandler, ForgeDirection, Integer>> tTanks = new ArrayList<>();
+
+        for (byte aSide, i = 0, j = (byte) aBaseMetaTileEntity.getRandomNumber(6); i < 6; i++) {
+            // Get a list of tanks accepting fluids, and what side they're on
+            aSide = (byte) ((i + j) % 6);
+            final byte tSide = GT_Utility.getOppositeSide(aSide);
+            final IFluidHandler tTank = aBaseMetaTileEntity.getITankContainerAtSide(aSide);
+            final IGregTechTileEntity gTank = tTank instanceof IGregTechTileEntity ? (IGregTechTileEntity) tTank : null;
+
+            if (isConnectedAtSide(aSide) && tTank != null && (mLastReceivedFrom & (1 << aSide)) == 0 &&
+                getBaseMetaTileEntity().getCoverBehaviorAtSide(aSide).letsFluidOut(aSide, getBaseMetaTileEntity().getCoverIDAtSide(aSide), getBaseMetaTileEntity().getCoverDataAtSide(aSide), tFluid.getFluid(), getBaseMetaTileEntity()) &&
+                (gTank == null || gTank.getCoverBehaviorAtSide(tSide).letsFluidIn(tSide, gTank.getCoverIDAtSide(tSide), gTank.getCoverDataAtSide(tSide), tFluid.getFluid(), gTank)))
+            {
+                if (tTank.fill(ForgeDirection.getOrientation(tSide), tFluid, false) > 0) {
+                    tTanks.add(new MutableTriple<>(tTank, ForgeDirection.getOrientation(tSide), 0));
+                }
+            }
+        }
+
+        // How much of this fluid is available for distribution?
+        double tAmount = Math.max(1, Math.min(mCapacity * 10, tFluid.amount)), tNumTanks = tTanks.size();
+        FluidStack maxFluid = tFluid.copy();
+        maxFluid.amount = Integer.MAX_VALUE;
+
+        double availableCapacity = 0;
+        // Calculate available capacity for distribution from all tanks
+        for (MutableTriple<IFluidHandler, ForgeDirection, Integer> tEntry: tTanks) {
+            tEntry.right = tEntry.left.fill(tEntry.middle, maxFluid, false);
+            availableCapacity += tEntry.right;
+        }
+
+        // Now distribute
+        for (MutableTriple<IFluidHandler, ForgeDirection, Integer> tEntry: tTanks) {
+            if (availableCapacity > tAmount) tEntry.right = (int) Math.floor(tEntry.right * tAmount / availableCapacity);
+            if (tEntry.right <= 0) continue;
+
+            int tFilledAmount = tEntry.left.fill(tEntry.middle, drainFromIndex(tEntry.right, false, index), false);
+
+            if (tFilledAmount > 0) tEntry.left.fill(tEntry.middle, drainFromIndex(tFilledAmount, true, index), true);
+        }
+
     }
 
     @Override
@@ -351,73 +367,53 @@ public class GT_MetaPipeEntity_Fluid extends MetaPipeEntity {
         return false;
     }
 
-	@Override
-	public int connect(byte aSide) {
-		int rConnect = 0;
-		if (aSide >= 6) return rConnect;
-		IFluidHandler tTileEntity = getBaseMetaTileEntity().getITankContainerAtSide(aSide);
-		GT_MetaPipeEntity_Fluid tFluidPipe = null;
-		byte tSide = GT_Utility.getOppositeSide(aSide);
-		if (tTileEntity != null) {
-            if (tTileEntity instanceof IGregTechTileEntity) {
-                if (getBaseMetaTileEntity().getColorization() >= 0) {
-                    byte tColor = ((IGregTechTileEntity) tTileEntity).getColorization();
-                    if (tColor >= 0 && (tColor & 15) != (getBaseMetaTileEntity().getColorization() & 15)) {
-                        return rConnect;
-                    }
-                }
-                if (((IGregTechTileEntity) tTileEntity).getMetaTileEntity() instanceof GT_MetaPipeEntity_Fluid) {
-                	tFluidPipe = (GT_MetaPipeEntity_Fluid) ((IGregTechTileEntity) tTileEntity).getMetaTileEntity();
-                }
-            } else if(GregTech_API.mTranslocator == true && tTileEntity instanceof tconstruct.smeltery.logic.FaucetLogic) {
-                // Tinker Construct Faucets return a null tank info, so check the class
-                rConnect = 1;
-            }
-            
-            FluidTankInfo[] tInfo = tTileEntity.getTankInfo(ForgeDirection.getOrientation(aSide).getOpposite());
-            if (tInfo != null) {
-            	if (tInfo.length > 0) {
-            		if (getBaseMetaTileEntity().getCoverBehaviorAtSide(aSide).letsFluidIn(aSide, getBaseMetaTileEntity().getCoverIDAtSide(aSide), getBaseMetaTileEntity().getCoverDataAtSide(aSide), null, getBaseMetaTileEntity())) {
-            			rConnect = 1;
-                    }
-            		if (getBaseMetaTileEntity().getCoverBehaviorAtSide(aSide).letsFluidOut(aSide, getBaseMetaTileEntity().getCoverIDAtSide(aSide), getBaseMetaTileEntity().getCoverDataAtSide(aSide), null, getBaseMetaTileEntity())) {
-                    	rConnect = 2;
-                    }
-            	} else if (tInfo.length == 0) {
-            		IGregTechTileEntity tSideTile = getBaseMetaTileEntity().getIGregTechTileEntityAtSide(aSide);
-                    if (tSideTile != null){
-                    	ItemStack tCover = tSideTile.getCoverItemAtSide(tSide);
-                    	if (tCover!=null &&(GT_Utility.areStacksEqual(tCover, ItemList.FluidRegulator_LV.get(1, new Object[]{},true)) || 
-                    			GT_Utility.areStacksEqual(tCover, ItemList.FluidRegulator_MV.get(1, new Object[]{},true)) || 
-                    			GT_Utility.areStacksEqual(tCover, ItemList.FluidRegulator_HV.get(1, new Object[]{},true)) || 
-                    			GT_Utility.areStacksEqual(tCover, ItemList.FluidRegulator_EV.get(1, new Object[]{},true)) || 
-                    			GT_Utility.areStacksEqual(tCover, ItemList.FluidRegulator_IV.get(1, new Object[]{},true)))) {
-                    		rConnect = 1;
-                    	}
-                    } else if(GregTech_API.mTranslocator == true && tTileEntity instanceof codechicken.translocator.TileLiquidTranslocator) {
-                        // Translocators return a TankInfo, but it's of 0 length - so check the class if we see this pattern
-                        rConnect = 1;
-                    }
-            	}
+    @Override
+    public boolean letsIn(GT_CoverBehavior coverBehavior, byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity) {
+        return coverBehavior.letsFluidIn(aSide, aCoverID, aCoverVariable, null, aTileEntity);
+    }
+
+    @Override
+    public boolean letsOut(GT_CoverBehavior coverBehavior, byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity) {
+        return coverBehavior.letsFluidOut(aSide, aCoverID, aCoverVariable, null, aTileEntity);
+    }
+
+    @Override
+    public boolean canConnect(byte aSide, TileEntity tTileEntity) {
+        if (tTileEntity == null) return false;
+
+        final byte tSide = (byte)ForgeDirection.getOrientation(aSide).getOpposite().ordinal();
+        final GT_CoverBehavior coverBehavior = getBaseMetaTileEntity().getCoverBehaviorAtSide(aSide);
+        final IGregTechTileEntity gTileEntity = (tTileEntity instanceof IGregTechTileEntity) ? (IGregTechTileEntity) tTileEntity : null;
+
+        if (coverBehavior instanceof GT_Cover_Drain) return true;
+
+        if (gTileEntity != null && getBaseMetaTileEntity().getColorization() >= 0) {
+            // If we're painted...
+            byte tColor = gTileEntity.getColorization();
+            if (tColor >= 0 && (tColor & 15) != (getBaseMetaTileEntity().getColorization() & 15)) {
+                // and the other tile entity is painted.. then we must both be painted the same color
+                return false;
             }
         }
-		if (rConnect == 0) {
-			if (!getBaseMetaTileEntity().getWorld().getChunkProvider().chunkExists(getBaseMetaTileEntity().getOffsetX(aSide, 1) >> 4, getBaseMetaTileEntity().getOffsetZ(aSide, 1) >> 4)) { // if chunk unloaded
-				rConnect = -1;
-			}
-		}
-		if (rConnect > 0) {
-			if (GT_Mod.gregtechproxy.gt6Pipe && tFluidPipe != null) {
-				if ((mDisableInput & (1 << aSide)) == 0 || (tFluidPipe.mDisableInput & (1 << tSide)) == 0) {
-					mConnections |= (1 << aSide);
-					if (!tFluidPipe.isConnectedAtSide(tSide)) tFluidPipe.connect(tSide);
-				} else rConnect = 0;
-			} else {
-				mConnections |= (1 << aSide);
-			}
-		}
-		return rConnect;
-	}
+
+        // Tinker Construct Faucets return a null tank info, so check the class
+        if (GregTech_API.mTConstruct && tTileEntity instanceof tconstruct.smeltery.logic.FaucetLogic) return true;
+
+        final IFluidHandler fTileEntity = (tTileEntity instanceof IFluidHandler) ? (IFluidHandler) tTileEntity : null;
+
+        if (fTileEntity != null) {
+        FluidTankInfo[] tInfo = fTileEntity.getTankInfo(ForgeDirection.getOrientation(tSide));
+            if (tInfo != null) {
+                if (tInfo.length > 0) return true;  // Already checked letsFluidIn/Out in connect()
+
+                // Translocators return a TankInfo, but it's of 0 length - so check the class if we see this pattern
+                if (GregTech_API.mTranslocator  && tTileEntity instanceof codechicken.translocator.TileLiquidTranslocator) return true;
+                if (gTileEntity != null && gTileEntity.getCoverBehaviorAtSide(tSide) instanceof GT_Cover_FluidRegulator) return true;
+
+            }
+       }
+        return false;
+    }
 
     @Override
     public void doSound(byte aIndex, double aX, double aY, double aZ) {

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Item.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Item.java
@@ -1,15 +1,16 @@
 package gregtech.api.metatileentity.implementations;
 
 import gregtech.GT_Mod;
-import gregtech.api.GregTech_API;
 import gregtech.api.enums.*;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntityItemPipe;
+import gregtech.api.interfaces.tileentity.ICoverable;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.BaseMetaPipeEntity;
 import gregtech.api.metatileentity.MetaPipeEntity;
 import gregtech.api.objects.GT_RenderedTexture;
+import gregtech.api.util.GT_CoverBehavior;
 import gregtech.api.util.GT_Utility;
 import gregtech.common.GT_Client;
 import net.minecraft.entity.Entity;
@@ -37,7 +38,6 @@ public class GT_MetaPipeEntity_Item extends MetaPipeEntity implements IMetaTileE
     public int mTransferredItems = 0;
     public byte mLastReceivedFrom = 0, oLastReceivedFrom = 0;
     public boolean mIsRestrictive = false;
-    private boolean mCheckConnections = !GT_Mod.gregtechproxy.gt6Pipe;
 
     public GT_MetaPipeEntity_Item(int aID, String aName, String aNameRegional, float aThickNess, Materials aMaterial, int aInvSlotCount, int aStepSize, boolean aIsRestrictive, int aTickTime) {
         super(aID, aName, aNameRegional, aInvSlotCount, false);
@@ -149,8 +149,6 @@ public class GT_MetaPipeEntity_Item extends MetaPipeEntity implements IMetaTileE
     public void loadNBTData(NBTTagCompound aNBT) {
         mLastReceivedFrom = aNBT.getByte("mLastReceivedFrom");
         if (GT_Mod.gregtechproxy.gt6Pipe) {
-        	if (!aNBT.hasKey("mConnections"))
-        		mCheckConnections = true;
         	mConnections = aNBT.getByte("mConnections");
         }
     }
@@ -159,18 +157,8 @@ public class GT_MetaPipeEntity_Item extends MetaPipeEntity implements IMetaTileE
     public void onPostTick(IGregTechTileEntity aBaseMetaTileEntity, long aTick) {
         if (aBaseMetaTileEntity.isServerSide() && aTick % 10 == 0) {
             if (aTick % mTickTime == 0) mTransferredItems = 0;
-            
-            for (byte tSide = 0; tSide < 6; tSide++) {
-            	IGregTechTileEntity tBaseMetaTileEntity = aBaseMetaTileEntity.getIGregTechTileEntityAtSide(tSide);
-            	byte uSide = GT_Utility.getOppositeSide(tSide);
-                if ((mCheckConnections || isConnectedAtSide(tSide)
-                			|| aBaseMetaTileEntity.getCoverBehaviorAtSide(tSide).alwaysLookConnected(tSide, aBaseMetaTileEntity.getCoverIDAtSide(tSide), aBaseMetaTileEntity.getCoverDataAtSide(tSide), aBaseMetaTileEntity)
-                			|| (tBaseMetaTileEntity != null && tBaseMetaTileEntity.getCoverBehaviorAtSide(uSide).alwaysLookConnected(uSide, tBaseMetaTileEntity.getCoverIDAtSide(uSide), tBaseMetaTileEntity.getCoverDataAtSide(uSide), tBaseMetaTileEntity)))
-                		&& connect(tSide) == 0) {
-                	disconnect(tSide);
-                }
-            }
-            if (GT_Mod.gregtechproxy.gt6Pipe) mCheckConnections = false;
+
+            if (!GT_Mod.gregtechproxy.gt6Pipe) checkConnections();
 
             if (oLastReceivedFrom == mLastReceivedFrom) {
                 doTickProfilingInThisTick = false;
@@ -212,61 +200,52 @@ public class GT_MetaPipeEntity_Item extends MetaPipeEntity implements IMetaTileE
         return false;
     }
 
-	@Override
-	public int connect(byte aSide) {
-		int rConnect = 0;
-		if (aSide >= 6) return rConnect;
-		TileEntity tTileEntity = getBaseMetaTileEntity().getTileEntityAtSide(aSide);
-		byte tSide = GT_Utility.getOppositeSide(aSide);
-        if (tTileEntity != null) {
-            boolean temp = GT_Utility.isConnectableNonInventoryPipe(tTileEntity, tSide);
-            if (tTileEntity instanceof IGregTechTileEntity) {
-                temp = true;
-                if (((IGregTechTileEntity) tTileEntity).getMetaTileEntity() == null) return rConnect;
-                if (getBaseMetaTileEntity().getColorization() >= 0) {
-                    byte tColor = ((IGregTechTileEntity) tTileEntity).getColorization();
-                    if (tColor >= 0 && tColor != getBaseMetaTileEntity().getColorization()) {
-                    	return rConnect;
-                    }
-                }
-                if (((IGregTechTileEntity) tTileEntity).getMetaTileEntity().connectsToItemPipe(tSide)) {
-                	rConnect = 1;
-                }
-            } else if(GregTech_API.mTranslocator == true && tTileEntity instanceof codechicken.translocator.TileItemTranslocator) {
-                rConnect = 1;
-            }
-            if (rConnect == 0) {
-            	if (tTileEntity instanceof IInventory) {
-                    temp = true;
-                    if (((IInventory) tTileEntity).getSizeInventory() <= 0) {
-                    	return rConnect;
-                    }
-                }
-                if (tTileEntity instanceof ISidedInventory) {
-                    temp = true;
-                    int[] tSlots = ((ISidedInventory) tTileEntity).getAccessibleSlotsFromSide(tSide);
-                    if (tSlots == null || tSlots.length <= 0) {
-                    	return rConnect;
-                    }
-                }
-                if (temp) {
-                    if (getBaseMetaTileEntity().getCoverBehaviorAtSide(aSide).letsItemsIn(aSide, getBaseMetaTileEntity().getCoverIDAtSide(aSide), getBaseMetaTileEntity().getCoverDataAtSide(aSide), -1, getBaseMetaTileEntity())
-                    		|| getBaseMetaTileEntity().getCoverBehaviorAtSide(aSide).letsItemsOut(aSide, getBaseMetaTileEntity().getCoverIDAtSide(aSide), getBaseMetaTileEntity().getCoverDataAtSide(aSide), -1, getBaseMetaTileEntity())) {
-                    	rConnect = 1;
-                    }
+    @Override
+    public boolean letsIn(GT_CoverBehavior coverBehavior, byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity) {
+        return coverBehavior.letsItemsIn(aSide, aCoverID, aCoverVariable, -1, aTileEntity);
+    }
+
+    @Override
+    public boolean letsOut(GT_CoverBehavior coverBehavior, byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity) {
+        return coverBehavior.letsItemsOut(aSide, aCoverID, aCoverVariable, -1, aTileEntity);
+    }
+
+    @Override
+    public boolean canConnect(byte aSide, TileEntity tTileEntity) {
+        if (tTileEntity == null) return false;
+
+        final byte tSide = GT_Utility.getOppositeSide(aSide);
+        boolean connectable = GT_Utility.isConnectableNonInventoryPipe(tTileEntity, tSide);
+
+        final IGregTechTileEntity gTileEntity = (tTileEntity instanceof IGregTechTileEntity) ? (IGregTechTileEntity) tTileEntity : null;
+        if (gTileEntity != null) {
+            if (gTileEntity.getMetaTileEntity() == null) return false;
+            connectable = true;
+            if ( getBaseMetaTileEntity().getColorization() >= 0) {
+                // If we're painted...
+                byte tColor = gTileEntity.getColorization();
+                if (tColor >= 0 && (tColor & 15) != (getBaseMetaTileEntity().getColorization() & 15)) {
+                    // and the other tile entity is painted.. then we must both be painted the same color
+                    return false;
                 }
             }
+            if (gTileEntity.getMetaTileEntity().connectsToItemPipe(tSide)) return true;
         }
-		if (rConnect == 0) {
-			if (!getBaseMetaTileEntity().getWorld().getChunkProvider().chunkExists(getBaseMetaTileEntity().getOffsetX(aSide, 1) >> 4, getBaseMetaTileEntity().getOffsetZ(aSide, 1) >> 4)) { // if chunk unloaded
-				rConnect = -1;
-			}
-		}
-        if (rConnect > 0) {
-        	super.connect(aSide);
+
+        if (tTileEntity instanceof IInventory) {
+            if (((IInventory) tTileEntity).getSizeInventory() <= 0) return false;
+            connectable = true;
         }
-        return rConnect;
-	}
+        if (tTileEntity instanceof ISidedInventory) {
+            int[] tSlots = ((ISidedInventory) tTileEntity).getAccessibleSlotsFromSide(tSide);
+            if (tSlots == null || tSlots.length <= 0) return false;
+
+            connectable = true;
+        }
+
+        return connectable;
+    }
+
 
     @Override
     public boolean incrementTransferCounter(int aIncrement) {

--- a/src/main/java/gregtech/api/util/GT_Utility.java
+++ b/src/main/java/gregtech/api/util/GT_Utility.java
@@ -365,9 +365,11 @@ public class GT_Utility {
     public static boolean isConnectableNonInventoryPipe(Object aTileEntity, int aSide) {
         if (aTileEntity == null) return false;
         checkAvailabilities();
-        if (TE_CHECK) if (aTileEntity instanceof IItemDuct) return true;
-        if (BC_CHECK) if (aTileEntity instanceof buildcraft.api.transport.IPipeTile)
+        if (TE_CHECK && aTileEntity instanceof IItemDuct) return true;
+        if (BC_CHECK && aTileEntity instanceof buildcraft.api.transport.IPipeTile)
             return ((buildcraft.api.transport.IPipeTile) aTileEntity).isPipeConnected(ForgeDirection.getOrientation(aSide));
+        if (GregTech_API.mTranslocator && aTileEntity instanceof codechicken.translocator.TileItemTranslocator) return true;
+
         return false;
     }
     /**

--- a/src/main/java/gregtech/common/blocks/GT_Item_Machines.java
+++ b/src/main/java/gregtech/common/blocks/GT_Item_Machines.java
@@ -158,8 +158,16 @@ public class GT_Item_Machines
                     tTileEntity.setOwnerName(aPlayer.getDisplayName());
                 }
                 tTileEntity.getMetaTileEntity().initDefaultModes(aStack.getTagCompound());
+                final byte aSide = GT_Utility.getOppositeSide(side);
                 if (tTileEntity.getMetaTileEntity() instanceof IConnectable) {
-                	((IConnectable) tTileEntity.getMetaTileEntity()).connect(GT_Utility.getOppositeSide(side));
+                    // If we're connectable, try connecting to whatever we're up against
+                	((IConnectable) tTileEntity.getMetaTileEntity()).connect(aSide);
+                } else if (aPlayer != null && aPlayer.isSneaking()) {
+                    // If we're being placed against something that is connectable, try telling it to connect to us
+                    IGregTechTileEntity aTileEntity = tTileEntity.getIGregTechTileEntityAtSide(aSide);
+                    if (aTileEntity != null && aTileEntity.getMetaTileEntity() instanceof IConnectable) {
+                        ((IConnectable) aTileEntity.getMetaTileEntity()).connect((byte)side);
+                    }
                 }
             }
         } else if (!aWorld.setBlock(aX, aY, aZ, this.field_150939_a, tDamage, 3)) {

--- a/src/main/java/gregtech/common/covers/GT_Cover_Fluidfilter.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_Fluidfilter.java
@@ -8,8 +8,18 @@ import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.*;
 
 
-public class GT_Cover_Fluidfilter
-        extends GT_CoverBehavior {
+public class GT_Cover_Fluidfilter extends GT_CoverBehavior {
+
+    // Uses the lower 3 bits of the cover variable, so we have 8 options to work with (0-7)
+    private final int FILTER_INPUT_DENY_OUTPUT = 0;
+    private final int INVERT_INPUT_DENY_OUTPUT = 1;
+    private final int FILTER_INPUT_ANY_OUTPUT = 2;
+    private final int INVERT_INPUT_ANY_OUTPUT = 3;
+    private final int DENY_INPUT_FILTER_OUTPUT = 4;
+    private final int DENY_INPUT_INVERT_OUTPUT = 5;
+    private final int ANY_INPUT_FILTER_OUTPUT = 6;
+    private final int ANY_INPUT_INVERT_OUTPUT = 7;
+
             
     public int doCoverThings(byte aSide, byte aInputRedstone, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
         return aCoverVariable;
@@ -17,42 +27,53 @@ public class GT_Cover_Fluidfilter
 
     public int onCoverScrewdriverclick(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, EntityPlayer aPlayer, float aX, float aY, float aZ) {
         int aFilterMode = aCoverVariable & 7;
-        aCoverVariable ^=aFilterMode;
-        aFilterMode = (aFilterMode + (aPlayer.isSneaking()? -1 : 1)) % 4;
-        if(aFilterMode < 0){aFilterMode = 3;}
+        aCoverVariable ^= aFilterMode;
+        aFilterMode = (aFilterMode + (aPlayer.isSneaking()? -1 : 1)) % 8;
+        if (aFilterMode < 0) {
+            aFilterMode = 7;
+        }
         switch(aFilterMode) {
-            case 0: GT_Utility.sendChatToPlayer(aPlayer, trans("043", "Allow input, no output")); break;
-            case 1: GT_Utility.sendChatToPlayer(aPlayer, trans("044", "Deny input, no output")); break;
-            case 2: GT_Utility.sendChatToPlayer(aPlayer, trans("045", "Allow input, permit any output")); break;
-            case 3: GT_Utility.sendChatToPlayer(aPlayer, trans("046", "Deny input, permit any output")); break;
+            case FILTER_INPUT_DENY_OUTPUT: GT_Utility.sendChatToPlayer(aPlayer, trans("043", "Filter input, Deny output")); break;
+            case INVERT_INPUT_DENY_OUTPUT: GT_Utility.sendChatToPlayer(aPlayer, trans("044", "Invert input, Deny output")); break;
+            case FILTER_INPUT_ANY_OUTPUT: GT_Utility.sendChatToPlayer(aPlayer, trans("045", "Filter input, Permit any output")); break;
+            case INVERT_INPUT_ANY_OUTPUT: GT_Utility.sendChatToPlayer(aPlayer, trans("046", "Invert input, Permit any output")); break;
+            case DENY_INPUT_FILTER_OUTPUT: GT_Utility.sendChatToPlayer(aPlayer, trans("219", "Deny input, Filter output")); break;
+            case DENY_INPUT_INVERT_OUTPUT: GT_Utility.sendChatToPlayer(aPlayer, trans("220", "Deny input, Invert output")); break;
+            case ANY_INPUT_FILTER_OUTPUT: GT_Utility.sendChatToPlayer(aPlayer, trans("221", "Permit any input, Filter output")); break;
+            case ANY_INPUT_INVERT_OUTPUT: GT_Utility.sendChatToPlayer(aPlayer, trans("222", "Permit any input, Invert output")); break;
         }
         aCoverVariable|=aFilterMode;
         return aCoverVariable;
     }
-    
+
     public boolean onCoverRightclick(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, EntityPlayer aPlayer, float aX, float aY, float aZ) {
-       //System.out.println("rightclick");
-        if (((aX > 0.375D) && (aX < 0.625D)) || ((aSide > 3) && (((aY > 0.375D) && (aY < 0.625D)) || ((aSide < 2) && (((aZ > 0.375D) && (aZ < 0.625D)) || (aSide == 2) || (aSide == 3)))))) {
+        //System.out.println("rightclick");
+        if (
+                ((aX > 0.375D) && (aX < 0.625D)) ||
+                ((aSide > 3) && ((aY > 0.375D) && (aY < 0.625D))) ||
+                ((aSide < 2) && ((aZ > 0.375D) && (aZ < 0.625D))) ||
+                (aSide == 2) ||
+                (aSide == 3)
+        ) {
             ItemStack tStack = aPlayer.inventory.getCurrentItem();
-            if(tStack!=null){
+            if (tStack == null) return true;
+
             FluidStack tFluid = FluidContainerRegistry.getFluidForFilledItem(tStack);
-            if(tFluid!=null){
-                //System.out.println(tFluid.getLocalizedName()+" "+tFluid.getFluidID());
+            if (tFluid != null) {
                 int aFluid = tFluid.getFluidID();
                 aCoverVariable = (aCoverVariable & 7) | (aFluid << 3);
                 aTileEntity.setCoverDataAtSide(aSide, aCoverVariable);
-                FluidStack sFluid = new FluidStack(FluidRegistry.getFluid(aFluid),1000);
+                FluidStack sFluid = new FluidStack(FluidRegistry.getFluid(aFluid), 1000);
                 GT_Utility.sendChatToPlayer(aPlayer, trans("047", "Filter Fluid: ") + sFluid.getLocalizedName());
-            }else if(tStack.getItem() instanceof IFluidContainerItem){
-                IFluidContainerItem tContainer = (IFluidContainerItem)tStack.getItem();
-                if(tContainer.getFluid(tStack) != null) {
+            } else if (tStack.getItem() instanceof IFluidContainerItem) {
+                IFluidContainerItem tContainer = (IFluidContainerItem) tStack.getItem();
+                if (tContainer.getFluid(tStack) != null) {
                     int aFluid = tContainer.getFluid(tStack).getFluidID();
                     aCoverVariable = (aCoverVariable & 7) | (aFluid << 3);
                     aTileEntity.setCoverDataAtSide(aSide, aCoverVariable);
-                    FluidStack sFluid = new FluidStack(FluidRegistry.getFluid(aFluid),1000);
+                    FluidStack sFluid = new FluidStack(FluidRegistry.getFluid(aFluid), 1000);
                     GT_Utility.sendChatToPlayer(aPlayer, trans("047", "Filter Fluid: ") + sFluid.getLocalizedName());
                 }
-            }
             }
             return true;
         }
@@ -61,18 +82,38 @@ public class GT_Cover_Fluidfilter
     
     @Override
     public boolean letsFluidIn(byte aSide, int aCoverID, int aCoverVariable, Fluid aFluid, ICoverable aTileEntity) {
-        if(aFluid==null){
-        	return true;
-        }
+        if (aFluid == null) return true;
+
         int aFilterMode = aCoverVariable & 7;
         int aFilterFluid = aCoverVariable >>> 3;
-        return aFluid.getID() == aFilterFluid ? aFilterMode == 0 || aFilterMode == 2 : aFilterMode == 1 || aFilterMode == 3;
+
+        if (aFilterMode == DENY_INPUT_FILTER_OUTPUT || aFilterMode == DENY_INPUT_INVERT_OUTPUT)
+            return false;
+        else if (aFilterMode == ANY_INPUT_FILTER_OUTPUT || aFilterMode == ANY_INPUT_INVERT_OUTPUT)
+            return true;
+        else if (aFluid.getID() == aFilterFluid)
+            return aFilterMode == FILTER_INPUT_DENY_OUTPUT || aFilterMode == FILTER_INPUT_ANY_OUTPUT;
+        else
+            return aFilterMode == INVERT_INPUT_DENY_OUTPUT || aFilterMode == INVERT_INPUT_ANY_OUTPUT;
+
     }
     
     @Override
     public boolean letsFluidOut(byte aSide, int aCoverID, int aCoverVariable, Fluid aFluid, ICoverable aTileEntity) {
+        if (aFluid == null) return true;
+
         int aFilterMode = aCoverVariable & 7;
-        return  aFilterMode != 0 && aFilterMode != 1;
+        int aFilterFluid = aCoverVariable >>> 3;
+
+        if (aFilterMode == FILTER_INPUT_DENY_OUTPUT || aFilterMode == INVERT_INPUT_DENY_OUTPUT)
+            return false;
+        else if (aFilterMode == FILTER_INPUT_ANY_OUTPUT || aFilterMode == INVERT_INPUT_ANY_OUTPUT)
+            return true;
+        else if (aFluid.getID() == aFilterFluid)
+            return aFilterMode == DENY_INPUT_FILTER_OUTPUT || aFilterMode == ANY_INPUT_FILTER_OUTPUT;
+        else
+            return aFilterMode == DENY_INPUT_INVERT_OUTPUT || aFilterMode == ANY_INPUT_INVERT_OUTPUT;
+
     }
     
     public boolean alwaysLookConnected(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity) {


### PR DESCRIPTION
*** DO NOT MERGE YET ***

CHANGED:
* Unified connect() method for pipes/wires - each subclass has it's own canConnect(), letsIn(), and letsOut() methods that map to the specifics for that implementation
* Shift Clicking while placing a GT machine will now try connecting to the cable/pipe it is placed on
* You can open a connection to the air for pipes & wires, allowing the next thing you place down to auto connect (ie: a JABBA barrel)
* Distribute Fluids - Modeled after several of the upstream PRs
* Fluid regulators on pipes should stop spazzing out now
* Fluid filter covers - Now work with filtering output

BUG/TODO:
* Spray paint doesn't seem to keep wires/pipes from connecting properly
* Spray paint on wires/pipes should force a disconnection check