### PR TITLE
FluidRenderer Fixes

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 minecraft.version=1.7.10
 forge.version=10.13.4.1614-1.7.10
-gt.version=5.09.33.44
+gt.version=5.09.33.45
 
 ae2.version=rv3-beta-22
 applecore.version=1.7.10-1.2.1+107.59407

--- a/src/main/java/gregtech/common/items/GT_FluidDisplayItem.java
+++ b/src/main/java/gregtech/common/items/GT_FluidDisplayItem.java
@@ -18,9 +18,11 @@ import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
 
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
 
-public class GT_FluidDisplayItem
-        extends GT_Generic_Item {
+@SuppressWarnings({"rawtypes","unchecked"})
+public class GT_FluidDisplayItem extends GT_Generic_Item {
     public GT_FluidDisplayItem() {
         super("GregTech_FluidDisplay", "Fluid Display", null);
         ItemList.Display_Fluid.set(this);
@@ -49,8 +51,12 @@ public class GT_FluidDisplayItem
     }
 
     public IIcon getIconFromDamage(int aMeta) {
-        Fluid tFluid = FluidRegistry.getFluid(aMeta);
-        return tFluid == null ? FluidRegistry.WATER.getStillIcon() : tFluid.getStillIcon();
+        return Stream.of(FluidRegistry.getFluid(aMeta), FluidRegistry.WATER)
+                .filter(Objects::nonNull)
+                .map(Fluid::getStillIcon)
+                .filter(Objects::nonNull)
+                .findFirst()
+                .orElseThrow(IllegalStateException::new);
     }
 
     @SideOnly(Side.CLIENT)

--- a/src/main/java/gregtech/common/render/GT_FluidDisplayStackRenderer.java
+++ b/src/main/java/gregtech/common/render/GT_FluidDisplayStackRenderer.java
@@ -29,7 +29,7 @@ public class GT_FluidDisplayStackRenderer implements IItemRenderer {
     }
 
     @Override
-    public boolean shouldUseRenderHelper (ItemRenderType type, ItemStack item, ItemRendererHelper helper)
+    public boolean shouldUseRenderHelper(ItemRenderType type, ItemStack item, ItemRendererHelper helper)
     {
         //not sure what this does.
         return false;
@@ -59,8 +59,11 @@ public class GT_FluidDisplayStackRenderer implements IItemRenderer {
         tess.addVertexWithUV( 0,  0, 0, x_min, y_min);
         tess.draw();
 
-        if(item.getTagCompound() == null)
+        if(item.getTagCompound() == null) {
+            GL11.glDisable(GL11.GL_BLEND);
+            GL11.glDisable(GL11.GL_ALPHA_TEST);
             return;
+        }
 
         // Render Fluid amount text
         long fluidAmount = item.getTagCompound().getLong("mFluidDisplayAmount");
@@ -87,6 +90,8 @@ public class GT_FluidDisplayStackRenderer implements IItemRenderer {
             GL11.glScalef(smallTextScale, smallTextScale, 1.0f);
 
             fontRender.drawString( amountString, 0, (int) (16/smallTextScale) - fontRender.FONT_HEIGHT + 1, 0xFFFFFF, true);
+            GL11.glScalef(1f, 1f, 1f);
+            GL11.glDisable(GL11.GL_ALPHA_TEST);
         }
     }
 }


### PR DESCRIPTION
+ Made GT_FluidDisplayItem.getIconFromDamage NEVER return null
+ Made GT_FluidDisplayStackRenderer reset its OpenGL calls before returning

Signed-off-by: bartimaeusnek <33183715+bartimaeusnek@users.noreply.github.com>