### PR TITLE
Require each LDP endpoints to be at least 64 blocks away

### DIFF
--- a/src/main/java/gregtech/GT_Mod.java
+++ b/src/main/java/gregtech/GT_Mod.java
@@ -28,6 +28,7 @@ import gregtech.common.items.GT_MetaGenerated_Tool_01;
 import gregtech.common.items.behaviors.Behaviour_DataOrb;
 import gregtech.common.misc.GT_Command;
 import gregtech.common.tileentities.machines.basic.GT_MetaTileEntity_Massfabricator;
+import gregtech.common.tileentities.machines.long_distance.GT_MetaTileEntity_LongDistancePipelineBase;
 import gregtech.common.tileentities.machines.multi.GT_MetaTileEntity_Cleanroom;
 import gregtech.common.tileentities.storage.GT_MetaTileEntity_DigitalChestBase;
 import gregtech.loaders.ExtraIcons;
@@ -409,6 +410,7 @@ public class GT_Mod implements IGT_Mod {
         gregtechproxy.ic2EnergySourceCompat = tMainConfig.get("general", "Ic2EnergySourceCompat", true).getBoolean(true);
         gregtechproxy.costlyCableConnection = tMainConfig.get("general", "CableConnectionRequiresSolderingMaterial", false).getBoolean(false);
         GT_LanguageManager.i18nPlaceholder = tMainConfig.get("general", "EnablePlaceholderForMaterialNamesInLangFile", true).getBoolean(true);
+        GT_MetaTileEntity_LongDistancePipelineBase.minimalDistancePoints = tMainConfig.get("general", "LongDistancePipelineMinimalDistancePoints", 64).getInt(64);
 
         GregTech_API.mUseOnlyGoodSolderingMaterials = GregTech_API.sRecipeFile.get(ConfigCategories.Recipes.harderrecipes, "useonlygoodsolderingmaterials", GregTech_API.mUseOnlyGoodSolderingMaterials);
         gregtechproxy.mChangeHarvestLevels = GregTech_API.sMaterialProperties.get("havestLevel", "activateHarvestLevelChange", false);//TODO CHECK

--- a/src/main/java/gregtech/common/tileentities/machines/long_distance/GT_MetaTileEntity_LongDistancePipelineBase.java
+++ b/src/main/java/gregtech/common/tileentities/machines/long_distance/GT_MetaTileEntity_LongDistancePipelineBase.java
@@ -46,6 +46,7 @@ import java.util.LinkedList;
 import java.util.Queue;
 
 public abstract class GT_MetaTileEntity_LongDistancePipelineBase extends GT_MetaTileEntity_BasicHull_NonElectric {
+    public static int minimalDistancePoints = 64;
     protected GT_MetaTileEntity_LongDistancePipelineBase mTarget = null, mSender = null;
     protected ChunkCoordinates mTargetPos = null;
     
@@ -77,6 +78,8 @@ public abstract class GT_MetaTileEntity_LongDistancePipelineBase extends GT_Meta
                 aNBT.getInteger("target.y"),
                 aNBT.getInteger("target.z")
             );
+            if (getDistanceToSelf(mTargetPos) < minimalDistancePoints)
+                mTargetPos = null;
         }
     }
 
@@ -210,9 +213,13 @@ public abstract class GT_MetaTileEntity_LongDistancePipelineBase extends GT_Meta
                             tGtTile.getFacingOffset((BaseMetaTileEntity)tTileEntity, ((BaseMetaTileEntity) tTileEntity).getFrontFacing())    
                         )) {
                             // If it's the same class, and we've scanned a wire in front of it (the input side), we've found our target
-                            mTarget = tGtTile;
-                            mTargetPos = tGtTile.getCoords();
-                            return;
+                            // still need to check if it's distant enough
+                            int distance = getDistanceToSelf(aCoords);
+                            if (distance > minimalDistancePoints) {
+                                mTarget = tGtTile;
+                                mTargetPos = tGtTile.getCoords();
+                                return;
+                            }
                         }
                         
                         // Remove this block from the visited because we might end up back here from another wire that IS connected to the
@@ -224,7 +231,13 @@ public abstract class GT_MetaTileEntity_LongDistancePipelineBase extends GT_Meta
         }
         
     }
-    
+
+    protected int getDistanceToSelf(ChunkCoordinates aCoords) {
+        return Math.abs(getBaseMetaTileEntity().getXCoord() - aCoords.posX) +
+                Math.abs(getBaseMetaTileEntity().getYCoord() - aCoords.posY) /  2 +
+                Math.abs(getBaseMetaTileEntity().getZCoord() - aCoords.posZ);
+    }
+
     public ChunkCoordinates getFacingOffset(IGregTechTileEntity gt_tile, byte aSide) {
         return new ChunkCoordinates(
             gt_tile.getOffsetX(aSide, 1), gt_tile.getOffsetY(aSide, 1), gt_tile.getOffsetZ(aSide, 1)


### PR DESCRIPTION
They are called long distance pipelines, so they should at least cover some range before working.

To prevent hax again, twists and turns are not counted towards distance, and vertical difference only count half as much towards the 64 mininimal requirement.