### PR TITLE
Adjust card recycling recipes for NC2 cards

### DIFF
--- a/src/main/java/gregtech/loaders/load/GT_ItemIterator.java
+++ b/src/main/java/gregtech/loaders/load/GT_ItemIterator.java
@@ -107,12 +107,6 @@ public class GT_ItemIterator implements Runnable {
                         if ((tItem instanceof IFluidContainerItem)) {
                             GT_OreDictUnificator.addToBlacklist(new ItemStack(tItem, 1, 32767));
                         }
-                        if ((tName.equals("item.ItemSensorLocationCard")) || (tName.equals("item.ItemEnergySensorLocationCard")) || (tName.equals("item.ItemEnergyArrayLocationCard")) || (tName.equals("item.ItemTextCard")) || (tName.equals("item.ItemVanillaMachineCard")) || (tName.equals("item.RFSensorCard")) || (tName.equals("item.Item55ReactorCard"))) {
-                            GT_Values.RA.addAssemblerRecipe(new ItemStack(tItem, 1, 32767), null, GT_ModHandler.getIC2Item("electronicCircuit", 2L), 200, 30);
-                        }
-                        if ((tName.equals("item.ItemTimeCard")) || (tName.equals("item.itemCounterSensorLocationCard")) || (tName.equals("item.ItemLiquidSensorLocationCard")) || (tName.equals("item.ItemGeneratorSensorLocationCard")) || (tName.equals("item.ItemLiquidArrayLocationCard")) || (tName.equals("item.ItemInventoryScannerCard")) || (tName.equals("item.AppengCard")) || (tName.equals("item.RFenergyCard")) || (tName.equals("item.ItemVanillaMachineCard"))) {
-                            GT_Values.RA.addAssemblerRecipe(new ItemStack(tItem, 1, 32767), null, GT_ModHandler.getIC2Item("electronicCircuit", 1L), 100, 30);
-                        }
                         if (tName.equals("tile.ArsMagica:ore_vinteum")) {
                             GT_OreDictUnificator.set(OrePrefixes.ore, Materials.Vinteum, new ItemStack(tItem, 1, 0));
                         }

--- a/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
@@ -1545,12 +1545,20 @@ public class GT_MachineRecipeLoader implements Runnable {
         GT_Values.RA.addAssemblerRecipe(GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1L), ItemList.IC2_Resin.get(1L), new ItemStack(Blocks.torch, 6), 400, 1);
         GT_Values.RA.addAssemblerRecipe(GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Coal, 8L), new ItemStack(Items.flint, 1), ItemList.IC2_Compressed_Coal_Ball.get(1L), 400, 4);
 
