### PR TITLE
fix(rendering): cover dumb block teture on bottom face

### DIFF
--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingPlate.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingPlate.java
@@ -1,9 +1,13 @@
 package gregtech.loaders.oreprocessing;
 
 import gregtech.api.GregTech_API;
-import gregtech.api.enums.*;
+import gregtech.api.enums.ConfigCategories;
+import gregtech.api.enums.ItemList;
+import gregtech.api.enums.Materials;
+import gregtech.api.enums.OrePrefixes;
+import gregtech.api.enums.SubTag;
+import gregtech.api.enums.ToolDictNames;
 import gregtech.api.objects.GT_CopiedBlockTexture;
-import gregtech.api.objects.GT_RenderedTexture;
 import gregtech.api.objects.GT_StdRenderedTexture;
 import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_OreDictUnificator;
@@ -11,9 +15,14 @@ import gregtech.api.util.GT_RecipeRegistrator;
 import gregtech.api.util.GT_Utility;
 import gregtech.common.GT_Proxy;
 import net.minecraft.init.Blocks;
+import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 
-public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegistrator {//TODO COMPARE WITH OLD PLATE## generator
+import static gregtech.api.enums.GT_Values.RA;
+import static gregtech.api.util.GT_ModHandler.RecipeBits.BUFFERED;
+import static gregtech.api.util.GT_ModHandler.RecipeBits.DO_NOT_CHECK_FOR_COLLISIONS;
+
+public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegistrator {
     public ProcessingPlate() {
         OrePrefixes.plate.add(this);
         OrePrefixes.plateDouble.add(this);
@@ -25,195 +34,389 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
         OrePrefixes.itemCasing.add(this);
     }
 
-    public void registerOre(OrePrefixes aPrefix, Materials aMaterial, String aOreDictName, String aModName, ItemStack aStack) {
-        boolean aNoSmashing = aMaterial.contains(SubTag.NO_SMASHING);
-        boolean aNoWorking = aMaterial.contains(SubTag.NO_WORKING);
-        long aMaterialMass = aMaterial.getMass();
-        
+    /**
+     * Register processes for the item stack by its Ore Dictionary Name property for all plate related items
+     *
+     * @param aPrefix      always != null, the Ore Prefix
+     * @param aMaterial    always != null, and can be == _NULL if the Prefix is Self Referencing or not Material based!
+     * @param aOreDictName the Ore Dictionary Name
+     * @param aModName     the name of the mod providing this stack
+     * @param aStack       always != null, the {@link ItemStack} to register
+     */
+    public void registerOre(OrePrefixes aPrefix,
+                            Materials aMaterial,
+                            String aOreDictName,
+                            String aModName,
+                            ItemStack aStack) {
+        final boolean aNoSmashing = aMaterial.contains(SubTag.NO_SMASHING);
+        final boolean aNoWorking = aMaterial.contains(SubTag.NO_WORKING);
+        final long aMaterialMass = aMaterial.getMass();
+
         switch (aPrefix) {
             case plate:
-                GT_ModHandler.removeRecipeByOutputDelayed(aStack);
-                GT_ModHandler.removeRecipeDelayed(aStack);
-
-                if (aMaterial.mStandardMoltenFluid != null) {
-                    if (!(aMaterial == Materials.AnnealedCopper || aMaterial == Materials.WroughtIron)) {
-                        GT_Values.RA.addFluidSolidifierRecipe(ItemList.Shape_Mold_Plate.get(0L), aMaterial.getMolten(144L), GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L), 32, 8);
-                    }
-                }
-                switch (aMaterial.mName) {
-                    case "Iron":
-                        GregTech_API.registerCover(aStack, new GT_CopiedBlockTexture(Blocks.iron_block, 1, 0), null);
-                        break;
-                    case "Gold":
-                        GregTech_API.registerCover(aStack, new GT_CopiedBlockTexture(Blocks.gold_block, 1, 0), null);
-                        break;
-                    case "Diamond":
-                        GregTech_API.registerCover(aStack, new GT_CopiedBlockTexture(Blocks.diamond_block, 1, 0), null);
-                        break;
-                    case "Emerald":
-                        GregTech_API.registerCover(aStack, new GT_CopiedBlockTexture(Blocks.emerald_block, 1, 0), null);
-                        break;
-                    case "Lapis":
-                        GregTech_API.registerCover(aStack, new GT_CopiedBlockTexture(Blocks.lapis_block, 1, 0), null);
-                        break;
-                    case "Coal":
-                        GregTech_API.registerCover(aStack, new GT_CopiedBlockTexture(Blocks.coal_block, 1, 0), null);
-                        break;
-                    case "Redstone":
-                        GregTech_API.registerCover(aStack, new GT_CopiedBlockTexture(Blocks.redstone_block, 1, 0), null);
-                        break;
-                    case "Glowstone":
-                        GregTech_API.registerCover(aStack, new GT_CopiedBlockTexture(Blocks.glowstone, 1, 0), null);
-                        break;
-                    case "NetherQuartz":
-                        GregTech_API.registerCover(aStack, new GT_CopiedBlockTexture(Blocks.quartz_block, 1, 0), null);
-                        break;
-                    case "Obsidian":
-                        GregTech_API.registerCover(aStack, new GT_CopiedBlockTexture(Blocks.obsidian, 1, 0), null);
-                        break;
-                    case "Stone":
-                        GregTech_API.registerCover(aStack, new GT_CopiedBlockTexture(Blocks.stone, 1, 0), null);
-                        break;
-                    case "GraniteBlack":
-                        GregTech_API.registerCover(aStack, new GT_StdRenderedTexture(gregtech.api.enums.Textures.BlockIcons.GRANITE_BLACK_SMOOTH), null);
-                        break;
-                    case "GraniteRed":
-                        GregTech_API.registerCover(aStack, new GT_StdRenderedTexture(gregtech.api.enums.Textures.BlockIcons.GRANITE_RED_SMOOTH), null);
-                        break;
-                    case "Basalt":
-                        GregTech_API.registerCover(aStack, new GT_StdRenderedTexture(gregtech.api.enums.Textures.BlockIcons.BASALT_SMOOTH), null);
-                        break;
-                    case "Marble":
-                        GregTech_API.registerCover(aStack, new GT_StdRenderedTexture(gregtech.api.enums.Textures.BlockIcons.MARBLE_SMOOTH), null);
-                        break;
-                    case "Concrete":
-                        GregTech_API.registerCover(aStack, new GT_StdRenderedTexture(gregtech.api.enums.Textures.BlockIcons.CONCRETE_LIGHT_SMOOTH), null);
-                        break;
-                    default:
-                        GregTech_API.registerCover(aStack, new GT_StdRenderedTexture(aMaterial.mIconSet.mTextures[71], aMaterial.mRGBa, false), null);
-                }
-
-                if (aMaterial.mFuelPower > 0)
-                    GT_Values.RA.addFuel(GT_Utility.copyAmount(1L, aStack), null, aMaterial.mFuelPower, aMaterial.mFuelType);
-                GT_Utility.removeSimpleIC2MachineRecipe(GT_Utility.copyAmount(9L, aStack), GT_ModHandler.getCompressorRecipeList(), GT_OreDictUnificator.get(OrePrefixes.plateDense, aMaterial, 1L));
-                GT_ModHandler.addCraftingRecipe(GT_OreDictUnificator.get(OrePrefixes.foil, aMaterial, 2L), GT_Proxy.tBits, new Object[]{"hX", 'X', OrePrefixes.plate.get(aMaterial)});
-                
-                if (aMaterial == Materials.Paper)
-                    GT_ModHandler.addCraftingRecipe(GT_Utility.copyAmount(GregTech_API.sRecipeFile.get(gregtech.api.enums.ConfigCategories.Recipes.harderrecipes, aStack, true) ? 2L : 3L, aStack), GT_ModHandler.RecipeBits.BUFFERED, new Object[]{"XXX", 'X', new ItemStack(net.minecraft.init.Items.reeds, 1, 32767)});
-
-                if ((aMaterial.mUnificatable) && (aMaterial.mMaterialInto == aMaterial)) {
-                    if (!aNoSmashing && GregTech_API.sRecipeFile.get(ConfigCategories.Tools.hammerplating, aMaterial.toString(), true)) {
-                        GT_ModHandler.addCraftingRecipe(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L), GT_Proxy.tBits, new Object[]{"h", "X", "X", 'X', OrePrefixes.ingot.get(aMaterial)});
-                        GT_ModHandler.addCraftingRecipe(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L), GT_Proxy.tBits, new Object[]{"H", "X", 'H', ToolDictNames.craftingToolForgeHammer, 'X', OrePrefixes.ingot.get(aMaterial)});
-                        GT_ModHandler.addCraftingRecipe(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L), GT_Proxy.tBits, new Object[]{"h", "X", 'X', OrePrefixes.gem.get(aMaterial)});
-                        GT_ModHandler.addCraftingRecipe(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L), GT_Proxy.tBits, new Object[]{"H", "X", 'H', ToolDictNames.craftingToolForgeHammer, 'X', OrePrefixes.gem.get(aMaterial)});
-                        //GT_ModHandler.addCraftingRecipe(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L), GT_Proxy.tBits, new Object[]{"h", "X", 'X', OrePrefixes.ingotDouble.get(aMaterial)});
-                        //GT_ModHandler.addCraftingRecipe(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 2L), GT_Proxy.tBits, new Object[]{"H", "X", 'H', ToolDictNames.craftingToolForgeHammer, 'X', OrePrefixes.ingotDouble.get(aMaterial)});
-                    }
-                    if ((aMaterial.contains(SubTag.MORTAR_GRINDABLE)) && (GregTech_API.sRecipeFile.get(ConfigCategories.Tools.mortar, aMaterial.mName, true)))
-                        GT_ModHandler.addCraftingRecipe(GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial, 1L), GT_Proxy.tBits, new Object[]{"X", "m", 'X', OrePrefixes.plate.get(aMaterial)});
-                }
+                registerPlate(aMaterial, aStack, aNoSmashing);
                 break;
             case plateDouble:
