### PR TITLE
feat(cover): handles transparent covers

### DIFF
--- a/src/main/java/gregtech/api/interfaces/tileentity/IPipeRenderedTileEntity.java
+++ b/src/main/java/gregtech/api/interfaces/tileentity/IPipeRenderedTileEntity.java
@@ -10,5 +10,7 @@ public interface IPipeRenderedTileEntity extends ICoverable, ITexturedTileEntity
 
     ITexture[] getTextureUncovered(byte aSide);
 
-    ITexture[] getTextureCovered(Block aBlock, byte aSide);
+    default ITexture[] getTextureCovered(Block aBlock, byte aSide) {
+        return getTextureUncovered(aSide);
+    };
 }

--- a/src/main/java/gregtech/api/interfaces/tileentity/IPipeRenderedTileEntity.java
+++ b/src/main/java/gregtech/api/interfaces/tileentity/IPipeRenderedTileEntity.java
@@ -10,7 +10,7 @@ public interface IPipeRenderedTileEntity extends ICoverable, ITexturedTileEntity
 
     ITexture[] getTextureUncovered(byte aSide);
 
-    default ITexture[] getTextureCovered(Block aBlock, byte aSide) {
+    default ITexture[] getTextureCovered(byte aSide) {
         return getTextureUncovered(aSide);
     };
 }

--- a/src/main/java/gregtech/api/interfaces/tileentity/IPipeRenderedTileEntity.java
+++ b/src/main/java/gregtech/api/interfaces/tileentity/IPipeRenderedTileEntity.java
@@ -1,6 +1,7 @@
 package gregtech.api.interfaces.tileentity;
 
 import gregtech.api.interfaces.ITexture;
+import net.minecraft.block.Block;
 
 public interface IPipeRenderedTileEntity extends ICoverable, ITexturedTileEntity {
     float getThickNess();
@@ -8,4 +9,6 @@ public interface IPipeRenderedTileEntity extends ICoverable, ITexturedTileEntity
     byte getConnections();
 
     ITexture[] getTextureUncovered(byte aSide);
+
+    ITexture[] getTextureCovered(Block aBlock, byte aSide);
 }

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
@@ -784,6 +784,20 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
     }
 
     @Override
+    public ITexture[] getTextureCovered(Block aBlock, byte aSide) {
+        ITexture coverTexture = getCoverTexture(aSide);
+        ITexture[] textureUncovered = getTextureUncovered(aSide);
+        ITexture[] textureCovered;
+        if (coverTexture != null) {
+            textureCovered = Arrays.copyOf(textureUncovered, textureUncovered.length + 1);
+            textureCovered[textureUncovered.length] = coverTexture;
+            return textureCovered;
+        } else {
+            return textureUncovered;
+        }
+    }
+
+    @Override
     public ITexture[] getTextureUncovered(byte aSide) {
         if ((mConnections & 64) != 0) return Textures.BlockIcons.FRESHFOAM;
         if ((mConnections & -128) != 0) return Textures.BlockIcons.HARDENEDFOAMS[mColor];

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
@@ -784,7 +784,7 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
     }
 
     @Override
