### PR TITLE
fix potential index out of bound in assline

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_AssemblyLine.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_AssemblyLine.java
@@ -239,12 +239,25 @@ public class GT_MetaTileEntity_AssemblyLine
             // If we run into missing buses/hatches or bad inputs, we go to the next data stick.
             // This check only happens if we have a valid up to date data stick.
 
+            // first validate we have enough input busses and input hatches for this recipe
+            if (mInputBusses.size() < tRecipe.mInputs.length || mInputHatches.size() < tRecipe.mFluidInputs.length) {
+                if (GT_Values.D1) {
+                    GT_FML_LOGGER.info(
+                            "Not enough sources: Need ({}, {}), has ({}, {})",
+                            mInputBusses.size(),
+                            tRecipe.mInputs.length,
+                            mInputHatches.size(),
+                            tRecipe.mFluidInputs.length);
+                }
+                continue;
+            }
+
             // Check Inputs allign
             int aItemCount = tRecipe.mInputs.length;
             tStack = new int[aItemCount];
             for (int i = 0; i < aItemCount; i++) {
                 GT_MetaTileEntity_Hatch_InputBus tInputBus = mInputBusses.get(i);
-                if (tInputBus == null) {
+                if (!isValidMetaTileEntity(tInputBus)) {
                     continue nextDataStick;
                 }
                 ItemStack tSlotStack = tInputBus.getStackInSlot(0);
@@ -262,7 +275,7 @@ public class GT_MetaTileEntity_AssemblyLine
             tFluids = new int[aFluidCount];
             tFluidSlot = new int[aFluidCount];
             for (int i = 0; i < aFluidCount; i++) {
-                if (mInputHatches.get(i) == null) {
+                if (!isValidMetaTileEntity(mInputHatches.get(i))) {
                     continue nextDataStick;
                 } else {
                     if (mInputHatches.get(i) instanceof GT_MetaTileEntity_Hatch_MultiInput) {


### PR DESCRIPTION
at least something good comes out of the reinvestigation of assline issues

The various mInputXXX.get() might throw IndexOutOfBoundException if user placed too few hatches. This exception will the catched by GT and logged to console, but not cause any immediate crash. The player will then notice some of his ingredients does not fit in the input slots and change structures, hence no reports of this error either way.