### PR TITLE
init the hashmap after game loading finished

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_IntegratedOreFactory.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_IntegratedOreFactory.java
@@ -78,11 +78,12 @@ public class GT_MetaTileEntity_IntegratedOreFactory extends GT_MetaTileEntity_En
     private static final HashSet<Integer> isImpureDust = new HashSet<>();
     private static final HashSet<Integer> isThermal = new HashSet<>();
     private static final HashSet<Integer> isOre = new HashSet<>();
+    private static boolean isInit = false;
     private ItemStack[] sMidProduct;
     private int sMode = 0;
     private boolean sVoidStone = false;
 
-    static {
+    private static void initHash() {
         for (String name : OreDictionary.getOreNames()) {
             if (name == null || name.isEmpty()) continue;
             if (name.startsWith("crushedPurified")) {
@@ -228,6 +229,11 @@ public class GT_MetaTileEntity_IntegratedOreFactory extends GT_MetaTileEntity_En
 
     @Override
     public boolean checkRecipe(ItemStack aStack) {
+        if (!isInit) {
+            initHash();
+            isInit = true;
+        }
+
         int tCharged = MAX_PARA;
         List<ItemStack> tInput = getStoredInputs();
         List<FluidStack> tInputFluid = getStoredFluids();


### PR DESCRIPTION
fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/10569
the static block is executed in preload time, when the oredict isn't fully registered. now puts it in the first time the recipe check begin