### PR TITLE
Make Input Bus and Input Hatch to remember recipe map

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_Input.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_Input.java
@@ -9,6 +9,7 @@ import gregtech.api.util.GT_Recipe.GT_Recipe_Map;
 import gregtech.api.util.GT_Utility;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.fluids.FluidStack;
 
 import static gregtech.api.enums.Textures.BlockIcons.FLUID_IN_SIGN;
@@ -63,6 +64,19 @@ public class GT_MetaTileEntity_Hatch_Input extends GT_MetaTileEntity_Hatch {
     @Override
     public MetaTileEntity newMetaEntity(IGregTechTileEntity aTileEntity) {
         return new GT_MetaTileEntity_Hatch_Input(mName, mTier, mDescriptionArray, mTextures);
+    }
+
+    @Override
+    public void saveNBTData(NBTTagCompound aNBT) {
+        super.saveNBTData(aNBT);
+        if (mRecipeMap != null)
+            aNBT.setString("recipeMap", mRecipeMap.mUniqueIdentifier);
+    }
+
+    @Override
+    public void loadNBTData(NBTTagCompound aNBT) {
+        super.loadNBTData(aNBT);
+        mRecipeMap = GT_Recipe_Map.sIndexedMappings.getOrDefault(aNBT.getString("recipeMap"), null);
     }
 
     @Override

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_InputBus.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_InputBus.java
@@ -169,6 +169,8 @@ public class GT_MetaTileEntity_Hatch_InputBus extends GT_MetaTileEntity_Hatch {
         aNBT.setBoolean("disableSort", disableSort);
         aNBT.setBoolean("disableFilter", disableFilter);
         aNBT.setBoolean("disableLimited", disableLimited);
+        if (mRecipeMap != null)
+            aNBT.setString("recipeMap", mRecipeMap.mUniqueIdentifier);
     }
 
     @Override
@@ -178,6 +180,7 @@ public class GT_MetaTileEntity_Hatch_InputBus extends GT_MetaTileEntity_Hatch {
         disableFilter = aNBT.getBoolean("disableFilter");
         if(aNBT.hasKey("disableLimited"))
             disableLimited = aNBT.getBoolean("disableLimited");
+        mRecipeMap = GT_Recipe_Map.sIndexedMappings.getOrDefault(aNBT.getString("recipeMap"), null);
     }
 
     @Override

--- a/src/main/java/gregtech/api/util/GT_Recipe.java
+++ b/src/main/java/gregtech/api/util/GT_Recipe.java
@@ -572,6 +572,10 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
          * Contains all Recipe Maps
          */
         public static final Collection<GT_Recipe_Map> sMappings = new ArrayList<>();
+        /**
+         * All recipe maps indexed by their {@link #mUniqueIdentifier}.
+         */
+        public static final Map<String, GT_Recipe_Map> sIndexedMappings = new HashMap<>();
 
         public static final GT_Recipe_Map sOreWasherRecipes = new GT_Recipe_Map(new HashSet<>(500), "gt.recipe.orewasher", "Ore Washing Plant", null, RES_PATH_GUI + "basicmachines/OreWasher", 1, 3, 1, 1, 1, E, 1, E, true, true);
         public static final GT_Recipe_Map sThermalCentrifugeRecipes = new GT_Recipe_Map(new HashSet<>(1000), "gt.recipe.thermalcentrifuge", "Thermal Centrifuge", null, RES_PATH_GUI + "basicmachines/ThermalCentrifuge", 1, 3, 1, 0, 2, E, 1, E, true, true);
@@ -686,6 +690,12 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
         public final boolean mNEIAllowed, mShowVoltageAmperageInNEI;
 
         /**
+         * Unique identifier for this recipe map. Generated from aUnlocalizedName and a few other parameters.
+         * See constructor for details.
+         */
+        public final String mUniqueIdentifier;
+
+        /**
          * Initialises a new type of Recipe Handler.
          *
          * @param aRecipeList                a List you specify as Recipe List. Usually just an ArrayList with a pre-initialised Size.
@@ -717,6 +727,9 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
             GregTech_API.sFluidMappings.add(mRecipeFluidMap);
             GregTech_API.sItemStackMappings.add(mRecipeItemMap);
             GT_LanguageManager.addStringLocalization(mUnlocalizedName = aUnlocalizedName, aLocalName);
+            mUniqueIdentifier = String.format("%s_%d_%d_%d_%d_%d", aUnlocalizedName, aAmperage, aUsualInputCount, aUsualOutputCount, aMinimalInputFluids, aMinimalInputItems);
+            if (sIndexedMappings.put(mUniqueIdentifier, this) != null)
+                throw new IllegalArgumentException("Duplicate recipe map registered: " + mUniqueIdentifier);
         }
 
         public GT_Recipe addRecipe(boolean aOptimize, ItemStack[] aInputs, ItemStack[] aOutputs, Object aSpecial, int[] aOutputChances, FluidStack[] aFluidInputs, FluidStack[] aFluidOutputs, int aDuration, int aEUt, int aSpecialValue) {


### PR DESCRIPTION
This recipe map is used to filter input. After chunk load, there will be a short delay between event "chunk finished loading" and "multiblock controller sets the recipe map". Not remembering it makes the hatch to temporarily accept arbitrary input until that happens.