### PR TITLE
Prioritize Assembler recipe over crafting one in Disassembler

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_Disassembler.java
+++ b/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_Disassembler.java
@@ -203,11 +203,11 @@ public class GT_MetaTileEntity_Disassembler extends GT_MetaTileEntity_BasicMachi
     }
 
     private int process(){
-        int statusCode = checkRecipeMap();
+        int statusCode = onTheFlyGeneration();
         if (statusCode != DID_NOT_FIND_RECIPE)
             return statusCode;
 
-        return onTheFlyGeneration();
+        return checkRecipeMap();
     }
 
     private int onTheFlyGeneration() {


### PR DESCRIPTION
Prevent dupes to some extent.
I'm not sure if this does not harm any of current Disassembler behavior. Assembler recipe is cheaper than crafting one in general, so I _think_ it's fine, but it needs testing.