### PR TITLE
fix rare NPE in fluid pipe code

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Fluid.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Fluid.java
@@ -374,6 +374,8 @@ public class GT_MetaPipeEntity_Fluid extends MetaPipeEntity {
             int tFilledAmount = tEntry.left.fill(tEntry.middle, drainFromIndex(tEntry.right, false, index), false);
 
             if (tFilledAmount > 0) tEntry.left.fill(tEntry.middle, drainFromIndex(tFilledAmount, true, index), true);
+
+            if (mFluids[index] == null || mFluids[index].amount <= 0) return;
         }
 
     }


### PR DESCRIPTION
Link to zeta console message: https://discord.com/channels/181078474394566657/523810261753135106/1011169418954420224

Stack trace is

```
! [Mon 09:06:57 WARN ] java.lang.NullPointerException
! [Mon 09:06:57 WARN ]     at ic2.core.block.TileEntityLiquidTankElectricMachine.fill(TileEntityLiquidTankElectricMachine.java:81)
! [Mon 09:06:57 WARN ]     at gregtech.api.metatileentity.implementations.GT_MetaPipeEntity_Fluid.distributeFluid(GT_MetaPipeEntity_Fluid.java:374)
! [Mon 09:06:57 WARN ]     at gregtech.api.metatileentity.implementations.GT_MetaPipeEntity_Fluid.onPostTick(GT_MetaPipeEntity_Fluid.java:275)
! [Mon 09:06:57 WARN ]     at gregtech.api.metatileentity.BaseMetaPipeEntity.func_145845_h(BaseMetaPipeEntity.java:220)
! [Mon 09:06:57 WARN ]     at net.minecraft.world.World.func_72939_s(World.java:2583)
! [Mon 09:06:57 WARN ]     at net.minecraft.world.WorldServer.func_72939_s(WorldServer.java:1542)
! [Mon 09:06:57 WARN ]     at net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:991)
! [Mon 09:06:57 WARN ]     at net.minecraft.server.dedicated.DedicatedServer.func_71190_q(DedicatedServer.java:432)
! [Mon 09:06:57 WARN ]     at net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:846)
! [Mon 09:06:57 WARN ]     at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:698)
! [Mon 09:06:57 WARN ]     at java.lang.Thread.run(Thread.java:748)
```

Server didn't crash due to the catch all clause in BaseMetaPipeEntity.