### PR TITLE
Add chemical formula to ore tooltip

### DIFF
--- a/src/main/java/gregtech/common/blocks/GT_Block_Ores_Abstract.java
+++ b/src/main/java/gregtech/common/blocks/GT_Block_Ores_Abstract.java
@@ -39,6 +39,7 @@ import net.minecraft.world.World;
 
 public abstract class GT_Block_Ores_Abstract extends GT_Generic_Block implements ITileEntityProvider {
     private static final String DOT_NAME = ".name";
+    private static final String DOT_TOOLTIP = ".tooltip";
     public static ThreadLocal<GT_TileEntity_Ores> mTemporaryTileEntity = new ThreadLocal<>();
     public static boolean FUCKING_LOCK = false;
     public static boolean tHideOres;
@@ -66,11 +67,17 @@ public abstract class GT_Block_Ores_Abstract extends GT_Generic_Block implements
                                     ? getLocalizedNameFormat(GregTech_API.sGeneratedMaterials[i])
                                     : getLocalizedName(GregTech_API.sGeneratedMaterials[i]));
                     GT_LanguageManager.addStringLocalization(
+                            getUnlocalizedName() + "." + (i + (j * 1000)) + DOT_TOOLTIP,
+                            GregTech_API.sGeneratedMaterials[i].getToolTip());
+                    GT_LanguageManager.addStringLocalization(
                             getUnlocalizedName() + "." + ((i + 16000) + (j * 1000)) + DOT_NAME,
                             "Small "
                                     + (GT_LanguageManager.i18nPlaceholder
                                             ? getLocalizedNameFormat(GregTech_API.sGeneratedMaterials[i])
                                             : getLocalizedName(GregTech_API.sGeneratedMaterials[i])));
+                    GT_LanguageManager.addStringLocalization(
+                            getUnlocalizedName() + "." + ((i + 16000) + (j * 1000)) + DOT_TOOLTIP,
+                            GregTech_API.sGeneratedMaterials[i].getToolTip());
                     if ((GregTech_API.sGeneratedMaterials[i].mTypes & 0x8) != 0
                             && !aBlockedOres.contains(GregTech_API.sGeneratedMaterials[i])) {
                         GT_OreDictUnificator.registerOre(

--- a/src/main/java/gregtech/common/blocks/GT_Item_Ores.java
+++ b/src/main/java/gregtech/common/blocks/GT_Item_Ores.java
@@ -2,11 +2,14 @@ package gregtech.common.blocks;
 
 import gregtech.api.GregTech_API;
 import gregtech.api.enums.Materials;
+import java.util.List;
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
+import org.apache.commons.lang3.StringUtils;
 
 public class GT_Item_Ores extends ItemBlock {
     public GT_Item_Ores(Block block) {
@@ -82,5 +85,12 @@ public class GT_Item_Ores extends ItemBlock {
             this.field_150939_a.onPostBlockPlaced(aWorld, aX, aY, aZ, tDamage);
         }
         return true;
+    }
+
+    @Override
+    public void addInformation(ItemStack aStack, EntityPlayer aPlayer, List aList, boolean aF3_H) {
+        String formula = StatCollector.translateToLocal(field_150939_a.getUnlocalizedName() + '.' + getDamage(aStack) + ".tooltip");
+        if (!StringUtils.isBlank(formula))
+            aList.add(formula);
     }
 }

--- a/src/main/java/gregtech/common/blocks/GT_Item_Ores.java
+++ b/src/main/java/gregtech/common/blocks/GT_Item_Ores.java
@@ -89,8 +89,8 @@ public class GT_Item_Ores extends ItemBlock {
 
     @Override
     public void addInformation(ItemStack aStack, EntityPlayer aPlayer, List aList, boolean aF3_H) {
-        String formula = StatCollector.translateToLocal(field_150939_a.getUnlocalizedName() + '.' + getDamage(aStack) + ".tooltip");
-        if (!StringUtils.isBlank(formula))
-            aList.add(formula);
+        String formula = StatCollector.translateToLocal(
+                field_150939_a.getUnlocalizedName() + '.' + getDamage(aStack) + ".tooltip");
+        if (!StringUtils.isBlank(formula)) aList.add(formula);
     }
 }


### PR DESCRIPTION
Mostly useful when you want copper or iron, but doesn't care what this ore is. Also help new player to understand the value of a particular type of ore.