### PR TITLE
LGT Final Changes for Next Stable

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeTurbine_Gas.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeTurbine_Gas.java
@@ -42,8 +42,9 @@ public class GT_MetaTileEntity_LargeTurbine_Gas extends GT_MetaTileEntity_LargeT
         tt.addMachineType("Gas Turbine")
                 .addInfo("Controller block for the Large Gas Turbine")
                 .addInfo("Needs a Turbine, place inside controller")
-                .addInfo("Can only produce up to 8192 EU/t, regardless of Dynamo Hatch")
-                .addInfo("The excess fuel that gets consumed will be voided!")
+                .addInfo("Warning: Will be capped at 8192 EU/t in a future update")
+                .addInfo("See the Advanced Large Gas Turbine as the next, uncapped, option")
+                //.addInfo("The excess fuel that gets consumed will be voided!")
                 .addPollutionAmount(getPollutionPerSecond(null))
                 .addSeparator()
                 .beginStructureBlock(3, 3, 4, true)
@@ -143,10 +144,10 @@ public class GT_MetaTileEntity_LargeTurbine_Gas extends GT_MetaTileEntity_LargeT
                 tEU = GT_Utility.safeInt((long) tEU * (long) aBaseEff / 10000L);
             }
 
-            // EU/t output cap to properly tier the LGT against the Advanced LGT
-            if (tEU > 8192) {
+            // EU/t output cap to properly tier the LGT against the Advanced LGT, will be implemented in a future dev update
+            /*if (tEU > 8192) {
                 tEU = 8192;
-            }
+            }*/
 
             // If next output is above the maximum the dynamo can handle, set it to the maximum instead of exploding the turbine
             // Raising the maximum allowed flow rate to account for the efficiency changes beyond the optimal flow

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeTurbine_GasAdvanced.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeTurbine_GasAdvanced.java
@@ -40,6 +40,7 @@ public class GT_MetaTileEntity_LargeTurbine_GasAdvanced extends GT_MetaTileEntit
     protected GT_Multiblock_Tooltip_Builder createTooltip() {
         final GT_Multiblock_Tooltip_Builder tt = new GT_Multiblock_Tooltip_Builder();
         tt.addMachineType("Gas Turbine")
+            .addInfo("Warning: This is an experimental multiblock, subject to changes ")
             .addInfo("Controller block for the Large Advanced Gas Turbine")
             .addInfo("Needs a Turbine, place inside controller")
             .addInfo("Only accepts gases above 800k EU/bucket")


### PR DESCRIPTION
As an agreement with @boubou19, we have decided to remove the limit on the Large Gas Turbine, but keep the advanced version's recipe up, so that people can transition to it over the next stable. In a dev version after that, the advanced LGT will be implemented with new mechanics, and the LGT will be capped.

Tooltips on both multis were changed to clarify this situation. 