### PR TITLE
Reduce price of magic generators

### DIFF
--- a/src/main/java/gregtech/api/enums/OrePrefixes.java
+++ b/src/main/java/gregtech/api/enums/OrePrefixes.java
@@ -703,7 +703,7 @@ public enum OrePrefixes {
                 if (!enableUnusedTriplePlates && !(aMaterial == Materials.Paper)) plateTriple.mDisabledItems.add(aMaterial);
                 if (!enableUnusedQuadPlates && !(aMaterial == Materials.Paper)) plateQuadruple.mDisabledItems.add(aMaterial);
                 if (!enableUnusedQuinPlates && !(aMaterial == Materials.Paper)) plateQuintuple.mDisabledItems.add(aMaterial);
-                if (!(enableUnusedDensePlates || GregTech_API.mGTPlusPlus) && !(aMaterial == Materials.Iron || aMaterial == Materials.Copper || aMaterial == Materials.Lead || aMaterial == Materials.Paper))
+                if (!(enableUnusedDensePlates || GregTech_API.mGTPlusPlus) && !(aMaterial == Materials.Iron || aMaterial == Materials.Copper || aMaterial == Materials.Lead || aMaterial == Materials.Paper || aMaterial == Materials.Thaumium || aMaterial == Materials.Titanium))
                     plateDense.mDisabledItems.add(aMaterial);
                 //Rotors
                 if (!enableUnusedRotors && !(aMaterial == Materials.Titanium || aMaterial == Materials.Chrome || aMaterial == Materials.Tin || aMaterial == Materials.Osmium ||

--- a/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
@@ -2636,10 +2636,10 @@ public class GT_MachineRecipeLoader implements Runnable {
                                         ItemList.Hull_LV.get(1L),
                                         new ItemStack[]{
                                                 new ItemStack(Blocks.beacon),
-                                                GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Advanced, 1L),
-                                                GT_OreDictUnificator.get(OrePrefixes.plate, Materials.StainlessSteel, 1L),
+                                                GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Good, 1L),
+                                                GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Aluminium, 1L),
                                                 ItemList.Sensor_MV.get(2L),
-                                                GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Advanced, 1L),
+                                                GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Good, 1L),
                                                 GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L),
                                                 ItemList.Sensor_MV.get(2L)
                                         },
@@ -2668,11 +2668,11 @@ public class GT_MachineRecipeLoader implements Runnable {
                                         ItemList.Hull_MV.get(1L),
                                         new ItemStack[]{
                                                 new ItemStack(Blocks.beacon),
-                                                GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Data, 1L),
+                                                GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Advanced, 1L),
                                                 GT_OreDictUnificator.get(OrePrefixes.plateDouble, Materials.Thaumium, 1L),
                                                 ItemList.Sensor_HV.get(2L),
-                                                GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Data, 1L),
-                                                GT_OreDictUnificator.get(OrePrefixes.plateDouble, Materials.Titanium, 1L),
+                                                GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Advanced, 1L),
+                                                GT_OreDictUnificator.get(OrePrefixes.plateDouble, Materials.StainlessSteel, 1L),
                                                 ItemList.Sensor_HV.get(2L)
                                         },
                                         ItemList.MagicEnergyConverter_MV.get(1L),
@@ -2700,11 +2700,11 @@ public class GT_MachineRecipeLoader implements Runnable {
                                         ItemList.Hull_HV.get(1L),
                                         new ItemStack[]{
                                                 new ItemStack(Blocks.beacon),
-                                                GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Elite, 1L),
+                                                GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Data, 1L),
                                                 GT_OreDictUnificator.get(OrePrefixes.plateDense, Materials.Thaumium, 1L),
                                                 ItemList.Field_Generator_MV.get(1L),
-                                                GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Elite, 1L),
-                                                GT_OreDictUnificator.get(OrePrefixes.plateDense, Materials.TungstenSteel, 1L),
+                                                GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Data, 1L),
+                                                GT_OreDictUnificator.get(OrePrefixes.plateDense, Materials.Titanium, 1L),
                                                 ItemList.Field_Generator_MV.get(1L)
                                         },
                                         ItemList.MagicEnergyConverter_HV.get(1L),
@@ -2733,7 +2733,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                                         ItemList.Hull_LV.get(1L),
                                         new ItemStack[]{
                                                 ItemList.MagicEnergyConverter_LV.get(1L),
-                                                GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Advanced, 1L),
+                                                GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Good, 1L),
                                                 GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L),
                                                 ItemList.Sensor_MV.get(2L)
                                         },
@@ -2785,11 +2785,11 @@ public class GT_MachineRecipeLoader implements Runnable {
                                 ItemList.Hull_HV.get(1L),
                                 new ItemStack[]{
                                         ItemList.MagicEnergyConverter_MV.get(1L),
-                                        GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Elite, 1L),
-                                        GT_ModHandler.getModItem("Thaumcraft", "ItemResource", 1, 16),
+                                        GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Data, 1L),
+                                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1),
                                         ItemList.Field_Generator_MV.get(1L),
-                                        GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Elite, 1L),
-                                        GT_ModHandler.getModItem("Thaumcraft", "ItemResource", 1, 16)
+                                        GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Data, 1L),
+                                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1),
                                 },
                                 ItemList.MagicEnergyAbsorber_HV.get(1L),
                                 8,
@@ -2805,11 +2805,13 @@ public class GT_MachineRecipeLoader implements Runnable {
                                 ItemList.Hull_EV.get(1L),
                                 new ItemStack[]{
                                         ItemList.MagicEnergyConverter_HV.get(1L),
-                                        GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Master, 1L),
-                                        GT_ModHandler.getModItem("Thaumcraft", "ItemResource", 1, 16),
+                                        GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Elite, 1L),
+                                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1),
+                                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.TungstenSteel, 1),
                                         ItemList.Field_Generator_HV.get(1L),
-                                        GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Master, 1L),
-                                        GT_ModHandler.getModItem("Thaumcraft", "ItemResource", 1, 16)
+                                        GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Elite, 1L),
+                                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1),
+                                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.TungstenSteel, 1),
                                 },
                                 ItemList.MagicEnergyAbsorber_EV.get(1L),
                                 10,


### PR DESCRIPTION
See GTNewHorizons/GT-New-Horizons-Modpack#7540 for related discussionsGTNewHorizons/GT-New-Horizons-Modpack#7540

Basically make the recipes use T+1 circuits/metal instead of T+2. EV magic generator will additionally require tungsten steel plates to prevent it from becoming too cheap.

The changes in OrePrefixes is to make sure the used dense plates are generated when GT++ is not present.