### PR TITLE
fix(rendering): bottom side orientation

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Fluid.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Fluid.java
@@ -111,7 +111,7 @@ public class GT_MetaPipeEntity_Fluid extends MetaPipeEntity {
         if (aSide >= 0 && aSide < 6) {
             for (byte i = 0; i < 4; i++) if (isInputDisabledAtSide(sRestrictionArray[aSide][i])) tMask |= 1 << i;
             //Full block size renderer flips side 5 and 2  textures, flip restrictor textures to compensate
-            if (aSide == 5 || aSide == 2 || aSide == 0)
+            if (aSide == 5 || aSide == 2)
                 if (tMask > 3 && tMask < 12)
                     tMask = (byte) (tMask ^ 12);
         }

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Buffer.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Buffer.java
@@ -97,10 +97,10 @@ public abstract class GT_MetaTileEntity_Buffer extends GT_MetaTileEntity_TieredM
                 break;
             case WEST:
                 switch (side) {
-                    case DOWN:
                     case UP:
                     case SOUTH:
                         return mTextures[ARROW_RIGHT_INDEX][colorIndex]; // ARROW_RIGHT
+                    case DOWN:
                     case NORTH:
                         return mTextures[ARROW_LEFT_INDEX][colorIndex]; // ARROW_LEFT
                     default:
@@ -108,10 +108,10 @@ public abstract class GT_MetaTileEntity_Buffer extends GT_MetaTileEntity_TieredM
                 break;
             case EAST:
                 switch (side) {
-                    case DOWN:
                     case UP:
                     case SOUTH:
                         return mTextures[ARROW_LEFT_INDEX][colorIndex]; // ARROW_LEFT
+                    case DOWN:
                     case NORTH:
                         return mTextures[ARROW_RIGHT_INDEX][colorIndex]; // ARROW_RIGHT
                     default:

--- a/src/main/java/gregtech/api/objects/GT_CopiedBlockTexture.java
+++ b/src/main/java/gregtech/api/objects/GT_CopiedBlockTexture.java
@@ -36,7 +36,7 @@ public class GT_CopiedBlockTexture implements ITexture {
         this(aBlock, aSide, aMeta, Dyes._NULL.mRGBa);
     }
 
-    private final IIcon getIcon(int aSide) {
+    private IIcon getIcon(int aSide) {
         if (mSide == 6) return mBlock.getIcon(aSide, mMeta);
         return mBlock.getIcon(mSide, mMeta);
     }
@@ -45,9 +45,9 @@ public class GT_CopiedBlockTexture implements ITexture {
     public void renderXPos(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
         IIcon aIcon = getIcon(5);
         Tessellator.instance.setColorRGBA((int) (mRGBa[0] * 0.6F), (int) (mRGBa[1] * 0.6F), (int) (mRGBa[2] * 0.6F), mAllowAlpha ? 255 - mRGBa[3] : 255);
-//		aRenderer.flipTexture = !aRenderer.flipTexture;
+        aRenderer.field_152631_f = true;
         aRenderer.renderFaceXPos(aBlock, aX, aY, aZ, aIcon);
-//		aRenderer.flipTexture = !aRenderer.flipTexture;
+        aRenderer.field_152631_f = false;
     }
 
     @Override
@@ -82,9 +82,9 @@ public class GT_CopiedBlockTexture implements ITexture {
     public void renderZNeg(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
         IIcon aIcon = getIcon(2);
         Tessellator.instance.setColorRGBA((int) (mRGBa[0] * 0.8F), (int) (mRGBa[1] * 0.8F), (int) (mRGBa[2] * 0.8F), mAllowAlpha ? 255 - mRGBa[3] : 255);
-//		aRenderer.flipTexture = !aRenderer.flipTexture;
+        aRenderer.field_152631_f = true;
         aRenderer.renderFaceZNeg(aBlock, aX, aY, aZ, aIcon);
-//		aRenderer.flipTexture = !aRenderer.flipTexture;
+        aRenderer.field_152631_f = false;
     }
 
     @Override

--- a/src/main/java/gregtech/api/objects/GT_RenderedTexture.java
+++ b/src/main/java/gregtech/api/objects/GT_RenderedTexture.java
@@ -10,8 +10,8 @@ import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.util.IIcon;
 
 public class GT_RenderedTexture implements ITexture, IColorModulationContainer {
-    private final IIconContainer mIconContainer;
-    private final boolean mAllowAlpha;
+    final IIconContainer mIconContainer;
+    final boolean mAllowAlpha;
     /**
      * DO NOT MANIPULATE THE VALUES INSIDE THIS ARRAY!!!
      * <p/>
@@ -37,12 +37,12 @@ public class GT_RenderedTexture implements ITexture, IColorModulationContainer {
 
     @Override
     public void renderXPos(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
-        final Tessellator tesselator = Tessellator.instance;
-        tesselator.setColorRGBA((int) (mRGBa[0] * 0.6F), (int) (mRGBa[1] * 0.6F), (int) (mRGBa[2] * 0.6F), mAllowAlpha ? 255 - mRGBa[3] : 255);
+        final Tessellator tessellator = Tessellator.instance;
+        tessellator.setColorRGBA((int) (mRGBa[0] * 0.6F), (int) (mRGBa[1] * 0.6F), (int) (mRGBa[2] * 0.6F), mAllowAlpha ? 255 - mRGBa[3] : 255);
         aRenderer.field_152631_f = true;
         aRenderer.renderFaceXPos(aBlock, aX, aY, aZ, mIconContainer.getIcon());
         if (mIconContainer.getOverlayIcon() != null) {
-            tesselator.setColorRGBA(153, 153, 153, 255);
+            tessellator.setColorRGBA(153, 153, 153, 255);
             aRenderer.renderFaceXPos(aBlock, aX, aY, aZ, mIconContainer.getOverlayIcon());
         }
         aRenderer.field_152631_f = false;
@@ -51,60 +51,107 @@ public class GT_RenderedTexture implements ITexture, IColorModulationContainer {
 
     @Override
     public void renderXNeg(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
-        final Tessellator tesselator = Tessellator.instance;
-        tesselator.setColorRGBA((int) (mRGBa[0] * 0.6F), (int) (mRGBa[1] * 0.6F), (int) (mRGBa[2] * 0.6F), mAllowAlpha ? 255 - mRGBa[3] : 255);
+        final Tessellator tessellator = Tessellator.instance;
+        tessellator.setColorRGBA((int) (mRGBa[0] * 0.6F), (int) (mRGBa[1] * 0.6F), (int) (mRGBa[2] * 0.6F), mAllowAlpha ? 255 - mRGBa[3] : 255);
         aRenderer.renderFaceXNeg(aBlock, aX, aY, aZ, mIconContainer.getIcon());
         if (mIconContainer.getOverlayIcon() != null) {
-            tesselator.setColorRGBA(153, 153, 153, 255);
+            tessellator.setColorRGBA(153, 153, 153, 255);
             aRenderer.renderFaceXNeg(aBlock, aX, aY, aZ, mIconContainer.getOverlayIcon());
         }
     }
 
     @Override
     public void renderYPos(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
-        final Tessellator tesselator = Tessellator.instance;
-        tesselator.setColorRGBA((int) (mRGBa[0] * 1.0F), (int) (mRGBa[1] * 1.0F), (int) (mRGBa[2] * 1.0F), mAllowAlpha ? 255 - mRGBa[3] : 255);
+        final Tessellator tessellator = Tessellator.instance;
+        tessellator.setColorRGBA((int) (mRGBa[0] * 1.0F), (int) (mRGBa[1] * 1.0F), (int) (mRGBa[2] * 1.0F), mAllowAlpha ? 255 - mRGBa[3] : 255);
         aRenderer.renderFaceYPos(aBlock, aX, aY, aZ, mIconContainer.getIcon());
         if (mIconContainer.getOverlayIcon() != null) {
-            tesselator.setColorRGBA(255, 255, 255, 255);
+            tessellator.setColorRGBA(255, 255, 255, 255);
             aRenderer.renderFaceYPos(aBlock, aX, aY, aZ, mIconContainer.getOverlayIcon());
         }
     }
 
     @Override
     public void renderYNeg(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
-        final Tessellator tesselator = Tessellator.instance;
-        tesselator.setColorRGBA((int) (mRGBa[0] * 0.5F), (int) (mRGBa[1] * 0.5F), (int) (mRGBa[2] * 0.5F), mAllowAlpha ? 255 - mRGBa[3] : 255);
-        aRenderer.field_152631_f = true;
-        aRenderer.flipTexture = true;
-        aRenderer.renderFaceYNeg(aBlock, aX, aY, aZ, mIconContainer.getIcon());
-        if (mIconContainer.getOverlayIcon() != null) {
-            tesselator.setColorRGBA(128, 128, 128, 255);
-            aRenderer.renderFaceYNeg(aBlock, aX, aY, aZ, mIconContainer.getOverlayIcon());
+        final Tessellator tessellator = Tessellator.instance;
+        tessellator.setColorRGBA((int) (mRGBa[0] * 0.5F), (int) (mRGBa[1] * 0.5F), (int) (mRGBa[2] * 0.5F), mAllowAlpha ? 255 - mRGBa[3] : 255);
+        IIcon aIcon = mIconContainer.getIcon();
+
+        float minU = aIcon.getInterpolatedU((1.0D - aRenderer.renderMaxX) * 16.0D);
+        float maxU = aIcon.getInterpolatedU((1.0D - aRenderer.renderMinX) * 16.0D);
+        float minV = aIcon.getInterpolatedV(aRenderer.renderMinZ * 16.0D);
+        float maxV = aIcon.getInterpolatedV(aRenderer.renderMaxZ * 16.0D);
+
+        if (aRenderer.renderMinX < 0.0D || aRenderer.renderMaxX > 1.0D) {
+            minU = 16.0F - aIcon.getMaxU();
+            maxU = 16.0F - aIcon.getMinU();
         }
-        aRenderer.field_152631_f = false;
-        aRenderer.flipTexture = false;
+
+        if (aRenderer.renderMinZ < 0.0D || aRenderer.renderMaxZ > 1.0D) {
+            minV = aIcon.getMinV();
+            maxV = aIcon.getMaxV();
+        }
+
+        double minX = aX + aRenderer.renderMinX;
+        double maxX = aX + aRenderer.renderMaxX;
+        double minY = aY + aRenderer.renderMinY;
+        double minZ = aZ + aRenderer.renderMinZ;
+        double maxZ = aZ + aRenderer.renderMaxZ;
+
+        tessellator.addVertexWithUV(minX, minY, maxZ, maxU, maxV);
+        tessellator.addVertexWithUV(minX, minY, minZ, maxU, minV);
+        tessellator.addVertexWithUV(maxX, minY, minZ, minU, minV);
+        tessellator.addVertexWithUV(maxX, minY, maxZ, minU, maxV);
+        if (mIconContainer.getOverlayIcon() != null) {
+            tessellator.setColorRGBA(128, 128, 128, 255);
+
+            minU = aIcon.getInterpolatedU((1.0D - aRenderer.renderMaxX) * 16.0D);
+            maxU = aIcon.getInterpolatedU((1.0D - aRenderer.renderMinX) * 16.0D);
+            minV = aIcon.getInterpolatedV(aRenderer.renderMinZ * 16.0D);
+            maxV = aIcon.getInterpolatedV(aRenderer.renderMaxZ * 16.0D);
+
+            if (aRenderer.renderMinX < 0.0D || aRenderer.renderMaxX > 1.0D) {
+                minU = 16.0F - aIcon.getMaxU();
+                maxU = 16.0F - aIcon.getMinU();
+            }
+
+            if (aRenderer.renderMinZ < 0.0D || aRenderer.renderMaxZ > 1.0D) {
+                minV = aIcon.getMinV();
+                maxV = aIcon.getMaxV();
+            }
+
+            minX = aX + (float)aRenderer.renderMinX;
+            maxX = aX + (float)aRenderer.renderMaxX;
+            minY = aY + (float)aRenderer.renderMinY;
+            minZ = aZ + (float)aRenderer.renderMinZ;
+            maxZ = aZ + (float)aRenderer.renderMaxZ;
+
+            tessellator.addVertexWithUV(minX, minY, maxZ, maxU, maxV);
+            tessellator.addVertexWithUV(minX, minY, minZ, maxU, minV);
+            tessellator.addVertexWithUV(maxX, minY, minZ, minU, minV);
+            tessellator.addVertexWithUV(maxX, minY, maxZ, minU, maxV);
+        }
     }
 
     @Override
     public void renderZPos(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
-        final Tessellator tesselator = Tessellator.instance;
-        tesselator.setColorRGBA((int) (mRGBa[0] * 0.8F), (int) (mRGBa[1] * 0.8F), (int) (mRGBa[2] * 0.8F), mAllowAlpha ? 255 - mRGBa[3] : 255);
+        final Tessellator tessellator = Tessellator.instance;
+        tessellator.setColorRGBA((int) (mRGBa[0] * 0.8F), (int) (mRGBa[1] * 0.8F), (int) (mRGBa[2] * 0.8F), mAllowAlpha ? 255 - mRGBa[3] : 255);
         aRenderer.renderFaceZPos(aBlock, aX, aY, aZ, mIconContainer.getIcon());
         if (mIconContainer.getOverlayIcon() != null) {
-            tesselator.setColorRGBA(204, 204, 204, 255);
+            tessellator.setColorRGBA(204, 204, 204, 255);
             aRenderer.renderFaceZPos(aBlock, aX, aY, aZ, mIconContainer.getOverlayIcon());
         }
     }
 
     @Override
     public void renderZNeg(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
-        final Tessellator tesselator = Tessellator.instance;
-        tesselator.setColorRGBA((int) (mRGBa[0] * 0.8F), (int) (mRGBa[1] * 0.8F), (int) (mRGBa[2] * 0.8F), mAllowAlpha ? 255 - mRGBa[3] : 255);
+        final Tessellator tessellator = Tessellator.instance;
+        tessellator.setColorRGBA((int) (mRGBa[0] * 0.8F), (int) (mRGBa[1] * 0.8F), (int) (mRGBa[2] * 0.8F), mAllowAlpha ? 255 - mRGBa[3] : 255);
         aRenderer.field_152631_f = true;
         aRenderer.renderFaceZNeg(aBlock, aX, aY, aZ, mIconContainer.getIcon());
         if (mIconContainer.getOverlayIcon() != null) {
-            tesselator.setColorRGBA(204, 204, 204, 255);
+            tessellator.setColorRGBA(204, 204, 204, 255);
             aRenderer.renderFaceZNeg(aBlock, aX, aY, aZ, mIconContainer.getOverlayIcon());
         }
         aRenderer.field_152631_f = false;

--- a/src/main/java/gregtech/api/objects/GT_SidedTexture.java
+++ b/src/main/java/gregtech/api/objects/GT_SidedTexture.java
@@ -6,11 +6,9 @@ import gregtech.api.interfaces.IIconContainer;
 import gregtech.api.interfaces.ITexture;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
-import net.minecraft.client.renderer.Tessellator;
 
 public class GT_SidedTexture implements ITexture, IColorModulationContainer {
-    private final IIconContainer[] mIconContainer;
-    private final boolean mAllowAlpha;
+    private final ITexture[] mTextures;
     /**
      * DO NOT MANIPULATE THE VALUES INSIDE THIS ARRAY!!!
      * <p/>
@@ -21,8 +19,14 @@ public class GT_SidedTexture implements ITexture, IColorModulationContainer {
 
     public GT_SidedTexture(IIconContainer aIcon0, IIconContainer aIcon1, IIconContainer aIcon2, IIconContainer aIcon3, IIconContainer aIcon4, IIconContainer aIcon5, short[] aRGBa, boolean aAllowAlpha) {
         if (aRGBa.length != 4) throw new IllegalArgumentException("RGBa doesn't have 4 Values @ GT_RenderedTexture");
-        mIconContainer = new IIconContainer[]{aIcon0, aIcon1, aIcon2, aIcon3, aIcon4, aIcon5};
-        mAllowAlpha = aAllowAlpha;
+        mTextures = new ITexture[]{
+            new GT_RenderedTexture(aIcon0, aRGBa, aAllowAlpha),
+            new GT_RenderedTexture(aIcon1, aRGBa, aAllowAlpha),
+            new GT_RenderedTexture(aIcon2, aRGBa, aAllowAlpha),
+            new GT_RenderedTexture(aIcon3, aRGBa, aAllowAlpha),
+            new GT_RenderedTexture(aIcon4, aRGBa, aAllowAlpha),
+            new GT_RenderedTexture(aIcon5, aRGBa, aAllowAlpha)
+        };
         mRGBa = aRGBa;
     }
 
@@ -44,76 +48,32 @@ public class GT_SidedTexture implements ITexture, IColorModulationContainer {
 
     @Override
     public void renderXPos(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
-        final Tessellator tessellator = Tessellator.instance;
-        tessellator.setColorRGBA((int) (mRGBa[0] * 0.6F), (int) (mRGBa[1] * 0.6F), (int) (mRGBa[2] * 0.6F), mAllowAlpha ? 255 - mRGBa[3] : 255);
-        aRenderer.field_152631_f = true;
-        aRenderer.renderFaceXPos(aBlock, aX, aY, aZ, mIconContainer[5].getIcon());
-        if (mIconContainer[5].getOverlayIcon() != null) {
-            tessellator.setColorRGBA(153, 153, 153, 255);
-            aRenderer.renderFaceXPos(aBlock, aX, aY, aZ, mIconContainer[5].getOverlayIcon());
-        }
-        aRenderer.field_152631_f = false;
+        mTextures[5].renderXPos(aRenderer, aBlock, aX ,aY, aZ);
     }
 
     @Override
     public void renderXNeg(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
-        final Tessellator tessellator = Tessellator.instance;
-        tessellator.setColorRGBA((int) (mRGBa[0] * 0.6F), (int) (mRGBa[1] * 0.6F), (int) (mRGBa[2] * 0.6F), mAllowAlpha ? 255 - mRGBa[3] : 255);
-        aRenderer.renderFaceXNeg(aBlock, aX, aY, aZ, mIconContainer[4].getIcon());
-        if (mIconContainer[4].getOverlayIcon() != null) {
-            tessellator.setColorRGBA(153, 153, 153, 255);
-            aRenderer.renderFaceXNeg(aBlock, aX, aY, aZ, mIconContainer[4].getOverlayIcon());
-        }
+        mTextures[4].renderXNeg(aRenderer, aBlock, aX ,aY, aZ);
     }
 
     @Override
     public void renderYPos(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
-        final Tessellator tessellator = Tessellator.instance;
-        tessellator.setColorRGBA((int) (mRGBa[0] * 1.0F), (int) (mRGBa[1] * 1.0F), (int) (mRGBa[2] * 1.0F), mAllowAlpha ? 255 - mRGBa[3] : 255);
-        aRenderer.renderFaceYPos(aBlock, aX, aY, aZ, mIconContainer[1].getIcon());
-        if (mIconContainer[1].getOverlayIcon() != null) {
-            tessellator.setColorRGBA(255, 255, 255, 255);
-            aRenderer.renderFaceYPos(aBlock, aX, aY, aZ, mIconContainer[1].getOverlayIcon());
-        }
+        mTextures[1].renderYPos(aRenderer, aBlock, aX ,aY, aZ);
     }
 
     @Override
     public void renderYNeg(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
-        final Tessellator tessellator = Tessellator.instance;
-        tessellator.setColorRGBA((int) (mRGBa[0] * 0.5F), (int) (mRGBa[1] * 0.5F), (int) (mRGBa[2] * 0.5F), mAllowAlpha ? 255 - mRGBa[3] : 255);
-        aRenderer.field_152631_f = true;
-        aRenderer.flipTexture = true;
-        aRenderer.renderFaceYNeg(aBlock, aX, aY, aZ, mIconContainer[1].getIcon());
-        if (mIconContainer[0].getOverlayIcon() != null) {
-            tessellator.setColorRGBA(128, 128, 128, 255);
-            aRenderer.renderFaceYNeg(aBlock, aX, aY, aZ, mIconContainer[1].getOverlayIcon());
-        }
-        aRenderer.field_152631_f = false;
-        aRenderer.flipTexture = false;
+        mTextures[0].renderYNeg(aRenderer, aBlock, aX ,aY, aZ);
     }
 
     @Override
     public void renderZPos(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
-        final Tessellator tessellator = Tessellator.instance;
-        tessellator.setColorRGBA((int) (mRGBa[0] * 0.8F), (int) (mRGBa[1] * 0.8F), (int) (mRGBa[2] * 0.8F), mAllowAlpha ? 255 - mRGBa[3] : 255);
-        aRenderer.renderFaceZPos(aBlock, aX, aY, aZ, mIconContainer[3].getIcon());
-        if (mIconContainer[3].getOverlayIcon() != null) {
-            tessellator.setColorRGBA(204, 204, 204, 255);
-            aRenderer.renderFaceZPos(aBlock, aX, aY, aZ, mIconContainer[3].getOverlayIcon());
-        }
+        mTextures[3].renderZPos(aRenderer, aBlock, aX ,aY, aZ);
     }
 
     @Override
     public void renderZNeg(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
-        final Tessellator tessellator = Tessellator.instance;
-        tessellator.setColorRGBA((int) (mRGBa[0] * 0.8F), (int) (mRGBa[1] * 0.8F), (int) (mRGBa[2] * 0.8F), mAllowAlpha ? 255 - mRGBa[3] : 255);
-        aRenderer.field_152631_f = true;
-        aRenderer.renderFaceZNeg(aBlock, aX, aY, aZ, mIconContainer[2].getIcon());
-        if (mIconContainer[2].getOverlayIcon() != null) {
-            tessellator.setColorRGBA(204, 204, 204, 255);
-            aRenderer.renderFaceZNeg(aBlock, aX, aY, aZ, mIconContainer[2].getOverlayIcon());
-        }
-        aRenderer.field_152631_f = false;
+        mTextures[2].renderZNeg(aRenderer, aBlock, aX ,aY, aZ);
     }
 
     @Override
@@ -123,6 +83,9 @@ public class GT_SidedTexture implements ITexture, IColorModulationContainer {
 
     @Override
     public boolean isValidTexture() {
-        return mIconContainer != null && mIconContainer[0] != null && mIconContainer[1] != null && mIconContainer[2] != null && mIconContainer[3] != null && mIconContainer[4] != null && mIconContainer[5] != null;
+        for (ITexture renderedTexture : mTextures) {
+            if (!renderedTexture.isValidTexture()) return false;
+        }
+        return true;
     }
 }

--- a/src/main/java/gregtech/api/objects/GT_StdRenderedTexture.java
+++ b/src/main/java/gregtech/api/objects/GT_StdRenderedTexture.java
@@ -1,0 +1,41 @@
+package gregtech.api.objects;
+
+import gregtech.api.enums.Dyes;
+import gregtech.api.interfaces.IIconContainer;
+import net.minecraft.block.Block;
+import net.minecraft.client.renderer.RenderBlocks;
+import net.minecraft.client.renderer.Tessellator;
+
+/**
+ * This ITexture implementation extends the GT_RenderedTexture class
+ * to render with bottom side flipped as with dumb blocks rendering.
+ * It is used in Ore blocks rendering so they better blends with dumb block ores
+ * from vanilla or other mods, when seen from bottom.
+ */
+public class GT_StdRenderedTexture extends GT_RenderedTexture{
+
+    @SuppressWarnings("unused")
+    public GT_StdRenderedTexture(IIconContainer aIcon, short[] aRGBa, boolean aAllowAlpha) {
+        super(aIcon, aRGBa, aAllowAlpha);
+    }
+
+    public GT_StdRenderedTexture(IIconContainer aIcon, short[] aRGBa) {
+        super(aIcon, aRGBa, true);
+    }
+
+    @SuppressWarnings("unused")
+    public GT_StdRenderedTexture(IIconContainer aIcon) {
+        super(aIcon, Dyes._NULL.mRGBa);
+    }
+
+    @Override
+    public void renderYNeg(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
+        final Tessellator tessellator = Tessellator.instance;
+        tessellator.setColorRGBA((int) (mRGBa[0] * 0.5F), (int) (mRGBa[1] * 0.5F), (int) (mRGBa[2] * 0.5F), mAllowAlpha ? 255 - mRGBa[3] : 255);
+        aRenderer.renderFaceYNeg(aBlock, aX, aY, aZ, mIconContainer.getIcon());
+        if (mIconContainer.getOverlayIcon() != null) {
+            tessellator.setColorRGBA(128, 128, 128, 255);
+            aRenderer.renderFaceYNeg(aBlock, aX, aY, aZ, mIconContainer.getOverlayIcon());
+        }
+    }
+}

--- a/src/main/java/gregtech/common/blocks/GT_TileEntity_Ores.java
+++ b/src/main/java/gregtech/common/blocks/GT_TileEntity_Ores.java
@@ -8,6 +8,7 @@ import gregtech.api.enums.OrePrefixes;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.tileentity.ITexturedTileEntity;
 import gregtech.api.objects.GT_CopiedBlockTexture;
+import gregtech.api.objects.GT_StdRenderedTexture;
 import gregtech.api.objects.GT_RenderedTexture;
 import gregtech.api.objects.XSTR;
 import gregtech.api.util.GT_OreDictUnificator;
@@ -276,7 +277,7 @@ public class GT_TileEntity_Ores extends TileEntity implements ITexturedTileEntit
     public ITexture[] getTexture(Block aBlock, byte aSide) {
         Materials aMaterial = GregTech_API.sGeneratedMaterials[(this.mMetaData % 1000)];
         if ((aMaterial != null) && (this.mMetaData < 32000)) {
-            GT_RenderedTexture aIconSet = new GT_RenderedTexture(aMaterial.mIconSet.mTextures[this.mMetaData / 16000 == 0 ? OrePrefixes.ore.mTextureIndex : OrePrefixes.oreSmall.mTextureIndex], aMaterial.mRGBa);
+            GT_StdRenderedTexture aIconSet = new GT_StdRenderedTexture(aMaterial.mIconSet.mTextures[this.mMetaData / 16000 == 0 ? OrePrefixes.ore.mTextureIndex : OrePrefixes.oreSmall.mTextureIndex], aMaterial.mRGBa);
             if (aBlock instanceof GT_Block_Ores_Abstract) {
                 return new ITexture[]{((GT_Block_Ores_Abstract) aBlock).getTextureSet()[((this.mMetaData / 1000) % 16)], aIconSet};
             }


### PR DESCRIPTION
- Fix bottom side texture orientation to not flip texture. Special
  thanks to @GregoriusT who raised awareness of potential issue with
  texture where direction matters (like button panels or texts).
- Implement a flipped bottom texture rendering to have ore blocks
  use the very same orientation as dumb blocks ore textures from other mods.
- Refactor GT_SidedTexture to use GT_RenderedTexture for rendering,
  rather than duplicate the rendering code of it.