### PR TITLE
Add option to disable input machine on single block machines

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/examples/GT_MetaTileEntity_E_Furnace.java
+++ b/src/main/java/gregtech/api/metatileentity/examples/GT_MetaTileEntity_E_Furnace.java
@@ -44,7 +44,7 @@ public class GT_MetaTileEntity_E_Furnace extends GT_MetaTileEntity_BasicMachine 
 
     @Override
     public boolean allowPutStack(IGregTechTileEntity aBaseMetaTileEntity, int aIndex, byte aSide, ItemStack aStack) {
-        return super.allowPutStack(aBaseMetaTileEntity, aIndex, aSide, aStack) && GT_ModHandler.getSmeltingOutput(GT_Utility.copyAmount(64, aStack), false, null) != null;
+        return super.allowPutStack(aBaseMetaTileEntity, aIndex, aSide, aStack) && (mDisableFilter || GT_ModHandler.getSmeltingOutput(GT_Utility.copyAmount(64, aStack), false, null) != null);
     }
 
     @Override

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicMachine_GT_Recipe.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicMachine_GT_Recipe.java
@@ -746,7 +746,7 @@ public class GT_MetaTileEntity_BasicMachine_GT_Recipe extends GT_MetaTileEntity_
     @Override
     public boolean allowPutStack(IGregTechTileEntity aBaseMetaTileEntity, int aIndex, byte aSide, ItemStack aStack) {
         if (!super.allowPutStack(aBaseMetaTileEntity, aIndex, aSide, aStack)) return false;
-        if (this.mInventory[aIndex] != null) return true;
+        if (this.mInventory[aIndex] != null || mDisableFilter) return true;
         switch (this.mInputSlotCount) {
             case 0:
                 return false;

--- a/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_Boxinator.java
+++ b/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_Boxinator.java
@@ -126,6 +126,7 @@ public class GT_MetaTileEntity_Boxinator
 
     public boolean allowPutStack(IGregTechTileEntity aBaseMetaTileEntity, int aIndex, byte aSide, ItemStack aStack) {
         if (super.allowPutStack(aBaseMetaTileEntity, aIndex, aSide, aStack)) {
+            if (mDisableFilter) return true;
             ItemStack tInput1 = getInputAt(1);
             if ((ItemList.Schematic_1by1.isStackEqual(tInput1)) || (ItemList.Schematic_2by2.isStackEqual(tInput1)) || (ItemList.Schematic_3by3.isStackEqual(tInput1))) {
                 if (hasValidCache(aStack,aTypeCache,false))

--- a/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_CuringOven.java
+++ b/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_CuringOven.java
@@ -36,7 +36,7 @@ public class GT_MetaTileEntity_CuringOven
     }
 
     public boolean allowPutStack(IGregTechTileEntity aBaseMetaTileEntity, int aIndex, byte aSide, ItemStack aStack) {
-        return (super.allowPutStack(aBaseMetaTileEntity, aIndex, aSide, aStack)) && (ItemList.Cell_Empty.isStackEqual(aStack));
+        return (super.allowPutStack(aBaseMetaTileEntity, aIndex, aSide, aStack)) && (mDisableFilter || (ItemList.Cell_Empty.isStackEqual(aStack)));
     }
 
     public boolean isFluidInputAllowed(FluidStack aFluid) {

--- a/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_Disassembler.java
+++ b/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_Disassembler.java
@@ -421,7 +421,6 @@ public class GT_MetaTileEntity_Disassembler
     }
 
     public boolean allowPutStack(IGregTechTileEntity aBaseMetaTileEntity, int aIndex, byte aSide, ItemStack aStack) {
-        return //(aIndex == 4 && GT_Utility.areStacksEqual(aStack, new ItemStack(Items.egg))) ||
-                (super.allowPutStack(aBaseMetaTileEntity, aIndex, aSide, aStack)) && (aStack.getTagCompound() != null) && (aStack.getTagCompound().getCompoundTag("GT.CraftingComponents") != null);
+        return (super.allowPutStack(aBaseMetaTileEntity, aIndex, aSide, aStack)) && (mDisableFilter || (aStack.getTagCompound() != null) && (aStack.getTagCompound().getCompoundTag("GT.CraftingComponents") != null));
     }
 }

--- a/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_Miner.java
+++ b/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_Miner.java
@@ -80,7 +80,7 @@ public class GT_MetaTileEntity_Miner extends GT_MetaTileEntity_BasicMachine {
     }
 
     public boolean allowPutStack(IGregTechTileEntity aBaseMetaTileEntity, int aIndex, byte aSide, ItemStack aStack) {
-        return (super.allowPutStack(aBaseMetaTileEntity, aIndex, aSide, aStack)) && (aStack.getItem() == MINING_PIPE.getItem());
+        return (super.allowPutStack(aBaseMetaTileEntity, aIndex, aSide, aStack)) && (mDisableFilter || aStack.getItem() == MINING_PIPE.getItem());
     }
 
     public boolean hasFreeSpace() {

--- a/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_PotionBrewer.java
+++ b/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_PotionBrewer.java
@@ -132,7 +132,7 @@ public class GT_MetaTileEntity_PotionBrewer
     }
 
     public boolean allowPutStack(IGregTechTileEntity aBaseMetaTileEntity, int aIndex, byte aSide, ItemStack aStack) {
-        return (super.allowPutStack(aBaseMetaTileEntity, aIndex, aSide, aStack)) && (getRecipeList().containsInput(aStack));
+        return super.allowPutStack(aBaseMetaTileEntity, aIndex, aSide, aStack) && (mDisableFilter || getRecipeList().containsInput(aStack));
     }
 
     public boolean isFluidInputAllowed(FluidStack aFluid) {

--- a/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_Replicator.java
+++ b/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_Replicator.java
@@ -102,7 +102,7 @@ public class GT_MetaTileEntity_Replicator
     }
 
     public boolean allowPutStack(IGregTechTileEntity aBaseMetaTileEntity, int aIndex, byte aSide, ItemStack aStack) {
-        return (super.allowPutStack(aBaseMetaTileEntity, aIndex, aSide, aStack)) && (ItemList.Cell_Empty.isStackEqual(aStack));
+        return super.allowPutStack(aBaseMetaTileEntity, aIndex, aSide, aStack) && (mDisableFilter || ItemList.Cell_Empty.isStackEqual(aStack));
     }
 
     public boolean isFluidInputAllowed(FluidStack aFluid) {

--- a/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_RockBreaker.java
+++ b/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_RockBreaker.java
@@ -37,7 +37,7 @@ public class GT_MetaTileEntity_RockBreaker
     }
 
     public boolean allowPutStack(IGregTechTileEntity aBaseMetaTileEntity, int aIndex, byte aSide, ItemStack aStack) {
-        return (super.allowPutStack(aBaseMetaTileEntity, aIndex, aSide, aStack)) && (getRecipeList().containsInput(aStack));
+        return (super.allowPutStack(aBaseMetaTileEntity, aIndex, aSide, aStack)) && (mDisableFilter || getRecipeList().containsInput(aStack));
     }
 
     public int checkRecipe() {

--- a/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_Scanner.java
+++ b/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_Scanner.java
@@ -350,13 +350,13 @@ public class GT_MetaTileEntity_Scanner
     }
 
     public boolean allowPutStack(IGregTechTileEntity aBaseMetaTileEntity, int aIndex, byte aSide, ItemStack aStack) {
-        return (super.allowPutStack(aBaseMetaTileEntity, aIndex, aSide, aStack)) && (getRecipeList().containsInput(aStack));
+        return (super.allowPutStack(aBaseMetaTileEntity, aIndex, aSide, aStack)) && (mDisableFilter || getRecipeList().containsInput(aStack));
     }
 
     public void startSoundLoop(byte aIndex, double aX, double aY, double aZ) {
         super.startSoundLoop(aIndex, aX, aY, aZ);
         if (aIndex == 1) {
-            GT_Utility.doSoundAtClient((String) GregTech_API.sSoundList.get(Integer.valueOf(212)), 10, 1.0F, aX, aY, aZ);
+            GT_Utility.doSoundAtClient((String) GregTech_API.sSoundList.get(212), 10, 1.0F, aX, aY, aZ);
         }
     }
 

--- a/src/main/java/gregtech/common/tileentities/machines/steam/GT_MetaTileEntity_Furnace_Bronze.java
+++ b/src/main/java/gregtech/common/tileentities/machines/steam/GT_MetaTileEntity_Furnace_Bronze.java
@@ -47,13 +47,13 @@ public class GT_MetaTileEntity_Furnace_Bronze extends GT_MetaTileEntity_BasicMac
         if (!super.allowPutStack(aBaseMetaTileEntity, aIndex, aSide, aStack)) {
             return false;
         }
-        return GT_ModHandler.getSmeltingOutput(GT_Utility.copyAmount(64L, new Object[]{aStack}), false, null) != null;
+        return mDisableFilter || GT_ModHandler.getSmeltingOutput(GT_Utility.copyAmount(64L, aStack), false, null) != null;
     }
 
     public void startSoundLoop(byte aIndex, double aX, double aY, double aZ) {
         super.startSoundLoop(aIndex, aX, aY, aZ);
         if (aIndex == 1) {
-            GT_Utility.doSoundAtClient((String) GregTech_API.sSoundList.get(Integer.valueOf(207)), 10, 1.0F, aX, aY, aZ);
+            GT_Utility.doSoundAtClient(GregTech_API.sSoundList.get(207), 10, 1.0F, aX, aY, aZ);
         }
     }
 

--- a/src/main/java/gregtech/common/tileentities/machines/steam/GT_MetaTileEntity_Furnace_Steel.java
+++ b/src/main/java/gregtech/common/tileentities/machines/steam/GT_MetaTileEntity_Furnace_Steel.java
@@ -47,13 +47,13 @@ public class GT_MetaTileEntity_Furnace_Steel extends GT_MetaTileEntity_BasicMach
         if (!super.allowPutStack(aBaseMetaTileEntity, aIndex, aSide, aStack)) {
             return false;
         }
-        return GT_ModHandler.getSmeltingOutput(GT_Utility.copyAmount(64L, new Object[]{aStack}), false, null) != null;
+        return mDisableFilter || GT_ModHandler.getSmeltingOutput(GT_Utility.copyAmount(64L, aStack), false, null) != null;
     }
 
     public void startSoundLoop(byte aIndex, double aX, double aY, double aZ) {
         super.startSoundLoop(aIndex, aX, aY, aZ);
         if (aIndex == 1) {
-            GT_Utility.doSoundAtClient((String) GregTech_API.sSoundList.get(Integer.valueOf(207)), 10, 1.0F, aX, aY, aZ);
+            GT_Utility.doSoundAtClient(GregTech_API.sSoundList.get(207), 10, 1.0F, aX, aY, aZ);
         }
     }
 

--- a/src/main/java/gregtech/common/tileentities/machines/steam/GT_MetaTileEntity_Macerator_Bronze.java
+++ b/src/main/java/gregtech/common/tileentities/machines/steam/GT_MetaTileEntity_Macerator_Bronze.java
@@ -73,13 +73,13 @@ public class GT_MetaTileEntity_Macerator_Bronze extends GT_MetaTileEntity_BasicM
         if (!super.allowPutStack(aBaseMetaTileEntity, aIndex, aSide, aStack)) {
             return false;
         }
-        return GT_Recipe.GT_Recipe_Map.sMaceratorRecipes.containsInput(GT_Utility.copyAmount(64L, new Object[]{aStack}));
+        return mDisableFilter || GT_Recipe.GT_Recipe_Map.sMaceratorRecipes.containsInput(GT_Utility.copyAmount(64L, aStack));
     }
 
     public void startSoundLoop(byte aIndex, double aX, double aY, double aZ) {
         super.startSoundLoop(aIndex, aX, aY, aZ);
         if (aIndex == 1) {
-            GT_Utility.doSoundAtClient((String) GregTech_API.sSoundList.get(Integer.valueOf(201)), 10, 1.0F, aX, aY, aZ);
+            GT_Utility.doSoundAtClient(GregTech_API.sSoundList.get(201), 10, 1.0F, aX, aY, aZ);
         }
     }
 