-    public ITexture[] getTextureCovered(Block aBlock, byte aSide) {
+    public ITexture[] getTextureCovered(byte aSide) {
         ITexture coverTexture = getCoverTexture(aSide);
         ITexture[] textureUncovered = getTextureUncovered(aSide);
         ITexture[] textureCovered;

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
@@ -8,7 +8,6 @@ import appeng.me.helpers.AENetworkProxy;
 import appeng.me.helpers.IGridProxyable;
 import appeng.tile.TileEvent;
 import appeng.tile.events.TileEventType;
-import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.Optional;
 import gregtech.GT_Mod;
 import gregtech.api.GregTech_API;
@@ -22,7 +21,11 @@ import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_BasicMachin
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch;
 import gregtech.api.net.GT_Packet_TileEntity;
 import gregtech.api.objects.GT_ItemStack;
-import gregtech.api.util.*;
+import gregtech.api.util.GT_CoverBehavior;
+import gregtech.api.util.GT_Log;
+import gregtech.api.util.GT_ModHandler;
+import gregtech.api.util.GT_OreDictUnificator;
+import gregtech.api.util.GT_Utility;
 import gregtech.common.GT_Pollution;
 import ic2.api.Direction;
 import net.minecraft.block.Block;
@@ -1169,11 +1172,18 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
 
     @Override
     public ITexture[] getTexture(Block aBlock, byte aSide) {
-        ITexture rIcon = getCoverTexture(aSide);
-        if (rIcon != null) return new ITexture[]{rIcon};
-        if (hasValidMetaTileEntity())
-            return mMetaTileEntity.getTexture(this, aSide, mFacing, (byte) (mColor - 1), mActive, getOutputRedstoneSignal(aSide) > 0);
-        return Textures.BlockIcons.ERROR_RENDERING;
+        ITexture coverTexture = getCoverTexture(aSide);
+        ITexture[] textureUncovered = hasValidMetaTileEntity() ?
+                mMetaTileEntity.getTexture(this, aSide, mFacing, (byte) (mColor - 1), mActive, getOutputRedstoneSignal(aSide) > 0) :
+                Textures.BlockIcons.ERROR_RENDERING;
+        ITexture[] textureCovered;
+        if (coverTexture != null) {
+            textureCovered = Arrays.copyOf(textureUncovered, textureUncovered.length + 1);
+            textureCovered[textureUncovered.length] = coverTexture;
+            return textureCovered;
+        } else {
+            return textureUncovered;
+        }
     }
 
     private boolean isEnergyInputSide(byte aSide) {

--- a/src/main/java/gregtech/common/render/GT_Renderer_Block.java
+++ b/src/main/java/gregtech/common/render/GT_Renderer_Block.java
@@ -120,12 +120,12 @@ public class GT_Renderer_Block implements ISimpleBlockRenderingHandler {
         TileEntity tTileEntity = aWorld.getTileEntity(aX, aY, aZ);
         if ((tTileEntity instanceof IPipeRenderedTileEntity)) {
             return renderStandardBlock(aWorld, aX, aY, aZ, aBlock, aRenderer, new ITexture[][]{
-                    ((IPipeRenderedTileEntity) tTileEntity).getTextureCovered(aBlock, (byte) 0),
-                    ((IPipeRenderedTileEntity) tTileEntity).getTextureCovered(aBlock, (byte) 1),
-                    ((IPipeRenderedTileEntity) tTileEntity).getTextureCovered(aBlock, (byte) 2),
-                    ((IPipeRenderedTileEntity) tTileEntity).getTextureCovered(aBlock, (byte) 3),
-                    ((IPipeRenderedTileEntity) tTileEntity).getTextureCovered(aBlock, (byte) 4),
-                    ((IPipeRenderedTileEntity) tTileEntity).getTextureCovered(aBlock, (byte) 5)});
+                    ((IPipeRenderedTileEntity) tTileEntity).getTextureCovered((byte) 0),
+                    ((IPipeRenderedTileEntity) tTileEntity).getTextureCovered((byte) 1),
+                    ((IPipeRenderedTileEntity) tTileEntity).getTextureCovered((byte) 2),
+                    ((IPipeRenderedTileEntity) tTileEntity).getTextureCovered((byte) 3),
+                    ((IPipeRenderedTileEntity) tTileEntity).getTextureCovered((byte) 4),
+                    ((IPipeRenderedTileEntity) tTileEntity).getTextureCovered((byte) 5)});
         }
         if ((tTileEntity instanceof ITexturedTileEntity)) {
             return renderStandardBlock(aWorld, aX, aY, aZ, aBlock, aRenderer, new ITexture[][]{

--- a/src/main/java/gregtech/common/render/GT_Renderer_Block.java
+++ b/src/main/java/gregtech/common/render/GT_Renderer_Block.java
@@ -21,6 +21,7 @@ import net.minecraft.world.IBlockAccess;
 import org.lwjgl.opengl.GL11;
 
 public class GT_Renderer_Block implements ISimpleBlockRenderingHandler {
+    private static final float NoZFightOffset = 1.0F / 16384.0F;
     public static GT_Renderer_Block INSTANCE;
     public final int mRenderID;
 
@@ -117,8 +118,23 @@ public class GT_Renderer_Block implements ISimpleBlockRenderingHandler {
 
     public static boolean renderStandardBlock(IBlockAccess aWorld, int aX, int aY, int aZ, Block aBlock, RenderBlocks aRenderer) {
         TileEntity tTileEntity = aWorld.getTileEntity(aX, aY, aZ);
+        if ((tTileEntity instanceof IPipeRenderedTileEntity)) {
+            return renderStandardBlock(aWorld, aX, aY, aZ, aBlock, aRenderer, new ITexture[][]{
+                    ((IPipeRenderedTileEntity) tTileEntity).getTextureCovered(aBlock, (byte) 0),
+                    ((IPipeRenderedTileEntity) tTileEntity).getTextureCovered(aBlock, (byte) 1),
+                    ((IPipeRenderedTileEntity) tTileEntity).getTextureCovered(aBlock, (byte) 2),
+                    ((IPipeRenderedTileEntity) tTileEntity).getTextureCovered(aBlock, (byte) 3),
+                    ((IPipeRenderedTileEntity) tTileEntity).getTextureCovered(aBlock, (byte) 4),
+                    ((IPipeRenderedTileEntity) tTileEntity).getTextureCovered(aBlock, (byte) 5)});
+        }
         if ((tTileEntity instanceof ITexturedTileEntity)) {
-            return renderStandardBlock(aWorld, aX, aY, aZ, aBlock, aRenderer, new ITexture[][]{((ITexturedTileEntity) tTileEntity).getTexture(aBlock, (byte) 0), ((ITexturedTileEntity) tTileEntity).getTexture(aBlock, (byte) 1), ((ITexturedTileEntity) tTileEntity).getTexture(aBlock, (byte) 2), ((ITexturedTileEntity) tTileEntity).getTexture(aBlock, (byte) 3), ((ITexturedTileEntity) tTileEntity).getTexture(aBlock, (byte) 4), ((ITexturedTileEntity) tTileEntity).getTexture(aBlock, (byte) 5)});
+            return renderStandardBlock(aWorld, aX, aY, aZ, aBlock, aRenderer, new ITexture[][]{
+                    ((ITexturedTileEntity) tTileEntity).getTexture(aBlock, (byte) 0),
+                    ((ITexturedTileEntity) tTileEntity).getTexture(aBlock, (byte) 1),
+                    ((ITexturedTileEntity) tTileEntity).getTexture(aBlock, (byte) 2),
+                    ((ITexturedTileEntity) tTileEntity).getTexture(aBlock, (byte) 3),
+                    ((ITexturedTileEntity) tTileEntity).getTexture(aBlock, (byte) 4),
+                    ((ITexturedTileEntity) tTileEntity).getTexture(aBlock, (byte) 5)});
         }
         return false;
     }
@@ -182,12 +198,10 @@ public class GT_Renderer_Block implements ISimpleBlockRenderingHandler {
             renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[1], false);
             renderNegativeZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[2], false);
             renderPositiveZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[3], false);
-            if (!tIsCovered[4]) {
-                renderNegativeXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[4], false);
-            }
-            if (!tIsCovered[5]) {
-                renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[5], false);
-            }
+
+            renderNegativeXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[4], false);
+            renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[5], false);
+
         } else if (tConnections == 12) {
             aBlock.setBlockBounds(sp, 0.0F, sp, sp + tThickness, 1.0F, sp + tThickness);
             aRenderer.setRenderBoundsFromBlock(aBlock);
@@ -195,12 +209,10 @@ public class GT_Renderer_Block implements ISimpleBlockRenderingHandler {
             renderPositiveZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[3], false);
             renderNegativeXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[4], false);
             renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[5], false);
