### PR TITLE
Added Use for Cactus/Sugar Coke in BBF

### DIFF
--- a/src/main/java/gregtech/common/GT_RecipeAdder.java
+++ b/src/main/java/gregtech/common/GT_RecipeAdder.java
@@ -267,8 +267,8 @@ public class GT_RecipeAdder implements IGT_RecipeAdder {
             GT_Recipe.GT_Recipe_Map.sPrimitiveBlastRecipes.addRecipe(true, new ItemStack[]{aInput1, aInput2, RailcraftToolItems.getCoalCoke(aCoalAmount / 2)}, new ItemStack[]{aOutput1, aOutput2, Materials.Ash.getDustTiny(aCoalAmount / 2)}, null, null, null, null, aDuration * 2 / 3, 0, 0);
         }
         if (Loader.isModLoaded("miscutils")) {
-            GT_Recipe.GT_Recipe_Map.sPrimitiveBlastRecipes.addRecipe(true, new ItemStack[]{aInput1, aInput2, GT_ModHandler.getModItem("miscutils", "itemCokeCactus", (aCoalAmount * 2))}, new ItemStack[]{aOutput1, aOutput2, Materials.Ash.getDustTiny(aCoalAmount * 2)}, null, null, null, null, aDuration * 2 / 3, 0, 0);
-            GT_Recipe.GT_Recipe_Map.sPrimitiveBlastRecipes.addRecipe(true, new ItemStack[]{aInput1, aInput2, GT_ModHandler.getModItem("miscutils", "itemCokeSugar", (aCoalAmount * 2))}, new ItemStack[]{aOutput1, aOutput2, Materials.Ash.getDustTiny(aCoalAmount * 2)}, null, null, null, null, aDuration * 2 / 3, 0, 0);
+            GT_Recipe.GT_Recipe_Map.sPrimitiveBlastRecipes.addRecipe(true, new ItemStack[]{aInput1, aInput2, GT_ModHandler.getModItem("miscutils", "itemCactusCoke", (aCoalAmount * 2))}, new ItemStack[]{aOutput1, aOutput2, Materials.Ash.getDustTiny(aCoalAmount * 2)}, null, null, null, null, aDuration * 2 / 3, 0, 0);
+            GT_Recipe.GT_Recipe_Map.sPrimitiveBlastRecipes.addRecipe(true, new ItemStack[]{aInput1, aInput2, GT_ModHandler.getModItem("miscutils", "itemSugarCoke", (aCoalAmount * 2))}, new ItemStack[]{aOutput1, aOutput2, Materials.Ash.getDustTiny(aCoalAmount * 2)}, null, null, null, null, aDuration * 2 / 3, 0, 0);
         }
         if ((aInput1 == null || aInput1.stackSize <= 6) && (aInput2 == null || aInput2.stackSize <= 6) &&
                 (aOutput1 == null || aOutput1.stackSize <= 6) && (aOutput2 == null || aOutput2.stackSize <= 6)) {


### PR DESCRIPTION
- Added Cactus and Sugar Coke to the first Blast Furnace, with the same recipe time as Coal Coke but with 4x the amount needed, as these Cokes have 1/4 the burn time as Coal Coke.

For https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/10233.