### PR TITLE
Add burn time for Diamond in GT way

### DIFF
--- a/src/main/java/gregtech/common/GT_Proxy.java
+++ b/src/main/java/gregtech/common/GT_Proxy.java
@@ -427,6 +427,13 @@ public abstract class GT_Proxy implements IGT_Mod, IGuiHandler, IFuelHandler, IG
         oreDictBurnTimes.put("dustCaesium", 6000);
         oreDictBurnTimes.put("blockLignite", 12000);
         oreDictBurnTimes.put("blockCharcoal", 16000);
+        oreDictBurnTimes.put("gemDiamond", 102400);
+        oreDictBurnTimes.put("blockDiamond", 1024000);
+        oreDictBurnTimes.put("crushedDiamond", 102400);
+        oreDictBurnTimes.put("dustImpureDiamond", 102400);
+        oreDictBurnTimes.put("dustDiamond", 102400);
+        oreDictBurnTimes.put("dustSmallDiamond", 25600);
+        oreDictBurnTimes.put("dustTinyDiamond", 11378);
     }
 
 


### PR DESCRIPTION
This will also give Diamond Dust family a burn time

you can remove [this](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/blob/dab196b9e50dff77b83a7db6cee81453ecfc00b1/config/GTNewHorizons/CustomFuels.xml#L3-L4) by this PR