### PR TITLE
Ensure conservation of masses in boilers

### DIFF
--- a/src/main/java/gregtech/api/enums/GT_Values.java
+++ b/src/main/java/gregtech/api/enums/GT_Values.java
@@ -300,4 +300,5 @@ public class GT_Values {
     public static boolean cls_enabled;
     
     public static boolean hideAssLineRecipes = false;
+    public static final int STEAM_PER_WATER = 160;
 }

--- a/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Bronze.java
+++ b/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Bronze.java
@@ -9,8 +9,6 @@ import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.objects.GT_RenderedTexture;
 import gregtech.api.objects.XSTR;
-import gregtech.api.util.GT_Log;
-import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_OreDictUnificator;
 import gregtech.api.util.GT_Utility;
 import gregtech.common.GT_Pollution;
@@ -19,9 +17,6 @@ import gregtech.common.gui.GT_GUIContainer_Boiler;
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.tileentity.TileEntityFurnace;
-import net.minecraftforge.common.util.ForgeDirection;
-import net.minecraftforge.fluids.FluidStack;
-import net.minecraftforge.fluids.IFluidHandler;
 
 public class GT_MetaTileEntity_Boiler_Bronze extends GT_MetaTileEntity_Boiler {
     public GT_MetaTileEntity_Boiler_Bronze(int aID, String aName, String aNameRegional) {
@@ -72,130 +67,98 @@ public class GT_MetaTileEntity_Boiler_Bronze extends GT_MetaTileEntity_Boiler {
     }
 
     public void onPostTick(IGregTechTileEntity aBaseMetaTileEntity, long aTick) {
-        singleBlockBoilerLogic(aBaseMetaTileEntity,aTick,1,45,25L,20);
+        super.onPostTick(aBaseMetaTileEntity, aTick);
+        if ((aBaseMetaTileEntity.isServerSide()) && (aTick > 20L) && this.mProcessingEnergy > 0 && (aTick % 20L == 0L)) {
+            GT_Pollution.addPollution(getBaseMetaTileEntity(), getPollution());
+        }
     }
 
-    protected void singleBlockBoilerLogic(IGregTechTileEntity aBaseMetaTileEntity, long aTick, int aMultiplier, int aTimer, long aTickDivider, int aPollution){
-        if ((aBaseMetaTileEntity.isServerSide()) && (aTick > 20L)) {
-            if (this.mTemperature <= 20) {
-                this.mTemperature = 20;
-                this.mLossTimer = 0;
-            }
-            if (++this.mLossTimer > aTimer) {
-                this.mTemperature -= 1;
-                this.mLossTimer = 0;
-            }
-            for (byte i = 1; (this.mSteam != null) && (i < 6); i = (byte) (i + 1)) {
-                if (i != aBaseMetaTileEntity.getFrontFacing()) {
-                    IFluidHandler tTileEntity = aBaseMetaTileEntity.getITankContainerAtSide(i);
-                    if (tTileEntity != null) {
-                        FluidStack tDrained = aBaseMetaTileEntity.drain(ForgeDirection.getOrientation(i), Math.max(1, this.mSteam.amount / 2), false);
-                        if (tDrained != null) {
-                            int tFilledAmount = tTileEntity.fill(ForgeDirection.getOrientation(i).getOpposite(), tDrained, false);
-                            if (tFilledAmount > 0) {
-                                tTileEntity.fill(ForgeDirection.getOrientation(i).getOpposite(), aBaseMetaTileEntity.drain(ForgeDirection.getOrientation(i), tFilledAmount, true), true);
-                            }
-                        }
-                    }
-                }
-            }
-            if (aTick % aTickDivider == 0L) {
-                if (this.mTemperature > 100) {
-                    if ((this.mFluid == null) || (!GT_ModHandler.isWater(this.mFluid)) || (this.mFluid.amount <= 0)) {
-                        this.mHadNoWater = true;
-                    } else {
-                        if (this.mHadNoWater) {
-                            GT_Log.exp.println("Boiler "+this.mName+" had no Water!");
-                            aBaseMetaTileEntity.doExplosion(2048L);
-                            return;
-                        }
-                        this.mFluid.amount -= 1;
-                        if (this.mSteam == null) {
-                            this.mSteam = GT_ModHandler.getSteam(150L);
-                        } else if (GT_ModHandler.isSteam(this.mSteam)) {
-                            this.mSteam.amount += 150;
-                        } else {
-                            this.mSteam = GT_ModHandler.getSteam(150L);
-                        }
-                    }
-                } else {
-                    this.mHadNoWater = false;
-                }
-            }
-            if ((this.mSteam != null) &&
-                    (this.mSteam.amount > (16000*aMultiplier))) {
-                sendSound((byte) 1);
-                this.mSteam.amount = (12000*aMultiplier);
-            }
-            if ((this.mProcessingEnergy <= 0) && (aBaseMetaTileEntity.isAllowedToWork()) &&
-                    (this.mInventory[2] != null)) {
-                if (
-                        (GT_Utility.isPartOfMaterials(this.mInventory[2],Materials.Coal) && !GT_Utility.isPartOfOrePrefix(this.mInventory[2],OrePrefixes.block)) ||
-                        (GT_Utility.isPartOfMaterials(this.mInventory[2],Materials.Charcoal) && !GT_Utility.isPartOfOrePrefix(this.mInventory[2],OrePrefixes.block)) ||
-                        (GT_Utility.isPartOfMaterials(this.mInventory[2],Materials.Lignite) && !GT_Utility.isPartOfOrePrefix(this.mInventory[2],OrePrefixes.block)) ||
-                        (GT_Utility.isPartOfMaterials(this.mInventory[2],Materials.Diamond) && !GT_Utility.isPartOfOrePrefix(this.mInventory[2],OrePrefixes.block)) ||
-                        GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], "fuelCoke") ||
-                        GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], "fuelCactusCharcoal") ||
-                        GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], "fuelCactusCoke") ||
-                        GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], "fuelSugarCharcoal") ||
-                        GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], "fuelSugarCoke")
-                ) {
-                    if ((TileEntityFurnace.getItemBurnTime(this.mInventory[2])/10) > 0) {
-                        this.mProcessingEnergy += (TileEntityFurnace.getItemBurnTime(this.mInventory[2])/10);
-                        aBaseMetaTileEntity.decrStackSize(2, 1);
-                        if (XSTR.XSTR_INSTANCE.nextInt(GT_Utility.isPartOfMaterials(this.mInventory[2],Materials.Coal) || GT_Utility.isPartOfMaterials(this.mInventory[2],Materials.Charcoal) ? 3 : GT_Utility.isPartOfMaterials(this.mInventory[2],Materials.Lignite) ? 8 : 2 ) == 0) {
-                            aBaseMetaTileEntity.addStackToSlot(3, GT_OreDictUnificator.get(OrePrefixes.dustTiny, (GT_Utility.isPartOfMaterials(this.mInventory[2],Materials.Lignite) || GT_Utility.isPartOfMaterials(this.mInventory[2],Materials.Coal)) ? Materials.DarkAsh : Materials.Ash, 1L));
-                        }
-                    }
-                }
-                else if (
-                        //If its a block of the following materials
-                        GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.block.get(Materials.Coal)) ||
-                        GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.block.get(Materials.Lignite)) ||
-                        GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.block.get(Materials.Charcoal))||
-                        GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.block.get(Materials.Diamond)) ||
+    @Override
+    protected int getPollution() {
+        return 20;
+    }
 
