### PR TITLE
Enables tiles handle client-side randomDisplayTick

### DIFF
--- a/src/main/java/gregtech/api/interfaces/metatileentity/IMetaTileEntity.java
+++ b/src/main/java/gregtech/api/interfaces/metatileentity/IMetaTileEntity.java
@@ -424,4 +424,14 @@ public interface IMetaTileEntity extends ISidedInventory, IFluidTank, IFluidHand
         return true;
     }
 
+    /**
+     * A randomly called display update to be able to add particles or other items for display
+     *
+     * @param aBaseMetaTileEntity The entity that will handle the {@see Block#randomDisplayTick}
+     */
+    @SideOnly(Side.CLIENT)
+    default void onRandomDisplayTick(IGregTechTileEntity aBaseMetaTileEntity) {
+        /* do nothing */
+    }
+
 }

--- a/src/main/java/gregtech/api/interfaces/tileentity/IGregTechTileEntity.java
+++ b/src/main/java/gregtech/api/interfaces/tileentity/IGregTechTileEntity.java
@@ -1,7 +1,10 @@
 package gregtech.api.interfaces.tileentity;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import gregtech.api.interfaces.IDescribable;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
+import gregtech.common.blocks.GT_Block_Machines;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
@@ -157,4 +160,15 @@ public interface IGregTechTileEntity extends ITexturedTileEntity, IGearEnergyTil
     }
 
     default void setShutdownStatus(boolean newStatus) {return;}
+
+    /**
+     * A randomly called display update to be able to add particles or other items for display
+     * The event is proxied by the {@link GT_Block_Machines#randomDisplayTick}
+     */
+    @SideOnly(Side.CLIENT)
+    default void onRandomDisplayTick() {
+        if (getMetaTileEntity() != null && getMetaTileEntity().getBaseMetaTileEntity() == this) {
+            getMetaTileEntity().onRandomDisplayTick(this);
+        }
+    }
 }

--- a/src/main/java/gregtech/common/blocks/GT_Block_Machines.java
+++ b/src/main/java/gregtech/common/blocks/GT_Block_Machines.java
@@ -1,4 +1,5 @@
 package gregtech.common.blocks;
+import static gregtech.api.objects.XSTR.XSTR_INSTANCE;
 
 import com.cricketcraft.chisel.api.IFacade;
 import cpw.mods.fml.common.Optional;
@@ -48,6 +49,7 @@ import net.minecraftforge.common.util.ForgeDirection;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Random;
 
 import static gregtech.GT_Mod.GT_FML_LOGGER;
 import static gregtech.api.enums.GT_Values.SIDE_UP;
