### PR TITLE
Waila improvements for basic machines

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicMachine.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicMachine.java
@@ -1195,7 +1195,7 @@ public abstract class GT_MetaTileEntity_BasicMachine extends GT_MetaTileEntity_B
                 tag.getInteger("progressSingleBlock"), tag.getInteger("maxProgressSingleBlock")));
 
         currenttip.add(String.format(
-                "Main Facing: %s", ForgeDirection.getOrientation(mMainFacing).name()));
+                "Machine Facing: %s", ForgeDirection.getOrientation(mMainFacing).name()));
 
         currenttip.add(String.format(
                 "Output Facing: %s",

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicMachine.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicMachine.java
@@ -1193,7 +1193,14 @@ public abstract class GT_MetaTileEntity_BasicMachine extends GT_MetaTileEntity_B
         currenttip.add(String.format(
                 "Progress: %d s / %d s",
                 tag.getInteger("progressSingleBlock"), tag.getInteger("maxProgressSingleBlock")));
-        super.getWailaBody(itemStack, currenttip, accessor, config);
+
+        currenttip.add(String.format(
+                "Main Facing: %s", ForgeDirection.getOrientation(mMainFacing).name()));
+
+        currenttip.add(String.format(
+                "Output Facing: %s",
+                ForgeDirection.getOrientation(getBaseMetaTileEntity().getFrontFacing())
+                        .name()));
     }
 
     @Override

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicMachine.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicMachine.java
@@ -1189,18 +1189,22 @@ public abstract class GT_MetaTileEntity_BasicMachine extends GT_MetaTileEntity_B
     public void getWailaBody(
             ItemStack itemStack, List<String> currenttip, IWailaDataAccessor accessor, IWailaConfigHandler config) {
         final NBTTagCompound tag = accessor.getNBTData();
+        IGregTechTileEntity baseTileEntity = getBaseMetaTileEntity();
 
-        currenttip.add(String.format(
-                "Progress: %d s / %d s",
-                tag.getInteger("progressSingleBlock"), tag.getInteger("maxProgressSingleBlock")));
+        if (baseTileEntity.isActive()) {
+            currenttip.add(String.format(
+                    "Progress: %d s / %d s",
+                    tag.getInteger("progressSingleBlock"), tag.getInteger("maxProgressSingleBlock")));
+        } else {
+            currenttip.add("Idle");
+        }
 
         currenttip.add(String.format(
                 "Machine Facing: %s", ForgeDirection.getOrientation(mMainFacing).name()));
 
         currenttip.add(String.format(
                 "Output Facing: %s",
-                ForgeDirection.getOrientation(getBaseMetaTileEntity().getFrontFacing())
-                        .name()));
+                ForgeDirection.getOrientation(baseTileEntity.getFrontFacing()).name()));
     }
 
     @Override

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicMachine.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicMachine.java
@@ -1189,22 +1189,25 @@ public abstract class GT_MetaTileEntity_BasicMachine extends GT_MetaTileEntity_B
     public void getWailaBody(
             ItemStack itemStack, List<String> currenttip, IWailaDataAccessor accessor, IWailaConfigHandler config) {
         final NBTTagCompound tag = accessor.getNBTData();
-        IGregTechTileEntity baseTileEntity = getBaseMetaTileEntity();
 
-        if (baseTileEntity.isActive()) {
-            currenttip.add(String.format(
-                    "Progress: %d s / %d s",
-                    tag.getInteger("progressSingleBlock"), tag.getInteger("maxProgressSingleBlock")));
+        if (tag.getBoolean("stutteringSingleBlock")) {
+            currenttip.add("Status: insufficient energy");
         } else {
-            currenttip.add("Idle");
+            currenttip.add(GT_Waila.getMachineProgressString(
+                    tag.getBoolean("isActiveSingleBlock"),
+                    tag.getInteger("maxProgressSingleBlock"),
+                    tag.getInteger("progressSingleBlock")));
         }
 
         currenttip.add(String.format(
-                "Machine Facing: %s", ForgeDirection.getOrientation(mMainFacing).name()));
+                "Machine Facing: %s",
+                ForgeDirection.getOrientation(tag.getInteger("mainFacingSingleBlock"))
+                        .name()));
 
         currenttip.add(String.format(
                 "Output Facing: %s",
-                ForgeDirection.getOrientation(baseTileEntity.getFrontFacing()).name()));
+                ForgeDirection.getOrientation(tag.getInteger("outputFacingSingleBlock"))
+                        .name()));
     }
 
     @Override
