### PR TITLE
Reduce ECE Coolant Rate to Match LCE

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_ExtremeDieselEngine.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_ExtremeDieselEngine.java
@@ -41,7 +41,7 @@ public class GT_MetaTileEntity_ExtremeDieselEngine extends GT_MetaTileEntity_Die
         tt.addMachineType("Combustion Generator")
                 .addInfo("Controller block for the Extreme Combustion Engine")
                 .addInfo("Supply High Octane Gasoline and 8000L of Lubricant per hour to run")
-                .addInfo("Supply 80L/s of Liquid Oxygen to boost output (optional)")
+                .addInfo("Supply 40L/s of Liquid Oxygen to boost output (optional)")
                 .addInfo("Default: Produces 10900EU/t at 100% fuel efficiency")
                 .addInfo("Boosted: Produces 32700EU/t at 150% fuel efficiency")
                 .addInfo("You need to wait for it to reach 300% to output full power")
@@ -169,7 +169,7 @@ public class GT_MetaTileEntity_ExtremeDieselEngine extends GT_MetaTileEntity_Die
 
     @Override
     protected int getAdditiveFactor() {
-        return 2;
+        return 1;
     }
 
     @Override


### PR DESCRIPTION
- Changed LOX amount to boost the ECE from 80 L/s to 40 L/s.

(In the code, the "additiveFactor" is a multiplier of the LCE's 40 L/s coolant rate for boosting, for the coolant used in this multi.)

I had previously lowered the rate from 320 L/s to 80 L/s, thinking it was enough, but I found that ~7% of the power generation of an ECE goes to make the LOX needed to boost it. I thought it was fine at the time, but this is a lot higher than most alternatives, on top of the restriction of only using HOG. Since this is an engine dedicated to that, I thought I should just make the rate the same as the LHE, with LOX instead of Oxygen, with 3 HV or 1 EV/1 HV Vacuum Freezers per multi. 

With some tweaks to HOG's disproportionate consumption of some oil fractions, I think that this fuel can be competitive.