### PR TITLE
Fix fusion display stuff

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_FusionComputer2.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_FusionComputer2.java
@@ -66,7 +66,7 @@ public class GT_MetaTileEntity_FusionComputer2 extends GT_MetaTileEntity_FusionC
         tt.addMachineType("Fusion Reactor")
                 .addInfo("It's over 9000!!!")
                 .addInfo("Controller block for the Fusion Reactor Mk II")
-                .addInfo("4096EU/t and 20M EU capacity per Energy Hatch")
+                .addInfo("8192EU/t and 20M EU capacity per Energy Hatch")
                 .addInfo("If the recipe has a startup cost greater than the")
                 .addInfo("number of energy hatches * cap, you can't do it")
                 .addSeparator()

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_FusionComputer3.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_FusionComputer3.java
@@ -66,7 +66,7 @@ public class GT_MetaTileEntity_FusionComputer3 extends GT_MetaTileEntity_FusionC
         tt.addMachineType("Fusion Reactor")
                 .addInfo("A SUN DOWN ON EARTH")
                 .addInfo("Controller block for the Fusion Reactor Mk III")
-                .addInfo("8192EU/t and 40M EU capacity per Energy Hatch")
+                .addInfo("32768EU/t and 40M EU capacity per Energy Hatch")
                 .addInfo("If the recipe has a startup cost greater than the")
                 .addInfo("number of energy hatches * cap, you can't do it")
                 .addSeparator()

--- a/src/main/java/gregtech/nei/GT_NEI_DefaultHandler.java
+++ b/src/main/java/gregtech/nei/GT_NEI_DefaultHandler.java
@@ -494,9 +494,11 @@ public class GT_NEI_DefaultHandler extends RecipeMapHandler {
         } else {
             tier = 4;
         }
-        if (Voltage <= 65536) {
+        if (Voltage <= GT_Values.V[6]) {
+            //no-op
+        } else if (Voltage <= GT_Values.V[7]) {
             tier = Math.max(tier, 2);
-        } else if (Voltage <= 131072) {
+        } else if (Voltage <= GT_Values.V[8]) {
             tier = Math.max(tier, 3);
         } else {
             tier = 4;


### PR DESCRIPTION
- Fix all recipes are shown at least mk2
- Adjust NEI controller tier and tooltip values to match new EU/t value introduced in https://github.com/GTNewHorizons/GT5-Unofficial/pull/1181
  - At first I thought I inadvertently buffed some recipes with that change, but I checked all fusion recipes and none of them has tier moved as a result.