### PR TITLE
Delete no longer needed dynamic pyrolyse recipe code

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 minecraft.version=1.7.10
 forge.version=10.13.4.1614-1.7.10
-gt.version=5.09.37.01
+gt.version=5.09.37.02
 ae2.version=rv3-beta-22
 applecore.version=1.7.10-1.2.1+107.59407
 buildcraft.version=7.1.11

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_PyrolyseOven.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_PyrolyseOven.java
@@ -16,13 +16,11 @@ import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GT_Multiblock_Tooltip_Builder;
 import gregtech.api.util.GT_Recipe;
 import gregtech.api.util.GT_Utility;
-import gregtech.loaders.oreprocessing.ProcessingLog;
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.FluidStack;
-import net.minecraftforge.oredict.OreDictionary;
 import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.lwjgl.input.Keyboard;
 
@@ -108,10 +106,6 @@ public class GT_MetaTileEntity_PyrolyseOven extends GT_MetaTileEntity_MultiBlock
         byte tTier = (byte) Math.max(1, GT_Utility.getTier(tVoltage));
         GT_Recipe tRecipe = GT_Recipe.GT_Recipe_Map.sPyrolyseRecipes.findRecipe(getBaseMetaTileEntity(), false, gregtech.api.enums.GT_Values.V[tTier], tFluids, tInputs);
 
-        //Dynamic recipe adding for newly found logWoods - wont be visible in nei most probably
-        if (tRecipe == null)
-            tRecipe = addRecipesDynamically(tInputs, tFluids, tTier);
-
         if (tRecipe == null || !tRecipe.isRecipeInputEqual(true, tFluids, tInputs))
             return false;
 
@@ -131,21 +125,6 @@ public class GT_MetaTileEntity_PyrolyseOven extends GT_MetaTileEntity_MultiBlock
             this.mOutputFluids = new FluidStack[]{tRecipe.getFluidOutput(0)};
         updateSlots();
         return true;
-    }
-
-    private GT_Recipe addRecipesDynamically(ItemStack[] tInputs, FluidStack[] tFluids, int tTier) {
-        if (tInputs.length > 1 || (tInputs[0] != null && tInputs[0].getItem() != GT_Utility.getIntegratedCircuit(0).getItem())) {
-            int oreId = OreDictionary.getOreID("logWood");
-            for (ItemStack is : tInputs) {
-                for (int id : OreDictionary.getOreIDs(is)) {
-                    if (oreId == id) {
-                        ProcessingLog.addPyrolyeOvenRecipes(is);
-                        return GT_Recipe.GT_Recipe_Map.sPyrolyseRecipes.findRecipe(getBaseMetaTileEntity(), false, gregtech.api.enums.GT_Values.V[tTier], tFluids, tInputs);
-                    }
-                }
-            }
-        }
-        return null;
     }
 
     @Override


### PR DESCRIPTION
Delete the dynamic pyrolyse oven recipe generation code, which causes lag and is now redundant. This is the GT equivalent of
 * https://github.com/GTNewHorizons/bartworks/pull/19

This pull request shouldn't be merged until the pull request adding the new pyrolyse recipe code is merged:
 * GTNewHorizons/NewHorizonsCoreMod/pull/197
 * See GTNewHorizons/GT-New-Horizons-Modpack/issues/8047