### PR TITLE
Fix wrong ternary operator causing electrolyzer recipes disappear

### DIFF
--- a/src/main/java/gregtech/GT_Mod.java
+++ b/src/main/java/gregtech/GT_Mod.java
@@ -101,6 +101,7 @@ import static gregtech.api.enums.GT_Values.MOD_ID_FR;
         guiFactory = "gregtech.client.GT_GuiFactory",
         dependencies = " required-after:IC2;" +
                 " required-after:structurelib;" +
+                " required-after:gtnhlib;" +
                 " after:dreamcraft;" +
                 " after:Forestry;" +
                 " after:PFAAGeologica;" +

--- a/src/main/java/gregtech/api/enums/Materials.java
+++ b/src/main/java/gregtech/api/enums/Materials.java
@@ -2176,7 +2176,7 @@ public class Materials implements IColorModulationContainer, ISubTagContainer {
     private static void addDensityValues(Materials aMaterial, String aConfigPath) {
         aMaterial.mDensityMultiplier = GregTech_API.sMaterialProperties.get(aConfigPath, "DensityMultiplier", aMaterial.mDensityMultiplier);
         aMaterial.mDensityDivider = GregTech_API.sMaterialProperties.get(aConfigPath, "DensityDivider", aMaterial.mDensityDivider);
-        aMaterial.mDensity = GregTech_API.sMaterialProperties.get(aConfigPath, "Density", (M * aMaterial.mDensityMultiplier) / aMaterial.mDensityDivider != 0 ? aMaterial.mDensityDivider : 1);
+        aMaterial.mDensity = (long) GregTech_API.sMaterialProperties.get(aConfigPath, "Density", ((double) M * aMaterial.mDensityMultiplier) / (aMaterial.mDensityDivider != 0 ? aMaterial.mDensityDivider : 1));
     }
 
     private static void addColorValues(Materials aMaterial, String aConfigPath) {


### PR DESCRIPTION
And add GTNHLib as required dependency for `@Mod` annotation
Close https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/11017