### PR TITLE
Provide owner's UUID to forge event bus for fake players.

### DIFF
--- a/src/main/java/gregtech/api/interfaces/tileentity/IGregTechTileEntity.java
+++ b/src/main/java/gregtech/api/interfaces/tileentity/IGregTechTileEntity.java
@@ -12,6 +12,7 @@ import net.minecraftforge.fluids.IFluidHandler;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 /**
  * A simple compound Interface for all my TileEntities.
@@ -91,6 +92,16 @@ public interface IGregTechTileEntity extends ITexturedTileEntity, IGearEnergyTil
      * gets the Name of the Machines Owner or "Player" if not set.
      */
     public String getOwnerName();
+
+    /**
+     * Gets the UniqueID of the Machines Owner.
+     */
+    public UUID getOwnerUuid();
+
+    /**
+     * Sets the UniqueID of the Machines Owner.
+     */
+    public void setOwnerUuid(UUID uuid);
 
     /**
      * Sets initial Values from NBT

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
@@ -6,6 +6,7 @@ import static gregtech.api.enums.GT_Values.NW;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 
 import gregtech.api.GregTech_API;
 import gregtech.api.enums.Textures;
@@ -1173,6 +1174,16 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
     @Override
     public String setOwnerName(String aName) {
         return "Player";
+    }
+
+    @Override
+    public UUID getOwnerUuid() {
+        return GT_Utility.defaultUuid;
+    }
+
+    @Override
+    public void setOwnerUuid(UUID uuid) {
+
     }
 
     @Override

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
@@ -39,6 +39,7 @@ import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 
 import static gregtech.GT_Mod.GT_FML_LOGGER;
 import static gregtech.api.enums.GT_Values.NW;
@@ -69,6 +70,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
     public long mLastSoundTick = 0;
     private long mLastCheckTick = 0;
     private String mOwnerName = "";
+    private UUID mOwnerUuid = GT_Utility.defaultUuid;
     private NBTTagCompound mRecipeStuff = new NBTTagCompound();
 
     private static final Field ENTITY_ITEM_HEALTH_FIELD;
@@ -116,6 +118,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
             aNBT.setByte("mStrongRedstone", mStrongRedstone);
             aNBT.setShort("mFacing", mFacing);
             aNBT.setString("mOwnerName", mOwnerName);
+            aNBT.setString("mOwnerUuid", mOwnerUuid == null ? "" : mOwnerUuid.toString());
             aNBT.setBoolean("mLockUpgrade", mLockUpgrade);
             aNBT.setBoolean("mMuffler", mMuffler);
             aNBT.setBoolean("mSteamConverter", mSteamConverter);
@@ -181,6 +184,11 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
             mStrongRedstone = aNBT.getByte("mStrongRedstone");
             mFacing = oFacing = (byte) aNBT.getShort("mFacing");
             mOwnerName = aNBT.getString("mOwnerName");
+            try {
+                mOwnerUuid = UUID.fromString(aNBT.getString("mOwnerUuid"));
+            } catch (IllegalArgumentException e){
+                mOwnerUuid = null;
+            }
             mLockUpgrade = aNBT.getBoolean("mLockUpgrade");
             mMuffler = aNBT.getBoolean("mMuffler");
             mSteamConverter = aNBT.getBoolean("mSteamConverter");
@@ -541,7 +549,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
                                                 oTexturePage = (hasValidMetaTileEntity() && mMetaTileEntity instanceof GT_MetaTileEntity_Hatch) ? ((GT_MetaTileEntity_Hatch) mMetaTileEntity).getTexturePage() : 0,
                                                 oUpdateData = hasValidMetaTileEntity() ? mMetaTileEntity.getUpdateData() : 0,
                                                 oRedstoneData = (byte) (((mSidedRedstone[0] > 0) ? 1 : 0) | ((mSidedRedstone[1] > 0) ? 2 : 0) | ((mSidedRedstone[2] > 0) ? 4 : 0) | ((mSidedRedstone[3] > 0) ? 8 : 0) | ((mSidedRedstone[4] > 0) ? 16 : 0) | ((mSidedRedstone[5] > 0) ? 32 : 0)),
-                                                oColor = mColor), 
+                                                oColor = mColor),
                                         xCoord, zCoord);
                                 mSendClientData = false;
                             }
@@ -1191,8 +1199,10 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
     public boolean playerOwnsThis(EntityPlayer aPlayer, boolean aCheckPrecicely) {
         if (!canAccessData()) return false;
         if (aCheckPrecicely || privateAccess() || (mOwnerName.length() == 0))
-            if ((mOwnerName.length() == 0) && isServerSide()) setOwnerName(aPlayer.getDisplayName());
-            else if (privateAccess() && !aPlayer.getDisplayName().equals("Player") && !mOwnerName.equals("Player") && !mOwnerName.equals(aPlayer.getDisplayName()))
+            if ((mOwnerName.length() == 0) && isServerSide()) {
+                setOwnerName(aPlayer.getDisplayName());
+                setOwnerUuid(aPlayer.getUniqueID());
+            } else if (privateAccess() && !aPlayer.getDisplayName().equals("Player") && !mOwnerName.equals("Player") && !mOwnerName.equals(aPlayer.getDisplayName()))
                 return false;
         return true;
     }
@@ -1244,7 +1254,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
             mMetaTileEntity.doExplosion(aAmount);
         }
     }
-    
+
     public void dropItems(ItemStack tItem){
     	if(tItem==null)return;
         EntityItem tItemEntity = new EntityItem(this.worldObj, this.xCoord + XSTR_INSTANCE.nextFloat() * 0.8F + 0.1F, this.yCoord + XSTR_INSTANCE.nextFloat() * 0.8F + 0.1F, this.zCoord + XSTR_INSTANCE.nextFloat() * 0.8F + 0.1F, new ItemStack(tItem.getItem(), tItem.stackSize, tItem.getItemDamage()));
@@ -1261,7 +1271,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
                 ENTITY_ITEM_HEALTH_FIELD.setInt(tItemEntity, 99999999);
 		} catch (Exception ignored) {}
         this.worldObj.spawnEntityInWorld(tItemEntity);
-        tItem.stackSize = 0;                       	
+        tItem.stackSize = 0;
     }
 
     @Override
@@ -1365,7 +1375,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
                         doEnetUpdate();
                         return true;
                     }
-                    
+
                     if (GT_Utility.isStackInList(tCurrentItem, GregTech_API.sWireCutterList)) {
                     	byte tSide = GT_Utility.determineWrenchingSide(aSide, aX, aY, aZ);
                         if (mMetaTileEntity.onWireCutterRightClick(aSide, tSide, aPlayer, aX, aY, aZ)) {
@@ -1421,6 +1431,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
                         if (isUpgradable() && !mLockUpgrade) {
                             mLockUpgrade = true;
                             setOwnerName(aPlayer.getDisplayName());
+                            setOwnerUuid(aPlayer.getUniqueID());
                             GT_Utility.sendSoundToPlayers(worldObj, GregTech_API.sSoundList.get(3), 1.0F, -1, xCoord, yCoord, zCoord);
                             if (!aPlayer.capabilities.isCreativeMode) aPlayer.inventory.getCurrentItem().stackSize--;
                         }
@@ -1527,7 +1538,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
     public byte getOutputRedstoneSignal(byte aSide) {
         return getCoverBehaviorAtSide(aSide).manipulatesSidedRedstoneOutput(aSide, getCoverIDAtSide(aSide), getCoverDataAtSide(aSide), this) ? mSidedRedstone[aSide] : getGeneralRS(aSide);
     }
-    
+
     public byte getGeneralRS(byte aSide){
     	if(mMetaTileEntity==null)return 0;
     	return mMetaTileEntity.allowGeneralRedstoneOutput() ? mSidedRedstone[aSide] : 0;
@@ -1724,6 +1735,16 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
     public String setOwnerName(String aName) {
         if (GT_Utility.isStringInvalid(aName)) return mOwnerName = "Player";
         return mOwnerName = aName;
+    }
+
+    @Override
+    public UUID getOwnerUuid() {
+        return mOwnerUuid;
+    }
+
+    @Override
+    public void setOwnerUuid(UUID uuid) {
+        mOwnerUuid = uuid;
     }
 
     @Override

--- a/src/main/java/gregtech/api/util/GT_Utility.java
+++ b/src/main/java/gregtech/api/util/GT_Utility.java
@@ -95,6 +95,8 @@ public class GT_Utility {
     public static boolean TE_CHECK = false, BC_CHECK = false, CHECK_ALL = true, RF_CHECK = false;
     public static Map<GT_PlayedSound, Integer> sPlayedSoundMap = new /*Concurrent*/HashMap<GT_PlayedSound, Integer>();
     private static int sBookCount = 0;
