### PR TITLE
replace oxide chemical with raosted ore dust

### DIFF
--- a/src/main/java/gregtech/api/enums/Materials.java
+++ b/src/main/java/gregtech/api/enums/Materials.java
@@ -609,6 +609,17 @@ public class Materials implements IColorModulationContainer, ISubTagContainer {
     public static Materials SaltWater                 = new MaterialBuilder(692, TextureSet.SET_FLUID      ,                                                                                                     "Salt Water").addCell().addFluid().setRGB(0, 0, 200).setColor(Dyes.dyeBlue).constructMaterial();
     public static Materials IronIIIChloride           = new MaterialBuilder(693, TextureSet.SET_FLUID      ,                                                                                                     "Iron III Chloride").setName("IronIIIChloride").addCell().addFluid().setRGB(22, 21, 14).setColor(Dyes.dyeBlack).setMaterialList(new MaterialStack(Chlorine, 3), new MaterialStack(Iron, 1)).addElectrolyzerRecipe().constructMaterial();
     public static Materials LifeEssence               = new MaterialBuilder(694, TextureSet.SET_FLUID      ,                                                                                                     "Life").setName("lifeessence").addCell().addFluid().setFuelPower(100).setFuelType(5).setRGB(110, 3, 3).setColor(Dyes.dyeRed).setMaterialList().constructMaterial();
+
+    //Raosted Ore Dust
+    public static Materials RaostedCopper             = new MaterialBuilder(546, TextureSet.SET_DULL    , "Raosted Copper").setName("RaostedCopper").addDustItems().setRGB(77, 18, 18).constructMaterial();
+    public static Materials RaostedAntimony           = new MaterialBuilder(547, TextureSet.SET_DULL    , "Raosted Antimony").setName("RaostedAntimony").addDustItems().setRGB(196, 178, 194).constructMaterial();
+    public static Materials RaostedIron               = new MaterialBuilder(548, TextureSet.SET_DULL    , "Raosted Iron").setName("RaostedIron").addDustItems().setRGB(148, 98, 98).addOreItems().constructMaterial();
+    public static Materials RaostedNickel             = new MaterialBuilder(549, TextureSet.SET_METALLIC, "Raosted Nickel").setName("RaostedNickel").addDustItems().setRGB(70, 140, 45).addOreItems().constructMaterial();
+    public static Materials RaostedZinc               = new MaterialBuilder(550, TextureSet.SET_DULL    , "Raosted Zinc").setName("RaostedZinc").addDustItems().setRGB(209, 209, 209).constructMaterial();
+    public static Materials RaostedCobalt             = new MaterialBuilder(551, TextureSet.SET_METALLIC, "Raosted Cobalt").setName("RaostedCobalt").addDustItems().setRGB(8, 64, 9).constructMaterial();
+    public static Materials RaostedArsenic            = new MaterialBuilder(552, TextureSet.SET_SHINY   , "Raosted Arsenic").setName("RaostedArsenic").addDustItems().setRGB(240, 240, 240).constructMaterial();
+    public static Materials RaostedLead               = new MaterialBuilder(553, TextureSet.SET_SHINY   , "Raosted Lead").setName("RaostedLead").addDustItems().setRGB(168, 149, 43).constructMaterial();
+
     //Silicon Line
     public static Materials SiliconSG               = new Materials(  856, TextureSet.SET_METALLIC         ,   1.0F,      0,  2, 1|2  |8   |32             ,  80,  80, 100,   0,   "SiliconSolarGrade"  ,   "Silicon Solar Grade (Poly SI)"      ,    0,       0,         2273,   2273, true, false,   1,   1,   1, Dyes.dyeBlack       , Arrays.asList(new TC_AspectStack(TC_Aspects.METALLUM, 4), new TC_AspectStack(TC_Aspects.TENEBRAE, 2)));
     public static Materials CalciumDisilicide       = new Materials(  971, TextureSet.SET_METALLIC         ,   1.0F,      0,  2, 1    |8                   , 180, 180, 180,   0,   "CalciumDisilicide"       ,   "Calcium Disilicide"            ,    0,       0,       1313,   -1, false, false,   1,   1,   1, Dyes.dyeGray        ,1         , Arrays.asList(new MaterialStack(Calcium, 1), new MaterialStack(Silicon, 2)), Arrays.asList(new TC_AspectStack(TC_Aspects.TERRA, 1), new TC_AspectStack(TC_Aspects.ORDO, 1)));//CaSi2
@@ -771,7 +782,7 @@ public class Materials implements IColorModulationContainer, ISubTagContainer {
     public static Materials Diphenylisophthalate = new MaterialBuilder(598, TextureSet.SET_FLUID             ,                                                                                                     "Diphenyl Isophtalate").addCell().addFluid().setRGB(36, 110, 87).setColor(Dyes.dyeOrange).setMaterialList(new MaterialStack(Carbon, 20),new MaterialStack(Hydrogen, 14),new MaterialStack(Oxygen, 4)).constructMaterial();
     public static Materials Polybenzimidazole   = new Materials(599, TextureSet.SET_DULL                 ,3.0F,     64,  1, 1|2          |64|128      , 45, 45,  45,   0,   "Polybenzimidazole"   ,   "Polybenzimidazole"  ,    0,       0,        1450,    0, false, false,   1,   1,   1, Dyes.dyeBlack       , 0, Arrays.asList(new MaterialStack(Carbon, 20), new MaterialStack(Nitrogen, 4), new MaterialStack(Hydrogen, 12)), Arrays.asList(new TC_AspectStack(TC_Aspects.ORDO, 2),new TC_AspectStack(TC_Aspects.VOLATUS, 1)));
 
-
+    //Gasoline
     public static Materials MTBEMixture        = new MaterialBuilder(983, TextureSet.SET_FLUID             ,                                                                                                      "MTBE Reaction Mixture").addCell().addGas().setRGB(255, 255, 255).setColor(Dyes.dyeWhite).constructMaterial();
     public static Materials NitrousOxide       = new MaterialBuilder(993, TextureSet.SET_FLUID             ,                                                                                                      "Nitrous Oxide").addCell().addGas().setRGB(125, 200, 255).setColor(Dyes.dyeBlue).setMaterialList(new MaterialStack(Nitrogen, 2), new MaterialStack(Oxygen, 1)).addElectrolyzerRecipe().constructMaterial();
     public static Materials AntiKnock          = new MaterialBuilder(994, TextureSet.SET_FLUID             ,                                                                                                      "Anti-Knock Agent").setName("EthylTertButylEther").addCell().addFluid().setRGB(255, 255, 255).setColor(Dyes.dyeWhite).constructMaterial();
@@ -1207,6 +1218,8 @@ public class Materials implements IColorModulationContainer, ISubTagContainer {
 
     private static void setOthers() {
         Mercury.add(SubTag.SMELTING_TO_GEM);
+        BandedIron.setOreReplacement(RaostedIron);
+        Garnierite.setOreReplacement(RaostedNickel);
     }
 
     private static void setDirectSmelting() {
@@ -1230,9 +1243,16 @@ public class Materials implements IColorModulationContainer, ISubTagContainer {
         Cobaltite.setDirectSmelting(Cobalt);
         Stibnite.setDirectSmelting(Antimony);
         Cooperite.setDirectSmelting(Platinum).add(SubTag.DONT_ADD_DEFAULT_BBF_RECIPE);
-        Magnesite.add(SubTag.DONT_ADD_DEFAULT_BBF_RECIPE);
         Molybdenite.setDirectSmelting(Molybdenum).add(SubTag.DONT_ADD_DEFAULT_BBF_RECIPE);
         Galena.setDirectSmelting(Lead);
+        RaostedIron.setDirectSmelting(Iron);
+        RaostedAntimony.setDirectSmelting(Antimony);
+        RaostedLead.setDirectSmelting(Lead);
+        RaostedArsenic.setDirectSmelting(Arsenic);
+        RaostedCobalt.setDirectSmelting(Cobalt);
+        RaostedZinc.setDirectSmelting(Zinc);
+        RaostedNickel.setDirectSmelting(Nickel);
+        RaostedCopper.setDirectSmelting(Copper);
     }
 
     private static void setMultipliers() {
@@ -1573,6 +1593,7 @@ public class Materials implements IColorModulationContainer, ISubTagContainer {
         InfusedGold.addOreByProduct(Gold);
         Cryolite.addOreByProducts(Aluminiumoxide, Sodium);
         Naquadria.addOreByProduct(Naquadria);
+        RaostedNickel.addOreByProduct(Nickel);
     }
 
     private static void setColors() {

--- a/src/main/java/gregtech/api/enums/Materials.java
+++ b/src/main/java/gregtech/api/enums/Materials.java
@@ -610,15 +610,15 @@ public class Materials implements IColorModulationContainer, ISubTagContainer {
     public static Materials IronIIIChloride           = new MaterialBuilder(693, TextureSet.SET_FLUID      ,                                                                                                     "Iron III Chloride").setName("IronIIIChloride").addCell().addFluid().setRGB(22, 21, 14).setColor(Dyes.dyeBlack).setMaterialList(new MaterialStack(Chlorine, 3), new MaterialStack(Iron, 1)).addElectrolyzerRecipe().constructMaterial();
     public static Materials LifeEssence               = new MaterialBuilder(694, TextureSet.SET_FLUID      ,                                                                                                     "Life").setName("lifeessence").addCell().addFluid().setFuelPower(100).setFuelType(5).setRGB(110, 3, 3).setColor(Dyes.dyeRed).setMaterialList().constructMaterial();
 
-    //Raosted Ore Dust
-    public static Materials RaostedCopper             = new MaterialBuilder(546, TextureSet.SET_DULL    , "Raosted Copper").setName("RaostedCopper").addDustItems().setRGB(77, 18, 18).constructMaterial();
-    public static Materials RaostedAntimony           = new MaterialBuilder(547, TextureSet.SET_DULL    , "Raosted Antimony").setName("RaostedAntimony").addDustItems().setRGB(196, 178, 194).constructMaterial();
-    public static Materials RaostedIron               = new MaterialBuilder(548, TextureSet.SET_DULL    , "Raosted Iron").setName("RaostedIron").addDustItems().setRGB(148, 98, 98).addOreItems().constructMaterial();
-    public static Materials RaostedNickel             = new MaterialBuilder(549, TextureSet.SET_METALLIC, "Raosted Nickel").setName("RaostedNickel").addDustItems().setRGB(70, 140, 45).addOreItems().constructMaterial();
-    public static Materials RaostedZinc               = new MaterialBuilder(550, TextureSet.SET_DULL    , "Raosted Zinc").setName("RaostedZinc").addDustItems().setRGB(209, 209, 209).constructMaterial();
-    public static Materials RaostedCobalt             = new MaterialBuilder(551, TextureSet.SET_METALLIC, "Raosted Cobalt").setName("RaostedCobalt").addDustItems().setRGB(8, 64, 9).constructMaterial();
-    public static Materials RaostedArsenic            = new MaterialBuilder(552, TextureSet.SET_SHINY   , "Raosted Arsenic").setName("RaostedArsenic").addDustItems().setRGB(240, 240, 240).constructMaterial();
-    public static Materials RaostedLead               = new MaterialBuilder(553, TextureSet.SET_SHINY   , "Raosted Lead").setName("RaostedLead").addDustItems().setRGB(168, 149, 43).constructMaterial();
+    //Roasted Ore Dust
+    public static Materials RoastedCopper             = new MaterialBuilder(546, TextureSet.SET_DULL    , "Roasted Copper").setName("RoastedCopper").addDustItems().setRGB(77, 18, 18).constructMaterial();
+    public static Materials RoastedAntimony           = new MaterialBuilder(547, TextureSet.SET_DULL    , "Roasted Antimony").setName("RoastedAntimony").addDustItems().setRGB(196, 178, 194).constructMaterial();
+    public static Materials RoastedIron               = new MaterialBuilder(548, TextureSet.SET_DULL    , "Roasted Iron").setName("RoastedIron").addDustItems().setRGB(148, 98, 98).addOreItems().constructMaterial();
+    public static Materials RoastedNickel             = new MaterialBuilder(549, TextureSet.SET_METALLIC, "Roasted Nickel").setName("RoastedNickel").addDustItems().setRGB(70, 140, 45).addOreItems().constructMaterial();
+    public static Materials RoastedZinc               = new MaterialBuilder(550, TextureSet.SET_DULL    , "Roasted Zinc").setName("RoastedZinc").addDustItems().setRGB(209, 209, 209).constructMaterial();
+    public static Materials RoastedCobalt             = new MaterialBuilder(551, TextureSet.SET_METALLIC, "Roasted Cobalt").setName("RoastedCobalt").addDustItems().setRGB(8, 64, 9).constructMaterial();
+    public static Materials RoastedArsenic            = new MaterialBuilder(552, TextureSet.SET_SHINY   , "Roasted Arsenic").setName("RoastedArsenic").addDustItems().setRGB(240, 240, 240).constructMaterial();
+    public static Materials RoastedLead               = new MaterialBuilder(553, TextureSet.SET_SHINY   , "Roasted Lead").setName("RoastedLead").addDustItems().setRGB(168, 149, 43).constructMaterial();
 
     //Silicon Line
     public static Materials SiliconSG               = new Materials(  856, TextureSet.SET_METALLIC         ,   1.0F,      0,  2, 1|2  |8   |32             ,  80,  80, 100,   0,   "SiliconSolarGrade"  ,   "Silicon Solar Grade (Poly SI)"      ,    0,       0,         2273,   2273, true, false,   1,   1,   1, Dyes.dyeBlack       , Arrays.asList(new TC_AspectStack(TC_Aspects.METALLUM, 4), new TC_AspectStack(TC_Aspects.TENEBRAE, 2)));
@@ -1218,8 +1218,8 @@ public class Materials implements IColorModulationContainer, ISubTagContainer {
 
     private static void setOthers() {
         Mercury.add(SubTag.SMELTING_TO_GEM);
-        BandedIron.setOreReplacement(RaostedIron);
-        Garnierite.setOreReplacement(RaostedNickel);
+        BandedIron.setOreReplacement(RoastedIron);
+        Garnierite.setOreReplacement(RoastedNickel);
     }
 
     private static void setDirectSmelting() {
@@ -1245,14 +1245,14 @@ public class Materials implements IColorModulationContainer, ISubTagContainer {
         Cooperite.setDirectSmelting(Platinum).add(SubTag.DONT_ADD_DEFAULT_BBF_RECIPE);
         Molybdenite.setDirectSmelting(Molybdenum).add(SubTag.DONT_ADD_DEFAULT_BBF_RECIPE);
         Galena.setDirectSmelting(Lead);
-        RaostedIron.setDirectSmelting(Iron);
-        RaostedAntimony.setDirectSmelting(Antimony);
-        RaostedLead.setDirectSmelting(Lead);
-        RaostedArsenic.setDirectSmelting(Arsenic);
-        RaostedCobalt.setDirectSmelting(Cobalt);
-        RaostedZinc.setDirectSmelting(Zinc);
-        RaostedNickel.setDirectSmelting(Nickel);
-        RaostedCopper.setDirectSmelting(Copper);
+        RoastedIron.setDirectSmelting(Iron);
+        RoastedAntimony.setDirectSmelting(Antimony);
+        RoastedLead.setDirectSmelting(Lead);
+        RoastedArsenic.setDirectSmelting(Arsenic);
+        RoastedCobalt.setDirectSmelting(Cobalt);
+        RoastedZinc.setDirectSmelting(Zinc);
+        RoastedNickel.setDirectSmelting(Nickel);
+        RoastedCopper.setDirectSmelting(Copper);
     }
 
     private static void setMultipliers() {
@@ -1593,7 +1593,7 @@ public class Materials implements IColorModulationContainer, ISubTagContainer {
         InfusedGold.addOreByProduct(Gold);
         Cryolite.addOreByProducts(Aluminiumoxide, Sodium);
         Naquadria.addOreByProduct(Naquadria);
-        RaostedNickel.addOreByProduct(Nickel);
+        RoastedNickel.addOreByProduct(Nickel);
     }
 
     private static void setColors() {

--- a/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
@@ -3852,6 +3852,13 @@ public class GT_MachineRecipeLoader implements Runnable {
         GT_Values.RA.addMultiblockChemicalRecipe(new ItemStack[]{GT_Utility.getIntegratedCircuit(24)}, new FluidStack[]{Materials.Ethanol.getFluid(1000), Materials.Butene.getGas(1000)}, new FluidStack[]{Materials.AntiKnock.getFluid(2000)}, null,400, 480);
         GT_Values.RA.addMultiblockChemicalRecipe(new ItemStack[]{GT_Utility.getIntegratedCircuit(24)}, new FluidStack[]{Materials.Methanol.getFluid(1000), Materials.Butene.getGas(1000)}, new FluidStack[]{Materials.MTBEMixture.getGas(2000)}, null, 20, 480);
 
+        //Oxide Recipe
+        GT_Values.RA.addChemicalRecipe(GT_Utility.getIntegratedCircuit(2), Materials.Antimony.getDust(2), Materials.Oxygen.getGas(3000), GT_Values.NF, Materials.AntimonyTrioxide.getDust(5), 20, 30);
+        GT_Values.RA.addChemicalRecipe(GT_Utility.getIntegratedCircuit(2), Materials.Lead.getDust(1), Materials.Oxygen.getGas(1000), GT_Values.NF, Materials.Massicot.getDust(2), 20, 30);
+        GT_Values.RA.addChemicalRecipe(GT_Utility.getIntegratedCircuit(2), Materials.Arsenic.getDust(2), Materials.Oxygen.getGas(3000), GT_Values.NF, Materials.ArsenicTrioxide.getDust(5), 20, 30);
+        GT_Values.RA.addChemicalRecipe(GT_Utility.getIntegratedCircuit(2), Materials.Cobalt.getDust(1), Materials.Oxygen.getGas(1000), GT_Values.NF, Materials.CobaltOxide.getDust(2), 20, 30);
+        GT_Values.RA.addChemicalRecipe(GT_Utility.getIntegratedCircuit(2), Materials.Zinc.getDust(1), Materials.Oxygen.getGas(1000), GT_Values.NF, Materials.Zincite.getDust(2), 20, 30);
+
     }
 
     public void addPotionRecipes(String aName,ItemStack aItem){
@@ -3882,23 +3889,27 @@ public class GT_MachineRecipeLoader implements Runnable {
         GT_Values.RA.addPrimitiveBlastRecipe(Materials.Iron.getBlocks(1), GT_Values.NI, 36, Materials.Steel.getIngots(9), GT_Values.NI, 64800);
         GT_Values.RA.addPrimitiveBlastRecipe(Materials.Steel.getDust(1), GT_Values.NI, 2, Materials.Steel.getIngots(1), GT_Values.NI, 7200);
 
+        ItemStack[] tSiliconDioxide = new ItemStack[]{Materials.SiliconDioxide.getDust(3), Materials.NetherQuartz.getDust(3), Materials.CertusQuartz.getDust(3), Materials.Quartzite.getDust(6)};
+
         //Roasting
 
-        GT_Values.RA.addBlastRecipe(Materials.Tetrahedrite.getDust(1), GT_Values.NI, Materials.Oxygen.getGas(6000), Materials.SulfurDioxide.getGas(2000), Materials.CupricOxide.getDust(6), Materials.AntimonyTrioxide.getDustTiny(15), 120, 120, 1200);
+        for (ItemStack silicon : tSiliconDioxide) {
+            GT_Values.RA.addBlastRecipe(Materials.Chalcopyrite.getDust(1), silicon, Materials.Oxygen.getGas(3000), Materials.SulfurDioxide.getGas(2000), Materials.RaostedCopper.getDust(1), Materials.Ferrosilite.getDust(5), 120, 120, 1200);
+        }
 
-        GT_Values.RA.addBlastRecipe(Materials.Chalcopyrite.getDust(1), Materials.SiliconDioxide.getDust(3), Materials.Oxygen.getGas(6000), Materials.SulfurDioxide.getGas(2000), Materials.CupricOxide.getDust(6), Materials.Ferrosilite.getDust(5), 120, 120, 1200);
+        GT_Values.RA.addBlastRecipe(Materials.Tetrahedrite.getDust(1), GT_Values.NI, Materials.Oxygen.getGas(3000), Materials.SulfurDioxide.getGas(2000), Materials.RaostedCopper.getDust(1), Materials.RaostedAntimony.getDustTiny(3), 120, 120, 1200);
 
-        GT_Values.RA.addBlastRecipe(Materials.Pyrite.getDust(1), GT_Values.NI, Materials.Oxygen.getGas(6000), Materials.SulfurDioxide.getGas(2000), Materials.BandedIron.getDust(5), Materials.Ash.getDustTiny(1), 120, 120, 1200);
+        GT_Values.RA.addBlastRecipe(Materials.Pyrite.getDust(1), GT_Values.NI, Materials.Oxygen.getGas(3000), Materials.SulfurDioxide.getGas(2000), Materials.RaostedIron.getDust(1), Materials.Ash.getDustTiny(1), 120, 120, 1200);
 
-        GT_Values.RA.addBlastRecipe(Materials.Pentlandite.getDust(1), GT_Values.NI, Materials.Oxygen.getGas(3000), Materials.SulfurDioxide.getGas(1000), Materials.Garnierite.getDust(3), Materials.Ash.getDustTiny(1), 120, 120, 1200);
+        GT_Values.RA.addBlastRecipe(Materials.Pentlandite.getDust(1), GT_Values.NI, Materials.Oxygen.getGas(3000), Materials.SulfurDioxide.getGas(1000), Materials.RaostedNickel.getDust(1), Materials.Ash.getDustTiny(1), 120, 120, 1200);
 
-        GT_Values.RA.addBlastRecipe(Materials.Sphalerite.getDust(1), GT_Values.NI, Materials.Oxygen.getGas(3000), Materials.SulfurDioxide.getGas(1000), Materials.Zincite.getDust(2), Materials.Ash.getDustTiny(1), 120, 120, 1200);
+        GT_Values.RA.addBlastRecipe(Materials.Sphalerite.getDust(1), GT_Values.NI, Materials.Oxygen.getGas(3000), Materials.SulfurDioxide.getGas(1000), Materials.RaostedZinc.getDust(1), Materials.Ash.getDustTiny(1), 120, 120, 1200);
 
-        GT_Values.RA.addBlastRecipe(Materials.Cobaltite.getDust(1), GT_Values.NI, Materials.Oxygen.getGas(3000), Materials.SulfurDioxide.getGas(1000), Materials.CobaltOxide.getDust(2), Materials.ArsenicTrioxide.getDust(15), 120, 120, 1200);
+        GT_Values.RA.addBlastRecipe(Materials.Cobaltite.getDust(1), GT_Values.NI, Materials.Oxygen.getGas(3000), Materials.SulfurDioxide.getGas(1000), Materials.RaostedCobalt.getDust(1), Materials.RaostedArsenic.getDust(1), 120, 120, 1200);
 
-        GT_Values.RA.addBlastRecipe(Materials.Stibnite.getDust(1), GT_Values.NI, Materials.Oxygen.getGas(3000), Materials.SulfurDioxide.getGas(1500), Materials.AntimonyTrioxide.getDustSmall(10), Materials.Ash.getDustTiny(1), 120, 120, 1200);
+        GT_Values.RA.addBlastRecipe(Materials.Stibnite.getDust(1), GT_Values.NI, Materials.Oxygen.getGas(3000), Materials.SulfurDioxide.getGas(1500), Materials.RaostedAntimony.getDust(1), Materials.Ash.getDustTiny(1), 120, 120, 1200);
 
-        GT_Values.RA.addBlastRecipe(Materials.Galena.getDust(1), GT_Values.NI, Materials.Oxygen.getGas(3000), Materials.SulfurDioxide.getGas(1000), Materials.Massicot.getDust(6), Materials.Ash.getDustTiny(1), 120, 120, 1200);
+        GT_Values.RA.addBlastRecipe(Materials.Galena.getDust(1), GT_Values.NI, Materials.Oxygen.getGas(3000), Materials.SulfurDioxide.getGas(1000), Materials.RaostedLead.getDust(1), Materials.Ash.getDustTiny(1), 120, 120, 1200);
 
         //Decomposition
 
@@ -3907,12 +3918,17 @@ public class GT_MachineRecipeLoader implements Runnable {
         //Carbothermic Reduction
         //Depend on real amount except real ores
         int outputIngotAmount = GT_Mod.gregtechproxy.mMixedOreOnlyYieldsTwoThirdsOfPureOre ? 2 : 3;
-        GT_Values.RA.addBlastRecipe(Materials.CupricOxide.getDust(2),         Materials.Carbon.getDust(1),      GT_Values.NF, Materials.CarbonDioxide.getGas(1000),  Materials.Copper.getIngots(1),           Materials.Ash.getDustTiny(2), 240, 120, 1200);
+
+        GT_Values.RA.addBlastRecipe(Materials.RaostedCopper.getDust(2),       Materials.Carbon.getDust(1),      GT_Values.NF, Materials.CarbonDioxide.getGas(1000),  Materials.Copper.getIngots(outputIngotAmount),   Materials.Ash.getDustTiny(2), 240, 120, 1200);
+        GT_Values.RA.addBlastRecipe(Materials.RaostedAntimony.getDust(2),     Materials.Carbon.getDust(1),      GT_Values.NF, Materials.CarbonDioxide.getGas(1000),  Materials.Antimony.getIngots(outputIngotAmount), Materials.Ash.getDustTiny(2), 240, 120, 1200);
+        GT_Values.RA.addBlastRecipe(Materials.RaostedIron.getDust(2),         Materials.Carbon.getDust(1),      GT_Values.NF, Materials.CarbonDioxide.getGas(1000),  Materials.Iron.getIngots(outputIngotAmount),     Materials.Ash.getDustTiny(2), 240, 120, 1200);
+        GT_Values.RA.addBlastRecipe(Materials.RaostedNickel.getDust(2),       Materials.Carbon.getDust(1),      GT_Values.NF, Materials.CarbonDioxide.getGas(1000),  Materials.Nickel.getIngots(outputIngotAmount),   Materials.Ash.getDustTiny(2), 240, 120, 1200);
+        GT_Values.RA.addBlastRecipe(Materials.RaostedZinc.getDust(2),         Materials.Carbon.getDust(1),      GT_Values.NF, Materials.CarbonDioxide.getGas(1000),  Materials.Zinc.getIngots(outputIngotAmount),     Materials.Ash.getDustTiny(2), 240, 120, 1200);
+        GT_Values.RA.addBlastRecipe(Materials.RaostedCobalt.getDust(2),       Materials.Carbon.getDust(1),      GT_Values.NF, Materials.CarbonDioxide.getGas(1000),  Materials.Cobalt.getIngots(outputIngotAmount),   Materials.Ash.getDustTiny(2), 240, 120, 1200);
+        GT_Values.RA.addBlastRecipe(Materials.RaostedArsenic.getDust(2),      Materials.Carbon.getDust(1),      GT_Values.NF, Materials.CarbonDioxide.getGas(1000),  Materials.Arsenic.getIngots(outputIngotAmount),  Materials.Ash.getDustTiny(2), 240, 120, 1200);
+        GT_Values.RA.addBlastRecipe(Materials.RaostedLead.getDust(2),         Materials.Carbon.getDust(1),      GT_Values.NF, Materials.CarbonDioxide.getGas(1000),  Materials.Lead.getIngots(outputIngotAmount),     Materials.Ash.getDustTiny(2), 240, 120, 1200);
+
         GT_Values.RA.addBlastRecipe(Materials.Malachite.getDust(2),           Materials.Carbon.getDust(1),      GT_Values.NF, Materials.CarbonDioxide.getGas(3000),  Materials.Copper.getIngots(outputIngotAmount),   Materials.Ash.getDustTiny(2), 240, 120, 1200);
-
-        GT_Values.RA.addBlastRecipe(Materials.AntimonyTrioxide.getDust(5),    Materials.Carbon.getDust(1),      GT_Values.NF, Materials.CarbonDioxide.getGas(3000),  Materials.Antimony.getIngots(2),         Materials.Ash.getDustTiny(2), 240, 120, 1200);
-
-        GT_Values.RA.addBlastRecipe(Materials.BandedIron.getDust(5),          Materials.Carbon.getDust(1),      GT_Values.NF, Materials.CarbonDioxide.getGas(1000),  Materials.Iron.getIngots(2),             Materials.Ash.getDustTiny(2), 240, 120, 1200);
         GT_Values.RA.addBlastRecipe(Materials.Magnetite.getDust(2),           Materials.Carbon.getDust(1),      GT_Values.NF, Materials.CarbonDioxide.getGas(1000),  Materials.Iron.getIngots(outputIngotAmount),     Materials.Ash.getDustTiny(2), 240, 120, 1200);
         GT_Values.RA.addBlastRecipe(Materials.YellowLimonite.getDust(2),      Materials.Carbon.getDust(1),      GT_Values.NF, Materials.CarbonDioxide.getGas(1000),  Materials.Iron.getIngots(outputIngotAmount),     Materials.Ash.getDustTiny(2), 240, 120, 1200);
         GT_Values.RA.addBlastRecipe(Materials.BrownLimonite.getDust(2),       Materials.Carbon.getDust(1),      GT_Values.NF, Materials.CarbonDioxide.getGas(1000),  Materials.Iron.getIngots(outputIngotAmount),     Materials.Ash.getDustTiny(2), 240, 120, 1200);
@@ -3921,14 +3937,6 @@ public class GT_MachineRecipeLoader implements Runnable {
 
         GT_Values.RA.addBlastRecipe(Materials.Cassiterite.getDust(2),         Materials.Carbon.getDust(1),      GT_Values.NF, Materials.CarbonDioxide.getGas(1000),  Materials.Tin.getIngots(outputIngotAmount),      Materials.Ash.getDustTiny(2), 240, 120, 1200);
         GT_Values.RA.addBlastRecipe(Materials.CassiteriteSand.getDust(2),     Materials.Carbon.getDust(1),      GT_Values.NF, Materials.CarbonDioxide.getGas(1000),  Materials.Tin.getIngots(outputIngotAmount),      Materials.Ash.getDustTiny(2), 240, 120, 1200);
-
-        GT_Values.RA.addBlastRecipe(Materials.Garnierite.getDust(2),          Materials.Carbon.getDust(1),      GT_Values.NF, Materials.CarbonDioxide.getGas(1000),  Materials.Nickel.getIngots(1),           Materials.Ash.getDustTiny(2), 240, 120, 1200);
-
-        GT_Values.RA.addBlastRecipe(Materials.CobaltOxide.getDust(2),         Materials.Carbon.getDust(1),      GT_Values.NF, Materials.CarbonDioxide.getGas(1000),  Materials.Cobalt.getIngots(1),           Materials.Ash.getDustTiny(2), 240, 120, 1200);
-
-        GT_Values.RA.addBlastRecipe(Materials.ArsenicTrioxide.getDust(5),     Materials.Carbon.getDust(1),      GT_Values.NF, Materials.CarbonDioxide.getGas(1000),  Materials.Arsenic.getIngots(2),          Materials.Ash.getDustTiny(2), 240, 120, 1200);
-
-        GT_Values.RA.addBlastRecipe(Materials.Massicot.getDust(2),            Materials.Carbon.getDust(1),      GT_Values.NF, Materials.CarbonDioxide.getGas(1000),  Materials.Lead.getIngots(1),             Materials.Ash.getDustTiny(2), 240, 120, 1200);
 
         GT_Values.RA.addBlastRecipe(Materials.SiliconDioxide.getDust(3),      Materials.Carbon.getDust(2),      GT_Values.NF, Materials.CarbonMonoxide.getGas(2000), Materials.Silicon.getIngots(1),          Materials.Ash.getDustTiny(1),  80, 120, 1200);
 

--- a/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
@@ -3894,22 +3894,22 @@ public class GT_MachineRecipeLoader implements Runnable {
         //Roasting
 
         for (ItemStack silicon : tSiliconDioxide) {
-            GT_Values.RA.addBlastRecipe(Materials.Chalcopyrite.getDust(1), silicon, Materials.Oxygen.getGas(3000), Materials.SulfurDioxide.getGas(2000), Materials.RaostedCopper.getDust(1), Materials.Ferrosilite.getDust(5), 120, 120, 1200);
+            GT_Values.RA.addBlastRecipe(Materials.Chalcopyrite.getDust(1), silicon, Materials.Oxygen.getGas(3000), Materials.SulfurDioxide.getGas(2000), Materials.RoastedCopper.getDust(1), Materials.Ferrosilite.getDust(5), 120, 120, 1200);
         }
 
-        GT_Values.RA.addBlastRecipe(Materials.Tetrahedrite.getDust(1), GT_Values.NI, Materials.Oxygen.getGas(3000), Materials.SulfurDioxide.getGas(2000), Materials.RaostedCopper.getDust(1), Materials.RaostedAntimony.getDustTiny(3), 120, 120, 1200);
+        GT_Values.RA.addBlastRecipe(Materials.Tetrahedrite.getDust(1), GT_Values.NI, Materials.Oxygen.getGas(3000), Materials.SulfurDioxide.getGas(2000), Materials.RoastedCopper.getDust(1), Materials.RoastedAntimony.getDustTiny(3), 120, 120, 1200);
 
-        GT_Values.RA.addBlastRecipe(Materials.Pyrite.getDust(1), GT_Values.NI, Materials.Oxygen.getGas(3000), Materials.SulfurDioxide.getGas(2000), Materials.RaostedIron.getDust(1), Materials.Ash.getDustTiny(1), 120, 120, 1200);
+        GT_Values.RA.addBlastRecipe(Materials.Pyrite.getDust(1), GT_Values.NI, Materials.Oxygen.getGas(3000), Materials.SulfurDioxide.getGas(2000), Materials.RoastedIron.getDust(1), Materials.Ash.getDustTiny(1), 120, 120, 1200);
 
-        GT_Values.RA.addBlastRecipe(Materials.Pentlandite.getDust(1), GT_Values.NI, Materials.Oxygen.getGas(3000), Materials.SulfurDioxide.getGas(1000), Materials.RaostedNickel.getDust(1), Materials.Ash.getDustTiny(1), 120, 120, 1200);
+        GT_Values.RA.addBlastRecipe(Materials.Pentlandite.getDust(1), GT_Values.NI, Materials.Oxygen.getGas(3000), Materials.SulfurDioxide.getGas(1000), Materials.RoastedNickel.getDust(1), Materials.Ash.getDustTiny(1), 120, 120, 1200);
 
-        GT_Values.RA.addBlastRecipe(Materials.Sphalerite.getDust(1), GT_Values.NI, Materials.Oxygen.getGas(3000), Materials.SulfurDioxide.getGas(1000), Materials.RaostedZinc.getDust(1), Materials.Ash.getDustTiny(1), 120, 120, 1200);
+        GT_Values.RA.addBlastRecipe(Materials.Sphalerite.getDust(1), GT_Values.NI, Materials.Oxygen.getGas(3000), Materials.SulfurDioxide.getGas(1000), Materials.RoastedZinc.getDust(1), Materials.Ash.getDustTiny(1), 120, 120, 1200);
 
-        GT_Values.RA.addBlastRecipe(Materials.Cobaltite.getDust(1), GT_Values.NI, Materials.Oxygen.getGas(3000), Materials.SulfurDioxide.getGas(1000), Materials.RaostedCobalt.getDust(1), Materials.RaostedArsenic.getDust(1), 120, 120, 1200);
+        GT_Values.RA.addBlastRecipe(Materials.Cobaltite.getDust(1), GT_Values.NI, Materials.Oxygen.getGas(3000), Materials.SulfurDioxide.getGas(1000), Materials.RoastedCobalt.getDust(1), Materials.RoastedArsenic.getDust(1), 120, 120, 1200);
 
-        GT_Values.RA.addBlastRecipe(Materials.Stibnite.getDust(1), GT_Values.NI, Materials.Oxygen.getGas(3000), Materials.SulfurDioxide.getGas(1500), Materials.RaostedAntimony.getDust(1), Materials.Ash.getDustTiny(1), 120, 120, 1200);
+        GT_Values.RA.addBlastRecipe(Materials.Stibnite.getDust(1), GT_Values.NI, Materials.Oxygen.getGas(3000), Materials.SulfurDioxide.getGas(1500), Materials.RoastedAntimony.getDust(1), Materials.Ash.getDustTiny(1), 120, 120, 1200);
 
-        GT_Values.RA.addBlastRecipe(Materials.Galena.getDust(1), GT_Values.NI, Materials.Oxygen.getGas(3000), Materials.SulfurDioxide.getGas(1000), Materials.RaostedLead.getDust(1), Materials.Ash.getDustTiny(1), 120, 120, 1200);
+        GT_Values.RA.addBlastRecipe(Materials.Galena.getDust(1), GT_Values.NI, Materials.Oxygen.getGas(3000), Materials.SulfurDioxide.getGas(1000), Materials.RoastedLead.getDust(1), Materials.Ash.getDustTiny(1), 120, 120, 1200);
 
         //Decomposition
 
@@ -3919,14 +3919,14 @@ public class GT_MachineRecipeLoader implements Runnable {
         //Depend on real amount except real ores
         int outputIngotAmount = GT_Mod.gregtechproxy.mMixedOreOnlyYieldsTwoThirdsOfPureOre ? 2 : 3;
 
-        GT_Values.RA.addBlastRecipe(Materials.RaostedCopper.getDust(2),       Materials.Carbon.getDust(1),      GT_Values.NF, Materials.CarbonDioxide.getGas(1000),  Materials.Copper.getIngots(outputIngotAmount),   Materials.Ash.getDustTiny(2), 240, 120, 1200);
-        GT_Values.RA.addBlastRecipe(Materials.RaostedAntimony.getDust(2),     Materials.Carbon.getDust(1),      GT_Values.NF, Materials.CarbonDioxide.getGas(1000),  Materials.Antimony.getIngots(outputIngotAmount), Materials.Ash.getDustTiny(2), 240, 120, 1200);
-        GT_Values.RA.addBlastRecipe(Materials.RaostedIron.getDust(2),         Materials.Carbon.getDust(1),      GT_Values.NF, Materials.CarbonDioxide.getGas(1000),  Materials.Iron.getIngots(outputIngotAmount),     Materials.Ash.getDustTiny(2), 240, 120, 1200);
-        GT_Values.RA.addBlastRecipe(Materials.RaostedNickel.getDust(2),       Materials.Carbon.getDust(1),      GT_Values.NF, Materials.CarbonDioxide.getGas(1000),  Materials.Nickel.getIngots(outputIngotAmount),   Materials.Ash.getDustTiny(2), 240, 120, 1200);
-        GT_Values.RA.addBlastRecipe(Materials.RaostedZinc.getDust(2),         Materials.Carbon.getDust(1),      GT_Values.NF, Materials.CarbonDioxide.getGas(1000),  Materials.Zinc.getIngots(outputIngotAmount),     Materials.Ash.getDustTiny(2), 240, 120, 1200);
-        GT_Values.RA.addBlastRecipe(Materials.RaostedCobalt.getDust(2),       Materials.Carbon.getDust(1),      GT_Values.NF, Materials.CarbonDioxide.getGas(1000),  Materials.Cobalt.getIngots(outputIngotAmount),   Materials.Ash.getDustTiny(2), 240, 120, 1200);
-        GT_Values.RA.addBlastRecipe(Materials.RaostedArsenic.getDust(2),      Materials.Carbon.getDust(1),      GT_Values.NF, Materials.CarbonDioxide.getGas(1000),  Materials.Arsenic.getIngots(outputIngotAmount),  Materials.Ash.getDustTiny(2), 240, 120, 1200);
-        GT_Values.RA.addBlastRecipe(Materials.RaostedLead.getDust(2),         Materials.Carbon.getDust(1),      GT_Values.NF, Materials.CarbonDioxide.getGas(1000),  Materials.Lead.getIngots(outputIngotAmount),     Materials.Ash.getDustTiny(2), 240, 120, 1200);
+        GT_Values.RA.addBlastRecipe(Materials.RoastedCopper.getDust(2),       Materials.Carbon.getDust(1),      GT_Values.NF, Materials.CarbonDioxide.getGas(1000),  Materials.Copper.getIngots(outputIngotAmount),   Materials.Ash.getDustTiny(2), 240, 120, 1200);
+        GT_Values.RA.addBlastRecipe(Materials.RoastedAntimony.getDust(2),     Materials.Carbon.getDust(1),      GT_Values.NF, Materials.CarbonDioxide.getGas(1000),  Materials.Antimony.getIngots(outputIngotAmount), Materials.Ash.getDustTiny(2), 240, 120, 1200);
+        GT_Values.RA.addBlastRecipe(Materials.RoastedIron.getDust(2),         Materials.Carbon.getDust(1),      GT_Values.NF, Materials.CarbonDioxide.getGas(1000),  Materials.Iron.getIngots(outputIngotAmount),     Materials.Ash.getDustTiny(2), 240, 120, 1200);
+        GT_Values.RA.addBlastRecipe(Materials.RoastedNickel.getDust(2),       Materials.Carbon.getDust(1),      GT_Values.NF, Materials.CarbonDioxide.getGas(1000),  Materials.Nickel.getIngots(outputIngotAmount),   Materials.Ash.getDustTiny(2), 240, 120, 1200);
+        GT_Values.RA.addBlastRecipe(Materials.RoastedZinc.getDust(2),         Materials.Carbon.getDust(1),      GT_Values.NF, Materials.CarbonDioxide.getGas(1000),  Materials.Zinc.getIngots(outputIngotAmount),     Materials.Ash.getDustTiny(2), 240, 120, 1200);
+        GT_Values.RA.addBlastRecipe(Materials.RoastedCobalt.getDust(2),       Materials.Carbon.getDust(1),      GT_Values.NF, Materials.CarbonDioxide.getGas(1000),  Materials.Cobalt.getIngots(outputIngotAmount),   Materials.Ash.getDustTiny(2), 240, 120, 1200);
+        GT_Values.RA.addBlastRecipe(Materials.RoastedArsenic.getDust(2),      Materials.Carbon.getDust(1),      GT_Values.NF, Materials.CarbonDioxide.getGas(1000),  Materials.Arsenic.getIngots(outputIngotAmount),  Materials.Ash.getDustTiny(2), 240, 120, 1200);
+        GT_Values.RA.addBlastRecipe(Materials.RoastedLead.getDust(2),         Materials.Carbon.getDust(1),      GT_Values.NF, Materials.CarbonDioxide.getGas(1000),  Materials.Lead.getIngots(outputIngotAmount),     Materials.Ash.getDustTiny(2), 240, 120, 1200);
 
         GT_Values.RA.addBlastRecipe(Materials.Malachite.getDust(2),           Materials.Carbon.getDust(1),      GT_Values.NF, Materials.CarbonDioxide.getGas(3000),  Materials.Copper.getIngots(outputIngotAmount),   Materials.Ash.getDustTiny(2), 240, 120, 1200);
         GT_Values.RA.addBlastRecipe(Materials.Magnetite.getDust(2),           Materials.Carbon.getDust(1),      GT_Values.NF, Materials.CarbonDioxide.getGas(1000),  Materials.Iron.getIngots(outputIngotAmount),     Materials.Ash.getDustTiny(2), 240, 120, 1200);


### PR DESCRIPTION
rip off the chemical oxide property of these raosted ore dust, so the origin bounbs recipe can kept unchanged.
also add the chemical reactor recipe of these origin oxide. close https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/8664 they won't cause material dupe now