-                GT_ModHandler.removeRecipeByOutputDelayed(aStack);
-                GregTech_API.registerCover(aStack, new gregtech.api.objects.GT_StdRenderedTexture(aMaterial.mIconSet.mTextures[72], aMaterial.mRGBa, false), null);
-                if (!aNoSmashing) {
-                    GT_Values.RA.addBenderRecipe(GT_Utility.copyAmount(2L, aStack), GT_OreDictUnificator.get(OrePrefixes.plateQuadruple, aMaterial, 1L), (int) Math.max(aMaterialMass * 2L, 1L), 96);
-                    if (GregTech_API.sRecipeFile.get(gregtech.api.enums.ConfigCategories.Tools.hammerdoubleplate, OrePrefixes.plate.get(aMaterial).toString(), true)) {
-                        Object aPlateStack = OrePrefixes.plate.get(aMaterial);
-                        GT_ModHandler.addCraftingRecipe(GT_Utility.copyAmount(1L, aStack), gregtech.api.util.GT_ModHandler.RecipeBits.DO_NOT_CHECK_FOR_COLLISIONS | gregtech.api.util.GT_ModHandler.RecipeBits.BUFFERED, new Object[]{"I", "B", "h", 'I', aPlateStack, 'B', aPlateStack});
-                        GT_ModHandler.addShapelessCraftingRecipe(GT_Utility.copyAmount(1L, aStack), new Object[]{gregtech.api.enums.ToolDictNames.craftingToolForgeHammer, aPlateStack, aPlateStack});
-                    }
-                    GT_Values.RA.addBenderRecipe(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 2L), GT_Utility.copyAmount(1L, aStack), (int) Math.max(aMaterialMass * 2L, 1L), 96);
-                } else {
-                        GT_Values.RA.addAssemblerRecipe(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 2L), gregtech.api.enums.ItemList.Circuit_Integrated.getWithDamage(0L, 2L), Materials.Glue.getFluid(10L), GT_Utility.copyAmount(1L, aStack), 64, 8);
-                    }
+                registerPlateDouble(aMaterial, aStack, aNoSmashing, aMaterialMass);
                 break;
             case plateTriple:
-                GT_ModHandler.removeRecipeByOutputDelayed(aStack);
-                GregTech_API.registerCover(aStack, new gregtech.api.objects.GT_StdRenderedTexture(aMaterial.mIconSet.mTextures[73], aMaterial.mRGBa, false), null);
-                if (!aNoSmashing) {
-                    GT_Values.RA.addBenderRecipe(GT_Utility.copyAmount(3L, aStack), GT_OreDictUnificator.get(OrePrefixes.plateDense, aMaterial, 1L), (int) Math.max(aMaterialMass * 3L, 1L), 96);
-                    if (GregTech_API.sRecipeFile.get(gregtech.api.enums.ConfigCategories.Tools.hammertripleplate, OrePrefixes.plate.get(aMaterial).toString(), true)) {
-                        Object aPlateStack = OrePrefixes.plate.get(aMaterial);
-                        GT_ModHandler.addCraftingRecipe(GT_Utility.copyAmount(1L, aStack), gregtech.api.util.GT_ModHandler.RecipeBits.DO_NOT_CHECK_FOR_COLLISIONS | gregtech.api.util.GT_ModHandler.RecipeBits.BUFFERED, new Object[]{"I", "B", "h", 'I', OrePrefixes.plateDouble.get(aMaterial), 'B', aPlateStack});
-                        GT_ModHandler.addShapelessCraftingRecipe(GT_Utility.copyAmount(1L, aStack), new Object[]{gregtech.api.enums.ToolDictNames.craftingToolForgeHammer, aPlateStack, aPlateStack, aPlateStack});
-                    } 
-                    GT_Values.RA.addBenderRecipe(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 3L), GT_Utility.copyAmount(1L, aStack), (int) Math.max(aMaterialMass * 3L, 1L), 96);
-                }else {
-                        GT_Values.RA.addAssemblerRecipe(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 3L), gregtech.api.enums.ItemList.Circuit_Integrated.getWithDamage(0L, 3L), Materials.Glue.getFluid(20L), GT_Utility.copyAmount(1L, aStack), 96, 8);
-                    }
-                GT_Values.RA.addImplosionRecipe(GT_Utility.copyAmount(1L, aStack), 2, GT_OreDictUnificator.get(OrePrefixes.compressed, aMaterial, 1L), GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 1L));//added
+                registerPlateTriple(aMaterial, aStack, aNoSmashing, aMaterialMass);
                 break;
             case plateQuadruple:
-                GT_ModHandler.removeRecipeByOutputDelayed(aStack);
-                GregTech_API.registerCover(aStack, new gregtech.api.objects.GT_StdRenderedTexture(aMaterial.mIconSet.mTextures[74], aMaterial.mRGBa, false), null);
-                if (!aNoWorking)
-                    GT_Values.RA.addCNCRecipe(GT_Utility.copyAmount(1L, aStack), GT_OreDictUnificator.get(OrePrefixes.gearGt, aMaterial, 1L), (int) Math.max(aMaterialMass * 2L, 1L), 30);
-                if (!aNoSmashing) {
-                    if (GregTech_API.sRecipeFile.get(gregtech.api.enums.ConfigCategories.Tools.hammerquadrupleplate, OrePrefixes.plate.get(aMaterial).toString(), true)) {
-                        Object aPlateStack = OrePrefixes.plate.get(aMaterial);
-                        GT_ModHandler.addCraftingRecipe(GT_Utility.copyAmount(1L, aStack), gregtech.api.util.GT_ModHandler.RecipeBits.DO_NOT_CHECK_FOR_COLLISIONS | gregtech.api.util.GT_ModHandler.RecipeBits.BUFFERED, new Object[]{"I", "B", "h", 'I', OrePrefixes.plateTriple.get(aMaterial), 'B', aPlateStack});
-                        GT_ModHandler.addShapelessCraftingRecipe(GT_Utility.copyAmount(1L, aStack), new Object[]{gregtech.api.enums.ToolDictNames.craftingToolForgeHammer, aPlateStack, aPlateStack, aPlateStack, aPlateStack});
-                    }
-                    GT_Values.RA.addBenderRecipe(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 4L), GT_Utility.copyAmount(1L, aStack), (int) Math.max(aMaterialMass * 4L, 1L), 96);
-                } else {
-                        GT_Values.RA.addAssemblerRecipe(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 4L), gregtech.api.enums.ItemList.Circuit_Integrated.getWithDamage(0L, 4L), Materials.Glue.getFluid(30L), GT_Utility.copyAmount(1L, aStack), 128, 8);
-                    }
+                registerPlateQuadruple(aMaterial, aStack, aNoSmashing, aMaterialMass, aNoWorking);
                 break;
             case plateQuintuple:
-                GT_ModHandler.removeRecipeByOutputDelayed(aStack);
-                GregTech_API.registerCover(aStack, new gregtech.api.objects.GT_StdRenderedTexture(aMaterial.mIconSet.mTextures[75], aMaterial.mRGBa, false), null);
-                if (!aNoSmashing) {
-                    if (GregTech_API.sRecipeFile.get(gregtech.api.enums.ConfigCategories.Tools.hammerquintupleplate, OrePrefixes.plate.get(aMaterial).toString(), true)) {
-                        Object aPlateStack = OrePrefixes.plate.get(aMaterial);
-                        GT_ModHandler.addCraftingRecipe(GT_Utility.copyAmount(1L, aStack), GT_ModHandler.RecipeBits.DO_NOT_CHECK_FOR_COLLISIONS | GT_ModHandler.RecipeBits.BUFFERED, new Object[]{"I", "B", "h", 'I', OrePrefixes.plateQuadruple.get(aMaterial), 'B', aPlateStack});
-                        GT_ModHandler.addShapelessCraftingRecipe(GT_Utility.copyAmount(1L, aStack), new Object[]{ToolDictNames.craftingToolForgeHammer, aPlateStack, aPlateStack, aPlateStack, aPlateStack, aPlateStack});
-                    }
-                    GT_Values.RA.addBenderRecipe(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 5L), GT_Utility.copyAmount(1L, aStack), (int) Math.max(aMaterialMass * 5L, 1L), 96);
-                } else {
-                        gregtech.api.enums.GT_Values.RA.addAssemblerRecipe(gregtech.api.util.GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 5L), ItemList.Circuit_Integrated.getWithDamage(0L, 5L), Materials.Glue.getFluid(40L), GT_Utility.copyAmount(1L, aStack), 160, 8);
-                    }
+                registerPlateQuintuple(aMaterial, aStack, aNoSmashing, aMaterialMass);
                 break;
             case plateDense:
-                GT_ModHandler.removeRecipeByOutputDelayed(aStack);
-                GregTech_API.registerCover(aStack, new GT_StdRenderedTexture(aMaterial.mIconSet.mTextures[76], aMaterial.mRGBa, false), null);
-                if (!aNoSmashing) {
-                    GT_Values.RA.addBenderRecipe(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 9L), GT_Utility.copyAmount(1L, aStack), (int) Math.max(aMaterialMass * 9L, 1L), 96);
-                }
+                registerPlateDense(aMaterial, aStack, aNoSmashing, aMaterialMass);
                 break;
             case itemCasing:
