### PR TITLE
Remove NBT data from turbines, preventing them from being disassembled.

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
@@ -435,7 +435,7 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity {
                     NBTTagCompound tNBT = mInventory[1].getTagCompound();
                     if (tNBT != null) {
                         NBTTagCompound tNBT2 = tNBT.getCompoundTag("GT.CraftingComponents");//tNBT2 dont use out if
-                        if (!tNBT.getBoolean("mDis")) {
+                        /*if (!tNBT.getBoolean("mDis")) {
                             tNBT2 = new NBTTagCompound();
                             Materials tMaterial = GT_MetaGenerated_Tool.getPrimaryMaterial(mInventory[1]);
                             ItemStack tTurbine = GT_OreDictUnificator.get(OrePrefixes.turbineBlade, tMaterial, 1);
@@ -487,7 +487,7 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity {
                             tNBT.setBoolean("mDis", true);
                             mInventory[1].setTagCompound(tNBT);
 
-                        }
+                        }*/
                     }
                     ((GT_MetaGenerated_Tool) mInventory[1].getItem()).doDamage(mInventory[1], (long)getDamageToComponent(mInventory[1]) * (long) Math.min(mEUt / this.damageFactorLow, Math.pow(mEUt, this.damageFactorHigh)));
                     if (mInventory[1].stackSize == 0) mInventory[1] = null;


### PR DESCRIPTION
As requested [here](https://github.com/GTNewHorizons/NewHorizons/issues/4970#issuecomment-547326772)

Turbine disassembly data does not exist when the turbine is initially crafted. After the rotor is inserted into a turbine, and damage is applied to it for the first time, the GT_MetaTileEntity_MulitBlockBase class writes the correct components to the rotors NBT. Simply commenting out the code that accomplishes this prevents disassembly data from being written to the rotors NBT.

I've tested this, the turbine still takes damage as it should, and breaks once it reaches zero durability. You can no longer disassemble the turbine, however. I don't think this affects any other functionality, but someone else should go and have a look.

Excuse the second account, needed it for a clean fork.