### PR TITLE
GC Energy Compatibility & TransferEnergy updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,6 +107,10 @@ dependencies {
     provided ("com.enderio:EnderIO:${config.enderio.version}:dev") {
         transitive = false
     }
+//    compile files("libs/Galacticraft-API-1.7-${config.gc.version}.jar")
+//    compile files("libs/GalacticraftCore-Dev-${config.gc.version}.jar")
+    provided name: "Galacticraft-API", version: config.gc.version, ext: 'jar'
+    provided name: "GalacticraftCore-Dev", version: config.gc.version, ext: 'jar'
     provided name: 'CoFHLib', version: config.cofhlib.version, ext: 'jar'
     provided name: 'CoFHCore', version: config.cofhcore.version, ext: 'jar'
     provided name: 'Railcraft', version: config.railcraft.version, ext: 'jar'

--- a/build.properties
+++ b/build.properties
@@ -16,6 +16,7 @@ enderio.cf=2219/296
 enderio.version=1.7.10-2.3.0.417_beta
 enderiocore.version=1.7.10-0.1.0.25_beta
 forestry.version=4.2.10.58
+gc.version=1.7-3.0.12.504
 ic2.version=2.2.790-experimental
 nei.version=1.0.3.57
 railcraft.cf=2299/713

--- a/src/main/java/gregtech/GT_Mod.java
+++ b/src/main/java/gregtech/GT_Mod.java
@@ -180,9 +180,11 @@ public class GT_Mod implements IGT_Mod {
         GregTech_API.mGTPlusPlus = Loader.isModLoaded("miscutils");
         GregTech_API.mTranslocator = Loader.isModLoaded("Translocator");
         GregTech_API.mTConstruct = Loader.isModLoaded("TConstruct");
+        GregTech_API.mGalacticraft = Loader.isModLoaded("GalacticraftCore");
         GT_Log.out.println("GT_Mod: Are you there Translocator? " + GregTech_API.mTranslocator);
         GT_Log.out.println("GT_Mod: Are you there TConstruct? " + GregTech_API.mTConstruct);
-        
+        GT_Log.out.println("GT_Mod: Are you there GalacticraftCore? " + GregTech_API.mGalacticraft);
+
         GT_Log.mLogFile = new File(aEvent.getModConfigurationDirectory().getParentFile(), "logs/GregTech.log");
         if (!GT_Log.mLogFile.exists()) {
             try {
@@ -349,6 +351,7 @@ public class GT_Mod implements IGT_Mod {
         gregtechproxy.enableBasaltOres = GregTech_API.sWorldgenFile.get("general", "enableBasaltOres", gregtechproxy.enableBasaltOres);
         gregtechproxy.gt6Pipe = tMainConfig.get("general", "GT6StyledPipesConnection", true).getBoolean(true);
         gregtechproxy.gt6Cable = tMainConfig.get("general", "GT6StyledWiresConnection", true).getBoolean(true);
+        gregtechproxy.ic2EnergySourceCompat = tMainConfig.get("general", "Ic2EnergySourceCompat", true).getBoolean(true);
         gregtechproxy.costlyCableConnection = tMainConfig.get("general", "CableConnectionRequiresSolderingMaterial", false).getBoolean(false);
         GT_LanguageManager.i18nPlaceholder = tMainConfig.get("general", "EnablePlaceholderForMaterialNamesInLangFile", true).getBoolean(true);
 

--- a/src/main/java/gregtech/api/GregTech_API.java
+++ b/src/main/java/gregtech/api/GregTech_API.java
@@ -198,6 +198,7 @@ public class GregTech_API {
     public static boolean mGTPlusPlus = false;
     public static boolean mTranslocator = false;
     public static boolean mTConstruct = false;
+    public static boolean mGalacticraft = false;
 
     /**
      * Option to not use MACHINE_METAL mixing into colors

--- a/src/main/java/gregtech/api/interfaces/metatileentity/IMetaTileEntityCable.java
+++ b/src/main/java/gregtech/api/interfaces/metatileentity/IMetaTileEntityCable.java
@@ -3,7 +3,11 @@ package gregtech.api.interfaces.metatileentity;
 import net.minecraft.tileentity.TileEntity;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 
 public interface IMetaTileEntityCable extends IMetaTileEntity {
+    @Deprecated
     public long transferElectricity(byte aSide, long aVoltage, long aAmperage, ArrayList<TileEntity> aAlreadyPassedTileEntityList);
+
+    public long transferElectricity(byte aSide, long aVoltage, long aAmperage, HashSet<TileEntity> aAlreadyPassedSet);
 }

--- a/src/main/java/gregtech/api/interfaces/tileentity/IEnergyConnected.java
+++ b/src/main/java/gregtech/api/interfaces/tileentity/IEnergyConnected.java
@@ -64,10 +64,6 @@ public interface IEnergyConnected extends IColoredTileEntity, IHasWorldObjectAnd
                             if (tColor >= 0 && tColor != aEmitter.getColorization()) continue;
                         }
                         rUsedAmperes += ((IEnergyConnected) tTileEntity).injectEnergyUnits(j, aVoltage, aAmperage - rUsedAmperes);
-//				} else if (tTileEntity instanceof IEnergySink) {
-//	        		if (((IEnergySink)tTileEntity).acceptsEnergyFrom((TileEntity)aEmitter, ForgeDirection.getOrientation(j))) {
-//	        			while (aAmperage > rUsedAmperes && ((IEnergySink)tTileEntity).demandedEnergyUnits() > 0 && ((IEnergySink)tTileEntity).injectEnergyUnits(ForgeDirection.getOrientation(j), aVoltage) < aVoltage) rUsedAmperes++;
-//	        		}
                     } else if (tTileEntity instanceof IEnergySink) {
                         if (((IEnergySink) tTileEntity).acceptsEnergyFrom((TileEntity) aEmitter, ForgeDirection.getOrientation(j))) {
                             while (aAmperage > rUsedAmperes && ((IEnergySink) tTileEntity).getDemandedEnergy() > 0 && ((IEnergySink) tTileEntity).injectEnergy(ForgeDirection.getOrientation(j), aVoltage, aVoltage) < aVoltage)

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Cable.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Cable.java
@@ -214,7 +214,7 @@ public class GT_MetaPipeEntity_Cable extends MetaPipeEntity implements IMetaTile
             if (i != aSide && isConnectedAtSide(i) && baseMetaTile.getCoverBehaviorAtSide(i).letsEnergyOut(i, baseMetaTile.getCoverIDAtSide(i), baseMetaTile.getCoverDataAtSide(i), baseMetaTile)) {
                 final TileEntity tTileEntity = baseMetaTile.getTileEntityAtSide(i);
 
-                if (aAlreadyPassedSet.add(tTileEntity)) {
+                if (tTileEntity != null && aAlreadyPassedSet.add(tTileEntity)) {
                     final byte tSide = GT_Utility.getOppositeSide(i);
                     final IGregTechTileEntity tBaseMetaTile = tTileEntity instanceof IGregTechTileEntity ? ((IGregTechTileEntity) tTileEntity) : null;
                     final IMetaTileEntity tMeta = tBaseMetaTile != null ? tBaseMetaTile.getMetaTileEntity() : null;
@@ -243,7 +243,7 @@ public class GT_MetaPipeEntity_Cable extends MetaPipeEntity implements IMetaTile
     }
 
     private long insertEnergyInto(TileEntity tTileEntity, byte tSide, long aVoltage, long aAmperage) {
-        if (aAmperage == 0) return 0;
+        if (aAmperage == 0 || tTileEntity == null) return 0;
 
         final IGregTechTileEntity baseMetaTile = getBaseMetaTileEntity();
         final ForgeDirection tDirection = ForgeDirection.getOrientation(tSide);

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Fluid.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Fluid.java
@@ -382,7 +382,10 @@ public class GT_MetaPipeEntity_Fluid extends MetaPipeEntity {
         if (tTileEntity == null) return false;
 
         final byte tSide = (byte)ForgeDirection.getOrientation(aSide).getOpposite().ordinal();
-        final GT_CoverBehavior coverBehavior = getBaseMetaTileEntity().getCoverBehaviorAtSide(aSide);
+        final IGregTechTileEntity baseMetaTile = getBaseMetaTileEntity();
+        if (baseMetaTile == null) return false;
+
+        final GT_CoverBehavior coverBehavior = baseMetaTile.getCoverBehaviorAtSide(aSide);
         final IGregTechTileEntity gTileEntity = (tTileEntity instanceof IGregTechTileEntity) ? (IGregTechTileEntity) tTileEntity : null;
 
         if (coverBehavior instanceof GT_Cover_Drain) return true;
@@ -393,9 +396,9 @@ public class GT_MetaPipeEntity_Fluid extends MetaPipeEntity {
         final IFluidHandler fTileEntity = (tTileEntity instanceof IFluidHandler) ? (IFluidHandler) tTileEntity : null;
 
         if (fTileEntity != null) {
-        FluidTankInfo[] tInfo = fTileEntity.getTankInfo(ForgeDirection.getOrientation(tSide));
+            FluidTankInfo[] tInfo = fTileEntity.getTankInfo(ForgeDirection.getOrientation(tSide));
             if (tInfo != null) {
-                if (tInfo.length > 0) return true;  // Already checked letsFluidIn/Out in connect()
+                if (tInfo.length > 0) return true;
 
                 // Translocators return a TankInfo, but it's of 0 length - so check the class if we see this pattern
                 if (GregTech_API.mTranslocator  && tTileEntity instanceof codechicken.translocator.TileLiquidTranslocator) return true;

--- a/src/main/java/gregtech/common/GT_Proxy.java
+++ b/src/main/java/gregtech/common/GT_Proxy.java
@@ -207,6 +207,7 @@ public abstract class GT_Proxy implements IGT_Mod, IGuiHandler, IFuelHandler {
     public boolean enableBasaltOres = true;
     public boolean gt6Pipe = true;
     public boolean gt6Cable = true;
+    public boolean ic2EnergySourceCompat = true;
     public boolean costlyCableConnection = false;
 
     public GT_Proxy() {


### PR DESCRIPTION
GC Energy Compat
* GT cables now properly fill GalacticCraft machines with Energy

IC2/AE2 Energy Compat
* Updated IC2 & AE2 energy compatibility
* Added an option ic2EnergySourceCompat (default is on) to allow GT cables to pull energy directly from IC2 energy sources (nuclear reactors, MSFUs, etc) without the need for a transformer
* Filling IC2/AE2 energy buffers will now send multiple amps if needed

Misc
* Use a set instead of an arraylist for transfer electricity; deprecated backwards compatible method left in