### PR TITLE
Revert "Fix charger slot in Regulator not dropping item stored when broken" to fix stable crash

### DIFF
--- a/src/main/java/gregtech/common/tileentities/automation/GT_MetaTileEntity_Regulator.java
+++ b/src/main/java/gregtech/common/tileentities/automation/GT_MetaTileEntity_Regulator.java
@@ -58,7 +58,7 @@ public class GT_MetaTileEntity_Regulator extends GT_MetaTileEntity_Buffer {
 
     @Override
     public boolean isValidSlot(int aIndex) {
-        return aIndex < 9 || aIndex == rechargerSlotStartIndex();
+        return aIndex < 9;
     }
 
     @Override


### PR DESCRIPTION
Reverts GTNewHorizons/GT5-Unofficial#1417