-        if(Loader.isModLoaded("IC2NuclearControl")) {
-        	GT_Values.RA.addAssemblerRecipe(ItemList.NC_SensorCard.get(1L), ItemList.Circuit_Integrated.getWithDamage(0L, 1L), GT_ModHandler.getIC2Item("electronicCircuit", 3L), 200, 30);
-            GT_Values.RA.addAssemblerRecipe(GT_ModHandler.getModItem("IC2NuclearControl", "ItemMultipleSensorLocationCard", 1L, 0), GT_ModHandler.getModItem("IC2NuclearControl", "ItemMultipleSensorLocationCard", 1L, 0),  GT_ModHandler.getIC2Item("electronicCircuit", 1L), 200, 30);
-            GT_Values.RA.addAssemblerRecipe(GT_ModHandler.getModItem("IC2NuclearControl", "ItemMultipleSensorLocationCard", 1L, 1), GT_ModHandler.getModItem("IC2NuclearControl", "ItemMultipleSensorLocationCard", 1L, 1),  GT_ModHandler.getIC2Item("electronicCircuit", 1L), 200, 30);
-            GT_Values.RA.addAssemblerRecipe(GT_ModHandler.getModItem("IC2NuclearControl", "ItemMultipleSensorLocationCard", 1L, 2), GT_ModHandler.getModItem("IC2NuclearControl", "ItemMultipleSensorLocationCard", 1L, 2),  GT_ModHandler.getIC2Item("electronicCircuit", 1L), 200, 30);
-            GT_Values.RA.addAssemblerRecipe(GT_ModHandler.getModItem("IC2NuclearControl", "RFSensorCard", 1L, 0), GT_ModHandler.getModItem("IC2NuclearControl", "RFSensorCard", 1L, 0),  GT_ModHandler.getIC2Item("electronicCircuit", 1L), 200, 30);
+        if(Loader.isModLoaded("IC2NuclearControl")) {//Card recycling recipes
+            GT_Values.RA.addAssemblerRecipe(GT_ModHandler.getModItem("IC2NuclearControl", "ItemVanillaMachineCard", 1L, 0), ItemList.Circuit_Integrated.getWithDamage(0L, 1L),  GT_ModHandler.getIC2Item("electronicCircuit", 2L), 200, 30);
+            GT_Values.RA.addAssemblerRecipe(GT_ModHandler.getModItem("IC2NuclearControl", "ItemInventoryScannerCard", 1L, 0), ItemList.Circuit_Integrated.getWithDamage(0L, 1L),  GT_ModHandler.getIC2Item("electronicCircuit", 2L), 200, 30);
+            GT_Values.RA.addAssemblerRecipe(GT_ModHandler.getModItem("IC2NuclearControl", "ItemEnergySensorLocationCard", 1L, 0), ItemList.Circuit_Integrated.getWithDamage(0L, 1L),  GT_ModHandler.getIC2Item("electronicCircuit", 2L), 200, 30);
+            GT_Values.RA.addAssemblerRecipe(GT_ModHandler.getModItem("IC2NuclearControl", "RFSensorCard", 1L, 0), ItemList.Circuit_Integrated.getWithDamage(0L, 1L),  GT_ModHandler.getIC2Item("electronicCircuit", 2L), 200, 30);
+            GT_Values.RA.addAssemblerRecipe(GT_ModHandler.getModItem("IC2NuclearControl", "ItemMultipleSensorLocationCard", 1L, 0), ItemList.Circuit_Integrated.getWithDamage(0L, 1L),  GT_ModHandler.getIC2Item("electronicCircuit", 1L), 200, 30);//counter
+            GT_Values.RA.addAssemblerRecipe(GT_ModHandler.getModItem("IC2NuclearControl", "ItemMultipleSensorLocationCard", 1L, 1), ItemList.Circuit_Integrated.getWithDamage(0L, 1L),  GT_ModHandler.getIC2Item("electronicCircuit", 1L), 200, 30);//liquid
+            GT_Values.RA.addAssemblerRecipe(GT_ModHandler.getModItem("IC2NuclearControl", "ItemMultipleSensorLocationCard", 1L, 2), ItemList.Circuit_Integrated.getWithDamage(0L, 1L),  GT_ModHandler.getIC2Item("electronicCircuit", 2L), 200, 30);//generator
+            GT_Values.RA.addAssemblerRecipe(GT_ModHandler.getModItem("IC2NuclearControl", "ItemLiquidArrayLocationCard", 1L, 0), ItemList.Circuit_Integrated.getWithDamage(0L, 1L),  GT_ModHandler.getIC2Item("electronicCircuit", 2L), 200, 30);//2-6 liquid
+            GT_Values.RA.addAssemblerRecipe(GT_ModHandler.getModItem("IC2NuclearControl", "ItemEnergyArrayLocationCard", 1L, 0), ItemList.Circuit_Integrated.getWithDamage(0L, 1L),  GT_ModHandler.getIC2Item("electronicCircuit", 2L), 200, 30);//2-6 energy
+            GT_Values.RA.addAssemblerRecipe(GT_ModHandler.getModItem("IC2NuclearControl", "ItemSensorLocationCard", 1L, 0), ItemList.Circuit_Integrated.getWithDamage(0L, 1L),  GT_OreDictUnificator.get(OrePrefixes.circuit.get(Materials.Good), 2L), 200, 30);//non-fluid nuke
+            GT_Values.RA.addAssemblerRecipe(GT_ModHandler.getModItem("IC2NuclearControl", "Item55ReactorCard", 1L, 0), ItemList.Circuit_Integrated.getWithDamage(0L, 1L),  GT_OreDictUnificator.get(OrePrefixes.circuit.get(Materials.Good), 2L), 200, 30);
+            GT_Values.RA.addAssemblerRecipe(GT_ModHandler.getModItem("IC2NuclearControl", "CardAppeng", 1L, 0), ItemList.Circuit_Integrated.getWithDamage(0L, 1L),  GT_ModHandler.getIC2Item("electronicCircuit", 2L), 200, 30);
+            GT_Values.RA.addAssemblerRecipe(ItemList.NC_SensorCard.get(1L), ItemList.Circuit_Integrated.getWithDamage(0L, 1L), GT_ModHandler.getIC2Item("electronicCircuit", 3L), 200, 30);
         }
 
         if (!GT_Mod.gregtechproxy.mDisableIC2Cables) {


### PR DESCRIPTION
See https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/8698
Card and time cards have no kit, and do not need recycling to begin with.