### PR TITLE
Remove glass from universal fluid cell

### DIFF
--- a/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
@@ -661,7 +661,7 @@ public class GT_MachineRecipeLoader implements Runnable {
         GT_Values.RA.addAssemblerRecipe(GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Paper, 3L), GT_OreDictUnificator.get(OrePrefixes.plateQuadruple, Materials.Paper, 1L), Materials.Glue.getFluid(20L), new ItemStack(Items.book, 1, 0), 32, 8);
         GT_Values.RA.addAssemblerRecipe(ItemList.Paper_Printed_Pages.get(1L), new ItemStack(Items.leather, 1, 32767), Materials.Glue.getFluid(20L), new ItemStack(Items.written_book, 1, 0), 32, 8);
         GT_Values.RA.addAssemblerRecipe(ItemList.Paper_Printed_Pages.get(1L), GT_ModHandler.getModItem(MOD_ID_DC, "item.ArtificialLeather", 1L, 0), Materials.Glue.getFluid(20L), new ItemStack(Items.written_book, 1, 0), 32, 8);
-        GT_Values.RA.addAssemblerRecipe(GT_OreDictUnificator.get(OrePrefixes.itemCasing, Materials.Tin, 4L), new ItemStack(Blocks.glass_pane, 1, 32767), GT_Values.NF, ItemList.Cell_Universal_Fluid.get(1L), 128, 8);
+        GT_Values.RA.addAssemblerRecipe(new ItemStack[]{GT_OreDictUnificator.get(OrePrefixes.itemCasing, Materials.Tin, 4L)}, GT_Values.NF, ItemList.Cell_Universal_Fluid.get(1L), 128, 8);
         GT_Values.RA.addAssemblerRecipe(ItemList.Food_Baked_Cake.get(1L), new ItemStack(Items.egg, 1, 0), Materials.Milk.getFluid(3000L), new ItemStack(Items.cake, 1, 0), 100, 8);
         GT_Values.RA.addAssemblerRecipe(ItemList.Food_Sliced_Bun.get(2L), ItemList.Circuit_Integrated.getWithDamage(0L, 2L), GT_Values.NF, ItemList.Food_Sliced_Buns.get(1L), 100, 4);
         GT_Values.RA.addAssemblerRecipe(ItemList.Food_Sliced_Bread.get(2L), ItemList.Circuit_Integrated.getWithDamage(0L, 2L), GT_Values.NF, ItemList.Food_Sliced_Breads.get(1L), 100, 4);

--- a/src/main/java/gregtech/loaders/preload/GT_Loader_ItemData.java
+++ b/src/main/java/gregtech/loaders/preload/GT_Loader_ItemData.java
@@ -88,7 +88,7 @@ public class GT_Loader_ItemData implements Runnable {
         GT_OreDictUnificator.addItemData(new ItemStack(Blocks.anvil, 1, 1), new ItemData(Materials.Iron, 72576000L));
         GT_OreDictUnificator.addItemData(new ItemStack(Blocks.anvil, 1, 2), new ItemData(Materials.Iron, 36288000L));
         GT_OreDictUnificator.addItemData(new ItemStack(Blocks.hopper, 1, 32767), new ItemData(Materials.Iron, 18144000L, new MaterialStack(Materials.Wood, 29030400L)));
-        GT_OreDictUnificator.addItemData(ItemList.Cell_Universal_Fluid.get(1L), new ItemData(Materials.Tin, 7257600L, new MaterialStack(Materials.Glass, 1360800L)));
+        GT_OreDictUnificator.addItemData(ItemList.Cell_Universal_Fluid.get(1L), new ItemData(Materials.Tin, 7257600L));
         GT_OreDictUnificator.addItemData(ItemList.Cell_Empty.get(1L), new ItemData(Materials.Tin, 7257600L));
         GT_OreDictUnificator.addItemData(new ItemStack(Blocks.tripwire_hook, 1, 32767), new ItemData(Materials.Iron, OrePrefixes.ring.mMaterialAmount * 2L, new MaterialStack(Materials.Wood, 3628800L)));
         GT_OreDictUnificator.addItemData(ItemList.Bottle_Empty.get(1L), new ItemData(Materials.Glass, 3628800L));


### PR DESCRIPTION
@xTwi wasn't sure if you were still working on this, but I had the changes up so figured I'd send this out?

 * Glass removed from universal fluid cell assembler recipe input
 * Glass removed from universal fluid cell macerator and arc furnace recipe outputs (though not sure if the latter returned the glass prior to this change)
 * Fix for https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/8797