-                GT_ModHandler.removeRecipeByOutputDelayed(aStack);
-                if (aMaterial.mStandardMoltenFluid != null) {
-                    GT_Values.RA.addFluidSolidifierRecipe(ItemList.Shape_Mold_Casing.get(0L), aMaterial.getMolten(72L), GT_OreDictUnificator.get(OrePrefixes.itemCasing, aMaterial, 1L), 16, 8);
-                }
-                if ((aMaterial.mUnificatable) && (aMaterial.mMaterialInto == aMaterial)) {
-                    if (!aNoSmashing && GregTech_API.sRecipeFile.get(ConfigCategories.Tools.hammerplating, aMaterial.toString(), true)) {
-                        GT_ModHandler.addCraftingRecipe(GT_OreDictUnificator.get(OrePrefixes.itemCasing, aMaterial, 1L), GT_Proxy.tBits, new Object[]{"h X", 'X', OrePrefixes.plate.get(aMaterial)});
-                        GT_ModHandler.addCraftingRecipe(GT_OreDictUnificator.get(OrePrefixes.itemCasing, aMaterial, 1L), GT_Proxy.tBits, new Object[]{"H X", 'H', ToolDictNames.craftingToolForgeHammer, 'X', OrePrefixes.plate.get(aMaterial)});
-                    }
-                }
-                GT_Values.RA.addAlloySmelterRecipe(GT_OreDictUnificator.get(OrePrefixes.ingot, aMaterial, 2L), ItemList.Shape_Mold_Casing.get(0L), GT_Utility.copyAmount(3L, aStack), 128, 15);
-                GT_Values.RA.addCutterRecipe(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L), GT_OreDictUnificator.get(OrePrefixes.itemCasing, aMaterial, 2L), null, (int) Math.max(aMaterial.getMass(), 1L), 16);
-                GT_Values.RA.addExtruderRecipe(GT_OreDictUnificator.get(OrePrefixes.ingot, aMaterial, 1L), ItemList.Shape_Extruder_Casing.get(0L), GT_OreDictUnificator.get(OrePrefixes.itemCasing, aMaterial, 2L), (int) Math.max(aMaterial.getMass(), 1L), 45);
-                GT_RecipeRegistrator.registerReverseFluidSmelting(aStack, aMaterial, aPrefix.mMaterialAmount, null);
+                registerItemCasing(aPrefix, aMaterial, aStack, aNoSmashing);
                 break;
-
             case plateAlloy:
-                switch (aOreDictName) {
-                    case "plateAlloyCarbon":
-                        GT_Values.RA.addAssemblerRecipe(GT_ModHandler.getIC2Item("generator", 1L), GT_Utility.copyAmount(4L, aStack), GT_ModHandler.getIC2Item("windMill", 1L), 6400, 8);
-                    case "plateAlloyAdvanced":
-                        GT_ModHandler.addAlloySmelterRecipe(GT_Utility.copyAmount(1L, aStack), new ItemStack(Blocks.glass, 3, 32767), GT_ModHandler.getIC2Item("reinforcedGlass", 4L), 400, 4, false);
-                        GT_ModHandler.addAlloySmelterRecipe(GT_Utility.copyAmount(1L, aStack), GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Glass, 3L), GT_ModHandler.getIC2Item("reinforcedGlass", 4L), 400, 4, false);
-                    case "plateAlloyIridium":
-                        GT_ModHandler.removeRecipeByOutputDelayed(aStack);
-                    case "plateIron": case "plateCopper": case "plateTin": case "plateBronze": case "plateGold": case "plateSteel ": case "plateLead": case "plateAluminium": case "plateStainlessSteel": case "plateTitanium": case "plateTungsten": case "plateTungstenSteel": case "plateIridium": case "plateChrome": case "plateOsmium": case "plateNeutronium":
-                        GT_ModHandler.removeRecipeByOutputDelayed(aStack);
-                }
+                registerPlateAlloy(aOreDictName, aStack);
                 break;
