### PR TITLE
increase the generator's eu capacity

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicGenerator.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicGenerator.java
@@ -152,7 +152,7 @@ public abstract class GT_MetaTileEntity_BasicGenerator extends GT_MetaTileEntity
 
     @Override
     public long maxEUStore() {
-        return Math.max(getEUVar(), V[mTier] * 40L + getMinimumStoredEU());
+        return Math.max(getEUVar(), V[mTier] * 80L + getMinimumStoredEU());
     }
 
     @Override


### PR DESCRIPTION
fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/7740
fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/7493
the LV combustion engine can't comsume the HOG correctly beacuse its capacity is too small.