### PR TITLE
Fix crash caused by re-entry to the overworld via Galacticraft

### DIFF
--- a/src/main/java/gregtech/api/util/GT_SpawnEventHandler.java
+++ b/src/main/java/gregtech/api/util/GT_SpawnEventHandler.java
@@ -9,12 +9,12 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.living.LivingSpawnEvent.CheckSpawn;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 public class GT_SpawnEventHandler {
 
-    public static volatile List<int[]> mobReps = new ArrayList();
+    public static volatile List<int[]> mobReps = new CopyOnWriteArrayList<>();
 
     public GT_SpawnEventHandler() {
         MinecraftForge.EVENT_BUS.register(this);

--- a/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_MonsterRepellent.java
+++ b/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_MonsterRepellent.java
@@ -10,6 +10,8 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import java.util.Arrays;
+
 import static gregtech.api.enums.GT_Values.V;
 import static gregtech.api.enums.Textures.BlockIcons.MACHINE_CASINGS;
 import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_TELEPORTER;
@@ -75,7 +77,7 @@ public class GT_MetaTileEntity_MonsterRepellent extends GT_MetaTileEntity_Tiered
     @Override
     public void onRemoval() {
         int[] tCoords = {this.getBaseMetaTileEntity().getXCoord(), this.getBaseMetaTileEntity().getYCoord(), this.getBaseMetaTileEntity().getZCoord(), this.getBaseMetaTileEntity().getWorld().provider.dimensionId};
-        GT_SpawnEventHandler.mobReps.remove(tCoords);
+        GT_SpawnEventHandler.mobReps.removeIf(coords -> Arrays.equals(coords, tCoords));
     }
 
     @Override


### PR DESCRIPTION
As the title says. I have a very consistent crash that happens when re-entering the overworld via Galacticraft. It occurs ~100% of the time; I've not yet seen it not happen. I also never get the para-chest containing my used rocket; might be related.

[Crash log](https://gist.github.com/queer/b07c3dde5884fb9587d232f07e4dcdbf)

Since it's caused by this list being concurrently modified, this seemed to be the easiest fix.

I unfortunately do not have a more consistent reproduction method than "re-enter the Overworld via Galacticraft."

GT5-U is at version `5.09.34.02` which is what MultiMC installed.