### PR TITLE
improvements to the wireless redstone covers

### DIFF
--- a/src/main/java/gregtech/common/covers/GT_Cover_RedstoneWirelessBase.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_RedstoneWirelessBase.java
@@ -33,7 +33,10 @@ public abstract class GT_Cover_RedstoneWirelessBase extends GT_CoverBehavior {
     public boolean onCoverRightclick(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, EntityPlayer aPlayer, float aX, float aY, float aZ) {
         if (((aX > 0.375D) && (aX < 0.625D)) || ((aSide > 3) && ((aY > 0.375D) && (aY < 0.625D)))) {
             GregTech_API.sWirelessRedstone.put(Integer.valueOf(aCoverVariable), Byte.valueOf((byte) 0));
-            aCoverVariable = (aCoverVariable & (PRIVATE_MASK | CHECKBOX_MASK)) | (((Integer)GT_Utility.stackToInt(aPlayer.inventory.getCurrentItem())).hashCode() & PUBLIC_MASK);
+
+            int val = GT_Utility.stackToInt(aPlayer.inventory.getCurrentItem()) * (1 + aPlayer.inventory.getCurrentItem().getItemDamage());
+
+            aCoverVariable = (aCoverVariable & (PRIVATE_MASK | CHECKBOX_MASK)) | (val & PUBLIC_MASK);
 
             aTileEntity.setCoverDataAtSide(aSide, aCoverVariable);
             GT_Utility.sendChatToPlayer(aPlayer, trans("081", "Frequency: ") + (aCoverVariable & PUBLIC_MASK));

--- a/src/main/java/gregtech/common/covers/GT_Cover_RedstoneWirelessBase.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_RedstoneWirelessBase.java
@@ -36,7 +36,7 @@ public abstract class GT_Cover_RedstoneWirelessBase extends GT_CoverBehavior {
             aCoverVariable = (aCoverVariable & (PRIVATE_MASK | CHECKBOX_MASK)) | (((Integer)GT_Utility.stackToInt(aPlayer.inventory.getCurrentItem())).hashCode() & PUBLIC_MASK);
 
             aTileEntity.setCoverDataAtSide(aSide, aCoverVariable);
-            GT_Utility.sendChatToPlayer(aPlayer, trans("081", "Frequency: ") + aCoverVariable);
+            GT_Utility.sendChatToPlayer(aPlayer, trans("081", "Frequency: ") + (aCoverVariable & PUBLIC_MASK));
             return true;
         }
         return false;
@@ -76,7 +76,7 @@ public abstract class GT_Cover_RedstoneWirelessBase extends GT_CoverBehavior {
                 aCoverVariable = (aCoverVariable & (PRIVATE_MASK | CHECKBOX_MASK)) | tPublicChannel;
             }
         }
-        GT_Utility.sendChatToPlayer(aPlayer, trans("081", "Frequency: ") + aCoverVariable);
+        GT_Utility.sendChatToPlayer(aPlayer, trans("081", "Frequency: ") + (aCoverVariable & PUBLIC_MASK));
         return aCoverVariable;
     }
 


### PR DESCRIPTION
Currently wireless redstone covers have a discrepancy between the channel sent to the player in a chat message and the one displayed inside the gui after right-clicking an item onto the cover.

wireless redstone also currently only look at the itemID of the item right-clicked onto the cover. This is an issue since a lot of GT items share the same itemID, but have different damage values
