### PR TITLE
Delegate NEI recipe stack position placement to recipemap instead of recipe itself

### DIFF
--- a/src/main/java/gregtech/api/util/GT_Recipe.java
+++ b/src/main/java/gregtech/api/util/GT_Recipe.java
@@ -555,17 +555,19 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
     }
 
     /**
-     * Overriding this method and getOutputPositionedStacks allows for custom NEI stack placement
-     * @return A list of input stacks
+     * Use {@link GT_Recipe_Map#getInputPositionedStacks(GT_Recipe)} instead
      */
+    @SuppressWarnings("DeprecatedIsStillUsed")
+    @Deprecated
     public ArrayList<PositionedStack> getInputPositionedStacks(){
     	return null;
     }
 
     /**
-     * Overriding this method and getInputPositionedStacks allows for custom NEI stack placement
-     * @return A list of output stacks
+     * Use {@link GT_Recipe_Map#getOutputPositionedStacks(GT_Recipe)} instead
      */
+    @SuppressWarnings("DeprecatedIsStillUsed")
+    @Deprecated
     public ArrayList<PositionedStack> getOutputPositionedStacks(){
     	return null;
     }
@@ -1195,6 +1197,22 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
          */
         public boolean usesSpecialSlot() {
             return mUsesSpecialSlot;
+        }
+
+        /**
+         * Overriding this method and getOutputPositionedStacks allows custom NEI stack placement
+         * @return A list of input stacks
+         */
+        public ArrayList<PositionedStack> getInputPositionedStacks(GT_Recipe recipe){
+            return null;
+        }
+
+        /**
+         * Overriding this method and getInputPositionedStacks allows custom NEI stack placement
+         * @return A list of output stacks
+         */
+        public ArrayList<PositionedStack> getOutputPositionedStacks(GT_Recipe recipe){
+            return null;
         }
 
         public void addRecipe(Object o, FluidStack[] fluidInputArray, FluidStack[] fluidOutputArray) {
@@ -2096,76 +2114,69 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
             aOutputs = adjustedOutputs.toArray(new ItemStack[0]);
             aFluidOutputs = adjustedFluidOutputs.toArray(new FluidStack[0]);
 
-            return addRecipe(new GT_Recipe_LargeChemicalReactor(aOptimize, aInputs, aOutputs, aSpecial, aOutputChances, aFluidInputs, aFluidOutputs, aDuration, aEUt, aSpecialValue));
+            return super.addRecipe(aOptimize, aInputs, aOutputs, aSpecial, aOutputChances, aFluidInputs, aFluidOutputs, aDuration, aEUt, aSpecialValue);
         }
 
