### PR TITLE
Fix pollution ticking and reading

### DIFF
--- a/src/main/java/gregtech/api/util/GT_ChunkAssociatedData.java
+++ b/src/main/java/gregtech/api/util/GT_ChunkAssociatedData.java
@@ -296,7 +296,7 @@ public abstract class GT_ChunkAssociatedData<T extends GT_ChunkAssociatedData.ID
 		}
 
 		public boolean isCreated(int subRegionX, int subRegionZ) {
-			return this.data[getIndex(subRegionX, subRegionZ)] == null;
+			return this.data[getIndex(subRegionX, subRegionZ)] != null;
 		}
 
 		public ChunkCoordIntPair getCoord() {


### PR DESCRIPTION
1. There was a bug preventing GT scanners from showing any pollutions. With this patch they will no longer report "no pollution" in a chunk with positive pollution
   Electric Prospectors from Detrav Scanner in pollution mode is however not affected by this bug, which is why I didn't catch this in dev .
2. There was a bug causing chunk pollution to only get ticked intermittently. With this patch, chunk pollution will start receiving ticks immediately upon turning positive, instead of on next server reboot.
   I restarted my dev test world multiple times and missed this completely.