### PR TITLE
Only modify aStack when doDrain == true [Cell Bug Fix]

### DIFF
--- a/src/main/java/gregtech/api/items/GT_MetaBase_Item.java
+++ b/src/main/java/gregtech/api/items/GT_MetaBase_Item.java
@@ -514,11 +514,14 @@ public abstract class GT_MetaBase_Item extends GT_Generic_Item implements ISpeci
         if (tFluid != null && maxDrain >= tFluid.amount) {
             ItemStack tStack = GT_Utility.getContainerItem(aStack, false);
             if (tStack == null) {
-                aStack.stackSize = 0;
+                if(doDrain) aStack.stackSize = 0;
                 return tFluid;
             }
-            aStack.setItemDamage(tStack.getItemDamage());
-            aStack.func_150996_a(tStack.getItem());
+            if(doDrain) {
+                GT_Log.out.println("FUCKTHECELLS - Draining " + aStack.getDisplayName() + " and setting to " + tStack.getDisplayName());
+                aStack.setItemDamage(tStack.getItemDamage());
+                aStack.func_150996_a(tStack.getItem());
+            }
             return tFluid;
         }
 

--- a/src/main/java/gregtech/api/items/GT_MetaBase_Item.java
+++ b/src/main/java/gregtech/api/items/GT_MetaBase_Item.java
@@ -518,7 +518,6 @@ public abstract class GT_MetaBase_Item extends GT_Generic_Item implements ISpeci
                 return tFluid;
             }
             if(doDrain) {
-                GT_Log.out.println("FUCKTHECELLS - Draining " + aStack.getDisplayName() + " and setting to " + tStack.getDisplayName());
                 aStack.setItemDamage(tStack.getItemDamage());
                 aStack.func_150996_a(tStack.getItem());
             }


### PR DESCRIPTION
BQ3 backported a fluid task, which was calling `drain(amount=5000, doDrain=false)` on cells. 

The correct behavior is to simulate, and NOT change anything.  However the check 
`if (tFluid != null && maxDrain [5000] >= tFluid.amount [1000]) {` was getting tripped, and setting the cell to an empty cell, then returning.  

This modifies the behavior to only modify the underlying cell/item if `doDrain = True`.  This _should_ fix the cell bug that pops up, but will need more testing to make sure nothing else is relying on this broken behavior.