### PR TITLE
Centrifuge Changes

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -8,6 +8,11 @@ dependencies {
     compile("com.github.GTNewHorizons:NotEnoughItems:2.2.20-GTNH:dev")
     compile("com.github.GTNewHorizons:CodeChickenLib:1.1.5.3:dev")
     compile("com.github.GTNewHorizons:waila:1.5.18:dev")
+    compile('com.github.GTNewHorizons:inventory-tweaks:1.5.14:api')
+    compile('com.github.GTNewHorizons:BuildCraft:7.1.27:api')
+    compile('net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev')
+
+    compile('curse.maven:cofh-lib-220333:2388748')
 
     compile("com.github.GTNewHorizons:GTNHLib:0.0.1:dev")
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -8,11 +8,6 @@ dependencies {
     compile("com.github.GTNewHorizons:NotEnoughItems:2.2.20-GTNH:dev")
     compile("com.github.GTNewHorizons:CodeChickenLib:1.1.5.3:dev")
     compile("com.github.GTNewHorizons:waila:1.5.18:dev")
-    compile('com.github.GTNewHorizons:inventory-tweaks:1.5.14:api')
-    compile('com.github.GTNewHorizons:BuildCraft:7.1.27:api')
-    compile('net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev')
-
-    compile('curse.maven:cofh-lib-220333:2388748')
 
     compile("com.github.GTNewHorizons:GTNHLib:0.0.1:dev")
 

--- a/src/main/java/gregtech/common/items/ItemComb.java
+++ b/src/main/java/gregtech/common/items/ItemComb.java
@@ -404,9 +404,9 @@ public class ItemComb extends Item {
             addCentrifugeToItemStack(CombType.SEAWEED, new ItemStack[]{ItemList.FR_Wax.get(1L), GT_ModHandler.getModItem("GalaxySpace", "tcetiedandelions", 1L, 0)}, new int[]{50 * 100, 100 * 100}, Voltage.UV, 100);
         }
 		//Infinity Line
-		addCentrifugeToMaterial(CombType.COSMICNEUTRONIUM, new Materials[] {Materials.CosmicNeutronium, Materials.Neutronium}, new int[] {(int) (0.5 * 100), 1 * 100}, new int[] {}, Voltage.UHV, 12000, NI, 50 * 100);
-		addCentrifugeToMaterial(CombType.INFINITYCATALYST, new Materials[] {Materials.InfinityCatalyst, Materials.Neutronium}, new int[] {(int) (0.05 * 100), 1 * 100}, new int[] {}, Voltage.UEV, 48000, NI, 50 * 100);
-		addCentrifugeToMaterial(CombType.INFINITY, new Materials[] {Materials.Infinity, Materials.InfinityCatalyst}, new int[] {(int) (0.01 * 100), (int) (0.05 * 100)}, new int[] {}, Voltage.UIV, 96000, NI, 50 * 100);
+		addCentrifugeToMaterial(CombType.COSMICNEUTRONIUM, new Materials[] {Materials.CosmicNeutronium, Materials.Neutronium}, new int[] {(int) (15 * 100), 1 * 100}, new int[] {}, Voltage.UHV, 1200, NI, 50 * 100);
+		addCentrifugeToMaterial(CombType.INFINITYCATALYST, new Materials[] {Materials.InfinityCatalyst, Materials.Neutronium}, new int[] {(int) (25 * 100), 20 * 100}, new int[] {}, Voltage.ZPM, 100, NI, 50 * 100);
+		addCentrifugeToMaterial(CombType.INFINITY, new Materials[] {Materials.Infinity, Materials.InfinityCatalyst}, new int[] {(int) (20 * 100), (int) (0.05 * 100)}, new int[] {}, Voltage.UV, 1000, NI, 50 * 100);
 
         //(Noble)gas Line
         addFluidExtractorProcess(CombType.HELIUM, Materials.Helium.getGas(250), Voltage.HV);
@@ -481,7 +481,7 @@ public class ItemComb extends Item {
 	 * @param chance chance to get result, 10000 == 100%
 	 * @param volt required Voltage Tier for this recipe, this also affect the duration, amount of UU-Matter, and needed liquid type and amount for chemical reactor
 	 * @param stackSize This parameter can be null, in that case stack size will be just 1. This handle the stackSize of the resulting Item, and Also the Type of Item. if this value is multiple of 9, than related Material output will be dust, if this value is multiple of 4 than output will be Small dust, else the output will be Tiny dust
-	 * @param beeWax if this is null, than the comb will product default Bee wax. But if aMaterial is more than 5, beeWax will be ignored in Gregtech Centrifuge.
+	 * @param beeWax if this is null, then the comb will product default Bee wax. But if aMaterial is more than 5, beeWax will be ignored in Gregtech Centrifuge.
 	 * @param waxChance have same format like "chance"
 	**/
 	public void addCentrifugeToMaterial(CombType comb, Materials[] aMaterial, int[] chance, int[] stackSize, Voltage volt, ItemStack beeWax, int waxChance) {
@@ -499,9 +499,9 @@ public class ItemComb extends Item {
 			if(Math.max(1, stackSize[i]) % 9 == 0) {
 				aOutPut[i] = GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial[i], (Math.max(1, stackSize[i])/9) );
 			}else if(Math.max(1, stackSize[i]) % 4 == 0) {
-				aOutPut[i] = GT_OreDictUnificator.get(OrePrefixes.dustSmall, aMaterial[i], (Math.max(1, stackSize[i])/4) );
+				aOutPut[i] = GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial[i], (Math.max(1, stackSize[i])/4) );
 			}else {
-				aOutPut[i] = GT_OreDictUnificator.get(OrePrefixes.dustTiny, aMaterial[i], Math.max(1, stackSize[i]));
+				aOutPut[i] = GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial[i], Math.max(1, stackSize[i]));
 			}
 		}
 		if(beeWax != NI) {

--- a/src/main/java/gregtech/common/items/ItemComb.java
+++ b/src/main/java/gregtech/common/items/ItemComb.java
@@ -456,7 +456,7 @@ public class ItemComb extends Item {
                 switch(comb) {
                     case NEUTRONIUM:
                         RA.addAutoclaveRecipe(GT_Utility.copyAmount(9, tComb), GT_Utility.getIntegratedCircuit(i+1), Materials.UUMatter.getFluid(Math.max(1, ((aMaterial[i].getMass()+volt.getUUAmplifier())/10))), GT_OreDictUnificator.get(OrePrefixes.crushedPurified, aMaterial[i], 4), 10000, (int) (aMaterial[i].getMass() * 128), volt.getAutoClaveEnergy(), volt.compareTo(Voltage.HV) > 0);
-                        RA.addChemicalRecipe(GT_Utility.copyAmount(4, tComb), null, volt.getFluidAccordingToCombTier(), Materials.Neutronium.getMolten(576l), Materials.Neutronium.getDustSmall(1), NI, volt.getComplexTime()*17, volt.getChemicalEnergy(), volt.compareTo(Voltage.IV) > 0);
+                        RA.addChemicalRecipe(GT_Utility.copyAmount(4, tComb), null, volt.getFluidAccordingToCombTier(), Materials.Neutronium.getMolten(576l), Materials.Neutronium.getNuggets(1), NI, volt.getComplexTime()*17, volt.getChemicalEnergy(), volt.compareTo(Voltage.IV) > 0);
                     case OSMIUM:
                         RA.addAutoclaveRecipe(GT_Utility.copyAmount(9, tComb), GT_Utility.getIntegratedCircuit(i+1), Materials.UUMatter.getFluid(Math.max(1, ((aMaterial[i].getMass()+volt.getUUAmplifier())/10))), GT_OreDictUnificator.get(OrePrefixes.crushedPurified, aMaterial[i], 4), 10000, (int) (aMaterial[i].getMass() * 128), volt.getAutoClaveEnergy(), volt.compareTo(Voltage.HV) > 0);
                         RA.addChemicalRecipe(GT_Utility.copyAmount(4, tComb), null, volt.getFluidAccordingToCombTier(), Materials.Osmium.getMolten(288l), Materials.Osmium.getNuggets(1), NI, volt.getComplexTime()*17, volt.getChemicalEnergy(), volt.compareTo(Voltage.IV) > 0);


### PR DESCRIPTION
All of the Centrifuge recipes for bees were a joke. Thus, I kept chances and made it output a full dust instead.

Also, Infinity Catalyst, Cosmic Neutronium and Infinity are properly integrated into their respective tiers with better chances.

+ fixed spelling mistake

Example: 
Infinity comb needed 1.375 seconds in apiary for 1 comb and 1 comb would produce 1 tiny pile with 0.01 chance at UIV Voltage needing 4800 seconds.

Now it needs 1375 seconds for 1 comb but produces 1 full dust with 20% chance at 50 seconds UV 