### PR TITLE
Add default behavior for looking up NEI catalysts

### DIFF
--- a/src/main/java/gregtech/nei/GT_NEI_DefaultHandler.java
+++ b/src/main/java/gregtech/nei/GT_NEI_DefaultHandler.java
@@ -196,6 +196,9 @@ public class GT_NEI_DefaultHandler extends RecipeMapHandler {
                     Power power = ((GT_MetaTileEntity_BasicMachine) gtTileEntity).getPower();
                     handler.loadCraftingRecipes(getOverlayIdentifier(), power);
                     return handler;
+                } else {
+                    handler.loadCraftingRecipes(getOverlayIdentifier(), (Object) null);
+                    return handler;
                 }
             }
         }


### PR DESCRIPTION
Fix lookup for multiblock controllers.