### PR TITLE
Update GT_MetaTileEntity_ProcessingArray.java

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_ProcessingArray.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_ProcessingArray.java
@@ -142,7 +142,7 @@ public class GT_MetaTileEntity_ProcessingArray extends GT_MetaTileEntity_CubicMu
 
     @Override
     public boolean isCorrectMachinePart(ItemStack aStack) {
-        return aStack != null && aStack.getUnlocalizedName().startsWith("gt.blockmachines.basicmachine.");
+        return aStack != null && aStack.getUnlocalizedName().startsWith("gt.blockmachines.");
     }
 
     @Override


### PR DESCRIPTION
Allows machines not using the .basicmachine prefix to work.

This allows machines registered via GT_ProcessingArray_Manager to work.