### PR TITLE
Add Drag-And-Drop support for digital tank

### DIFF
--- a/src/main/java/gregtech/api/gui/GT_Container_BasicMachine.java
+++ b/src/main/java/gregtech/api/gui/GT_Container_BasicMachine.java
@@ -4,6 +4,7 @@ import static gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Basi
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import gregtech.api.interfaces.IFluidAccess;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_BasicMachine;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_BasicTank;
@@ -221,7 +222,7 @@ public class GT_Container_BasicMachine extends GT_Container_BasicTank {
                         tTank.setFillableStack(GT_Utility.getFluidFromDisplayStack(tTank.getStackInSlot(2)));
                     }
                     GT_MetaTileEntity_BasicTank tTank = (GT_MetaTileEntity_BasicTank) mTileEntity.getMetaTileEntity();
-                    BasicTankFluidAccess tFillableAccess = BasicTankFluidAccess.from(tTank, true);
+                    IFluidAccess tFillableAccess = constructFluidAccess(tTank, true);
                     GT_Recipe_Map recipes = machine.getRecipeList();
                     // If the  machine has recipes but no fluid inputs, disallow filling this slot with fluids.
                     ItemStack tToken = handleFluidSlotClick(

--- a/src/main/java/gregtech/api/gui/GT_Container_BasicTank.java
+++ b/src/main/java/gregtech/api/gui/GT_Container_BasicTank.java
@@ -54,7 +54,7 @@ public class GT_Container_BasicTank extends GT_ContainerMetaTile_Machine {
                 tTank.setDrainableStack(GT_Utility.getFluidFromDisplayStack(tTank.getStackInSlot(2)));
             }
             GT_MetaTileEntity_BasicTank tTank = (GT_MetaTileEntity_BasicTank) mTileEntity.getMetaTileEntity();
-            BasicTankFluidAccess tDrainableAccess = BasicTankFluidAccess.from(tTank, false);
+            IFluidAccess tDrainableAccess = constructFluidAccess(tTank, false);
             return handleFluidSlotClick(
                     tDrainableAccess, aPlayer, aMouseclick == 0, true, !tTank.isDrainableStackSeparate());
         }
@@ -106,9 +106,13 @@ public class GT_Container_BasicTank extends GT_ContainerMetaTile_Machine {
         return 1;
     }
 
