### PR TITLE
Fix Charcoal Pit Igniter choking on pollution

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_Charcoal_Pit.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_Charcoal_Pit.java
@@ -264,4 +264,11 @@ public class GT_MetaTileEntity_Charcoal_Pit extends GT_MetaTileEntity_MultiBlock
         }
         return new ITexture[]{casingTexturePages[0][10]};
     }
+    
+    @Override
+    public boolean polluteEnvironment(int aPollutionLevel) {
+        // Do nothing and don't choke on pollution. This is fine because we add
+        // all the pollution at once when the recipe starts
+        return true;
+    }
 }


### PR DESCRIPTION
Necessary because the pollution per tick is no longer 0.

Would fix GTNewHorizons/GT-New-Horizons-Modpack#9055, GTNewHorizons/GT-New-Horizons-Modpack#9273 and GTNewHorizons/GT-New-Horizons-Modpack#9374.