### PR TITLE
Increase transformer eu storage cap

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Transformer.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Transformer.java
@@ -115,7 +115,7 @@ public class GT_MetaTileEntity_Transformer extends GT_MetaTileEntity_TieredMachi
 
     @Override
     public long maxEUStore() {
-        return 512L + V[mTier + 1] * 2L;
+        return Math.min(512L, 1L << mTier) + V[mTier + 1] * 2L;
     }
 
     @Override


### PR DESCRIPTION
GTNewHorizons/GT-New-Horizons-Modpack#4135

The eu storage cap is not high enough for high tier transformers, so it can never properly output power in step up mode.