### PR TITLE
Update GT_VolumetricFlask.java

### DIFF
--- a/src/main/java/gregtech/common/items/GT_VolumetricFlask.java
+++ b/src/main/java/gregtech/common/items/GT_VolumetricFlask.java
@@ -122,6 +122,7 @@ public class GT_VolumetricFlask extends GT_Generic_Item implements IFluidContain
     }
 
     @Override
+    @SideOnly(Side.CLIENT)
     public void registerIcons(IIconRegister aIconRegister) {
         super.registerIcons(aIconRegister);
         iconWindow = aIconRegister.registerIcon(RES_PATH_ITEM + "gt."+unlocalFlaskName+".window");


### PR DESCRIPTION
 Fixed missing annotation, prevents crashing Server Side if class is accessed reflectively.