### PR TITLE
make the debuff time depend on contents

### DIFF
--- a/src/main/java/gregtech/common/blocks/GT_Item_Machines.java
+++ b/src/main/java/gregtech/common/blocks/GT_Item_Machines.java
@@ -243,11 +243,18 @@ public class GT_Item_Machines extends ItemBlock implements IFluidContainerItem {
             NBTTagCompound tNBT = aStack.stackTagCompound;
             if (tNBT == null) return;
             if ((tNBT.hasKey("mItemCount") && tNBT.getInteger("mItemCount") > 0) ||
-                    tNBT.hasKey("mFluid")) {
-                tPlayer.addPotionEffect(new PotionEffect(Potion.hunger.id, 12000, 4));
-                tPlayer.addPotionEffect(new PotionEffect(Potion.moveSlowdown.id, 12000, 4));
-                tPlayer.addPotionEffect(new PotionEffect(Potion.digSlowdown.id, 12000, 4));
-                tPlayer.addPotionEffect(new PotionEffect(Potion.weakness.id, 12000, 4));
+                    (tNBT.hasKey("mFluid") && FluidStack.loadFluidStackFromNBT(tNBT.getCompoundTag("mFluid")).amount > 64000)) {
+                double tFluidAmount = FluidStack.loadFluidStackFromNBT(tNBT.getCompoundTag("mFluid")).amount;
+                double tMiddlePoint = 4096000;
+                double tSmoothingCoefficient = 2000000;
+                int tMaxLastingTime = 12000;
+                double tmp = (tFluidAmount - tMiddlePoint) / tSmoothingCoefficient;
+                int tLasing = (int) (Math.exp(tmp) / (Math.exp(tmp) + Math.exp(-tmp)) * tMaxLastingTime);
+                if (tFluidAmount == 0) tLasing = 1200;
+                tPlayer.addPotionEffect(new PotionEffect(Potion.hunger.id, tLasing, 4));
+                tPlayer.addPotionEffect(new PotionEffect(Potion.moveSlowdown.id, tLasing, 4));
+                tPlayer.addPotionEffect(new PotionEffect(Potion.digSlowdown.id, tLasing, 4));
+                tPlayer.addPotionEffect(new PotionEffect(Potion.weakness.id, tLasing, 4));
             }
         }
     }


### PR DESCRIPTION
it won't give player debuff when its contents amount is less 64000L.
the relationship between contents amount and lasing time:
![image](https://user-images.githubusercontent.com/60341015/144751060-268cc0af-8eaa-49d7-87c5-b0b4ece62c46.png)
![image](https://user-images.githubusercontent.com/60341015/144751079-cb214931-be06-4376-8e79-7600c547762d.png)
it will reach 10mins at last
fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/8934
