### PR TITLE
Fix ItemFilter GUI broken

### DIFF
--- a/src/main/java/gregtech/common/covers/GT_Cover_ItemFilter.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_ItemFilter.java
@@ -246,10 +246,8 @@ public class GT_Cover_ItemFilter extends GT_CoverBehaviorBase<GT_Cover_ItemFilte
         @Override
         public void buttonClicked(GuiButton btn) {
             if (btn == btnMode) {
-                if (coverVariable.mWhitelist != btnMode.isChecked()) {
-                    coverVariable.mWhitelist = btnMode.isChecked();
-                    GT_Values.NW.sendToServer(new GT_Packet_TileEntityCoverNew(side, coverID, coverVariable, tile));
-                }
+                coverVariable.mWhitelist = !coverVariable.mWhitelist;
+                GT_Values.NW.sendToServer(new GT_Packet_TileEntityCoverNew(side, coverID, coverVariable, tile));
             }
             updateButtons();
         }


### PR DESCRIPTION
Previously ItemFilter GUI's whitelist button does not work (i.e. do nothing upon clicked). This PR fixes this. Don't ask me who broke it pls.