### PR TITLE
Add ticks display when recipe duration is under 1 second in NEI

### DIFF
--- a/src/main/java/gregtech/nei/GT_NEI_DefaultHandler.java
+++ b/src/main/java/gregtech/nei/GT_NEI_DefaultHandler.java
@@ -416,11 +416,14 @@ public class GT_NEI_DefaultHandler extends RecipeMapHandler {
         }
         if (mPower.getDurationTicks() > 0) {
             if (GT_Mod.gregtechproxy.mNEIRecipeSecondMode) {
-                if(mPower.getDurationSeconds() > 1.0d){
+                if (mPower.getDurationSeconds() > 1.0d) {
                     drawLine(lineCounter, GT_Utility.trans("158", "Time: ") + mPower.getDurationStringSeconds());
-                }
-                else{
-                    drawLine(lineCounter, GT_Utility.trans("158", "Time: ") + mPower.getDurationStringSeconds() + String.format(" (%s)", mPower.getDurationStringTicks()));
+                } else {
+                    drawLine(
+                            lineCounter,
+                            GT_Utility.trans("158", "Time: ")
+                                    + mPower.getDurationStringSeconds()
+                                    + String.format(" (%s)", mPower.getDurationStringTicks()));
                 }
             } else {
                 drawLine(lineCounter, GT_Utility.trans("158", "Time: ") + mPower.getDurationStringTicks());

--- a/src/main/java/gregtech/nei/GT_NEI_DefaultHandler.java
+++ b/src/main/java/gregtech/nei/GT_NEI_DefaultHandler.java
@@ -416,7 +416,12 @@ public class GT_NEI_DefaultHandler extends RecipeMapHandler {
         }
         if (mPower.getDurationTicks() > 0) {
             if (GT_Mod.gregtechproxy.mNEIRecipeSecondMode) {
-                drawLine(lineCounter, GT_Utility.trans("158", "Time: ") + mPower.getDurationStringSeconds());
+                if(mPower.getDurationSeconds() > 1.0d){
+                    drawLine(lineCounter, GT_Utility.trans("158", "Time: ") + mPower.getDurationStringSeconds());
+                }
+                else{
+                    drawLine(lineCounter, GT_Utility.trans("158", "Time: ") + mPower.getDurationStringSeconds() + String.format(" (%s)", mPower.getDurationStringTicks()));
+                }
             } else {
                 drawLine(lineCounter, GT_Utility.trans("158", "Time: ") + mPower.getDurationStringTicks());
             }


### PR DESCRIPTION
Some people are having trouble to read very short times
I know it can be controversial, so I added ticks alongside seconds
![キャプチャ1637](https://user-images.githubusercontent.com/39122497/189399612-b49676df-ccf8-4241-ad68-3dc9a70a97e4.PNG)