### PR TITLE
It's ugly, but it works.

### DIFF
--- a/src/main/java/gregtech/api/util/GT_ModHandler.java
+++ b/src/main/java/gregtech/api/util/GT_ModHandler.java
@@ -63,6 +63,7 @@ import java.util.stream.Collectors;
 
 import static gregtech.GT_Mod.GT_FML_LOGGER;
 import static gregtech.api.enums.GT_Values.B;
+
 import static gregtech.api.enums.GT_Values.D1;
 import static gregtech.api.enums.GT_Values.DW;
 import static gregtech.api.enums.GT_Values.E;
@@ -1332,6 +1333,7 @@ public class GT_ModHandler {
         delayedRemovalByRecipe.add(aCrafting);
     }
 
+    @SuppressWarnings("unchecked")
     public static void bulkRemoveByRecipe(List<InventoryCrafting> toRemove) {
         ArrayList<IRecipe> tList = (ArrayList<IRecipe>) CraftingManager.getInstance().getRecipeList();
         GT_FML_LOGGER.info("BulkRemoveByRecipe: tList: " + tList.size() + " toRemove: " + toRemove.size() );
@@ -1483,14 +1485,23 @@ public class GT_ModHandler {
      * Used for Recipe Detection.
      */
     public static ItemStack getRecipeOutput(ItemStack... aRecipe) {
-        return getRecipeOutput(false, aRecipe);
+        return getRecipeOutput(false, true, aRecipe);
     }
-
+    
+    public static ItemStack getRecipeOutputNoOreDict(ItemStack... aRecipe) {
+        return getRecipeOutput(false,false, aRecipe);
+    }
+    
+    public static ItemStack getRecipeOutput(boolean aUncopiedStack, ItemStack... aRecipe) {
+        return getRecipeOutput(aUncopiedStack, true, aRecipe);
+    }
+    
     /**
      * Gives you a copy of the Output from a Crafting Recipe
      * Used for Recipe Detection.
      */
-    public static ItemStack getRecipeOutput(boolean aUncopiedStack, ItemStack... aRecipe) {
+    @SuppressWarnings("unchecked")
+    public static ItemStack getRecipeOutput(boolean aUncopiedStack, boolean allowOreDict, ItemStack... aRecipe) {
         if (aRecipe == null || Arrays.stream(aRecipe).noneMatch(Objects::nonNull)) return null;
 
         InventoryCrafting aCrafting = new InventoryCrafting(new Container() {
@@ -1505,6 +1516,8 @@ public class GT_ModHandler {
         
         for (IRecipe iRecipe : tList) {
             found = false;
+            if (!allowOreDict && iRecipe instanceof ShapedOreRecipe) continue;
+            
             try {
                 found = iRecipe.matches(aCrafting, DW);
             } catch (Throwable e) {

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingPlank.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingPlank.java
@@ -36,6 +36,7 @@ public class ProcessingPlank implements gregtech.api.interfaces.IOreRecipeRegist
             if (aStack.getItemDamage() == 32767) {
                 for (byte i = 0; i < 64; i = (byte) (i + 1)) {
                     ItemStack tStack = GT_Utility.copyMetaData(i, aStack);
+                    // Get Recipe and Output, add recipe to delayed removal
                     ItemStack tOutput = GT_ModHandler.getRecipeOutput(tStack, tStack, tStack);
                     if ((tOutput != null) && (tOutput.stackSize >= 3)) {
                         GT_Values.RA.addCutterRecipe(GT_Utility.copyAmount(1L, tStack), GT_Utility.copyAmount(tOutput.stackSize / 3, tOutput), null, 25, 4);
@@ -45,7 +46,7 @@ public class ProcessingPlank implements gregtech.api.interfaces.IOreRecipeRegist
                     if((tStack == null) && (i >= 16)) break;
                 }
             } else {
-                ItemStack tOutput = GT_ModHandler.getRecipeOutput(aStack, aStack, aStack);
+                ItemStack tOutput = !aModName.equalsIgnoreCase("thaumcraft") ? GT_ModHandler.getRecipeOutput(aStack, aStack, aStack) : GT_ModHandler.getRecipeOutputNoOreDict(aStack, aStack, aStack);
                 if ((tOutput != null) && (tOutput.stackSize >= 3)) {
                     GT_Values.RA.addCutterRecipe(GT_Utility.copyAmount(1L, aStack), GT_Utility.copyAmount(tOutput.stackSize / 3, tOutput), null, 25, 4);
                     GT_ModHandler.removeRecipeDelayed(aStack, aStack, aStack);


### PR DESCRIPTION
Problem:  ProcessingPlank goes through each plank, finds the first recipe that matches `{plank, plank, plank}`, removes that recipe, and then adds the GT recipes for slabs.  This worked until buffered deletes & additions were added, the same slab can be found multiple times.

Correct solution: Don't allow a "removed" recipe to be found.  Problem is that's expensive without a bunch of re architecture, and only seems to be impacting the greatwood & silverwood slabs.

Hacky solution: Don't allow oredict recipes for slabs when looking at a thaumcraft plank --> slab.


Open to other ideas, but this works.