### PR TITLE
Remove unnecessary redstone state query for covers

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
@@ -279,7 +279,8 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
                                     GT_CoverBehavior tCover = getCoverBehaviorAtSide(i);
                                     int tCoverTickRate = tCover.getTickRate(i, getCoverIDAtSide(i), mCoverData[i], this);
                                     if (tCoverTickRate > 0 && mTickTimer % tCoverTickRate == 0) {
-                                        mCoverData[i] = tCover.doCoverThings(i, getInputRedstoneSignal(i), getCoverIDAtSide(i), mCoverData[i], this, mTickTimer);
+                                        byte tRedstone = tCover.isRedstoneSensitive(i, getCoverIDAtSide(i), mCoverData[i], this, mTickTimer) ? getInputRedstoneSignal(i) : 0;
+                                        mCoverData[i] = tCover.doCoverThings(i, tRedstone, getCoverIDAtSide(i), mCoverData[i], this, mTickTimer);
                                         if (!hasValidMetaTileEntity()) return;
                                     }
                                 }

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
@@ -377,7 +377,8 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
                                 GT_CoverBehavior tCover = getCoverBehaviorAtSide(i);
                                 int tCoverTickRate = tCover.getTickRate(i, getCoverIDAtSide(i), mCoverData[i], this);
                                 if (tCoverTickRate > 0 && mTickTimer % tCoverTickRate == 0) {
-                                    mCoverData[i] = tCover.doCoverThings(i, getInputRedstoneSignal(i), getCoverIDAtSide(i), mCoverData[i], this, mTickTimer);
+                                    byte tRedstone = tCover.isRedstoneSensitive(i, getCoverIDAtSide(i), mCoverData[i], this, mTickTimer) ? getInputRedstoneSignal(i) : 0;
+                                    mCoverData[i] = tCover.doCoverThings(i, tRedstone, getCoverIDAtSide(i), mCoverData[i], this, mTickTimer);
                                     if (!hasValidMetaTileEntity()) {
                                         mRunningThroughTick = false;
                                         return;

--- a/src/main/java/gregtech/api/util/GT_CoverBehavior.java
+++ b/src/main/java/gregtech/api/util/GT_CoverBehavior.java
@@ -18,6 +18,10 @@ public abstract class GT_CoverBehavior {
 
     public EntityPlayer lastPlayer = null;
 
+    public boolean isRedstoneSensitive(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
+        return true;
+    }
+
     /**
      * Called by updateEntity inside the covered TileEntity. aCoverVariable is the Value you returned last time.
      */

--- a/src/main/java/gregtech/common/covers/GT_Cover_Arm.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_Arm.java
@@ -31,6 +31,11 @@ public class GT_Cover_Arm extends GT_CoverBehavior {
     }
 
     @Override
+    public boolean isRedstoneSensitive(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
+        return false;
+    }
+
+    @Override
     public int doCoverThings(byte aSide, byte aInputRedstone, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
         if ((((aTileEntity instanceof IMachineProgress)) && (!((IMachineProgress) aTileEntity).isAllowedToWork()))) {
             return aCoverVariable;

--- a/src/main/java/gregtech/common/covers/GT_Cover_Conveyor.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_Conveyor.java
@@ -31,6 +31,11 @@ public class GT_Cover_Conveyor extends GT_CoverBehavior {
     }
 
     @Override
+    public boolean isRedstoneSensitive(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
+        return false;
+    }
+
+    @Override
     public int doCoverThings(byte aSide, byte aInputRedstone, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
         if ((aCoverVariable % 6 > 1) && ((aTileEntity instanceof IMachineProgress))) {
             if (((IMachineProgress) aTileEntity).isAllowedToWork() != aCoverVariable % 6 < 4) {

--- a/src/main/java/gregtech/common/covers/GT_Cover_Crafting.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_Crafting.java
@@ -9,6 +9,11 @@ import net.minecraft.network.play.server.S2DPacketOpenWindow;
 
 public class GT_Cover_Crafting extends GT_CoverBehavior {
     @Override
+    public boolean isRedstoneSensitive(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
+        return false;
+    }
+
+    @Override
     public boolean onCoverRightclick(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, EntityPlayer aPlayer, float aX, float aY, float aZ) {
         if ((aPlayer instanceof EntityPlayerMP)) {
             ((EntityPlayerMP) aPlayer).getNextWindowId();

--- a/src/main/java/gregtech/common/covers/GT_Cover_DoesWork.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_DoesWork.java
@@ -16,6 +16,11 @@ import net.minecraftforge.fluids.Fluid;
 
 public class GT_Cover_DoesWork extends GT_CoverBehavior {
     @Override
+    public boolean isRedstoneSensitive(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
+        return false;
+    }
+
+    @Override
     public int doCoverThings(byte aSide, byte aInputRedstone, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
         if ((aTileEntity instanceof IMachineProgress)) {
             if (aCoverVariable < 2) {

--- a/src/main/java/gregtech/common/covers/GT_Cover_Drain.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_Drain.java
@@ -16,6 +16,10 @@ import net.minecraftforge.fluids.IFluidHandler;
 
 public class GT_Cover_Drain extends GT_CoverBehavior {
     @Override
+    public boolean isRedstoneSensitive(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
+        return false;
+    }
+    @Override
     public int doCoverThings(byte aSide, byte aInputRedstone, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
         if ((aCoverVariable % 3 > 1) && ((aTileEntity instanceof IMachineProgress))) {
             if (((IMachineProgress) aTileEntity).isAllowedToWork() != aCoverVariable % 3 < 2) {

--- a/src/main/java/gregtech/common/covers/GT_Cover_EUMeter.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_EUMeter.java
@@ -21,6 +21,11 @@ import net.minecraftforge.fluids.Fluid;
 
 public class GT_Cover_EUMeter extends GT_CoverBehavior {
     @Override
+    public boolean isRedstoneSensitive(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
+        return false;
+    }
+
+    @Override
     public int doCoverThings(byte aSide, byte aInputRedstone, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
         long tScale = 0L;
         if (aCoverVariable < 2) {

--- a/src/main/java/gregtech/common/covers/GT_Cover_EnergyOnly.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_EnergyOnly.java
@@ -9,6 +9,11 @@ import net.minecraftforge.fluids.Fluid;
 
 public class GT_Cover_EnergyOnly extends GT_CoverBehavior {
     @Override
+    public boolean isRedstoneSensitive(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
+        return false;
+    }
+
+    @Override
     public int onCoverScrewdriverclick(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, EntityPlayer aPlayer, float aX, float aY, float aZ) {
         aCoverVariable = (aCoverVariable + 1) % 3;
         switch(aCoverVariable) {

--- a/src/main/java/gregtech/common/covers/GT_Cover_FluidRegulator.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_FluidRegulator.java
@@ -64,6 +64,11 @@ public class GT_Cover_FluidRegulator extends GT_CoverBehavior {
 	}
 
 	@Override
+	public boolean isRedstoneSensitive(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
+		return false;
+	}
+
+	@Override
     public int doCoverThings(byte aSide, byte aInputRedstone, int aCoverID, int aCoverVariable, ICoverable aTileEntity,
                              long aTimer) {
 		int tSpeed = getSpeed(aCoverVariable);

--- a/src/main/java/gregtech/common/covers/GT_Cover_Fluidfilter.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_Fluidfilter.java
@@ -39,6 +39,10 @@ public class GT_Cover_Fluidfilter extends GT_CoverBehavior {
         return(String.format("Filtering Fluid: %s  Mode: %s", sFluid.getLocalizedName(), getFilterMode(aFilterMode)));
     }
 
+    @Override
+    public boolean isRedstoneSensitive(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
+        return false;
+    }
 
     @Override
     public int doCoverThings(byte aSide, byte aInputRedstone, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {

--- a/src/main/java/gregtech/common/covers/GT_Cover_ItemFilter.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_ItemFilter.java
@@ -29,6 +29,11 @@ public class GT_Cover_ItemFilter extends GT_CoverBehavior {
     }
 
     @Override
+    public boolean isRedstoneSensitive(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
+        return false;
+    }
+
+    @Override
     public int doCoverThings(byte aSide, byte aInputRedstone, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
         TileEntity tTileEntity = aTileEntity.getTileEntityAtSide(aSide);
         Object fromEntity = mExport ? aTileEntity : tTileEntity,

--- a/src/main/java/gregtech/common/covers/GT_Cover_ItemMeter.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_ItemMeter.java
@@ -26,6 +26,11 @@ public class GT_Cover_ItemMeter extends GT_CoverBehavior {
     private static final int INVERT_BIT = 0x40000000;
 
     @Override
+    public boolean isRedstoneSensitive(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
+        return false;
+    }
+
+    @Override
     public int doCoverThings(byte aSide, byte aInputRedstone, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
         //Convert from ver. 5.09.33.50
         if ((CONVERTED_BIT & aCoverVariable) == 0)

--- a/src/main/java/gregtech/common/covers/GT_Cover_Lens.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_Lens.java
@@ -11,6 +11,11 @@ public class GT_Cover_Lens extends GT_CoverBehavior {
     }
 
     @Override
+    public boolean isRedstoneSensitive(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
+        return false;
+    }
+
+    @Override
     public byte getLensColor(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity) {
         return this.mColor;
     }

--- a/src/main/java/gregtech/common/covers/GT_Cover_LiquidMeter.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_LiquidMeter.java
@@ -18,6 +18,11 @@ import net.minecraftforge.fluids.IFluidHandler;
 
 public class GT_Cover_LiquidMeter extends GT_CoverBehavior {
     @Override
+    public boolean isRedstoneSensitive(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
+        return false;
+    }
+
+    @Override
     public int doCoverThings(byte aSide, byte aInputRedstone, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
         if ((aTileEntity instanceof IFluidHandler)) {
             FluidTankInfo[] tTanks = ((IFluidHandler) aTileEntity).getTankInfo(ForgeDirection.UNKNOWN);

--- a/src/main/java/gregtech/common/covers/GT_Cover_NeedMaintainance.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_NeedMaintainance.java
@@ -24,6 +24,11 @@ public class GT_Cover_NeedMaintainance extends GT_CoverBehavior {
     }
 
     @Override
+    public boolean isRedstoneSensitive(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
+        return false;
+    }
+
+    @Override
     public int doCoverThings(byte aSide, byte aInputRedstone, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
         boolean needsRepair = false;
         if (aTileEntity instanceof IGregTechTileEntity) {

--- a/src/main/java/gregtech/common/covers/GT_Cover_PlayerDetector.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_PlayerDetector.java
@@ -20,6 +20,11 @@ public class GT_Cover_PlayerDetector extends GT_CoverBehavior {
     private int range = 8;
 
     @Override
+    public boolean isRedstoneSensitive(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
+        return false;
+    }
+
+    @Override
     public int doCoverThings(byte aSide, byte aInputRedstone, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
         boolean playerDetected = false;
 

--- a/src/main/java/gregtech/common/covers/GT_Cover_Pump.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_Pump.java
@@ -24,6 +24,11 @@ public class GT_Cover_Pump extends GT_CoverBehavior{
     }
 
     @Override
+    public boolean isRedstoneSensitive(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
+        return false;
+    }
+
+    @Override
     public int doCoverThings(byte aSide, byte aInputRedstone, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
         if ((aCoverVariable % 6 > 1) && ((aTileEntity instanceof IMachineProgress))) {
             if (((IMachineProgress) aTileEntity).isAllowedToWork() != aCoverVariable % 6 < 4) {

--- a/src/main/java/gregtech/common/covers/GT_Cover_RedstoneConductor.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_RedstoneConductor.java
@@ -8,6 +8,11 @@ import net.minecraftforge.fluids.Fluid;
 
 public class GT_Cover_RedstoneConductor extends GT_CoverBehavior {
     @Override
+    public boolean isRedstoneSensitive(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
+        return false;
+    }
+
+    @Override
     public int doCoverThings(byte aSide, byte aInputRedstone, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
         if (aCoverVariable == 0) {
             aTileEntity.setOutputRedstoneSignal(aSide, aTileEntity.getStrongestRedstone());

--- a/src/main/java/gregtech/common/covers/GT_Cover_RedstoneReceiverExternal.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_RedstoneReceiverExternal.java
@@ -5,6 +5,11 @@ import gregtech.api.interfaces.tileentity.ICoverable;
 
 public class GT_Cover_RedstoneReceiverExternal extends GT_Cover_RedstoneWirelessBase {
     @Override
+    public boolean isRedstoneSensitive(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
+        return false;
+    }
+
+    @Override
     public int doCoverThings(byte aSide, byte aInputRedstone, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
         aTileEntity.setOutputRedstoneSignal(aSide, GregTech_API.sWirelessRedstone.get(Integer.valueOf(aCoverVariable)) == null ? 0 : ((Byte) GregTech_API.sWirelessRedstone.get(Integer.valueOf(aCoverVariable))).byteValue());
         return aCoverVariable;

--- a/src/main/java/gregtech/common/covers/GT_Cover_RedstoneSignalizer.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_RedstoneSignalizer.java
@@ -9,6 +9,11 @@ import net.minecraftforge.fluids.Fluid;
 
 public class GT_Cover_RedstoneSignalizer extends GT_CoverBehavior {
     @Override
+    public boolean isRedstoneSensitive(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
+        return false;
+    }
+
+    @Override
     public int onCoverScrewdriverclick(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, EntityPlayer aPlayer, float aX, float aY, float aZ) {
         aCoverVariable = (aCoverVariable + 1) % 48;
         switch(aCoverVariable / 16) {

--- a/src/main/java/gregtech/common/covers/GT_Cover_RedstoneTransmitterInternal.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_RedstoneTransmitterInternal.java
@@ -5,6 +5,11 @@ import gregtech.api.interfaces.tileentity.ICoverable;
 
 public class GT_Cover_RedstoneTransmitterInternal extends GT_Cover_RedstoneWirelessBase {
     @Override
+    public boolean isRedstoneSensitive(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
+        return false;
+    }
+
+    @Override
     public int doCoverThings(byte aSide, byte aInputRedstone, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
         GregTech_API.sWirelessRedstone.put(Integer.valueOf(aCoverVariable), Byte.valueOf(aTileEntity.getOutputRedstoneSignal(aSide)));
         return aCoverVariable;

--- a/src/main/java/gregtech/common/covers/GT_Cover_Screen.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_Screen.java
@@ -7,6 +7,11 @@ import net.minecraftforge.fluids.Fluid;
 
 public class GT_Cover_Screen extends GT_CoverBehavior {
     @Override
+    public boolean isRedstoneSensitive(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
+        return false;
+    }
+
+    @Override
     public float getBlastProofLevel(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity) {
         return 20.0F;
     }

--- a/src/main/java/gregtech/common/covers/GT_Cover_Shutter.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_Shutter.java
@@ -15,6 +15,11 @@ import net.minecraftforge.fluids.Fluid;
 
 public class GT_Cover_Shutter extends GT_CoverBehavior {
     @Override
+    public boolean isRedstoneSensitive(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
+        return false;
+    }
+
+    @Override
     public int doCoverThings(byte aSide, byte aInputRedstone, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
         return aCoverVariable;
     }

--- a/src/main/java/gregtech/common/covers/GT_Cover_SolarPanel.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_SolarPanel.java
@@ -17,6 +17,11 @@ public class GT_Cover_SolarPanel extends GT_CoverBehavior {
     }
 
     @Override
+    public boolean isRedstoneSensitive(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
+        return false;
+    }
+
+    @Override
     public int doCoverThings(byte aSide, byte aInputRedstone, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
         if(aSide != 1)return 0;
         int coverState=aCoverVariable&0x3;

--- a/src/main/java/gregtech/common/covers/GT_Cover_SteamValve.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_SteamValve.java
@@ -1,5 +1,6 @@
 package gregtech.common.covers;
 
+import gregtech.api.interfaces.tileentity.ICoverable;
 import gregtech.api.util.GT_ModHandler;
 import net.minecraftforge.fluids.FluidStack;
 
@@ -7,6 +8,11 @@ public class GT_Cover_SteamValve extends GT_Cover_Pump {
 
     public GT_Cover_SteamValve(int aTransferRate) {
         super(aTransferRate);
+    }
+
+    @Override
+    public boolean isRedstoneSensitive(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
+        return false;
     }
 
     @Override

--- a/src/main/java/gregtech/common/covers/GT_Cover_Vent.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_Vent.java
@@ -13,6 +13,11 @@ public class GT_Cover_Vent extends GT_CoverBehavior {
     }
 
     @Override
+    public boolean isRedstoneSensitive(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
+        return false;
+    }
+
+    @Override
     public int doCoverThings(byte aSide, byte aInputRedstone, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
         if ((aTileEntity instanceof IMachineProgress)) {
             if ((((IMachineProgress) aTileEntity).hasThingsToDo()) && (aCoverVariable != ((IMachineProgress) aTileEntity).getProgress()) &&


### PR DESCRIPTION
Most covers don't actually need to know the input redstone state, however this state is provided to the covers nontheless. This unnecessary query has shown up on warmroast as a major CPU time consume (2nd in the GT tile subcategory)

This PR add a method to the base cover behavior to signal whether the cover at that stage need to know the input redstone signal. This method defaults to true to maintain compatibility with covers from addons. All base gt covers that don't require redstone are modified to override this method and return false. 