### PR TITLE
Improvements to Vanilla Replacement & GT_Utility#copy

### DIFF
--- a/src/main/java/gregtech/api/gui/GT_Container.java
+++ b/src/main/java/gregtech/api/gui/GT_Container.java
@@ -142,7 +142,7 @@ public class GT_Container extends Container {
                 if (aSlot != null && aSlot.canTakeStack(aPlayer)) {
                     tTempStack = this.transferStackInSlot(aPlayer, aSlotIndex);
                     if (tTempStack != null) {
-                        rStack = GT_Utility.copy(tTempStack);
+                        rStack = GT_Utility.copyOrNull(tTempStack);
                         if (aSlot.getStack() != null && aSlot.getStack().getItem() == tTempStack.getItem()) {
                             slotClick(aSlotIndex, aMouseclick, aShifthold, aPlayer);
                         }
@@ -157,7 +157,7 @@ public class GT_Container extends Container {
                     tTempStack = aSlot.getStack();
                     ItemStack var13 = aPlayerInventory.getItemStack();
                     if (tTempStack != null) {
-                        rStack = GT_Utility.copy(tTempStack);
+                        rStack = GT_Utility.copyOrNull(tTempStack);
                     }
                     if (tTempStack == null) {
                         if (var13 != null && aSlot.isItemValid(var13)) {
@@ -253,7 +253,7 @@ public class GT_Container extends Container {
         } else if (aShifthold == 3 && aPlayer.capabilities.isCreativeMode && aPlayerInventory.getItemStack() == null && aSlotIndex >= 0) {
             aSlot = (Slot) this.inventorySlots.get(aSlotIndex);
             if (aSlot != null && aSlot.getHasStack()) {
-                tTempStack = GT_Utility.copy(aSlot.getStack());
+                tTempStack = GT_Utility.copyOrNull(aSlot.getStack());
                 tTempStack.stackSize = tTempStack.getMaxStackSize();
                 aPlayerInventory.setItemStack(tTempStack);
             }
@@ -271,7 +271,7 @@ public class GT_Container extends Container {
         //null checks and checks if the item can be stacked (maxStackSize > 1)
         if (getSlotCount() > 0 && slotObject != null && slotObject.getHasStack() && !(slotObject instanceof GT_Slot_Holo)) {
             ItemStack stackInSlot = slotObject.getStack();
-            stack = GT_Utility.copy(stackInSlot);
+            stack = GT_Utility.copyOrNull(stackInSlot);
 
             //TileEntity -> Player
             if (aSlotIndex < getAllSlotCount()) {

--- a/src/main/java/gregtech/api/metatileentity/MetaPipeEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaPipeEntity.java
@@ -503,7 +503,7 @@ public abstract class MetaPipeEntity implements IMetaTileEntity, IConnectable {
 
     @Override
     public ItemStack decrStackSize(int aIndex, int aAmount) {
-        ItemStack tStack = getStackInSlot(aIndex), rStack = GT_Utility.copy(tStack);
+        ItemStack tStack = getStackInSlot(aIndex), rStack = GT_Utility.copyOrNull(tStack);
         if (tStack != null) {
             if (tStack.stackSize <= aAmount) {
                 if (setStackToZeroInsteadOfNull(aIndex)) tStack.stackSize = 0;

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -696,7 +696,7 @@ public abstract class MetaTileEntity implements IMetaTileEntity {
 
     @Override
     public ItemStack decrStackSize(int aIndex, int aAmount) {
-        ItemStack tStack = getStackInSlot(aIndex), rStack = GT_Utility.copy(tStack);
+        ItemStack tStack = getStackInSlot(aIndex), rStack = GT_Utility.copyOrNull(tStack);
         if (tStack != null) {
             if (tStack.stackSize <= aAmount) {
                 if (setStackToZeroInsteadOfNull(aIndex)) tStack.stackSize = 0;

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicGenerator.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicGenerator.java
@@ -303,7 +303,7 @@ public abstract class GT_MetaTileEntity_BasicGenerator extends GT_MetaTileEntity
     public ItemStack getEmptyContainer(ItemStack aStack) {
         if (GT_Utility.isStackInvalid(aStack) || getRecipes() == null) return null;
         GT_Recipe tFuel = getRecipes().findRecipe(getBaseMetaTileEntity(), false, Long.MAX_VALUE, null, aStack);
-        if (tFuel != null) return GT_Utility.copy(tFuel.getOutput(0));
+        if (tFuel != null) return GT_Utility.copyOrNull(tFuel.getOutput(0));
         return GT_Utility.getContainerItem(aStack, true);
     }
 

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicMachine.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicMachine.java
@@ -549,7 +549,7 @@ public abstract class GT_MetaTileEntity_BasicMachine extends GT_MetaTileEntity_B
                         for (int i = getInputSlot(), j = i + mInputSlotCount; i < j; i++)
                             if (mInventory[i] != null && mInventory[i].stackSize <= 0) mInventory[i] = null;
                         for (int i = 0; i < mOutputItems.length; i++) {
-                            mOutputItems[i] = GT_Utility.copy(mOutputItems[i]);
+                            mOutputItems[i] = GT_Utility.copyOrNull(mOutputItems[i]);
                             if (mOutputItems[i] != null && mOutputItems[i].stackSize > 64)
                                 mOutputItems[i].stackSize = 64;
                             mOutputItems[i] = GT_OreDictUnificator.get(true, mOutputItems[i]);

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
@@ -741,7 +741,7 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity {
 
     public boolean addOutput(ItemStack aStack) {
         if (GT_Utility.isStackInvalid(aStack)) return false;
-        aStack = GT_Utility.copy(aStack);
+        aStack = GT_Utility.copyOrNull(aStack);
         for (GT_MetaTileEntity_Hatch_OutputBus tHatch : mOutputBusses) {
             if (isValidMetaTileEntity(tHatch) && tHatch.storeAll(aStack)) {
                 return true;

--- a/src/main/java/gregtech/api/util/GT_BaseCrop.java
+++ b/src/main/java/gregtech/api/util/GT_BaseCrop.java
@@ -68,7 +68,7 @@ public class GT_BaseCrop extends CropCard implements ICropCardInfo {
         aID = GT_Config.addIDConfig(ConfigCategories.IDs.crops, mName.replaceAll(" ", "_"), aID);
         if (aDiscoveredBy != null && !aDiscoveredBy.equals(E)) mDiscoveredBy = aDiscoveredBy;
         if (aDrop != null && aID > 0 && aID < 256) {
-            mDrop = GT_Utility.copy(aDrop);
+            mDrop = GT_Utility.copyOrNull(aDrop);
             mSpecialDrops = aSpecialDrops;
             mTier = Math.max(1, aTier);
             mMaxSize = Math.max(3, aMaxSize);
@@ -177,9 +177,9 @@ public class GT_BaseCrop extends CropCard implements ICropCardInfo {
     public ItemStack getGain(ICropTile aCrop) {
         int tDrop = 0;
         if (mSpecialDrops != null && (tDrop = java.util.concurrent.ThreadLocalRandom.current().nextInt(0, (mSpecialDrops.length*2) + 2)) < mSpecialDrops.length && mSpecialDrops[tDrop] != null) {
-            return GT_Utility.copy(mSpecialDrops[tDrop]);
+            return GT_Utility.copyOrNull(mSpecialDrops[tDrop]);
         }
-        return GT_Utility.copy(mDrop);
+        return GT_Utility.copyOrNull(mDrop);
     }
 
     @Override
@@ -247,9 +247,9 @@ public class GT_BaseCrop extends CropCard implements ICropCardInfo {
     @Override
     public ItemStack getDisplayItem() {
         if (mSpecialDrops != null && mSpecialDrops[mSpecialDrops.length - 1] != null) {
-            return GT_Utility.copy(mSpecialDrops[mSpecialDrops.length - 1]);
+            return GT_Utility.copyOrNull(mSpecialDrops[mSpecialDrops.length - 1]);
         }
-        return GT_Utility.copy(mDrop);
+        return GT_Utility.copyOrNull(mDrop);
     }
 
 }

--- a/src/main/java/gregtech/api/util/GT_FoodStat.java
+++ b/src/main/java/gregtech/api/util/GT_FoodStat.java
@@ -36,7 +36,7 @@ public class GT_FoodStat implements IFoodStat {
         mSaturation = aSaturation;
         mAction = aAction == null ? EnumAction.eat : aAction;
         mPotionEffects = aPotionEffects;
-        mEmptyContainer = GT_Utility.copy(aEmptyContainer);
+        mEmptyContainer = GT_Utility.copyOrNull(aEmptyContainer);
         mInvisibleParticles = aInvisibleParticles;
         mAlwaysEdible = aAlwaysEdible;
         mIsRotten = aIsRotten;
@@ -65,7 +65,7 @@ public class GT_FoodStat implements IFoodStat {
     @Override
     public void onEaten(GT_MetaBase_Item aItem, ItemStack aStack, EntityPlayer aPlayer) {
         aStack.stackSize--;
-        ItemStack tStack = GT_OreDictUnificator.get(GT_Utility.copy(mEmptyContainer));
+        ItemStack tStack = GT_OreDictUnificator.get(GT_Utility.copyOrNull(mEmptyContainer));
         if (tStack != null && !aPlayer.inventory.addItemStackToInventory(tStack))
             aPlayer.dropPlayerItemWithRandomChoice(tStack, true);
 

--- a/src/main/java/gregtech/api/util/GT_ModHandler.java
+++ b/src/main/java/gregtech/api/util/GT_ModHandler.java
@@ -460,8 +460,8 @@ public class GT_ModHandler {
         aChance = (float) GregTech_API.sRecipeFile.get(ConfigCategories.Machines.scrapboxdrops, aOutput, aChance);
         if (aChance <= 0) return false;
         try {
-            GT_Utility.callMethod(GT_Utility.getFieldContent("ic2.api.recipe.Recipes", "scrapboxDrops", true, true), "addDrop", true, false, true, GT_Utility.copy(aOutput), aChance);
-            GT_Utility.callMethod(GT_Utility.getFieldContent("ic2.api.recipe.Recipes", "scrapboxDrops", true, true), "addRecipe", true, true, false, GT_Utility.copy(aOutput), aChance);
+            GT_Utility.callMethod(GT_Utility.getFieldContent("ic2.api.recipe.Recipes", "scrapboxDrops", true, true), "addDrop", true, false, true, GT_Utility.copyOrNull(aOutput), aChance);
+            GT_Utility.callMethod(GT_Utility.getFieldContent("ic2.api.recipe.Recipes", "scrapboxDrops", true, true), "addRecipe", true, true, false, GT_Utility.copyOrNull(aOutput), aChance);
         } catch (Throwable e) {/*Do nothing*/}
         return true;
     }
@@ -484,7 +484,7 @@ public class GT_ModHandler {
         aOutput = GT_OreDictUnificator.get(true, aOutput);
         if (aInput == null || aOutput == null || GT_Utility.getContainerItem(aInput, false) != null) return false;
         if (!GregTech_API.sRecipeFile.get(ConfigCategories.Machines.smelting, aInput, true)) return false;
-        FurnaceRecipes.smelting().func_151394_a(aInput, GT_Utility.copy(aOutput), 0.0F);
+        FurnaceRecipes.smelting().func_151394_a(aInput, GT_Utility.copyOrNull(aOutput), 0.0F);
         return true;
     }
 
@@ -562,8 +562,8 @@ public class GT_ModHandler {
         aOutput = GT_OreDictUnificator.get(true, aOutput);
         if (aInput == null || aOutput == null || aTime <= 0) return false;
         if (!GregTech_API.sRecipeFile.get(ConfigCategories.Machines.rcblastfurnace, aInput, true)) return false;
-        aInput = GT_Utility.copy(aInput);
-        aOutput = GT_Utility.copy(aOutput);
+        aInput = GT_Utility.copyOrNull(aInput);
+        aOutput = GT_Utility.copyOrNull(aOutput);
         try {
             mods.railcraft.api.crafting.RailcraftCraftingManager.blastFurnace.addRecipe(aInput, true, false, aTime, aOutput);
         } catch (Throwable e) {
@@ -614,28 +614,28 @@ public class GT_ModHandler {
                 if (Materials.Wood.contains(aOutput1)) {
                     if (aEnableTEMachineRecipes && GregTech_API.sRecipeFile.get(ConfigCategories.Machines.pulverization, aInput, true)) {
                         if (aOutput2 == null)
-                            ThermalExpansion.addSawmillRecipe(32000, GT_Utility.copy(aInput), GT_Utility.copy(aOutput1));
+                            ThermalExpansion.addSawmillRecipe(32000, GT_Utility.copyOrNull(aInput), GT_Utility.copyOrNull(aOutput1));
                         else
-                            ThermalExpansion.addSawmillRecipe(32000, GT_Utility.copy(aInput), GT_Utility.copy(aOutput1), GT_Utility.copy(aOutput2), aChance2 <= 0 ? 10 : aChance2);
+                            ThermalExpansion.addSawmillRecipe(32000, GT_Utility.copyOrNull(aInput), GT_Utility.copyOrNull(aOutput1), GT_Utility.copyOrNull(aOutput2), aChance2 <= 0 ? 10 : aChance2);
                     }
                 } else {
                     if (GregTech_API.sRecipeFile.get(ConfigCategories.Machines.rockcrushing, aInput, true)) {
                         try {
                             if (GT_Utility.getBlockFromStack(aInput) != Blocks.obsidian && GT_Utility.getBlockFromStack(aInput) != Blocks.gravel) {
                                 mods.railcraft.api.crafting.IRockCrusherRecipe tRecipe = mods.railcraft.api.crafting.RailcraftCraftingManager.rockCrusher.createNewRecipe(GT_Utility.copyAmount(1, aInput), aInput.getItemDamage() != W, false);
-                                tRecipe.addOutput(GT_Utility.copy(aOutput1), 1.0F / aInput.stackSize);
+                                tRecipe.addOutput(GT_Utility.copyOrNull(aOutput1), 1.0F / aInput.stackSize);
                                 if (aOutput2 != null)
-                                    tRecipe.addOutput(GT_Utility.copy(aOutput2), (0.01F * (aChance2 <= 0 ? 10 : aChance2)) / aInput.stackSize);
+                                    tRecipe.addOutput(GT_Utility.copyOrNull(aOutput2), (0.01F * (aChance2 <= 0 ? 10 : aChance2)) / aInput.stackSize);
                                 if (aOutput3 != null)
-                                    tRecipe.addOutput(GT_Utility.copy(aOutput3), (0.01F * (aChance3 <= 0 ? 10 : aChance3)) / aInput.stackSize);
+                                    tRecipe.addOutput(GT_Utility.copyOrNull(aOutput3), (0.01F * (aChance3 <= 0 ? 10 : aChance3)) / aInput.stackSize);
                             }
                         } catch (Throwable e) {/*Do nothing*/}
                     }
                     if (aEnableTEMachineRecipes && GregTech_API.sRecipeFile.get(ConfigCategories.Machines.pulverization, aInput, true)) {
                         if (aOutput2 == null)
-                            ThermalExpansion.addPulverizerRecipe(32000, GT_Utility.copy(aInput), GT_Utility.copy(aOutput1));
+                            ThermalExpansion.addPulverizerRecipe(32000, GT_Utility.copyOrNull(aInput), GT_Utility.copyOrNull(aOutput1));
                         else
-                            ThermalExpansion.addPulverizerRecipe(32000, GT_Utility.copy(aInput), GT_Utility.copy(aOutput1), GT_Utility.copy(aOutput2), aChance2 <= 0 ? 10 : aChance2);
+                            ThermalExpansion.addPulverizerRecipe(32000, GT_Utility.copyOrNull(aInput), GT_Utility.copyOrNull(aOutput1), GT_Utility.copyOrNull(aOutput2), aChance2 <= 0 ? 10 : aChance2);
                     }
                 }
             }
@@ -702,7 +702,7 @@ public class GT_ModHandler {
         if (!GT_Mod.gregtechproxy.mTEMachineRecipes && !GregTech_API.sRecipeFile.get(ConfigCategories.Machines.inductionsmelter, aInput2 == null ? aInput1 : aOutput1, true))
             return false;
         try {
-            ThermalExpansion.addSmelterRecipe(aEnergy * 10, GT_Utility.copy(aInput1), aInput2 == null ? new ItemStack(Blocks.sand, 1, 0) : aInput2, aOutput1, aOutput2, aChance);
+            ThermalExpansion.addSmelterRecipe(aEnergy * 10, GT_Utility.copyOrNull(aInput1), aInput2 == null ? new ItemStack(Blocks.sand, 1, 0) : aInput2, aOutput1, aOutput2, aChance);
         } catch (Throwable e) {/*Do nothing*/}
         return true;
     }
@@ -713,7 +713,7 @@ public class GT_ModHandler {
     public static boolean addOreToIngotSmeltingRecipe(ItemStack aInput, ItemStack aOutput) {
         aOutput = GT_OreDictUnificator.get(true, aOutput);
         if (aInput == null || aOutput == null) return false;
-        FurnaceRecipes.smelting().func_151394_a(aInput, GT_Utility.copy(aOutput), 0.0F);
+        FurnaceRecipes.smelting().func_151394_a(aInput, GT_Utility.copyOrNull(aOutput), 0.0F);
         return true;
     }
 
@@ -847,9 +847,9 @@ public class GT_ModHandler {
         aResult = GT_OreDictUnificator.get(true, aResult);
         if (aResult == null || aRecipe == null || aResult.stackSize <= 0) return false;
         try {
-            mods.railcraft.api.crafting.RailcraftCraftingManager.rollingMachine.getRecipeList().add(new ShapedOreRecipe(GT_Utility.copy(aResult), aRecipe));
+            mods.railcraft.api.crafting.RailcraftCraftingManager.rollingMachine.getRecipeList().add(new ShapedOreRecipe(GT_Utility.copyOrNull(aResult), aRecipe));
         } catch (Throwable e) {
-            return addCraftingRecipe(GT_Utility.copy(aResult), aRecipe);
+            return addCraftingRecipe(GT_Utility.copyOrNull(aResult), aRecipe);
         }
         return true;
     }
@@ -1084,8 +1084,9 @@ public class GT_ModHandler {
                 Character chr = (Character) aRecipe[idx];
                 Object in = aRecipe[idx + 1];
                 if (in instanceof ItemStack) {
-                    tItemStackMap.put(chr, GT_Utility.copy(in));
-                    tItemDataMap.put(chr, GT_OreDictUnificator.getItemData((ItemStack) in));
+                    ItemStack is = (ItemStack) in;
+                    tItemStackMap.put(chr, GT_Utility.copyOrNull(is));
+                    tItemDataMap.put(chr, GT_OreDictUnificator.getItemData(is));
                 } else if (in instanceof ItemData) {
                     String tString = in.toString();
                     switch (tString) {
@@ -1184,9 +1185,9 @@ public class GT_ModHandler {
 
         if (tThereWasARecipe || !aOnlyAddIfThereIsAnyRecipeOutputtingThis) {
             if (sBufferCraftingRecipes && aBuffered)
-                sBufferRecipeList.add(new GT_Shaped_Recipe(GT_Utility.copy(aResult), aDismantleable, aRemovable, aKeepNBT, aEnchantmentsAdded, aEnchantmentLevelsAdded, aRecipe).setMirrored(aMirrored));
+                sBufferRecipeList.add(new GT_Shaped_Recipe(GT_Utility.copyOrNull(aResult), aDismantleable, aRemovable, aKeepNBT, aEnchantmentsAdded, aEnchantmentLevelsAdded, aRecipe).setMirrored(aMirrored));
             else
-                GameRegistry.addRecipe(new GT_Shaped_Recipe(GT_Utility.copy(aResult), aDismantleable, aRemovable, aKeepNBT, aEnchantmentsAdded, aEnchantmentLevelsAdded, aRecipe).setMirrored(aMirrored));
+                GameRegistry.addRecipe(new GT_Shaped_Recipe(GT_Utility.copyOrNull(aResult), aDismantleable, aRemovable, aKeepNBT, aEnchantmentsAdded, aEnchantmentLevelsAdded, aRecipe).setMirrored(aMirrored));
         }
         return true;
     }
@@ -1260,9 +1261,9 @@ public class GT_ModHandler {
         GT_Utility.updateItemStack(aResult);
 
         if (sBufferCraftingRecipes && aBuffered)
-            sBufferRecipeList.add(new GT_Shapeless_Recipe(GT_Utility.copy(aResult), aDismantleable, aRemovable, aKeepNBT, aEnchantmentsAdded, aEnchantmentLevelsAdded, aRecipe));
+            sBufferRecipeList.add(new GT_Shapeless_Recipe(GT_Utility.copyOrNull(aResult), aDismantleable, aRemovable, aKeepNBT, aEnchantmentsAdded, aEnchantmentLevelsAdded, aRecipe));
         else
-            GameRegistry.addRecipe(new GT_Shapeless_Recipe(GT_Utility.copy(aResult), aDismantleable, aRemovable, aKeepNBT, aEnchantmentsAdded, aEnchantmentLevelsAdded, aRecipe));
+            GameRegistry.addRecipe(new GT_Shapeless_Recipe(GT_Utility.copyOrNull(aResult), aDismantleable, aRemovable, aKeepNBT, aEnchantmentsAdded, aEnchantmentLevelsAdded, aRecipe));
         return true;
     }
 
@@ -1531,7 +1532,7 @@ public class GT_ModHandler {
                         throw new GT_ItsNotMyFaultException("Seems another Mod added a Crafting Recipe with null Output. Tell the Developer of said Mod to fix that.");
                 } else {
                     if (aUncopiedStack) return tOutput;
-                    return GT_Utility.copy(tOutput);
+                    return GT_Utility.copyOrNull(tOutput);
                 }
             }
         }
@@ -1679,7 +1680,7 @@ public class GT_ModHandler {
                 if (tRecipe instanceof ShapelessRecipes) continue;
                 if (tRecipe instanceof ShapelessOreRecipe) continue;
                 if (tRecipe instanceof IGT_CraftingRecipe) continue;
-                rList.add(GT_Utility.copy(tOutput));
+                rList.add(GT_Utility.copyOrNull(tOutput));
                 aList.remove(i--);
             }
         }
@@ -1691,7 +1692,7 @@ public class GT_ModHandler {
      */
     @Deprecated
     public static ItemStack getMaceratorOutput(ItemStack aInput, boolean aRemoveInput, ItemStack aOutputSlot) {
-        return GT_Utility.copy(getMachineOutput(aInput, getMaceratorRecipeList(), aRemoveInput, new NBTTagCompound(), aOutputSlot)[0]);
+        return GT_Utility.copyOrNull(getMachineOutput(aInput, getMaceratorRecipeList(), aRemoveInput, new NBTTagCompound(), aOutputSlot)[0]);
     }
 
     /**
@@ -1699,7 +1700,7 @@ public class GT_ModHandler {
      */
     @Deprecated
     public static ItemStack getExtractorOutput(ItemStack aInput, boolean aRemoveInput, ItemStack aOutputSlot) {
-        return GT_Utility.copy(getMachineOutput(aInput, getExtractorRecipeList(), aRemoveInput, new NBTTagCompound(), aOutputSlot)[0]);
+        return GT_Utility.copyOrNull(getMachineOutput(aInput, getExtractorRecipeList(), aRemoveInput, new NBTTagCompound(), aOutputSlot)[0]);
     }
 
     /**
@@ -1707,7 +1708,7 @@ public class GT_ModHandler {
      */
     @Deprecated
     public static ItemStack getCompressorOutput(ItemStack aInput, boolean aRemoveInput, ItemStack aOutputSlot) {
-        return GT_Utility.copy(getMachineOutput(aInput, getCompressorRecipeList(), aRemoveInput, new NBTTagCompound(), aOutputSlot)[0]);
+        return GT_Utility.copyOrNull(getMachineOutput(aInput, getCompressorRecipeList(), aRemoveInput, new NBTTagCompound(), aOutputSlot)[0]);
     }
 
     /**
@@ -1748,7 +1749,7 @@ public class GT_ModHandler {
                         for (byte i = 0; i < aOutputSlots.length && i < tList.length; i++) {
                             if (tList[i] != null) {
                                 if (aOutputSlots[i] == null || (GT_Utility.areStacksEqual(tList[i], aOutputSlots[i]) && tList[i].stackSize + aOutputSlots[i].stackSize <= aOutputSlots[i].getMaxStackSize())) {
-                                    rList[i] = GT_Utility.copy(tList[i]);
+                                    rList[i] = GT_Utility.copyOrNull(tList[i]);
                                 } else {
                                     return new ItemStack[aOutputSlots.length];
                                 }

--- a/src/main/java/gregtech/api/util/GT_OreDictUnificator.java
+++ b/src/main/java/gregtech/api/util/GT_OreDictUnificator.java
@@ -123,7 +123,7 @@ public class GT_OreDictUnificator {
     }
 
     public static ItemStack[] setStackArray(boolean aUseBlackList, ItemStack... aStacks) {
-        for (int i = 0; i < aStacks.length; i++) aStacks[i] = get(aUseBlackList, GT_Utility.copy(aStacks[i]));
+        for (int i = 0; i < aStacks.length; i++) aStacks[i] = get(aUseBlackList, GT_Utility.copyOrNull(aStacks[i]));
         return aStacks;
     }
 
@@ -155,15 +155,15 @@ public class GT_OreDictUnificator {
         ItemData tPrefixMaterial = getAssociation(aStack);
         ItemStack rStack = null;
         if (tPrefixMaterial == null || !tPrefixMaterial.hasValidPrefixMaterialData() || (aUseBlackList && tPrefixMaterial.mBlackListed))
-            return GT_Utility.copy(aStack);
+            return GT_Utility.copyOrNull(aStack);
         if (aUseBlackList && !GregTech_API.sUnificationEntriesRegistered && isBlacklisted(aStack)) {
             tPrefixMaterial.mBlackListed = true;
-            return GT_Utility.copy(aStack);
+            return GT_Utility.copyOrNull(aStack);
         }
         if (tPrefixMaterial.mUnificationTarget == null)
             tPrefixMaterial.mUnificationTarget = sName2StackMap.get(tPrefixMaterial.toString());
         rStack = tPrefixMaterial.mUnificationTarget;
-        if (GT_Utility.isStackInvalid(rStack)) return GT_Utility.copy(aStack);
+        if (GT_Utility.isStackInvalid(rStack)) return GT_Utility.copyOrNull(aStack);
         assert rStack != null;
         rStack.setTagCompound(aStack.getTagCompound());
         return GT_Utility.copyAmount(aStack.stackSize, rStack);

--- a/src/main/java/gregtech/api/util/GT_Recipe.java
+++ b/src/main/java/gregtech/api/util/GT_Recipe.java
@@ -312,12 +312,12 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
 
     public ItemStack getRepresentativeInput(int aIndex) {
         if (aIndex < 0 || aIndex >= mInputs.length) return null;
-        return GT_Utility.copy(mInputs[aIndex]);
+        return GT_Utility.copyOrNull(mInputs[aIndex]);
     }
 
     public ItemStack getOutput(int aIndex) {
         if (aIndex < 0 || aIndex >= mOutputs.length) return null;
-        return GT_Utility.copy(mOutputs[aIndex]);
+        return GT_Utility.copyOrNull(mOutputs[aIndex]);
     }
 
     public int getOutputChance(int aIndex) {
@@ -1215,7 +1215,7 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
         public GT_Recipe findRecipe(IHasWorldObjectAndCoords aTileEntity, GT_Recipe aRecipe, boolean aNotUnificated, long aVoltage, FluidStack[] aFluids, ItemStack aSpecialSlot, ItemStack... aInputs) {
             if (aInputs == null || aInputs.length <= 0 || aInputs[0] == null) return null;
             if (aRecipe != null && aRecipe.isRecipeInputEqual(false, true, aFluids, aInputs)) return aRecipe;
-            ItemStack tComparedInput = GT_Utility.copy(aInputs[0]);
+            ItemStack tComparedInput = GT_Utility.copyOrNull(aInputs[0]);
             ItemStack[] tOutputItems = GT_ModHandler.getMachineOutput(tComparedInput, ic2.api.recipe.Recipes.compressor.getRecipes(), true, new NBTTagCompound(), null, null, null);
             return GT_Utility.arrayContainsNonNull(tOutputItems) ? new GT_Recipe(false, new ItemStack[]{GT_Utility.copyAmount(aInputs[0].stackSize - tComparedInput.stackSize, aInputs[0])}, tOutputItems, null, null, null, null, 400, 2, 0) : null;
         }
@@ -1238,7 +1238,7 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
         public GT_Recipe findRecipe(IHasWorldObjectAndCoords aTileEntity, GT_Recipe aRecipe, boolean aNotUnificated, long aVoltage, FluidStack[] aFluids, ItemStack aSpecialSlot, ItemStack... aInputs) {
             if (aInputs == null || aInputs.length <= 0 || aInputs[0] == null) return null;
             if (aRecipe != null && aRecipe.isRecipeInputEqual(false, true, aFluids, aInputs)) return aRecipe;
-            ItemStack tComparedInput = GT_Utility.copy(aInputs[0]);
+            ItemStack tComparedInput = GT_Utility.copyOrNull(aInputs[0]);
             ItemStack[] tOutputItems = GT_ModHandler.getMachineOutput(tComparedInput, ic2.api.recipe.Recipes.extractor.getRecipes(), true, new NBTTagCompound(), null, null, null);
             return GT_Utility.arrayContainsNonNull(tOutputItems) ? new GT_Recipe(false, new ItemStack[]{GT_Utility.copyAmount(aInputs[0].stackSize - tComparedInput.stackSize, aInputs[0])}, tOutputItems, null, null, null, null, 400, 2, 0) : null;
         }
@@ -1261,7 +1261,7 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
         public GT_Recipe findRecipe(IHasWorldObjectAndCoords aTileEntity, GT_Recipe aRecipe, boolean aNotUnificated, long aVoltage, FluidStack[] aFluids, ItemStack aSpecialSlot, ItemStack... aInputs) {
             if (aInputs == null || aInputs.length <= 0 || aInputs[0] == null) return null;
             if (aRecipe != null && aRecipe.isRecipeInputEqual(false, true, aFluids, aInputs)) return aRecipe;
-            ItemStack tComparedInput = GT_Utility.copy(aInputs[0]);
+            ItemStack tComparedInput = GT_Utility.copyOrNull(aInputs[0]);
             ItemStack[] tOutputItems = GT_ModHandler.getMachineOutput(tComparedInput, ic2.api.recipe.Recipes.centrifuge.getRecipes(), true, new NBTTagCompound(), null, null, null);
             return GT_Utility.arrayContainsNonNull(tOutputItems) ? new GT_Recipe(false, new ItemStack[]{GT_Utility.copyAmount(aInputs[0].stackSize - tComparedInput.stackSize, aInputs[0])}, tOutputItems, null, null, null, null, 400, 48, 0) : null;
         }
@@ -1285,7 +1285,7 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
             if (aInputs == null || aInputs.length <= 0 || aInputs[0] == null || aFluids == null || aFluids.length < 1 || !GT_ModHandler.isWater(aFluids[0]))
                 return null;
             if (aRecipe != null && aRecipe.isRecipeInputEqual(false, true, aFluids, aInputs)) return aRecipe;
-            ItemStack tComparedInput = GT_Utility.copy(aInputs[0]);
+            ItemStack tComparedInput = GT_Utility.copyOrNull(aInputs[0]);
             NBTTagCompound aRecipeMetaData = new NBTTagCompound();
             ItemStack[] tOutputItems = GT_ModHandler.getMachineOutput(tComparedInput, ic2.api.recipe.Recipes.oreWashing.getRecipes(), true, aRecipeMetaData, null, null, null);
             return GT_Utility.arrayContainsNonNull(tOutputItems) ? new GT_Recipe(false, new ItemStack[]{GT_Utility.copyAmount(aInputs[0].stackSize - tComparedInput.stackSize, aInputs[0])}, tOutputItems, null, null, new FluidStack[]{new FluidStack(aFluids[0].getFluid(), ((NBTTagCompound) aRecipeMetaData.getTag("return")).getInteger("amount"))}, null, 400, 16, 0) : null;
@@ -1334,7 +1334,7 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
                 if (D1) GT_Log.err.println("Railcraft Not loaded");
             } catch (NullPointerException e) {/**/}
 
-            ItemStack tComparedInput = GT_Utility.copy(aInputs[0]);
+            ItemStack tComparedInput = GT_Utility.copyOrNull(aInputs[0]);
             ItemStack[] tOutputItems = GT_ModHandler.getMachineOutput(tComparedInput, ic2.api.recipe.Recipes.macerator.getRecipes(), true, new NBTTagCompound(), null, null, null);
             return GT_Utility.arrayContainsNonNull(tOutputItems) ? new GT_Recipe(false, new ItemStack[]{GT_Utility.copyAmount(aInputs[0].stackSize - tComparedInput.stackSize, aInputs[0])}, tOutputItems, null, null, null, null, 400, 2, 0) : null;
         }
@@ -1823,13 +1823,13 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
 	        	if (mOreDictAlt[aIndex] != null && mOreDictAlt[aIndex].length > 0) {
 	        		ItemStack[] rStacks = new ItemStack[mOreDictAlt[aIndex].length];
 	        		for (int i = 0; i < mOreDictAlt[aIndex].length; i++) {
-	        			rStacks[i] = GT_Utility.copy(mOreDictAlt[aIndex][i]);
+	        			rStacks[i] = GT_Utility.copyOrNull(mOreDictAlt[aIndex][i]);
 	        		}
 	        		return rStacks;
 	        	}
 	        }
 	        if (aIndex >= mInputs.length) return null;
-	        return GT_Utility.copy(mInputs[aIndex]);
+	        return GT_Utility.copyOrNull(mInputs[aIndex]);
 	    }
     	
     }

--- a/src/main/java/gregtech/api/util/GT_RecipeRegistrator.java
+++ b/src/main/java/gregtech/api/util/GT_RecipeRegistrator.java
@@ -1,5 +1,6 @@
 package gregtech.api.util;
 
+import com.google.common.base.Stopwatch;
 import gregtech.GT_Mod;
 import gregtech.api.GregTech_API;
 import gregtech.api.enums.*;
@@ -28,52 +29,52 @@ public class GT_RecipeRegistrator {
     public static final List<Materials> sRodMaterialList = new ArrayList<Materials>();
     private static final ItemStack sMt1 = new ItemStack(Blocks.dirt, 1, 0), sMt2 = new ItemStack(Blocks.dirt, 1, 0);
     private static final String s_H = "h", s_F = "f", s_I = "I", s_P = "P", s_R = "R";
-    private static final ItemStack[][]
-            sShapes1 = new ItemStack[][]{
-            {sMt1, null, sMt1, sMt1, sMt1, sMt1, null, sMt1, null},
-            {sMt1, null, sMt1, sMt1, null, sMt1, sMt1, sMt1, sMt1},
-            {null, sMt1, null, sMt1, sMt1, sMt1, sMt1, null, sMt1},
-            {sMt1, sMt1, sMt1, sMt1, null, sMt1, null, null, null},
-            {sMt1, null, sMt1, sMt1, sMt1, sMt1, sMt1, sMt1, sMt1},
-            {sMt1, sMt1, sMt1, sMt1, null, sMt1, sMt1, null, sMt1},
-            {null, null, null, sMt1, null, sMt1, sMt1, null, sMt1},
-            {null, sMt1, null, null, sMt1, null, null, sMt2, null},
-            {sMt1, sMt1, sMt1, null, sMt2, null, null, sMt2, null},
-            {null, sMt1, null, null, sMt2, null, null, sMt2, null},
-            {sMt1, sMt1, null, sMt1, sMt2, null, null, sMt2, null},
-            {null, sMt1, sMt1, null, sMt2, sMt1, null, sMt2, null},
-            {sMt1, sMt1, null, null, sMt2, null, null, sMt2, null},
-            {null, sMt1, sMt1, null, sMt2, null, null, sMt2, null},
-            {null, sMt1, null, sMt1, null, null, null, sMt1, sMt2},
-            {null, sMt1, null, null, null, sMt1, sMt2, sMt1, null},
-            {null, sMt1, null, sMt1, null, sMt1, null, null, sMt2},
-            {null, sMt1, null, sMt1, null, sMt1, sMt2, null, null},
-            {null, sMt2, null, null, sMt1, null, null, sMt1, null},
-            {null, sMt2, null, null, sMt2, null, sMt1, sMt1, sMt1},
-            {null, sMt2, null, null, sMt2, null, null, sMt1, null},
-            {null, sMt2, null, sMt1, sMt2, null, sMt1, sMt1, null},
-            {null, sMt2, null, null, sMt2, sMt1, null, sMt1, sMt1},
-            {null, sMt2, null, null, sMt2, null, sMt1, sMt1, null},
-            {sMt1, null, null, null, sMt2, null, null, null, sMt2},
-            {null, null, sMt1, null, sMt2, null, sMt2, null, null},
-            {sMt1, null, null, null, sMt2, null, null, null, null},
-            {null, null, sMt1, null, sMt2, null, null, null, null},
-            {sMt1, sMt2, null, null, null, null, null, null, null},
-            {sMt2, sMt1, null, null, null, null, null, null, null},
-            {sMt1, null, null, sMt2, null, null, null, null, null},
-            {sMt2, null, null, sMt1, null, null, null, null, null},
-            {sMt1, sMt1, sMt1, sMt1, sMt1, sMt1, null, sMt2, null},
-            {sMt1, sMt1, null, sMt1, sMt1, sMt2, sMt1, sMt1, null},
-            {null, sMt1, sMt1, sMt2, sMt1, sMt1, null, sMt1, sMt1},
-            {null, sMt2, null, sMt1, sMt1, sMt1, sMt1, sMt1, sMt1},
-            {sMt1, sMt1, sMt1, sMt1, sMt2, sMt1, null, sMt2, null},
-            {sMt1, sMt1, null, sMt1, sMt2, sMt2, sMt1, sMt1, null},
-            {null, sMt1, sMt1, sMt2, sMt2, sMt1, null, sMt1, sMt1},
-            {null, sMt2, null, sMt1, sMt2, sMt1, sMt1, sMt1, sMt1},
-            {sMt1, null, null, null, sMt1, null, null, null, null},
-            {null, sMt1, null, sMt1, null, null, null, null, null},
-            {sMt1, sMt1, null, sMt2, null, sMt1, sMt2, null, null},
-            {null, sMt1, sMt1, sMt1, null, sMt2, null, null, sMt2}
+    private static final RecipeShape[]
+            sShapes = new RecipeShape[]{
+            new RecipeShape(sMt1, null, sMt1, sMt1, sMt1, sMt1, null, sMt1, null),
+            new RecipeShape(sMt1, null, sMt1, sMt1, null, sMt1, sMt1, sMt1, sMt1),
+            new RecipeShape(null, sMt1, null, sMt1, sMt1, sMt1, sMt1, null, sMt1),
+            new RecipeShape(sMt1, sMt1, sMt1, sMt1, null, sMt1, null, null, null),
+            new RecipeShape(sMt1, null, sMt1, sMt1, sMt1, sMt1, sMt1, sMt1, sMt1),
+            new RecipeShape(sMt1, sMt1, sMt1, sMt1, null, sMt1, sMt1, null, sMt1),
+            new RecipeShape(null, null, null, sMt1, null, sMt1, sMt1, null, sMt1),
+            new RecipeShape(null, sMt1, null, null, sMt1, null, null, sMt2, null),
+            new RecipeShape(sMt1, sMt1, sMt1, null, sMt2, null, null, sMt2, null),
+            new RecipeShape(null, sMt1, null, null, sMt2, null, null, sMt2, null),
+            new RecipeShape(sMt1, sMt1, null, sMt1, sMt2, null, null, sMt2, null),
+            new RecipeShape(null, sMt1, sMt1, null, sMt2, sMt1, null, sMt2, null),
+            new RecipeShape(sMt1, sMt1, null, null, sMt2, null, null, sMt2, null),
+            new RecipeShape(null, sMt1, sMt1, null, sMt2, null, null, sMt2, null),
+            new RecipeShape(null, sMt1, null, sMt1, null, null, null, sMt1, sMt2),
+            new RecipeShape(null, sMt1, null, null, null, sMt1, sMt2, sMt1, null),
+            new RecipeShape(null, sMt1, null, sMt1, null, sMt1, null, null, sMt2),
+            new RecipeShape(null, sMt1, null, sMt1, null, sMt1, sMt2, null, null),
+            new RecipeShape(null, sMt2, null, null, sMt1, null, null, sMt1, null),
+            new RecipeShape(null, sMt2, null, null, sMt2, null, sMt1, sMt1, sMt1),
+            new RecipeShape(null, sMt2, null, null, sMt2, null, null, sMt1, null),
+            new RecipeShape(null, sMt2, null, sMt1, sMt2, null, sMt1, sMt1, null),
+            new RecipeShape(null, sMt2, null, null, sMt2, sMt1, null, sMt1, sMt1),
+            new RecipeShape(null, sMt2, null, null, sMt2, null, sMt1, sMt1, null),
+            new RecipeShape(sMt1, null, null, null, sMt2, null, null, null, sMt2),
+            new RecipeShape(null, null, sMt1, null, sMt2, null, sMt2, null, null),
+            new RecipeShape(sMt1, null, null, null, sMt2, null, null, null, null),
+            new RecipeShape(null, null, sMt1, null, sMt2, null, null, null, null),
+            new RecipeShape(sMt1, sMt2, null, null, null, null, null, null, null),
+            new RecipeShape(sMt2, sMt1, null, null, null, null, null, null, null),
+            new RecipeShape(sMt1, null, null, sMt2, null, null, null, null, null),
+            new RecipeShape(sMt2, null, null, sMt1, null, null, null, null, null),
+            new RecipeShape(sMt1, sMt1, sMt1, sMt1, sMt1, sMt1, null, sMt2, null),
+            new RecipeShape(sMt1, sMt1, null, sMt1, sMt1, sMt2, sMt1, sMt1, null),
+            new RecipeShape(null, sMt1, sMt1, sMt2, sMt1, sMt1, null, sMt1, sMt1),
+            new RecipeShape(null, sMt2, null, sMt1, sMt1, sMt1, sMt1, sMt1, sMt1),
+            new RecipeShape(sMt1, sMt1, sMt1, sMt1, sMt2, sMt1, null, sMt2, null),
+            new RecipeShape(sMt1, sMt1, null, sMt1, sMt2, sMt2, sMt1, sMt1, null),
+            new RecipeShape(null, sMt1, sMt1, sMt2, sMt2, sMt1, null, sMt1, sMt1),
+            new RecipeShape(null, sMt2, null, sMt1, sMt2, sMt1, sMt1, sMt1, sMt1),
+            new RecipeShape(sMt1, null, null, null, sMt1, null, null, null, null),
+            new RecipeShape(null, sMt1, null, sMt1, null, null, null, null, null),
+            new RecipeShape(sMt1, sMt1, null, sMt2, null, sMt1, sMt2, null, null),
+            new RecipeShape(null, sMt1, sMt1, sMt1, null, sMt2, null, null, sMt2)
     };
     private static final String[][] sShapesA = new String[][]{
             null,
@@ -307,10 +308,7 @@ public class GT_RecipeRegistrator {
      */
     public static synchronized void registerUsagesForMaterials(String aPlate, boolean aRecipeReplacing, ItemStack... aMats) {
         for (ItemStack aMat : aMats) {
-            if (aMat == null)
-                continue;
-
-            aMat = GT_Utility.copy(aMat);
+            aMat = GT_Utility.copyOrNull(aMat);
 
             if (aMat == null)
                 continue;
@@ -327,20 +325,17 @@ public class GT_RecipeRegistrator {
             sMt2.stackSize = 1;
             Items.feather.setDamage(sMt2, 0);
 
-            for (ItemStack[] tRecipe : sShapes1) {
-                int tAmount1 = 0;
-                for (ItemStack tMat : tRecipe) {
-                    if (tMat == sMt1) tAmount1++;
-                }
-                if (aItemData != null && aItemData.hasValidPrefixMaterialData())
-                    for (ItemStack tCrafted : GT_ModHandler.getRecipeOutputsBuffered(tRecipe)) {
-                        GT_OreDictUnificator.addItemData(tCrafted, new ItemData(aItemData.mMaterial.mMaterial, aItemData.mMaterial.mAmount * tAmount1));
-//                        GT_Log.out.println("###################################################################################");
-//                        GT_Log.out.println("registerUsagesForMaterials used aPlate: "+aPlate);
-//                        GT_Log.out.println("registerUsagesForMaterials used aPlate: "+aMat.getUnlocalizedName());
-//                        GT_Log.out.println("registerUsagesForMaterials used aPlate: "+aMat.getDisplayName());
-//                        GT_Log.out.println("###################################################################################");
+            if(aItemData != null && aItemData.hasValidPrefixMaterialData()) {
+                for (RecipeShape tRecipe : sShapes) {
+                    for (ItemStack tCrafted : GT_ModHandler.getRecipeOutputsBuffered(tRecipe.shape)) {
+                        GT_OreDictUnificator.addItemData(tCrafted, new ItemData(aItemData.mMaterial.mMaterial, aItemData.mMaterial.mAmount * tRecipe.amount1));
+                        //                        GT_Log.out.println("###################################################################################");
+                        //                        GT_Log.out.println("registerUsagesForMaterials used aPlate: "+aPlate);
+                        //                        GT_Log.out.println("registerUsagesForMaterials used aPlate: "+aMat.getUnlocalizedName());
+                        //                        GT_Log.out.println("registerUsagesForMaterials used aPlate: "+aMat.getDisplayName());
+                        //                        GT_Log.out.println("###################################################################################");
                     }
+                }
             }
             registerStickStuff(aPlate, aItemData, aRecipeReplacing);
         }
@@ -355,22 +350,17 @@ public class GT_RecipeRegistrator {
                 sMt2.stackSize = 1;
                 Items.feather.setDamage(sMt2, Items.feather.getDamage(tMt2));
 
-                for (int i = 0; i < sShapes1.length; i++) {
-                    ItemStack[] tRecipe = sShapes1[i];
+                for (int i = 0; i < sShapes.length; i++) {
+                    RecipeShape tRecipe = sShapes[i];
 
-                    int tAmount1 = 0, tAmount2 = 0;
-                    for (ItemStack tMat : tRecipe) {
-                        if (tMat == sMt1) tAmount1++;
-                        if (tMat == sMt2) tAmount2++;
-                    }
-                    for (ItemStack tCrafted : GT_ModHandler.getVanillyToolRecipeOutputs(tRecipe)) {
+                    for (ItemStack tCrafted : GT_ModHandler.getVanillyToolRecipeOutputs(tRecipe.shape)) {
                         if (aItemData != null && aItemData.hasValidPrefixMaterialData())
-                            GT_OreDictUnificator.addItemData(tCrafted, new ItemData(aItemData.mMaterial.mMaterial, aItemData.mMaterial.mAmount * tAmount1, new MaterialStack(tMaterial, OrePrefixes.stick.mMaterialAmount * tAmount2)));
+                            GT_OreDictUnificator.addItemData(tCrafted, new ItemData(aItemData.mMaterial.mMaterial, aItemData.mMaterial.mAmount * tRecipe.amount1, new MaterialStack(tMaterial, OrePrefixes.stick.mMaterialAmount * tRecipe.amount2)));
 
                         if (aRecipeReplacing && aPlate != null && sShapesA[i] != null && sShapesA[i].length > 1) {
                             assert aItemData != null;
                             if (GregTech_API.sRecipeFile.get(ConfigCategories.Recipes.recipereplacements, aItemData.mMaterial.mMaterial + "." + sShapesA[i][0], true)) {
-                                if (null != (tStack = GT_ModHandler.removeRecipe(tRecipe))) {
+                                if (null != (tStack = GT_ModHandler.removeRecipe(tRecipe.shape))) {
 //                                    GT_Log.out.println("###################################################################################");
 //                                    GT_Log.out.println("registerStickStuff used aPlate: "+aPlate);
 //                                    GT_Log.out.println("###################################################################################");
@@ -398,4 +388,18 @@ public class GT_RecipeRegistrator {
         return Arrays.stream(VANILLA_MATS).anyMatch(mat -> mat == materials);
     }
 
+    private static class RecipeShape {
+        private final ItemStack[] shape;
+        private int amount1;
+        private int amount2;
+
+        public RecipeShape(ItemStack... shape) {
+            this.shape = shape;
+
+            for (ItemStack stack : shape) {
+                if(stack == sMt1) this.amount1++;
+                if(stack == sMt2) this.amount2++;
+            }
+        }
+    }
 }

--- a/src/main/java/gregtech/api/util/GT_Utility.java
+++ b/src/main/java/gregtech/api/util/GT_Utility.java
@@ -90,6 +90,7 @@ import net.minecraftforge.fluids.IFluidContainerItem;
 import net.minecraftforge.fluids.IFluidHandler;
 import net.minecraftforge.oredict.OreDictionary;
 
+import javax.annotation.Nullable;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -1648,6 +1649,12 @@ public class GT_Utility {
 
     public static ItemStack copy(Object... aStacks) {
         for (Object tStack : aStacks) if (isStackValid(tStack)) return ((ItemStack) tStack).copy();
+        return null;
+    }
+
+    @Nullable
+    public static ItemStack copyOrNull(@Nullable ItemStack stack) {
+        if (isStackValid(stack)) return stack.copy();
         return null;
     }
 

--- a/src/main/java/gregtech/api/util/GT_Utility.java
+++ b/src/main/java/gregtech/api/util/GT_Utility.java
@@ -89,6 +89,8 @@ import net.minecraftforge.fluids.FluidTankInfo;
 import net.minecraftforge.fluids.IFluidContainerItem;
 import net.minecraftforge.fluids.IFluidHandler;
 import net.minecraftforge.oredict.OreDictionary;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import javax.annotation.Nullable;
 import java.lang.reflect.Constructor;
@@ -439,7 +441,7 @@ public class GT_Utility {
                         if (isAllowedToTakeFromSlot(aTileEntity1, aGrabSlot, (byte) aGrabFrom, aTileEntity1.getStackInSlot(aGrabSlot))) {
                             if (Math.max(aMinMoveAtOnce, aMinTargetStackSize) <= aTileEntity1.getStackInSlot(aGrabSlot).stackSize) {
                                 ItemStack tStack = copyAmount(Math.min(aTileEntity1.getStackInSlot(aGrabSlot).stackSize, Math.min(aMaxMoveAtOnce, aMaxTargetStackSize)), aTileEntity1.getStackInSlot(aGrabSlot));
-                                ItemStack rStack = ((IItemDuct) aTileEntity2).insertItem(ForgeDirection.getOrientation(aPutTo), copy(tStack));
+                                ItemStack rStack = ((IItemDuct) aTileEntity2).insertItem(ForgeDirection.getOrientation(aPutTo), copyOrNull(tStack));
                                 byte tMovedItemCount = (byte) (tStack.stackSize - (rStack == null ? 0 : rStack.stackSize));
                                 if (tMovedItemCount >= 1/*Math.max(aMinMoveAtOnce, aMinTargetStackSize)*/) {
                                     //((cofh.api.transport.IItemConduit)aTileEntity2).insertItem(ForgeDirection.getOrientation(aPutTo), copyAmount(tMovedItemCount, tStack), F);
@@ -459,7 +461,7 @@ public class GT_Utility {
                         if (isAllowedToTakeFromSlot(aTileEntity1, aGrabSlot, (byte) aGrabFrom, aTileEntity1.getStackInSlot(aGrabSlot))) {
                             if (Math.max(aMinMoveAtOnce, aMinTargetStackSize) <= aTileEntity1.getStackInSlot(aGrabSlot).stackSize) {
                                 ItemStack tStack = copyAmount(Math.min(aTileEntity1.getStackInSlot(aGrabSlot).stackSize, Math.min(aMaxMoveAtOnce, aMaxTargetStackSize)), aTileEntity1.getStackInSlot(aGrabSlot));
-                                byte tMovedItemCount = (byte) ((buildcraft.api.transport.IPipeTile) aTileEntity2).injectItem(copy(tStack), false, ForgeDirection.getOrientation(aPutTo));
+                                byte tMovedItemCount = (byte) ((buildcraft.api.transport.IPipeTile) aTileEntity2).injectItem(copyOrNull(tStack), false, ForgeDirection.getOrientation(aPutTo));
                                 if (tMovedItemCount >= Math.max(aMinMoveAtOnce, aMinTargetStackSize)) {
                                     tMovedItemCount = (byte) (((buildcraft.api.transport.IPipeTile) aTileEntity2).injectItem(copyAmount(tMovedItemCount, tStack), true, ForgeDirection.getOrientation(aPutTo)));
                                     aTileEntity1.decrStackSize(aGrabSlot, tMovedItemCount);
@@ -510,7 +512,7 @@ public class GT_Utility {
         ItemStack tStack1 = aTileEntity1.getStackInSlot(aGrabFrom), tStack2 = aTileEntity2.getStackInSlot(aPutTo), tStack3 = null;
         if (tStack1 != null) {
             if (tStack2 != null && !areStacksEqual(tStack1, tStack2)) return 0;
-            tStack3 = copy(tStack1);
+            tStack3 = copyOrNull(tStack1);
             aMaxTargetStackSize = (byte) Math.min(aMaxTargetStackSize, Math.min(tStack3.getMaxStackSize(), Math.min(tStack2 == null ? Integer.MAX_VALUE : tStack2.getMaxStackSize(), aTileEntity2.getInventoryStackLimit())));
             tStack3.stackSize = Math.min(tStack3.stackSize, aMaxTargetStackSize - (tStack2 == null ? 0 : tStack2.stackSize));
             if (tStack3.stackSize > aMaxMoveAtOnce) tStack3.stackSize = aMaxMoveAtOnce;
@@ -519,7 +521,7 @@ public class GT_Utility {
                 aTileEntity1.markDirty();
                 if (tStack3 != null) {
                     if (tStack2 == null) {
-                        aTileEntity2.setInventorySlotContents(aPutTo, copy(tStack3));
+                        aTileEntity2.setInventorySlotContents(aPutTo, copyOrNull(tStack3));
                     } else {
                         tStack2.stackSize += tStack3.stackSize;
                     }
@@ -1147,7 +1149,7 @@ public class GT_Utility {
         	if(tOreName.toString().equals("dustAsh")&&tStack[0].getUnlocalizedName().equals("tile.volcanicAsh"))return false;
             aRecipeList.put(new RecipeInputOreDict(tOreName.toString(), aInput.stackSize), new RecipeOutput(aNBT, tStack));
         } else {
-            aRecipeList.put(new RecipeInputItemStack(copy(aInput), aInput.stackSize), new RecipeOutput(aNBT, tStack));
+            aRecipeList.put(new RecipeInputItemStack(copyOrNull(aInput), aInput.stackSize), new RecipeOutput(aNBT, tStack));
         }
         return true;
     }
@@ -1191,7 +1193,7 @@ public class GT_Utility {
         rStack.setTagCompound(tNBT);
         GT_Log.out.println("GT_Mod: Added Book to Book List  -  Mapping: '" + aMapping + "'  -  Name: '" + aTitle + "'  -  Author: '" + aAuthor + "'");
         GregTech_API.sBookList.put(aMapping, rStack);
-        return copy(rStack);
+        return copyOrNull(rStack);
     }
 
     public static boolean doSoundAtClient(String aSoundName, int aTimeUntilNextSound, float aSoundStrength) {

--- a/src/main/java/gregtech/common/GT_ThaumcraftCompat.java
+++ b/src/main/java/gregtech/common/GT_ThaumcraftCompat.java
@@ -182,7 +182,7 @@ public class GT_ThaumcraftCompat implements IThaumcraftCompat {
         if ((GT_Utility.isStringInvalid(aResearch)) || (aInput == null) || (aOutput == null) || (aAspects == null) || (aAspects.isEmpty())) {
             return null;
         }
-        return ThaumcraftApi.addCrucibleRecipe(aResearch, GT_Utility.copy(new Object[]{aOutput}), ((aInput instanceof ItemStack)) || ((aInput instanceof ArrayList)) ? aInput : aInput.toString(), getAspectList(aAspects));
+        return ThaumcraftApi.addCrucibleRecipe(aResearch, GT_Utility.copyOrNull(aOutput), ((aInput instanceof ItemStack)) || ((aInput instanceof ArrayList)) ? aInput : aInput.toString(), getAspectList(aAspects));
     }
 
     @Override
@@ -190,7 +190,7 @@ public class GT_ThaumcraftCompat implements IThaumcraftCompat {
         if ((GT_Utility.isStringInvalid(aResearch)) || (aMainInput == null) || (aSideInputs == null) || (aOutput == null) || (aAspects == null) || (aAspects.isEmpty())) {
             return null;
         }
-        return ThaumcraftApi.addInfusionCraftingRecipe(aResearch, GT_Utility.copy(new Object[]{aOutput}), aInstability, getAspectList(aAspects), aMainInput, aSideInputs);
+        return ThaumcraftApi.addInfusionCraftingRecipe(aResearch, GT_Utility.copyOrNull(aOutput), aInstability, getAspectList(aAspects), aMainInput, aSideInputs);
     }
     
 	@Override

--- a/src/main/java/gregtech/common/entities/GT_Entity_Arrow.java
+++ b/src/main/java/gregtech/common/entities/GT_Entity_Arrow.java
@@ -345,7 +345,7 @@ public class GT_Entity_Arrow extends EntityArrow {
     }
 
     public ItemStack getArrowItem() {
-        return GT_Utility.copy(this.mArrow);
+        return GT_Utility.copyOrNull(this.mArrow);
     }
 
     public void setArrowItem(ItemStack aStack) {

--- a/src/main/java/gregtech/common/gui/GT_Container_Regulator.java
+++ b/src/main/java/gregtech/common/gui/GT_Container_Regulator.java
@@ -81,7 +81,7 @@ public class GT_Container_Regulator extends GT_ContainerMetaTile_Machine {
             if ((aSlotIndex < 19)) {
                 ItemStack tStack = aPlayer.inventory.getItemStack();
                 if (tStack != null) {
-                    tSlot.putStack(GT_Utility.copy(new Object[]{tStack}));
+                    tSlot.putStack(GT_Utility.copyOrNull(tStack));
                 } else if (tSlot.getStack() != null) {
                     if (aMouseclick == 0) {
                         tSlot.getStack().stackSize -= (aShifthold == 1 ? 8 : 1);

--- a/src/main/java/gregtech/common/items/behaviors/Behaviour_DataOrb.java
+++ b/src/main/java/gregtech/common/items/behaviors/Behaviour_DataOrb.java
@@ -14,7 +14,7 @@ public class Behaviour_DataOrb extends Behaviour_None {
             if (aNewContent[i] == null) {
                 aInventory[i] = null;
             } else {
-                aInventory[i] = GT_Utility.copy(new Object[]{aNewContent[i]});
+                aInventory[i] = GT_Utility.copyOrNull(aNewContent[i]);
             }
         }
     }

--- a/src/main/java/gregtech/common/items/behaviors/Behaviour_Sonictron.java
+++ b/src/main/java/gregtech/common/items/behaviors/Behaviour_Sonictron.java
@@ -90,7 +90,7 @@ public class Behaviour_Sonictron extends Behaviour_None {
             if (aNewContent[i] == null) {
                 aInventory[i] = null;
             } else {
-                aInventory[i] = GT_Utility.copy(aNewContent[i]);
+                aInventory[i] = GT_Utility.copyOrNull(aNewContent[i]);
             }
         }
     }

--- a/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_Scanner.java
+++ b/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_Scanner.java
@@ -86,7 +86,7 @@ public class GT_MetaTileEntity_Scanner extends GT_MetaTileEntity_BasicMachine {
                     if (tIndividual != null) {
                         if (tIndividual.analyze()) {
                             getFillableStack().amount -= 100;
-                            this.mOutputItems[0] = GT_Utility.copy(aStack);
+                            this.mOutputItems[0] = GT_Utility.copyOrNull(aStack);
                             aStack.stackSize = 0;
                             NBTTagCompound tNBT = new NBTTagCompound();
                             tIndividual.writeToNBT(tNBT);
@@ -97,7 +97,7 @@ public class GT_MetaTileEntity_Scanner extends GT_MetaTileEntity_BasicMachine {
                                 return FOUND_RECIPE_BUT_DID_NOT_MEET_REQUIREMENTS;
                             return 2;
                         }
-                        this.mOutputItems[0] = GT_Utility.copy(aStack);
+                        this.mOutputItems[0] = GT_Utility.copyOrNull(aStack);
                         aStack.stackSize = 0;
                         this.mMaxProgresstime = 1;
                         this.mEUt = 1;

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_DrillerBase.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_DrillerBase.java
@@ -207,7 +207,7 @@ public abstract class GT_MetaTileEntity_DrillerBase extends GT_MetaTileEntity_Mu
             if (!storedItem.isItemEqual(miningPipe)) continue;
 
             if (pipes == null) {
-                setInventorySlotContents(1, GT_Utility.copy(miningPipe));
+                setInventorySlotContents(1, GT_Utility.copyOrNull(miningPipe));
                 pipes = getStackInSlot(1);
             }
 

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_PrimitiveBlastFurnace.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_PrimitiveBlastFurnace.java
@@ -282,7 +282,7 @@ public abstract class GT_MetaTileEntity_PrimitiveBlastFurnace extends MetaTileEn
         for (int i = 0; i < limit; i++) {
             int absi = INPUT_SLOTS + i;
             if (this.mInventory[absi] == null) {
-                this.mInventory[absi] = GT_Utility.copy(this.mOutputItems[i]);
+                this.mInventory[absi] = GT_Utility.copyOrNull(this.mOutputItems[i]);
             } else if (GT_Utility.areStacksEqual(this.mInventory[absi], this.mOutputItems[i])) {
                 this.mInventory[absi].stackSize = Math.min(this.mInventory[absi].getMaxStackSize(),
                         this.mInventory[absi].stackSize + this.mOutputItems[i].stackSize);

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingLog.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingLog.java
@@ -56,9 +56,9 @@ public class ProcessingLog implements gregtech.api.interfaces.IOreRecipeRegistra
                 }
                 else
                 {
-                    ItemStack tPlanks = GT_Utility.copy(tStack);
+                    ItemStack tPlanks = GT_Utility.copyOrNull(tStack);
                     tPlanks.stackSize = (tPlanks.stackSize * 3 / 2);
-                    GT_Values.RA.addCutterRecipe(new ItemStack(aStack.getItem(), 1, i), Materials.Lubricant.getFluid(1L), GT_Utility.copy(tPlanks), GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 1L), 200, 8);
+                    GT_Values.RA.addCutterRecipe(new ItemStack(aStack.getItem(), 1, i), Materials.Lubricant.getFluid(1L), GT_Utility.copyOrNull(tPlanks), GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 1L), 200, 8);
                     GT_Values.RA.addCutterRecipe(new ItemStack(aStack.getItem(), 1, i), GT_Utility.copyAmount(GT_Mod.gregtechproxy.mNerfedWoodPlank ? tStack.stackSize : tStack.stackSize * 5 / 4, tStack), GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 2L), 200, 8);
                     GT_ModHandler.addSawmillRecipe(new ItemStack(aStack.getItem(), 1, i), tPlanks, GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 1L));
                     GT_ModHandler.removeRecipeDelayed(new ItemStack(aStack.getItem(), 1, i));
@@ -75,9 +75,9 @@ public class ProcessingLog implements gregtech.api.interfaces.IOreRecipeRegistra
             }
             ItemStack tStack = GT_ModHandler.getRecipeOutput(GT_Utility.copyAmount(1L, aStack));
             if (tStack != null) {
-                ItemStack tPlanks = GT_Utility.copy(tStack);
+                ItemStack tPlanks = GT_Utility.copyOrNull(tStack);
                 tPlanks.stackSize = (tPlanks.stackSize * 3 / 2);
-                GT_Values.RA.addCutterRecipe(GT_Utility.copyAmount(1L, aStack), Materials.Lubricant.getFluid(1L), GT_Utility.copy(tPlanks), GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 1L), 200, 8);
+                GT_Values.RA.addCutterRecipe(GT_Utility.copyAmount(1L, aStack), Materials.Lubricant.getFluid(1L), GT_Utility.copyOrNull(tPlanks), GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 1L), 200, 8);
                 GT_Values.RA.addCutterRecipe(GT_Utility.copyAmount(1L, aStack), GT_Utility.copyAmount(GT_Mod.gregtechproxy.mNerfedWoodPlank ? tStack.stackSize : tStack.stackSize * 5 / 4, tStack), GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 2L), 200, 8);
                 GT_ModHandler.addSawmillRecipe(GT_Utility.copyAmount(1L, aStack), tPlanks, GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 1L));
                 GT_ModHandler.removeRecipeDelayed(GT_Utility.copyAmount(1L, aStack));

--- a/src/main/java/gregtech/nei/GT_NEI_AssLineHandler.java
+++ b/src/main/java/gregtech/nei/GT_NEI_AssLineHandler.java
@@ -105,7 +105,7 @@ public class GT_NEI_AssLineHandler extends TemplateRecipeHandler {
             tResults.add(GT_Utility.getFluidDisplayStack(tFluid, false));
             for (FluidContainerRegistry.FluidContainerData tData : FluidContainerRegistry.getRegisteredFluidContainerData()) {
                 if (tData.fluid.isFluidEqual(tFluid)) {
-                    tResults.add(GT_Utility.copy(tData.filledContainer));
+                    tResults.add(GT_Utility.copyOrNull(tData.filledContainer));
                 }
             }
         }
@@ -147,7 +147,7 @@ public class GT_NEI_AssLineHandler extends TemplateRecipeHandler {
             tInputs.add(GT_Utility.getFluidDisplayStack(tFluid, false));
             for (FluidContainerRegistry.FluidContainerData tData : FluidContainerRegistry.getRegisteredFluidContainerData()) {
                 if (tData.fluid.isFluidEqual(tFluid)) {
-                    tInputs.add(GT_Utility.copy(tData.filledContainer));
+                    tInputs.add(GT_Utility.copyOrNull(tData.filledContainer));
                 }
             }
         }
@@ -370,7 +370,7 @@ public class GT_NEI_AssLineHandler extends TemplateRecipeHandler {
                             tDisplayStacks.add(base);
                         }
                     } else {
-                        tDisplayStacks.add(GT_Utility.copy(new Object[]{tStack}));
+                        tDisplayStacks.add(GT_Utility.copyOrNull(tStack));
                     }
                 }
             }

--- a/src/main/java/gregtech/nei/GT_NEI_DefaultHandler.java
+++ b/src/main/java/gregtech/nei/GT_NEI_DefaultHandler.java
@@ -102,7 +102,7 @@ public class GT_NEI_DefaultHandler extends TemplateRecipeHandler {
             tResults.add(GT_Utility.getFluidDisplayStack(tFluid, false));
             for (FluidContainerRegistry.FluidContainerData tData : FluidContainerRegistry.getRegisteredFluidContainerData()) {
                 if (tData.fluid.isFluidEqual(tFluid)) {
-                    tResults.add(GT_Utility.copy(tData.filledContainer));
+                    tResults.add(GT_Utility.copyOrNull(tData.filledContainer));
                 }
             }
         }
@@ -136,7 +136,7 @@ public class GT_NEI_DefaultHandler extends TemplateRecipeHandler {
             tInputs.add(GT_Utility.getFluidDisplayStack(tFluid, false));
             for (FluidContainerRegistry.FluidContainerData tData : FluidContainerRegistry.getRegisteredFluidContainerData()) {
                 if (tData.fluid.isFluidEqual(tFluid)) {
-                    tInputs.add(GT_Utility.copy(tData.filledContainer));
+                    tInputs.add(GT_Utility.copyOrNull(tData.filledContainer));
                 }
             }
         }
@@ -385,7 +385,7 @@ public class GT_NEI_DefaultHandler extends TemplateRecipeHandler {
                             tDisplayStacks.add(base);
                         }
                     } else {
-                        tDisplayStacks.add(GT_Utility.copy(tStack));
+                        tDisplayStacks.add(GT_Utility.copyOrNull(tStack));
                     }
                 }
             }


### PR DESCRIPTION
Improving Vanilla Materials Replacement code, removed uselessly-repeated operations (checking the amount of stacks in the same recipe shape) - (minus at least 1 second of loading, yeeeeah).
Removed useless array creation in most #copy methods by changing them to #copyOrNull variant with single parameter.