### PR TITLE
Allow wire cutters to toggle cobblestone replacing on MBM

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_OreDrillingPlantBase.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_OreDrillingPlantBase.java
@@ -51,13 +51,18 @@ public abstract class GT_MetaTileEntity_OreDrillingPlantBase extends GT_MetaTile
     public void saveNBTData(NBTTagCompound aNBT) {
         super.saveNBTData(aNBT);
         aNBT.setInteger("chunkRadiusConfig", chunkRadiusConfig);
+        aNBT.setBoolean("replaceWithCobblestone", replaceWithCobblestone);
     }
 
     @Override
     public void loadNBTData(NBTTagCompound aNBT) {
         super.loadNBTData(aNBT);
-        if (aNBT.hasKey("chunkRadiusConfig"))
+        if (aNBT.hasKey("chunkRadiusConfig")) {
             chunkRadiusConfig = aNBT.getInteger("chunkRadiusConfig");
+        }
+        if (aNBT.hasKey("replaceWithCobblestone")) {
+            replaceWithCobblestone = aNBT.getBoolean("replaceWithCobblestone");
+        }
     }
 
     @Override


### PR DESCRIPTION
Could only test it on 5.09.40.48-dev because of a bunch of annoying crashes, but it should work on the latest version too.