### PR TITLE
Add interop for HydroEnergy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,6 +84,9 @@ repositories {
         name = 'gtnh_download_source'
         artifactPattern("http://downloads.gtnewhorizons.com/Mods_for_Jenkins/[module]-[revision].[ext]")
     }
+    maven {
+        url 'https://jitpack.io'
+    }
 }
 
 dependencies {
@@ -98,6 +101,9 @@ dependencies {
     api "codechicken:NotEnoughItems:${config.minecraft.version}-${config.nei.version}:dev"
     api "com.enderio.core:EnderCore:${config.enderiocore.version}:dev"
     api ("com.enderio:EnderIO:${config.enderio.version}:dev"){
+        transitive = false
+    }
+    compileOnly ("com.github.SinTh0r4s:HydroEnergy:master-SNAPSHOT:api") {
         transitive = false
     }
 

--- a/src/main/java/gregtech/common/render/GT_PollutionRenderer.java
+++ b/src/main/java/gregtech/common/render/GT_PollutionRenderer.java
@@ -1,7 +1,5 @@
 package gregtech.common.render;
 
-import com.sinthoras.hydroenergy.api.HEGetMaterialUtil;
-import com.sinthoras.hydroenergy.api.IHEHasCustomMaterialCalculation;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.Optional;

--- a/src/main/java/gregtech/common/render/GT_PollutionRenderer.java
+++ b/src/main/java/gregtech/common/render/GT_PollutionRenderer.java
@@ -1,5 +1,6 @@
 package gregtech.common.render;
 
+import com.sinthoras.hydroenergy.api.IHEHasCustomMaterialCalculation;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.Optional;

--- a/src/main/java/gregtech/common/render/GT_PollutionRenderer.java
+++ b/src/main/java/gregtech/common/render/GT_PollutionRenderer.java
@@ -1,5 +1,6 @@
 package gregtech.common.render;
 
+import com.sinthoras.hydroenergy.api.HEGetMaterialUtil;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.eventhandler.EventPriority;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
@@ -105,7 +106,7 @@ public class GT_PollutionRenderer {
         if (!DEBUG && Minecraft.getMinecraft().thePlayer.capabilities.isCreativeMode)
             return;
 
-        if (event.block.getMaterial() == Material.water ||
+        if (HEGetMaterialUtil.getMaterialWrapper(event.block, event.entity.posY + event.entity.getEyeHeight()) == Material.water ||
             event.block.getMaterial() == Material.lava)
             return;
 


### PR DESCRIPTION
Provide proper interoperability with [HydroEnergy](https://github.com/SinTh0r4s/HydroEnergy). Water in this mod has air or water as material depending on the height and therefore, requires a different call to get it.

ToDo: Fix to specific version

HydroEnergy is not quite yet release ready. Please wait with merging