-		default:
-			break;
+            default:
+                break;
+        }
+    }
+
+    private void registerPlate(final Materials aMaterial, final ItemStack aStack, final boolean aNoSmashing) {
+
+        GT_ModHandler.removeRecipeByOutputDelayed(aStack);
+        GT_ModHandler.removeRecipeDelayed(aStack);
+
+        if (aMaterial.mStandardMoltenFluid != null &&
+                !(aMaterial == Materials.AnnealedCopper || aMaterial == Materials.WroughtIron)) {
+            RA.addFluidSolidifierRecipe(
+                    ItemList.Shape_Mold_Plate.get(0L),
+                    aMaterial.getMolten(144L),
+                    GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L),
+                    32, 8);
+        }
+
+        registerCover(aMaterial, aStack);
+
+        if (aMaterial.mFuelPower > 0)
+            RA.addFuel(GT_Utility.copyAmount(1L, aStack), null, aMaterial.mFuelPower, aMaterial.mFuelType);
+
+        GT_Utility.removeSimpleIC2MachineRecipe(
+                GT_Utility.copyAmount(9L, aStack),
+                GT_ModHandler.getCompressorRecipeList(),
+                GT_OreDictUnificator.get(OrePrefixes.plateDense, aMaterial, 1L));
+        GT_ModHandler.addCraftingRecipe(
+                GT_OreDictUnificator.get(OrePrefixes.foil, aMaterial, 2L),
+                GT_Proxy.tBits,
+                new Object[]{"hX", 'X', OrePrefixes.plate.get(aMaterial)});
+
+        if (aMaterial == Materials.Paper)
+            GT_ModHandler.addCraftingRecipe(
+                    GT_Utility.copyAmount(
+                            GregTech_API.sRecipeFile.get(
+                                    gregtech.api.enums.ConfigCategories.Recipes.harderrecipes, aStack, true
+                            ) ? 2L : 3L,
+                            aStack),
+                    BUFFERED,
+                    new Object[]{"XXX", 'X', new ItemStack(net.minecraft.init.Items.reeds, 1, 32767)});
+
+        if ((aMaterial.mUnificatable) && (aMaterial.mMaterialInto == aMaterial)) {
+            if (!aNoSmashing &&
+                    GregTech_API.sRecipeFile.get(ConfigCategories.Tools.hammerplating, aMaterial.toString(), true)) {
+                GT_ModHandler.addCraftingRecipe(
+                        GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L),
+                        GT_Proxy.tBits, new Object[]{"h", "X", "X", 'X', OrePrefixes.ingot.get(aMaterial)});
+                GT_ModHandler.addCraftingRecipe(
+                        GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L),
+                        GT_Proxy.tBits,
+                        new Object[]{
+                                "H", "X", 'H', ToolDictNames.craftingToolForgeHammer,
+                                'X', OrePrefixes.ingot.get(aMaterial)});
+                GT_ModHandler.addCraftingRecipe(
+                        GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L),
+                        GT_Proxy.tBits,
+                        new Object[]{"h", "X", 'X', OrePrefixes.gem.get(aMaterial)});
+                GT_ModHandler.addCraftingRecipe(
+                        GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L),
+                        GT_Proxy.tBits,
+                        new Object[]{
+                                "H", "X", 'H', ToolDictNames.craftingToolForgeHammer,
+                                'X', OrePrefixes.gem.get(aMaterial)});
+            }
+            if ((aMaterial.contains(SubTag.MORTAR_GRINDABLE)) &&
+                    (GregTech_API.sRecipeFile.get(ConfigCategories.Tools.mortar, aMaterial.mName, true))) {
+                GT_ModHandler.addCraftingRecipe(
+                        GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial, 1L),
+                        GT_Proxy.tBits,
+                        new Object[]{"X", "m", 'X', OrePrefixes.plate.get(aMaterial)});
+            }
+        }
+    }
+
+    private void registerPlateDouble(final Materials aMaterial,
+                                     final ItemStack aStack,
+                                     final boolean aNoSmashing,
+                                     final long aMaterialMass) {
+        GT_ModHandler.removeRecipeByOutputDelayed(aStack);
+        registerCover(aMaterial, aStack);
+        if (!aNoSmashing) {
+            RA.addBenderRecipe(
+                    GT_Utility.copyAmount(2L, aStack),
+                    GT_OreDictUnificator.get(OrePrefixes.plateQuadruple, aMaterial, 1L),
+                    (int) Math.max(aMaterialMass * 2L, 1L), 96);
+            if (GregTech_API.sRecipeFile.get(
+                    gregtech.api.enums.ConfigCategories.Tools.hammerdoubleplate,
+                    OrePrefixes.plate.get(aMaterial).toString(), true)) {
+                Object aPlateStack = OrePrefixes.plate.get(aMaterial);
+                GT_ModHandler.addCraftingRecipe(
+                        GT_Utility.copyAmount(1L, aStack),
+                        DO_NOT_CHECK_FOR_COLLISIONS | BUFFERED,
+                        new Object[]{"I", "B", "h", 'I', aPlateStack, 'B', aPlateStack});
+                GT_ModHandler.addShapelessCraftingRecipe(
+                        GT_Utility.copyAmount(1L, aStack),
+                        new Object[]{
+                                gregtech.api.enums.ToolDictNames.craftingToolForgeHammer,
+                                aPlateStack,
+                                aPlateStack});
+            }
+            RA.addBenderRecipe(
+                    GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 2L),
+                    GT_Utility.copyAmount(1L, aStack),
+                    (int) Math.max(aMaterialMass * 2L, 1L),
+                    96);
+        } else {
+            RA.addAssemblerRecipe(
+                    GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 2L),
+                    gregtech.api.enums.ItemList.Circuit_Integrated.getWithDamage(0L, 2L),
+                    Materials.Glue.getFluid(10L),
+                    GT_Utility.copyAmount(1L, aStack),
+                    64, 8);
+        }
+    }
+
+    private void registerPlateTriple(final Materials aMaterial,
+                                     final ItemStack aStack,
+                                     final boolean aNoSmashing,
+                                     final long aMaterialMass) {
+        GT_ModHandler.removeRecipeByOutputDelayed(aStack);
+        registerCover(aMaterial, aStack);
+        if (!aNoSmashing) {
+            RA.addBenderRecipe(
+                    GT_Utility.copyAmount(3L, aStack),
+                    GT_OreDictUnificator.get(OrePrefixes.plateDense, aMaterial, 1L),
+                    (int) Math.max(aMaterialMass * 3L, 1L),
+                    96);
+            if (GregTech_API.sRecipeFile.get(
+                    gregtech.api.enums.ConfigCategories.Tools.hammertripleplate,
+                    OrePrefixes.plate.get(aMaterial).toString(), true)) {
+                Object aPlateStack = OrePrefixes.plate.get(aMaterial);
+                GT_ModHandler.addCraftingRecipe(
+                        GT_Utility.copyAmount(1L, aStack),
+                        DO_NOT_CHECK_FOR_COLLISIONS | BUFFERED,
+                        new Object[]{"I", "B", "h", 'I', OrePrefixes.plateDouble.get(aMaterial), 'B', aPlateStack});
+                GT_ModHandler.addShapelessCraftingRecipe(
+                        GT_Utility.copyAmount(1L, aStack),
+                        new Object[]{
+                                gregtech.api.enums.ToolDictNames.craftingToolForgeHammer,
+                                aPlateStack, aPlateStack, aPlateStack});
+            }
+            RA.addBenderRecipe(
+                    GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 3L),
+                    GT_Utility.copyAmount(1L, aStack),
+                    (int) Math.max(aMaterialMass * 3L, 1L),
+                    96);
+        } else {
+            RA.addAssemblerRecipe(
+                    GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 3L),
+                    gregtech.api.enums.ItemList.Circuit_Integrated.getWithDamage(0L, 3L),
+                    Materials.Glue.getFluid(20L),
+                    GT_Utility.copyAmount(1L, aStack),
+                    96, 8);
+        }
+        RA.addImplosionRecipe(
+                GT_Utility.copyAmount(1L, aStack),
+                2,
+                GT_OreDictUnificator.get(OrePrefixes.compressed, aMaterial, 1L),
+                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 1L));
+    }
+
+    private void registerPlateQuadruple(final Materials aMaterial,
+                                        final ItemStack aStack,
+                                        final boolean aNoSmashing,
+                                        final long aMaterialMass,
+                                        final boolean aNoWorking) {
+        GT_ModHandler.removeRecipeByOutputDelayed(aStack);
+        registerCover(aMaterial, aStack);
+        if (!aNoWorking)
+            RA.addCNCRecipe(
+                    GT_Utility.copyAmount(1L, aStack),
+                    GT_OreDictUnificator.get(OrePrefixes.gearGt, aMaterial, 1L),
+                    (int) Math.max(aMaterialMass * 2L, 1L),
+                    30);
+        if (!aNoSmashing) {
+            if (GregTech_API.sRecipeFile.get(
+                    gregtech.api.enums.ConfigCategories.Tools.hammerquadrupleplate,
+                    OrePrefixes.plate.get(aMaterial).toString(), true)) {
+                Object aPlateStack = OrePrefixes.plate.get(aMaterial);
+                GT_ModHandler.addCraftingRecipe(
+                        GT_Utility.copyAmount(1L, aStack),
+                        DO_NOT_CHECK_FOR_COLLISIONS | BUFFERED,
+                        new Object[]{"I", "B", "h", 'I', OrePrefixes.plateTriple.get(aMaterial), 'B', aPlateStack});
+                GT_ModHandler.addShapelessCraftingRecipe(
+                        GT_Utility.copyAmount(1L, aStack),
+                        new Object[]{gregtech.api.enums.ToolDictNames.craftingToolForgeHammer,
+                                aPlateStack, aPlateStack, aPlateStack, aPlateStack});
+            }
+            RA.addBenderRecipe(
+                    GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 4L),
+                    GT_Utility.copyAmount(1L, aStack),
+                    (int) Math.max(aMaterialMass * 4L, 1L),
+                    96);
+        } else {
+            RA.addAssemblerRecipe(
+                    GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 4L),
+                    gregtech.api.enums.ItemList.Circuit_Integrated.getWithDamage(0L, 4L),
+                    Materials.Glue.getFluid(30L), GT_Utility.copyAmount(1L, aStack),
+                    128, 8);
+        }
+    }
+
+    private void registerPlateQuintuple(final Materials aMaterial,
+                                        final ItemStack aStack,
+                                        final boolean aNoSmashing,
+                                        final long aMaterialMass) {
+        GT_ModHandler.removeRecipeByOutputDelayed(aStack);
+        registerCover(aMaterial, aStack);
+        if (!aNoSmashing) {
+            if (GregTech_API.sRecipeFile.get(
+                    gregtech.api.enums.ConfigCategories.Tools.hammerquintupleplate,
+                    OrePrefixes.plate.get(aMaterial).toString(), true)) {
+                Object aPlateStack = OrePrefixes.plate.get(aMaterial);
+                GT_ModHandler.addCraftingRecipe(
+                        GT_Utility.copyAmount(1L, aStack),
+                        DO_NOT_CHECK_FOR_COLLISIONS | BUFFERED,
+                        new Object[]{"I", "B", "h", 'I', OrePrefixes.plateQuadruple.get(aMaterial), 'B', aPlateStack});
+                GT_ModHandler.addShapelessCraftingRecipe(
+                        GT_Utility.copyAmount(1L, aStack),
+                        new Object[]{ToolDictNames.craftingToolForgeHammer,
+                                aPlateStack, aPlateStack, aPlateStack, aPlateStack, aPlateStack});
+            }
+            RA.addBenderRecipe(
+                    GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 5L),
+                    GT_Utility.copyAmount(1L, aStack),
+                    (int) Math.max(aMaterialMass * 5L, 1L),
+                    96);
+        } else {
+            RA.addAssemblerRecipe(
+                    gregtech.api.util.GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 5L),
+                    ItemList.Circuit_Integrated.getWithDamage(0L, 5L),
+                    Materials.Glue.getFluid(40L),
+                    GT_Utility.copyAmount(1L, aStack),
+                    160, 8);
+        }
+    }
+
+    private void registerPlateDense(final Materials aMaterial,
+                                    final ItemStack aStack,
+                                    final boolean aNoSmashing,
+                                    final long aMaterialMass) {
+        GT_ModHandler.removeRecipeByOutputDelayed(aStack);
+        registerCover(aMaterial, aStack);
+        if (!aNoSmashing) {
+            RA.addBenderRecipe(
+                    GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 9L),
+                    GT_Utility.copyAmount(1L, aStack), (int) Math.max(aMaterialMass * 9L, 1L),
+                    96);
+        }
+    }
+
+    private void registerItemCasing(final OrePrefixes aPrefix,
+                                    final Materials aMaterial,
+                                    final ItemStack aStack,
+                                    final boolean aNoSmashing) {
+        GT_ModHandler.removeRecipeByOutputDelayed(aStack);
+        if (aMaterial.mStandardMoltenFluid != null) {
+            RA.addFluidSolidifierRecipe(
+                    ItemList.Shape_Mold_Casing.get(0L),
+                    aMaterial.getMolten(72L),
+                    GT_OreDictUnificator.get(OrePrefixes.itemCasing, aMaterial, 1L),
+                    16, 8);
+        }
+        if (aMaterial.mUnificatable &&
+                aMaterial.mMaterialInto == aMaterial &&
+                !aNoSmashing &&
+                GregTech_API.sRecipeFile.get(ConfigCategories.Tools.hammerplating, aMaterial.toString(), true)) {
+            GT_ModHandler.addCraftingRecipe(
+                    GT_OreDictUnificator.get(OrePrefixes.itemCasing, aMaterial, 1L),
+                    GT_Proxy.tBits, new Object[]{"h X", 'X', OrePrefixes.plate.get(aMaterial)});
+            GT_ModHandler.addCraftingRecipe(
+                    GT_OreDictUnificator.get(OrePrefixes.itemCasing, aMaterial, 1L),
+                    GT_Proxy.tBits,
+                    new Object[]{
+                            "H X", 'H', ToolDictNames.craftingToolForgeHammer, 'X', OrePrefixes.plate.get(aMaterial)});
+        }
+        RA.addAlloySmelterRecipe(
+                GT_OreDictUnificator.get(OrePrefixes.ingot, aMaterial, 2L),
+                ItemList.Shape_Mold_Casing.get(0L), GT_Utility.copyAmount(3L, aStack), 128, 15);
+        RA.addCutterRecipe(
+                GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L),
+                GT_OreDictUnificator.get(OrePrefixes.itemCasing, aMaterial, 2L),
+                null,
+                (int) Math.max(aMaterial.getMass(), 1L),
+                16);
+        RA.addExtruderRecipe(
+                GT_OreDictUnificator.get(OrePrefixes.ingot, aMaterial, 1L),
+                ItemList.Shape_Extruder_Casing.get(0L),
+                GT_OreDictUnificator.get(OrePrefixes.itemCasing, aMaterial, 2L),
+                (int) Math.max(aMaterial.getMass(), 1L),
+                45);
+        GT_RecipeRegistrator.registerReverseFluidSmelting(aStack, aMaterial, aPrefix.mMaterialAmount, null);
+    }
+
+    private void registerPlateAlloy(final String aOreDictName, final ItemStack aStack) {
+        switch (aOreDictName) {
+            case "plateAlloyCarbon":
+                RA.addAssemblerRecipe(
+                        GT_ModHandler.getIC2Item("generator", 1L),
+                        GT_Utility.copyAmount(4L, aStack),
+                        GT_ModHandler.getIC2Item("windMill", 1L),
+                        6400, 8);
+                break;
+            case "plateAlloyAdvanced":
+                GT_ModHandler.addAlloySmelterRecipe(
+                        GT_Utility.copyAmount(1L, aStack),
+                        new ItemStack(Blocks.glass, 3, 32767),
+                        GT_ModHandler.getIC2Item("reinforcedGlass", 4L),
+                        400, 4, false);
+                GT_ModHandler.addAlloySmelterRecipe(
+                        GT_Utility.copyAmount(1L, aStack),
+                        GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Glass, 3L),
+                        GT_ModHandler.getIC2Item("reinforcedGlass", 4L),
+                        400, 4, false);
+                break;
+            case "plateAlloyIridium":
+                // Remove IC2 Shaped recipe for Iridium Reinforced Plate
+                GT_ModHandler.removeRecipeByOutputDelayed(aStack);
+                break;
+            default:
+                break;
+        }
+    }
+
+    private void registerCover(final Materials aMaterial, final ItemStack aStack) {
+        final ItemStack tStack = aMaterial.getBlocks(1);
+        if (tStack != null) {
+            ItemBlock tItemBlock = (ItemBlock) tStack.getItem();
+
+            GregTech_API.registerCover(
+                    aStack,
+                    new GT_CopiedBlockTexture((tItemBlock).field_150939_a, 1, tStack.getItemDamage()),
+                    null);
+        } else {
+            GregTech_API.registerCover(
+                    aStack,
+                    new GT_StdRenderedTexture(aMaterial.mIconSet.mTextures[71], aMaterial.mRGBa, false),
+                    null);
         }
     }
 }

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingPlate.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingPlate.java
@@ -4,6 +4,7 @@ import gregtech.api.GregTech_API;
 import gregtech.api.enums.*;
 import gregtech.api.objects.GT_CopiedBlockTexture;
 import gregtech.api.objects.GT_RenderedTexture;
