### PR TITLE
Remove `interpolate` tags from mcmeta files

### DIFF
--- a/src/main/resources/assets/gregtech/textures/items/gt.metaitem.03/174.png.mcmeta
+++ b/src/main/resources/assets/gregtech/textures/items/gt.metaitem.03/174.png.mcmeta
@@ -1,4 +1,3 @@
 {
-"animation": {
-}
+  "animation": {}
 }

--- a/src/main/resources/assets/gregtech/textures/items/gt.metaitem.03/175.png.mcmeta
+++ b/src/main/resources/assets/gregtech/textures/items/gt.metaitem.03/175.png.mcmeta
@@ -1,5 +1,3 @@
 {
-"animation": {
-"interpolate": true
-}
+  "animation": {}
 }

--- a/src/main/resources/assets/gregtech/textures/items/gt.metaitem.03/176.png.mcmeta
+++ b/src/main/resources/assets/gregtech/textures/items/gt.metaitem.03/176.png.mcmeta
@@ -1,5 +1,3 @@
 {
-"animation": {
-"interpolate": true
-}
+  "animation": {}
 }

--- a/src/main/resources/assets/gregtech/textures/items/gt.metaitem.03/177.png.mcmeta
+++ b/src/main/resources/assets/gregtech/textures/items/gt.metaitem.03/177.png.mcmeta
@@ -1,5 +1,3 @@
 {
-"animation": {
-"interpolate": true
-}
+  "animation": {}
 }


### PR DESCRIPTION
Interpolation of animated textures was introduced in 1.8 snapshot 14w25a. ([Source](https://minecraft.fandom.com/wiki/Resource_Pack#History))