### PR TITLE
Loose Mode Turbine Changes

### DIFF
--- a/src/main/java/gregtech/api/items/GT_MetaGenerated_Tool.java
+++ b/src/main/java/gregtech/api/items/GT_MetaGenerated_Tool.java
@@ -354,24 +354,43 @@ public abstract class GT_MetaGenerated_Tool extends GT_MetaBase_Item implements 
 				aList.add(tOffset + 0, EnumChatFormatting.WHITE + String.format(transItem("001", "Durability: %s/%s"), "" + EnumChatFormatting.GREEN + (tMaxDamage - getToolDamage(aStack)) + " ", " " + tMaxDamage) + EnumChatFormatting.GRAY);
 				aList.add(tOffset + 1, EnumChatFormatting.WHITE + String.format(transItem("002", "%s lvl %s"), tMaterial.mLocalizedName + EnumChatFormatting.YELLOW, "" + getHarvestLevel(aStack, "")) + EnumChatFormatting.GRAY);
 				aList.add(tOffset + 2, EnumChatFormatting.WHITE + String.format(transItem("005", "Turbine Efficiency: %s"), "" + EnumChatFormatting.BLUE + (50.0F + (10.0F * getToolCombatDamage(aStack)))) + EnumChatFormatting.GRAY);
-				aList.add(tOffset + 3, EnumChatFormatting.WHITE + String.format(transItem("006", "Optimal Steam flow: %sL/sec"), "" + EnumChatFormatting.GOLD + Math.max(Float.MIN_NORMAL, tStats.getSpeedMultiplier() * getPrimaryMaterial(aStack).mToolSpeed * 1000) + EnumChatFormatting.GRAY));
+				aList.add(tOffset + 3, EnumChatFormatting.WHITE + String.format(transItem("006", "Optimal Steam flow: %sL/t"), "" + EnumChatFormatting.GOLD + Math.max(Float.MIN_NORMAL, tStats.getSpeedMultiplier() * getPrimaryMaterial(aStack).mToolSpeed * (1000 / 20)) + EnumChatFormatting.GRAY));
+                aList.add(tOffset + 4, EnumChatFormatting.WHITE + String.format(transItem("900", "Energy from Optimal Steam Flow: %sL/t"), "" + EnumChatFormatting.GOLD + Math.max(Float.MIN_NORMAL, tStats.getSpeedMultiplier() * getPrimaryMaterial(aStack).mToolSpeed * (1000 / 20)) / 2 + EnumChatFormatting.GRAY));
                 {
                     int aBaseEff=(int)(5+getToolCombatDamage(aStack))*1000;
                     int aOptFlowLoose=aOptFlow*4;
-                    if(aBaseEff>10000){
-                        aOptFlowLoose*=Math.pow(1.1f,((aBaseEff-7500)/10000F)*20f);
-                        aBaseEff=7500;
-                    }else if(aBaseEff>7500){
-                        aOptFlowLoose*=Math.pow(1.1f,((aBaseEff-7500)/10000F)*20f);
-                        aBaseEff*=0.75f;
+                    if(aBaseEff>=26000){
+                        aOptFlowLoose*=Math.pow(1.1f,((aBaseEff-8000)/10000F)*20f);
+                        aBaseEff*=0.6f;
+                    }else if(aBaseEff>22000){
+                        aOptFlowLoose*=Math.pow(1.1f,((aBaseEff-7000)/10000F)*20f);
+                        aBaseEff*=0.65f;
+                    }else if(aBaseEff>18000){
+                        aOptFlowLoose*=Math.pow(1.1f,((aBaseEff-6000)/10000F)*20f);
+                        aBaseEff*=0.70f;
+                    }else if(aBaseEff>14000) {
+                        aOptFlowLoose *= Math.pow(1.1f, ((aBaseEff - 5000) / 10000F) * 20f);
+                        aBaseEff *= 0.75f;
+                    }else if(aBaseEff>10000) {
+                        aOptFlowLoose *= Math.pow(1.1f, ((aBaseEff - 4000) / 10000F) * 20f);
+                        aBaseEff *= 0.8f;
+                    }else if(aBaseEff>6000) {
+                        aOptFlowLoose *= Math.pow(1.1f, ((aBaseEff - 3000) / 10000F) * 20f);
+                        aBaseEff *= 0.85f;
                     }else{
-                        aBaseEff*=0.75f;
+                        aBaseEff*=0.9f;
                     }
-					aList.add(tOffset + 4, EnumChatFormatting.GRAY + String.format(transItem("500", "Turbine Efficiency (Loose): %s"), "" + EnumChatFormatting.BLUE + aBaseEff/100f) + EnumChatFormatting.DARK_GRAY);
-					aList.add(tOffset + 5, EnumChatFormatting.GRAY + String.format(transItem("501", "Optimal Steam flow (Loose): %s L/t"), "" + EnumChatFormatting.GOLD + aOptFlowLoose + EnumChatFormatting.DARK_GRAY));
+
+                    if (aBaseEff % 100 != 0){
+                        aBaseEff -= aBaseEff % 100;
+                    }
+					aList.add(tOffset + 5, EnumChatFormatting.GRAY + String.format(transItem("500", "Turbine Efficiency (Loose): %s"), "" + EnumChatFormatting.BLUE + aBaseEff/100f) + EnumChatFormatting.DARK_GRAY);
+					aList.add(tOffset + 6, EnumChatFormatting.GRAY + String.format(transItem("501", "Optimal Steam flow (Loose): %s L/t"), "" + EnumChatFormatting.GOLD + aOptFlowLoose + EnumChatFormatting.DARK_GRAY));
+                    aList.add(tOffset + 7, EnumChatFormatting.GRAY + String.format(transItem("901", "Energy from Optimal Steam Flow (Loose): %s L/t"), "" + EnumChatFormatting.GOLD + aOptFlowLoose / 2 + EnumChatFormatting.DARK_GRAY));
+
                 }
-				aList.add(tOffset + 6, EnumChatFormatting.WHITE + String.format(transItem("007", "Optimal Gas flow(EU burnvalue per tick): %sEU/t"), "" + EnumChatFormatting.GOLD + Math.max(Float.MIN_NORMAL, tStats.getSpeedMultiplier() * getPrimaryMaterial(aStack).mToolSpeed * 50) + EnumChatFormatting.GRAY));
-				aList.add(tOffset + 7, EnumChatFormatting.WHITE + String.format(transItem("008", "Optimal Plasma flow(Plasma energyvalue per tick): %sEU/t"), "" + EnumChatFormatting.GOLD + Math.max(Float.MIN_NORMAL, tStats.getSpeedMultiplier() * getPrimaryMaterial(aStack).mToolSpeed * 2000) + EnumChatFormatting.GRAY));
+				aList.add(tOffset + 8, EnumChatFormatting.WHITE + String.format(transItem("007", "Energy from Optimal Gas Flow: %sEU/t"), "" + EnumChatFormatting.GOLD + Math.max(Float.MIN_NORMAL, tStats.getSpeedMultiplier() * getPrimaryMaterial(aStack).mToolSpeed * 50) + EnumChatFormatting.GRAY));
+				aList.add(tOffset + 9, EnumChatFormatting.WHITE + String.format(transItem("008", "Energy from Optimal Plasma Flow: %sEU/t"), "" + EnumChatFormatting.GOLD + Math.max(Float.MIN_NORMAL, tStats.getSpeedMultiplier() * getPrimaryMaterial(aStack).mToolSpeed * 2000) + EnumChatFormatting.GRAY));
 
             } else {
 				aList.add(tOffset + 0, EnumChatFormatting.WHITE + String.format(transItem("001", "Durability: %s/%s"), "" + EnumChatFormatting.GREEN + (tMaxDamage - getToolDamage(aStack)) + " ", " " + tMaxDamage) + EnumChatFormatting.GRAY);

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeTurbine_Steam.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeTurbine_Steam.java
@@ -96,14 +96,30 @@ public class GT_MetaTileEntity_LargeTurbine_Steam extends GT_MetaTileEntity_Larg
     int fluidIntoPower(ArrayList<FluidStack> aFluids, int aOptFlow, int aBaseEff) {
         if (looseFit) {
             aOptFlow *= 4;
-            if (aBaseEff > 10000) {
-                aOptFlow *= Math.pow(1.1f, ((aBaseEff - 7500) / 10000F) * 20f);
-                aBaseEff = 7500;
-            } else if (aBaseEff > 7500) {
-                aOptFlow *= Math.pow(1.1f, ((aBaseEff - 7500) / 10000F) * 20f);
+            if(aBaseEff>=26000) {
+                aOptFlow *= Math.pow(1.1f, ((aBaseEff - 8000) / 10000F) * 20f);
+                aBaseEff *= 0.6f;
+            }else if(aBaseEff>22000) {
+                aOptFlow *= Math.pow(1.1f, ((aBaseEff - 7000) / 10000F) * 20f);
+                aBaseEff *= 0.65f;
+            }else if(aBaseEff>18000) {
+                aOptFlow *= Math.pow(1.1f, ((aBaseEff - 6000) / 10000F) * 20f);
+                aBaseEff *= 0.70f;
+            }else if(aBaseEff>14000) {
+                aOptFlow *= Math.pow(1.1f, ((aBaseEff - 5000) / 10000F) * 20f);
                 aBaseEff *= 0.75f;
-            } else {
-                aBaseEff *= 0.75f;
+            }else if(aBaseEff>10000) {
+                aOptFlow *= Math.pow(1.1f, ((aBaseEff - 4000) / 10000F) * 20f);
+                aBaseEff *= 0.8f;
+            }else if(aBaseEff>6000) {
+                aOptFlow *= Math.pow(1.1f, ((aBaseEff - 3000) / 10000F) * 20f);
+                aBaseEff *= 0.85f;
+            }else{
+                aBaseEff*=0.9f;
+            }
+
+            if (aBaseEff % 100 != 0){
+                aBaseEff -= aBaseEff % 100;
             }
         }
         int tEU = 0;


### PR DESCRIPTION
- Changed Steam loose mode efficiency and optimal flow to improve this mode, especially on the lategame turbines. Efficiency was capped at 75% regardless of the regular value, with this change setting it to always be a percentage of the tight mode efficiency, down to 60% for those lategame turbines, and a maximum of 90% of the tight mode value for the lowest efficiency turbines.
- Also changed the optimal flow calculation to grant a larger optimal flow in loose mode than it was before the change, for all turbines except the highest efficiency ones;
- Improved the tooltip for these turbines, updating to these new values, fixing a typo and showing the EU/t for steam at optimal flow, in both modes.

This is the first of several turbine chantes I'd like to make. This one focuses on the loose mode, which has been largely overlooked because it's mostly used to prevent turbine spam in later powergen setups, from fluid nukes onwards. However, the fuel efficiency of this mode is capped at 75%, even as regular turbine efficiencies jump to 150% or above that. 

With this change, the loose mode efficiency will always be a percentage of the regular efficiency, although a smaller percentage as the turbine's efficiency improves. Additionally, the optimal flow calculation for loose mode is changed to improve this optimal flow, particularly for the good midgame turbines like Oriharukon, the stage of the game where steam power is likely to be used, before fusion is available. The tooltip has been updated to reflect the changes and show the expected EU/t values for each mode on each turbine.

The regular steam power generation (tight mode) is unchanged.

