### PR TITLE
fix(solarboilers): fixes and QOL improvements

### DIFF
--- a/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler.java
+++ b/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler.java
@@ -201,7 +201,7 @@ public abstract class GT_MetaTileEntity_Boiler extends GT_MetaTileEntity_BasicTa
     protected void produceSteam(int aAmount) {
         mExcessWater -= aAmount;
         if (mExcessWater < 0) {
-            int tWaterToConsume = -mExcessWater / GT_Values.STEAM_PER_WATER + 1;
+            int tWaterToConsume = -mExcessWater / GT_Values.STEAM_PER_WATER;
             mFluid.amount -= tWaterToConsume;
             mExcessWater += GT_Values.STEAM_PER_WATER * tWaterToConsume;
         }

--- a/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Solar.java
+++ b/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Solar.java
@@ -22,7 +22,6 @@ import static gregtech.api.enums.ConfigCategories.machineconfig;
 
 @SuppressWarnings("unused")
 public class GT_MetaTileEntity_Boiler_Solar extends GT_MetaTileEntity_Boiler {
-    public static final String DEFAULT_STR = "Default: ";
     public static final String LPS_FMT = "%s L/s";
     private static final String localizedDescFormat = GT_LanguageManager.addStringLocalization(
             "gt.blockmachines.boiler.solar.desc.format",
@@ -30,6 +29,7 @@ public class GT_MetaTileEntity_Boiler_Solar extends GT_MetaTileEntity_Boiler {
                     "Produces %sL of Steam per second%n" +
                     "Calcifies over time, reducing Steam output to %sL/s%n" +
                     "Break and replace to descale");
+    private final Config config = new Config();
     protected int calcificationTicks;
     protected int minOutputPerSecond;
     protected int maxOutputPerSecond;
@@ -39,39 +39,17 @@ public class GT_MetaTileEntity_Boiler_Solar extends GT_MetaTileEntity_Boiler {
 
     public GT_MetaTileEntity_Boiler_Solar(int aID, String aName, String aNameRegional) {
         super(aID, aName, aNameRegional, new String[0]);
-        onConfigLoad();
-    }
-
-    protected void onConfigLoad() {
-        final Configuration config = GregTech_API.sMachineFile.mConfig;
-        final String configCategory = machineconfig + ".boiler.solar.bronze";
-
-        final int defaultCalcificationTicks = 1080000; // 15 hours
-        final int defaultMinOutputPerSecond = 40;
-        final int defaultMaxOutputPerSecond = 120;
-        final int defaultCoolDownTicks = 45;
-
-        calcificationTicks = config.get(configCategory, "CalcificationTicks", defaultCalcificationTicks,
-                "Number of run-time ticks before boiler starts calcification.\n" +
-                        "100% calcification and minimal output will be reached at 2 times this.\n" +
-                        DEFAULT_STR + defaultCalcificationTicks).getInt();
-        minOutputPerSecond = config.get(configCategory, "MinOutputPerSecond", defaultMinOutputPerSecond,
-                DEFAULT_STR + defaultMinOutputPerSecond).getInt();
-        maxOutputPerSecond = config.get(configCategory, "MaxOutputPerSecond", defaultMaxOutputPerSecond,
-                DEFAULT_STR + defaultMaxOutputPerSecond).getInt();
-        coolDownTicks = config.get(configCategory, "CoolDownTicks", defaultCoolDownTicks,
-                "Number of ticks it takes to lose 1°C.\n" +
-                        DEFAULT_STR + defaultCoolDownTicks).getInt();
+        config.onConfigLoad();
     }
 
     public GT_MetaTileEntity_Boiler_Solar(String aName, int aTier, String aDescription, ITexture[][][] aTextures) {
         super(aName, aTier, aDescription, aTextures);
-        onConfigLoad();
+        config.onConfigLoad();
     }
 
     public GT_MetaTileEntity_Boiler_Solar(String aName, int aTier, String[] aDescription, ITexture[][][] aTextures) {
         super(aName, aTier, aDescription, aTextures);
-        onConfigLoad();
+        config.onConfigLoad();
     }
 
     /**
@@ -272,5 +250,69 @@ public class GT_MetaTileEntity_Boiler_Solar extends GT_MetaTileEntity_Boiler {
     @Override
     public MetaTileEntity newMetaEntity(IGregTechTileEntity aTileEntity) {
         return new GT_MetaTileEntity_Boiler_Solar(mName, mTier, mDescriptionArray, mTextures);
+    }
+
+    protected class Config {
+        public static final String DEFAULT_STR = "Default: ";
+        private static final String localCategory = "boiler.solar.bronze";
+        private static final int defaultCalcificationTicks = 1080000; // 15 hours
+        private static final String defaultCalcificationTicksComment =
+                "Number of run-time ticks before boiler starts calcification.\n" +
+                        "100% calcification and minimal output will be reached at 2 times this.\n";
+        private static final int defaultMinOutputPerSecond = 40;
+        private static final String defaultMinOutputPerSecondComment = "";
+        private static final int defaultMaxOutputPerSecond = 120;
+        private static final String defaultMaxOutputPerSecondComment = "";
+        private static final int defaultCoolDownTicks = 45;
+        private static final String defaultCoolDownTicksComment = "Number of ticks it takes to lose 1°C.\n";
+        final Configuration configuration = GregTech_API.sMachineFile.mConfig;
+        final String configCategory = getConfigCategory();
+
+        protected String getConfigCategory() {
+            return machineconfig + "." + localCategory;
+        }
+
+        protected void onConfigLoad() {
+            calcificationTicks = configuration.get(configCategory, "CalcificationTicks", getDefaultCalcificationTicks(),
+                    getDefaultCalcificationTicksComment() + DEFAULT_STR + getDefaultCalcificationTicks()).getInt();
+            minOutputPerSecond = configuration.get(configCategory, "MinOutputPerSecond", getDefaultMinOutputPerSecond(),
+                    getDefaultMinOutputPerSecondComment() + DEFAULT_STR + getDefaultMinOutputPerSecond()).getInt();
+            maxOutputPerSecond = configuration.get(configCategory, "MaxOutputPerSecond", getDefaultMaxOutputPerSecond(),
+                    getDefaultMaxOutputPerSecondComment() + DEFAULT_STR + getDefaultMaxOutputPerSecond()).getInt();
+            coolDownTicks = configuration.get(configCategory, "CoolDownTicks", getDefaultCoolDownTicks(),
+                    getDefaultCoolDownTicksComment() + DEFAULT_STR + getDefaultCoolDownTicks()).getInt();
+        }
+
+        protected int getDefaultCalcificationTicks() {
+            return defaultCalcificationTicks;
+        }
+
+        protected String getDefaultCalcificationTicksComment() {
+            return defaultCalcificationTicksComment;
+        }
+
+        protected int getDefaultMinOutputPerSecond() {
+            return defaultMinOutputPerSecond;
+        }
+
+        protected String getDefaultMinOutputPerSecondComment() {
+            return defaultMinOutputPerSecondComment;
+        }
+
+        protected int getDefaultMaxOutputPerSecond() {
+            return defaultMaxOutputPerSecond;
+        }
+
+        protected String getDefaultMaxOutputPerSecondComment() {
+            return defaultMaxOutputPerSecondComment;
+        }
+
+        protected int getDefaultCoolDownTicks() {
+            return defaultCoolDownTicks;
+        }
+
+        protected String getDefaultCoolDownTicksComment() {
+            return defaultCoolDownTicksComment;
+        }
     }
 }

--- a/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Solar_Steel.java
+++ b/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Solar_Steel.java
@@ -1,6 +1,5 @@
 package gregtech.common.tileentities.boilers;
 
-import gregtech.api.GregTech_API;
 import gregtech.api.enums.Dyes;
 import gregtech.api.enums.Textures.BlockIcons;
 import gregtech.api.interfaces.ITexture;
@@ -9,39 +8,25 @@ import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.objects.GT_RenderedTexture;
 import gregtech.common.gui.GT_GUIContainer_Boiler;
 import net.minecraft.entity.player.InventoryPlayer;
-import net.minecraftforge.common.config.Configuration;
 
 import static gregtech.api.enums.ConfigCategories.machineconfig;
 
 public class GT_MetaTileEntity_Boiler_Solar_Steel extends GT_MetaTileEntity_Boiler_Solar {
+    private final GT_MetaTileEntity_Boiler_Solar_Steel.Config config = new GT_MetaTileEntity_Boiler_Solar_Steel.Config();
 
     public GT_MetaTileEntity_Boiler_Solar_Steel(int aID, String aName, String aNameRegional) {
         super(aID, aName, aNameRegional);
-        onConfigLoad();
+        config.onConfigLoad();
     }
 
-    @Override
-    protected void onConfigLoad() {
-        final Configuration config = GregTech_API.sMachineFile.mConfig;
-        final String configCategory = machineconfig + ".boiler.solar.steel";
+    public GT_MetaTileEntity_Boiler_Solar_Steel(String aName, int aTier, String aDescription, ITexture[][][] aTextures) {
+        super(aName, aTier, aDescription, aTextures);
+        config.onConfigLoad();
+    }
 
-        final int defaultCalcificationTicks = 1080000; // 15 hours
-        final int defaultMinOutputPerSecond = 120;
-        final int defaultMaxOutputPerSecond = 360;
-        final int defaultCoolDownTicks = 75;
-
-        calcificationTicks = config.get(configCategory, "CalcificationTicks", defaultCalcificationTicks,
-                "Number of run-time ticks before boiler starts calcification.\n" +
-                        "100% calcification and minimal output will be reached at 2 times this.\n" +
-                        DEFAULT_STR + defaultCalcificationTicks).getInt();
-        minOutputPerSecond = config.get(configCategory, "MinOutputPerSecond", defaultMinOutputPerSecond,
-                DEFAULT_STR + defaultMinOutputPerSecond).getInt();
-        maxOutputPerSecond = config.get(configCategory, "MaxOutputPerSecond", defaultMaxOutputPerSecond,
-                DEFAULT_STR + defaultMaxOutputPerSecond).getInt();
-        coolDownTicks = config.get(configCategory, "CoolDownTicks", defaultCoolDownTicks,
-                "Number of ticks it takes to loose 1°C (Cools down slower than a normal boiler).\n" +
-                        DEFAULT_STR + defaultCoolDownTicks).getInt();
-
+    public GT_MetaTileEntity_Boiler_Solar_Steel(String aName, int aTier, String[] aDescription, ITexture[][][] aTextures) {
+        super(aName, aTier, aDescription, aTextures);
+        config.onConfigLoad();
     }
 
     @Override
@@ -80,14 +65,37 @@ public class GT_MetaTileEntity_Boiler_Solar_Steel extends GT_MetaTileEntity_Boil
         return new GT_MetaTileEntity_Boiler_Solar_Steel(this.mName, this.mTier, this.mDescriptionArray, this.mTextures);
     }
 
-    public GT_MetaTileEntity_Boiler_Solar_Steel(String aName, int aTier, String aDescription, ITexture[][][] aTextures) {
-        super(aName, aTier, aDescription, aTextures);
-        onConfigLoad();
-    }
+    protected class Config extends GT_MetaTileEntity_Boiler_Solar.Config {
+        private static final String localCategory = "boiler.solar.steel";
+        private static final int defaultMinOutputPerSecond = 120;
+        private static final int defaultMaxOutputPerSecond = 360;
+        private static final int defaultCoolDownTicks = 75;
+        private static final String defaultCoolDownTicksComment = "Number of ticks it takes to loose 1°C (Cools down slower than a normal boiler).\n";
 
-    public GT_MetaTileEntity_Boiler_Solar_Steel(String aName, int aTier, String[] aDescription, ITexture[][][] aTextures) {
-        super(aName, aTier, aDescription, aTextures);
-        onConfigLoad();
+        @Override
+        protected String getConfigCategory() {
+            return machineconfig + "." + localCategory;
+        }
+
+        @Override
+        protected int getDefaultMinOutputPerSecond() {
+            return defaultMinOutputPerSecond;
+        }
+
+        @Override
+        protected int getDefaultMaxOutputPerSecond() {
+            return defaultMaxOutputPerSecond;
+        }
+
+        @Override
+        protected int getDefaultCoolDownTicks() {
+            return defaultCoolDownTicks;
+        }
+
+        @Override
+        protected String getDefaultCoolDownTicksComment() {
+            return defaultCoolDownTicksComment;
+        }
     }
 
 }

--- a/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Solar_Steel.java
+++ b/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Solar_Steel.java
@@ -1,5 +1,6 @@
 package gregtech.common.tileentities.boilers;
 
+import gregtech.api.GregTech_API;
 import gregtech.api.enums.Dyes;
 import gregtech.api.enums.Textures.BlockIcons;
 import gregtech.api.interfaces.ITexture;
@@ -8,33 +9,40 @@ import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.objects.GT_RenderedTexture;
 import gregtech.common.gui.GT_GUIContainer_Boiler;
 import net.minecraft.entity.player.InventoryPlayer;
+import net.minecraftforge.common.config.Configuration;
+
+import static gregtech.api.enums.ConfigCategories.machineconfig;
 
 public class GT_MetaTileEntity_Boiler_Solar_Steel extends GT_MetaTileEntity_Boiler_Solar {
+    private static final int defaultCalcificationTicks = 54000;
 
     public GT_MetaTileEntity_Boiler_Solar_Steel(int aID, String aName, String aNameRegional) {
         super(aID, aName, aNameRegional);
-        configure();
-    }
-
-    private void configure() {
-        minOutputPer25Ticks = 150;
-        maxOutputPer25Ticks = 450;
-        basicLossTimerLimit = 75; // Cools down slower than normal boiler
-    }
-
-    public GT_MetaTileEntity_Boiler_Solar_Steel(String aName, int aTier, String aDescription, ITexture[][][] aTextures) {
-        super(aName, aTier, aDescription, aTextures);
-        configure();
-    }
-
-    public GT_MetaTileEntity_Boiler_Solar_Steel(String aName, int aTier, String[] aDescription, ITexture[][][] aTextures) {
-        super(aName, aTier, aDescription, aTextures);
-        configure();
+        onConfigLoad();
     }
 
     @Override
-    public int getCapacity() {
-        return 32000;
+    protected void onConfigLoad() {
+        final Configuration config = GregTech_API.sMachineFile.mConfig;
+        final String configCategory = machineconfig + ".HighPressureSolarBoiler";
+
+        final int defaultCalcificationTicks = 54000;
+        final int defaultMinOutputPerSecond = 120;
+        final int defaultMaxOutputPerSecond = 360;
+        final int defaultCoolDownTicks = 75;
+
+        calcificationTicks = config.get(configCategory, "CalcificationTicks", defaultCalcificationTicks,
+                "Number of run-time ticks before boiler starts calcification.\n" +
+                        "100% calcification and minimal output will be reached at 2 times this.\n" +
+                        DEFAULT_STR + defaultCalcificationTicks).getInt();
+        minOutputPerSecond = config.get(configCategory, "MinOutputPerSecond", defaultMinOutputPerSecond,
+                DEFAULT_STR + defaultMinOutputPerSecond).getInt();
+        maxOutputPerSecond = config.get(configCategory, "MaxOutputPerSecond", defaultMaxOutputPerSecond,
+                DEFAULT_STR + defaultMaxOutputPerSecond).getInt();
+        coolDownTicks = config.get(configCategory, "CoolDownTicks", defaultCoolDownTicks,
+                "Number of ticks it takes to loose 1°C (Cools down slower than normal boiler).\n" +
+                        DEFAULT_STR + defaultCoolDownTicks).getInt();
+
     }
 
     @Override
@@ -64,8 +72,23 @@ public class GT_MetaTileEntity_Boiler_Solar_Steel extends GT_MetaTileEntity_Boil
     }
 
     @Override
+    public int getCapacity() {
+        return 32000;
+    }
+
+    @Override
     public MetaTileEntity newMetaEntity(IGregTechTileEntity aTileEntity) {
         return new GT_MetaTileEntity_Boiler_Solar_Steel(this.mName, this.mTier, this.mDescriptionArray, this.mTextures);
+    }
+
+    public GT_MetaTileEntity_Boiler_Solar_Steel(String aName, int aTier, String aDescription, ITexture[][][] aTextures) {
+        super(aName, aTier, aDescription, aTextures);
+        onConfigLoad();
+    }
+
+    public GT_MetaTileEntity_Boiler_Solar_Steel(String aName, int aTier, String[] aDescription, ITexture[][][] aTextures) {
+        super(aName, aTier, aDescription, aTextures);
+        onConfigLoad();
     }
 
 }

--- a/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Solar_Steel.java
+++ b/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Solar_Steel.java
@@ -14,7 +14,6 @@ import net.minecraftforge.common.config.Configuration;
 import static gregtech.api.enums.ConfigCategories.machineconfig;
 
 public class GT_MetaTileEntity_Boiler_Solar_Steel extends GT_MetaTileEntity_Boiler_Solar {
-    private static final int defaultCalcificationTicks = 54000;
 
     public GT_MetaTileEntity_Boiler_Solar_Steel(int aID, String aName, String aNameRegional) {
         super(aID, aName, aNameRegional);
@@ -24,9 +23,9 @@ public class GT_MetaTileEntity_Boiler_Solar_Steel extends GT_MetaTileEntity_Boil
     @Override
     protected void onConfigLoad() {
         final Configuration config = GregTech_API.sMachineFile.mConfig;
-        final String configCategory = machineconfig + ".HighPressureSolarBoiler";
+        final String configCategory = machineconfig + ".boiler.solar.steel";
 
-        final int defaultCalcificationTicks = 54000;
+        final int defaultCalcificationTicks = 1080000; // 15 hours
         final int defaultMinOutputPerSecond = 120;
         final int defaultMaxOutputPerSecond = 360;
         final int defaultCoolDownTicks = 75;
@@ -40,7 +39,7 @@ public class GT_MetaTileEntity_Boiler_Solar_Steel extends GT_MetaTileEntity_Boil
         maxOutputPerSecond = config.get(configCategory, "MaxOutputPerSecond", defaultMaxOutputPerSecond,
                 DEFAULT_STR + defaultMaxOutputPerSecond).getInt();
         coolDownTicks = config.get(configCategory, "CoolDownTicks", defaultCoolDownTicks,
-                "Number of ticks it takes to loose 1°C (Cools down slower than normal boiler).\n" +
+                "Number of ticks it takes to loose 1°C (Cools down slower than a normal boiler).\n" +
                         DEFAULT_STR + defaultCoolDownTicks).getInt();
 
     }


### PR DESCRIPTION
- Change run-time counter from seconds to ticks since solar boilers are
  ticking every 10 ticks, or 0.5 second.
- Prevent run-time counter from overflowing `Integer.MAX_VALUE` ticks.
- Fix missing check of available steam before pushing to output.
- Fix the cool-down rate that broke in GTNH 2.1.0.6.
- Make the solar boilers entirely configurable.
