### PR TITLE
clean up output hatch lock code

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_Output.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_Output.java
@@ -8,9 +8,11 @@ import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.render.TextureFactory;
+import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_Utility;
 import gregtech.common.gui.GT_Container_OutputHatch;
 import gregtech.common.gui.GT_GUIContainer_OutputHatch;
+import java.lang.ref.WeakReference;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.item.ItemStack;
@@ -22,7 +24,7 @@ import net.minecraftforge.fluids.*;
 
 public class GT_MetaTileEntity_Hatch_Output extends GT_MetaTileEntity_Hatch {
     private String lockedFluidName = null;
-    private EntityPlayer playerThatLockedfluid = null;
+    private WeakReference<EntityPlayer> playerThatLockedfluid = null;
     public byte mMode = 0;
 
     public GT_MetaTileEntity_Hatch_Output(int aID, String aName, String aNameRegional, int aTier) {
@@ -263,7 +265,7 @@ public class GT_MetaTileEntity_Hatch_Output extends GT_MetaTileEntity_Hatch {
                 this.setLockedFluidName(null);
                 break;
             case 8:
-                playerThatLockedfluid = aPlayer;
+                playerThatLockedfluid = new WeakReference<>(aPlayer);
                 if (mFluid == null) {
                     this.setLockedFluidName(null);
                     inBrackets = GT_Utility.trans(
@@ -280,7 +282,7 @@ public class GT_MetaTileEntity_Hatch_Output extends GT_MetaTileEntity_Hatch {
                                 GT_Utility.trans("151.1", "Outputs items and 1 specific Fluid"), inBrackets));
                 break;
             case 9:
-                playerThatLockedfluid = aPlayer;
+                playerThatLockedfluid = new WeakReference<>(aPlayer);
                 if (mFluid == null) {
                     this.setLockedFluidName(null);
                     inBrackets = GT_Utility.trans(
@@ -378,6 +380,15 @@ public class GT_MetaTileEntity_Hatch_Output extends GT_MetaTileEntity_Hatch {
         this.lockedFluidName = lockedFluidName;
     }
 
+    public boolean canStoreFluid(Fluid fluid) {
+        if (isFluidLocked()) {
+            if (lockedFluidName == null) return true;
+            return lockedFluidName.equals(fluid.getName());
+        }
+        if (GT_ModHandler.isSteam(new FluidStack(fluid, 0))) return outputsSteam();
+        return outputsLiquids();
+    }
+
     @Override
     public int getTankPressure() {
         return +100;
@@ -385,12 +396,15 @@ public class GT_MetaTileEntity_Hatch_Output extends GT_MetaTileEntity_Hatch {
 
     @Override
     protected void onEmptyingContainerWhenEmpty() {
-        if (this.lockedFluidName == null && this.mFluid != null) {
+        if (this.lockedFluidName == null && this.mFluid != null && isFluidLocked()) {
             this.setLockedFluidName(this.mFluid.getFluid().getName());
+            EntityPlayer player;
+            if (playerThatLockedfluid == null || (player = playerThatLockedfluid.get()) == null) return;
             GT_Utility.sendChatToPlayer(
-                    playerThatLockedfluid,
+                    player,
                     String.format(
                             GT_Utility.trans("151.4", "Sucessfully locked Fluid to %s"), mFluid.getLocalizedName()));
+            playerThatLockedfluid = null;
         }
     }
 

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
@@ -17,7 +17,6 @@ import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.objects.GT_ItemStack;
 import gregtech.api.util.GT_ExoticEnergyInputHelper;
 import gregtech.api.util.GT_Log;
-import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_Recipe.GT_Recipe_Map;
 import gregtech.api.util.GT_Single_Recipe_Check;
 import gregtech.api.util.GT_Utility;
@@ -795,21 +794,7 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity {
             if (!isValidMetaTileEntity(tHatch) || (restrictiveHatchesOnly && tHatch.mMode == 0)) {
                 continue;
             }
-            if (GT_ModHandler.isSteam(copiedFluidStack)) {
-                if (!tHatch.outputsSteam()) {
-                    continue;
-                }
-            } else {
-                if (!tHatch.outputsLiquids()) {
-                    continue;
-                }
-                if (tHatch.isFluidLocked()
-                        && tHatch.getLockedFluidName() != null
-                        && !tHatch.getLockedFluidName()
-                                .equals(copiedFluidStack.getFluid().getName())) {
-                    continue;
-                }
-            }
+            if (!tHatch.canStoreFluid(copiedFluidStack.getFluid())) continue;
             int tAmount = tHatch.fill(copiedFluidStack, false);
             if (tAmount >= copiedFluidStack.amount) {
                 boolean filled = tHatch.fill(copiedFluidStack, true) >= copiedFluidStack.amount;


### PR DESCRIPTION
1. Store player as weak reference to prevent memory leak
2. Only set locked fluid name when we are in locking mode (this was why GT++ canBufferOutput breaks in the first place)
3. Expose an API to check if fluid is accepted. 
