### PR TITLE
feat(i18n): itemlist withname locale

### DIFF
--- a/src/main/java/gregtech/api/enums/ItemList.java
+++ b/src/main/java/gregtech/api/enums/ItemList.java
@@ -1,6 +1,7 @@
 package gregtech.api.enums;
 
 import gregtech.api.interfaces.IItemContainer;
+import gregtech.api.util.GT_LanguageManager;
 import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_OreDictUnificator;
 import gregtech.api.util.GT_Utility;
@@ -9,6 +10,9 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.Fluid;
 
+import java.util.Locale;
+
+import static gregtech.api.enums.GT_Values.NI;
 import static gregtech.api.enums.GT_Values.W;
 
 /**
@@ -2007,8 +2011,24 @@ public enum ItemList implements IItemContainer {
     public ItemStack getWithName(long aAmount, String aDisplayName, Object... aReplacements) {
         ItemStack rStack = get(1, aReplacements);
         if (GT_Utility.isStackInvalid(rStack))
-            return null;
-        rStack.setStackDisplayName(aDisplayName);
+            return NI;
+
+        // CamelCase alphanumeric words from aDisplayName
+        StringBuilder tCamelCasedDisplayNameBuilder = new StringBuilder();
+        final String[] tDisplayNameWords = aDisplayName.split("\\W");
+        for (String tWord : tDisplayNameWords){
+            if (tWord.length() > 0) tCamelCasedDisplayNameBuilder.append(tWord.substring(0, 1).toUpperCase(Locale.US));
+            if (tWord.length() > 1) tCamelCasedDisplayNameBuilder.append(tWord.substring(1).toLowerCase(Locale.US));
+        }
+        if (tCamelCasedDisplayNameBuilder.length() == 0) {
+            // CamelCased DisplayName is empty, so use hash of aDisplayName
+            tCamelCasedDisplayNameBuilder.append(((Long) (long)aDisplayName.hashCode()).toString());
+        }
+
+        // Construct a translation key from UnlocalizedName and CamelCased DisplayName
+        final String tKey = rStack.getUnlocalizedName() + ".with." + tCamelCasedDisplayNameBuilder.toString() + ".name";
+
+        rStack.setStackDisplayName(GT_LanguageManager.addStringLocalization(tKey, aDisplayName));
         return GT_Utility.copyAmount(aAmount, rStack);
     }
 


### PR DESCRIPTION
Automatically generates entries into `Gregtech.lang` for items
with custom names (mostly used for recipes display in NEI).

Ported from: https://github.com/Blood-Asp/GT5-Unofficial/pull/1552

Will provide new localization keys and default English texts.

Newly generated entries in `Gregtech.lang`:
```yaml
    S:gt.metaitem.01.32707.with.CopyOfTheOrb.name=Copy of the Orb
    S:gt.metaitem.01.32707.with.OrbToCopy.name=Orb to copy
    S:gt.metaitem.01.32707.with.OrbToOverwrite.name=Orb to overwrite
    S:gt.metaitem.01.32708.with.AnalyzedProspectionData.name=Analyzed Prospection Data
    S:gt.metaitem.01.32708.with.CopyOfTheStick.name=Copy of the Stick
    S:gt.metaitem.01.32708.with.RawProspectionData.name=Raw Prospection Data
    S:gt.metaitem.01.32708.with.ReadsResearchResult.name=Reads Research result
    S:gt.metaitem.01.32708.with.ScannedBookData.name=Scanned Book Data
    S:gt.metaitem.01.32708.with.ScannedMapData.name=Scanned Map Data
    S:gt.metaitem.01.32708.with.ScannedSchematic.name=Scanned Schematic
    S:gt.metaitem.01.32708.with.StickToCopy.name=Stick to copy
    S:gt.metaitem.01.32708.with.StickToOverwrite.name=Stick to overwrite
    S:gt.metaitem.01.32708.with.StickToSaveItTo.name=Stick to save it to
    S:gt.metaitem.01.32708.with.WithPunchCardData.name=With Punch Card Data
    S:gt.metaitem.01.32708.with.WithScannedBookData.name=With Scanned Book Data
    S:gt.metaitem.01.32708.with.WithScannedMapData.name=With Scanned Map Data
    S:gt.metaitem.01.32708.with.WritesResearchResult.name=Writes Research result
    S:ic2.crop.invalid.with.ScannedSeeds.name=Scanned Seeds
    S:item.for.beeDroneGE.with.ScannedDrone.name=Scanned Drone
    S:item.for.beeLarvaeGE.with.ScannedLarvae.name=Scanned Larvae
    S:item.for.beePrincessGE.with.ScannedPrincess.name=Scanned Princess
    S:item.for.beeQueenGE.with.ScannedQueen.name=Scanned Queen
    S:item.for.butterflyGE.with.ScannedButterfly.name=Scanned Butterfly
    S:item.for.caterpillarGE.with.ScannedCaterpillar.name=Scanned Caterpillar
    S:item.for.pollenFertile.with.ScannedPollen.name=Scanned Pollen
    S:item.for.sapling.with.ScannedSapling.name=Scanned Sapling
    S:item.for.serumGE.with.ScannedSerum.name=Scanned Serum
```