### PR TITLE
Fix cached recipes not updating permutations in NEI

### DIFF
--- a/src/main/java/gregtech/nei/GT_NEI_AssLineHandler.java
+++ b/src/main/java/gregtech/nei/GT_NEI_AssLineHandler.java
@@ -1,6 +1,7 @@
 package gregtech.nei;
 
 import codechicken.lib.gui.GuiDraw;
+import codechicken.nei.NEIClientUtils;
 import codechicken.nei.PositionedStack;
 import codechicken.nei.guihook.GuiContainerManager;
 import codechicken.nei.guihook.IContainerInputHandler;
@@ -39,6 +40,12 @@ public class GT_NEI_AssLineHandler extends RecipeMapHandler {
     public static final int sOffsetX = 5;
     public static final int sOffsetY = 11;
 
+    /**
+     * Static version of {@link TemplateRecipeHandler#cycleticks}.
+     * Can be referenced from cached recipes.
+     */
+    public static int cycleTicksStatic = Math.abs((int) System.currentTimeMillis());
+
     static {
         GuiContainerManager.addInputHandler(new GT_RectHandler());
         GuiContainerManager.addTooltipHandler(new GT_RectHandler());
@@ -54,7 +61,7 @@ public class GT_NEI_AssLineHandler extends RecipeMapHandler {
         Collections.sort(result);
         return result;
     }
-    
+
     public static void drawText(int aX, int aY, String aString, int aColor) {
         Minecraft.getMinecraft().fontRenderer.drawString(aString, aX, aY, aColor);
     }
@@ -175,6 +182,13 @@ public class GT_NEI_AssLineHandler extends RecipeMapHandler {
         GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
         GuiDraw.changeTexture(getGuiTexture());
         GuiDraw.drawTexturedModalRect(-4, -8, 1, 3, 174, 79);
+    }
+
+    @Override
+    public void onUpdate() {
+        super.onUpdate();
+        if (!NEIClientUtils.shiftKey())
+            cycleTicksStatic++;
     }
 
     @Override
@@ -420,7 +434,7 @@ public class GT_NEI_AssLineHandler extends RecipeMapHandler {
 
         @Override
         public List<PositionedStack> getIngredients() {
-            return getCycledIngredients(GT_NEI_AssLineHandler.this.cycleticks / 10, this.mInputs);
+            return getCycledIngredients(cycleTicksStatic / 10, this.mInputs);
         }
 
         @Override

--- a/src/main/java/gregtech/nei/GT_NEI_DefaultHandler.java
+++ b/src/main/java/gregtech/nei/GT_NEI_DefaultHandler.java
@@ -1,6 +1,7 @@
 package gregtech.nei;
 
 import codechicken.lib.gui.GuiDraw;
+import codechicken.nei.NEIClientUtils;
 import codechicken.nei.PositionedStack;
 import codechicken.nei.guihook.GuiContainerManager;
 import codechicken.nei.guihook.IContainerInputHandler;
@@ -60,6 +61,12 @@ public class GT_NEI_DefaultHandler extends RecipeMapHandler {
     private String mRecipeName; // Name of the handler displayed on top
     private NEIHandlerAbsoluteTooltip mRecipeNameTooltip;
     private static final int RECIPE_NAME_WIDTH = 140;
+
+     /**
+     * Static version of {@link TemplateRecipeHandler#cycleticks}.
+     * Can be referenced from cached recipes.
+     */
+    public static int cycleTicksStatic = Math.abs((int) System.currentTimeMillis());
 
     static {
         GuiContainerManager.addInputHandler(new GT_RectHandler());
@@ -224,6 +231,13 @@ public class GT_NEI_DefaultHandler extends RecipeMapHandler {
         GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
         GuiDraw.changeTexture(getGuiTexture());
         GuiDraw.drawTexturedModalRect(-4, -8, 1, 3, 174, 78);
+    }
+
+    @Override
+    public void onUpdate() {
+        super.onUpdate();
+        if (!NEIClientUtils.shiftKey())
+            cycleTicksStatic++;
     }
 
     @Override
@@ -1023,7 +1037,7 @@ public class GT_NEI_DefaultHandler extends RecipeMapHandler {
 
         @Override
         public List<PositionedStack> getIngredients() {
-            return getCycledIngredients(GT_NEI_DefaultHandler.this.cycleticks / 10, this.mInputs);
+            return getCycledIngredients(cycleTicksStatic / 10, this.mInputs);
         }
 
         @Override


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/9738
New instances are created whenever NEI calls `getRecipeHandler` or `getUsageHandler`, which prevents cached recipes from updating non-static variable `cycleticks`. This is a workaround to deal with it.