### PR TITLE
Allow client send preference to server

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicMachine.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicMachine.java
@@ -15,6 +15,7 @@ import gregtech.api.util.GT_OreDictUnificator;
 import gregtech.api.util.GT_Recipe;
 import gregtech.api.util.GT_Recipe.GT_Recipe_Map;
 import gregtech.api.util.GT_Utility;
+import gregtech.api.util.GT_ClientPreference;
 import gregtech.common.tileentities.machines.multi.GT_MetaTileEntity_Cleanroom;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
@@ -417,6 +418,11 @@ public abstract class GT_MetaTileEntity_BasicMachine extends GT_MetaTileEntity_B
     @Override
     public void initDefaultModes(NBTTagCompound aNBT) {
         mMainFacing = -1;
+        if (!getBaseMetaTileEntity().getWorld().isRemote) {
+            GT_ClientPreference tPreference = GT_Mod.gregtechproxy.getClientPreference(getBaseMetaTileEntity().getOwnerUuid());
+            if (tPreference != null)
+                mDisableFilter = !tPreference.isSingleBlockInitialFilterEnabled();
+        }
     }
 
     @Override

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_InputBus.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_InputBus.java
@@ -1,5 +1,6 @@
 package gregtech.api.metatileentity.implementations;
 
+import gregtech.GT_Mod;
 import gregtech.api.gui.GT_Container_1by1;
 import gregtech.api.gui.GT_Container_2by2;
 import gregtech.api.gui.GT_Container_3by3;
@@ -12,6 +13,7 @@ import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.render.TextureFactory;
+import gregtech.api.util.GT_ClientPreference;
 import gregtech.api.util.GT_LanguageManager;
 import gregtech.api.util.GT_Recipe.GT_Recipe_Map;
 import gregtech.api.util.GT_Utility;
@@ -96,6 +98,15 @@ public class GT_MetaTileEntity_Hatch_InputBus extends GT_MetaTileEntity_Hatch {
                 return new GT_Container_3by3(aPlayerInventory, aBaseMetaTileEntity);
             default:
                 return new GT_Container_4by4(aPlayerInventory, aBaseMetaTileEntity);
+        }
+    }
+
+    @Override
+    public void initDefaultModes(NBTTagCompound aNBT) {
+        if (!getBaseMetaTileEntity().getWorld().isRemote) {
+            GT_ClientPreference tPreference = GT_Mod.gregtechproxy.getClientPreference(getBaseMetaTileEntity().getOwnerUuid());
+            if (tPreference != null)
+                disableFilter = !tPreference.isInputBusInitialFilterEnabled();
         }
     }
 

--- a/src/main/java/gregtech/api/net/GT_Packet.java
+++ b/src/main/java/gregtech/api/net/GT_Packet.java
@@ -2,6 +2,7 @@ package gregtech.api.net;
 
 import com.google.common.io.ByteArrayDataInput;
 import io.netty.buffer.ByteBuf;
+import net.minecraft.network.INetHandler;
 import net.minecraft.world.IBlockAccess;
 
 /**
@@ -46,4 +47,9 @@ public abstract class GT_Packet {
      * @param aWorld null if message is received on server side, the client world if message is received on client side
      */
     public abstract void process(IBlockAccess aWorld);
+
+    /**
+     * This will be called just before {@link #process(IBlockAccess)} to inform the handler about the source and type of connection
+     */
+    public void setINetHandler(INetHandler aHandler) {}
 }

--- a/src/main/java/gregtech/api/net/GT_Packet_ClientPreference.java
+++ b/src/main/java/gregtech/api/net/GT_Packet_ClientPreference.java
@@ -1,0 +1,52 @@
+package gregtech.api.net;
+
+import com.google.common.io.ByteArrayDataInput;
+import gregtech.GT_Mod;
+import gregtech.api.util.GT_ClientPreference;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.network.INetHandler;
+import net.minecraft.network.NetHandlerPlayServer;
+import net.minecraft.world.IBlockAccess;
+
+public class GT_Packet_ClientPreference extends GT_Packet_New {
+    private GT_ClientPreference mPreference;
+    private EntityPlayerMP mPlayer;
+
+    public GT_Packet_ClientPreference() {
+        super(true);
+    }
+
+    public GT_Packet_ClientPreference(GT_ClientPreference mPreference) {
+        super(false);
+        this.mPreference = mPreference;
+    }
+
+    @Override
+    public byte getPacketID() {
+        return 9;
+    }
+
+    @Override
+    public void setINetHandler(INetHandler aHandler) {
+        if (aHandler instanceof NetHandlerPlayServer) {
+            mPlayer = ((NetHandlerPlayServer) aHandler).playerEntity;
+        }
+    }
+
+    @Override
+    public void process(IBlockAccess aWorld) {
+        if (mPlayer != null)
+            GT_Mod.gregtechproxy.setClientPreference(mPlayer.getUniqueID(), mPreference);
+    }
+
+    @Override
+    public void encode(ByteBuf aOut) {
+        aOut.writeBoolean(mPreference.isSingleBlockInitialFilterEnabled());
+    }
+
+    @Override
+    public GT_Packet_New decode(ByteArrayDataInput aData) {
+        return new GT_Packet_ClientPreference(new GT_ClientPreference(aData.readBoolean()));
+    }
+}

