### PR TITLE
Move log centrifuging for methane from GT++, also add circuit

### DIFF
--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingLog.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingLog.java
@@ -22,6 +22,7 @@ public class ProcessingLog implements gregtech.api.interfaces.IOreRecipeRegistra
             GT_ModHandler.addExtractionRecipe(GT_Utility.copyAmount(1L, aStack), GT_OreDictUnificator.get(OrePrefixes.dust, Materials.RawRubber, 1L));
             GT_ModHandler.addPulverisationRecipe(GT_Utility.copyAmount(1L, aStack), GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 6L), ItemList.IC2_Resin.get(1L), 33, false);
         } else {
+        	GT_Values.RA.addCentrifugeRecipe(GT_Utility.copyAmount(1L, aStack), GT_Utility.getIntegratedCircuit(1), null, Materials.Methane.getGas(60L), GT_Values.NI, GT_Values.NI, GT_Values.NI, GT_Values.NI, GT_Values.NI, GT_Values.NI, null, 200, 20);
             GT_ModHandler.addPulverisationRecipe(GT_Utility.copyAmount(1L, aStack), GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 6L), GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 1L), 80, false);
         }
 


### PR DESCRIPTION
Also see https://github.com/GTNewHorizons/GTPP/pull/4, https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/5243.

I moved over the methane centrifuging recipe since apparently there was none inGT5U. With a different circuit in each, it _should_ work now. And it did in my tests.

Though there's about 30 pages of log centrifuging in NEI instead of cycling through them (some do though) which I don't know how to fix.