### PR TITLE
fix(exception): class not found is normal when galactic greg absent

### DIFF
--- a/src/main/java/gregtech/loaders/postload/GT_Worldgenloader.java
+++ b/src/main/java/gregtech/loaders/postload/GT_Worldgenloader.java
@@ -218,8 +218,11 @@ public class GT_Worldgenloader implements Runnable {
             GT_Log.out.println("Started Galactic Greg ore gen code");
             //this function calls Galactic Greg and enables its generation.
         } catch (Exception e) {
-            GT_Log.err.println("Unable to start Galactic Greg ore gen code");
-            e.printStackTrace(GT_Log.err);
+            // ClassNotFound is expected if Galactic Greg is absent, so only report if other problem
+            if (!(e instanceof ClassNotFoundException)) {
+                GT_Log.err.println("Unable to start Galactic Greg ore gen code");
+                e.printStackTrace(GT_Log.err);
+            }
         }
         //DO NOT DELETE ^ THIS ^
         


### PR DESCRIPTION
Remove useless stacktrace by the worldgen loader when Galactic Greg is absent.

If Galactic Greg is not installed, this is useless spam of `Gregtech.log`:
```none
java.lang.ClassNotFoundException: bloodasp.galacticgreg.WorldGenGaGT
        at net.minecraft.launchwrapper.LaunchClassLoader.findClass(LaunchClassLoader.java:191)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:418)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
        at java.lang.Class.forName0(Native Method)
        at java.lang.Class.forName(Class.java:264)
        at gregtech.loaders.postload.GT_Worldgenloader.run(GT_Worldgenloader.java:214)
        at gregtech.GT_Mod.onPostLoad(GT_Mod.java:747)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at cpw.mods.fml.common.FMLModContainer.handleModStateEvent(FMLModContainer.java:532)
        at sun.reflect.GeneratedMethodAccessor3.invoke(Unknown Source)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at com.google.common.eventbus.EventSubscriber.handleEvent(EventSubscriber.java:74)
        at com.google.common.eventbus.SynchronizedEventSubscriber.handleEvent(SynchronizedEventSubscriber.java:47)
        at com.google.common.eventbus.EventBus.dispatch(EventBus.java:322)
        at com.google.common.eventbus.EventBus.dispatchQueuedEvents(EventBus.java:304)
        at com.google.common.eventbus.EventBus.post(EventBus.java:275)
        at cpw.mods.fml.common.LoadController.sendEventToModContainer(LoadController.java:212)
        at cpw.mods.fml.common.LoadController.propogateStateMessage(LoadController.java:190)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at com.google.common.eventbus.EventSubscriber.handleEvent(EventSubscriber.java:74)
        at com.google.common.eventbus.SynchronizedEventSubscriber.handleEvent(SynchronizedEventSubscriber.java:47)
        at com.google.common.eventbus.EventBus.dispatch(EventBus.java:322)
        at com.google.common.eventbus.EventBus.dispatchQueuedEvents(EventBus.java:304)
        at com.google.common.eventbus.EventBus.post(EventBus.java:275)
        at cpw.mods.fml.common.LoadController.distributeStateMessage(LoadController.java:119)
        at cpw.mods.fml.common.Loader.initializeMods(Loader.java:742)
        at cpw.mods.fml.client.FMLClientHandler.finishMinecraftLoading(FMLClientHandler.java:311)
        at net.minecraft.client.Minecraft.func_71384_a(Minecraft.java:552)
        at net.minecraft.client.Minecraft.func_99999_d(Minecraft.java:878)
        at net.minecraft.client.main.Main.main(SourceFile:148)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at net.minecraft.launchwrapper.Launch.launch(Launch.java:135)
        at net.minecraft.launchwrapper.Launch.main(Launch.java:28)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.multimc.onesix.OneSixLauncher.launchWithMainClass(OneSixLauncher.java:196)
        at org.multimc.onesix.OneSixLauncher.launch(OneSixLauncher.java:231)
        at org.multimc.EntryPoint.listen(EntryPoint.java:143)
        at org.multimc.EntryPoint.main(EntryPoint.java:34)
Caused by: java.lang.NullPointerException
```