--- a/src/main/java/gregtech/api/net/GT_Packet_ClientPreference.java
+++ b/src/main/java/gregtech/api/net/GT_Packet_ClientPreference.java
@@ -43,10 +43,11 @@ public class GT_Packet_ClientPreference extends GT_Packet_New {
     @Override
     public void encode(ByteBuf aOut) {
         aOut.writeBoolean(mPreference.isSingleBlockInitialFilterEnabled());
+        aOut.writeBoolean(mPreference.isInputBusInitialFilterEnabled());
     }
 
     @Override
     public GT_Packet_New decode(ByteArrayDataInput aData) {
-        return new GT_Packet_ClientPreference(new GT_ClientPreference(aData.readBoolean()));
+        return new GT_Packet_ClientPreference(new GT_ClientPreference(aData.readBoolean(), aData.readBoolean()));
     }
 }

--- a/src/main/java/gregtech/api/util/GT_ClientPreference.java
+++ b/src/main/java/gregtech/api/util/GT_ClientPreference.java
@@ -1,0 +1,17 @@
+package gregtech.api.util;
+
+public class GT_ClientPreference {
+    private final boolean mSingleBlockInitialFilter;
+
+    public GT_ClientPreference(boolean mSingleBlockInitialFilter) {
+        this.mSingleBlockInitialFilter = mSingleBlockInitialFilter;
+    }
+
+    public GT_ClientPreference(GT_Config aClientDataFile) {
+        this.mSingleBlockInitialFilter = aClientDataFile.get("preference", "mSingleBlockInitialFilter", false);
+    }
+
+    public boolean isSingleBlockInitialFilterEnabled() {
+        return mSingleBlockInitialFilter;
+    }
+}

--- a/src/main/java/gregtech/api/util/GT_ClientPreference.java
+++ b/src/main/java/gregtech/api/util/GT_ClientPreference.java
@@ -2,16 +2,23 @@ package gregtech.api.util;
 
 public class GT_ClientPreference {
     private final boolean mSingleBlockInitialFilter;
+    private final boolean mInputBusInitialFilter;
 
-    public GT_ClientPreference(boolean mSingleBlockInitialFilter) {
+    public GT_ClientPreference(boolean mSingleBlockInitialFilter, boolean mInputBusInitialFilter) {
         this.mSingleBlockInitialFilter = mSingleBlockInitialFilter;
+        this.mInputBusInitialFilter = mInputBusInitialFilter;
     }
 
     public GT_ClientPreference(GT_Config aClientDataFile) {
         this.mSingleBlockInitialFilter = aClientDataFile.get("preference", "mSingleBlockInitialFilter", false);
+        this.mInputBusInitialFilter = aClientDataFile.get("preference", "mInputBusInitialFilter", true);
     }
 
     public boolean isSingleBlockInitialFilterEnabled() {
         return mSingleBlockInitialFilter;
+    }
+
+    public boolean isInputBusInitialFilterEnabled() {
+        return mInputBusInitialFilter;
     }
 }

--- a/src/main/java/gregtech/common/GT_Client.java
+++ b/src/main/java/gregtech/common/GT_Client.java
@@ -9,6 +9,7 @@ import codechicken.lib.vec.Rotation;
 import cpw.mods.fml.client.registry.RenderingRegistry;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.TickEvent;
+import cpw.mods.fml.common.network.FMLNetworkEvent;
 import gregtech.GT_Mod;
 import gregtech.api.GregTech_API;
 import gregtech.api.enums.GT_Values;
@@ -18,6 +19,7 @@ import gregtech.api.interfaces.tileentity.ICoverable;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.interfaces.tileentity.ITurnable;
 import gregtech.api.metatileentity.BaseMetaPipeEntity;
+import gregtech.api.net.GT_Packet_ClientPreference;
 import gregtech.api.objects.GT_ItemStack;
 import gregtech.api.util.*;
 import gregtech.common.entities.GT_Entity_Arrow;
@@ -27,6 +29,7 @@ import gregtech.common.render.*;
 import ic2.api.tile.IWrenchable;
 import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.WorldClient;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
@@ -36,6 +39,7 @@ import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.world.ChunkCoordIntPair;
 import net.minecraft.world.World;
 import net.minecraftforge.client.event.DrawBlockHighlightEvent;
+import net.minecraftforge.event.world.WorldEvent;
 import net.minecraftforge.oredict.OreDictionary;
 import org.lwjgl.opengl.GL11;
 
@@ -85,6 +89,8 @@ public class GT_Client extends GT_Proxy
     private int mLastUpdatedBlockZ;
     private boolean isFirstClientPlayerTick;
     private String mMessage;
+    private GT_ClientPreference mPreference;
+    private boolean mFirstTick = false;
     public GT_Client() {
     	mCapeRenderer = new GT_CapeRenderer(mCapeList);
         mAnimationTick = 0L;
@@ -303,6 +309,8 @@ public class GT_Client extends GT_Proxy
         (new Thread(this)).start();
 
         mPollutionRenderer.preLoad();
+
+        mPreference = new GT_ClientPreference(GregTech_API.sClientDataFile);
     }
 
     @Override
@@ -390,7 +398,13 @@ public class GT_Client extends GT_Proxy
         } catch (Throwable e) {
         }**/
     }
