### PR TITLE
fix(#10881) persist fire on netherrack bound ores

### DIFF
--- a/src/main/java/gregtech/common/blocks/GT_Block_Ores.java
+++ b/src/main/java/gregtech/common/blocks/GT_Block_Ores.java
@@ -9,9 +9,12 @@ import gregtech.api.enums.OrePrefixes;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.render.TextureFactory;
 import net.minecraft.block.Block;
+import net.minecraft.block.material.MapColor;
 import net.minecraft.block.material.Material;
 import net.minecraft.init.Blocks;
 import net.minecraft.util.IIcon;
+import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
 
 import java.util.Arrays;
 
@@ -57,6 +60,22 @@ public class GT_Block_Ores extends GT_Block_Ores_Abstract {
             default:
                 return Blocks.stone.getIcon(side, 0);
         }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public boolean isFireSource(World world, int x, int y, int z, ForgeDirection side) {
+        return (side == ForgeDirection.UP && getDamageValue(world, x, y, z) / 1000 % 16 == 1);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public MapColor getMapColor(int meta) {
+        return meta == 1 ? MapColor.netherrackColor : MapColor.stoneColor;
     }
 
     @Override


### PR DESCRIPTION
Address issue [#10881](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/10881)

Make fire to persist over nether rack bound ores:

![2022-08-08_19 00 55](https://user-images.githubusercontent.com/1111474/183474023-2c79cf9a-92e9-4316-897b-e48d036d2ebb.png)
