### PR TITLE
Allow PA to parallel over 64 for UEV+ machines

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_ProcessingArray.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_ProcessingArray.java
@@ -284,7 +284,7 @@ public class GT_MetaTileEntity_ProcessingArray extends GT_MetaTileEntity_CubicMu
 
         boolean recipeLocked = false;
         mLastRecipe = tRecipe;
-        int machines = Math.min(64, mInventory[1].stackSize << mMult); //Upped max Cap to 64
+        int machines = mInventory[1].stackSize << mMult;
         int i = 0;
         for (; i < machines; i++) {
             if (!tRecipe.isRecipeInputEqual(true, tFluids, tInputs)) {

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_ProcessingArray.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_ProcessingArray.java
@@ -261,7 +261,7 @@ public class GT_MetaTileEntity_ProcessingArray extends GT_MetaTileEntity_CubicMu
     public boolean processLockedRecipe() {
         GT_Single_Recipe_Check_Processing_Array tSingleRecipeCheck = (GT_Single_Recipe_Check_Processing_Array) mSingleRecipeCheck;
 
-        int machines = Math.min(64, mInventory[1].stackSize << mMult); //Upped max Cap to 64
+        int machines = mInventory[1].stackSize << mMult;
         int parallel = tSingleRecipeCheck.checkRecipeInputs(true, machines);
 
         return processRecipeOutputs(tSingleRecipeCheck.getRecipe(), tSingleRecipeCheck.getRecipeAmperage(), parallel);


### PR DESCRIPTION
Allow PA to parallel over 64 when using UEV+ machine. This makes the scanner output correct and allows to use a full stack of UEV machines in a PA instead of having to split it between 4

Fix [GT-New-Horizons-Modpack/issues/8409](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/8409)