### PR TITLE
add infinite oil rig

### DIFF
--- a/src/main/java/gregtech/api/enums/ItemList.java
+++ b/src/main/java/gregtech/api/enums/ItemList.java
@@ -1559,6 +1559,7 @@ public enum ItemList implements IItemContainer {
     OilDrill1,
     OilDrill2,
     OilDrill3,
+    OilDrillInfinite,
     ConcreteBackfiller1,
     ConcreteBackfiller2,
     OreDrill1,

--- a/src/main/java/gregtech/common/GT_UndergroundOil.java
+++ b/src/main/java/gregtech/common/GT_UndergroundOil.java
@@ -92,11 +92,13 @@ public class GT_UndergroundOil {
                 // if XSTR_INSTANCE is < chance then subtract 1
                 chunkData.changeAmount(-decrease);//diminish amount, "randomly" adjusted to double value (averageDecrease)
             }
-        } else {//just get info
+        }
+        else {//just get info
             if (chunkData.amount <= DIVIDER) {
                 chunkData.setAmount(0);
             } else {
-                fluidInChunk.amount = chunkData.amount / DIVIDER;//give moderate extraction speed
+                //get the expected current output
+                fluidInChunk.amount = (int) Math.floor(chunkData.getAmount() * (double) -readOrDrainCoefficient / DIVIDER);
             }
         }
         return fluidInChunk;

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_OilDrillBase.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_OilDrillBase.java
@@ -147,6 +147,10 @@ public abstract class GT_MetaTileEntity_OilDrillBase extends GT_MetaTileEntity_D
                 ) >> tier);
     }
 