+    protected IFluidAccess constructFluidAccess(GT_MetaTileEntity_BasicTank aTank, boolean aIsFillableStack) {
+        return new BasicTankFluidAccess(aTank, aIsFillableStack);
+    }
+
     static class BasicTankFluidAccess implements IFluidAccess {
-        private final GT_MetaTileEntity_BasicTank mTank;
-        private final boolean mIsFillableStack;
+        protected final GT_MetaTileEntity_BasicTank mTank;
+        protected final boolean mIsFillableStack;
 
         public BasicTankFluidAccess(GT_MetaTileEntity_BasicTank aTank, boolean aIsFillableStack) {
             this.mTank = aTank;
@@ -131,23 +135,6 @@ public class GT_Container_BasicTank extends GT_ContainerMetaTile_Machine {
         @Override
         public int getCapacity() {
             return mTank.getCapacity();
-        }
-
-        @Override
-        public int getRealCapacity() {
-            if (mTank instanceof GT_MetaTileEntity_DigitalTankBase) {
-                return ((GT_MetaTileEntity_DigitalTankBase) mTank).getRealCapacity();
-            }
-            return IFluidAccess.super.getRealCapacity();
-        }
-
-        static BasicTankFluidAccess from(GT_MetaTileEntity_BasicTank aTank, boolean aIsFillableStack) {
-            return new BasicTankFluidAccess(aTank, aIsFillableStack);
-        }
-
-        @Override
-        public void verifyFluidStack() {
-            if (!(mTank instanceof GT_MetaTileEntity_DigitalTankBase) && get() != null && get().amount <= 0) set(null);
         }
     }
 }

--- a/src/main/java/gregtech/api/gui/GT_Container_DigitalTank.java
+++ b/src/main/java/gregtech/api/gui/GT_Container_DigitalTank.java
@@ -2,7 +2,9 @@ package gregtech.api.gui;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import gregtech.api.interfaces.IFluidAccess;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
+import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_BasicTank;
 import gregtech.api.util.GT_Utility;
 import gregtech.common.tileentities.storage.GT_MetaTileEntity_DigitalTankBase;
 import net.minecraft.entity.player.EntityPlayer;
@@ -53,15 +55,16 @@ public class GT_Container_DigitalTank extends GT_Container_BasicTank {
             mte.mLockFluid = !mte.mLockFluid;
             if (mte.mLockFluid) {
                 if (mte.mFluid == null) {
-                    mte.lockedFluidName = null;
+                    mte.setLockedFluidName(null);
                     inBrackets = GT_Utility.trans("264", "currently none, will be locked to the next that is put in");
                 } else {
-                    mte.lockedFluidName = mte.getDrainableStack().getUnlocalizedName();
+                    mte.setLockedFluidName(mte.getDrainableStack().getFluid().getName());
                     inBrackets = mte.getDrainableStack().getLocalizedName();
                 }
                 GT_Utility.sendChatToPlayer(
                         aPlayer, String.format("%s (%s)", GT_Utility.trans("265", "1 specific Fluid"), inBrackets));
             } else {
+                mte.setLockedFluidName(null);
                 GT_Utility.sendChatToPlayer(aPlayer, GT_Utility.trans("266", "Lock Fluid Mode Disabled"));
             }
             return null;
@@ -151,5 +154,25 @@ public class GT_Container_DigitalTank extends GT_Container_BasicTank {
                 mAllowInputFromOutputSide = (value != 0);
                 break;
         }
+    }
+
+    @Override
+    protected IFluidAccess constructFluidAccess(GT_MetaTileEntity_BasicTank aTank, boolean aIsFillableStack) {
+        return new DigitalTankFluidAccess(aTank, aIsFillableStack);
+    }
+
+    static class DigitalTankFluidAccess extends BasicTankFluidAccess {
+
+        public DigitalTankFluidAccess(GT_MetaTileEntity_BasicTank aTank, boolean aIsFillableStack) {
+            super(aTank, aIsFillableStack);
+        }
+
+        @Override
+        public int getRealCapacity() {
+            return ((GT_MetaTileEntity_DigitalTankBase) mTank).getRealCapacity();
+        }
+
+        @Override
+        public void verifyFluidStack() {}
     }
 }

