### PR TITLE
impr(rendering): Machine block casts an ambient occlusion shadow

### DIFF
--- a/src/main/java/gregtech/api/GregTech_API.java
+++ b/src/main/java/gregtech/api/GregTech_API.java
@@ -739,4 +739,23 @@ public class GregTech_API {
         sToolList.add(new GT_ItemStack(GT_Utility.copyAmount(1, aTool)));
         return true;
     }
+
+    /**
+     * Sets the {@link IIconRegister} for Block Icons
+     * @param aIconRegister The {@link IIconRegister} Icon Register
+     */
+    @SideOnly(Side.CLIENT)
+    public static void setBlockIconRegister(IIconRegister aIconRegister) {
+        sBlockIcons = aIconRegister;
+    };
+
+    /**
+     * Sets the {@link IIconRegister} for Items Icons
+     * @param aIconRegister The {@link IIconRegister} Icon Register
+     */
+    @SideOnly(Side.CLIENT)
+    public static void setItemIconRegister(IIconRegister aIconRegister) {
+        GregTech_API.sItemIcons = aIconRegister;
+    }
+
 }

--- a/src/main/java/gregtech/api/util/LightingHelper.java
+++ b/src/main/java/gregtech/api/util/LightingHelper.java
@@ -286,6 +286,21 @@ public class LightingHelper {
     }
 
     /**
+     * Gets mixed ambient occlusion value from two inputs, with a
+     * ratio applied to the final result.
+     *
+     * @param ao1   the first ambient occlusion value
+     * @param ao2   the second ambient occlusion value
+     * @param ratio the ratio for mixing
+     * @return the mixed red, green, blue float values
+     */
+    public static float getMixedAo(float ao1, float ao2, double ratio) {
+        float diff = (float) (Math.abs(ao1 - ao2) * (1.0F - ratio));
+
+        return ao1 > ao2 ? ao1 - diff : ao1 + diff;
+    }
+
+    /**
      * Sets up lighting for the West face and returns the {@link LightingHelper}.
      * <p>
      * This is a consolidated <code>method</code> that sets side shading
@@ -303,15 +318,16 @@ public class LightingHelper {
      * @return the {@link LightingHelper}
      */
     public LightingHelper setupLightingXNeg(Block block, int x, int y, int z) {
-        int xOffset = renderBlocks.renderMinX > 0.0F ? x : x - 1;
 
         if (renderBlocks.enableAO) {
+
+            int xOffset = renderBlocks.renderMinX > 0.0F ? x : x - 1;
 
             int mixedBrightness = block.getMixedBrightnessForBlock(renderBlocks.blockAccess, xOffset, y, z);
             brightness = mixedBrightness;
 
             float ratio = (float) (1.0F - renderBlocks.renderMinX);
-            float aoLightValue = renderBlocks.blockAccess.getBlock(xOffset, y, z).getAmbientOcclusionLightValue();
+            float aoLightValue = renderBlocks.blockAccess.getBlock(x - 1, y, z).getAmbientOcclusionLightValue();
 
             renderBlocks.aoBrightnessXYNN = block.getMixedBrightnessForBlock(renderBlocks.blockAccess, xOffset, y - 1, z);
             renderBlocks.aoBrightnessXZNN = block.getMixedBrightnessForBlock(renderBlocks.blockAccess, xOffset, y, z - 1);
@@ -356,21 +372,6 @@ public class LightingHelper {
     }
 
     /**
-     * Gets mixed ambient occlusion value from two inputs, with a
-     * ratio applied to the final result.
-     *
-     * @param ao1   the first ambient occlusion value
-     * @param ao2   the second ambient occlusion value
-     * @param ratio the ratio for mixing
-     * @return the mixed red, green, blue float values
-     */
-    public static float getMixedAo(float ao1, float ao2, double ratio) {
-        float diff = (float) (Math.abs(ao1 - ao2) * (1.0F - ratio));
-
-        return ao1 > ao2 ? ao1 - diff : ao1 + diff;
-    }
-
-    /**
      * Sets up lighting for the East face and returns the {@link LightingHelper}.
      * <p>
      * This is a consolidated <code>method</code> that sets side shading
@@ -388,14 +389,15 @@ public class LightingHelper {
      * @return the {@link LightingHelper}
      */
     public LightingHelper setupLightingXPos(Block block, int x, int y, int z) {
-        int xOffset = renderBlocks.renderMaxX < 1.0F ? x : x + 1;
 
         if (renderBlocks.enableAO) {
+
+            int xOffset = renderBlocks.renderMaxX < 1.0F ? x : x + 1;
 
             int mixedBrightness = block.getMixedBrightnessForBlock(renderBlocks.blockAccess, xOffset, y, z);
             brightness = mixedBrightness;
 
-            float aoLightValue = renderBlocks.blockAccess.getBlock(xOffset, y, z).getAmbientOcclusionLightValue();
+            float aoLightValue = renderBlocks.blockAccess.getBlock(x + 1, y, z).getAmbientOcclusionLightValue();
 
             renderBlocks.aoBrightnessXYPN = block.getMixedBrightnessForBlock(renderBlocks.blockAccess, xOffset, y - 1, z);
             renderBlocks.aoBrightnessXZPN = block.getMixedBrightnessForBlock(renderBlocks.blockAccess, xOffset, y, z - 1);
@@ -458,15 +460,15 @@ public class LightingHelper {
      */
     public LightingHelper setupLightingYNeg(Block block, int x, int y, int z) {
 
-        int yOffset = renderBlocks.renderMinY > 0.0F ? y : y - 1;
-
         if (renderBlocks.enableAO) {
+
+            int yOffset = renderBlocks.renderMinY > 0.0F ? y : y - 1;
 
             int mixedBrightness = block.getMixedBrightnessForBlock(renderBlocks.blockAccess, x, yOffset, z);
             brightness = mixedBrightness;
 
             float ratio = (float) (1.0F - renderBlocks.renderMinY);
-            float aoLightValue = renderBlocks.blockAccess.getBlock(x, yOffset, z).getAmbientOcclusionLightValue();
+            float aoLightValue = renderBlocks.blockAccess.getBlock(x, y - 1, z).getAmbientOcclusionLightValue();
 
             renderBlocks.aoBrightnessXYNN = block.getMixedBrightnessForBlock(renderBlocks.blockAccess, x - 1, yOffset, z);
             renderBlocks.aoBrightnessYZNN = block.getMixedBrightnessForBlock(renderBlocks.blockAccess, x, yOffset, z - 1);
@@ -528,14 +530,15 @@ public class LightingHelper {
      * @return the {@link LightingHelper}
      */
     public LightingHelper setupLightingYPos(Block block, int x, int y, int z) {
-        int yOffset = renderBlocks.renderMaxY < 1.0F ? y : y + 1;
 
         if (renderBlocks.enableAO) {
+
+            int yOffset = renderBlocks.renderMaxY < 1.0F ? y : y + 1;
 
             int mixedBrightness = block.getMixedBrightnessForBlock(renderBlocks.blockAccess, x, yOffset, z);
             brightness = mixedBrightness;
 
-            float aoLightValue = renderBlocks.blockAccess.getBlock(x, yOffset, z).getAmbientOcclusionLightValue();
+            float aoLightValue = renderBlocks.blockAccess.getBlock(x, y + 1, z).getAmbientOcclusionLightValue();
 
             renderBlocks.aoBrightnessXYNP = block.getMixedBrightnessForBlock(renderBlocks.blockAccess, x - 1, yOffset, z);
             renderBlocks.aoBrightnessXYPP = block.getMixedBrightnessForBlock(renderBlocks.blockAccess, x + 1, yOffset, z);
@@ -596,15 +599,16 @@ public class LightingHelper {
      * @return the {@link LightingHelper}
      */
     public LightingHelper setupLightingZNeg(Block block, int x, int y, int z) {
-        int zOffset = renderBlocks.renderMinZ > 0.0F ? z : z - 1;
 
         if (renderBlocks.enableAO) {
+
+            int zOffset = renderBlocks.renderMinZ > 0.0F ? z : z - 1;
 
             int mixedBrightness = block.getMixedBrightnessForBlock(renderBlocks.blockAccess, x, y, zOffset);
             brightness = mixedBrightness;
 
             float ratio = (float) (1.0F - renderBlocks.renderMinZ);
-            float aoLightValue = renderBlocks.blockAccess.getBlock(x, y, zOffset).getAmbientOcclusionLightValue();
+            float aoLightValue = renderBlocks.blockAccess.getBlock(x, y, z - 1).getAmbientOcclusionLightValue();
 
             renderBlocks.aoBrightnessXZNN = block.getMixedBrightnessForBlock(renderBlocks.blockAccess, x - 1, y, zOffset);
             renderBlocks.aoBrightnessYZNN = block.getMixedBrightnessForBlock(renderBlocks.blockAccess, x, y - 1, zOffset);
@@ -666,14 +670,15 @@ public class LightingHelper {
      * @return the {@link LightingHelper}
      */
     public LightingHelper setupLightingZPos(Block block, int x, int y, int z) {
-        int zOffset = renderBlocks.renderMaxZ < 1.0F ? z : z + 1;
 
         if (renderBlocks.enableAO) {
+
+            int zOffset = renderBlocks.renderMaxZ < 1.0F ? z : z + 1;
 
             int mixedBrightness = block.getMixedBrightnessForBlock(renderBlocks.blockAccess, x, y, zOffset);
             brightness = mixedBrightness;
 
-            float aoLightValue = renderBlocks.blockAccess.getBlock(x, y, zOffset).getAmbientOcclusionLightValue();
+            float aoLightValue = renderBlocks.blockAccess.getBlock(x, y, z + 1).getAmbientOcclusionLightValue();
 
             renderBlocks.aoBrightnessXZNP = block.getMixedBrightnessForBlock(renderBlocks.blockAccess, x - 1, y, zOffset);
             renderBlocks.aoBrightnessXZPP = block.getMixedBrightnessForBlock(renderBlocks.blockAccess, x + 1, y, zOffset);

--- a/src/main/java/gregtech/common/blocks/GT_Block_Machines.java
+++ b/src/main/java/gregtech/common/blocks/GT_Block_Machines.java
@@ -39,13 +39,15 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static gregtech.GT_Mod.GT_FML_LOGGER;
 import static gregtech.api.objects.XSTR.XSTR_INSTANCE;
 
 public class GT_Block_Machines extends GT_Generic_Block implements IDebugableBlock, ITileEntityProvider {
-    public static ThreadLocal<IGregTechTileEntity> mTemporaryTileEntity = new ThreadLocal();
+    private static final ThreadLocal<IGregTechTileEntity> mTemporaryTileEntity = new ThreadLocal<>();
+    private boolean renderAsNormalBlock;
 
     public GT_Block_Machines() {
         super(GT_Item_Machines.class, "gt.blockmachines", new GT_Material_Machines());
@@ -55,8 +57,11 @@ public class GT_Block_Machines extends GT_Generic_Block implements IDebugableBlo
         setStepSound(soundTypeMetal);
         setCreativeTab(GregTech_API.TAB_GREGTECH);
         this.isBlockContainer = true;
+        this.renderAsNormalBlock = true;
+        this.useNeighborBrightness = true;
     }
 
+    @Override
     public String getHarvestTool(int aMeta) {
         if (aMeta >= 8 && aMeta <= 11) {
             return "cutter";
@@ -64,14 +69,17 @@ public class GT_Block_Machines extends GT_Generic_Block implements IDebugableBlo
         return "wrench";
     }
 
+    @Override
     public int getHarvestLevel(int aMeta) {
         return aMeta % 4;
     }
 
+    @Override
     protected boolean canSilkHarvest() {
         return false;
     }
 
+    @Override
     public void onNeighborChange(IBlockAccess aWorld, int aX, int aY, int aZ, int aTileX, int aTileY, int aTileZ) {
         TileEntity tTileEntity = aWorld.getTileEntity(aX, aY, aZ);
         if ((tTileEntity instanceof BaseTileEntity)) {
@@ -79,6 +87,7 @@ public class GT_Block_Machines extends GT_Generic_Block implements IDebugableBlo
         }
     }
 
+    @Override
     public void onNeighborBlockChange(World aWorld, int aX, int aY, int aZ, Block aBlock) {
         TileEntity tTileEntity = aWorld.getTileEntity(aX, aY, aZ);
         if ((tTileEntity instanceof BaseMetaPipeEntity)) {
@@ -86,6 +95,7 @@ public class GT_Block_Machines extends GT_Generic_Block implements IDebugableBlo
         }
     }
 
+    @Override
     public void onBlockAdded(World aWorld, int aX, int aY, int aZ) {
         super.onBlockAdded(aWorld, aX, aY, aZ);
         if (GregTech_API.isMachineBlock(this, aWorld.getBlockMetadata(aX, aY, aZ))) {
@@ -93,22 +103,27 @@ public class GT_Block_Machines extends GT_Generic_Block implements IDebugableBlo
         }
     }
 
+    @Override
     public String getUnlocalizedName() {
         return "gt.blockmachines";
     }
 
+    @Override
     public String getLocalizedName() {
         return StatCollector.translateToLocal(getUnlocalizedName() + ".name");
     }
 
+    @Override
     public int getFlammability(IBlockAccess aWorld, int aX, int aY, int aZ, ForgeDirection face) {
         return 0;
     }
 
+    @Override
     public int getFireSpreadSpeed(IBlockAccess aWorld, int aX, int aY, int aZ, ForgeDirection face) {
-        return (GregTech_API.sMachineFlammable) && (aWorld.getBlockMetadata(aX, aY, aZ) == 0) ? 100 : 0;
+        return GregTech_API.sMachineFlammable && (aWorld.getBlockMetadata(aX, aY, aZ) == 0) ? 100 : 0;
     }
 
+    @Override
     public int getRenderType() {
         if (GT_Renderer_Block.INSTANCE == null) {
             return super.getRenderType();
@@ -116,80 +131,109 @@ public class GT_Block_Machines extends GT_Generic_Block implements IDebugableBlo
         return GT_Renderer_Block.INSTANCE.mRenderID;
     }
 
+    @Override
     public boolean isFireSource(World aWorld, int aX, int aY, int aZ, ForgeDirection side) {
-        return (GregTech_API.sMachineFlammable) && (aWorld.getBlockMetadata(aX, aY, aZ) == 0);
+        return GregTech_API.sMachineFlammable && (aWorld.getBlockMetadata(aX, aY, aZ) == 0);
     }
 
+    @Override
     public boolean isFlammable(IBlockAccess aWorld, int aX, int aY, int aZ, ForgeDirection face) {
-        return (GregTech_API.sMachineFlammable) && (aWorld.getBlockMetadata(aX, aY, aZ) == 0);
+        return GregTech_API.sMachineFlammable && (aWorld.getBlockMetadata(aX, aY, aZ) == 0);
     }
 
+    @Override
     public boolean canCreatureSpawn(EnumCreatureType type, IBlockAccess aWorld, int aX, int aY, int aZ) {
         return false;
     }
 
+    @Override
     public boolean canConnectRedstone(IBlockAccess var1, int var2, int var3, int var4, int var5) {
         return true;
     }
 
+    @Override
     public boolean canBeReplacedByLeaves(IBlockAccess aWorld, int aX, int aY, int aZ) {
         return false;
     }
 
+    @Override
     public boolean isNormalCube(IBlockAccess aWorld, int aX, int aY, int aZ) {
         return false;
     }
 
+    @Override
     public boolean hasTileEntity(int aMeta) {
         return true;
     }
 
+    @Override
     public boolean hasComparatorInputOverride() {
         return true;
     }
 
+    @Override
     public boolean renderAsNormalBlock() {
-        return false;
+        return renderAsNormalBlock;
     }
 
+    public GT_Block_Machines setRenderAsNormalBlock(boolean aBool) {
+        renderAsNormalBlock = aBool;
+        return this;
+    }
+
+    @Override
     public boolean canProvidePower() {
         return true;
     }
 
+    @Override
     public boolean isOpaqueCube() {
         return false;
     }
 
+    @Override
     public TileEntity createNewTileEntity(World aWorld, int aMeta) {
         return createTileEntity(aWorld, aMeta);
     }
 
+    @SideOnly(Side.CLIENT)
+    @Override
     public IIcon getIcon(IBlockAccess aIBlockAccess, int aX, int aY, int aZ, int aSide) {
         return Textures.BlockIcons.MACHINE_LV_SIDE.getIcon();
     }
 
+    @SideOnly(Side.CLIENT)
+    @Override
     public IIcon getIcon(int aSide, int aMeta) {
         return Textures.BlockIcons.MACHINE_LV_SIDE.getIcon();
     }
 
+    @Override
     public boolean onBlockEventReceived(World aWorld, int aX, int aY, int aZ, int aData1, int aData2) {
         super.onBlockEventReceived(aWorld, aX, aY, aZ, aData1, aData2);
         TileEntity tTileEntity = aWorld.getTileEntity(aX, aY, aZ);
-        return tTileEntity != null ? tTileEntity.receiveClientEvent(aData1, aData2) : false;
+        return tTileEntity != null && tTileEntity.receiveClientEvent(aData1, aData2);
     }
 
-    public void addCollisionBoxesToList(World aWorld, int aX, int aY, int aZ, AxisAlignedBB inputAABB, List outputAABB, Entity collider) {
+    @SuppressWarnings("unchecked") // Old API uses raw List type
+    @Override
+    public void addCollisionBoxesToList(
+            World aWorld, int aX, int aY, int aZ, AxisAlignedBB inputAABB, List outputAABB, Entity collider) {
         TileEntity tTileEntity = aWorld.getTileEntity(aX, aY, aZ);
-        if (((tTileEntity instanceof IGregTechTileEntity)) && (((IGregTechTileEntity) tTileEntity).getMetaTileEntity() != null)) {
-            ((IGregTechTileEntity) tTileEntity).addCollisionBoxesToList(aWorld, aX, aY, aZ, inputAABB, outputAABB, collider);
+        if (tTileEntity instanceof IGregTechTileEntity &&
+                ((IGregTechTileEntity) tTileEntity).getMetaTileEntity() != null) {
+            ((IGregTechTileEntity) tTileEntity)
+                    .addCollisionBoxesToList(aWorld, aX, aY, aZ, inputAABB, outputAABB, collider);
             return;
         }
         super.addCollisionBoxesToList(aWorld, aX, aY, aZ, inputAABB, outputAABB, collider);
     }
 
+    @Override
     public AxisAlignedBB getCollisionBoundingBoxFromPool(World aWorld, int aX, int aY, int aZ) {
         TileEntity tTileEntity = aWorld.getTileEntity(aX, aY, aZ);
-        if (((tTileEntity instanceof IGregTechTileEntity)) && (((IGregTechTileEntity) tTileEntity).getMetaTileEntity() != null)) {
+        if (tTileEntity instanceof IGregTechTileEntity &&
+                ((IGregTechTileEntity) tTileEntity).getMetaTileEntity() != null) {
             return ((IGregTechTileEntity) tTileEntity).getCollisionBoundingBoxFromPool(aWorld, aX, aY, aZ);
         }
         return super.getCollisionBoundingBoxFromPool(aWorld, aX, aY, aZ);
@@ -197,10 +241,10 @@ public class GT_Block_Machines extends GT_Generic_Block implements IDebugableBlo
 
     @Override
     @SideOnly(Side.CLIENT)
-    public AxisAlignedBB getSelectedBoundingBoxFromPool(World aWorld, int aX, int aY, int aZ)
-    {
+    public AxisAlignedBB getSelectedBoundingBoxFromPool(World aWorld, int aX, int aY, int aZ) {
         TileEntity tTileEntity = aWorld.getTileEntity(aX, aY, aZ);
-        if (((tTileEntity instanceof IGregTechTileEntity)) && (((IGregTechTileEntity) tTileEntity).getMetaTileEntity() != null)) {
+        if (tTileEntity instanceof IGregTechTileEntity &&
+                ((IGregTechTileEntity) tTileEntity).getMetaTileEntity() != null) {
             return ((IGregTechTileEntity) tTileEntity).getCollisionBoundingBoxFromPool(aWorld, aX, aY, aZ);
         }
         return super.getSelectedBoundingBoxFromPool(aWorld, aX, aY, aZ);
@@ -209,27 +253,32 @@ public class GT_Block_Machines extends GT_Generic_Block implements IDebugableBlo
     @Override  //THIS
     public void setBlockBoundsBasedOnState(IBlockAccess blockAccess, int aX, int aY, int aZ) {
         TileEntity tTileEntity = blockAccess.getTileEntity(aX, aY, aZ);
-        if (((tTileEntity instanceof IGregTechTileEntity)) && (((IGregTechTileEntity) tTileEntity).getMetaTileEntity() != null)) {
-            AxisAlignedBB bbb=((IGregTechTileEntity)tTileEntity).getCollisionBoundingBoxFromPool(((IGregTechTileEntity)tTileEntity).getWorld(), 0, 0, 0);
-            minX=bbb.minX;//This essentially sets block bounds
-            minY=bbb.minY;
-            minZ=bbb.minZ;
-            maxX=bbb.maxX;
-            maxY=bbb.maxY;
-            maxZ=bbb.maxZ;
+        if (tTileEntity instanceof IGregTechTileEntity &&
+                (((IGregTechTileEntity) tTileEntity).getMetaTileEntity() != null)) {
+            AxisAlignedBB bbb = ((IGregTechTileEntity) tTileEntity)
+                    .getCollisionBoundingBoxFromPool(
+                            ((IGregTechTileEntity) tTileEntity).getWorld(), 0, 0, 0);
+            minX = bbb.minX; //This essentially sets block bounds
+            minY = bbb.minY;
+            minZ = bbb.minZ;
+            maxX = bbb.maxX;
+            maxY = bbb.maxY;
+            maxZ = bbb.maxZ;
             return;
         }
-        super.setBlockBoundsBasedOnState(blockAccess,aX,aY,aZ);
+        super.setBlockBoundsBasedOnState(blockAccess, aX, aY, aZ);
     }
 
     @Override
     public void setBlockBoundsForItemRender() {
-        super.setBlockBounds(0,0,0,1,1,1);
+        super.setBlockBounds(0, 0, 0, 1, 1, 1);
     }
 
+    @Override
     public void onEntityCollidedWithBlock(World aWorld, int aX, int aY, int aZ, Entity collider) {
         TileEntity tTileEntity = aWorld.getTileEntity(aX, aY, aZ);
-        if (((tTileEntity instanceof IGregTechTileEntity)) && (((IGregTechTileEntity) tTileEntity).getMetaTileEntity() != null)) {
+        if (tTileEntity instanceof IGregTechTileEntity &&
+                ((IGregTechTileEntity) tTileEntity).getMetaTileEntity() != null) {
             ((IGregTechTileEntity) tTileEntity).onEntityCollidedWithBlock(aWorld, aX, aY, aZ, collider);
             return;
         }
@@ -237,69 +286,74 @@ public class GT_Block_Machines extends GT_Generic_Block implements IDebugableBlo
     }
 
     @SideOnly(Side.CLIENT)
+    @Override
     public void registerBlockIcons(IIconRegister aIconRegister) {
-        if (GregTech_API.sPostloadFinished) {
-            GT_Log.out.println("GT_Mod: Setting up Icon Register for Blocks");
-            GregTech_API.sBlockIcons = aIconRegister;
+        if (!GregTech_API.sPostloadFinished) return;
+        GT_Log.out.println("GT_Mod: Setting up Icon Register for Blocks");
+        GregTech_API.setBlockIconRegister(aIconRegister);
 
-            GT_Log.out.println("GT_Mod: Registering MetaTileEntity specific Textures");
-            try {
-                for (IMetaTileEntity tMetaTileEntity : GregTech_API.METATILEENTITIES) {
-                    if (tMetaTileEntity != null) {
-                        tMetaTileEntity.registerIcons(aIconRegister);
-                    }
+        GT_Log.out.println("GT_Mod: Registering MetaTileEntity specific Textures");
+        try {
+            for (IMetaTileEntity tMetaTileEntity : GregTech_API.METATILEENTITIES) {
+                if (tMetaTileEntity != null) {
+                    tMetaTileEntity.registerIcons(aIconRegister);
                 }
-            } catch (Throwable e) {e.printStackTrace(GT_Log.err);}
-            GT_Log.out.println("GT_Mod: Registering Crop specific Textures");
-            try {
-                for (GT_BaseCrop tCrop : GT_BaseCrop.sCropList) {
-                    tCrop.registerSprites(aIconRegister);
-                }
-            } catch (Throwable e) {
-                e.printStackTrace(GT_Log.err);
             }
-            GT_Log.out.println("GT_Mod: Starting Block Icon Load Phase");
-            GT_FML_LOGGER.info("GT_Mod: Starting Block Icon Load Phase");
-            try {
-                for (Runnable tRunnable : GregTech_API.sGTBlockIconload) {
-                    tRunnable.run();
-                }
-            } catch (Throwable e) {e.printStackTrace(GT_Log.err);}
-            GT_Log.out.println("GT_Mod: Finished Block Icon Load Phase");
-            GT_FML_LOGGER.info("GT_Mod: Finished Block Icon Load Phase");
+        } catch (Exception e) {
+            e.printStackTrace(GT_Log.err);
         }
+        GT_Log.out.println("GT_Mod: Registering Crop specific Textures");
+        try {
+            for (GT_BaseCrop tCrop : GT_BaseCrop.sCropList) {
+                tCrop.registerSprites(aIconRegister);
+            }
+        } catch (Exception e) {
+            e.printStackTrace(GT_Log.err);
+        }
+        GT_Log.out.println("GT_Mod: Starting Block Icon Load Phase");
+        GT_FML_LOGGER.info("GT_Mod: Starting Block Icon Load Phase");
+        try {
+            for (Runnable tRunnable : GregTech_API.sGTBlockIconload) {
+                tRunnable.run();
+            }
+        } catch (Exception e) {
+            e.printStackTrace(GT_Log.err);
+        }
+        GT_Log.out.println("GT_Mod: Finished Block Icon Load Phase");
+        GT_FML_LOGGER.info("GT_Mod: Finished Block Icon Load Phase");
     }
 
-    public float getBlockHardness(World aWorld, int aX, int aY, int aZ) {
-        return super.getBlockHardness(aWorld, aX, aY, aZ);
-    }
-
+    @Override
     public float getPlayerRelativeBlockHardness(EntityPlayer aPlayer, World aWorld, int aX, int aY, int aZ) {
         TileEntity tTileEntity = aWorld.getTileEntity(aX, aY, aZ);
-        if (((tTileEntity instanceof BaseMetaTileEntity)) && (((BaseMetaTileEntity) tTileEntity).privateAccess()) && (!((BaseMetaTileEntity) tTileEntity).playerOwnsThis(aPlayer, true))) {
-            return -1.0F;
-        }
-        return super.getPlayerRelativeBlockHardness(aPlayer, aWorld, aX, aY, aZ);
+        return tTileEntity instanceof BaseMetaTileEntity &&
+                ((BaseMetaTileEntity) tTileEntity).privateAccess() &&
+                !((BaseMetaTileEntity) tTileEntity).playerOwnsThis(aPlayer, true) ?
+                -1.0F : super.getPlayerRelativeBlockHardness(aPlayer, aWorld, aX, aY, aZ);
     }
 
-    public boolean onBlockActivated(World aWorld, int aX, int aY, int aZ, EntityPlayer aPlayer, int aSide, float par1, float par2, float par3) {
+    @Override
+    public boolean onBlockActivated(
+            World aWorld, int aX, int aY, int aZ, EntityPlayer aPlayer, int aSide, float par1, float par2, float par3) {
         TileEntity tTileEntity = aWorld.getTileEntity(aX, aY, aZ);
         if (tTileEntity == null) {
             return false;
         }
-        if(aPlayer.isSneaking()){
-        	ItemStack tCurrentItem = aPlayer.inventory.getCurrentItem();
-        	if(tCurrentItem!=null){
-        		if(!GT_Utility.isStackInList(tCurrentItem, GregTech_API.sScrewdriverList) && !GT_Utility.isStackInList(tCurrentItem, GregTech_API.sWrenchList) && !GT_Utility.isStackInList(tCurrentItem, GregTech_API.sWireCutterList) && !GT_Utility.isStackInList(tCurrentItem, GregTech_API.sSolderingToolList)){
-        			return false;
-        		}
-        	}
+        if (aPlayer.isSneaking()) {
+            ItemStack tCurrentItem = aPlayer.inventory.getCurrentItem();
+            if (
+                    tCurrentItem != null &&
+                    !GT_Utility.isStackInList(tCurrentItem, GregTech_API.sScrewdriverList) &&
+                    !GT_Utility.isStackInList(tCurrentItem, GregTech_API.sWrenchList) &&
+                    !GT_Utility.isStackInList(tCurrentItem, GregTech_API.sWireCutterList) &&
+                    !GT_Utility.isStackInList(tCurrentItem, GregTech_API.sSolderingToolList)
+            ) return false;
         }
         if ((tTileEntity instanceof IGregTechTileEntity)) {
             if (((IGregTechTileEntity) tTileEntity).getTimer() < 50L) {
                 return false;
             }
-            if ((!aWorld.isRemote) && (!((IGregTechTileEntity) tTileEntity).isUseableByPlayer(aPlayer))) {
+            if ((!aWorld.isRemote) && !((IGregTechTileEntity) tTileEntity).isUseableByPlayer(aPlayer)) {
                 return true;
             }
             return ((IGregTechTileEntity) tTileEntity).onRightclick(aPlayer, (byte) aSide, par1, par2, par3);
@@ -307,46 +361,55 @@ public class GT_Block_Machines extends GT_Generic_Block implements IDebugableBlo
         return false;
     }
 
+    @Override
     public void onBlockClicked(World aWorld, int aX, int aY, int aZ, EntityPlayer aPlayer) {
         TileEntity tTileEntity = aWorld.getTileEntity(aX, aY, aZ);
-        if (((tTileEntity instanceof IGregTechTileEntity))) {
+        if (tTileEntity instanceof IGregTechTileEntity) {
             ((IGregTechTileEntity) tTileEntity).onLeftclick(aPlayer);
         }
     }
 
+    @Override
     public int getDamageValue(World aWorld, int aX, int aY, int aZ) {
         TileEntity tTileEntity = aWorld.getTileEntity(aX, aY, aZ);
-        if ((tTileEntity instanceof IGregTechTileEntity)) {
+        if (tTileEntity instanceof IGregTechTileEntity) {
             return ((IGregTechTileEntity) tTileEntity).getMetaTileID();
         }
         return 0;
     }
 
+    @Override
     public void onBlockExploded(World aWorld, int aX, int aY, int aZ, Explosion aExplosion) {
         TileEntity tTileEntity = aWorld.getTileEntity(aX, aY, aZ);
-        if ((tTileEntity instanceof BaseMetaTileEntity)) {
-            GT_Log.exp.println("Explosion at :"+aX + " | " + aY+ " | "  + aZ +" DIMID: " + aWorld.provider.dimensionId+ " due to near explosion!");
+        if (tTileEntity instanceof BaseMetaTileEntity) {
+            GT_Log.exp.printf("Explosion at : %d | %d | %d DIMID: %s due to near explosion!%n",
+                    aX, aY, aZ, aWorld.provider.dimensionId);
             ((BaseMetaTileEntity) tTileEntity).doEnergyExplosion();
         }
         super.onBlockExploded(aWorld, aX, aY, aZ, aExplosion);
     }
 
+    @Override
     public void breakBlock(World aWorld, int aX, int aY, int aZ, Block par5, int par6) {
         GregTech_API.causeMachineUpdate(aWorld, aX, aY, aZ);
         TileEntity tTileEntity = aWorld.getTileEntity(aX, aY, aZ);
-        if ((tTileEntity instanceof IGregTechTileEntity)) {
+        if (tTileEntity instanceof IGregTechTileEntity) {
             IGregTechTileEntity tGregTechTileEntity = (IGregTechTileEntity) tTileEntity;
             mTemporaryTileEntity.set(tGregTechTileEntity);
             for (int i = 0; i < tGregTechTileEntity.getSizeInventory(); i++) {
                 ItemStack tItem = tGregTechTileEntity.getStackInSlot(i);
                 if ((tItem != null) && (tItem.stackSize > 0) && (tGregTechTileEntity.isValidSlot(i))) {
-                    EntityItem tItemEntity = new EntityItem(aWorld, aX + XSTR_INSTANCE.nextFloat() * 0.8F + 0.1F, aY + XSTR_INSTANCE.nextFloat() * 0.8F + 0.1F, aZ + XSTR_INSTANCE.nextFloat() * 0.8F + 0.1F, new ItemStack(tItem.getItem(), tItem.stackSize, tItem.getItemDamage()));
+                    EntityItem tItemEntity = new EntityItem(aWorld,
+                            aX + XSTR_INSTANCE.nextFloat() * 0.8F + 0.1F,
+                            aY + XSTR_INSTANCE.nextFloat() * 0.8F + 0.1F,
+                            aZ + XSTR_INSTANCE.nextFloat() * 0.8F + 0.1F,
+                            new ItemStack(tItem.getItem(), tItem.stackSize, tItem.getItemDamage()));
                     if (tItem.hasTagCompound()) {
                         tItemEntity.getEntityItem().setTagCompound((NBTTagCompound) tItem.getTagCompound().copy());
                     }
-                    tItemEntity.motionX = (XSTR_INSTANCE.nextGaussian() * 0.0500000007450581D);
-                    tItemEntity.motionY = (XSTR_INSTANCE.nextGaussian() * 0.0500000007450581D + 0.2000000029802322D);
-                    tItemEntity.motionZ = (XSTR_INSTANCE.nextGaussian() * 0.0500000007450581D);
+                    tItemEntity.motionX = (XSTR_INSTANCE.nextGaussian() * 0.05D);
+                    tItemEntity.motionY = (XSTR_INSTANCE.nextGaussian() * 0.25D);
+                    tItemEntity.motionZ = (XSTR_INSTANCE.nextGaussian() * 0.05D);
                     aWorld.spawnEntityInWorld(tItemEntity);
                     tItem.stackSize = 0;
                     tGregTechTileEntity.setInventorySlotContents(i, null);
@@ -357,65 +420,76 @@ public class GT_Block_Machines extends GT_Generic_Block implements IDebugableBlo
         aWorld.removeTileEntity(aX, aY, aZ);
     }
 
+    @Override
     public ArrayList<ItemStack> getDrops(World aWorld, int aX, int aY, int aZ, int aMeta, int aFortune) {
         TileEntity tTileEntity = aWorld.getTileEntity(aX, aY, aZ);
         if ((tTileEntity instanceof IGregTechTileEntity)) {
             return ((IGregTechTileEntity) tTileEntity).getDrops();
         }
-        return mTemporaryTileEntity.get() == null ? new ArrayList() : ((IGregTechTileEntity) mTemporaryTileEntity.get()).getDrops();
-    }
-    @Override
-    public boolean removedByPlayer(World aWorld, EntityPlayer aPlayer, int aX, int aY, int aZ, boolean aWillHarvest) {
-        if (aWillHarvest) {
-            return true; // This delays deletion of the block until after getDrops
+        IGregTechTileEntity tGregTechTileEntity = mTemporaryTileEntity.get();
+        ArrayList<ItemStack> tDrops;
+        if (tGregTechTileEntity == null) {
+            tDrops = (ArrayList<ItemStack>) Collections.<ItemStack>emptyList();
         } else {
-            return super.removedByPlayer(aWorld, aPlayer, aX, aY, aZ, false);
+            tDrops = tGregTechTileEntity.getDrops();
+            mTemporaryTileEntity.remove();
         }
+        return tDrops;
     }
 
     @Override
-    public void harvestBlock(World aWorld, EntityPlayer aPlayer, int aX, int aY, int aZ, int aMeta)
-    {
+    public boolean removedByPlayer(World aWorld, EntityPlayer aPlayer, int aX, int aY, int aZ, boolean aWillHarvest) {
+        // This delays deletion of the block until after getDrops
+        return aWillHarvest || super.removedByPlayer(aWorld, aPlayer, aX, aY, aZ, false);
+    }
+
+    @Override
+    public void harvestBlock(World aWorld, EntityPlayer aPlayer, int aX, int aY, int aZ, int aMeta) {
         super.harvestBlock(aWorld, aPlayer, aX, aY, aZ, aMeta);
         aWorld.setBlockToAir(aX, aY, aZ);
     }
-    
+
+    @Override
     public int getComparatorInputOverride(World aWorld, int aX, int aY, int aZ, int aSide) {
         TileEntity tTileEntity = aWorld.getTileEntity(aX, aY, aZ);
-        if (((tTileEntity instanceof IGregTechTileEntity))) {
+        if (tTileEntity instanceof IGregTechTileEntity) {
             return ((IGregTechTileEntity) tTileEntity).getComparatorValue((byte) aSide);
         }
         return 0;
     }
 
+    @Override
     public int isProvidingWeakPower(IBlockAccess aWorld, int aX, int aY, int aZ, int aSide) {
-        if ((aSide < 0) || (aSide > 5)) {
+        if (aSide < 0 || aSide > 5) {
             return 0;
         }
         TileEntity tTileEntity = aWorld.getTileEntity(aX, aY, aZ);
-        if (((tTileEntity instanceof IGregTechTileEntity))) {
+        if (tTileEntity instanceof IGregTechTileEntity) {
             return ((IGregTechTileEntity) tTileEntity).getOutputRedstoneSignal(GT_Utility.getOppositeSide(aSide));
         }
         return 0;
     }
 
+    @Override
     public int isProvidingStrongPower(IBlockAccess aWorld, int aX, int aY, int aZ, int aSide) {
-        if ((aSide < 0) || (aSide > 5)) {
+        if (aSide < 0 || aSide > 5) {
             return 0;
         }
         TileEntity tTileEntity = aWorld.getTileEntity(aX, aY, aZ);
-        if (((tTileEntity instanceof IGregTechTileEntity))) {
+        if (tTileEntity instanceof IGregTechTileEntity) {
             return ((IGregTechTileEntity) tTileEntity).getStrongOutputRedstoneSignal(GT_Utility.getOppositeSide(aSide));
         }
         return 0;
     }
 
+    @Override
     public void dropBlockAsItemWithChance(World aWorld, int aX, int aY, int aZ, int par5, float chance, int par7) {
         if (!aWorld.isRemote) {
             TileEntity tTileEntity = aWorld.getTileEntity(aX, aY, aZ);
-            if ((tTileEntity != null) && (chance < 1.0F)) {
-                if (((tTileEntity instanceof BaseMetaTileEntity)) && (GregTech_API.sMachineNonWrenchExplosions)) {
-                    GT_Log.exp.println("Explosion at :"+aX + " | " + aY+ " | "  + aZ +" DIMID: "+ aWorld.provider.dimensionId+ " due to NonWrench picking/Rain!");
+            if (tTileEntity != null && (chance < 1.0F)) {
+                if (tTileEntity instanceof BaseMetaTileEntity && (GregTech_API.sMachineNonWrenchExplosions)) {
+                    GT_Log.exp.printf("Explosion at : %d | %d | %d DIMID: %s NonWrench picking/Rain!%n",
+                            aX, aY, aZ, aWorld.provider.dimensionId);
                     ((BaseMetaTileEntity) tTileEntity).doEnergyExplosion();
                 }
             } else {
@@ -424,44 +498,60 @@ public class GT_Block_Machines extends GT_Generic_Block implements IDebugableBlo
         }
     }
 
+    @Override
     public boolean isSideSolid(IBlockAccess aWorld, int aX, int aY, int aZ, ForgeDirection aSide) {
         if (aWorld.getBlockMetadata(aX, aY, aZ) == 0) {
             return true;
         }
         TileEntity tTileEntity = aWorld.getTileEntity(aX, aY, aZ);
         if (tTileEntity != null) {
-            if ((tTileEntity instanceof BaseMetaTileEntity)) {
+            if (tTileEntity instanceof BaseMetaTileEntity) {
                 return true;
             }
-            if (((tTileEntity instanceof BaseMetaPipeEntity)) && ((((BaseMetaPipeEntity) tTileEntity).mConnections & 0xFFFFFFC0) != 0)) {
+            if (tTileEntity instanceof BaseMetaPipeEntity &&
+                    (((BaseMetaPipeEntity) tTileEntity).mConnections & 0xFFFFFFC0) != 0) {
                 return true;
             }
-            if (((tTileEntity instanceof ICoverable)) && (((ICoverable) tTileEntity).getCoverIDAtSide((byte) aSide.ordinal()) != 0)) {
-                return true;
-            }
+            return tTileEntity instanceof ICoverable &&
+                    ((ICoverable) tTileEntity).getCoverIDAtSide((byte) aSide.ordinal()) != 0;
         }
         return false;
     }
 
+    @Override
+    public boolean isBlockNormalCube() {
+        return true;
+    }
+
+    /**
+     * Returns the default ambient occlusion value based on block opacity
+     */
+    @SideOnly(Side.CLIENT)
+    @Override
+    public float getAmbientOcclusionLightValue()
+    {
+        return this.renderAsNormalBlock() ? 0.2F : 0.5F;
+    }
+
+    @Override
     public int getLightOpacity(IBlockAccess aWorld, int aX, int aY, int aZ) {
         TileEntity tTileEntity = aWorld.getTileEntity(aX, aY, aZ);
-        if (tTileEntity == null) {
-            return 0;
-        }
-        if ((tTileEntity instanceof IGregTechTileEntity)) {
+        if (tTileEntity instanceof IGregTechTileEntity) {
             return ((IGregTechTileEntity) tTileEntity).getLightOpacity();
         }
         return aWorld.getBlockMetadata(aX, aY, aZ) == 0 ? 255 : 0;
     }
 
+    @Override
     public int getLightValue(IBlockAccess aWorld, int aX, int aY, int aZ) {
         TileEntity tTileEntity = aWorld.getTileEntity(aX, aY, aZ);
-        if ((tTileEntity instanceof BaseMetaTileEntity)) {
+        if (tTileEntity instanceof BaseMetaTileEntity) {
             return ((BaseMetaTileEntity) tTileEntity).getLightValue();
         }
         return 0;
     }
 
+    @Override
     public TileEntity createTileEntity(World aWorld, int aMeta) {
         if (aMeta < 4) {
             return GregTech_API.constructBaseMetaTileEntity();
@@ -469,76 +559,87 @@ public class GT_Block_Machines extends GT_Generic_Block implements IDebugableBlo
         return new BaseMetaPipeEntity();
     }
 
-    public float getExplosionResistance(Entity par1Entity, World aWorld, int aX, int aY, int aZ, double explosionX, double explosionY, double explosionZ) {
+    @Override
+    public float getExplosionResistance(
+            Entity par1Entity, World aWorld, int aX, int aY, int aZ,
+            double explosionX, double explosionY, double explosionZ) {
         TileEntity tTileEntity = aWorld.getTileEntity(aX, aY, aZ);
-        if (((tTileEntity instanceof IGregTechTileEntity))) {
+        if (tTileEntity instanceof IGregTechTileEntity) {
             return ((IGregTechTileEntity) tTileEntity).getBlastResistance((byte) 6);
         }
         return 10.0F;
     }
 
     @SideOnly(Side.CLIENT)
-    public void getSubBlocks(Item par1, CreativeTabs par2CreativeTabs, List par3List) {
+    @Override
+    @SuppressWarnings("unchecked") // Old API uses raw List type
+    public void getSubBlocks(Item par1Item, CreativeTabs par2CreativeTabs, List par3List) {
         for (int i = 1; i < GregTech_API.METATILEENTITIES.length; i++) {
             if (GregTech_API.METATILEENTITIES[i] != null) {
-                par3List.add(new ItemStack(par1, 1, i));
+                par3List.add(new ItemStack(par1Item, 1, i));
             }
         }
     }
 
+    @Override
     public void onBlockPlacedBy(World aWorld, int aX, int aY, int aZ, EntityLivingBase aPlayer, ItemStack aStack) {
         TileEntity tTileEntity = aWorld.getTileEntity(aX, aY, aZ);
-        if (tTileEntity == null) {
+        if (!(tTileEntity instanceof IGregTechTileEntity)) {
             return;
         }
-        if ((tTileEntity instanceof IGregTechTileEntity)) {
-            IGregTechTileEntity var6 = (IGregTechTileEntity) tTileEntity;
-            if (aPlayer == null) {
-                var6.setFrontFacing((byte) 1);
-            } else {
-                int var7 = MathHelper.floor_double(aPlayer.rotationYaw * 4.0F / 360.0F + 0.5D) & 0x3;
-                int var8 = Math.round(aPlayer.rotationPitch);
-                if ((var8 >= 65) && (var6.isValidFacing((byte) 1))) {
-                    var6.setFrontFacing((byte) 1);
-                } else if ((var8 <= -65) && (var6.isValidFacing((byte) 0))) {
-                    var6.setFrontFacing((byte) 0);
-                } else {
-                    switch (var7) {
-                        case 0:
-                            var6.setFrontFacing((byte) 2);
-                            break;
-                        case 1:
-                            var6.setFrontFacing((byte) 5);
-                            break;
-                        case 2:
-                            var6.setFrontFacing((byte) 3);
-                            break;
-                        case 3:
-                            var6.setFrontFacing((byte) 4);
-                    }
-                }
-            }
+        IGregTechTileEntity iGregTechTileEntity = (IGregTechTileEntity) tTileEntity;
+        if (aPlayer == null) {
+            iGregTechTileEntity.setFrontFacing((byte) ForgeDirection.UP.ordinal());
+            return;
+        }
+        int yawQuadrant = MathHelper.floor_double(aPlayer.rotationYaw * 4.0F / 360.0F + 0.5D) & 0x3;
+        int pitch = Math.round(aPlayer.rotationPitch);
+        if (pitch >= 65 && iGregTechTileEntity.isValidFacing((byte) ForgeDirection.UP.ordinal())) {
+            iGregTechTileEntity.setFrontFacing((byte) ForgeDirection.UP.ordinal());
+            return;
+        }
+        if (pitch <= -65 && iGregTechTileEntity.isValidFacing((byte) ForgeDirection.DOWN.ordinal())) {
+            iGregTechTileEntity.setFrontFacing((byte) ForgeDirection.DOWN.ordinal());
+            return;
+        }
+        switch (yawQuadrant) {
+            case 0:
+                iGregTechTileEntity.setFrontFacing((byte) ForgeDirection.NORTH.ordinal());
+                break;
+            case 1:
+                iGregTechTileEntity.setFrontFacing((byte) ForgeDirection.EAST.ordinal());
+                break;
+            case 2:
+                iGregTechTileEntity.setFrontFacing((byte) ForgeDirection.SOUTH.ordinal());
+                break;
+            case 3:
+                iGregTechTileEntity.setFrontFacing((byte) ForgeDirection.WEST.ordinal());
+                break;
+            default:
+                break;
         }
     }
 
-    public ArrayList<String> getDebugInfo(EntityPlayer aPlayer, int aX, int aY, int aZ, int aLogLevel) {
+    @Override
+        public ArrayList<String> getDebugInfo(EntityPlayer aPlayer, int aX, int aY, int aZ, int aLogLevel) {
         TileEntity tTileEntity = aPlayer.worldObj.getTileEntity(aX, aY, aZ);
-        if ((tTileEntity instanceof BaseMetaTileEntity)) {
+        if (tTileEntity instanceof BaseMetaTileEntity) {
             return ((BaseMetaTileEntity) tTileEntity).getDebugInfo(aPlayer, aLogLevel);
         }
-        if ((tTileEntity instanceof BaseMetaPipeEntity)) {
+        if (tTileEntity instanceof BaseMetaPipeEntity) {
             return ((BaseMetaPipeEntity) tTileEntity).getDebugInfo(aPlayer, aLogLevel);
         }
-        return null;
+        return (ArrayList<String>) Collections.<String>emptyList();
     }
 
+    @Override
     public boolean recolourBlock(World aWorld, int aX, int aY, int aZ, ForgeDirection aSide, int aColor) {
         TileEntity tTileEntity = aWorld.getTileEntity(aX, aY, aZ);
-        if ((tTileEntity instanceof IGregTechTileEntity)) {
-            if (((IGregTechTileEntity) tTileEntity).getColorization() == (byte) ((aColor ^ 0xFFFFFFFF) & 0xF)) {
+        if (tTileEntity instanceof IGregTechTileEntity) {
+            if (((IGregTechTileEntity) tTileEntity).getColorization() == (byte) ((~aColor) & 0xF)) {
                 return false;
             }
-            ((IGregTechTileEntity) tTileEntity).setColorization((byte) ((aColor ^ 0xFFFFFFFF) & 0xF));
+            ((IGregTechTileEntity) tTileEntity).setColorization((byte) ((~aColor) & 0xF));
             return true;
         }
         return false;

--- a/src/main/java/gregtech/common/blocks/GT_Material_Machines.java
+++ b/src/main/java/gregtech/common/blocks/GT_Material_Machines.java
@@ -12,6 +12,6 @@ public class GT_Material_Machines extends Material {
     }
 
     public boolean isOpaque() {
-        return false;
+        return true;
     }
 }


### PR DESCRIPTION

![AOShade](https://user-images.githubusercontent.com/1111474/109742976-3d7dca00-7bd0-11eb-8256-0f8215311937.gif)
- Implement the missing ambient occlusion shadow from machine block over neighbour blocks.
- Fix the LightingHelper to properly shade pipes/cables/wires against an opaque block.
- Refactor and cleanup the GT_Block_Machines class of all bad practices and code smell,
  checked and validated with Sonarlint.