### PR TITLE
isRecipeInputEqual optimization

### DIFF
--- a/src/main/java/gregtech/api/util/GT_OreDictUnificator.java
+++ b/src/main/java/gregtech/api/util/GT_OreDictUnificator.java
@@ -156,6 +156,59 @@ public class GT_OreDictUnificator {
         return GT_Utility.copyAmount(aStack.stackSize, rStack);
     }
 
+    /** Doesn't copy the returned stack or set quantity. Be careful and do not mutate it;
+     * intended only to optimize comparisons */
+    public static ItemStack get_nocopy(boolean aUseBlackList, ItemStack aStack) {
+        if (GT_Utility.isStackInvalid(aStack)) return null;
+        ItemData tPrefixMaterial = getAssociation(aStack);
+        ItemStack rStack = null;
+        if (tPrefixMaterial == null || !tPrefixMaterial.hasValidPrefixMaterialData() || (aUseBlackList && tPrefixMaterial.mBlackListed))
+            return aStack;
+        if (aUseBlackList && !GregTech_API.sUnificationEntriesRegistered && isBlacklisted(aStack)) {
+            tPrefixMaterial.mBlackListed = true;
+            return aStack;
+        }
+        if (tPrefixMaterial.mUnificationTarget == null)
+            tPrefixMaterial.mUnificationTarget = sName2StackMap.get(tPrefixMaterial.toString());
+        rStack = tPrefixMaterial.mUnificationTarget;
+        if (GT_Utility.isStackInvalid(rStack)) return aStack;
+        assert rStack != null;
+        rStack.setTagCompound(aStack.getTagCompound());
+        return rStack;
+    }
+
+    /** Compares the first argument against an already-unificated second argument as if
+     * aUseBlackList was both true and false. */
+    public static boolean isInputStackEqual(ItemStack aStack, ItemStack unified_tStack) {
+        boolean alreadyCompared = false;
+        if (GT_Utility.isStackInvalid(aStack)) return false;
+        ItemData tPrefixMaterial = getAssociation(aStack);
+        ItemStack rStack = null;
+        if (tPrefixMaterial == null || !tPrefixMaterial.hasValidPrefixMaterialData())
+            return GT_Utility.areStacksEqual(aStack, unified_tStack, true);
+        else if(tPrefixMaterial.mBlackListed) {
+            if (GT_Utility.areStacksEqual(aStack, unified_tStack, true))
+                return true;
+            else
+                alreadyCompared = true;
+        }
+        if (!alreadyCompared && !GregTech_API.sUnificationEntriesRegistered && isBlacklisted(aStack)) {
+            tPrefixMaterial.mBlackListed = true;
+            if (GT_Utility.areStacksEqual(aStack, unified_tStack, true))
+                return true;
+            else
+                alreadyCompared = true;
+        }
+        if (tPrefixMaterial.mUnificationTarget == null)
+            tPrefixMaterial.mUnificationTarget = sName2StackMap.get(tPrefixMaterial.toString());
+        rStack = tPrefixMaterial.mUnificationTarget;
+        if (GT_Utility.isStackInvalid(rStack))
+            return !alreadyCompared && GT_Utility.areStacksEqual(aStack, unified_tStack, true);
+        assert rStack != null;
+        rStack.setTagCompound(aStack.getTagCompound());
+        return GT_Utility.areStacksEqual(rStack, unified_tStack, true);
+    }
+
     public static List<ItemStack> getNonUnifiedStacks(Object obj) {
     	synchronized (sUnificationTable) {
     		if (sUnificationTable.isEmpty() && !sItemStack2DataMap.isEmpty()) {

--- a/src/main/java/gregtech/api/util/GT_OreDictUnificator.java
+++ b/src/main/java/gregtech/api/util/GT_OreDictUnificator.java
@@ -158,7 +158,7 @@ public class GT_OreDictUnificator {
 
     /** Doesn't copy the returned stack or set quantity. Be careful and do not mutate it;
      * intended only to optimize comparisons */
-    public static ItemStack get_nocopy(boolean aUseBlackList, ItemStack aStack) {
+    static ItemStack get_nocopy(boolean aUseBlackList, ItemStack aStack) {
         if (GT_Utility.isStackInvalid(aStack)) return null;
         ItemData tPrefixMaterial = getAssociation(aStack);
         ItemStack rStack = null;

--- a/src/main/java/gregtech/api/util/GT_Recipe.java
+++ b/src/main/java/gregtech/api/util/GT_Recipe.java
@@ -389,11 +389,12 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
         if (mInputs.length > 0 && aInputs == null) return false;
 
         for (ItemStack tStack : mInputs) {
-            if (tStack != null) {
+            ItemStack unified_tStack = GT_OreDictUnificator.get_nocopy(true, tStack);
+            if (unified_tStack != null) {
                 amt = tStack.stackSize;
                 boolean temp = true;
                 for (ItemStack aStack : aInputs) {
-                    if ((GT_Utility.areUnificationsEqual(aStack, tStack, true) || GT_Utility.areUnificationsEqual(GT_OreDictUnificator.get(false, aStack), tStack, true))) {
+                    if (GT_OreDictUnificator.isInputStackEqual(aStack, unified_tStack)) {
                         if (GTppRecipeHelper) {//remove once the fix is out
                             if (GT_Utility.areStacksEqual(aStack, Ic2Items.FluidCell.copy(), true) || GT_Utility.areStacksEqual(aStack, ItemList.Tool_DataStick.get(1L), true) || GT_Utility.areStacksEqual(aStack, ItemList.Tool_DataOrb.get(1L), true)) {
                                 if (!GT_Utility.areStacksEqual(aStack, tStack, false))


### PR DESCRIPTION
Significantly reduces the amount of work GT does when checking whether new
recipes are duplicates, and probably other places as well. Saves noticeable
time during startup. However, the implementation here is kinda poor, and
there are still savings to be made. So this commit is more about sharing a
prototype with others than seriously intended to be merged as-is.