### PR TITLE
Allow client to proactively request fluid display updates

### DIFF
--- a/src/main/java/gregtech/GT_Mod.java
+++ b/src/main/java/gregtech/GT_Mod.java
@@ -265,6 +265,7 @@ public class GT_Mod implements IGT_Mod {
         GT_Values.D1 = tMainConfig.get(aTextGeneral, "Debug", false).getBoolean(false);
         GT_Values.D2 = tMainConfig.get(aTextGeneral, "Debug2", false).getBoolean(false);
         GT_Values.hideAssLineRecipes = tMainConfig.get(aTextGeneral, "hide assline recipes", false).getBoolean(false);
+        GT_Values.updateFluidDisplayItems = tMainConfig.get(aTextGeneral, "update fluid display items", true).getBoolean(true);
         GT_Values.allow_broken_recipemap = tMainConfig.get(aTextGeneral, "debug allow broken recipemap", false).getBoolean(false);
         GT_Values.debugCleanroom = tMainConfig.get(aTextGeneral, "debugCleanroom", false).getBoolean(false);
         GT_Values.debugDriller = tMainConfig.get(aTextGeneral, "debugDriller", false).getBoolean(false);

--- a/src/main/java/gregtech/api/enums/GT_Values.java
+++ b/src/main/java/gregtech/api/enums/GT_Values.java
@@ -300,5 +300,6 @@ public class GT_Values {
     public static boolean cls_enabled;
     
     public static boolean hideAssLineRecipes = false;
+    public static boolean updateFluidDisplayItems = true;
     public static final int STEAM_PER_WATER = 160;
 }

--- a/src/main/java/gregtech/api/interfaces/IHasFluidDisplayItem.java
+++ b/src/main/java/gregtech/api/interfaces/IHasFluidDisplayItem.java
@@ -1,0 +1,5 @@
+package gregtech.api.interfaces;
+
+public interface IHasFluidDisplayItem {
+    void updateFluidDisplayItem();
+}

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicMachine.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicMachine.java
@@ -579,7 +579,7 @@ public abstract class GT_MetaTileEntity_BasicMachine extends GT_MetaTileEntity_B
     }
 
     @Override
