### PR TITLE
Make miners replace ore blocks with cobblestone

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 minecraft.version=1.7.10
 forge.version=10.13.4.1614-1.7.10
-gt.version=5.09.38.00
+gt.version=5.09.38.01
 structurelib.version=1.0.6
 ae2.version=rv3-beta-22
 applecore.version=1.7.10-1.2.1+107.59407

--- a/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_Miner.java
+++ b/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_Miner.java
@@ -265,7 +265,7 @@ public class GT_MetaTileEntity_Miner extends GT_MetaTileEntity_BasicMachine {
                 mOutputItems[0] = drops.get(0);
             if (drops.size() > 1)
                 mOutputItems[1] = drops.get(1);
-            aBaseMetaTileEntity.getWorld().setBlockToAir(x, y, z);
+            aBaseMetaTileEntity.getWorld().setBlock(x, y, z, Blocks.cobblestone);
             if (debugBlockMiner)
                 GT_Log.out.println("MINER: Mining GT ore block at " + x + " " + y + " " + z);
         }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_OreDrillingPlantBase.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_OreDrillingPlantBase.java
@@ -123,7 +123,7 @@ public abstract class GT_MetaTileEntity_OreDrillingPlantBase extends GT_MetaTile
         }
         if (oreBlock != null && oreBlock != Blocks.air) {
             Collection<ItemStack> oreBlockDrops = getBlockDrops(oreBlock, oreBlockPos.chunkPosX, oreBlockPos.chunkPosY, oreBlockPos.chunkPosZ);
-            getBaseMetaTileEntity().getWorld().setBlockToAir(oreBlockPos.chunkPosX, oreBlockPos.chunkPosY, oreBlockPos.chunkPosZ);
+            getBaseMetaTileEntity().getWorld().setBlock(oreBlockPos.chunkPosX, oreBlockPos.chunkPosY, oreBlockPos.chunkPosZ, Blocks.cobblestone);
             mOutputItems = getOutputByDrops(oreBlockDrops);
         }
         return true;


### PR DESCRIPTION
Make GT miners (single- and multi-block) replace mined ores with cobblestone.

See:
 * https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/7837
 * https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/8422