### PR TITLE
Add number formatting for tooltips & recipes

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 minecraft.version=1.7.10
 forge.version=10.13.4.1614-1.7.10
-gt.version=5.09.37.06
+gt.version=5.09.37.07
 structurelib.version=1.0.6
 ae2.version=rv3-beta-22
 applecore.version=1.7.10-1.2.1+107.59407

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Cable.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Cable.java
@@ -329,9 +329,9 @@ public class GT_MetaPipeEntity_Cable extends MetaPipeEntity implements IMetaTile
     @Override
     public String[] getDescription() {
         return new String[]{
-                "Max Voltage: %%%" + EnumChatFormatting.GREEN + GT_Utility.formatPow2(mVoltage) + " (" + VN[GT_Utility.getTier(mVoltage)] + ")" + EnumChatFormatting.GRAY,
-                "Max Amperage: %%%" + EnumChatFormatting.YELLOW + GT_Utility.formatPow2(mAmperage) + EnumChatFormatting.GRAY,
-                "Loss/Meter/Ampere: %%%" + EnumChatFormatting.RED + GT_Utility.formatPow2(mCableLossPerMeter) + EnumChatFormatting.GRAY + "%%% EU-Volt"
+                "Max Voltage: %%%" + EnumChatFormatting.GREEN + GT_Utility.formatNumbers(mVoltage) + " (" + VN[GT_Utility.getTier(mVoltage)] + ")" + EnumChatFormatting.GRAY,
+                "Max Amperage: %%%" + EnumChatFormatting.YELLOW + GT_Utility.formatNumbers(mAmperage) + EnumChatFormatting.GRAY,
+                "Loss/Meter/Ampere: %%%" + EnumChatFormatting.RED + GT_Utility.formatNumbers(mCableLossPerMeter) + EnumChatFormatting.GRAY + "%%% EU-Volt"
         };
     }
 

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Cable.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Cable.java
@@ -329,9 +329,9 @@ public class GT_MetaPipeEntity_Cable extends MetaPipeEntity implements IMetaTile
     @Override
     public String[] getDescription() {
         return new String[]{
-                "Max Voltage: %%%" + EnumChatFormatting.GREEN + mVoltage + " (" + VN[GT_Utility.getTier(mVoltage)] + ")" + EnumChatFormatting.GRAY,
-                "Max Amperage: %%%" + EnumChatFormatting.YELLOW + mAmperage + EnumChatFormatting.GRAY,
-                "Loss/Meter/Ampere: %%%" + EnumChatFormatting.RED + mCableLossPerMeter + EnumChatFormatting.GRAY + "%%% EU-Volt"
+                "Max Voltage: %%%" + EnumChatFormatting.GREEN + GT_Utility.formatPow2(mVoltage) + " (" + VN[GT_Utility.getTier(mVoltage)] + ")" + EnumChatFormatting.GRAY,
+                "Max Amperage: %%%" + EnumChatFormatting.YELLOW + GT_Utility.formatPow2(mAmperage) + EnumChatFormatting.GRAY,
+                "Loss/Meter/Ampere: %%%" + EnumChatFormatting.RED + GT_Utility.formatPow2(mCableLossPerMeter) + EnumChatFormatting.GRAY + "%%% EU-Volt"
         };
     }
 

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Fluid.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Fluid.java
@@ -642,12 +642,12 @@ public class GT_MetaPipeEntity_Fluid extends MetaPipeEntity {
     public String[] getDescription() {
         if (mPipeAmount == 1) {
             return new String[]{
-                    EnumChatFormatting.BLUE + "Fluid Capacity: %%%" + (mCapacity * 20) + "%%% L/sec" + EnumChatFormatting.GRAY,
+                    EnumChatFormatting.BLUE + "Fluid Capacity: %%%" + GT_Utility.formatNumbers(mCapacity * 20) + "%%% L/sec" + EnumChatFormatting.GRAY,
                     EnumChatFormatting.RED + "Heat Limit: %%%" + mHeatResistance + "%%% K" + EnumChatFormatting.GRAY
             };
         } else {
             return new String[]{
-                    EnumChatFormatting.BLUE + "Fluid Capacity: %%%" + (mCapacity * 20) + "%%% L/sec" + EnumChatFormatting.GRAY,
+                    EnumChatFormatting.BLUE + "Fluid Capacity: %%%" + GT_Utility.formatNumbers(mCapacity * 20) + "%%% L/sec" + EnumChatFormatting.GRAY,
                     EnumChatFormatting.RED + "Heat Limit: %%%" + mHeatResistance + "%%% K" + EnumChatFormatting.GRAY,
                     EnumChatFormatting.AQUA + "Pipe Amount: %%%" + mPipeAmount + EnumChatFormatting.GRAY
             };

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Item.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Item.java
@@ -345,11 +345,11 @@ public class GT_MetaPipeEntity_Item extends MetaPipeEntity implements IMetaTileE
     @Override
     public String[] getDescription() {
         if (mTickTime == 20)
-            return new String[]{"Item Capacity: %%%" + getMaxPipeCapacity() + "%%% Stacks/sec", "Routing Value: %%%" + mStepSize};
+            return new String[]{"Item Capacity: %%%" + getMaxPipeCapacity() + "%%% Stacks/sec", "Routing Value: %%%" + GT_Utility.formatNumbers(mStepSize)};
         else if (mTickTime % 20 == 0)
-            return new String[]{"Item Capacity: %%%" + getMaxPipeCapacity() + "%%% Stacks/%%%" + (mTickTime / 20) + "%%% sec", "Routing Value: %%%" + mStepSize};
+            return new String[]{"Item Capacity: %%%" + getMaxPipeCapacity() + "%%% Stacks/%%%" + (mTickTime / 20) + "%%% sec", "Routing Value: %%%" + GT_Utility.formatNumbers(mStepSize)};
         else
-            return new String[]{"Item Capacity: %%%" + getMaxPipeCapacity() + "%%% Stacks/%%%" + mTickTime + "%%% ticks", "Routing Value: %%%" + mStepSize};
+            return new String[]{"Item Capacity: %%%" + getMaxPipeCapacity() + "%%% Stacks/%%%" + mTickTime + "%%% ticks", "Routing Value: %%%" + GT_Utility.formatNumbers(mStepSize)};
     }
 
     private boolean isInventoryEmpty() {

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_Input.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_Input.java
@@ -16,7 +16,9 @@ public class GT_MetaTileEntity_Hatch_Input extends GT_MetaTileEntity_Hatch {
     public GT_Recipe_Map mRecipeMap = null;
 
     public GT_MetaTileEntity_Hatch_Input(int aID, String aName, String aNameRegional, int aTier) {
-        super(aID, aName, aNameRegional, aTier, 3, new String[]{"Fluid Input for Multiblocks",  "Capacity: " + (8000+8000*(aTier*(aTier+1)>>1)) + "L"});
+        super(aID, aName, aNameRegional, aTier, 3, new String[]{
+                "Fluid Input for Multiblocks",
+                "Capacity: " + GT_Utility.formatNumbers(8000+8000*(aTier*(aTier+1)>>1)) + "L"});
     }
 
     public GT_MetaTileEntity_Hatch_Input(String aName, int aTier, String aDescription, ITexture[][][] aTextures) {

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_Output.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_Output.java
@@ -27,7 +27,7 @@ public class GT_MetaTileEntity_Hatch_Output extends GT_MetaTileEntity_Hatch {
     public GT_MetaTileEntity_Hatch_Output(int aID, String aName, String aNameRegional, int aTier) {
         super(aID, aName, aNameRegional, aTier, 3, new String[]{
         		"Fluid Output for Multiblocks",
-        		"Capacity: "  + (8000+8000*(aTier*(aTier+1)>>1)) + "L",
+        		"Capacity: "  + GT_Utility.formatNumbers(8000+8000*(aTier*(aTier+1)>>1)) + "L",
         		"Right click with screwdriver to restrict output",
         		"Can be restricted to put out Items and/or Steam/No Steam/1 specific Fluid",
         		"Restricted Output Hatches are given priority for Multiblock Fluid output"});

--- a/src/main/java/gregtech/api/util/GT_Utility.java
+++ b/src/main/java/gregtech/api/util/GT_Utility.java
@@ -2228,6 +2228,15 @@ public class GT_Utility {
         return formatter.format(aNumber);
     }
 
+    public static String formatNumbers(double aNumber) {
+        DecimalFormat formatter = (DecimalFormat) NumberFormat.getInstance(Locale.US);
+        DecimalFormatSymbols symbols = formatter.getDecimalFormatSymbols();
+        symbols.setGroupingSeparator(' ');
+        formatter.setDecimalFormatSymbols(symbols);
+        formatter.setMaximumFractionDigits(2);
+        return formatter.format(aNumber);
+    }
+
     /**
      * Formats a positive integer with grouping separators, and also attempts to display it as a (small multiple of a)
      * power of 2.

--- a/src/main/java/gregtech/api/util/GT_Utility.java
+++ b/src/main/java/gregtech/api/util/GT_Utility.java
@@ -79,7 +79,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
-import java.text.NumberFormat;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.function.IntFunction;
@@ -95,6 +94,7 @@ import static gregtech.common.GT_UndergroundOil.undergroundOilReadInformation;
  * Just a few Utility Functions I use.
  */
 public class GT_Utility {
+    private static final DecimalFormat decimalFormat = new DecimalFormat();
     /**
      * Forge screwed the Fluid Registry up again, so I make my own, which is also much more efficient than the stupid Stuff over there.
      */
@@ -108,6 +108,11 @@ public class GT_Utility {
     public static UUID defaultUuid = null; // maybe default non-null? UUID.fromString("00000000-0000-0000-0000-000000000000");
 
     static {
+        DecimalFormatSymbols symbols = decimalFormat.getDecimalFormatSymbols();
+        symbols.setGroupingSeparator(' ');
+        decimalFormat.setDecimalFormatSymbols(symbols);
+        decimalFormat.setMaximumFractionDigits(2);
+
         GregTech_API.sItemStackMappings.add(sFilledContainerToData);
         GregTech_API.sItemStackMappings.add(sEmptyContainerToFluidToData);
     }
@@ -2221,20 +2226,11 @@ public class GT_Utility {
     }
 
     public static String formatNumbers(long aNumber) {
-        DecimalFormat formatter = (DecimalFormat) NumberFormat.getInstance(Locale.US);
-        DecimalFormatSymbols symbols = formatter.getDecimalFormatSymbols();
-        symbols.setGroupingSeparator(' ');
-        formatter.setDecimalFormatSymbols(symbols);
-        return formatter.format(aNumber);
+        return decimalFormat.format(aNumber);
     }
 
     public static String formatNumbers(double aNumber) {
-        DecimalFormat formatter = (DecimalFormat) NumberFormat.getInstance(Locale.US);
-        DecimalFormatSymbols symbols = formatter.getDecimalFormatSymbols();
-        symbols.setGroupingSeparator(' ');
-        formatter.setDecimalFormatSymbols(symbols);
-        formatter.setMaximumFractionDigits(2);
-        return formatter.format(aNumber);
+        return decimalFormat.format(aNumber);
     }
 
     /**

--- a/src/main/java/gregtech/api/util/GT_Utility.java
+++ b/src/main/java/gregtech/api/util/GT_Utility.java
@@ -2224,7 +2224,34 @@ public class GT_Utility {
         DecimalFormat formatter = (DecimalFormat) NumberFormat.getInstance(Locale.US);
         DecimalFormatSymbols symbols = formatter.getDecimalFormatSymbols();
         symbols.setGroupingSeparator(' ');
+        formatter.setDecimalFormatSymbols(symbols);
         return formatter.format(aNumber);
+    }
+
+    /**
+     * Formats a positive integer with grouping separators, and also attempts to display it as a (small multiple of a)
+     * power of 2.
+     */
+    public static String formatPow2(long number) {
+        String formatted = formatNumbers(number);
+        if (number == V[V.length - 1]) {
+            formatted += " (MAX)";
+        } else if (number >= 256) {
+            // Try to figure out if number is a (small multiple of a) power of 2.
+            long curr = number;
+            int pow = 0;
+            while ((curr & 1) == 0) {
+                curr = curr >>> 1;
+                pow++;
+            }
+
+            if (curr == 1) {
+                formatted += String.format(" (2^%d)", pow);
+            } else if (curr <= 7) {
+                formatted += String.format(" (%d*2^%d)", curr, pow);
+            }
+        }
+        return formatted;
     }
 
     /*

--- a/src/main/java/gregtech/api/util/GT_Utility.java
+++ b/src/main/java/gregtech/api/util/GT_Utility.java
@@ -94,7 +94,11 @@ import static gregtech.common.GT_UndergroundOil.undergroundOilReadInformation;
  * Just a few Utility Functions I use.
  */
 public class GT_Utility {
-    private static final DecimalFormat decimalFormat = new DecimalFormat();
+    /** Formats a number with group separator and at most 2 fraction digits. */
+    private static final DecimalFormat basicFormatter = new DecimalFormat();
+    /** Formats a number into scientific notation with at most 2 fraction digits. Meant for large numbers. */
+    private static final DecimalFormat scientificNotationFormatter = new DecimalFormat("0.##E0");
+
     /**
      * Forge screwed the Fluid Registry up again, so I make my own, which is also much more efficient than the stupid Stuff over there.
      */
@@ -108,10 +112,10 @@ public class GT_Utility {
     public static UUID defaultUuid = null; // maybe default non-null? UUID.fromString("00000000-0000-0000-0000-000000000000");
 
     static {
-        DecimalFormatSymbols symbols = decimalFormat.getDecimalFormatSymbols();
+        DecimalFormatSymbols symbols = basicFormatter.getDecimalFormatSymbols();
         symbols.setGroupingSeparator(' ');
-        decimalFormat.setDecimalFormatSymbols(symbols);
-        decimalFormat.setMaximumFractionDigits(2);
+        basicFormatter.setDecimalFormatSymbols(symbols);
+        basicFormatter.setMaximumFractionDigits(2);
 
         GregTech_API.sItemStackMappings.add(sFilledContainerToData);
         GregTech_API.sItemStackMappings.add(sEmptyContainerToFluidToData);
@@ -2226,35 +2230,17 @@ public class GT_Utility {
     }
 
     public static String formatNumbers(long aNumber) {
-        return decimalFormat.format(aNumber);
+        String formatted = basicFormatter.format(aNumber);
+        if (aNumber >= 1_000_000_000L) {
+            formatted += " [" + scientificNotationFormatter.format(aNumber) + "]";
+        }
+        return formatted;
     }
 
     public static String formatNumbers(double aNumber) {
-        return decimalFormat.format(aNumber);
-    }
-
-    /**
-     * Formats a positive integer with grouping separators, and also attempts to display it as a (small multiple of a)
-     * power of 2.
-     */
-    public static String formatPow2(long number) {
-        String formatted = formatNumbers(number);
-        if (number == V[V.length - 1]) {
-            formatted += " (MAX)";
-        } else if (number >= 256) {
-            // Try to figure out if number is a (small multiple of a) power of 2.
-            long curr = number;
-            int pow = 0;
-            while ((curr & 1) == 0) { // N.B. this won't terminate if curr == 0
-                curr = curr >>> 1;
-                pow++;
-            }
-
-            if (curr == 1) {
-                formatted += String.format(" (2^%d)", pow);
-            } else if (curr <= 7) {
-                formatted += String.format(" (%d*2^%d)", curr, pow);
-            }
+        String formatted = basicFormatter.format(aNumber);
+        if (aNumber >= 1_000_000_000d) {
+            formatted += " [" + scientificNotationFormatter.format(aNumber) + "]";
         }
         return formatted;
     }

--- a/src/main/java/gregtech/common/blocks/GT_Item_Machines.java
+++ b/src/main/java/gregtech/common/blocks/GT_Item_Machines.java
@@ -70,16 +70,16 @@ public class GT_Item_Machines extends ItemBlock {
                 if (tTileEntity.getEUCapacity() > 0L) {
                     if (tTileEntity.getInputVoltage() > 0L) {
                         int inputTier = GT_Utility.getTier(tTileEntity.getInputVoltage());
-                        aList.add(GT_LanguageManager.addStringLocalization("TileEntity_EUp_IN", "Voltage IN: ", !GregTech_API.sPostloadFinished ) + EnumChatFormatting.GREEN + GT_Utility.formatPow2(tTileEntity.getInputVoltage()) + " (" + GT_Values.TIER_COLORS[inputTier] + GT_Values.VN[inputTier] + EnumChatFormatting.GREEN +")" + EnumChatFormatting.GRAY);
+                        aList.add(GT_LanguageManager.addStringLocalization("TileEntity_EUp_IN", "Voltage IN: ", !GregTech_API.sPostloadFinished ) + EnumChatFormatting.GREEN + GT_Utility.formatNumbers(tTileEntity.getInputVoltage()) + " (" + GT_Values.TIER_COLORS[inputTier] + GT_Values.VN[inputTier] + EnumChatFormatting.GREEN +")" + EnumChatFormatting.GRAY);
                     }
                     if (tTileEntity.getOutputVoltage() > 0L) {
                         int outputTier = GT_Utility.getTier(tTileEntity.getOutputVoltage());
-                        aList.add(GT_LanguageManager.addStringLocalization("TileEntity_EUp_OUT", "Voltage OUT: ", !GregTech_API.sPostloadFinished ) + EnumChatFormatting.GREEN + GT_Utility.formatPow2(tTileEntity.getOutputVoltage()) + " (" + GT_Values.TIER_COLORS[outputTier] + GT_Values.VN[outputTier] + EnumChatFormatting.GREEN + ")" + EnumChatFormatting.GRAY);
+                        aList.add(GT_LanguageManager.addStringLocalization("TileEntity_EUp_OUT", "Voltage OUT: ", !GregTech_API.sPostloadFinished ) + EnumChatFormatting.GREEN + GT_Utility.formatNumbers(tTileEntity.getOutputVoltage()) + " (" + GT_Values.TIER_COLORS[outputTier] + GT_Values.VN[outputTier] + EnumChatFormatting.GREEN + ")" + EnumChatFormatting.GRAY);
                     }
                     if (tTileEntity.getOutputAmperage() > 1L) {
-                        aList.add(GT_LanguageManager.addStringLocalization("TileEntity_EUp_AMOUNT", "Amperage: ", !GregTech_API.sPostloadFinished ) + EnumChatFormatting.YELLOW + GT_Utility.formatPow2(tTileEntity.getOutputAmperage()) + EnumChatFormatting.GRAY);
+                        aList.add(GT_LanguageManager.addStringLocalization("TileEntity_EUp_AMOUNT", "Amperage: ", !GregTech_API.sPostloadFinished ) + EnumChatFormatting.YELLOW + GT_Utility.formatNumbers(tTileEntity.getOutputAmperage()) + EnumChatFormatting.GRAY);
                     }
-                    aList.add(GT_LanguageManager.addStringLocalization("TileEntity_EUp_STORE", "Capacity: ", !GregTech_API.sPostloadFinished ) + EnumChatFormatting.BLUE + GT_Utility.formatPow2(tTileEntity.getEUCapacity()) + EnumChatFormatting.GRAY);
+                    aList.add(GT_LanguageManager.addStringLocalization("TileEntity_EUp_STORE", "Capacity: ", !GregTech_API.sPostloadFinished ) + EnumChatFormatting.BLUE + GT_Utility.formatNumbers(tTileEntity.getEUCapacity()) + EnumChatFormatting.GRAY);
                 }
             }
             NBTTagCompound aNBT = aStack.getTagCompound();

--- a/src/main/java/gregtech/common/blocks/GT_Item_Machines.java
+++ b/src/main/java/gregtech/common/blocks/GT_Item_Machines.java
@@ -70,16 +70,16 @@ public class GT_Item_Machines extends ItemBlock {
                 if (tTileEntity.getEUCapacity() > 0L) {
                     if (tTileEntity.getInputVoltage() > 0L) {
                         int inputTier = GT_Utility.getTier(tTileEntity.getInputVoltage());
-                        aList.add(GT_LanguageManager.addStringLocalization("TileEntity_EUp_IN", "Voltage IN: ", !GregTech_API.sPostloadFinished ) + EnumChatFormatting.GREEN + tTileEntity.getInputVoltage() + " (" + GT_Values.TIER_COLORS[inputTier] + GT_Values.VN[inputTier] + EnumChatFormatting.GREEN +")" + EnumChatFormatting.GRAY);
+                        aList.add(GT_LanguageManager.addStringLocalization("TileEntity_EUp_IN", "Voltage IN: ", !GregTech_API.sPostloadFinished ) + EnumChatFormatting.GREEN + GT_Utility.formatPow2(tTileEntity.getInputVoltage()) + " (" + GT_Values.TIER_COLORS[inputTier] + GT_Values.VN[inputTier] + EnumChatFormatting.GREEN +")" + EnumChatFormatting.GRAY);
                     }
                     if (tTileEntity.getOutputVoltage() > 0L) {
                         int outputTier = GT_Utility.getTier(tTileEntity.getOutputVoltage());
-                        aList.add(GT_LanguageManager.addStringLocalization("TileEntity_EUp_OUT", "Voltage OUT: ", !GregTech_API.sPostloadFinished ) + EnumChatFormatting.GREEN + tTileEntity.getOutputVoltage() + " (" + GT_Values.TIER_COLORS[outputTier] + GT_Values.VN[outputTier] + EnumChatFormatting.GREEN + ")" + EnumChatFormatting.GRAY);
+                        aList.add(GT_LanguageManager.addStringLocalization("TileEntity_EUp_OUT", "Voltage OUT: ", !GregTech_API.sPostloadFinished ) + EnumChatFormatting.GREEN + GT_Utility.formatPow2(tTileEntity.getOutputVoltage()) + " (" + GT_Values.TIER_COLORS[outputTier] + GT_Values.VN[outputTier] + EnumChatFormatting.GREEN + ")" + EnumChatFormatting.GRAY);
                     }
                     if (tTileEntity.getOutputAmperage() > 1L) {
-                        aList.add(GT_LanguageManager.addStringLocalization("TileEntity_EUp_AMOUNT", "Amperage: ", !GregTech_API.sPostloadFinished ) + EnumChatFormatting.YELLOW + tTileEntity.getOutputAmperage() + EnumChatFormatting.GRAY);
+                        aList.add(GT_LanguageManager.addStringLocalization("TileEntity_EUp_AMOUNT", "Amperage: ", !GregTech_API.sPostloadFinished ) + EnumChatFormatting.YELLOW + GT_Utility.formatPow2(tTileEntity.getOutputAmperage()) + EnumChatFormatting.GRAY);
                     }
-                    aList.add(GT_LanguageManager.addStringLocalization("TileEntity_EUp_STORE", "Capacity: ", !GregTech_API.sPostloadFinished ) + EnumChatFormatting.BLUE + tTileEntity.getEUCapacity() + EnumChatFormatting.GRAY);
+                    aList.add(GT_LanguageManager.addStringLocalization("TileEntity_EUp_STORE", "Capacity: ", !GregTech_API.sPostloadFinished ) + EnumChatFormatting.BLUE + GT_Utility.formatPow2(tTileEntity.getEUCapacity()) + EnumChatFormatting.GRAY);
                 }
             }
             NBTTagCompound aNBT = aStack.getTagCompound();

--- a/src/main/java/gregtech/common/blocks/GT_Item_Machines.java
+++ b/src/main/java/gregtech/common/blocks/GT_Item_Machines.java
@@ -60,7 +60,7 @@ public class GT_Item_Machines extends ItemBlock {
                                     for (int j = 0; j < tString.length; j++)
                                         if (j % 2 == 0) tBuffer.append(tString[j]);
                                         else {tBuffer.append(" %s"); tRep[j / 2] = tString[j];}
-                                    aList.add(String.format(GT_LanguageManager.addStringLocalization("TileEntity_" + suffix + "DESCRIPTION_" + tDamage + "_Index_" + i++, tBuffer.toString(), !GregTech_API.sPostloadFinished ), tRep));
+                                    aList.add(String.format(GT_LanguageManager.addStringLocalization("TileEntity_" + suffix + "DESCRIPTION_" + tDamage + "_Index_" + i++, tBuffer.toString(), !GregTech_API.sPostloadFinished ), (Object[]) tRep));
                                 }
                             }else{String tTranslated = GT_LanguageManager.addStringLocalization("TileEntity_" + suffix + "DESCRIPTION_" + tDamage + "_Index_" + i++, tDescription, !GregTech_API.sPostloadFinished );
                                 aList.add(tTranslated.equals("") ? tDescription : tTranslated);}

--- a/src/main/java/gregtech/common/tileentities/storage/GT_MetaTileEntity_DigitalChestBase.java
+++ b/src/main/java/gregtech/common/tileentities/storage/GT_MetaTileEntity_DigitalChestBase.java
@@ -31,7 +31,7 @@ public abstract class GT_MetaTileEntity_DigitalChestBase extends GT_MetaTileEnti
 
     public GT_MetaTileEntity_DigitalChestBase(int aID, String aName, String aNameRegional, int aTier) {
         super(aID, aName, aNameRegional, aTier, 3, new String[]{
-                "This Chest stores " + commonSizeCompute(aTier) + " Blocks",
+                "This Chest stores " + GT_Utility.formatNumbers(commonSizeCompute(aTier)) + " Blocks",
                 "Use a screwdriver to enable",
                 "voiding items on overflow"
         });

--- a/src/main/java/gregtech/common/tileentities/storage/GT_MetaTileEntity_QuantumTank.java
+++ b/src/main/java/gregtech/common/tileentities/storage/GT_MetaTileEntity_QuantumTank.java
@@ -5,6 +5,7 @@ import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_BasicTank;
 import gregtech.api.render.TextureFactory;
+import gregtech.api.util.GT_Utility;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraftforge.common.util.ForgeDirection;
@@ -15,7 +16,8 @@ import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_QTANK_GLOW;
 
 public class GT_MetaTileEntity_QuantumTank extends GT_MetaTileEntity_BasicTank {
     public GT_MetaTileEntity_QuantumTank(int aID, String aName, String aNameRegional, int aTier) {
-        super(aID, aName, aNameRegional, aTier, 3, "Stores " + commonSizeCompute(aTier) + "L of fluid");
+        super(aID, aName, aNameRegional, aTier, 3,
+                "Stores " + GT_Utility.formatNumbers(commonSizeCompute(aTier)) + "L of fluid");
     }
 
     private static int commonSizeCompute(int tier) {

--- a/src/main/java/gregtech/common/tileentities/storage/GT_MetaTileEntity_SuperTank.java
+++ b/src/main/java/gregtech/common/tileentities/storage/GT_MetaTileEntity_SuperTank.java
@@ -5,6 +5,7 @@ import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_BasicTank;
 import gregtech.api.render.TextureFactory;
+import gregtech.api.util.GT_Utility;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraftforge.common.util.ForgeDirection;
@@ -15,7 +16,8 @@ import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_QTANK_GLOW;
 
 public class GT_MetaTileEntity_SuperTank extends GT_MetaTileEntity_BasicTank {
     public GT_MetaTileEntity_SuperTank(int aID, String aName, String aNameRegional, int aTier) {
-        super(aID, aName, aNameRegional, aTier, 3, "Stores " + commonSizeCompute(aTier) + "L of fluid");
+        super(aID, aName, aNameRegional, aTier, 3,
+                "Stores " + GT_Utility.formatNumbers(commonSizeCompute(aTier)) + "L of fluid");
     }
 
     private static int commonSizeCompute(int tier) {

--- a/src/main/java/gregtech/nei/GT_NEI_AssLineHandler.java
+++ b/src/main/java/gregtech/nei/GT_NEI_AssLineHandler.java
@@ -235,11 +235,11 @@ public class GT_NEI_AssLineHandler extends TemplateRecipeHandler {
         String[] recipeDesc = ((CachedDefaultRecipe) this.arecipes.get(aRecipeIndex)).mRecipe.getNeiDesc();
         if (recipeDesc == null) {
             if (tEUt != 0) {
-                drawText(10, 73, trans("152","Total: ") + ((long)tDuration * tEUt) + " EU", -16777216);
-                drawText(10, 83, trans("153","Usage: ") + tEUt + " EU/t", -16777216);
+                drawText(10, 73, trans("152","Total: ") + GT_Utility.formatNumbers((long)tDuration * tEUt) + " EU", -16777216);
+                drawText(10, 83, trans("153","Usage: ") + GT_Utility.formatNumbers(tEUt) + " EU/t", -16777216);
                 if (this.mRecipeMap.mShowVoltageAmperageInNEI) {
-                    drawText(10, 93, trans("154","Voltage: ") + tEUt / this.mRecipeMap.mAmperage + " EU", -16777216);
-                    drawText(10, 103, trans("155","Amperage: ") + this.mRecipeMap.mAmperage, -16777216);
+                    drawText(10, 93, trans("154","Voltage: ") + GT_Utility.formatNumbers(tEUt / this.mRecipeMap.mAmperage) + " EU", -16777216);
+                    drawText(10, 103, trans("155","Amperage: ") + GT_Utility.formatNumbers(this.mRecipeMap.mAmperage), -16777216);
                 } else {
                     drawText(10, 93, trans("156","Voltage: unspecified"), -16777216);
                     drawText(10, 103, trans("157","Amperage: unspecified"), -16777216);

--- a/src/main/java/gregtech/nei/GT_NEI_AssLineHandler.java
+++ b/src/main/java/gregtech/nei/GT_NEI_AssLineHandler.java
@@ -246,7 +246,7 @@ public class GT_NEI_AssLineHandler extends TemplateRecipeHandler {
                 }
             }
             if (tDuration > 0) {
-                drawText(10, 113, trans("158","Time: ")+String.format("%.2f " + trans("161"," secs"), 0.05F * tDuration), -16777216);
+                drawText(10, 113, trans("158","Time: ") + GT_Utility.formatNumbers(0.05d * tDuration) + trans("161"," secs"), -16777216);
             }
             int tSpecial = ((CachedDefaultRecipe) this.arecipes.get(aRecipeIndex)).mRecipe.mSpecialValue;
             if (tSpecial == -100 && GT_Mod.gregtechproxy.mLowGravProcessing) {

--- a/src/main/java/gregtech/nei/GT_NEI_DefaultHandler.java
+++ b/src/main/java/gregtech/nei/GT_NEI_DefaultHandler.java
@@ -233,7 +233,7 @@ public class GT_NEI_DefaultHandler extends TemplateRecipeHandler {
 				}
 			}
 			if (tDuration > 0) {
-				drawText(10, 113, trans("158","Time: ")+String.format("%.2f " + trans("161"," secs"), 0.05F * tDuration), -16777216);
+				drawText(10, 113, trans("158","Time: ") + GT_Utility.formatNumbers(0.05d * tDuration) + trans("161"," secs"), -16777216);
 			}
 			int tSpecial = ((CachedDefaultRecipe) this.arecipes.get(aRecipeIndex)).mRecipe.mSpecialValue;
 			if (tSpecial == -100 && GT_Mod.gregtechproxy.mLowGravProcessing) {

--- a/src/main/java/gregtech/nei/GT_NEI_DefaultHandler.java
+++ b/src/main/java/gregtech/nei/GT_NEI_DefaultHandler.java
@@ -217,16 +217,16 @@ public class GT_NEI_DefaultHandler extends TemplateRecipeHandler {
 		String[] recipeDesc = ((CachedDefaultRecipe) this.arecipes.get(aRecipeIndex)).mRecipe.getNeiDesc();
 		if (recipeDesc == null) {
 			if (tEUt != 0) {
-				drawText(10, 73, trans("152","Total: ") + ((long)tDuration * tEUt) + " EU", -16777216);
-				drawText(10, 83, trans("153","Usage: ") + tEUt + " EU/t", -16777216);
+				drawText(10, 73, trans("152","Total: ") + GT_Utility.formatNumbers((long)tDuration * tEUt) + " EU", -16777216);
+				drawText(10, 83, trans("153","Usage: ") + GT_Utility.formatNumbers(tEUt) + " EU/t", -16777216);
 				if (this.mRecipeMap.mShowVoltageAmperageInNEI) {
                     byte tier=GT_Utility.getTier(tEUt / this.mRecipeMap.mAmperage);
                     if(tier<0||tier>=16){
-                        drawText(10, 93, trans("154","Voltage: ") + tEUt / this.mRecipeMap.mAmperage + " EU", 0xffFF0000);
+                        drawText(10, 93, trans("154","Voltage: ") + GT_Utility.formatNumbers(tEUt / this.mRecipeMap.mAmperage) + " EU", 0xffFF0000);
 //add here gt logger
                     }else{
-                        drawText(10, 93, trans("154","Voltage: ") + tEUt / this.mRecipeMap.mAmperage + " EU ("+GT_Values.VN[tier]+")", -16777216);
-                    }drawText(10, 103, trans("155","Amperage: ") + this.mRecipeMap.mAmperage, -16777216);
+                        drawText(10, 93, trans("154","Voltage: ") + GT_Utility.formatNumbers(tEUt / this.mRecipeMap.mAmperage) + " EU ("+GT_Values.VN[tier]+")", -16777216);
+                    }drawText(10, 103, trans("155","Amperage: ") + GT_Utility.formatNumbers(this.mRecipeMap.mAmperage), -16777216);
 				} else {
 					drawText(10, 93, trans("156","Voltage: unspecified"), -16777216);
 					drawText(10, 103, trans("157","Amperage: unspecified"), -16777216);


### PR DESCRIPTION
Changes:
 * Fix a bug that was causing the existing `GT_Utility.formatNumbers()` method to use a comma as the thousands separator, rather than a space.
 * Add number formatting to tooltips and NEI recipe display.
 * For numbers that are likely to be a power of 2, try to show the power of 2. Right now, this includes voltage, amperage, and EU capacity.
 * Other mods like bartworks and TecTech also need to have their tooltips updated. I want to just have them use the new public methods added in this PR. They seem to be referencing the `SNAPSHOT` version of GT5, so I'm guessing I just need to wait for this PR to get merged and built on Maven?

See:
 * https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/8346

Screenshots:
![Tooltip](https://user-images.githubusercontent.com/54219287/128593639-16b13255-47d8-4398-a39b-4acc2a74541d.png)
![Tooltip2](https://user-images.githubusercontent.com/54219287/128593643-8addb38f-3db1-43fc-bc1b-43bdacc22e31.png)
![Recipe](https://user-images.githubusercontent.com/54219287/128594458-7ce11ce9-b8ed-4b7c-a592-b981b591b299.png)
