### PR TITLE
fix entity.gregtech.GT_Entity_Arrow.name localization

### DIFF
--- a/src/main/resources/assets/gregtech/lang/en_US.lang
+++ b/src/main/resources/assets/gregtech/lang/en_US.lang
@@ -1044,3 +1044,5 @@ gregtech.speedUnproductive=Unproductive
 gregtech.speedAccelerated=Accelerated
 gregtech.lifeBlink=Blink 
 gregtech.lifeEon=Eon
+
+entity.gregtech.GT_Entity_Arrow.name= a GregTech arrow


### PR DESCRIPTION
add the missing localization that can happen sometimes when a skeleton kills a player with a GT arrow:
`boubou_19 was shot by entity.gregtech.GT_Entity_Arrow.name`