### PR TITLE
feat(vent_cover): cool hot-coolant

### DIFF
--- a/src/main/java/gregtech/common/covers/GT_Cover_Vent.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_Vent.java
@@ -4,9 +4,22 @@ import gregtech.api.interfaces.tileentity.ICoverable;
 import gregtech.api.interfaces.tileentity.IMachineProgress;
 import gregtech.api.util.GT_CoverBehavior;
 import gregtech.api.util.GT_Utility;
+import net.minecraft.block.Block;
+import net.minecraft.init.Blocks;
+import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
+import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidRegistry;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.IFluidHandler;
+
+import static gregtech.api.enums.GT_Values.SIDE_UNKNOWN;
+import static gregtech.api.objects.XSTR.XSTR_INSTANCE;
 
 public class GT_Cover_Vent extends GT_CoverBehavior {
     private final int mEfficiency;
+    private final Fluid IC2_HOT_COOLANT = FluidRegistry.getFluid("ic2hotcoolant");
+    private final Fluid IC2_COOLANT = FluidRegistry.getFluid("ic2coolant");
 
     public GT_Cover_Vent(int aEfficiency) {
         this.mEfficiency = aEfficiency;
@@ -19,14 +32,15 @@ public class GT_Cover_Vent extends GT_CoverBehavior {
 
     @Override
     public int doCoverThings(byte aSide, byte aInputRedstone, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
-        if ((aTileEntity instanceof IMachineProgress)) {
-            if ((((IMachineProgress) aTileEntity).hasThingsToDo()) && (aCoverVariable != ((IMachineProgress) aTileEntity).getProgress()) &&
-                    (!GT_Utility.hasBlockHitBox(aTileEntity.getWorld(), aTileEntity.getOffsetX(aSide, 1), aTileEntity.getOffsetY(aSide, 1), aTileEntity.getOffsetZ(aSide, 1)))) {
-                ((IMachineProgress) aTileEntity).increaseProgress(this.mEfficiency);
-            }
-            return ((IMachineProgress) aTileEntity).getProgress();
+        if (aSide == SIDE_UNKNOWN) return 0;
+        int ret = 0;
+        if (aTileEntity instanceof IFluidHandler) {
+            ret = doCoolFluid(aSide, aTileEntity);
         }
-        return 0;
+        if ((aTileEntity instanceof IMachineProgress)) {
+            ret = doProgressEfficiency(aSide, (IMachineProgress) aTileEntity, aCoverID);
+        }
+        return ret;
     }
 
     @Override
@@ -37,5 +51,69 @@ public class GT_Cover_Vent extends GT_CoverBehavior {
     @Override
     public int getTickRate(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity) {
         return 100;
+    }
+
+    protected int doProgressEfficiency(final byte aSide, final IMachineProgress aTileEntity, final int aCoverVariable) {
+        final int offsetX = aTileEntity.getOffsetX(aSide, 1);
+        final int offsetY = aTileEntity.getOffsetY(aSide, 1);
+        final int offsetZ = aTileEntity.getOffsetZ(aSide, 1);
+        final World world = aTileEntity.getWorld();
+        if (aTileEntity.hasThingsToDo()
+                && aCoverVariable != aTileEntity.getProgress()
+                && !GT_Utility.hasBlockHitBox(world, offsetX, offsetY, offsetZ)) {
+            aTileEntity.increaseProgress(this.mEfficiency);
+        }
+        return aTileEntity.getProgress();
+    }
+
+    protected int doCoolFluid(final byte aSide, final ICoverable aTileEntity) {
+        final int offsetX = aTileEntity.getOffsetX(aSide, 1);
+        final int offsetY = aTileEntity.getOffsetY(aSide, 1);
+        final int offsetZ = aTileEntity.getOffsetZ(aSide, 1);
+        final World world = aTileEntity.getWorld();
+        final IFluidHandler fluidHandler = (IFluidHandler) aTileEntity;
+        if (!fluidHandler.canDrain(ForgeDirection.UNKNOWN, IC2_HOT_COOLANT)) {
+            return 0;
+        }
+        final int chances; // 10000 = 100%
+        final Block blockAtSide = aTileEntity.getBlockAtSide(aSide);
+        if (blockAtSide == null) {
+            return 0;
+        }
+        if (blockAtSide == Blocks.water || blockAtSide == Blocks.flowing_water) {
+            switch (mEfficiency) {
+                case 2:
+                    chances = 10000; // 100% chances for Diamond reactor vent with water
+                    break;
+                case 1:
+                    chances = 5000; // 50% chances for Gold and Overclocked reactor vents with water
+                    break;
+                default:
+                    chances = 2500; // 25% chances for Basic reactor vent with water
+                    break;
+            }
+        } else if (blockAtSide.isAir(world, offsetX, offsetY, offsetZ)) {
+            switch (mEfficiency) {
+                case 2:
+                    chances = 2500; // 25% chances for Diamond reactor vent with air
+                    break;
+                case 1:
+                    chances = 1250; // 12.5% chances for Gold and Overclocked reactor vents with air
+                    break;
+                default:
+                    return 0; // Basic reactor vent cannot be used with air
+            }
+        } else {
+            return 0; // Vent cover need water or air
+        }
+        if (chances > XSTR_INSTANCE.nextInt(10000)) {
+            final FluidStack hotFluidStack =
+                    fluidHandler.drain(ForgeDirection.UNKNOWN, Integer.MAX_VALUE, true);
+            final FluidStack coldFluidStack =
+                    new FluidStack(IC2_COOLANT, hotFluidStack.amount);
+            fluidHandler.fill(ForgeDirection.UNKNOWN, coldFluidStack, true);
+            return hotFluidStack.amount;
+        }
+        return 0;
     }
 }


### PR DESCRIPTION
Provides a low tech method to cool down hot-coolant using vent covers.
It is meant for reprocessing hot coolant before having access to
a Large Heat Exchanger or a VacuumFreezer.
The tier of vent cover and the type of air or water in front of it
determines the cooling speed.

Feature preview:

[![Feature preview video](https://user-images.githubusercontent.com/1111474/186532195-77126e74-bfab-4a42-b777-5197775dd089.png)](https://youtu.be/g5a-WuVBqOI)


