### PR TITLE
Actually hide filled volumetric flask in NEI

### DIFF
--- a/src/main/java/gregtech/common/items/GT_VolumetricFlask.java
+++ b/src/main/java/gregtech/common/items/GT_VolumetricFlask.java
@@ -43,16 +43,6 @@ public class GT_VolumetricFlask extends GT_Generic_Item implements IFluidContain
         unlocalFlaskName = unlocalized;
         setMaxStackSize(16);
         setNoRepair();
-        if (Loader.isModLoaded("NotEnoughItems")) {
-            hideItemInNEI();
-        }
-    }
-
-    @Optional.Method(modid = "NotEnoughItems")
-    private void hideItemInNEI() {
-        codechicken.nei.api.API.addItemFilter(
-                () -> aStack -> aStack.getItem() == this && this.getFluid(aStack) != null
-        );
     }
 
     public ItemStack onItemRightClick(ItemStack stack, World world, EntityPlayer player) {

--- a/src/main/java/gregtech/common/items/GT_VolumetricFlask.java
+++ b/src/main/java/gregtech/common/items/GT_VolumetricFlask.java
@@ -2,6 +2,7 @@
 package gregtech.common.items;
 
 import cpw.mods.fml.common.Loader;
+import cpw.mods.fml.common.Optional;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import gregtech.api.enums.GT_Values;
@@ -43,15 +44,15 @@ public class GT_VolumetricFlask extends GT_Generic_Item implements IFluidContain
         setMaxStackSize(16);
         setNoRepair();
         if (Loader.isModLoaded("NotEnoughItems")) {
-            for (Fluid fluid : FluidRegistry.getRegisteredFluids().values()) {
-                if (fluid != null) {
-                    ItemStack stack = new ItemStack(this);
-                    setCapacity(stack, getMaxCapacity());
-                    fill(stack, new FluidStack(fluid, Integer.MAX_VALUE), true);
-                    codechicken.nei.api.API.hideItem(stack);
-                }
-            }
+            hideItemInNEI();
         }
+    }
+
+    @Optional.Method(modid = "NotEnoughItems")
+    private void hideItemInNEI() {
+        codechicken.nei.api.API.addItemFilter(
+                () -> aStack -> aStack.getItem() == this && this.getFluid(aStack) != null
+        );
     }
 
     public ItemStack onItemRightClick(ItemStack stack, World world, EntityPlayer player) {

--- a/src/main/java/gregtech/common/items/GT_VolumetricFlask.java
+++ b/src/main/java/gregtech/common/items/GT_VolumetricFlask.java
@@ -1,8 +1,6 @@
 
 package gregtech.common.items;
 
-import cpw.mods.fml.common.Loader;
-import cpw.mods.fml.common.Optional;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import gregtech.api.enums.GT_Values;

--- a/src/main/java/gregtech/nei/NEI_GT_Config.java
+++ b/src/main/java/gregtech/nei/NEI_GT_Config.java
@@ -17,7 +17,7 @@ public class NEI_GT_Config
                 new GT_NEI_DefaultHandler(tMap);
             }
         }
-        if(FMLCommonHandler.instance().getEffectiveSide().isClient()) {
+        if (FMLCommonHandler.instance().getEffectiveSide().isClient()) {
             ALH = new GT_NEI_AssLineHandler(GT_Recipe.GT_Recipe_Map.sAssemblylineVisualRecipes);
             codechicken.nei.api.API.addItemListEntry(ItemList.VOLUMETRIC_FLASK.get(1));
         }

--- a/src/main/java/gregtech/nei/NEI_GT_Config.java
+++ b/src/main/java/gregtech/nei/NEI_GT_Config.java
@@ -2,6 +2,7 @@ package gregtech.nei;
 
 import codechicken.nei.api.IConfigureNEI;
 import cpw.mods.fml.common.FMLCommonHandler;
+import gregtech.api.enums.ItemList;
 import gregtech.api.util.GT_Recipe;
 
 public class NEI_GT_Config
@@ -16,8 +17,10 @@ public class NEI_GT_Config
                 new GT_NEI_DefaultHandler(tMap);
             }
         }
-        if(FMLCommonHandler.instance().getEffectiveSide().isClient())
-            ALH=new GT_NEI_AssLineHandler(GT_Recipe.GT_Recipe_Map.sAssemblylineVisualRecipes);
+        if(FMLCommonHandler.instance().getEffectiveSide().isClient()) {
+            ALH = new GT_NEI_AssLineHandler(GT_Recipe.GT_Recipe_Map.sAssemblylineVisualRecipes);
+            codechicken.nei.api.API.addItemListEntry(ItemList.VOLUMETRIC_FLASK.get(1));
+        }
         sIsAdded = true;
     }
 


### PR DESCRIPTION
This functionality was added at day 0 but it never worked perfectly. Previously this is called too early that many GT fluid are simply not yet registered.

Hiding filled volumetric flask should do no harm to daily fluid recipe/usage look up. Filled universal cells (or even crystal capsules) are not hidden so they can be used instead.

Extra care was taken to prevent the filter from hiding the empty volumetric flask, which would prevent looking up the recipe of flask itself.