@@ -538,6 +540,18 @@ public class GT_Block_Machines extends GT_Generic_Block implements IDebugableBlo
     public float getAmbientOcclusionLightValue()
     {
         return this.renderAsNormalBlock() ? 0.2F : 0.5F;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    @SideOnly(Side.CLIENT)
+    public void randomDisplayTick(World aWorld, int aX, int aY, int aZ, Random aRandom) {
+        final TileEntity tTileEntity = aWorld.getTileEntity(aX, aY, aZ);
+        if (tTileEntity instanceof IGregTechTileEntity) {
+            ((IGregTechTileEntity) tTileEntity).onRandomDisplayTick();
+        }
     }
 
     @Override

--- a/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Bronze.java
+++ b/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Bronze.java
@@ -1,5 +1,7 @@
 package gregtech.common.tileentities.boilers;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import gregtech.GT_Mod;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
@@ -10,12 +12,14 @@ import gregtech.api.objects.XSTR;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GT_OreDictUnificator;
 import gregtech.api.util.GT_Utility;
+import gregtech.api.util.WorldSpawnedEventBuilder;
 import gregtech.common.GT_Pollution;
 import gregtech.common.gui.GT_Container_Boiler;
 import gregtech.common.gui.GT_GUIContainer_Boiler;
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.tileentity.TileEntityFurnace;
+import net.minecraftforge.common.util.ForgeDirection;
 
 import static gregtech.api.enums.Textures.BlockIcons.BOILER_FRONT;
 import static gregtech.api.enums.Textures.BlockIcons.BOILER_FRONT_ACTIVE;
@@ -25,6 +29,7 @@ import static gregtech.api.enums.Textures.BlockIcons.MACHINE_BRONZEBRICKS_BOTTOM
 import static gregtech.api.enums.Textures.BlockIcons.MACHINE_BRONZEBRICKS_SIDE;
 import static gregtech.api.enums.Textures.BlockIcons.MACHINE_BRONZEBRICKS_TOP;
 import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_PIPE;
+import static gregtech.api.objects.XSTR.XSTR_INSTANCE;
 
 public class GT_MetaTileEntity_Boiler_Bronze extends GT_MetaTileEntity_Boiler {
     public GT_MetaTileEntity_Boiler_Bronze(int aID, String aName, String aNameRegional) {
@@ -88,6 +93,57 @@ public class GT_MetaTileEntity_Boiler_Bronze extends GT_MetaTileEntity_Boiler {
     @Override
     public MetaTileEntity newMetaEntity(IGregTechTileEntity aTileEntity) {
         return new GT_MetaTileEntity_Boiler_Bronze(this.mName, this.mTier, this.mDescriptionArray, this.mTextures);
+    }
+
+    @SideOnly(Side.CLIENT)
+    @Override
+    public void onRandomDisplayTick(IGregTechTileEntity aBaseMetaTileEntity) {
+        if (aBaseMetaTileEntity.isActive()) {
+
+            final byte frontFacing = aBaseMetaTileEntity.getFrontFacing();
+
+            final double oX = aBaseMetaTileEntity.getOffsetX(frontFacing, 1) + 0.5F;
+            final double oY = aBaseMetaTileEntity.getOffsetY(frontFacing, 1) + XSTR_INSTANCE.nextFloat() * 6.0F / 16.0F;
+            final double oZ = aBaseMetaTileEntity.getOffsetZ(frontFacing, 1) + 0.5F;
+            final double offset = -0.48F;
+            final double horizontal = XSTR_INSTANCE.nextFloat() * 0.6F - 0.3F;
+
+            final double x, z;
+
+            if (frontFacing == ForgeDirection.WEST.ordinal())
+            {
+                x = (oX - offset);
+                z = oZ + horizontal;
+            }
+            else if (frontFacing == ForgeDirection.EAST.ordinal())
+            {
+                x = oX + offset;
+                z = oZ + horizontal;
+            }
+            else if (frontFacing == ForgeDirection.NORTH.ordinal())
+            {
+                x = oX + horizontal;
+                z = oZ - offset;
+            }
+            else // if (frontFacing == ForgeDirection.SOUTH.ordinal())
+            {
+               x = oX + horizontal;
+               z = oZ + offset;
+            }
+
+            new WorldSpawnedEventBuilder.ParticleEventBuilder()
+                    .setMotion(0D, 0.0D, 0D)
+                    .setIdentifier("smoke")
+                    .setPosition(x, oY, z)
+                    .setWorld(getBaseMetaTileEntity().getWorld())
+                    .run();
+            new WorldSpawnedEventBuilder.ParticleEventBuilder()
+                    .setMotion(0D, 0.0D, 0D)
+                    .setIdentifier("flame")
+                    .setPosition(x, oY, z)
+                    .setWorld(getBaseMetaTileEntity().getWorld())
+                    .run();
+        }
     }
 
     @Override


### PR DESCRIPTION
`Block#randomDisplayTick` method is proxied to the `IGregTechTileEntity`, so the client-side random ticking of `randomDisplayTick` can be delegated to Gregtech Tile-Entities.

This allows for example, mostly cost-less display of flames and smoke when a bronze boiler is active.
This specific implementation is provided as reference and example with this patch.

As it is entirely client-side handled, it generates no ticking lag.

[![Example](https://user-images.githubusercontent.com/1111474/179418604-e38014c1-1579-45bd-9ccb-c77cb0699f83.png)](https://i.imgur.com/PaPvSsE.mp4)