### PR TITLE
Large Boiler Whitelist and NEI Large Boiler Tab Update

### DIFF
--- a/src/main/java/gregtech/api/util/GT_Recipe.java
+++ b/src/main/java/gregtech/api/util/GT_Recipe.java
@@ -1875,7 +1875,7 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
                         String.format("Bronze Boiler: %.4f", bronzeBurnTime),
                         String.format("Steel Boiler: %.4f", steelBurnTime),
                         "Titanium Boiler: Not allowed",
-                        "Tungstensteel Boiler: Not allowed");
+                        "Tungstenst. Boiler: Not allowed");
             }
 
     		return super.addRecipe(recipe);
@@ -1895,7 +1895,7 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
                     String.format("Bronze Boiler: %.4f", bronzeBurnTime),
                     String.format("Steel Boiler: %.4f", steelBurnTime),
                     "Titanium Boiler: Not allowed",
-                    "Tungstensteel Boiler: Not allowed");
+                    "Tungstenst. Boiler: Not allowed");
 
             return super.addRecipe(recipe);
         }

--- a/src/main/java/gregtech/api/util/GT_Recipe.java
+++ b/src/main/java/gregtech/api/util/GT_Recipe.java
@@ -1816,7 +1816,7 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
     }
 
     public static class GT_Recipe_Map_LargeBoilerFakeFuels extends GT_Recipe_Map {
-    	
+
         public GT_Recipe_Map_LargeBoilerFakeFuels() {
             super(new HashSet<>(55), "gt.recipe.largeboilerfakefuels", "Large Boiler", null, RES_PATH_GUI + "basicmachines/Default", 1, 0, 1, 0, 1, E, 1, E, true, true);
             GT_Recipe explanatoryRecipe = new GT_Recipe(true, new ItemStack[]{}, new ItemStack[]{}, null, null, null, null, 1, 1, 1);
@@ -1825,11 +1825,11 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
         }
 
         public GT_Recipe addDenseLiquidRecipe(GT_Recipe recipe) {
-            return addRecipe(recipe, ((double) recipe.mSpecialValue) / 10);
+            return addRecipe(recipe, ((double) recipe.mSpecialValue) / 10, false);
         }
 
         public GT_Recipe addDieselRecipe(GT_Recipe recipe) {
-            return addRecipe(recipe, ((double) recipe.mSpecialValue) / 40);
+            return addRecipe(recipe, ((double) recipe.mSpecialValue) / 40, false);
         }
 
         public void addSolidRecipes(ItemStack... itemStacks) {
@@ -1839,28 +1839,45 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
         }
 
         public GT_Recipe addSolidRecipe(ItemStack fuelItemStack) {
-            return addRecipe(new GT_Recipe(true, new ItemStack[]{fuelItemStack}, new ItemStack[]{}, null, null, null, null, 1, 0, GT_ModHandler.getFuelValue(fuelItemStack) / 1600), ((double) GT_ModHandler.getFuelValue(fuelItemStack)) / 1600);
+            boolean allowedFuel = false;
+            if (fuelItemStack != null) {
+                if (fuelItemStack.getDisplayName().equals("gt.blockreinforced.6.name") || fuelItemStack.getDisplayName().equals("gt.blockreinforced.7.name")) {
+                    allowedFuel = true;
+                }
+            }
+            return addRecipe(new GT_Recipe(true, new ItemStack[]{fuelItemStack}, new ItemStack[]{}, null, null, null, null, 1, 0, GT_ModHandler.getFuelValue(fuelItemStack) / 1600), ((double) GT_ModHandler.getFuelValue(fuelItemStack)) / 1600, allowedFuel);
         }
 
-        private GT_Recipe addRecipe(GT_Recipe recipe, double baseBurnTime) {
+        private GT_Recipe addRecipe(GT_Recipe recipe, double baseBurnTime, boolean allowedFuel) {
 			recipe = new GT_Recipe(recipe);
 			//Some recipes will have a burn time like 15.9999999 and % always rounds down
 			double floatErrorCorrection = 0.0001;
 			
     		double bronzeBurnTime = baseBurnTime * 2 + floatErrorCorrection;
     		bronzeBurnTime -= bronzeBurnTime % 0.05;
-    		double steelBurnTime = baseBurnTime * 1.5 + floatErrorCorrection;
+    		double steelBurnTime = baseBurnTime + floatErrorCorrection;
     		steelBurnTime -= steelBurnTime % 0.05;
-    		double titaniumBurnTime = baseBurnTime * 1.3 + floatErrorCorrection;
+    		double titaniumBurnTime = baseBurnTime * 0.3 + floatErrorCorrection;
     		titaniumBurnTime -= titaniumBurnTime % 0.05;
-    		double tungstensteelBurnTime = baseBurnTime * 1.2 + floatErrorCorrection;
+    		double tungstensteelBurnTime = baseBurnTime * 0.15 + floatErrorCorrection;
     		tungstensteelBurnTime -= tungstensteelBurnTime % 0.05;
-    		
-    		recipe.setNeiDesc("Burn time in seconds:", 
-    				String.format("Bronze Boiler: %.4f", bronzeBurnTime), 
-    				String.format("Steel Boiler: %.4f", steelBurnTime), 
-    				String.format("Titanium Boiler: %.4f", titaniumBurnTime), 
-    				String.format("Tungstensteel Boiler: %.4f", tungstensteelBurnTime));
+
+            if (allowedFuel) {
+                recipe.setNeiDesc("Burn time in seconds:",
+                        String.format("Bronze Boiler: %.4f", bronzeBurnTime),
+                        String.format("Steel Boiler: %.4f", steelBurnTime),
+                        String.format("Titanium Boiler: %.4f", titaniumBurnTime),
+                        String.format("Tungstensteel Boiler: %.4f", tungstensteelBurnTime));
+            }
+
+            else {
+                recipe.setNeiDesc("Burn time in seconds:",
+                        String.format("Bronze Boiler: %.4f", bronzeBurnTime),
+                        String.format("Steel Boiler: %.4f", steelBurnTime),
+                        "Titanium Boiler: Not allowed",
+                        "Tungstensteel Boiler: Not allowed");
+            }
+
     		return super.addRecipe(recipe);
     	}
     	

--- a/src/main/java/gregtech/api/util/GT_Recipe.java
+++ b/src/main/java/gregtech/api/util/GT_Recipe.java
@@ -1890,10 +1890,6 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
             bronzeBurnTime -= bronzeBurnTime % 0.05;
             double steelBurnTime = baseBurnTime + floatErrorCorrection;
             steelBurnTime -= steelBurnTime % 0.05;
-            double titaniumBurnTime = baseBurnTime * 0.3 + floatErrorCorrection;
-            titaniumBurnTime -= titaniumBurnTime % 0.05;
-            double tungstensteelBurnTime = baseBurnTime * 0.15 + floatErrorCorrection;
-            tungstensteelBurnTime -= tungstensteelBurnTime % 0.05;
 
             recipe.setNeiDesc("Burn time in seconds:",
                     String.format("Bronze Boiler: %.4f", bronzeBurnTime),

--- a/src/main/java/gregtech/api/util/GT_Recipe.java
+++ b/src/main/java/gregtech/api/util/GT_Recipe.java
@@ -1820,16 +1820,16 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
         public GT_Recipe_Map_LargeBoilerFakeFuels() {
             super(new HashSet<>(55), "gt.recipe.largeboilerfakefuels", "Large Boiler", null, RES_PATH_GUI + "basicmachines/Default", 1, 0, 1, 0, 1, E, 1, E, true, true);
             GT_Recipe explanatoryRecipe = new GT_Recipe(true, new ItemStack[]{}, new ItemStack[]{}, null, null, null, null, 1, 1, 1);
-            explanatoryRecipe.setNeiDesc("Not all solid fuels are listed.", "Any item that burns in a", "vanilla furnace will burn in", "a Large Boiler.");
+            explanatoryRecipe.setNeiDesc("Not all solid fuels are listed.", "Any item that burns in a", "vanilla furnace will burn in", "a Large Bronze or Steel Boiler.");
             addRecipe(explanatoryRecipe);
         }
 
         public GT_Recipe addDenseLiquidRecipe(GT_Recipe recipe) {
-            return addRecipe(recipe, ((double) recipe.mSpecialValue) / 10, false);
+            return addRecipe(recipe, ((double) recipe.mSpecialValue) / 10);
         }
 
         public GT_Recipe addDieselRecipe(GT_Recipe recipe) {
-            return addRecipe(recipe, ((double) recipe.mSpecialValue) / 40, false);
+            return addRecipe(recipe, ((double) recipe.mSpecialValue) / 40);
         }
 
         public void addSolidRecipes(ItemStack... itemStacks) {
@@ -1848,7 +1848,7 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
             return addRecipe(new GT_Recipe(true, new ItemStack[]{fuelItemStack}, new ItemStack[]{}, null, null, null, null, 1, 0, GT_ModHandler.getFuelValue(fuelItemStack) / 1600), ((double) GT_ModHandler.getFuelValue(fuelItemStack)) / 1600, allowedFuel);
         }
 
-        private GT_Recipe addRecipe(GT_Recipe recipe, double baseBurnTime, boolean allowedFuel) {
+        private GT_Recipe addRecipe(GT_Recipe recipe, double baseBurnTime, boolean isAllowedFuel) {
 			recipe = new GT_Recipe(recipe);
 			//Some recipes will have a burn time like 15.9999999 and % always rounds down
 			double floatErrorCorrection = 0.0001;
@@ -1862,7 +1862,7 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
     		double tungstensteelBurnTime = baseBurnTime * 0.15 + floatErrorCorrection;
     		tungstensteelBurnTime -= tungstensteelBurnTime % 0.05;
 
-            if (allowedFuel) {
+            if (isAllowedFuel) {
                 recipe.setNeiDesc("Burn time in seconds:",
                         String.format("Bronze Boiler: %.4f", bronzeBurnTime),
                         String.format("Steel Boiler: %.4f", steelBurnTime),
@@ -1880,6 +1880,29 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
 
     		return super.addRecipe(recipe);
     	}
+
+        private GT_Recipe addRecipe(GT_Recipe recipe, double baseBurnTime) {
+            recipe = new GT_Recipe(recipe);
+            //Some recipes will have a burn time like 15.9999999 and % always rounds down
+            double floatErrorCorrection = 0.0001;
+
+            double bronzeBurnTime = baseBurnTime * 2 + floatErrorCorrection;
+            bronzeBurnTime -= bronzeBurnTime % 0.05;
+            double steelBurnTime = baseBurnTime + floatErrorCorrection;
+            steelBurnTime -= steelBurnTime % 0.05;
+            double titaniumBurnTime = baseBurnTime * 0.3 + floatErrorCorrection;
+            titaniumBurnTime -= titaniumBurnTime % 0.05;
+            double tungstensteelBurnTime = baseBurnTime * 0.15 + floatErrorCorrection;
+            tungstensteelBurnTime -= tungstensteelBurnTime % 0.05;
+
+            recipe.setNeiDesc("Burn time in seconds:",
+                    String.format("Bronze Boiler: %.4f", bronzeBurnTime),
+                    String.format("Steel Boiler: %.4f", steelBurnTime),
+                    "Titanium Boiler: Not allowed",
+                    "Tungstensteel Boiler: Not allowed");
+
+            return super.addRecipe(recipe);
+        }
     	
     }
 

--- a/src/main/java/gregtech/api/util/GT_Recipe.java
+++ b/src/main/java/gregtech/api/util/GT_Recipe.java
@@ -15,6 +15,7 @@ import gregtech.nei.GT_NEI_DefaultHandler.FixedPositionedStack;
 import ic2.core.Ic2Items;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntityFurnace;
@@ -1816,12 +1817,34 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
     }
 
     public static class GT_Recipe_Map_LargeBoilerFakeFuels extends GT_Recipe_Map {
+    	
+    	private static final List<String> ALLOWED_SOLID_FUELS = Arrays.asList(GregTech_API.sMachineFile.mConfig.getStringList(
+    			"LargeBoiler.allowedFuels",
+    			ConfigCategories.machineconfig.toString(),
+    			new String[] {"gregtech:gt.blockreinforced:6", "gregtech:gt.blockreinforced:7"},
+    			"Allowed fuels for the Large Titanium Boiler and Large Tungstensteel Boiler"));
 
         public GT_Recipe_Map_LargeBoilerFakeFuels() {
             super(new HashSet<>(55), "gt.recipe.largeboilerfakefuels", "Large Boiler", null, RES_PATH_GUI + "basicmachines/Default", 1, 0, 1, 0, 1, E, 1, E, true, true);
             GT_Recipe explanatoryRecipe = new GT_Recipe(true, new ItemStack[]{}, new ItemStack[]{}, null, null, null, null, 1, 1, 1);
             explanatoryRecipe.setNeiDesc("Not all solid fuels are listed.", "Any item that burns in a", "vanilla furnace will burn in", "a Large Bronze or Steel Boiler.");
             addRecipe(explanatoryRecipe);
+        }
+        
+        public static boolean isAllowedSolidFuel(ItemStack stack) {
+        	return isAllowedSolidFuel(Item.itemRegistry.getNameForObject(stack.getItem()), stack.getItemDamage());
+        }
+        
+        public static boolean isAllowedSolidFuel(String itemRegistryName, int meta) {
+        	return ALLOWED_SOLID_FUELS.contains(itemRegistryName + ":" + meta);
+        }
+        
+        public static boolean addAllowedSolidFuel(ItemStack stack) {
+        	return addAllowedSolidFuel(Item.itemRegistry.getNameForObject(stack.getItem()), stack.getItemDamage());
+        }
+        
+        public static boolean addAllowedSolidFuel(String itemregistryName, int meta) {
+        	return ALLOWED_SOLID_FUELS.add(itemregistryName + ":" + meta);
         }
 
         public GT_Recipe addDenseLiquidRecipe(GT_Recipe recipe) {
@@ -1841,9 +1864,8 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
         public GT_Recipe addSolidRecipe(ItemStack fuelItemStack) {
             boolean allowedFuel = false;
             if (fuelItemStack != null) {
-                if (fuelItemStack.getDisplayName().equals("gt.blockreinforced.6.name") || fuelItemStack.getDisplayName().equals("gt.blockreinforced.7.name")) {
-                    allowedFuel = true;
-                }
+            	String registryName = Item.itemRegistry.getNameForObject(fuelItemStack.getItem());
+            	allowedFuel = ALLOWED_SOLID_FUELS.contains(registryName + ":" + fuelItemStack.getItemDamage());
             }
             return addRecipe(new GT_Recipe(true, new ItemStack[]{fuelItemStack}, new ItemStack[]{}, null, null, null, null, 1, 0, GT_ModHandler.getFuelValue(fuelItemStack) / 1600), ((double) GT_ModHandler.getFuelValue(fuelItemStack)) / 1600, allowedFuel);
         }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeBoiler.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeBoiler.java
@@ -196,30 +196,33 @@ public abstract class GT_MetaTileEntity_LargeBoiler extends GT_MetaTileEntity_En
         }
 
         this.mSuperEfficencyIncrease = 0;
-        for (GT_Recipe tRecipe : GT_Recipe.GT_Recipe_Map.sDieselFuels.mRecipeList) {
-            FluidStack tFluid = GT_Utility.getFluidForFilledItem(tRecipe.getRepresentativeInput(0), true);
-            if (tFluid != null && tRecipe.mSpecialValue > 1) {
-                tFluid.amount = 1000;
-                if (depleteInput(tFluid)) {
-                    this.mMaxProgresstime = adjustBurnTimeForConfig(runtimeBoost(tRecipe.mSpecialValue / 2));
-                    this.mEUt = adjustEUtForConfig(getEUt());
-                    this.mEfficiencyIncrease = this.mMaxProgresstime * getEfficiencyIncrease() * 4;
-                    return true;
+        if (!isSuperheated()) {
+            for (GT_Recipe tRecipe : GT_Recipe.GT_Recipe_Map.sDieselFuels.mRecipeList) {
+                FluidStack tFluid = GT_Utility.getFluidForFilledItem(tRecipe.getRepresentativeInput(0), true);
+                if (tFluid != null && tRecipe.mSpecialValue > 1) {
+                    tFluid.amount = 1000;
+                    if (depleteInput(tFluid)) {
+                        this.mMaxProgresstime = adjustBurnTimeForConfig(runtimeBoost(tRecipe.mSpecialValue / 2));
+                        this.mEUt = adjustEUtForConfig(getEUt());
+                        this.mEfficiencyIncrease = this.mMaxProgresstime * getEfficiencyIncrease() * 4;
+                        return true;
+                    }
+                }
+            }
+            for (GT_Recipe tRecipe : GT_Recipe.GT_Recipe_Map.sDenseLiquidFuels.mRecipeList) {
+                FluidStack tFluid = GT_Utility.getFluidForFilledItem(tRecipe.getRepresentativeInput(0), true);
+                if (tFluid != null) {
+                    tFluid.amount = 1000;
+                    if (depleteInput(tFluid)) {
+                        this.mMaxProgresstime = adjustBurnTimeForConfig(Math.max(1, runtimeBoost(tRecipe.mSpecialValue * 2)));
+                        this.mEUt = adjustEUtForConfig(getEUt());
+                        this.mEfficiencyIncrease = this.mMaxProgresstime * getEfficiencyIncrease();
+                        return true;
+                    }
                 }
             }
         }
-        for (GT_Recipe tRecipe : GT_Recipe.GT_Recipe_Map.sDenseLiquidFuels.mRecipeList) {
-            FluidStack tFluid = GT_Utility.getFluidForFilledItem(tRecipe.getRepresentativeInput(0), true);
-            if (tFluid != null) {
-                tFluid.amount = 1000;
-                if (depleteInput(tFluid)) {
-                    this.mMaxProgresstime = adjustBurnTimeForConfig(Math.max(1, runtimeBoost(tRecipe.mSpecialValue * 2)));
-                    this.mEUt = adjustEUtForConfig(getEUt());
-                    this.mEfficiencyIncrease = this.mMaxProgresstime * getEfficiencyIncrease();
-                    return true;
-                }
-            }
-        }
+
         ArrayList<ItemStack> tInputList = getStoredInputs();
         if (!tInputList.isEmpty()) {
             if (isSuperheated()) {

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeBoiler.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeBoiler.java
@@ -94,8 +94,8 @@ public abstract class GT_MetaTileEntity_LargeBoiler extends GT_MetaTileEntity_En
                 if (isSuperheated()) {
                     tt.addInfo("Produces " + (getEUt() * 40) * ((runtimeBoost(20) / (20f)) / superToNormalSteam) + "L of Superheated Steam with 1 Coal at " + (getEUt() * 40) / superToNormalSteam + "L/s")//?
                     .addInfo("A programmed circuit in the main block throttles the boiler (-1000L/s per config)")
-                    .addInfo("Solid Fuels with a burn value that is too high or too low will not work")
-                    .addInfo("Coal/Charcoal/Coal Coke and their compressed forms will not work here!");
+                    .addInfo("Only some solid fuels are allowed (check the NEI Large Boiler tab for details)")
+                    .addInfo("If there are any disallowed fuels in the input bus, the boiler won't run!");
                 }
                 else {
                     tt.addInfo("Produces " + (getEUt() * 40) * (runtimeBoost(20) / 20f) + "L of Steam with 1 Coal at " + getEUt() * 40 + "L/s")//?
@@ -224,25 +224,22 @@ public abstract class GT_MetaTileEntity_LargeBoiler extends GT_MetaTileEntity_En
         if (!tInputList.isEmpty()) {
             if (isSuperheated()) {
                 for (ItemStack tInput : tInputList) {
-                    // Checking for Solid Super Fuel and Magic Solid Super Fuel with their burn values. This needs to be replaced with a whitelist configurable in the config file.
-                    if (GT_ModHandler.getFuelValue(tInput) == 100000 || GT_ModHandler.getFuelValue(tInput) == 150000) {
-                        if (tInput != GT_OreDictUnificator.get(OrePrefixes.bucket, Materials.Lava, 1)){
-                            if (GT_Utility.getFluidForFilledItem(tInput, true) == null && (this.mMaxProgresstime = GT_ModHandler.getFuelValue(tInput) / 80) > 0) {
-                                this.excessFuel += GT_ModHandler.getFuelValue(tInput) % 80;
-                                this.mMaxProgresstime += this.excessFuel / 80;
-                                this.excessFuel %= 80;
-                                this.mMaxProgresstime = adjustBurnTimeForConfig(runtimeBoost(this.mMaxProgresstime));
-                                this.mEUt = adjustEUtForConfig(getEUt());
-                                this.mEfficiencyIncrease = this.mMaxProgresstime * getEfficiencyIncrease();
-                                this.mOutputItems = new ItemStack[]{GT_Utility.getContainerItem(tInput, true)};
-                                tInput.stackSize -= 1;
-                                updateSlots();
-                                if (this.mEfficiencyIncrease > 5000) {
-                                    this.mEfficiencyIncrease = 0;
-                                    this.mSuperEfficencyIncrease = 20;
-                                }
-                                return true;
+                    if (tInput != GT_OreDictUnificator.get(OrePrefixes.bucket, Materials.Lava, 1)){
+                        if (GT_Utility.getFluidForFilledItem(tInput, true) == null && (this.mMaxProgresstime = GT_ModHandler.getFuelValue(tInput) / 80) > 0) {
+                            this.excessFuel += GT_ModHandler.getFuelValue(tInput) % 80;
+                            this.mMaxProgresstime += this.excessFuel / 80;
+                            this.excessFuel %= 80;
+                            this.mMaxProgresstime = adjustBurnTimeForConfig(runtimeBoost(this.mMaxProgresstime));
+                            this.mEUt = adjustEUtForConfig(getEUt());
+                            this.mEfficiencyIncrease = this.mMaxProgresstime * getEfficiencyIncrease();
+                            this.mOutputItems = new ItemStack[]{GT_Utility.getContainerItem(tInput, true)};
+                            tInput.stackSize -= 1;
+                            updateSlots();
+                            if (this.mEfficiencyIncrease > 5000) {
+                                this.mEfficiencyIncrease = 0;
+                                this.mSuperEfficencyIncrease = 20;
                             }
+                            return true;
                         }
                     }
                 }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeBoiler_Titanium.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeBoiler_Titanium.java
@@ -2,16 +2,11 @@ package gregtech.common.tileentities.machines.multi;
 
 import gregtech.GT_Mod;
 import gregtech.api.GregTech_API;
-import gregtech.api.enums.ConfigCategories;
-import gregtech.api.enums.ItemList;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
+import gregtech.api.util.GT_Recipe.GT_Recipe_Map_LargeBoilerFakeFuels;
 import net.minecraft.block.Block;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-
-import java.util.Arrays;
-import java.util.List;
 
 public class GT_MetaTileEntity_LargeBoiler_Titanium extends GT_MetaTileEntity_LargeBoiler {
     public GT_MetaTileEntity_LargeBoiler_Titanium(int aID, String aName, String aNameRegional) {
@@ -97,18 +92,11 @@ public class GT_MetaTileEntity_LargeBoiler_Titanium extends GT_MetaTileEntity_La
     @Override
     boolean isSuperheated() { return true; }
 
-    public static final List<String> ALLOWED_FUELS = Arrays.asList(GregTech_API.sMachineFile.mConfig.getStringList(
-            "LargeBoiler.allowedFuels",
-            ConfigCategories.machineconfig.toString(),
-            new String[] {"gregtech:gt.blockreinforced:6", "gregtech:gt.blockreinforced:7"},
-            "Allowed fuels for the Large Titanium Boiler and Large Tungstensteel Boiler"));
-
     @Override
     public boolean checkRecipe(ItemStack aStack) {
         for(ItemStack input : getStoredInputs()) {
-            if(!ALLOWED_FUELS.contains(Item.itemRegistry.getNameForObject(input.getItem()) + ":" + input.getItemDamage())
-                    || input.getItem() == ItemList.Circuit_Integrated.getItem()) {
-                //if any item is not in ALLOWED_FUELS, operation cannot be allowed because it might still be consumed
+            if(!GT_Recipe_Map_LargeBoilerFakeFuels.isAllowedSolidFuel(input)) {
+                //if any item is not in ALLOWED_SOLID_FUELS, operation cannot be allowed because it might still be consumed
                 this.mMaxProgresstime = 0;
                 this.mEUt = 0;
                 return false;

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeBoiler_Titanium.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeBoiler_Titanium.java
@@ -2,10 +2,16 @@ package gregtech.common.tileentities.machines.multi;
 
 import gregtech.GT_Mod;
 import gregtech.api.GregTech_API;
+import gregtech.api.enums.ConfigCategories;
+import gregtech.api.enums.ItemList;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import net.minecraft.block.Block;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+
+import java.util.Arrays;
+import java.util.List;
 
 public class GT_MetaTileEntity_LargeBoiler_Titanium extends GT_MetaTileEntity_LargeBoiler {
     public GT_MetaTileEntity_LargeBoiler_Titanium(int aID, String aName, String aNameRegional) {
@@ -90,4 +96,24 @@ public class GT_MetaTileEntity_LargeBoiler_Titanium extends GT_MetaTileEntity_La
 
     @Override
     boolean isSuperheated() { return true; }
+
+    public static final List<String> ALLOWED_FUELS = Arrays.asList(GregTech_API.sMachineFile.mConfig.getStringList(
+            "LargeBoiler.allowedFuels",
+            ConfigCategories.machineconfig.toString(),
+            new String[] {"gregtech:gt.blockreinforced:6", "gregtech:gt.blockreinforced:7"},
+            "Allowed fuels for the Large Titanium Boiler and Large Tungstensteel Boiler"));
+
+    @Override
+    public boolean checkRecipe(ItemStack aStack) {
+        for(ItemStack input : getStoredInputs()) {
+            if(!ALLOWED_FUELS.contains(Item.itemRegistry.getNameForObject(input.getItem()) + ":" + input.getItemDamage())
+                    || input.getItem() == ItemList.Circuit_Integrated.getItem()) {
+                //if any item is not in ALLOWED_FUELS, operation cannot be allowed because it might still be consumed
+                this.mMaxProgresstime = 0;
+                this.mEUt = 0;
+                return false;
+            }
+        }
+        return super.checkRecipe(aStack);
+    }
 }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeBoiler_TungstenSteel.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeBoiler_TungstenSteel.java
@@ -2,16 +2,11 @@ package gregtech.common.tileentities.machines.multi;
 
 import gregtech.GT_Mod;
 import gregtech.api.GregTech_API;
-import gregtech.api.enums.ConfigCategories;
-import gregtech.api.enums.ItemList;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
+import gregtech.api.util.GT_Recipe.GT_Recipe_Map_LargeBoilerFakeFuels;
 import net.minecraft.block.Block;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-
-import java.util.Arrays;
-import java.util.List;
 
 public class GT_MetaTileEntity_LargeBoiler_TungstenSteel extends GT_MetaTileEntity_LargeBoiler {
     public GT_MetaTileEntity_LargeBoiler_TungstenSteel(int aID, String aName, String aNameRegional) {
@@ -95,18 +90,11 @@ public class GT_MetaTileEntity_LargeBoiler_TungstenSteel extends GT_MetaTileEnti
     @Override
     boolean isSuperheated() { return true; }
 
-    public static final List<String> ALLOWED_FUELS = Arrays.asList(GregTech_API.sMachineFile.mConfig.getStringList(
-            "LargeBoiler.allowedFuels",
-            ConfigCategories.machineconfig.toString(),
-            new String[] {"gregtech:gt.blockreinforced:6", "gregtech:gt.blockreinforced:7"},
-            "Allowed fuels for the Large Titanium Boiler and Large Tungstensteel Boiler"));
-
     @Override
     public boolean checkRecipe(ItemStack aStack) {
         for(ItemStack input : getStoredInputs()) {
-            if(!ALLOWED_FUELS.contains(Item.itemRegistry.getNameForObject(input.getItem()) + ":" + input.getItemDamage())
-                    || input.getItem() == ItemList.Circuit_Integrated.getItem()) {
-                //if any item is not in ALLOWED_FUELS, operation cannot be allowed because it might still be consumed
+            if(!GT_Recipe_Map_LargeBoilerFakeFuels.isAllowedSolidFuel(input)) {
+                //if any item is not in ALLOWED_SOLID_FUELS, operation cannot be allowed because it might still be consumed
                 this.mMaxProgresstime = 0;
                 this.mEUt = 0;
                 return false;

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeBoiler_TungstenSteel.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeBoiler_TungstenSteel.java
@@ -2,10 +2,16 @@ package gregtech.common.tileentities.machines.multi;
 
 import gregtech.GT_Mod;
 import gregtech.api.GregTech_API;
+import gregtech.api.enums.ConfigCategories;
+import gregtech.api.enums.ItemList;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import net.minecraft.block.Block;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+
+import java.util.Arrays;
+import java.util.List;
 
 public class GT_MetaTileEntity_LargeBoiler_TungstenSteel extends GT_MetaTileEntity_LargeBoiler {
     public GT_MetaTileEntity_LargeBoiler_TungstenSteel(int aID, String aName, String aNameRegional) {
@@ -88,4 +94,24 @@ public class GT_MetaTileEntity_LargeBoiler_TungstenSteel extends GT_MetaTileEnti
 
     @Override
     boolean isSuperheated() { return true; }
+
+    public static final List<String> ALLOWED_FUELS = Arrays.asList(GregTech_API.sMachineFile.mConfig.getStringList(
+            "LargeBoiler.allowedFuels",
+            ConfigCategories.machineconfig.toString(),
+            new String[] {"gregtech:gt.blockreinforced:6", "gregtech:gt.blockreinforced:7"},
+            "Allowed fuels for the Large Titanium Boiler and Large Tungstensteel Boiler"));
+
+    @Override
+    public boolean checkRecipe(ItemStack aStack) {
+        for(ItemStack input : getStoredInputs()) {
+            if(!ALLOWED_FUELS.contains(Item.itemRegistry.getNameForObject(input.getItem()) + ":" + input.getItemDamage())
+                    || input.getItem() == ItemList.Circuit_Integrated.getItem()) {
+                //if any item is not in ALLOWED_FUELS, operation cannot be allowed because it might still be consumed
+                this.mMaxProgresstime = 0;
+                this.mEUt = 0;
+                return false;
+            }
+        }
+        return super.checkRecipe(aStack);
+    }
 }


### PR DESCRIPTION
The Titanium and Tungstensteel Large Boilers' allowed fuel selection is now able to be changed in the appropriate config file, instead of being locked to the two Super Fuels.

The Large Boiler NEI tab now has updated information for the burn times, and whether or not fuels can be burned, for each boiler, as of #866. This does not use the whitelist mentioned above, since I wasn't sure how to include it here. It will need to be changed at a later time.
