### PR TITLE
null check

### DIFF
--- a/src/main/java/gregtech/common/tileentities/storage/GT_MetaTileEntity_DigitalChestBase.java
+++ b/src/main/java/gregtech/common/tileentities/storage/GT_MetaTileEntity_DigitalChestBase.java
@@ -199,6 +199,8 @@ public abstract class GT_MetaTileEntity_DigitalChestBase extends GT_MetaTileEnti
         final ItemStack inputStack = input.getItemStack();
         if (inputStack == null)
             return null;
+        if (getBaseMetaTileEntity() == null)
+            return input;
         if (mode != appeng.api.config.Actionable.SIMULATE)
             getBaseMetaTileEntity().markDirty();
         ItemStack storedStack = getItemStack();
@@ -240,6 +242,8 @@ public abstract class GT_MetaTileEntity_DigitalChestBase extends GT_MetaTileEnti
     @Optional.Method(modid = "appliedenergistics2")
     public appeng.api.storage.data.IAEItemStack extractItems(final appeng.api.storage.data.IAEItemStack request, final appeng.api.config.Actionable mode, final appeng.api.networking.security.BaseActionSource src) {
         if (request.isSameType(getItemStack())) {
+            if (getBaseMetaTileEntity() == null)
+                return null;
             if (mode != appeng.api.config.Actionable.SIMULATE)
                 getBaseMetaTileEntity().markDirty();
             if (request.getStackSize() >= getItemCount()) {


### PR DESCRIPTION
Happened on Delta
```
java.lang.NullPointerException: Ticking GridNode
	at gregtech.common.tileentities.storage.GT_MetaTileEntity_DigitalChestBase.injectItems(GT_MetaTileEntity_DigitalChestBase.java:203)
	at gregtech.common.tileentities.storage.GT_MetaTileEntity_DigitalChestBase.injectItems(GT_MetaTileEntity_DigitalChestBase.java:28)
	at appeng.me.storage.MEInventoryHandler.injectItems(MEInventoryHandler.java:106)
	at appeng.me.storage.NetworkInventoryHandler.injectItems(NetworkInventoryHandler.java:121)
	at appeng.me.cache.NetworkMonitor.injectItems(NetworkMonitor.java:155)
	at appeng.util.Platform.poweredInsert(Platform.java:1483)
```
Perhaps the chest and the storage bus are in different chunks and the chest got unloaded