### PR TITLE
convert cover data storage to a full nbt tag

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 minecraft.version=1.7.10
 forge.version=10.13.4.1614-1.7.10
-gt.version=5.09.38.05
+gt.version=5.09.39.00
 structurelib.version=1.0.6
 ae2.version=rv3-beta-22
 applecore.version=1.7.10-1.2.1+107.59407

--- a/src/main/java/gregtech/GT_Mod.java
+++ b/src/main/java/gregtech/GT_Mod.java
@@ -115,7 +115,7 @@ import static gregtech.api.enums.GT_Values.MOD_ID_FR;
                 " after:TConstruct;" +
                 " after:Translocator;")
 public class GT_Mod implements IGT_Mod {
-    public static final int VERSION = 509, SUBVERSION = 33;
+    public static final int VERSION = 509, SUBVERSION = 39;
     public static final int TOTAL_VERSION = calculateTotalGTVersion(VERSION, SUBVERSION);
     public static final int REQUIRED_IC2 = 624;
     @Mod.Instance("gregtech")

--- a/src/main/java/gregtech/api/GregTech_API.java
+++ b/src/main/java/gregtech/api/GregTech_API.java
@@ -113,7 +113,7 @@ public class GregTech_API {
     /**
      * The List of Cover Behaviors for the Covers
      */
-    public static final Map<GT_ItemStack, GT_CoverBehavior> sCoverBehaviors = new ConcurrentHashMap<>();
+    public static final Map<GT_ItemStack, GT_CoverBehavior_New<?>> sCoverBehaviors = new ConcurrentHashMap<>();
     /**
      * The List of Circuit Behaviors for the Redstone Circuit Block
      */
@@ -615,6 +615,10 @@ public class GregTech_API {
     }
 
     public static void registerCover(ItemStack aStack, ITexture aCover, GT_CoverBehavior aBehavior) {
+        registerCover(aStack, aCover, (GT_CoverBehavior_New<?>) aBehavior);
+    }
+
+    public static void registerCover(ItemStack aStack, ITexture aCover, GT_CoverBehavior_New<?> aBehavior) {
         if (!sCovers.containsKey(new GT_ItemStack(aStack)))
             sCovers.put(new GT_ItemStack(aStack), aCover == null || !aCover.isValidTexture() ? Textures.BlockIcons.ERROR_RENDERING[0] : aCover);
         if (aBehavior != null)
@@ -622,6 +626,10 @@ public class GregTech_API {
     }
 
     public static void registerCoverBehavior(ItemStack aStack, GT_CoverBehavior aBehavior) {
+        registerCoverBehavior(aStack, (GT_CoverBehavior_New<?>) aBehavior);
+    }
+
+    public static void registerCoverBehavior(ItemStack aStack, GT_CoverBehavior_New<?> aBehavior) {
         sCoverBehaviors.put(new GT_ItemStack(aStack), aBehavior == null ? sDefaultBehavior : aBehavior);
     }
 
@@ -631,6 +639,15 @@ public class GregTech_API {
      * @param aBehavior can be null
      */
     public static void registerCover(Collection<ItemStack> aStackList, ITexture aCover, GT_CoverBehavior aBehavior) {
+        registerCover(aStackList, aCover, aBehavior);
+    }
+
+    /**
+     * Registers multiple Cover Items. I use that for the OreDict Functionality.
+     *
+     * @param aBehavior can be null
+     */
+    public static void registerCover(Collection<ItemStack> aStackList, ITexture aCover, GT_CoverBehavior_New<?> aBehavior) {
         if (aCover.isValidTexture())
             aStackList.forEach(tStack -> GregTech_API.registerCover(tStack, aCover, aBehavior));
     }
@@ -638,10 +655,24 @@ public class GregTech_API {
     /**
      * returns a Cover behavior, guaranteed to not return null after preload
      */
+    @Deprecated
     public static GT_CoverBehavior getCoverBehavior(ItemStack aStack) {
         if (aStack == null || aStack.getItem() == null)
             return sNoBehavior;
-        GT_CoverBehavior rCover = sCoverBehaviors.get(new GT_ItemStack(aStack));
+        GT_CoverBehavior_New<?> rCover = sCoverBehaviors.get(new GT_ItemStack(aStack));
+        if (!(rCover instanceof GT_CoverBehavior) || rCover == null)
+            return sDefaultBehavior;
+        return (GT_CoverBehavior) rCover;
+    }
+
+    /**
+     * returns a Cover behavior, guaranteed to not return null after preload
+     * @return
+     */
+    public static GT_CoverBehavior_New<?> getCoverBehaviorNew(ItemStack aStack) {
+        if (aStack == null || aStack.getItem() == null)
+            return sNoBehavior;
+        GT_CoverBehavior_New<?> rCover = sCoverBehaviors.get(new GT_ItemStack(aStack));
         if (rCover == null)
             return sDefaultBehavior;
         return rCover;
@@ -650,10 +681,20 @@ public class GregTech_API {
     /**
      * returns a Cover behavior, guaranteed to not return null
      */
+    @Deprecated
     public static GT_CoverBehavior getCoverBehavior(int aStack) {
         if (aStack == 0)
             return sNoBehavior;
         return getCoverBehavior(GT_Utility.intToStack(aStack));
+    }
+
+    /**
+     * returns a Cover behavior, guaranteed to not return null
+     */
+    public static GT_CoverBehavior_New<?> getCoverBehaviorNew(int aStack) {
+        if (aStack == 0)
+            return sNoBehavior;
+        return getCoverBehaviorNew(GT_Utility.intToStack(aStack));
     }
 
     /**

--- a/src/main/java/gregtech/api/GregTech_API.java
+++ b/src/main/java/gregtech/api/GregTech_API.java
@@ -113,7 +113,7 @@ public class GregTech_API {
     /**
      * The List of Cover Behaviors for the Covers
      */
-    public static final Map<GT_ItemStack, GT_CoverBehavior_New<?>> sCoverBehaviors = new ConcurrentHashMap<>();
+    public static final Map<GT_ItemStack, GT_CoverBehaviorBase<?>> sCoverBehaviors = new ConcurrentHashMap<>();
     /**
      * The List of Circuit Behaviors for the Redstone Circuit Block
      */
@@ -615,10 +615,10 @@ public class GregTech_API {
     }
 
     public static void registerCover(ItemStack aStack, ITexture aCover, GT_CoverBehavior aBehavior) {
-        registerCover(aStack, aCover, (GT_CoverBehavior_New<?>) aBehavior);
+        registerCover(aStack, aCover, (GT_CoverBehaviorBase<?>) aBehavior);
     }
 
-    public static void registerCover(ItemStack aStack, ITexture aCover, GT_CoverBehavior_New<?> aBehavior) {
+    public static void registerCover(ItemStack aStack, ITexture aCover, GT_CoverBehaviorBase<?> aBehavior) {
         if (!sCovers.containsKey(new GT_ItemStack(aStack)))
             sCovers.put(new GT_ItemStack(aStack), aCover == null || !aCover.isValidTexture() ? Textures.BlockIcons.ERROR_RENDERING[0] : aCover);
         if (aBehavior != null)
@@ -626,10 +626,10 @@ public class GregTech_API {
     }
 
     public static void registerCoverBehavior(ItemStack aStack, GT_CoverBehavior aBehavior) {
-        registerCoverBehavior(aStack, (GT_CoverBehavior_New<?>) aBehavior);
+        registerCoverBehavior(aStack, (GT_CoverBehaviorBase<?>) aBehavior);
     }
 
-    public static void registerCoverBehavior(ItemStack aStack, GT_CoverBehavior_New<?> aBehavior) {
+    public static void registerCoverBehavior(ItemStack aStack, GT_CoverBehaviorBase<?> aBehavior) {
         sCoverBehaviors.put(new GT_ItemStack(aStack), aBehavior == null ? sDefaultBehavior : aBehavior);
     }
 
@@ -647,7 +647,7 @@ public class GregTech_API {
      *
      * @param aBehavior can be null
      */
-    public static void registerCover(Collection<ItemStack> aStackList, ITexture aCover, GT_CoverBehavior_New<?> aBehavior) {
+    public static void registerCover(Collection<ItemStack> aStackList, ITexture aCover, GT_CoverBehaviorBase<?> aBehavior) {
         if (aCover.isValidTexture())
             aStackList.forEach(tStack -> GregTech_API.registerCover(tStack, aCover, aBehavior));
     }
@@ -659,7 +659,7 @@ public class GregTech_API {
     public static GT_CoverBehavior getCoverBehavior(ItemStack aStack) {
         if (aStack == null || aStack.getItem() == null)
             return sNoBehavior;
-        GT_CoverBehavior_New<?> rCover = sCoverBehaviors.get(new GT_ItemStack(aStack));
+        GT_CoverBehaviorBase<?> rCover = sCoverBehaviors.get(new GT_ItemStack(aStack));
         if (!(rCover instanceof GT_CoverBehavior) || rCover == null)
             return sDefaultBehavior;
         return (GT_CoverBehavior) rCover;
@@ -669,10 +669,10 @@ public class GregTech_API {
      * returns a Cover behavior, guaranteed to not return null after preload
      * @return
      */
-    public static GT_CoverBehavior_New<?> getCoverBehaviorNew(ItemStack aStack) {
+    public static GT_CoverBehaviorBase<?> getCoverBehaviorNew(ItemStack aStack) {
         if (aStack == null || aStack.getItem() == null)
             return sNoBehavior;
-        GT_CoverBehavior_New<?> rCover = sCoverBehaviors.get(new GT_ItemStack(aStack));
+        GT_CoverBehaviorBase<?> rCover = sCoverBehaviors.get(new GT_ItemStack(aStack));
         if (rCover == null)
             return sDefaultBehavior;
         return rCover;
@@ -691,7 +691,7 @@ public class GregTech_API {
     /**
      * returns a Cover behavior, guaranteed to not return null
      */
-    public static GT_CoverBehavior_New<?> getCoverBehaviorNew(int aStack) {
+    public static GT_CoverBehaviorBase<?> getCoverBehaviorNew(int aStack) {
         if (aStack == 0)
             return sNoBehavior;
         return getCoverBehaviorNew(GT_Utility.intToStack(aStack));

--- a/src/main/java/gregtech/api/gui/widgets/GT_GuiIconCheckButton.java
+++ b/src/main/java/gregtech/api/gui/widgets/GT_GuiIconCheckButton.java
@@ -3,13 +3,22 @@ package gregtech.api.gui.widgets;
 import gregtech.api.interfaces.IGuiScreen;
 
 public class GT_GuiIconCheckButton extends GT_GuiIconButton {
-    private GT_GuiIcon checkedIcon, normalIcon;
+    private final GT_GuiIcon checkedIcon;
+    private final GT_GuiIcon normalIcon;
+    private final String checkedTooltip;
+    private final String normalTooltip;
     private boolean checked = false;
 
     public GT_GuiIconCheckButton(IGuiScreen gui, int id, int x, int y, GT_GuiIcon checkedIcon, GT_GuiIcon normalIcon) {
+        this(gui, id, x, y, checkedIcon, normalIcon, null, null);
+    }
+
+    public GT_GuiIconCheckButton(IGuiScreen gui, int id, int x, int y, GT_GuiIcon checkedIcon, GT_GuiIcon normalIcon, String checkedTooltip, String normalTooltip) {
         super(gui, id, x, y, normalIcon);
         this.checkedIcon = checkedIcon;
         this.normalIcon = normalIcon;
+        this.checkedTooltip = checkedTooltip;
+        this.normalTooltip = normalTooltip;
     }
 
     @Override
@@ -27,6 +36,7 @@ public class GT_GuiIconCheckButton extends GT_GuiIconButton {
 
     public void setChecked(boolean checked) {
         super.setIcon(checked ? checkedIcon : normalIcon);
+        super.setTooltipText(checked ? checkedTooltip : normalTooltip);
         this.checked = checked;
     }
 }

--- a/src/main/java/gregtech/api/interfaces/metatileentity/IMetaTileEntityItemPipe.java
+++ b/src/main/java/gregtech/api/interfaces/metatileentity/IMetaTileEntityItemPipe.java
@@ -59,7 +59,7 @@ public interface IMetaTileEntityItemPipe extends IMetaTileEntity {
                             continue;
                         j = GT_Utility.getOppositeSide(i);
                         if (aSuckItems) {
-                            if (aBaseMetaTileEntity.getCoverBehaviorAtSide(i).letsItemsIn(i, aBaseMetaTileEntity.getCoverIDAtSide(i), aBaseMetaTileEntity.getCoverDataAtSide(i), -2, aBaseMetaTileEntity)) {
+                            if (aBaseMetaTileEntity.getCoverBehaviorAtSideNew(i).letsItemsIn(i, aBaseMetaTileEntity.getCoverIDAtSide(i), aBaseMetaTileEntity.getCoverDataAtSideNew(i), -2, aBaseMetaTileEntity)) {
                                 IGregTechTileEntity tItemPipe = aBaseMetaTileEntity.getIGregTechTileEntityAtSide(i);
                                 if (aBaseMetaTileEntity.getColorization() >= 0) {
                                     byte tColor = tItemPipe.getColorization();
@@ -69,13 +69,13 @@ public interface IMetaTileEntityItemPipe extends IMetaTileEntity {
                                 }
                                 if (tItemPipe instanceof BaseMetaPipeEntity) {
                                     IMetaTileEntity tMetaTileEntity = tItemPipe.getMetaTileEntity();
-                                    if (tMetaTileEntity instanceof IMetaTileEntityItemPipe && tItemPipe.getCoverBehaviorAtSide(j).letsItemsOut(j, tItemPipe.getCoverIDAtSide(j), tItemPipe.getCoverDataAtSide(j), -2, tItemPipe)) {
+                                    if (tMetaTileEntity instanceof IMetaTileEntityItemPipe && tItemPipe.getCoverBehaviorAtSideNew(j).letsItemsOut(j, tItemPipe.getCoverIDAtSide(j), tItemPipe.getCoverDataAtSideNew(j), -2, tItemPipe)) {
                                         scanPipes((IMetaTileEntityItemPipe) tMetaTileEntity, aMap, aStep, aSuckItems, aIgnoreCapacity);
                                     }
                                 }
                             }
                         } else {
-                            if (aBaseMetaTileEntity.getCoverBehaviorAtSide(i).letsItemsOut(i, aBaseMetaTileEntity.getCoverIDAtSide(i), aBaseMetaTileEntity.getCoverDataAtSide(i), -2, aBaseMetaTileEntity)) {
+                            if (aBaseMetaTileEntity.getCoverBehaviorAtSideNew(i).letsItemsOut(i, aBaseMetaTileEntity.getCoverIDAtSide(i), aBaseMetaTileEntity.getCoverDataAtSideNew(i), -2, aBaseMetaTileEntity)) {
                                 IGregTechTileEntity tItemPipe = aBaseMetaTileEntity.getIGregTechTileEntityAtSide(i);
                                 if (tItemPipe != null) {
                                     if (aBaseMetaTileEntity.getColorization() >= 0) {
@@ -86,7 +86,7 @@ public interface IMetaTileEntityItemPipe extends IMetaTileEntity {
                                     }
                                     if (tItemPipe instanceof BaseMetaPipeEntity) {
                                         IMetaTileEntity tMetaTileEntity = tItemPipe.getMetaTileEntity();
-                                        if (tMetaTileEntity instanceof IMetaTileEntityItemPipe && tItemPipe.getCoverBehaviorAtSide(j).letsItemsIn(j, tItemPipe.getCoverIDAtSide(j), tItemPipe.getCoverDataAtSide(j), -2, tItemPipe)) {
+                                        if (tMetaTileEntity instanceof IMetaTileEntityItemPipe && tItemPipe.getCoverBehaviorAtSideNew(j).letsItemsIn(j, tItemPipe.getCoverIDAtSide(j), tItemPipe.getCoverDataAtSideNew(j), -2, tItemPipe)) {
                                             scanPipes((IMetaTileEntityItemPipe) tMetaTileEntity, aMap, aStep, aSuckItems, aIgnoreCapacity);
                                         }
                                     }

--- a/src/main/java/gregtech/api/interfaces/metatileentity/IMetaTileEntityItemPipe.java
+++ b/src/main/java/gregtech/api/interfaces/metatileentity/IMetaTileEntityItemPipe.java
@@ -59,7 +59,7 @@ public interface IMetaTileEntityItemPipe extends IMetaTileEntity {
                             continue;
                         j = GT_Utility.getOppositeSide(i);
                         if (aSuckItems) {
-                            if (aBaseMetaTileEntity.getCoverBehaviorAtSideNew(i).letsItemsIn(i, aBaseMetaTileEntity.getCoverIDAtSide(i), aBaseMetaTileEntity.getCoverDataAtSideNew(i), -2, aBaseMetaTileEntity)) {
+                            if (aBaseMetaTileEntity.getCoverBehaviorAtSideNew(i).letsItemsIn(i, aBaseMetaTileEntity.getCoverIDAtSide(i), aBaseMetaTileEntity.getComplexCoverDataAtSide(i), -2, aBaseMetaTileEntity)) {
                                 IGregTechTileEntity tItemPipe = aBaseMetaTileEntity.getIGregTechTileEntityAtSide(i);
                                 if (aBaseMetaTileEntity.getColorization() >= 0) {
                                     byte tColor = tItemPipe.getColorization();
@@ -69,13 +69,13 @@ public interface IMetaTileEntityItemPipe extends IMetaTileEntity {
                                 }
                                 if (tItemPipe instanceof BaseMetaPipeEntity) {
                                     IMetaTileEntity tMetaTileEntity = tItemPipe.getMetaTileEntity();
-                                    if (tMetaTileEntity instanceof IMetaTileEntityItemPipe && tItemPipe.getCoverBehaviorAtSideNew(j).letsItemsOut(j, tItemPipe.getCoverIDAtSide(j), tItemPipe.getCoverDataAtSideNew(j), -2, tItemPipe)) {
+                                    if (tMetaTileEntity instanceof IMetaTileEntityItemPipe && tItemPipe.getCoverBehaviorAtSideNew(j).letsItemsOut(j, tItemPipe.getCoverIDAtSide(j), tItemPipe.getComplexCoverDataAtSide(j), -2, tItemPipe)) {
                                         scanPipes((IMetaTileEntityItemPipe) tMetaTileEntity, aMap, aStep, aSuckItems, aIgnoreCapacity);
                                     }
                                 }
                             }
                         } else {
-                            if (aBaseMetaTileEntity.getCoverBehaviorAtSideNew(i).letsItemsOut(i, aBaseMetaTileEntity.getCoverIDAtSide(i), aBaseMetaTileEntity.getCoverDataAtSideNew(i), -2, aBaseMetaTileEntity)) {
+                            if (aBaseMetaTileEntity.getCoverBehaviorAtSideNew(i).letsItemsOut(i, aBaseMetaTileEntity.getCoverIDAtSide(i), aBaseMetaTileEntity.getComplexCoverDataAtSide(i), -2, aBaseMetaTileEntity)) {
                                 IGregTechTileEntity tItemPipe = aBaseMetaTileEntity.getIGregTechTileEntityAtSide(i);
                                 if (tItemPipe != null) {
                                     if (aBaseMetaTileEntity.getColorization() >= 0) {
@@ -86,7 +86,7 @@ public interface IMetaTileEntityItemPipe extends IMetaTileEntity {
                                     }
                                     if (tItemPipe instanceof BaseMetaPipeEntity) {
                                         IMetaTileEntity tMetaTileEntity = tItemPipe.getMetaTileEntity();
-                                        if (tMetaTileEntity instanceof IMetaTileEntityItemPipe && tItemPipe.getCoverBehaviorAtSideNew(j).letsItemsIn(j, tItemPipe.getCoverIDAtSide(j), tItemPipe.getCoverDataAtSideNew(j), -2, tItemPipe)) {
+                                        if (tMetaTileEntity instanceof IMetaTileEntityItemPipe && tItemPipe.getCoverBehaviorAtSideNew(j).letsItemsIn(j, tItemPipe.getCoverIDAtSide(j), tItemPipe.getComplexCoverDataAtSide(j), -2, tItemPipe)) {
                                             scanPipes((IMetaTileEntityItemPipe) tMetaTileEntity, aMap, aStep, aSuckItems, aIgnoreCapacity);
                                         }
                                     }

--- a/src/main/java/gregtech/api/interfaces/tileentity/ICoverable.java
+++ b/src/main/java/gregtech/api/interfaces/tileentity/ICoverable.java
@@ -1,7 +1,7 @@
 package gregtech.api.interfaces.tileentity;
 
 import gregtech.api.util.GT_CoverBehavior;
-import gregtech.api.util.GT_CoverBehavior_New;
+import gregtech.api.util.GT_CoverBehaviorBase;
 import gregtech.api.util.ISerializableObject;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
@@ -28,7 +28,7 @@ public interface ICoverable extends IRedstoneTileEntity, IHasInventory, IBasicEn
     @Deprecated
     int getCoverDataAtSide(byte aSide);
 
-    default ISerializableObject getCoverDataAtSideNew(byte aSide) {
+    default ISerializableObject getComplexCoverDataAtSide(byte aSide) {
         return new ISerializableObject.LegacyCoverData(getCoverDataAtSide(aSide));
     }
 
@@ -39,7 +39,7 @@ public interface ICoverable extends IRedstoneTileEntity, IHasInventory, IBasicEn
     @Deprecated
     GT_CoverBehavior getCoverBehaviorAtSide(byte aSide);
 
-    default GT_CoverBehavior_New<?> getCoverBehaviorAtSideNew(byte aSide) {
+    default GT_CoverBehaviorBase<?> getCoverBehaviorAtSideNew(byte aSide) {
         return getCoverBehaviorAtSide(aSide);
     }
 

--- a/src/main/java/gregtech/api/interfaces/tileentity/ICoverable.java
+++ b/src/main/java/gregtech/api/interfaces/tileentity/ICoverable.java
@@ -1,6 +1,9 @@
 package gregtech.api.interfaces.tileentity;
 
 import gregtech.api.util.GT_CoverBehavior;
+import gregtech.api.util.GT_CoverBehavior_New;
+import gregtech.api.util.ISerializableObject;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 
 public interface ICoverable extends IRedstoneTileEntity, IHasInventory, IBasicEnergyContainer {
@@ -10,19 +13,35 @@ public interface ICoverable extends IRedstoneTileEntity, IHasInventory, IBasicEn
 
     boolean dropCover(byte aSide, byte aDroppedSide, boolean aForced);
 
+    @Deprecated
     void setCoverDataAtSide(byte aSide, int aData);
+
+    default void setCoverDataAtSide(byte aSide, ISerializableObject aData) {
+        if (aData instanceof ISerializableObject.LegacyCoverData)
+            setCoverDataAtSide(aSide, ((ISerializableObject.LegacyCoverData) aData).get());
+    }
 
     void setCoverIDAtSide(byte aSide, int aID);
 
     void setCoverItemAtSide(byte aSide, ItemStack aCover);
 
+    @Deprecated
     int getCoverDataAtSide(byte aSide);
+
+    default ISerializableObject getCoverDataAtSideNew(byte aSide) {
+        return new ISerializableObject.LegacyCoverData(getCoverDataAtSide(aSide));
+    }
 
     int getCoverIDAtSide(byte aSide);
 
     ItemStack getCoverItemAtSide(byte aSide);
 
+    @Deprecated
     GT_CoverBehavior getCoverBehaviorAtSide(byte aSide);
+
+    default GT_CoverBehavior_New<?> getCoverBehaviorAtSideNew(byte aSide) {
+        return getCoverBehaviorAtSide(aSide);
+    }
 
     /**
      * For use by the regular MetaTileEntities. Returns the Cover Manipulated input Redstone.
@@ -46,4 +65,13 @@ public interface ICoverable extends IRedstoneTileEntity, IHasInventory, IBasicEn
      * Receiving a packet with cover data.
      */
     void receiveCoverData(byte coverSide, int coverID, int coverData);
+
+    /**
+     * Receiving a packet with cover data.
+     * @param aPlayer the player who made the change
+     */
+    default void receiveCoverData(byte aCoverSide, int aCoverID, ISerializableObject aCoverData, EntityPlayerMP aPlayer) {
+        if (aCoverData instanceof ISerializableObject.LegacyCoverData)
+            receiveCoverData(aCoverSide, aCoverID, ((ISerializableObject.LegacyCoverData) aCoverData).get());
+    }
 }

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
@@ -1,5 +1,14 @@
 package gregtech.api.metatileentity;
 
+import static gregtech.GT_Mod.GT_FML_LOGGER;
+import static gregtech.api.enums.GT_Values.NW;
+import static gregtech.api.metatileentity.BaseMetaTileEntity.COVER_DATA_NBT_KEYS;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
 import gregtech.GT_Mod;
 import gregtech.api.GregTech_API;
 import gregtech.api.enums.Textures;
@@ -11,16 +20,22 @@ import gregtech.api.interfaces.metatileentity.IConnectable;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.interfaces.tileentity.IPipeRenderedTileEntity;
-import gregtech.api.metatileentity.BaseMetaTileEntity.ClientEvents;
 import gregtech.api.net.GT_Packet_TileEntity;
 import gregtech.api.objects.GT_ItemStack;
-import gregtech.api.util.*;
+import gregtech.api.util.GT_CoverBehavior;
+import gregtech.api.util.GT_CoverBehavior_New;
+import gregtech.api.util.GT_Log;
+import gregtech.api.util.GT_ModHandler;
+import gregtech.api.util.GT_OreDictUnificator;
+import gregtech.api.util.GT_Utility;
+import gregtech.api.util.ISerializableObject;
 import gregtech.common.GT_Client;
 import gregtech.common.covers.GT_Cover_Fluidfilter;
 import net.minecraft.block.Block;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -32,27 +47,18 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.*;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.UUID;
-
-import static gregtech.GT_Mod.GT_FML_LOGGER;
-import static gregtech.api.enums.GT_Values.NW;
-
 /**
  * NEVER INCLUDE THIS FILE IN YOUR MOD!!!
  * <p/>
  * This is the main TileEntity for EVERYTHING.
  */
 public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileEntity, IPipeRenderedTileEntity {
-    private final GT_CoverBehavior[] mCoverBehaviors = new GT_CoverBehavior[]{GregTech_API.sNoBehavior, GregTech_API.sNoBehavior, GregTech_API.sNoBehavior, GregTech_API.sNoBehavior, GregTech_API.sNoBehavior, GregTech_API.sNoBehavior};
+    private final GT_CoverBehavior_New<?>[] mCoverBehaviors = new GT_CoverBehavior_New<?>[]{GregTech_API.sNoBehavior, GregTech_API.sNoBehavior, GregTech_API.sNoBehavior, GregTech_API.sNoBehavior, GregTech_API.sNoBehavior, GregTech_API.sNoBehavior};
     public byte mConnections = IConnectable.NO_CONNECTION;
     protected MetaPipeEntity mMetaTileEntity;
     private byte[] mSidedRedstone = new byte[]{0, 0, 0, 0, 0, 0};
-    private int[] mCoverSides = new int[]{0, 0, 0, 0, 0, 0};
-    private int[] mCoverData = new int[]{0, 0, 0, 0, 0, 0};
-    private final int[] mTimeStatistics = new int[GregTech_API.TICKS_FOR_LAG_AVERAGING];
+    private int[] mCoverSides = new int[]{0, 0, 0, 0, 0, 0}, mTimeStatistics = new int[GregTech_API.TICKS_FOR_LAG_AVERAGING];
+    private ISerializableObject[] mCoverData = new ISerializableObject[6];
     private boolean mInventoryChanged = false, mWorkUpdate = false, mWorks = true, mNeedsUpdate = true, mNeedsBlockUpdate = true, mSendClientData = false;
     private final boolean mCheckConnections = false;
     private byte mColor = 0, oColor = 0, mStrongRedstone = 0, oStrongRedstone = 0, oRedstoneData = 63, oTextureData = 0, oUpdateData = 0, mLagWarningCount = 0;
@@ -92,27 +98,18 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
         }
         try {
             aNBT.setInteger("mID", mID);
-            aNBT.setIntArray("mCoverData", mCoverData);
+            for (int i = 0; i < mCoverData.length; i++) {
+                if (mCoverData[i] != null)
+                    aNBT.setTag(COVER_DATA_NBT_KEYS[i], mCoverData[i].saveDataToNBT());
+            }
             aNBT.setIntArray("mCoverSides", mCoverSides);
             aNBT.setByteArray("mRedstoneSided", mSidedRedstone);
             aNBT.setByte("mConnections", mConnections);
             aNBT.setByte("mColor", mColor);
             aNBT.setByte("mStrongRedstone", mStrongRedstone);
             aNBT.setBoolean("mWorks", !mWorks);
-
-            for(int i=0;i < mCoverData.length; i++) {
-                if (GregTech_API.getCoverBehavior(mCoverSides[i]) instanceof GT_Cover_Fluidfilter) {
-                    final int fluidId = mCoverData[i] >>> 3;
-                    final Fluid fluid = FluidRegistry.getFluid(fluidId);
-                    if(fluid != null) {
-                        final String fluidName = FluidRegistry.getFluidName(fluid);
-                        aNBT.setString(String.format("fluidFilter%d", i), fluidName);
-                    }
-                }
-            }
-
         } catch (Throwable e) {
-            GT_Log.err.println("Encountered CRITICAL ERROR while saving MetaTileEntity, the Chunk whould've been corrupted by now, but I prevented that. Please report immediately to GregTech Intergalactical!!!");
+            GT_Log.err.println("Encountered CRITICAL ERROR while saving MetaTileEntity, the Chunk would've been corrupted by now, but I prevented that. Please report immediately to GregTech Intergalactical!!!");
             e.printStackTrace(GT_Log.err);
         }
         try {
@@ -158,28 +155,61 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
             if (aID <= 0) mID = (short) aNBT.getInteger("mID");
             else mID = aID;
             mCoverSides = aNBT.getIntArray("mCoverSides");
-            mCoverData = aNBT.getIntArray("mCoverData");
             mSidedRedstone = aNBT.getByteArray("mRedstoneSided");
             mConnections = aNBT.getByte("mConnections");
             mColor = aNBT.getByte("mColor");
             mStrongRedstone = aNBT.getByte("mStrongRedstone");
             mWorks = !aNBT.getBoolean("mWorks");
 
-            if (mCoverData.length != 6) mCoverData = new int[]{0, 0, 0, 0, 0, 0};
             if (mCoverSides.length != 6) mCoverSides = new int[]{0, 0, 0, 0, 0, 0};
-            if (mSidedRedstone.length != 6) mSidedRedstone = new byte[]{0, 0, 0, 0, 0, 0};
-
-            for (byte i = 0; i < 6; i++) {
-                mCoverBehaviors[i] = GregTech_API.getCoverBehavior(mCoverSides[i]);
-                if(mCoverBehaviors[i] instanceof GT_Cover_Fluidfilter) {
-                    final String filterKey = String.format("fluidFilter%d", i);
-                    if (aNBT.hasKey(filterKey)) {
-                        mCoverData[i] = (mCoverData[i] & 7) | (FluidRegistry.getFluidID(aNBT.getString(filterKey)) << 3);
-                    }
+            // check old form of data
+            mCoverData = null;
+            if (aNBT.hasKey("mCoverData", 11)) {
+                int[] tOldData = aNBT.getIntArray("mCoverData");
+                if (tOldData.length == 6)
+                    mCoverData = Arrays.stream(tOldData).mapToObj(ISerializableObject.LegacyCoverData::new).toArray(ISerializableObject[]::new);
+            }
+            // if no old data
+            if (mCoverData == null) {
+                mCoverData = new ISerializableObject[6];
+                for (byte i = 0; i<6; i++) {
+                    GT_CoverBehavior_New<?> tBehavior = getCoverBehaviorAtSideNew(i);
+                    if (tBehavior == null)
+                        continue;
+                    mCoverData[i] = tBehavior.createDataObject();
+                    if (aNBT.hasKey(COVER_DATA_NBT_KEYS[i]))
+                        mCoverData[i].loadDataFromNBT(aNBT.getTag(COVER_DATA_NBT_KEYS[i]));
                 }
             }
+            if (mSidedRedstone.length != 6) mSidedRedstone = new byte[]{0, 0, 0, 0, 0, 0};
 
+            for (byte i = 0; i < 6; i++) mCoverBehaviors[i] = GregTech_API.getCoverBehaviorNew(mCoverSides[i]);
 
+            // check old form of data
+            mCoverData = new ISerializableObject[6];
+            if (aNBT.hasKey("mCoverData", 11) && aNBT.getIntArray("mCoverData").length == 6) {
+                int[] tOldData = aNBT.getIntArray("mCoverData");
+                for (int i = 0; i < tOldData.length; i++) {
+                    if(mCoverBehaviors[i] instanceof GT_Cover_Fluidfilter) {
+                        final String filterKey = String.format("fluidFilter%d", i);
+                        if (aNBT.hasKey(filterKey)) {
+                            mCoverData[i] = mCoverBehaviors[i].createDataObject((tOldData[i] & 7) | (FluidRegistry.getFluidID(aNBT.getString(filterKey)) << 3));
+                        }
+                    } else if (mCoverBehaviors[i] != null && mCoverBehaviors[i] != GregTech_API.sNoBehavior) {
+                        mCoverData[i] = mCoverBehaviors[i].createDataObject(tOldData[i]);
+                    }
+                }
+            } else {
+                // no old data
+                for (byte i = 0; i<6; i++) {
+                    if (mCoverBehaviors[i] == null)
+                        continue;
+                    if (aNBT.hasKey(COVER_DATA_NBT_KEYS[i]))
+                        mCoverData[i] = mCoverBehaviors[i].createDataObject(aNBT.getTag(COVER_DATA_NBT_KEYS[i]));
+                    else
+                        mCoverData[i] = mCoverBehaviors[i].createDataObject();
+                }
+            }
             if (mID != 0 && createNewMetatileEntity(mID)) {
                 NBTTagList tItemList = aNBT.getTagList("Inventory", 10);
                 for (int i = 0; i < tItemList.tagCount(); i++) {
@@ -199,11 +229,11 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
             }
         }
 
-        if (mCoverData.length != 6) mCoverData = new int[]{0, 0, 0, 0, 0, 0};
+        if (mCoverData == null || mCoverData.length != 6) mCoverData = new ISerializableObject[6];
         if (mCoverSides.length != 6) mCoverSides = new int[]{0, 0, 0, 0, 0, 0};
         if (mSidedRedstone.length != 6) mSidedRedstone = new byte[]{0, 0, 0, 0, 0, 0};
 
-        for (byte i = 0; i < 6; i++) mCoverBehaviors[i] = GregTech_API.getCoverBehavior(mCoverSides[i]);
+        for (byte i = 0; i < 6; i++) mCoverBehaviors[i] = GregTech_API.getCoverBehaviorNew(mCoverSides[i]);
     }
 
     private boolean createNewMetatileEntity(short aID) {
@@ -271,7 +301,7 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
                             for (byte i = (byte) (tCode - 2); i < 6; i++)
                                 if (getCoverIDAtSide(i) != 0) {
                                     tCode++;
-                                    GT_CoverBehavior tCover = getCoverBehaviorAtSide(i);
+                                    GT_CoverBehavior_New<?> tCover = getCoverBehaviorAtSideNew(i);
                                     int tCoverTickRate = tCover.getTickRate(i, getCoverIDAtSide(i), mCoverData[i], this);
                                     if (tCoverTickRate > 0 && mTickTimer % tCoverTickRate == 0) {
                                         byte tRedstone = tCover.isRedstoneSensitive(i, getCoverIDAtSide(i), mCoverData[i], this, mTickTimer) ? getInputRedstoneSignal(i) : 0;
@@ -298,7 +328,7 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
                         if (isServerSide()) {
                             if (mTickTimer == 10) {
                                 for (byte i = 0; i < 6; i++)
-                                    mCoverBehaviors[i] = GregTech_API.getCoverBehavior(mCoverSides[i]);
+                                    mCoverBehaviors[i] = GregTech_API.getCoverBehaviorNew(mCoverSides[i]);
                                 issueBlockUpdate();
                                 joinEnet();
                             }
@@ -326,15 +356,12 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
                             }
 
                             if (mTickTimer > 10) {
-                                if (mConnections != oTextureData)
-                                    sendBlockEvent(ClientEvents.CHANGE_COMMON_DATA, oTextureData = mConnections);
+                                if (mConnections != oTextureData) sendBlockEvent((byte) 0, oTextureData = mConnections);
                                 byte tData = mMetaTileEntity.getUpdateData();
-                                if (tData != oUpdateData)
-                                    sendBlockEvent(ClientEvents.CHANGE_CUSTOM_DATA, oUpdateData = tData);
-                                if (mColor != oColor) sendBlockEvent(ClientEvents.CHANGE_COLOR, oColor = mColor);
+                                if (tData != oUpdateData) sendBlockEvent((byte) 1, oUpdateData = tData);
+                                if (mColor != oColor) sendBlockEvent((byte) 2, oColor = mColor);
                                 tData = (byte) (((mSidedRedstone[0] > 0) ? 1 : 0) | ((mSidedRedstone[1] > 0) ? 2 : 0) | ((mSidedRedstone[2] > 0) ? 4 : 0) | ((mSidedRedstone[3] > 0) ? 8 : 0) | ((mSidedRedstone[4] > 0) ? 16 : 0) | ((mSidedRedstone[5] > 0) ? 32 : 0));
-                                if (tData != oRedstoneData)
-                                    sendBlockEvent(ClientEvents.CHANGE_REDSTONE_OUTPUT, oRedstoneData = tData);
+                                if (tData != oRedstoneData) sendBlockEvent((byte) 3, oRedstoneData = tData);
                             }
 
                             if (mNeedsBlockUpdate) {
@@ -384,7 +411,7 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
         mCoverSides[4] = aCover4;
         mCoverSides[5] = aCover5;
 
-        for (byte i = 0; i < 6; i++) mCoverBehaviors[i] = GregTech_API.getCoverBehavior(mCoverSides[i]);
+        for (byte i = 0; i < 6; i++) mCoverBehaviors[i] = GregTech_API.getCoverBehaviorNew(mCoverSides[i]);
 
         receiveClientEvent(0, aTextureData);
         receiveClientEvent(1, aUpdateData);
@@ -495,6 +522,12 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
     public void receiveCoverData(byte coverSide, int coverID, int coverData) {
         if ((coverSide >= 0 && coverSide < 6) && (mCoverSides[coverSide] == coverID))
             setCoverDataAtSide(coverSide, coverData);
+    }
+
+    @Override
+    public void receiveCoverData(byte aCoverSide, int aCoverID, ISerializableObject aCoverData, EntityPlayerMP aPlayer) {
+        if ((aCoverSide >= 0 && aCoverSide < 6) && (mCoverSides[aCoverSide] == aCoverID))
+            setCoverDataAtSide(aCoverSide, aCoverData);
     }
 
     @Override
@@ -869,7 +902,8 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
         if (mStrongRedstone > 0) tNBT.setByte("mStrongRedstone", mStrongRedstone);
         for (byte i = 0; i < mCoverSides.length; i++) {
             if (mCoverSides[i] != 0) {
-                tNBT.setIntArray("mCoverData", mCoverData);
+                if (mCoverData[i] != null) // this really shouldn't be null if a cover is there already, but whatever
+                    tNBT.setTag(COVER_DATA_NBT_KEYS[i], mCoverData[i].saveDataToNBT());
                 tNBT.setIntArray("mCoverSides", mCoverSides);
                 break;
             }
@@ -909,13 +943,13 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
                 if (GT_Utility.isStackInList(tCurrentItem, GregTech_API.sScrewdriverList)) {
                     if (getCoverIDAtSide(aSide) == 0 && getCoverIDAtSide(tSide) != 0) {
                         if (GT_ModHandler.damageOrDechargeItem(tCurrentItem, 1, 200, aPlayer)) {
-                            setCoverDataAtSide(tSide, getCoverBehaviorAtSide(tSide).onCoverScrewdriverclick(tSide, getCoverIDAtSide(tSide), getCoverDataAtSide(tSide), this, aPlayer, 0.5F, 0.5F, 0.5F));
+                            setCoverDataAtSide(tSide, getCoverBehaviorAtSideNew(tSide).onCoverScrewdriverClick(tSide, getCoverIDAtSide(tSide), getCoverDataAtSideNew(tSide), this, aPlayer, 0.5F, 0.5F, 0.5F));
                             mMetaTileEntity.onScrewdriverRightClick(tSide, aPlayer, aX, aY, aZ);
                             GT_Utility.sendSoundToPlayers(worldObj, GregTech_API.sSoundList.get(100), 1.0F, -1, xCoord, yCoord, zCoord);
                         }
                     } else {
                         if (GT_ModHandler.damageOrDechargeItem(tCurrentItem, 1, 1000, aPlayer)) {
-                            setCoverDataAtSide(aSide, getCoverBehaviorAtSide(aSide).onCoverScrewdriverclick(aSide, getCoverIDAtSide(aSide), getCoverDataAtSide(aSide), this, aPlayer, aX, aY, aZ));
+                            setCoverDataAtSide(aSide, getCoverBehaviorAtSideNew(aSide).onCoverScrewdriverClick(aSide, getCoverIDAtSide(aSide), getCoverDataAtSideNew(aSide), this, aPlayer, aX, aY, aZ));
                             mMetaTileEntity.onScrewdriverRightClick(aSide, aPlayer, aX, aY, aZ);
                             GT_Utility.sendSoundToPlayers(worldObj, GregTech_API.sSoundList.get(100), 1.0F, -1, xCoord, yCoord, zCoord);
                         }
@@ -968,7 +1002,7 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
 
                 if (getCoverIDAtSide(coverSide) == 0) {
                     if (GregTech_API.sCovers.containsKey(new GT_ItemStack(tCurrentItem))) {
-                        if (GregTech_API.getCoverBehavior(tCurrentItem).isCoverPlaceable(coverSide, new GT_ItemStack(tCurrentItem), this) &&
+                        if (GregTech_API.getCoverBehaviorNew(tCurrentItem).isCoverPlaceable(coverSide, new GT_ItemStack(tCurrentItem), this) &&
                             mMetaTileEntity.allowCoverOnSide(coverSide, new GT_ItemStack(tCurrentItem)))
                         {
                             setCoverItemAtSide(coverSide, tCurrentItem);
@@ -989,14 +1023,14 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
             }
             else if (aPlayer.isSneaking()) { //Sneak click, no tool -> open cover config or turn back.
                 aSide = (getCoverIDAtSide(aSide) == 0) ? GT_Utility.determineWrenchingSide(aSide, aX, aY, aZ) : aSide;
-                return getCoverIDAtSide(aSide) > 0 && getCoverBehaviorAtSide(aSide).onCoverShiftRightclick(aSide, getCoverIDAtSide(aSide), getCoverDataAtSide(aSide), this, aPlayer);
+                return getCoverIDAtSide(aSide) > 0 && getCoverBehaviorAtSideNew(aSide).onCoverShiftRightClick(aSide, getCoverIDAtSide(aSide), getCoverDataAtSideNew(aSide), this, aPlayer);
             }
 
-            if (getCoverBehaviorAtSide(aSide).onCoverRightclick(aSide, getCoverIDAtSide(aSide), getCoverDataAtSide(aSide), this, aPlayer, aX, aY, aZ))
+            if (getCoverBehaviorAtSideNew(aSide).onCoverRightClick(aSide, getCoverIDAtSide(aSide), getCoverDataAtSideNew(aSide), this, aPlayer, aX, aY, aZ))
                 return true;
         }
 
-        if (!getCoverBehaviorAtSide(aSide).isGUIClickable(aSide, getCoverIDAtSide(aSide), getCoverDataAtSide(aSide), this))
+        if (!getCoverBehaviorAtSideNew(aSide).isGUIClickable(aSide, getCoverIDAtSide(aSide), getCoverDataAtSideNew(aSide), this))
             return false;
 
         try {
@@ -1053,7 +1087,7 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
      */
     @Override
     public int[] getAccessibleSlotsFromSide(int aSide) {
-        if (canAccessData() && (getCoverBehaviorAtSide((byte) aSide).letsItemsOut((byte) aSide, getCoverIDAtSide((byte) aSide), getCoverDataAtSide((byte) aSide), -1, this) || getCoverBehaviorAtSide((byte) aSide).letsItemsIn((byte) aSide, getCoverIDAtSide((byte) aSide), getCoverDataAtSide((byte) aSide), -1, this)))
+        if (canAccessData() && (getCoverBehaviorAtSideNew((byte) aSide).letsItemsOut((byte) aSide, getCoverIDAtSide((byte) aSide), getCoverDataAtSideNew((byte) aSide), -1, this) || getCoverBehaviorAtSide((byte) aSide).letsItemsIn((byte) aSide, getCoverIDAtSide((byte) aSide), getCoverDataAtSideNew((byte) aSide), -1, this)))
             return mMetaTileEntity.getAccessibleSlotsFromSide(aSide);
         return new int[0];
     }
@@ -1063,7 +1097,7 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
      */
     @Override
     public boolean canInsertItem(int aIndex, ItemStack aStack, int aSide) {
-        return canAccessData() && getCoverBehaviorAtSide((byte) aSide).letsItemsIn((byte) aSide, getCoverIDAtSide((byte) aSide), getCoverDataAtSide((byte) aSide), aIndex, this) && mMetaTileEntity.canInsertItem(aIndex, aStack, aSide);
+        return canAccessData() && getCoverBehaviorAtSide((byte) aSide).letsItemsIn((byte) aSide, getCoverIDAtSide((byte) aSide), getCoverDataAtSideNew((byte) aSide), aIndex, this) && mMetaTileEntity.canInsertItem(aIndex, aStack, aSide);
     }
 
     /**
@@ -1071,7 +1105,7 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
      */
     @Override
     public boolean canExtractItem(int aIndex, ItemStack aStack, int aSide) {
-        return canAccessData() && getCoverBehaviorAtSide((byte) aSide).letsItemsOut((byte) aSide, getCoverIDAtSide((byte) aSide), getCoverDataAtSide((byte) aSide), aIndex, this) && mMetaTileEntity.canExtractItem(aIndex, aStack, aSide);
+        return canAccessData() && getCoverBehaviorAtSide((byte) aSide).letsItemsOut((byte) aSide, getCoverIDAtSide((byte) aSide), getCoverDataAtSideNew((byte) aSide), aIndex, this) && mMetaTileEntity.canExtractItem(aIndex, aStack, aSide);
     }
 
     @Override
@@ -1081,7 +1115,7 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
 
     @Override
     public byte getInternalInputRedstoneSignal(byte aSide) {
-        return (byte) (getCoverBehaviorAtSide(aSide).getRedstoneInput(aSide, getInputRedstoneSignal(aSide), getCoverIDAtSide(aSide), getCoverDataAtSide(aSide), this) & 15);
+        return (byte) (getCoverBehaviorAtSide(aSide).getRedstoneInput(aSide, getInputRedstoneSignal(aSide), getCoverIDAtSide(aSide), getCoverDataAtSideNew(aSide), this) & 15);
     }
 
     @Override
@@ -1091,12 +1125,12 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
 
     @Override
     public byte getOutputRedstoneSignal(byte aSide) {
-        return (byte) (getCoverBehaviorAtSide(aSide).manipulatesSidedRedstoneOutput(aSide, getCoverIDAtSide(aSide), getCoverDataAtSide(aSide), this) || (getCoverBehaviorAtSide(aSide).letsRedstoneGoOut(aSide, getCoverIDAtSide(aSide), getCoverDataAtSide(aSide), this)) ? mSidedRedstone[aSide] & 15 : 0);
+        return (byte) (getCoverBehaviorAtSideNew(aSide).manipulatesSidedRedstoneOutput(aSide, getCoverIDAtSide(aSide), getCoverDataAtSideNew(aSide), this) || (getCoverBehaviorAtSideNew(aSide).letsRedstoneGoOut(aSide, getCoverIDAtSide(aSide), getCoverDataAtSideNew(aSide), this)) ? mSidedRedstone[aSide] & 15 : 0);
     }
 
     @Override
     public void setInternalOutputRedstoneSignal(byte aSide, byte aStrength) {
-        if (!getCoverBehaviorAtSide(aSide).manipulatesSidedRedstoneOutput(aSide, getCoverIDAtSide(aSide), getCoverDataAtSide(aSide), this))
+        if (!getCoverBehaviorAtSideNew(aSide).manipulatesSidedRedstoneOutput(aSide, getCoverIDAtSide(aSide), getCoverDataAtSideNew(aSide), this))
             setOutputRedstoneSignal(aSide, aStrength);
     }
 
@@ -1159,16 +1193,19 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
     }
 
     @Override
+    @Deprecated
     public GT_CoverBehavior getCoverBehaviorAtSide(byte aSide) {
-        return aSide >= 0 && aSide < mCoverBehaviors.length ? mCoverBehaviors[aSide] : GregTech_API.sNoBehavior;
+        if (aSide >= 0 && aSide < mCoverBehaviors.length && mCoverBehaviors[aSide] instanceof GT_CoverBehavior)
+            return (GT_CoverBehavior) mCoverBehaviors[aSide];
+        return GregTech_API.sNoBehavior;
     }
 
     @Override
     public void setCoverIDAtSide(byte aSide, int aID) {
         if (aSide >= 0 && aSide < 6) {
             mCoverSides[aSide] = aID;
-            mCoverData[aSide] = 0;
-            mCoverBehaviors[aSide] = GregTech_API.getCoverBehavior(aID);
+            mCoverBehaviors[aSide] = GregTech_API.getCoverBehaviorNew(aID);
+            mCoverData[aSide] = mCoverBehaviors[aSide].createDataObject();
             issueCoverUpdate(aSide);
             issueBlockUpdate();
         }
@@ -1176,7 +1213,7 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
 
     @Override
     public void setCoverItemAtSide(byte aSide, ItemStack aCover) {
-        GregTech_API.getCoverBehavior(aCover).placeCover(aSide, aCover, this);
+        GregTech_API.getCoverBehaviorNew(aCover).placeCover(aSide, aCover, this);
     }
 
     @Override
@@ -1201,14 +1238,33 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
     }
 
     @Override
+    @Deprecated
     public void setCoverDataAtSide(byte aSide, int aData) {
-        if (aSide >= 0 && aSide < 6) mCoverData[aSide] = aData;
+        if (aSide >= 0 && aSide < 6 && mCoverData[aSide] instanceof ISerializableObject.LegacyCoverData)
+            mCoverData[aSide] = new ISerializableObject.LegacyCoverData(aData);
     }
 
     @Override
+    @Deprecated
     public int getCoverDataAtSide(byte aSide) {
-        if (aSide >= 0 && aSide < 6) return mCoverData[aSide];
+        if (aSide >= 0 && aSide < 6 && mCoverData[aSide] instanceof ISerializableObject.LegacyCoverData)
+            return ((ISerializableObject.LegacyCoverData) mCoverData[aSide]).get();
         return 0;
+    }
+
+    @Override
+    public void setCoverDataAtSide(byte aSide, ISerializableObject aData) {
+        mCoverData[aSide] = aData;
+    }
+
+    @Override
+    public ISerializableObject getCoverDataAtSideNew(byte aSide) {
+        return mCoverData[aSide];
+    }
+
+    @Override
+    public GT_CoverBehavior_New<?> getCoverBehaviorAtSideNew(byte aSide) {
+        return mCoverBehaviors[aSide];
     }
 
     @Override
@@ -1228,8 +1284,8 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
 
     @Override
     public boolean dropCover(byte aSide, byte aDroppedSide, boolean aForced) {
-        if (getCoverBehaviorAtSide(aSide).onCoverRemoval(aSide, getCoverIDAtSide(aSide), mCoverData[aSide], this, aForced) || aForced) {
-            ItemStack tStack = getCoverBehaviorAtSide(aSide).getDrop(aSide, getCoverIDAtSide(aSide), getCoverDataAtSide(aSide), this);
+        if (getCoverBehaviorAtSideNew(aSide).onCoverRemoval(aSide, getCoverIDAtSide(aSide), mCoverData[aSide], this, aForced) || aForced) {
+            ItemStack tStack = getCoverBehaviorAtSideNew(aSide).getDrop(aSide, getCoverIDAtSide(aSide), getCoverDataAtSideNew(aSide), this);
             if (tStack != null) {
                 tStack.setTagCompound(null);
                 EntityItem tEntity = new EntityItem(worldObj, getOffsetX(aDroppedSide, 1) + 0.5, getOffsetY(aDroppedSide, 1) + 0.5, getOffsetZ(aDroppedSide, 1) + 0.5, tStack);
@@ -1323,12 +1379,15 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
         if (tTileEntity != null && !mMetaTileEntity.isConnectedAtSide((byte) aSide.ordinal()))
             return false;
 
-        if (isFill && mMetaTileEntity.isLiquidInput((byte) aSide.ordinal())
-                && getCoverBehaviorAtSide((byte) aSide.ordinal()).letsFluidIn((byte) aSide.ordinal(), getCoverIDAtSide((byte) aSide.ordinal()), getCoverDataAtSide((byte) aSide.ordinal()), aFluid, this))
+        if(isFill && mMetaTileEntity.isLiquidInput((byte) aSide.ordinal())
+                && getCoverBehaviorAtSide((byte) aSide.ordinal()).letsFluidIn((byte) aSide.ordinal(), getCoverIDAtSide((byte) aSide.ordinal()), getCoverDataAtSideNew((byte) aSide.ordinal()), aFluid, this))
             return true;
 
-        return !isFill && mMetaTileEntity.isLiquidOutput((byte) aSide.ordinal())
-                && getCoverBehaviorAtSide((byte) aSide.ordinal()).letsFluidOut((byte) aSide.ordinal(), getCoverIDAtSide((byte) aSide.ordinal()), getCoverDataAtSide((byte) aSide.ordinal()), aFluid, this);
+        if (!isFill && mMetaTileEntity.isLiquidOutput((byte) aSide.ordinal())
+                && getCoverBehaviorAtSide((byte) aSide.ordinal()).letsFluidOut((byte) aSide.ordinal(), getCoverIDAtSide((byte) aSide.ordinal()), getCoverDataAtSideNew((byte) aSide.ordinal()),aFluid, this))
+            return true;
+
+        return false;
     }
 
     @Override
@@ -1371,8 +1430,8 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
         if (canAccessData()
             && (aSide == ForgeDirection.UNKNOWN 
                 || (mMetaTileEntity.isLiquidInput((byte) aSide.ordinal())
-                    && getCoverBehaviorAtSide((byte) aSide.ordinal()).letsFluidIn((byte) aSide.ordinal(), getCoverIDAtSide((byte) aSide.ordinal()), getCoverDataAtSide((byte) aSide.ordinal()), null, this))
-                || (mMetaTileEntity.isLiquidOutput((byte) aSide.ordinal()) && getCoverBehaviorAtSide((byte) aSide.ordinal()).letsFluidOut((byte) aSide.ordinal(), getCoverIDAtSide((byte) aSide.ordinal()), getCoverDataAtSide((byte) aSide.ordinal()), null, this))
+                    && getCoverBehaviorAtSide((byte) aSide.ordinal()).letsFluidIn((byte) aSide.ordinal(), getCoverIDAtSide((byte) aSide.ordinal()), getCoverDataAtSideNew((byte) aSide.ordinal()), null, this))
+                || (mMetaTileEntity.isLiquidOutput((byte) aSide.ordinal()) && getCoverBehaviorAtSide((byte) aSide.ordinal()).letsFluidOut((byte) aSide.ordinal(), getCoverIDAtSide((byte) aSide.ordinal()), getCoverDataAtSideNew((byte) aSide.ordinal()), null, this))
                     // Doesn't need to be connected to get Tank Info -- otherwise things can't connect
                )
             )

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
@@ -23,7 +23,7 @@ import gregtech.api.interfaces.tileentity.IPipeRenderedTileEntity;
 import gregtech.api.net.GT_Packet_TileEntity;
 import gregtech.api.objects.GT_ItemStack;
 import gregtech.api.util.GT_CoverBehavior;
-import gregtech.api.util.GT_CoverBehavior_New;
+import gregtech.api.util.GT_CoverBehaviorBase;
 import gregtech.api.util.GT_Log;
 import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_OreDictUnificator;
@@ -53,7 +53,7 @@ import net.minecraftforge.fluids.*;
  * This is the main TileEntity for EVERYTHING.
  */
 public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileEntity, IPipeRenderedTileEntity {
-    private final GT_CoverBehavior_New<?>[] mCoverBehaviors = new GT_CoverBehavior_New<?>[]{GregTech_API.sNoBehavior, GregTech_API.sNoBehavior, GregTech_API.sNoBehavior, GregTech_API.sNoBehavior, GregTech_API.sNoBehavior, GregTech_API.sNoBehavior};
+    private final GT_CoverBehaviorBase<?>[] mCoverBehaviors = new GT_CoverBehaviorBase<?>[]{GregTech_API.sNoBehavior, GregTech_API.sNoBehavior, GregTech_API.sNoBehavior, GregTech_API.sNoBehavior, GregTech_API.sNoBehavior, GregTech_API.sNoBehavior};
     public byte mConnections = IConnectable.NO_CONNECTION;
     protected MetaPipeEntity mMetaTileEntity;
     private byte[] mSidedRedstone = new byte[]{0, 0, 0, 0, 0, 0};
@@ -173,7 +173,7 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
             if (mCoverData == null) {
                 mCoverData = new ISerializableObject[6];
                 for (byte i = 0; i<6; i++) {
-                    GT_CoverBehavior_New<?> tBehavior = getCoverBehaviorAtSideNew(i);
+                    GT_CoverBehaviorBase<?> tBehavior = getCoverBehaviorAtSideNew(i);
                     if (tBehavior == null)
                         continue;
                     mCoverData[i] = tBehavior.createDataObject();
@@ -301,7 +301,7 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
                             for (byte i = (byte) (tCode - 2); i < 6; i++)
                                 if (getCoverIDAtSide(i) != 0) {
                                     tCode++;
-                                    GT_CoverBehavior_New<?> tCover = getCoverBehaviorAtSideNew(i);
+                                    GT_CoverBehaviorBase<?> tCover = getCoverBehaviorAtSideNew(i);
                                     int tCoverTickRate = tCover.getTickRate(i, getCoverIDAtSide(i), mCoverData[i], this);
                                     if (tCoverTickRate > 0 && mTickTimer % tCoverTickRate == 0) {
                                         byte tRedstone = tCover.isRedstoneSensitive(i, getCoverIDAtSide(i), mCoverData[i], this, mTickTimer) ? getInputRedstoneSignal(i) : 0;
@@ -943,13 +943,13 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
                 if (GT_Utility.isStackInList(tCurrentItem, GregTech_API.sScrewdriverList)) {
                     if (getCoverIDAtSide(aSide) == 0 && getCoverIDAtSide(tSide) != 0) {
                         if (GT_ModHandler.damageOrDechargeItem(tCurrentItem, 1, 200, aPlayer)) {
-                            setCoverDataAtSide(tSide, getCoverBehaviorAtSideNew(tSide).onCoverScrewdriverClick(tSide, getCoverIDAtSide(tSide), getCoverDataAtSideNew(tSide), this, aPlayer, 0.5F, 0.5F, 0.5F));
+                            setCoverDataAtSide(tSide, getCoverBehaviorAtSideNew(tSide).onCoverScrewdriverClick(tSide, getCoverIDAtSide(tSide), getComplexCoverDataAtSide(tSide), this, aPlayer, 0.5F, 0.5F, 0.5F));
                             mMetaTileEntity.onScrewdriverRightClick(tSide, aPlayer, aX, aY, aZ);
                             GT_Utility.sendSoundToPlayers(worldObj, GregTech_API.sSoundList.get(100), 1.0F, -1, xCoord, yCoord, zCoord);
                         }
                     } else {
                         if (GT_ModHandler.damageOrDechargeItem(tCurrentItem, 1, 1000, aPlayer)) {
-                            setCoverDataAtSide(aSide, getCoverBehaviorAtSideNew(aSide).onCoverScrewdriverClick(aSide, getCoverIDAtSide(aSide), getCoverDataAtSideNew(aSide), this, aPlayer, aX, aY, aZ));
+                            setCoverDataAtSide(aSide, getCoverBehaviorAtSideNew(aSide).onCoverScrewdriverClick(aSide, getCoverIDAtSide(aSide), getComplexCoverDataAtSide(aSide), this, aPlayer, aX, aY, aZ));
                             mMetaTileEntity.onScrewdriverRightClick(aSide, aPlayer, aX, aY, aZ);
                             GT_Utility.sendSoundToPlayers(worldObj, GregTech_API.sSoundList.get(100), 1.0F, -1, xCoord, yCoord, zCoord);
                         }
@@ -1023,14 +1023,14 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
             }
             else if (aPlayer.isSneaking()) { //Sneak click, no tool -> open cover config or turn back.
                 aSide = (getCoverIDAtSide(aSide) == 0) ? GT_Utility.determineWrenchingSide(aSide, aX, aY, aZ) : aSide;
-                return getCoverIDAtSide(aSide) > 0 && getCoverBehaviorAtSideNew(aSide).onCoverShiftRightClick(aSide, getCoverIDAtSide(aSide), getCoverDataAtSideNew(aSide), this, aPlayer);
+                return getCoverIDAtSide(aSide) > 0 && getCoverBehaviorAtSideNew(aSide).onCoverShiftRightClick(aSide, getCoverIDAtSide(aSide), getComplexCoverDataAtSide(aSide), this, aPlayer);
             }
 
-            if (getCoverBehaviorAtSideNew(aSide).onCoverRightClick(aSide, getCoverIDAtSide(aSide), getCoverDataAtSideNew(aSide), this, aPlayer, aX, aY, aZ))
+            if (getCoverBehaviorAtSideNew(aSide).onCoverRightClick(aSide, getCoverIDAtSide(aSide), getComplexCoverDataAtSide(aSide), this, aPlayer, aX, aY, aZ))
                 return true;
         }
 
-        if (!getCoverBehaviorAtSideNew(aSide).isGUIClickable(aSide, getCoverIDAtSide(aSide), getCoverDataAtSideNew(aSide), this))
+        if (!getCoverBehaviorAtSideNew(aSide).isGUIClickable(aSide, getCoverIDAtSide(aSide), getComplexCoverDataAtSide(aSide), this))
             return false;
 
         try {
@@ -1087,7 +1087,7 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
      */
     @Override
     public int[] getAccessibleSlotsFromSide(int aSide) {
-        if (canAccessData() && (getCoverBehaviorAtSideNew((byte) aSide).letsItemsOut((byte) aSide, getCoverIDAtSide((byte) aSide), getCoverDataAtSideNew((byte) aSide), -1, this) || getCoverBehaviorAtSide((byte) aSide).letsItemsIn((byte) aSide, getCoverIDAtSide((byte) aSide), getCoverDataAtSideNew((byte) aSide), -1, this)))
+        if (canAccessData() && (getCoverBehaviorAtSideNew((byte) aSide).letsItemsOut((byte) aSide, getCoverIDAtSide((byte) aSide), getComplexCoverDataAtSide((byte) aSide), -1, this) || getCoverBehaviorAtSide((byte) aSide).letsItemsIn((byte) aSide, getCoverIDAtSide((byte) aSide), getComplexCoverDataAtSide((byte) aSide), -1, this)))
             return mMetaTileEntity.getAccessibleSlotsFromSide(aSide);
         return new int[0];
     }
@@ -1097,7 +1097,7 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
      */
     @Override
     public boolean canInsertItem(int aIndex, ItemStack aStack, int aSide) {
-        return canAccessData() && getCoverBehaviorAtSide((byte) aSide).letsItemsIn((byte) aSide, getCoverIDAtSide((byte) aSide), getCoverDataAtSideNew((byte) aSide), aIndex, this) && mMetaTileEntity.canInsertItem(aIndex, aStack, aSide);
+        return canAccessData() && getCoverBehaviorAtSide((byte) aSide).letsItemsIn((byte) aSide, getCoverIDAtSide((byte) aSide), getComplexCoverDataAtSide((byte) aSide), aIndex, this) && mMetaTileEntity.canInsertItem(aIndex, aStack, aSide);
     }
 
     /**
@@ -1105,7 +1105,7 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
      */
     @Override
     public boolean canExtractItem(int aIndex, ItemStack aStack, int aSide) {
-        return canAccessData() && getCoverBehaviorAtSide((byte) aSide).letsItemsOut((byte) aSide, getCoverIDAtSide((byte) aSide), getCoverDataAtSideNew((byte) aSide), aIndex, this) && mMetaTileEntity.canExtractItem(aIndex, aStack, aSide);
+        return canAccessData() && getCoverBehaviorAtSide((byte) aSide).letsItemsOut((byte) aSide, getCoverIDAtSide((byte) aSide), getComplexCoverDataAtSide((byte) aSide), aIndex, this) && mMetaTileEntity.canExtractItem(aIndex, aStack, aSide);
     }
 
     @Override
@@ -1115,7 +1115,7 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
 
     @Override
     public byte getInternalInputRedstoneSignal(byte aSide) {
-        return (byte) (getCoverBehaviorAtSide(aSide).getRedstoneInput(aSide, getInputRedstoneSignal(aSide), getCoverIDAtSide(aSide), getCoverDataAtSideNew(aSide), this) & 15);
+        return (byte) (getCoverBehaviorAtSide(aSide).getRedstoneInput(aSide, getInputRedstoneSignal(aSide), getCoverIDAtSide(aSide), getComplexCoverDataAtSide(aSide), this) & 15);
     }
 
     @Override
@@ -1125,12 +1125,12 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
 
     @Override
     public byte getOutputRedstoneSignal(byte aSide) {
-        return (byte) (getCoverBehaviorAtSideNew(aSide).manipulatesSidedRedstoneOutput(aSide, getCoverIDAtSide(aSide), getCoverDataAtSideNew(aSide), this) || (getCoverBehaviorAtSideNew(aSide).letsRedstoneGoOut(aSide, getCoverIDAtSide(aSide), getCoverDataAtSideNew(aSide), this)) ? mSidedRedstone[aSide] & 15 : 0);
+        return (byte) (getCoverBehaviorAtSideNew(aSide).manipulatesSidedRedstoneOutput(aSide, getCoverIDAtSide(aSide), getComplexCoverDataAtSide(aSide), this) || (getCoverBehaviorAtSideNew(aSide).letsRedstoneGoOut(aSide, getCoverIDAtSide(aSide), getComplexCoverDataAtSide(aSide), this)) ? mSidedRedstone[aSide] & 15 : 0);
     }
 
     @Override
     public void setInternalOutputRedstoneSignal(byte aSide, byte aStrength) {
-        if (!getCoverBehaviorAtSideNew(aSide).manipulatesSidedRedstoneOutput(aSide, getCoverIDAtSide(aSide), getCoverDataAtSideNew(aSide), this))
+        if (!getCoverBehaviorAtSideNew(aSide).manipulatesSidedRedstoneOutput(aSide, getCoverIDAtSide(aSide), getComplexCoverDataAtSide(aSide), this))
             setOutputRedstoneSignal(aSide, aStrength);
     }
 
@@ -1258,12 +1258,12 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
     }
 
     @Override
-    public ISerializableObject getCoverDataAtSideNew(byte aSide) {
+    public ISerializableObject getComplexCoverDataAtSide(byte aSide) {
         return mCoverData[aSide];
     }
 
     @Override
-    public GT_CoverBehavior_New<?> getCoverBehaviorAtSideNew(byte aSide) {
+    public GT_CoverBehaviorBase<?> getCoverBehaviorAtSideNew(byte aSide) {
         return mCoverBehaviors[aSide];
     }
 
@@ -1285,7 +1285,7 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
     @Override
     public boolean dropCover(byte aSide, byte aDroppedSide, boolean aForced) {
         if (getCoverBehaviorAtSideNew(aSide).onCoverRemoval(aSide, getCoverIDAtSide(aSide), mCoverData[aSide], this, aForced) || aForced) {
-            ItemStack tStack = getCoverBehaviorAtSideNew(aSide).getDrop(aSide, getCoverIDAtSide(aSide), getCoverDataAtSideNew(aSide), this);
+            ItemStack tStack = getCoverBehaviorAtSideNew(aSide).getDrop(aSide, getCoverIDAtSide(aSide), getComplexCoverDataAtSide(aSide), this);
             if (tStack != null) {
                 tStack.setTagCompound(null);
                 EntityItem tEntity = new EntityItem(worldObj, getOffsetX(aDroppedSide, 1) + 0.5, getOffsetY(aDroppedSide, 1) + 0.5, getOffsetZ(aDroppedSide, 1) + 0.5, tStack);
@@ -1380,11 +1380,11 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
             return false;
 
         if(isFill && mMetaTileEntity.isLiquidInput((byte) aSide.ordinal())
-                && getCoverBehaviorAtSide((byte) aSide.ordinal()).letsFluidIn((byte) aSide.ordinal(), getCoverIDAtSide((byte) aSide.ordinal()), getCoverDataAtSideNew((byte) aSide.ordinal()), aFluid, this))
+                && getCoverBehaviorAtSide((byte) aSide.ordinal()).letsFluidIn((byte) aSide.ordinal(), getCoverIDAtSide((byte) aSide.ordinal()), getComplexCoverDataAtSide((byte) aSide.ordinal()), aFluid, this))
             return true;
 
         if (!isFill && mMetaTileEntity.isLiquidOutput((byte) aSide.ordinal())
-                && getCoverBehaviorAtSide((byte) aSide.ordinal()).letsFluidOut((byte) aSide.ordinal(), getCoverIDAtSide((byte) aSide.ordinal()), getCoverDataAtSideNew((byte) aSide.ordinal()),aFluid, this))
+                && getCoverBehaviorAtSide((byte) aSide.ordinal()).letsFluidOut((byte) aSide.ordinal(), getCoverIDAtSide((byte) aSide.ordinal()), getComplexCoverDataAtSide((byte) aSide.ordinal()),aFluid, this))
             return true;
 
         return false;
@@ -1430,8 +1430,8 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
         if (canAccessData()
             && (aSide == ForgeDirection.UNKNOWN 
                 || (mMetaTileEntity.isLiquidInput((byte) aSide.ordinal())
-                    && getCoverBehaviorAtSide((byte) aSide.ordinal()).letsFluidIn((byte) aSide.ordinal(), getCoverIDAtSide((byte) aSide.ordinal()), getCoverDataAtSideNew((byte) aSide.ordinal()), null, this))
-                || (mMetaTileEntity.isLiquidOutput((byte) aSide.ordinal()) && getCoverBehaviorAtSide((byte) aSide.ordinal()).letsFluidOut((byte) aSide.ordinal(), getCoverIDAtSide((byte) aSide.ordinal()), getCoverDataAtSideNew((byte) aSide.ordinal()), null, this))
+                    && getCoverBehaviorAtSide((byte) aSide.ordinal()).letsFluidIn((byte) aSide.ordinal(), getCoverIDAtSide((byte) aSide.ordinal()), getComplexCoverDataAtSide((byte) aSide.ordinal()), null, this))
+                || (mMetaTileEntity.isLiquidOutput((byte) aSide.ordinal()) && getCoverBehaviorAtSide((byte) aSide.ordinal()).letsFluidOut((byte) aSide.ordinal(), getCoverIDAtSide((byte) aSide.ordinal()), getComplexCoverDataAtSide((byte) aSide.ordinal()), null, this))
                     // Doesn't need to be connected to get Tank Info -- otherwise things can't connect
                )
             )

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
@@ -79,7 +79,7 @@ import static gregtech.api.objects.XSTR.XSTR_INSTANCE;
     @Optional.Interface(iface = "appeng.me.helpers.IGridProxyable", modid = "appliedenergistics2", striprefs = true)})
 public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileEntity, IActionHost, IGridProxyable, IAlignmentProvider, IConstructableProvider {
     static final String[] COVER_DATA_NBT_KEYS = Arrays.stream(ForgeDirection.VALID_DIRECTIONS).mapToInt(Enum::ordinal).mapToObj(i -> "mCoverData" + i).toArray(String[]::new);
-    private final GT_CoverBehavior_New<?>[] mCoverBehaviors = new GT_CoverBehavior_New<?>[]{GregTech_API.sNoBehavior, GregTech_API.sNoBehavior, GregTech_API.sNoBehavior, GregTech_API.sNoBehavior, GregTech_API.sNoBehavior, GregTech_API.sNoBehavior};
+    private final GT_CoverBehaviorBase<?>[] mCoverBehaviors = new GT_CoverBehaviorBase<?>[]{GregTech_API.sNoBehavior, GregTech_API.sNoBehavior, GregTech_API.sNoBehavior, GregTech_API.sNoBehavior, GregTech_API.sNoBehavior, GregTech_API.sNoBehavior};
     protected MetaTileEntity mMetaTileEntity;
     protected long mStoredEnergy = 0, mStoredSteam = 0;
     protected int mAverageEUInputIndex = 0, mAverageEUOutputIndex = 0;
@@ -401,7 +401,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
                         for (byte i = (byte) (tCode - 2); i < 6; i++)
                             if (getCoverIDAtSide(i) != 0) {
                                 tCode++;
-                                GT_CoverBehavior_New<?> tCover = getCoverBehaviorAtSideNew(i);
+                                GT_CoverBehaviorBase<?> tCover = getCoverBehaviorAtSideNew(i);
                                 int tCoverTickRate = tCover.getTickRate(i, getCoverIDAtSide(i), mCoverData[i], this);
                                 if (tCoverTickRate > 0 && mTickTimer % tCoverTickRate == 0) {
                                     byte tRedstone = tCover.isRedstoneSensitive(i, getCoverIDAtSide(i), mCoverData[i], this, mTickTimer) ? getInputRedstoneSignal(i) : 0;
@@ -1279,7 +1279,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
 
     private boolean isEnergyInputSide(byte aSide) {
         if (aSide >= 0 && aSide < 6) {
-            if (!getCoverBehaviorAtSideNew(aSide).letsEnergyIn(aSide, getCoverIDAtSide(aSide), getCoverDataAtSideNew(aSide), this))
+            if (!getCoverBehaviorAtSideNew(aSide).letsEnergyIn(aSide, getCoverIDAtSide(aSide), getComplexCoverDataAtSide(aSide), this))
                 return false;
             if (isInvalid() || mReleaseEnergy) return false;
             if (canAccessData() && mMetaTileEntity.isElectric() && mMetaTileEntity.isEnetInput())
@@ -1290,7 +1290,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
 
     private boolean isEnergyOutputSide(byte aSide) {
         if (aSide >= 0 && aSide < 6) {
-            if (!getCoverBehaviorAtSideNew(aSide).letsEnergyOut(aSide, getCoverIDAtSide(aSide), getCoverDataAtSideNew(aSide), this))
+            if (!getCoverBehaviorAtSideNew(aSide).letsEnergyOut(aSide, getCoverIDAtSide(aSide), getComplexCoverDataAtSide(aSide), this))
                 return false;
             if (isInvalid() || mReleaseEnergy) return mReleaseEnergy;
             if (canAccessData() && mMetaTileEntity.isElectric() && mMetaTileEntity.isEnetOutput())
@@ -1466,7 +1466,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
                 return true;
             }
 
-            if (!getCoverBehaviorAtSideNew(aSide).isGUIClickable(aSide, getCoverIDAtSide(aSide), getCoverDataAtSideNew(aSide), this))
+            if (!getCoverBehaviorAtSideNew(aSide).isGUIClickable(aSide, getCoverIDAtSide(aSide), getComplexCoverDataAtSide(aSide), this))
                 return false;
         }
         if (isServerSide()) {
@@ -1493,7 +1493,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
 
                     if (GT_Utility.isStackInList(tCurrentItem, GregTech_API.sScrewdriverList)) {
                         if (GT_ModHandler.damageOrDechargeItem(tCurrentItem, 1, 200, aPlayer)) {
-                            setCoverDataAtSide(aSide, getCoverBehaviorAtSideNew(aSide).onCoverScrewdriverClick(aSide, getCoverIDAtSide(aSide), getCoverDataAtSideNew(aSide), this, aPlayer, aX, aY, aZ));
+                            setCoverDataAtSide(aSide, getCoverBehaviorAtSideNew(aSide).onCoverScrewdriverClick(aSide, getCoverIDAtSide(aSide), getComplexCoverDataAtSide(aSide), this, aPlayer, aX, aY, aZ));
                             mMetaTileEntity.onScrewdriverRightClick(aSide, aPlayer, aX, aY, aZ);
                             GT_Utility.sendSoundToPlayers(worldObj, GregTech_API.sSoundList.get(100), 1.0F, -1, xCoord, yCoord, zCoord);
                         }
@@ -1578,13 +1578,13 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
                 }
                 else if (aPlayer.isSneaking()) { //Sneak click, no tool -> open cover config if possible.
                     aSide = (getCoverIDAtSide(aSide) == 0) ? GT_Utility.determineWrenchingSide(aSide, aX, aY, aZ) : aSide;
-                    return getCoverIDAtSide(aSide) > 0 && getCoverBehaviorAtSideNew(aSide).onCoverShiftRightClick(aSide, getCoverIDAtSide(aSide), getCoverDataAtSideNew(aSide), this, aPlayer);
+                    return getCoverIDAtSide(aSide) > 0 && getCoverBehaviorAtSideNew(aSide).onCoverShiftRightClick(aSide, getCoverIDAtSide(aSide), getComplexCoverDataAtSide(aSide), this, aPlayer);
                 }
 
-                if (getCoverBehaviorAtSideNew(aSide).onCoverRightClick(aSide, getCoverIDAtSide(aSide), getCoverDataAtSideNew(aSide), this, aPlayer, aX, aY, aZ))
+                if (getCoverBehaviorAtSideNew(aSide).onCoverRightClick(aSide, getCoverIDAtSide(aSide), getComplexCoverDataAtSide(aSide), this, aPlayer, aX, aY, aZ))
                     return true;
 
-                if (!getCoverBehaviorAtSideNew(aSide).isGUIClickable(aSide, getCoverIDAtSide(aSide), getCoverDataAtSideNew(aSide), this))
+                if (!getCoverBehaviorAtSideNew(aSide).isGUIClickable(aSide, getCoverIDAtSide(aSide), getComplexCoverDataAtSide(aSide), this))
                     return false;
 
                 if (isUpgradable() && tCurrentItem != null) {/*
@@ -1673,7 +1673,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
      */
     @Override
     public int[] getAccessibleSlotsFromSide(int aSide) {
-        if (canAccessData() && (getCoverBehaviorAtSideNew((byte) aSide).letsItemsOut((byte) aSide, getCoverIDAtSide((byte) aSide), getCoverDataAtSideNew((byte) aSide), -1, this) || getCoverBehaviorAtSideNew((byte) aSide).letsItemsIn((byte) aSide, getCoverIDAtSide((byte) aSide), getCoverDataAtSideNew((byte) aSide), -1, this)))
+        if (canAccessData() && (getCoverBehaviorAtSideNew((byte) aSide).letsItemsOut((byte) aSide, getCoverIDAtSide((byte) aSide), getComplexCoverDataAtSide((byte) aSide), -1, this) || getCoverBehaviorAtSideNew((byte) aSide).letsItemsIn((byte) aSide, getCoverIDAtSide((byte) aSide), getComplexCoverDataAtSide((byte) aSide), -1, this)))
             return mMetaTileEntity.getAccessibleSlotsFromSide(aSide);
         return new int[0];
     }
@@ -1683,7 +1683,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
      */
     @Override
     public boolean canInsertItem(int aIndex, ItemStack aStack, int aSide) {
-        return canAccessData() && (mRunningThroughTick || !mInputDisabled) && getCoverBehaviorAtSideNew((byte) aSide).letsItemsIn((byte) aSide, getCoverIDAtSide((byte) aSide), getCoverDataAtSideNew((byte) aSide), aIndex, this) && mMetaTileEntity.canInsertItem(aIndex, aStack, aSide);
+        return canAccessData() && (mRunningThroughTick || !mInputDisabled) && getCoverBehaviorAtSideNew((byte) aSide).letsItemsIn((byte) aSide, getCoverIDAtSide((byte) aSide), getComplexCoverDataAtSide((byte) aSide), aIndex, this) && mMetaTileEntity.canInsertItem(aIndex, aStack, aSide);
     }
 
     /**
@@ -1691,7 +1691,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
      */
     @Override
     public boolean canExtractItem(int aIndex, ItemStack aStack, int aSide) {
-        return canAccessData() && (mRunningThroughTick || !mOutputDisabled) && getCoverBehaviorAtSideNew((byte) aSide).letsItemsOut((byte) aSide, getCoverIDAtSide((byte) aSide), getCoverDataAtSideNew((byte) aSide), aIndex, this) && mMetaTileEntity.canExtractItem(aIndex, aStack, aSide);
+        return canAccessData() && (mRunningThroughTick || !mOutputDisabled) && getCoverBehaviorAtSideNew((byte) aSide).letsItemsOut((byte) aSide, getCoverIDAtSide((byte) aSide), getComplexCoverDataAtSide((byte) aSide), aIndex, this) && mMetaTileEntity.canExtractItem(aIndex, aStack, aSide);
     }
 
     @Override
@@ -1701,7 +1701,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
 
     @Override
     public byte getInternalInputRedstoneSignal(byte aSide) {
-        return (byte) (getCoverBehaviorAtSideNew(aSide).getRedstoneInput(aSide, getInputRedstoneSignal(aSide), getCoverIDAtSide(aSide), getCoverDataAtSideNew(aSide), this) & 15);
+        return (byte) (getCoverBehaviorAtSideNew(aSide).getRedstoneInput(aSide, getInputRedstoneSignal(aSide), getCoverIDAtSide(aSide), getComplexCoverDataAtSide(aSide), this) & 15);
     }
 
     @Override
@@ -1711,7 +1711,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
 
     @Override
     public byte getOutputRedstoneSignal(byte aSide) {
-        return getCoverBehaviorAtSideNew(aSide).manipulatesSidedRedstoneOutput(aSide, getCoverIDAtSide(aSide), getCoverDataAtSideNew(aSide), this) ? mSidedRedstone[aSide] : getGeneralRS(aSide);
+        return getCoverBehaviorAtSideNew(aSide).manipulatesSidedRedstoneOutput(aSide, getCoverIDAtSide(aSide), getComplexCoverDataAtSide(aSide), this) ? mSidedRedstone[aSide] : getGeneralRS(aSide);
     }
 
     public byte getGeneralRS(byte aSide){
@@ -1721,7 +1721,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
 
     @Override
     public void setInternalOutputRedstoneSignal(byte aSide, byte aStrength) {
-        if (!getCoverBehaviorAtSideNew(aSide).manipulatesSidedRedstoneOutput(aSide, getCoverIDAtSide(aSide), getCoverDataAtSideNew(aSide), this))
+        if (!getCoverBehaviorAtSideNew(aSide).manipulatesSidedRedstoneOutput(aSide, getCoverIDAtSide(aSide), getComplexCoverDataAtSide(aSide), this))
             setOutputRedstoneSignal(aSide, aStrength);
     }
 
@@ -1871,12 +1871,12 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
     }
 
     @Override
-    public ISerializableObject getCoverDataAtSideNew(byte aSide) {
+    public ISerializableObject getComplexCoverDataAtSide(byte aSide) {
         return mCoverData[aSide];
     }
 
     @Override
-    public GT_CoverBehavior_New<?> getCoverBehaviorAtSideNew(byte aSide) {
+    public GT_CoverBehaviorBase<?> getCoverBehaviorAtSideNew(byte aSide) {
         return mCoverBehaviors[aSide];
     }
 
@@ -1910,7 +1910,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
     @Override
     public boolean dropCover(byte aSide, byte aDroppedSide, boolean aForced) {
         if (getCoverBehaviorAtSideNew(aSide).onCoverRemoval(aSide, getCoverIDAtSide(aSide), mCoverData[aSide], this, aForced) || aForced) {
-            ItemStack tStack = getCoverBehaviorAtSideNew(aSide).getDrop(aSide, getCoverIDAtSide(aSide), getCoverDataAtSideNew(aSide), this);
+            ItemStack tStack = getCoverBehaviorAtSideNew(aSide).getDrop(aSide, getCoverIDAtSide(aSide), getComplexCoverDataAtSide(aSide), this);
             if (tStack != null) {
                 tStack.setTagCompound(null);
                 EntityItem tEntity = new EntityItem(worldObj, getOffsetX(aDroppedSide, 1) + 0.5, getOffsetY(aDroppedSide, 1) + 0.5, getOffsetZ(aDroppedSide, 1) + 0.5, tStack);
@@ -2025,7 +2025,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
                 aSide == ForgeDirection.UNKNOWN ||
                 (
                     mMetaTileEntity.isLiquidInput((byte) aSide.ordinal()) &&
-                    getCoverBehaviorAtSideNew((byte) aSide.ordinal()).letsFluidIn((byte) aSide.ordinal(), getCoverIDAtSide((byte) aSide.ordinal()), getCoverDataAtSideNew((byte) aSide.ordinal()), aFluid == null ? null : aFluid.getFluid(), this)
+                    getCoverBehaviorAtSideNew((byte) aSide.ordinal()).letsFluidIn((byte) aSide.ordinal(), getCoverIDAtSide((byte) aSide.ordinal()), getComplexCoverDataAtSide((byte) aSide.ordinal()), aFluid == null ? null : aFluid.getFluid(), this)
                 )
             )
         )
@@ -2041,7 +2041,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
                 aSide == ForgeDirection.UNKNOWN ||
                 (
                     mMetaTileEntity.isLiquidOutput((byte) aSide.ordinal()) &&
-                    getCoverBehaviorAtSideNew((byte) aSide.ordinal()).letsFluidOut((byte) aSide.ordinal(), getCoverIDAtSide((byte) aSide.ordinal()), getCoverDataAtSideNew((byte) aSide.ordinal()), mMetaTileEntity.getFluid() == null ? null : mMetaTileEntity.getFluid().getFluid(), this)
+                    getCoverBehaviorAtSideNew((byte) aSide.ordinal()).letsFluidOut((byte) aSide.ordinal(), getCoverIDAtSide((byte) aSide.ordinal()), getComplexCoverDataAtSide((byte) aSide.ordinal()), mMetaTileEntity.getFluid() == null ? null : mMetaTileEntity.getFluid().getFluid(), this)
                 )
             )
         )
@@ -2057,7 +2057,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
                 aSide == ForgeDirection.UNKNOWN ||
                 (
                     mMetaTileEntity.isLiquidOutput((byte) aSide.ordinal()) &&
-                    getCoverBehaviorAtSideNew((byte) aSide.ordinal()).letsFluidOut((byte) aSide.ordinal(), getCoverIDAtSide((byte) aSide.ordinal()), getCoverDataAtSideNew((byte) aSide.ordinal()), aFluid == null ? null : aFluid.getFluid(), this)
+                    getCoverBehaviorAtSideNew((byte) aSide.ordinal()).letsFluidOut((byte) aSide.ordinal(), getCoverIDAtSide((byte) aSide.ordinal()), getComplexCoverDataAtSide((byte) aSide.ordinal()), aFluid == null ? null : aFluid.getFluid(), this)
                 )
             )
         )
@@ -2073,7 +2073,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
                 aSide == ForgeDirection.UNKNOWN ||
                 (
                     mMetaTileEntity.isLiquidInput((byte) aSide.ordinal()) &&
-                    getCoverBehaviorAtSideNew((byte) aSide.ordinal()).letsFluidIn((byte) aSide.ordinal(), getCoverIDAtSide((byte) aSide.ordinal()), getCoverDataAtSideNew((byte) aSide.ordinal()), aFluid, this)
+                    getCoverBehaviorAtSideNew((byte) aSide.ordinal()).letsFluidIn((byte) aSide.ordinal(), getCoverIDAtSide((byte) aSide.ordinal()), getComplexCoverDataAtSide((byte) aSide.ordinal()), aFluid, this)
                 )
             )
         )
@@ -2089,7 +2089,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
                 aSide == ForgeDirection.UNKNOWN ||
                 (
                     mMetaTileEntity.isLiquidOutput((byte) aSide.ordinal()) &&
-                        getCoverBehaviorAtSideNew((byte) aSide.ordinal()).letsFluidOut((byte) aSide.ordinal(), getCoverIDAtSide((byte) aSide.ordinal()), getCoverDataAtSideNew((byte) aSide.ordinal()), aFluid, this)
+                        getCoverBehaviorAtSideNew((byte) aSide.ordinal()).letsFluidOut((byte) aSide.ordinal(), getCoverIDAtSide((byte) aSide.ordinal()), getComplexCoverDataAtSide((byte) aSide.ordinal()), aFluid, this)
                 )
             )
         )
@@ -2104,8 +2104,8 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
                 aSide == ForgeDirection.UNKNOWN ||
                 (
                     mMetaTileEntity.isLiquidInput((byte) aSide.ordinal()) &&
-                    getCoverBehaviorAtSideNew((byte) aSide.ordinal()).letsFluidIn((byte) aSide.ordinal(), getCoverIDAtSide((byte) aSide.ordinal()), getCoverDataAtSideNew((byte) aSide.ordinal()), null, this)) || (mMetaTileEntity.isLiquidOutput((byte) aSide.ordinal()) &&
-                    getCoverBehaviorAtSideNew((byte) aSide.ordinal()).letsFluidOut((byte) aSide.ordinal(), getCoverIDAtSide((byte) aSide.ordinal()), getCoverDataAtSideNew((byte) aSide.ordinal()), null, this)
+                    getCoverBehaviorAtSideNew((byte) aSide.ordinal()).letsFluidIn((byte) aSide.ordinal(), getCoverIDAtSide((byte) aSide.ordinal()), getComplexCoverDataAtSide((byte) aSide.ordinal()), null, this)) || (mMetaTileEntity.isLiquidOutput((byte) aSide.ordinal()) &&
+                    getCoverBehaviorAtSideNew((byte) aSide.ordinal()).letsFluidOut((byte) aSide.ordinal(), getCoverIDAtSide((byte) aSide.ordinal()), getComplexCoverDataAtSide((byte) aSide.ordinal()), null, this)
                 )
             )
         )

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
@@ -40,6 +40,7 @@ import net.minecraft.block.BlockFire;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -74,23 +75,22 @@ import static gregtech.api.objects.XSTR.XSTR_INSTANCE;
  * This is the main TileEntity for EVERYTHING.
  */
 @Optional.InterfaceList(value = {
-        @Optional.Interface(iface = "appeng.api.networking.security.IActionHost", modid = "appliedenergistics2", striprefs = true),
-        @Optional.Interface(iface = "appeng.me.helpers.IGridProxyable", modid = "appliedenergistics2", striprefs = true)})
+    @Optional.Interface(iface = "appeng.api.networking.security.IActionHost", modid = "appliedenergistics2", striprefs = true),
+    @Optional.Interface(iface = "appeng.me.helpers.IGridProxyable", modid = "appliedenergistics2", striprefs = true)})
 public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileEntity, IActionHost, IGridProxyable, IAlignmentProvider, IConstructableProvider {
-    private final GT_CoverBehavior[] mCoverBehaviors = new GT_CoverBehavior[]{GregTech_API.sNoBehavior, GregTech_API.sNoBehavior, GregTech_API.sNoBehavior, GregTech_API.sNoBehavior, GregTech_API.sNoBehavior, GregTech_API.sNoBehavior};
+    static final String[] COVER_DATA_NBT_KEYS = Arrays.stream(ForgeDirection.VALID_DIRECTIONS).mapToInt(Enum::ordinal).mapToObj(i -> "mCoverData" + i).toArray(String[]::new);
+    private final GT_CoverBehavior_New<?>[] mCoverBehaviors = new GT_CoverBehavior_New<?>[]{GregTech_API.sNoBehavior, GregTech_API.sNoBehavior, GregTech_API.sNoBehavior, GregTech_API.sNoBehavior, GregTech_API.sNoBehavior, GregTech_API.sNoBehavior};
     protected MetaTileEntity mMetaTileEntity;
     protected long mStoredEnergy = 0, mStoredSteam = 0;
     protected int mAverageEUInputIndex = 0, mAverageEUOutputIndex = 0;
     protected boolean mReleaseEnergy = false;
     protected long[] mAverageEUInput = new long[]{0, 0, 0, 0, 0}, mAverageEUOutput = new long[]{0, 0, 0, 0, 0};
-    private final boolean[] mActiveEUInputs = new boolean[]{false, false, false, false, false, false};
-    private final boolean[] mActiveEUOutputs = new boolean[]{false, false, false, false, false, false};
+    private boolean[] mActiveEUInputs = new boolean[]{false, false, false, false, false, false}, mActiveEUOutputs = new boolean[]{false, false, false, false, false, false};
     private byte[] mSidedRedstone = new byte[]{15, 15, 15, 15, 15, 15};
-    private int[] mCoverSides = new int[]{0, 0, 0, 0, 0, 0};
-    private int[] mCoverData = new int[]{0, 0, 0, 0, 0, 0};
-    private final int[] mTimeStatistics = new int[GregTech_API.TICKS_FOR_LAG_AVERAGING];
+    private int[] mCoverSides = new int[]{0, 0, 0, 0, 0, 0}, mTimeStatistics = new int[GregTech_API.TICKS_FOR_LAG_AVERAGING];
+    private ISerializableObject[] mCoverData = new ISerializableObject[6];
     private boolean mHasEnoughEnergy = true, mRunningThroughTick = false, mInputDisabled = false, mOutputDisabled = false, mMuffler = false, mLockUpgrade = false, mActive = false, mRedstone = false, mWorkUpdate = false, mSteamConverter = false, mInventoryChanged = false, mWorks = true, mNeedsUpdate = true, mNeedsBlockUpdate = true, mSendClientData = false, oRedstone = false;
-    private byte mColor = 0, oColor = 0, oStrongRedstone = 0, mStrongRedstone = 0, oRedstoneData = 63, oTextureData = 0, oUpdateData = 0, oTexturePage = 0, oLightValueClient = -1, oLightValue = -1, mLightValue = 0, mOtherUpgrades = 0, mFacing = 0, oFacing = 0, mWorkData = 0;
+    private byte mColor = 0, oColor = 0, oStrongRedstone = 0, mStrongRedstone = 0, oRedstoneData = 63, oTextureData = 0, oUpdateData = 0, oTexturePage=0, oLightValueClient = -1, oLightValue = -1, mLightValue = 0, mOtherUpgrades = 0, mFacing = 0, oFacing = 0, mWorkData = 0;
     private int mDisplayErrorCode = 0, oX = 0, oY = 0, oZ = 0, mTimeStatisticsIndex = 0, mLagWarningCount = 0;
     private short mID = 0;
     public long mTickTimer = 0;
@@ -139,7 +139,10 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
             aNBT.setInteger("mID", mID);
             aNBT.setLong("mStoredSteam", mStoredSteam);
             aNBT.setLong("mStoredEnergy", mStoredEnergy);
-            aNBT.setIntArray("mCoverData", mCoverData);
+            for (int i = 0; i < mCoverData.length; i++) {
+                if (mCoverData[i] != null)
+                    aNBT.setTag(COVER_DATA_NBT_KEYS[i], mCoverData[i].saveDataToNBT());
+            }
             aNBT.setIntArray("mCoverSides", mCoverSides);
             aNBT.setByteArray("mRedstoneSided", mSidedRedstone);
             aNBT.setByte("mColor", mColor);
@@ -230,19 +233,37 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
             mOutputDisabled = aNBT.getBoolean("mOutputDisabled");
             mOtherUpgrades = (byte) (aNBT.getByte("mOtherUpgrades") + aNBT.getByte("mBatteries") + aNBT.getByte("mLiBatteries"));
             mCoverSides = aNBT.getIntArray("mCoverSides");
-            mCoverData = aNBT.getIntArray("mCoverData");
             mSidedRedstone = aNBT.getByteArray("mRedstoneSided");
             mRecipeStuff = aNBT.getCompoundTag("GT.CraftingComponents");
             int nbtVersion = aNBT.getInteger("nbtVersion");
 
-            if (mCoverData.length != 6) mCoverData = new int[]{0, 0, 0, 0, 0, 0};
             if (mCoverSides.length != 6) mCoverSides = new int[]{0, 0, 0, 0, 0, 0};
             if (mSidedRedstone.length != 6)
                 if (hasValidMetaTileEntity() && mMetaTileEntity.hasSidedRedstoneOutputBehavior())
                     mSidedRedstone = new byte[]{0, 0, 0, 0, 0, 0};
                 else mSidedRedstone = new byte[]{15, 15, 15, 15, 15, 15};
 
-            for (byte i = 0; i < 6; i++) mCoverBehaviors[i] = GregTech_API.getCoverBehavior(mCoverSides[i]);
+            for (byte i = 0; i < 6; i++) mCoverBehaviors[i] = GregTech_API.getCoverBehaviorNew(mCoverSides[i]);
+
+            // check legacy data
+            mCoverData = new ISerializableObject[6];
+            if (aNBT.hasKey("mCoverData", 11) && aNBT.getIntArray("mCoverData").length == 6) {
+                int[] tOldData = aNBT.getIntArray("mCoverData");
+                for (int i = 0; i < tOldData.length; i++) {
+                    if (mCoverBehaviors[i] != null)
+                        mCoverData[i] = mCoverBehaviors[i].createDataObject(tOldData[i]);
+                }
+            } else {
+                // no old data
+                for (byte i = 0; i<6; i++) {
+                    if (mCoverBehaviors[i] == null)
+                        continue;
+                    if (aNBT.hasKey(COVER_DATA_NBT_KEYS[i]))
+                        mCoverData[i] = mCoverBehaviors[i].createDataObject(aNBT.getTag(COVER_DATA_NBT_KEYS[i]));
+                    else
+                        mCoverData[i] = mCoverBehaviors[i].createDataObject();
+                }
+            }
 
             if (mID != 0 && createNewMetatileEntity(mID)) {
                 NBTTagList tItemList = aNBT.getTagList("Inventory", 10);
@@ -264,14 +285,14 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
             }
         }
 
-        if (mCoverData.length != 6) mCoverData = new int[]{0, 0, 0, 0, 0, 0};
+        if (mCoverData == null || mCoverData.length != 6) mCoverData = new ISerializableObject[6];
         if (mCoverSides.length != 6) mCoverSides = new int[]{0, 0, 0, 0, 0, 0};
         if (mSidedRedstone.length != 6)
             if (hasValidMetaTileEntity() && mMetaTileEntity.hasSidedRedstoneOutputBehavior())
                 mSidedRedstone = new byte[]{0, 0, 0, 0, 0, 0};
             else mSidedRedstone = new byte[]{15, 15, 15, 15, 15, 15};
 
-        for (byte i = 0; i < 6; i++) mCoverBehaviors[i] = GregTech_API.getCoverBehavior(mCoverSides[i]);
+        for (byte i = 0; i < 6; i++) mCoverBehaviors[i] = GregTech_API.getCoverBehaviorNew(mCoverSides[i]);
     }
 
     private boolean createNewMetatileEntity(short aID) {
@@ -380,7 +401,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
                         for (byte i = (byte) (tCode - 2); i < 6; i++)
                             if (getCoverIDAtSide(i) != 0) {
                                 tCode++;
-                                GT_CoverBehavior tCover = getCoverBehaviorAtSide(i);
+                                GT_CoverBehavior_New<?> tCover = getCoverBehaviorAtSideNew(i);
                                 int tCoverTickRate = tCover.getTickRate(i, getCoverIDAtSide(i), mCoverData[i], this);
                                 if (tCoverTickRate > 0 && mTickTimer % tCoverTickRate == 0) {
                                     byte tRedstone = tCover.isRedstoneSensitive(i, getCoverIDAtSide(i), mCoverData[i], this, mTickTimer) ? getInputRedstoneSignal(i) : 0;
@@ -414,7 +435,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
                     if (aSideServer) {
                         if (mRedstone != oRedstone || mTickTimer == 10) {
                             for (byte i = 0; i < 6; i++)
-                                mCoverBehaviors[i] = GregTech_API.getCoverBehavior(mCoverSides[i]);
+                                mCoverBehaviors[i] = GregTech_API.getCoverBehaviorNew(mCoverSides[i]);
                             oRedstone = mRedstone;
                             issueBlockUpdate();
                         }
@@ -492,7 +513,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
                                         if (GregTech_API.sMachineRainExplosions && worldObj.isRaining() && getBiome().rainfall > 0) {
                                             if (getRandomNumber(10) == 0) {
                                                 try{
-                                                    GT_Mod.achievements.issueAchievement(this.getWorldObj().getPlayerEntityByName(mOwnerName), "badweather");
+                                                    GT_Mod.instance.achievements.issueAchievement(this.getWorldObj().getPlayerEntityByName(mOwnerName), "badweather");
                                                 }catch(Exception e){
 
                                                 }
@@ -508,9 +529,9 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
                                             return;
                                         }
                                         if (GregTech_API.sMachineThunderExplosions && worldObj.isThundering() && getBiome().rainfall > 0 && getRandomNumber(3) == 0) {
-                                        	try {
-                                                GT_Mod.achievements.issueAchievement(this.getWorldObj().getPlayerEntityByName(mOwnerName), "badweather");
-                                            }catch(Exception e){
+                                        	try{
+                                        	    GT_Mod.instance.achievements.issueAchievement(this.getWorldObj().getPlayerEntityByName(mOwnerName), "badweather");
+                                        	}catch(Exception e){
 
                                             }
                                             GT_Log.exp.println("Machine at: "+ this.getXCoord()+" | "+ this.getYCoord()+" | "+ this.getZCoord()+" DIMID: " +this.worldObj.provider.dimensionId + " explosion due to Thunderstorm!");
@@ -678,7 +699,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
         mCoverSides[4] = aCover4;
         mCoverSides[5] = aCover5;
 
-        for (byte i = 0; i < 6; i++) mCoverBehaviors[i] = GregTech_API.getCoverBehavior(mCoverSides[i]);
+        for (byte i = 0; i < 6; i++) mCoverBehaviors[i] = GregTech_API.getCoverBehaviorNew(mCoverSides[i]);
 
         receiveClientEvent(ClientEvents.CHANGE_COMMON_DATA, aTextureData);
         receiveClientEvent(ClientEvents.CHANGE_CUSTOM_DATA, aUpdateData & 0x7F);
@@ -702,7 +723,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
         mCoverSides[4] = aCover4;
         mCoverSides[5] = aCover5;
 
-        for (byte i = 0; i < 6; i++) mCoverBehaviors[i] = GregTech_API.getCoverBehavior(mCoverSides[i]);
+        for (byte i = 0; i < 6; i++) mCoverBehaviors[i] = GregTech_API.getCoverBehaviorNew(mCoverSides[i]);
 
         receiveClientEvent(ClientEvents.CHANGE_COMMON_DATA, aTextureData);
         receiveClientEvent(ClientEvents.CHANGE_CUSTOM_DATA, aUpdateData & 0x7F);
@@ -848,6 +869,12 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
     public void receiveCoverData(byte coverSide, int coverID, int coverData) {
         if ((coverSide >= 0 && coverSide < 6) && (mCoverSides[coverSide] == coverID))
             setCoverDataAtSide(coverSide, coverData);
+    }
+
+    @Override
+    public void receiveCoverData(byte aCoverSide, int aCoverID, ISerializableObject aCoverData, EntityPlayerMP aPlayer) {
+        if ((aCoverSide >= 0 && aCoverSide < 6) && (mCoverSides[aCoverSide] == aCoverID))
+            setCoverDataAtSide(aCoverSide, aCoverData);
     }
 
     @Override
@@ -1028,7 +1055,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
 
     @Override
     public boolean increaseProgress(int aProgressAmountInTicks) {
-        return canAccessData() && mMetaTileEntity.increaseProgress(aProgressAmountInTicks) != aProgressAmountInTicks;
+        return canAccessData() ? mMetaTileEntity.increaseProgress(aProgressAmountInTicks) != aProgressAmountInTicks : false;
     }
 
     @Override
@@ -1252,7 +1279,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
 
     private boolean isEnergyInputSide(byte aSide) {
         if (aSide >= 0 && aSide < 6) {
-            if (!getCoverBehaviorAtSide(aSide).letsEnergyIn(aSide, getCoverIDAtSide(aSide), getCoverDataAtSide(aSide), this))
+            if (!getCoverBehaviorAtSideNew(aSide).letsEnergyIn(aSide, getCoverIDAtSide(aSide), getCoverDataAtSideNew(aSide), this))
                 return false;
             if (isInvalid() || mReleaseEnergy) return false;
             if (canAccessData() && mMetaTileEntity.isElectric() && mMetaTileEntity.isEnetInput())
@@ -1263,7 +1290,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
 
     private boolean isEnergyOutputSide(byte aSide) {
         if (aSide >= 0 && aSide < 6) {
-            if (!getCoverBehaviorAtSide(aSide).letsEnergyOut(aSide, getCoverIDAtSide(aSide), getCoverDataAtSide(aSide), this))
+            if (!getCoverBehaviorAtSideNew(aSide).letsEnergyOut(aSide, getCoverIDAtSide(aSide), getCoverDataAtSideNew(aSide), this))
                 return false;
             if (isInvalid() || mReleaseEnergy) return mReleaseEnergy;
             if (canAccessData() && mMetaTileEntity.isElectric() && mMetaTileEntity.isEnetOutput())
@@ -1413,7 +1440,8 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
         if (mStrongRedstone > 0) tNBT.setByte("mStrongRedstone", mStrongRedstone);
         for (byte i = 0; i < mCoverSides.length; i++) {
             if (mCoverSides[i] != 0) {
-                tNBT.setIntArray("mCoverData", mCoverData);
+                if (mCoverData[i] != null) // this really shouldn't be null if a cover is there already, but whatever
+                    tNBT.setTag(COVER_DATA_NBT_KEYS[i], mCoverData[i].saveDataToNBT());
                 tNBT.setIntArray("mCoverSides", mCoverSides);
                 break;
             }
@@ -1433,12 +1461,12 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
             //Configure Cover, sneak can also be: screwdriver, wrench, side cutter, soldering iron
             if (aPlayer.isSneaking()) {
                 byte tSide = (getCoverIDAtSide(aSide) == 0) ? GT_Utility.determineWrenchingSide(aSide, aX, aY, aZ) : aSide;
-                return (getCoverBehaviorAtSide(tSide).hasCoverGUI());
-            } else if (getCoverBehaviorAtSide(aSide).onCoverRightclickClient(aSide, this, aPlayer, aX, aY, aZ)) {
+                return (getCoverBehaviorAtSideNew(tSide).hasCoverGUI());
+            } else if (getCoverBehaviorAtSideNew(aSide).onCoverRightclickClient(aSide, this, aPlayer, aX, aY, aZ)) {
                 return true;
             }
 
-            if (!getCoverBehaviorAtSide(aSide).isGUIClickable(aSide, getCoverIDAtSide(aSide), getCoverDataAtSide(aSide), this))
+            if (!getCoverBehaviorAtSideNew(aSide).isGUIClickable(aSide, getCoverIDAtSide(aSide), getCoverDataAtSideNew(aSide), this))
                 return false;
         }
         if (isServerSide()) {
@@ -1465,7 +1493,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
 
                     if (GT_Utility.isStackInList(tCurrentItem, GregTech_API.sScrewdriverList)) {
                         if (GT_ModHandler.damageOrDechargeItem(tCurrentItem, 1, 200, aPlayer)) {
-                            setCoverDataAtSide(aSide, getCoverBehaviorAtSide(aSide).onCoverScrewdriverclick(aSide, getCoverIDAtSide(aSide), getCoverDataAtSide(aSide), this, aPlayer, aX, aY, aZ));
+                            setCoverDataAtSide(aSide, getCoverBehaviorAtSideNew(aSide).onCoverScrewdriverClick(aSide, getCoverIDAtSide(aSide), getCoverDataAtSideNew(aSide), this, aPlayer, aX, aY, aZ));
                             mMetaTileEntity.onScrewdriverRightClick(aSide, aPlayer, aX, aY, aZ);
                             GT_Utility.sendSoundToPlayers(worldObj, GregTech_API.sSoundList.get(100), 1.0F, -1, xCoord, yCoord, zCoord);
                         }
@@ -1529,7 +1557,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
 
                     if (getCoverIDAtSide(coverSide) == 0) {
                         if (GregTech_API.sCovers.containsKey(new GT_ItemStack(tCurrentItem))) {
-                            if (GregTech_API.getCoverBehavior(tCurrentItem).isCoverPlaceable(coverSide, new GT_ItemStack(tCurrentItem), this) &&
+                            if (GregTech_API.getCoverBehaviorNew(tCurrentItem).isCoverPlaceable(coverSide, new GT_ItemStack(tCurrentItem), this) &&
                                 mMetaTileEntity.allowCoverOnSide(coverSide, new GT_ItemStack(tCurrentItem)))
                             {
                                 setCoverItemAtSide(coverSide, tCurrentItem);
@@ -1550,13 +1578,13 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
                 }
                 else if (aPlayer.isSneaking()) { //Sneak click, no tool -> open cover config if possible.
                     aSide = (getCoverIDAtSide(aSide) == 0) ? GT_Utility.determineWrenchingSide(aSide, aX, aY, aZ) : aSide;
-                    return getCoverIDAtSide(aSide) > 0 && getCoverBehaviorAtSide(aSide).onCoverShiftRightclick(aSide, getCoverIDAtSide(aSide), getCoverDataAtSide(aSide), this, aPlayer);
+                    return getCoverIDAtSide(aSide) > 0 && getCoverBehaviorAtSideNew(aSide).onCoverShiftRightClick(aSide, getCoverIDAtSide(aSide), getCoverDataAtSideNew(aSide), this, aPlayer);
                 }
 
-                if (getCoverBehaviorAtSide(aSide).onCoverRightclick(aSide, getCoverIDAtSide(aSide), getCoverDataAtSide(aSide), this, aPlayer, aX, aY, aZ))
+                if (getCoverBehaviorAtSideNew(aSide).onCoverRightClick(aSide, getCoverIDAtSide(aSide), getCoverDataAtSideNew(aSide), this, aPlayer, aX, aY, aZ))
                     return true;
 
-                if (!getCoverBehaviorAtSide(aSide).isGUIClickable(aSide, getCoverIDAtSide(aSide), getCoverDataAtSide(aSide), this))
+                if (!getCoverBehaviorAtSideNew(aSide).isGUIClickable(aSide, getCoverIDAtSide(aSide), getCoverDataAtSideNew(aSide), this))
                     return false;
 
                 if (isUpgradable() && tCurrentItem != null) {/*
@@ -1645,7 +1673,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
      */
     @Override
     public int[] getAccessibleSlotsFromSide(int aSide) {
-        if (canAccessData() && (getCoverBehaviorAtSide((byte) aSide).letsItemsOut((byte) aSide, getCoverIDAtSide((byte) aSide), getCoverDataAtSide((byte) aSide), -1, this) || getCoverBehaviorAtSide((byte) aSide).letsItemsIn((byte) aSide, getCoverIDAtSide((byte) aSide), getCoverDataAtSide((byte) aSide), -1, this)))
+        if (canAccessData() && (getCoverBehaviorAtSideNew((byte) aSide).letsItemsOut((byte) aSide, getCoverIDAtSide((byte) aSide), getCoverDataAtSideNew((byte) aSide), -1, this) || getCoverBehaviorAtSideNew((byte) aSide).letsItemsIn((byte) aSide, getCoverIDAtSide((byte) aSide), getCoverDataAtSideNew((byte) aSide), -1, this)))
             return mMetaTileEntity.getAccessibleSlotsFromSide(aSide);
         return new int[0];
     }
@@ -1655,7 +1683,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
      */
     @Override
     public boolean canInsertItem(int aIndex, ItemStack aStack, int aSide) {
-        return canAccessData() && (mRunningThroughTick || !mInputDisabled) && getCoverBehaviorAtSide((byte) aSide).letsItemsIn((byte) aSide, getCoverIDAtSide((byte) aSide), getCoverDataAtSide((byte) aSide), aIndex, this) && mMetaTileEntity.canInsertItem(aIndex, aStack, aSide);
+        return canAccessData() && (mRunningThroughTick || !mInputDisabled) && getCoverBehaviorAtSideNew((byte) aSide).letsItemsIn((byte) aSide, getCoverIDAtSide((byte) aSide), getCoverDataAtSideNew((byte) aSide), aIndex, this) && mMetaTileEntity.canInsertItem(aIndex, aStack, aSide);
     }
 
     /**
@@ -1663,7 +1691,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
      */
     @Override
     public boolean canExtractItem(int aIndex, ItemStack aStack, int aSide) {
-        return canAccessData() && (mRunningThroughTick || !mOutputDisabled) && getCoverBehaviorAtSide((byte) aSide).letsItemsOut((byte) aSide, getCoverIDAtSide((byte) aSide), getCoverDataAtSide((byte) aSide), aIndex, this) && mMetaTileEntity.canExtractItem(aIndex, aStack, aSide);
+        return canAccessData() && (mRunningThroughTick || !mOutputDisabled) && getCoverBehaviorAtSideNew((byte) aSide).letsItemsOut((byte) aSide, getCoverIDAtSide((byte) aSide), getCoverDataAtSideNew((byte) aSide), aIndex, this) && mMetaTileEntity.canExtractItem(aIndex, aStack, aSide);
     }
 
     @Override
@@ -1673,7 +1701,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
 
     @Override
     public byte getInternalInputRedstoneSignal(byte aSide) {
-        return (byte) (getCoverBehaviorAtSide(aSide).getRedstoneInput(aSide, getInputRedstoneSignal(aSide), getCoverIDAtSide(aSide), getCoverDataAtSide(aSide), this) & 15);
+        return (byte) (getCoverBehaviorAtSideNew(aSide).getRedstoneInput(aSide, getInputRedstoneSignal(aSide), getCoverIDAtSide(aSide), getCoverDataAtSideNew(aSide), this) & 15);
     }
 
     @Override
@@ -1683,7 +1711,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
 
     @Override
     public byte getOutputRedstoneSignal(byte aSide) {
-        return getCoverBehaviorAtSide(aSide).manipulatesSidedRedstoneOutput(aSide, getCoverIDAtSide(aSide), getCoverDataAtSide(aSide), this) ? mSidedRedstone[aSide] : getGeneralRS(aSide);
+        return getCoverBehaviorAtSideNew(aSide).manipulatesSidedRedstoneOutput(aSide, getCoverIDAtSide(aSide), getCoverDataAtSideNew(aSide), this) ? mSidedRedstone[aSide] : getGeneralRS(aSide);
     }
 
     public byte getGeneralRS(byte aSide){
@@ -1693,7 +1721,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
 
     @Override
     public void setInternalOutputRedstoneSignal(byte aSide, byte aStrength) {
-        if (!getCoverBehaviorAtSide(aSide).manipulatesSidedRedstoneOutput(aSide, getCoverIDAtSide(aSide), getCoverDataAtSide(aSide), this))
+        if (!getCoverBehaviorAtSideNew(aSide).manipulatesSidedRedstoneOutput(aSide, getCoverIDAtSide(aSide), getCoverDataAtSideNew(aSide), this))
             setOutputRedstoneSignal(aSide, aStrength);
     }
 
@@ -1779,16 +1807,19 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
     }
 
     @Override
+    @Deprecated
     public GT_CoverBehavior getCoverBehaviorAtSide(byte aSide) {
-        return aSide >= 0 && aSide < mCoverBehaviors.length ? mCoverBehaviors[aSide] : GregTech_API.sNoBehavior;
+        if (aSide >= 0 && aSide < mCoverBehaviors.length && mCoverBehaviors[aSide] instanceof GT_CoverBehavior)
+            return (GT_CoverBehavior) mCoverBehaviors[aSide];
+        return GregTech_API.sNoBehavior;
     }
 
     @Override
     public void setCoverIDAtSide(byte aSide, int aID) {
         if (aSide >= 0 && aSide < 6) {
             mCoverSides[aSide] = aID;
-            mCoverData[aSide] = 0;
-            mCoverBehaviors[aSide] = GregTech_API.getCoverBehavior(aID);
+            mCoverBehaviors[aSide] = GregTech_API.getCoverBehaviorNew(aID);
+            mCoverData[aSide] = mCoverBehaviors[aSide].createDataObject();
             issueCoverUpdate(aSide);
             issueBlockUpdate();
         }
@@ -1796,7 +1827,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
 
     @Override
     public void setCoverItemAtSide(byte aSide, ItemStack aCover) {
-        GregTech_API.getCoverBehavior(aCover).placeCover(aSide, aCover, this);
+        GregTech_API.getCoverBehaviorNew(aCover).placeCover(aSide, aCover, this);
     }
 
     @Override
@@ -1821,14 +1852,32 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
     }
 
     @Override
+    @Deprecated
     public void setCoverDataAtSide(byte aSide, int aData) {
-        if (aSide >= 0 && aSide < 6) mCoverData[aSide] = aData;
+        if (aSide >= 0 && aSide < 6) mCoverData[aSide] = new ISerializableObject.LegacyCoverData(aData);
     }
 
     @Override
+    @Deprecated
     public int getCoverDataAtSide(byte aSide) {
-        if (aSide >= 0 && aSide < 6) return mCoverData[aSide];
+        if (aSide >= 0 && aSide < 6 && mCoverData[aSide] instanceof ISerializableObject.LegacyCoverData)
+            return ((ISerializableObject.LegacyCoverData) mCoverData[aSide]).get();
         return 0;
+    }
+
+    @Override
+    public void setCoverDataAtSide(byte aSide, ISerializableObject aData) {
+        mCoverData[aSide] = aData;
+    }
+
+    @Override
+    public ISerializableObject getCoverDataAtSideNew(byte aSide) {
+        return mCoverData[aSide];
+    }
+
+    @Override
+    public GT_CoverBehavior_New<?> getCoverBehaviorAtSideNew(byte aSide) {
+        return mCoverBehaviors[aSide];
     }
 
     public byte getLightValue() {
@@ -1860,8 +1909,8 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
 
     @Override
     public boolean dropCover(byte aSide, byte aDroppedSide, boolean aForced) {
-        if (getCoverBehaviorAtSide(aSide).onCoverRemoval(aSide, getCoverIDAtSide(aSide), mCoverData[aSide], this, aForced) || aForced) {
-            ItemStack tStack = getCoverBehaviorAtSide(aSide).getDrop(aSide, getCoverIDAtSide(aSide), getCoverDataAtSide(aSide), this);
+        if (getCoverBehaviorAtSideNew(aSide).onCoverRemoval(aSide, getCoverIDAtSide(aSide), mCoverData[aSide], this, aForced) || aForced) {
+            ItemStack tStack = getCoverBehaviorAtSideNew(aSide).getDrop(aSide, getCoverIDAtSide(aSide), getCoverDataAtSideNew(aSide), this);
             if (tStack != null) {
                 tStack.setTagCompound(null);
                 EntityItem tEntity = new EntityItem(worldObj, getOffsetX(aDroppedSide, 1) + 0.5, getOffsetY(aDroppedSide, 1) + 0.5, getOffsetZ(aDroppedSide, 1) + 0.5, tStack);
@@ -1976,7 +2025,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
                 aSide == ForgeDirection.UNKNOWN ||
                 (
                     mMetaTileEntity.isLiquidInput((byte) aSide.ordinal()) &&
-                    getCoverBehaviorAtSide((byte) aSide.ordinal()).letsFluidIn((byte) aSide.ordinal(), getCoverIDAtSide((byte) aSide.ordinal()), getCoverDataAtSide((byte) aSide.ordinal()), aFluid == null ? null : aFluid.getFluid(), this)
+                    getCoverBehaviorAtSideNew((byte) aSide.ordinal()).letsFluidIn((byte) aSide.ordinal(), getCoverIDAtSide((byte) aSide.ordinal()), getCoverDataAtSideNew((byte) aSide.ordinal()), aFluid == null ? null : aFluid.getFluid(), this)
                 )
             )
         )
@@ -1992,7 +2041,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
                 aSide == ForgeDirection.UNKNOWN ||
                 (
                     mMetaTileEntity.isLiquidOutput((byte) aSide.ordinal()) &&
-                    getCoverBehaviorAtSide((byte) aSide.ordinal()).letsFluidOut((byte) aSide.ordinal(), getCoverIDAtSide((byte) aSide.ordinal()), getCoverDataAtSide((byte) aSide.ordinal()), mMetaTileEntity.getFluid() == null ? null : mMetaTileEntity.getFluid().getFluid(), this)
+                    getCoverBehaviorAtSideNew((byte) aSide.ordinal()).letsFluidOut((byte) aSide.ordinal(), getCoverIDAtSide((byte) aSide.ordinal()), getCoverDataAtSideNew((byte) aSide.ordinal()), mMetaTileEntity.getFluid() == null ? null : mMetaTileEntity.getFluid().getFluid(), this)
                 )
             )
         )
@@ -2008,7 +2057,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
                 aSide == ForgeDirection.UNKNOWN ||
                 (
                     mMetaTileEntity.isLiquidOutput((byte) aSide.ordinal()) &&
-                    getCoverBehaviorAtSide((byte) aSide.ordinal()).letsFluidOut((byte) aSide.ordinal(), getCoverIDAtSide((byte) aSide.ordinal()), getCoverDataAtSide((byte) aSide.ordinal()), aFluid == null ? null : aFluid.getFluid(), this)
+                    getCoverBehaviorAtSideNew((byte) aSide.ordinal()).letsFluidOut((byte) aSide.ordinal(), getCoverIDAtSide((byte) aSide.ordinal()), getCoverDataAtSideNew((byte) aSide.ordinal()), aFluid == null ? null : aFluid.getFluid(), this)
                 )
             )
         )
@@ -2024,7 +2073,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
                 aSide == ForgeDirection.UNKNOWN ||
                 (
                     mMetaTileEntity.isLiquidInput((byte) aSide.ordinal()) &&
-                    getCoverBehaviorAtSide((byte) aSide.ordinal()).letsFluidIn((byte) aSide.ordinal(), getCoverIDAtSide((byte) aSide.ordinal()), getCoverDataAtSide((byte) aSide.ordinal()), aFluid, this)
+                    getCoverBehaviorAtSideNew((byte) aSide.ordinal()).letsFluidIn((byte) aSide.ordinal(), getCoverIDAtSide((byte) aSide.ordinal()), getCoverDataAtSideNew((byte) aSide.ordinal()), aFluid, this)
                 )
             )
         )
@@ -2040,7 +2089,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
                 aSide == ForgeDirection.UNKNOWN ||
                 (
                     mMetaTileEntity.isLiquidOutput((byte) aSide.ordinal()) &&
-                        getCoverBehaviorAtSide((byte) aSide.ordinal()).letsFluidOut((byte) aSide.ordinal(), getCoverIDAtSide((byte) aSide.ordinal()), getCoverDataAtSide((byte) aSide.ordinal()), aFluid, this)
+                        getCoverBehaviorAtSideNew((byte) aSide.ordinal()).letsFluidOut((byte) aSide.ordinal(), getCoverIDAtSide((byte) aSide.ordinal()), getCoverDataAtSideNew((byte) aSide.ordinal()), aFluid, this)
                 )
             )
         )
@@ -2055,8 +2104,8 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
                 aSide == ForgeDirection.UNKNOWN ||
                 (
                     mMetaTileEntity.isLiquidInput((byte) aSide.ordinal()) &&
-                    getCoverBehaviorAtSide((byte) aSide.ordinal()).letsFluidIn((byte) aSide.ordinal(), getCoverIDAtSide((byte) aSide.ordinal()), getCoverDataAtSide((byte) aSide.ordinal()), null, this)) || (mMetaTileEntity.isLiquidOutput((byte) aSide.ordinal()) &&
-                    getCoverBehaviorAtSide((byte) aSide.ordinal()).letsFluidOut((byte) aSide.ordinal(), getCoverIDAtSide((byte) aSide.ordinal()), getCoverDataAtSide((byte) aSide.ordinal()), null, this)
+                    getCoverBehaviorAtSideNew((byte) aSide.ordinal()).letsFluidIn((byte) aSide.ordinal(), getCoverIDAtSide((byte) aSide.ordinal()), getCoverDataAtSideNew((byte) aSide.ordinal()), null, this)) || (mMetaTileEntity.isLiquidOutput((byte) aSide.ordinal()) &&
+                    getCoverBehaviorAtSideNew((byte) aSide.ordinal()).letsFluidOut((byte) aSide.ordinal(), getCoverIDAtSide((byte) aSide.ordinal()), getCoverDataAtSideNew((byte) aSide.ordinal()), null, this)
                 )
             )
         )

--- a/src/main/java/gregtech/api/metatileentity/MetaPipeEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaPipeEntity.java
@@ -178,7 +178,10 @@ public abstract class MetaPipeEntity implements IMetaTileEntity, IConnectable {
         if (difference > 1.05 && difference < 1.4) {
             aSide = 5;
         }
-        boolean tCovered = aSide < 6 && mBaseMetaTileEntity.getCoverIDAtSide(aSide) > 0;
+        boolean tCovered = false;
+        if (aSide < 6 && mBaseMetaTileEntity.getCoverIDAtSide(aSide) > 0) {
+            tCovered = true;
+        }
         if(isConnectedAtSide(aSide)){
         	tCovered = true;
         }
@@ -518,9 +521,9 @@ public abstract class MetaPipeEntity implements IMetaTileEntity, IConnectable {
     public int[] getAccessibleSlotsFromSide(int aSide) {
         ArrayList<Integer> tList = new ArrayList<Integer>();
         IGregTechTileEntity tTileEntity = getBaseMetaTileEntity();
-        boolean tSkip = tTileEntity.getCoverBehaviorAtSide((byte) aSide).letsItemsIn((byte) aSide, tTileEntity.getCoverIDAtSide((byte) aSide), tTileEntity.getCoverDataAtSide((byte) aSide), -2, tTileEntity) || tTileEntity.getCoverBehaviorAtSide((byte) aSide).letsItemsOut((byte) aSide, tTileEntity.getCoverIDAtSide((byte) aSide), tTileEntity.getCoverDataAtSide((byte) aSide), -2, tTileEntity);
+        boolean tSkip = tTileEntity.getCoverBehaviorAtSideNew((byte) aSide).letsItemsIn((byte) aSide, tTileEntity.getCoverIDAtSide((byte) aSide), tTileEntity.getCoverDataAtSideNew((byte) aSide), -2, tTileEntity) || tTileEntity.getCoverBehaviorAtSideNew((byte) aSide).letsItemsOut((byte) aSide, tTileEntity.getCoverIDAtSide((byte) aSide), tTileEntity.getCoverDataAtSideNew((byte) aSide), -2, tTileEntity);
         for (int i = 0; i < getSizeInventory(); i++)
-            if (isValidSlot(i) && (tSkip || tTileEntity.getCoverBehaviorAtSide((byte) aSide).letsItemsOut((byte) aSide, tTileEntity.getCoverIDAtSide((byte) aSide), tTileEntity.getCoverDataAtSide((byte) aSide), i, tTileEntity) || tTileEntity.getCoverBehaviorAtSide((byte) aSide).letsItemsIn((byte) aSide, tTileEntity.getCoverIDAtSide((byte) aSide), tTileEntity.getCoverDataAtSide((byte) aSide), i, tTileEntity)))
+            if (isValidSlot(i) && (tSkip || tTileEntity.getCoverBehaviorAtSideNew((byte) aSide).letsItemsOut((byte) aSide, tTileEntity.getCoverIDAtSide((byte) aSide), tTileEntity.getCoverDataAtSideNew((byte) aSide), i, tTileEntity) || tTileEntity.getCoverBehaviorAtSideNew((byte) aSide).letsItemsIn((byte) aSide, tTileEntity.getCoverIDAtSide((byte) aSide), tTileEntity.getCoverDataAtSideNew((byte) aSide), i, tTileEntity)))
                 tList.add(i);
         int[] rArray = new int[tList.size()];
         for (int i = 0; i < rArray.length; i++) rArray[i] = tList.get(i);
@@ -766,7 +769,7 @@ public abstract class MetaPipeEntity implements IMetaTileEntity, IConnectable {
         if (tTileEntity instanceof IColoredTileEntity) {
             if (getBaseMetaTileEntity().getColorization() >= 0) {
                 byte tColor = ((IColoredTileEntity) tTileEntity).getColorization();
-                return tColor < 0 || tColor == getBaseMetaTileEntity().getColorization();
+                if (tColor >= 0 && tColor != getBaseMetaTileEntity().getColorization()) return false;
             }
         }
 
@@ -781,9 +784,9 @@ public abstract class MetaPipeEntity implements IMetaTileEntity, IConnectable {
 		final IGregTechTileEntity baseMetaTile = getBaseMetaTileEntity();
 		if (baseMetaTile == null || !baseMetaTile.isServerSide()) return 0;
 
-        final GT_CoverBehavior coverBehavior = baseMetaTile.getCoverBehaviorAtSide(aSide);
-        final int coverId = baseMetaTile.getCoverIDAtSide(aSide),
-                  coverData = baseMetaTile.getCoverDataAtSide(aSide);
+        final GT_CoverBehavior_New<?> coverBehavior = baseMetaTile.getCoverBehaviorAtSideNew(aSide);
+        final int coverId = baseMetaTile.getCoverIDAtSide(aSide);
+        ISerializableObject coverData = baseMetaTile.getCoverDataAtSideNew(aSide);
 
         boolean alwaysLookConnected = coverBehavior.alwaysLookConnected(aSide, coverId, coverData, baseMetaTile);
         boolean letsIn = letsIn(coverBehavior, aSide, coverId, coverData, baseMetaTile);
@@ -852,6 +855,9 @@ public abstract class MetaPipeEntity implements IMetaTileEntity, IConnectable {
 
 	public boolean letsIn(GT_CoverBehavior coverBehavior, byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity) { return false; }
     public boolean letsOut(GT_CoverBehavior coverBehavior, byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity) { return false; }
+
+    public boolean letsIn(GT_CoverBehavior_New<?> coverBehavior, byte aSide, int aCoverID, ISerializableObject aCoverVariable, ICoverable aTileEntity) { return false; }
+    public boolean letsOut(GT_CoverBehavior_New<?> coverBehavior, byte aSide, int aCoverID, ISerializableObject aCoverVariable, ICoverable aTileEntity) { return false; }
 
 	public boolean canConnect(byte aSide, TileEntity tTileEntity) { return false; }
 	public boolean getGT6StyleConnection() { return false; }

--- a/src/main/java/gregtech/api/metatileentity/MetaPipeEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaPipeEntity.java
@@ -521,9 +521,9 @@ public abstract class MetaPipeEntity implements IMetaTileEntity, IConnectable {
     public int[] getAccessibleSlotsFromSide(int aSide) {
         ArrayList<Integer> tList = new ArrayList<Integer>();
         IGregTechTileEntity tTileEntity = getBaseMetaTileEntity();
-        boolean tSkip = tTileEntity.getCoverBehaviorAtSideNew((byte) aSide).letsItemsIn((byte) aSide, tTileEntity.getCoverIDAtSide((byte) aSide), tTileEntity.getCoverDataAtSideNew((byte) aSide), -2, tTileEntity) || tTileEntity.getCoverBehaviorAtSideNew((byte) aSide).letsItemsOut((byte) aSide, tTileEntity.getCoverIDAtSide((byte) aSide), tTileEntity.getCoverDataAtSideNew((byte) aSide), -2, tTileEntity);
+        boolean tSkip = tTileEntity.getCoverBehaviorAtSideNew((byte) aSide).letsItemsIn((byte) aSide, tTileEntity.getCoverIDAtSide((byte) aSide), tTileEntity.getComplexCoverDataAtSide((byte) aSide), -2, tTileEntity) || tTileEntity.getCoverBehaviorAtSideNew((byte) aSide).letsItemsOut((byte) aSide, tTileEntity.getCoverIDAtSide((byte) aSide), tTileEntity.getComplexCoverDataAtSide((byte) aSide), -2, tTileEntity);
         for (int i = 0; i < getSizeInventory(); i++)
-            if (isValidSlot(i) && (tSkip || tTileEntity.getCoverBehaviorAtSideNew((byte) aSide).letsItemsOut((byte) aSide, tTileEntity.getCoverIDAtSide((byte) aSide), tTileEntity.getCoverDataAtSideNew((byte) aSide), i, tTileEntity) || tTileEntity.getCoverBehaviorAtSideNew((byte) aSide).letsItemsIn((byte) aSide, tTileEntity.getCoverIDAtSide((byte) aSide), tTileEntity.getCoverDataAtSideNew((byte) aSide), i, tTileEntity)))
+            if (isValidSlot(i) && (tSkip || tTileEntity.getCoverBehaviorAtSideNew((byte) aSide).letsItemsOut((byte) aSide, tTileEntity.getCoverIDAtSide((byte) aSide), tTileEntity.getComplexCoverDataAtSide((byte) aSide), i, tTileEntity) || tTileEntity.getCoverBehaviorAtSideNew((byte) aSide).letsItemsIn((byte) aSide, tTileEntity.getCoverIDAtSide((byte) aSide), tTileEntity.getComplexCoverDataAtSide((byte) aSide), i, tTileEntity)))
                 tList.add(i);
         int[] rArray = new int[tList.size()];
         for (int i = 0; i < rArray.length; i++) rArray[i] = tList.get(i);
@@ -784,9 +784,9 @@ public abstract class MetaPipeEntity implements IMetaTileEntity, IConnectable {
 		final IGregTechTileEntity baseMetaTile = getBaseMetaTileEntity();
 		if (baseMetaTile == null || !baseMetaTile.isServerSide()) return 0;
 
-        final GT_CoverBehavior_New<?> coverBehavior = baseMetaTile.getCoverBehaviorAtSideNew(aSide);
+        final GT_CoverBehaviorBase<?> coverBehavior = baseMetaTile.getCoverBehaviorAtSideNew(aSide);
         final int coverId = baseMetaTile.getCoverIDAtSide(aSide);
-        ISerializableObject coverData = baseMetaTile.getCoverDataAtSideNew(aSide);
+        ISerializableObject coverData = baseMetaTile.getComplexCoverDataAtSide(aSide);
 
         boolean alwaysLookConnected = coverBehavior.alwaysLookConnected(aSide, coverId, coverData, baseMetaTile);
         boolean letsIn = letsIn(coverBehavior, aSide, coverId, coverData, baseMetaTile);
@@ -856,8 +856,8 @@ public abstract class MetaPipeEntity implements IMetaTileEntity, IConnectable {
 	public boolean letsIn(GT_CoverBehavior coverBehavior, byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity) { return false; }
     public boolean letsOut(GT_CoverBehavior coverBehavior, byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity) { return false; }
 
-    public boolean letsIn(GT_CoverBehavior_New<?> coverBehavior, byte aSide, int aCoverID, ISerializableObject aCoverVariable, ICoverable aTileEntity) { return false; }
-    public boolean letsOut(GT_CoverBehavior_New<?> coverBehavior, byte aSide, int aCoverID, ISerializableObject aCoverVariable, ICoverable aTileEntity) { return false; }
+    public boolean letsIn(GT_CoverBehaviorBase<?> coverBehavior, byte aSide, int aCoverID, ISerializableObject aCoverVariable, ICoverable aTileEntity) { return false; }
+    public boolean letsOut(GT_CoverBehaviorBase<?> coverBehavior, byte aSide, int aCoverID, ISerializableObject aCoverVariable, ICoverable aTileEntity) { return false; }
 
 	public boolean canConnect(byte aSide, TileEntity tTileEntity) { return false; }
 	public boolean getGT6StyleConnection() { return false; }

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -714,9 +714,9 @@ public abstract class MetaTileEntity implements IMetaTileEntity {
     public int[] getAccessibleSlotsFromSide(int aSide) {
         ArrayList<Integer> tList = new ArrayList<Integer>();
         IGregTechTileEntity tTileEntity = getBaseMetaTileEntity();
-        boolean tSkip = tTileEntity.getCoverBehaviorAtSideNew((byte) aSide).letsItemsIn((byte) aSide, tTileEntity.getCoverIDAtSide((byte) aSide), tTileEntity.getCoverDataAtSideNew((byte) aSide), -2, tTileEntity) || tTileEntity.getCoverBehaviorAtSideNew((byte) aSide).letsItemsOut((byte) aSide, tTileEntity.getCoverIDAtSide((byte) aSide), tTileEntity.getCoverDataAtSideNew((byte) aSide), -2, tTileEntity);
+        boolean tSkip = tTileEntity.getCoverBehaviorAtSideNew((byte) aSide).letsItemsIn((byte) aSide, tTileEntity.getCoverIDAtSide((byte) aSide), tTileEntity.getComplexCoverDataAtSide((byte) aSide), -2, tTileEntity) || tTileEntity.getCoverBehaviorAtSideNew((byte) aSide).letsItemsOut((byte) aSide, tTileEntity.getCoverIDAtSide((byte) aSide), tTileEntity.getComplexCoverDataAtSide((byte) aSide), -2, tTileEntity);
         for (int i = 0; i < getSizeInventory(); i++)
-            if (isValidSlot(i) && (tSkip || tTileEntity.getCoverBehaviorAtSideNew((byte) aSide).letsItemsOut((byte) aSide, tTileEntity.getCoverIDAtSide((byte) aSide), tTileEntity.getCoverDataAtSideNew((byte) aSide), i, tTileEntity) || tTileEntity.getCoverBehaviorAtSideNew((byte) aSide).letsItemsIn((byte) aSide, tTileEntity.getCoverIDAtSide((byte) aSide), tTileEntity.getCoverDataAtSideNew((byte) aSide), i, tTileEntity)))
+            if (isValidSlot(i) && (tSkip || tTileEntity.getCoverBehaviorAtSideNew((byte) aSide).letsItemsOut((byte) aSide, tTileEntity.getCoverIDAtSide((byte) aSide), tTileEntity.getComplexCoverDataAtSide((byte) aSide), i, tTileEntity) || tTileEntity.getCoverBehaviorAtSideNew((byte) aSide).letsItemsIn((byte) aSide, tTileEntity.getCoverIDAtSide((byte) aSide), tTileEntity.getComplexCoverDataAtSide((byte) aSide), i, tTileEntity)))
                 tList.add(i);
         int[] rArray = new int[tList.size()];
         for (int i = 0; i < rArray.length; i++) rArray[i] = tList.get(i);

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -714,9 +714,9 @@ public abstract class MetaTileEntity implements IMetaTileEntity {
     public int[] getAccessibleSlotsFromSide(int aSide) {
         ArrayList<Integer> tList = new ArrayList<Integer>();
         IGregTechTileEntity tTileEntity = getBaseMetaTileEntity();
-        boolean tSkip = tTileEntity.getCoverBehaviorAtSide((byte) aSide).letsItemsIn((byte) aSide, tTileEntity.getCoverIDAtSide((byte) aSide), tTileEntity.getCoverDataAtSide((byte) aSide), -2, tTileEntity) || tTileEntity.getCoverBehaviorAtSide((byte) aSide).letsItemsOut((byte) aSide, tTileEntity.getCoverIDAtSide((byte) aSide), tTileEntity.getCoverDataAtSide((byte) aSide), -2, tTileEntity);
+        boolean tSkip = tTileEntity.getCoverBehaviorAtSideNew((byte) aSide).letsItemsIn((byte) aSide, tTileEntity.getCoverIDAtSide((byte) aSide), tTileEntity.getCoverDataAtSideNew((byte) aSide), -2, tTileEntity) || tTileEntity.getCoverBehaviorAtSideNew((byte) aSide).letsItemsOut((byte) aSide, tTileEntity.getCoverIDAtSide((byte) aSide), tTileEntity.getCoverDataAtSideNew((byte) aSide), -2, tTileEntity);
         for (int i = 0; i < getSizeInventory(); i++)
-            if (isValidSlot(i) && (tSkip || tTileEntity.getCoverBehaviorAtSide((byte) aSide).letsItemsOut((byte) aSide, tTileEntity.getCoverIDAtSide((byte) aSide), tTileEntity.getCoverDataAtSide((byte) aSide), i, tTileEntity) || tTileEntity.getCoverBehaviorAtSide((byte) aSide).letsItemsIn((byte) aSide, tTileEntity.getCoverIDAtSide((byte) aSide), tTileEntity.getCoverDataAtSide((byte) aSide), i, tTileEntity)))
+            if (isValidSlot(i) && (tSkip || tTileEntity.getCoverBehaviorAtSideNew((byte) aSide).letsItemsOut((byte) aSide, tTileEntity.getCoverIDAtSide((byte) aSide), tTileEntity.getCoverDataAtSideNew((byte) aSide), i, tTileEntity) || tTileEntity.getCoverBehaviorAtSideNew((byte) aSide).letsItemsIn((byte) aSide, tTileEntity.getCoverIDAtSide((byte) aSide), tTileEntity.getCoverDataAtSideNew((byte) aSide), i, tTileEntity)))
                 tList.add(i);
         int[] rArray = new int[tList.size()];
         for (int i = 0; i < rArray.length; i++) rArray[i] = tList.get(i);

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Cable.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Cable.java
@@ -159,7 +159,7 @@ public class GT_MetaPipeEntity_Cable extends MetaPipeEntity implements IMetaTile
     public long injectEnergyUnits(byte aSide, long aVoltage, long aAmperage) {
     	if (!isConnectedAtSide(aSide) && aSide != 6)
     		return 0;
-        if (!getBaseMetaTileEntity().getCoverBehaviorAtSide(aSide).letsEnergyIn(aSide, getBaseMetaTileEntity().getCoverIDAtSide(aSide), getBaseMetaTileEntity().getCoverDataAtSide(aSide), getBaseMetaTileEntity()))
+        if (!getBaseMetaTileEntity().getCoverBehaviorAtSideNew(aSide).letsEnergyIn(aSide, getBaseMetaTileEntity().getCoverIDAtSide(aSide), getBaseMetaTileEntity().getCoverDataAtSideNew(aSide), getBaseMetaTileEntity()))
             return 0;
         HashSet<TileEntity> nul = null;
         return transferElectricity(aSide, aVoltage, aAmperage,nul);
@@ -254,11 +254,21 @@ public class GT_MetaPipeEntity_Cable extends MetaPipeEntity implements IMetaTile
         return coverBehavior.letsEnergyOut(aSide, aCoverID, aCoverVariable, aTileEntity);
     }
 
+    @Override
+    public boolean letsIn(GT_CoverBehavior_New<?> coverBehavior, byte aSide, int aCoverID, ISerializableObject aCoverVariable, ICoverable aTileEntity) {
+        return coverBehavior.letsEnergyIn(aSide, aCoverID, aCoverVariable, aTileEntity);
+    }
+
+    @Override
+    public boolean letsOut(GT_CoverBehavior_New<?> coverBehavior, byte aSide, int aCoverID, ISerializableObject aCoverVariable, ICoverable aTileEntity) {
+        return coverBehavior.letsEnergyOut(aSide, aCoverID, aCoverVariable, aTileEntity);
+    }
+
 
     @Override
     public boolean canConnect(byte aSide, TileEntity tTileEntity) {
         final IGregTechTileEntity baseMetaTile = getBaseMetaTileEntity();
-        final GT_CoverBehavior coverBehavior = baseMetaTile.getCoverBehaviorAtSide(aSide);
+        final GT_CoverBehavior_New<?> coverBehavior = baseMetaTile.getCoverBehaviorAtSideNew(aSide);
         final byte tSide = GT_Utility.getOppositeSide(aSide);
         final ForgeDirection tDir = ForgeDirection.getOrientation(tSide);
 

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Cable.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Cable.java
@@ -1,7 +1,6 @@
 package gregtech.api.metatileentity.implementations;
 
 import cofh.api.energy.IEnergyReceiver;
-import com.google.common.collect.Sets;
 import cpw.mods.fml.common.Loader;
 import gregtech.GT_Mod;
 import gregtech.api.GregTech_API;
@@ -159,7 +158,7 @@ public class GT_MetaPipeEntity_Cable extends MetaPipeEntity implements IMetaTile
     public long injectEnergyUnits(byte aSide, long aVoltage, long aAmperage) {
     	if (!isConnectedAtSide(aSide) && aSide != 6)
     		return 0;
-        if (!getBaseMetaTileEntity().getCoverBehaviorAtSideNew(aSide).letsEnergyIn(aSide, getBaseMetaTileEntity().getCoverIDAtSide(aSide), getBaseMetaTileEntity().getCoverDataAtSideNew(aSide), getBaseMetaTileEntity()))
+        if (!getBaseMetaTileEntity().getCoverBehaviorAtSideNew(aSide).letsEnergyIn(aSide, getBaseMetaTileEntity().getCoverIDAtSide(aSide), getBaseMetaTileEntity().getComplexCoverDataAtSide(aSide), getBaseMetaTileEntity()))
             return 0;
         HashSet<TileEntity> nul = null;
         return transferElectricity(aSide, aVoltage, aAmperage,nul);
@@ -255,12 +254,12 @@ public class GT_MetaPipeEntity_Cable extends MetaPipeEntity implements IMetaTile
     }
 
     @Override
-    public boolean letsIn(GT_CoverBehavior_New<?> coverBehavior, byte aSide, int aCoverID, ISerializableObject aCoverVariable, ICoverable aTileEntity) {
+    public boolean letsIn(GT_CoverBehaviorBase<?> coverBehavior, byte aSide, int aCoverID, ISerializableObject aCoverVariable, ICoverable aTileEntity) {
         return coverBehavior.letsEnergyIn(aSide, aCoverID, aCoverVariable, aTileEntity);
     }
 
     @Override
-    public boolean letsOut(GT_CoverBehavior_New<?> coverBehavior, byte aSide, int aCoverID, ISerializableObject aCoverVariable, ICoverable aTileEntity) {
+    public boolean letsOut(GT_CoverBehaviorBase<?> coverBehavior, byte aSide, int aCoverID, ISerializableObject aCoverVariable, ICoverable aTileEntity) {
         return coverBehavior.letsEnergyOut(aSide, aCoverID, aCoverVariable, aTileEntity);
     }
 
@@ -268,7 +267,7 @@ public class GT_MetaPipeEntity_Cable extends MetaPipeEntity implements IMetaTile
     @Override
     public boolean canConnect(byte aSide, TileEntity tTileEntity) {
         final IGregTechTileEntity baseMetaTile = getBaseMetaTileEntity();
-        final GT_CoverBehavior_New<?> coverBehavior = baseMetaTile.getCoverBehaviorAtSideNew(aSide);
+        final GT_CoverBehaviorBase<?> coverBehavior = baseMetaTile.getCoverBehaviorAtSideNew(aSide);
         final byte tSide = GT_Utility.getOppositeSide(aSide);
         final ForgeDirection tDir = ForgeDirection.getOrientation(tSide);
 

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Fluid.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Fluid.java
@@ -15,7 +15,7 @@ import gregtech.api.metatileentity.BaseMetaPipeEntity;
 import gregtech.api.metatileentity.MetaPipeEntity;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GT_CoverBehavior;
-import gregtech.api.util.GT_CoverBehavior_New;
+import gregtech.api.util.GT_CoverBehaviorBase;
 import gregtech.api.util.GT_Log;
 import gregtech.api.util.GT_Utility;
 import gregtech.api.util.ISerializableObject;
@@ -347,8 +347,8 @@ public class GT_MetaPipeEntity_Fluid extends MetaPipeEntity {
             final IGregTechTileEntity gTank = tTank instanceof IGregTechTileEntity ? (IGregTechTileEntity) tTank : null;
 
             if (isConnectedAtSide(aSide) && tTank != null && (mLastReceivedFrom & (1 << aSide)) == 0 &&
-                    getBaseMetaTileEntity().getCoverBehaviorAtSideNew(aSide).letsFluidOut(aSide, getBaseMetaTileEntity().getCoverIDAtSide(aSide), getBaseMetaTileEntity().getCoverDataAtSideNew(aSide), tFluid.getFluid(), getBaseMetaTileEntity()) &&
-                    (gTank == null || gTank.getCoverBehaviorAtSideNew(tSide).letsFluidIn(tSide, gTank.getCoverIDAtSide(tSide), gTank.getCoverDataAtSideNew(tSide), tFluid.getFluid(), gTank))) {
+                    getBaseMetaTileEntity().getCoverBehaviorAtSideNew(aSide).letsFluidOut(aSide, getBaseMetaTileEntity().getCoverIDAtSide(aSide), getBaseMetaTileEntity().getComplexCoverDataAtSide(aSide), tFluid.getFluid(), getBaseMetaTileEntity()) &&
+                    (gTank == null || gTank.getCoverBehaviorAtSideNew(tSide).letsFluidIn(tSide, gTank.getCoverIDAtSide(tSide), gTank.getComplexCoverDataAtSide(tSide), tFluid.getFluid(), gTank))) {
                 if (tTank.fill(ForgeDirection.getOrientation(tSide), tFluid, false) > 0) {
                     tTanks.add(new MutableTriple<>(tTank, ForgeDirection.getOrientation(tSide), 0));
                 }
@@ -422,12 +422,12 @@ public class GT_MetaPipeEntity_Fluid extends MetaPipeEntity {
     }
 
     @Override
-    public boolean letsIn(GT_CoverBehavior_New<?> coverBehavior, byte aSide, int aCoverID, ISerializableObject aCoverVariable, ICoverable aTileEntity) {
+    public boolean letsIn(GT_CoverBehaviorBase<?> coverBehavior, byte aSide, int aCoverID, ISerializableObject aCoverVariable, ICoverable aTileEntity) {
         return coverBehavior.letsFluidIn(aSide, aCoverID, aCoverVariable, null, aTileEntity);
     }
 
     @Override
-    public boolean letsOut(GT_CoverBehavior_New<?> coverBehavior, byte aSide, int aCoverID, ISerializableObject aCoverVariable, ICoverable aTileEntity) {
+    public boolean letsOut(GT_CoverBehaviorBase<?> coverBehavior, byte aSide, int aCoverID, ISerializableObject aCoverVariable, ICoverable aTileEntity) {
         return coverBehavior.letsFluidOut(aSide, aCoverID, aCoverVariable, null, aTileEntity);
     }
 
@@ -441,7 +441,7 @@ public class GT_MetaPipeEntity_Fluid extends MetaPipeEntity {
         if (baseMetaTile == null)
             return false;
 
-        final GT_CoverBehavior_New<?> coverBehavior = baseMetaTile.getCoverBehaviorAtSideNew(aSide);
+        final GT_CoverBehaviorBase<?> coverBehavior = baseMetaTile.getCoverBehaviorAtSideNew(aSide);
         final IGregTechTileEntity gTileEntity = (tTileEntity instanceof IGregTechTileEntity) ? (IGregTechTileEntity) tTileEntity : null;
 
         if (coverBehavior instanceof GT_Cover_Drain || (GregTech_API.mTConstruct && isTConstructFaucet(tTileEntity)))

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Fluid.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Fluid.java
@@ -15,8 +15,10 @@ import gregtech.api.metatileentity.BaseMetaPipeEntity;
 import gregtech.api.metatileentity.MetaPipeEntity;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GT_CoverBehavior;
+import gregtech.api.util.GT_CoverBehavior_New;
 import gregtech.api.util.GT_Log;
 import gregtech.api.util.GT_Utility;
+import gregtech.api.util.ISerializableObject;
 import gregtech.api.util.WorldSpawnedEventBuilder;
 import gregtech.common.GT_Client;
 import gregtech.common.covers.GT_Cover_Drain;
@@ -345,8 +347,8 @@ public class GT_MetaPipeEntity_Fluid extends MetaPipeEntity {
             final IGregTechTileEntity gTank = tTank instanceof IGregTechTileEntity ? (IGregTechTileEntity) tTank : null;
 
             if (isConnectedAtSide(aSide) && tTank != null && (mLastReceivedFrom & (1 << aSide)) == 0 &&
-                    getBaseMetaTileEntity().getCoverBehaviorAtSide(aSide).letsFluidOut(aSide, getBaseMetaTileEntity().getCoverIDAtSide(aSide), getBaseMetaTileEntity().getCoverDataAtSide(aSide), tFluid.getFluid(), getBaseMetaTileEntity()) &&
-                    (gTank == null || gTank.getCoverBehaviorAtSide(tSide).letsFluidIn(tSide, gTank.getCoverIDAtSide(tSide), gTank.getCoverDataAtSide(tSide), tFluid.getFluid(), gTank))) {
+                    getBaseMetaTileEntity().getCoverBehaviorAtSideNew(aSide).letsFluidOut(aSide, getBaseMetaTileEntity().getCoverIDAtSide(aSide), getBaseMetaTileEntity().getCoverDataAtSideNew(aSide), tFluid.getFluid(), getBaseMetaTileEntity()) &&
+                    (gTank == null || gTank.getCoverBehaviorAtSideNew(tSide).letsFluidIn(tSide, gTank.getCoverIDAtSide(tSide), gTank.getCoverDataAtSideNew(tSide), tFluid.getFluid(), gTank))) {
                 if (tTank.fill(ForgeDirection.getOrientation(tSide), tFluid, false) > 0) {
                     tTanks.add(new MutableTriple<>(tTank, ForgeDirection.getOrientation(tSide), 0));
                 }
@@ -420,6 +422,16 @@ public class GT_MetaPipeEntity_Fluid extends MetaPipeEntity {
     }
 
     @Override
+    public boolean letsIn(GT_CoverBehavior_New<?> coverBehavior, byte aSide, int aCoverID, ISerializableObject aCoverVariable, ICoverable aTileEntity) {
+        return coverBehavior.letsFluidIn(aSide, aCoverID, aCoverVariable, null, aTileEntity);
+    }
+
+    @Override
+    public boolean letsOut(GT_CoverBehavior_New<?> coverBehavior, byte aSide, int aCoverID, ISerializableObject aCoverVariable, ICoverable aTileEntity) {
+        return coverBehavior.letsFluidOut(aSide, aCoverID, aCoverVariable, null, aTileEntity);
+    }
+
+    @Override
     public boolean canConnect(byte aSide, TileEntity tTileEntity) {
         if (tTileEntity == null)
             return false;
@@ -429,7 +441,7 @@ public class GT_MetaPipeEntity_Fluid extends MetaPipeEntity {
         if (baseMetaTile == null)
             return false;
 
-        final GT_CoverBehavior coverBehavior = baseMetaTile.getCoverBehaviorAtSide(aSide);
+        final GT_CoverBehavior_New<?> coverBehavior = baseMetaTile.getCoverBehaviorAtSideNew(aSide);
         final IGregTechTileEntity gTileEntity = (tTileEntity instanceof IGregTechTileEntity) ? (IGregTechTileEntity) tTileEntity : null;
 
         if (coverBehavior instanceof GT_Cover_Drain || (GregTech_API.mTConstruct && isTConstructFaucet(tTileEntity)))
@@ -442,7 +454,7 @@ public class GT_MetaPipeEntity_Fluid extends MetaPipeEntity {
             if (tInfo != null) {
                 return tInfo.length > 0
                         || (GregTech_API.mTranslocator && isTranslocator(tTileEntity))
-                        || gTileEntity != null && gTileEntity.getCoverBehaviorAtSide(tSide) instanceof GT_Cover_FluidRegulator;
+                        || gTileEntity != null && gTileEntity.getCoverBehaviorAtSideNew(tSide) instanceof GT_Cover_FluidRegulator;
 
             }
         }

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Item.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Item.java
@@ -13,7 +13,7 @@ import gregtech.api.metatileentity.BaseMetaPipeEntity;
 import gregtech.api.metatileentity.MetaPipeEntity;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GT_CoverBehavior;
-import gregtech.api.util.GT_CoverBehavior_New;
+import gregtech.api.util.GT_CoverBehaviorBase;
 import gregtech.api.util.GT_Utility;
 import gregtech.api.util.ISerializableObject;
 import gregtech.common.GT_Client;
@@ -218,12 +218,12 @@ public class GT_MetaPipeEntity_Item extends MetaPipeEntity implements IMetaTileE
     }
 
     @Override
-    public boolean letsIn(GT_CoverBehavior_New<?> coverBehavior, byte aSide, int aCoverID, ISerializableObject aCoverVariable, ICoverable aTileEntity) {
+    public boolean letsIn(GT_CoverBehaviorBase<?> coverBehavior, byte aSide, int aCoverID, ISerializableObject aCoverVariable, ICoverable aTileEntity) {
         return coverBehavior.letsItemsIn(aSide, aCoverID, aCoverVariable, -1, aTileEntity);
     }
 
     @Override
-    public boolean letsOut(GT_CoverBehavior_New<?> coverBehavior, byte aSide, int aCoverID, ISerializableObject aCoverVariable, ICoverable aTileEntity) {
+    public boolean letsOut(GT_CoverBehaviorBase<?> coverBehavior, byte aSide, int aCoverID, ISerializableObject aCoverVariable, ICoverable aTileEntity) {
         return coverBehavior.letsItemsOut(aSide, aCoverID, aCoverVariable, -1, aTileEntity);
     }
 
@@ -283,7 +283,7 @@ public class GT_MetaPipeEntity_Item extends MetaPipeEntity implements IMetaTileE
 
     @Override
     public boolean insertItemStackIntoTileEntity(Object aSender, byte aSide) {
-        if (getBaseMetaTileEntity().getCoverBehaviorAtSideNew(aSide).letsItemsOut(aSide, getBaseMetaTileEntity().getCoverIDAtSide(aSide), getBaseMetaTileEntity().getCoverDataAtSideNew(aSide), -1, getBaseMetaTileEntity())) {
+        if (getBaseMetaTileEntity().getCoverBehaviorAtSideNew(aSide).letsItemsOut(aSide, getBaseMetaTileEntity().getCoverIDAtSide(aSide), getBaseMetaTileEntity().getComplexCoverDataAtSide(aSide), -1, getBaseMetaTileEntity())) {
             TileEntity tInventory = getBaseMetaTileEntity().getTileEntityAtSide(aSide);
             if (tInventory != null && !(tInventory instanceof BaseMetaPipeEntity)) {
                 if ((!(tInventory instanceof TileEntityHopper) && !(tInventory instanceof TileEntityDispenser)) || getBaseMetaTileEntity().getMetaIDAtSide(aSide) != GT_Utility.getOppositeSide(aSide)) {
@@ -332,7 +332,7 @@ public class GT_MetaPipeEntity_Item extends MetaPipeEntity implements IMetaTileE
     @Override
     public int[] getAccessibleSlotsFromSide(int aSide) {
         IGregTechTileEntity tTileEntity = getBaseMetaTileEntity();
-        boolean tAllow = tTileEntity.getCoverBehaviorAtSideNew((byte) aSide).letsItemsIn((byte) aSide, tTileEntity.getCoverIDAtSide((byte) aSide), tTileEntity.getCoverDataAtSideNew((byte) aSide), -2, tTileEntity) || tTileEntity.getCoverBehaviorAtSideNew((byte) aSide).letsItemsOut((byte) aSide, tTileEntity.getCoverIDAtSide((byte) aSide), tTileEntity.getCoverDataAtSideNew((byte) aSide), -2, tTileEntity);
+        boolean tAllow = tTileEntity.getCoverBehaviorAtSideNew((byte) aSide).letsItemsIn((byte) aSide, tTileEntity.getCoverIDAtSide((byte) aSide), tTileEntity.getComplexCoverDataAtSide((byte) aSide), -2, tTileEntity) || tTileEntity.getCoverBehaviorAtSideNew((byte) aSide).letsItemsOut((byte) aSide, tTileEntity.getCoverIDAtSide((byte) aSide), tTileEntity.getComplexCoverDataAtSide((byte) aSide), -2, tTileEntity);
         if (tAllow) {
             if (cacheSides == null)
                 cacheSides = super.getAccessibleSlotsFromSide(aSide);

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Item.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Item.java
@@ -13,7 +13,9 @@ import gregtech.api.metatileentity.BaseMetaPipeEntity;
 import gregtech.api.metatileentity.MetaPipeEntity;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GT_CoverBehavior;
+import gregtech.api.util.GT_CoverBehavior_New;
 import gregtech.api.util.GT_Utility;
+import gregtech.api.util.ISerializableObject;
 import gregtech.common.GT_Client;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
@@ -216,6 +218,16 @@ public class GT_MetaPipeEntity_Item extends MetaPipeEntity implements IMetaTileE
     }
 
     @Override
+    public boolean letsIn(GT_CoverBehavior_New<?> coverBehavior, byte aSide, int aCoverID, ISerializableObject aCoverVariable, ICoverable aTileEntity) {
+        return coverBehavior.letsItemsIn(aSide, aCoverID, aCoverVariable, -1, aTileEntity);
+    }
+
+    @Override
+    public boolean letsOut(GT_CoverBehavior_New<?> coverBehavior, byte aSide, int aCoverID, ISerializableObject aCoverVariable, ICoverable aTileEntity) {
+        return coverBehavior.letsItemsOut(aSide, aCoverID, aCoverVariable, -1, aTileEntity);
+    }
+
+    @Override
     public boolean canConnect(byte aSide, TileEntity tTileEntity) {
         if (tTileEntity == null) return false;
 
@@ -271,7 +283,7 @@ public class GT_MetaPipeEntity_Item extends MetaPipeEntity implements IMetaTileE
 
     @Override
     public boolean insertItemStackIntoTileEntity(Object aSender, byte aSide) {
-        if (getBaseMetaTileEntity().getCoverBehaviorAtSide(aSide).letsItemsOut(aSide, getBaseMetaTileEntity().getCoverIDAtSide(aSide), getBaseMetaTileEntity().getCoverDataAtSide(aSide), -1, getBaseMetaTileEntity())) {
+        if (getBaseMetaTileEntity().getCoverBehaviorAtSideNew(aSide).letsItemsOut(aSide, getBaseMetaTileEntity().getCoverIDAtSide(aSide), getBaseMetaTileEntity().getCoverDataAtSideNew(aSide), -1, getBaseMetaTileEntity())) {
             TileEntity tInventory = getBaseMetaTileEntity().getTileEntityAtSide(aSide);
             if (tInventory != null && !(tInventory instanceof BaseMetaPipeEntity)) {
                 if ((!(tInventory instanceof TileEntityHopper) && !(tInventory instanceof TileEntityDispenser)) || getBaseMetaTileEntity().getMetaIDAtSide(aSide) != GT_Utility.getOppositeSide(aSide)) {
@@ -320,7 +332,7 @@ public class GT_MetaPipeEntity_Item extends MetaPipeEntity implements IMetaTileE
     @Override
     public int[] getAccessibleSlotsFromSide(int aSide) {
         IGregTechTileEntity tTileEntity = getBaseMetaTileEntity();
-        boolean tAllow = tTileEntity.getCoverBehaviorAtSide((byte) aSide).letsItemsIn((byte) aSide, tTileEntity.getCoverIDAtSide((byte) aSide), tTileEntity.getCoverDataAtSide((byte) aSide), -2, tTileEntity) || tTileEntity.getCoverBehaviorAtSide((byte) aSide).letsItemsOut((byte) aSide, tTileEntity.getCoverIDAtSide((byte) aSide), tTileEntity.getCoverDataAtSide((byte) aSide), -2, tTileEntity);
+        boolean tAllow = tTileEntity.getCoverBehaviorAtSideNew((byte) aSide).letsItemsIn((byte) aSide, tTileEntity.getCoverIDAtSide((byte) aSide), tTileEntity.getCoverDataAtSideNew((byte) aSide), -2, tTileEntity) || tTileEntity.getCoverBehaviorAtSideNew((byte) aSide).letsItemsOut((byte) aSide, tTileEntity.getCoverIDAtSide((byte) aSide), tTileEntity.getCoverDataAtSideNew((byte) aSide), -2, tTileEntity);
         if (tAllow) {
             if (cacheSides == null)
                 cacheSides = super.getAccessibleSlotsFromSide(aSide);

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicMachine.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicMachine.java
@@ -10,6 +10,7 @@ import gregtech.api.interfaces.metatileentity.IMachineCallback;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.objects.GT_ItemStack;
 import gregtech.api.render.TextureFactory;
+import gregtech.api.util.GT_CoverBehavior_New;
 import gregtech.api.util.GT_Log;
 import gregtech.api.util.GT_OreDictUnificator;
 import gregtech.api.util.GT_Recipe;
@@ -823,8 +824,9 @@ public abstract class GT_MetaTileEntity_BasicMachine extends GT_MetaTileEntity_B
 
     @Override
     public boolean allowCoverOnSide(byte aSide, GT_ItemStack aCoverID) {
-        return (aSide != mMainFacing || GregTech_API.getCoverBehavior(aCoverID.toStack()).isGUIClickable(aSide, GT_Utility.stackToInt(aCoverID.toStack()), 0, getBaseMetaTileEntity()));
-    }
+        if (aSide != mMainFacing) return true;
+        GT_CoverBehavior_New<?> tBehavior = GregTech_API.getCoverBehaviorNew(aCoverID.toStack());
+        return tBehavior.isGUIClickable(aSide, GT_Utility.stackToInt(aCoverID.toStack()), tBehavior.createDataObject(), getBaseMetaTileEntity());}
 
     @Override
     public boolean allowPullStack(IGregTechTileEntity aBaseMetaTileEntity, int aIndex, byte aSide, ItemStack aStack) {

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicMachine.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicMachine.java
@@ -10,7 +10,7 @@ import gregtech.api.interfaces.metatileentity.IMachineCallback;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.objects.GT_ItemStack;
 import gregtech.api.render.TextureFactory;
-import gregtech.api.util.GT_CoverBehavior_New;
+import gregtech.api.util.GT_CoverBehaviorBase;
 import gregtech.api.util.GT_Log;
 import gregtech.api.util.GT_OreDictUnificator;
 import gregtech.api.util.GT_Recipe;
@@ -825,7 +825,7 @@ public abstract class GT_MetaTileEntity_BasicMachine extends GT_MetaTileEntity_B
     @Override
     public boolean allowCoverOnSide(byte aSide, GT_ItemStack aCoverID) {
         if (aSide != mMainFacing) return true;
-        GT_CoverBehavior_New<?> tBehavior = GregTech_API.getCoverBehaviorNew(aCoverID.toStack());
+        GT_CoverBehaviorBase<?> tBehavior = GregTech_API.getCoverBehaviorNew(aCoverID.toStack());
         return tBehavior.isGUIClickable(aSide, GT_Utility.stackToInt(aCoverID.toStack()), tBehavior.createDataObject(), getBaseMetaTileEntity());}
 
     @Override

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicMachine_Bronze.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicMachine_Bronze.java
@@ -186,7 +186,7 @@ public abstract class GT_MetaTileEntity_BasicMachine_Bronze extends GT_MetaTileE
 
     @Override
     public boolean allowCoverOnSide(byte aSide, GT_ItemStack aCoverID) {
-        return GregTech_API.getCoverBehavior(aCoverID.toStack()).isSimpleCover() && super.allowCoverOnSide(aSide, aCoverID);
+        return GregTech_API.getCoverBehaviorNew(aCoverID.toStack()).isSimpleCover() && super.allowCoverOnSide(aSide, aCoverID);
     }
 
     public float getSteamDamage() {

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_InputBus.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_InputBus.java
@@ -185,7 +185,7 @@ public class GT_MetaTileEntity_Hatch_InputBus extends GT_MetaTileEntity_Hatch {
 
     @Override
     public void onScrewdriverRightClick(byte aSide, EntityPlayer aPlayer, float aX, float aY, float aZ) {
-        if (!getBaseMetaTileEntity().getCoverBehaviorAtSide(aSide).isGUIClickable(aSide, getBaseMetaTileEntity().getCoverIDAtSide(aSide), getBaseMetaTileEntity().getCoverDataAtSide(aSide), getBaseMetaTileEntity()))
+        if (!getBaseMetaTileEntity().getCoverBehaviorAtSideNew(aSide).isGUIClickable(aSide, getBaseMetaTileEntity().getCoverIDAtSide(aSide), getBaseMetaTileEntity().getCoverDataAtSideNew(aSide), getBaseMetaTileEntity()))
             return;
         if (aPlayer.isSneaking()) {
             if(disableSort) {

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_InputBus.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_InputBus.java
@@ -185,7 +185,7 @@ public class GT_MetaTileEntity_Hatch_InputBus extends GT_MetaTileEntity_Hatch {
 
     @Override
     public void onScrewdriverRightClick(byte aSide, EntityPlayer aPlayer, float aX, float aY, float aZ) {
-        if (!getBaseMetaTileEntity().getCoverBehaviorAtSideNew(aSide).isGUIClickable(aSide, getBaseMetaTileEntity().getCoverIDAtSide(aSide), getBaseMetaTileEntity().getCoverDataAtSideNew(aSide), getBaseMetaTileEntity()))
+        if (!getBaseMetaTileEntity().getCoverBehaviorAtSideNew(aSide).isGUIClickable(aSide, getBaseMetaTileEntity().getCoverIDAtSide(aSide), getBaseMetaTileEntity().getComplexCoverDataAtSide(aSide), getBaseMetaTileEntity()))
             return;
         if (aPlayer.isSneaking()) {
             if(disableSort) {

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_Output.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_Output.java
@@ -202,7 +202,7 @@ public class GT_MetaTileEntity_Hatch_Output extends GT_MetaTileEntity_Hatch {
 
     @Override
     public void onScrewdriverRightClick(byte aSide, EntityPlayer aPlayer, float aX, float aY, float aZ) {
-        if (!getBaseMetaTileEntity().getCoverBehaviorAtSideNew(aSide).isGUIClickable(aSide, getBaseMetaTileEntity().getCoverIDAtSide(aSide), getBaseMetaTileEntity().getCoverDataAtSideNew(aSide), getBaseMetaTileEntity()))
+        if (!getBaseMetaTileEntity().getCoverBehaviorAtSideNew(aSide).isGUIClickable(aSide, getBaseMetaTileEntity().getCoverIDAtSide(aSide), getBaseMetaTileEntity().getComplexCoverDataAtSide(aSide), getBaseMetaTileEntity()))
             return;
         if (aPlayer.isSneaking()) {
             mMode = (byte) ((mMode + 9) % 10);
@@ -269,7 +269,7 @@ public class GT_MetaTileEntity_Hatch_Output extends GT_MetaTileEntity_Hatch {
     }
 
     private boolean tryToLockHatch(EntityPlayer aPlayer, byte aSide) {
-        if (!getBaseMetaTileEntity().getCoverBehaviorAtSideNew(aSide).isGUIClickable(aSide, getBaseMetaTileEntity().getCoverIDAtSide(aSide), getBaseMetaTileEntity().getCoverDataAtSideNew(aSide), getBaseMetaTileEntity()))
+        if (!getBaseMetaTileEntity().getCoverBehaviorAtSideNew(aSide).isGUIClickable(aSide, getBaseMetaTileEntity().getCoverIDAtSide(aSide), getBaseMetaTileEntity().getComplexCoverDataAtSide(aSide), getBaseMetaTileEntity()))
             return false;
         if (!isFluidLocked())
             return false;

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_Output.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_Output.java
@@ -202,7 +202,7 @@ public class GT_MetaTileEntity_Hatch_Output extends GT_MetaTileEntity_Hatch {
 
     @Override
     public void onScrewdriverRightClick(byte aSide, EntityPlayer aPlayer, float aX, float aY, float aZ) {
-        if (!getBaseMetaTileEntity().getCoverBehaviorAtSide(aSide).isGUIClickable(aSide, getBaseMetaTileEntity().getCoverIDAtSide(aSide), getBaseMetaTileEntity().getCoverDataAtSide(aSide), getBaseMetaTileEntity()))
+        if (!getBaseMetaTileEntity().getCoverBehaviorAtSideNew(aSide).isGUIClickable(aSide, getBaseMetaTileEntity().getCoverIDAtSide(aSide), getBaseMetaTileEntity().getCoverDataAtSideNew(aSide), getBaseMetaTileEntity()))
             return;
         if (aPlayer.isSneaking()) {
             mMode = (byte) ((mMode + 9) % 10);
@@ -269,7 +269,7 @@ public class GT_MetaTileEntity_Hatch_Output extends GT_MetaTileEntity_Hatch {
     }
 
     private boolean tryToLockHatch(EntityPlayer aPlayer, byte aSide) {
-        if (!getBaseMetaTileEntity().getCoverBehaviorAtSide(aSide).isGUIClickable(aSide, getBaseMetaTileEntity().getCoverIDAtSide(aSide), getBaseMetaTileEntity().getCoverDataAtSide(aSide), getBaseMetaTileEntity()))
+        if (!getBaseMetaTileEntity().getCoverBehaviorAtSideNew(aSide).isGUIClickable(aSide, getBaseMetaTileEntity().getCoverIDAtSide(aSide), getBaseMetaTileEntity().getCoverDataAtSideNew(aSide), getBaseMetaTileEntity()))
             return false;
         if (!isFluidLocked())
             return false;

--- a/src/main/java/gregtech/api/util/GT_CoverBehavior.java
+++ b/src/main/java/gregtech/api/util/GT_CoverBehavior.java
@@ -14,7 +14,7 @@ import static gregtech.api.enums.GT_Values.E;
 /**
  * For Covers with a special behavior. Has fixed storage format of 4 byte. Not very convenient...
  */
-public abstract class GT_CoverBehavior extends GT_CoverBehavior_New<ISerializableObject.LegacyCoverData> {
+public abstract class GT_CoverBehavior extends GT_CoverBehaviorBase<ISerializableObject.LegacyCoverData> {
 
     public EntityPlayer lastPlayer = null;
 

--- a/src/main/java/gregtech/api/util/GT_CoverBehavior.java
+++ b/src/main/java/gregtech/api/util/GT_CoverBehavior.java
@@ -3,20 +3,178 @@ package gregtech.api.util;
 import gregtech.api.enums.GT_Values;
 import gregtech.api.interfaces.tileentity.ICoverable;
 import gregtech.api.net.GT_Packet_TileEntityCoverGUI;
-import gregtech.api.objects.GT_ItemStack;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
 import net.minecraftforge.fluids.Fluid;
 
 import static gregtech.api.enums.GT_Values.E;
 
 /**
- * For Covers with a special behavior.
+ * For Covers with a special behavior. Has fixed storage format of 4 byte. Not very convenient...
  */
-public abstract class GT_CoverBehavior {
+public abstract class GT_CoverBehavior extends GT_CoverBehavior_New<ISerializableObject.LegacyCoverData> {
 
     public EntityPlayer lastPlayer = null;
+
+    public GT_CoverBehavior() {
+        super(ISerializableObject.LegacyCoverData.class);
+    }
+
+    private static int convert(ISerializableObject.LegacyCoverData data) {
+        return data == null ? 0 : data.get();
+    }
+
+    // region bridge the parent call to legacy calls
+
+    @Override
+    public final ISerializableObject.LegacyCoverData createDataObject() {
+        return new ISerializableObject.LegacyCoverData();
+    }
+
+    @Override
+    public ISerializableObject.LegacyCoverData createDataObject(int aLegacyData) {
+        return new ISerializableObject.LegacyCoverData(aLegacyData);
+    }
+
+    @Override
+    protected boolean isRedstoneSensitiveImpl(byte aSide, int aCoverID, ISerializableObject.LegacyCoverData aCoverVariable, ICoverable aTileEntity, long aTimer) {
+        return isRedstoneSensitive(aSide, aCoverID, aCoverVariable.get(), aTileEntity, aTimer);
+    }
+
+    @Override
+    protected ISerializableObject.LegacyCoverData doCoverThingsImpl(byte aSide, byte aInputRedstone, int aCoverID, ISerializableObject.LegacyCoverData aCoverVariable, ICoverable aTileEntity, long aTimer) {
+        if (aCoverVariable == null)
+            aCoverVariable = new ISerializableObject.LegacyCoverData();
+        aCoverVariable.set(doCoverThings(aSide, aInputRedstone, aCoverID, aCoverVariable.get(), aTileEntity, aTimer));
+        return aCoverVariable;
+    }
+
+    @Override
+    protected boolean onCoverRightClickImpl(byte aSide, int aCoverID, ISerializableObject.LegacyCoverData aCoverVariable, ICoverable aTileEntity, EntityPlayer aPlayer, float aX, float aY, float aZ) {
+        return onCoverRightclick(aSide, aCoverID, convert(aCoverVariable), aTileEntity, aPlayer, aX, aY, aZ);
+    }
+
+    @Override
+    protected ISerializableObject.LegacyCoverData onCoverScrewdriverClickImpl(byte aSide, int aCoverID, ISerializableObject.LegacyCoverData aCoverVariable, ICoverable aTileEntity, EntityPlayer aPlayer, float aX, float aY, float aZ) {
+        if (aCoverVariable == null)
+            aCoverVariable = new ISerializableObject.LegacyCoverData();
+        aCoverVariable.set(onCoverScrewdriverclick(aSide, aCoverID, convert(aCoverVariable), aTileEntity, aPlayer, aX, aY, aZ));
+        return aCoverVariable;
+    }
+
+    @Override
+    protected boolean onCoverShiftRightClickImpl(byte aSide, int aCoverID, ISerializableObject.LegacyCoverData aCoverVariable, ICoverable aTileEntity, EntityPlayer aPlayer) {
+        return onCoverShiftRightclick(aSide, aCoverID, convert(aCoverVariable), aTileEntity, aPlayer);
+    }
+
+    @Override
+    protected Object getClientGUIImpl(byte aSide, int aCoverID, ISerializableObject.LegacyCoverData aCoverVariable, ICoverable aTileEntity, EntityPlayer aPlayer, World aWorld) {
+        return getClientGUI(aSide, aCoverID, convert(aCoverVariable), aTileEntity);
+    }
+
+    @Override
+    protected boolean onCoverRemovalImpl(byte aSide, int aCoverID, ISerializableObject.LegacyCoverData aCoverVariable, ICoverable aTileEntity, boolean aForced) {
+        return onCoverRemoval(aSide, aCoverID, convert(aCoverVariable), aTileEntity, aForced);
+    }
+
+    @Override
+    protected String getDescriptionImpl(byte aSide, int aCoverID, ISerializableObject.LegacyCoverData aCoverVariable, ICoverable aTileEntity) {
+        return getDescription(aSide, aCoverID, convert(aCoverVariable), aTileEntity);
+    }
+
+    @Override
+    protected float getBlastProofLevelImpl(byte aSide, int aCoverID, ISerializableObject.LegacyCoverData aCoverVariable, ICoverable aTileEntity) {
+        return getBlastProofLevel(aSide, aCoverID, convert(aCoverVariable), aTileEntity);
+    }
+
+    @Override
+    protected boolean letsRedstoneGoInImpl(byte aSide, int aCoverID, ISerializableObject.LegacyCoverData aCoverVariable, ICoverable aTileEntity) {
+        return letsRedstoneGoIn(aSide, aCoverID, convert(aCoverVariable), aTileEntity);
+    }
+
+    @Override
+    protected boolean letsRedstoneGoOutImpl(byte aSide, int aCoverID, ISerializableObject.LegacyCoverData aCoverVariable, ICoverable aTileEntity) {
+        return letsRedstoneGoOut(aSide, aCoverID, convert(aCoverVariable), aTileEntity);
+    }
+
+    @Override
+    protected boolean letsFibreGoInImpl(byte aSide, int aCoverID, ISerializableObject.LegacyCoverData aCoverVariable, ICoverable aTileEntity) {
+        return letsFibreGoIn(aSide, aCoverID, convert(aCoverVariable), aTileEntity);
+    }
+
+    @Override
+    protected boolean letsFibreGoOutImpl(byte aSide, int aCoverID, ISerializableObject.LegacyCoverData aCoverVariable, ICoverable aTileEntity) {
+        return letsFibreGoOut(aSide, aCoverID, convert(aCoverVariable), aTileEntity);
+    }
+
+    @Override
+    protected boolean letsEnergyInImpl(byte aSide, int aCoverID, ISerializableObject.LegacyCoverData aCoverVariable, ICoverable aTileEntity) {
+        return letsEnergyIn(aSide, aCoverID, convert(aCoverVariable), aTileEntity);
+    }
+
+    @Override
+    protected boolean letsEnergyOutImpl(byte aSide, int aCoverID, ISerializableObject.LegacyCoverData aCoverVariable, ICoverable aTileEntity) {
+        return letsEnergyOut(aSide, aCoverID, convert(aCoverVariable), aTileEntity);
+    }
+
+    @Override
+    protected boolean letsFluidInImpl(byte aSide, int aCoverID, ISerializableObject.LegacyCoverData aCoverVariable, Fluid aFluid, ICoverable aTileEntity) {
+        return letsFluidIn(aSide, aCoverID, convert(aCoverVariable), aFluid, aTileEntity);
+    }
+
+    @Override
+    protected boolean letsFluidOutImpl(byte aSide, int aCoverID, ISerializableObject.LegacyCoverData aCoverVariable, Fluid aFluid, ICoverable aTileEntity) {
+        return letsFluidOut(aSide, aCoverID, convert(aCoverVariable), aFluid, aTileEntity);
+    }
+
+    @Override
+    protected boolean letsItemsInImpl(byte aSide, int aCoverID, ISerializableObject.LegacyCoverData aCoverVariable, int aSlot, ICoverable aTileEntity) {
+        return letsItemsIn(aSide, aCoverID, convert(aCoverVariable), aSlot, aTileEntity);
+    }
+
+    @Override
+    protected boolean letsItemsOutImpl(byte aSide, int aCoverID, ISerializableObject.LegacyCoverData aCoverVariable, int aSlot, ICoverable aTileEntity) {
+        return letsItemsOut(aSide, aCoverID, convert(aCoverVariable), aSlot, aTileEntity);
+    }
+
+    @Override
+    protected boolean isGUIClickableImpl(byte aSide, int aCoverID, ISerializableObject.LegacyCoverData aCoverVariable, ICoverable aTileEntity) {
+        return isGUIClickable(aSide, aCoverID, convert(aCoverVariable), aTileEntity);
+    }
+
+    @Override
+    protected boolean manipulatesSidedRedstoneOutputImpl(byte aSide, int aCoverID, ISerializableObject.LegacyCoverData aCoverVariable, ICoverable aTileEntity) {
+        return manipulatesSidedRedstoneOutput(aSide, aCoverID, convert(aCoverVariable), aTileEntity);
+    }
+
+    @Override
+    protected boolean alwaysLookConnectedImpl(byte aSide, int aCoverID, ISerializableObject.LegacyCoverData aCoverVariable, ICoverable aTileEntity) {
+        return alwaysLookConnected(aSide, aCoverID, convert(aCoverVariable), aTileEntity);
+    }
+
+    @Override
+    protected byte getRedstoneInputImpl(byte aSide, byte aInputRedstone, int aCoverID, ISerializableObject.LegacyCoverData aCoverVariable, ICoverable aTileEntity) {
+        return getRedstoneInput(aSide, aInputRedstone, aCoverID, convert(aCoverVariable), aTileEntity);
+    }
+
+    @Override
+    protected int getTickRateImpl(byte aSide, int aCoverID, ISerializableObject.LegacyCoverData aCoverVariable, ICoverable aTileEntity) {
+        return getTickRate(aSide, aCoverID, convert(aCoverVariable), aTileEntity);
+    }
+
+    @Override
+    protected byte getLensColorImpl(byte aSide, int aCoverID, ISerializableObject.LegacyCoverData aCoverVariable, ICoverable aTileEntity) {
+        return getLensColor(aSide, aCoverID, convert(aCoverVariable), aTileEntity);
+    }
+
+    @Override
+    protected ItemStack getDropImpl(byte aSide, int aCoverID, ISerializableObject.LegacyCoverData aCoverVariable, ICoverable aTileEntity) {
+        return getDrop(aSide, aCoverID, convert(aCoverVariable), aTileEntity);
+    }
+
+    // endregion
 
     public boolean isRedstoneSensitive(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
         return true;
@@ -35,15 +193,6 @@ public abstract class GT_CoverBehavior {
      * return true, if something actually happens.
      */
     public boolean onCoverRightclick(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, EntityPlayer aPlayer, float aX, float aY, float aZ) {
-        return false;
-    }
-
-    /**
-     * Called when someone rightclicks this Cover Client Side
-     * <p/>
-     * return true, if something actually happens.
-     */
-    public boolean onCoverRightclickClient(byte aSide, ICoverable aTileEntity, EntityPlayer aPlayer, float aX, float aY, float aZ) {
         return false;
     }
 
@@ -68,19 +217,8 @@ public abstract class GT_CoverBehavior {
         return false;
     }
 
-    public boolean hasCoverGUI() {
-        return false;
-    }
-
     public Object getClientGUI(byte aSide, int aCoverID, int coverData, ICoverable aTileEntity) {
         return null;
-    }
-
-    /**
-     * Checks if the Cover can be placed on this.
-     */
-    public boolean isCoverPlaceable(byte aSide, GT_ItemStack aStack, ICoverable aTileEntity) {
-        return true;
     }
 
     /**
@@ -219,13 +357,6 @@ public abstract class GT_CoverBehavior {
     }
 
     /**
-     * If this is a simple Cover, which can also be used on Bronze Machines and similar.
-     */
-    public boolean isSimpleCover() {
-        return false;
-    }
-
-    /**
      * The MC Color of this Lens. -1 for no Color (meaning this isn't a Lens then).
      */
     public byte getLensColor(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity) {
@@ -237,16 +368,5 @@ public abstract class GT_CoverBehavior {
      */
     public ItemStack getDrop(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity) {
         return GT_OreDictUnificator.get(true, aTileEntity.getCoverItemAtSide(aSide));
-    }
-
-    /**
-     * @return sets the Cover upon placement.
-     */
-    public void placeCover(byte aSide, ItemStack aCover, ICoverable aTileEntity) {
-        aTileEntity.setCoverIDAtSide(aSide, GT_Utility.stackToInt(aCover));
-    }
-    
-    public String trans(String aNr, String aEnglish){
-    	return GT_LanguageManager.addStringLocalization("Interaction_DESCRIPTION_Index_"+aNr, aEnglish, false);
     }
 }

--- a/src/main/java/gregtech/api/util/GT_CoverBehaviorBase.java
+++ b/src/main/java/gregtech/api/util/GT_CoverBehaviorBase.java
@@ -18,12 +18,12 @@ import static gregtech.api.enums.GT_Values.E;
  *
  * @author glease
  */
-public abstract class GT_CoverBehavior_New<T extends ISerializableObject> {
+public abstract class GT_CoverBehaviorBase<T extends ISerializableObject> {
 
     public EntityPlayer lastPlayer = null;
     private final Class<T> typeToken;
 
-    protected GT_CoverBehavior_New(Class<T> typeToken) {
+    protected GT_CoverBehaviorBase(Class<T> typeToken) {
         this.typeToken = typeToken;
     }
 

--- a/src/main/java/gregtech/api/util/GT_CoverBehavior_New.java
+++ b/src/main/java/gregtech/api/util/GT_CoverBehavior_New.java
@@ -1,0 +1,480 @@
+package gregtech.api.util;
+
+import gregtech.api.enums.GT_Values;
+import gregtech.api.interfaces.tileentity.ICoverable;
+import gregtech.api.net.GT_Packet_TileEntityCoverGUI;
+import gregtech.api.objects.GT_ItemStack;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTBase;
+import net.minecraft.world.World;
+import net.minecraftforge.fluids.Fluid;
+
+import static gregtech.api.enums.GT_Values.E;
+
+/**
+ * For Covers with a special behavior.
+ */
+public abstract class GT_CoverBehavior_New<T extends ISerializableObject> {
+
+    public EntityPlayer lastPlayer = null;
+    private final Class<T> typeToken;
+
+    protected GT_CoverBehavior_New(Class<T> typeToken) {
+        this.typeToken = typeToken;
+    }
+
+    public abstract T createDataObject(int aLegacyData);
+
+    public abstract T createDataObject();
+
+    public T createDataObject(NBTBase aNBT) {
+        T ret = createDataObject();
+        ret.loadDataFromNBT(aNBT);
+        return ret;
+    }
+
+    public final T cast(ISerializableObject aData) {
+        if (typeToken.isInstance(aData))
+            return forceCast(aData);
+        return null;
+    }
+
+    private T forceCast(ISerializableObject aData) {
+        return typeToken.cast(aData);
+    }
+
+    // region facade
+
+    public final boolean isRedstoneSensitive(byte aSide, int aCoverID, ISerializableObject aCoverVariable, ICoverable aTileEntity, long aTimer) {
+        return isRedstoneSensitiveImpl(aSide, aCoverID, forceCast(aCoverVariable), aTileEntity, aTimer);
+    }
+
+    /**
+     * Called by updateEntity inside the covered TileEntity. aCoverVariable is the Value you returned last time.
+     */
+    public final T doCoverThings(byte aSide, byte aInputRedstone, int aCoverID, ISerializableObject aCoverVariable, ICoverable aTileEntity, long aTimer) {
+        return doCoverThingsImpl(aSide, aInputRedstone, aCoverID, forceCast(aCoverVariable), aTileEntity, aTimer);
+    }
+
+    /**
+     * Called when someone rightclicks this Cover.
+     * <p/>
+     * return true, if something actually happens.
+     */
+    public final boolean onCoverRightClick(byte aSide, int aCoverID, ISerializableObject aCoverVariable, ICoverable aTileEntity, EntityPlayer aPlayer, float aX, float aY, float aZ) {
+        return onCoverRightClickImpl(aSide, aCoverID, forceCast(aCoverVariable), aTileEntity, aPlayer, aX, aY, aZ);
+    }
+
+    /**
+     * Called when someone rightclicks this Cover with a Screwdriver. Doesn't call @onCoverRightclick in this Case.
+     * <p/>
+     * return the new Value of the Cover Variable
+     */
+    public final T onCoverScrewdriverClick(byte aSide, int aCoverID, ISerializableObject aCoverVariable, ICoverable aTileEntity, EntityPlayer aPlayer, float aX, float aY, float aZ) {
+        return onCoverScrewdriverClickImpl(aSide, aCoverID, forceCast(aCoverVariable), aTileEntity, aPlayer, aX, aY, aZ);
+    }
+
+    /**
+     * Called when someone shift-rightclicks this Cover with no tool. Doesn't call @onCoverRightclick in this Case.
+     */
+    public final boolean onCoverShiftRightClick(byte aSide, int aCoverID, ISerializableObject aCoverVariable, ICoverable aTileEntity, EntityPlayer aPlayer) {
+        return onCoverShiftRightClickImpl(aSide, aCoverID, forceCast(aCoverVariable), aTileEntity, aPlayer);
+    }
+
+    public final Object getClientGUI(byte aSide, int aCoverID, ISerializableObject aCoverVariable, ICoverable aTileEntity, EntityPlayer aPlayer, World aWorld) {
+        return getClientGUIImpl(aSide, aCoverID, forceCast(aCoverVariable), aTileEntity, aPlayer, aWorld);
+    }
+
+    /**
+     * Removes the Cover if this returns true, or if aForced is true.
+     * Doesn't get called when the Machine Block is getting broken, only if you break the Cover away from the Machine.
+     */
+    public final boolean onCoverRemoval(byte aSide, int aCoverID, ISerializableObject aCoverVariable, ICoverable aTileEntity, boolean aForced) {
+        return onCoverRemovalImpl(aSide, aCoverID, forceCast(aCoverVariable), aTileEntity, aForced);
+    }
+
+    /**
+     * Gives a small Text for the status of the Cover.
+     */
+    public final String getDescription(byte aSide, int aCoverID, ISerializableObject aCoverVariable, ICoverable aTileEntity) {
+        return getDescriptionImpl(aSide, aCoverID, forceCast(aCoverVariable), aTileEntity);
+    }
+
+    /**
+     * How Blast Proof the Cover is. 30 is normal.
+     */
+    public final float getBlastProofLevel(byte aSide, int aCoverID, ISerializableObject aCoverVariable, ICoverable aTileEntity) {
+        return getBlastProofLevelImpl(aSide, aCoverID, forceCast(aCoverVariable), aTileEntity);
+    }
+
+    /**
+     * If it lets RS-Signals into the Block
+     * <p/>
+     * This is just Informative so that Machines know if their Redstone Input is blocked or not
+     */
+    public final boolean letsRedstoneGoIn(byte aSide, int aCoverID, ISerializableObject aCoverVariable, ICoverable aTileEntity) {
+        return letsRedstoneGoInImpl(aSide, aCoverID, forceCast(aCoverVariable), aTileEntity);
+    }
+
+    /**
+     * If it lets RS-Signals out of the Block
+     */
+    public final boolean letsRedstoneGoOut(byte aSide, int aCoverID, ISerializableObject aCoverVariable, ICoverable aTileEntity) {
+        return letsRedstoneGoOutImpl(aSide, aCoverID, forceCast(aCoverVariable), aTileEntity);
+    }
+
+    /**
+     * If it lets Fibre-Signals into the Block
+     * <p/>
+     * This is just Informative so that Machines know if their Redstone Input is blocked or not
+     */
+    public final boolean letsFibreGoIn(byte aSide, int aCoverID, ISerializableObject aCoverVariable, ICoverable aTileEntity) {
+        return letsFibreGoInImpl(aSide, aCoverID, forceCast(aCoverVariable), aTileEntity);
+    }
+
+    /**
+     * If it lets Fibre-Signals out of the Block
+     */
+    public final boolean letsFibreGoOut(byte aSide, int aCoverID, ISerializableObject aCoverVariable, ICoverable aTileEntity) {
+        return letsFibreGoOutImpl(aSide, aCoverID, forceCast(aCoverVariable), aTileEntity);
+    }
+
+    /**
+     * If it lets Energy into the Block
+     */
+    public final boolean letsEnergyIn(byte aSide, int aCoverID, ISerializableObject aCoverVariable, ICoverable aTileEntity) {
+        return letsEnergyInImpl(aSide, aCoverID, forceCast(aCoverVariable), aTileEntity);
+    }
+
+    /**
+     * If it lets Energy out of the Block
+     */
+    public final boolean letsEnergyOut(byte aSide, int aCoverID, ISerializableObject aCoverVariable, ICoverable aTileEntity) {
+        return letsEnergyOutImpl(aSide, aCoverID, forceCast(aCoverVariable), aTileEntity);
+    }
+
+    /**
+     * If it lets Liquids into the Block, aFluid can be null meaning if this is generally allowing Fluids or not.
+     */
+    public final boolean letsFluidIn(byte aSide, int aCoverID, ISerializableObject aCoverVariable, Fluid aFluid, ICoverable aTileEntity) {
+        return letsFluidInImpl(aSide, aCoverID, forceCast(aCoverVariable), aFluid, aTileEntity);
+    }
+
+    /**
+     * If it lets Liquids out of the Block, aFluid can be null meaning if this is generally allowing Fluids or not.
+     */
+    public final boolean letsFluidOut(byte aSide, int aCoverID, ISerializableObject aCoverVariable, Fluid aFluid, ICoverable aTileEntity) {
+        return letsFluidOutImpl(aSide, aCoverID, forceCast(aCoverVariable), aFluid, aTileEntity);
+    }
+
+    /**
+     * If it lets Items into the Block, aSlot = -1 means if it is generally accepting Items (return false for no eraction at all), aSlot = -2 means if it would accept for all Slots Impl(return true to skip the Checks for each Slot).
+     */
+    public final boolean letsItemsIn(byte aSide, int aCoverID, ISerializableObject aCoverVariable, int aSlot, ICoverable aTileEntity) {
+        return letsItemsInImpl(aSide, aCoverID, forceCast(aCoverVariable), aSlot, aTileEntity);
+    }
+
+    /**
+     * If it lets Items out of the Block, aSlot = -1 means if it is generally accepting Items (return false for no eraction at all), aSlot = -2 means if it would accept for all Slots Impl(return true to skip the Checks for each Slot).
+     */
+    public final boolean letsItemsOut(byte aSide, int aCoverID, ISerializableObject aCoverVariable, int aSlot, ICoverable aTileEntity) {
+        return letsItemsOutImpl(aSide, aCoverID, forceCast(aCoverVariable), aSlot, aTileEntity);
+    }
+
+    /**
+     * If it lets you rightclick the Machine normally
+     */
+    public final boolean isGUIClickable(byte aSide, int aCoverID, ISerializableObject aCoverVariable, ICoverable aTileEntity) {
+        return isGUIClickableImpl(aSide, aCoverID, forceCast(aCoverVariable), aTileEntity);
+    }
+
+    /**
+     * Needs to return true for Covers, which have a Redstone Output on their Facing.
+     */
+    public final boolean manipulatesSidedRedstoneOutput(byte aSide, int aCoverID, ISerializableObject aCoverVariable, ICoverable aTileEntity) {
+        return manipulatesSidedRedstoneOutputImpl(aSide, aCoverID, forceCast(aCoverVariable), aTileEntity);
+    }
+
+    /**
+     * if this Cover should let Pipe Connections look connected even if it is not the case.
+     */
+    public final boolean alwaysLookConnected(byte aSide, int aCoverID, ISerializableObject aCoverVariable, ICoverable aTileEntity) {
+        return alwaysLookConnectedImpl(aSide, aCoverID, forceCast(aCoverVariable), aTileEntity);
+    }
+
+    /**
+     * Called to determine the incoming Redstone Signal of a Machine.
+     * Returns the original Redstone per default.
+     * The Cover should @letsRedstoneGoIn or the aInputRedstone Parameter is always 0.
+     */
+    public final byte getRedstoneInput(byte aSide, byte aInputRedstone, int aCoverID, ISerializableObject aCoverVariable, ICoverable aTileEntity) {
+        return getRedstoneInputImpl(aSide, aInputRedstone, aCoverID, forceCast(aCoverVariable), aTileEntity);
+    }
+
+    /**
+     * Gets the Tick Rate for doCoverThings of the Cover
+     * <p/>
+     * 0 = No Ticks! Yes, 0 is Default, you have to override this
+     */
+    public final int getTickRate(byte aSide, int aCoverID, ISerializableObject aCoverVariable, ICoverable aTileEntity) {
+        return getTickRateImpl(aSide, aCoverID, forceCast(aCoverVariable), aTileEntity);
+    }
+
+
+    /**
+     * The MC Color of this Lens. -1 for no Color (meaning this isn't a Lens then).
+     */
+    public final byte getLensColor(byte aSide, int aCoverID, ISerializableObject aCoverVariable, ICoverable aTileEntity) {
+        return getLensColorImpl(aSide, aCoverID, forceCast(aCoverVariable), aTileEntity);
+    }
+
+    /**
+     * @return the ItemStack dropped by this Cover
+     */
+    public final ItemStack getDrop(byte aSide, int aCoverID, ISerializableObject aCoverVariable, ICoverable aTileEntity) {
+        return getDropImpl(aSide, aCoverID, forceCast(aCoverVariable), aTileEntity);
+    }
+    // endregion
+
+    // region impl
+
+    protected boolean isRedstoneSensitiveImpl(byte aSide, int aCoverID, T aCoverVariable, ICoverable aTileEntity, long aTimer) {
+        return true;
+    }
+
+    /**
+     * Called by updateEntity inside the covered TileEntity. aCoverVariable is the Value you returned last time.
+     */
+    protected T doCoverThingsImpl(byte aSide, byte aInputRedstone, int aCoverID, T aCoverVariable, ICoverable aTileEntity, long aTimer) {
+        return aCoverVariable;
+    }
+
+    /**
+     * Called when someone rightclicks this Cover.
+     * <p/>
+     * return true, if something actually happens.
+     */
+    protected boolean onCoverRightClickImpl(byte aSide, int aCoverID, T aCoverVariable, ICoverable aTileEntity, EntityPlayer aPlayer, float aX, float aY, float aZ) {
+        return false;
+    }
+
+    /**
+     * Called when someone rightclicks this Cover with a Screwdriver. Doesn't call @onCoverRightclick in this Case.
+     * <p/>
+     * return the new Value of the Cover Variable
+     */
+    protected T onCoverScrewdriverClickImpl(byte aSide, int aCoverID, T aCoverVariable, ICoverable aTileEntity, EntityPlayer aPlayer, float aX, float aY, float aZ) {
+        return aCoverVariable;
+    }
+
+    /**
+     * Called when someone shift-rightclicks this Cover with no tool. Doesn't call @onCoverRightclick in this Case.
+     */
+    protected boolean onCoverShiftRightClickImpl(byte aSide, int aCoverID, T aCoverVariable, ICoverable aTileEntity, EntityPlayer aPlayer) {
+        if (hasCoverGUI() && aPlayer instanceof EntityPlayerMP) {
+            lastPlayer = aPlayer;
+            GT_Values.NW.sendToPlayer(new GT_Packet_TileEntityCoverGUI(aSide, aCoverID, aCoverVariable, aTileEntity, (EntityPlayerMP) aPlayer), (EntityPlayerMP) aPlayer);
+            return true;
+        }
+        return false;
+    }
+
+    protected Object getClientGUIImpl(byte aSide, int aCoverID, T aCoverVariable, ICoverable aTileEntity, EntityPlayer aPlayer, World aWorld) {
+        return null;
+    }
+
+    /**
+     * Removes the Cover if this returns true, or if aForced is true.
+     * Doesn't get called when the Machine Block is getting broken, only if you break the Cover away from the Machine.
+     */
+    protected boolean onCoverRemovalImpl(byte aSide, int aCoverID, T aCoverVariable, ICoverable aTileEntity, boolean aForced) {
+        return true;
+    }
+
+    /**
+     * Gives a small Text for the status of the Cover.
+     */
+    protected String getDescriptionImpl(byte aSide, int aCoverID, T aCoverVariable, ICoverable aTileEntity) {
+        return E;
+    }
+
+    /**
+     * How Blast Proof the Cover is. 30 is normal.
+     */
+    protected float getBlastProofLevelImpl(byte aSide, int aCoverID, T aCoverVariable, ICoverable aTileEntity) {
+        return 10.0F;
+    }
+
+    /**
+     * If it lets RS-Signals into the Block
+     * <p/>
+     * This is just Informative so that Machines know if their Redstone Input is blocked or not
+     */
+    protected boolean letsRedstoneGoInImpl(byte aSide, int aCoverID, T aCoverVariable, ICoverable aTileEntity) {
+        return false;
+    }
+
+    /**
+     * If it lets RS-Signals out of the Block
+     */
+    protected boolean letsRedstoneGoOutImpl(byte aSide, int aCoverID, T aCoverVariable, ICoverable aTileEntity) {
+        return false;
+    }
+
+    /**
+     * If it lets Fibre-Signals into the Block
+     * <p/>
+     * This is just Informative so that Machines know if their Redstone Input is blocked or not
+     */
+    protected boolean letsFibreGoInImpl(byte aSide, int aCoverID, T aCoverVariable, ICoverable aTileEntity) {
+        return false;
+    }
+
+    /**
+     * If it lets Fibre-Signals out of the Block
+     */
+    protected boolean letsFibreGoOutImpl(byte aSide, int aCoverID, T aCoverVariable, ICoverable aTileEntity) {
+        return false;
+    }
+
+    /**
+     * If it lets Energy into the Block
+     */
+    protected boolean letsEnergyInImpl(byte aSide, int aCoverID, T aCoverVariable, ICoverable aTileEntity) {
+        return false;
+    }
+
+    /**
+     * If it lets Energy out of the Block
+     */
+    protected boolean letsEnergyOutImpl(byte aSide, int aCoverID, T aCoverVariable, ICoverable aTileEntity) {
+        return false;
+    }
+
+    /**
+     * If it lets Liquids into the Block, aFluid can be null meaning if this is generally allowing Fluids or not.
+     */
+    protected boolean letsFluidInImpl(byte aSide, int aCoverID, T aCoverVariable, Fluid aFluid, ICoverable aTileEntity) {
+        return false;
+    }
+
+    /**
+     * If it lets Liquids out of the Block, aFluid can be null meaning if this is generally allowing Fluids or not.
+     */
+    protected boolean letsFluidOutImpl(byte aSide, int aCoverID, T aCoverVariable, Fluid aFluid, ICoverable aTileEntity) {
+        return false;
+    }
+
+    /**
+     * If it lets Items into the Block, aSlot = -1 means if it is generally accepting Items (return false for no Interaction at all), aSlot = -2 means if it would accept for all Slots (return true to skip the Checks for each Slot).
+     */
+    protected boolean letsItemsInImpl(byte aSide, int aCoverID, T aCoverVariable, int aSlot, ICoverable aTileEntity) {
+        return false;
+    }
+
+    /**
+     * If it lets Items out of the Block, aSlot = -1 means if it is generally accepting Items (return false for no Interaction at all), aSlot = -2 means if it would accept for all Slots (return true to skip the Checks for each Slot).
+     */
+    protected boolean letsItemsOutImpl(byte aSide, int aCoverID, T aCoverVariable, int aSlot, ICoverable aTileEntity) {
+        return false;
+    }
+
+    /**
+     * If it lets you rightclick the Machine normally
+     */
+    protected boolean isGUIClickableImpl(byte aSide, int aCoverID, T aCoverVariable, ICoverable aTileEntity) {
+        return false;
+    }
+
+    /**
+     * Needs to return true for Covers, which have a Redstone Output on their Facing.
+     */
+    protected boolean manipulatesSidedRedstoneOutputImpl(byte aSide, int aCoverID, T aCoverVariable, ICoverable aTileEntity) {
+        return false;
+    }
+
+    /**
+     * if this Cover should let Pipe Connections look connected even if it is not the case.
+     */
+    protected boolean alwaysLookConnectedImpl(byte aSide, int aCoverID, T aCoverVariable, ICoverable aTileEntity) {
+        return false;
+    }
+
+    /**
+     * Called to determine the incoming Redstone Signal of a Machine.
+     * Returns the original Redstone per default.
+     * The Cover should @letsRedstoneGoIn or the aInputRedstone Parameter is always 0.
+     */
+    protected byte getRedstoneInputImpl(byte aSide, byte aInputRedstone, int aCoverID, T aCoverVariable, ICoverable aTileEntity) {
+        return letsRedstoneGoIn(aSide, aCoverID, aCoverVariable, aTileEntity) ? aInputRedstone : 0;
+    }
+
+    /**
+     * Gets the Tick Rate for doCoverThings of the Cover
+     * <p/>
+     * 0 = No Ticks! Yes, 0 is Default, you have to override this
+     */
+    protected int getTickRateImpl(byte aSide, int aCoverID, T aCoverVariable, ICoverable aTileEntity) {
+        return 0;
+    }
+
+
+    /**
+     * The MC Color of this Lens. -1 for no Color (meaning this isn't a Lens then).
+     */
+    protected byte getLensColorImpl(byte aSide, int aCoverID, T aCoverVariable, ICoverable aTileEntity) {
+        return -1;
+    }
+
+    /**
+     * @return the ItemStack dropped by this Cover
+     */
+    protected ItemStack getDropImpl(byte aSide, int aCoverID, T aCoverVariable, ICoverable aTileEntity) {
+        return GT_OreDictUnificator.get(true, aTileEntity.getCoverItemAtSide(aSide));
+    }
+
+    //endregion
+
+    // region no data
+
+    /**
+     * Checks if the Cover can be placed on this.
+     */
+    public boolean isCoverPlaceable(byte aSide, GT_ItemStack aStack, ICoverable aTileEntity) {
+        return true;
+    }
+
+    public boolean hasCoverGUI() {
+        return false;
+    }
+
+    /**
+     * Called when someone rightclicks this Cover Client Side
+     * <p/>
+     * return true, if something actually happens.
+     */
+    public boolean onCoverRightclickClient(byte aSide, ICoverable aTileEntity, EntityPlayer aPlayer, float aX, float aY, float aZ) {
+        return false;
+    }
+
+    /**
+     * If this is a simple Cover, which can also be used on Bronze Machines and similar.
+     */
+    public boolean isSimpleCover() {
+        return false;
+    }
+
+    /**
+     * sets the Cover upon placement.
+     */
+    public void placeCover(byte aSide, ItemStack aCover, ICoverable aTileEntity) {
+        aTileEntity.setCoverIDAtSide(aSide, GT_Utility.stackToInt(aCover));
+    }
+
+    public String trans(String aNr, String aEnglish) {
+        return GT_LanguageManager.addStringLocalization("Interaction_DESCRIPTION_Index_" + aNr, aEnglish, false);
+    }
+    // endregion
+}

--- a/src/main/java/gregtech/api/util/GT_CoverBehavior_New.java
+++ b/src/main/java/gregtech/api/util/GT_CoverBehavior_New.java
@@ -15,6 +15,8 @@ import static gregtech.api.enums.GT_Values.E;
 
 /**
  * For Covers with a special behavior.
+ *
+ * @author glease
  */
 public abstract class GT_CoverBehavior_New<T extends ISerializableObject> {
 

--- a/src/main/java/gregtech/api/util/GT_Utility.java
+++ b/src/main/java/gregtech/api/util/GT_Utility.java
@@ -2157,7 +2157,7 @@ public class GT_Utility {
             try {
                 if (tTileEntity instanceof ICoverable) {
                     rEUAmount += 300;
-                    String tString = ((ICoverable) tTileEntity).getCoverBehaviorAtSide((byte) aSide).getDescription((byte) aSide, ((ICoverable) tTileEntity).getCoverIDAtSide((byte) aSide), ((ICoverable) tTileEntity).getCoverDataAtSide((byte) aSide), (ICoverable) tTileEntity);
+                    String tString = ((ICoverable) tTileEntity).getCoverBehaviorAtSideNew((byte) aSide).getDescription((byte) aSide, ((ICoverable) tTileEntity).getCoverIDAtSide((byte) aSide), ((ICoverable) tTileEntity).getCoverDataAtSideNew((byte) aSide), (ICoverable) tTileEntity);
                     if (tString != null && !tString.equals(E)) tList.add(tString);
                 }
             } catch (Throwable e) {

--- a/src/main/java/gregtech/api/util/GT_Utility.java
+++ b/src/main/java/gregtech/api/util/GT_Utility.java
@@ -104,16 +104,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.text.NumberFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
@@ -2157,7 +2148,7 @@ public class GT_Utility {
             try {
                 if (tTileEntity instanceof ICoverable) {
                     rEUAmount += 300;
-                    String tString = ((ICoverable) tTileEntity).getCoverBehaviorAtSideNew((byte) aSide).getDescription((byte) aSide, ((ICoverable) tTileEntity).getCoverIDAtSide((byte) aSide), ((ICoverable) tTileEntity).getCoverDataAtSideNew((byte) aSide), (ICoverable) tTileEntity);
+                    String tString = ((ICoverable) tTileEntity).getCoverBehaviorAtSideNew((byte) aSide).getDescription((byte) aSide, ((ICoverable) tTileEntity).getCoverIDAtSide((byte) aSide), ((ICoverable) tTileEntity).getComplexCoverDataAtSide((byte) aSide), (ICoverable) tTileEntity);
                     if (tString != null && !tString.equals(E)) tList.add(tString);
                 }
             } catch (Throwable e) {

--- a/src/main/java/gregtech/api/util/ISerializableObject.java
+++ b/src/main/java/gregtech/api/util/ISerializableObject.java
@@ -3,10 +3,16 @@ package gregtech.api.util;
 import com.google.common.io.ByteArrayDataInput;
 import io.netty.buffer.ByteBuf;
 import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.CompressedStreamTools;
 import net.minecraft.nbt.NBTBase;
+import net.minecraft.nbt.NBTSizeTracker;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagInt;
 
 import javax.annotation.Nonnull;
+import java.io.IOException;
 
 /**
  * We could well have used {@link java.io.Serializable}, but that's too slow and should generally be avoided
@@ -36,6 +42,41 @@ public interface ISerializableObject {
     // the NBT is an unfortunate piece of tech. everything uses it but its API is not as efficient as could be
     @Nonnull
     ISerializableObject readFromPacket(ByteArrayDataInput aBuf, EntityPlayerMP aPlayer);
+
+    /**
+     * Reverse engineered and adapted {@link cpw.mods.fml.common.network.ByteBufUtils#readTag(ByteBuf)}
+     * Given buffer must contain a serialized NBTTagCompound in minecraft encoding
+     */
+    static NBTTagCompound readCompoundTagFromGreggyByteBuf(ByteArrayDataInput aBuf) {
+        short size = aBuf.readShort();
+        if (size < 0)
+            return null;
+        else  {
+            byte[] buf = new byte[size]; // this is shit, how many copies have we been doing?
+            aBuf.readFully(buf);
+            try {
+                return CompressedStreamTools.func_152457_a(buf, new NBTSizeTracker(2097152L));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    /**
+     * Reverse engineered and adapted {@link cpw.mods.fml.common.network.ByteBufUtils#readItemStack(ByteBuf)}
+     * Given buffer must contain a serialized ItemStack in minecraft encoding
+     */
+    static ItemStack readItemStackFromGreggyByteBuf(ByteArrayDataInput aBuf) {
+        ItemStack stack = null;
+        short id = aBuf.readShort();
+        if (id >= 0) {
+            byte size = aBuf.readByte();
+            short meta = aBuf.readShort();
+            stack = new ItemStack(Item.getItemById(id), size, meta);
+            stack.stackTagCompound = readCompoundTagFromGreggyByteBuf(aBuf);
+        }
+        return stack;
+    }
 
     final class LegacyCoverData implements ISerializableObject {
         private int mData;

--- a/src/main/java/gregtech/api/util/ISerializableObject.java
+++ b/src/main/java/gregtech/api/util/ISerializableObject.java
@@ -1,0 +1,107 @@
+package gregtech.api.util;
+
+import com.google.common.io.ByteArrayDataInput;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.nbt.NBTBase;
+import net.minecraft.nbt.NBTTagInt;
+
+import javax.annotation.Nonnull;
+
+/**
+ * We could well have used {@link java.io.Serializable}, but that's too slow and should generally be avoided
+ */
+public interface ISerializableObject {
+
+    @Nonnull
+    ISerializableObject copy();
+
+    @Nonnull
+    NBTBase saveDataToNBT();
+
+    /**
+     * Write data to given ByteBuf
+     * The data saved this way is intended to be stored for short amount of time over network.
+     * DO NOT store it to disks.
+     */
+    // the NBT is an unfortunate piece of tech. everything uses it but its API is not as efficient as could be
+    void writeToByteBuf(ByteBuf aBuf);
+
+    void loadDataFromNBT(NBTBase aNBT);
+
+    /**
+     * Read data from given parameter and return this.
+     * The data read this way is intended to be stored for short amount of time over network.
+     */
+    // the NBT is an unfortunate piece of tech. everything uses it but its API is not as efficient as could be
+    @Nonnull
+    ISerializableObject readFromPacket(ByteArrayDataInput aBuf, EntityPlayerMP aPlayer);
+
+    final class LegacyCoverData implements ISerializableObject {
+        private int mData;
+
+        public LegacyCoverData() {
+        }
+
+        public LegacyCoverData(int mData) {
+            this.mData = mData;
+        }
+
+        @Override
+        @Nonnull
+        public ISerializableObject copy() {
+            return new LegacyCoverData(mData);
+        }
+
+        @Override
+        @Nonnull
+        public NBTBase saveDataToNBT() {
+            return new NBTTagInt(mData);
+        }
+
+        @Override
+        public void writeToByteBuf(ByteBuf aBuf) {
+            aBuf.writeInt(mData);
+        }
+
+        @Override
+        public void loadDataFromNBT(NBTBase aNBT) {
+            mData = aNBT instanceof NBTBase.NBTPrimitive ? ((NBTBase.NBTPrimitive) aNBT).func_150287_d() : 0;
+        }
+
+        @Override
+        @Nonnull
+        public ISerializableObject readFromPacket(ByteArrayDataInput aBuf, EntityPlayerMP aPlayer) {
+            mData = aBuf.readInt();
+            return this;
+        }
+
+        public int get() {
+            return mData;
+        }
+
+        public void set(int mData) {
+            this.mData = mData;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            LegacyCoverData that = (LegacyCoverData) o;
+
+            return mData == that.mData;
+        }
+
+        @Override
+        public int hashCode() {
+            return mData;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(mData);
+        }
+    }
+}

--- a/src/main/java/gregtech/api/util/ISerializableObject.java
+++ b/src/main/java/gregtech/api/util/ISerializableObject.java
@@ -16,6 +16,8 @@ import java.io.IOException;
 
 /**
  * We could well have used {@link java.io.Serializable}, but that's too slow and should generally be avoided
+ *
+ * @author glease
  */
 public interface ISerializableObject {
 

--- a/src/main/java/gregtech/common/GT_Network.java
+++ b/src/main/java/gregtech/common/GT_Network.java
@@ -36,7 +36,7 @@ public class GT_Network extends MessageToMessageCodec<FMLProxyPacket, GT_Packet>
 
     public GT_Network() {
         this.mChannel = NetworkRegistry.INSTANCE.newChannel("GregTech", this, new HandlerShared());
-        this.mSubChannels = new GT_Packet[]{new GT_Packet_TileEntity(), new GT_Packet_Sound(), new GT_Packet_Block_Event(), new GT_Packet_Ores(), new GT_Packet_Pollution(), new MessageSetFlaskCapacity(), new GT_Packet_TileEntityCover(), new GT_Packet_TileEntityCoverGUI(), new MessageUpdateFluidDisplayItem(), new GT_Packet_ClientPreference(), new GT_Packet_WirelessRedstoneCover()};
+        this.mSubChannels = new GT_Packet[]{new GT_Packet_TileEntity(), new GT_Packet_Sound(), new GT_Packet_Block_Event(), new GT_Packet_Ores(), new GT_Packet_Pollution(), new MessageSetFlaskCapacity(), new GT_Packet_TileEntityCover(), new GT_Packet_TileEntityCoverGUI(), new MessageUpdateFluidDisplayItem(), new GT_Packet_ClientPreference(), new GT_Packet_WirelessRedstoneCover(), new GT_Packet_TileEntityCoverNew()};
     }
 
     @Override

--- a/src/main/java/gregtech/common/covers/GT_Cover_Arm.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_Arm.java
@@ -11,6 +11,7 @@ import gregtech.api.interfaces.tileentity.IMachineProgress;
 import gregtech.api.net.GT_Packet_TileEntityCover;
 import gregtech.api.util.GT_CoverBehavior;
 import gregtech.api.util.GT_Utility;
+import gregtech.api.util.ISerializableObject;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
@@ -111,6 +112,16 @@ public class GT_Cover_Arm extends GT_CoverBehavior {
     }
 
     @Override
+    protected boolean onCoverRightClickImpl(byte aSide, int aCoverID, ISerializableObject.LegacyCoverData aCoverVariable, ICoverable aTileEntity, EntityPlayer aPlayer, float aX, float aY, float aZ) {
+        int step = (GT_Utility.getClickedFacingCoords(aSide, aX, aY, aZ)[0] >= 0.5F) ? 1 : -1;
+        int tCoverVariable = getNewVar(aCoverVariable.get(), step);
+        sendMessageToPlayer(aPlayer, tCoverVariable);
+        aCoverVariable.set(tCoverVariable);
+        return true;
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
     public boolean onCoverRightclick(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, EntityPlayer aPlayer, float aX, float aY, float aZ) {
         int step = (GT_Utility.getClickedFacingCoords(aSide, aX, aY, aZ)[0] >= 0.5F) ? 1 : -1;
         aCoverVariable = getNewVar(aCoverVariable, step);

--- a/src/main/java/gregtech/common/covers/GT_Cover_FluidRegulator.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_FluidRegulator.java
@@ -9,6 +9,7 @@ import gregtech.api.interfaces.tileentity.ICoverable;
 import gregtech.api.net.GT_Packet_TileEntityCover;
 import gregtech.api.util.GT_CoverBehavior;
 import gregtech.api.util.GT_Utility;
+import gregtech.api.util.ISerializableObject;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraftforge.common.util.ForgeDirection;
@@ -136,6 +137,18 @@ public class GT_Cover_FluidRegulator extends GT_CoverBehavior {
 	}
 
 	@Override
+	protected boolean onCoverRightClickImpl(byte aSide, int aCoverID, ISerializableObject.LegacyCoverData aCoverVariable, ICoverable aTileEntity, EntityPlayer aPlayer, float aX, float aY, float aZ) {
+		if (GT_Utility.getClickedFacingCoords(aSide, aX, aY, aZ)[0] >= 0.5F) {
+			aCoverVariable.set(adjustSpeed(aPlayer, aCoverVariable.get(), 1));
+		} else {
+			aCoverVariable.set(adjustSpeed(aPlayer, aCoverVariable.get(), -1));
+		}
+		aTileEntity.setCoverDataAtSide(aSide, aCoverVariable);
+		return true;
+	}
+
+	@Override
+	@SuppressWarnings("deprecation")
     public boolean onCoverRightclick(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity,
                                      EntityPlayer aPlayer, float aX, float aY, float aZ) {
 		if (GT_Utility.getClickedFacingCoords(aSide, aX, aY, aZ)[0] >= 0.5F) {

--- a/src/main/java/gregtech/common/covers/GT_Cover_Fluidfilter.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_Fluidfilter.java
@@ -8,7 +8,7 @@ import gregtech.api.gui.widgets.GT_GuiIcon;
 import gregtech.api.gui.widgets.GT_GuiIconButton;
 import gregtech.api.interfaces.tileentity.ICoverable;
 import gregtech.api.net.GT_Packet_TileEntityCoverNew;
-import gregtech.api.util.GT_CoverBehavior_New;
+import gregtech.api.util.GT_CoverBehaviorBase;
 import gregtech.api.util.GT_Utility;
 import gregtech.api.util.ISerializableObject;
 import io.netty.buffer.ByteBuf;
@@ -27,7 +27,7 @@ import javax.annotation.Nonnull;
 
 import static gregtech.api.enums.GT_Values.E;
 
-public class GT_Cover_Fluidfilter extends GT_CoverBehavior_New<GT_Cover_Fluidfilter.FluidFilterData> {
+public class GT_Cover_Fluidfilter extends GT_CoverBehaviorBase<GT_Cover_Fluidfilter.FluidFilterData> {
 
     // Uses the lower 3 bits of the cover variable, so we have 8 options to work with (0-7)
     private final int FILTER_INPUT_DENY_OUTPUT = 0; //  000

--- a/src/main/java/gregtech/common/covers/GT_Cover_Fluidfilter.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_Fluidfilter.java
@@ -1,22 +1,33 @@
 package gregtech.common.covers;
 
+import com.google.common.io.ByteArrayDataInput;
 import gregtech.api.enums.GT_Values;
 import gregtech.api.gui.GT_GUICover;
 import gregtech.api.gui.widgets.GT_GuiFakeItemButton;
 import gregtech.api.gui.widgets.GT_GuiIcon;
 import gregtech.api.gui.widgets.GT_GuiIconButton;
 import gregtech.api.interfaces.tileentity.ICoverable;
-import gregtech.api.net.GT_Packet_TileEntityCover;
-import gregtech.api.util.GT_CoverBehavior;
+import gregtech.api.net.GT_Packet_TileEntityCoverNew;
+import gregtech.api.util.GT_CoverBehavior_New;
 import gregtech.api.util.GT_Utility;
+import gregtech.api.util.ISerializableObject;
+import io.netty.buffer.ByteBuf;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
-import net.minecraftforge.fluids.*;
+import net.minecraft.nbt.NBTBase;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.world.World;
+import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidRegistry;
+import net.minecraftforge.fluids.FluidStack;
+
+import javax.annotation.Nonnull;
 
 import static gregtech.api.enums.GT_Values.E;
 
-public class GT_Cover_Fluidfilter extends GT_CoverBehavior {
+public class GT_Cover_Fluidfilter extends GT_CoverBehavior_New<GT_Cover_Fluidfilter.FluidFilterData> {
 
     // Uses the lower 3 bits of the cover variable, so we have 8 options to work with (0-7)
     private final int FILTER_INPUT_DENY_OUTPUT = 0; //  000
@@ -28,99 +39,115 @@ public class GT_Cover_Fluidfilter extends GT_CoverBehavior {
     private final int ANY_INPUT_FILTER_OUTPUT = 6;  //  110
     private final int ANY_INPUT_INVERT_OUTPUT = 7;  //  111
 
-    @Override
-    public String getDescription(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity) {
-        int aFilterMode = aCoverVariable & 7;
-        int aFilterFluid = aCoverVariable >>> 3;
-        final Fluid fluid = FluidRegistry.getFluid(aFilterFluid);
-        if(fluid == null) return E;
-        
-        final FluidStack sFluid = new FluidStack(fluid, 1000);
-        return(String.format("Filtering Fluid: %s  Mode: %s", sFluid.getLocalizedName(), getFilterMode(aFilterMode)));
+    public GT_Cover_Fluidfilter() {
+        super(FluidFilterData.class);
     }
 
     @Override
-    public boolean isRedstoneSensitive(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
+    public FluidFilterData createDataObject() {
+        return new FluidFilterData(-1, 0);
+    }
+
+    @Override
+    public FluidFilterData createDataObject(int aLegacyData) {
+        return new FluidFilterData(aLegacyData >>> 3, aLegacyData & 0x7);
+    }
+
+    @Override
+    protected String getDescriptionImpl(byte aSide, int aCoverID, FluidFilterData aCoverVariable, ICoverable aTileEntity) {
+        final Fluid fluid = FluidRegistry.getFluid(aCoverVariable.mFluidID);
+        if (fluid == null) return E;
+
+        final FluidStack sFluid = new FluidStack(fluid, 1000);
+        return (String.format("Filtering Fluid: %s  Mode: %s", sFluid.getLocalizedName(), getFilterMode(aCoverVariable.mFilterMode)));
+    }
+
+    @Override
+    protected boolean isRedstoneSensitiveImpl(byte aSide, int aCoverID, FluidFilterData aCoverVariable, ICoverable aTileEntity, long aTimer) {
         return false;
     }
 
     @Override
-    public int doCoverThings(byte aSide, byte aInputRedstone, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
+    protected FluidFilterData doCoverThingsImpl(byte aSide, byte aInputRedstone, int aCoverID, FluidFilterData aCoverVariable, ICoverable aTileEntity, long aTimer) {
         return aCoverVariable;
     }
 
     public String getFilterMode(int aFilterMode) {
-        switch(aFilterMode) {
-            case FILTER_INPUT_DENY_OUTPUT: return(trans("043", "Filter input, Deny output"));
-            case INVERT_INPUT_DENY_OUTPUT: return(trans("044", "Invert input, Deny output"));
-            case FILTER_INPUT_ANY_OUTPUT: return(trans("045", "Filter input, Permit any output"));
-            case INVERT_INPUT_ANY_OUTPUT: return(trans("046", "Invert input, Permit any output"));
-            case DENY_INPUT_FILTER_OUTPUT: return(trans("219", "Deny input, Filter output"));
-            case DENY_INPUT_INVERT_OUTPUT: return(trans("220", "Deny input, Invert output"));
-            case ANY_INPUT_FILTER_OUTPUT: return(trans("221", "Permit any input, Filter output"));
-            case ANY_INPUT_INVERT_OUTPUT: return(trans("222", "Permit any input, Invert output"));
-            default: return("UNKNOWN");
+        switch (aFilterMode) {
+            case FILTER_INPUT_DENY_OUTPUT:
+                return (trans("043", "Filter input, Deny output"));
+            case INVERT_INPUT_DENY_OUTPUT:
+                return (trans("044", "Invert input, Deny output"));
+            case FILTER_INPUT_ANY_OUTPUT:
+                return (trans("045", "Filter input, Permit any output"));
+            case INVERT_INPUT_ANY_OUTPUT:
+                return (trans("046", "Invert input, Permit any output"));
+            case DENY_INPUT_FILTER_OUTPUT:
+                return (trans("219", "Deny input, Filter output"));
+            case DENY_INPUT_INVERT_OUTPUT:
+                return (trans("220", "Deny input, Invert output"));
+            case ANY_INPUT_FILTER_OUTPUT:
+                return (trans("221", "Permit any input, Filter output"));
+            case ANY_INPUT_INVERT_OUTPUT:
+                return (trans("222", "Permit any input, Invert output"));
+            default:
+                return ("UNKNOWN");
         }
 
     }
 
     @Override
-    public int onCoverScrewdriverclick(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, EntityPlayer aPlayer, float aX, float aY, float aZ) {
-        int aFilterMode = aCoverVariable & 7;
-        aCoverVariable ^= aFilterMode;
-        aFilterMode = (aFilterMode + (aPlayer.isSneaking()? -1 : 1)) % 8;
-        if (aFilterMode < 0) {
-            aFilterMode = 7;
+    protected FluidFilterData onCoverScrewdriverClickImpl(byte aSide, int aCoverID, FluidFilterData aCoverVariable, ICoverable aTileEntity, EntityPlayer aPlayer, float aX, float aY, float aZ) {
+        aCoverVariable.mFilterMode = (aCoverVariable.mFilterMode + (aPlayer.isSneaking() ? -1 : 1)) % 8;
+        if (aCoverVariable.mFilterMode < 0) {
+            aCoverVariable.mFilterMode = 7;
         }
 
-        GT_Utility.sendChatToPlayer(aPlayer, getFilterMode(aFilterMode));
-
-        aCoverVariable|=aFilterMode;
+        GT_Utility.sendChatToPlayer(aPlayer, getFilterMode(aCoverVariable.mFilterMode));
 
         return aCoverVariable;
     }
 
     @Override
-    public boolean onCoverRightclick(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, EntityPlayer aPlayer, float aX, float aY, float aZ) {
-        //GT_FML_LOGGER.info("rightclick");
+    protected boolean onCoverRightClickImpl(byte aSide, int aCoverID, FluidFilterData aCoverVariable, ICoverable aTileEntity, EntityPlayer aPlayer, float aX, float aY, float aZ) {
         if (
                 ((aX > 0.375D) && (aX < 0.625D)) ||
-                ((aSide > 3) && ((aY > 0.375D) && (aY < 0.625D))) ||
-                ((aSide < 2) && ((aZ > 0.375D) && (aZ < 0.625D))) ||
-                (aSide == 2) ||
-                (aSide == 3)
+                        ((aSide > 3) && ((aY > 0.375D) && (aY < 0.625D))) ||
+                        ((aSide < 2) && ((aZ > 0.375D) && (aZ < 0.625D))) ||
+                        (aSide == 2) ||
+                        (aSide == 3)
         ) {
             ItemStack tStack = aPlayer.inventory.getCurrentItem();
             if (tStack == null) return true;
 
-            FluidStack tFluid = FluidContainerRegistry.getFluidForFilledItem(tStack);
+            FluidStack tFluid = GT_Utility.getFluidForFilledItem(tStack, true);
             if (tFluid != null) {
                 int aFluid = tFluid.getFluidID();
-                aCoverVariable = (aCoverVariable & 7) | (aFluid << 3);
+                aCoverVariable.mFluidID = aFluid;
                 aTileEntity.setCoverDataAtSide(aSide, aCoverVariable);
                 FluidStack sFluid = new FluidStack(FluidRegistry.getFluid(aFluid), 1000);
                 GT_Utility.sendChatToPlayer(aPlayer, trans("047", "Filter Fluid: ") + sFluid.getLocalizedName());
-            } else if (tStack.getItem() instanceof IFluidContainerItem) {
-                IFluidContainerItem tContainer = (IFluidContainerItem) tStack.getItem();
-                if (tContainer.getFluid(tStack) != null) {
-                    int aFluid = tContainer.getFluid(tStack).getFluidID();
-                    aCoverVariable = (aCoverVariable & 7) | (aFluid << 3);
-                    aTileEntity.setCoverDataAtSide(aSide, aCoverVariable);
-                    FluidStack sFluid = new FluidStack(FluidRegistry.getFluid(aFluid), 1000);
-                    GT_Utility.sendChatToPlayer(aPlayer, trans("047", "Filter Fluid: ") + sFluid.getLocalizedName());
-                }
             }
             return true;
         }
         return false;
     }
-    
+
     @Override
-    public boolean letsFluidIn(byte aSide, int aCoverID, int aCoverVariable, Fluid aFluid, ICoverable aTileEntity) {
+    protected boolean letsFluidInImpl(byte aSide, int aCoverID, FluidFilterData aCoverVariable, Fluid aFluid, ICoverable aTileEntity) {
+        return isFluidAllowed(aCoverVariable, aFluid);
+    }
+
+    @Override
+    protected boolean letsFluidOutImpl(byte aSide, int aCoverID, FluidFilterData aCoverVariable, Fluid aFluid, ICoverable aTileEntity) {
+        return isFluidAllowed(aCoverVariable, aFluid);
+    }
+
+    protected boolean isFluidAllowed(FluidFilterData aCoverVariable, Fluid aFluid) {
         if (aFluid == null) return true;
 
-        int aFilterMode = aCoverVariable & 7;
-        int aFilterFluid = aCoverVariable >>> 3;
+        int aFilterMode = aCoverVariable.mFilterMode;
+        int aFilterFluid = aCoverVariable.mFluidID;
 
         if (aFilterMode == DENY_INPUT_FILTER_OUTPUT || aFilterMode == DENY_INPUT_INVERT_OUTPUT)
             return false;
@@ -130,36 +157,18 @@ public class GT_Cover_Fluidfilter extends GT_CoverBehavior {
             return aFilterMode == FILTER_INPUT_DENY_OUTPUT || aFilterMode == FILTER_INPUT_ANY_OUTPUT;
         else
             return aFilterMode == INVERT_INPUT_DENY_OUTPUT || aFilterMode == INVERT_INPUT_ANY_OUTPUT;
-
     }
-    
+
     @Override
-    public boolean letsFluidOut(byte aSide, int aCoverID, int aCoverVariable, Fluid aFluid, ICoverable aTileEntity) {
-        if (aFluid == null) return true;
-
-        int aFilterMode = aCoverVariable & 7;
-        int aFilterFluid = aCoverVariable >>> 3;
-
-        if (aFilterMode == FILTER_INPUT_DENY_OUTPUT || aFilterMode == INVERT_INPUT_DENY_OUTPUT)
-            return false;
-        else if (aFilterMode == FILTER_INPUT_ANY_OUTPUT || aFilterMode == INVERT_INPUT_ANY_OUTPUT)
-            return true;
-        else if (aFluid.getID() == aFilterFluid)
-            return aFilterMode == DENY_INPUT_FILTER_OUTPUT || aFilterMode == ANY_INPUT_FILTER_OUTPUT;
-        else
-            return aFilterMode == DENY_INPUT_INVERT_OUTPUT || aFilterMode == ANY_INPUT_INVERT_OUTPUT;
-
-    }
-    
-    @Override
-    public boolean alwaysLookConnected(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity) {
+    protected boolean alwaysLookConnectedImpl(byte aSide, int aCoverID, FluidFilterData aCoverVariable, ICoverable aTileEntity) {
         return true;
     }
 
     @Override
-    public int getTickRate(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity) {
+    protected int getTickRateImpl(byte aSide, int aCoverID, FluidFilterData aCoverVariable, ICoverable aTileEntity) {
         return 0;
     }
+
     /**
      * GUI Stuff
      */
@@ -170,14 +179,14 @@ public class GT_Cover_Fluidfilter extends GT_CoverBehavior {
     }
 
     @Override
-    public Object getClientGUI(byte aSide, int aCoverID, int coverData, ICoverable aTileEntity)  {
+    protected Object getClientGUIImpl(byte aSide, int aCoverID, FluidFilterData coverData, ICoverable aTileEntity, EntityPlayer aPlayer, World aWorld) {
         return new GT_FluidFilterGUICover(aSide, aCoverID, coverData, aTileEntity);
     }
 
     private class GT_FluidFilterGUICover extends GT_GUICover {
         private final byte side;
         private final int coverID;
-        private int coverVariable;
+        private final FluidFilterData coverVariable;
         private final GT_GuiFakeItemButton fluidFilterButton;
         protected String fluidFilterName;
 
@@ -186,8 +195,7 @@ public class GT_Cover_Fluidfilter extends GT_CoverBehavior {
         private static final int spaceX = 18;
         private static final int spaceY = 18;
 
-        public GT_FluidFilterGUICover(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity)
-        {
+        public GT_FluidFilterGUICover(byte aSide, int aCoverID, FluidFilterData aCoverVariable, ICoverable aTileEntity) {
             super(aTileEntity, 176, 107, GT_Utility.intToStack(aCoverID));
             this.side = aSide;
             this.coverID = aCoverID;
@@ -201,35 +209,38 @@ public class GT_Cover_Fluidfilter extends GT_CoverBehavior {
             b = new GT_GuiIconButton(this, 4, startX + spaceX*0, startY+spaceY*1, GT_GuiIcon.WHITELIST).setTooltipText(trans("236","Whitelist Fluid"));
             b = new GT_GuiIconButton(this, 5, startX + spaceX*1, startY+spaceY*1, GT_GuiIcon.BLACKLIST).setTooltipText(trans("237","Blacklist Fluid"));
 
-            fluidFilterButton = new GT_GuiFakeItemButton(this, startX, startY+spaceY*3+2, GT_GuiIcon.SLOT_DARKGRAY);
+            fluidFilterButton = new GT_GuiFakeItemButton(this, startX, startY + spaceY * 3 + 2, GT_GuiIcon.SLOT_DARKGRAY);
         }
 
-        private int getNewCoverVariable(int id) {
+        private int getNewFilterMode(int id) {
             switch (id) {
                 case 0:
-                    return (coverVariable & ~0x7) | (coverVariable & 0x3);
+                    return (coverVariable.mFilterMode & 0x3);
                 case 1:
-                    return (coverVariable & ~0x7) | (coverVariable | 0x4);
+                    return (coverVariable.mFilterMode | 0x4);
                 case 2:
-                    return (coverVariable & ~0x7) | (coverVariable & 0x5);
+                    return (coverVariable.mFilterMode & 0x5);
                 case 3:
-                    return (coverVariable & ~0x7) | (coverVariable | 0x2);
+                    return (coverVariable.mFilterMode | 0x2);
                 case 4:
-                    return (coverVariable & ~0x7) | (coverVariable & 0x6);
+                    return (coverVariable.mFilterMode & 0x6);
                 case 5:
-                    return (coverVariable & ~0x7) | (coverVariable | 0x1);
+                    return (coverVariable.mFilterMode | 0x1);
             }
-            return coverVariable;
+            return coverVariable.mFilterMode;
         }
 
         private boolean getClickable(int id) {
             switch (id) {
-                case 0: case 1:
-                    return (coverVariable>>2 & 0x1) != (id & 0x1);
-                case 2: case 3:
-                    return (coverVariable>>1 & 0x1) != (id & 0x1);
-                case 4: case 5:
-                    return (coverVariable & 0x1) != (id & 0x1);
+                case 0:
+                case 1:
+                    return (coverVariable.mFilterMode >> 2 & 0x1) != (id & 0x1);
+                case 2:
+                case 3:
+                    return (coverVariable.mFilterMode >> 1 & 0x1) != (id & 0x1);
+                case 4:
+                case 5:
+                    return (coverVariable.mFilterMode & 0x1) != (id & 0x1);
             }
             return false;
         }
@@ -250,15 +261,15 @@ public class GT_Cover_Fluidfilter extends GT_CoverBehavior {
         }
 
         @Override
-        public void buttonClicked(GuiButton btn){
-            if (getClickable(btn.id)){
-                coverVariable = getNewCoverVariable(btn.id);
-                GT_Values.NW.sendToServer(new GT_Packet_TileEntityCover(side, coverID, coverVariable, tile));
+        public void buttonClicked(GuiButton btn) {
+            if (getClickable(btn.id)) {
+                coverVariable.mFilterMode = (byte) getNewFilterMode(btn.id);
+                GT_Values.NW.sendToServer(new GT_Packet_TileEntityCoverNew(side, coverID, coverVariable, tile));
             }
             updateButtons();
         }
 
-        private void updateButtons(){
+        private void updateButtons() {
             GT_GuiIconButton b;
             for (Object o : buttonList) {
                 if (o instanceof GT_GuiIconButton) {
@@ -277,7 +288,7 @@ public class GT_Cover_Fluidfilter extends GT_CoverBehavior {
                     }
                 }
             }
-            Fluid f = FluidRegistry.getFluid(coverVariable >>> 3);
+            Fluid f = FluidRegistry.getFluid(coverVariable.mFluidID);
             if (f != null) {
                 ItemStack item = GT_Utility.getFluidDisplayStack(f);
                 if (item != null) {
@@ -288,6 +299,53 @@ public class GT_Cover_Fluidfilter extends GT_CoverBehavior {
             }
             fluidFilterButton.setItem(null);
             fluidFilterName = trans("224", "Filter Empty");
+        }
+    }
+
+    public static class FluidFilterData implements ISerializableObject {
+        private int mFluidID;
+        private int mFilterMode;
+
+        public FluidFilterData(int mFluidID, int mFilterMode) {
+            this.mFluidID = mFluidID;
+            this.mFilterMode = mFilterMode;
+        }
+
+        @Override
+        @Nonnull
+        public ISerializableObject copy() {
+            return new FluidFilterData(mFluidID, mFilterMode);
+        }
+
+        @Override
+        @Nonnull
+        public NBTBase saveDataToNBT() {
+            NBTTagCompound tNBT = new NBTTagCompound();
+            tNBT.setInteger("mFilterMode", mFilterMode);
+            tNBT.setString("mFluid", FluidRegistry.getFluid(mFluidID).getName());
+            return tNBT;
+        }
+
+        @Override
+        public void writeToByteBuf(ByteBuf aBuf) {
+            aBuf.writeByte(mFilterMode).writeInt(mFluidID);
+        }
+
+        @Override
+        public void loadDataFromNBT(NBTBase aNBT) {
+            if (aNBT instanceof NBTTagCompound) {
+                NBTTagCompound tNBT = (NBTTagCompound) aNBT;
+                mFilterMode = tNBT.getByte("mFilterMod");
+                mFluidID = FluidRegistry.getFluidID(tNBT.getString("mFluid"));
+            }
+        }
+
+        @Override
+        @Nonnull
+        public ISerializableObject readFromPacket(ByteArrayDataInput aBuf, EntityPlayerMP aPlayer) {
+            mFilterMode = aBuf.readByte();
+            mFluidID = aBuf.readInt();
+            return this;
         }
     }
 }

--- a/src/main/java/gregtech/common/covers/GT_Cover_ItemFilter.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_ItemFilter.java
@@ -9,7 +9,7 @@ import gregtech.api.gui.widgets.GT_GuiIcon;
 import gregtech.api.gui.widgets.GT_GuiIconCheckButton;
 import gregtech.api.interfaces.tileentity.ICoverable;
 import gregtech.api.net.GT_Packet_TileEntityCoverNew;
-import gregtech.api.util.GT_CoverBehavior_New;
+import gregtech.api.util.GT_CoverBehaviorBase;
 import gregtech.api.util.GT_Utility;
 import gregtech.api.util.ISerializableObject;
 import io.netty.buffer.ByteBuf;
@@ -31,7 +31,7 @@ import java.util.List;
 import static gregtech.api.util.GT_Utility.intToStack;
 import static gregtech.api.util.GT_Utility.moveMultipleItemStacks;
 
-public class GT_Cover_ItemFilter extends GT_CoverBehavior_New<GT_Cover_ItemFilter.ItemFilterData> {
+public class GT_Cover_ItemFilter extends GT_CoverBehaviorBase<GT_Cover_ItemFilter.ItemFilterData> {
 
     private final boolean mExport;
 

--- a/src/main/java/gregtech/common/covers/GT_Cover_ItemFilter.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_ItemFilter.java
@@ -9,6 +9,7 @@ import gregtech.api.interfaces.tileentity.ICoverable;
 import gregtech.api.net.GT_Packet_TileEntityCover;
 import gregtech.api.util.GT_CoverBehavior;
 import gregtech.api.util.GT_Utility;
+import gregtech.api.util.ISerializableObject;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
@@ -18,7 +19,9 @@ import net.minecraftforge.fluids.Fluid;
 import java.util.Collections;
 import java.util.List;
 
-import static gregtech.api.util.GT_Utility.*;
+import static gregtech.api.util.GT_Utility.intToStack;
+import static gregtech.api.util.GT_Utility.moveMultipleItemStacks;
+import static gregtech.api.util.GT_Utility.stackToInt;
 
 public class GT_Cover_ItemFilter extends GT_CoverBehavior {
 
@@ -52,6 +55,22 @@ public class GT_Cover_ItemFilter extends GT_CoverBehavior {
     }
 
     @Override
+    protected boolean onCoverRightClickImpl(byte aSide, int aCoverID, ISerializableObject.LegacyCoverData aCoverVariable, ICoverable aTileEntity, EntityPlayer aPlayer, float aX, float aY, float aZ) {
+        ItemStack tStack = aPlayer.inventory.getCurrentItem();
+        int tCoverVariable = aCoverVariable.get() & 1;
+        if (tStack != null) {
+            tCoverVariable = (stackToInt(tStack) << 1) + tCoverVariable;
+            aCoverVariable.set(tCoverVariable);
+            GT_Utility.sendChatToPlayer(aPlayer, trans("301", "Item Filter: ") + tStack.getDisplayName());
+        } else {
+            aCoverVariable.set(tCoverVariable);
+            GT_Utility.sendChatToPlayer(aPlayer, trans("300", "Filter Cleared!"));
+        }
+        return true;
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
     public boolean onCoverRightclick(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, EntityPlayer aPlayer, float aX, float aY, float aZ){
             ItemStack tStack = aPlayer.inventory.getCurrentItem();
             if (tStack != null){

--- a/src/main/java/gregtech/common/covers/GT_Cover_ItemFilter.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_ItemFilter.java
@@ -1,153 +1,142 @@
 package gregtech.common.covers;
 
+import com.google.common.io.ByteArrayDataInput;
+import cpw.mods.fml.common.network.ByteBufUtils;
 import gregtech.api.enums.GT_Values;
 import gregtech.api.gui.GT_GUICover;
 import gregtech.api.gui.widgets.GT_GuiFakeItemButton;
 import gregtech.api.gui.widgets.GT_GuiIcon;
-import gregtech.api.gui.widgets.GT_GuiIconButton;
+import gregtech.api.gui.widgets.GT_GuiIconCheckButton;
 import gregtech.api.interfaces.tileentity.ICoverable;
-import gregtech.api.net.GT_Packet_TileEntityCover;
-import gregtech.api.util.GT_CoverBehavior;
+import gregtech.api.net.GT_Packet_TileEntityCoverNew;
+import gregtech.api.util.GT_CoverBehavior_New;
 import gregtech.api.util.GT_Utility;
 import gregtech.api.util.ISerializableObject;
+import io.netty.buffer.ByteBuf;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTBase;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.World;
+import net.minecraftforge.common.util.Constants;
 import net.minecraftforge.fluids.Fluid;
 
+import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.List;
 
 import static gregtech.api.util.GT_Utility.intToStack;
 import static gregtech.api.util.GT_Utility.moveMultipleItemStacks;
-import static gregtech.api.util.GT_Utility.stackToInt;
 
-public class GT_Cover_ItemFilter extends GT_CoverBehavior {
+public class GT_Cover_ItemFilter extends GT_CoverBehavior_New<GT_Cover_ItemFilter.ItemFilterData> {
 
     private final boolean mExport;
 
-    public GT_Cover_ItemFilter(boolean isExport){
+    public GT_Cover_ItemFilter(boolean isExport) {
+        super(ItemFilterData.class);
         this.mExport = isExport;
     }
 
     @Override
-    public boolean isRedstoneSensitive(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
+    public ItemFilterData createDataObject(int aLegacyData) {
+        return new ItemFilterData((aLegacyData & 0x1) == 0, intToStack(aLegacyData >>> 1));
+    }
+
+    @Override
+    public ItemFilterData createDataObject() {
+        return new ItemFilterData();
+    }
+
+    @Override
+    protected boolean isRedstoneSensitiveImpl(byte aSide, int aCoverID, ItemFilterData aCoverVariable, ICoverable aTileEntity, long aTimer) {
         return false;
     }
 
     @Override
-    public int doCoverThings(byte aSide, byte aInputRedstone, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
+    protected ItemFilterData doCoverThingsImpl(byte aSide, byte aInputRedstone, int aCoverID, ItemFilterData aCoverVariable, ICoverable aTileEntity, long aTimer) {
         TileEntity tTileEntity = aTileEntity.getTileEntityAtSide(aSide);
         Object fromEntity = mExport ? aTileEntity : tTileEntity,
                 toEntity = !mExport ? aTileEntity : tTileEntity;
         byte fromSide = !mExport ? GT_Utility.getOppositeSide(aSide) : aSide,
                 toSide = mExport ? GT_Utility.getOppositeSide(aSide) : aSide;
 
-        int FilterId = aCoverVariable >>> 1;
-        List<ItemStack> Filter = Collections.singletonList(intToStack(FilterId));
+        List<ItemStack> Filter = Collections.singletonList(aCoverVariable.mFilter);
 
-        boolean isWhiteList = (aCoverVariable & 1) != 0;
-
-        moveMultipleItemStacks(fromEntity, toEntity, fromSide , toSide, Filter, isWhiteList, (byte) 64, (byte) 1, (byte) 64, (byte) 1,64);
+        moveMultipleItemStacks(fromEntity, toEntity, fromSide, toSide, Filter, aCoverVariable.mWhitelist, (byte) 64, (byte) 1, (byte) 64, (byte) 1, 64);
 
         return aCoverVariable;
     }
 
     @Override
-    protected boolean onCoverRightClickImpl(byte aSide, int aCoverID, ISerializableObject.LegacyCoverData aCoverVariable, ICoverable aTileEntity, EntityPlayer aPlayer, float aX, float aY, float aZ) {
+    protected boolean onCoverRightClickImpl(byte aSide, int aCoverID, ItemFilterData aCoverVariable, ICoverable aTileEntity, EntityPlayer aPlayer, float aX, float aY, float aZ) {
         ItemStack tStack = aPlayer.inventory.getCurrentItem();
-        int tCoverVariable = aCoverVariable.get() & 1;
         if (tStack != null) {
-            tCoverVariable = (stackToInt(tStack) << 1) + tCoverVariable;
-            aCoverVariable.set(tCoverVariable);
+            aCoverVariable.mFilter = tStack;
             GT_Utility.sendChatToPlayer(aPlayer, trans("301", "Item Filter: ") + tStack.getDisplayName());
         } else {
-            aCoverVariable.set(tCoverVariable);
+            aCoverVariable.mFilter = null;
             GT_Utility.sendChatToPlayer(aPlayer, trans("300", "Filter Cleared!"));
         }
         return true;
     }
 
     @Override
-    @SuppressWarnings("deprecation")
-    public boolean onCoverRightclick(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, EntityPlayer aPlayer, float aX, float aY, float aZ){
-            ItemStack tStack = aPlayer.inventory.getCurrentItem();
-            if (tStack != null){
-                aCoverVariable = (stackToInt(tStack) << 1) + (aCoverVariable & 1);
-                aTileEntity.setCoverDataAtSide(aSide, aCoverVariable);
-                GT_Utility.sendChatToPlayer(aPlayer, trans("301", "Item Filter: ") + tStack.getDisplayName());
-            }
-            else{
-                aCoverVariable = aCoverVariable & 1;
-                aTileEntity.setCoverDataAtSide(aSide, aCoverVariable);
-                GT_Utility.sendChatToPlayer(aPlayer, trans("300", "Filter Cleared!"));
-            }
-            return true;
-    }
-
-    @Override
-    public int onCoverScrewdriverclick(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, EntityPlayer aPlayer, float aX, float aY, float aZ) {
-        int mode = aCoverVariable & 1;
-        if (mode == 1) mode = 0;
-        else mode = 1;
-        if (mode == 1){
-            GT_Utility.sendChatToPlayer(aPlayer, trans("124", "Blacklist Mode"));
-        }
-        else{
-            GT_Utility.sendChatToPlayer(aPlayer, trans("125", "Whitelist Mode"));
-        }
-        aCoverVariable = (aCoverVariable & ~0x1) + mode;
+    protected ItemFilterData onCoverScrewdriverClickImpl(byte aSide, int aCoverID, ItemFilterData aCoverVariable, ICoverable aTileEntity, EntityPlayer aPlayer, float aX, float aY, float aZ) {
+        aCoverVariable.mWhitelist = !aCoverVariable.mWhitelist;
+        GT_Utility.sendChatToPlayer(aPlayer, aCoverVariable.mWhitelist ? trans("125", "Whitelist Mode") : trans("124", "Blacklist Mode"));
         return aCoverVariable;
     }
 
     @Override
-    public boolean letsRedstoneGoIn(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity) {
+    protected boolean letsRedstoneGoInImpl(byte aSide, int aCoverID, ItemFilterData aCoverVariable, ICoverable aTileEntity) {
         return true;
     }
 
     @Override
-    public boolean letsRedstoneGoOut(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity) {
+    protected boolean letsRedstoneGoOutImpl(byte aSide, int aCoverID, ItemFilterData aCoverVariable, ICoverable aTileEntity) {
         return true;
     }
 
     @Override
-    public boolean letsEnergyIn(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity) {
+    protected boolean letsEnergyInImpl(byte aSide, int aCoverID, ItemFilterData aCoverVariable, ICoverable aTileEntity) {
         return true;
     }
 
     @Override
-    public boolean letsEnergyOut(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity) {
+    protected boolean letsEnergyOutImpl(byte aSide, int aCoverID, ItemFilterData aCoverVariable, ICoverable aTileEntity) {
         return true;
     }
 
     @Override
-    public boolean letsFluidIn(byte aSide, int aCoverID, int aCoverVariable, Fluid aFluid, ICoverable aTileEntity) {
+    protected boolean letsFluidInImpl(byte aSide, int aCoverID, ItemFilterData aCoverVariable, Fluid aFluid, ICoverable aTileEntity) {
         return false;
     }
 
     @Override
-    public boolean letsFluidOut(byte aSide, int aCoverID, int aCoverVariable, Fluid aFluid, ICoverable aTileEntity) {
+    protected boolean letsFluidOutImpl(byte aSide, int aCoverID, ItemFilterData aCoverVariable, Fluid aFluid, ICoverable aTileEntity) {
         return false;
     }
 
     @Override
-    public boolean letsItemsIn(byte aSide, int aCoverID, int aCoverVariable, int aSlot, ICoverable aTileEntity) {
+    protected boolean letsItemsInImpl(byte aSide, int aCoverID, ItemFilterData aCoverVariable, int aSlot, ICoverable aTileEntity) {
         return true;
     }
 
     @Override
-    public boolean letsItemsOut(byte aSide, int aCoverID, int aCoverVariable, int aSlot, ICoverable aTileEntity) {
+    protected boolean letsItemsOutImpl(byte aSide, int aCoverID, ItemFilterData aCoverVariable, int aSlot, ICoverable aTileEntity) {
         return true;
     }
 
     @Override
-    public boolean alwaysLookConnected(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity) {
+    protected boolean alwaysLookConnectedImpl(byte aSide, int aCoverID, ItemFilterData aCoverVariable, ICoverable aTileEntity) {
         return true;
     }
 
     @Override
-    public int getTickRate(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity) {
+    protected int getTickRateImpl(byte aSide, int aCoverID, ItemFilterData aCoverVariable, ICoverable aTileEntity) {
         return 1;
     }
 
@@ -161,14 +150,68 @@ public class GT_Cover_ItemFilter extends GT_CoverBehavior {
     }
 
     @Override
-    public Object getClientGUI(byte aSide, int aCoverID, int coverData, ICoverable aTileEntity)  {
-        return new GT_Cover_ItemFilter.GUI(aSide, aCoverID, coverData, aTileEntity);
+    protected Object getClientGUIImpl(byte aSide, int aCoverID, ItemFilterData aCoverVariable, ICoverable aTileEntity, EntityPlayer aPlayer, World aWorld) {
+        return new GT_Cover_ItemFilter.GUI(aSide, aCoverID, aCoverVariable, aTileEntity);
+    }
+
+    public static class ItemFilterData implements ISerializableObject {
+        private boolean mWhitelist;
+        private ItemStack mFilter;
+
+        public ItemFilterData() {
+        }
+
+        public ItemFilterData(boolean mWhitelist, ItemStack mFilter) {
+            this.mWhitelist = mWhitelist;
+            this.mFilter = mFilter;
+        }
+
+        @Nonnull
+        @Override
+        public ISerializableObject copy() {
+            return new ItemFilterData(mWhitelist, mFilter);
+        }
+
+        @Nonnull
+        @Override
+        public NBTBase saveDataToNBT() {
+            NBTTagCompound tag = new NBTTagCompound();
+            tag.setBoolean("mWhitelist", mWhitelist);
+            if (mFilter != null)
+                tag.setTag("mFilter", mFilter.writeToNBT(new NBTTagCompound()));
+            return tag;
+        }
+
+        @Override
+        public void writeToByteBuf(ByteBuf aBuf) {
+            aBuf.writeBoolean(mWhitelist);
+            ByteBufUtils.writeItemStack(aBuf, mFilter);
+        }
+
+        @Override
+        public void loadDataFromNBT(NBTBase aNBT) {
+            NBTTagCompound tag = (NBTTagCompound) aNBT;
+            mWhitelist = tag.getBoolean("mWhitelist");
+            if (tag.hasKey("mFilter", Constants.NBT.TAG_COMPOUND))
+                mFilter = ItemStack.loadItemStackFromNBT(tag.getCompoundTag("mFilter"));
+            else
+                mFilter = null;
+        }
+
+        @Nonnull
+        @Override
+        public ISerializableObject readFromPacket(ByteArrayDataInput aBuf, EntityPlayerMP aPlayer) {
+            mWhitelist = aBuf.readBoolean();
+            mFilter = ISerializableObject.readItemStackFromGreggyByteBuf(aBuf);
+            return this;
+        }
     }
 
     private class GUI extends GT_GUICover {
         private final byte side;
         private final int coverID;
-        private int coverVariable;
+        private final GT_GuiIconCheckButton btnMode;
+        private final ItemFilterData coverVariable;
         private final GT_GuiFakeItemButton itemFilterButtons;
 
         private static final int startX = 10;
@@ -176,17 +219,15 @@ public class GT_Cover_ItemFilter extends GT_CoverBehavior {
         private static final int spaceX = 18;
         private static final int spaceY = 18;
 
-        public GUI(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity) {
+        public GUI(byte aSide, int aCoverID, ItemFilterData aCoverVariable, ICoverable aTileEntity) {
             super(aTileEntity, 176, 107, GT_Utility.intToStack(aCoverID));
             this.side = aSide;
             this.coverID = aCoverID;
             this.coverVariable = aCoverVariable;
 
-            GT_GuiIconButton b;
-            b = new GT_GuiIconButton(this, 0, startX + spaceX*0, startY+spaceY*0, GT_GuiIcon.WHITELIST).setTooltipText(trans("125","Whitelist Mode"));
-            b = new GT_GuiIconButton(this, 1, startX + spaceX*1, startY+spaceY*0, GT_GuiIcon.BLACKLIST).setTooltipText(trans("124","Blacklist Mode"));
+            btnMode = new GT_GuiIconCheckButton(this, 0, startX + spaceX * 0, startY + spaceY * 0, GT_GuiIcon.WHITELIST, GT_GuiIcon.BLACKLIST, trans("125", "Whitelist Mode"), trans("124", "Blacklist Mode"));
 
-            itemFilterButtons = new GT_GuiFakeItemButton(this ,startX + spaceX*0, startY+spaceY*2, GT_GuiIcon.SLOT_GRAY);
+            itemFilterButtons = new GT_GuiFakeItemButton(this, startX + spaceX * 0, startY + spaceY * 2, GT_GuiIcon.SLOT_GRAY);
         }
 
         @Override
@@ -202,46 +243,19 @@ public class GT_Cover_ItemFilter extends GT_CoverBehavior {
         }
 
         @Override
-        public void buttonClicked(GuiButton btn){
-            if (getClickable(btn.id)){
-                coverVariable = getNewCoverVariable(btn.id);
-                GT_Values.NW.sendToServer(new GT_Packet_TileEntityCover(side, coverID, coverVariable, tile));
+        public void buttonClicked(GuiButton btn) {
+            if (btn == btnMode) {
+                if (coverVariable.mWhitelist != btnMode.isChecked()) {
+                    coverVariable.mWhitelist = btnMode.isChecked();
+                    GT_Values.NW.sendToServer(new GT_Packet_TileEntityCoverNew(side, coverID, coverVariable, tile));
+                }
             }
             updateButtons();
         }
 
-        private void updateButtons(){
-            GuiButton b;
-            for (Object o : buttonList) {
-                b = (GuiButton) o;
-                b.enabled = getClickable(b.id);
-            }
-            ItemStack tItemStack = intToStack(coverVariable >>> 1);
-            if (tItemStack != null){
-                itemFilterButtons.setItem(tItemStack);
-                return;
-            }
-            itemFilterButtons.setItem(null);
-        }
-
-        private int getNewCoverVariable(int id) {
-            switch (id) {
-                case 0:
-                    return coverVariable & ~0x1;
-                case 1:
-                    return coverVariable | 0x1;
-            }
-            return coverVariable;
-        }
-
-        private boolean getClickable(int id) {
-            switch (id) {
-                case 0:
-                    return (0x1 & coverVariable) != 0;
-                case 1:
-                    return (0x1 & coverVariable) == 0;
-            }
-            return false;
+        private void updateButtons() {
+            btnMode.setChecked(coverVariable.mWhitelist);
+            itemFilterButtons.setItem(coverVariable.mFilter);
         }
     }
 }

--- a/src/main/java/gregtech/common/covers/GT_Cover_ItemMeter.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_ItemMeter.java
@@ -6,12 +6,14 @@ import gregtech.api.gui.widgets.GT_GuiFakeItemButton;
 import gregtech.api.gui.widgets.GT_GuiIcon;
 import gregtech.api.gui.widgets.GT_GuiIconCheckButton;
 import gregtech.api.gui.widgets.GT_GuiIntegerTextBox;
+import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.ICoverable;
+import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.net.GT_Packet_TileEntityCover;
 import gregtech.api.util.GT_CoverBehavior;
 import gregtech.api.util.GT_Utility;
+import gregtech.common.tileentities.machines.GT_MetaTileEntity_Hatch_OutputBus_ME;
 import gregtech.common.tileentities.storage.GT_MetaTileEntity_DigitalChestBase;
-
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
@@ -43,16 +45,22 @@ public class GT_Cover_ItemMeter extends GT_CoverBehavior {
 
         long tMax = 0;
         long tUsed = 0;
-        if (aTileEntity instanceof GT_MetaTileEntity_DigitalChestBase) {
-            GT_MetaTileEntity_DigitalChestBase dc = (GT_MetaTileEntity_DigitalChestBase)aTileEntity;
+        IMetaTileEntity mte = ((IGregTechTileEntity) aTileEntity).getMetaTileEntity();
+        if (mte instanceof GT_MetaTileEntity_DigitalChestBase) {
+            GT_MetaTileEntity_DigitalChestBase dc = (GT_MetaTileEntity_DigitalChestBase) mte;
             tMax = dc.getMaxItemCount(); // currently it is limited by int, but there is not much reason for that
             ItemStack[] inv = dc.getStoredItemData();
             if (inv != null && inv.length > 1 && inv[1] != null)
                 tUsed = inv[1].stackSize;
+        } else if (mte instanceof GT_MetaTileEntity_Hatch_OutputBus_ME) {
+            if (((GT_MetaTileEntity_Hatch_OutputBus_ME) mte).isLastOutputFailed()) {
+                tMax = 64;
+                tUsed = 64;
+            }
         } else {
             int[] tSlots = (aCoverVariable & SLOT_MASK) > 0 ?
-                 new int[] {(aCoverVariable & SLOT_MASK) - 1} :
-                 aTileEntity.getAccessibleSlotsFromSide(aSide);
+                    new int[]{(aCoverVariable & SLOT_MASK) - 1} :
+                    aTileEntity.getAccessibleSlotsFromSide(aSide);
 
             for (int i : tSlots) {
                 if (i >= 0 && i < aTileEntity.getSizeInventory()) {

--- a/src/main/java/gregtech/common/covers/GT_Cover_ItemMeter.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_ItemMeter.java
@@ -6,13 +6,10 @@ import gregtech.api.gui.widgets.GT_GuiFakeItemButton;
 import gregtech.api.gui.widgets.GT_GuiIcon;
 import gregtech.api.gui.widgets.GT_GuiIconCheckButton;
 import gregtech.api.gui.widgets.GT_GuiIntegerTextBox;
-import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.ICoverable;
-import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.net.GT_Packet_TileEntityCover;
 import gregtech.api.util.GT_CoverBehavior;
 import gregtech.api.util.GT_Utility;
-import gregtech.common.tileentities.machines.GT_MetaTileEntity_Hatch_OutputBus_ME;
 import gregtech.common.tileentities.storage.GT_MetaTileEntity_DigitalChestBase;
 
 import net.minecraft.client.gui.GuiButton;
@@ -46,22 +43,13 @@ public class GT_Cover_ItemMeter extends GT_CoverBehavior {
 
         long tMax = 0;
         long tUsed = 0;
-        IMetaTileEntity mte = ((IGregTechTileEntity)aTileEntity).getMetaTileEntity();
-        if (mte instanceof GT_MetaTileEntity_DigitalChestBase) {
-            GT_MetaTileEntity_DigitalChestBase dc = (GT_MetaTileEntity_DigitalChestBase)mte;
+        if (aTileEntity instanceof GT_MetaTileEntity_DigitalChestBase) {
+            GT_MetaTileEntity_DigitalChestBase dc = (GT_MetaTileEntity_DigitalChestBase)aTileEntity;
             tMax = dc.getMaxItemCount(); // currently it is limited by int, but there is not much reason for that
             ItemStack[] inv = dc.getStoredItemData();
             if (inv != null && inv.length > 1 && inv[1] != null)
                 tUsed = inv[1].stackSize;
-        }
-        else if (mte instanceof GT_MetaTileEntity_Hatch_OutputBus_ME) {
-            if (((GT_MetaTileEntity_Hatch_OutputBus_ME)mte).isLastOutputFailed())
-            {
-                tMax = 64;
-                tUsed = 64;
-            }
-        }
-        else {
+        } else {
             int[] tSlots = (aCoverVariable & SLOT_MASK) > 0 ?
                  new int[] {(aCoverVariable & SLOT_MASK) - 1} :
                  aTileEntity.getAccessibleSlotsFromSide(aSide);

--- a/src/main/java/gregtech/common/covers/GT_Cover_RedstoneWirelessBase.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_RedstoneWirelessBase.java
@@ -12,6 +12,7 @@ import gregtech.api.net.GT_Packet_TileEntityCover;
 import gregtech.api.net.GT_Packet_WirelessRedstoneCover;
 import gregtech.api.util.GT_CoverBehavior;
 import gregtech.api.util.GT_Utility;
+import gregtech.api.util.ISerializableObject;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraftforge.fluids.Fluid;
@@ -25,14 +26,26 @@ public abstract class GT_Cover_RedstoneWirelessBase extends GT_CoverBehavior {
 
     @Override
     public boolean onCoverRemoval(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, boolean aForced) {
-        GregTech_API.sWirelessRedstone.put(Integer.valueOf(aCoverVariable), Byte.valueOf((byte) 0));
+        GregTech_API.sWirelessRedstone.put(aCoverVariable, (byte) 0);
         return true;
     }
 
     @Override
+    protected boolean onCoverRightClickImpl(byte aSide, int aCoverID, ISerializableObject.LegacyCoverData aCoverVariable, ICoverable aTileEntity, EntityPlayer aPlayer, float aX, float aY, float aZ) {
+        if (((aX > 0.375D) && (aX < 0.625D)) || ((aSide > 3) && ((aY > 0.375D) && (aY < 0.625D)))) {
+            GregTech_API.sWirelessRedstone.put(aCoverVariable.get(), (byte) 0);
+            aCoverVariable.set((aCoverVariable.get() & (PRIVATE_MASK | CHECKBOX_MASK)) | (((Integer)GT_Utility.stackToInt(aPlayer.inventory.getCurrentItem())).hashCode() & PUBLIC_MASK));
+            GT_Utility.sendChatToPlayer(aPlayer, trans("081", "Frequency: ") + aCoverVariable);
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
     public boolean onCoverRightclick(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, EntityPlayer aPlayer, float aX, float aY, float aZ) {
         if (((aX > 0.375D) && (aX < 0.625D)) || ((aSide > 3) && ((aY > 0.375D) && (aY < 0.625D)))) {
-            GregTech_API.sWirelessRedstone.put(Integer.valueOf(aCoverVariable), Byte.valueOf((byte) 0));
+            GregTech_API.sWirelessRedstone.put(aCoverVariable, (byte) 0);
 
             int val = GT_Utility.stackToInt(aPlayer.inventory.getCurrentItem()) * (1 + aPlayer.inventory.getCurrentItem().getItemDamage());
 
@@ -48,7 +61,7 @@ public abstract class GT_Cover_RedstoneWirelessBase extends GT_CoverBehavior {
     @Override
     public int onCoverScrewdriverclick(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, EntityPlayer aPlayer, float aX, float aY, float aZ) {
         if (((aX > 0.375D) && (aX < 0.625D)) || ((aSide <= 3) || (((aY > 0.375D) && (aY < 0.625D)) || ((((aZ <= 0.375D) || (aZ >= 0.625D))))))) {
-            GregTech_API.sWirelessRedstone.put(Integer.valueOf(aCoverVariable), Byte.valueOf((byte) 0));
+            GregTech_API.sWirelessRedstone.put(aCoverVariable, (byte) 0);
             float[] tCoords = GT_Utility.getClickedFacingCoords(aSide, aX, aY, aZ);
 
             short tAdjustVal = 0;

--- a/src/main/java/gregtech/common/covers/GT_Cover_SolarPanel.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_SolarPanel.java
@@ -3,6 +3,7 @@ package gregtech.common.covers;
 import gregtech.api.interfaces.tileentity.ICoverable;
 import gregtech.api.util.GT_CoverBehavior;
 import gregtech.api.util.GT_Utility;
+import gregtech.api.util.ISerializableObject;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
@@ -58,6 +59,29 @@ public class GT_Cover_SolarPanel extends GT_CoverBehavior {
     }
 
     @Override
+    protected boolean onCoverRightClickImpl(byte aSide, int aCoverID, ISerializableObject.LegacyCoverData aCoverVariable, ICoverable aTileEntity, EntityPlayer aPlayer, float aX, float aY, float aZ) {
+        if(aPlayer.capabilities.isCreativeMode){
+            GT_Utility.sendChatToPlayer(aPlayer,"Cleaned solar panel from "+(aCoverVariable.get()>>2)+"% dirt");
+             aCoverVariable.set(aCoverVariable.get() & 0x3);
+            return true;
+        }
+        for(int i=0;i<aPlayer.inventory.mainInventory.length;i++){
+            ItemStack is=aPlayer.inventory.mainInventory[i];
+            if(is==null) continue;
+            if(is.getUnlocalizedName().equals(new ItemStack(Items.water_bucket).getUnlocalizedName())){
+                aPlayer.inventory.mainInventory[i]=new ItemStack(Items.bucket);
+                if (aPlayer.inventoryContainer != null) aPlayer.inventoryContainer.detectAndSendChanges();
+                GT_Utility.sendChatToPlayer(aPlayer,"Cleaned solar panel from "+(aCoverVariable.get()>>2)+"% dirt");
+                aCoverVariable.set(aCoverVariable.get() & 0x3);
+                return true;
+            }
+        }
+        GT_Utility.sendChatToPlayer(aPlayer,"You need water bucket in inventory to clean the panel.");
+        return false;
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
     public boolean onCoverRightclick(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, EntityPlayer aPlayer, float aX, float aY, float aZ) {
         if(aPlayer.capabilities.isCreativeMode){
             GT_Utility.sendChatToPlayer(aPlayer,"Cleaned solar panel from "+(aCoverVariable>>2)+"% dirt");

--- a/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler.java
+++ b/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler.java
@@ -175,7 +175,7 @@ public abstract class GT_MetaTileEntity_Boiler extends GT_MetaTileEntity_BasicTa
 
     @Override
     public boolean allowCoverOnSide(byte aSide, GT_ItemStack aCover) {
-        return GregTech_API.getCoverBehavior(aCover.toStack()).isSimpleCover();
+        return GregTech_API.getCoverBehaviorNew(aCover.toStack()).isSimpleCover();
     }
 
     @Override

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_PrimitiveBlastFurnace.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_PrimitiveBlastFurnace.java
@@ -114,7 +114,7 @@ public abstract class GT_MetaTileEntity_PrimitiveBlastFurnace extends MetaTileEn
 
     @Override
     public boolean allowCoverOnSide(byte aSide, GT_ItemStack aCoverID) {
-        return (GregTech_API.getCoverBehavior(aCoverID.toStack()).isSimpleCover()) && (super.allowCoverOnSide(aSide, aCoverID));
+        return (GregTech_API.getCoverBehaviorNew(aCoverID.toStack()).isSimpleCover()) && (super.allowCoverOnSide(aSide, aCoverID));
     }
 
 	@Override


### PR DESCRIPTION
WARNING: This is an old patch set (~3 months) I just resurrect from my git stash today. Expect bugs to come.

Enable covers to use a full nbt tag as cover variable instead of just 4 bytes. Pave path (but does not directly address) for @leagris's paintable cover and much more.

----

Items to test:

- [ ] Whether all covers, including those from addons, are still working properly
- [ ] Whether all existing covers inherits its old setting **except fluid filter**. Fluid filter is just too ill coded that a proper and complete migration is too tedious.
- [ ] Whether all cover GUIs still work.
- [ ] Whether broken blocks retain cover data just fine.

---

Key points:

1. Full binary and source code compatibility with old addons. (supposedly)
  This is done by inserting a super class into GT_CoverBehavior's class hiearchy.
2. Existing cover code will still use the old 4 byte storage, until someone decide to migrate it over. I'm not going to do it this time.
3. Example of migration include GT_Cover_ItemFilter and GT_Cover_Fluidfilter. Ask on discord if in doubt.