-            if (!tIsCovered[0]) {
-                renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[0], false);
-            }
-            if (!tIsCovered[1]) {
-                renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[1], false);
-            }
+
+            renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[0], false);
+            renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[1], false);
+
         } else if (tConnections == 48) {
             aBlock.setBlockBounds(sp, sp, 0.0F, sp + tThickness, sp + tThickness, 1.0F);
             aRenderer.setRenderBoundsFromBlock(aBlock);
@@ -208,17 +220,14 @@ public class GT_Renderer_Block implements ISimpleBlockRenderingHandler {
             renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[1], false);
             renderNegativeXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[4], false);
             renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[5], false);
-            if (!tIsCovered[2]) {
-                renderNegativeZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[2], false);
-            }
-            if (!tIsCovered[3]) {
-                renderPositiveZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[3], false);
-            }
+
+            renderNegativeZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[2], false);
+            renderPositiveZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[3], false);
+
         } else {
             if ((tConnections & 0x1) == 0) {
                 aBlock.setBlockBounds(sp, sp, sp, sp + tThickness, sp + tThickness, sp + tThickness);
                 aRenderer.setRenderBoundsFromBlock(aBlock);
-                renderNegativeXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[4], false);
             } else {
                 aBlock.setBlockBounds(0.0F, sp, sp, sp, sp + tThickness, sp + tThickness);
                 aRenderer.setRenderBoundsFromBlock(aBlock);
@@ -226,14 +235,12 @@ public class GT_Renderer_Block implements ISimpleBlockRenderingHandler {
                 renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[1], false);
                 renderNegativeZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[2], false);
                 renderPositiveZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[3], false);
