### PR TITLE
Adjust NEI recipe pages

### DIFF
--- a/src/main/java/gregtech/api/util/GT_LanguageManager.java
+++ b/src/main/java/gregtech/api/util/GT_LanguageManager.java
@@ -364,7 +364,8 @@ public class GT_LanguageManager {
 		addStringLocalization("Interaction_DESCRIPTION_Index_221", "Item threshold");
 		addStringLocalization("Interaction_DESCRIPTION_Index_222", "Fluid threshold");
 		addStringLocalization("Interaction_DESCRIPTION_Index_223", "Single recipe locking enabled. Will lock to next recipe.");
-		addStringLocalization("Interaction_DESCRIPTION_Index_500", "Fitting: Loose - More Flow");
+        addStringLocalization("Interaction_DESCRIPTION_Index_224", " ticks");
+        addStringLocalization("Interaction_DESCRIPTION_Index_500", "Fitting: Loose - More Flow");
 		addStringLocalization("Interaction_DESCRIPTION_Index_501", "Fitting: Tight - More Efficiency");
 
 		addStringLocalization("Item_DESCRIPTION_Index_000", "Stored Heat: %s");

--- a/src/main/java/gregtech/common/GT_Proxy.java
+++ b/src/main/java/gregtech/common/GT_Proxy.java
@@ -153,6 +153,7 @@ public abstract class GT_Proxy implements IGT_Mod, IGuiHandler, IFuelHandler {
     public boolean mIncreaseDungeonLoot = true;
     public boolean mAxeWhenAdventure = true;
     public boolean mSurvivalIntoAdventure = false;
+    public boolean mNEIRecipeSecondMode = false;
     public boolean mNerfedWoodPlank = true;
     public boolean mNerfedVanillaTools = true;
     public boolean mHardRock = false;

--- a/src/main/java/gregtech/common/GT_Proxy.java
+++ b/src/main/java/gregtech/common/GT_Proxy.java
@@ -153,7 +153,7 @@ public abstract class GT_Proxy implements IGT_Mod, IGuiHandler, IFuelHandler {
     public boolean mIncreaseDungeonLoot = true;
     public boolean mAxeWhenAdventure = true;
     public boolean mSurvivalIntoAdventure = false;
-    public boolean mNEIRecipeSecondMode = false;
+    public boolean mNEIRecipeSecondMode = true;
     public boolean mNerfedWoodPlank = true;
     public boolean mNerfedVanillaTools = true;
     public boolean mHardRock = false;

--- a/src/main/java/gregtech/common/power/Power.java
+++ b/src/main/java/gregtech/common/power/Power.java
@@ -34,8 +34,12 @@ public abstract class Power {
         return 0.05d * getDurationTicks();
     }
 
-    public String getDurationString() {
+    public String getDurationStringSeconds() {
         return GT_Utility.formatNumbers(getDurationSeconds()) + GT_Utility.trans("161", " secs");
+    }
+
+    public String getDurationStringTicks() {
+        return GT_Utility.formatNumbers(getDurationTicks()) + GT_Utility.trans("161", " ticks");
     }
 
     public abstract String getTotalPowerString();

--- a/src/main/java/gregtech/common/power/Power.java
+++ b/src/main/java/gregtech/common/power/Power.java
@@ -39,7 +39,7 @@ public abstract class Power {
     }
 
     public String getDurationStringTicks() {
-        return GT_Utility.formatNumbers(getDurationTicks()) + GT_Utility.trans("161", " ticks");
+        return GT_Utility.formatNumbers(getDurationTicks()) + GT_Utility.trans("224", " ticks");
     }
 
     public abstract String getTotalPowerString();

--- a/src/main/java/gregtech/loaders/preload/GT_PreLoad.java
+++ b/src/main/java/gregtech/loaders/preload/GT_PreLoad.java
@@ -238,12 +238,12 @@ public class GT_PreLoad {
 
         List<String> mMTTags = new ArrayList<>();
         oreTags.stream()
-                .filter(test -> StringUtils.startsWithAny(test, preS))
-                .forEach(test -> {
-                    mMTTags.add(test);
-                    if (GT_Values.D1)
-                        GT_FML_LOGGER.info("oretag: " + test);
-                });
+            .filter(test -> StringUtils.startsWithAny(test, preS))
+            .forEach(test -> {
+                mMTTags.add(test);
+                if (GT_Values.D1)
+                    GT_FML_LOGGER.info("oretag: " + test);
+            });
 
         GT_FML_LOGGER.info("reenableMetaItems");
 
@@ -377,6 +377,7 @@ public class GT_PreLoad {
         GT_Mod.gregtechproxy.mAxeWhenAdventure = tMainConfig.get(GT_Mod.aTextGeneral, "AdventureModeStartingAxe", true).getBoolean(true);
         GT_Mod.gregtechproxy.mHardcoreCables = tMainConfig.get(GT_Mod.aTextGeneral, "HardCoreCableLoss", false).getBoolean(false);
         GT_Mod.gregtechproxy.mSurvivalIntoAdventure = tMainConfig.get(GT_Mod.aTextGeneral, "forceAdventureMode", false).getBoolean(false);
+        GT_Mod.gregtechproxy.mNEIRecipeSecondMode = tMainConfig.get(GT_Mod.aTextGeneral, "NEI_recipe_second_mode", false).getBoolean(false);
         GT_Mod.gregtechproxy.mHungerEffect = tMainConfig.get(GT_Mod.aTextGeneral, "AFK_Hunger", false).getBoolean(false);
         GT_Mod.gregtechproxy.mHardRock = tMainConfig.get(GT_Mod.aTextGeneral, "harderstone", false).getBoolean(false);
         GT_Mod.gregtechproxy.mInventoryUnification = tMainConfig.get(GT_Mod.aTextGeneral, "InventoryUnification", true).getBoolean(true);
@@ -490,8 +491,8 @@ public class GT_PreLoad {
             GT_Mod.gregtechproxy.mGraniteHavestLevel = GregTech_API.sMaterialProperties.get("havestLevel", "graniteHarvestLevel", 3);
             GT_Mod.gregtechproxy.mMaxHarvestLevel = Math.min(15, GregTech_API.sMaterialProperties.get("havestLevel", "maxLevel", 7));
             Materials.getMaterialsMap().values().parallelStream().filter(tMaterial -> tMaterial != null && tMaterial.mToolQuality > 0 && tMaterial.mMetaItemSubID < GT_Mod.gregtechproxy.mHarvestLevel.length && tMaterial.mMetaItemSubID >= 0).forEach(
-                    tMaterial -> GT_Mod.gregtechproxy.mHarvestLevel[tMaterial.mMetaItemSubID] = GregTech_API.sMaterialProperties.get("materialHavestLevel", tMaterial.mDefaultLocalName, tMaterial.mToolQuality)
-                                                                                                                                                                                                                                                       );
+                tMaterial -> GT_Mod.gregtechproxy.mHarvestLevel[tMaterial.mMetaItemSubID] = GregTech_API.sMaterialProperties.get("materialHavestLevel", tMaterial.mDefaultLocalName, tMaterial.mToolQuality)
+            );
         }
 
         if (tMainConfig.get("general", "hardermobspawners", true).getBoolean(true)) {
@@ -519,12 +520,12 @@ public class GT_PreLoad {
     public static void loadClientConfig() {
         String SBdye0 = "ColorModulation.";
         Arrays.stream(Dyes.values()).filter(tDye -> (tDye != Dyes._NULL) && (tDye.mIndex < 0)).forEach(tDye -> {
-                    String SBdye1 = SBdye0 + tDye;
-                    tDye.mRGBa[0] = ((short) Math.min(255, Math.max(0, GregTech_API.sClientDataFile.get(SBdye1, "R", tDye.mOriginalRGBa[0]))));
-                    tDye.mRGBa[1] = ((short) Math.min(255, Math.max(0, GregTech_API.sClientDataFile.get(SBdye1, "G", tDye.mOriginalRGBa[1]))));
-                    tDye.mRGBa[2] = ((short) Math.min(255, Math.max(0, GregTech_API.sClientDataFile.get(SBdye1, "B", tDye.mOriginalRGBa[2]))));
-                }
-                                                                                                      );
+                String SBdye1 = SBdye0 + tDye;
+                tDye.mRGBa[0] = ((short) Math.min(255, Math.max(0, GregTech_API.sClientDataFile.get(SBdye1, "R", tDye.mOriginalRGBa[0]))));
+                tDye.mRGBa[1] = ((short) Math.min(255, Math.max(0, GregTech_API.sClientDataFile.get(SBdye1, "G", tDye.mOriginalRGBa[1]))));
+                tDye.mRGBa[2] = ((short) Math.min(255, Math.max(0, GregTech_API.sClientDataFile.get(SBdye1, "B", tDye.mOriginalRGBa[2]))));
+            }
+        );
         GT_Mod.gregtechproxy.mRenderTileAmbientOcclusion = GregTech_API.sClientDataFile.get("render", "TileAmbientOcclusion", true);
         GT_Mod.gregtechproxy.mRenderGlowTextures = GregTech_API.sClientDataFile.get("render", "GlowTextures", true);
         GT_Mod.gregtechproxy.mRenderFlippedMachinesFlipped = GregTech_API.sClientDataFile.get("render", "RenderFlippedMachinesFlipped", true);

--- a/src/main/java/gregtech/loaders/preload/GT_PreLoad.java
+++ b/src/main/java/gregtech/loaders/preload/GT_PreLoad.java
@@ -377,7 +377,7 @@ public class GT_PreLoad {
         GT_Mod.gregtechproxy.mAxeWhenAdventure = tMainConfig.get(GT_Mod.aTextGeneral, "AdventureModeStartingAxe", true).getBoolean(true);
         GT_Mod.gregtechproxy.mHardcoreCables = tMainConfig.get(GT_Mod.aTextGeneral, "HardCoreCableLoss", false).getBoolean(false);
         GT_Mod.gregtechproxy.mSurvivalIntoAdventure = tMainConfig.get(GT_Mod.aTextGeneral, "forceAdventureMode", false).getBoolean(false);
-        GT_Mod.gregtechproxy.mNEIRecipeSecondMode = tMainConfig.get(GT_Mod.aTextGeneral, "NEI_recipe_second_mode", false).getBoolean(false);
+        GT_Mod.gregtechproxy.mNEIRecipeSecondMode = tMainConfig.get(GT_Mod.aTextGeneral, "NEI_recipe_second_mode", true).getBoolean(true);
         GT_Mod.gregtechproxy.mHungerEffect = tMainConfig.get(GT_Mod.aTextGeneral, "AFK_Hunger", false).getBoolean(false);
         GT_Mod.gregtechproxy.mHardRock = tMainConfig.get(GT_Mod.aTextGeneral, "harderstone", false).getBoolean(false);
         GT_Mod.gregtechproxy.mInventoryUnification = tMainConfig.get(GT_Mod.aTextGeneral, "InventoryUnification", true).getBoolean(true);

--- a/src/main/java/gregtech/loaders/preload/GT_PreLoad.java
+++ b/src/main/java/gregtech/loaders/preload/GT_PreLoad.java
@@ -377,7 +377,6 @@ public class GT_PreLoad {
         GT_Mod.gregtechproxy.mAxeWhenAdventure = tMainConfig.get(GT_Mod.aTextGeneral, "AdventureModeStartingAxe", true).getBoolean(true);
         GT_Mod.gregtechproxy.mHardcoreCables = tMainConfig.get(GT_Mod.aTextGeneral, "HardCoreCableLoss", false).getBoolean(false);
         GT_Mod.gregtechproxy.mSurvivalIntoAdventure = tMainConfig.get(GT_Mod.aTextGeneral, "forceAdventureMode", false).getBoolean(false);
-        GT_Mod.gregtechproxy.mNEIRecipeSecondMode = tMainConfig.get(GT_Mod.aTextGeneral, "NEI_recipe_second_mode", true).getBoolean(true);
         GT_Mod.gregtechproxy.mHungerEffect = tMainConfig.get(GT_Mod.aTextGeneral, "AFK_Hunger", false).getBoolean(false);
         GT_Mod.gregtechproxy.mHardRock = tMainConfig.get(GT_Mod.aTextGeneral, "harderstone", false).getBoolean(false);
         GT_Mod.gregtechproxy.mInventoryUnification = tMainConfig.get(GT_Mod.aTextGeneral, "InventoryUnification", true).getBoolean(true);
@@ -536,6 +535,8 @@ public class GT_PreLoad {
         GT_Mod.gregtechproxy.mCoverTabsFlipped = GregTech_API.sClientDataFile.get("interface", "FlipCoverTabs", false);
         GT_Mod.gregtechproxy.mTooltipVerbosity = GregTech_API.sClientDataFile.get("interface", "TooltipVerbosity", 2);
         GT_Mod.gregtechproxy.mTooltipShiftVerbosity = GregTech_API.sClientDataFile.get("interface", "TooltipShiftVerbosity", 3);
+        GT_Mod.gregtechproxy.mNEIRecipeSecondMode = GregTech_API.sClientDataFile.get("features", "NEI_recipe_second_mode", true);
+
         final String[] Circuits = GregTech_API.sClientDataFile.get("interface", "CircuitsOrder" );
         GT_Mod.gregtechproxy.mCircuitsOrder.clear();
         for (int i = 0; i < Circuits.length; i++) {

--- a/src/main/java/gregtech/nei/GT_NEI_DefaultHandler.java
+++ b/src/main/java/gregtech/nei/GT_NEI_DefaultHandler.java
@@ -373,11 +373,6 @@ public class GT_NEI_DefaultHandler extends RecipeMapHandler {
                 lineCounter++;
             }
 
-//            if ((mPower.getAmperageString() != null) && (!mPower.getAmperageString().equals("unspecified")) && (Integer.parseInt(mPower.getAmperageString()) != 1)) {
-//                drawLine(lineCounter, GT_Utility.trans("155", "Amperage: ") + mPower.getAmperageString());
-//                lineCounter++;
-//            }
-
         }
         if (mPower.getDurationTicks() > 0) {
             if(GT_Mod.gregtechproxy.mNEIRecipeSecondMode) {

--- a/src/main/java/gregtech/nei/GT_NEI_DefaultHandler.java
+++ b/src/main/java/gregtech/nei/GT_NEI_DefaultHandler.java
@@ -20,11 +20,7 @@ import gregtech.api.gui.GT_GUIContainer;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_BasicMachine;
 import gregtech.api.objects.ItemData;
-import gregtech.api.util.GT_LanguageManager;
-import gregtech.api.util.GT_Log;
-import gregtech.api.util.GT_OreDictUnificator;
-import gregtech.api.util.GT_Recipe;
-import gregtech.api.util.GT_Utility;
+import gregtech.api.util.*;
 import gregtech.common.power.EUPower;
 import gregtech.common.power.Power;
 import gregtech.common.power.UnspecifiedEUPower;
@@ -64,7 +60,7 @@ public class GT_NEI_DefaultHandler extends RecipeMapHandler {
     private NEIHandlerAbsoluteTooltip mRecipeNameTooltip;
     private static final int RECIPE_NAME_WIDTH = 140;
 
-     /**
+    /**
      * Static version of {@link TemplateRecipeHandler#cycleticks}.
      * Can be referenced from cached recipes.
      */
@@ -96,10 +92,10 @@ public class GT_NEI_DefaultHandler extends RecipeMapHandler {
         List<CachedDefaultRecipe> cache;
         if (cacheHolder.getCachedRecipesVersion() != GT_Mod.gregtechproxy.getReloadCount() || (cache = cacheHolder.getCachedRecipes()) == null) {
             cache = mRecipeMap.mRecipeList.stream()  // do not use parallel stream. This is already parallelized by NEI
-                    .filter(r -> !r.mHidden)
-                    .sorted()
-                    .map(CachedDefaultRecipe::new)
-                    .collect(Collectors.toList());
+                .filter(r -> !r.mHidden)
+                .sorted()
+                .map(CachedDefaultRecipe::new)
+                .collect(Collectors.toList());
             // while the NEI parallelize handlers, for each individual handler it still uses sequential execution model
             // so we do not need any synchronization here
             // even if it does break, at worst case it's just recreating the cache multiple times, which should be fine
@@ -314,7 +310,7 @@ public class GT_NEI_DefaultHandler extends RecipeMapHandler {
             for (PositionedStack tStack : tRecipe.mInputs) {
                 if (aStack == tStack.item) {
                     if ((gregtech.api.enums.ItemList.Display_Fluid.isStackEqual(tStack.item, true, true)) ||
-                            (tStack.item.stackSize != 0)) {
+                        (tStack.item.stackSize != 0)) {
                         break;
                     }
                     currenttip.add(GT_Utility.trans("151", "Does not get consumed in the process"));
@@ -356,23 +352,38 @@ public class GT_NEI_DefaultHandler extends RecipeMapHandler {
             mPower = getPowerFromRecipeMap();
         }
         mPower.computePowerUsageAndDuration(recipe.mEUt, recipe.mDuration);
+
+        int lineCounter = 0;
         if (mPower.getEuPerTick() > 0) {
-            drawPowerUsageLines();
+            drawLine(lineCounter, GT_Utility.trans("152", "Total: ") + mPower.getTotalPowerString());
+            lineCounter++;
+            drawLine(lineCounter, GT_Utility.trans("153", "Usage: ") + mPower.getPowerUsageString());
+            lineCounter++;
+
+            if ((mPower.getVoltageString() != null) && (mPower.getVoltageString() != "unspecified") && (Integer.parseInt(mPower.getAmperageString()) != 1)) {
+                drawLine(lineCounter, GT_Utility.trans("154", "Voltage: ") + mPower.getVoltageString());
+                lineCounter++;
+            }
+
+            if ((mPower.getAmperageString() != null) && (mPower.getAmperageString() != "unspecified") && (Integer.parseInt(mPower.getAmperageString()) != 1)) {
+                drawLine(lineCounter, GT_Utility.trans("155", "Amperage: ") + mPower.getAmperageString());
+                lineCounter++;
+            }
+
         }
         if (mPower.getDurationTicks() > 0) {
-            drawLine(4, GT_Utility.trans("158", "Time: ") + mPower.getDurationString());
+            if(GT_Mod.gregtechproxy.mNEIRecipeSecondMode) {
+                drawLine(lineCounter, GT_Utility.trans("158", "Time: ") + mPower.getDurationStringSeconds());
+                lineCounter++;
+            } else {
+                drawLine(lineCounter, GT_Utility.trans("158", "Time: ") + mPower.getDurationStringTicks());
+                lineCounter++;
+            }
         }
         if (this.mRecipeMap.mNEIName.equals("gt.recipe.fusionreactor")) {
-            drawOptionalLine(5, getSpecialInfo(recipe.mSpecialValue) + " " + formatSpecialValueFusion(recipe.mSpecialValue, recipe.mEUt));
+            drawOptionalLine(lineCounter, getSpecialInfo(recipe.mSpecialValue) + " " + formatSpecialValueFusion(recipe.mSpecialValue, recipe.mEUt));
         }
-        drawOptionalLine(5, getSpecialInfo(recipe.mSpecialValue));
-    }
-
-    private void drawPowerUsageLines() {
-        drawLine(0, GT_Utility.trans("152", "Total: ") + mPower.getTotalPowerString());
-        drawLine(1, GT_Utility.trans("153", "Usage: ") + mPower.getPowerUsageString());
-        drawOptionalLine(2, mPower.getVoltageString(), GT_Utility.trans("154", "Voltage: "));
-        drawOptionalLine(3, mPower.getAmperageString(), GT_Utility.trans("155", "Amperage: "));
+        drawOptionalLine(lineCounter, getSpecialInfo(recipe.mSpecialValue));
     }
 
     private void drawOverrideDescription(String[] recipeDesc) {
@@ -403,13 +414,13 @@ public class GT_NEI_DefaultHandler extends RecipeMapHandler {
 
     private boolean hasSpecialValueFormat() {
         return (GT_Utility.isStringValid(this.mRecipeMap.mNEISpecialValuePre))
-                || (GT_Utility.isStringValid(this.mRecipeMap.mNEISpecialValuePost));
+            || (GT_Utility.isStringValid(this.mRecipeMap.mNEISpecialValuePost));
     }
 
     private String formatSpecialValue(int SpecialValue) {
         return this.mRecipeMap.mNEISpecialValuePre + GT_Utility.formatNumbers(
-                (long) SpecialValue * this.mRecipeMap.mNEISpecialValueMultiplier)
-                + this.mRecipeMap.mNEISpecialValuePost;
+            (long) SpecialValue * this.mRecipeMap.mNEISpecialValueMultiplier)
+            + this.mRecipeMap.mNEISpecialValuePost;
     }
 
     private String formatSpecialValueFusion(int SpecialValue, int Voltage) {
@@ -436,13 +447,13 @@ public class GT_NEI_DefaultHandler extends RecipeMapHandler {
     }
 
     private void drawOptionalLine(int lineNumber, String line, String prefix) {
-        if (line != null) {
+        if ((line != null) && (line != "unspecified")) {
             drawLine(lineNumber, prefix + line);
         }
     }
 
     private void drawOptionalLine(int lineNumber, String line) {
-        if (line != null) {
+        if ((line != null) && (line != "unspecified")) {
             drawLine(lineNumber, line);
         }
     }
@@ -452,7 +463,7 @@ public class GT_NEI_DefaultHandler extends RecipeMapHandler {
     }
 
     public static class GT_RectHandler
-            implements IContainerInputHandler, IContainerTooltipHandler {
+        implements IContainerInputHandler, IContainerTooltipHandler {
         @Override
         public boolean mouseClicked(GuiContainer gui, int mousex, int mousey, int button) {
             if (canHandle(gui)) {
@@ -471,8 +482,8 @@ public class GT_NEI_DefaultHandler extends RecipeMapHandler {
 
         private Point getMousePos(GuiContainer gui, int mousex, int mousey) {
             Point point = new Point(
-                    mousex - ((GT_GUIContainer) gui).getLeft() - getGuiOffset(gui)[0],
-                    mousey - ((GT_GUIContainer) gui).getTop() - getGuiOffset(gui)[1]);
+                mousex - ((GT_GUIContainer) gui).getLeft() - getGuiOffset(gui)[0],
+                mousey - ((GT_GUIContainer) gui).getTop() - getGuiOffset(gui)[1]);
             return point;
         }
 
@@ -602,7 +613,7 @@ public class GT_NEI_DefaultHandler extends RecipeMapHandler {
     }
 
     public class CachedDefaultRecipe
-            extends TemplateRecipeHandler.CachedRecipe {
+        extends TemplateRecipeHandler.CachedRecipe {
         public final GT_Recipe mRecipe;
         public final List<PositionedStack> mOutputs;
         public final List<PositionedStack> mInputs;

--- a/src/main/java/gregtech/nei/GT_NEI_DefaultHandler.java
+++ b/src/main/java/gregtech/nei/GT_NEI_DefaultHandler.java
@@ -451,13 +451,13 @@ public class GT_NEI_DefaultHandler extends RecipeMapHandler {
     }
 
     private void drawOptionalLine(int lineNumber, String line, String prefix) {
-        if ((line != null) && (!line.equals("unspecified"))) {
+        if (!"unspecified".equals(line)) {
             drawLine(lineNumber, prefix + line);
         }
     }
 
     private void drawOptionalLine(int lineNumber, String line) {
-        if ((line != null) && (!line.equals("unspecified"))) {
+        if (!"unspecified".equals(line)) {
             drawLine(lineNumber, line);
         }
     }

--- a/src/main/java/gregtech/nei/GT_NEI_DefaultHandler.java
+++ b/src/main/java/gregtech/nei/GT_NEI_DefaultHandler.java
@@ -357,18 +357,26 @@ public class GT_NEI_DefaultHandler extends RecipeMapHandler {
         if (mPower.getEuPerTick() > 0) {
             drawLine(lineCounter, GT_Utility.trans("152", "Total: ") + mPower.getTotalPowerString());
             lineCounter++;
-            drawLine(lineCounter, GT_Utility.trans("153", "Usage: ") + mPower.getPowerUsageString());
-            lineCounter++;
 
-            if ((mPower.getVoltageString() != null) && (mPower.getVoltageString() != "unspecified") && (Integer.parseInt(mPower.getAmperageString()) != 1)) {
+            if (mPower.getAmperageString().equals("1")) {
                 drawLine(lineCounter, GT_Utility.trans("154", "Voltage: ") + mPower.getVoltageString());
                 lineCounter++;
-            }
-
-            if ((mPower.getAmperageString() != null) && (mPower.getAmperageString() != "unspecified") && (Integer.parseInt(mPower.getAmperageString()) != 1)) {
+            } else if (mPower.getAmperageString().equals("unspecified")){
+                drawLine(lineCounter, GT_Utility.trans("153", "Usage: ") + mPower.getPowerUsageString());
+                lineCounter++;
+            } else {
+                drawLine(lineCounter, GT_Utility.trans("153", "Usage: ") + mPower.getPowerUsageString());
+                lineCounter++;
+                drawLine(lineCounter, GT_Utility.trans("154", "Voltage: ") + mPower.getVoltageString());
+                lineCounter++;
                 drawLine(lineCounter, GT_Utility.trans("155", "Amperage: ") + mPower.getAmperageString());
                 lineCounter++;
             }
+
+//            if ((mPower.getAmperageString() != null) && (!mPower.getAmperageString().equals("unspecified")) && (Integer.parseInt(mPower.getAmperageString()) != 1)) {
+//                drawLine(lineCounter, GT_Utility.trans("155", "Amperage: ") + mPower.getAmperageString());
+//                lineCounter++;
+//            }
 
         }
         if (mPower.getDurationTicks() > 0) {
@@ -447,13 +455,13 @@ public class GT_NEI_DefaultHandler extends RecipeMapHandler {
     }
 
     private void drawOptionalLine(int lineNumber, String line, String prefix) {
-        if ((line != null) && (line != "unspecified")) {
+        if ((line != null) && (!line.equals("unspecified"))) {
             drawLine(lineNumber, prefix + line);
         }
     }
 
     private void drawOptionalLine(int lineNumber, String line) {
-        if ((line != null) && (line != "unspecified")) {
+        if ((line != null) && (!line.equals("unspecified"))) {
             drawLine(lineNumber, line);
         }
     }

--- a/src/main/java/gregtech/nei/GT_NEI_DefaultHandler.java
+++ b/src/main/java/gregtech/nei/GT_NEI_DefaultHandler.java
@@ -14,6 +14,7 @@ import codechicken.nei.recipe.IUsageHandler;
 import codechicken.nei.recipe.RecipeCatalysts;
 import codechicken.nei.recipe.TemplateRecipeHandler;
 import gregtech.GT_Mod;
+import gregtech.api.GregTech_API;
 import gregtech.api.enums.GT_Values;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.gui.GT_GUIContainer;
@@ -358,11 +359,11 @@ public class GT_NEI_DefaultHandler extends RecipeMapHandler {
             drawLine(lineCounter, GT_Utility.trans("152", "Total: ") + mPower.getTotalPowerString());
             lineCounter++;
 
-            if (mPower.getAmperageString().equals("1")) {
-                drawLine(lineCounter, GT_Utility.trans("154", "Voltage: ") + mPower.getVoltageString());
-                lineCounter++;
-            } else if (mPower.getAmperageString().equals("unspecified")){
+            if (mPower.getAmperageString().equals("unspecified") || mPower.getPowerUsageString().contains("(OC)")){
                 drawLine(lineCounter, GT_Utility.trans("153", "Usage: ") + mPower.getPowerUsageString());
+                lineCounter++;
+            } else if (mPower.getAmperageString().equals("1")) {
+                drawLine(lineCounter, GT_Utility.trans("154", "Voltage: ") + mPower.getVoltageString());
                 lineCounter++;
             } else {
                 drawLine(lineCounter, GT_Utility.trans("153", "Usage: ") + mPower.getPowerUsageString());
@@ -450,13 +451,13 @@ public class GT_NEI_DefaultHandler extends RecipeMapHandler {
     }
 
     private void drawOptionalLine(int lineNumber, String line, String prefix) {
-        if (!line.equals("unspecified")) {
+        if ((line != null) && (!line.equals("unspecified"))) {
             drawLine(lineNumber, prefix + line);
         }
     }
 
     private void drawOptionalLine(int lineNumber, String line) {
-        if (!line.equals("unspecified")) {
+        if ((line != null) && (!line.equals("unspecified"))) {
             drawLine(lineNumber, line);
         }
     }

--- a/src/main/java/gregtech/nei/GT_NEI_DefaultHandler.java
+++ b/src/main/java/gregtech/nei/GT_NEI_DefaultHandler.java
@@ -450,13 +450,13 @@ public class GT_NEI_DefaultHandler extends RecipeMapHandler {
     }
 
     private void drawOptionalLine(int lineNumber, String line, String prefix) {
-        if ((line != null) && (!line.equals("unspecified"))) {
+        if (!line.equals("unspecified")) {
             drawLine(lineNumber, prefix + line);
         }
     }
 
     private void drawOptionalLine(int lineNumber, String line) {
-        if ((line != null) && (!line.equals("unspecified"))) {
+        if (!line.equals("unspecified")) {
             drawLine(lineNumber, line);
         }
     }

--- a/src/main/resources/assets/gregtech/lang/en_US.lang
+++ b/src/main/resources/assets/gregtech/lang/en_US.lang
@@ -202,7 +202,7 @@ GT5U.config.render.RenderFlippedMachinesFlipped=Render flipped machines with fli
 GT5U.config.render.RenderIndicatorsOnHatch=Render indicator on hatch
 GT5U.config.render.RenderPollutionFog=Render pollution fog
 GT5U.config.render.TileAmbientOcclusion=Enable Ambient Occlusion
-GT5U.config.feature.NEI_recipe_second_mode=If true NEI will display GT recipes using seconds, if false it will use ticks.
+GT5U.config.feature.NEI_recipe_second_mode=Show NEI recipes using seconds (as opposed to ticks).
 
 // Cover tabs
 GT5U.interface.coverTabs.down=Bottom

--- a/src/main/resources/assets/gregtech/lang/en_US.lang
+++ b/src/main/resources/assets/gregtech/lang/en_US.lang
@@ -127,8 +127,8 @@ GT5U.machines.stalled_stuttering.tooltip.3=§7the recipe to complete it.
 GT5U.machines.stalled_stuttering.tooltip.extended=§7Progress was lost, but not
 GT5U.machines.stalled_stuttering.tooltip.extended.1=§7the recipe's output.
 GT5U.machines.stalled_vent.tooltip=§4Stalled: Cannot vent steam!
-GT5U.machines.stalled_vent.tooltip.1=§7Right-click with a wrench to 
-GT5U.machines.stalled_vent.tooltip.2=§7point this machine's steam 
+GT5U.machines.stalled_vent.tooltip.1=§7Right-click with a wrench to
+GT5U.machines.stalled_vent.tooltip.2=§7point this machine's steam
 GT5U.machines.stalled_vent.tooltip.3=§7vent towards an empty space.
 GT5U.machines.stalled_vent.tooltip.extended=§7Progress was lost, but not
 GT5U.machines.stalled_vent.tooltip.extended.1=§7the recipe's output.
@@ -202,6 +202,7 @@ GT5U.config.render.RenderFlippedMachinesFlipped=Render flipped machines with fli
 GT5U.config.render.RenderIndicatorsOnHatch=Render indicator on hatch
 GT5U.config.render.RenderPollutionFog=Render pollution fog
 GT5U.config.render.TileAmbientOcclusion=Enable Ambient Occlusion
+GT5U.config.feature.NEI_recipe_second_mode=If true NEI will display GT recipes using seconds, if false it will use ticks.
 
 // Cover tabs
 GT5U.interface.coverTabs.down=Bottom
@@ -807,7 +808,7 @@ gregtech.areaLethargic=Lethargic
 gregtech.areaExploratory=Exploratory
 gregtech.speedUnproductive=Unproductive
 gregtech.speedAccelerated=Accelerated
-gregtech.lifeBlink=Blink 
+gregtech.lifeBlink=Blink
 gregtech.lifeEon=Eon
 
 entity.gregtech.GT_Entity_Arrow.name= a GregTech arrow


### PR DESCRIPTION
This is a small cleanup that I feel was necessary. I have added the config option for the user to be able to change the recipe time displayed in NEI from ticks to seconds. In addition to this I have disabled the showing of amperage/voltage information if the amperage is 1 or unspecified. This way you prevent a situation like:

<img width="337" alt="Screenshot 2022-06-09 at 03 20 54" src="https://user-images.githubusercontent.com/52056774/172750440-eea3cb74-f6c0-4392-86cb-76d6204e0708.png">

Or

<img width="330" alt="Screenshot 2022-06-09 at 03 17 01" src="https://user-images.githubusercontent.com/52056774/172750481-fc287cdc-8269-4968-bbc4-55c75b7239af.png">

Or

<img width="329" alt="Screenshot 2022-06-09 at 03 21 45" src="https://user-images.githubusercontent.com/52056774/172750525-d9f9b4ea-f5b6-4ccd-b8e0-de3dd85534b2.png">

This information is clearly redundant or just straight up not helpful. See new changes:

<img width="327" alt="Screenshot 2022-06-09 at 00 32 40" src="https://user-images.githubusercontent.com/52056774/172750573-3a0aa56a-bc94-4ca0-af23-34bdeb2d3164.png">
<img width="499" alt="Screenshot 2022-06-09 at 03 25 36" src="https://user-images.githubusercontent.com/52056774/172750973-bd2413e4-e74b-4df9-b036-7cc6bdf26416.png">

With config enabled:

<img width="342" alt="Screenshot 2022-06-09 at 03 29 15" src="https://user-images.githubusercontent.com/52056774/172751410-9b881685-8910-4afe-8d99-1b136890bdfa.png">

You can also see that these do not strip information away on machines that truly do need it (i.e. arc furnace).
<img width="330" alt="Screenshot 2022-06-09 at 03 31 28" src="https://user-images.githubusercontent.com/52056774/172751657-6082eda5-47e4-47a4-9ef9-8abba7d86fa1.png">

