### PR TITLE
Make FluidTankInfo capacity larger in overflow voiding mode

### DIFF
--- a/src/main/java/gregtech/common/tileentities/storage/GT_MetaTileEntity_DigitalTankBase.java
+++ b/src/main/java/gregtech/common/tileentities/storage/GT_MetaTileEntity_DigitalTankBase.java
@@ -439,7 +439,7 @@ public abstract class GT_MetaTileEntity_DigitalTankBase extends GT_MetaTileEntit
 
     @Override
     public FluidTankInfo getInfo() {
-        return new FluidTankInfo(getFluid(), getRealCapacity());
+        return new FluidTankInfo(getFluid(), getCapacity());
     }
 
     @Override


### PR DESCRIPTION
Should fix <https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/11352> - the getCapacity() method was already reporting infinite capacity, but the fluid tank info didn't match, leading to two different behaviours depending on which fluid api another mod used.