### PR TITLE
Fix redstone cover textbox UX being weird

### DIFF
--- a/src/main/java/gregtech/api/gui/GT_GUICover.java
+++ b/src/main/java/gregtech/api/gui/GT_GUICover.java
@@ -252,10 +252,17 @@ public abstract class GT_GUICover extends GuiScreen implements GT_IToolTipRender
             textBox.setFocused(textBox.equals(boxToFocus) && textBox.isEnabled());
         }
     }
+
+    /**
+     * Given textbox's value might have changed.
+     */
     public void applyTextBox(GT_GuiIntegerTextBox box) {
 
     }
 
+    /**
+     * Reset the given textbox to the last valid value, <b>NOT</b> 0.
+     */
     public void resetTextBox(GT_GuiIntegerTextBox box) {
 
     }

--- a/src/main/java/gregtech/common/covers/GT_Cover_RedstoneWirelessBase.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_RedstoneWirelessBase.java
@@ -222,7 +222,7 @@ public abstract class GT_Cover_RedstoneWirelessBase extends GT_CoverBehavior {
 
         @Override
         public void resetTextBox(GT_GuiIntegerTextBox box) {
-            box.setText(String.valueOf(0));
+            box.setText(String.valueOf(coverVariable & PUBLIC_MASK));
         }
 
         @Override
@@ -256,7 +256,8 @@ public abstract class GT_Cover_RedstoneWirelessBase extends GT_CoverBehavior {
             public boolean textboxKeyTyped(char c, int key) {
                 int tValue = 0;
 
-                super.textboxKeyTyped(c, key);
+                if(!super.textboxKeyTyped(c, key))
+                    return false;
 
                 int cursorPos = this.getCursorPosition();
 


### PR DESCRIPTION
The behavior of this cover GUI is radically different from other cover GUIs. This PR aims to bring it back in line with other GUIs.

What was changed
1. reset channel to 0 and loss focus upon ESC => reset channel to last valid value and loss focus upon ESC
2. do nothing upon pressing E (or any other custom keybind) => loss focus upon pressing E