### PR TITLE
changed rods to work with gt_utility hazmat check

### DIFF
--- a/src/main/java/gregtech/api/items/GT_RadioactiveCellIC_Item.java
+++ b/src/main/java/gregtech/api/items/GT_RadioactiveCellIC_Item.java
@@ -2,6 +2,7 @@ package gregtech.api.items;
 
 
 import gregtech.api.GregTech_API;
+import gregtech.api.util.GT_Utility;
 import ic2.api.reactor.IReactor;
 import ic2.api.reactor.IReactorComponent;
 import ic2.core.IC2Potion;
@@ -153,7 +154,7 @@ public class GT_RadioactiveCellIC_Item extends GT_RadioactiveCell_Item implement
     public void onUpdate(ItemStack stack, World world, Entity entity, int slotIndex, boolean isCurrentItem) {
         if (this.sRadiation > 0 && (entity instanceof EntityLivingBase)) {
             EntityLivingBase entityLiving = (EntityLivingBase) entity;
-            if (!GregTech_API.mIC2Classic&&!ItemArmorHazmat.hasCompleteHazmat(entityLiving)) {
+            if (!GregTech_API.mIC2Classic&&!GT_Utility.isWearingFullRadioHazmat(entityLiving)) {
                 IC2Potion.radiation.applyTo(entityLiving, sRadiation * 20, sRadiation * 10);
             }
         }


### PR DESCRIPTION
Fix for https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/8310

I noticed rods only give radiation poisoning so I'm checking only for radio protection.
Should this be full hazmat check?