### PR TITLE
fix(rendering): brightness of no-z-fighting offset faces

### DIFF
--- a/src/main/java/gregtech/api/util/LightingHelper.java
+++ b/src/main/java/gregtech/api/util/LightingHelper.java
@@ -31,6 +31,7 @@ import net.minecraft.client.renderer.Tessellator;
 public class LightingHelper {
     public static final int NORMAL_BRIGHTNESS = 0xff00ff;
     public static final int MAX_BRIGHTNESS = 0xf000f0;
+    public static final float NO_Z_FIGHT_OFFSET = 1.0F / 16384.0F;
     protected static final float[] LIGHTNESS = {0.5F, 1.0F, 0.8F, 0.8F, 0.6F, 0.6F};
     private final RenderBlocks renderBlocks;
     /**
@@ -321,7 +322,7 @@ public class LightingHelper {
 
         if (renderBlocks.enableAO) {
 
-            int xOffset = renderBlocks.renderMinX > 0.0F ? x : x - 1;
+            int xOffset = renderBlocks.renderMinX > 0.0F + NO_Z_FIGHT_OFFSET ? x : x - 1;
 
             int mixedBrightness = block.getMixedBrightnessForBlock(renderBlocks.blockAccess, xOffset, y, z);
             brightness = mixedBrightness;
@@ -392,7 +393,7 @@ public class LightingHelper {
 
         if (renderBlocks.enableAO) {
 
-            int xOffset = renderBlocks.renderMaxX < 1.0F ? x : x + 1;
+            int xOffset = renderBlocks.renderMaxX < 1.0F - NO_Z_FIGHT_OFFSET ? x : x + 1;
 
             int mixedBrightness = block.getMixedBrightnessForBlock(renderBlocks.blockAccess, xOffset, y, z);
             brightness = mixedBrightness;
@@ -462,7 +463,7 @@ public class LightingHelper {
 
         if (renderBlocks.enableAO) {
 
-            int yOffset = renderBlocks.renderMinY > 0.0F ? y : y - 1;
+            int yOffset = renderBlocks.renderMinY > 0.0F + NO_Z_FIGHT_OFFSET ? y : y - 1;
 
             int mixedBrightness = block.getMixedBrightnessForBlock(renderBlocks.blockAccess, x, yOffset, z);
             brightness = mixedBrightness;
@@ -497,7 +498,7 @@ public class LightingHelper {
             float aoMixedXYZNNN = (renderBlocks.aoLightValueScratchXYNN + renderBlocks.aoLightValueScratchXYZNNN + aoLightValue + renderBlocks.aoLightValueScratchYZNN) / 4.0F;
             float aoMixedXYZNNP = (renderBlocks.aoLightValueScratchXYZNNP + renderBlocks.aoLightValueScratchXYNN + renderBlocks.aoLightValueScratchYZNP + aoLightValue) / 4.0F;
 
-            aoTopLeft  = (float) (aoMixedXYZNNP * renderBlocks.renderMaxZ * (1.0D - renderBlocks.renderMinX) + aoMixedXYZPNP * renderBlocks.renderMaxZ * renderBlocks.renderMinX + aoMixedXYZPNN * (1.0D - renderBlocks.renderMaxZ) * renderBlocks.renderMinX + aoMixedXYZNNN * (1.0D - renderBlocks.renderMaxZ) * (1.0D - renderBlocks.renderMinX));
+            aoTopLeft = (float) (aoMixedXYZNNP * renderBlocks.renderMaxZ * (1.0D - renderBlocks.renderMinX) + aoMixedXYZPNP * renderBlocks.renderMaxZ * renderBlocks.renderMinX + aoMixedXYZPNN * (1.0D - renderBlocks.renderMaxZ) * renderBlocks.renderMinX + aoMixedXYZNNN * (1.0D - renderBlocks.renderMaxZ) * (1.0D - renderBlocks.renderMinX));
             aoBottomLeft = (float) (aoMixedXYZNNP * renderBlocks.renderMinZ * (1.0D - renderBlocks.renderMinX) + aoMixedXYZPNP * renderBlocks.renderMinZ * renderBlocks.renderMinX + aoMixedXYZPNN * (1.0D - renderBlocks.renderMinZ) * renderBlocks.renderMinX + aoMixedXYZNNN * (1.0D - renderBlocks.renderMinZ) * (1.0D - renderBlocks.renderMinX));
             aoBottomRight = (float) (aoMixedXYZNNP * renderBlocks.renderMinZ * (1.0D - renderBlocks.renderMaxX) + aoMixedXYZPNP * renderBlocks.renderMinZ * renderBlocks.renderMaxX + aoMixedXYZPNN * (1.0D - renderBlocks.renderMinZ) * renderBlocks.renderMaxX + aoMixedXYZNNN * (1.0D - renderBlocks.renderMinZ) * (1.0D - renderBlocks.renderMaxX));
             aoTopRight = (float) (aoMixedXYZNNP * renderBlocks.renderMaxZ * (1.0D - renderBlocks.renderMaxX) + aoMixedXYZPNP * renderBlocks.renderMaxZ * renderBlocks.renderMaxX + aoMixedXYZPNN * (1.0D - renderBlocks.renderMaxZ) * renderBlocks.renderMaxX + aoMixedXYZNNN * (1.0D - renderBlocks.renderMaxZ) * (1.0D - renderBlocks.renderMaxX));
@@ -533,7 +534,7 @@ public class LightingHelper {
 
         if (renderBlocks.enableAO) {
 
-            int yOffset = renderBlocks.renderMaxY < 1.0F ? y : y + 1;
+            int yOffset = renderBlocks.renderMaxY < 1.0F - NO_Z_FIGHT_OFFSET ? y : y + 1;
 
             int mixedBrightness = block.getMixedBrightnessForBlock(renderBlocks.blockAccess, x, yOffset, z);
             brightness = mixedBrightness;
@@ -602,7 +603,7 @@ public class LightingHelper {
 
         if (renderBlocks.enableAO) {
 
-            int zOffset = renderBlocks.renderMinZ > 0.0F ? z : z - 1;
+            int zOffset = renderBlocks.renderMinZ > 0.0F + NO_Z_FIGHT_OFFSET ? z : z - 1;
 
             int mixedBrightness = block.getMixedBrightnessForBlock(renderBlocks.blockAccess, x, y, zOffset);
             brightness = mixedBrightness;
@@ -673,7 +674,7 @@ public class LightingHelper {
 
         if (renderBlocks.enableAO) {
 
-            int zOffset = renderBlocks.renderMaxZ < 1.0F ? z : z + 1;
+            int zOffset = renderBlocks.renderMaxZ < 1.0F - NO_Z_FIGHT_OFFSET ? z : z + 1;
 
             int mixedBrightness = block.getMixedBrightnessForBlock(renderBlocks.blockAccess, x, y, zOffset);
             brightness = mixedBrightness;

--- a/src/main/java/gregtech/common/render/GT_Renderer_Block.java
+++ b/src/main/java/gregtech/common/render/GT_Renderer_Block.java
@@ -20,8 +20,9 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.IBlockAccess;
 import org.lwjgl.opengl.GL11;
 
+import static gregtech.api.util.LightingHelper.NO_Z_FIGHT_OFFSET;
+
 public class GT_Renderer_Block implements ISimpleBlockRenderingHandler {
-    private static final float NoZFightOffset = 1.0F / 16384.0F;
     public static GT_Renderer_Block INSTANCE;
     public final int mRenderID;
 
@@ -305,7 +306,7 @@ public class GT_Renderer_Block implements ISimpleBlockRenderingHandler {
             renderPositiveZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[3], false);
         }
         if (tIsCovered[0]) {
-            aBlock.setBlockBounds(0.0F, 0.0F + NoZFightOffset, 0.0F, 1.0F, 0.125F, 1.0F);
+            aBlock.setBlockBounds(0.0F, 0.0F + NO_Z_FIGHT_OFFSET, 0.0F, 1.0F, 0.125F, 1.0F);
             aRenderer.setRenderBoundsFromBlock(aBlock);
             renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[0], false);
             renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[0], false);
@@ -323,7 +324,7 @@ public class GT_Renderer_Block implements ISimpleBlockRenderingHandler {
             }
         }
         if (tIsCovered[1]) {
-            aBlock.setBlockBounds(0.0F, 0.875F, 0.0F, 1.0F, 1.0F - NoZFightOffset, 1.0F);
+            aBlock.setBlockBounds(0.0F, 0.875F, 0.0F, 1.0F, 1.0F - NO_Z_FIGHT_OFFSET, 1.0F);
             aRenderer.setRenderBoundsFromBlock(aBlock);
             renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[1], false);
             renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[1], false);
@@ -341,7 +342,7 @@ public class GT_Renderer_Block implements ISimpleBlockRenderingHandler {
             }
         }
         if (tIsCovered[2]) {
-            aBlock.setBlockBounds(0.0F, 0.0F, 0.0F + NoZFightOffset, 1.0F, 1.0F, 0.125F);
+            aBlock.setBlockBounds(0.0F, 0.0F, 0.0F + NO_Z_FIGHT_OFFSET, 1.0F, 1.0F, 0.125F);
             aRenderer.setRenderBoundsFromBlock(aBlock);
             if (!tIsCovered[0]) {
                 renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[2], false);
@@ -359,7 +360,7 @@ public class GT_Renderer_Block implements ISimpleBlockRenderingHandler {
             }
         }
         if (tIsCovered[3]) {
-            aBlock.setBlockBounds(0.0F, 0.0F, 0.875F, 1.0F, 1.0F, 1.0F - NoZFightOffset);
+            aBlock.setBlockBounds(0.0F, 0.0F, 0.875F, 1.0F, 1.0F, 1.0F - NO_Z_FIGHT_OFFSET);
             aRenderer.setRenderBoundsFromBlock(aBlock);
             if (!tIsCovered[0]) {
                 renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[3], false);
@@ -377,7 +378,7 @@ public class GT_Renderer_Block implements ISimpleBlockRenderingHandler {
             }
         }
         if (tIsCovered[4]) {
-            aBlock.setBlockBounds(0.0F + NoZFightOffset, 0.0F, 0.0F, 0.125F, 1.0F, 1.0F);
+            aBlock.setBlockBounds(0.0F + NO_Z_FIGHT_OFFSET, 0.0F, 0.0F, 0.125F, 1.0F, 1.0F);
             aRenderer.setRenderBoundsFromBlock(aBlock);
             if (!tIsCovered[0]) {
                 renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[4], false);
@@ -395,7 +396,7 @@ public class GT_Renderer_Block implements ISimpleBlockRenderingHandler {
             renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[4], false);
         }
         if (tIsCovered[5]) {
-            aBlock.setBlockBounds(0.875F, 0.0F, 0.0F, 1.0F - NoZFightOffset, 1.0F, 1.0F);
+            aBlock.setBlockBounds(0.875F, 0.0F, 0.0F, 1.0F - NO_Z_FIGHT_OFFSET, 1.0F, 1.0F);
             aRenderer.setRenderBoundsFromBlock(aBlock);
             if (!tIsCovered[0]) {
                 renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[5], false);


### PR DESCRIPTION
Ignore the z-fighting offset when detecting if a face uses the block's brightness
or the brightness from the block above.
Make the `NO_Z_FIGHT_OFFSET constant, a  public member of the `LightingHelper`.