### PR TITLE
Fix single-block boiler GUI handling of water capacity. Also set lava boiler to 32000 capacity.

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 minecraft.version=1.7.10
 forge.version=10.13.4.1614-1.7.10
-gt.version=5.09.36.00
+gt.version=5.09.37.00
 ae2.version=rv3-beta-22
 applecore.version=1.7.10-1.2.1+107.59407
 buildcraft.version=7.1.11

--- a/src/main/java/gregtech/common/gui/GT_Container_Boiler.java
+++ b/src/main/java/gregtech/common/gui/GT_Container_Boiler.java
@@ -52,8 +52,8 @@ public class GT_Container_Boiler extends GT_ContainerMetaTile_Machine {
         this.mWaterAmount = (((GT_MetaTileEntity_Boiler) this.mTileEntity.getMetaTileEntity()).mFluid == null ? 0 : ((GT_MetaTileEntity_Boiler) this.mTileEntity.getMetaTileEntity()).mFluid.amount);
 
         this.mTemperature = Math.min(54, Math.max(0, this.mTemperature * 54 / (((GT_MetaTileEntity_Boiler) this.mTileEntity.getMetaTileEntity()).maxProgresstime() - 10)));
-        this.mSteamAmount = Math.min(54, Math.max(0, this.mSteamAmount * 54 / capacity));
-        this.mWaterAmount = Math.min(54, Math.max(0, this.mWaterAmount * 54 / capacity));
+        this.mSteamAmount = Math.min(54, Math.max(0, this.mSteamAmount * 54 / (capacity - 100)));
+        this.mWaterAmount = Math.min(54, Math.max(0, this.mWaterAmount * 54 / (capacity - 100)));
         this.mProcessingEnergy = Math.min(14, Math.max(this.mProcessingEnergy > 0 ? 1 : 0, this.mProcessingEnergy * 14 / 1000));
 
         for (Object crafter : this.crafters) {

--- a/src/main/java/gregtech/common/gui/GT_Container_Boiler.java
+++ b/src/main/java/gregtech/common/gui/GT_Container_Boiler.java
@@ -10,14 +10,12 @@ import net.minecraft.inventory.ICrafting;
 import net.minecraft.inventory.Slot;
 
 public class GT_Container_Boiler extends GT_ContainerMetaTile_Machine {
-    private int mSteamCapacity = 0;//FB: UR - UR_UNINIT_READ_CALLED_FROM_SUPER_CONSTRUCTOR
     public int mWaterAmount = 0;
     public int mSteamAmount = 0;
     public int mProcessingEnergy = 0;
     public int mTemperature = 2;
-    public GT_Container_Boiler(InventoryPlayer aInventoryPlayer, IGregTechTileEntity aTileEntity, int aSteamCapacity) {
+    public GT_Container_Boiler(InventoryPlayer aInventoryPlayer, IGregTechTileEntity aTileEntity) {
         super(aInventoryPlayer, aTileEntity);
-        this.mSteamCapacity = aSteamCapacity;
     }
 
     @Override
@@ -44,14 +42,18 @@ public class GT_Container_Boiler extends GT_ContainerMetaTile_Machine {
         if ((this.mTileEntity.isClientSide()) || (this.mTileEntity.getMetaTileEntity() == null)) {
             return;
         }
+
+        // GT_MetaTileEntity_Boilder.getCapacity() is used for both water and steam capacity.
+        int capacity = ((GT_MetaTileEntity_Boiler) this.mTileEntity.getMetaTileEntity()).getCapacity();
+
         this.mTemperature = ((GT_MetaTileEntity_Boiler) this.mTileEntity.getMetaTileEntity()).mTemperature;
         this.mProcessingEnergy = ((GT_MetaTileEntity_Boiler) this.mTileEntity.getMetaTileEntity()).mProcessingEnergy;
         this.mSteamAmount = (((GT_MetaTileEntity_Boiler) this.mTileEntity.getMetaTileEntity()).mSteam == null ? 0 : ((GT_MetaTileEntity_Boiler) this.mTileEntity.getMetaTileEntity()).mSteam.amount);
         this.mWaterAmount = (((GT_MetaTileEntity_Boiler) this.mTileEntity.getMetaTileEntity()).mFluid == null ? 0 : ((GT_MetaTileEntity_Boiler) this.mTileEntity.getMetaTileEntity()).mFluid.amount);
 
         this.mTemperature = Math.min(54, Math.max(0, this.mTemperature * 54 / (((GT_MetaTileEntity_Boiler) this.mTileEntity.getMetaTileEntity()).maxProgresstime() - 10)));
-        this.mSteamAmount = Math.min(54, Math.max(0, this.mSteamAmount * 54 / (this.mSteamCapacity - 100)));
-        this.mWaterAmount = Math.min(54, Math.max(0, this.mWaterAmount * 54 / 15900));
+        this.mSteamAmount = Math.min(54, Math.max(0, this.mSteamAmount * 54 / capacity));
+        this.mWaterAmount = Math.min(54, Math.max(0, this.mWaterAmount * 54 / capacity));
         this.mProcessingEnergy = Math.min(14, Math.max(this.mProcessingEnergy > 0 ? 1 : 0, this.mProcessingEnergy * 14 / 1000));
 
         for (Object crafter : this.crafters) {

--- a/src/main/java/gregtech/common/gui/GT_Container_Boiler.java
+++ b/src/main/java/gregtech/common/gui/GT_Container_Boiler.java
@@ -43,7 +43,7 @@ public class GT_Container_Boiler extends GT_ContainerMetaTile_Machine {
             return;
         }
 
-        // GT_MetaTileEntity_Boilder.getCapacity() is used for both water and steam capacity.
+        // GT_MetaTileEntity_Boiler.getCapacity() is used for both water and steam capacity.
         int capacity = ((GT_MetaTileEntity_Boiler) this.mTileEntity.getMetaTileEntity()).getCapacity();
 
         this.mTemperature = ((GT_MetaTileEntity_Boiler) this.mTileEntity.getMetaTileEntity()).mTemperature;

--- a/src/main/java/gregtech/common/gui/GT_GUIContainer_Boiler.java
+++ b/src/main/java/gregtech/common/gui/GT_GUIContainer_Boiler.java
@@ -5,8 +5,8 @@ import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import net.minecraft.entity.player.InventoryPlayer;
 
 public class GT_GUIContainer_Boiler extends GT_GUIContainerMetaTile_Machine {
-    public GT_GUIContainer_Boiler(InventoryPlayer aInventoryPlayer, IGregTechTileEntity aTileEntity, String aTextureName, int aSteamCapacity) {
-        super(new GT_Container_Boiler(aInventoryPlayer, aTileEntity, aSteamCapacity), "gregtech:textures/gui/" + aTextureName);
+    public GT_GUIContainer_Boiler(InventoryPlayer aInventoryPlayer, IGregTechTileEntity aTileEntity, String aTextureName) {
+        super(new GT_Container_Boiler(aInventoryPlayer, aTileEntity), "gregtech:textures/gui/" + aTextureName);
     }
 
     @Override

--- a/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Bronze.java
+++ b/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Bronze.java
@@ -76,12 +76,12 @@ public class GT_MetaTileEntity_Boiler_Bronze extends GT_MetaTileEntity_Boiler {
 
     @Override
     public Object getServerGUI(int aID, InventoryPlayer aPlayerInventory, IGregTechTileEntity aBaseMetaTileEntity) {
-        return new GT_Container_Boiler(aPlayerInventory, aBaseMetaTileEntity, 16000);
+        return new GT_Container_Boiler(aPlayerInventory, aBaseMetaTileEntity);
     }
 
     @Override
     public Object getClientGUI(int aID, InventoryPlayer aPlayerInventory, IGregTechTileEntity aBaseMetaTileEntity) {
-        return new GT_GUIContainer_Boiler(aPlayerInventory, aBaseMetaTileEntity, "BronzeBoiler.png", 16000);
+        return new GT_GUIContainer_Boiler(aPlayerInventory, aBaseMetaTileEntity, "BronzeBoiler.png");
     }
 
     @Override

--- a/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Lava.java
+++ b/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Lava.java
@@ -87,7 +87,9 @@ public class GT_MetaTileEntity_Boiler_Lava extends GT_MetaTileEntity_Boiler {
     }
 
     @Override
-    public int getCapacity() { return 32000; }
+    public int getCapacity() {
+        return 32000;
+    }
 
     @Override
     public MetaTileEntity newMetaEntity(IGregTechTileEntity aTileEntity) {

--- a/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Lava.java
+++ b/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Lava.java
@@ -78,13 +78,16 @@ public class GT_MetaTileEntity_Boiler_Lava extends GT_MetaTileEntity_Boiler {
 
     @Override
     public Object getServerGUI(int aID, InventoryPlayer aPlayerInventory, IGregTechTileEntity aBaseMetaTileEntity) {
-        return new GT_Container_Boiler(aPlayerInventory, aBaseMetaTileEntity, 32000);
+        return new GT_Container_Boiler(aPlayerInventory, aBaseMetaTileEntity);
     }
 
     @Override
     public Object getClientGUI(int aID, InventoryPlayer aPlayerInventory, IGregTechTileEntity aBaseMetaTileEntity) {
-        return new GT_GUIContainer_Boiler(aPlayerInventory, aBaseMetaTileEntity, "SteelBoiler.png", 32000);
+        return new GT_GUIContainer_Boiler(aPlayerInventory, aBaseMetaTileEntity, "SteelBoiler.png");
     }
+
+    @Override
+    public int getCapacity() { return 32000; }
 
     @Override
     public MetaTileEntity newMetaEntity(IGregTechTileEntity aTileEntity) {

--- a/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Solar.java
+++ b/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Solar.java
@@ -114,12 +114,12 @@ public class GT_MetaTileEntity_Boiler_Solar extends GT_MetaTileEntity_Boiler {
 
     @Override
     public Object getServerGUI(int aID, InventoryPlayer aPlayerInventory, IGregTechTileEntity aBaseMetaTileEntity) {
-        return new GT_Container_Boiler(aPlayerInventory, aBaseMetaTileEntity, getCapacity());
+        return new GT_Container_Boiler(aPlayerInventory, aBaseMetaTileEntity);
     }
 
     @Override
     public Object getClientGUI(int aID, InventoryPlayer aPlayerInventory, IGregTechTileEntity aBaseMetaTileEntity) {
-        return new GT_GUIContainer_Boiler(aPlayerInventory, aBaseMetaTileEntity, "SolarBoiler.png", getCapacity());
+        return new GT_GUIContainer_Boiler(aPlayerInventory, aBaseMetaTileEntity, "SolarBoiler.png");
     }
 
     @Override

--- a/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Solar_Steel.java
+++ b/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Solar_Steel.java
@@ -56,7 +56,7 @@ public class GT_MetaTileEntity_Boiler_Solar_Steel extends GT_MetaTileEntity_Boil
 
     @Override
     public Object getClientGUI(int aID, InventoryPlayer aPlayerInventory, IGregTechTileEntity aBaseMetaTileEntity) {
-        return new GT_GUIContainer_Boiler(aPlayerInventory, aBaseMetaTileEntity, "SolarHPBoiler.png", getCapacity());
+        return new GT_GUIContainer_Boiler(aPlayerInventory, aBaseMetaTileEntity, "SolarHPBoiler.png");
     }
 
     @Override

--- a/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Steel.java
+++ b/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Steel.java
@@ -66,12 +66,12 @@ public class GT_MetaTileEntity_Boiler_Steel extends GT_MetaTileEntity_Boiler_Bro
 
     @Override
     public Object getServerGUI(int aID, InventoryPlayer aPlayerInventory, IGregTechTileEntity aBaseMetaTileEntity) {
-        return new GT_Container_Boiler(aPlayerInventory, aBaseMetaTileEntity, 32000);
+        return new GT_Container_Boiler(aPlayerInventory, aBaseMetaTileEntity);
     }
 
     @Override
     public Object getClientGUI(int aID, InventoryPlayer aPlayerInventory, IGregTechTileEntity aBaseMetaTileEntity) {
-        return new GT_GUIContainer_Boiler(aPlayerInventory, aBaseMetaTileEntity, "SteelBoiler.png", 32000);
+        return new GT_GUIContainer_Boiler(aPlayerInventory, aBaseMetaTileEntity, "SteelBoiler.png");
     }
 
     @Override


### PR DESCRIPTION
I'm new to modding, so apologies in advance if I did something wrong or missed something.

Related pull request:
 * https://github.com/GTNewHorizons/GTPP/pull/12

Bug fixes
---
 * Fixes incorrect GUI water capacity display of `16000` instead of `32000` for the GregTech HP coal and HP solar boilers.
 * Fixes incorrect GUI steam capacity display of `32000` instead of `16000` for the GregTech lava boiler.
 * Fixes GTNewHorizons/GT-New-Horizons-Modpack#8253

Changes
---
 * GregTech lava boiler set to have `32000` water & steam capacity instead of `16000`, bringing it in-line with the other steel-hulled GregTech boilers.
   * I believe that it was a mistake that it had `16000` capacity instead of `32000`. It used to have `32000` steam capacity, but a change deleted the overridden `onPostTick()` method that allowed it to have that capacity. Since `getCapacity()` was never overridden (this was probably an oversight), it continued to return the standard value of `16000`, causing the lava boiler to revert to having `16000` steam capacity.
   * https://github.com/GTNewHorizons/GT5-Unofficial/commit/0f6f89f7bbfd35628fa07f42ac3af8a29b88cfd8#diff-8a675176491e824dbd3955764420e7643ea38199d2f3b1db1de36068c580ccf7L114

API changes
---
 * `int aSteamCapacity` parameter removed from `GT_Container_Boiler` and `GT_GUIContainer_Boiler` constructors.
   * This parameter was only used to set the displayed maximum steam capacity, and did not actually modify the machine's steam capacity. Being able to set this parameter is confusing, because using any value here besides the one that's actually used in internal calculations (i.e. `getCapacity()`) is just going to cause the GUI to show the wrong value.
 * I searched on GitHub and I believe that GT++ is the only other repository which uses either of these two API methods, and I have updated those usages separately. If there are any other repositories which use this API, then they must be updated as well or this change will break them. Alternatively, I could add the parameter back in.
