### PR TITLE
Fix recipe input check

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 minecraft.version=1.7.10
 forge.version=10.13.4.1614-1.7.10
-gt.version=5.09.39.00
+gt.version=5.09.39.01
 structurelib.version=1.0.6
 ae2.version=rv3-beta-22
 applecore.version=1.7.10-1.2.1+107.59407

--- a/src/main/java/gregtech/api/util/GT_Recipe.java
+++ b/src/main/java/gregtech/api/util/GT_Recipe.java
@@ -376,6 +376,19 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
         return isRecipeInputEqual(aDecreaseStacksizeBySuccess, false, aFluidInputs, aInputs);
     }
 
+    /**
+     * Okay, did some code archeology to figure out what's going on here.
+     *
+     * <p>This variable was added in
+     * <a href=https://github.com/GTNewHorizons/GT5-Unofficial/commit/9959ab7443982a19ad329bca424ab515493432e9>this commit,</a>
+     * in order to fix the issues mentioned in
+     * <a href=https://github.com/GTNewHorizons/GT5-Unofficial/pull/183>the PR</a>.
+     *
+     * <p>It looks like it controls checking NBT. At this point, since we are still using universal
+     * fluid cells which store their fluids in NBT, it probably will not be safe to disable the NBT
+     * checks in the near future. Data sticks may be another case. Anyway, we probably can't get rid
+     * of this without some significant changes to clean up recipe inputs.
+     */
     public static boolean GTppRecipeHelper;
 
     /**
@@ -443,7 +456,7 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
                     for (int i = 0; i < aInputs.length; i++) {
                         ItemStack providedItem = aInputs[i];
                         if (GT_OreDictUnificator.isInputStackEqual(providedItem, unifiedItemCost)) {
-                            if (GTppRecipeHelper) { // remove once the fix is out
+                            if (GTppRecipeHelper) { // Please see JavaDoc on GTppRecipeHelper for why this is here.
                                 if (GT_Utility.areStacksEqual(providedItem, Ic2Items.FluidCell.copy(), true) || GT_Utility.areStacksEqual(providedItem, ItemList.Tool_DataStick.get(1L), true) || GT_Utility.areStacksEqual(providedItem, ItemList.Tool_DataOrb.get(1L), true)) {
                                     if (!GT_Utility.areStacksEqual(providedItem, recipeItemCost, false))
                                         continue;


### PR DESCRIPTION
It's been a long time, but I finally got around to sending out a PR for this.

 * Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/8303
 * Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/8824

---

It's difficult to test recipe code thoroughly, so please review carefully. Here's a quick explanation of how the new algorithm is supposed to work:

In order to properly handle the possibility of multiple stacks of the same item in the recipe inputs, we need to store the stack amounts of the machine inputs so that we can dynamically modify them. This allows us to have a single machine input stack count towards more than one recipe input stack: for example, if the recipe requires two stacks of size 32, the new algorithm can satisfy both of those with a single stack of size 64. The old algorithm could not, because it had nowhere to store the leftover 32 items after the first recipe input stack is checked; this is the root cause of the bug.

The key optimization here is that the math to do this is identical to the math we need to do later to decrease the machine input stack sizes. So we just hold on to those stored stack sizes, and copy them over to the machine inputs later; this cuts the amount of work we need to do in half for this case. As a slight optimization, we lazily initialize the stored stack sizes: we start with an array of all `null`, and only write a value into the array when we modify a stack size. This saves us an array initialization loop, and also reduces the amount of work we need to do to copy values back at the end.

---

I tested this with my profiling code (mentioned [here](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/8303#issue-955177177)) on a few setups, and got somewhere between 1% and 75% speed-up. Yes, that is a huge range, which I think is because my profiling setup was pretty seriously flawed (algorithms are too fast for stopwatch to measure properly), and also the fact that there are many different edge cases with different performance characteristics. In general, I expected the new algorithm to be roughly equal in speed when not decreasing inputs, and roughly twice as fast when decreasing inputs.

In the hope of getting more accurate data, I tested this on boubou's test world and compared against the data that I had here:
 * https://github.com/GTNewHorizons/GT5-Unofficial/pull/732#issuecomment-969524037

The locked recipe code is completely separate, so hopefully I can use it as an anchor to compare the old and new algorithms. Here's what I got with the new algorithm:

Tick time:
 * ~1.8 ms unlocked
 * ~1.6 ms locked

Tricorder:
 * ~80 μs unlocked
 * ~36 μs locked

The tricorder ratio is roughly the same, and the tick time ratio is substantially better, which I guess is a good sign? Not sure why the tricorder times are so much greater than in the linked comment, though.

