### PR TITLE
fix DT log spam

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_DistillationTower.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_DistillationTower.java
@@ -358,7 +358,9 @@ public class GT_MetaTileEntity_DistillationTower
     @Override
     protected void addFluidOutputs(FluidStack[] mOutputFluids2) {
         for (int i = 0; i < mOutputFluids2.length && i < mOutputHatchesByLayer.size(); i++) {
-            FluidStack tStack = mOutputFluids2[i].copy();
+            final FluidStack fluidStack = mOutputFluids2[i];
+            if (fluidStack == null) continue;
+            FluidStack tStack = fluidStack.copy();
             if (!dumpFluid(mOutputHatchesByLayer.get(i), tStack, true))
                 dumpFluid(mOutputHatchesByLayer.get(i), tStack, false);
         }


### PR DESCRIPTION
although should it be fixed by adding a null check like I did, or by making sure there aren't any recipes containing null that can make their way to where this crash happened ?


fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/11258