### PR TITLE
Expose all fluid tanks properly when there are more than one internal tank

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicMachine.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicMachine.java
@@ -382,6 +382,11 @@ public abstract class GT_MetaTileEntity_BasicMachine extends GT_MetaTileEntity_B
     }
 
     @Override
+    public boolean isDrainableStackSeparate() {
+        return true;
+    }
+
+    @Override
     public boolean onRightclick(IGregTechTileEntity aBaseMetaTileEntity, EntityPlayer aPlayer) {
         if (aBaseMetaTileEntity.isClientSide()) return true;
         if(!GT_Mod.gregtechproxy.mForceFreeFace) {

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicTank.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicTank.java
@@ -9,7 +9,9 @@ import gregtech.api.util.GT_Utility;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.FluidTankInfo;
 
 /**
  * NEVER INCLUDE THIS FILE IN YOUR MOD!!!
@@ -100,6 +102,9 @@ public abstract class GT_MetaTileEntity_BasicTank extends GT_MetaTileEntity_Tier
         return mFluid;
     }
 
+    /**
+     * If you override this and change the field returned, be sure to override {@link #isDrainableStackSeparate()} as well!
+     */
     public FluidStack getDrainableStack() {
         return mFluid;
     }
@@ -107,6 +112,10 @@ public abstract class GT_MetaTileEntity_BasicTank extends GT_MetaTileEntity_Tier
     public FluidStack setDrainableStack(FluidStack aFluid) {
         mFluid = aFluid;
         return mFluid;
+    }
+
+    public boolean isDrainableStackSeparate() {
+        return false;
     }
 
     public FluidStack getDisplayedFluid() {
@@ -246,6 +255,19 @@ public abstract class GT_MetaTileEntity_BasicTank extends GT_MetaTileEntity_Tier
         }
 
         return drained;
+    }
+
+    @Override
+    public FluidTankInfo[] getTankInfo(ForgeDirection aSide) {
+        if (getCapacity() <= 0 && !getBaseMetaTileEntity().hasSteamEngineUpgrade()) return new FluidTankInfo[]{};
+        if (isDrainableStackSeparate()) {
+            return new FluidTankInfo[]{
+                    new FluidTankInfo(getFillableStack(), getCapacity()),
+                    new FluidTankInfo(getDrainableStack(), getCapacity())
+            };
+        } else {
+            return new FluidTankInfo[]{new FluidTankInfo(this)};
+        }
     }
 
     @Override

--- a/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler.java
+++ b/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler.java
@@ -138,6 +138,11 @@ public abstract class GT_MetaTileEntity_Boiler extends GT_MetaTileEntity_BasicTa
         return this.mSteam;
     }
 
+    @Override
+    public boolean isDrainableStackSeparate() {
+        return true;
+    }
+
     public boolean allowCoverOnSide(byte aSide, GT_ItemStack aCover) {
         return GregTech_API.getCoverBehavior(aCover.toStack()).isSimpleCover();
     }


### PR DESCRIPTION
This will make all automation to correctly identify what fluid is in input and what's in output. Werid how those OC fanatics haven't caught this already.