### PR TITLE
Use HashSet for machine block update and limit recursion depth

### DIFF
--- a/src/main/java/gregtech/api/GregTech_API.java
+++ b/src/main/java/gregtech/api/GregTech_API.java
@@ -390,7 +390,7 @@ public class GregTech_API {
      */
     public static boolean causeMachineUpdate(World aWorld, int aX, int aY, int aZ) {
         if (!aWorld.isRemote)
-            new Thread(new GT_Runnable_MachineBlockUpdate(aWorld, aX, aY, aZ), "Machine Block Updating").start();
+            new GT_Runnable_MachineBlockUpdate(aWorld, aX, aY, aZ).run();
         return true;
     }
 

--- a/src/main/java/gregtech/api/threads/GT_Runnable_MachineBlockUpdate.java
+++ b/src/main/java/gregtech/api/threads/GT_Runnable_MachineBlockUpdate.java
@@ -20,9 +20,6 @@ public class GT_Runnable_MachineBlockUpdate implements Runnable {
     private final World mWorld;
     private final Set<ChunkPosition> mVisited;
 
-    // Hopefully large enough for most multi-block machines
-    private static final int MAX_UPDATE_DEPTH = 128;
-
     public GT_Runnable_MachineBlockUpdate(World aWorld, int aX, int aY, int aZ) {
         mWorld = aWorld;
         mX = aX;
@@ -32,9 +29,6 @@ public class GT_Runnable_MachineBlockUpdate implements Runnable {
     }
 
     private boolean shouldRecurse(TileEntity aTileEntity, int aX, int aY, int aZ) {
-        if (aTileEntity == null)
-            return false;
-
         if (aTileEntity instanceof IGregTechTileEntity) {
             // Stop recursion on GregTech cables, item pipes, and fluid pipes
             IMetaTileEntity tMetaTileEntity = ((IGregTechTileEntity) aTileEntity).getMetaTileEntity();
@@ -49,11 +43,11 @@ public class GT_Runnable_MachineBlockUpdate implements Runnable {
     }
 
     private void stepToUpdateMachine(int aX, int aY, int aZ) {
-        if (!mVisited.add(new ChunkPosition(aX, aY, aZ)) || mVisited.size() > MAX_UPDATE_DEPTH)
+        if (!mVisited.add(new ChunkPosition(aX, aY, aZ)))
             return;
 
         TileEntity tTileEntity = mWorld.getTileEntity(aX, aY, aZ);
-        if (tTileEntity != null && tTileEntity instanceof IMachineBlockUpdateable)
+        if (tTileEntity instanceof IMachineBlockUpdateable)
             ((IMachineBlockUpdateable) tTileEntity).onMachineBlockUpdate();
 
         if (mVisited.size() < 5 || shouldRecurse(tTileEntity, aX, aY, aZ)) {

--- a/src/main/java/gregtech/api/threads/GT_Runnable_MachineBlockUpdate.java
+++ b/src/main/java/gregtech/api/threads/GT_Runnable_MachineBlockUpdate.java
@@ -20,6 +20,7 @@ public class GT_Runnable_MachineBlockUpdate implements Runnable {
     private final World mWorld;
     private final Set<ChunkPosition> mVisited;
 
+    // Hopefully large enough for most multi-block machines
     private static final int MAX_UPDATE_DEPTH = 128;
 
     public GT_Runnable_MachineBlockUpdate(World aWorld, int aX, int aY, int aZ) {
@@ -35,9 +36,12 @@ public class GT_Runnable_MachineBlockUpdate implements Runnable {
     }
 
     private boolean shouldUpdate(TileEntity aTileEntity) {
-        // Stop recursion on cables and pipes
-        if (aTileEntity == null || !(aTileEntity instanceof IGregTechTileEntity))
+        if (aTileEntity == null)
           return false;
+
+        // Stop recursion on GregTech cables, item pipes, and fluid pipes
+        if (!(aTileEntity instanceof IGregTechTileEntity))
+          return true;
         IMetaTileEntity tMetaTileEntity = ((IGregTechTileEntity) aTileEntity).getMetaTileEntity();
         return
             !(tMetaTileEntity instanceof GT_MetaPipeEntity_Cable) &&

--- a/src/main/java/gregtech/api/threads/GT_Runnable_MachineBlockUpdate.java
+++ b/src/main/java/gregtech/api/threads/GT_Runnable_MachineBlockUpdate.java
@@ -1,43 +1,75 @@
 package gregtech.api.threads;
 
 import gregtech.api.GregTech_API;
+import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.interfaces.tileentity.IMachineBlockUpdateable;
+import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
+import gregtech.api.metatileentity.implementations.GT_MetaPipeEntity_Cable;
+import gregtech.api.metatileentity.implementations.GT_MetaPipeEntity_Fluid;
+import gregtech.api.metatileentity.implementations.GT_MetaPipeEntity_Item;
+
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.ChunkPosition;
 import net.minecraft.world.World;
 
-import java.util.ArrayList;
+import java.util.Set;
+import java.util.HashSet;
 
 public class GT_Runnable_MachineBlockUpdate implements Runnable {
     private final int mX, mY, mZ;
     private final World mWorld;
+    private final Set<ChunkPosition> mVisited;
+
+    private static final int MAX_UPDATE_DEPTH = 128;
 
     public GT_Runnable_MachineBlockUpdate(World aWorld, int aX, int aY, int aZ) {
         mWorld = aWorld;
         mX = aX;
         mY = aY;
         mZ = aZ;
+        mVisited = new HashSet<ChunkPosition>(80);
     }
 
-    private static void stepToUpdateMachine(World aWorld, int aX, int aY, int aZ, ArrayList<ChunkPosition> aList) {
-        aList.add(new ChunkPosition(aX, aY, aZ));
+    private boolean shouldVisit(int aX, int aY, int aZ) {
+        return !mVisited.contains(new ChunkPosition(aX, aY, aZ));
+    }
+
+    private boolean shouldUpdate(TileEntity aTileEntity) {
+        // Stop recursion on cables and pipes
+        if (aTileEntity == null || !(aTileEntity instanceof IGregTechTileEntity))
+          return false;
+        IMetaTileEntity tMetaTileEntity = ((IGregTechTileEntity) aTileEntity).getMetaTileEntity();
+        return
+            !(tMetaTileEntity instanceof GT_MetaPipeEntity_Cable) &&
+            !(tMetaTileEntity instanceof GT_MetaPipeEntity_Fluid) &&
+            !(tMetaTileEntity instanceof GT_MetaPipeEntity_Item);
+    }
+
+    private void stepToUpdateMachine(World aWorld, int aX, int aY, int aZ) {
+        mVisited.add(new ChunkPosition(aX, aY, aZ));
         TileEntity tTileEntity = aWorld.getTileEntity(aX, aY, aZ);
+        if (!shouldUpdate(tTileEntity) || mVisited.size() > MAX_UPDATE_DEPTH)
+            return;
+
         if (tTileEntity instanceof IMachineBlockUpdateable)
             ((IMachineBlockUpdateable) tTileEntity).onMachineBlockUpdate();
-        if (aList.size() < 5 || (tTileEntity instanceof IMachineBlockUpdateable) || GregTech_API.isMachineBlock(aWorld.getBlock(aX, aY, aZ), aWorld.getBlockMetadata(aX, aY, aZ))) {
-            if (!aList.contains(new ChunkPosition(aX + 1, aY, aZ))) stepToUpdateMachine(aWorld, aX + 1, aY, aZ, aList);
-            if (!aList.contains(new ChunkPosition(aX - 1, aY, aZ))) stepToUpdateMachine(aWorld, aX - 1, aY, aZ, aList);
-            if (!aList.contains(new ChunkPosition(aX, aY + 1, aZ))) stepToUpdateMachine(aWorld, aX, aY + 1, aZ, aList);
-            if (!aList.contains(new ChunkPosition(aX, aY - 1, aZ))) stepToUpdateMachine(aWorld, aX, aY - 1, aZ, aList);
-            if (!aList.contains(new ChunkPosition(aX, aY, aZ + 1))) stepToUpdateMachine(aWorld, aX, aY, aZ + 1, aList);
-            if (!aList.contains(new ChunkPosition(aX, aY, aZ - 1))) stepToUpdateMachine(aWorld, aX, aY, aZ - 1, aList);
+
+        if (mVisited.size() < 5 ||
+            (tTileEntity instanceof IMachineBlockUpdateable) ||
+            GregTech_API.isMachineBlock(aWorld.getBlock(aX, aY, aZ), aWorld.getBlockMetadata(aX, aY, aZ))) {
+            if (shouldVisit(aX + 1, aY, aZ)) stepToUpdateMachine(aWorld, aX + 1, aY, aZ);
+            if (shouldVisit(aX - 1, aY, aZ)) stepToUpdateMachine(aWorld, aX - 1, aY, aZ);
+            if (shouldVisit(aX, aY + 1, aZ)) stepToUpdateMachine(aWorld, aX, aY + 1, aZ);
+            if (shouldVisit(aX, aY - 1, aZ)) stepToUpdateMachine(aWorld, aX, aY - 1, aZ);
+            if (shouldVisit(aX, aY, aZ + 1)) stepToUpdateMachine(aWorld, aX, aY, aZ + 1);
+            if (shouldVisit(aX, aY, aZ - 1)) stepToUpdateMachine(aWorld, aX, aY, aZ - 1);
         }
     }
 
     @Override
     public void run() {
         try {
-            stepToUpdateMachine(mWorld, mX, mY, mZ, new ArrayList<ChunkPosition>());
+            stepToUpdateMachine(mWorld, mX, mY, mZ);
         } catch (Throwable e) {/**/}
     }
 }


### PR DESCRIPTION
As per https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/5906

* Changed `ArrayList` to `HashSet`
* Halted update recursion on cables, fluid pipes, and item pipes
* Set a max recursion depth, which is hopefully large enough for anything but the mega machines
* Took the update out of a thread

From my testing, I found that multiblock machines would still form correctly and detect hatches, etc.