### PR TITLE
Add Naquadria OreByProduct

### DIFF
--- a/src/main/java/gregtech/api/enums/Materials.java
+++ b/src/main/java/gregtech/api/enums/Materials.java
@@ -1537,6 +1537,7 @@ public class Materials implements IColorModulationContainer, ISubTagContainer {
         Silicon.addOreByProducts(SiliconDioxide);
         InfusedGold.addOreByProduct(Gold);
         Cryolite.addOreByProducts(Aluminiumoxide, Sodium);
+        Naquadria.addOreByProduct(Naquadria);
     }
 
     private static void setColors() {


### PR DESCRIPTION
Allows certain processes, like the Stargatium Leaf and Naquadria Combs with crushed Naquadria Ore to yield 144L of Molten Naquadria; if GoodGenerator is loaded, this instead will be "Naquadria Goo" and requires further processing

Thank you GlodBlock for leading me to where this was located, heh