+    public static UUID defaultUuid = null; // maybe default non-null? UUID.fromString("00000000-0000-0000-0000-000000000000");
+
 
     static {
         GregTech_API.sItemStackMappings.add(sFilledContainerToData);
@@ -1974,7 +1976,7 @@ public class GT_Utility {
 
     public static FakePlayer getFakePlayer(IGregTechTileEntity aBaseMetaTileEntity) {
         if (aBaseMetaTileEntity.getWorld() instanceof WorldServer) {
-            return FakePlayerFactory.get((WorldServer) aBaseMetaTileEntity.getWorld(), new GameProfile(null, aBaseMetaTileEntity.getOwnerName()));
+            return FakePlayerFactory.get((WorldServer) aBaseMetaTileEntity.getWorld(), new GameProfile(aBaseMetaTileEntity.getOwnerUuid(), aBaseMetaTileEntity.getOwnerName()));
         }
         return null;
     }
@@ -2189,7 +2191,8 @@ public class GT_Utility {
                     + "Oils: " + (tOils != null ? tOils.length : 0) + "\n\n"
                     + "Ores within " + tRadius + " blocks\n\n"
                     + "Location is center of orevein\n\n"
-                    + "Check NEI to confirm orevein type";
+                    + 
+"Check NEI to confirm orevein type";
                 tNBTList.appendTag(new NBTTagString(tPageText));
   
                 if (tOres != null)

--- a/src/main/java/gregtech/common/blocks/GT_Item_Machines.java
+++ b/src/main/java/gregtech/common/blocks/GT_Item_Machines.java
@@ -156,6 +156,7 @@ public class GT_Item_Machines
                 tTileEntity.setInitialValuesAsNBT(tTileEntity.isServerSide() ? aStack.getTagCompound() : null, tDamage);
                 if (aPlayer != null) {
                     tTileEntity.setOwnerName(aPlayer.getDisplayName());
+                    tTileEntity.setOwnerUuid(aPlayer.getUniqueID());
                 }
                 tTileEntity.getMetaTileEntity().initDefaultModes(aStack.getTagCompound());
                 final byte aSide = GT_Utility.getOppositeSide(side);


### PR DESCRIPTION
Adds loading and saving a owner UUID to the machine.
When checking permissions for breaking or replacement of a block, the UUID of the owner is indicated as the UUID of the fake player also. Miners, pumps.
Required for compatibility with server  claiming plugins (GriefPrevention) and other security plugins (Essentials, PEX).

Tested on KCauldron 1.7.10, no errors detected. Player's bases are stay unaffected.
Requires miners and pumps block/controller replacement for new checks.

Forked from tag 5.09.33.30