### PR TITLE
Get tank info real capacity instead of capacity

### DIFF
--- a/src/main/java/gregtech/common/tileentities/storage/GT_MetaTileEntity_DigitalTankBase.java
+++ b/src/main/java/gregtech/common/tileentities/storage/GT_MetaTileEntity_DigitalTankBase.java
@@ -439,7 +439,7 @@ public abstract class GT_MetaTileEntity_DigitalTankBase extends GT_MetaTileEntit
 
     @Override
     public FluidTankInfo getInfo() {
-        return new FluidTankInfo(getFluid(), getCapacity());
+        return new FluidTankInfo(getFluid(), getRealCapacity());
     }
 
     @Override


### PR DESCRIPTION
Makes Waila display the real tank max capacity instead of Max_integer when overflow voiding  is enable.
Issue: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/11519