### PR TITLE
Clean up translations for new fluid cells

### DIFF
--- a/src/main/java/gregtech/common/items/GT_MetaGenerated_Item_98.java
+++ b/src/main/java/gregtech/common/items/GT_MetaGenerated_Item_98.java
@@ -68,6 +68,7 @@ public class GT_MetaGenerated_Item_98 extends GT_MetaGenerated_Item {
         ESCHERICHIA_COLI_FLUID(11, "escherichiakolifluid", CellType.REGULAR),
         PENICILLIN(12, "penicillin", CellType.REGULAR),
         FLUORESCENT_DNA(13, "fluorecentddna", CellType.REGULAR),
+        POLYMERASE(17, "polymerase", CellType.REGULAR),
 
         // Good Generator
         COMBUSTION_PROMOTER(14, "combustionpromotor", CellType.REGULAR),
@@ -82,9 +83,6 @@ public class GT_MetaGenerated_Item_98 extends GT_MetaGenerated_Item {
         BACTERIA(15, "binnie.bacteria", CellType.REGULAR),
         MUTAGEN(2, "mutagen", CellType.REGULAR),
         LIQUID_DNA(16, "liquiddna", CellType.REGULAR),
-
-        // Genetics
-        POLYMERASE(17, "polymerase", CellType.REGULAR),
 
         // Tinker's Construct
         LIQUID_ENDER(3, "ender", CellType.REGULAR),

--- a/src/main/resources/assets/gregtech/lang/en_US.lang
+++ b/src/main/resources/assets/gregtech/lang/en_US.lang
@@ -1112,21 +1112,23 @@ fluid.Ammonium Dinitramide=Ammonium Dinitramide
 fluid.LMP-103S=LMP-103S
 fluid.Nitromethane=Nitromethane
 fluid.O-Xylene=O-Xylene
+//GT_MetaGenerated_Item_98 cells
+fluid.UnknownNutrientAgar=Unknown Nutrient Agar
+fluid.SeaweedBroth=Seaweed Broth
+fluid.EnzymesSollution=Enzyme Solution
+fluid.escherichiakolifluid=eColi Bacteria Fluid
+fluid.Penicillin=Penicillin
+fluid.FluorecentdDNA=Fluorescent DNA
+fluid.Polymerase=Polymerase
 //No cell, most from bart bio
 fluid.Monomethylhydrazine=Monomethylhydrazine
 fluid.binnibacteriafluid=binnibacteriafluid
-fluid.SeaweedBroth=SeaweedBroth
 fluid.barnadafisarboriatorisfluid=barnadafisarboriatorisfluid
-fluid.Polymerase=Polymerase
 fluid.GelatinMixture=GelatinMixture
-fluid.FluorecentdDNA=FluorecentdDNA
-fluid.Penicillin=Penicillin
 fluid.sludge=sludge
-fluid.EnzymesSollution=EnzymesSollution
 fluid.Formaldehyde=Formaldehyde
 fluid.tcetieisfucusserratusfluid=tcetieisfucusserratusfluid
 fluid.MeatExtract=MeatExtract
-fluid.UnknownNutrientAgar=UnknownNutrientAgar
 //No recipe
 fluid.CompressedOxygen=CompressedOxygen
 fluid.CompressedNitrogen=CompressedNitrogen

--- a/src/main/resources/assets/gregtech/lang/zh_CN.lang
+++ b/src/main/resources/assets/gregtech/lang/zh_CN.lang
@@ -1104,21 +1104,23 @@ fluid.Ammonium Dinitramide=二硝酰胺铵
 fluid.LMP-103S=LMP-103S
 fluid.Nitromethane=硝基甲烷
 fluid.O-Xylene=邻二甲苯
+//GT_MetaGenerated_Item_98 cells
+fluid.UnknownNutrientAgar=未知营养琼脂
+fluid.SeaweedBroth=海藻基质
+fluid.EnzymesSollution=酶溶液
+fluid.escherichiakolifluid=eColi Bacteria Fluid
+fluid.Penicillin=青霉素
+fluid.FluorecentdDNA=荧光DNA
+fluid.Polymerase=聚合酶
 //以下流体没有单元形式，大部分是bart的生物科技
 fluid.Monomethylhydrazine=一甲基肼
 fluid.binnibacteriafluid=双杆菌液体
-fluid.SeaweedBroth=海藻基质
 fluid.barnadafisarboriatorisfluid=巴纳德乔木培养液
-fluid.Polymerase=聚合酶
 fluid.GelatinMixture=明胶混合物
-fluid.FluorecentdDNA=荧光DNA
-fluid.Penicillin=青霉素
 fluid.sludge=菌泥
-fluid.EnzymesSollution=酶溶液
 fluid.Formaldehyde=甲醛
 fluid.tcetieisfucusserratusfluid=鲸鱼座T星藻类培养液
 fluid.MeatExtract=肉汁
-fluid.UnknownNutrientAgar=未知营养琼脂
 //以下流体有贴图没有配方
 fluid.CompressedOxygen=压缩氧气
 fluid.CompressedNitrogen=压缩氮气


### PR DESCRIPTION
Fix some spelling and add missing translations for E. coli fluid. Follow-on to:
 * https://github.com/GTNewHorizons/GT5-Unofficial/pull/710

The source of some of the fluid names is a mystery, though. Drilling fluid, squid ink appear to be localized only in the full pack, and not with minimum mods.