-                         //if its either a Railcraft Coke Block or a custom GTNH compressed Coal/charcoal/lignite/coke block
-                        (
-                         Block.getBlockFromItem(this.mInventory[2].getItem()) != null && //check if the block exists
-                        (
-                         Block.getBlockFromItem(this.mInventory[2].getItem()).getUnlocalizedName().toLowerCase().contains("tile") && //check if the block is a tile -> block
-                        (
-                         //If the name of the block contains these names
-                         Block.getBlockFromItem(this.mInventory[2].getItem()).getUnlocalizedName().toLowerCase().contains("charcoal") ||
-                         Block.getBlockFromItem(this.mInventory[2].getItem()).getUnlocalizedName().toLowerCase().contains("coal") ||
-                         Block.getBlockFromItem(this.mInventory[2].getItem()).getUnlocalizedName().toLowerCase().contains("diamond") ||
-                         Block.getBlockFromItem(this.mInventory[2].getItem()).getUnlocalizedName().toLowerCase().contains("coke") ||
-                         Block.getBlockFromItem(this.mInventory[2].getItem()).getUnlocalizedName().toLowerCase().contains("railcraft.cube") ||
-                         Block.getBlockFromItem(this.mInventory[2].getItem()).getUnlocalizedName().toLowerCase().contains("lignite")
-                        )
-                        )
-                        )
-                ){
-                    //try to add 10% of the burnvalue as Processing energy, no boost for coal coke here
-                    if ((TileEntityFurnace.getItemBurnTime(this.mInventory[2])/10) > 0) {
-                        this.mProcessingEnergy += (TileEntityFurnace.getItemBurnTime(this.mInventory[2]) / 10);
-                        aBaseMetaTileEntity.decrStackSize(2, 1);
-                        aBaseMetaTileEntity.addStackToSlot(3, GT_OreDictUnificator.get(OrePrefixes.dust, (GT_Utility.isPartOfMaterials(this.mInventory[2],Materials.Lignite) || GT_Utility.isPartOfMaterials(this.mInventory[2],Materials.Coal) || Block.getBlockFromItem(this.mInventory[2].getItem()).getUnlocalizedName().toLowerCase().contains("coal") || Block.getBlockFromItem(this.mInventory[2].getItem()).getUnlocalizedName().toLowerCase().contains("lignite") ) ? Materials.DarkAsh : Materials.Ash, 1L));
-                    }
-                    //enables every other fuel with at least 2000 burntime as a fuel, i.e. peat, Magic/Solid Super Fuel, Coal Singularities, Nitor, while bucket of creosite should be blocked same goes for lava
-                }else if ((TileEntityFurnace.getItemBurnTime(this.mInventory[2])) >= 2000 && !(this.mInventory[2].getUnlocalizedName().toLowerCase().contains("bucket") || this.mInventory[2].getUnlocalizedName().toLowerCase().contains("cell"))){
-                    this.mProcessingEnergy += (TileEntityFurnace.getItemBurnTime(this.mInventory[2]) / 10);
-                    aBaseMetaTileEntity.decrStackSize(2, 1);
-                    //adds tiny pile of ash for burntime under 10k, small pile for under 100k and pile for bigger values
-                    if (XSTR.XSTR_INSTANCE.nextInt(2) == 0)
-                        aBaseMetaTileEntity.addStackToSlot(3, GT_OreDictUnificator.get( (TileEntityFurnace.getItemBurnTime(this.mInventory[2]) >= 10000 ? TileEntityFurnace.getItemBurnTime(this.mInventory[2]) >= 100000 ? OrePrefixes.dust : OrePrefixes.dustSmall : OrePrefixes.dustTiny), Materials.Ash, 1L));
+    @Override
+    protected int getProductionPerSecond() {
+        return 120;
+    }
+
+    @Override
+    protected int getMaxTemperature() {
+        return 500;
+    }
+
+    @Override
+    protected int getEnergyConsumption() {
+        return 1;
+    }
+
+    @Override
+    protected int getCooldownInterval() {
+        return 45;
+    }
+
+    @Override
+    protected void updateFuel(IGregTechTileEntity aBaseMetaTileEntity, long aTick) {
+        if (this.mInventory[2] == null) return;
+        if (
+                (GT_Utility.isPartOfMaterials(this.mInventory[2],Materials.Coal) && !GT_Utility.isPartOfOrePrefix(this.mInventory[2],OrePrefixes.block)) ||
+                (GT_Utility.isPartOfMaterials(this.mInventory[2],Materials.Charcoal) && !GT_Utility.isPartOfOrePrefix(this.mInventory[2],OrePrefixes.block)) ||
+                (GT_Utility.isPartOfMaterials(this.mInventory[2],Materials.Lignite) && !GT_Utility.isPartOfOrePrefix(this.mInventory[2],OrePrefixes.block)) ||
+                (GT_Utility.isPartOfMaterials(this.mInventory[2],Materials.Diamond) && !GT_Utility.isPartOfOrePrefix(this.mInventory[2],OrePrefixes.block)) ||
+                GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], "fuelCoke") ||
+                GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], "fuelCactusCharcoal") ||
+                GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], "fuelCactusCoke") ||
+                GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], "fuelSugarCharcoal") ||
+                GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], "fuelSugarCoke")
+        ) {
+            if ((TileEntityFurnace.getItemBurnTime(this.mInventory[2])/10) > 0) {
+                this.mProcessingEnergy += (TileEntityFurnace.getItemBurnTime(this.mInventory[2])/10);
+                aBaseMetaTileEntity.decrStackSize(2, 1);
+                if (XSTR.XSTR_INSTANCE.nextInt(GT_Utility.isPartOfMaterials(this.mInventory[2],Materials.Coal) || GT_Utility.isPartOfMaterials(this.mInventory[2],Materials.Charcoal) ? 3 : GT_Utility.isPartOfMaterials(this.mInventory[2],Materials.Lignite) ? 8 : 2 ) == 0) {
+                    aBaseMetaTileEntity.addStackToSlot(3, GT_OreDictUnificator.get(OrePrefixes.dustTiny, (GT_Utility.isPartOfMaterials(this.mInventory[2],Materials.Lignite) || GT_Utility.isPartOfMaterials(this.mInventory[2],Materials.Coal)) ? Materials.DarkAsh : Materials.Ash, 1L));
                 }
             }
-            if ((this.mTemperature < (500*aMultiplier)) && (this.mProcessingEnergy > 0) && (aTick % 12L == 0L)) {
-                this.mProcessingEnergy -= aMultiplier;
-                this.mTemperature += 1;
-            }
-            if (this.mProcessingEnergy > 0 && (aTick % 20L == 0L)) {
-                GT_Pollution.addPollution(getBaseMetaTileEntity(), aPollution);
-            }
-            aBaseMetaTileEntity.setActive(this.mProcessingEnergy > 0);
         }