--- a/src/main/java/gregtech/api/interfaces/IDragAndDropSupport.java
+++ b/src/main/java/gregtech/api/interfaces/IDragAndDropSupport.java
@@ -1,0 +1,53 @@
+package gregtech.api.interfaces;
+
+import codechicken.nei.NEIClientUtils;
+import codechicken.nei.VisiblityData;
+import codechicken.nei.api.INEIGuiHandler;
+import codechicken.nei.api.TaggedInventoryArea;
+import cpw.mods.fml.common.Optional;
+import java.util.Collections;
+import java.util.List;
+import net.minecraft.client.gui.inventory.GuiContainer;
+import net.minecraft.item.ItemStack;
+
+/**
+ * Implement this interface if your GuiContainer supports Drag-And-Drop behavior on NEI.
+ */
+@Optional.Interface(modid = "NotEnoughItems", iface = "codechicken.nei.api.INEIGuiHandler")
+public interface IDragAndDropSupport extends INEIGuiHandler {
+
+    /**
+     * Implement this to handle Drag-And-Drop behavior.
+     * This may be invoked on normal click too ({@code isGhost==false}), so be careful
+     * if your slot supports both Drag-And-Drop and other behaviors e.g. fluid I/O with FluidDisplay click
+     * @param gui Current gui instance. Make sure to check if it is an instance of your GuiContainer.
+     * @param mousex X position of the mouse
+     * @param mousey Y position of the mouse
+     * @param draggedStack ItemStack user is holding on cursor
+     * @param button 0 = left click, 1 = right click
+     * @param isGhost Whether {@code draggedStack} is dragged from ItemPanel/BookmarkPanel, or actual item player holds
+     * @return True if success
+     */
+    boolean handleDragAndDropGT(
+            GuiContainer gui, int mousex, int mousey, ItemStack draggedStack, int button, boolean isGhost);
+
+    default boolean handleDragNDrop(GuiContainer gui, int mousex, int mousey, ItemStack draggedStack, int button) {
+        return handleDragAndDropGT(gui, mousex, mousey, draggedStack, button, NEIClientUtils.getHeldItem() == null);
+    }
+
+    default VisiblityData modifyVisiblity(GuiContainer gui, VisiblityData currentVisibility) {
+        return currentVisibility;
+    }
+
+    default Iterable<Integer> getItemSpawnSlots(GuiContainer gui, ItemStack item) {
+        return Collections.emptyList();
+    }
+
+    default List<TaggedInventoryArea> getInventoryAreas(GuiContainer gui) {
+        return null;
+    }
+
+    default boolean hideItemPanelSlot(GuiContainer gui, int x, int y, int w, int h) {
+        return false;
+    }
+}

--- a/src/main/java/gregtech/api/interfaces/metatileentity/IFluidLockable.java
+++ b/src/main/java/gregtech/api/interfaces/metatileentity/IFluidLockable.java
@@ -1,0 +1,29 @@
+package gregtech.api.interfaces.metatileentity;
+
+import net.minecraftforge.fluids.Fluid;
+
+/**
+ * Implement this interface if your MetaTileEntity supports fluid lock mechanism.
+ */
+@SuppressWarnings({"BooleanMethodIsAlwaysInverted", "unused"})
+public interface IFluidLockable {
+
+    /**
+     * Use {@link Fluid#getName()} instead of {@link Fluid#getUnlocalizedName()} for fluid name
+     */
+    void setLockedFluidName(String name);
+
+    String getLockedFluidName();
+
+    /**
+     * Set fluid lock state.
+     * Would be useful when you don't necessarily want to change mode when locked fluid is changed.
+     */
+    void lockFluid(boolean lock);
+
+    boolean isFluidLocked();
+
+    boolean allowChangingLockedFluid(String name);
+
+    default void onFluidLockPacketReceived(String name) {}
+}

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_Output.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_Output.java
@@ -5,6 +5,7 @@ import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_PIPE_OUT;
 
 import gregtech.GT_Mod;
 import gregtech.api.interfaces.ITexture;
+import gregtech.api.interfaces.metatileentity.IFluidLockable;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.render.TextureFactory;
@@ -22,7 +23,7 @@ import net.minecraft.util.StatCollector;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.*;
 
-public class GT_MetaTileEntity_Hatch_Output extends GT_MetaTileEntity_Hatch {
+public class GT_MetaTileEntity_Hatch_Output extends GT_MetaTileEntity_Hatch implements IFluidLockable {
     private String lockedFluidName = null;
     private WeakReference<EntityPlayer> playerThatLockedfluid = null;
     public byte mMode = 0;
@@ -368,16 +369,29 @@ public class GT_MetaTileEntity_Hatch_Output extends GT_MetaTileEntity_Hatch {
         return mMode % 4 < 2 && mMode != 9;
     }
 
-    public boolean isFluidLocked() {
-        return mMode == 8 || mMode == 9;
-    }
-
+    @Override
     public String getLockedFluidName() {
         return lockedFluidName;
     }
 
+    @Override
     public void setLockedFluidName(String lockedFluidName) {
         this.lockedFluidName = lockedFluidName;
+    }
+
+    @Override
+    public void lockFluid(boolean lock) {
+        this.mMode = (byte) (lock ? 9 : 0);
+    }
+
+    @Override
+    public boolean isFluidLocked() {
+        return mMode == 8 || mMode == 9;
+    }
+
+    @Override
+    public boolean allowChangingLockedFluid(String name) {
+        return true;
     }
 
     public boolean canStoreFluid(Fluid fluid) {
@@ -403,7 +417,7 @@ public class GT_MetaTileEntity_Hatch_Output extends GT_MetaTileEntity_Hatch {
             GT_Utility.sendChatToPlayer(
                     player,
                     String.format(
-                            GT_Utility.trans("151.4", "Sucessfully locked Fluid to %s"), mFluid.getLocalizedName()));
+                            GT_Utility.trans("151.4", "Successfully locked Fluid to %s"), mFluid.getLocalizedName()));
             playerThatLockedfluid = null;
         }
     }

