### PR TITLE
Only update fluid display items when necessary

### DIFF
--- a/src/main/java/gregtech/api/gui/GT_Container.java
+++ b/src/main/java/gregtech/api/gui/GT_Container.java
@@ -26,6 +26,7 @@ public class GT_Container extends Container {
 
         mTileEntity = aTileEntityInventory;
         mPlayerInventory = aPlayerInventory;
+        mTileEntity.openInventory();
     }
 
     /**
@@ -468,6 +469,7 @@ public class GT_Container extends Container {
     public void onContainerClosed(EntityPlayer par1EntityPlayer) {
         try {
             super.onContainerClosed(par1EntityPlayer);
+            mTileEntity.closeInventory();
         } catch (Throwable e) {
             e.printStackTrace(GT_Log.err);
         }

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicMachine.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicMachine.java
@@ -576,8 +576,12 @@ public abstract class GT_MetaTileEntity_BasicMachine extends GT_MetaTileEntity_B
             mHasBeenUpdated = true;
             getBaseMetaTileEntity().setFrontFacing(getBaseMetaTileEntity().getBackFacing());
         }
+    }
 
-        if (mOpenerCount > 0 && displaysInputFluid()) {
+    @Override
+    protected void updateFluidDisplayItem() {
+        super.updateFluidDisplayItem();
+        if (displaysInputFluid()) {
             int tDisplayStackSlot = OTHER_SLOT_COUNT + mInputSlotCount + mOutputItems.length;
             if (getFillableStack() == null) {
                 if (ItemList.Display_Fluid.isStackEqual(mInventory[tDisplayStackSlot], true, true))

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicMachine.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicMachine.java
@@ -577,7 +577,7 @@ public abstract class GT_MetaTileEntity_BasicMachine extends GT_MetaTileEntity_B
             getBaseMetaTileEntity().setFrontFacing(getBaseMetaTileEntity().getBackFacing());
         }
 
-        if (displaysInputFluid()) {
+        if (mOpenerCount > 0 && displaysInputFluid()) {
             int tDisplayStackSlot = OTHER_SLOT_COUNT + mInputSlotCount + mOutputItems.length;
             if (getFillableStack() == null) {
                 if (ItemList.Display_Fluid.isStackEqual(mInventory[tDisplayStackSlot], true, true))

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicTank.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicTank.java
@@ -21,6 +21,7 @@ import net.minecraftforge.fluids.FluidTankInfo;
 public abstract class GT_MetaTileEntity_BasicTank extends GT_MetaTileEntity_TieredMachineBlock {
 
     public FluidStack mFluid;
+    protected int mOpenerCount;
 
     /**
      * @param aInvSlotCount should be 3
@@ -133,12 +134,24 @@ public abstract class GT_MetaTileEntity_BasicTank extends GT_MetaTileEntity_Tier
     }
 
     @Override
+    public void onOpenGUI() {
+        super.onOpenGUI();
+        mOpenerCount++;
+    }
+
+    @Override
+    public void onCloseGUI() {
+        super.onCloseGUI();
+        mOpenerCount--;
+    }
+
+    @Override
     public void onPreTick(IGregTechTileEntity aBaseMetaTileEntity, long aTick) {
         if (aBaseMetaTileEntity.isServerSide()) {
             if (isFluidChangingAllowed() && getFillableStack() != null && getFillableStack().amount <= 0)
                 setFillableStack(null);
 
-            if (displaysItemStack() && getStackDisplaySlot() >= 0 && getStackDisplaySlot() < mInventory.length) {
+            if (mOpenerCount > 0 && displaysItemStack() && getStackDisplaySlot() >= 0 && getStackDisplaySlot() < mInventory.length) {
                 if (getDisplayedFluid() == null) {
                     if (ItemList.Display_Fluid.isStackEqual(mInventory[getStackDisplaySlot()], true, true))
                         mInventory[getStackDisplaySlot()] = null;

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicTank.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicTank.java
@@ -137,6 +137,8 @@ public abstract class GT_MetaTileEntity_BasicTank extends GT_MetaTileEntity_Tier
     public void onOpenGUI() {
         super.onOpenGUI();
         mOpenerCount++;
+        if (mOpenerCount == 1)
+            updateFluidDisplayItem();
     }
 
     @Override
@@ -151,14 +153,8 @@ public abstract class GT_MetaTileEntity_BasicTank extends GT_MetaTileEntity_Tier
             if (isFluidChangingAllowed() && getFillableStack() != null && getFillableStack().amount <= 0)
                 setFillableStack(null);
 
-            if (mOpenerCount > 0 && displaysItemStack() && getStackDisplaySlot() >= 0 && getStackDisplaySlot() < mInventory.length) {
-                if (getDisplayedFluid() == null) {
-                    if (ItemList.Display_Fluid.isStackEqual(mInventory[getStackDisplaySlot()], true, true))
-                        mInventory[getStackDisplaySlot()] = null;
-                } else {
-                    mInventory[getStackDisplaySlot()] = GT_Utility.getFluidDisplayStack(getDisplayedFluid(), displaysStackSize());
-                }
-            }
+            if (mOpenerCount > 0)
+                updateFluidDisplayItem();
 
             if (doesEmptyContainers()) {
                 FluidStack tFluid = GT_Utility.getFluidForFilledItem(mInventory[getInputSlot()], true);
@@ -190,6 +186,17 @@ public abstract class GT_MetaTileEntity_BasicTank extends GT_MetaTileEntity_Tier
                     if (tFluid != null) getDrainableStack().amount -= tFluid.amount;
                     if (getDrainableStack().amount <= 0 && isFluidChangingAllowed()) setDrainableStack(null);
                 }
+            }
+        }
+    }
+
+    protected void updateFluidDisplayItem() {
+        if (displaysItemStack() && getStackDisplaySlot() >= 0 && getStackDisplaySlot() < mInventory.length) {
+            if (getDisplayedFluid() == null) {
+                if (ItemList.Display_Fluid.isStackEqual(mInventory[getStackDisplaySlot()], true, true))
+                    mInventory[getStackDisplaySlot()] = null;
+            } else {
+                mInventory[getStackDisplaySlot()] = GT_Utility.getFluidDisplayStack(getDisplayedFluid(), displaysStackSize());
             }
         }
     }


### PR DESCRIPTION
This update will prevent GT from regenerating the fluid display item unless there is someone looking at its GUI.
