### PR TITLE
Fix single block pump description

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_Pump.java
+++ b/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_Pump.java
@@ -58,7 +58,7 @@ public class GT_MetaTileEntity_Pump extends GT_MetaTileEntity_Hatch {
     public GT_MetaTileEntity_Pump(int aID, String aName, String aNameRegional, int aTier) {
         super(aID, aName, aNameRegional, aTier, 3,
                 new String[]{"The best way to empty Oceans! Outputs on top",
-                        getEuUsagePerTier(aTier) + " EU/operation, " + GT_Utility.safeInt(160 / (long)Math.pow(2, aTier) ) + " sec per bucket, no stuttering",
+                        getEuUsagePerTier(aTier) + " EU/operation, " + GT_Utility.safeInt(160 / 20 / (long)Math.pow(2, aTier) ) + " sec per bucket, no stuttering",
                         "Maximum pumping area: " + (getMaxDistanceForTier( aTier) * 2 + 1) + "x" + (getMaxDistanceForTier( aTier) * 2 + 1),
                         "Use Screwdriver to regulate pumping area"});
         radiusConfig = getMaxDistanceForTier(mTier);


### PR DESCRIPTION
80 second for 1 bucket of fluid is ridiculous. It is never meant to, nor actually did pump 1 block every 80 seconds. This does not alter the behavior of this machine. This merely correct the description.