### PR TITLE
Add a Heating Counter for LHE Explosions

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_HeatExchanger.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_HeatExchanger.java
@@ -38,6 +38,8 @@ import net.minecraftforge.fluids.FluidStack;
 public class GT_MetaTileEntity_HeatExchanger
         extends GT_MetaTileEntity_EnhancedMultiBlockBase<GT_MetaTileEntity_HeatExchanger>
         implements ISurvivalConstructable {
+    private static int dryHeatCounter = 0; // Counts up to dryHeatMaximum to check for explosion conditions
+    private static final int dryHeatMaximum = 2000; // 2000 ticks = 100 seconds
     private static final int CASING_INDEX = 50;
     private static final String STRUCTURE_PIECE_MAIN = "main";
     private static final IStructureDefinition<GT_MetaTileEntity_HeatExchanger> STRUCTURE_DEFINITION =
@@ -278,9 +280,17 @@ public class GT_MetaTileEntity_HeatExchanger
                     } else {
                         addOutput(GT_ModHandler.getSteam(tGeneratedEU)); // Generate regular steam
                     }
+                    if (dryHeatCounter != 0) {
+                        dryHeatCounter = 0;
+                    }
                 } else {
-                    GT_Log.exp.println(this.mName + " had no more Distilled water!");
-                    explodeMultiblock(); // Generate crater
+                    if (dryHeatCounter < dryHeatMaximum) {
+                        dryHeatCounter += 1;
+                    }
+                    else {
+                        GT_Log.exp.println(this.mName + " was too hot and had no more Distilled Water!");
+                        explodeMultiblock(); // Generate crater
+                    }
                 }
             }
             return true;

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_HeatExchanger.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_HeatExchanger.java
@@ -38,7 +38,7 @@ import net.minecraftforge.fluids.FluidStack;
 public class GT_MetaTileEntity_HeatExchanger
         extends GT_MetaTileEntity_EnhancedMultiBlockBase<GT_MetaTileEntity_HeatExchanger>
         implements ISurvivalConstructable {
-    private static int dryHeatCounter = 0; // Counts up to dryHeatMaximum to check for explosion conditions
+    private int dryHeatCounter = 0; // Counts up to dryHeatMaximum to check for explosion conditions
     private static final int dryHeatMaximum = 2000; // 2000 ticks = 100 seconds
     private static final int CASING_INDEX = 50;
     private static final String STRUCTURE_PIECE_MAIN = "main";
@@ -280,9 +280,7 @@ public class GT_MetaTileEntity_HeatExchanger
                     } else {
                         addOutput(GT_ModHandler.getSteam(tGeneratedEU)); // Generate regular steam
                     }
-                    if (dryHeatCounter != 0) {
-                        dryHeatCounter = 0;
-                    }
+                    dryHeatCounter = 0;
                 } else {
                     if (dryHeatCounter < dryHeatMaximum) {
                         dryHeatCounter += 1;

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_HeatExchanger.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_HeatExchanger.java
@@ -284,8 +284,7 @@ public class GT_MetaTileEntity_HeatExchanger
                 } else {
                     if (dryHeatCounter < dryHeatMaximum) {
                         dryHeatCounter += 1;
-                    }
-                    else {
+                    } else {
                         GT_Log.exp.println(this.mName + " was too hot and had no more Distilled Water!");
                         explodeMultiblock(); // Generate crater
                     }


### PR DESCRIPTION
- Change the LHE code to start counting up to a specific value on every tick where there's no distilled water, only exploding after a certain time has passed without water, instead of instantly.

With this change, I wanted to keep the LHE explosion, but also prevent it from exploding immediately after losing all of its Distilled Water. Theoretically, the explosion happens because the structure heats up too much, and adding water to a very hot container causes it to boil violently and explode due to the pressure. However, the LHE should not instantly heat up to this situation.

Additionally, there are some situations, such as AE2 not loading up instantly on world restart, which causes the water flow to stop for a few seconds. Having this counter, it should be possible to avoid explosions in that situation.