### PR TITLE
Add threshold support to item and fluid covers

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
@@ -176,9 +176,10 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
                     GT_CoverBehaviorBase<?> tBehavior = getCoverBehaviorAtSideNew(i);
                     if (tBehavior == null)
                         continue;
-                    mCoverData[i] = tBehavior.createDataObject();
                     if (aNBT.hasKey(COVER_DATA_NBT_KEYS[i]))
-                        mCoverData[i].loadDataFromNBT(aNBT.getTag(COVER_DATA_NBT_KEYS[i]));
+                        mCoverData[i] = tBehavior.createDataObject(aNBT.getTag(COVER_DATA_NBT_KEYS[i]));
+                    else
+                        mCoverData[i] = tBehavior.createDataObject();
                 }
             }
             if (mSidedRedstone.length != 6) mSidedRedstone = new byte[]{0, 0, 0, 0, 0, 0};

--- a/src/main/java/gregtech/api/util/GT_CoverBehaviorBase.java
+++ b/src/main/java/gregtech/api/util/GT_CoverBehaviorBase.java
@@ -8,6 +8,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTBase;
+import net.minecraft.nbt.NBTTagInt;
 import net.minecraft.world.World;
 import net.minecraftforge.fluids.Fluid;
 
@@ -31,7 +32,12 @@ public abstract class GT_CoverBehaviorBase<T extends ISerializableObject> {
 
     public abstract T createDataObject();
 
-    public T createDataObject(NBTBase aNBT) {
+    public final T createDataObject(NBTBase aNBT) {
+        // Handle legacy data (migrating from GT_CoverBehavior to GT_CoverBehaviorBase)
+        if (aNBT instanceof NBTTagInt) {
+            return createDataObject(((NBTTagInt) aNBT).func_150287_d());
+        }
+
         T ret = createDataObject();
         ret.loadDataFromNBT(aNBT);
         return ret;

--- a/src/main/java/gregtech/api/util/GT_LanguageManager.java
+++ b/src/main/java/gregtech/api/util/GT_LanguageManager.java
@@ -337,6 +337,8 @@ public class GT_LanguageManager {
 		addStringLocalization("Interaction_DESCRIPTION_Index_218", "Transfer size mode. Add exactly this many items in destination input slots as long as there is room.");
 		addStringLocalization("Interaction_DESCRIPTION_Index_219", "Single recipe locking enabled. Will lock to next recipe.");
 		addStringLocalization("Interaction_DESCRIPTION_Index_220", "Single recipe locking disabled.");
+		addStringLocalization("Interaction_DESCRIPTION_Index_221", "Item threshold");
+		addStringLocalization("Interaction_DESCRIPTION_Index_222", "Fluid threshold (KL)");
 		addStringLocalization("Interaction_DESCRIPTION_Index_500", "Fitting: Loose - More Flow");
 		addStringLocalization("Interaction_DESCRIPTION_Index_501", "Fitting: Tight - More Efficiency");
 

--- a/src/main/java/gregtech/api/util/GT_LanguageManager.java
+++ b/src/main/java/gregtech/api/util/GT_LanguageManager.java
@@ -338,7 +338,7 @@ public class GT_LanguageManager {
 		addStringLocalization("Interaction_DESCRIPTION_Index_219", "Single recipe locking enabled. Will lock to next recipe.");
 		addStringLocalization("Interaction_DESCRIPTION_Index_220", "Single recipe locking disabled.");
 		addStringLocalization("Interaction_DESCRIPTION_Index_221", "Item threshold");
-		addStringLocalization("Interaction_DESCRIPTION_Index_222", "Fluid threshold (KL)");
+		addStringLocalization("Interaction_DESCRIPTION_Index_222", "Fluid threshold");
 		addStringLocalization("Interaction_DESCRIPTION_Index_500", "Fitting: Loose - More Flow");
 		addStringLocalization("Interaction_DESCRIPTION_Index_501", "Fitting: Tight - More Efficiency");
 

--- a/src/main/java/gregtech/api/util/ISerializableObject.java
+++ b/src/main/java/gregtech/api/util/ISerializableObject.java
@@ -24,6 +24,11 @@ public interface ISerializableObject {
     @Nonnull
     ISerializableObject copy();
 
+    /**
+     * If you are overriding this, you must <b>NOT</b> return {@link NBTTagInt} here! That return
+     * type is how we tell that we are loading legacy data, and only {@link LegacyCoverData} is
+     * allowed to return it. You probably want to return {@link NBTTagCompound} anyway.
+     */
     @Nonnull
     NBTBase saveDataToNBT();
 
@@ -109,7 +114,7 @@ public interface ISerializableObject {
 
         @Override
         public void loadDataFromNBT(NBTBase aNBT) {
-            mData = aNBT instanceof NBTBase.NBTPrimitive ? ((NBTBase.NBTPrimitive) aNBT).func_150287_d() : 0;
+            mData = aNBT instanceof NBTTagInt ? ((NBTTagInt) aNBT).func_150287_d() : 0;
         }
 
         @Override

--- a/src/main/java/gregtech/common/covers/GT_Cover_ItemMeter.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_ItemMeter.java
@@ -309,7 +309,7 @@ public class GT_Cover_ItemMeter extends GT_CoverBehaviorBase<GT_Cover_ItemMeter.
                 intSlot.setEnabled(false);
 
             thresholdSlot = new GT_GuiIntegerTextBox(this, 2, startX + spaceX * 0, startY + spaceY * 2 + 2, spaceX * 2 + 5, 12);
-            thresholdSlot.setMaxStringLength(5);
+            thresholdSlot.setMaxStringLength(6);
         }
 
         @Override
@@ -365,7 +365,7 @@ public class GT_Cover_ItemMeter extends GT_CoverBehaviorBase<GT_Cover_ItemMeter.
 
                 val += step * Integer.signum(delta);
 
-                int upperBound = maxSlot > 0 ? maxSlot * 64 : Integer.MAX_VALUE;
+                int upperBound = maxSlot > 0 ? maxSlot * 64 : 999_999;
                 val = GT_Utility.clamp(val, 0, upperBound);
                 thresholdSlot.setText(Integer.toString(val));
             }
@@ -448,7 +448,7 @@ public class GT_Cover_ItemMeter extends GT_CoverBehaviorBase<GT_Cover_ItemMeter.
                     return 0;
                 }
 
-                int upperBound = maxSlot > 0 ? maxSlot * 64 : Integer.MAX_VALUE;
+                int upperBound = maxSlot > 0 ? maxSlot * 64 : 999_999;
                 return GT_Utility.clamp(val, 0, upperBound);
             }
 


### PR DESCRIPTION
This adds a field to configure minimum amount of items / fluid (in kilo-liters) to the item detector cover and the fluid detector cover. If the amount of items / fluid is below the configured threshold, it will be treated as though it were 0[^1].

This should cut down on the amount of dense redstone, etc. needed to use these covers. Though, I did run a bit low on bits for the item detector cover, so the max is only 64, which means that this feature is best used when detecting a specific slot (as opposed to the entire container).

[^1]: It's actually a bit more complicated than that. The exact semantics are as follows:
    * If set to 0, then the threshold feature is turned off
    * If in normal mode, then the configured threshold will be treated as a lower bound: no redstone signal will be output until it is reached
    * If in inverted mode, then the configured threshold will be treated as an upper bound: once it is reached, the redstone signal will be stopped even if the container is not full yet