### PR TITLE
Uncommented LV and HV fake circuit OreDict defs

### DIFF
--- a/src/main/java/gregtech/loaders/preload/GT_Loader_OreDictionary.java
+++ b/src/main/java/gregtech/loaders/preload/GT_Loader_OreDictionary.java
@@ -320,12 +320,12 @@ public class GT_Loader_OreDictionary implements Runnable {
         // Fake Circuits
         GT_OreDictUnificator.registerOre(
                 OrePrefixes.circuit, Materials.Primitive, GT_ModHandler.getModItem(MOD_ID_DC, "item.CircuitULV", 1L));
-        // GT_OreDictUnificator.registerOre(OrePrefixes.circuit, Materials.Basic, GT_ModHandler.getModItem(MOD_ID_DC,
-        // "item.CircuitLV", 1L));
+        GT_OreDictUnificator.registerOre(
+                OrePrefixes.circuit, Materials.Basic, GT_ModHandler.getModItem(MOD_ID_DC, "item.CircuitLV", 1L));
         GT_OreDictUnificator.registerOre(
                 OrePrefixes.circuit, Materials.Good, GT_ModHandler.getModItem(MOD_ID_DC, "item.CircuitMV", 1L));
-        // GT_OreDictUnificator.registerOre(OrePrefixes.circuit, Materials.Advanced, GT_ModHandler.getModItem(MOD_ID_DC,
-        // "item.CircuitHV", 1L));
+        GT_OreDictUnificator.registerOre(
+                OrePrefixes.circuit, Materials.Advanced, GT_ModHandler.getModItem(MOD_ID_DC, "item.CircuitHV", 1L));
         GT_OreDictUnificator.registerOre(
                 OrePrefixes.circuit, Materials.Data, GT_ModHandler.getModItem(MOD_ID_DC, "item.CircuitEV", 1L));
         GT_OreDictUnificator.registerOre(


### PR DESCRIPTION
For some reason these were commented out, and it broke using them for AE2 autocrafting, even with OreDict substitutions on.

Now they exist properly!
![image](https://user-images.githubusercontent.com/16748195/188760154-59cff78a-41ed-48e2-bb52-5b73c471ab7f.png)

(I also verified that the game doesn't explode if they're left on, so I'm not sure why they were commented before but there doesn't seem to be a reason to leave them at this point)
