### PR TITLE
Remove ic2 iridium ore to iridium ingot recipe

### DIFF
--- a/src/main/java/gregtech/GT_Mod.java
+++ b/src/main/java/gregtech/GT_Mod.java
@@ -800,6 +800,12 @@ public class GT_Mod implements IGT_Mod {
 
         stopwatch.reset();
         stopwatch.start();
+        // remove gemIridium exploit
+        ItemStack iridiumOre = GT_ModHandler.getIC2Item("iridiumOre", 1);
+        aCompressorRecipeList.entrySet().parallelStream()
+                .filter(e -> e.getKey().getInputs().size() == 1 && e.getKey().getInputs().get(0).isItemEqual(iridiumOre))
+                .findAny()
+                .ifPresent(e -> aCompressorRecipeList.remove(e.getKey()));
         //Add default IC2 recipe to GT
         GT_ModHandler.addIC2RecipesToGT(aMaceratorRecipeList, GT_Recipe.GT_Recipe_Map.sMaceratorRecipes, true, true, true);
         GT_ModHandler.addIC2RecipesToGT(aCompressorRecipeList, GT_Recipe.GT_Recipe_Map.sCompressorRecipes, true, true, true);


### PR DESCRIPTION
GTNewHorizons/GT-New-Horizons-Modpack#7858

The recipe that enables exploits is this one.
![exploit](https://user-images.githubusercontent.com/64061913/115972920-330fea80-a506-11eb-8345-c9dfefa9b785.png)
This recipe is copied over from ic2 machines.
 I'm unable to find out who added this recipe to ic2 in the first place, so I'll just find a convenient place and remove it.