### PR TITLE
fix(hidecover) unchained posttick caused missed texture and size change

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Cable.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Cable.java
@@ -294,6 +294,7 @@ public class GT_MetaPipeEntity_Cable extends MetaPipeEntity implements IMetaTile
 
     @Override
     public void onPostTick(IGregTechTileEntity aBaseMetaTileEntity, long aTick) {
+        super.onPostTick(aBaseMetaTileEntity, aTick);
         if (aBaseMetaTileEntity.isServerSide()) {
 
             { //amp handler

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Fluid.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Fluid.java
@@ -232,6 +232,7 @@ public class GT_MetaPipeEntity_Fluid extends MetaPipeEntity {
 
     @Override
     public void onPostTick(IGregTechTileEntity aBaseMetaTileEntity, long aTick) {
+        super.onPostTick(aBaseMetaTileEntity, aTick);
         if (aBaseMetaTileEntity.isServerSide() && aTick % 5 == 0) {
             mLastReceivedFrom &= 63;
             if (mLastReceivedFrom == 63) {

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Item.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Item.java
@@ -156,6 +156,7 @@ public class GT_MetaPipeEntity_Item extends MetaPipeEntity implements IMetaTileE
 
     @Override
     public void onPostTick(IGregTechTileEntity aBaseMetaTileEntity, long aTick) {
+        super.onPostTick(aBaseMetaTileEntity, aTick);
         if (aBaseMetaTileEntity.isServerSide() && aTick % 10 == 0) {
             if (aTick % mTickTime == 0) mTransferredItems = 0;
 


### PR DESCRIPTION
Add missing chaining of the `onPostTick` event handler to parent class.

`GT_MetaPipeEntity_(Cable|Pipe|Fluid)` classes were not forwarding
the `onPostTick` event handler to their parent `MetaPipeEntity` class,
so pipes were not rendering the change unless another machine tile which
did properly chain the event handler to its parent
(like `GT_MetaTileEntity_TieredMachineBlock`) was present in same chunk.