### PR TITLE
Fix NPE in GT_Client

### DIFF
--- a/src/main/java/gregtech/common/GT_Client.java
+++ b/src/main/java/gregtech/common/GT_Client.java
@@ -415,7 +415,7 @@ public class GT_Client extends GT_Proxy
             if(!GregTech_API.mServerStarted) GregTech_API.mServerStarted = true;
             if (GT_Values.updateFluidDisplayItems) {
                 MovingObjectPosition trace = Minecraft.getMinecraft().objectMouseOver;
-                if (trace.typeOfHit == MovingObjectPosition.MovingObjectType.BLOCK &&
+                if (trace != null && trace.typeOfHit == MovingObjectPosition.MovingObjectType.BLOCK &&
                         (mLastUpdatedBlockX != trace.blockX &&
                         mLastUpdatedBlockY != trace.blockY &&
                         mLastUpdatedBlockZ != trace.blockZ || afterSomeTime % 10 == 0)) {


### PR DESCRIPTION
https://cdn.discordapp.com/attachments/522098956491030558/843959046229721128/crash-2021-05-17_14.10.19-client.txt

It appears some mod in full pack would cause this field to be null. Let's ignore this condition. It will be overwritten into something better soon next or next several ticks.