-                if (!tIsCovered[4]) {
-                    renderNegativeXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[4], false);
-                }
+
             }
+            renderNegativeXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[4], false);
             if ((tConnections & 0x2) == 0) {
                 aBlock.setBlockBounds(sp, sp, sp, sp + tThickness, sp + tThickness, sp + tThickness);
                 aRenderer.setRenderBoundsFromBlock(aBlock);
-                renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[5], false);
             } else {
                 aBlock.setBlockBounds(sp + tThickness, sp, sp, 1.0F, sp + tThickness, sp + tThickness);
                 aRenderer.setRenderBoundsFromBlock(aBlock);
@@ -241,14 +248,12 @@ public class GT_Renderer_Block implements ISimpleBlockRenderingHandler {
                 renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[1], false);
                 renderNegativeZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[2], false);
                 renderPositiveZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[3], false);
-                if (!tIsCovered[5]) {
-                    renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[5], false);
-                }
+
             }
+            renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[5], false);
             if ((tConnections & 0x4) == 0) {
                 aBlock.setBlockBounds(sp, sp, sp, sp + tThickness, sp + tThickness, sp + tThickness);
                 aRenderer.setRenderBoundsFromBlock(aBlock);
-                renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[0], false);
             } else {
                 aBlock.setBlockBounds(sp, 0.0F, sp, sp + tThickness, sp, sp + tThickness);
                 aRenderer.setRenderBoundsFromBlock(aBlock);
@@ -256,14 +261,12 @@ public class GT_Renderer_Block implements ISimpleBlockRenderingHandler {
                 renderPositiveZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[3], false);
                 renderNegativeXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[4], false);
                 renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[5], false);
-                if (!tIsCovered[0]) {
-                    renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[0], false);
-                }
+
             }
+            renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[0], false);
             if ((tConnections & 0x8) == 0) {
                 aBlock.setBlockBounds(sp, sp, sp, sp + tThickness, sp + tThickness, sp + tThickness);
                 aRenderer.setRenderBoundsFromBlock(aBlock);
-                renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[1], false);
             } else {
                 aBlock.setBlockBounds(sp, sp + tThickness, sp, sp + tThickness, 1.0F, sp + tThickness);
                 aRenderer.setRenderBoundsFromBlock(aBlock);
@@ -271,14 +274,12 @@ public class GT_Renderer_Block implements ISimpleBlockRenderingHandler {
                 renderPositiveZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[3], false);
                 renderNegativeXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[4], false);
                 renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[5], false);
-                if (!tIsCovered[1]) {
-                    renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[1], false);
-                }
+
             }
+            renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[1], false);
             if ((tConnections & 0x10) == 0) {
                 aBlock.setBlockBounds(sp, sp, sp, sp + tThickness, sp + tThickness, sp + tThickness);
                 aRenderer.setRenderBoundsFromBlock(aBlock);
-                renderNegativeZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[2], false);
             } else {
                 aBlock.setBlockBounds(sp, sp, 0.0F, sp + tThickness, sp + tThickness, sp);
                 aRenderer.setRenderBoundsFromBlock(aBlock);
@@ -286,14 +287,12 @@ public class GT_Renderer_Block implements ISimpleBlockRenderingHandler {
                 renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[1], false);
                 renderNegativeXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[4], false);
                 renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[5], false);
-                if (!tIsCovered[2]) {
-                    renderNegativeZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[2], false);
-                }
+
             }
