### PR TITLE
Crash fix

### DIFF
--- a/src/main/java/gregtech/api/util/GT_Utility.java
+++ b/src/main/java/gregtech/api/util/GT_Utility.java
@@ -1431,6 +1431,7 @@ public class GT_Utility {
     }
 
     public static boolean doSoundAtClient(String aSoundName, int aTimeUntilNextSound, float aSoundStrength) {
+        if (aSoundName == null) return false;
         return doSoundAtClient(aSoundName, aTimeUntilNextSound, aSoundStrength, GT.getThePlayer());
     }
 
@@ -1443,7 +1444,7 @@ public class GT_Utility {
     }
 
     public static boolean doSoundAtClient(String aSoundName, int aTimeUntilNextSound, float aSoundStrength, Entity aEntity) {
-        if (aEntity == null) return false;
+        if (aEntity == null || aSoundName == null) return false;
         return doSoundAtClient(aSoundName, aTimeUntilNextSound, aSoundStrength, aEntity.posX, aEntity.posY, aEntity.posZ);
     }
 
@@ -1462,6 +1463,7 @@ public class GT_Utility {
      */
     @Deprecated
     public static boolean doSoundAtClient(String aSoundName, int aTimeUntilNextSound, float aSoundStrength, double aX, double aY, double aZ) {
+        if (aSoundName == null) return false;
         return doSoundAtClient(new ResourceLocation(aSoundName), aTimeUntilNextSound, aSoundStrength, 1.01818028F, aX, aY, aZ);
     }
 

--- a/src/main/java/gregtech/common/tools/GT_Tool_Scoop.java
+++ b/src/main/java/gregtech/common/tools/GT_Tool_Scoop.java
@@ -2,6 +2,7 @@ package gregtech.common.tools;
 
 import cpw.mods.fml.common.Loader;
 import gregtech.api.enums.GT_Values;
+import gregtech.api.enums.SoundResource;
 import gregtech.api.enums.Textures;
 import gregtech.api.interfaces.IIconContainer;
 import gregtech.api.items.GT_MetaGenerated_Tool;
@@ -71,7 +72,7 @@ public class GT_Tool_Scoop extends GT_Tool {
 
     @Override
     public String getMiningSound() {
-        return null;
+        return SoundResource.NONE.toString();
     }
 
     @Override

--- a/src/main/java/gregtech/common/tools/GT_Tool_Scoop.java
+++ b/src/main/java/gregtech/common/tools/GT_Tool_Scoop.java
@@ -72,7 +72,7 @@ public class GT_Tool_Scoop extends GT_Tool {
 
     @Override
     public String getMiningSound() {
-        return SoundResource.NONE.toString();
+        return null;
     }
 
     @Override


### PR DESCRIPTION
The Scoop returned null as a mining sound instead of the new NONE sound from the Enums, resulting into a crash of the client. 