### PR TITLE
Removed excess constructor with the same parameters

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_OutputBus.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_OutputBus.java
@@ -44,10 +44,6 @@ public class GT_MetaTileEntity_Hatch_OutputBus extends GT_MetaTileEntity_Hatch {
         super(aName, aTier, getSlots(aTier), aDescription, aTextures);
     }
 
-    public GT_MetaTileEntity_Hatch_OutputBus(String aName, int aTier, String[] aDescription, int inventorySize, ITexture[][][] aTextures) {
-        super(aName, aTier, inventorySize, aDescription, aTextures);
-    }
-
     public GT_MetaTileEntity_Hatch_OutputBus(String name, int tier, int slots, String[] description, ITexture[][][] textures) {
         super(name, tier, slots, description, textures);
     }

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_OutputBus_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_OutputBus_ME.java
@@ -2,7 +2,6 @@ package gregtech.common.tileentities.machines;
 
 import appeng.api.AEApi;
 import appeng.api.networking.GridFlags;
-import appeng.api.networking.energy.IEnergySource;
 import appeng.api.networking.security.BaseActionSource;
 import appeng.api.networking.security.IActionHost;
 import appeng.api.networking.security.MachineSource;
@@ -22,7 +21,6 @@ import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_OutputBus;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GT_Utility;
-
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTBase;
@@ -45,7 +43,7 @@ public class GT_MetaTileEntity_Hatch_OutputBus_ME extends GT_MetaTileEntity_Hatc
     }
 
     public GT_MetaTileEntity_Hatch_OutputBus_ME(String aName, int aTier, String[] aDescription, ITexture[][][] aTextures) {
-        super(aName, aTier, aDescription, 0, aTextures);
+        super(aName, aTier, 0, aDescription, aTextures);
     }
 
     @Override


### PR DESCRIPTION
The suggestion after: https://github.com/GTNewHorizons/GT5-Unofficial/pull/622#discussion_r681231949

Tested in modpack - it didn't cause any incompatibility.