### PR TITLE
do not return IAlignment if MTE is not IAlignmentProvider

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
@@ -2079,30 +2079,13 @@ public class BaseMetaTileEntity extends CommonMetaTileEntity implements IGregTec
 
     @Override
     public IAlignment getAlignment() {
-        return getMetaTileEntity() instanceof IAlignmentProvider ? ((IAlignmentProvider) getMetaTileEntity()).getAlignment() : new BasicAlignment();
+        return getMetaTileEntity() instanceof IAlignmentProvider ? ((IAlignmentProvider) getMetaTileEntity()).getAlignment() :
+            getMetaTileEntity() instanceof IAlignment ? (IAlignment) getMetaTileEntity() : null;
     }
 
     @Nullable
     @Override
     public IConstructable getConstructable() {
         return getMetaTileEntity() instanceof IConstructable ? (IConstructable) getMetaTileEntity() : null;
-    }
-
-    private class BasicAlignment implements IAlignment {
-
-        @Override
-        public ExtendedFacing getExtendedFacing() {
-            return ExtendedFacing.of(ForgeDirection.getOrientation(getFrontFacing()));
-        }
-
-        @Override
-        public void setExtendedFacing(ExtendedFacing alignment) {
-            setFrontFacing((byte) Math.min(alignment.getDirection().ordinal(), ForgeDirection.UNKNOWN.ordinal() - 1));
-        }
-
-        @Override
-        public IAlignmentLimits getAlignmentLimits() {
-            return (direction, rotation, flip) -> rotation.isNotRotated() && flip.isNotFlipped();
-        }
     }
 }

--- a/src/main/java/gregtech/common/render/GT_RenderedTexture.java
+++ b/src/main/java/gregtech/common/render/GT_RenderedTexture.java
@@ -1,5 +1,6 @@
 package gregtech.common.render;
 
+import com.gtnewhorizon.structurelib.alignment.IAlignment;
 import com.gtnewhorizon.structurelib.alignment.IAlignmentProvider;
 import com.gtnewhorizon.structurelib.alignment.enumerable.ExtendedFacing;
 import com.gtnewhorizon.structurelib.alignment.enumerable.Flip;
@@ -365,16 +366,18 @@ public class GT_RenderedTexture extends GT_TextureBase implements ITexture, ICol
         final World w = player.getEntityWorld();
         if (w == null) return ExtendedFacing.DEFAULT;
         final TileEntity te = w.getTileEntity(x, y, z);
+        IAlignment alignment = null;
         if (te instanceof IGregTechTileEntity) {
             final IMetaTileEntity meta = ((IGregTechTileEntity) te).getMetaTileEntity();
             if (meta instanceof IAlignmentProvider) {
-                return ((IAlignmentProvider) meta).getAlignment().getExtendedFacing();
+                alignment = ((IAlignmentProvider) meta).getAlignment();
             } else if (meta != null) {
                 return ExtendedFacing.of(ForgeDirection.getOrientation(meta.getBaseMetaTileEntity().getFrontFacing()));
             }
         } else if (te instanceof IAlignmentProvider) {
-            return ((IAlignmentProvider) te).getAlignment().getExtendedFacing();
+            alignment = ((IAlignmentProvider) te).getAlignment();
         }
+        if (alignment != null) return alignment.getExtendedFacing();
         return ExtendedFacing.DEFAULT;
     }
 }


### PR DESCRIPTION
This fix rotation markers being displayed on single block machines.