### PR TITLE
loosen the generic restrictions on hatch elements

### DIFF
--- a/src/main/java/gregtech/api/enums/GT_HatchElement.java
+++ b/src/main/java/gregtech/api/enums/GT_HatchElement.java
@@ -19,52 +19,52 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-public enum GT_HatchElement implements IHatchElement<GT_MetaTileEntity_EnhancedMultiBlockBase<?>> {
+public enum GT_HatchElement implements IHatchElement<GT_MetaTileEntity_MultiBlockBase> {
     Muffler(GT_MetaTileEntity_MultiBlockBase::addMufflerToMachineList, GT_MetaTileEntity_Hatch_Muffler.class) {
         @Override
-        public long count(GT_MetaTileEntity_EnhancedMultiBlockBase<?> t) {
+        public long count(GT_MetaTileEntity_MultiBlockBase t) {
             return t.mMufflerHatches.size();
         }
     },
     Maintenance(GT_MetaTileEntity_MultiBlockBase::addMaintenanceToMachineList, GT_MetaTileEntity_Hatch_Maintenance.class) {
         @Override
-        public long count(GT_MetaTileEntity_EnhancedMultiBlockBase<?> t) {
+        public long count(GT_MetaTileEntity_MultiBlockBase t) {
             return t.mMaintenanceHatches.size();
         }
     },
     InputHatch(GT_MetaTileEntity_MultiBlockBase::addInputHatchToMachineList, GT_MetaTileEntity_Hatch_Input.class) {
         @Override
-        public long count(GT_MetaTileEntity_EnhancedMultiBlockBase<?> t) {
+        public long count(GT_MetaTileEntity_MultiBlockBase t) {
             return t.mInputHatches.size();
         }
     },
     InputBus(GT_MetaTileEntity_MultiBlockBase::addInputBusToMachineList, GT_MetaTileEntity_Hatch_InputBus.class) {
         @Override
-        public long count(GT_MetaTileEntity_EnhancedMultiBlockBase<?> t) {
+        public long count(GT_MetaTileEntity_MultiBlockBase t) {
             return t.mInputBusses.size();
         }
     },
     OutputHatch(GT_MetaTileEntity_MultiBlockBase::addOutputHatchToMachineList, GT_MetaTileEntity_Hatch_Output.class) {
         @Override
-        public long count(GT_MetaTileEntity_EnhancedMultiBlockBase<?> t) {
+        public long count(GT_MetaTileEntity_MultiBlockBase t) {
             return t.mOutputHatches.size();
         }
     },
     OutputBus(GT_MetaTileEntity_MultiBlockBase::addOutputBusToMachineList, GT_MetaTileEntity_Hatch_OutputBus.class) {
         @Override
-        public long count(GT_MetaTileEntity_EnhancedMultiBlockBase<?> t) {
+        public long count(GT_MetaTileEntity_MultiBlockBase t) {
             return t.mOutputBusses.size();
         }
     },
     Energy(GT_MetaTileEntity_MultiBlockBase::addEnergyInputToMachineList, GT_MetaTileEntity_Hatch_Energy.class) {
         @Override
-        public long count(GT_MetaTileEntity_EnhancedMultiBlockBase<?> t) {
+        public long count(GT_MetaTileEntity_MultiBlockBase t) {
             return t.mEnergyHatches.size();
         }
     },
     Dynamo(GT_MetaTileEntity_MultiBlockBase::addDynamoToMachineList, GT_MetaTileEntity_Hatch_Dynamo.class) {
         @Override
-        public long count(GT_MetaTileEntity_EnhancedMultiBlockBase<?> t) {
+        public long count(GT_MetaTileEntity_MultiBlockBase t) {
             return t.mDynamoHatches.size();
         }
     },
@@ -75,16 +75,16 @@ public enum GT_HatchElement implements IHatchElement<GT_MetaTileEntity_EnhancedM
         }
 
         @Override
-        public long count(GT_MetaTileEntity_EnhancedMultiBlockBase<?> t) {
+        public long count(GT_MetaTileEntity_MultiBlockBase t) {
             return t.getExoticEnergyHatches().size();
         }
     },
     ;
     private final List<Class<? extends IMetaTileEntity>> mteClasses;
-    private final IGT_HatchAdder<GT_MetaTileEntity_EnhancedMultiBlockBase<?>> adder;
+    private final IGT_HatchAdder<GT_MetaTileEntity_MultiBlockBase> adder;
 
     @SafeVarargs
-    GT_HatchElement(IGT_HatchAdder<GT_MetaTileEntity_EnhancedMultiBlockBase<?>> adder, Class<? extends IMetaTileEntity>... mteClasses) {
+    GT_HatchElement(IGT_HatchAdder<GT_MetaTileEntity_MultiBlockBase> adder, Class<? extends IMetaTileEntity>... mteClasses) {
         this.mteClasses = Collections.unmodifiableList(Arrays.asList(mteClasses));
         this.adder = adder;
     }
@@ -94,7 +94,7 @@ public enum GT_HatchElement implements IHatchElement<GT_MetaTileEntity_EnhancedM
         return mteClasses;
     }
 
-    public IGT_HatchAdder<? super GT_MetaTileEntity_EnhancedMultiBlockBase<?>> adder() {
+    public IGT_HatchAdder<? super GT_MetaTileEntity_MultiBlockBase> adder() {
         return adder;
     }
 }

--- a/src/main/java/gregtech/api/interfaces/IHatchElement.java
+++ b/src/main/java/gregtech/api/interfaces/IHatchElement.java
@@ -4,6 +4,7 @@ import com.gtnewhorizon.structurelib.structure.IStructureElement;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_EnhancedMultiBlockBase;
+import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_MultiBlockBase;
 import gregtech.api.util.GT_StructureUtility;
 import gregtech.api.util.IGT_HatchAdder;
 
@@ -13,7 +14,7 @@ import java.util.List;
 import java.util.function.BiPredicate;
 import java.util.function.ToLongFunction;
 
-public interface IHatchElement<T extends GT_MetaTileEntity_EnhancedMultiBlockBase<?>> {
+public interface IHatchElement<T> {
     List<? extends Class<? extends IMetaTileEntity>> mteClasses();
 
     IGT_HatchAdder<? super T> adder();
@@ -73,7 +74,7 @@ public interface IHatchElement<T extends GT_MetaTileEntity_EnhancedMultiBlockBas
     }
 }
 
-class HatchElement<T extends GT_MetaTileEntity_EnhancedMultiBlockBase<?>> implements IHatchElement<T> {
+class HatchElement<T> implements IHatchElement<T> {
     private final List<Class<? extends IMetaTileEntity>> mClasses;
     private final IGT_HatchAdder<? super T> mAdder;
     private final String mName;

--- a/src/main/java/gregtech/api/util/GT_HatchElementBuilder.java
+++ b/src/main/java/gregtech/api/util/GT_HatchElementBuilder.java
@@ -10,6 +10,7 @@ import gregtech.api.interfaces.IHatchElement;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_EnhancedMultiBlockBase;
+import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_MultiBlockBase;
 import gregtech.common.blocks.GT_Item_Machines;
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -28,7 +29,7 @@ import java.util.stream.Stream;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofBlock;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofChain;
 
-public class GT_HatchElementBuilder<T extends GT_MetaTileEntity_EnhancedMultiBlockBase<?>> {
+public class GT_HatchElementBuilder<T> {
     private interface Builtin {
     }
 
@@ -44,7 +45,7 @@ public class GT_HatchElementBuilder<T extends GT_MetaTileEntity_EnhancedMultiBlo
     private GT_HatchElementBuilder() {
     }
 
-    public static <T extends GT_MetaTileEntity_EnhancedMultiBlockBase<?>> GT_HatchElementBuilder<T> builder() {
+    public static <T> GT_HatchElementBuilder<T> builder() {
         return new GT_HatchElementBuilder<>();
     }
 

--- a/src/main/java/gregtech/api/util/GT_StructureUtility.java
+++ b/src/main/java/gregtech/api/util/GT_StructureUtility.java
@@ -16,6 +16,7 @@ import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.BaseMetaPipeEntity;
 import gregtech.api.metatileentity.implementations.GT_MetaPipeEntity_Frame;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_EnhancedMultiBlockBase;
+import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_MultiBlockBase;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_TieredMachineBlock;
 import gregtech.common.blocks.GT_Block_Casings5;
 import gregtech.common.blocks.GT_Item_Machines;
@@ -98,14 +99,14 @@ public class GT_StructureUtility {
         };
     }
 
-    public static <T extends GT_MetaTileEntity_EnhancedMultiBlockBase<?>> GT_HatchElementBuilder<T> buildHatchAdder() {
+    public static <T> GT_HatchElementBuilder<T> buildHatchAdder() {
         return GT_HatchElementBuilder.builder();
     }
 
     /**
      * Completely equivalent to {@link #buildHatchAdder()}, except it plays nicer with type inference when statically imported
      */
-    public static <T extends GT_MetaTileEntity_EnhancedMultiBlockBase<?>> GT_HatchElementBuilder<T> buildHatchAdder(Class<T> typeToken) {
+    public static <T> GT_HatchElementBuilder<T> buildHatchAdder(Class<T> typeToken) {
         return GT_HatchElementBuilder.builder();
     }
 


### PR DESCRIPTION
It honestly never occurred to me that SOMEONE would not derive from GT_MetaTileEntity_EnhancedMultiblockBase