+import gregtech.api.objects.GT_StdRenderedTexture;
 import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_OreDictUnificator;
 import gregtech.api.util.GT_RecipeRegistrator;
@@ -74,22 +75,22 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
                         GregTech_API.registerCover(aStack, new GT_CopiedBlockTexture(Blocks.stone, 1, 0), null);
                         break;
                     case "GraniteBlack":
-                        GregTech_API.registerCover(aStack, new GT_RenderedTexture(gregtech.api.enums.Textures.BlockIcons.GRANITE_BLACK_SMOOTH), null);
+                        GregTech_API.registerCover(aStack, new GT_StdRenderedTexture(gregtech.api.enums.Textures.BlockIcons.GRANITE_BLACK_SMOOTH), null);
                         break;
                     case "GraniteRed":
-                        GregTech_API.registerCover(aStack, new GT_RenderedTexture(gregtech.api.enums.Textures.BlockIcons.GRANITE_RED_SMOOTH), null);
+                        GregTech_API.registerCover(aStack, new GT_StdRenderedTexture(gregtech.api.enums.Textures.BlockIcons.GRANITE_RED_SMOOTH), null);
                         break;
                     case "Basalt":
-                        GregTech_API.registerCover(aStack, new GT_RenderedTexture(gregtech.api.enums.Textures.BlockIcons.BASALT_SMOOTH), null);
+                        GregTech_API.registerCover(aStack, new GT_StdRenderedTexture(gregtech.api.enums.Textures.BlockIcons.BASALT_SMOOTH), null);
                         break;
                     case "Marble":
-                        GregTech_API.registerCover(aStack, new GT_RenderedTexture(gregtech.api.enums.Textures.BlockIcons.MARBLE_SMOOTH), null);
+                        GregTech_API.registerCover(aStack, new GT_StdRenderedTexture(gregtech.api.enums.Textures.BlockIcons.MARBLE_SMOOTH), null);
                         break;
                     case "Concrete":
-                        GregTech_API.registerCover(aStack, new GT_RenderedTexture(gregtech.api.enums.Textures.BlockIcons.CONCRETE_LIGHT_SMOOTH), null);
+                        GregTech_API.registerCover(aStack, new GT_StdRenderedTexture(gregtech.api.enums.Textures.BlockIcons.CONCRETE_LIGHT_SMOOTH), null);
                         break;
                     default:
-                        GregTech_API.registerCover(aStack, new GT_RenderedTexture(aMaterial.mIconSet.mTextures[71], aMaterial.mRGBa, false), null);
+                        GregTech_API.registerCover(aStack, new GT_StdRenderedTexture(aMaterial.mIconSet.mTextures[71], aMaterial.mRGBa, false), null);
                 }
 
                 if (aMaterial.mFuelPower > 0)
@@ -115,7 +116,7 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
                 break;
             case plateDouble:
                 GT_ModHandler.removeRecipeByOutputDelayed(aStack);
