### PR TITLE
Simple optimization to GT_Utility.moveOneItemStack

### DIFF
--- a/src/main/java/gregtech/api/util/GT_Utility.java
+++ b/src/main/java/gregtech/api/util/GT_Utility.java
@@ -559,16 +559,14 @@ public class GT_Utility {
 
             for (int i = 0; i < tGrabSlots.length; i++) {
             	byte tMovedItemCount = 0;
-
-                if (listContainsItem(aFilter, aTileEntity1.getStackInSlot(tGrabSlots[i]), true, aInvertFilter)) {
-                    ItemStack tGrabStack = aTileEntity1.getStackInSlot(tGrabSlots[i]);
-                    for (int j = 0; j < tPutSlots.length; j++) {
-                        if (isAllowedToTakeFromSlot(aTileEntity1, tGrabSlots[i], aGrabFrom, tGrabStack)) {
+                ItemStack tGrabStack = aTileEntity1.getStackInSlot(tGrabSlots[i]);
+                if (listContainsItem(aFilter, tGrabStack, true, aInvertFilter)) {
+                    if (isAllowedToTakeFromSlot(aTileEntity1, tGrabSlots[i], aGrabFrom, tGrabStack)) {
+                        for (int j = 0; j < tPutSlots.length; j++) {
                              if (isAllowedToPutIntoSlot((IInventory) aTileEntity2, tPutSlots[j], aPutTo, tGrabStack, aMaxTargetStackSize)) {
-                                tMovedItemCount += moveStackFromSlotAToSlotB(aTileEntity1, (IInventory) aTileEntity2, tGrabSlots[i], tPutSlots[j], aMaxTargetStackSize, aMinTargetStackSize, (byte) (aMaxMoveAtOnce - tMovedItemCount), aMinMoveAtOnce);
+                                 tMovedItemCount += moveStackFromSlotAToSlotB(aTileEntity1, (IInventory) aTileEntity2, tGrabSlots[i], tPutSlots[j], aMaxTargetStackSize, aMinTargetStackSize, (byte) (aMaxMoveAtOnce - tMovedItemCount), aMinMoveAtOnce);
                                  if (tMovedItemCount >= aMaxMoveAtOnce) {
                                      return tMovedItemCount;
-
                                 }
                             }
                         }

--- a/src/main/java/gregtech/api/util/GT_Utility.java
+++ b/src/main/java/gregtech/api/util/GT_Utility.java
@@ -559,10 +559,12 @@ public class GT_Utility {
 
             for (int i = 0; i < tGrabSlots.length; i++) {
             	byte tMovedItemCount = 0;
-                for (int j = 0; j < tPutSlots.length; j++) {
-                    if (listContainsItem(aFilter, aTileEntity1.getStackInSlot(tGrabSlots[i]), true, aInvertFilter)) {
-                        if (isAllowedToTakeFromSlot(aTileEntity1, tGrabSlots[i], aGrabFrom, aTileEntity1.getStackInSlot(tGrabSlots[i]))) {
-                            if (isAllowedToPutIntoSlot((IInventory) aTileEntity2, tPutSlots[j], aPutTo, aTileEntity1.getStackInSlot(tGrabSlots[i]), aMaxTargetStackSize)) {
+
+                if (listContainsItem(aFilter, aTileEntity1.getStackInSlot(tGrabSlots[i]), true, aInvertFilter)) {
+                    ItemStack tGrabStack = aTileEntity1.getStackInSlot(tGrabSlots[i]);
+                    for (int j = 0; j < tPutSlots.length; j++) {
+                        if (isAllowedToTakeFromSlot(aTileEntity1, tGrabSlots[i], aGrabFrom, tGrabStack)) {
+                             if (isAllowedToPutIntoSlot((IInventory) aTileEntity2, tPutSlots[j], aPutTo, tGrabStack, aMaxTargetStackSize)) {
                                 tMovedItemCount += moveStackFromSlotAToSlotB(aTileEntity1, (IInventory) aTileEntity2, tGrabSlots[i], tPutSlots[j], aMaxTargetStackSize, aMinTargetStackSize, (byte) (aMaxMoveAtOnce - tMovedItemCount), aMinMoveAtOnce);
                                  if (tMovedItemCount >= aMaxMoveAtOnce) {
                                      return tMovedItemCount;


### PR DESCRIPTION
Moved a couple of things from inner loop to outer one as the values don't change in the inner loop anyway so they can be precalculated only once instead of every iteration of the inner loop.