-    protected void updateFluidDisplayItem() {
+    public void updateFluidDisplayItem() {
         super.updateFluidDisplayItem();
         if (displaysInputFluid()) {
             int tDisplayStackSlot = OTHER_SLOT_COUNT + mInputSlotCount + mOutputItems.length;

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicTank.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicTank.java
@@ -3,6 +3,7 @@ package gregtech.api.metatileentity.implementations;
 import gregtech.api.enums.ItemList;
 import gregtech.api.gui.GT_Container_BasicTank;
 import gregtech.api.gui.GT_GUIContainer_BasicTank;
+import gregtech.api.interfaces.IHasFluidDisplayItem;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.util.GT_Utility;
@@ -18,7 +19,7 @@ import net.minecraftforge.fluids.FluidTankInfo;
  * <p/>
  * This is the main construct for my generic Tanks. Filling and emptying behavior have to be implemented manually
  */
-public abstract class GT_MetaTileEntity_BasicTank extends GT_MetaTileEntity_TieredMachineBlock {
+public abstract class GT_MetaTileEntity_BasicTank extends GT_MetaTileEntity_TieredMachineBlock implements IHasFluidDisplayItem {
 
     public FluidStack mFluid;
     protected int mOpenerCount;
@@ -190,7 +191,8 @@ public abstract class GT_MetaTileEntity_BasicTank extends GT_MetaTileEntity_Tier
         }
     }
 
-    protected void updateFluidDisplayItem() {
+    @Override
+    public void updateFluidDisplayItem() {
         if (displaysItemStack() && getStackDisplaySlot() >= 0 && getStackDisplaySlot() < mInventory.length) {
             if (getDisplayedFluid() == null) {
                 if (ItemList.Display_Fluid.isStackEqual(mInventory[getStackDisplaySlot()], true, true))

--- a/src/main/java/gregtech/common/GT_Network.java
+++ b/src/main/java/gregtech/common/GT_Network.java
@@ -11,6 +11,7 @@ import gregtech.api.enums.GT_Values;
 import gregtech.api.net.*;
 import gregtech.common.blocks.GT_Packet_Ores;
 import gregtech.common.net.MessageSetFlaskCapacity;
+import gregtech.common.net.MessageUpdateFluidDisplayItem;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
@@ -32,8 +33,8 @@ public class GT_Network extends MessageToMessageCodec<FMLProxyPacket, GT_Packet>
     private final GT_Packet[] mSubChannels;
 
     public GT_Network() {
-        this.mChannel = NetworkRegistry.INSTANCE.newChannel("GregTech", new ChannelHandler[]{this, new HandlerShared()});
-        this.mSubChannels = new GT_Packet[]{new GT_Packet_TileEntity(), new GT_Packet_Sound(), new GT_Packet_Block_Event(), new GT_Packet_Ores(), new GT_Packet_Pollution(), new MessageSetFlaskCapacity(), new GT_Packet_TileEntityCover(), new GT_Packet_TileEntityCoverGUI()};
+        this.mChannel = NetworkRegistry.INSTANCE.newChannel("GregTech", this, new HandlerShared());
+        this.mSubChannels = new GT_Packet[]{new GT_Packet_TileEntity(), new GT_Packet_Sound(), new GT_Packet_Block_Event(), new GT_Packet_Ores(), new GT_Packet_Pollution(), new MessageSetFlaskCapacity(), new GT_Packet_TileEntityCover(), new GT_Packet_TileEntityCoverGUI(), new MessageUpdateFluidDisplayItem()};
     }
 
     protected void encode(ChannelHandlerContext aContext, GT_Packet aPacket, List<Object> aOutput)

--- a/src/main/java/gregtech/common/net/MessageUpdateFluidDisplayItem.java
+++ b/src/main/java/gregtech/common/net/MessageUpdateFluidDisplayItem.java
@@ -1,0 +1,64 @@
+package gregtech.common.net;
+
+import com.google.common.io.ByteArrayDataInput;
+import com.google.common.io.ByteArrayDataOutput;
+import com.google.common.io.ByteStreams;
+import gregtech.api.interfaces.IHasFluidDisplayItem;
+import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
+import gregtech.api.net.GT_Packet;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.IBlockAccess;
+import net.minecraft.world.WorldServer;
+import net.minecraftforge.common.DimensionManager;
+
+public class MessageUpdateFluidDisplayItem extends GT_Packet {
+    private int mBlockX, mBlockY, mBlockZ, mDim;
+
+    public MessageUpdateFluidDisplayItem() {
+        super(true);
+    }
+
+    public MessageUpdateFluidDisplayItem(int mBlockX, int mBlockY, int mBlockZ, int mDim) {
+        super(false);
+        this.mBlockX = mBlockX;
+        this.mBlockY = mBlockY;
+        this.mBlockZ = mBlockZ;
+        this.mDim = mDim;
+    }
+
+    @Override
+    public byte getPacketID() {
+        return 8;
+    }
+
+    @Override
+    public byte[] encode() {
+        ByteArrayDataOutput os = ByteStreams.newDataOutput(32);
+        os.writeInt(mBlockX);
+        os.writeInt(mBlockY);
+        os.writeInt(mBlockZ);
+        os.writeInt(mDim);
+        return os.toByteArray();
+    }
+
+    @Override
+    public GT_Packet decode(ByteArrayDataInput aData) {
+        return new MessageUpdateFluidDisplayItem(aData.readInt(), aData.readInt(), aData.readInt(), aData.readInt());
+    }
+
+    @Override
+    public void process(IBlockAccess aWorld) {
+        WorldServer world = DimensionManager.getWorld(mDim);
+        if (world != null) {
+            if (world.blockExists(mBlockX, mBlockY, mBlockZ)) {
+                TileEntity tileEntity = world.getTileEntity(mBlockX, mBlockY, mBlockZ);
+                if (tileEntity instanceof IGregTechTileEntity) {
+                    IGregTechTileEntity gtTile = (IGregTechTileEntity) tileEntity;
+                    if (gtTile.getMetaTileEntity() instanceof IHasFluidDisplayItem) {
+                        ((IHasFluidDisplayItem) gtTile.getMetaTileEntity()).updateFluidDisplayItem();
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Currently client will only request update on blocks being looked at. However it can be easily extended to include other situation as well. Any suggestion would be welcomed.