### PR TITLE
Large Boiler Rebalance

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeBoiler.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeBoiler.java
@@ -87,53 +87,37 @@ public abstract class GT_MetaTileEntity_LargeBoiler extends GT_MetaTileEntity_En
     @Override
     protected GT_Multiblock_Tooltip_Builder createTooltip() {
         final GT_Multiblock_Tooltip_Builder tt = new GT_Multiblock_Tooltip_Builder();
-        if (isSuperheated()) {
-            tt.addMachineType("Boiler")
-                    .addInfo("Controller block for the Large " + getCasingMaterial() + " Boiler")
-                    .addInfo("Produces " + (getEUt() * 40) * ((runtimeBoost(20) / (20f)) / superToNormalSteam) + "L of Superheated Steam with 1 Coal at " + (getEUt() * 40) / superToNormalSteam + "L/s")//?
+
+        tt.addMachineType("Boiler")
+                .addInfo("Controller block for the Large " + getCasingMaterial() + " Boiler");
+                // Tooltip differs between the boilers that output Superheated Steam (Titanium and Tungstensteel) and the ones that do not (Bronze and Steel)
+                if (isSuperheated()) {
+                    tt.addInfo("Produces " + (getEUt() * 40) * ((runtimeBoost(20) / (20f)) / superToNormalSteam) + "L of Superheated Steam with 1 Coal at " + (getEUt() * 40) / superToNormalSteam + "L/s")//?
                     .addInfo("A programmed circuit in the main block throttles the boiler (-1000L/s per config)")
                     .addInfo("Solid Fuels with a burn value that is too high or too low will not work")
-                    .addInfo("Coal/Charcoal/Coal Coke and their compressed forms will not work here!")
-                    .addInfo(String.format("Diesel fuels have 1/4 efficiency - Takes %.2f seconds to heat up", 500.0 / getEfficiencyIncrease()))//? check semifluid again
-                    .addPollutionAmount(getPollutionPerSecond(null))
-                    .addSeparator()
-                    .beginStructureBlock(3, 5, 3, false)
-                    .addController("Front bottom")
-                    .addCasingInfo(getCasingMaterial() + " " + getCasingBlockType() + " Casing", 24)//?
-                    .addOtherStructurePart(getCasingMaterial() + " Fire Boxes", "Bottom layer, 3 minimum")
-                    .addOtherStructurePart(getCasingMaterial() + " Pipe Casing Blocks", "Inner 3 blocks")
-                    .addMaintenanceHatch("Any firebox", 1)
-                    .addMufflerHatch("Any firebox", 1)
-                    .addInputBus("Solid fuel, Any firebox", 1)
-                    .addInputHatch("Liquid fuel, Any firebox", 1)
-                    .addStructureInfo("You can use either, or both")
-                    .addInputHatch("Water, Any firebox", 1)
-                    .addOutputHatch("Steam, any casing", 2)
-                    .toolTipFinisher("Gregtech");
-        }
-        else {
-            tt.addMachineType("Boiler")
-                    .addInfo("Controller block for the Large " + getCasingMaterial() + " Boiler")
-                    .addInfo("Produces " + (getEUt() * 40) * (runtimeBoost(20) / 20f) + "L of Steam with 1 Coal at " + getEUt() * 40 + "L/s")//?
+                    .addInfo("Coal/Charcoal/Coal Coke and their compressed forms will not work here!");
+                }
+                else {
+                    tt.addInfo("Produces " + (getEUt() * 40) * (runtimeBoost(20) / 20f) + "L of Steam with 1 Coal at " + getEUt() * 40 + "L/s")//?
                     .addInfo("A programmed circuit in the main block throttles the boiler (-1000L/s per config)")
-                    .addInfo("Solid Fuels with a burn value that is too high or too low will not work")
-                    .addInfo(String.format("Diesel fuels have 1/4 efficiency - Takes %.2f seconds to heat up", 500.0 / getEfficiencyIncrease()))//? check semifluid again
-                    .addPollutionAmount(getPollutionPerSecond(null))
-                    .addSeparator()
-                    .beginStructureBlock(3, 5, 3, false)
-                    .addController("Front bottom")
-                    .addCasingInfo(getCasingMaterial() + " " + getCasingBlockType() + " Casing", 24)//?
-                    .addOtherStructurePart(getCasingMaterial() + " Fire Boxes", "Bottom layer, 3 minimum")
-                    .addOtherStructurePart(getCasingMaterial() + " Pipe Casing Blocks", "Inner 3 blocks")
-                    .addMaintenanceHatch("Any firebox", 1)
-                    .addMufflerHatch("Any firebox", 1)
-                    .addInputBus("Solid fuel, Any firebox", 1)
-                    .addInputHatch("Liquid fuel, Any firebox", 1)
-                    .addStructureInfo("You can use either, or both")
-                    .addInputHatch("Water, Any firebox", 1)
-                    .addOutputHatch("Steam, any casing", 2)
-                    .toolTipFinisher("Gregtech");
-        }
+                    .addInfo("Solid Fuels with a burn value that is too high or too low will not work");
+                }
+                tt.addInfo(String.format("Diesel fuels have 1/4 efficiency - Takes %.2f seconds to heat up", 500.0 / getEfficiencyIncrease()))//? check semifluid again
+                .addPollutionAmount(getPollutionPerSecond(null))
+                .addSeparator()
+                .beginStructureBlock(3, 5, 3, false)
+                .addController("Front bottom")
+                .addCasingInfo(getCasingMaterial() + " " + getCasingBlockType() + " Casing", 24)//?
+                .addOtherStructurePart(getCasingMaterial() + " Fire Boxes", "Bottom layer, 3 minimum")
+                .addOtherStructurePart(getCasingMaterial() + " Pipe Casing Blocks", "Inner 3 blocks")
+                .addMaintenanceHatch("Any firebox", 1)
+                .addMufflerHatch("Any firebox", 1)
+                .addInputBus("Solid fuel, Any firebox", 1)
+                .addInputHatch("Liquid fuel, Any firebox", 1)
+                .addStructureInfo("You can use either, or both")
+                .addInputHatch("Water, Any firebox", 1)
+                .addOutputHatch("Steam, any casing", 2)
+                .toolTipFinisher("Gregtech");
 
         return tt;
     }
