### PR TITLE
Fix regulator not working when some slots are empty

### DIFF
--- a/src/main/java/gregtech/api/util/GT_Utility.java
+++ b/src/main/java/gregtech/api/util/GT_Utility.java
@@ -886,13 +886,16 @@ public class GT_Utility {
     public static boolean listContainsItem(Collection<ItemStack> aList, ItemStack aStack, boolean aTIfListEmpty, boolean aInvertFilter) {
         if (aStack == null || aStack.stackSize < 1) return false;
         if (aList == null) return aTIfListEmpty;
-        aList.removeIf(Objects::isNull);
-        if (aList.size() < 1) return aTIfListEmpty;
-        Iterator<ItemStack> tIterator = aList.iterator();
-        ItemStack tStack = null;
-        while (tIterator.hasNext())
-            if ((tStack = tIterator.next()) != null && areStacksEqual(aStack, tStack)) return !aInvertFilter;
-        return aInvertFilter;
+        boolean tEmpty = true;
+        for (ItemStack tStack : aList) {
+            if (tStack != null) {
+                tEmpty = false;
+                if (areStacksEqual(aStack, tStack)) {
+                    return !aInvertFilter;
+                }
+            }
+        }
+        return tEmpty ? aTIfListEmpty : aInvertFilter;
     }
 
     public static boolean areStacksOrToolsEqual(ItemStack aStack1, ItemStack aStack2) {

--- a/src/main/java/gregtech/common/tileentities/automation/GT_MetaTileEntity_Filter.java
+++ b/src/main/java/gregtech/common/tileentities/automation/GT_MetaTileEntity_Filter.java
@@ -23,7 +23,7 @@ public class GT_MetaTileEntity_Filter extends GT_MetaTileEntity_Buffer {
         super(aID, aName, aNameRegional, aTier, 19, new String[]{
                 "Filters up to 9 different Items",
                 "Use Screwdriver to regulate output stack size",
-                "Consumes 1EU per moved Item"});
+                "Does not consume energy to move Item"});
     }
 
     public GT_MetaTileEntity_Filter(String aName, int aTier, int aInvSlotCount, String aDescription, ITexture[][][] aTextures) {

--- a/src/main/java/gregtech/common/tileentities/automation/GT_MetaTileEntity_ItemDistributor.java
+++ b/src/main/java/gregtech/common/tileentities/automation/GT_MetaTileEntity_ItemDistributor.java
@@ -27,7 +27,7 @@ public class GT_MetaTileEntity_ItemDistributor extends GT_MetaTileEntity_Buffer 
                 "Distributes Items between different Machine Sides",
                 "Default Items per Machine Side: 0",
                 "Use Screwdriver to increase/decrease Items per Side",
-                "Consumes 1EU per moved Item"});
+                "Does not consume energy to move Item"});
     }
 
     public GT_MetaTileEntity_ItemDistributor(int aID, String aName, String aNameRegional, int aTier, int aInvSlotCount,

--- a/src/main/java/gregtech/common/tileentities/automation/GT_MetaTileEntity_Regulator.java
+++ b/src/main/java/gregtech/common/tileentities/automation/GT_MetaTileEntity_Regulator.java
@@ -28,7 +28,7 @@ public class GT_MetaTileEntity_Regulator
                 "Filters up to 9 different Items",
                 "Allows Item-specific output stack size",
                 "Allows Item-specific output slot",
-                "Consumes 1EU per moved Item"});
+                "Does not consume energy to move Item"});
     }
 
     public GT_MetaTileEntity_Regulator(String aName, int aTier, int aInvSlotCount, String aDescription, ITexture[][][] aTextures) {

--- a/src/main/java/gregtech/common/tileentities/automation/GT_MetaTileEntity_TypeFilter.java
+++ b/src/main/java/gregtech/common/tileentities/automation/GT_MetaTileEntity_TypeFilter.java
@@ -29,7 +29,7 @@ public class GT_MetaTileEntity_TypeFilter extends GT_MetaTileEntity_Buffer {
         super(aID, aName, aNameRegional, aTier, 11, new String[]{
                 "Filters 1 Item Type",
                 "Use Screwdriver to regulate output stack size",
-                "Consumes 1 EU per moved Item"});
+                "Does not consume energy to move Item"});
     }
 
     public GT_MetaTileEntity_TypeFilter(String aName, int aTier, int aInvSlotCount, String aDescription, ITexture[][][] aTextures) {


### PR DESCRIPTION
Some Collections passed in does not support removal, and had been throwing UnsupportedOperationException all day long.

BTW why did anyone thought it to be a good idea to modify the list in a method that sounds like an immutable function?