-                GregTech_API.registerCover(aStack, new gregtech.api.objects.GT_RenderedTexture(aMaterial.mIconSet.mTextures[72], aMaterial.mRGBa, false), null);
+                GregTech_API.registerCover(aStack, new gregtech.api.objects.GT_StdRenderedTexture(aMaterial.mIconSet.mTextures[72], aMaterial.mRGBa, false), null);
                 if (!aNoSmashing) {
                     GT_Values.RA.addBenderRecipe(GT_Utility.copyAmount(2L, aStack), GT_OreDictUnificator.get(OrePrefixes.plateQuadruple, aMaterial, 1L), (int) Math.max(aMaterialMass * 2L, 1L), 96);
                     if (GregTech_API.sRecipeFile.get(gregtech.api.enums.ConfigCategories.Tools.hammerdoubleplate, OrePrefixes.plate.get(aMaterial).toString(), true)) {
@@ -130,7 +131,7 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
                 break;
             case plateTriple:
                 GT_ModHandler.removeRecipeByOutputDelayed(aStack);
-                GregTech_API.registerCover(aStack, new gregtech.api.objects.GT_RenderedTexture(aMaterial.mIconSet.mTextures[73], aMaterial.mRGBa, false), null);
+                GregTech_API.registerCover(aStack, new gregtech.api.objects.GT_StdRenderedTexture(aMaterial.mIconSet.mTextures[73], aMaterial.mRGBa, false), null);
                 if (!aNoSmashing) {
                     GT_Values.RA.addBenderRecipe(GT_Utility.copyAmount(3L, aStack), GT_OreDictUnificator.get(OrePrefixes.plateDense, aMaterial, 1L), (int) Math.max(aMaterialMass * 3L, 1L), 96);
                     if (GregTech_API.sRecipeFile.get(gregtech.api.enums.ConfigCategories.Tools.hammertripleplate, OrePrefixes.plate.get(aMaterial).toString(), true)) {
@@ -146,7 +147,7 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
                 break;
             case plateQuadruple:
                 GT_ModHandler.removeRecipeByOutputDelayed(aStack);
-                GregTech_API.registerCover(aStack, new gregtech.api.objects.GT_RenderedTexture(aMaterial.mIconSet.mTextures[74], aMaterial.mRGBa, false), null);
+                GregTech_API.registerCover(aStack, new gregtech.api.objects.GT_StdRenderedTexture(aMaterial.mIconSet.mTextures[74], aMaterial.mRGBa, false), null);
                 if (!aNoWorking)
                     GT_Values.RA.addCNCRecipe(GT_Utility.copyAmount(1L, aStack), GT_OreDictUnificator.get(OrePrefixes.gearGt, aMaterial, 1L), (int) Math.max(aMaterialMass * 2L, 1L), 30);
                 if (!aNoSmashing) {
@@ -162,7 +163,7 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
                 break;
             case plateQuintuple:
                 GT_ModHandler.removeRecipeByOutputDelayed(aStack);
-                GregTech_API.registerCover(aStack, new gregtech.api.objects.GT_RenderedTexture(aMaterial.mIconSet.mTextures[75], aMaterial.mRGBa, false), null);
+                GregTech_API.registerCover(aStack, new gregtech.api.objects.GT_StdRenderedTexture(aMaterial.mIconSet.mTextures[75], aMaterial.mRGBa, false), null);
                 if (!aNoSmashing) {
                     if (GregTech_API.sRecipeFile.get(gregtech.api.enums.ConfigCategories.Tools.hammerquintupleplate, OrePrefixes.plate.get(aMaterial).toString(), true)) {
                         Object aPlateStack = OrePrefixes.plate.get(aMaterial);
@@ -176,7 +177,7 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
                 break;
             case plateDense:
                 GT_ModHandler.removeRecipeByOutputDelayed(aStack);
-                GregTech_API.registerCover(aStack, new GT_RenderedTexture(aMaterial.mIconSet.mTextures[76], aMaterial.mRGBa, false), null);
+                GregTech_API.registerCover(aStack, new GT_StdRenderedTexture(aMaterial.mIconSet.mTextures[76], aMaterial.mRGBa, false), null);
                 if (!aNoSmashing) {
                     GT_Values.RA.addBenderRecipe(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 9L), GT_Utility.copyAmount(1L, aStack), (int) Math.max(aMaterialMass * 9L, 1L), 96);
                 }

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingPlate.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingPlate.java
@@ -14,14 +14,19 @@ import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_OreDictUnificator;
 import gregtech.api.util.GT_RecipeRegistrator;
 import gregtech.api.util.GT_Utility;
-import gregtech.common.GT_Proxy;
 import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
+import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 
+import static gregtech.api.enums.ConfigCategories.Recipes.harderrecipes;
+import static gregtech.api.enums.GT_Values.L;
+import static gregtech.api.enums.GT_Values.NI;
 import static gregtech.api.enums.GT_Values.RA;
+import static gregtech.api.enums.GT_Values.W;
 import static gregtech.api.util.GT_ModHandler.RecipeBits.BUFFERED;
 import static gregtech.api.util.GT_ModHandler.RecipeBits.DO_NOT_CHECK_FOR_COLLISIONS;
+import static gregtech.common.GT_Proxy.tBits;
 
 public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegistrator {
     public ProcessingPlate() {
@@ -50,6 +55,7 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
                             String aOreDictName,
                             String aModName,
                             ItemStack aStack) {
+
         final boolean aNoSmashing = aMaterial.contains(SubTag.NO_SMASHING);
         final boolean aNoWorking = aMaterial.contains(SubTag.NO_WORKING);
         final long aMaterialMass = aMaterial.getMass();
@@ -86,71 +92,111 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
 
     private void registerPlate(final Materials aMaterial, final ItemStack aStack, final boolean aNoSmashing) {
 
-        GT_ModHandler.removeRecipeByOutputDelayed(aStack);
-        GT_ModHandler.removeRecipeDelayed(aStack);
-
-        if (aMaterial.mStandardMoltenFluid != null &&
-                !(aMaterial == Materials.AnnealedCopper || aMaterial == Materials.WroughtIron)) {
-            RA.addFluidSolidifierRecipe(
-                    ItemList.Shape_Mold_Plate.get(0L),
-                    aMaterial.getMolten(144L),
-                    GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L),
-                    32, 8);
-        }
-
         registerCover(aMaterial, aStack);
 
-        if (aMaterial.mFuelPower > 0)
-            RA.addFuel(GT_Utility.copyAmount(1L, aStack), null, aMaterial.mFuelPower, aMaterial.mFuelType);
+        GT_ModHandler.removeRecipeByOutputDelayed(aStack);
+        GT_ModHandler.removeRecipeDelayed(aStack);
 
         GT_Utility.removeSimpleIC2MachineRecipe(
                 GT_Utility.copyAmount(9L, aStack),
                 GT_ModHandler.getCompressorRecipeList(),
                 GT_OreDictUnificator.get(OrePrefixes.plateDense, aMaterial, 1L));
+
+        if (aMaterial.mFuelPower > 0) {
+
+            RA.addFuel(
+                    GT_Utility.copyAmount(1L, aStack),
+                    NI,
+                    aMaterial.mFuelPower,
+                    aMaterial.mFuelType);
+
+        }
+
+        if (aMaterial.mStandardMoltenFluid != null &&
+                !(aMaterial == Materials.AnnealedCopper || aMaterial == Materials.WroughtIron)) {
+
+            RA.addFluidSolidifierRecipe(
+                    ItemList.Shape_Mold_Plate.get(0L),
+                    aMaterial.getMolten(L),
+                    aMaterial.getPlates(1),
+                    32, 8);
+
+        }
+
         GT_ModHandler.addCraftingRecipe(
                 GT_OreDictUnificator.get(OrePrefixes.foil, aMaterial, 2L),
-                GT_Proxy.tBits,
-                new Object[]{"hX", 'X', OrePrefixes.plate.get(aMaterial)});
+                tBits, // DO_NOT_CHECK_FOR_COLLISIONS|BUFFERED|ONLY_ADD_IF_RESULT_IS_NOT_NULL|NOT_REMOVABLE
+                new Object[]{
+                        "hX",
+                        'X', OrePrefixes.plate.get(aMaterial)});
 
-        if (aMaterial == Materials.Paper)
+        if (aMaterial == Materials.Paper) {
+
             GT_ModHandler.addCraftingRecipe(
                     GT_Utility.copyAmount(
-                            GregTech_API.sRecipeFile.get(
-                                    gregtech.api.enums.ConfigCategories.Recipes.harderrecipes, aStack, true
-                            ) ? 2L : 3L,
+                            GregTech_API.sRecipeFile.get(harderrecipes, aStack, true) ? 2L : 3L,
                             aStack),
                     BUFFERED,
-                    new Object[]{"XXX", 'X', new ItemStack(net.minecraft.init.Items.reeds, 1, 32767)});
+                    new Object[]{
+                            "XXX",
+                            'X', new ItemStack(Items.reeds, 1, W)});
+        }
 
-        if ((aMaterial.mUnificatable) && (aMaterial.mMaterialInto == aMaterial)) {
+        if (aMaterial.mUnificatable && aMaterial.mMaterialInto == aMaterial) {
+
             if (!aNoSmashing &&
                     GregTech_API.sRecipeFile.get(ConfigCategories.Tools.hammerplating, aMaterial.toString(), true)) {
+
                 GT_ModHandler.addCraftingRecipe(
-                        GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L),
-                        GT_Proxy.tBits, new Object[]{"h", "X", "X", 'X', OrePrefixes.ingot.get(aMaterial)});
-                GT_ModHandler.addCraftingRecipe(
-                        GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L),
-                        GT_Proxy.tBits,
+                        aMaterial.getPlates(1),
+                        tBits, // DO_NOT_CHECK_FOR_COLLISIONS|BUFFERED|ONLY_ADD_IF_RESULT_IS_NOT_NULL|NOT_REMOVABLE
                         new Object[]{
-                                "H", "X", 'H', ToolDictNames.craftingToolForgeHammer,
+                                "h", // craftingToolHardHammer
+                                "X",
+                                "X",
                                 'X', OrePrefixes.ingot.get(aMaterial)});
+
+                // Only added if IC2 Forge Hammer is enabled in Recipes.cfg: B:ic2forgehammer_true=false
                 GT_ModHandler.addCraftingRecipe(
-                        GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L),
-                        GT_Proxy.tBits,
-                        new Object[]{"h", "X", 'X', OrePrefixes.gem.get(aMaterial)});
-                GT_ModHandler.addCraftingRecipe(
-                        GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L),
-                        GT_Proxy.tBits,
+                        aMaterial.getPlates(1),
+                        tBits, // DO_NOT_CHECK_FOR_COLLISIONS|BUFFERED|ONLY_ADD_IF_RESULT_IS_NOT_NULL|NOT_REMOVABLE
                         new Object[]{
-                                "H", "X", 'H', ToolDictNames.craftingToolForgeHammer,
+                                "H", // craftingToolForgeHammer
+                                "X",
+                                'H', ToolDictNames.craftingToolForgeHammer,
+                                'X', OrePrefixes.ingot.get(aMaterial)});
+
+                GT_ModHandler.addCraftingRecipe(
+                        aMaterial.getPlates(1),
+                        tBits, // DO_NOT_CHECK_FOR_COLLISIONS|BUFFERED|ONLY_ADD_IF_RESULT_IS_NOT_NULL|NOT_REMOVABLE
+                        new Object[]{
+                                "h", // craftingToolHardHammer
+                                "X",
                                 'X', OrePrefixes.gem.get(aMaterial)});
+
+                // Only added if IC2 Forge Hammer is enabled in Recipes.cfg: B:ic2forgehammer_true=false
+                GT_ModHandler.addCraftingRecipe(
+                        aMaterial.getPlates(1),
+                        tBits, // DO_NOT_CHECK_FOR_COLLISIONS|BUFFERED|ONLY_ADD_IF_RESULT_IS_NOT_NULL|NOT_REMOVABLE
+                        new Object[]{
+                                "H", // craftingToolForgeHammer
+                                "X",
+                                'H', ToolDictNames.craftingToolForgeHammer,
+                                'X', OrePrefixes.gem.get(aMaterial)});
+
             }
+
             if ((aMaterial.contains(SubTag.MORTAR_GRINDABLE)) &&
                     (GregTech_API.sRecipeFile.get(ConfigCategories.Tools.mortar, aMaterial.mName, true))) {
+
                 GT_ModHandler.addCraftingRecipe(
-                        GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial, 1L),
-                        GT_Proxy.tBits,
-                        new Object[]{"X", "m", 'X', OrePrefixes.plate.get(aMaterial)});
+                        aMaterial.getDust(1),
+                        tBits, // DO_NOT_CHECK_FOR_COLLISIONS|BUFFERED|ONLY_ADD_IF_RESULT_IS_NOT_NULL|NOT_REMOVABLE
+                        new Object[]{
+                                "X",
+                                "m",
+                                'X', OrePrefixes.plate.get(aMaterial)});
+
             }
         }
     }
