### PR TITLE
feat(coding standards): add a .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# This is the universal Text Editor Configuration
+# for all GTNewHorizons projects
+# See: https://editorconfig.org/
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+tab_size = 4
+trim_trailing_whitespace = true
+
+[*.{bat,ini}]
+end_of_line = crlf
+
+[*.{dtd,gradle,json,mcmeta,md,sh,svg,xml,xsd,xsl,yaml,yml}]
+indent_size = 2
+tab_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -10,7 +10,6 @@ end_of_line = lf
 indent_size = 4
 indent_style = space
 insert_final_newline = true
-tab_size = 4
 trim_trailing_whitespace = true
 
 [*.{bat,ini}]
@@ -18,4 +17,3 @@ end_of_line = crlf
 
 [*.{dtd,gradle,json,mcmeta,md,sh,svg,xml,xsd,xsl,yaml,yml}]
 indent_size = 2
-tab_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -15,5 +15,5 @@ trim_trailing_whitespace = true
 [*.{bat,ini}]
 end_of_line = crlf
 
-[*.{dtd,gradle,json,mcmeta,md,sh,svg,xml,xsd,xsl,yaml,yml}]
+[*.{dtd,json,mcmeta,md,sh,svg,xml,xsd,xsl,yaml,yml}]
 indent_size = 2


### PR DESCRIPTION
Basics of a coding standard with a .editorconfig file.

Helps contributors to use consistent text encoding, newline and indentation.

See: https://editorconfig.org/