### PR TITLE
unlimit the lgt

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeTurbine_Gas.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeTurbine_Gas.java
@@ -42,7 +42,6 @@ public class GT_MetaTileEntity_LargeTurbine_Gas extends GT_MetaTileEntity_LargeT
         tt.addMachineType("Gas Turbine")
                 .addInfo("Controller block for the Large Gas Turbine")
                 .addInfo("Needs a Turbine, place inside controller")
-                .addInfo("Can only produce up to 8192 EU/t, regardless of Dynamo Hatch")
                 .addInfo("The excess fuel that gets consumed will be voided!")
                 .addPollutionAmount(getPollutionPerSecond(null))
                 .addSeparator()
@@ -141,11 +140,6 @@ public class GT_MetaTileEntity_LargeTurbine_Gas extends GT_MetaTileEntity_LargeT
                 float efficiency = getOverflowEfficiency(totalFlow, actualOptimalFlow, overflowMultiplier);
                 tEU *= efficiency;
                 tEU = GT_Utility.safeInt((long) tEU * (long) aBaseEff / 10000L);
-            }
-
-            // EU/t output cap to properly tier the LGT against the Advanced LGT
-            if (tEU > 8192) {
-                tEU = 8192;
             }
 
             // If next output is above the maximum the dynamo can handle, set it to the maximum instead of exploding the turbine

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeTurbine_GasAdvanced.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeTurbine_GasAdvanced.java
@@ -40,19 +40,7 @@ public class GT_MetaTileEntity_LargeTurbine_GasAdvanced extends GT_MetaTileEntit
     protected GT_Multiblock_Tooltip_Builder createTooltip() {
         final GT_Multiblock_Tooltip_Builder tt = new GT_Multiblock_Tooltip_Builder();
         tt.addMachineType("Gas Turbine")
-            .addInfo("Controller block for the Large Advanced Gas Turbine")
-            .addInfo("Needs a Turbine, place inside controller")
-            .addInfo("Only accepts gases above 800k EU/bucket")
-            .addInfo("Has no maximum EU/t output, only depends on the Dynamo Hatch")
-            .addPollutionAmount(getPollutionPerSecond(null))
-            .addSeparator()
-            .beginStructureBlock(3, 3, 4, true)
-            .addController("Front center")
-            .addCasingInfo("Advanced Gas Turbine Casing", 24)
-            .addDynamoHatch("Back center", 1)
-            .addMaintenanceHatch("Side centered", 2)
-            .addMufflerHatch("Side centered", 2)
-            .addInputHatch("Gas Fuel, Side centered", 2)
+            .addInfo("[WIP]")
             .toolTipFinisher("Gregtech");
         return tt;
     }
@@ -95,10 +83,6 @@ public class GT_MetaTileEntity_LargeTurbine_GasAdvanced extends GT_MetaTileEntit
 
             FluidStack firstFuelType = new FluidStack(aFluids.get(0), 0); // Identify a SINGLE type of fluid to process.  Doesn't matter which one. Ignore the rest!
             int fuelValue = getFuelValue(firstFuelType);
-
-            if (fuelValue < 100) {
-                return 0;
-            }
 
             if (aOptFlow < fuelValue) {
                 // turbine too weak and/or fuel too powerful

--- a/src/main/java/gregtech/loaders/preload/GT_Loader_MetaTileEntities.java
+++ b/src/main/java/gregtech/loaders/preload/GT_Loader_MetaTileEntities.java
@@ -1193,7 +1193,6 @@ public class GT_Loader_MetaTileEntities implements Runnable {//TODO CHECK CIRCUI
 
         GT_ModHandler.addCraftingRecipe(ItemList.LargeSteamTurbine.get(1L), bitsd, new Object[]{"CPC", aTextPlateMotor, "BPB", 'M', ItemList.Hull_HV, 'B', OrePrefixes.pipeLarge.get(Materials.Steel), 'C', OrePrefixes.circuit.get(Materials.Advanced), 'P', OrePrefixes.gearGt.get(Materials.Steel)});
         GT_ModHandler.addCraftingRecipe(ItemList.LargeGasTurbine.get(1L), bitsd, new Object[]{"CPC", aTextPlateMotor, "BPB", 'M', ItemList.Hull_EV, 'B', OrePrefixes.pipeLarge.get(Materials.StainlessSteel), 'C', OrePrefixes.circuit.get(Materials.Data), 'P', OrePrefixes.gearGt.get(Materials.StainlessSteel)});
-        GT_ModHandler.addCraftingRecipe(ItemList.LargeAdvancedGasTurbine.get(1L), bitsd, new Object[]{"CPC", aTextPlateMotor, "BPB", 'M', ItemList.Hull_IV, 'B', OrePrefixes.pipeLarge.get(Materials.TungstenSteel), 'C', OrePrefixes.circuit.get(Materials.Master), 'P', OrePrefixes.gearGt.get(Materials.HSSG)});
 
         ItemList.Pump_LV.set(new GT_MetaTileEntity_Pump(1140, "basicmachine.pump.tier.01", "Basic Pump", 1).getStackForm(1L));
         ItemList.Pump_MV.set(new GT_MetaTileEntity_Pump(1141, "basicmachine.pump.tier.02", "Advanced Pump", 2).getStackForm(1L));


### PR DESCRIPTION
revert the limitation on lgt of https://github.com/GTNewHorizons/GT5-Unofficial/pull/1106

the limitation on lgt was for the abuse of benzene from tgs in early game like mv. now the tgs is tiered at iv so if you want reach such scale with eio farmer, you will need to power a hv or ev world acceralater which is expensive to affard in terms of energy and material.

also the advanced lgt is still kept, but its recipe is removed temparory. basically the so-called advanced lgt is just the copy of lgt which has no new or interesting mechanism. it will be kept unchanged in the this stable version (2.1.2.4) and a real rework on it will begin in next stable update. it will needs a new discord channel to discuss it properly with nh community