### PR TITLE
Use ThreadLocalRandom for RNG

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/BaseTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseTileEntity.java
@@ -20,6 +20,8 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.IFluidHandler;
 
+import java.util.concurrent.ThreadLocalRandom;
+
 import static gregtech.api.enums.GT_Values.GT;
 import static gregtech.api.enums.GT_Values.NW;
 
@@ -117,7 +119,7 @@ public abstract class BaseTileEntity extends TileEntity implements IHasWorldObje
 
     @Override
     public final int getRandomNumber(int aRange) {
-        return worldObj.rand.nextInt(aRange);
+        return ThreadLocalRandom.current().nextInt(aRange);
     }
 
     @Override


### PR DESCRIPTION
`ThreadLocalRandom` is faster than the global `Random` instance because it doesn't need to sync across threads.

I measured a _slight_ increase in TPS on my server, but that could just be confirmation bias.