@@ -1212,8 +1215,16 @@ public abstract class GT_MetaTileEntity_BasicMachine extends GT_MetaTileEntity_B
             EntityPlayerMP player, TileEntity tile, NBTTagCompound tag, World world, int x, int y, int z) {
         super.getWailaNBTData(player, tile, tag, world, x, y, z);
 
-        tag.setInteger("progressSingleBlock", mProgresstime / 20);
-        tag.setInteger("maxProgressSingleBlock", mMaxProgresstime / 20);
+        tag.setInteger("progressSingleBlock", mProgresstime);
+        tag.setInteger("maxProgressSingleBlock", mMaxProgresstime);
+        tag.setInteger("mainFacingSingleBlock", mMainFacing);
+        tag.setBoolean("stutteringSingleBlock", mStuttering);
+
+        IGregTechTileEntity tileEntity = getBaseMetaTileEntity();
+        if (tileEntity != null) {
+            tag.setBoolean("isActiveSingleBlock", tileEntity.isActive());
+            tag.setInteger("outputFacingSingleBlock", tileEntity.getFrontFacing());
+        }
     }
 
     public Power getPower() {

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
@@ -15,11 +15,8 @@ import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.items.GT_MetaGenerated_Tool;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.objects.GT_ItemStack;
-import gregtech.api.util.GT_ExoticEnergyInputHelper;
-import gregtech.api.util.GT_Log;
+import gregtech.api.util.*;
 import gregtech.api.util.GT_Recipe.GT_Recipe_Map;
-import gregtech.api.util.GT_Single_Recipe_Check;
-import gregtech.api.util.GT_Utility;
 import gregtech.common.GT_Pollution;
 import gregtech.common.items.GT_MetaGenerated_Tool_01;
 import java.util.ArrayList;
@@ -1248,12 +1245,8 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity {
         currentTip.add((tag.getBoolean("hasProblems") ? (RED + "** HAS PROBLEMS **") : GREEN + "Running Fine") + RESET
                 + "  Efficiency: " + tag.getFloat("efficiency") + "%");
 
-        if (getBaseMetaTileEntity().isActive()) {
-            currentTip.add(
-                    String.format("Progress: %d s / %d s", tag.getInteger("progress"), tag.getInteger("maxProgress")));
-        } else {
-            currentTip.add("Idle");
-        }
+        currentTip.add(GT_Waila.getMachineProgressString(
+                tag.getBoolean("isActive"), tag.getInteger("maxProgress"), tag.getInteger("progress")));
 
         super.getWailaBody(itemStack, currentTip, accessor, config);
     }
@@ -1265,9 +1258,14 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity {
 
         tag.setBoolean("hasProblems", (getIdealStatus() - getRepairStatus()) > 0);
         tag.setFloat("efficiency", mEfficiency / 100.0F);
-        tag.setInteger("progress", mProgresstime / 20);
-        tag.setInteger("maxProgress", mMaxProgresstime / 20);
+        tag.setInteger("progress", mProgresstime);
+        tag.setInteger("maxProgress", mMaxProgresstime);
         tag.setBoolean("incompleteStructure", (getBaseMetaTileEntity().getErrorDisplayID() & 64) != 0);
+
+        IGregTechTileEntity tileEntity = getBaseMetaTileEntity();
+        if (tileEntity != null) {
+            tag.setBoolean("isActive", tileEntity.isActive());
+        }
     }
 
     public List<GT_MetaTileEntity_Hatch> getExoticEnergyHatches() {

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
@@ -1248,8 +1248,12 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity {
         currentTip.add((tag.getBoolean("hasProblems") ? (RED + "** HAS PROBLEMS **") : GREEN + "Running Fine") + RESET
                 + "  Efficiency: " + tag.getFloat("efficiency") + "%");
 
-        currentTip.add(
-                String.format("Progress: %d s / %d s", tag.getInteger("progress"), tag.getInteger("maxProgress")));
+        if (getBaseMetaTileEntity().isActive()) {
+            currentTip.add(
+                    String.format("Progress: %d s / %d s", tag.getInteger("progress"), tag.getInteger("maxProgress")));
+        } else {
+            currentTip.add("Idle");
+        }
 
         super.getWailaBody(itemStack, currentTip, accessor, config);
     }

--- a/src/main/java/gregtech/api/util/GT_Waila.java
+++ b/src/main/java/gregtech/api/util/GT_Waila.java
@@ -1,0 +1,22 @@
+package gregtech.api.util;
+
+import joptsimple.internal.Strings;
+
+public abstract class GT_Waila {
+
+    public static String getMachineProgressString(boolean isActive, int maxProgress, int progress) {
+        StringBuilder stringBuilder = new StringBuilder(Strings.EMPTY);
+
+        if (isActive) {
+            if (maxProgress > 20) {
+                stringBuilder.append(String.format("Progress: %d s / %d s", progress / 20, maxProgress / 20));
+            } else {
+                stringBuilder.append(String.format("Progress: %d ticks remaining", maxProgress));
+            }
+        } else {
+            stringBuilder.append("Idle");
+        }
+
+        return stringBuilder.toString();
+    }
+}

--- a/src/main/java/gregtech/api/util/GT_Waila.java
+++ b/src/main/java/gregtech/api/util/GT_Waila.java
@@ -1,22 +1,20 @@
 package gregtech.api.util;
 
-import joptsimple.internal.Strings;
-
 public abstract class GT_Waila {
 
     public static String getMachineProgressString(boolean isActive, int maxProgress, int progress) {
-        StringBuilder stringBuilder = new StringBuilder(Strings.EMPTY);
+        final String result;
 
         if (isActive) {
-            if (maxProgress > 20) {
-                stringBuilder.append(String.format("Progress: %d s / %d s", progress / 20, maxProgress / 20));
+            if (maxProgress < 20) {
+                result = String.format("Progress: %d ticks remaining", maxProgress);
             } else {
-                stringBuilder.append(String.format("Progress: %d ticks remaining", maxProgress));
+                result = String.format("Progress: %d s / %d s", progress / 20, maxProgress / 20);
             }
         } else {
-            stringBuilder.append("Idle");
+            result = "Idle";
         }
 
-        return stringBuilder.toString();
+        return result;
     }
 }


### PR DESCRIPTION
- Facings for basic machines is different than general meta tile entity, since it has a "main" facing.
- Show progress time only when machine is active
- Show total recipe tick time when it requires less than a second to complete (Addresses https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/11268)
![image](https://user-images.githubusercontent.com/87545780/189479704-2d9a1b1a-8a38-4a63-b354-95f505a1662d.png)
![image](https://user-images.githubusercontent.com/87545780/189479720-970352ce-b616-4cc0-93a8-e3e73915f4d1.png)