-    
+
+    @Override
+    @SubscribeEvent
+    public void onClientConnectedToServerEvent(FMLNetworkEvent.ClientConnectedToServerEvent aEvent) {
+        mFirstTick = true;
+    }
+
     @SubscribeEvent
     public void receiveRenderSpecialsEvent(net.minecraftforge.client.event.RenderPlayerEvent.Specials.Pre aEvent) {
         mCapeRenderer.receiveRenderSpecialsEvent(aEvent);
@@ -399,6 +413,10 @@ public class GT_Client extends GT_Proxy
     @SubscribeEvent
     public void onPlayerTickEventClient(TickEvent.PlayerTickEvent aEvent) {
         if ((aEvent.side.isClient()) && (aEvent.phase == TickEvent.Phase.END) && (!aEvent.player.isDead)) {
+            if (mFirstTick) {
+                mFirstTick = false;
+                GT_Values.NW.sendToServer(new GT_Packet_ClientPreference(mPreference));
+            }
             afterSomeTime++;
             if(afterSomeTime>=100L) {
                 afterSomeTime=0;

--- a/src/main/java/gregtech/common/GT_Network.java
+++ b/src/main/java/gregtech/common/GT_Network.java
@@ -36,7 +36,7 @@ public class GT_Network extends MessageToMessageCodec<FMLProxyPacket, GT_Packet>
 
     public GT_Network() {
         this.mChannel = NetworkRegistry.INSTANCE.newChannel("GregTech", this, new HandlerShared());
-        this.mSubChannels = new GT_Packet[]{new GT_Packet_TileEntity(), new GT_Packet_Sound(), new GT_Packet_Block_Event(), new GT_Packet_Ores(), new GT_Packet_Pollution(), new MessageSetFlaskCapacity(), new GT_Packet_TileEntityCover(), new GT_Packet_TileEntityCoverGUI(), new MessageUpdateFluidDisplayItem()};
+        this.mSubChannels = new GT_Packet[]{new GT_Packet_TileEntity(), new GT_Packet_Sound(), new GT_Packet_Block_Event(), new GT_Packet_Ores(), new GT_Packet_Pollution(), new MessageSetFlaskCapacity(), new GT_Packet_TileEntityCover(), new GT_Packet_TileEntityCoverGUI(), new MessageUpdateFluidDisplayItem(), new GT_Packet_ClientPreference()};
     }
 
     @Override
@@ -51,7 +51,9 @@ public class GT_Network extends MessageToMessageCodec<FMLProxyPacket, GT_Packet>
     protected void decode(ChannelHandlerContext aContext, FMLProxyPacket aPacket, List<Object> aOutput)
             throws Exception {
         ByteArrayDataInput aData = ByteStreams.newDataInput(aPacket.payload().array());
-        aOutput.add(this.mSubChannels[aData.readByte()].decode(aData));
+        GT_Packet tPacket = this.mSubChannels[aData.readByte()].decode(aData);
+        tPacket.setINetHandler(aPacket.handler());
+        aOutput.add(tPacket);
     }
 
     @Override

--- a/src/main/java/gregtech/common/GT_Proxy.java
+++ b/src/main/java/gregtech/common/GT_Proxy.java
@@ -101,6 +101,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -257,6 +260,7 @@ public abstract class GT_Proxy implements IGT_Mod, IGuiHandler, IFuelHandler {
     // Locking
     public static ReentrantLock TICK_LOCK = new ReentrantLock();
     
+    private final ConcurrentMap<UUID, GT_ClientPreference> mClientPrefernces = new ConcurrentHashMap<>();
 
     static {
         oreDictBurnTimes.put("dustTinyWood", 11);
@@ -1590,6 +1594,14 @@ public abstract class GT_Proxy implements IGT_Mod, IGuiHandler, IFuelHandler {
                 }
             }
         }
+    }
+
+    public GT_ClientPreference getClientPreference(UUID aPlayerID) {
+        return mClientPrefernces.get(aPlayerID);
+    }
+
+    public void setClientPreference(UUID aPlayerID, GT_ClientPreference aPreference) {
+        mClientPrefernces.put(aPlayerID, aPreference);
     }
 
     @Override


### PR DESCRIPTION
Some code probably could have been placed somewhere else, but I don't have better idea.

This can be easily extended to send more than initial input filter configuration. Any further extension is however out of the scope of this change, and should have its own PR.