### PR TITLE
Fix magic absorber consume enchantments from item without generate EU and move item to output slots.

### DIFF
--- a/src/main/java/gregtech/common/tileentities/generators/GT_MetaTileEntity_MagicalEnergyAbsorber.java
+++ b/src/main/java/gregtech/common/tileentities/generators/GT_MetaTileEntity_MagicalEnergyAbsorber.java
@@ -392,15 +392,17 @@ public class GT_MetaTileEntity_MagicalEnergyAbsorber extends GT_MetaTileEntity_B
             }
         }
         if (isDisenchantableItem(tStack)) {
-            EnchantmentHelper.setEnchantments(new HashMap(), tStack);
             tEU = tEU * getEfficiency() / 100;
-        } else if (isEnchantedBook(tStack)) {
-            tStack = new ItemStack(Items.book, 1);
         }
 
         // Only consume input if can store EU and push output
         if ((getBaseMetaTileEntity().getStoredEU() + tEU) < getBaseMetaTileEntity().getEUCapacity()
                 && getBaseMetaTileEntity().addStackToSlot(getOutputSlot(), tStack)) {
+            if (isDisenchantableItem(tStack)) {
+                EnchantmentHelper.setEnchantments(new HashMap(), tStack);
+            } else if (isEnchantedBook(tStack)) {
+                tStack = new ItemStack(Items.book, 1);
+            }
             decrStackSize(getInputSlot(), 1);
         } else {
             tEU = 0;


### PR DESCRIPTION
Fix Issue:
https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/9783