### PR TITLE
Fix solar boiler problems due to refactor

### DIFF
--- a/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler.java
+++ b/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler.java
@@ -284,20 +284,24 @@ public abstract class GT_MetaTileEntity_Boiler extends GT_MetaTileEntity_BasicTa
         return false;
     }
 
-    private void pushSteamToInventories(IGregTechTileEntity aBaseMetaTileEntity) {
+    protected final void pushSteamToSide(IGregTechTileEntity aBaseMetaTileEntity, int aSide) {
+        IFluidHandler tTileEntity = aBaseMetaTileEntity.getITankContainerAtSide((byte) aSide);
+        if (tTileEntity == null)
+            return;
+        FluidStack tDrained = aBaseMetaTileEntity.drain(ForgeDirection.getOrientation(aSide), Math.max(1, this.mSteam.amount / 2), false);
+        if (tDrained == null)
+            return;
+        int tFilledAmount = tTileEntity.fill(ForgeDirection.getOrientation(aSide).getOpposite(), tDrained, false);
+        if (tFilledAmount <= 0)
+            return;
+        tTileEntity.fill(ForgeDirection.getOrientation(aSide).getOpposite(), aBaseMetaTileEntity.drain(ForgeDirection.getOrientation(aSide), tFilledAmount, true), true);
+    }
+
+    protected void pushSteamToInventories(IGregTechTileEntity aBaseMetaTileEntity) {
         for (int i = 1; (this.mSteam != null) && (i < 6); i++) {
             if (i == aBaseMetaTileEntity.getFrontFacing())
                 continue;
-            IFluidHandler tTileEntity = aBaseMetaTileEntity.getITankContainerAtSide((byte) i);
-            if (tTileEntity == null)
-                continue;
-            FluidStack tDrained = aBaseMetaTileEntity.drain(ForgeDirection.getOrientation(i), Math.max(1, this.mSteam.amount / 2), false);
-            if (tDrained == null)
-                continue;
-            int tFilledAmount = tTileEntity.fill(ForgeDirection.getOrientation(i).getOpposite(), tDrained, false);
-            if (tFilledAmount <= 0)
-                continue;
-            tTileEntity.fill(ForgeDirection.getOrientation(i).getOpposite(), aBaseMetaTileEntity.drain(ForgeDirection.getOrientation(i), tFilledAmount, true), true);
+            pushSteamToSide(aBaseMetaTileEntity, i);
         }
     }
 
@@ -345,6 +349,10 @@ public abstract class GT_MetaTileEntity_Boiler extends GT_MetaTileEntity_BasicTa
     @Override
     public int getTankPressure() {
         return 100;
+    }
+
+    protected boolean isOutputToFront() {
+        return false;
     }
 
     protected abstract int getPollution();

--- a/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Solar.java
+++ b/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Solar.java
@@ -160,4 +160,14 @@ public class GT_MetaTileEntity_Boiler_Solar extends GT_MetaTileEntity_Boiler {
             mProcessingEnergy += bRain && aBaseMetaTileEntity.getWorld().skylightSubtracted >= 4 || !aBaseMetaTileEntity.getSkyAtSide((byte) 1) ? 0 : !bRain && aBaseMetaTileEntity.getWorld().isDaytime() ? 8 * basicTemperatureMod : basicTemperatureMod;
         }
     }
+
+    /** for waila */
+    public int getBasicOutput() {
+        return basicOutput;
+    }
+
+    /** for waila */
+    public int getCalcificationOutput() {
+        return getProductionPerSecond();
+    }
 }

--- a/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Solar.java
+++ b/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Solar.java
@@ -93,7 +93,7 @@ public class GT_MetaTileEntity_Boiler_Solar extends GT_MetaTileEntity_Boiler {
                 + "    Hot time: " + EnumChatFormatting.RED + GT_Utility.formatNumbers(this.mRunTime*25/20)+EnumChatFormatting.RESET+" s",
                 "Min output: " + EnumChatFormatting.RED + GT_Utility.formatNumbers(this.basicMaxOuput*20/25)+EnumChatFormatting.RESET+ " L/s"
                 + "    Max output: " + EnumChatFormatting.RED + GT_Utility.formatNumbers(this.basicOutput*20/25)+EnumChatFormatting.RESET+" L/s",
-                "Current Output: " + EnumChatFormatting.YELLOW + GT_Utility.formatNumbers(getCalcificationOutput()*20/25) +EnumChatFormatting.RESET+" L/s"};
+                "Current Output: " + EnumChatFormatting.YELLOW + GT_Utility.formatNumbers(getProductionPerSecond()*20/25) +EnumChatFormatting.RESET+" L/s"};
     }
 
     @Override
@@ -108,23 +108,16 @@ public class GT_MetaTileEntity_Boiler_Solar extends GT_MetaTileEntity_Boiler {
 
     // Calcification start time is 43200*25/20=54,000s or 15 hours of game time.
     static final int CALCIFICATION_TIME = 43200;
-    
-    public int getCalcificationOutput() { // Returns how much output the boiler can do.
-        if (this.mTemperature < 100 ) {
-            return 0;
-        }
-        if (this.mRunTime > CALCIFICATION_TIME) {
-            // Calcification takes about 2/3 CALCIFICATION_TIME to completely calcify on basic solar. For HP solar, it takes about 2x CALCIFICATION_TIME
-            return Math.max(this.basicMaxOuput, this.basicOutput - ((this.mRunTime - CALCIFICATION_TIME) / (CALCIFICATION_TIME/150))); // Every 288*25 ticks, or 6 minutes, lose 1 L output.
-        } else {
-            return this.basicOutput;
-        }
-    }
 
     @Override
     protected void produceSteam(int aAmount) {
         super.produceSteam(aAmount);
         mRunTime++;
+    }
+
+    @Override
+    protected void pushSteamToInventories(IGregTechTileEntity aBaseMetaTileEntity) {
+        pushSteamToSide(aBaseMetaTileEntity, aBaseMetaTileEntity.getFrontFacing());
     }
 
     @Override


### PR DESCRIPTION
1. Solar boilers used to output to the side with a vent marking only. In the previous PR an oversight changed this into all side except bottom and vent facing. This PR will revert it back to old behavior.
2. WAILA GT5U plugin expect two particular method to be present. They were all removed during the refactor as WAILA compatibility wasn't tested. They are added back to ensure the plugin still works.