### PR TITLE
fix(charcoalpit): stop the igniter from capturing right-click

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_Charcoal_Pit.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_Charcoal_Pit.java
@@ -75,9 +75,8 @@ public class GT_MetaTileEntity_Charcoal_Pit extends GT_MetaTileEntity_MultiBlock
 
     @Override
     public boolean onRightclick(IGregTechTileEntity aBaseMetaTileEntity, EntityPlayer aPlayer) {
-        if (aBaseMetaTileEntity.isClientSide()) return true;
-
-        return true;
+        // No GUI, do not capture right-click so it does not interfere when placing logs
+        return false;
     }
 
     public boolean isCorrectMachinePart(ItemStack aStack) {


### PR DESCRIPTION
The Charcoal-Pit Igniter has no GUI but was needlessly capturing player's right-clicks.

It was an inconvenience when right-clicking on the pit's ceiling, because when reaching the Igniter, the right-click was captured and player needed to sneak, to place a log block under the Igniter.