@@ -159,40 +205,61 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
                                      final ItemStack aStack,
                                      final boolean aNoSmashing,
                                      final long aMaterialMass) {
-        GT_ModHandler.removeRecipeByOutputDelayed(aStack);
+
         registerCover(aMaterial, aStack);
+
+        GT_ModHandler.removeRecipeByOutputDelayed(aStack);
+
         if (!aNoSmashing) {
+
             RA.addBenderRecipe(
                     GT_Utility.copyAmount(2L, aStack),
                     GT_OreDictUnificator.get(OrePrefixes.plateQuadruple, aMaterial, 1L),
-                    (int) Math.max(aMaterialMass * 2L, 1L), 96);
+                    (int) Math.max(aMaterialMass * 2L, 1L),
+                    96);
+
             if (GregTech_API.sRecipeFile.get(
                     gregtech.api.enums.ConfigCategories.Tools.hammerdoubleplate,
                     OrePrefixes.plate.get(aMaterial).toString(), true)) {
+
                 Object aPlateStack = OrePrefixes.plate.get(aMaterial);
+
                 GT_ModHandler.addCraftingRecipe(
                         GT_Utility.copyAmount(1L, aStack),
                         DO_NOT_CHECK_FOR_COLLISIONS | BUFFERED,
-                        new Object[]{"I", "B", "h", 'I', aPlateStack, 'B', aPlateStack});
+                        new Object[]{
+                                "I",
+                                "B",
+                                "h", // craftingToolHardHammer
+                                'I', aPlateStack,
+                                'B', aPlateStack});
+
+                // Only added if IC2 Forge Hammer is enabled in Recipes.cfg: B:ic2forgehammer_true=false
                 GT_ModHandler.addShapelessCraftingRecipe(
                         GT_Utility.copyAmount(1L, aStack),
+                        DO_NOT_CHECK_FOR_COLLISIONS | BUFFERED,
                         new Object[]{
                                 gregtech.api.enums.ToolDictNames.craftingToolForgeHammer,
                                 aPlateStack,
                                 aPlateStack});
+
             }
+
             RA.addBenderRecipe(
                     GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 2L),
                     GT_Utility.copyAmount(1L, aStack),
                     (int) Math.max(aMaterialMass * 2L, 1L),
                     96);
+
         } else {
+
             RA.addAssemblerRecipe(
                     GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 2L),
                     gregtech.api.enums.ItemList.Circuit_Integrated.getWithDamage(0L, 2L),
                     Materials.Glue.getFluid(10L),
                     GT_Utility.copyAmount(1L, aStack),
                     64, 8);
+
         }
     }
 
@@ -200,46 +267,67 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
                                      final ItemStack aStack,
                                      final boolean aNoSmashing,
                                      final long aMaterialMass) {
-        GT_ModHandler.removeRecipeByOutputDelayed(aStack);
+
         registerCover(aMaterial, aStack);
+
+        GT_ModHandler.removeRecipeByOutputDelayed(aStack);
+
         if (!aNoSmashing) {
+
             RA.addBenderRecipe(
                     GT_Utility.copyAmount(3L, aStack),
                     GT_OreDictUnificator.get(OrePrefixes.plateDense, aMaterial, 1L),
                     (int) Math.max(aMaterialMass * 3L, 1L),
                     96);
+
             if (GregTech_API.sRecipeFile.get(
                     gregtech.api.enums.ConfigCategories.Tools.hammertripleplate,
                     OrePrefixes.plate.get(aMaterial).toString(), true)) {
+
                 Object aPlateStack = OrePrefixes.plate.get(aMaterial);
+
                 GT_ModHandler.addCraftingRecipe(
                         GT_Utility.copyAmount(1L, aStack),
                         DO_NOT_CHECK_FOR_COLLISIONS | BUFFERED,
-                        new Object[]{"I", "B", "h", 'I', OrePrefixes.plateDouble.get(aMaterial), 'B', aPlateStack});
+                        new Object[]{
+                                "I",
+                                "B",
+                                "h", // craftingToolHardHammer
+                                'I', OrePrefixes.plateDouble.get(aMaterial),
+                                'B', aPlateStack});
+
                 GT_ModHandler.addShapelessCraftingRecipe(
                         GT_Utility.copyAmount(1L, aStack),
+                        DO_NOT_CHECK_FOR_COLLISIONS | BUFFERED,
                         new Object[]{
                                 gregtech.api.enums.ToolDictNames.craftingToolForgeHammer,
                                 aPlateStack, aPlateStack, aPlateStack});
+
             }
+
             RA.addBenderRecipe(
                     GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 3L),
                     GT_Utility.copyAmount(1L, aStack),
                     (int) Math.max(aMaterialMass * 3L, 1L),
                     96);
+
         } else {
+
             RA.addAssemblerRecipe(
                     GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 3L),
                     gregtech.api.enums.ItemList.Circuit_Integrated.getWithDamage(0L, 3L),
                     Materials.Glue.getFluid(20L),
                     GT_Utility.copyAmount(1L, aStack),
                     96, 8);
+
         }
+
         RA.addImplosionRecipe(
                 GT_Utility.copyAmount(1L, aStack),
                 2,
                 GT_OreDictUnificator.get(OrePrefixes.compressed, aMaterial, 1L),
                 GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 1L));
+
     }
 
     private void registerPlateQuadruple(final Materials aMaterial,
@@ -247,39 +335,59 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
                                         final boolean aNoSmashing,
                                         final long aMaterialMass,
                                         final boolean aNoWorking) {
-        GT_ModHandler.removeRecipeByOutputDelayed(aStack);
+
         registerCover(aMaterial, aStack);
+
+        GT_ModHandler.removeRecipeByOutputDelayed(aStack);
+
         if (!aNoWorking)
+
             RA.addCNCRecipe(
                     GT_Utility.copyAmount(1L, aStack),
                     GT_OreDictUnificator.get(OrePrefixes.gearGt, aMaterial, 1L),
                     (int) Math.max(aMaterialMass * 2L, 1L),
                     30);
+
         if (!aNoSmashing) {
+
             if (GregTech_API.sRecipeFile.get(
                     gregtech.api.enums.ConfigCategories.Tools.hammerquadrupleplate,
                     OrePrefixes.plate.get(aMaterial).toString(), true)) {
+
                 Object aPlateStack = OrePrefixes.plate.get(aMaterial);
+
                 GT_ModHandler.addCraftingRecipe(
                         GT_Utility.copyAmount(1L, aStack),
                         DO_NOT_CHECK_FOR_COLLISIONS | BUFFERED,
-                        new Object[]{"I", "B", "h", 'I', OrePrefixes.plateTriple.get(aMaterial), 'B', aPlateStack});
+                        new Object[]{
+                                "I",
+                                "B",
+                                "h", // craftingToolHardHammer
+                                'I', OrePrefixes.plateTriple.get(aMaterial),
+                                'B', aPlateStack});
+
                 GT_ModHandler.addShapelessCraftingRecipe(
                         GT_Utility.copyAmount(1L, aStack),
+                        DO_NOT_CHECK_FOR_COLLISIONS | BUFFERED,
                         new Object[]{gregtech.api.enums.ToolDictNames.craftingToolForgeHammer,
                                 aPlateStack, aPlateStack, aPlateStack, aPlateStack});
+
             }
+
             RA.addBenderRecipe(
                     GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 4L),
                     GT_Utility.copyAmount(1L, aStack),
                     (int) Math.max(aMaterialMass * 4L, 1L),
                     96);
+
         } else {
+
             RA.addAssemblerRecipe(
                     GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 4L),
                     gregtech.api.enums.ItemList.Circuit_Integrated.getWithDamage(0L, 4L),
                     Materials.Glue.getFluid(30L), GT_Utility.copyAmount(1L, aStack),
                     128, 8);
+
         }
     }
 
@@ -287,34 +395,53 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
                                         final ItemStack aStack,
                                         final boolean aNoSmashing,
                                         final long aMaterialMass) {
-        GT_ModHandler.removeRecipeByOutputDelayed(aStack);
+
         registerCover(aMaterial, aStack);
+
+        GT_ModHandler.removeRecipeByOutputDelayed(aStack);
+
         if (!aNoSmashing) {
+
             if (GregTech_API.sRecipeFile.get(
                     gregtech.api.enums.ConfigCategories.Tools.hammerquintupleplate,
                     OrePrefixes.plate.get(aMaterial).toString(), true)) {
+
                 Object aPlateStack = OrePrefixes.plate.get(aMaterial);
+
                 GT_ModHandler.addCraftingRecipe(
                         GT_Utility.copyAmount(1L, aStack),
                         DO_NOT_CHECK_FOR_COLLISIONS | BUFFERED,
-                        new Object[]{"I", "B", "h", 'I', OrePrefixes.plateQuadruple.get(aMaterial), 'B', aPlateStack});
+                        new Object[]{
+                                "I",
+                                "B",
+                                "h", // craftingToolHardHammer
+                                'I', OrePrefixes.plateQuadruple.get(aMaterial),
+                                'B', aPlateStack});
+
                 GT_ModHandler.addShapelessCraftingRecipe(
                         GT_Utility.copyAmount(1L, aStack),
-                        new Object[]{ToolDictNames.craftingToolForgeHammer,
+                        DO_NOT_CHECK_FOR_COLLISIONS | BUFFERED,
+                        new Object[]{
+                                ToolDictNames.craftingToolForgeHammer,
                                 aPlateStack, aPlateStack, aPlateStack, aPlateStack, aPlateStack});
+
             }
+
             RA.addBenderRecipe(
                     GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 5L),
                     GT_Utility.copyAmount(1L, aStack),
                     (int) Math.max(aMaterialMass * 5L, 1L),
                     96);
+
         } else {
+
             RA.addAssemblerRecipe(
                     gregtech.api.util.GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 5L),
                     ItemList.Circuit_Integrated.getWithDamage(0L, 5L),
                     Materials.Glue.getFluid(40L),
                     GT_Utility.copyAmount(1L, aStack),
                     160, 8);
+
         }
     }
 
@@ -322,87 +449,127 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
                                     final ItemStack aStack,
                                     final boolean aNoSmashing,
                                     final long aMaterialMass) {
-        GT_ModHandler.removeRecipeByOutputDelayed(aStack);
+
         registerCover(aMaterial, aStack);
+
+        GT_ModHandler.removeRecipeByOutputDelayed(aStack);
+
         if (!aNoSmashing) {
+
             RA.addBenderRecipe(
                     GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 9L),
                     GT_Utility.copyAmount(1L, aStack), (int) Math.max(aMaterialMass * 9L, 1L),
                     96);
+
         }
