### PR TITLE
cleanup(ore particles): static analysis auto code cleanup and format

### DIFF
--- a/src/main/java/gregtech/common/blocks/GT_Block_Ores.java
+++ b/src/main/java/gregtech/common/blocks/GT_Block_Ores.java
@@ -1,5 +1,7 @@
 package gregtech.common.blocks;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import gregtech.GT_Mod;
 import gregtech.api.GregTech_API;
 import gregtech.api.enums.Materials;
@@ -9,6 +11,7 @@ import gregtech.api.render.TextureFactory;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.init.Blocks;
+import net.minecraft.util.IIcon;
 
 import java.util.Arrays;
 
@@ -16,16 +19,17 @@ import static gregtech.api.enums.Textures.BlockIcons.BASALT_STONE;
 import static gregtech.api.enums.Textures.BlockIcons.GRANITE_BLACK_STONE;
 import static gregtech.api.enums.Textures.BlockIcons.GRANITE_RED_STONE;
 import static gregtech.api.enums.Textures.BlockIcons.MARBLE_STONE;
-import net.minecraft.util.IIcon;
 
 public class GT_Block_Ores extends GT_Block_Ores_Abstract {
+    private static final String UNLOCALIZED_NAME = "gt.blockores";
+
     public GT_Block_Ores() {
-        super("gt.blockores", 7, false, Material.rock);
+        super(UNLOCALIZED_NAME, 7, false, Material.rock);
     }
 
     @Override
     public String getUnlocalizedName() {
-        return "gt.blockores";
+        return UNLOCALIZED_NAME;
     }
 
     @Override
@@ -34,39 +38,40 @@ public class GT_Block_Ores extends GT_Block_Ores_Abstract {
     }
 
     @Override
+    @SideOnly(Side.CLIENT)
     public IIcon getIcon(int side, int meta) {
         int index = ((meta / 1000) % 16);
         switch (index) {
-		case 0:
-			return Blocks.stone.getIcon(side, 0);
-		case 1:
-			return Blocks.netherrack.getIcon(side, 0);
-		case 2:
-			return Blocks.end_stone.getIcon(side, 0);
-		case 3:
-			return GRANITE_BLACK_STONE.getIcon();
-		case 4:
-			return GRANITE_RED_STONE.getIcon();
-		case 5:
-			return MARBLE_STONE.getIcon();
-		case 6:
-			return BASALT_STONE.getIcon();
-		default:
-			return Blocks.stone.getIcon(side, 0);
-		}
+            case 1:
+                return Blocks.netherrack.getIcon(side, 0);
+            case 2:
+                return Blocks.end_stone.getIcon(side, 0);
+            case 3:
+                return GRANITE_BLACK_STONE.getIcon();
+            case 4:
+                return GRANITE_RED_STONE.getIcon();
+            case 5:
+                return MARBLE_STONE.getIcon();
+            case 6:
+                return BASALT_STONE.getIcon();
+            default:
+                return Blocks.stone.getIcon(side, 0);
+        }
     }
 
     @Override
     public int getBaseBlockHarvestLevel(int aMeta) {
         switch (aMeta) {
             case 3:
-            case 4:return 3;
+            case 4:
+                return 3;
             case 0:
             case 1:
             case 2:
             case 5:
             case 6:
-            default:return 0;
+            default:
+                return 0;
         }
     }
 

