### PR TITLE
Update GT_MetaTileEntity_LargeChemicalReactor.java (keep OCing at 2t)

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeChemicalReactor.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeChemicalReactor.java
@@ -126,13 +126,13 @@ public class GT_MetaTileEntity_LargeChemicalReactor extends GT_MetaTileEntity_Mu
 				int EUt = recipe.mEUt;
 				int maxProgresstime = recipe.mDuration;
 
-				while (EUt <= gregtech.api.enums.GT_Values.V[tier - 1] && maxProgresstime > 2) {
+				while (EUt <= gregtech.api.enums.GT_Values.V[tier - 1]) {
 					EUt *= 4;
 					maxProgresstime /= 4;
 				}
 				if (maxProgresstime < 2) {
 					maxProgresstime = 2;
-					EUt = recipe.mEUt * recipe.mDuration / 2;
+		
 				}
 				
 				this.mEUt = -EUt;


### PR DESCRIPTION
LCR currently will stop OCing if the time reaches too low of a value. This makes it so the LCR will still consume power equal to the hatch tier, even if you can't OC a recipe any farther. I might have messed up how it works, but from what I can tell this should do it. Probably want someone else to look at it who's better at java than me, but it seems to work. 