### PR TITLE
fix running asslinecrash on data hatch break

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_AssemblyLine.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_AssemblyLine.java
@@ -253,6 +253,7 @@ public class GT_MetaTileEntity_AssemblyLine
     }
 
     public boolean checkMachine(IGregTechTileEntity aBaseMetaTileEntity, ItemStack aStack) {
+	mDataAccessHatches.clear();
         int xDir = ForgeDirection.getOrientation(aBaseMetaTileEntity.getBackFacing()).offsetX;
         int zDir = ForgeDirection.getOrientation(aBaseMetaTileEntity.getBackFacing()).offsetZ;
         if (xDir != 0) {


### PR DESCRIPTION
fix that when a fully formed assline with data hatch and when the data hatch would be replaced the onRunningTick would crash and stop the assline from ticking the recipe progression