### PR TITLE
Add recipe owner display

### DIFF
--- a/src/main/java/gregtech/common/GT_Proxy.java
+++ b/src/main/java/gregtech/common/GT_Proxy.java
@@ -153,7 +153,6 @@ public abstract class GT_Proxy implements IGT_Mod, IGuiHandler, IFuelHandler {
     public boolean mIncreaseDungeonLoot = true;
     public boolean mAxeWhenAdventure = true;
     public boolean mSurvivalIntoAdventure = false;
-    public boolean mNEIRecipeSecondMode = true;
     public boolean mNerfedWoodPlank = true;
     public boolean mNerfedVanillaTools = true;
     public boolean mHardRock = false;
@@ -290,6 +289,21 @@ public abstract class GT_Proxy implements IGT_Mod, IGuiHandler, IFuelHandler {
      * How verbose should tooltips be when LSHIFT is held? 0: disabled, 1: one-line, 2: normal, 3+: extended
      */
     public int mTooltipShiftVerbosity = 3;
+
+    /**
+     * Whether to show seconds or ticks on NEI
+     */
+    public boolean mNEIRecipeSecondMode = true;
+
+    /**
+     * This enables "Recipe by" display on NEI
+     */
+    public boolean mNEIRecipeOwner = false;
+
+    /**
+     * This enables showing stack traces where the recipe was added. Reboot needed
+     */
+    public boolean mNEIRecipeOwnerStackTrace = false;
 
     /**
      * What is the order of the circuits when they are selected?

--- a/src/main/java/gregtech/loaders/preload/GT_PreLoad.java
+++ b/src/main/java/gregtech/loaders/preload/GT_PreLoad.java
@@ -535,7 +535,9 @@ public class GT_PreLoad {
         GT_Mod.gregtechproxy.mCoverTabsFlipped = GregTech_API.sClientDataFile.get("interface", "FlipCoverTabs", false);
         GT_Mod.gregtechproxy.mTooltipVerbosity = GregTech_API.sClientDataFile.get("interface", "TooltipVerbosity", 2);
         GT_Mod.gregtechproxy.mTooltipShiftVerbosity = GregTech_API.sClientDataFile.get("interface", "TooltipShiftVerbosity", 3);
-        GT_Mod.gregtechproxy.mNEIRecipeSecondMode = GregTech_API.sClientDataFile.get("features", "NEI_recipe_second_mode", true);
+        GT_Mod.gregtechproxy.mNEIRecipeSecondMode = GregTech_API.sClientDataFile.get("nei", "RecipeSecondMode", true);
+        GT_Mod.gregtechproxy.mNEIRecipeOwner = GregTech_API.sClientDataFile.get("nei", "RecipeOwner", false);
+        GT_Mod.gregtechproxy.mNEIRecipeOwnerStackTrace = GregTech_API.sClientDataFile.get("nei", "RecipeOwnerStackTrace", false);
 
         final String[] Circuits = GregTech_API.sClientDataFile.get("interface", "CircuitsOrder" );
         GT_Mod.gregtechproxy.mCircuitsOrder.clear();

--- a/src/main/java/gregtech/nei/GT_NEI_AssLineHandler.java
+++ b/src/main/java/gregtech/nei/GT_NEI_AssLineHandler.java
@@ -24,6 +24,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumChatFormatting;
 import net.minecraftforge.fluids.FluidContainerRegistry;
 import net.minecraftforge.fluids.FluidStack;
 import org.lwjgl.opengl.GL11;
@@ -236,9 +237,10 @@ public class GT_NEI_AssLineHandler extends RecipeMapHandler {
 
     @Override
     public void drawExtras(int aRecipeIndex) {
-        int tEUt = ((CachedDefaultRecipe) this.arecipes.get(aRecipeIndex)).mRecipe.mEUt;
-        int tDuration = ((CachedDefaultRecipe) this.arecipes.get(aRecipeIndex)).mRecipe.mDuration;
-        String[] recipeDesc = ((CachedDefaultRecipe) this.arecipes.get(aRecipeIndex)).mRecipe.getNeiDesc();
+        GT_Recipe recipe = ((CachedDefaultRecipe) this.arecipes.get(aRecipeIndex)).mRecipe;
+        int tEUt = recipe.mEUt;
+        int tDuration = recipe.mDuration;
+        String[] recipeDesc = recipe.getNeiDesc();
         if (recipeDesc == null) {
             if (tEUt != 0) {
                 drawText(10, 73, trans("152","Total: ") + GT_Utility.formatNumbers((long) tDuration * tEUt) + " EU", 0xFF000000);
@@ -261,14 +263,32 @@ public class GT_NEI_AssLineHandler extends RecipeMapHandler {
                 drawText(10, 113, trans("158","Time: ") + GT_Utility.formatNumbers(0.05d * tDuration) + trans("161"," secs"), 0xFF000000);
             }
             int tSpecial = ((CachedDefaultRecipe) this.arecipes.get(aRecipeIndex)).mRecipe.mSpecialValue;
+            boolean specialDrew = false;
             if (tSpecial == -100 && GT_Mod.gregtechproxy.mLowGravProcessing) {
                 drawText(10, 123, trans("159","Needs Low Gravity"), 0xFF000000);
+                specialDrew = true;
             } else if (tSpecial == -200 && GT_Mod.gregtechproxy.mEnableCleanroom) {
                 drawText(10, 123, trans("160","Needs Cleanroom"), 0xFF000000);
+                specialDrew = true;
             } else if (tSpecial == -201) {
                 drawText(10, 123, trans("206","Scan for Assembly Line"), 0xFF000000);
+                specialDrew = true;
             } else if ((GT_Utility.isStringValid(this.mRecipeMap.mNEISpecialValuePre)) || (GT_Utility.isStringValid(this.mRecipeMap.mNEISpecialValuePost))) {
                 drawText(10, 123, this.mRecipeMap.mNEISpecialValuePre + GT_Utility.formatNumbers(tSpecial * this.mRecipeMap.mNEISpecialValueMultiplier) + this.mRecipeMap.mNEISpecialValuePost, 0xFF000000);
+                specialDrew = true;
+            }
+            int y = 123 + (specialDrew ? 10 : 0);
+            if (GT_Mod.gregtechproxy.mNEIRecipeOwner && recipe.owner != null) {
+                drawText(10, y, EnumChatFormatting.ITALIC + GT_Utility.trans("225", "Recipe by: ") + recipe.owner.getName(), 0xFF000000);
+                y += 10;
+            }
+            if (GT_Mod.gregtechproxy.mNEIRecipeOwnerStackTrace && recipe.stackTraces != null) {
+                drawText(10, y, "stackTrace:", 0xFF000000);
+                y += 10;
+                for (StackTraceElement stackTrace : recipe.stackTraces) {
+                    drawText(10, y, stackTrace.toString(), 0xFF000000);
+                    y += 10;
+                }
             }
         } else {
             int i = 0;

--- a/src/main/java/gregtech/nei/GT_NEI_DefaultHandler.java
+++ b/src/main/java/gregtech/nei/GT_NEI_DefaultHandler.java
@@ -34,6 +34,7 @@ import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumChatFormatting;
 import net.minecraftforge.fluids.FluidStack;
 import org.apache.commons.lang3.Range;
 import org.lwjgl.opengl.GL11;
@@ -395,9 +396,25 @@ public class GT_NEI_DefaultHandler extends RecipeMapHandler {
             }
         }
         if (this.mRecipeMap.mNEIName.equals("gt.recipe.fusionreactor") || this.mRecipeMap.mNEIName.equals("gt.recipe.complexfusionreactor")) {
-            drawOptionalLine(lineCounter, getSpecialInfo(recipe.mSpecialValue) + " " + formatSpecialValueFusion(recipe.mSpecialValue, recipe.mEUt));
+            if (drawOptionalLine(lineCounter, getSpecialInfo(recipe.mSpecialValue) + " " + formatSpecialValueFusion(recipe.mSpecialValue, recipe.mEUt))) {
+                lineCounter++;
+            }
         }
-        drawOptionalLine(lineCounter, getSpecialInfo(recipe.mSpecialValue));
+        if (drawOptionalLine(lineCounter, getSpecialInfo(recipe.mSpecialValue))) {
+            lineCounter++;
+        }
+        if (GT_Mod.gregtechproxy.mNEIRecipeOwner && recipe.owner != null) {
+            drawLine(lineCounter, EnumChatFormatting.ITALIC + GT_Utility.trans("225", "Recipe by: ") + recipe.owner.getName());
+            lineCounter++;
+        }
+        if (GT_Mod.gregtechproxy.mNEIRecipeOwnerStackTrace && recipe.stackTraces != null) {
+            drawLine(lineCounter, "stackTrace:");
+            lineCounter++;
+            for (StackTraceElement stackTrace : recipe.stackTraces) {
+                drawLine(lineCounter, stackTrace.toString());
+                lineCounter++;
+            }
+        }
     }
 
     private void drawOverrideDescription(String[] recipeDesc) {
@@ -460,16 +477,20 @@ public class GT_NEI_DefaultHandler extends RecipeMapHandler {
         return "(MK " + tier + ")";
     }
 
-    private void drawOptionalLine(int lineNumber, String line, String prefix) {
-        if (!"unspecified".equals(line)) {
+    private boolean drawOptionalLine(int lineNumber, String line, String prefix) {
+        if (!(line == null || "unspecified".equals(line))) {
             drawLine(lineNumber, prefix + line);
+            return true;
         }
+        return false;
     }
 
-    private void drawOptionalLine(int lineNumber, String line) {
-        if (!"unspecified".equals(line)) {
+    private boolean drawOptionalLine(int lineNumber, String line) {
+        if (!(line == null || "unspecified".equals(line))) {
             drawLine(lineNumber, line);
+            return true;
         }
+        return false;
     }
 
     private void drawLine(int lineNumber, String line) {

--- a/src/main/resources/assets/gregtech/lang/en_US.lang
+++ b/src/main/resources/assets/gregtech/lang/en_US.lang
@@ -204,7 +204,11 @@ GT5U.config.render.RenderFlippedMachinesFlipped=Render flipped machines with fli
 GT5U.config.render.RenderIndicatorsOnHatch=Render indicator on hatch
 GT5U.config.render.RenderPollutionFog=Render pollution fog
 GT5U.config.render.TileAmbientOcclusion=Enable Ambient Occlusion
-GT5U.config.feature.NEI_recipe_second_mode=Show NEI recipes using seconds (as opposed to ticks).
+GT5U.config.nei=NEI
+GT5U.config.nei.RecipeSecondMode=Show recipes using seconds (as opposed to ticks)
+GT5U.config.nei.RecipeOwner=Show which mod added the recipe
+GT5U.config.nei.RecipeOwnerStackTrace=[debug] Show stack traces of recipe addition
+GT5U.config.nei.RecipeOwnerStackTrace.tooltip=[requires reboot]
 
 // Cover tabs
 GT5U.interface.coverTabs.down=Bottom


### PR DESCRIPTION
Adds recipe owner display.
`mNEIRecipeOwnerStackTrace` needs rebooting, as storing every single element for all recipes is memory-hungry I guess. (If it's wrong please tell me)
There are still some issues that cannot be fixed within this PR, so I make them disabled by default. (and they're meant to be for debug anyway)
1. Some owners are incorrect
2. Some recipemaps don't support owner display (looking at you, GT++)

And regrouped NEI related settings. `RecipeSecondMode` is added after 2.1.2.3qf, so it should be fine.

![2022-07-15_23 24 26](https://user-images.githubusercontent.com/40035906/179249062-517aa00d-4fee-4b70-8bd7-57dd47e8b77d.png)