### PR TITLE
Fix GT++ semi-fluid generator

### DIFF
--- a/src/main/java/gregtech/api/util/GT_Recipe.java
+++ b/src/main/java/gregtech/api/util/GT_Recipe.java
@@ -1045,6 +1045,10 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
                     tFluid.amount = 0;
                     mRecipesByFluidInput.put(tFluid.getUnlocalizedName(), aRecipe);
                 }
+            } else if ((aRecipe.mInputs == null || GT_Utility.getNonnullElementCount(aRecipe.mInputs) == 0) &&
+                    aRecipe.mFluidInputs != null && GT_Utility.getNonnullElementCount(aRecipe.mFluidInputs) == 1 &&
+                    aRecipe.mFluidInputs[0] != null) {
+                mRecipesByFluidInput.put(aRecipe.mFluidInputs[0].getUnlocalizedName(), aRecipe);
             }
             return aRecipe;
         }


### PR DESCRIPTION
Fix for `GT_Recipe_Map_Fuel` not handling fluid recipes correctly. As it happens, the GT++ semi-fluid generator only (or mostly) uses fluid recipes.

 * Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/4306
 * Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/6313