### PR TITLE
Added batch mode to Processing Arrays adding up to 128 parallel

### DIFF
--- a/src/main/java/gregtech/api/util/GT_Recipe.java
+++ b/src/main/java/gregtech/api/util/GT_Recipe.java
@@ -538,7 +538,16 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
 
     public boolean isRecipeInputEqual(
             boolean aDecreaseStacksizeBySuccess, FluidStack[] aFluidInputs, ItemStack... aInputs) {
-        return isRecipeInputEqual(aDecreaseStacksizeBySuccess, false, aFluidInputs, aInputs);
+        return isRecipeInputEqual(aDecreaseStacksizeBySuccess, false, 1, aFluidInputs, aInputs);
+    }
+
+    // For non-multiplied recipe amount values
+    public boolean isRecipeInputEqual(
+            boolean aDecreaseStacksizeBySuccess,
+            boolean aDontCheckStackSizes,
+            FluidStack[] aFluidInputs,
+            ItemStack... aInputs) {
+        return isRecipeInputEqual(aDecreaseStacksizeBySuccess, false, 1, aFluidInputs, aInputs);
     }
 
     /**
@@ -563,6 +572,7 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
     public boolean isRecipeInputEqual(
             boolean aDecreaseStacksizeBySuccess,
             boolean aDontCheckStackSizes,
+            int amountMultiplier,
             FluidStack[] aFluidInputs,
             ItemStack... aInputs) {
         if (mInputs.length > 0 && aInputs == null) return false;
@@ -581,7 +591,7 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
             for (FluidStack recipeFluidCost : mFluidInputs) {
                 if (recipeFluidCost != null) {
                     inputFound = false;
-                    remainingCost = recipeFluidCost.amount;
+                    remainingCost = recipeFluidCost.amount * amountMultiplier;
 
                     for (int i = 0; i < aFluidInputs.length; i++) {
                         FluidStack providedFluid = aFluidInputs[i];
@@ -620,7 +630,7 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
                 ItemStack unifiedItemCost = GT_OreDictUnificator.get_nocopy(true, recipeItemCost);
                 if (unifiedItemCost != null) {
                     inputFound = false;
-                    remainingCost = recipeItemCost.stackSize;
+                    remainingCost = recipeItemCost.stackSize * amountMultiplier;
 
                     for (int i = 0; i < aInputs.length; i++) {
                         ItemStack providedItem = aInputs[i];

--- a/src/main/java/gregtech/api/util/GT_Recipe.java
+++ b/src/main/java/gregtech/api/util/GT_Recipe.java
@@ -547,7 +547,7 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
             boolean aDontCheckStackSizes,
             FluidStack[] aFluidInputs,
             ItemStack... aInputs) {
-        return isRecipeInputEqual(aDecreaseStacksizeBySuccess, false, 1, aFluidInputs, aInputs);
+        return isRecipeInputEqual(aDecreaseStacksizeBySuccess, aDontCheckStackSizes, 1, aFluidInputs, aInputs);
     }
 
     /**


### PR DESCRIPTION
A new toggleable feature to PAs, accessible by sneak-right clicking the controller with a wire cutter.

Calculates the maximum amount of parallels the machine can run back-to-back (up to 128) with the current items, and multiplies item inputs, outputs and recipe time by this number. This is only an anti-lag measure, preventing the expensive recipe lookups with fast machines from happening on every tick.

Tested on my server, reduces 1-ticking PA tick time by 99%. Does not generate new items or void items, works with both fluids and items.