### PR TITLE
Botania adjustments

### DIFF
--- a/src/main/java/gregtech/api/enums/Materials.java
+++ b/src/main/java/gregtech/api/enums/Materials.java
@@ -3,6 +3,7 @@ package gregtech.api.enums;
 import cpw.mods.fml.common.Loader;
 import gregtech.GT_Mod;
 import gregtech.api.GregTech_API;
+import gregtech.api.enums.MaterialsBotania;
 import gregtech.api.enums.TC_Aspects.TC_AspectStack;
 import gregtech.api.interfaces.IColorModulationContainer;
 import gregtech.api.interfaces.IMaterialHandler;
@@ -24,7 +25,6 @@ import java.util.stream.IntStream;
 
 import static gregtech.api.enums.GT_Values.M;
 import static gregtech.api.enums.GT_Values.MOD_ID_DC;
-import static gregtech.api.enums.MaterialsBotania.*;
 
 @SuppressWarnings("ALL")
 public class Materials implements IColorModulationContainer, ISubTagContainer {
@@ -1682,14 +1682,6 @@ public class Materials implements IColorModulationContainer, ISubTagContainer {
         Quartzite.mChemicalFormula = "SiO\u2082";
         CertusQuartz.mChemicalFormula = "SiO\u2082";
         SpaceTime.mChemicalFormula = "Reality itself distilled into liquid form";
-        GaiaSpirit.mChemicalFormula = "Gs";
-        Manasteel.mChemicalFormula = "Ms";
-        Livingwood.mChemicalFormula = "Lw";
-        Dreamwood.mChemicalFormula = "Dw";
-        BotaniaDragonstone.mChemicalFormula = "Dg";
-        Livingrock.mChemicalFormula = "Lv";
-        Terrasteel.mChemicalFormula = "Tr";
-        ElvenElementium.mChemicalFormula = "Ef";
     }
 
     private static void initSubTags() {
@@ -2161,13 +2153,6 @@ public class Materials implements IColorModulationContainer, ISubTagContainer {
         Forcillium.add(SubTag.CRYSTAL, SubTag.NO_SMASHING, SubTag.NO_SMELTING, SubTag.CRYSTALLISABLE, SubTag.MAGICAL);
         Force.add(SubTag.CRYSTAL, SubTag.MAGICAL, SubTag.UNBURNABLE);
         Magic.add(SubTag.CRYSTAL, SubTag.MAGICAL, SubTag.UNBURNABLE);
-
-        // Botania
-        Livingrock.add(SubTag.NO_SMASHING, SubTag.NO_SMELTING);
-        Livingwood.add(SubTag.WOOD, SubTag.FLAMMABLE, SubTag.NO_SMELTING, SubTag.NO_SMASHING);
-        Dreamwood.add(SubTag.WOOD, SubTag.FLAMMABLE, SubTag.NO_SMELTING, SubTag.NO_SMASHING);
-        ManaDiamond.add(SubTag.CRYSTAL, SubTag.NO_SMASHING, SubTag.NO_SMELTING);
-        BotaniaDragonstone.add(SubTag.CRYSTAL, SubTag.NO_SMASHING, SubTag.NO_SMELTING);
 
         Primitive.add(SubTag.NO_SMASHING, SubTag.NO_SMELTING);
         Basic.add(SubTag.NO_SMASHING, SubTag.NO_SMELTING);

--- a/src/main/java/gregtech/api/enums/MaterialsBotania.java
+++ b/src/main/java/gregtech/api/enums/MaterialsBotania.java
@@ -1,23 +1,60 @@
 package gregtech.api.enums;
 
-import gregtech.api.objects.MaterialStack;
+import gregtech.api.enums.TC_Aspects.TC_AspectStack;
 
 import java.util.Arrays;
+
+import static gregtech.api.enums.OrePrefixes.*;
 
 public class MaterialsBotania {
 
     // Botania materials.
-    public static Materials Manasteel               = new MaterialBuilder(201, TextureSet.SET_METALLIC, "Manasteel").setName("Manasteel").setRGBA(150,219,252,255).addDustItems().addMetalItems().addToolHeadItems().addGearItems().setToolSpeed(8.0F).setDurability(5120).setToolQuality(4).setMeltingPoint(1500).setBlastFurnaceTemp(1500).setBlastFurnaceRequired(true).setAspects(Arrays.asList(new TC_Aspects.TC_AspectStack(TC_Aspects.METALLUM, 2), new TC_Aspects.TC_AspectStack(TC_Aspects.PRAECANTATIO, 4))).constructMaterial();
-    public static Materials Terrasteel              = new MaterialBuilder(202, TextureSet.SET_METALLIC, "Terrasteel").setName("Terrasteel").setRGBA(76, 191, 38, 255).addDustItems().addMetalItems().addToolHeadItems().addGearItems().setToolSpeed(32.0F).setDurability(10240).setToolQuality(5).setMeltingPoint(5400).setBlastFurnaceTemp(5400).setBlastFurnaceRequired(true).setAspects(Arrays.asList(new TC_Aspects.TC_AspectStack(TC_Aspects.METALLUM, 2), new TC_Aspects.TC_AspectStack(TC_Aspects.PRAECANTATIO, 8))).constructMaterial();
-    public static Materials ElvenElementium         = new MaterialBuilder(203, TextureSet.SET_METALLIC, "Elementium").setName("Elementium").setRGBA(219, 37, 205, 255).addDustItems().addMetalItems().addToolHeadItems().addGearItems().setToolSpeed(20.0F).setDurability(32768).setToolQuality(7).setMeltingPoint(7200).setBlastFurnaceTemp(7200).setBlastFurnaceRequired(true).setAspects(Arrays.asList(new TC_Aspects.TC_AspectStack(TC_Aspects.PRAECANTATIO, 16))).constructMaterial();
-    public static Materials Livingrock              = new MaterialBuilder(204, new TextureSet("Livingrock", true) , "Livingrock").setName("Livingrock").addDustItems().addMetalItems().addToolHeadItems().addGearItems().setToolSpeed(1.0F).setDurability(0).setToolQuality(3).setOreValue(3).setDensityMultiplier(1).setDensityDivider(1).constructMaterial();
-    public static Materials GaiaSpirit              = new Materials(     205, new TextureSet("GaiaSpirit", true), 32.0F, 850000,  12, 1|2|64|128,   255,   255, 255,  0,   "GaiaSpirit"                ,   "Gaia Spirit"                      ,    -1,      -1,         0,    0, false,  true,   2,   1,   1, Dyes._NULL         , Arrays.asList(new TC_Aspects.TC_AspectStack(TC_Aspects.PRAECANTATIO, 1)));
-    public static Materials Livingwood              = new MaterialBuilder(206, new TextureSet("Livingwood", true) , "Livingwood").setName("Livingwood").addDustItems().addToolHeadItems().addGearItems().setToolSpeed(1.0F).setDurability(0).setToolQuality(3).setOreValue(3).setDensityMultiplier(1).setDensityDivider(1).constructMaterial();
-    public static Materials Dreamwood               = new MaterialBuilder(207, new TextureSet("Dreamwood", true) , "Dreamwood").setName("Dreamwood").addDustItems().addToolHeadItems().addGearItems().setToolSpeed(1.0F).setDurability(0).setToolQuality(3).setOreValue(3).setDensityMultiplier(1).setDensityDivider(1).constructMaterial();
-    public static Materials ManaDiamond             = new Materials(     208, TextureSet.SET_DIAMOND, 16.0F,   2560,  8, 1|4,   38, 237, 224,  255,   "ManaDiamond"                ,   "Mana Diamond"                      ,    -1,      -1,         0,    0, false,  true,   2,   1,   1, Dyes._NULL         , Arrays.asList(new TC_Aspects.TC_AspectStack(TC_Aspects.PRAECANTATIO, 2), new TC_Aspects.TC_AspectStack(TC_Aspects.ORDO, 1), new TC_Aspects.TC_AspectStack(TC_Aspects.VITREUS, 1)));
-    public static Materials BotaniaDragonstone      = new Materials(     209, TextureSet.SET_DIAMOND, 24.0F,      3840,  12, 1|4,   242, 44, 239, 255,   "BotaniaDragonstone"                ,   "Dragonstone"                      ,    -1,      -1,         0,    0, false,  true,   2,   1,   1, Dyes._NULL         , Arrays.asList(new TC_Aspects.TC_AspectStack(TC_Aspects.PRAECANTATIO, 2), new TC_Aspects.TC_AspectStack(TC_Aspects.ORDO, 1), new TC_Aspects.TC_AspectStack(TC_Aspects.VITREUS, 1)));
+    public static Materials Manasteel               = new MaterialBuilder(201, TextureSet.SET_METALLIC, "Manasteel").setName("Manasteel").setRGBA(150,219,252,255).addDustItems().addMetalItems().addToolHeadItems().addGearItems().setToolSpeed(8.0F).setDurability(5120).setToolQuality(4).setMeltingPoint(1500).setBlastFurnaceTemp(1500).setBlastFurnaceRequired(true).setAspects(Arrays.asList(new TC_AspectStack(TC_Aspects.METALLUM, 3), new TC_AspectStack(TC_Aspects.PRAECANTATIO, 1))).constructMaterial();
+    public static Materials Terrasteel              = new MaterialBuilder(202, TextureSet.SET_METALLIC, "Terrasteel").setName("Terrasteel").setRGBA(76, 191, 38, 255).addDustItems().addMetalItems().addToolHeadItems().addGearItems().setToolSpeed(32.0F).setDurability(10240).setToolQuality(5).setMeltingPoint(5400).setBlastFurnaceTemp(5400).setBlastFurnaceRequired(true).setAspects(Arrays.asList(new TC_AspectStack(TC_Aspects.METALLUM, 2), new TC_AspectStack(TC_Aspects.TERRA, 1), new TC_AspectStack(TC_Aspects.PRAECANTATIO, 1))).constructMaterial();
+    public static Materials ElvenElementium         = new MaterialBuilder(203, TextureSet.SET_METALLIC, "Elementium").setName("Elementium").setRGBA(219, 37, 205, 255).addDustItems().addMetalItems().addToolHeadItems().addGearItems().setToolSpeed(20.0F).setDurability(32768).setToolQuality(7).setMeltingPoint(7200).setBlastFurnaceTemp(7200).setBlastFurnaceRequired(true).setAspects(Arrays.asList(new TC_AspectStack(TC_Aspects.METALLUM, 3), new TC_AspectStack(TC_Aspects.PRAECANTATIO, 2), new TC_AspectStack(TC_Aspects.AURAM, 1))).constructMaterial();
+    public static Materials Livingrock              = new MaterialBuilder(204, new TextureSet("Livingrock", true) , "Livingrock").setName("Livingrock").addDustItems().addToolHeadItems().addGearItems().setToolSpeed(1.0F).setDurability(0).setToolQuality(3).setOreValue(3).setDensityMultiplier(1).setDensityDivider(1).setAspects(Arrays.asList(new TC_AspectStack(TC_Aspects.TERRA, 2), new TC_AspectStack(TC_Aspects.VICTUS, 2))).constructMaterial();
+    public static Materials GaiaSpirit              = new Materials(     205, new TextureSet("GaiaSpirit", true), 32.0F, 850000,  12, 1|2|64|128,   255,   255, 255,  0,   "GaiaSpirit"                ,   "Gaia Spirit"                      ,    -1,      -1,         0,    0, false,  true,   2,   1,   1, Dyes._NULL         , Arrays.asList(new TC_AspectStack(TC_Aspects.PRAECANTATIO, 27), new TC_AspectStack(TC_Aspects.AURAM, 24), new TC_AspectStack(TC_Aspects.VICTUS, 24), new TC_AspectStack(TC_Aspects.METALLUM, 1)));
+    public static Materials Livingwood              = new MaterialBuilder(206, new TextureSet("Livingwood", true) , "Livingwood").setName("Livingwood").addDustItems().addMetalItems().addToolHeadItems().addGearItems().setToolSpeed(1.0F).setDurability(0).setToolQuality(3).setOreValue(3).setDensityMultiplier(1).setDensityDivider(1).setAspects(Arrays.asList(new TC_AspectStack(TC_Aspects.ARBOR, 4), new TC_AspectStack(TC_Aspects.VICTUS, 2))).constructMaterial();
+    public static Materials Dreamwood               = new MaterialBuilder(207, new TextureSet("Dreamwood", true) , "Dreamwood").setName("Dreamwood").addDustItems().addMetalItems().addToolHeadItems().addGearItems().setToolSpeed(1.0F).setDurability(0).setToolQuality(3).setOreValue(3).setDensityMultiplier(1).setDensityDivider(1).setAspects(Arrays.asList(new TC_AspectStack(TC_Aspects.ARBOR, 4), new TC_AspectStack(TC_Aspects.AURAM, 2), new TC_AspectStack(TC_Aspects.PRAECANTATIO, 1))).constructMaterial();
+    public static Materials ManaDiamond             = new Materials(     208, TextureSet.SET_DIAMOND, 16.0F,   2560,  8, 1|4,   38, 237, 224,  255,   "ManaDiamond"                ,   "Mana Diamond"                      ,    -1,      -1,         0,    0, false,  true,   2,   1,   1, Dyes._NULL         , Arrays.asList(new TC_Aspects.TC_AspectStack(TC_Aspects.PRAECANTATIO, 4), new TC_Aspects.TC_AspectStack(TC_Aspects.VITREUS, 4), new TC_Aspects.TC_AspectStack(TC_Aspects.LUCRUM, 4)));
+    public static Materials BotaniaDragonstone      = new Materials(     209, TextureSet.SET_DIAMOND, 24.0F,      3840,  12, 1|4,   242, 44, 239, 255,   "BotaniaDragonstone"                ,   "Dragonstone"                      ,    -1,      -1,         0,    0, false,  true,   2,   1,   1, Dyes._NULL         , Arrays.asList(new TC_Aspects.TC_AspectStack(TC_Aspects.PRAECANTATIO, 6), new TC_Aspects.TC_AspectStack(TC_Aspects.VITREUS, 6), new TC_Aspects.TC_AspectStack(TC_Aspects.AURAM, 4)));
 
     public static void init() {
+        GaiaSpirit.mChemicalFormula = "Gs";
+        Manasteel.mChemicalFormula = "Ms";
+        Livingwood.mChemicalFormula = "Lw";
+        Dreamwood.mChemicalFormula = "Dw";
+        BotaniaDragonstone.mChemicalFormula = "Dg";
+        Livingrock.mChemicalFormula = "Lv";
+        Terrasteel.mChemicalFormula = "Tr";
+        ElvenElementium.mChemicalFormula = "Ef";
 
+        Livingrock.add(SubTag.NO_SMASHING, SubTag.NO_SMELTING);
+        Livingwood.add(SubTag.WOOD, SubTag.FLAMMABLE, SubTag.NO_SMELTING, SubTag.NO_SMASHING);
+        Dreamwood.add(SubTag.WOOD, SubTag.FLAMMABLE, SubTag.NO_SMELTING, SubTag.NO_SMASHING);
+        ManaDiamond.add(SubTag.CRYSTAL, SubTag.NO_SMASHING, SubTag.NO_SMELTING);
+        BotaniaDragonstone.add(SubTag.CRYSTAL, SubTag.NO_SMASHING, SubTag.NO_SMELTING);
+
+        // Botania native items
+        ingot.mNotGeneratedItems.add(Manasteel);
+        ingot.mNotGeneratedItems.add(Terrasteel);
+        ingot.mNotGeneratedItems.add(ElvenElementium);
+        ingot.mNotGeneratedItems.add(GaiaSpirit);
+        nugget.mNotGeneratedItems.add(Manasteel);
+        nugget.mNotGeneratedItems.add(Terrasteel);
+        nugget.mNotGeneratedItems.add(ElvenElementium);
+        gem.mNotGeneratedItems.add(ManaDiamond);
+        gem.mNotGeneratedItems.add(BotaniaDragonstone);
+
+        // other stuff we don't want
+        ingot.mNotGeneratedItems.add(Livingwood);
+        ingot.mNotGeneratedItems.add(Dreamwood);
+        nugget.mNotGeneratedItems.add(Livingwood);
+        nugget.mNotGeneratedItems.add(Dreamwood);
+        rotor.mNotGeneratedItems.add(Livingrock);
+
+        // stuff we want
+        plate.mGeneratedItems.add(Livingrock);
+        rod.mGeneratedItems.add(Livingrock); // this is not working
     }
 }

--- a/src/main/java/gregtech/api/enums/OrePrefixes.java
+++ b/src/main/java/gregtech/api/enums/OrePrefixes.java
@@ -438,17 +438,6 @@ public enum OrePrefixes {
         block.mNotGeneratedItems.add(Materials.Coal);
         toolHeadArrow.mNotGeneratedItems.add(Materials.Glass);
 
-        // Botania
-        ingot.mNotGeneratedItems.add(MaterialsBotania.Manasteel);
-        ingot.mNotGeneratedItems.add(MaterialsBotania.Terrasteel);
-        ingot.mNotGeneratedItems.add(MaterialsBotania.ElvenElementium);
-        ingot.mNotGeneratedItems.add(MaterialsBotania.GaiaSpirit);
-        nugget.mNotGeneratedItems.add(MaterialsBotania.Manasteel);
-        nugget.mNotGeneratedItems.add(MaterialsBotania.Terrasteel);
-        nugget.mNotGeneratedItems.add(MaterialsBotania.ElvenElementium);
-        gem.mNotGeneratedItems.add(MaterialsBotania.ManaDiamond);
-        gem.mNotGeneratedItems.add(MaterialsBotania.BotaniaDragonstone);
-
         //-----
 
         dustImpure.mGeneratedItems.add(Materials.GraniteRed);


### PR DESCRIPTION
- Add and remove some items to make Livingrock more stone-like and Livingwood / Dreamwood more wood-like
- Adjust TC aspects. Numbers are based on Botania native items
- Move material properties to `MaterialsBotania`
- Some of the items don't have recipe, I guess we can add them later as needed