### PR TITLE
Add option to not change GUI color based on color

### DIFF
--- a/src/main/java/gregtech/GT_Mod.java
+++ b/src/main/java/gregtech/GT_Mod.java
@@ -308,6 +308,7 @@ public class GT_Mod implements IGT_Mod {
         GregTech_API.sMachineThunderExplosions = tMainConfig.get("machines", "lightning_causes_explosions", true).getBoolean(false);
         GregTech_API.sConstantEnergy = tMainConfig.get("machines", "constant_need_of_energy", true).getBoolean(false);
         GregTech_API.sColoredGUI = tMainConfig.get("machines", "colored_guis_when_painted", true).getBoolean(false);
+        GregTech_API.sMachineMetalGUI = tMainConfig.get("machines", "guis_in_consistent_machine_metal_color", false).getBoolean(false);
 
         // Implementation for this is actually handled in NewHorizonsCoreMod in MainRegistry.java!
         GregTech_API.sUseMachineMetal = tMainConfig.get("machines", "use_machine_metal_tint", true).getBoolean(true);

--- a/src/main/java/gregtech/api/GregTech_API.java
+++ b/src/main/java/gregtech/api/GregTech_API.java
@@ -277,6 +277,7 @@ public class GregTech_API {
             sMultiThreadedSounds = false,
             sDoShowAllItemsInCreative = false,
             sColoredGUI = true,
+            sMachineMetalGUI = false,
             sConstantEnergy = true,
             sMachineExplosions = true,
             sMachineFlammable = true,

--- a/src/main/java/gregtech/api/gui/GT_GUIContainerMetaTile_Machine.java
+++ b/src/main/java/gregtech/api/gui/GT_GUIContainerMetaTile_Machine.java
@@ -27,7 +27,9 @@ public class GT_GUIContainerMetaTile_Machine extends GT_GUIContainer {
     @Override
     protected void drawGuiContainerBackgroundLayer(float par1, int par2, int par3) {
         super.drawGuiContainerBackgroundLayer(par1, par2, par3);
-        if (GregTech_API.sColoredGUI && mContainer != null && mContainer.mTileEntity != null) {
+        if (GregTech_API.sMachineMetalGUI) {
+            GL11.glColor3ub((byte) Dyes.MACHINE_METAL.mRGBa[0], (byte) Dyes.MACHINE_METAL.mRGBa[1], (byte) Dyes.MACHINE_METAL.mRGBa[2]);
+        } else if (GregTech_API.sColoredGUI && mContainer != null && mContainer.mTileEntity != null) {
             byte colorByte = mContainer.mTileEntity.getColorization();
             Dyes color;
             if (colorByte != -1)
@@ -35,7 +37,8 @@ public class GT_GUIContainerMetaTile_Machine extends GT_GUIContainer {
             else
                 color = Dyes.MACHINE_METAL;
             GL11.glColor3ub((byte) color.mRGBa[0], (byte) color.mRGBa[1], (byte) color.mRGBa[2]);
-        } else
+        } else {
             GL11.glColor3ub((byte) 255, (byte) 255, (byte) 255);
+        }
     }
 }


### PR DESCRIPTION
https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/8220

There is actually an existing option, but it will make the color slightly different than what we see on a default colored machine with the option on. This adds a new option that will override the old option (if set to true) and make the gui to look the same as a default colored machine.