--- a/src/main/java/gregtech/common/blocks/GT_Block_Ores_Abstract.java
+++ b/src/main/java/gregtech/common/blocks/GT_Block_Ores_Abstract.java
@@ -39,12 +39,11 @@ import java.util.List;
 import java.util.Set;
 
 public abstract class GT_Block_Ores_Abstract extends GT_Generic_Block implements ITileEntityProvider {
+    private static final String DOT_NAME = ".name";
     public static ThreadLocal<GT_TileEntity_Ores> mTemporaryTileEntity = new ThreadLocal<>();
     public static boolean FUCKING_LOCK = false;
     public static boolean tHideOres;
-    private final String aTextName = ".name";
-    private final String aTextSmall = "Small ";
-    public static Set<Materials> aBlockedOres = new HashSet<Materials>();
+    public static Set<Materials> aBlockedOres = new HashSet<>();
 
     protected GT_Block_Ores_Abstract(String aUnlocalizedName, int aOreMetaCount, boolean aHideFirstMeta, Material aMaterial) {
         super(GT_Item_Ores.class, aUnlocalizedName, aMaterial);
@@ -52,7 +51,7 @@ public abstract class GT_Block_Ores_Abstract extends GT_Generic_Block implements
         setStepSound(soundTypeStone);
         setCreativeTab(GregTech_API.TAB_GREGTECH_ORES);
         tHideOres = Loader.isModLoaded("NotEnoughItems") && GT_Mod.gregtechproxy.mHideUnusedOres;
-        if(aOreMetaCount > 8 || aOreMetaCount < 0) aOreMetaCount = 8;
+        if (aOreMetaCount > 8 || aOreMetaCount < 0) aOreMetaCount = 8;
 
         for (int i = 0; i < 16; i++) {
             GT_ModHandler.addValuableOre(this, i, 1);
@@ -61,8 +60,8 @@ public abstract class GT_Block_Ores_Abstract extends GT_Generic_Block implements
             if (GregTech_API.sGeneratedMaterials[i] != null) {
                 for (int j = 0; j < aOreMetaCount; j++) {
                     if (!this.getEnabledMetas()[j]) continue;
-                    GT_LanguageManager.addStringLocalization(getUnlocalizedName() + "." + (i + (j * 1000)) + aTextName, GT_LanguageManager.i18nPlaceholder ? getLocalizedNameFormat(GregTech_API.sGeneratedMaterials[i]) : getLocalizedName(GregTech_API.sGeneratedMaterials[i]));
-                    GT_LanguageManager.addStringLocalization(getUnlocalizedName() + "." + ((i + 16000) + (j * 1000)) + aTextName, aTextSmall + (GT_LanguageManager.i18nPlaceholder ? getLocalizedNameFormat(GregTech_API.sGeneratedMaterials[i]) : getLocalizedName(GregTech_API.sGeneratedMaterials[i])));
+                    GT_LanguageManager.addStringLocalization(getUnlocalizedName() + "." + (i + (j * 1000)) + DOT_NAME, GT_LanguageManager.i18nPlaceholder ? getLocalizedNameFormat(GregTech_API.sGeneratedMaterials[i]) : getLocalizedName(GregTech_API.sGeneratedMaterials[i]));
+                    GT_LanguageManager.addStringLocalization(getUnlocalizedName() + "." + ((i + 16000) + (j * 1000)) + DOT_NAME, "Small " + (GT_LanguageManager.i18nPlaceholder ? getLocalizedNameFormat(GregTech_API.sGeneratedMaterials[i]) : getLocalizedName(GregTech_API.sGeneratedMaterials[i])));
                     if ((GregTech_API.sGeneratedMaterials[i].mTypes & 0x8) != 0 && !aBlockedOres.contains(GregTech_API.sGeneratedMaterials[i])) {
                         GT_OreDictUnificator.registerOre(this.getProcessingPrefix()[j] != null ? this.getProcessingPrefix()[j].get(GregTech_API.sGeneratedMaterials[i]) : "", new ItemStack(this, 1, i + (j * 1000)));
                         if (tHideOres) {
@@ -107,30 +106,30 @@ public abstract class GT_Block_Ores_Abstract extends GT_Generic_Block implements
 
     public String getLocalizedNameFormat(Materials aMaterial) {
         switch (aMaterial.mName) {
-        case "InfusedAir":
-        case "InfusedDull":
-        case "InfusedEarth":
-        case "InfusedEntropy":
-        case "InfusedFire":
-        case "InfusedOrder":
-        case "InfusedVis":
-        case "InfusedWater":
-            return "%material Infused Stone";
-        case "Vermiculite":
-        case "Bentonite":
-        case "Kaolinite":
-        case "Talc":
-        case "BasalticMineralSand":
-        case "GraniticMineralSand":
-        case "GlauconiteSand":
-        case "CassiteriteSand":
-        case "GarnetSand":
-        case "QuartzSand":
-        case "Pitchblende":
-        case "FullersEarth":
-            return "%material";
-        default:
-            return "%material" + OrePrefixes.ore.mLocalizedMaterialPost;
+            case "InfusedAir":
+            case "InfusedDull":
+            case "InfusedEarth":
+            case "InfusedEntropy":
+            case "InfusedFire":
+            case "InfusedOrder":
+            case "InfusedVis":
+            case "InfusedWater":
+                return "%material Infused Stone";
+            case "Vermiculite":
+            case "Bentonite":
+            case "Kaolinite":
+            case "Talc":
+            case "BasalticMineralSand":
+            case "GraniticMineralSand":
+            case "GlauconiteSand":
+            case "CassiteriteSand":
+            case "GarnetSand":
+            case "QuartzSand":
+            case "Pitchblende":
+            case "FullersEarth":
+                return "%material";
+            default:
+                return "%material" + OrePrefixes.ore.mLocalizedMaterialPost;
         }
     }
 
@@ -158,7 +157,7 @@ public abstract class GT_Block_Ores_Abstract extends GT_Generic_Block implements
     public boolean onBlockEventReceived(World p_149696_1_, int p_149696_2_, int p_149696_3_, int p_149696_4_, int p_149696_5_, int p_149696_6_) {
         super.onBlockEventReceived(p_149696_1_, p_149696_2_, p_149696_3_, p_149696_4_, p_149696_5_, p_149696_6_);
         TileEntity tileentity = p_149696_1_.getTileEntity(p_149696_2_, p_149696_3_, p_149696_4_);
-        return tileentity != null ? tileentity.receiveClientEvent(p_149696_5_, p_149696_6_) : false;
+        return tileentity != null && tileentity.receiveClientEvent(p_149696_5_, p_149696_6_);
     }
 
     @Override
@@ -196,7 +195,7 @@ public abstract class GT_Block_Ores_Abstract extends GT_Generic_Block implements
 
     @Override
     public String getLocalizedName() {
-        return StatCollector.translateToLocal(getUnlocalizedName() + aTextName);
+        return StatCollector.translateToLocal(getUnlocalizedName() + DOT_NAME);
     }
 
     @Override
@@ -238,11 +237,13 @@ public abstract class GT_Block_Ores_Abstract extends GT_Generic_Block implements
     }
 
     @Override
+    @SideOnly(Side.CLIENT)
     public IIcon getIcon(IBlockAccess aIBlockAccess, int aX, int aY, int aZ, int aSide) {
         return Blocks.stone.getIcon(0, 0);
     }
 
     @Override
+    @SideOnly(Side.CLIENT)
     public IIcon getIcon(int aSide, int aMeta) {
         return Blocks.stone.getIcon(0, 0);
     }
@@ -251,14 +252,14 @@ public abstract class GT_Block_Ores_Abstract extends GT_Generic_Block implements
     @SideOnly(Side.CLIENT)
     public void registerBlockIcons(IIconRegister aIconRegister) {
     }
-    
+
     @Override
     @SideOnly(Side.CLIENT)
     public boolean addHitEffects(World worldObj, MovingObjectPosition target, EffectRenderer effectRenderer) {
         GT_Renderer_Block.addHitEffects(effectRenderer, this, worldObj, target.blockX, target.blockY, target.blockZ, target.sideHit);
         return true;
     }
-    
+
     @Override
     @SideOnly(Side.CLIENT)
     public boolean addDestroyEffects(World world, int x, int y, int z, int meta, EffectRenderer effectRenderer) {
@@ -299,7 +300,7 @@ public abstract class GT_Block_Ores_Abstract extends GT_Generic_Block implements
         if ((tTileEntity instanceof GT_TileEntity_Ores)) {
             return ((GT_TileEntity_Ores) tTileEntity).getDrops(getDroppedBlock(), aFortune);
         }
-        return mTemporaryTileEntity.get() == null ? new ArrayList<>() : ((GT_TileEntity_Ores) mTemporaryTileEntity.get()).getDrops(getDroppedBlock(), aFortune);
+        return mTemporaryTileEntity.get() == null ? new ArrayList<>() : mTemporaryTileEntity.get().getDrops(getDroppedBlock(), aFortune);
     }
 
     @Override
@@ -309,28 +310,17 @@ public abstract class GT_Block_Ores_Abstract extends GT_Generic_Block implements
 
     public abstract ITexture[] getTextureSet(); //Must have 16 entries.
 
-    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @SuppressWarnings({"unchecked"})
     @Override
+    @SideOnly(Side.CLIENT)
     public void getSubBlocks(Item aItem, CreativeTabs aTab, List aList) {
         for (int i = 0; i < GregTech_API.sGeneratedMaterials.length; i++) {
             Materials tMaterial = GregTech_API.sGeneratedMaterials[i];
-            if ((tMaterial != null) && ((tMaterial.mTypes & 0x8) != 0)&& !aBlockedOres.contains(tMaterial)) {
-                if (!(new ItemStack(aItem, 1, i).getDisplayName().contains(aTextName))) aList.add(new ItemStack(aItem, 1, i));
-                if (!(new ItemStack(aItem, 1, i + 1000).getDisplayName().contains(aTextName))) aList.add(new ItemStack(aItem, 1, i + 1000));
-                if (!(new ItemStack(aItem, 1, i + 2000).getDisplayName().contains(aTextName))) aList.add(new ItemStack(aItem, 1, i + 2000));
-                if (!(new ItemStack(aItem, 1, i + 3000).getDisplayName().contains(aTextName))) aList.add(new ItemStack(aItem, 1, i + 3000));
-                if (!(new ItemStack(aItem, 1, i + 4000).getDisplayName().contains(aTextName))) aList.add(new ItemStack(aItem, 1, i + 4000));
-                if (!(new ItemStack(aItem, 1, i + 5000).getDisplayName().contains(aTextName))) aList.add(new ItemStack(aItem, 1, i + 5000));
-                if (!(new ItemStack(aItem, 1, i + 6000).getDisplayName().contains(aTextName))) aList.add(new ItemStack(aItem, 1, i + 6000));
-                if (!(new ItemStack(aItem, 1, i + 7000).getDisplayName().contains(aTextName))) aList.add(new ItemStack(aItem, 1, i + 7000));
-                if (!(new ItemStack(aItem, 1, i + 16000).getDisplayName().contains(aTextName))) aList.add(new ItemStack(aItem, 1, i + 16000));
-                if (!(new ItemStack(aItem, 1, i + 17000).getDisplayName().contains(aTextName))) aList.add(new ItemStack(aItem, 1, i + 17000));
-                if (!(new ItemStack(aItem, 1, i + 18000).getDisplayName().contains(aTextName))) aList.add(new ItemStack(aItem, 1, i + 18000));
-                if (!(new ItemStack(aItem, 1, i + 19000).getDisplayName().contains(aTextName))) aList.add(new ItemStack(aItem, 1, i + 19000));
-                if (!(new ItemStack(aItem, 1, i + 20000).getDisplayName().contains(aTextName))) aList.add(new ItemStack(aItem, 1, i + 20000));
-                if (!(new ItemStack(aItem, 1, i + 21000).getDisplayName().contains(aTextName))) aList.add(new ItemStack(aItem, 1, i + 21000));
-                if (!(new ItemStack(aItem, 1, i + 22000).getDisplayName().contains(aTextName))) aList.add(new ItemStack(aItem, 1, i + 22000));
-                if (!(new ItemStack(aItem, 1, i + 23000).getDisplayName().contains(aTextName))) aList.add(new ItemStack(aItem, 1, i + 23000));
+            if ((tMaterial != null) && ((tMaterial.mTypes & 0x8) != 0) && !aBlockedOres.contains(tMaterial)) {
+                for (int meta = i; meta < 23000 + i; meta += 1000) {
+                    if (!(new ItemStack(aItem, 1, meta).getDisplayName().contains(DOT_NAME)))
+                        aList.add(new ItemStack(aItem, 1, meta));
+                }
             }
         }
     }


### PR DESCRIPTION
- Normalise indent chars, layout,
- Remove redundant casts, use diamond operators.
- Optimize and sort imports
- Sort member variables by attributes
- Remove redundant switch case
- static final text constants
- simplify conditions
- replace repeated inline code with iteration
- add missing `@SideOnly(Side.CLIENT)` prevents accidental server crashes