@@ -238,26 +222,55 @@ public abstract class GT_MetaTileEntity_LargeBoiler extends GT_MetaTileEntity_En
         }
         ArrayList<ItemStack> tInputList = getStoredInputs();
         if (!tInputList.isEmpty()) {
-            for (ItemStack tInput : tInputList) {
-                if (tInput != GT_OreDictUnificator.get(OrePrefixes.bucket, Materials.Lava, 1)){
-                    if (GT_Utility.getFluidForFilledItem(tInput, true) == null && (this.mMaxProgresstime = GT_ModHandler.getFuelValue(tInput) / 80) > 0 && (GT_ModHandler.getFuelValue(tInput) / this.getEUt()) > 1 && GT_ModHandler.getFuelValue(tInput) < 1000000) {
-                        this.excessFuel += GT_ModHandler.getFuelValue(tInput) % 80;
-                        this.mMaxProgresstime += this.excessFuel / 80;
-                        this.excessFuel %= 80;
-                        this.mMaxProgresstime = adjustBurnTimeForConfig(runtimeBoost(this.mMaxProgresstime));
-                        this.mEUt = adjustEUtForConfig(getEUt());
-                        this.mEfficiencyIncrease = this.mMaxProgresstime * getEfficiencyIncrease();
-                        this.mOutputItems = new ItemStack[]{GT_Utility.getContainerItem(tInput, true)};
-                        tInput.stackSize -= 1;
-                        updateSlots();
-                        if (this.mEfficiencyIncrease > 5000) {
-                            this.mEfficiencyIncrease = 0;
-                            this.mSuperEfficencyIncrease = 20;
+            if (isSuperheated()) {
+                for (ItemStack tInput : tInputList) {
+                    // Checking for Solid Super Fuel and Magic Solid Super Fuel with their burn values. This needs to be replaced with a whitelist configurable in the config file.
+                    if (GT_ModHandler.getFuelValue(tInput) == 100000 || GT_ModHandler.getFuelValue(tInput) == 150000) {
+                        if (tInput != GT_OreDictUnificator.get(OrePrefixes.bucket, Materials.Lava, 1)){
+                            if (GT_Utility.getFluidForFilledItem(tInput, true) == null && (this.mMaxProgresstime = GT_ModHandler.getFuelValue(tInput) / 80) > 0) {
+                                this.excessFuel += GT_ModHandler.getFuelValue(tInput) % 80;
+                                this.mMaxProgresstime += this.excessFuel / 80;
+                                this.excessFuel %= 80;
+                                this.mMaxProgresstime = adjustBurnTimeForConfig(runtimeBoost(this.mMaxProgresstime));
+                                this.mEUt = adjustEUtForConfig(getEUt());
+                                this.mEfficiencyIncrease = this.mMaxProgresstime * getEfficiencyIncrease();
+                                this.mOutputItems = new ItemStack[]{GT_Utility.getContainerItem(tInput, true)};
+                                tInput.stackSize -= 1;
+                                updateSlots();
+                                if (this.mEfficiencyIncrease > 5000) {
+                                    this.mEfficiencyIncrease = 0;
+                                    this.mSuperEfficencyIncrease = 20;
+                                }
+                                return true;
+                            }
                         }
-                        return true;
                     }
                 }
             }
+            else {
+                for (ItemStack tInput : tInputList) {
+                    if (tInput != GT_OreDictUnificator.get(OrePrefixes.bucket, Materials.Lava, 1)){
+                        // Solid fuels with burn values below getEUt are ignored (mostly items like sticks), and also those with very high fuel values that would cause an overflow error.
+                        if (GT_Utility.getFluidForFilledItem(tInput, true) == null && (this.mMaxProgresstime = GT_ModHandler.getFuelValue(tInput) / 80) > 0 && (GT_ModHandler.getFuelValue(tInput) / this.getEUt()) > 1 && GT_ModHandler.getFuelValue(tInput) < 100000000) {
+                            this.excessFuel += GT_ModHandler.getFuelValue(tInput) % 80;
+                            this.mMaxProgresstime += this.excessFuel / 80;
+                            this.excessFuel %= 80;
+                            this.mMaxProgresstime = adjustBurnTimeForConfig(runtimeBoost(this.mMaxProgresstime));
+                            this.mEUt = adjustEUtForConfig(getEUt());
+                            this.mEfficiencyIncrease = this.mMaxProgresstime * getEfficiencyIncrease();
+                            this.mOutputItems = new ItemStack[]{GT_Utility.getContainerItem(tInput, true)};
+                            tInput.stackSize -= 1;
+                            updateSlots();
+                            if (this.mEfficiencyIncrease > 5000) {
+                                this.mEfficiencyIncrease = 0;
+                                this.mSuperEfficencyIncrease = 20;
+                            }
+                            return true;
+                        }
+                    }
+                }
+            }
+
         }
         this.mMaxProgresstime = 0;
         this.mEUt = 0;
@@ -281,16 +294,25 @@ public abstract class GT_MetaTileEntity_LargeBoiler extends GT_MetaTileEntity_En
                 excessWater += amount * STEAM_PER_WATER - tGeneratedEU;
                 amount -= excessWater / STEAM_PER_WATER;
                 excessWater %= STEAM_PER_WATER;
-                if (depleteInput(Materials.Water.getFluid(amount)) || depleteInput(GT_ModHandler.getDistilledWater(amount))) {
-                    if (isSuperheated()) {
+                if (isSuperheated()) {
+                    // Consumes only one third of the water if producing Superheated Steam, to maintain water in the chain.
+                    if (depleteInput(Materials.Water.getFluid(amount / superToNormalSteam)) || depleteInput(GT_ModHandler.getDistilledWater(amount / superToNormalSteam))) {
+                        // Outputs Superheated Steam instead of Steam, at one third of the amount (equivalent in power output to the normal Steam amount).
                         addOutput(FluidRegistry.getFluidStack("ic2superheatedsteam", tGeneratedEU / superToNormalSteam));
+                    } else {
+                        GT_Log.exp.println("Boiler " + this.mName + " had no Water!");
+                        explodeMultiblock();
                     }
-                    else {
+                }
+
+                else {
+                    if (depleteInput(Materials.Water.getFluid(amount)) || depleteInput(GT_ModHandler.getDistilledWater(amount))) {
                         addOutput(GT_ModHandler.getSteam(tGeneratedEU));
+                    } else {
+                        GT_Log.exp.println("Boiler " + this.mName + " had no Water!");
+                        explodeMultiblock();
                     }
-                } else {
-                    GT_Log.exp.println("Boiler "+this.mName+" had no Water!");
-                    explodeMultiblock();
+
                 }
             }
             return true;

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeBoiler_Bronze.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeBoiler_Bronze.java
@@ -88,4 +88,7 @@ public class GT_MetaTileEntity_LargeBoiler_Bronze extends GT_MetaTileEntity_Larg
     int runtimeBoost(int mTime) {
         return mTime * 2;
     }
+
+    @Override
+    boolean isSuperheated() { return false; }
 }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeBoiler_Steel.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeBoiler_Steel.java
@@ -75,7 +75,7 @@ public class GT_MetaTileEntity_LargeBoiler_Steel extends GT_MetaTileEntity_Large
 
     @Override
     public int getEUt() {
-        return 600;
+        return 1000;
     }
 
     @Override
@@ -84,7 +84,8 @@ public class GT_MetaTileEntity_LargeBoiler_Steel extends GT_MetaTileEntity_Large
     }
 
     @Override
-    int runtimeBoost(int mTime) {
-        return mTime * 150 / 100;
-    }
+    int runtimeBoost(int mTime) { return mTime; }
+
+    @Override
+    boolean isSuperheated() { return false; }
 }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeBoiler_Titanium.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeBoiler_Titanium.java
@@ -75,7 +75,7 @@ public class GT_MetaTileEntity_LargeBoiler_Titanium extends GT_MetaTileEntity_La
 
     @Override
     public int getEUt() {
-        return 800;
+        return 6000;
     }
 
     @Override
@@ -85,6 +85,9 @@ public class GT_MetaTileEntity_LargeBoiler_Titanium extends GT_MetaTileEntity_La
 
     @Override
     int runtimeBoost(int mTime) {
-        return mTime * 130 / 100;
+        return mTime * 130 / 400;
     }
+
+    @Override
+    boolean isSuperheated() { return true; }
 }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeBoiler_Titanium.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeBoiler_Titanium.java
@@ -75,7 +75,7 @@ public class GT_MetaTileEntity_LargeBoiler_Titanium extends GT_MetaTileEntity_La
 
     @Override
     public int getEUt() {
-        return 6000;
+        return 4000;
     }
 
     @Override

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeBoiler_TungstenSteel.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeBoiler_TungstenSteel.java
@@ -75,7 +75,7 @@ public class GT_MetaTileEntity_LargeBoiler_TungstenSteel extends GT_MetaTileEnti
 
     @Override
     public int getEUt() {
-        return 1000;
+        return 18750;
     }
 
     @Override
@@ -84,8 +84,8 @@ public class GT_MetaTileEntity_LargeBoiler_TungstenSteel extends GT_MetaTileEnti
     }
 
     @Override
-    int runtimeBoost(int mTime) {
-        return mTime * 120 / 100;
-    }
+    int runtimeBoost(int mTime) { return mTime * 120 / 750; }
 
+    @Override
+    boolean isSuperheated() { return true; }
 }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeBoiler_TungstenSteel.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeBoiler_TungstenSteel.java
