### PR TITLE
Fix typo in NEI handler (1 ticks should be written as 1 tick).

### DIFF
--- a/src/main/java/gregtech/api/util/GT_LanguageManager.java
+++ b/src/main/java/gregtech/api/util/GT_LanguageManager.java
@@ -383,6 +383,7 @@ public class GT_LanguageManager {
         addStringLocalization(
                 "Interaction_DESCRIPTION_Index_223", "Single recipe locking enabled. Will lock to next recipe.");
         addStringLocalization("Interaction_DESCRIPTION_Index_224", " ticks");
+        addStringLocalization("Interaction_DESCRIPTION_Index_225", " tick");
         addStringLocalization("Interaction_DESCRIPTION_Index_500", "Fitting: Loose - More Flow");
         addStringLocalization("Interaction_DESCRIPTION_Index_501", "Fitting: Tight - More Efficiency");
 

--- a/src/main/java/gregtech/common/power/Power.java
+++ b/src/main/java/gregtech/common/power/Power.java
@@ -39,6 +39,9 @@ public abstract class Power {
     }
 
     public String getDurationStringTicks() {
+        if (getDurationTicks() == 1) {
+            return GT_Utility.formatNumbers(getDurationTicks()) + GT_Utility.trans("225", " tick");
+        }
         return GT_Utility.formatNumbers(getDurationTicks()) + GT_Utility.trans("224", " ticks");
     }
 


### PR DESCRIPTION
<img width="390" alt="Screenshot 2022-10-03 at 01 52 53" src="https://user-images.githubusercontent.com/52056774/193484546-7a94b16d-61a8-4222-ac92-6c09cd87b02f.png">
<img width="539" alt="Screenshot 2022-10-03 at 01 53 30" src="https://user-images.githubusercontent.com/52056774/193484577-59c57172-c250-4175-af15-a164e4f29175.png">
