### PR TITLE
Optimize addOutput

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
@@ -740,33 +740,15 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity {
     public boolean addOutput(ItemStack aStack) {
         if (GT_Utility.isStackInvalid(aStack)) return false;
         aStack = GT_Utility.copy(aStack);
+        for (GT_MetaTileEntity_Hatch_OutputBus tHatch : mOutputBusses) {
+            if (isValidMetaTileEntity(tHatch) && tHatch.storeAll(aStack)) {
+                return true;
+            }
+        }
         boolean outputSuccess = true;
         while (outputSuccess && aStack.stackSize > 0) {
             outputSuccess = false;
-
-            if (GregTech_API.mAE2) {
-                // this separate cycle may be refactored out, after this function will hopefully be totally refactored
-                // for now it is here to avoid splitting stack when we have ME output bus
-                for (GT_MetaTileEntity_Hatch_OutputBus tHatch : mOutputBusses) {
-                    // TODO: If ever there will be another hatch storing in some external storage, here should be an interface check
-                    if (tHatch instanceof GT_MetaTileEntity_Hatch_OutputBus_ME && isValidMetaTileEntity(tHatch)) {
-                        int rest = ((GT_MetaTileEntity_Hatch_OutputBus_ME) tHatch).store(aStack);
-                        if (rest != aStack.stackSize)
-                            outputSuccess = true;
-                        aStack.stackSize = rest;
-                        if (rest == 0)
-                            return true;
-                    }
-                }
-            }
             ItemStack single = aStack.splitStack(1);
-            for (GT_MetaTileEntity_Hatch_OutputBus tHatch : mOutputBusses) {
-                if (!outputSuccess && isValidMetaTileEntity(tHatch)) {
-                    for (int i = tHatch.getSizeInventory() - 1; i >= 0 && !outputSuccess; i--) {
-                        if (tHatch.getBaseMetaTileEntity().addStackToSlot(i, single)) outputSuccess = true;
-                    }
-                }
-            }
             for (GT_MetaTileEntity_Hatch_Output tHatch : mOutputHatches) {
                 if (!outputSuccess && isValidMetaTileEntity(tHatch) && tHatch.outputsItems()) {
                     if (tHatch.getBaseMetaTileEntity().addStackToSlot(1, single)) outputSuccess = true;

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_OutputBus_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_OutputBus_ME.java
@@ -18,6 +18,7 @@ import appeng.me.helpers.AENetworkProxy;
 import appeng.me.helpers.IGridProxyable;
 import appeng.util.Platform;
 import cpw.mods.fml.common.Optional;
+import gregtech.api.GregTech_API;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Textures;
 import gregtech.api.interfaces.ITexture;
@@ -58,6 +59,16 @@ public class GT_MetaTileEntity_Hatch_OutputBus_ME extends GT_MetaTileEntity_Hatc
     public void onFirstTick(IGregTechTileEntity aBaseMetaTileEntity) {
         super.onFirstTick(aBaseMetaTileEntity);
         getProxy();
+    }
+
+    @Override
+    public boolean storeAll(ItemStack aStack) {
+        if (!GregTech_API.mAE2)
+            return false;
+        int tTotal = aStack.stackSize;
+        int tStored = store(aStack);
+        aStack.stackSize -= tStored;
+        return tTotal < tStored;
     }
 
     @Optional.Method(modid = "appliedenergistics2")


### PR DESCRIPTION
GTNewHorizons/GT-New-Horizons-Modpack#7339

Works with GT++ super bus, normal output bus and ME output bus. Does not crash the game if ME output bus is used without AE2 installed somehow.