### PR TITLE
Fix typo in NEI handler (1 ticks should be written as 1 tick).

### DIFF
--- a/src/main/java/gregtech/api/util/GT_LanguageManager.java
+++ b/src/main/java/gregtech/api/util/GT_LanguageManager.java
@@ -371,6 +371,7 @@ public class GT_LanguageManager {
                 "Interaction_DESCRIPTION_Index_207", "Pump speed: %dL every %d ticks, %.2f L/sec on average");
         addStringLocalization("Interaction_DESCRIPTION_Index_208", " L");
         addStringLocalization("Interaction_DESCRIPTION_Index_209", " ticks");
+        addStringLocalization("Interaction_DESCRIPTION_Index_209.1", " ticks");
         addStringLocalization("Interaction_DESCRIPTION_Index_210", "Average: %.2f L/sec");
         addStringLocalization("Interaction_DESCRIPTION_Index_211", "Items per side: ");
         addStringLocalization("Interaction_DESCRIPTION_Index_212", "Input enabled");

--- a/src/main/java/gregtech/common/power/Power.java
+++ b/src/main/java/gregtech/common/power/Power.java
@@ -39,6 +39,9 @@ public abstract class Power {
     }
 
     public String getDurationStringTicks() {
+        if (getDurationTicks() == 1) {
+            return GT_Utility.formatNumbers(getDurationTicks()) + GT_Utility.trans("209.1", " tick");
+        }
         return GT_Utility.formatNumbers(getDurationTicks()) + GT_Utility.trans("209", " ticks");
     }
 


### PR DESCRIPTION
<img width="422" alt="Screenshot 2022-10-03 at 02 18 08" src="https://user-images.githubusercontent.com/52056774/193485964-a0838ba6-7709-4405-aa3e-aea23392a515.png">
vs
<img width="427" alt="Screenshot 2022-10-03 at 02 18 23" src="https://user-images.githubusercontent.com/52056774/193485976-6b72cd78-c8a2-4c4c-b309-34580e104dd8.png">
