### PR TITLE
Fix chest buffer infinite loop

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 minecraft.version=1.7.10
 forge.version=10.13.4.1614-1.7.10
-gt.version=5.09.37.06
+gt.version=5.09.37.07
 structurelib.version=1.0.6
 ae2.version=rv3-beta-22
 applecore.version=1.7.10-1.2.1+107.59407

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Buffer.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Buffer.java
@@ -329,20 +329,18 @@ public abstract class GT_MetaTileEntity_Buffer extends GT_MetaTileEntity_TieredM
     }
 
     protected void fillStacksIntoFirstSlots() {
-        if (bSortStacks) {
-            for (int i = 0; i < mInventory.length - 1; i++) {
-                if (!isValidSlot(i)) {
+        for (int i = 0; i < mInventory.length - 1; i++) {
+            if (!isValidSlot(i)) {
+                continue;
+            }
+
+            for (int j = i + 1; j < mInventory.length; j++) {
+                if (!isValidSlot(j)) {
                     continue;
                 }
 
-                for (int j = i + 1; j < mInventory.length; j++) {
-                    if (!isValidSlot(j)) {
-                        continue;
-                    }
-
-                    if (mInventory[j] != null && (mInventory[i] == null || GT_Utility.areStacksEqual(mInventory[i], mInventory[j])))
-                        GT_Utility.moveStackFromSlotAToSlotB(getBaseMetaTileEntity(), getBaseMetaTileEntity(), j, i, (byte) 64, (byte) 1, (byte) 64, (byte) 1);
-                }
+                if (mInventory[j] != null && (mInventory[i] == null || GT_Utility.areStacksEqual(mInventory[i], mInventory[j])))
+                    GT_Utility.moveStackFromSlotAToSlotB(getBaseMetaTileEntity(), getBaseMetaTileEntity(), j, i, (byte) 64, (byte) 1, (byte) 64, (byte) 1);
             }
         }
     }

--- a/src/main/java/gregtech/common/tileentities/automation/GT_MetaTileEntity_ChestBuffer.java
+++ b/src/main/java/gregtech/common/tileentities/automation/GT_MetaTileEntity_ChestBuffer.java
@@ -124,22 +124,7 @@ public class GT_MetaTileEntity_ChestBuffer extends GT_MetaTileEntity_Buffer {
     @Override
     protected void fillStacksIntoFirstSlots() {
         sortStacks();
-        // Merge small stacks together
-        // The last slot of mInventory is invalid, so we need to avoid iterating over it.
-        // Thus all max indices are reduced by 1 here.
-        for (int i = 0; i < this.mInventory.length - 2;) {
-            //GT_FML_LOGGER.info( (this.mInventory[i] == null) ? "Slot empty " + i : "Slot " + i + " holds " + this.mInventory[i].getDisplayName());
-            for (int j = i + 1; j < this.mInventory.length - 1; j++) {
-                if ((this.mInventory[j] != null) && ((GT_Utility.areStacksEqual(this.mInventory[i], this.mInventory[j])))) {
-                    GT_Utility.moveStackFromSlotAToSlotB(getBaseMetaTileEntity(), getBaseMetaTileEntity(), j, i, (byte) 64, (byte) 1, (byte) 64, (byte) 1);
-                    //GT_FML_LOGGER.info( "Moving slot " + j + " into slot " +  i );
-                }
-                else {
-                    i=j;
-                    break; // No more matching items for this i, do next i
-                }
-            }
-        }
+        super.fillStacksIntoFirstSlots();
     }
 
     @Override

--- a/src/main/java/gregtech/common/tileentities/automation/GT_MetaTileEntity_ItemDistributor.java
+++ b/src/main/java/gregtech/common/tileentities/automation/GT_MetaTileEntity_ItemDistributor.java
@@ -50,21 +50,6 @@ public class GT_MetaTileEntity_ItemDistributor extends GT_MetaTileEntity_Buffer 
     }
 
     @Override
-    protected void fillStacksIntoFirstSlots() {
-        // The last slot of mInventory is invalid, so we need to avoid iterating over it.
-        // Thus all max indices are reduced by 1 here.
-        for (int i = 0; i < this.mInventory.length - 2; i++) {
-            for (int j = i + 1; j < this.mInventory.length - 1; j++) {
-                if ((this.mInventory[j] != null)
-                        && ((this.mInventory[i] == null) || (GT_Utility.areStacksEqual(this.mInventory[i], this.mInventory[j])))) {
-                    GT_Utility.moveStackFromSlotAToSlotB(getBaseMetaTileEntity(), getBaseMetaTileEntity(), j, i, (byte) 64, (byte) 1,
-                            (byte) 64, (byte) 1);
-                }
-            }
-        }
-    }
-
-    @Override
     public Object getClientGUI(int aID, InventoryPlayer aPlayerInventory, IGregTechTileEntity aBaseMetaTileEntity) {
         return new GT_GUIContainer_ItemDistributor(aPlayerInventory, aBaseMetaTileEntity);
     }


### PR DESCRIPTION
Fix for infinite loop found by shawnbyday. Thanks for finding this, and the help with debugging!

The infinite loop happens in this code:
https://github.com/GTNewHorizons/GT5-Unofficial/blob/experimental/src/main/java/gregtech/common/tileentities/automation/GT_MetaTileEntity_ChestBuffer.java#L130-L142

The issue is that the outer `for`-loop doesn't increment `i`, so `i` is only incremented when the inner loop encounters an item stack that is not equal to the one at index `i`. If the entire rest of the inventory only contains equal stacks, then `i` is never incremented and we loop forever.

This only became an issue when I fixed the iteration over invalid slots. Previously, the iteration would proceed over the invalid slot, which is the last one, and that slot should always be empty, allowing `i` to be incremented. This was the breaking commit: https://github.com/GTNewHorizons/GT5-Unofficial/commit/6f3bddfb296a249040835e5f90bc45f5f7c8b024

I just got rid of the special code here entirely and called the super method. This means that we can no longer take advantage of knowing that the inventory is sorted (which is not guaranteed to be true in the super method), but this way, we can avoid having a non-obvious infinite loop failure mode. Also, the original code had some mishandled cases: if stacks got merged, then this would leave a gap in the inventory which would not be filled up. The super method correctly handles this case and will push stacks up to fill gaps left by merged stacks.

In order to make this work, I also had to get rid of the `bSortStacks` guard on `GT_MetaTileEntity_Buffer.fillStacksIntoFirstSlots()`. Removing that guard allowed me to get rid of the override `GT_MetaTileEntity_ItemDistributor.fillStacksIntoFirstSlots()` which basically did the same thing, just with a slightly more efficient slot validity check. The only call to `fillStacksIntoFirstSlots()` in `GT_MetaTileEntity_Buffer` was already guarded by `bSortStacks`, so removing the guard had no effect there; the only other calls to `fillStacksIntoFirstSlots()` were in `GT_MetaTileEntity_ChestBuffer` and `GT_MetaTileEntity_ItemDistributor` which previously had overrides that ignored `bSortStacks` anyway.