### PR TITLE
Buffed Wood Gas DT Recipe

### DIFF
--- a/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
@@ -2876,7 +2876,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                 new FluidStack[]{Materials.WoodTar.getFluid(250), Materials.WoodVinegar.getFluid(400), Materials.WoodGas.getGas(250), Materials.Dimethylbenzene.getFluid(100)},
                 Materials.Charcoal.getDustSmall(1),  40, 256);
         GT_Values.RA.addUniversalDistillationRecipe(Materials.WoodGas.getGas(1000),
-                new FluidStack[]{Materials.CarbonDioxide.getGas(490), Materials.Ethylene.getGas(20), Materials.Methane.getGas(130), Materials.CarbonMonoxide.getGas(340), Materials.Hydrogen.getGas(20)},
+                new FluidStack[]{Materials.CarbonDioxide.getGas(390), Materials.Ethylene.getGas(120), Materials.Methane.getGas(130), Materials.CarbonMonoxide.getGas(240), Materials.Hydrogen.getGas(120)},
                 GT_Values.NI,  40, 256);
         GT_Values.RA.addUniversalDistillationRecipe(Materials.WoodVinegar.getFluid(1000),
                 new FluidStack[]{Materials.AceticAcid.getFluid(100), Materials.Water.getFluid(500), Materials.Ethanol.getFluid(10), Materials.Methanol.getFluid(300), Materials.Acetone.getFluid(50), Materials.MethylAcetate.getFluid(10)},


### PR DESCRIPTION
- Changed the Wood Gas DT processing recipe to lower the amounts of CO2 and CO by 100L each, and increase the amounts of Ethylene and Hydrogen by 100L each.

(I don't know when the Kevlar line, and its associated DT recipe changes, will get reviewed and approved, so I decided to put this together separately.)

Wood Gas is one of those chemicals that has a DT recipe, but it's such a bad recipe that basically nobody bothers to make a DT for it. It's almost all waste products like CO2 and CO, which are obtainable in many other ways from the Benzene line itself. With this change, it can give more Hydrogen directly, but especially Ethylene, which would make it more worthwhile to process, without being too big of a change (Hydrogen can already be obtained from electrolyzing many of the byproducts of this line).