+            renderNegativeZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[2], false);
             if ((tConnections & 0x20) == 0) {
                 aBlock.setBlockBounds(sp, sp, sp, sp + tThickness, sp + tThickness, sp + tThickness);
                 aRenderer.setRenderBoundsFromBlock(aBlock);
-                renderPositiveZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[3], false);
             } else {
                 aBlock.setBlockBounds(sp, sp, sp + tThickness, sp + tThickness, sp + tThickness, 1.0F);
                 aRenderer.setRenderBoundsFromBlock(aBlock);
@@ -301,13 +300,12 @@ public class GT_Renderer_Block implements ISimpleBlockRenderingHandler {
                 renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[1], false);
                 renderNegativeXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[4], false);
                 renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[5], false);
-                if (!tIsCovered[3]) {
-                    renderPositiveZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[3], false);
-                }
+
             }
+            renderPositiveZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[3], false);
         }
         if (tIsCovered[0]) {
-            aBlock.setBlockBounds(0.0F, 0.0F, 0.0F, 1.0F, 0.125F, 1.0F);
+            aBlock.setBlockBounds(0.0F, 0.0F + NoZFightOffset, 0.0F, 1.0F, 0.125F, 1.0F);
             aRenderer.setRenderBoundsFromBlock(aBlock);
             renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[0], false);
             renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[0], false);
@@ -325,7 +323,7 @@ public class GT_Renderer_Block implements ISimpleBlockRenderingHandler {
             }
         }
         if (tIsCovered[1]) {
-            aBlock.setBlockBounds(0.0F, 0.875F, 0.0F, 1.0F, 1.0F, 1.0F);
+            aBlock.setBlockBounds(0.0F, 0.875F, 0.0F, 1.0F, 1.0F - NoZFightOffset, 1.0F);
             aRenderer.setRenderBoundsFromBlock(aBlock);
             renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[1], false);
             renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[1], false);
@@ -343,7 +341,7 @@ public class GT_Renderer_Block implements ISimpleBlockRenderingHandler {
             }
         }
         if (tIsCovered[2]) {
-            aBlock.setBlockBounds(0.0F, 0.0F, 0.0F, 1.0F, 1.0F, 0.125F);
+            aBlock.setBlockBounds(0.0F, 0.0F, 0.0F + NoZFightOffset, 1.0F, 1.0F, 0.125F);
             aRenderer.setRenderBoundsFromBlock(aBlock);
             if (!tIsCovered[0]) {
                 renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[2], false);
@@ -361,7 +359,7 @@ public class GT_Renderer_Block implements ISimpleBlockRenderingHandler {
             }
         }
         if (tIsCovered[3]) {
-            aBlock.setBlockBounds(0.0F, 0.0F, 0.875F, 1.0F, 1.0F, 1.0F);
+            aBlock.setBlockBounds(0.0F, 0.0F, 0.875F, 1.0F, 1.0F, 1.0F - NoZFightOffset);
             aRenderer.setRenderBoundsFromBlock(aBlock);
             if (!tIsCovered[0]) {
                 renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[3], false);
@@ -379,7 +377,7 @@ public class GT_Renderer_Block implements ISimpleBlockRenderingHandler {
             }
         }
         if (tIsCovered[4]) {
-            aBlock.setBlockBounds(0.0F, 0.0F, 0.0F, 0.125F, 1.0F, 1.0F);
+            aBlock.setBlockBounds(0.0F + NoZFightOffset, 0.0F, 0.0F, 0.125F, 1.0F, 1.0F);
             aRenderer.setRenderBoundsFromBlock(aBlock);
             if (!tIsCovered[0]) {
                 renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[4], false);
@@ -397,7 +395,7 @@ public class GT_Renderer_Block implements ISimpleBlockRenderingHandler {
             renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[4], false);
         }
         if (tIsCovered[5]) {
-            aBlock.setBlockBounds(0.875F, 0.0F, 0.0F, 1.0F, 1.0F, 1.0F);
+            aBlock.setBlockBounds(0.875F, 0.0F, 0.0F, 1.0F - NoZFightOffset, 1.0F, 1.0F);
             aRenderer.setRenderBoundsFromBlock(aBlock);
             if (!tIsCovered[0]) {
                 renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[5], false);


### PR DESCRIPTION
Add support for transparent covers (glass plate) on all GT Machines:
- See pipes, wires, cables through transparent covers
- Layer transparent covers over full-block pipes and machines

![Screenshot](https://i.imgur.com/IKLAZlg.png)