### PR TITLE
Changes to the PA code

### DIFF
--- a/src/main/java/gregtech/api/util/GT_ProcessingArray_Manager.java
+++ b/src/main/java/gregtech/api/util/GT_ProcessingArray_Manager.java
@@ -6,26 +6,19 @@ import java.util.HashMap;
 
 public class GT_ProcessingArray_Manager {
 
-    private static final HashMap<Integer, String> mMetaKeyMap = new HashMap<Integer, String>();
-    private static final HashMap<String, GT_Recipe_Map> mRecipeCache = new HashMap<String, GT_Recipe_Map>();
-
-    public static boolean registerRecipeMapForMeta(int aMeta, GT_Recipe_Map aMap) {
-        if (aMeta < 0 || aMeta > Short.MAX_VALUE || aMap == null) {
-            return false;
+    private static final HashMap<String, GT_Recipe_Map> mRecipeSaves = new HashMap<String, GT_Recipe_Map>();
+    //Adds recipe Maps to the PA using the machines unlocalized name.
+    //Example: basicmachine.electrolyzer, with its recipe map will add the  electrolyzer's recipe map to the PA
+    public static void addRecipeMapToPA(String aMachineName, GT_Recipe_Map aMap) {
+        if (aMachineName != null) {
+            mRecipeSaves.put(aMachineName, aMap);
         }
-        if (mMetaKeyMap.containsKey(aMeta)) {
-            return false;
-        }
-        String aMapNameKey = aMap.mUnlocalizedName;
-        mMetaKeyMap.put(aMeta, aMapNameKey);
-        if (!mRecipeCache.containsKey(aMapNameKey)) {
-            mRecipeCache.put(aMapNameKey, aMap);
-        }
-        return true;
     }
-
-    public static GT_Recipe_Map getRecipeMapForMeta(int aMeta) {
-        return mRecipeCache.get(mMetaKeyMap.get(aMeta));
+    //Allows the PA to extract the recipe map for the machine inside it.
+    public static GT_Recipe_Map giveRecipeMap(String aMachineName) {
+        if (aMachineName != null) {
+            return mRecipeSaves.get(aMachineName);
+        }
+        return null;
     }
-
 }

--- a/src/main/java/gregtech/loaders/postload/GT_ProcessingArrayRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/postload/GT_ProcessingArrayRecipeLoader.java
@@ -8,137 +8,92 @@ public class GT_ProcessingArrayRecipeLoader {
 
     public static void registerDefaultGregtechMaps() {
 
-        // Centrifuge
-        registerMapBetweenRange(361, 365, GT_Recipe.GT_Recipe_Map.sCentrifugeRecipes);
-
-        // Electrolyzer
-        registerMapBetweenRange(371, 375, GT_Recipe.GT_Recipe_Map.sElectrolyzerRecipes);
-
-        // Assembler
-        registerMapBetweenRange(211, 215, GT_Recipe.GT_Recipe_Map.sAssemblerRecipes);
-
-        // Compressor
-        registerMapBetweenRange(241, 245, GT_Recipe.GT_Recipe_Map.sCompressorRecipes);
-
+        //Alloy Smelter
+        GT_ProcessingArray_Manager.addRecipeMapToPA("basicmachine.alloysmelter",GT_Recipe_Map.sAlloySmelterRecipes);
+        //Arc Furnace
+        GT_ProcessingArray_Manager.addRecipeMapToPA("basicmachine.arcfurnace",GT_Recipe_Map.sArcFurnaceRecipes);
+        //Assembler
+        GT_ProcessingArray_Manager.addRecipeMapToPA("basicmachine.assembler",GT_Recipe_Map.sAssemblerRecipes);
+        //Autoclave
+        GT_ProcessingArray_Manager.addRecipeMapToPA("basicmachine.autoclave",GT_Recipe_Map.sAutoclaveRecipes);
+        //Bender
+        GT_ProcessingArray_Manager.addRecipeMapToPA("basicmachine.bender",GT_Recipe_Map.sBenderRecipes);
+        //Boxinator
+        GT_ProcessingArray_Manager.addRecipeMapToPA("basicmachine.boxinator",GT_Recipe_Map.sBoxinatorRecipes);
+        //Brewery
+        GT_ProcessingArray_Manager.addRecipeMapToPA("basicmachine.brewery",GT_Recipe_Map.sBrewingRecipes);
+        //Canner
+        GT_ProcessingArray_Manager.addRecipeMapToPA("basicmachine.canner",GT_Recipe_Map.sCannerRecipes);
+        //Centrifuge
+        GT_ProcessingArray_Manager.addRecipeMapToPA("basicmachine.centrifuge",GT_Recipe_Map.sCentrifugeRecipes);
+        //Chemical Bath
+        GT_ProcessingArray_Manager.addRecipeMapToPA("basicmachine.chemicalbath",GT_Recipe_Map.sChemicalBathRecipes);
+        //Chemical Reactor
+        GT_ProcessingArray_Manager.addRecipeMapToPA("basicmachine.chemicalreactor",GT_Recipe_Map.sChemicalRecipes);
+        //Circuit Assembler
+        GT_ProcessingArray_Manager.addRecipeMapToPA("basicmachine.circuitassembler",GT_Recipe_Map.sCircuitAssemblerRecipes);
+        //Compressor
+        GT_ProcessingArray_Manager.addRecipeMapToPA("basicmachine.compressor",GT_Recipe_Map.sCompressorRecipes);
+        //Cutting Machine
+        GT_ProcessingArray_Manager.addRecipeMapToPA("basicmachine.cutter",GT_Recipe_Map.sCutterRecipes);
+        //Distillery
+        GT_ProcessingArray_Manager.addRecipeMapToPA("basicmachine.distillery",GT_Recipe_Map.sDistilleryRecipes);
+        //Electrolyzer
+        GT_ProcessingArray_Manager.addRecipeMapToPA("basicmachine.electrolyzer",GT_Recipe_Map.sElectrolyzerRecipes);
         //Extractor
-        registerMapBetweenRange(271, 275, GT_Recipe.GT_Recipe_Map.sExtractorRecipes);
-
+        GT_ProcessingArray_Manager.addRecipeMapToPA("basicmachine.extractor",GT_Recipe_Map.sExtractorRecipes);
+        //Extruder
+        GT_ProcessingArray_Manager.addRecipeMapToPA("basicmachine.extruder",GT_Recipe_Map.sExtruderRecipes);
+        //Fermenter
+        GT_ProcessingArray_Manager.addRecipeMapToPA("basicmachine.fermenter",GT_Recipe_Map.sFermentingRecipes);
+        //Fluid Canner
+        GT_ProcessingArray_Manager.addRecipeMapToPA("basicmachine.fluidcanner",GT_Recipe_Map.sFluidCannerRecipes);
+        //Fluid Extractor
+        GT_ProcessingArray_Manager.addRecipeMapToPA("basicmachine.fluidextractor",GT_Recipe_Map.sFluidExtractionRecipes);
+        //Fluid Heater
+        GT_ProcessingArray_Manager.addRecipeMapToPA("basicmachine.fluidheater",GT_Recipe_Map.sFluidHeaterRecipes);
+        //Fluid Solidifier
+        GT_ProcessingArray_Manager.addRecipeMapToPA("basicmachine.fluidsolidifier",GT_Recipe_Map.sFluidSolidficationRecipes);
+        //Forge Hammer
+        GT_ProcessingArray_Manager.addRecipeMapToPA("basicmachine.hammer",GT_Recipe_Map.sHammerRecipes);
+        //Forming Press
+        GT_ProcessingArray_Manager.addRecipeMapToPA("basicmachine.press",GT_Recipe_Map.sPressRecipes);
+        //Laser Engraver
+        GT_ProcessingArray_Manager.addRecipeMapToPA("basicmachine.laserengraver",GT_Recipe_Map.sLaserEngraverRecipes);
+        //Lathe
+        GT_ProcessingArray_Manager.addRecipeMapToPA("basicmachine.lathe",GT_Recipe_Map.sLatheRecipes);
         //Macerator
-        registerMapBetweenRange(301, 305, GT_Recipe.GT_Recipe_Map.sMaceratorRecipes);
-
-        // Microwave (New)
-        registerMapBetweenRange(311, 315, GT_Recipe.GT_Recipe_Map.sMicrowaveRecipes);
-
+        GT_ProcessingArray_Manager.addRecipeMapToPA("basicmachine.macerator",GT_Recipe_Map.sMaceratorRecipes);
+        //Magnetic Separator
+        GT_ProcessingArray_Manager.addRecipeMapToPA("basicmachine.electromagneticseparator",GT_Recipe_Map.sElectroMagneticSeparatorRecipes);
+        //Matter Amplifier
+        GT_ProcessingArray_Manager.addRecipeMapToPA("basicmachine.amplifab",GT_Recipe_Map.sAmplifiers);
+        //Microwave
+        GT_ProcessingArray_Manager.addRecipeMapToPA("basicmachine.microwave",GT_Recipe_Map.sMicrowaveRecipes);
+        //Mixer
+        GT_ProcessingArray_Manager.addRecipeMapToPA("basicmachine.mixer",GT_Recipe_Map.sMixerRecipes);
+        //Ore Washer
+        GT_ProcessingArray_Manager.addRecipeMapToPA("basicmachine.orewasher",GT_Recipe_Map.sOreWasherRecipes);
+        //Plasma Arc Furnace
+        GT_ProcessingArray_Manager.addRecipeMapToPA("basicmachine.plasmaarcfurnace",GT_Recipe_Map.sPlasmaArcFurnaceRecipes);
+        //Polarizer
+        GT_ProcessingArray_Manager.addRecipeMapToPA("basicmachine.polarizer",GT_Recipe_Map.sPolarizerRecipes);
+        //Printer
+        GT_ProcessingArray_Manager.addRecipeMapToPA("basicmachine.printer",GT_Recipe_Map.sPrinterRecipes);
         //Recycler
-        registerMapBetweenRange(331, 335, GT_Recipe.GT_Recipe_Map.sRecyclerRecipes);
-
+        GT_ProcessingArray_Manager.addRecipeMapToPA("basicmachine.recycler",GT_Recipe_Map.sRecyclerRecipes);
+        //Scanner
+        GT_ProcessingArray_Manager.addRecipeMapToPA("basicmachine.scanner",GT_Recipe_Map.sScannerFakeRecipes);
+        //Sifter
+        GT_ProcessingArray_Manager.addRecipeMapToPA("basicmachine.sifter",GT_Recipe_Map.sSifterRecipes);
+        //Slicer
+        GT_ProcessingArray_Manager.addRecipeMapToPA("basicmachine.slicer",GT_Recipe_Map.sSlicerRecipes);
         //Thermal Centrifuge
-        registerMapBetweenRange(381, 385, GT_Recipe.GT_Recipe_Map.sThermalCentrifugeRecipes);
+        GT_ProcessingArray_Manager.addRecipeMapToPA("basicmachine.thermalcentrifuge",GT_Recipe_Map.sThermalCentrifugeRecipes);
+        //Unboxinator
+        GT_ProcessingArray_Manager.addRecipeMapToPA("basicmachine.unboxinator",GT_Recipe_Map.sUnboxinatorRecipes);
+        //Wiremill
+        GT_ProcessingArray_Manager.addRecipeMapToPA("basicmachine.wiremill",GT_Recipe_Map.sWiremillRecipes);
 
-        // Ore Washer
-        registerMapBetweenRange(391, 395, GT_Recipe.GT_Recipe_Map.sOreWasherRecipes);
-
-        // Chemical Reactor
-        registerMapBetweenRange(421, 425, GT_Recipe.GT_Recipe_Map.sChemicalRecipes);
-
-        // Chemical Bath
-        registerMapBetweenRange(541, 545, GT_Recipe.GT_Recipe_Map.sChemicalBathRecipes);
-
-        // Magnetic Seperator
-        registerMapBetweenRange(561, 565, GT_Recipe.GT_Recipe_Map.sElectroMagneticSeparatorRecipes);
-
-        // Autoclave
-        registerMapBetweenRange(571, 575, GT_Recipe.GT_Recipe_Map.sAutoclaveRecipes);
-
-        // Mixer
-        registerMapBetweenRange(581, 585, GT_Recipe.GT_Recipe_Map.sMixerRecipes);
-
-        // Forge Hammer
-        registerMapBetweenRange(611, 615, GT_Recipe.GT_Recipe_Map.sHammerRecipes);
-
-        // Sifter
-        registerMapBetweenRange(641, 645, GT_Recipe.GT_Recipe_Map.sSifterRecipes);
-
-        // Extruder
-        registerMapBetweenRange(281, 285, GT_Recipe.GT_Recipe_Map.sExtruderRecipes);
-
-        // Laser Engraver
-        registerMapBetweenRange(591, 595, GT_Recipe.GT_Recipe_Map.sLaserEngraverRecipes);
-
-        // Bender
-        registerMapBetweenRange(221, 225, GT_Recipe.GT_Recipe_Map.sBenderRecipes);
-
-        // Wiremill
-        registerMapBetweenRange(351, 355, GT_Recipe.GT_Recipe_Map.sWiremillRecipes);
-
-        // Arc Furnace
-        registerMapBetweenRange(651, 655, GT_Recipe.GT_Recipe_Map.sArcFurnaceRecipes);
-
-        // Plasma Arc Furnace
-        registerMapBetweenRange(661, 665, GT_Recipe.GT_Recipe_Map.sPlasmaArcFurnaceRecipes);
-
-        // Brewery
-        registerMapBetweenRange(491, 495, GT_Recipe.GT_Recipe_Map.sBrewingRecipes);
-
-        // Canner
-        registerMapBetweenRange(231, 235, GT_Recipe.GT_Recipe_Map.sCannerRecipes);
-
-        // Cutter
-        registerMapBetweenRange(251, 255, GT_Recipe.GT_Recipe_Map.sCutterRecipes);
-
-        // Fermenter
-        registerMapBetweenRange(501, 505, GT_Recipe.GT_Recipe_Map.sFermentingRecipes);
-
-        // Fluid Extractor
-        registerMapBetweenRange(511, 515, GT_Recipe.GT_Recipe_Map.sFluidExtractionRecipes);
-
-        // Fluid Solidifier
-        registerMapBetweenRange(521, 525, GT_Recipe.GT_Recipe_Map.sFluidSolidficationRecipes);
-
-        // Lathe
-        registerMapBetweenRange(291, 295, GT_Recipe.GT_Recipe_Map.sLatheRecipes);
-
-        // Boxinator
-        registerMapBetweenRange(401, 408, GT_Recipe.GT_Recipe_Map.sBoxinatorRecipes);
-
-        // Unboxinator
-        registerMapBetweenRange(411, 418, GT_Recipe.GT_Recipe_Map.sUnboxinatorRecipes);
-
-        // Polarizer
-        registerMapBetweenRange(551, 555, GT_Recipe.GT_Recipe_Map.sPolarizerRecipes);
-
-        // Printer
-        registerMapBetweenRange(321, 328, GT_Recipe.GT_Recipe_Map.sPrinterRecipes);
-
-        // Fluid Canner
-        registerMapBetweenRange(431, 435, GT_Recipe.GT_Recipe_Map.sFluidCannerRecipes);
-
-        // Fluid Heater
-        registerMapBetweenRange(621, 625, GT_Recipe.GT_Recipe_Map.sFluidHeaterRecipes);
-
-        // Distillery
-        registerMapBetweenRange(531, 535, GT_Recipe.GT_Recipe_Map.sDistilleryRecipes);
-
-        // Slicer
-        registerMapBetweenRange(631, 635, GT_Recipe.GT_Recipe_Map.sSlicerRecipes);
-
-        // Matter Amplifier
-        registerMapBetweenRange(471, 475, GT_Recipe.GT_Recipe_Map.sAmplifiers);
-
-        // Circuit Assembler
-        registerMapBetweenRange(1180, 1187, GT_Recipe.GT_Recipe_Map.sCircuitAssemblerRecipes);
-
-        // Alloy Smelter
-        registerMapBetweenRange(201, 205, GT_Recipe.GT_Recipe_Map.sAlloySmelterRecipes);
-
-        // Forming Press
-        registerMapBetweenRange(601, 605, GT_Recipe.GT_Recipe_Map.sPressRecipes);
-
-    }
-
-    private static final void registerMapBetweenRange(int aMin, int aMax, GT_Recipe_Map aMap) {
-        for (int i=aMin; i<=aMax;i++) {
-            GT_ProcessingArray_Manager.registerRecipeMapForMeta(i, aMap);
-        }
     }
 }


### PR DESCRIPTION
Changes the code of the Processing array to handle the tiers of the machines using metadata instead of the unlocalized names
Makes it so that the PA gets its recipe maps from the machine's unlocalized name. Tested works with every machine if added in the correct way.