### PR TITLE
Neutronium Fusion Buff

### DIFF
--- a/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
@@ -1144,7 +1144,7 @@ public class GT_MachineRecipeLoader implements Runnable {
         GT_Values.RA.addFusionReactorRecipe(Materials.Neodymium.getMolten(16), Materials.Hydrogen.getGas(48), Materials.Europium.getMolten(16), 32, 24576, 150000000); //FT1 - utility
         GT_Values.RA.addFusionReactorRecipe(Materials.Lutetium.getMolten(16), Materials.Chrome.getMolten(16), Materials.Americium.getMolten(16), 96, 49152, 200000000); //FT2 - utility
         GT_Values.RA.addFusionReactorRecipe(Materials.Plutonium.getMolten(16), Materials.Thorium.getMolten(16), Materials.Naquadah.getMolten(16), 64, 32700, 300000000); //FT1+ - utility
-        GT_Values.RA.addFusionReactorRecipe(Materials.Americium.getMolten(144), Materials.Naquadria.getMolten(144), Materials.Neutronium.getMolten(144), 80, 491520, 1000000000); //FT4 - utility
+        GT_Values.RA.addFusionReactorRecipe(Materials.Americium.getMolten(144), Materials.Naquadria.getMolten(144), Materials.Neutronium.getMolten(144), 240, 122880, 640000000); //FT3 - utility
         GT_Values.RA.addFusionReactorRecipe(Materials.Glowstone.getMolten(16), Materials.Helium.getPlasma(4), Materials.Sunnarium.getMolten(16), 32, 7680, 40000000); //Mark 1 Expensive //
 
         GT_Values.RA.addFusionReactorRecipe(Materials.Tungsten.getMolten(16), Materials.Helium.getGas(16), Materials.Osmium.getMolten(16), 256, 24578, 150000000); //FT1 - utility

--- a/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
@@ -1144,7 +1144,7 @@ public class GT_MachineRecipeLoader implements Runnable {
         GT_Values.RA.addFusionReactorRecipe(Materials.Neodymium.getMolten(16), Materials.Hydrogen.getGas(48), Materials.Europium.getMolten(16), 32, 24576, 150000000); //FT1 - utility
         GT_Values.RA.addFusionReactorRecipe(Materials.Lutetium.getMolten(16), Materials.Chrome.getMolten(16), Materials.Americium.getMolten(16), 96, 49152, 200000000); //FT2 - utility
         GT_Values.RA.addFusionReactorRecipe(Materials.Plutonium.getMolten(16), Materials.Thorium.getMolten(16), Materials.Naquadah.getMolten(16), 64, 32700, 300000000); //FT1+ - utility
-        GT_Values.RA.addFusionReactorRecipe(Materials.Americium.getMolten(144), Materials.Naquadria.getMolten(144), Materials.Neutronium.getMolten(144), 80, 1966080, 1000000000); //FT4 - utility
+        GT_Values.RA.addFusionReactorRecipe(Materials.Americium.getMolten(144), Materials.Naquadria.getMolten(144), Materials.Neutronium.getMolten(144), 80, 491520, 1000000000); //FT4 - utility
         GT_Values.RA.addFusionReactorRecipe(Materials.Glowstone.getMolten(16), Materials.Helium.getPlasma(4), Materials.Sunnarium.getMolten(16), 32, 7680, 40000000); //Mark 1 Expensive //
 
         GT_Values.RA.addFusionReactorRecipe(Materials.Tungsten.getMolten(16), Materials.Helium.getGas(16), Materials.Osmium.getMolten(16), 256, 24578, 150000000); //FT1 - utility

--- a/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
@@ -1144,7 +1144,7 @@ public class GT_MachineRecipeLoader implements Runnable {
         GT_Values.RA.addFusionReactorRecipe(Materials.Neodymium.getMolten(16), Materials.Hydrogen.getGas(48), Materials.Europium.getMolten(16), 32, 24576, 150000000); //FT1 - utility
         GT_Values.RA.addFusionReactorRecipe(Materials.Lutetium.getMolten(16), Materials.Chrome.getMolten(16), Materials.Americium.getMolten(16), 96, 49152, 200000000); //FT2 - utility
         GT_Values.RA.addFusionReactorRecipe(Materials.Plutonium.getMolten(16), Materials.Thorium.getMolten(16), Materials.Naquadah.getMolten(16), 64, 32700, 300000000); //FT1+ - utility
-        GT_Values.RA.addFusionReactorRecipe(Materials.Americium.getMolten(96), Materials.Naquadria.getMolten(96), Materials.Neutronium.getMolten(24), 60, 98304, 600000000); //FT3 - utility
+        GT_Values.RA.addFusionReactorRecipe(Materials.Americium.getMolten(144), Materials.Naquadria.getMolten(144), Materials.Neutronium.getMolten(144), 480, 122880, 600000000); //FT3 - utility
         GT_Values.RA.addFusionReactorRecipe(Materials.Glowstone.getMolten(16), Materials.Helium.getPlasma(4), Materials.Sunnarium.getMolten(16), 32, 7680, 40000000); //Mark 1 Expensive //
 
         GT_Values.RA.addFusionReactorRecipe(Materials.Tungsten.getMolten(16), Materials.Helium.getGas(16), Materials.Osmium.getMolten(16), 256, 24578, 150000000); //FT1 - utility

--- a/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
@@ -1144,7 +1144,7 @@ public class GT_MachineRecipeLoader implements Runnable {
         GT_Values.RA.addFusionReactorRecipe(Materials.Neodymium.getMolten(16), Materials.Hydrogen.getGas(48), Materials.Europium.getMolten(16), 32, 24576, 150000000); //FT1 - utility
         GT_Values.RA.addFusionReactorRecipe(Materials.Lutetium.getMolten(16), Materials.Chrome.getMolten(16), Materials.Americium.getMolten(16), 96, 49152, 200000000); //FT2 - utility
         GT_Values.RA.addFusionReactorRecipe(Materials.Plutonium.getMolten(16), Materials.Thorium.getMolten(16), Materials.Naquadah.getMolten(16), 64, 32700, 300000000); //FT1+ - utility
-        GT_Values.RA.addFusionReactorRecipe(Materials.Americium.getMolten(144), Materials.Naquadria.getMolten(144), Materials.Neutronium.getMolten(144), 480, 122880, 600000000); //FT3 - utility
+        GT_Values.RA.addFusionReactorRecipe(Materials.Americium.getMolten(144), Materials.Naquadria.getMolten(144), Materials.Neutronium.getMolten(144), 80, 1966080, 1000000000); //FT4 - utility
         GT_Values.RA.addFusionReactorRecipe(Materials.Glowstone.getMolten(16), Materials.Helium.getPlasma(4), Materials.Sunnarium.getMolten(16), 32, 7680, 40000000); //Mark 1 Expensive //
 
         GT_Values.RA.addFusionReactorRecipe(Materials.Tungsten.getMolten(16), Materials.Helium.getGas(16), Materials.Osmium.getMolten(16), 256, 24578, 150000000); //FT1 - utility


### PR DESCRIPTION
With the recent addition of the Naquadah line and making Naquadria a lot more difficult, it seems fair to buff this recipe for neutronium to not be completely garbage. Americium & Naquadria amount increased from 96L to 144L, and increased Neutronium gain from 24L to 144L.
Time required to craft this is now 24 seconds and requires 122880 EU/t, or a total of 58,982,400 EU (58M) to create one ingot. For reference, it takes 3.2B EU total for a single neutronium hot ingot to smelt with Radon gas in a regular EBF with no overclocks. However, it's also possible that MEBFs or potentially Volcanus's will inevitably out pace this after a certain point with large EU/t gain.

Thoughts on this? This may need some tiny adjustments.