### PR TITLE
Get rid of intermediate byte array while sending packet

### DIFF
--- a/src/main/java/gregtech/api/net/GT_Packet.java
+++ b/src/main/java/gregtech/api/net/GT_Packet.java
@@ -1,8 +1,13 @@
 package gregtech.api.net;
 
 import com.google.common.io.ByteArrayDataInput;
+import io.netty.buffer.ByteBuf;
 import net.minecraft.world.IBlockAccess;
 
+/**
+ * @deprecated Use {@link GT_Packet_New} instead
+ */
+@Deprecated
 public abstract class GT_Packet {
     public GT_Packet(boolean aIsReference) {
         //
@@ -17,13 +22,28 @@ public abstract class GT_Packet {
 
     /**
      * @return encoded byte Stream
+     * @deprecated Use {@link #encode(ByteBuf)} instead
      */
+    @Deprecated
     public abstract byte[] encode();
+
+    /**
+     * Encode the data into given byte buffer without creating an intermediate byte array.
+     * Default implementation just throw {@link UnsupportedOperationException}.
+     */
+    public void encode(ByteBuf aOut) {
+        throw new UnsupportedOperationException();
+    }
 
     /**
      * @return encoded byte Stream
      */
     public abstract GT_Packet decode(ByteArrayDataInput aData);
 
+    /**
+     * Process the packet
+     *
+     * @param aWorld null if message is received on server side, the client world if message is received on client side
+     */
     public abstract void process(IBlockAccess aWorld);
 }

--- a/src/main/java/gregtech/api/net/GT_Packet_Block_Event.java
+++ b/src/main/java/gregtech/api/net/GT_Packet_Block_Event.java
@@ -1,15 +1,14 @@
 package gregtech.api.net;
 
 import com.google.common.io.ByteArrayDataInput;
-import com.google.common.io.ByteArrayDataOutput;
-import com.google.common.io.ByteStreams;
+import io.netty.buffer.ByteBuf;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.IBlockAccess;
 
 /**
  * Used to transfer Block Events in a much better fashion
  */
-public class GT_Packet_Block_Event extends GT_Packet {
+public class GT_Packet_Block_Event extends GT_Packet_New {
     private int mX, mZ;
     private short mY;
     private byte mID, mValue;
@@ -28,18 +27,16 @@ public class GT_Packet_Block_Event extends GT_Packet {
     }
 
     @Override
-    public byte[] encode() {
-        ByteArrayDataOutput tOut = ByteStreams.newDataOutput(10);
-        tOut.writeInt(mX);
-        tOut.writeShort(mY);
-        tOut.writeInt(mZ);
-        tOut.writeByte(mID);
-        tOut.writeByte(mValue);
-        return tOut.toByteArray();
+    public void encode(ByteBuf aOut) {
+        aOut.writeInt(mX);
+        aOut.writeShort(mY);
+        aOut.writeInt(mZ);
+        aOut.writeByte(mID);
+        aOut.writeByte(mValue);
     }
 
     @Override
-    public GT_Packet decode(ByteArrayDataInput aData) {
+    public GT_Packet_New decode(ByteArrayDataInput aData) {
         return new GT_Packet_Block_Event(aData.readInt(), aData.readShort(), aData.readInt(), aData.readByte(), aData.readByte());
     }
 

--- a/src/main/java/gregtech/api/net/GT_Packet_New.java
+++ b/src/main/java/gregtech/api/net/GT_Packet_New.java
@@ -1,0 +1,28 @@
+package gregtech.api.net;
+
+import com.google.common.io.ByteArrayDataInput;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
+@SuppressWarnings("deprecation")
+public abstract class GT_Packet_New extends GT_Packet {
+	public GT_Packet_New(boolean aIsReference) {
+		super(aIsReference);
+	}
+
+	@Override
+	@Deprecated
+	public final byte[] encode() {
+		ByteBuf tOut = Unpooled.buffer();
+		encode(tOut);
+		byte[] bytes = new byte[tOut.readableBytes()];
+		tOut.readBytes(bytes);
+		return bytes;
+	}
+
+	@Override
+	public abstract void encode(ByteBuf aOut);
+
+	@Override
+	public abstract GT_Packet_New decode(ByteArrayDataInput aData);
+}

--- a/src/main/java/gregtech/api/net/GT_Packet_Pollution.java
+++ b/src/main/java/gregtech/api/net/GT_Packet_Pollution.java
@@ -2,12 +2,11 @@ package gregtech.api.net;
 
 import com.google.common.io.ByteArrayDataInput;
 import gregtech.common.GT_Client;
+import io.netty.buffer.ByteBuf;
 import net.minecraft.world.ChunkCoordIntPair;
 import net.minecraft.world.IBlockAccess;
 
-import java.nio.ByteBuffer;
-
-public class GT_Packet_Pollution extends GT_Packet {
+public class GT_Packet_Pollution extends GT_Packet_New {
     private ChunkCoordIntPair chunk;
     private int pollution;
 
@@ -22,17 +21,12 @@ public class GT_Packet_Pollution extends GT_Packet {
     }
 
     @Override
-    public byte[] encode() {
-        return ByteBuffer
-                .allocate(12)
-                .putInt(chunk.chunkXPos)
-                .putInt(chunk.chunkZPos)
-                .putInt(pollution)
-                .array();
+    public void encode(ByteBuf aOut) {
+        aOut.writeInt(chunk.chunkXPos).writeInt(chunk.chunkZPos).writeInt(pollution);
     }
 
     @Override
-    public GT_Packet decode(ByteArrayDataInput aData) {
+    public GT_Packet_New decode(ByteArrayDataInput aData) {
         return new GT_Packet_Pollution(
                 new ChunkCoordIntPair(aData.readInt(), aData.readInt()),
                 aData.readInt()

--- a/src/main/java/gregtech/api/net/GT_Packet_Sound.java
+++ b/src/main/java/gregtech/api/net/GT_Packet_Sound.java
@@ -1,12 +1,16 @@
 package gregtech.api.net;
 
 import com.google.common.io.ByteArrayDataInput;
-import com.google.common.io.ByteArrayDataOutput;
-import com.google.common.io.ByteStreams;
+import gregtech.api.util.GT_Log;
 import gregtech.api.util.GT_Utility;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufOutputStream;
 import net.minecraft.world.IBlockAccess;
 
-public class GT_Packet_Sound extends GT_Packet {
+import java.io.DataOutput;
+import java.io.IOException;
+
+public class GT_Packet_Sound extends GT_Packet_New {
     private int mX, mZ;
     private short mY;
     private String mSoundName;
@@ -27,19 +31,23 @@ public class GT_Packet_Sound extends GT_Packet {
     }
 
     @Override
-    public byte[] encode() {
-        ByteArrayDataOutput tOut = ByteStreams.newDataOutput(10);
-        tOut.writeUTF(mSoundName);
-        tOut.writeFloat(mSoundStrength);
-        tOut.writeFloat(mSoundPitch);
-        tOut.writeInt(mX);
-        tOut.writeShort(mY);
-        tOut.writeInt(mZ);
-        return tOut.toByteArray();
+    public void encode(ByteBuf aOut) {
+        DataOutput tOut = new ByteBufOutputStream(aOut);
+        try {
+            tOut.writeUTF(mSoundName);
+            tOut.writeFloat(mSoundStrength);
+            tOut.writeFloat(mSoundPitch);
+            tOut.writeInt(mX);
+            tOut.writeShort(mY);
+            tOut.writeInt(mZ);
+        } catch (IOException e) {
+            // this really shouldn't happen, but whatever
+            e.printStackTrace(GT_Log.err);
+        }
     }
 
     @Override
-    public GT_Packet decode(ByteArrayDataInput aData) {
+    public GT_Packet_New decode(ByteArrayDataInput aData) {
         return new GT_Packet_Sound(aData.readUTF(), aData.readFloat(), aData.readFloat(), aData.readInt(), aData.readShort(), aData.readInt());
     }
 

--- a/src/main/java/gregtech/api/net/GT_Packet_TileEntity.java
+++ b/src/main/java/gregtech/api/net/GT_Packet_TileEntity.java
@@ -1,14 +1,13 @@
 package gregtech.api.net;
 
 import com.google.common.io.ByteArrayDataInput;
-import com.google.common.io.ByteArrayDataOutput;
-import com.google.common.io.ByteStreams;
 import gregtech.api.metatileentity.BaseMetaPipeEntity;
 import gregtech.api.metatileentity.BaseMetaTileEntity;
+import io.netty.buffer.ByteBuf;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.IBlockAccess;
 
-public class GT_Packet_TileEntity extends GT_Packet {
+public class GT_Packet_TileEntity extends GT_Packet_New {
     private int mX, mZ, mC0, mC1, mC2, mC3, mC4, mC5;
     private short mY, mID;
     private byte mTexture, mTexturePage, mUpdate, mRedstone, mColor;
@@ -58,32 +57,28 @@ public class GT_Packet_TileEntity extends GT_Packet {
     }
 
     @Override
-    public byte[] encode() {
-        ByteArrayDataOutput tOut = ByteStreams.newDataOutput(41);
+    public void encode(ByteBuf aOut) {
+        aOut.writeInt(mX);
+        aOut.writeShort(mY);
+        aOut.writeInt(mZ);
+        aOut.writeShort(mID);
 
-        tOut.writeInt(mX);
-        tOut.writeShort(mY);
-        tOut.writeInt(mZ);
-        tOut.writeShort(mID);
+        aOut.writeInt(mC0);
+        aOut.writeInt(mC1);
+        aOut.writeInt(mC2);
+        aOut.writeInt(mC3);
+        aOut.writeInt(mC4);
+        aOut.writeInt(mC5);
 
-        tOut.writeInt(mC0);
-        tOut.writeInt(mC1);
-        tOut.writeInt(mC2);
-        tOut.writeInt(mC3);
-        tOut.writeInt(mC4);
-        tOut.writeInt(mC5);
-
-        tOut.writeByte(mTexture);
-        tOut.writeByte(mTexturePage);
-        tOut.writeByte(mUpdate);
-        tOut.writeByte(mRedstone);
-        tOut.writeByte(mColor);
-
-        return tOut.toByteArray();
+        aOut.writeByte(mTexture);
+        aOut.writeByte(mTexturePage);
+        aOut.writeByte(mUpdate);
+        aOut.writeByte(mRedstone);
+        aOut.writeByte(mColor);
     }
 
     @Override
-    public GT_Packet decode(ByteArrayDataInput aData) {
+    public GT_Packet_New decode(ByteArrayDataInput aData) {
         return new GT_Packet_TileEntity(aData.readInt(), aData.readShort(), aData.readInt(), aData.readShort(), aData.readInt(), aData.readInt(), aData.readInt(), aData.readInt(), aData.readInt(), aData.readInt(), aData.readByte(), aData.readByte(), aData.readByte(), aData.readByte(), aData.readByte());
     }
 

--- a/src/main/java/gregtech/api/net/GT_Packet_TileEntityCover.java
+++ b/src/main/java/gregtech/api/net/GT_Packet_TileEntityCover.java
@@ -1,10 +1,9 @@
 package gregtech.api.net;
 
 import com.google.common.io.ByteArrayDataInput;
-import com.google.common.io.ByteArrayDataOutput;
-import com.google.common.io.ByteStreams;
 import gregtech.api.interfaces.tileentity.ICoverable;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
+import io.netty.buffer.ByteBuf;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
@@ -14,7 +13,7 @@ import net.minecraftforge.common.DimensionManager;
  * Client -> Server: Update cover data
  */
 
-public class GT_Packet_TileEntityCover extends GT_Packet {
+public class GT_Packet_TileEntityCover extends GT_Packet_New {
     protected int mX;
     protected short mY;
     protected int mZ;
@@ -57,23 +56,20 @@ public class GT_Packet_TileEntityCover extends GT_Packet {
     }
 
     @Override
-    public byte[] encode() {
-        ByteArrayDataOutput tOut = ByteStreams.newDataOutput(4+2+4+1+4+4+4);
-        tOut.writeInt(mX);
-        tOut.writeShort(mY);
-        tOut.writeInt(mZ);
+    public void encode(ByteBuf aOut) {
+        aOut.writeInt(mX);
+        aOut.writeShort(mY);
+        aOut.writeInt(mZ);
 
-        tOut.writeByte(side);
-        tOut.writeInt(coverID);
-        tOut.writeInt(coverData);
+        aOut.writeByte(side);
+        aOut.writeInt(coverID);
+        aOut.writeInt(coverData);
 
-        tOut.writeInt(dimID);
-
-        return tOut.toByteArray();
+        aOut.writeInt(dimID);
     }
 
     @Override
-    public GT_Packet decode(ByteArrayDataInput aData) {
+    public GT_Packet_New decode(ByteArrayDataInput aData) {
         return new GT_Packet_TileEntityCover(
                 aData.readInt(),
                 aData.readShort(),

--- a/src/main/java/gregtech/api/net/GT_Packet_TileEntityCoverGUI.java
+++ b/src/main/java/gregtech/api/net/GT_Packet_TileEntityCoverGUI.java
@@ -1,12 +1,11 @@
 package gregtech.api.net;
 
 import com.google.common.io.ByteArrayDataInput;
-import com.google.common.io.ByteArrayDataOutput;
-import com.google.common.io.ByteStreams;
 import gregtech.api.enums.GT_Values;
 import gregtech.api.interfaces.tileentity.ICoverable;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.common.GT_Proxy;
+import io.netty.buffer.ByteBuf;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityClientPlayerMP;
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -18,7 +17,7 @@ import net.minecraft.world.World;
  * Server -> Client: Show GUI
  */
 
-public class GT_Packet_TileEntityCoverGUI extends GT_Packet {
+public class GT_Packet_TileEntityCoverGUI extends GT_Packet_New {
     protected int mX;
     protected short mY;
     protected int mZ;
@@ -79,24 +78,21 @@ public class GT_Packet_TileEntityCoverGUI extends GT_Packet {
     }
 
     @Override
-    public byte[] encode() {
-        ByteArrayDataOutput tOut = ByteStreams.newDataOutput(4+2+4+1+4+4+4+4);
-        tOut.writeInt(mX);
-        tOut.writeShort(mY);
-        tOut.writeInt(mZ);
+    public void encode(ByteBuf aOut) {
+        aOut.writeInt(mX);
+        aOut.writeShort(mY);
+        aOut.writeInt(mZ);
 
-        tOut.writeByte(side);
-        tOut.writeInt(coverID);
-        tOut.writeInt(coverData);
+        aOut.writeByte(side);
+        aOut.writeInt(coverID);
+        aOut.writeInt(coverData);
 
-        tOut.writeInt(dimID);
-        tOut.writeInt(playerID);
-
-        return tOut.toByteArray();
+        aOut.writeInt(dimID);
+        aOut.writeInt(playerID);
     }
 
     @Override
-    public GT_Packet decode(ByteArrayDataInput aData) {
+    public GT_Packet_New decode(ByteArrayDataInput aData) {
         return new GT_Packet_TileEntityCoverGUI(
                 aData.readInt(),
                 aData.readShort(),

--- a/src/main/java/gregtech/api/net/IGT_NetworkHandler.java
+++ b/src/main/java/gregtech/api/net/IGT_NetworkHandler.java
@@ -4,12 +4,13 @@ import cpw.mods.fml.common.network.NetworkRegistry.TargetPoint;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.world.World;
 
+@SuppressWarnings("deprecation")
 public interface IGT_NetworkHandler {
-    public void sendToPlayer(GT_Packet aPacket, EntityPlayerMP aPlayer);
+    void sendToPlayer(GT_Packet aPacket, EntityPlayerMP aPlayer);
 
-    public void sendToAllAround(GT_Packet aPacket, TargetPoint aPosition);
+    void sendToAllAround(GT_Packet aPacket, TargetPoint aPosition);
 
-    public void sendToServer(GT_Packet aPacket);
+    void sendToServer(GT_Packet aPacket);
 
-    public void sendPacketToAllPlayersInRange(World aWorld, GT_Packet aPacket, int aX, int aZ);
+    void sendPacketToAllPlayersInRange(World aWorld, GT_Packet aPacket, int aX, int aZ);
 }

--- a/src/main/java/gregtech/common/blocks/GT_Packet_Ores.java
+++ b/src/main/java/gregtech/common/blocks/GT_Packet_Ores.java
@@ -1,14 +1,13 @@
 package gregtech.common.blocks;
 
 import com.google.common.io.ByteArrayDataInput;
-import com.google.common.io.ByteArrayDataOutput;
-import com.google.common.io.ByteStreams;
-import gregtech.api.net.GT_Packet;
+import gregtech.api.net.GT_Packet_New;
+import io.netty.buffer.ByteBuf;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
-public class GT_Packet_Ores extends GT_Packet {
+public class GT_Packet_Ores extends GT_Packet_New {
     private int mX;
     private int mZ;
     private short mY;
@@ -26,18 +25,15 @@ public class GT_Packet_Ores extends GT_Packet {
         this.mMetaData = aMetaData;
     }
 
-    public byte[] encode() {
-        ByteArrayDataOutput tOut = ByteStreams.newDataOutput(12);
-
-        tOut.writeInt(this.mX);
-        tOut.writeShort(this.mY);
-        tOut.writeInt(this.mZ);
-        tOut.writeShort(this.mMetaData);
-
-        return tOut.toByteArray();
+    @Override
+    public void encode(ByteBuf aOut) {
+        aOut.writeInt(this.mX);
+        aOut.writeShort(this.mY);
+        aOut.writeInt(this.mZ);
+        aOut.writeShort(this.mMetaData);
     }
 
-    public GT_Packet decode(ByteArrayDataInput aData) {
+    public GT_Packet_New decode(ByteArrayDataInput aData) {
         return new GT_Packet_Ores(aData.readInt(), aData.readShort(), aData.readInt(), aData.readShort());
     }
 

--- a/src/main/java/gregtech/common/net/MessageSetFlaskCapacity.java
+++ b/src/main/java/gregtech/common/net/MessageSetFlaskCapacity.java
@@ -1,10 +1,9 @@
 package gregtech.common.net;
 
 import com.google.common.io.ByteArrayDataInput;
-import com.google.common.io.ByteArrayDataOutput;
-import com.google.common.io.ByteStreams;
-import gregtech.api.net.GT_Packet;
+import gregtech.api.net.GT_Packet_New;
 import gregtech.common.items.GT_VolumetricFlask;
+import io.netty.buffer.ByteBuf;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -12,7 +11,7 @@ import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.common.DimensionManager;
 
-public final class MessageSetFlaskCapacity extends GT_Packet {
+public final class MessageSetFlaskCapacity extends GT_Packet_New {
     private int capacity, dimID, playerID;
 
     public MessageSetFlaskCapacity() {
@@ -39,16 +38,14 @@ public final class MessageSetFlaskCapacity extends GT_Packet {
     }
 
     @Override
-    public byte[] encode() {
-        ByteArrayDataOutput tOut = ByteStreams.newDataOutput(10);
-        tOut.writeInt(capacity);
-        tOut.writeInt(dimID);
-        tOut.writeInt(playerID);
-        return tOut.toByteArray();
+    public void encode(ByteBuf aOut) {
+        aOut.writeInt(capacity);
+        aOut.writeInt(dimID);
+        aOut.writeInt(playerID);
     }
 
     @Override
-    public GT_Packet decode(ByteArrayDataInput aData) {
+    public GT_Packet_New decode(ByteArrayDataInput aData) {
         return new MessageSetFlaskCapacity(aData.readInt(), aData.readInt(), aData.readInt());
     }
 

--- a/src/main/java/gregtech/common/net/MessageUpdateFluidDisplayItem.java
+++ b/src/main/java/gregtech/common/net/MessageUpdateFluidDisplayItem.java
@@ -1,17 +1,16 @@
 package gregtech.common.net;
 
 import com.google.common.io.ByteArrayDataInput;
-import com.google.common.io.ByteArrayDataOutput;
-import com.google.common.io.ByteStreams;
 import gregtech.api.interfaces.IHasFluidDisplayItem;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
-import gregtech.api.net.GT_Packet;
+import gregtech.api.net.GT_Packet_New;
+import io.netty.buffer.ByteBuf;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.WorldServer;
 import net.minecraftforge.common.DimensionManager;
 
-public class MessageUpdateFluidDisplayItem extends GT_Packet {
+public class MessageUpdateFluidDisplayItem extends GT_Packet_New {
     private int mBlockX, mBlockY, mBlockZ, mDim;
 
     public MessageUpdateFluidDisplayItem() {
@@ -32,17 +31,15 @@ public class MessageUpdateFluidDisplayItem extends GT_Packet {
     }
 
     @Override
-    public byte[] encode() {
-        ByteArrayDataOutput os = ByteStreams.newDataOutput(32);
-        os.writeInt(mBlockX);
-        os.writeInt(mBlockY);
-        os.writeInt(mBlockZ);
-        os.writeInt(mDim);
-        return os.toByteArray();
+    public void encode(ByteBuf aOut) {
+        aOut.writeInt(mBlockX);
+        aOut.writeInt(mBlockY);
+        aOut.writeInt(mBlockZ);
+        aOut.writeInt(mDim);
     }
 
     @Override
-    public GT_Packet decode(ByteArrayDataInput aData) {
+    public GT_Packet_New decode(ByteArrayDataInput aData) {
         return new MessageUpdateFluidDisplayItem(aData.readInt(), aData.readInt(), aData.readInt(), aData.readInt());
     }
 


### PR DESCRIPTION
I'm fed up with this intermediate byte array creation during structure lib integration. This change 

1. Does not impact gameplay
2. Have minor performance improvement over old version
3. Is compatible with addons without recompile
4. Addons will not have compile errors. It would indeed give a bunch of deprecation warnings though.
5. Does not have new deprecation warnings when compiling GT5 itself.

This also removes an unnecessary `copy()` in `gregtech.common.GT_Network#encode`. I asked greg himself on irc and this is his response:

> <GregoriusTechneticies> hrrm, i actually copied that line myself from some forge thing, wouldnt be surprised if it was fucked up XD
> <GregoriusTechneticies> im gonna remove that copy() in gt6 and will see what happens