@@ -75,7 +75,7 @@ public class GT_MetaTileEntity_LargeBoiler_TungstenSteel extends GT_MetaTileEnti
 
     @Override
     public int getEUt() {
-        return 18750;
+        return 16000;
     }
 
     @Override


### PR DESCRIPTION
**The new numbers are not final.** Please share your opinion for what they should be, I'm not fit to decide on balanced numbers by myself.

- Changed Large Steel Boiler to output 1000 instead of 600 EU/t.
- Changed Large Titanium Boiler to output 6000 instead of 800 EU/t.
- Changed Large Tungstensteel Boiler to output 18750 instead of 1000 EU/t.
- Changed Titanium and Tungstensteel Boilers to output Superheated Steam instead of regular Steam.
- Added an upper bound for the burn value that can be processed by the boilers, in order to prevent an overflow.
- Added a lower bound for the burn value that can be processed by the boilers. This is a placeholder limitation intended to prevent the player from using the improved Titanium and Tungstensteel boilers to generate lots of power from easy solid fuels like Charcoal. A better way to implement this would be to make a whitelist of accepted fuels. The one I had in mind for these boilers was the Super Fuels, both the magic and non-magic ones.

The last two boilers had terrible numbers for their tier. High numbers would allow for charcoal powergen up to IV or LuV, though, so the better boilers should only accept solid fuels that are difficult to make and need a processing chain.