--- a/src/main/java/gregtech/api/util/GT_Utility.java
+++ b/src/main/java/gregtech/api/util/GT_Utility.java
@@ -2019,6 +2019,14 @@ public class GT_Utility {
         return null;
     }
 
+    public static FluidStack getFluidFromContainerOrFluidDisplay(ItemStack stack) {
+        FluidStack fluidStack = GT_Utility.getFluidForFilledItem(stack, true);
+        if (fluidStack == null) {
+            fluidStack = GT_Utility.getFluidFromDisplayStack(stack);
+        }
+        return fluidStack;
+    }
+
     public static synchronized boolean removeIC2BottleRecipe(
             ItemStack aContainer,
             ItemStack aInput,

--- a/src/main/java/gregtech/common/gui/GT_Container_OutputHatch.java
+++ b/src/main/java/gregtech/common/gui/GT_Container_OutputHatch.java
@@ -37,15 +37,15 @@ public class GT_Container_OutputHatch extends GT_Container_BasicTank {
                     || (tMode >= 8 && tReadyLockFluid.getFluid().getName().equals(tHatch.getLockedFluidName()))) {
                 tHatch.setLockedFluidName(null);
                 GT_Utility.sendChatToPlayer(aPlayer, GT_Utility.trans("300", "Fluid Lock Cleared."));
-                tHatch.mMode = 0;
+                tHatch.lockFluid(false);
             } else {
                 tHatch.setLockedFluidName(tReadyLockFluid.getFluid().getName());
                 GT_Utility.sendChatToPlayer(
                         aPlayer,
                         String.format(
-                                GT_Utility.trans("151.4", "Sucessfully locked Fluid to %s"),
+                                GT_Utility.trans("151.4", "Successfully locked Fluid to %s"),
                                 tReadyLockFluid.getLocalizedName()));
-                tHatch.mMode = 9;
+                tHatch.lockFluid(true);
             }
         }
         return super.slotClick(aSlotIndex, aMouseclick, aShifthold, aPlayer);

--- a/src/main/java/gregtech/common/gui/GT_GUIContainer_OutputHatch.java
+++ b/src/main/java/gregtech/common/gui/GT_GUIContainer_OutputHatch.java
@@ -2,25 +2,19 @@ package gregtech.common.gui;
 
 import static gregtech.api.enums.GT_Values.RES_PATH_GUI;
 
-import codechicken.nei.VisiblityData;
-import codechicken.nei.api.INEIGuiHandler;
-import codechicken.nei.api.TaggedInventoryArea;
-import cpw.mods.fml.common.Optional;
 import gregtech.api.enums.GT_Values;
 import gregtech.api.gui.GT_GUIContainerMetaTile_Machine;
+import gregtech.api.interfaces.IDragAndDropSupport;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.net.GT_Packet_SetLockedFluid;
 import gregtech.api.util.GT_Utility;
-import java.util.Collections;
-import java.util.List;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.StatCollector;
 import net.minecraftforge.fluids.FluidStack;
 
