### PR TITLE
Try start processing immediately upon manual fluid manipulation

### DIFF
--- a/src/main/java/gregtech/api/gui/GT_Container_BasicMachine.java
+++ b/src/main/java/gregtech/api/gui/GT_Container_BasicMachine.java
@@ -204,7 +204,10 @@ public class GT_Container_BasicMachine extends GT_Container_BasicTank {
                     }
                     GT_MetaTileEntity_BasicTank tTank = (GT_MetaTileEntity_BasicTank) mTileEntity.getMetaTileEntity();
                     IFluidAccess tFillableAccess = IFluidAccess.from(tTank, true);
-                    return handleFluidSlotClick(tFillableAccess, aPlayer, aMouseclick == 0, true, true);
+                    ItemStack tToken = handleFluidSlotClick(tFillableAccess, aPlayer, aMouseclick == 0, true, true);
+                    if (mTileEntity.isServerSide() && tToken != null)
+                        mTileEntity.markInventoryBeenModified();
+                    return tToken;
                 } else {
                     return super.slotClick(aSlotIndex, aMouseclick, aShifthold, aPlayer);
                 }

--- a/src/main/java/gregtech/api/interfaces/tileentity/IHasInventory.java
+++ b/src/main/java/gregtech/api/interfaces/tileentity/IHasInventory.java
@@ -5,6 +5,8 @@ import net.minecraft.item.ItemStack;
 
 public interface IHasInventory extends ISidedInventory, IHasWorldObjectAndCoords {
 
+    default void markInventoryBeenModified() {}
+
     /**
      * if the Inventory of this TileEntity got modified this tick
      */

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
@@ -1749,6 +1749,11 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
     }
 
     @Override
+    public void markInventoryBeenModified() {
+        mInventoryChanged = true;
+    }
+
+    @Override
     public void setGenericRedstoneOutput(boolean aOnOff) {
         mRedstone = aOnOff;
     }


### PR DESCRIPTION
Currently there will be a short delay between user put in some fluid via GUI and a single block machine retrying a recipe. This PR remove this delay.