### PR TITLE
Added Configuration tool support

### DIFF
--- a/src/main/java/gregtech/api/GregTech_API.java
+++ b/src/main/java/gregtech/api/GregTech_API.java
@@ -149,7 +149,8 @@ public class GregTech_API {
             sHardHammerList = new GT_HashSet<>(),
             sWireCutterList = new GT_HashSet<>(),
             sSolderingToolList = new GT_HashSet<>(),
-            sSolderingMetalList = new GT_HashSet<>();
+            sSolderingMetalList = new GT_HashSet<>(),
+            sConfiguratorList = new GT_HashSet<>();
     /**
      * The List of Hazmat Armors
      */
@@ -727,6 +728,8 @@ public class GregTech_API {
     public static boolean registerSolderingMetal(ItemStack aTool) {
         return registerTool(aTool, sSolderingMetalList);
     }
+
+    public static boolean registerConfigurator(ItemStack aTool) {return registerTool(aTool, sConfiguratorList); }
 
     /**
      * Generic Function to add Tools to the Lists.

--- a/src/main/java/gregtech/api/items/GT_Configurator_Item.java
+++ b/src/main/java/gregtech/api/items/GT_Configurator_Item.java
@@ -1,0 +1,17 @@
+package gregtech.api.items;
+
+import net.minecraft.item.Item;
+
+public class GT_Configurator_Item extends Item {
+
+    private int setting = 0;
+    private static final int MIN_SETTING = 0, MAX_SETTING = 32;
+
+    public void setSetting(int newSetting) {
+        setting = newSetting % MAX_SETTING;
+    }
+
+    public int getSetting() {
+        return setting;
+    }
+}

--- a/src/main/java/gregtech/api/items/GT_Configurator_Item.java
+++ b/src/main/java/gregtech/api/items/GT_Configurator_Item.java
@@ -1,5 +1,7 @@
 package gregtech.api.items;
 
+import gregtech.api.util.GT_Utility;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 
 public class GT_Configurator_Item extends Item {
@@ -7,11 +9,33 @@ public class GT_Configurator_Item extends Item {
     private int setting = 0;
     private static final int MIN_SETTING = 0, MAX_SETTING = 32;
 
+    public void adjust() {
+        setting = setting % MAX_SETTING;
+    }
+
     public void setSetting(int newSetting) {
-        setting = newSetting % MAX_SETTING;
+        setting = newSetting;
+        adjust();
     }
 
     public int getSetting() {
         return setting;
     }
+
+    public int bumpUp() {
+        setting++;
+        adjust();
+        return setting;
+    }
+
+    public int bumpDown() {
+        setting--;
+        adjust();
+        return setting;
+    }
+
+    public void notify(EntityPlayer aPlayer) {
+        GT_Utility.sendChatToPlayer(aPlayer, "Configuration: " + setting);
+    }
+
 }

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
@@ -18,6 +18,7 @@ import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.IEnergyConnected;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
+import gregtech.api.items.GT_Configurator_Item;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_BasicMachine;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch;
 import gregtech.api.net.GT_Packet_TileEntity;
@@ -1461,6 +1462,13 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
                         }
                         doEnetUpdate();
                         return true;
+                    }
+
+                    if (tCurrentItem.getItem() instanceof GT_Configurator_Item) {
+                        byte tSide = GT_Utility.determineWrenchingSide(aSide, aX, aY, aZ);
+                        if (mMetaTileEntity.onConfiguratorRightClick(aSide, tSide, aPlayer, aX, aY, aZ, ((GT_Configurator_Item) tCurrentItem.getItem()).getSetting())) {
+                            GT_Utility.sendSoundToPlayers(worldObj, GregTech_API.sSoundList.get(108), 1.0F, -1, xCoord, yCoord, zCoord);
+                        }
                     }
 
                     byte coverSide = aSide;

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -960,4 +960,8 @@ public abstract class MetaTileEntity implements IMetaTileEntity {
 
     @Optional.Method(modid = "appliedenergistics2")
     public void gridChanged() {}
+
+    public boolean onConfiguratorRightClick(byte aSide, byte tSide, EntityPlayer aPlayer, float aX, float aY, float aZ, int mode) {
+        return false;
+    }
 }


### PR DESCRIPTION
Added support for a type of tool that uses numbers to configure MetaTileEntity objects and the corresponding behavior. This is here so that people adding features to blocks aren't pigeonholed into using obscure tools and sneaking and such.
I did this in response to having to hunt through the code for a machine in order to figure out what tool I could use to change a setting I had added.