### PR TITLE
HOG-Focused Oil Tweaks and Raw Oil Viability

### DIFF
--- a/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
@@ -4895,9 +4895,9 @@ public class GT_MachineRecipeLoader implements Runnable {
                 Materials.OilMedium.getFluid(100),
                 new ItemStack[] {GT_Utility.getIntegratedCircuit(1)},
                 new FluidStack[] {
-                    Materials.SulfuricHeavyFuel.getFluid(15),
+                    Materials.SulfuricHeavyFuel.getFluid(10),
                     Materials.SulfuricLightFuel.getFluid(50),
-                    Materials.SulfuricNaphtha.getFluid(20),
+                    Materials.SulfuricNaphtha.getFluid(170),
                     Materials.SulfuricGas.getGas(60)
                 },
                 null,
@@ -18028,7 +18028,7 @@ public class GT_MachineRecipeLoader implements Runnable {
         GT_Values.RA.addUniversalDistillationRecipe(
                 Materials.Gas.getLightlyHydroCracked(1000),
                 new FluidStack[] {
-                    Materials.Methane.getGas(1400), Materials.Hydrogen.getGas(1340), Materials.Helium.getGas(20)
+                    Materials.Methane.getGas(1300), Materials.Hydrogen.getGas(1500), Materials.Helium.getGas(100)
                 },
                 GT_Values.NI,
                 120,
@@ -18036,7 +18036,7 @@ public class GT_MachineRecipeLoader implements Runnable {
         GT_Values.RA.addUniversalDistillationRecipe(
                 Materials.Gas.getModeratelyHydroCracked(1000),
                 new FluidStack[] {
-                    Materials.Methane.getGas(1400), Materials.Hydrogen.getGas(3340), Materials.Helium.getGas(20)
+                    Materials.Methane.getGas(1400), Materials.Hydrogen.getGas(3000), Materials.Helium.getGas(150)
                 },
                 GT_Values.NI,
                 120,
@@ -18044,7 +18044,7 @@ public class GT_MachineRecipeLoader implements Runnable {
         GT_Values.RA.addUniversalDistillationRecipe(
                 Materials.Gas.getSeverelyHydroCracked(1000),
                 new FluidStack[] {
-                    Materials.Methane.getGas(1400), Materials.Hydrogen.getGas(4340), Materials.Helium.getGas(20)
+                    Materials.Methane.getGas(1500), Materials.Hydrogen.getGas(4000), Materials.Helium.getGas(200)
                 },
                 GT_Values.NI,
                 120,
@@ -18052,11 +18052,11 @@ public class GT_MachineRecipeLoader implements Runnable {
         GT_Values.RA.addUniversalDistillationRecipe(
                 Materials.Gas.getLightlySteamCracked(1000),
                 new FluidStack[] {
-                    Materials.Propene.getGas(45),
-                    Materials.Ethane.getGas(8),
-                    Materials.Ethylene.getGas(85),
-                    Materials.Methane.getGas(1026),
-                    Materials.Helium.getGas(20)
+                    Materials.Propene.getGas(50),
+                    Materials.Ethane.getGas(10),
+                    Materials.Ethylene.getGas(100),
+                    Materials.Methane.getGas(500),
+                    Materials.Helium.getGas(50)
                 },
                 Materials.Carbon.getDustTiny(1),
                 120,
@@ -18064,11 +18064,11 @@ public class GT_MachineRecipeLoader implements Runnable {
         GT_Values.RA.addUniversalDistillationRecipe(
                 Materials.Gas.getModeratelySteamCracked(1000),
                 new FluidStack[] {
-                    Materials.Propene.getGas(8),
-                    Materials.Ethane.getGas(45),
-                    Materials.Ethylene.getGas(92),
-                    Materials.Methane.getGas(1018),
-                    Materials.Helium.getGas(20)
+                    Materials.Propene.getGas(10),
+                    Materials.Ethane.getGas(50),
+                    Materials.Ethylene.getGas(200),
+                    Materials.Methane.getGas(600),
+                    Materials.Helium.getGas(70)
                 },
                 Materials.Carbon.getDustTiny(1),
                 120,
@@ -18076,11 +18076,11 @@ public class GT_MachineRecipeLoader implements Runnable {
         GT_Values.RA.addUniversalDistillationRecipe(
                 Materials.Gas.getSeverelySteamCracked(1000),
                 new FluidStack[] {
-                    Materials.Propene.getGas(8),
-                    Materials.Ethane.getGas(8),
-                    Materials.Ethylene.getGas(25),
-                    Materials.Methane.getGas(1143),
-                    Materials.Helium.getGas(20)
+                    Materials.Propene.getGas(10),
+                    Materials.Ethane.getGas(10),
+                    Materials.Ethylene.getGas(300),
+                    Materials.Methane.getGas(700),
+                    Materials.Helium.getGas(100)
                 },
                 Materials.Carbon.getDustTiny(1),
                 120,

--- a/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
@@ -4897,7 +4897,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                 new FluidStack[] {
                     Materials.SulfuricHeavyFuel.getFluid(10),
                     Materials.SulfuricLightFuel.getFluid(50),
-                    Materials.SulfuricNaphtha.getFluid(170),
+                    Materials.SulfuricNaphtha.getFluid(150),
                     Materials.SulfuricGas.getGas(60)
                 },
                 null,


### PR DESCRIPTION
- Changed Raw Oil to be the Naphtha-focused oil type between the 4 types, instead of being directly worse than Oil;
- Changed Steam-cracked Refinery Gas to be a viable Ethylene source, both for realism and to shift the stress away from Naphtha;
- Improved the Helium output from cracked Refinery Gas, both for realism and to give an initial boost to Helium stockpiling early;

To be competitive, HOG needs a few glaring flaws to be fixed so that its strengths can shine. One of the biggest flaws is that Naphtha is a bottleneck, given that it is often used both for automated Ethylene and also in large quantities for the HOG chain itself. Meanwhile, Light Fuel is needed to get Octane, and Heavy Fuel can be distilled into Toluene + Benzene + Phenol, but Refinery Gas is mostly useless overall. In reality, it is a good source of Ethylene, so I changed its values to reflect that. IRL, Helium is also majorly sourced from natural gas, so I improved those numbers as well.

Additionally, while looking at these numbers, I remembered that Raw Oil only exists as a worse version of the Oil that everybody uses. At the same time, none of the 4 types are good for Naphtha, so I chose to kill two birds with one stone on this change.

