### PR TITLE
Fix black bronze mixer recipe taking less electrum than it should

### DIFF
--- a/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
@@ -360,7 +360,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                 120);
         GT_Values.RA.addMixerRecipe(
                 GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Copper, 3L),
-                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Electrum, 1L),
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Electrum, 2L),
                 GT_Values.NI,
                 GT_Values.NI,
                 GT_Values.NI,

--- a/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
@@ -367,7 +367,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                 GT_Utility.getIntegratedCircuit(1),
                 GT_Values.NF,
                 GT_Values.NF,
-                GT_OreDictUnificator.getDust(Materials.BlackBronze, 4L * OrePrefixes.dust.mMaterialAmount),
+                GT_OreDictUnificator.getDust(Materials.BlackBronze, 5L * OrePrefixes.dust.mMaterialAmount),
                 (int) (500L * OrePrefixes.dust.mMaterialAmount / 3628800L),
                 8);
         GT_Values.RA.addMixerRecipe(


### PR DESCRIPTION
BlackBronze is Cu3AuAg. 2 Electrum is 1 Au + 1Ag. So the recipe of BlackBronze should be 3Cu + 2 Electrum = 3 Cu + 1 Au + 1Ag