### PR TITLE
Make GT_LanguageManager injects into correct language

### DIFF
--- a/src/main/java/gregtech/GT_Mod.java
+++ b/src/main/java/gregtech/GT_Mod.java
@@ -450,6 +450,9 @@ public class GT_Mod implements IGT_Mod {
         GT_Log.out.println("GT_Mod: Generating Lang-File");
         GT_LanguageManager.sEnglishFile = new Configuration(new File(aEvent.getModConfigurationDirectory().getParentFile(), "GregTech.lang"));
         GT_LanguageManager.sEnglishFile.load();
+        if (GT_LanguageManager.sEnglishFile.get("EnableLangFile", "UseThisFileAsLanguageFile", false).getBoolean(false)) {
+            GT_LanguageManager.sLanguage = GT_LanguageManager.sEnglishFile.get("EnableLangFile", "Language", "en_US").getString();
+        }
 
         Materials.getMaterialsMap().values().parallelStream().filter(Objects::nonNull).forEach(aMaterial -> aMaterial.mLocalizedName = GT_LanguageManager.addStringLocalization("Material." + aMaterial.mName.toLowerCase(), aMaterial.mDefaultLocalName));
 

--- a/src/main/java/gregtech/api/util/GT_LanguageManager.java
+++ b/src/main/java/gregtech/api/util/GT_LanguageManager.java
@@ -16,6 +16,7 @@ import static gregtech.api.enums.GT_Values.E;
 public class GT_LanguageManager {
     public static final HashMap<String, String> TEMPMAP = new HashMap<String, String>(), BUFFERMAP = new HashMap<String, String>(), LANGMAP = new HashMap<String, String>();
     public static Configuration sEnglishFile;
+	public static String sLanguage = "en_US";
     public static boolean sUseEnglishFile = false;
     public static boolean i18nPlaceholder = true;
 
@@ -31,7 +32,7 @@ public class GT_LanguageManager {
         	}
         }
         TEMPMAP.put(aKey.trim(), aEnglish);
-        LanguageRegistry.instance().injectLanguage("en_US", TEMPMAP);
+        LanguageRegistry.instance().injectLanguage(sLanguage, TEMPMAP);
         TEMPMAP.clear();
         if(sUseEnglishFile && !aWriteIntoLangFile){
             if (!LANGMAP.containsKey(aKey)) {

--- a/src/main/resources/assets/gregtech/lang/en_US.lang
+++ b/src/main/resources/assets/gregtech/lang/en_US.lang
@@ -1,3 +1,14 @@
+# Creative ItemGroup Tab
+itemGroup.GregTech.GTPP_BLOCKS=GT++ Blocks
+itemGroup.GregTech.GTPP_MACHINES=GT++ Machines
+itemGroup.GregTech.GTPP_MISC=GT++ Misc
+itemGroup.GregTech.GTPP_OTHER=GT++ Other
+itemGroup.GregTech.GTPP_OTHER_2=GT++ Other II
+itemGroup.GregTech.GTPP_TOOLS=GT++ Tools
+itemGroup.GregTech.Main=Main
+itemGroup.GregTech.Materials=Materials
+itemGroup.GregTech.Ores=Ores
+
 # Multiblock Tooltip Builder Keywords
 # Context can be found in the class gregtech.api.util.GT_Multiblock_Tooltip_Builder
 GT5U.MBTT.MachineType=Machine Type

--- a/src/main/resources/assets/gregtech/lang/zh_CN.lang
+++ b/src/main/resources/assets/gregtech/lang/zh_CN.lang
@@ -1,3 +1,14 @@
+# Creative ItemGroup Tab
+itemGroup.GregTech.GTPP_BLOCKS=GT++方块
+itemGroup.GregTech.GTPP_MACHINES=GT++机器
+itemGroup.GregTech.GTPP_MISC=GT++杂项
+itemGroup.GregTech.GTPP_OTHER=GT++其他
+itemGroup.GregTech.GTPP_OTHER_2=GT++其他II
+itemGroup.GregTech.GTPP_TOOLS=GT++工具
+itemGroup.GregTech.Main=主体
+itemGroup.GregTech.Materials=材料
+itemGroup.GregTech.Ores=矿石
+
 # Multiblock Tooltip Builder Keywords
 # Context can be found in the class gregtech.api.util.GT_Multiblock_Tooltip_Builder
 GT5U.MBTT.MachineType=机器类型


### PR DESCRIPTION
GT_LanguageManager always injected contents in Gregtech.lang into en_US. It makes StatCollector cannot fetch correct text in other language. 

fix [Kiwi233/Translation-of-GTNH#127](https://github.com/Kiwi233/Translation-of-GTNH/issues/127)