### PR TITLE
McMeta-coloroverride hotfix

### DIFF
--- a/src/main/java/gregtech/api/util/GT_Util.java
+++ b/src/main/java/gregtech/api/util/GT_Util.java
@@ -133,7 +133,7 @@ public class GT_Util {
     }
 
     public static String toHexString(short[] aColors) {
-        return aColors == null ? "FFFFFF" : Integer.toString((aColors[0] << 16) | (aColors[1] << 8) | aColors[2], 16);
+        return aColors == null ? "FFFFFF" : Integer.toHexString((aColors[0] << 16) | (aColors[1] << 8) | aColors[2]);
     }
 
     public static int getRGBInt(short aR, short aG, short aB) {


### PR DESCRIPTION
Changed `toString(base 16)` to `toHexString()` in `GT_Util#toHexString`