+        else if (
+                //If its a block of the following materials
+                GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.block.get(Materials.Coal)) ||
+                GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.block.get(Materials.Lignite)) ||
+                GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.block.get(Materials.Charcoal))||
+                GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.block.get(Materials.Diamond)) ||
+
+                 //if its either a Railcraft Coke Block or a custom GTNH compressed Coal/charcoal/lignite/coke block
+                (
+                 Block.getBlockFromItem(this.mInventory[2].getItem()) != null && //check if the block exists
+                (
+                 Block.getBlockFromItem(this.mInventory[2].getItem()).getUnlocalizedName().toLowerCase().contains("tile") && //check if the block is a tile -> block
+                (
+                 //If the name of the block contains these names
+                 Block.getBlockFromItem(this.mInventory[2].getItem()).getUnlocalizedName().toLowerCase().contains("charcoal") ||
+                 Block.getBlockFromItem(this.mInventory[2].getItem()).getUnlocalizedName().toLowerCase().contains("coal") ||
+                 Block.getBlockFromItem(this.mInventory[2].getItem()).getUnlocalizedName().toLowerCase().contains("diamond") ||
+                 Block.getBlockFromItem(this.mInventory[2].getItem()).getUnlocalizedName().toLowerCase().contains("coke") ||
+                 Block.getBlockFromItem(this.mInventory[2].getItem()).getUnlocalizedName().toLowerCase().contains("railcraft.cube") ||
+                 Block.getBlockFromItem(this.mInventory[2].getItem()).getUnlocalizedName().toLowerCase().contains("lignite")
+                )
+                )
+                )
+        ){
+            //try to add 10% of the burnvalue as Processing energy, no boost for coal coke here
+            if ((TileEntityFurnace.getItemBurnTime(this.mInventory[2])/10) > 0) {
+                this.mProcessingEnergy += (TileEntityFurnace.getItemBurnTime(this.mInventory[2]) / 10);
+                aBaseMetaTileEntity.decrStackSize(2, 1);
+                aBaseMetaTileEntity.addStackToSlot(3, GT_OreDictUnificator.get(OrePrefixes.dust, (GT_Utility.isPartOfMaterials(this.mInventory[2],Materials.Lignite) || GT_Utility.isPartOfMaterials(this.mInventory[2],Materials.Coal) || Block.getBlockFromItem(this.mInventory[2].getItem()).getUnlocalizedName().toLowerCase().contains("coal") || Block.getBlockFromItem(this.mInventory[2].getItem()).getUnlocalizedName().toLowerCase().contains("lignite") ) ? Materials.DarkAsh : Materials.Ash, 1L));
+            }
+            //enables every other fuel with at least 2000 burntime as a fuel, i.e. peat, Magic/Solid Super Fuel, Coal Singularities, Nitor, while bucket of creosite should be blocked same goes for lava
+        }else if ((TileEntityFurnace.getItemBurnTime(this.mInventory[2])) >= 2000 && !(this.mInventory[2].getUnlocalizedName().toLowerCase().contains("bucket") || this.mInventory[2].getUnlocalizedName().toLowerCase().contains("cell"))){
+            this.mProcessingEnergy += (TileEntityFurnace.getItemBurnTime(this.mInventory[2]) / 10);
+            aBaseMetaTileEntity.decrStackSize(2, 1);
+            //adds tiny pile of ash for burntime under 10k, small pile for under 100k and pile for bigger values
+            if (XSTR.XSTR_INSTANCE.nextInt(2) == 0)
+                aBaseMetaTileEntity.addStackToSlot(3, GT_OreDictUnificator.get( (TileEntityFurnace.getItemBurnTime(this.mInventory[2]) >= 10000 ? TileEntityFurnace.getItemBurnTime(this.mInventory[2]) >= 100000 ? OrePrefixes.dust : OrePrefixes.dustSmall : OrePrefixes.dustTiny), Materials.Ash, 1L));
+        }
+
     }
 
 }

