### PR TITLE
fix(integrated_circuit): mask comparison mode bits from damage

### DIFF
--- a/src/main/java/gregtech/common/items/GT_IntegratedCircuit_Item.java
+++ b/src/main/java/gregtech/common/items/GT_IntegratedCircuit_Item.java
@@ -120,6 +120,7 @@ public class GT_IntegratedCircuit_Item extends GT_Generic_Item {
 
     @Override
     public IIcon getIconFromDamage(int damage) {
-        return (damage >= 0 && damage < mIconDamage.length ? mIconDamage[damage] : mIcon);
+        byte circuitMode = ((byte) (damage & 0xFF)); // Mask out the MSB Comparison Mode Bits. See: getModeString
+        return mIconDamage[circuitMode < mIconDamage.length ? circuitMode : 0];
     }
 }


### PR DESCRIPTION
Forgot to mask-out the MSB comparison mode bits from the damage value. It worked for `==` since it is the default mode with `0x00##`, but would have failed with the others: `0x01##` for `<=`, `0x02##` for `>=`, `0x03##` for `<`, `0x04##` for `>`.