### PR TITLE
Fixes slime spawn handling variances Issue 7298

### DIFF
--- a/src/main/java/gregtech/api/util/GT_SpawnEventHandler.java
+++ b/src/main/java/gregtech/api/util/GT_SpawnEventHandler.java
@@ -23,10 +23,11 @@ public class GT_SpawnEventHandler {
 
     @SubscribeEvent
     public void denyMobSpawn(CheckSpawn event) {
-        if (event.getResult() == Event.Result.ALLOW) {
+        if (event.getResult() == Event.Result.ALLOW && !(event.entityLiving instanceof EntitySlime)) {
             return;
         }
-        if (event.entityLiving.isCreatureType(EnumCreatureType.monster, false) || event.entityLiving instanceof EntitySlime) {
+
+        if (event.entityLiving.isCreatureType(EnumCreatureType.monster, false)) {
             for (int[] rep : mobReps) {
                 if (rep[3] == event.entity.worldObj.provider.dimensionId) {
                     TileEntity tTile = event.entity.worldObj.getTileEntity(rep[0], rep[1], rep[2]);
@@ -37,6 +38,7 @@ public class GT_SpawnEventHandler {
                         double dz = rep[2] + 0.5F - event.entity.posZ;
                         if ((dx * dx + dz * dz + dy * dy) <= Math.pow(r, 2)) {
                             event.setResult(Event.Result.DENY);
+                            event.entityLiving.isDead = true;
                         }
                     }
                 }

--- a/src/main/java/gregtech/api/util/GT_SpawnEventHandler.java
+++ b/src/main/java/gregtech/api/util/GT_SpawnEventHandler.java
@@ -23,12 +23,13 @@ public class GT_SpawnEventHandler {
 
     @SubscribeEvent
     public void denyMobSpawn(CheckSpawn event) {
-        if (event.getResult() == Event.Result.ALLOW && !(event.entityLiving instanceof EntitySlime)) {
-            return;
+        if (event.entityLiving instanceof EntitySlime && !(((EntitySlime) event.entityLiving).getCustomNameTag().length() > 0)) {
+            ((EntitySlime) event.entityLiving).setCustomNameTag("DoNotSpawnSlimes");
+            if(event.getResult() == Event.Result.ALLOW) event.setResult(Event.Result.DEFAULT);
         }
 
-        if(event.entityLiving instanceof EntitySlime) {
-            ((EntitySlime) event.entityLiving).setCustomNameTag("BlockedSlimeSpawn");
+        if (event.getResult() == Event.Result.ALLOW) {
+            return;
         }
 
         if (event.entityLiving.isCreatureType(EnumCreatureType.monster, false)) {
@@ -42,7 +43,6 @@ public class GT_SpawnEventHandler {
                         double dz = rep[2] + 0.5F - event.entity.posZ;
                         if ((dx * dx + dz * dz + dy * dy) <= Math.pow(r, 2)) {
                             event.setResult(Event.Result.DENY);
-                            event.entityLiving.isDead = true;
                         }
                     }
                 }

--- a/src/main/java/gregtech/api/util/GT_SpawnEventHandler.java
+++ b/src/main/java/gregtech/api/util/GT_SpawnEventHandler.java
@@ -27,6 +27,10 @@ public class GT_SpawnEventHandler {
             return;
         }
 
+        if(event.entityLiving instanceof EntitySlime) {
+            ((EntitySlime) event.entityLiving).setCustomNameTag("BlockedSlimeSpawn");
+        }
+
         if (event.entityLiving.isCreatureType(EnumCreatureType.monster, false)) {
             for (int[] rep : mobReps) {
                 if (rep[3] == event.entity.worldObj.provider.dimensionId) {


### PR DESCRIPTION
After testing, I was able to see 2 separate problems. 
1: event.getResult() was occasionally returning ALLOW for some of the world spawned slimes. Slime spawn denial is done regardless of the ALLOW/DENY flag. This does not impact slimes spawned via eggs or powered spawners or slimes spawning after a slime is killed which apparently return DEFAULT for getResult().
2: Slimes don't seem to properly handle a getResult() value of DENY. The checkSpawn event is not cancellable. To fix this, the entity is also destroyed by setting isDead to true. This does occasionally cause slimes to appear on the minimap briefly before disappearing.

Lastly, with a forge update this could be handled much better by using the EntitySlime.spawnReason enum. That is not present in the current forge version, so I would consider this a temporary workaround and this method could/should be reworked if/when forge is updated.

fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/7298