### PR TITLE
Pickup fluid instead if the input tank is full

### DIFF
--- a/src/main/java/gregtech/api/gui/GT_Container_BasicMachine.java
+++ b/src/main/java/gregtech/api/gui/GT_Container_BasicMachine.java
@@ -218,8 +218,9 @@ public class GT_Container_BasicMachine extends GT_Container_BasicTank {
                             return null;
                         return fillFluid(machine, aPlayer, tFluidHeld, aMouseclick == 0);
                     } else {
-                        if (tFluidHeld != null) {
-                            // both nonnull. actually both pickup and fill is reasonable, but I'll go with fill here
+                        if (tFluidHeld != null && tInputFluid.amount < machine.getCapacity()) {
+                            // both nonnull and have space left for filling.
+                            // actually both pickup and fill is reasonable, but I'll go with fill here
                             return fillFluid(machine, aPlayer, tFluidHeld, aMouseclick == 0);
                         } else {
                             tResultStack = pickupFluid(tInputFluid, aPlayer, aMouseclick == 0);


### PR DESCRIPTION
If the partially filled cell is used on a full input tank, it will now attempt to drain instead of attempt to fill. Thanks @Prometheus0000 for the suggestion.