### PR TITLE
Disable example code generating invalid materials

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 minecraft.version=1.7.10
 forge.version=10.13.4.1614-1.7.10
-gt.version=5.09.38.00
+gt.version=5.09.37.01
 ae2.version=rv3-beta-22
 applecore.version=1.7.10-1.2.1+107.59407
 buildcraft.version=7.1.11

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 minecraft.version=1.7.10
 forge.version=10.13.4.1614-1.7.10
-gt.version=5.09.37.00
+gt.version=5.09.38.00
 ae2.version=rv3-beta-22
 applecore.version=1.7.10-1.2.1+107.59407
 buildcraft.version=7.1.11

--- a/src/main/java/gregtech/loaders/materialprocessing/ProcessingConfig.java
+++ b/src/main/java/gregtech/loaders/materialprocessing/ProcessingConfig.java
@@ -15,7 +15,7 @@ public class ProcessingConfig implements gregtech.api.interfaces.IMaterialHandle
     @Override
     public void onMaterialsInit() {
         /** This is just left here as an example of how to add new materials. **/
-        // If you uncomment this, these custom ores will get added to the Deep Dark void miner ore list and cause bugged ores to be generated!
+        // If you uncomment this, these custom materials will get added to the Deep Dark void miner ore list and cause bugged ores to be generated!
         // See: com.dreammaster.bartworksHandler.VoidMinerLoader
         /*
         int i = 0;

--- a/src/main/java/gregtech/loaders/materialprocessing/ProcessingConfig.java
+++ b/src/main/java/gregtech/loaders/materialprocessing/ProcessingConfig.java
@@ -15,15 +15,13 @@ public class ProcessingConfig implements gregtech.api.interfaces.IMaterialHandle
     @Override
     public void onMaterialsInit() {
         /** This is just left here as an example of how to add new materials. **/
-        // If you uncomment this, these custom materials will get added to the Deep Dark void miner ore list and cause bugged ores to be generated!
-        // See: com.dreammaster.bartworksHandler.VoidMinerLoader
-        /*
-        int i = 0;
-        for (int j = GregTech_API.sMaterialProperties.get("general", "AmountOfCustomMaterialSlots", 16); i < j; i++) {
-            String aID = (i < 10 ? "0" : "") + i;
-            new Materials(-1, TextureSet.SET_METALLIC, 1.0F, 0, 0, 0, 255, 255, 255, 0, "CustomMat" + aID, "CustomMat" + aID, 0, 0, 0, 0, false, false, 1, 1, 1, Dyes._NULL, "custom", true, aID);
+        if (false) {
+            int i = 0;
+            for (int j = GregTech_API.sMaterialProperties.get("general", "AmountOfCustomMaterialSlots", 16); i < j; i++) {
+                String aID = (i < 10 ? "0" : "") + i;
+                new Materials(-1, TextureSet.SET_METALLIC, 1.0F, 0, 0, 0, 255, 255, 255, 0, "CustomMat" + aID, "CustomMat" + aID, 0, 0, 0, 0, false, false, 1, 1, 1, Dyes._NULL, "custom", true, aID);
+            }
         }
-        */
     }
 
     @Override

--- a/src/main/java/gregtech/loaders/materialprocessing/ProcessingConfig.java
+++ b/src/main/java/gregtech/loaders/materialprocessing/ProcessingConfig.java
@@ -15,11 +15,15 @@ public class ProcessingConfig implements gregtech.api.interfaces.IMaterialHandle
     @Override
     public void onMaterialsInit() {
         /** This is just left here as an example of how to add new materials. **/
+        // If you uncomment this, these custom ores will get added to the Deep Dark void miner ore list and cause bugged ores to be generated!
+        // See: com.dreammaster.bartworksHandler.VoidMinerLoader
+        /*
         int i = 0;
         for (int j = GregTech_API.sMaterialProperties.get("general", "AmountOfCustomMaterialSlots", 16); i < j; i++) {
             String aID = (i < 10 ? "0" : "") + i;
             new Materials(-1, TextureSet.SET_METALLIC, 1.0F, 0, 0, 0, 255, 255, 255, 0, "CustomMat" + aID, "CustomMat" + aID, 0, 0, 0, 0, false, false, 1, 1, 1, Dyes._NULL, "custom", true, aID);
         }
+        */
     }
 
     @Override


### PR DESCRIPTION
I added some debug code to the Deep Dark void miner, and noticed that the ore list includes some dummy example materials:
```
CustomMat00
CustomMat01
CustomMat02
CustomMat03
CustomMat04
CustomMat05
CustomMat06
CustomMat07
CustomMat08
CustomMat09
CustomMat10
CustomMat11
CustomMat12
CustomMat13
CustomMat14
CustomMat15
```

I checked that these example materials are creating null ores when mined by the void miner. This commit will remove these example materials, but it turns out that there are still some other bad materials that create null ores. Still, it seems like a good idea to reduce clutter by getting rid of these example materials.

It seems unlikely, but in the event that something actually uses these example materials, this commit will obviously break it. I checked that I can load into a world successfully, but I'm not sure how else to confirm that nothing breaks.

 * See: https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/196
 * Partial fix for GTNewHorizons/GT-New-Horizons-Modpack#6601