### PR TITLE
minor_typo(javadoc): Documentation typos 

### DIFF
--- a/src/main/java/gregtech/api/interfaces/fluid/IGT_RegisteredFluid.java
+++ b/src/main/java/gregtech/api/interfaces/fluid/IGT_RegisteredFluid.java
@@ -9,7 +9,7 @@ import net.minecraftforge.fluids.FluidContainerRegistry;
 public interface IGT_RegisteredFluid {
 
     /**
-     * Registers the containers in the {@link FluidContainerRegistry} for this {@link IGT_Fluid}
+     * Registers the containers in the {@link FluidContainerRegistry} for this {@link IGT_RegisteredFluid}
      *
      * @param fullContainer  The full fluid container
      * @param emptyContainer The empty fluid container
@@ -21,36 +21,36 @@ public interface IGT_RegisteredFluid {
             final ItemStack fullContainer, final ItemStack emptyContainer, final int containerSize);
 
     /**
-     * Registers the bucket-sized 1000L containers in the {@link FluidContainerRegistry} for this {@link IGT_Fluid}
+     * Registers the bucket-sized 1000L containers in the {@link FluidContainerRegistry} for this {@link IGT_RegisteredFluid}
      *
-     * @param fullContainer  The full container to associate with this {@link IGT_Fluid}
-     * @param emptyContainer The empty container associate with this {@link IGT_Fluid}
+     * @param fullContainer  The full container to associate with this {@link IGT_RegisteredFluid}
+     * @param emptyContainer The empty container associate with this {@link IGT_RegisteredFluid}
      * @return {@link IGT_RegisteredFluid} for call chaining
      */
     @SuppressWarnings("UnusedReturnValue") // Last call in chain, may not use this returned value
     IGT_RegisteredFluid registerBContainers(final ItemStack fullContainer, final ItemStack emptyContainer);
 
     /**
-     * Registers the potion-sized 250L containers in the {@link FluidContainerRegistry} for this {@link IGT_Fluid}
+     * Registers the potion-sized 250L containers in the {@link FluidContainerRegistry} for this {@link IGT_RegisteredFluid}
      *
-     * @param fullContainer  The full container to associate with this {@link IGT_Fluid}
-     * @param emptyContainer The empty container associate with this {@link IGT_Fluid}
+     * @param fullContainer  The full container to associate with this {@link IGT_RegisteredFluid}
+     * @param emptyContainer The empty container associate with this {@link IGT_RegisteredFluid}
      * @return {@link IGT_RegisteredFluid} self for call chaining
      */
     @SuppressWarnings("UnusedReturnValue") // Last call in chain, may not use this returned value
     IGT_RegisteredFluid registerPContainers(final ItemStack fullContainer, final ItemStack emptyContainer);
 
     /**
-     * Updates the {@link Materials}'s fluids from this {@link IGT_Fluid}'s state
+     * Updates the {@link Materials}'s fluids from this {@link IGT_RegisteredFluid}'s state
      *
-     * @param material the {@link Materials} to configure based on this {@link IGT_Fluid} and {@link FluidState}
+     * @param material the {@link Materials} to configure based on this {@link IGT_RegisteredFluid} and {@link FluidState}
      * @return The {@link IGT_RegisteredFluid} for call chaining
      */
     @SuppressWarnings("UnusedReturnValue") // Last call in chain, may not use this returned value
     IGT_RegisteredFluid configureMaterials(final Materials material);
 
     /**
-     * @return this {@link IGT_Fluid} cast to {@link Fluid}
+     * @return this {@link IGT_RegisteredFluid} cast to {@link Fluid}
      */
     Fluid asFluid();
 }


### PR DESCRIPTION
Fixes a minor typo in JavaDoc documentation for `IGT_RegisteredFluid` that referred to the wrong
`IGT_Fluid` Interface instead of `IGT_RegisteredFluid`

This fix does not change compiled code. Its scope is limited to the API documentation.