### PR TITLE
Add input bus like sorting to chest and super buffers

### DIFF
--- a/src/main/java/gregtech/common/tileentities/automation/GT_MetaTileEntity_ChestBuffer.java
+++ b/src/main/java/gregtech/common/tileentities/automation/GT_MetaTileEntity_ChestBuffer.java
@@ -5,7 +5,6 @@ import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Buffer;
 import gregtech.api.render.TextureFactory;
-import gregtech.api.util.GT_Utility;
 import gregtech.common.gui.GT_Container_ChestBuffer;
 import gregtech.common.gui.GT_GUIContainer_ChestBuffer;
 import net.minecraft.entity.player.InventoryPlayer;

--- a/src/main/java/gregtech/common/tileentities/automation/GT_MetaTileEntity_ChestBuffer.java
+++ b/src/main/java/gregtech/common/tileentities/automation/GT_MetaTileEntity_ChestBuffer.java
@@ -5,6 +5,7 @@ import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Buffer;
 import gregtech.api.render.TextureFactory;
+import gregtech.api.util.GT_Utility;
 import gregtech.common.gui.GT_Container_ChestBuffer;
 import gregtech.common.gui.GT_GUIContainer_ChestBuffer;
 import net.minecraft.entity.player.InventoryPlayer;
@@ -83,47 +84,12 @@ public class GT_MetaTileEntity_ChestBuffer extends GT_MetaTileEntity_Buffer {
         }
     }
 
-// Implementation using Java built in sort algorithm
-// Uses terribad string comparison to sort against.  Would be better if we did something else?
-    protected void sortStacks() {
-        Arrays.sort(this.mInventory, new Comparator<ItemStack>() {
-                @Override
-                // Taken from https://gist.github.com/Choonster/876acc3217229e172e46
-                public int compare(ItemStack o1, ItemStack o2) {
-                    if( o2 == null )
-                        return -1;
-                    if( o1 == null )
-                        return 1;
-                    Item item1 = o1.getItem();
-                    Item item2 = o2.getItem();
-
-                    if(item1 instanceof ItemBlock) {
-                        if (!(item2 instanceof ItemBlock))
-                            return -1; // If item1 is a block and item2 isn't, sort item1 before item2
-                    } else if (item2 instanceof ItemBlock)
-                        return 1; // If item2 is a block and item1 isn't, sort item1 after item2
-
-                    int id1 = Item.getIdFromItem( item1 );
-                    int id2 = Item.getIdFromItem( item2 );
-                    if ( id1 < id2 ) {
-                        return -1;
-                    }
-                    if ( id1 > id2 ) {
-                        return 1;
-                    }
-
-                    id1 = o1.getItemDamage();
-                    id2 = o2.getItemDamage();
-
-                    return Integer.compare(id1, id2);
-                }
-            });
-    }
-
     @Override
-    protected void fillStacksIntoFirstSlots() {
-        sortStacks();
-        super.fillStacksIntoFirstSlots();
+    public void onPostTick(IGregTechTileEntity aBaseMetaTileEntity, long aTimer) {
+        if (aBaseMetaTileEntity.isServerSide() && aBaseMetaTileEntity.hasInventoryBeenModified()) {
+            fillStacksIntoFirstSlots();
+        }
+        super.onPostTick(aBaseMetaTileEntity, aTimer);
     }
 
     @Override


### PR DESCRIPTION
Add input bus like filtering to chest and super buffers. They were still able to clog up (even with very small stack sizes like 4!). They can now be used reliably in any automation setup. For example, to boost the working speed of GT++ ore processing multis by only providing batches of 16 items so the multi won't run on single items that are slowly dripping in.

https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/7185