### PR TITLE
no more magical texture index

### DIFF
--- a/src/main/java/gregtech/api/enums/Textures.java
+++ b/src/main/java/gregtech/api/enums/Textures.java
@@ -9,6 +9,9 @@ import net.minecraft.client.renderer.texture.TextureMap;
 import net.minecraft.util.IIcon;
 import net.minecraft.util.ResourceLocation;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static gregtech.api.enums.GT_Values.RES_PATH_BLOCK;
 import static gregtech.api.enums.GT_Values.RES_PATH_ITEM;
 
@@ -1973,6 +1976,7 @@ public class Textures {
          */
         public static ITexture[][] casingTexturePages = new ITexture[128][];//page holder so we don't make an short long array
         public static final int ERROR_TEXTURE_INDEX = (1 << 7) + 97;
+        private static final Map<ITexture, Integer> reverseMap = new HashMap<>();
 
         static {
             for (byte i = 0; i < MACHINE_CASINGS.length; i++)
@@ -1999,11 +2003,18 @@ public class Textures {
         }
 
         public static void setCasingTextureForId(int id, ITexture iTexture) {
-            casingTexturePages[(id >> 7) & 0x7f][id & 0x7f] = iTexture;
+            casingTexturePages[(byte) ((id >> 7) & 0x7f)][(byte) (id & 0x7f)] = iTexture;
+            reverseMap.put(iTexture, id);
         }
 
         public static void setCasingTexture(byte page, byte index, ITexture iTexture) {
             casingTexturePages[page][index] = iTexture;
+            reverseMap.put(iTexture, (page << 7) + index);
+        }
+
+        public static int getTextureIndex(ITexture texture) {
+            Integer id = reverseMap.get(texture);
+            return id == null ? ERROR_TEXTURE_INDEX : id;
         }
 
         @Override

--- a/src/main/java/gregtech/api/enums/Textures.java
+++ b/src/main/java/gregtech/api/enums/Textures.java
@@ -1964,8 +1964,15 @@ public class Textures {
         public static ITexture[][] MACHINE_CASINGS = new ITexture[15][17];
         /**
          * by Default pages are null
+         * page 0:  0-63 GT casing 1-4, 64-127 GT++
+         * page 1:  0-15 GT casing 5, 22-26 GS dyson swarm, 48-57 GT casing 8, 63 EMT, 80-95 GT reinforced blocks,
+         *          96 casing 2 meta 6, 97 error casing
+         * page 8:  0-111 TecTech, 112-127 GT casing 6
+         * page 12: 0-127 GlodBlock
+         * page 42: 0-126 glee8e, 127 KekzTech LSC base
          */
         public static ITexture[][] casingTexturePages = new ITexture[128][];//page holder so we don't make an short long array
+        public static final int ERROR_TEXTURE_INDEX = (1 << 7) + 97;
 
         static {
             for (byte i = 0; i < MACHINE_CASINGS.length; i++)
@@ -1978,6 +1985,7 @@ public class Textures {
             //adds some known pages, modders also can do it...
             GT_Utility.addTexturePage((byte) 1);
             GT_Utility.addTexturePage((byte) 8);
+            setCasingTextureForId(ERROR_TEXTURE_INDEX, ERROR_RENDERING[0]);
         }
 
         protected IIcon mIcon;

--- a/src/main/java/gregtech/api/interfaces/IHasIndexedTexture.java
+++ b/src/main/java/gregtech/api/interfaces/IHasIndexedTexture.java
@@ -1,0 +1,15 @@
+package gregtech.api.interfaces;
+
+/**
+ * To be implemented on blocks. Usually machine casing blocks.
+ */
+public interface IHasIndexedTexture {
+    /**
+     * Returns the statically mapped texture for this casing. Return
+     * {@link gregtech.api.enums.Textures.BlockIcons#ERROR_TEXTURE_INDEX} if meta maps to a nonexistent block, or the
+     * block does not have a statically mapped texture.
+     * @param aMeta block meta
+     * @return texture index into {@link gregtech.api.enums.Textures.BlockIcons#casingTexturePages}
+     */
+    int getTextureIndex(int aMeta);
+}

--- a/src/main/java/gregtech/api/util/GT_Utility.java
+++ b/src/main/java/gregtech/api/util/GT_Utility.java
@@ -18,6 +18,7 @@ import gregtech.api.enums.*;
 import gregtech.api.events.BlockScanningEvent;
 import gregtech.api.interfaces.IBlockContainer;
 import gregtech.api.interfaces.IDebugableBlock;
+import gregtech.api.interfaces.IHasIndexedTexture;
 import gregtech.api.interfaces.IProjectileItem;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.tileentity.IBasicEnergyContainer;
@@ -3244,6 +3245,12 @@ public class GT_Utility {
         if (aUseStackSize) base = base * 31 + aStack.amount;
         if (aUseNBT) base = base * 31 + Objects.hashCode(aStack.tag);
         return base;
+    }
+
+    public static int getCasingTextureIndex(Block block, int meta) {
+        if (block instanceof IHasIndexedTexture)
+            return ((IHasIndexedTexture) block).getTextureIndex(meta);
+        return Textures.BlockIcons.ERROR_TEXTURE_INDEX;
     }
 
     @AutoValue

--- a/src/main/java/gregtech/common/blocks/GT_Block_Casings1.java
+++ b/src/main/java/gregtech/common/blocks/GT_Block_Casings1.java
@@ -1,15 +1,11 @@
 package gregtech.common.blocks;
 
-import gregtech.api.GregTech_API;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Textures;
-import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GT_LanguageManager;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
-
-import static gregtech.api.enums.GT_Values.RES_PATH_BLOCK;
 
 public class GT_Block_Casings1 extends GT_Block_Casings_Abstract {
 
@@ -29,10 +25,7 @@ public class GT_Block_Casings1 extends GT_Block_Casings_Abstract {
 
 
     public GT_Block_Casings1() {
-        super(GT_Item_Casings1.class, "gt.blockcasings", GT_Material_Casings.INSTANCE);
-        for (int i = 0; i < 16; i++) {
-            Textures.BlockIcons.casingTexturePages[0][i] = TextureFactory.of(this, i);
-        }
+        super(GT_Item_Casings1.class, "gt.blockcasings", GT_Material_Casings.INSTANCE, 16);
 
         GT_LanguageManager.addStringLocalization(getUnlocalizedName() + ".0.name", "ULV Machine Casing");
         GT_LanguageManager.addStringLocalization(getUnlocalizedName() + ".1.name", "LV Machine Casing");
@@ -66,6 +59,11 @@ public class GT_Block_Casings1 extends GT_Block_Casings_Abstract {
         ItemList.Casing_Dim_Injector.set(new ItemStack(this, 1, 13));
         ItemList.Casing_Dim_Bridge.set(new ItemStack(this, 1, 14));
         ItemList.Casing_Coil_Superconductor.set(new ItemStack(this, 1, 15));
+    }
+
+    @Override
+    public int getTextureIndex(int aMeta) {
+        return aMeta;
     }
 
     @Override

--- a/src/main/java/gregtech/common/blocks/GT_Block_Casings2.java
+++ b/src/main/java/gregtech/common/blocks/GT_Block_Casings2.java
@@ -15,12 +15,7 @@ import net.minecraftforge.common.util.ForgeDirection;
 
 public class GT_Block_Casings2 extends GT_Block_Casings_Abstract {
     public GT_Block_Casings2() {
-        super(GT_Item_Casings2.class, "gt.blockcasings2", GT_Material_Casings.INSTANCE);
-        for (int i = 0; i < 16; i++) {
-            if (i != 6) {
-                Textures.BlockIcons.casingTexturePages[0][(i + 16)] = TextureFactory.of(this, i);
-            }
-        }
+        super(GT_Item_Casings2.class, "gt.blockcasings2", GT_Material_Casings.INSTANCE, 96);
         //Special handler for Pyrolyse Oven Casing on hatches...
         Textures.BlockIcons.casingTexturePages[0][22] = TextureFactory.of(Block.getBlockFromItem(ItemList.Casing_ULV.get(1).getItem()), 0, ForgeDirection.UNKNOWN, Dyes.MACHINE_METAL.mRGBa);
 
@@ -56,8 +51,12 @@ public class GT_Block_Casings2 extends GT_Block_Casings_Abstract {
         ItemList.Casing_Pipe_Steel.set(new ItemStack(this, 1, 13));
         ItemList.Casing_Pipe_Titanium.set(new ItemStack(this, 1, 14));
         ItemList.Casing_Pipe_TungstenSteel.set(new ItemStack(this, 1, 15));
-        
-}
+    }
+
+    @Override
+    public int getTextureIndex(int aMeta) {
+        return aMeta == 6 ? ((1 << 7) + 96) : aMeta + 16;
+    }
 
     @Override
     public IIcon getIcon(int aSide, int aMeta) {

--- a/src/main/java/gregtech/common/blocks/GT_Block_Casings3.java
+++ b/src/main/java/gregtech/common/blocks/GT_Block_Casings3.java
@@ -2,17 +2,13 @@ package gregtech.common.blocks;
 
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Textures;
-import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GT_LanguageManager;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
 
 public class GT_Block_Casings3 extends GT_Block_Casings_Abstract {
     public GT_Block_Casings3() {
-        super(GT_Item_Casings3.class, "gt.blockcasings3", GT_Material_Casings.INSTANCE);
-        for (byte i = 0; i < 16; i = (byte) (i + 1)) {
-            Textures.BlockIcons.casingTexturePages[0][(i + 32)] = TextureFactory.of(this, i);
-        }
+        super(GT_Item_Casings3.class, "gt.blockcasings3", GT_Material_Casings.INSTANCE, 16);
         GT_LanguageManager.addStringLocalization(getUnlocalizedName() + ".0.name", "Yellow Stripes Block");
         GT_LanguageManager.addStringLocalization(getUnlocalizedName() + ".1.name", "Yellow Stripes Block");
         GT_LanguageManager.addStringLocalization(getUnlocalizedName() + ".2.name", "Radioactive Hazard Sign Block");
@@ -45,6 +41,11 @@ public class GT_Block_Casings3 extends GT_Block_Casings_Abstract {
         ItemList.Casing_Firebox_Bronze.set(new ItemStack(this, 1, 13));
         ItemList.Casing_Firebox_Steel.set(new ItemStack(this, 1, 14));
         ItemList.Casing_Firebox_TungstenSteel.set(new ItemStack(this, 1, 15));
+    }
+
+    @Override
+    public int getTextureIndex(int aMeta) {
+        return aMeta + 32;
     }
 
     @Override

--- a/src/main/java/gregtech/common/blocks/GT_Block_Casings4.java
+++ b/src/main/java/gregtech/common/blocks/GT_Block_Casings4.java
@@ -6,7 +6,6 @@ import gregtech.GT_Mod;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Textures;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
-import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GT_LanguageManager;
 import gregtech.api.util.GT_RenderingWorld;
 import gregtech.common.tileentities.machines.multi.GT_MetaTileEntity_LargeTurbine;
@@ -34,10 +33,7 @@ public class GT_Block_Casings4 extends GT_Block_Casings_Abstract {
     public static boolean mConnectedMachineTextures = true;
 
     public GT_Block_Casings4() {
-        super(GT_Item_Casings4.class, "gt.blockcasings4", GT_Material_Casings.INSTANCE);
-        for (byte i = 0; i < 16; i = (byte) (i + 1)) {
-            Textures.BlockIcons.casingTexturePages[0][i + 48] = TextureFactory.of(this, i);
-        }
+        super(GT_Item_Casings4.class, "gt.blockcasings4", GT_Material_Casings.INSTANCE, 16);
         GT_LanguageManager.addStringLocalization(getUnlocalizedName() + ".0.name", "Robust Tungstensteel Machine Casing");
         GT_LanguageManager.addStringLocalization(getUnlocalizedName() + ".1.name", "Clean Stainless Steel Machine Casing");
         GT_LanguageManager.addStringLocalization(getUnlocalizedName() + ".2.name", "Stable Titanium Machine Casing");
@@ -72,6 +68,11 @@ public class GT_Block_Casings4 extends GT_Block_Casings_Abstract {
 
         GT_Mod.gregtechproxy.mCTMBlockCache.put(this, (byte) 6, true);
         GT_Mod.gregtechproxy.mCTMBlockCache.put(this, (byte) 8, true);
+    }
+
+    @Override
+    public int getTextureIndex(int aMeta) {
+        return aMeta + 48;
     }
 
     @Override

--- a/src/main/java/gregtech/common/blocks/GT_Block_Casings5.java
+++ b/src/main/java/gregtech/common/blocks/GT_Block_Casings5.java
@@ -6,7 +6,6 @@ import gregtech.api.enums.HeatingCoilLevel;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Textures;
 import gregtech.api.interfaces.IHeatingCoil;
-import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GT_LanguageManager;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
@@ -18,10 +17,7 @@ import static gregtech.api.enums.HeatingCoilLevel.*;
 public class GT_Block_Casings5 extends GT_Block_Casings_Abstract implements IHeatingCoil {
 
     public GT_Block_Casings5() {
-        super(GT_Item_Casings5.class, "gt.blockcasings5", GT_Material_Casings.INSTANCE);
-        for (byte i = 0; i < 16; i = (byte) (i + 1)) {
-            Textures.BlockIcons.casingTexturePages[1][i] = TextureFactory.of(this, i);
-        }
+        super(GT_Item_Casings5.class, "gt.blockcasings5", GT_Material_Casings.INSTANCE, 16);
         GT_LanguageManager.addStringLocalization(getUnlocalizedName() + ".0.name", "Cupronickel Coil Block");
         GT_LanguageManager.addStringLocalization(getUnlocalizedName() + ".1.name", "Kanthal Coil Block");
         GT_LanguageManager.addStringLocalization(getUnlocalizedName() + ".2.name", "Nichrome Coil Block");
@@ -37,7 +33,7 @@ public class GT_Block_Casings5 extends GT_Block_Casings_Abstract implements IHea
         GT_LanguageManager.addStringLocalization(getUnlocalizedName() + ".12.name", "Hypogen Coil Block");
         GT_LanguageManager.addStringLocalization(getUnlocalizedName() + ".13.name", "Eternal Coil Block");
 
-        
+
         ItemList.Casing_Coil_Cupronickel.set(new ItemStack(this, 1, 0));
         ItemList.Casing_Coil_Kanthal.set(new ItemStack(this, 1, 1));
         ItemList.Casing_Coil_Nichrome.set(new ItemStack(this, 1, 2));
@@ -52,6 +48,11 @@ public class GT_Block_Casings5 extends GT_Block_Casings_Abstract implements IHea
         ItemList.Casing_Coil_Infinity.set(new ItemStack(this, 1, 11));
         ItemList.Casing_Coil_Hypogen.set(new ItemStack(this, 1, 12));
         ItemList.Casing_Coil_Eternal.set(new ItemStack(this, 1, 13));
+    }
+
+    @Override
+    public int getTextureIndex(int aMeta) {
+        return (1 << 7 ) | aMeta;
     }
 
     @Override
@@ -161,8 +162,8 @@ public class GT_Block_Casings5 extends GT_Block_Casings_Abstract implements IHea
                 return 0;
         }
     }
-    
-    
+
+
 
     @Override
     public HeatingCoilLevel getCoilHeat(int meta) {

--- a/src/main/java/gregtech/common/blocks/GT_Block_Casings6.java
+++ b/src/main/java/gregtech/common/blocks/GT_Block_Casings6.java
@@ -4,7 +4,6 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Textures;
-import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GT_LanguageManager;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
@@ -12,11 +11,8 @@ import net.minecraft.world.IBlockAccess;
 
 public class GT_Block_Casings6 extends GT_Block_Casings_Abstract {
     public GT_Block_Casings6() {
-        super(GT_Item_Casings6.class, "gt.blockcasings6", GT_Material_Casings.INSTANCE);
-        for (int i = 0; i < 16; i = (i + 1)) {
-            Textures.BlockIcons.casingTexturePages[8][i + 112] = TextureFactory.of(this, i);
-        }
-        
+        super(GT_Item_Casings6.class, "gt.blockcasings6", GT_Material_Casings.INSTANCE, 16);
+
         GT_LanguageManager.addStringLocalization(getUnlocalizedName() + ".0.name", "Hermetic Casing");
         GT_LanguageManager.addStringLocalization(getUnlocalizedName() + ".1.name", "Hermetic Casing I");
         GT_LanguageManager.addStringLocalization(getUnlocalizedName() + ".2.name", "Hermetic Casing II");
@@ -51,6 +47,12 @@ public class GT_Block_Casings6 extends GT_Block_Casings_Abstract {
         ItemList.Casing_Tank_14.set(new ItemStack(this, 1, 14));
         ItemList.Casing_Tank_15.set(new ItemStack(this, 1, 15));
     }
+
+    @Override
+    public int getTextureIndex(int aMeta) {
+        return (8 << 7) | (aMeta + 112);
+    }
+
     @Override
     @SideOnly(Side.CLIENT)
     public IIcon getIcon(int aSide, int aMeta) {

--- a/src/main/java/gregtech/common/blocks/GT_Block_Casings8.java
+++ b/src/main/java/gregtech/common/blocks/GT_Block_Casings8.java
@@ -2,11 +2,9 @@ package gregtech.common.blocks;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
-import gregtech.GT_Mod;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Textures;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
-import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GT_LanguageManager;
 import gregtech.api.util.GT_RenderingWorld;
 import gregtech.common.tileentities.machines.multi.GT_MetaTileEntity_LargeTurbine;
@@ -20,14 +18,12 @@ public class GT_Block_Casings8 extends GT_Block_Casings_Abstract {
 
     //WATCH OUT FOR TEXTURE ID's
     public GT_Block_Casings8() {
-        super(GT_Item_Casings8.class, "gt.blockcasings8", GT_Material_Casings.INSTANCE);
+        super(GT_Item_Casings8.class, "gt.blockcasings8", GT_Material_Casings.INSTANCE, 10);
         /*
          * DO NOT USE INDEX 15 !
          * USED HERE: https://github.com/GTNewHorizons/Electro-Magic-Tools/pull/17
          */
-        for (int i = 0; i < 10; i = (i + 1)) {
-            Textures.BlockIcons.casingTexturePages[1][i+48] = TextureFactory.of(this, i);
-        }
+
         GT_LanguageManager.addStringLocalization(getUnlocalizedName() + ".0.name", "Chemically Inert Machine Casing");
         GT_LanguageManager.addStringLocalization(getUnlocalizedName() + ".1.name", "PTFE Pipe Casing");
         GT_LanguageManager.addStringLocalization(getUnlocalizedName() + ".2.name", "Mining Neutronium Casing");
@@ -49,6 +45,11 @@ public class GT_Block_Casings8 extends GT_Block_Casings_Abstract {
         ItemList.Casing_Advanced_Iridium.set(new ItemStack(this, 1, 7));
         ItemList.Casing_Magical.set(new ItemStack(this, 1, 8));
         ItemList.Casing_TurbineGasAdvanced.set(new ItemStack(this, 1, 9));
+    }
+
+    @Override
+    public int getTextureIndex(int aMeta) {
+        return (1 << 7) | (aMeta + 48);
     }
 
     @Override

--- a/src/main/java/gregtech/common/blocks/GT_Block_Casings_Abstract.java
+++ b/src/main/java/gregtech/common/blocks/GT_Block_Casings_Abstract.java
@@ -3,7 +3,9 @@ package gregtech.common.blocks;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import gregtech.api.GregTech_API;
+import gregtech.api.enums.Textures;
 import gregtech.api.items.GT_Generic_Block;
+import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GT_LanguageManager;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
@@ -21,13 +23,20 @@ import net.minecraft.world.World;
 
 import java.util.List;
 
-public abstract class GT_Block_Casings_Abstract extends GT_Generic_Block {
+public abstract class GT_Block_Casings_Abstract extends GT_Generic_Block implements gregtech.api.interfaces.IHasIndexedTexture {
     public GT_Block_Casings_Abstract(Class<? extends ItemBlock> aItemClass, String aName, Material aMaterial) {
         super(aItemClass, aName, aMaterial);
         setStepSound(soundTypeMetal);
         setCreativeTab(GregTech_API.TAB_GREGTECH);
         GregTech_API.registerMachineBlock(this, -1);
         GT_LanguageManager.addStringLocalization(getUnlocalizedName() + "." + 32767 + ".name", "Any Sub Block of this");
+    }
+
+    public GT_Block_Casings_Abstract(Class<? extends ItemBlock> aItemClass, String aName, Material aMaterial, int aMaxMeta) {
+        this(aItemClass, aName, aMaterial);
+        for (int i = 0; i < aMaxMeta; i++) {
+            Textures.BlockIcons.setCasingTextureForId(getTextureIndex(i), TextureFactory.of(this, i));
+        }
     }
 
     @Override
@@ -116,5 +125,13 @@ public abstract class GT_Block_Casings_Abstract extends GT_Generic_Block {
             ItemStack aStack = new ItemStack(aItem, 1, i);
             if (!aStack.getDisplayName().contains(".name")) aList.add(aStack);
         }
+    }
+
+    /**
+     * Provide a fallback to subclasses in addons.
+     */
+    @Override
+    public int getTextureIndex(int aMeta) {
+        return Textures.BlockIcons.ERROR_TEXTURE_INDEX;
     }
 }


### PR DESCRIPTION
addons are free to implement this interface, but the gain is minimal.

if your multi's structure definition was like this
```java
.addElement('c', ofBlock(GregTech_API.sBlockCasing2, 12))
.addElement('m', Muffler.newAny(28, 1))
```
now you can rewrite it to
```java
.addElement('c', ofBlock(GregTech_API.sBlockCasing1, 12))
.addElement('m', Muffler.newAny(GT_Utlity.getCasingTextureIndex(GregTech_API.sBlockCasing2, 12), 1))
```
or
```java
.addElement('c', ofBlock(GregTech_API.sBlockCasing1, 12))
.addElement('m', Muffler.newAny(BlockIcons.getTextureIndex(BlockIcons.MACHINE_CASING_PIPE_BRONZE), 1))
```
Either is much clearer than that mysterious 28.