--- a/src/main/java/gregtech/common/tileentities/machines/steam/GT_MetaTileEntity_Macerator_Steel.java
+++ b/src/main/java/gregtech/common/tileentities/machines/steam/GT_MetaTileEntity_Macerator_Steel.java
@@ -73,13 +73,13 @@ public class GT_MetaTileEntity_Macerator_Steel extends GT_MetaTileEntity_BasicMa
         if (!super.allowPutStack(aBaseMetaTileEntity, aIndex, aSide, aStack)) {
             return false;
         }
-        return GT_Recipe.GT_Recipe_Map.sMaceratorRecipes.containsInput(GT_Utility.copyAmount(64L, new Object[]{aStack}));
+        return mDisableFilter || GT_Recipe.GT_Recipe_Map.sMaceratorRecipes.containsInput(GT_Utility.copyAmount(64L, new Object[]{aStack}));
     }
 
     public void startSoundLoop(byte aIndex, double aX, double aY, double aZ) {
         super.startSoundLoop(aIndex, aX, aY, aZ);
         if (aIndex == 1) {
-            GT_Utility.doSoundAtClient((String) GregTech_API.sSoundList.get(Integer.valueOf(201)), 10, 1.0F, aX, aY, aZ);
+            GT_Utility.doSoundAtClient(GregTech_API.sSoundList.get(201), 10, 1.0F, aX, aY, aZ);
         }
     }
 


### PR DESCRIPTION
GTNewHorizons/GT-New-Horizons-Modpack#7179

Input filter will now be an opt in feature instead of default on.

Key points:

1. Sneak right click the front face or output facing to toggle input filtering **with screwdriver**.
2. Existing machines will have input filter on to preserve the original behavior.
3. New machines will have input filter off in an attempt to reduce lag (especially for packagers)
4. May not work on addon machines if they override allowPutStack.
