### PR TITLE
BasicMachine fluid tank manipulations in GUI

### DIFF
--- a/src/main/java/gregtech/api/gui/GT_Container_BasicMachine.java
+++ b/src/main/java/gregtech/api/gui/GT_Container_BasicMachine.java
@@ -186,8 +186,8 @@ public class GT_Container_BasicMachine extends GT_Container_BasicTank {
 
     @Override
     public ItemStack slotClick(int aSlotIndex, int aMouseclick, int aShifthold, EntityPlayer aPlayer) {
-        if (mTileEntity.getMetaTileEntity() == null) return null;
         GT_MetaTileEntity_BasicMachine machine = (GT_MetaTileEntity_BasicMachine) mTileEntity.getMetaTileEntity();
+        if (machine == null) return null;
         switch (aSlotIndex) {
             case 0:
                 machine.mFluidTransfer = !machine.mFluidTransfer;
@@ -216,7 +216,7 @@ public class GT_Container_BasicMachine extends GT_Container_BasicTank {
                             // both nonnull. actually both pickup and fill is reasonable, but I'll go with fill here
                             return fillFluid(machine, aPlayer, tFluidHeld);
                         } else {
-                            return pickupFluid(machine.getFillableStack(), aPlayer);
+                            return pickupFluid(tInputFluid, aPlayer);
                         }
                     }
                 } else {

--- a/src/main/java/gregtech/api/gui/GT_Slot_Render.java
+++ b/src/main/java/gregtech/api/gui/GT_Slot_Render.java
@@ -1,7 +1,5 @@
 package gregtech.api.gui;
 
-import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_Maintenance;
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;

--- a/src/main/java/gregtech/api/gui/GT_Slot_Render.java
+++ b/src/main/java/gregtech/api/gui/GT_Slot_Render.java
@@ -1,5 +1,7 @@
 package gregtech.api.gui;
 
+import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_Maintenance;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;

--- a/src/main/java/gregtech/api/util/GT_Utility.java
+++ b/src/main/java/gregtech/api/util/GT_Utility.java
@@ -972,6 +972,15 @@ public class GT_Utility {
         return rStack;
     }
 
+    public static FluidStack getFluidFromDisplayStack(ItemStack aDisplayStack) {
+        if (!isStackValid(aDisplayStack) ||
+                aDisplayStack.getItem() != ItemList.Display_Fluid.getItem() ||
+                !aDisplayStack.hasTagCompound())
+            return null;
+        Fluid tFluid = FluidRegistry.getFluid(ItemList.Display_Fluid.getItem().getDamage(aDisplayStack));
+        return new FluidStack(tFluid, (int) aDisplayStack.getTagCompound().getLong("mFluidDisplayAmount"));
+    }
+
     public static boolean containsFluid(ItemStack aStack, FluidStack aFluid, boolean aCheckIFluidContainerItems) {
         if (isStackInvalid(aStack) || aFluid == null) return false;
         if (aCheckIFluidContainerItems && aStack.getItem() instanceof IFluidContainerItem && ((IFluidContainerItem) aStack.getItem()).getCapacity(aStack) > 0)
@@ -2767,5 +2776,17 @@ public class GT_Utility {
                         300, 30, 0
                 )
         );
+    }
+
+    /**
+     * Add an itemstack to player inventory, or drop on ground if full.
+     * Can be called on client but it probably won't work very well.
+     */
+    public static void addItemToPlayerInventory(EntityPlayer aPlayer, ItemStack aStack) {
+        if (isStackInvalid(aStack)) return;
+        if (!aPlayer.inventory.addItemStackToInventory(aStack) && !aPlayer.worldObj.isRemote) {
+            EntityItem dropItem = aPlayer.entityDropItem(aStack, 0);
+            dropItem.delayBeforeCanPickup = 0;
+        }
     }
 }


### PR DESCRIPTION
Still need some more testing on dedicated servers to ensure there isn't werid desync/dupe bugs. Any help is appreciated.

Known issues:
- [ ] Clicking too fast might result in wrong fluid amount being displayed. Data on server is correct however. Reopen the GUI would fix it.
- [x] ~~Does not respect shift clicking.~~ Not possible due to NEI getting in the way.
- [ ] Right click to process one item. Left click to process full stack.