+    protected float computeSpeed(){
+       return .5F+(GT_Utility.getTier(getMaxInputVoltage()) - getMinTier()) *.25F;
+    }
+
     @Override
     protected boolean workingAtBottom(ItemStack aStack, int xDrill, int yDrill, int zDrill, int xPipe, int zPipe, int yHead, int oldYHead) {
         switch (tryLowerPipeState(true)) {
@@ -160,7 +164,7 @@ public abstract class GT_MetaTileEntity_OilDrillBase extends GT_MetaTileEntity_D
                 GT_ChunkManager.requestChunkLoad((TileEntity) getBaseMetaTileEntity(), null);
                 mWorkChunkNeedsReload = false;
             }
-            float speed = .5F+(GT_Utility.getTier(getMaxInputVoltage()) - getMinTier()) *.25F;
+            float speed = computeSpeed();
             FluidStack tFluid = pumpOil(speed);
             if (tFluid != null && tFluid.amount > getTotalConfigValue()){
                 this.mOutputFluids = new FluidStack[]{tFluid};

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_OilDrillBase.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_OilDrillBase.java
@@ -234,7 +234,7 @@ public abstract class GT_MetaTileEntity_OilDrillBase extends GT_MetaTileEntity_D
         return !mOilFieldChunks.isEmpty();
     }
 
-    private FluidStack pumpOil(float speed){
+    protected FluidStack pumpOil(float speed){
         if (mOilId <= 0) return null;
         FluidStack tFluid, tOil;
         tOil = new FluidStack(FluidRegistry.getFluid(mOilId), 0);
@@ -245,13 +245,13 @@ public abstract class GT_MetaTileEntity_OilDrillBase extends GT_MetaTileEntity_D
         }
 
         ArrayList<Chunk> emptyChunks = new ArrayList<>();
-        
+
         for (Chunk tChunk : mOilFieldChunks) {
             tFluid = undergroundOil(tChunk,speed);
             if (debugDriller) {
                 GT_Log.out.println(
-                    " chunkX = " + tChunk.getChunkCoordIntPair().chunkXPos + 
-                    " chunkZ = " + tChunk.getChunkCoordIntPair().chunkZPos 
+                    " chunkX = " + tChunk.getChunkCoordIntPair().chunkXPos +
+                    " chunkZ = " + tChunk.getChunkCoordIntPair().chunkZPos
                 );
                 if( tFluid != null ) {
                     GT_Log.out.println(
@@ -259,10 +259,10 @@ public abstract class GT_MetaTileEntity_OilDrillBase extends GT_MetaTileEntity_D
                     );
                 } else {
                     GT_Log.out.println(
-                        "     No fluid pumped " 
+                        "     No fluid pumped "
                     );
                 }
-                
+
             }
             if (tFluid == null || tFluid.amount<1) emptyChunks.add(tChunk);
             if (tOil.isFluidEqual(tFluid)) tOil.amount += tFluid.amount;

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_OilDrillInfinite.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_OilDrillInfinite.java
@@ -4,9 +4,13 @@ import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
+import gregtech.api.objects.GT_ChunkManager;
 import gregtech.api.util.GT_Multiblock_Tooltip_Builder;
 import gregtech.api.util.GT_Utility;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.ChunkCoordIntPair;
 import net.minecraftforge.fluids.FluidStack;
 
 import static gregtech.api.enums.GT_Values.VN;
@@ -46,11 +50,10 @@ public class GT_MetaTileEntity_OilDrillInfinite extends GT_MetaTileEntity_OilDri
     public IMetaTileEntity newMetaEntity(IGregTechTileEntity aTileEntity) {
         return new GT_MetaTileEntity_OilDrillInfinite(mName);
     }
+
     @Override
     protected FluidStack pumpOil(float speed){
-        FluidStack baseRate = super.pumpOil(-1);
-        baseRate.amount *= 1+(GT_Utility.getTier(getMaxInputVoltage()) - getMinTier());
-        return baseRate;
+        return super.pumpOil(-speed);
     }
 
     @Override
@@ -80,6 +83,6 @@ public class GT_MetaTileEntity_OilDrillInfinite extends GT_MetaTileEntity_OilDri
 
     @Override
     protected int getMinTier() {
-        return 9;
+        return 4; //to match the speed of the oil drill III
     }
 }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_OilDrillInfinite.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_OilDrillInfinite.java
@@ -4,13 +4,8 @@ import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
-import gregtech.api.objects.GT_ChunkManager;
 import gregtech.api.util.GT_Multiblock_Tooltip_Builder;
 import gregtech.api.util.GT_Utility;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.item.ItemStack;
-import net.minecraft.tileentity.TileEntity;
-import net.minecraft.world.ChunkCoordIntPair;
 import net.minecraftforge.fluids.FluidStack;
 
 import static gregtech.api.enums.GT_Values.VN;
@@ -73,16 +68,16 @@ public class GT_MetaTileEntity_OilDrillInfinite extends GT_MetaTileEntity_OilDri
 
     @Override
     protected int getRangeInChunks() {
-        return 4;
+        return 8;
     }
 
     @Override
-    public void onScrewdriverRightClick(byte aSide, EntityPlayer aPlayer, float aX, float aY, float aZ){
-        return;
+    protected float computeSpeed(){
+        return .5F+(GT_Utility.getTier(getMaxInputVoltage()) - getMinTier()+5) *.25F;
     }
 
     @Override
     protected int getMinTier() {
-        return 4; //to match the speed of the oil drill III
+        return 9;
     }
 }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_OilDrillInfinite.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_OilDrillInfinite.java
@@ -1,0 +1,85 @@
+package gregtech.common.tileentities.machines.multi;
+
+import gregtech.api.enums.ItemList;
+import gregtech.api.enums.Materials;
+import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
+import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
+import gregtech.api.util.GT_Multiblock_Tooltip_Builder;
+import gregtech.api.util.GT_Utility;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraftforge.fluids.FluidStack;
+
+import static gregtech.api.enums.GT_Values.VN;
+
+public class GT_MetaTileEntity_OilDrillInfinite extends GT_MetaTileEntity_OilDrillBase{
+    public GT_MetaTileEntity_OilDrillInfinite(int aID, String aName, String aNameRegional) {
+        super(aID, aName, aNameRegional);
+    }
+
+    public GT_MetaTileEntity_OilDrillInfinite(String aName) {
+        super(aName);
+    }
+
+    @Override
+    protected GT_Multiblock_Tooltip_Builder createTooltip() {
+        String casings = getCasingBlockItem().get(0).getDisplayName();
+
+        final GT_Multiblock_Tooltip_Builder tt = new GT_Multiblock_Tooltip_Builder();
+        tt.addMachineType("Pump")
+                .addInfo("Controller Block for the Infinite Oil/Gas/Fluid Drilling Rig ")
+                .addInfo("Works on " + getRangeInChunks() + "x" + getRangeInChunks() + " chunks")
+                .addSeparator()
+                .beginStructureBlock(3, 7, 3, false)
+                .addController("Front bottom")
+                .addStructureInfo(casings + " form the 3x1x3 Base")
+                .addOtherStructurePart(casings, " 1x3x1 pillar above the center of the base (2 minimum total)")
+                .addOtherStructurePart(getFrameMaterial().mName + " Frame Boxes", "Each pillar's side and 1x3x1 on top")
+                .addEnergyHatch(VN[getMinTier()] + "+, Any base casing", 1)
+                .addMaintenanceHatch("Any base casing", 1)
+                .addInputBus("Mining Pipes or Circuits, optional, any base casing", 1)
+                .addOutputHatch("Any base casing", 1)
+                .toolTipFinisher("Gregtech");
+        return tt;
+    }
+
+    @Override
+    public IMetaTileEntity newMetaEntity(IGregTechTileEntity aTileEntity) {
+        return new GT_MetaTileEntity_OilDrillInfinite(mName);
+    }
+    @Override
+    protected FluidStack pumpOil(float speed){
+        FluidStack baseRate = super.pumpOil(-1);
+        baseRate.amount *= 1+(GT_Utility.getTier(getMaxInputVoltage()) - getMinTier());
+        return baseRate;
+    }
+
+    @Override
+    protected ItemList getCasingBlockItem() {
+        return ItemList.Casing_MiningNeutronium;
+    }
+
+    @Override
+    protected Materials getFrameMaterial() {
+        return Materials.Neutronium;
+    }
+
+    @Override
+    protected int getCasingTextureIndex() {
+        return 178;
+    }
+
+    @Override
+    protected int getRangeInChunks() {
+        return 1;
+    }
+
+    @Override
+    public void onScrewdriverRightClick(byte aSide, EntityPlayer aPlayer, float aX, float aY, float aZ){
+        return;
+    }
+
+    @Override
+    protected int getMinTier() {
+        return 9;
+    }
+}

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_OilDrillInfinite.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_OilDrillInfinite.java
@@ -70,7 +70,7 @@ public class GT_MetaTileEntity_OilDrillInfinite extends GT_MetaTileEntity_OilDri
 
     @Override
     protected int getRangeInChunks() {
-        return 1;
+        return 4;
     }
 
     @Override

--- a/src/main/java/gregtech/loaders/preload/GT_Loader_MetaTileEntities.java
+++ b/src/main/java/gregtech/loaders/preload/GT_Loader_MetaTileEntities.java
@@ -1007,6 +1007,7 @@ public class GT_Loader_MetaTileEntities implements Runnable {//TODO CHECK CIRCUI
         ItemList.OilDrill1.set(new GT_MetaTileEntity_OilDrill1(1157, "multimachine.oildrill1", "Oil/Gas/Fluid Drilling Rig").getStackForm(1));
         ItemList.OilDrill2.set(new GT_MetaTileEntity_OilDrill2(141, "multimachine.oildrill2", "Oil/Gas/Fluid Drilling Rig II").getStackForm(1));
         ItemList.OilDrill3.set(new GT_MetaTileEntity_OilDrill3(142, "multimachine.oildrill3", "Oil/Gas/Fluid Drilling Rig III").getStackForm(1));
+        ItemList.OilDrillInfinite.set(new GT_MetaTileEntity_OilDrillInfinite(148, "multimachine.oildrillinfinite", "Infinite Oil/Gas/Fluid Drilling Rig").getStackForm(1));
 
         ItemList.ConcreteBackfiller1.set(new GT_MetaTileEntity_ConcreteBackfiller1(143, "multimachine.concretebackfiller1", "Concrete Backfiller").getStackForm(1));
         ItemList.ConcreteBackfiller2.set(new GT_MetaTileEntity_ConcreteBackfiller2(144, "multimachine.concretebackfiller3", "Advanced Concrete Backfiller").getStackForm(1));


### PR DESCRIPTION
This PR adds a new tier of multiblock pump that will pump endlessly the fluid it's placed on. The target tier of this multi is UHV+

![2021-12-11_16 19 36](https://user-images.githubusercontent.com/12850933/145681779-fa307521-c4ab-4705-89e7-d476c761611a.png)
![2021-12-11_16 19 23](https://user-images.githubusercontent.com/12850933/145681782-8dabde59-a322-459f-a40c-190b85ea6c4f.png)