+
     }
 
     private void registerItemCasing(final OrePrefixes aPrefix,
                                     final Materials aMaterial,
                                     final ItemStack aStack,
                                     final boolean aNoSmashing) {
+
         GT_ModHandler.removeRecipeByOutputDelayed(aStack);
+
         if (aMaterial.mStandardMoltenFluid != null) {
+
             RA.addFluidSolidifierRecipe(
                     ItemList.Shape_Mold_Casing.get(0L),
-                    aMaterial.getMolten(72L),
+                    aMaterial.getMolten(L / 2),
                     GT_OreDictUnificator.get(OrePrefixes.itemCasing, aMaterial, 1L),
                     16, 8);
+
         }
+
         if (aMaterial.mUnificatable &&
                 aMaterial.mMaterialInto == aMaterial &&
                 !aNoSmashing &&
                 GregTech_API.sRecipeFile.get(ConfigCategories.Tools.hammerplating, aMaterial.toString(), true)) {
+
             GT_ModHandler.addCraftingRecipe(
                     GT_OreDictUnificator.get(OrePrefixes.itemCasing, aMaterial, 1L),
-                    GT_Proxy.tBits, new Object[]{"h X", 'X', OrePrefixes.plate.get(aMaterial)});
-            GT_ModHandler.addCraftingRecipe(
-                    GT_OreDictUnificator.get(OrePrefixes.itemCasing, aMaterial, 1L),
-                    GT_Proxy.tBits,
+                    tBits, // DO_NOT_CHECK_FOR_COLLISIONS|BUFFERED|ONLY_ADD_IF_RESULT_IS_NOT_NULL|NOT_REMOVABLE
                     new Object[]{
-                            "H X", 'H', ToolDictNames.craftingToolForgeHammer, 'X', OrePrefixes.plate.get(aMaterial)});
+                            "h X",
+                            'X', OrePrefixes.plate.get(aMaterial)});
+
+            // Only added if IC2 Forge Hammer is enabled in Recipes.cfg: B:ic2forgehammer_true=false
+            GT_ModHandler.addCraftingRecipe(
+                    GT_OreDictUnificator.get(OrePrefixes.itemCasing, aMaterial, 1L),
+                    tBits, // DO_NOT_CHECK_FOR_COLLISIONS|BUFFERED|ONLY_ADD_IF_RESULT_IS_NOT_NULL|NOT_REMOVABLE
+                    new Object[]{
+                            "H X",
+                            'H', ToolDictNames.craftingToolForgeHammer,
+                            'X', OrePrefixes.plate.get(aMaterial)});
+
         }
+
         RA.addAlloySmelterRecipe(
                 GT_OreDictUnificator.get(OrePrefixes.ingot, aMaterial, 2L),
                 ItemList.Shape_Mold_Casing.get(0L), GT_Utility.copyAmount(3L, aStack), 128, 15);
+
         RA.addCutterRecipe(
                 GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L),
                 GT_OreDictUnificator.get(OrePrefixes.itemCasing, aMaterial, 2L),
-                null,
+                NI,
                 (int) Math.max(aMaterial.getMass(), 1L),
                 16);
+
         RA.addExtruderRecipe(
                 GT_OreDictUnificator.get(OrePrefixes.ingot, aMaterial, 1L),
                 ItemList.Shape_Extruder_Casing.get(0L),
                 GT_OreDictUnificator.get(OrePrefixes.itemCasing, aMaterial, 2L),
                 (int) Math.max(aMaterial.getMass(), 1L),
                 45);
+
         GT_RecipeRegistrator.registerReverseFluidSmelting(aStack, aMaterial, aPrefix.mMaterialAmount, null);
+
     }
 
-    private void registerPlateAlloy(final String aOreDictName, final ItemStack aStack) {
+    private void registerPlateAlloy(final String aOreDictName,
+                                    final ItemStack aStack) {
+
         switch (aOreDictName) {
+
             case "plateAlloyCarbon":
+
                 RA.addAssemblerRecipe(
                         GT_ModHandler.getIC2Item("generator", 1L),
                         GT_Utility.copyAmount(4L, aStack),
                         GT_ModHandler.getIC2Item("windMill", 1L),
                         6400, 8);
+
                 break;
+
             case "plateAlloyAdvanced":
+
                 GT_ModHandler.addAlloySmelterRecipe(
                         GT_Utility.copyAmount(1L, aStack),
-                        new ItemStack(Blocks.glass, 3, 32767),
+                        new ItemStack(Blocks.glass, 3, W),
                         GT_ModHandler.getIC2Item("reinforcedGlass", 4L),
                         400, 4, false);
+
                 GT_ModHandler.addAlloySmelterRecipe(
                         GT_Utility.copyAmount(1L, aStack),
-                        GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Glass, 3L),
+                        Materials.Glass.getDust(3),
                         GT_ModHandler.getIC2Item("reinforcedGlass", 4L),
                         400, 4, false);
+
                 break;
+
             case "plateAlloyIridium":
+
                 // Remove IC2 Shaped recipe for Iridium Reinforced Plate
                 GT_ModHandler.removeRecipeByOutputDelayed(aStack);
+
                 break;
+
             default:
                 break;
+
         }
+
     }
 
     private void registerCover(final Materials aMaterial, final ItemStack aStack) {
@@ -414,12 +581,14 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
         GregTech_API.registerCover(
                 aStack,
                 // If there is an ItemStack of Block for Materials
-                tStack != null ?
+                tStack != NI ?
                         // Copy Block texture
                         new GT_CopiedBlockTexture(Block.getBlockFromItem(tStack.getItem()), 1, tStack.getItemDamage()) :
                         // or use Materials mRGBa dyed blocs/materialicons/MATERIALSET/block1 icons
                         new GT_StdRenderedTexture(
                                 aMaterial.mIconSet.mTextures[TextureSet.INDEX_block1], aMaterial.mRGBa, false),
                 null);
+
     }
+
 }

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingPlate.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingPlate.java
@@ -36,12 +36,13 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
     }
 
     /**
-     * Register processes for the item stack by its Ore Dictionary Name property for all plate related items
+     * Register processes for the {@link ItemStack} with Ore Dictionary Name Prefix "plate"
      *
-     * @param aPrefix      always != null, the Ore Prefix
+     * @param aPrefix      always != null, the {@link OrePrefixes} of the {@link ItemStack}
      * @param aMaterial    always != null, and can be == _NULL if the Prefix is Self Referencing or not Material based!
-     * @param aOreDictName the Ore Dictionary Name
-     * @param aModName     the name of the mod providing this stack
+     *                     the {@link Materials} of the {@link ItemStack}
+     * @param aOreDictName the Ore Dictionary Name {@link String} of the {@link ItemStack}
+     * @param aModName     the ModID {@link String} of the mod providing this {@link ItemStack}
      * @param aStack       always != null, the {@link ItemStack} to register
      */
     public void registerOre(OrePrefixes aPrefix,

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingPlate.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingPlate.java
@@ -6,6 +6,7 @@ import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.enums.SubTag;
+import gregtech.api.enums.TextureSet;
 import gregtech.api.enums.ToolDictNames;
 import gregtech.api.objects.GT_CopiedBlockTexture;
 import gregtech.api.objects.GT_StdRenderedTexture;
@@ -14,8 +15,8 @@ import gregtech.api.util.GT_OreDictUnificator;
 import gregtech.api.util.GT_RecipeRegistrator;
 import gregtech.api.util.GT_Utility;
 import gregtech.common.GT_Proxy;
+import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
-import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 
 import static gregtech.api.enums.GT_Values.RA;
@@ -404,19 +405,20 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
     }
 
     private void registerCover(final Materials aMaterial, final ItemStack aStack) {
-        final ItemStack tStack = aMaterial.getBlocks(1);
-        if (tStack != null) {
-            ItemBlock tItemBlock = (ItemBlock) tStack.getItem();
 
-            GregTech_API.registerCover(
-                    aStack,
-                    new GT_CopiedBlockTexture((tItemBlock).field_150939_a, 1, tStack.getItemDamage()),
-                    null);
-        } else {
-            GregTech_API.registerCover(
-                    aStack,
-                    new GT_StdRenderedTexture(aMaterial.mIconSet.mTextures[71], aMaterial.mRGBa, false),
-                    null);
-        }
+        // Get ItemStack of Block matching Materials
+        final ItemStack tStack = aMaterial.getBlocks(1);
+
+        // Register the cover
+        GregTech_API.registerCover(
+                aStack,
+                // If there is an ItemStack of Block for Materials
+                tStack != null ?
+                        // Copy Block texture
+                        new GT_CopiedBlockTexture(Block.getBlockFromItem(tStack.getItem()), 1, tStack.getItemDamage()) :
+                        // or use Materials mRGBa dyed blocs/materialicons/MATERIALSET/block1 icons
+                        new GT_StdRenderedTexture(
+                                aMaterial.mIconSet.mTextures[TextureSet.INDEX_block1], aMaterial.mRGBa, false),
+                null);
     }
 }


### PR DESCRIPTION
Render the bottom face of covers made of a dumb block, the same orientation as
the reference dumb block.

![fixed_cover_block_yneg](https://user-images.githubusercontent.com/1111474/111043122-2e551280-8441-11eb-9182-708a01884af9.gif)

fix(render): texture for covers of block material
    
- Copy the block texture to render covers made of a block's material
- Fix and refactor lint and tidy the whole `ProcessingPlate` class (no side-effect detected)

![2021-03-14_00 44 18](https://user-images.githubusercontent.com/1111474/111055086-a425a200-8472-11eb-986f-7ae8739ceccc.png)
