### PR TITLE
Super Tank Fluid Locking Fix

### DIFF
--- a/src/main/java/gregtech/api/gui/GT_Container.java
+++ b/src/main/java/gregtech/api/gui/GT_Container.java
@@ -670,6 +670,7 @@ public class GT_Container extends Container {
             }
             replaceCursorItemStack(aPlayer, tFilledContainer);
         }
+        aFluidAccess.verifyFluidStack();
         return tFilledContainer;
     }
 

--- a/src/main/java/gregtech/api/gui/GT_Container_BasicTank.java
+++ b/src/main/java/gregtech/api/gui/GT_Container_BasicTank.java
@@ -119,7 +119,7 @@ public class GT_Container_BasicTank extends GT_ContainerMetaTile_Machine {
         public void set(FluidStack stack) {
             if (mIsFillableStack) mTank.setFillableStack(stack);
             else mTank.setDrainableStack(stack);
-            if(mTank instanceof GT_MetaTileEntity_DigitalTankBase)
+            if (mTank instanceof GT_MetaTileEntity_DigitalTankBase)
                 ((GT_MetaTileEntity_DigitalTankBase) mTank).onEmptyingContainerWhenEmpty();
         }
 
@@ -146,7 +146,7 @@ public class GT_Container_BasicTank extends GT_ContainerMetaTile_Machine {
         }
 
         @Override
-        public void verifyFluidStack(){
+        public void verifyFluidStack() {
             if (!(mTank instanceof GT_MetaTileEntity_DigitalTankBase) && get().amount <= 0) set(null);
         }
     }

--- a/src/main/java/gregtech/api/gui/GT_Container_BasicTank.java
+++ b/src/main/java/gregtech/api/gui/GT_Container_BasicTank.java
@@ -147,7 +147,7 @@ public class GT_Container_BasicTank extends GT_ContainerMetaTile_Machine {
 
         @Override
         public void verifyFluidStack() {
-            if (!(mTank instanceof GT_MetaTileEntity_DigitalTankBase) && get().amount <= 0) set(null);
+            if (!(mTank instanceof GT_MetaTileEntity_DigitalTankBase) && get() != null && get().amount <= 0) set(null);
         }
     }
 }

--- a/src/main/java/gregtech/api/gui/GT_Container_BasicTank.java
+++ b/src/main/java/gregtech/api/gui/GT_Container_BasicTank.java
@@ -119,6 +119,8 @@ public class GT_Container_BasicTank extends GT_ContainerMetaTile_Machine {
         public void set(FluidStack stack) {
             if (mIsFillableStack) mTank.setFillableStack(stack);
             else mTank.setDrainableStack(stack);
+            if(mTank instanceof GT_MetaTileEntity_DigitalTankBase)
+                ((GT_MetaTileEntity_DigitalTankBase) mTank).onEmptyingContainerWhenEmpty();
         }
 
         @Override
@@ -141,6 +143,11 @@ public class GT_Container_BasicTank extends GT_ContainerMetaTile_Machine {
 
         static BasicTankFluidAccess from(GT_MetaTileEntity_BasicTank aTank, boolean aIsFillableStack) {
             return new BasicTankFluidAccess(aTank, aIsFillableStack);
+        }
+
+        @Override
+        public void verifyFluidStack(){
+            if (!(mTank instanceof GT_MetaTileEntity_DigitalTankBase) && get().amount <= 0) set(null);
         }
     }
 }

--- a/src/main/java/gregtech/api/interfaces/IFluidAccess.java
+++ b/src/main/java/gregtech/api/interfaces/IFluidAccess.java
@@ -21,6 +21,6 @@ public interface IFluidAccess {
     }
 
     default void verifyFluidStack() {
-        if (get().amount <= 0) set(null);
+        if (get() != null && get().amount <= 0) set(null);
     }
 }

--- a/src/main/java/gregtech/api/interfaces/IFluidAccess.java
+++ b/src/main/java/gregtech/api/interfaces/IFluidAccess.java
@@ -20,7 +20,7 @@ public interface IFluidAccess {
         }
     }
 
-    default void verifyFluidStack(){
+    default void verifyFluidStack() {
         if (get().amount <= 0) set(null);
     }
 }

--- a/src/main/java/gregtech/api/interfaces/IFluidAccess.java
+++ b/src/main/java/gregtech/api/interfaces/IFluidAccess.java
@@ -19,4 +19,8 @@ public interface IFluidAccess {
             get().amount = Math.min(get().amount + amount, getRealCapacity());
         }
     }
+
+    default void verifyFluidStack(){
+        if (get().amount <= 0) set(null);
+    }
 }


### PR DESCRIPTION
This PR (should) fix:

・Machines other than Super Tanks leaves empty fluid in output slot
・Super Tank does not lock fluid when player clicks the fluid slot with containers

Please work