-        private static class GT_Recipe_LargeChemicalReactor extends GT_Recipe {
+        @Override
+        public ArrayList<PositionedStack> getInputPositionedStacks(GT_Recipe recipe) {
+            int itemLimit = Math.min(recipe.mInputs.length, TOTAL_INPUT_COUNT);
+            int fluidLimit = Math.min(recipe.mFluidInputs.length, TOTAL_INPUT_COUNT - itemLimit);
+            int inputlimit = itemLimit + fluidLimit;
+            int j = 0;
 
-            protected GT_Recipe_LargeChemicalReactor(boolean aOptimize, ItemStack[] aInputs, ItemStack[] aOutputs, Object aSpecialItems, int[] aChances, FluidStack[] aFluidInputs, FluidStack[] aFluidOutputs, int aDuration, int aEUt, int aSpecialValue) {
-            	super(aOptimize, aInputs, aOutputs, aSpecialItems, aChances, aFluidInputs, aFluidOutputs, aDuration, aEUt, aSpecialValue);
-            }
+            ArrayList<PositionedStack> inputStacks = new ArrayList<>(inputlimit);
 
-			@Override
-			public ArrayList<PositionedStack> getInputPositionedStacks() {
-                int itemLimit = Math.min(mInputs.length, TOTAL_INPUT_COUNT);
-                int fluidLimit = Math.min(mFluidInputs.length, TOTAL_INPUT_COUNT - itemLimit);
-                int inputlimit = itemLimit + fluidLimit;
-                int j = 0;
-
-                ArrayList<PositionedStack> inputStacks = new ArrayList<>(inputlimit);
-
-                for (int i = 0; i < itemLimit; i++, j++) {
-                    if (this.mInputs == null || (this.mInputs[i] == null && (i == 0 && itemLimit == 1))) {
-                        if (this.mOutputs != null && this.mOutputs.length > 0 && this.mOutputs[0] != null)
-                            GT_Log.out.println("recipe " + this + " Output 0:" + this.mOutputs[0].getDisplayName() + " has errored!");
-                        else
-                            GT_Log.out.println("recipe " + this + " has errored!");
-
-                        new Exception("Recipe Fixme").printStackTrace(GT_Log.out);
-                    }
-
-
-                    if ((this.mInputs != null && this.mInputs[i] != null) || !GT_Values.allow_broken_recipemap)
-                        inputStacks.add(new FixedPositionedStack(this.mInputs[i].copy(), 48 - j % 3 * 18, (j >= 3 ? 5 : 23)));
+            for (int i = 0; i < itemLimit; i++, j++) {
+                if (recipe.mInputs == null || (recipe.mInputs[i] == null && (i == 0 && itemLimit == 1))) {
+                    if (recipe.mOutputs != null && recipe.mOutputs.length > 0 && recipe.mOutputs[0] != null)
+                        GT_Log.out.println("recipe " + recipe + " Output 0:" + recipe.mOutputs[0].getDisplayName() + " has errored!");
                     else
-                        inputStacks.add(new FixedPositionedStack(new ItemStack(Items.command_block_minecart), 48 - j % 3 * 18, (j >= 3 ? 5 : 23)));
-				}
+                        GT_Log.out.println("recipe " + recipe + " has errored!");
 
-				for (int i = 0; i < fluidLimit; i++, j++) {
-                    if (this.mFluidInputs == null || this.mFluidInputs[i] == null) {
-                        if (this.mOutputs != null && this.mOutputs.length > 0 && this.mOutputs[0] != null)
-                            GT_Log.out.println("recipe " + this + " Output 0:" + this.mOutputs[0].getDisplayName() + " has errored!");
-                        else
-                            GT_Log.out.println("recipe " + this + " has errored!");
-
-                        new Exception("Recipe Fixme").printStackTrace(GT_Log.out);
-                    }
-
-                    if ((this.mFluidInputs != null && this.mFluidInputs[i] != null) || !GT_Values.allow_broken_recipemap)
-                        inputStacks.add(new FixedPositionedStack(GT_Utility.getFluidDisplayStack(this.mFluidInputs[i], true), 48 - j % 3 * 18, (j >= 3 ? 5 : 23)));
+                    new Exception("Recipe Fixme").printStackTrace(GT_Log.out);
                 }
 
-				return inputStacks;
-			}
 
-			@Override
-			public ArrayList<PositionedStack> getOutputPositionedStacks() {
-                int itemLimit = Math.min(mOutputs.length, OUTPUT_COUNT);
-                int fluidLimit = Math.min(mFluidOutputs.length, FLUID_OUTPUT_COUNT);
-                ArrayList<PositionedStack> outputStacks = new ArrayList<>(itemLimit + fluidLimit);
-
-                int j = 0;
-
-                for (int i = 0; i < itemLimit; i++, j++) {
-                    outputStacks.add(new FixedPositionedStack(this.mOutputs[i].copy(), 102 + j % 3 * 18, (j >= 3 ? 5 : 23)));
-                }
-
-                for (int i = 0; i < fluidLimit; i++, j++) {
-                    outputStacks.add(new FixedPositionedStack(GT_Utility.getFluidDisplayStack(this.mFluidOutputs[i], true), 102 + j % 3 * 18, (j >= 3 ? 5 : 23)));
-                }
-
-                return outputStacks;
+                if ((recipe.mInputs != null && recipe.mInputs[i] != null) || !GT_Values.allow_broken_recipemap)
+                    inputStacks.add(new FixedPositionedStack(recipe.mInputs[i].copy(), 48 - j % 3 * 18, (j >= 3 ? 5 : 23)));
+                else
+                    inputStacks.add(new FixedPositionedStack(new ItemStack(Items.command_block_minecart), 48 - j % 3 * 18, (j >= 3 ? 5 : 23)));
             }
+
+            for (int i = 0; i < fluidLimit; i++, j++) {
+                if (recipe.mFluidInputs == null || recipe.mFluidInputs[i] == null) {
+                    if (recipe.mOutputs != null && recipe.mOutputs.length > 0 && recipe.mOutputs[0] != null)
+                        GT_Log.out.println("recipe " + recipe + " Output 0:" + recipe.mOutputs[0].getDisplayName() + " has errored!");
+                    else
+                        GT_Log.out.println("recipe " + recipe + " has errored!");
+
+                    new Exception("Recipe Fixme").printStackTrace(GT_Log.out);
+                }
+
+                if ((recipe.mFluidInputs != null && recipe.mFluidInputs[i] != null) || !GT_Values.allow_broken_recipemap)
+                    inputStacks.add(new FixedPositionedStack(GT_Utility.getFluidDisplayStack(recipe.mFluidInputs[i], true), 48 - j % 3 * 18, (j >= 3 ? 5 : 23)));
+            }
+
+            return inputStacks;
+        }
+
+        @Override
+        public ArrayList<PositionedStack> getOutputPositionedStacks(GT_Recipe recipe) {
+            int itemLimit = Math.min(recipe.mOutputs.length, OUTPUT_COUNT);
+            int fluidLimit = Math.min(recipe.mFluidOutputs.length, FLUID_OUTPUT_COUNT);
+            ArrayList<PositionedStack> outputStacks = new ArrayList<>(itemLimit + fluidLimit);
+
+            int j = 0;
+
+            for (int i = 0; i < itemLimit; i++, j++) {
+                outputStacks.add(new FixedPositionedStack(recipe.mOutputs[i].copy(), 102 + j % 3 * 18, (j >= 3 ? 5 : 23)));
+            }
+
+            for (int i = 0; i < fluidLimit; i++, j++) {
+                outputStacks.add(new FixedPositionedStack(GT_Utility.getFluidDisplayStack(recipe.mFluidOutputs[i], true), 102 + j % 3 * 18, (j >= 3 ? 5 : 23)));
+            }
+
+            return outputStacks;
         }
     }
     public static class GT_Recipe_Map_DistillationTower extends GT_Recipe_Map {
@@ -2177,78 +2188,61 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
         super(new HashSet<>(110), "gt.recipe.distillationtower", "Distillation Tower", null, RES_PATH_GUI + "basicmachines/DistillationTower", 2, 4, 0, 0, 1, E, 1, E, true, true);
     }
 
-    @Override
-    public GT_Recipe addRecipe(boolean aOptimize, ItemStack[] aInputs, ItemStack[] aOutputs, Object aSpecial, int[] aOutputChances, FluidStack[] aFluidInputs, FluidStack[] aFluidOutputs, int aDuration, int aEUt, int aSpecialValue) {
-        return addRecipe(new GT_Recipe_DistillationTower(aOptimize, aInputs, aOutputs, aSpecial, aOutputChances, aFluidInputs, aFluidOutputs, aDuration, aEUt, aSpecialValue));
-    }
+        @Override
+        public ArrayList<PositionedStack> getInputPositionedStacks(GT_Recipe recipe) {
+            int itemLimit = Math.min(recipe.mInputs.length, TOTAL_INPUT_COUNT);
+            int fluidLimit = Math.min(recipe.mFluidInputs.length, TOTAL_INPUT_COUNT - itemLimit);
+            int inputlimit = itemLimit + fluidLimit;
+            int j = 0;
 
-    @Override
-    public GT_Recipe addRecipe(boolean aOptimize, ItemStack[] aInputs, ItemStack[] aOutputs, Object aSpecial, FluidStack[] aFluidInputs, FluidStack[] aFluidOutputs, int aDuration, int aEUt, int aSpecialValue) {
-   	    return addRecipe(aOptimize, aInputs, aOutputs, aSpecial, null, aFluidInputs, aFluidOutputs, aDuration, aEUt, aSpecialValue);
-   	}
+            ArrayList<PositionedStack> inputStacks = new ArrayList<>(inputlimit);
 
-   	private static class GT_Recipe_DistillationTower extends GT_Recipe{
-   	    protected GT_Recipe_DistillationTower(boolean aOptimize, ItemStack[] aInputs, ItemStack[] aOutputs, Object aSpecialItems, int[] aChances, FluidStack[] aFluidInputs, FluidStack[] aFluidOutputs, int aDuration, int aEUt, int aSpecialValue) {
-   	        super(aOptimize, aInputs, aOutputs, aSpecialItems, aChances, aFluidInputs, aFluidOutputs, aDuration, aEUt, aSpecialValue);
-   	    }
+            for (int i = 0; i < itemLimit; i++, j++) {
+                if (recipe.mInputs == null || (recipe.mInputs[i] == null && (i == 0 && itemLimit == 1))) {
+                    if (recipe.mOutputs != null && recipe.mOutputs.length > 0 && recipe.mOutputs[0] != null)
+                        GT_Log.out.println("recipe " + recipe + " Output 0:" + recipe.mOutputs[0].getDisplayName() + " has errored!");
+                    else
+                        GT_Log.out.println("recipe " + recipe + " has errored!");
+                    new Exception("Recipe Fixme").printStackTrace(GT_Log.out);
+                }
 
-   	    @Override
-        public ArrayList<PositionedStack> getInputPositionedStacks() {
-   	        int itemLimit = Math.min(mInputs.length, TOTAL_INPUT_COUNT);
-   	        int fluidLimit = Math.min(mFluidInputs.length, TOTAL_INPUT_COUNT - itemLimit);
-   	        int inputlimit = itemLimit + fluidLimit;
-   	        int j = 0;
+                if ((recipe.mInputs != null && recipe.mInputs[i] != null) || !GT_Values.allow_broken_recipemap)
+                    inputStacks.add(new FixedPositionedStack(recipe.mInputs[i].copy(), 48 - j % 3 * 18, (j >= 3 ? 5 : 23)));
+                else
+                    inputStacks.add(new FixedPositionedStack(new ItemStack(Items.command_block_minecart), 48 - j % 3 * 18, (j >= 3 ? 5 : 23)));
+            }
 
-   	        ArrayList<PositionedStack> inputStacks = new ArrayList<>(inputlimit);
+            for (int i = 0; i < fluidLimit; i++, j++) {
+                if (recipe.mFluidInputs == null || recipe.mFluidInputs[i] == null) {
+                    if (recipe.mOutputs != null && recipe.mOutputs.length > 0 && recipe.mOutputs[0] != null)
+                        GT_Log.out.println("recipe " + recipe + " Output 0:" + recipe.mOutputs[0].getDisplayName() + " has errored!");
+                    else
+                        GT_Log.out.println("recipe " + recipe + " has errored!");
+                    new Exception("Recipe Fixme").printStackTrace(GT_Log.out);
+                }
 
-   	        for (int i = 0; i < itemLimit; i++, j++) {
-   	            if (this.mInputs == null || (this.mInputs[i] == null && (i == 0 && itemLimit == 1))) {
-   	                if (this.mOutputs != null && this.mOutputs.length > 0 && this.mOutputs[0] != null)
-   	                    GT_Log.out.println("recipe " + this + " Output 0:" + this.mOutputs[0].getDisplayName() + " has errored!");
-   	                else
-   	                    GT_Log.out.println("recipe " + this + " has errored!");
-   	                new Exception("Recipe Fixme").printStackTrace(GT_Log.out);
-   	            }
+                if ((recipe.mFluidInputs != null && recipe.mFluidInputs[i] != null) || !GT_Values.allow_broken_recipemap)
+                    inputStacks.add(new FixedPositionedStack(GT_Utility.getFluidDisplayStack(recipe.mFluidInputs[i], true), 48 - j % 3 * 18, (j >= 3 ? 5 : 23)));
+            }
 
-   	            if ((this.mInputs != null && this.mInputs[i] != null) || !GT_Values.allow_broken_recipemap)
-   	                inputStacks.add(new FixedPositionedStack(this.mInputs[i].copy(), 48 - j % 3 * 18, (j >= 3 ? 5 : 23)));
-   	            else
-   	                inputStacks.add(new FixedPositionedStack(new ItemStack(Items.command_block_minecart), 48 - j % 3 * 18, (j >= 3 ? 5 : 23)));
-   	        }
+            return inputStacks;
+        }
+        @Override
+        public ArrayList<PositionedStack> getOutputPositionedStacks(GT_Recipe recipe) {
+            int fluidLimit = Math.min(recipe.mFluidOutputs.length, FLUID_OUTPUT_COUNT);
+            ArrayList<PositionedStack> outputStacks = new ArrayList<>(1 + fluidLimit);
 
-   	        for (int i = 0; i < fluidLimit; i++, j++) {
-   	            if (this.mFluidInputs == null || this.mFluidInputs[i] == null) {
-   	                if (this.mOutputs != null && this.mOutputs.length > 0 && this.mOutputs[0] != null)
-   	                    GT_Log.out.println("recipe " + this + " Output 0:" + this.mOutputs[0].getDisplayName() + " has errored!");
-   	                else
-   	                    GT_Log.out.println("recipe " + this + " has errored!");
-   	                new Exception("Recipe Fixme").printStackTrace(GT_Log.out);
-   	            }
+            if (recipe.mOutputs.length > 0 && recipe.mOutputs[0] != null) {
+                outputStacks.add(new FixedPositionedStack(recipe.getOutput(0), 102, 52));
+            }
 
-   	            if ((this.mFluidInputs != null && this.mFluidInputs[i] != null) || !GT_Values.allow_broken_recipemap)
-   	                inputStacks.add(new FixedPositionedStack(GT_Utility.getFluidDisplayStack(this.mFluidInputs[i], true), 48 - j % 3 * 18, (j >= 3 ? 5 : 23)));
-   	        }
-
-   	        return inputStacks;
-   	    }
-   	    @Override
-        public ArrayList<PositionedStack> getOutputPositionedStacks() {
-   	        int fluidLimit = Math.min(mFluidOutputs.length, FLUID_OUTPUT_COUNT);
-   	        ArrayList<PositionedStack> outputStacks = new ArrayList<>(1 + fluidLimit);
-
-   	        if (this.mOutputs.length > 0 && this.mOutputs[0] != null) {
-   	            outputStacks.add(new FixedPositionedStack(this.getOutput(0), 102, 52));
-   	        }
-
-   	        for (int i = 0; i < fluidLimit; i++) {
-   	            int x = 102 + ((i + 1) % ROW_SIZE) * 18;
-   	            int y =  52 - ((i + 1) / ROW_SIZE) * 18;
-   	            outputStacks.add(new FixedPositionedStack(GT_Utility.getFluidDisplayStack(this.mFluidOutputs[i], true), x, y));
-   	        }
-   	        return outputStacks;
-   	    }
-
-   	}
+            for (int i = 0; i < fluidLimit; i++) {
+                int x = 102 + ((i + 1) % ROW_SIZE) * 18;
+                int y =  52 - ((i + 1) / ROW_SIZE) * 18;
+                outputStacks.add(new FixedPositionedStack(GT_Utility.getFluidDisplayStack(recipe.mFluidOutputs[i], true), x, y));
+            }
+            return outputStacks;
+        }
     }
 
     public static class GT_Recipe_Map_OilCracker extends GT_Recipe_Map {
@@ -2330,56 +2324,42 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
         }
 
         @Override
-        public GT_Recipe addRecipe(boolean aOptimize, ItemStack[] aInputs, ItemStack[] aOutputs, Object aSpecial, int[] aOutputChances, FluidStack[] aFluidInputs, FluidStack[] aFluidOutputs, int aDuration, int aEUt, int aSpecialValue) {
-            return addRecipe(new GT_Recipe_PlasmaForge(aOptimize, aInputs, aOutputs, aSpecial, aOutputChances, aFluidInputs, aFluidOutputs, aDuration, aEUt, aSpecialValue));
+        public ArrayList<PositionedStack> getInputPositionedStacks(GT_Recipe recipe) {
+            ArrayList<PositionedStack> inputStacks = new ArrayList<>();
+            int i = 0;
+            if (recipe.mInputs != null) {
+                for (int j = 0; j < recipe.mInputs.length; j ++, i ++) {
+                    if (recipe.mInputs[j] == NI) continue;
+                    inputStacks.add(new FixedPositionedStack(recipe.mInputs[j].copy(), 12 + 18 * (i % 3), 5 + 18 * (i / 3)));
+                }
+            }
+            if (recipe.mFluidInputs != null) {
+                for (int j = 0; j < recipe.mFluidInputs.length; j ++, i ++) {
+                    if (recipe.mFluidInputs[j] == NF) continue;
+                    inputStacks.add(new FixedPositionedStack(GT_Utility.getFluidDisplayStack(recipe.mFluidInputs[j], true), 12 + 18 * (i % 3), 5 + 18 * (i / 3)));
+                }
+            }
+            return inputStacks;
         }
 
-        private static class GT_Recipe_PlasmaForge extends GT_Recipe {
-
-            public GT_Recipe_PlasmaForge(boolean aOptimize, ItemStack[] aInputs, ItemStack[] aOutputs, Object aSpecialItems, int[] aChances, FluidStack[] aFluidInputs, FluidStack[] aFluidOutputs, int aDuration, int aEUt, int aSpecialValue) {
-                super(aOptimize, aInputs, aOutputs, aSpecialItems, aChances, aFluidInputs, aFluidOutputs, aDuration, aEUt, aSpecialValue);
+        @Override
+        public ArrayList<PositionedStack> getOutputPositionedStacks(GT_Recipe recipe) {
+            ArrayList<PositionedStack> outputStacks = new ArrayList<>();
+            int i = 0;
+            if (recipe.mOutputs != null) {
+                for (int j = 0; j < recipe.mOutputs.length; j ++, i ++) {
+                    if (recipe.mOutputs[j] == NI) continue;
+                    outputStacks.add(new FixedPositionedStack(recipe.mOutputs[j].copy(), 102 + 18 * (i % 3), 5 + 18 * (i / 3)));
+                }
             }
-
-            @Override
-            public ArrayList<PositionedStack> getInputPositionedStacks() {
-                ArrayList<PositionedStack> inputStacks = new ArrayList<>();
-                int i = 0;
-                if (mInputs != null) {
-                    for (int j = 0; j < mInputs.length; j ++, i ++) {
-                        if (mInputs[j] == NI) continue;
-                        inputStacks.add(new FixedPositionedStack(mInputs[j].copy(), 12 + 18 * (i % 3), 5 + 18 * (i / 3)));
-                    }
+            if (recipe.mFluidOutputs != null) {
+                for (int j = 0; j < recipe.mFluidOutputs.length; j ++, i ++) {
+                    if (recipe.mFluidOutputs[j] == NF) continue;
+                    outputStacks.add(new FixedPositionedStack(GT_Utility.getFluidDisplayStack(recipe.mFluidOutputs[j], true), 102 + 18 * (i % 3), 5 + 18 * (i / 3)));
                 }
-                if (mFluidInputs != null) {
-                    for (int j = 0; j < mFluidInputs.length; j ++, i ++) {
-                        if (mFluidInputs[j] == NF) continue;
-                        inputStacks.add(new FixedPositionedStack(GT_Utility.getFluidDisplayStack(mFluidInputs[j], true), 12 + 18 * (i % 3), 5 + 18 * (i / 3)));
-                    }
-                }
-                return inputStacks;
             }
-
-            @Override
-            public ArrayList<PositionedStack> getOutputPositionedStacks() {
-                ArrayList<PositionedStack> outputStacks = new ArrayList<>();
-                int i = 0;
-                if (mOutputs != null) {
-                    for (int j = 0; j < mOutputs.length; j ++, i ++) {
-                        if (mOutputs[j] == NI) continue;
-                        outputStacks.add(new FixedPositionedStack(mOutputs[j].copy(), 102 + 18 * (i % 3), 5 + 18 * (i / 3)));
-                    }
-                }
-                if (mFluidOutputs != null) {
-                    for (int j = 0; j < mFluidOutputs.length; j ++, i ++) {
-                        if (mFluidOutputs[j] == NF) continue;
-                        outputStacks.add(new FixedPositionedStack(GT_Utility.getFluidDisplayStack(mFluidOutputs[j], true), 102 + 18 * (i % 3), 5 + 18 * (i / 3)));
-                    }
-                }
-                return outputStacks;
-            }
-
+            return outputStacks;
         }
-
     }
 
     public static class GT_Recipe_Map_ComplexFusion extends GT_Recipe_Map {
@@ -2390,43 +2370,34 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
 
         @Override
         public GT_Recipe addRecipe(int[] aOutputChances, FluidStack[] aFluidInputs, FluidStack[] aFluidOutputs, int aDuration, int aEUt, int aSpecialValue) {
-            return addRecipe(new GT_Recipe_ComplexFusion(false, null, null, null, aOutputChances, aFluidInputs, aFluidOutputs, aDuration, aEUt, aSpecialValue), false, false, false);
+            return addRecipe(new GT_Recipe(false, null, null, null, aOutputChances, aFluidInputs, aFluidOutputs, aDuration, aEUt, aSpecialValue), false, false, false);
         }
 
-        private static class GT_Recipe_ComplexFusion extends GT_Recipe {
-
-            public GT_Recipe_ComplexFusion(boolean aOptimize, ItemStack[] aInputs, ItemStack[] aOutputs, Object aSpecialItems, int[] aChances, FluidStack[] aFluidInputs, FluidStack[] aFluidOutputs, int aDuration, int aEUt, int aSpecialValue) {
-                super(aOptimize, aInputs, aOutputs, aSpecialItems, aChances, aFluidInputs, aFluidOutputs, aDuration, aEUt, aSpecialValue);
-            }
-
-            @Override
-            public ArrayList<PositionedStack> getInputPositionedStacks() {
-                ArrayList<PositionedStack> inputStacks = new ArrayList<>();
-                int i = 0;
-                if (mFluidInputs != null) {
-                    for (int j = 0; j < mFluidInputs.length; j ++, i ++) {
-                        if (mFluidInputs[j] == NF) continue;
-                        inputStacks.add(new FixedPositionedStack(GT_Utility.getFluidDisplayStack(mFluidInputs[j], true), 3 + 18 * (i % 4), -1 + 18 * (i / 4)));
-                    }
+        @Override
+        public ArrayList<PositionedStack> getInputPositionedStacks(GT_Recipe recipe) {
+            ArrayList<PositionedStack> inputStacks = new ArrayList<>();
+            int i = 0;
+            if (recipe.mFluidInputs != null) {
+                for (int j = 0; j < recipe.mFluidInputs.length; j ++, i ++) {
+                    if (recipe.mFluidInputs[j] == NF) continue;
+                    inputStacks.add(new FixedPositionedStack(GT_Utility.getFluidDisplayStack(recipe.mFluidInputs[j], true), 3 + 18 * (i % 4), -1 + 18 * (i / 4)));
                 }
-                return inputStacks;
             }
-
-            @Override
-            public ArrayList<PositionedStack> getOutputPositionedStacks() {
-                ArrayList<PositionedStack> outputStacks = new ArrayList<>();
-                int i = 0;
-                if (mFluidOutputs != null) {
-                    for (int j = 0; j < mFluidOutputs.length; j ++, i ++) {
-                        if (mFluidOutputs[j] == NF) continue;
-                        outputStacks.add(new FixedPositionedStack(GT_Utility.getFluidDisplayStack(mFluidOutputs[j], true), 93 + 18 * (i % 4), -1 + 18 * (i / 4)));
-                    }
-                }
-                return outputStacks;
-            }
-
+            return inputStacks;
         }
 
+        @Override
+        public ArrayList<PositionedStack> getOutputPositionedStacks(GT_Recipe recipe) {
+            ArrayList<PositionedStack> outputStacks = new ArrayList<>();
+            int i = 0;
+            if (recipe.mFluidOutputs != null) {
+                for (int j = 0; j < recipe.mFluidOutputs.length; j ++, i ++) {
+                    if (recipe.mFluidOutputs[j] == NF) continue;
+                    outputStacks.add(new FixedPositionedStack(GT_Utility.getFluidDisplayStack(recipe.mFluidOutputs[j], true), 93 + 18 * (i % 4), -1 + 18 * (i / 4)));
+                }
+            }
+            return outputStacks;
+        }
     }
 
 }

--- a/src/main/java/gregtech/common/GT_RecipeAdder.java
+++ b/src/main/java/gregtech/common/GT_RecipeAdder.java
@@ -13,6 +13,7 @@ import gregtech.api.objects.GT_FluidStack;
 import gregtech.api.objects.ItemData;
 import gregtech.api.util.*;
 import gregtech.api.util.GT_Recipe.GT_Recipe_AssemblyLine;
+import gregtech.api.util.extensions.ArrayExt;
 import gregtech.common.items.GT_IntegratedCircuit_Item;
 import mods.railcraft.common.blocks.aesthetics.cube.EnumCube;
 import mods.railcraft.common.items.RailcraftToolItems;
@@ -186,7 +187,7 @@ public class GT_RecipeAdder implements IGT_RecipeAdder {
         GT_Recipe.GT_Recipe_Map.sChemicalRecipes.addRecipe(true, new ItemStack[]{aInput1, aInput2}, new ItemStack[]{aOutput, aOutput2}, null, null, new FluidStack[]{aFluidInput}, new FluidStack[]{aFluidOutput}, aDuration, aEUtick, aCleanroom ? -200 : 0);
         if (!(aInput1 != null && aInput1.getItem() instanceof GT_IntegratedCircuit_Item && aInput1.getItemDamage() >= 10)
                 && !(aInput2 != null && aInput2.getItem() instanceof GT_IntegratedCircuit_Item && aInput2.getItemDamage() >= 10)) {
-            GT_Recipe.GT_Recipe_Map.sMultiblockChemicalRecipes.addRecipe(false, new ItemStack[]{aInput1, aInput2}, new ItemStack[]{aOutput, aOutput2}, null, null, new FluidStack[]{aFluidInput}, new FluidStack[]{aFluidOutput}, aDuration, aEUtick, 0);
+            GT_Recipe.GT_Recipe_Map.sMultiblockChemicalRecipes.addRecipe(false, ArrayExt.withoutNulls(new ItemStack[]{aInput1, aInput2}, ItemStack[]::new), ArrayExt.withoutNulls(new ItemStack[]{aOutput, aOutput2}, ItemStack[]::new), null, null, new FluidStack[]{aFluidInput}, new FluidStack[]{aFluidOutput}, aDuration, aEUtick, 0);
         }
         return true;
     }

--- a/src/main/java/gregtech/common/GT_RecipeAdder.java
+++ b/src/main/java/gregtech/common/GT_RecipeAdder.java
@@ -13,7 +13,6 @@ import gregtech.api.objects.GT_FluidStack;
 import gregtech.api.objects.ItemData;
 import gregtech.api.util.*;
 import gregtech.api.util.GT_Recipe.GT_Recipe_AssemblyLine;
-import gregtech.api.util.extensions.ArrayExt;
 import gregtech.common.items.GT_IntegratedCircuit_Item;
 import mods.railcraft.common.blocks.aesthetics.cube.EnumCube;
 import mods.railcraft.common.items.RailcraftToolItems;
@@ -187,7 +186,7 @@ public class GT_RecipeAdder implements IGT_RecipeAdder {
         GT_Recipe.GT_Recipe_Map.sChemicalRecipes.addRecipe(true, new ItemStack[]{aInput1, aInput2}, new ItemStack[]{aOutput, aOutput2}, null, null, new FluidStack[]{aFluidInput}, new FluidStack[]{aFluidOutput}, aDuration, aEUtick, aCleanroom ? -200 : 0);
         if (!(aInput1 != null && aInput1.getItem() instanceof GT_IntegratedCircuit_Item && aInput1.getItemDamage() >= 10)
                 && !(aInput2 != null && aInput2.getItem() instanceof GT_IntegratedCircuit_Item && aInput2.getItemDamage() >= 10)) {
-            GT_Recipe.GT_Recipe_Map.sMultiblockChemicalRecipes.addRecipe(false, ArrayExt.withoutNulls(new ItemStack[]{aInput1, aInput2}, ItemStack[]::new), ArrayExt.withoutNulls(new ItemStack[]{aOutput, aOutput2}, ItemStack[]::new), null, null, new FluidStack[]{aFluidInput}, new FluidStack[]{aFluidOutput}, aDuration, aEUtick, 0);
+            GT_Recipe.GT_Recipe_Map.sMultiblockChemicalRecipes.addRecipe(false, new ItemStack[]{aInput1, aInput2}, new ItemStack[]{aOutput, aOutput2}, null, null, new FluidStack[]{aFluidInput}, new FluidStack[]{aFluidOutput}, aDuration, aEUtick, 0);
         }
         return true;
     }

--- a/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
@@ -1418,7 +1418,7 @@ public class GT_MachineRecipeLoader implements Runnable {
         //4HSiCl3 = 3SiCl4 + SiH4
         GT_Values.RA.addChemicalRecipe(ItemList.Cell_Empty.get(1L), GT_Utility.getIntegratedCircuit(2), Materials.Trichlorosilane.getFluid(4000), Materials.SiliconTetrachloride.getFluid(3000), GT_OreDictUnificator.get(OrePrefixes.cell, Materials.Silane, 1), 240, 30);
         //SiH4 = Si + 4H
-        GT_Values.RA.addChemicalRecipe(GT_Values.NI, GT_Utility.getIntegratedCircuit(1), Materials.Silane.getGas(1000), Materials.Hydrogen.getGas(4000), GT_OreDictUnificator.get(OrePrefixes.dust, Materials.SiliconSG, 1), 300, 30);
+        GT_Values.RA.addChemicalRecipe(GT_Utility.getIntegratedCircuit(1), GT_Values.NI, Materials.Silane.getGas(1000), Materials.Hydrogen.getGas(4000), GT_OreDictUnificator.get(OrePrefixes.dust, Materials.SiliconSG, 1), 300, 30);
         GT_Values.RA.addChemicalRecipeForBasicMachineOnly(GT_OreDictUnificator.get(OrePrefixes.cell, Materials.Silane, 1), GT_Utility.getIntegratedCircuit(1), GT_Values.NF, Materials.Hydrogen.getGas(4000), GT_OreDictUnificator.get(OrePrefixes.dust, Materials.SiliconSG, 1), ItemList.Cell_Empty.get(1L),300, 30);
         GT_Values.RA.addChemicalRecipeForBasicMachineOnly(GT_OreDictUnificator.get(OrePrefixes.cell, Materials.Silane, 1), ItemList.Cell_Empty.get(3L), GT_Values.NF, GT_Values.NF, GT_OreDictUnificator.get(OrePrefixes.dust, Materials.SiliconSG, 1), GT_OreDictUnificator.get(OrePrefixes.cell, Materials.Hydrogen, 4),300, 30);
         //Ca + 2H = CaH2

--- a/src/main/java/gregtech/nei/GT_NEI_DefaultHandler.java
+++ b/src/main/java/gregtech/nei/GT_NEI_DefaultHandler.java
@@ -771,11 +771,33 @@ public class GT_NEI_DefaultHandler extends RecipeMapHandler {
             }
         }
 
+        @SuppressWarnings("deprecation")
         public CachedDefaultRecipe(GT_Recipe aRecipe) {
             super();
             this.mRecipe = aRecipe;
             List<PositionedStack> maybeIn;
             List<PositionedStack> maybeOut;
+
+            try {
+                maybeIn = GT_NEI_DefaultHandler.this.mRecipeMap.getInputPositionedStacks(aRecipe);
+            } catch (NullPointerException npe) {
+                maybeIn = null;
+                GT_Log.err.println("CachedDefaultRecipe - Invalid InputPositionedStacks " + aRecipe);
+                npe.printStackTrace(GT_Log.err);
+            }
+            try {
+                maybeOut = GT_NEI_DefaultHandler.this.mRecipeMap.getOutputPositionedStacks(aRecipe);
+            } catch (NullPointerException npe) {
+                maybeOut = null;
+                GT_Log.err.println("CachedDefaultRecipe - Invalid OutputPositionedStacks " + aRecipe);
+                npe.printStackTrace(GT_Log.err);
+            }
+
+            if (maybeOut != null && maybeIn != null) {
+                mOutputs = maybeOut;
+                mInputs = maybeIn;
+                return;
+            }
 
             try {
                 maybeIn = aRecipe.getInputPositionedStacks();


### PR DESCRIPTION
When someone add recipe via `addRecipe(GT_Recipe)` instead of recipe adder methods, stack positions can be broken, because stack positions are handled by specific recipe class rather than recipemap. This PR fixes the situation.

Also fixes stack positions of Silicon SG LCR recipe are broken, because of `GT_Recipe` removing only trailing nulls, resulting to internal NPE.

before:
![2022-08-27_13 18 49](https://user-images.githubusercontent.com/40035906/187015695-721a64f8-17b8-4e7c-beb0-588a9148cba3.png)
after:
![2022-08-27_13 29 36](https://user-images.githubusercontent.com/40035906/187015701-d2db046e-1085-4c4c-944f-d51c42232b5e.png)

