### PR TITLE
Set Huge Turbines to Higher Efficiency than Large

### DIFF
--- a/src/main/java/gregtech/common/tools/GT_Tool_Turbine_Huge.java
+++ b/src/main/java/gregtech/common/tools/GT_Tool_Turbine_Huge.java
@@ -16,7 +16,7 @@ public class GT_Tool_Turbine_Huge extends GT_Tool_Turbine {
 
     @Override
     public float getBaseDamage() {
-        return 3.0F;
+        return 7.5F;
     }
 
     @Override


### PR DESCRIPTION
- Changed Huge Turbines (the rotor items) so that they have 25% efficiency added to what Large Turbines have, instead of 20% less.

Huge Turbines are gated behind Americium, which means that they are only available in ZPM. Given this, and also considering that a problem with endgame plasma is that more and more turbines are needed, I believe that Huge turbines should be a considerable upgrade to Large ones, when they become accessible.

The 25% addition on top of Large mirrors the same 25% increase per tier, from Small to Normal to Large. Another number might be better, or this upgrade might be too strong to even be considered, but I think that Huge turbines should be the default choice once made available.