-@Optional.Interface(modid = "NotEnoughItems", iface = "codechicken.nei.api.INEIGuiHandler")
-public class GT_GUIContainer_OutputHatch extends GT_GUIContainerMetaTile_Machine implements INEIGuiHandler {
+public class GT_GUIContainer_OutputHatch extends GT_GUIContainerMetaTile_Machine implements IDragAndDropSupport {
 
     private final String mName;
     private final int textColor = this.getTextColorOrDefault("text", 0xFAFAFF),
@@ -62,31 +56,12 @@ public class GT_GUIContainer_OutputHatch extends GT_GUIContainerMetaTile_Machine
     }
 
     @Override
-    @Optional.Method(modid = "NotEnoughItems")
-    public VisiblityData modifyVisiblity(GuiContainer gui, VisiblityData currentVisibility) {
-        return currentVisibility;
-    }
-
-    @Override
-    public Iterable<Integer> getItemSpawnSlots(GuiContainer gui, ItemStack item) {
-        return Collections.emptyList();
-    }
-
-    @Override
-    public List<TaggedInventoryArea> getInventoryAreas(GuiContainer gui) {
-        return null;
-    }
-
-    @Override
-    public boolean handleDragNDrop(GuiContainer gui, int mousex, int mousey, ItemStack draggedStack, int button) {
+    public boolean handleDragAndDropGT(
+            GuiContainer gui, int mousex, int mousey, ItemStack draggedStack, int button, boolean isGhost) {
         if (gui instanceof GT_GUIContainer_OutputHatch
                 && ((GT_GUIContainer_OutputHatch) gui).isMouseOverSlot(3, mousex, mousey)) {
             // the instanceof check should be unnecessary, but we will do it regardless, just in case.
-            FluidStack tFluidStack;
-            tFluidStack = GT_Utility.getFluidForFilledItem(draggedStack, true);
-            if (tFluidStack == null) {
-                tFluidStack = GT_Utility.getFluidFromDisplayStack(draggedStack);
-            }
+            FluidStack tFluidStack = GT_Utility.getFluidFromContainerOrFluidDisplay(draggedStack);
             if (tFluidStack != null) {
                 GT_Values.NW.sendToServer(new GT_Packet_SetLockedFluid(
                         ((GT_GUIContainer_OutputHatch) gui).mContainer.mTileEntity, tFluidStack));
@@ -94,11 +69,6 @@ public class GT_GUIContainer_OutputHatch extends GT_GUIContainerMetaTile_Machine
                 return true;
             }
         }
-        return false;
-    }
-
-    @Override
-    public boolean hideItemPanelSlot(GuiContainer gui, int x, int y, int w, int h) {
         return false;
     }
 }

--- a/src/main/java/gregtech/common/tileentities/storage/GT_MetaTileEntity_DigitalTankBase.java
+++ b/src/main/java/gregtech/common/tileentities/storage/GT_MetaTileEntity_DigitalTankBase.java
@@ -205,7 +205,7 @@ public abstract class GT_MetaTileEntity_DigitalTankBase extends GT_MetaTileEntit
 
     @Override
     public boolean allowChangingLockedFluid(String name) {
-        return this.lockedFluidName == null || getFluidAmount() == 0;
+        return getFluidAmount() == 0;
     }
 
     @Override


### PR DESCRIPTION
Implementation details:
- Extract `handleDragNDrop` from `INEIGuiHandler` to separated interface `IDragAndDropSupport`. Other methods are not used in GT.
- Make `GT_Packet_SetLockedFluid` accept any kind of MTE by introducing `IFluidLockable` interface.
- Change stored locked fluid name to `Fluid#getName` from `FluidStack#getUnlocalizedName`, which is the same behavior with Output Hatch. Existing tanks will be updated when unlocked and re-locked.
- Add `DigitalTankFluidAccess` that extends `BasicTankFluidAccess` and move digitaltank-specific things to there.

Also fix 0-amount `mFluid` not being saved when broken.

Close https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/11167