--- a/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Steel.java
+++ b/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Steel.java
@@ -61,7 +61,33 @@ public class GT_MetaTileEntity_Boiler_Steel extends GT_MetaTileEntity_Boiler_Bro
         return new GT_MetaTileEntity_Boiler_Steel(this.mName, this.mTier, this.mDescriptionArray, this.mTextures);
     }
 
-    public void onPostTick(IGregTechTileEntity aBaseMetaTileEntity, long aTick) {
-       super.singleBlockBoilerLogic(aBaseMetaTileEntity,aTick,2,40,10L,30);
+    @Override
+    protected int getPollution() {
+        return 30;
+    }
+
+    @Override
+    public int getCapacity() {
+        return 32000;
+    }
+
+    @Override
+    protected int getProductionPerSecond() {
+        return 300;
+    }
+
+    @Override
+    protected int getMaxTemperature() {
+        return 1000;
+    }
+
+    @Override
+    protected int getEnergyConsumption() {
+        return 2;
+    }
+
+    @Override
+    protected int getCooldownInterval() {
+        return 40;
     }
 }


### PR DESCRIPTION
Unified single block boiler logic. As a consequence,

1. Lava boilers will use 1L of water for 160L steam, up from 1L water per 300L steam, just like everywhere else.
2. Small coal boiler and its high pressure version will use 1L of water per 160L steam, down from 1L water per 150L steam, just like everywhere else.
3. All boilers will remember fractions of water they consumed regardless of how much steam it produce, so it's possible to run a boiler with output not a multiple of 160 with absolutely 0 **additional** water input, assuming there is enough water initially provided to let the loop run.
4. All boilers will produce once every 10 ticks. The tooltip will still display per second (i.e. per 20 ticks) values.

Large Steam turbines are also updated to remember fractions of water they produced, to ensure a strict close cycle.

## What is not changed

1. Large heat exchanger is not updated on purpose as it's replaced by bartwork.
2. Average steam production rate of anything.
3. Average fuel consumption rate of anything.