### PR TITLE
refactor(fluid_api): fluent interface

### DIFF
--- a/src/main/java/gregtech/api/enums/FluidState.java
+++ b/src/main/java/gregtech/api/enums/FluidState.java
@@ -10,7 +10,7 @@ public enum FluidState {
     public static final FluidState[] VALID_STATES = new FluidState[] {SLURRY, LIQUID, GAS, PLASMA, MOLTEN};
 
     public static FluidState fromValue(int stateValue) {
-        return stateValue > 0 && stateValue < FluidState.VALID_STATES.length
+        return stateValue >= 0 && stateValue < FluidState.VALID_STATES.length
                 ? FluidState.VALID_STATES[stateValue]
                 : FluidState.LIQUID;
     }

--- a/src/main/java/gregtech/api/enums/FluidState.java
+++ b/src/main/java/gregtech/api/enums/FluidState.java
@@ -6,5 +6,12 @@ public enum FluidState {
     MOLTEN,
     PLASMA,
     SLURRY;
-    public static final FluidState[] VALUES = new FluidState[] {SLURRY, LIQUID, GAS, PLASMA, MOLTEN};
+
+    public static final FluidState[] VALID_STATES = new FluidState[] {SLURRY, LIQUID, GAS, PLASMA, MOLTEN};
+
+    public static FluidState fromValue(int stateValue) {
+        return stateValue > 0 && stateValue < FluidState.VALID_STATES.length
+                ? FluidState.VALID_STATES[stateValue]
+                : FluidState.LIQUID;
+    }
 }

--- a/src/main/java/gregtech/api/fluid/GT_FluidFactory.java
+++ b/src/main/java/gregtech/api/fluid/GT_FluidFactory.java
@@ -39,9 +39,9 @@ public class GT_FluidFactory {
      * @param material The {@link Materials} of this {@link IGT_Fluid}
      * @param state The {@link FluidState} of this {@link IGT_Fluid}
      * @param temperature The fluid temperature in Kelvin
-     * @return the registered {@link IGT_Fluid}
+     * @return the registered {@link Fluid}
      */
-    public static IGT_Fluid of(
+    public static Fluid of(
             final String fluidName,
             final String localizedName,
             final Materials material,
@@ -51,7 +51,8 @@ public class GT_FluidFactory {
                 .withLocalizedName(localizedName)
                 .withStateAndTemperature(state, temperature)
                 .buildAndRegister()
-                .configureMaterials(material);
+                .configureMaterials(material)
+                .asFluid();
     }
 
     /**
@@ -60,14 +61,15 @@ public class GT_FluidFactory {
      * @param localizedName The localized name of this {@link IGT_Fluid}
      * @param state The {@link FluidState} of this {@link IGT_Fluid}
      * @param temperature The fluid temperature in Kelvin
-     * @return the registered {@link IGT_Fluid}
+     * @return the registered {@link Fluid}
      */
-    public static IGT_Fluid of(
+    public static Fluid of(
             final String fluidName, final String localizedName, final FluidState state, final int temperature) {
         return builder(fluidName)
                 .withLocalizedName(localizedName)
                 .withStateAndTemperature(state, temperature)
-                .buildAndRegister();
+                .buildAndRegister()
+                .asFluid();
     }
 
     /**

--- a/src/main/java/gregtech/api/interfaces/fluid/IGT_Fluid.java
+++ b/src/main/java/gregtech/api/interfaces/fluid/IGT_Fluid.java
@@ -1,11 +1,5 @@
 package gregtech.api.interfaces.fluid;
 
-import gregtech.api.enums.FluidState;
-import gregtech.api.enums.Materials;
-import net.minecraft.item.ItemStack;
-import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.fluids.Fluid;
-import net.minecraftforge.fluids.FluidContainerRegistry;
 import net.minecraftforge.fluids.FluidRegistry;
 
 @SuppressWarnings("unused") // API might legitimately expose unused methods within this local project's scope
@@ -14,68 +8,7 @@ public interface IGT_Fluid {
     /**
      * Adds this {@link IGT_Fluid} to the {@link FluidRegistry} and internally-implemented registrations
      *
-     * @return {@link IGT_Fluid} self for call chaining
+     * @return {@link IGT_RegisteredFluid} The GregTech registered fluid
      */
-    IGT_Fluid addFluid();
-
-    /**
-     * Registers the containers in the {@link FluidContainerRegistry} for this {@link IGT_Fluid}
-     *
-     * @param fullContainer  The full fluid container
-     * @param emptyContainer The empty fluid container
-     * @param containerSize  The size of the container
-     * @return The {@link IGT_Fluid} for chaining
-     *
-     * @throws IllegalStateException on attempt to register containers for an unregistered fluid
-     */
-    IGT_Fluid registerContainers(
-            final ItemStack fullContainer, final ItemStack emptyContainer, final int containerSize);
-
-    /**
-     * Registers the bucket-sized 1000L containers in the {@link FluidContainerRegistry} for this {@link IGT_Fluid}
-     *
-     * @param fullContainer  The full container to associate with this {@link IGT_Fluid}
-     * @param emptyContainer The empty container associate with this {@link IGT_Fluid}
-     * @return {@link IGT_Fluid} self for call chaining
-     *
-     * @throws IllegalStateException on attempt to register containers for an unregistered fluid
-     */
-    IGT_Fluid registerBContainers(final ItemStack fullContainer, final ItemStack emptyContainer);
-
-    /**
-     * Registers the potion-sized 250L containers in the {@link FluidContainerRegistry} for this {@link IGT_Fluid}
-     *
-     * @param fullContainer  The full container to associate with this {@link IGT_Fluid}
-     * @param emptyContainer The empty container associate with this {@link IGT_Fluid}
-     * @return {@link IGT_Fluid} self for call chaining
-     *
-     * @throws IllegalStateException on attempt to register containers for an unregistered fluid
-     */
-    IGT_Fluid registerPContainers(final ItemStack fullContainer, final ItemStack emptyContainer);
-
-    /**
-     * Updates the {@link Materials}'s fluids from this {@link IGT_Fluid}'s state
-     *
-     * @param material the {@link Materials} to configure based on this {@link IGT_Fluid} and {@link FluidState}
-     * @return The {@link IGT_Fluid} for chaining
-     *
-     * @throws IllegalStateException on unknown {@link FluidState}
-     * @throws IllegalStateException on attempt to register containers for an unregistered fluid
-     */
-    IGT_Fluid configureMaterials(final Materials material);
-
-    /**
-     * @return this {@link IGT_Fluid} cast to {@link Fluid}
-     */
-    Fluid asFluid();
-
-    /**
-     * @return the {@link ResourceLocation} of the still fluid texture
-     */
-    ResourceLocation getStillIconResourceLocation();
-
-    /**
-     * @return the {@link ResourceLocation} of the flowing fluid texture
-     */
-    ResourceLocation getFlowingIconResourceLocation();
+    IGT_RegisteredFluid addFluid();
 }

--- a/src/main/java/gregtech/api/interfaces/fluid/IGT_FluidBuilder.java
+++ b/src/main/java/gregtech/api/interfaces/fluid/IGT_FluidBuilder.java
@@ -3,7 +3,6 @@ package gregtech.api.interfaces.fluid;
 import gregtech.api.enums.FluidState;
 import javax.annotation.Nonnull;
 import net.minecraft.block.Block;
-import net.minecraft.util.IIcon;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
@@ -59,14 +58,6 @@ public interface IGT_FluidBuilder {
      */
     @SuppressWarnings("UnusedReturnValue") // Last call in chain, may not use this returned value
     IGT_FluidBuilder withFluidBlock(final Block fluidBlock);
-
-    /**
-     * @param stillIcon   The {@link IIcon} of the still fluid texture
-     * @param flowingIcon The {@link IIcon} of the flowing fluid texture
-     * @return {@link IGT_FluidBuilder} self for call chaining
-     */
-    @SuppressWarnings("UnusedReturnValue") // Last call in chain, may not use this returned value
-    IGT_FluidBuilder withIcons(final IIcon stillIcon, final IIcon flowingIcon);
 
     /**
      * @param fromFluid the {@link Fluid} to copy the icons from

--- a/src/main/java/gregtech/api/interfaces/fluid/IGT_FluidBuilder.java
+++ b/src/main/java/gregtech/api/interfaces/fluid/IGT_FluidBuilder.java
@@ -1,7 +1,9 @@
 package gregtech.api.interfaces.fluid;
 
 import gregtech.api.enums.FluidState;
+import javax.annotation.Nonnull;
 import net.minecraft.block.Block;
+import net.minecraft.util.IIcon;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
@@ -12,12 +14,14 @@ public interface IGT_FluidBuilder {
      * @param colorRGBA The {@code short[]} RGBA color of the {@link Fluid} or {@code null} for no defined RGBA color
      * @return {@link IGT_FluidBuilder} self for call chaining
      */
+    @SuppressWarnings("UnusedReturnValue") // Last call in chain, may not use this returned value
     IGT_FluidBuilder withColorRGBA(final short[] colorRGBA);
 
     /**
      * @param localizedName The localized name of this {@link IGT_FluidBuilder}
      * @return {@link IGT_FluidBuilder} self for call chaining
      */
+    @SuppressWarnings("UnusedReturnValue") // Last call in chain, may not use this returned value
     IGT_FluidBuilder withLocalizedName(final String localizedName);
 
     /**
@@ -25,43 +29,58 @@ public interface IGT_FluidBuilder {
      * @param temperature The Kelvin temperature of this {@link IGT_FluidBuilder}
      * @return {@link IGT_FluidBuilder} self for call chaining
      */
+    @SuppressWarnings("UnusedReturnValue") // Last call in chain, may not use this returned value
     IGT_FluidBuilder withStateAndTemperature(final FluidState fluidState, final int temperature);
 
     /**
      * @param stillIconResourceLocation the {@link ResourceLocation} of the still fluid icon
      * @return {@link IGT_FluidBuilder} self for call chaining
      */
+    @SuppressWarnings("UnusedReturnValue") // Last call in chain, may not use this returned value
     IGT_FluidBuilder withStillIconResourceLocation(final ResourceLocation stillIconResourceLocation);
 
     /**
      * @param flowingIconResourceLocation the {@link ResourceLocation} of the flowing fluid icon
      * @return {@link IGT_FluidBuilder} self for call chaining
      */
+    @SuppressWarnings("UnusedReturnValue") // Last call in chain, may not use this returned value
     IGT_FluidBuilder withFlowingIconResourceLocation(final ResourceLocation flowingIconResourceLocation);
 
     /**
      * @param textureName The name of the GregTech mod texture of this {@link IGT_FluidBuilder}
      * @return {@link IGT_FluidBuilder} self for call chaining
      */
+    @SuppressWarnings("UnusedReturnValue") // Last call in chain, may not use this returned value
     IGT_FluidBuilder withTextureName(final String textureName);
-
-    /**
-     * @param fromGTFluid the {@link IGT_Fluid} to copy the texture from
-     * @return {@link IGT_FluidBuilder} self for call chaining
-     */
-    IGT_FluidBuilder withTextureFrom(final IGT_Fluid fromGTFluid);
 
     /**
      * @param fluidBlock the {@link Block} implementation of the {@link IGT_Fluid}
      * @return {@link IGT_FluidBuilder} self for call chaining
      */
+    @SuppressWarnings("UnusedReturnValue") // Last call in chain, may not use this returned value
     IGT_FluidBuilder withFluidBlock(final Block fluidBlock);
+
+    /**
+     * @param stillIcon   The {@link IIcon} of the still fluid texture
+     * @param flowingIcon The {@link IIcon} of the flowing fluid texture
+     * @return {@link IGT_FluidBuilder} self for call chaining
+     */
+    @SuppressWarnings("UnusedReturnValue") // Last call in chain, may not use this returned value
+    IGT_FluidBuilder withIcons(final IIcon stillIcon, final IIcon flowingIcon);
+
+    /**
+     * @param fromFluid the {@link Fluid} to copy the icons from
+     * @return {@link IGT_FluidBuilder} self for call chaining
+     */
+    @SuppressWarnings("UnusedReturnValue") // Last call in chain, may not use this returned value
+    IGT_FluidBuilder withIconsFrom(@Nonnull final Fluid fromFluid);
 
     /**
      * @param stillIconResourceLocation   The {@link ResourceLocation} of the still fluid texture
      * @param flowingIconResourceLocation The {@link ResourceLocation} of the flowing fluid texture
      * @return {@link IGT_FluidBuilder} self for call chaining
      */
+    @SuppressWarnings("UnusedReturnValue") // Last call in chain, may not use this returned value
     IGT_FluidBuilder withTextures(
             final ResourceLocation stillIconResourceLocation, final ResourceLocation flowingIconResourceLocation);
 
@@ -79,5 +98,5 @@ public interface IGT_FluidBuilder {
      * @see #build()
      * @see IGT_Fluid#addFluid()
      */
-    IGT_Fluid buildAndRegister();
+    IGT_RegisteredFluid buildAndRegister();
 }

--- a/src/main/java/gregtech/api/interfaces/fluid/IGT_RegisteredFluid.java
+++ b/src/main/java/gregtech/api/interfaces/fluid/IGT_RegisteredFluid.java
@@ -1,0 +1,56 @@
+package gregtech.api.interfaces.fluid;
+
+import gregtech.api.enums.FluidState;
+import gregtech.api.enums.Materials;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidContainerRegistry;
+
+public interface IGT_RegisteredFluid {
+
+    /**
+     * Registers the containers in the {@link FluidContainerRegistry} for this {@link IGT_Fluid}
+     *
+     * @param fullContainer  The full fluid container
+     * @param emptyContainer The empty fluid container
+     * @param containerSize  The size of the container
+     * @return The {@link IGT_RegisteredFluid} for call chaining
+     */
+    @SuppressWarnings("UnusedReturnValue") // Last call in chain, may not use this returned value
+    IGT_RegisteredFluid registerContainers(
+            final ItemStack fullContainer, final ItemStack emptyContainer, final int containerSize);
+
+    /**
+     * Registers the bucket-sized 1000L containers in the {@link FluidContainerRegistry} for this {@link IGT_Fluid}
+     *
+     * @param fullContainer  The full container to associate with this {@link IGT_Fluid}
+     * @param emptyContainer The empty container associate with this {@link IGT_Fluid}
+     * @return {@link IGT_RegisteredFluid} for call chaining
+     */
+    @SuppressWarnings("UnusedReturnValue") // Last call in chain, may not use this returned value
+    IGT_RegisteredFluid registerBContainers(final ItemStack fullContainer, final ItemStack emptyContainer);
+
+    /**
+     * Registers the potion-sized 250L containers in the {@link FluidContainerRegistry} for this {@link IGT_Fluid}
+     *
+     * @param fullContainer  The full container to associate with this {@link IGT_Fluid}
+     * @param emptyContainer The empty container associate with this {@link IGT_Fluid}
+     * @return {@link IGT_RegisteredFluid} self for call chaining
+     */
+    @SuppressWarnings("UnusedReturnValue") // Last call in chain, may not use this returned value
+    IGT_RegisteredFluid registerPContainers(final ItemStack fullContainer, final ItemStack emptyContainer);
+
+    /**
+     * Updates the {@link Materials}'s fluids from this {@link IGT_Fluid}'s state
+     *
+     * @param material the {@link Materials} to configure based on this {@link IGT_Fluid} and {@link FluidState}
+     * @return The {@link IGT_RegisteredFluid} for call chaining
+     */
+    @SuppressWarnings("UnusedReturnValue") // Last call in chain, may not use this returned value
+    IGT_RegisteredFluid configureMaterials(final Materials material);
+
+    /**
+     * @return this {@link IGT_Fluid} cast to {@link Fluid}
+     */
+    Fluid asFluid();
+}

--- a/src/main/java/gregtech/common/fluid/GT_Fluid.java
+++ b/src/main/java/gregtech/common/fluid/GT_Fluid.java
@@ -22,7 +22,9 @@ public class GT_Fluid extends Fluid implements IGT_Fluid, IGT_RegisteredFluid, R
     private final ResourceLocation flowingIconResourceLocation;
     private final short[] colorRGBA;
     private final FluidState fluidState;
+    private final Fluid iconsFrom;
     private Fluid registeredFluid;
+    private boolean hasRun = false;
 
     /**
      * Constructs this {@link IGT_Fluid} implementation from an {@link GT_FluidBuilder} instance
@@ -34,8 +36,7 @@ public class GT_Fluid extends Fluid implements IGT_Fluid, IGT_RegisteredFluid, R
         this.localizedName = builder.localizedName;
         this.stillIconResourceLocation = builder.stillIconResourceLocation;
         this.flowingIconResourceLocation = builder.flowingIconResourceLocation;
-        this.stillIcon = builder.stillIcon;
-        this.flowingIcon = builder.flowingIcon;
+        this.iconsFrom = builder.iconsFrom;
         this.block = builder.fluidBlock;
         this.colorRGBA = builder.colorRGBA;
         this.fluidState = builder.fluidState;
@@ -185,11 +186,21 @@ public class GT_Fluid extends Fluid implements IGT_Fluid, IGT_RegisteredFluid, R
      */
     @Override
     public void run() {
-        if (stillIconResourceLocation != null) {
-            stillIcon = GregTech_API.sBlockIcons.registerIcon(stillIconResourceLocation.toString());
-        }
-        if (flowingIconResourceLocation != null) {
-            flowingIcon = GregTech_API.sBlockIcons.registerIcon(flowingIconResourceLocation.toString());
+        if (!hasRun) {
+            if (iconsFrom instanceof GT_Fluid) {
+                // Needs the GT_Fluid to have registered its icons
+                ((GT_Fluid) iconsFrom).run();
+                stillIcon = iconsFrom.getStillIcon();
+                flowingIcon = iconsFrom.getFlowingIcon();
+            } else {
+                if (stillIconResourceLocation != null) {
+                    stillIcon = GregTech_API.sBlockIcons.registerIcon(stillIconResourceLocation.toString());
+                }
+                if (flowingIconResourceLocation != null) {
+                    flowingIcon = GregTech_API.sBlockIcons.registerIcon(flowingIconResourceLocation.toString());
+                }
+            }
+            hasRun = true;
         }
     }
 }

--- a/src/main/java/gregtech/common/fluid/GT_FluidBuilder.java
+++ b/src/main/java/gregtech/common/fluid/GT_FluidBuilder.java
@@ -6,21 +6,27 @@ import gregtech.api.enums.Dyes;
 import gregtech.api.enums.FluidState;
 import gregtech.api.interfaces.fluid.IGT_Fluid;
 import gregtech.api.interfaces.fluid.IGT_FluidBuilder;
+import gregtech.api.interfaces.fluid.IGT_RegisteredFluid;
 import java.util.Locale;
+import javax.annotation.Nonnull;
 import net.minecraft.block.Block;
+import net.minecraft.util.IIcon;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fluids.Fluid;
 
 public class GT_FluidBuilder implements IGT_FluidBuilder {
-    protected final String fluidName;
-    protected String localizedName;
-    protected ResourceLocation stillIconResourceLocation = null, flowingIconResourceLocation = null;
-    protected short[] colorRGBA = Dyes._NULL.getRGBA();
-    protected Block fluidBlock = null;
-    protected FluidState fluidState;
-    protected int temperature;
+    final String fluidName;
+    String localizedName;
+    ResourceLocation stillIconResourceLocation = null, flowingIconResourceLocation = null;
+    short[] colorRGBA = Dyes._NULL.getRGBA();
+    Block fluidBlock = null;
+    FluidState fluidState;
+    int temperature;
+    IIcon stillIcon;
+    IIcon flowingIcon;
 
     public GT_FluidBuilder(final String fluidName) {
-        this.fluidName = fluidName;
+        this.fluidName = fluidName.toLowerCase(Locale.ENGLISH);
     }
 
     /**
@@ -83,10 +89,8 @@ public class GT_FluidBuilder implements IGT_FluidBuilder {
      * @inheritDoc
      */
     @Override
-    public IGT_FluidBuilder withTextureFrom(final IGT_Fluid fromGTFluid) {
-        this.stillIconResourceLocation = fromGTFluid.getStillIconResourceLocation();
-        this.flowingIconResourceLocation = fromGTFluid.getFlowingIconResourceLocation();
-        return this;
+    public IGT_FluidBuilder withIconsFrom(@Nonnull final Fluid fromFluid) {
+        return withIcons(fromFluid.getStillIcon(), fromFluid.getFlowingIcon());
     }
 
     /**
@@ -95,6 +99,16 @@ public class GT_FluidBuilder implements IGT_FluidBuilder {
     @Override
     public IGT_FluidBuilder withFluidBlock(final Block fluidBlock) {
         this.fluidBlock = fluidBlock;
+        return this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public IGT_FluidBuilder withIcons(final IIcon stillIcon, final IIcon flowingIcon) {
+        this.stillIcon = stillIcon;
+        this.flowingIcon = flowingIcon;
         return this;
     }
 
@@ -114,8 +128,14 @@ public class GT_FluidBuilder implements IGT_FluidBuilder {
      */
     @Override
     public IGT_Fluid build() {
+        if (colorRGBA == null) {
+            colorRGBA = Dyes._NULL.getRGBA();
+        }
         if (stillIconResourceLocation == null) {
             withTextureName(fluidName.toLowerCase(Locale.ENGLISH));
+        }
+        if (localizedName == null) {
+            localizedName = fluidName;
         }
         return new GT_Fluid(this);
     }
@@ -124,7 +144,7 @@ public class GT_FluidBuilder implements IGT_FluidBuilder {
      * @inheritDoc
      */
     @Override
-    public IGT_Fluid buildAndRegister() {
+    public IGT_RegisteredFluid buildAndRegister() {
         if (stillIconResourceLocation == null) {
             withTextureName(fluidName.toLowerCase(Locale.ENGLISH));
         }

--- a/src/main/java/gregtech/common/fluid/GT_FluidBuilder.java
+++ b/src/main/java/gregtech/common/fluid/GT_FluidBuilder.java
@@ -24,6 +24,7 @@ public class GT_FluidBuilder implements IGT_FluidBuilder {
     int temperature;
     IIcon stillIcon;
     IIcon flowingIcon;
+    Fluid iconsFrom;
 
     public GT_FluidBuilder(final String fluidName) {
         this.fluidName = fluidName.toLowerCase(Locale.ENGLISH);
@@ -90,7 +91,8 @@ public class GT_FluidBuilder implements IGT_FluidBuilder {
      */
     @Override
     public IGT_FluidBuilder withIconsFrom(@Nonnull final Fluid fromFluid) {
-        return withIcons(fromFluid.getStillIcon(), fromFluid.getFlowingIcon());
+        this.iconsFrom = fromFluid;
+        return this;
     }
 
     /**
@@ -99,16 +101,6 @@ public class GT_FluidBuilder implements IGT_FluidBuilder {
     @Override
     public IGT_FluidBuilder withFluidBlock(final Block fluidBlock) {
         this.fluidBlock = fluidBlock;
-        return this;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    @Override
-    public IGT_FluidBuilder withIcons(final IIcon stillIcon, final IIcon flowingIcon) {
-        this.stillIcon = stillIcon;
-        this.flowingIcon = flowingIcon;
         return this;
     }
 

--- a/src/main/java/gregtech/common/fluid/GT_FluidBuilder.java
+++ b/src/main/java/gregtech/common/fluid/GT_FluidBuilder.java
@@ -145,9 +145,6 @@ public class GT_FluidBuilder implements IGT_FluidBuilder {
      */
     @Override
     public IGT_RegisteredFluid buildAndRegister() {
-        if (stillIconResourceLocation == null) {
-            withTextureName(fluidName.toLowerCase(Locale.ENGLISH));
-        }
         return build().addFluid();
     }
 }

--- a/src/main/java/gregtech/loaders/preload/GT_Loader_Item_Block_And_Fluid.java
+++ b/src/main/java/gregtech/loaders/preload/GT_Loader_Item_Block_And_Fluid.java
@@ -915,8 +915,7 @@ public class GT_Loader_Item_Block_And_Fluid implements Runnable {
         Materials.Ice.mGas = Materials.Water.mGas;
         Materials.Water.mGas.setTemperature(375).setGaseous(true);
 
-        ItemList.sOilExtraHeavy = GT_FluidFactory.of("liquid_extra_heavy_oil", "Very Heavy Oil", LIQUID, 295)
-                .asFluid();
+        ItemList.sOilExtraHeavy = GT_FluidFactory.of("liquid_extra_heavy_oil", "Very Heavy Oil", LIQUID, 295);
         ItemList.sEpichlorhydrin = GT_FluidFactory.builder("liquid_epichlorhydrin")
                 .withLocalizedName("Epichlorohydrin")
                 .withStateAndTemperature(LIQUID, 295)
@@ -924,8 +923,7 @@ public class GT_Loader_Item_Block_And_Fluid implements Runnable {
                 .configureMaterials(Materials.Epichlorohydrin)
                 .registerBContainers(Materials.Epichlorohydrin.getCells(1), Materials.Empty.getCells(1))
                 .asFluid();
-        ItemList.sDrillingFluid = GT_FluidFactory.of("liquid_drillingfluid", "Drilling Fluid", LIQUID, 295)
-                .asFluid();
+        ItemList.sDrillingFluid = GT_FluidFactory.of("liquid_drillingfluid", "Drilling Fluid", LIQUID, 295);
         ItemList.sToluene = GT_FluidFactory.builder("liquid_toluene")
                 .withLocalizedName("Toluene")
                 .withStateAndTemperature(LIQUID, 295)
@@ -1321,21 +1319,23 @@ public class GT_Loader_Item_Block_And_Fluid implements Runnable {
         for (byte i = 0; i < Dyes.VALUES.length; i = (byte) (i + 1)) {
             Dyes tDye = Dyes.VALUES[i];
             Fluid tFluid;
-            tDye.addFluidDye((Fluid)
+            tDye.addFluidDye(
                     GT_FluidFactory.builder("dye.watermixed." + tDye.name().toLowerCase(Locale.ENGLISH))
                             .withTextureName("dyes")
                             .withLocalizedName("Water Mixed " + tDye.mName + " Dye")
                             .withColorRGBA(tDye.getRGBA())
                             .withStateAndTemperature(LIQUID, 295)
-                            .buildAndRegister());
-            tDye.addFluidDye((Fluid) GT_FluidFactory.builder(
-                            "dye.chemical." + tDye.name().toLowerCase(Locale.ENGLISH))
-                    .withTextureName("dyes")
-                    .withLocalizedName("Chemical " + tDye.mName + " Dye")
-                    .withColorRGBA(tDye.getRGBA())
-                    .withStateAndTemperature(LIQUID, 295)
-                    .buildAndRegister()
-                    .registerContainers(ItemList.SPRAY_CAN_DYES[i].get(1L), ItemList.Spray_Empty.get(1L), 2304));
+                            .buildAndRegister()
+                            .asFluid());
+            tDye.addFluidDye(
+                    GT_FluidFactory.builder("dye.chemical." + tDye.name().toLowerCase(Locale.ENGLISH))
+                            .withTextureName("dyes")
+                            .withLocalizedName("Chemical " + tDye.mName + " Dye")
+                            .withColorRGBA(tDye.getRGBA())
+                            .withStateAndTemperature(LIQUID, 295)
+                            .buildAndRegister()
+                            .registerContainers(ItemList.SPRAY_CAN_DYES[i].get(1L), ItemList.Spray_Empty.get(1L), 2304)
+                            .asFluid());
         }
         GT_FluidFactory.builder("ice")
                 .withLocalizedName("Crushed Ice")


### PR DESCRIPTION
Improves the initial construction model into a fluent interface.
See: https://java-design-patterns.com/patterns/fluentinterface/

This change provides the built and registered states of a GT_Fluid, with their own interface, so that: object state validations are performed at build time, rather than causing an `IllegalStateException` to be thrown at runtime, with the previous implementation.

This also allows the IDE to display and check the applicable methods for the GT_Fluid object's state, as it moves through the call chain.