### PR TITLE
Fix Fluid Detector RS signal

### DIFF
--- a/src/main/java/gregtech/common/covers/GT_Cover_LiquidMeter.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_LiquidMeter.java
@@ -8,10 +8,12 @@ import gregtech.api.gui.widgets.GT_GuiIconCheckButton;
 import gregtech.api.gui.widgets.GT_GuiIntegerTextBox;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.tileentity.ICoverable;
+import gregtech.api.metatileentity.BaseMetaTileEntity;
 import gregtech.api.net.GT_Packet_TileEntityCoverNew;
 import gregtech.api.util.GT_CoverBehaviorBase;
 import gregtech.api.util.GT_Utility;
 import gregtech.api.util.ISerializableObject;
+import gregtech.common.tileentities.storage.GT_MetaTileEntity_DigitalTankBase;
 import io.netty.buffer.ByteBuf;
 import java.util.Arrays;
 import javax.annotation.Nonnull;
@@ -61,7 +63,13 @@ public class GT_Cover_LiquidMeter extends GT_CoverBehaviorBase<GT_Cover_LiquidMe
             if (tanks != null) {
                 for (FluidTankInfo tank : tanks) {
                     if (tank != null) {
-                        max += tank.capacity;
+                        if (tileEntity instanceof BaseMetaTileEntity
+                                && ((BaseMetaTileEntity) tileEntity).getMetaTileEntity()
+                                        instanceof GT_MetaTileEntity_DigitalTankBase) {
+                            max += ((GT_MetaTileEntity_DigitalTankBase)
+                                            ((BaseMetaTileEntity) tileEntity).getMetaTileEntity())
+                                    .getRealCapacity();
+                        } else max += tank.capacity;
                         FluidStack tLiquid = tank.fluid;
                         if (tLiquid != null) {
                             used += tLiquid.amount;


### PR DESCRIPTION
Fix the Redstone signal outputed by Fluid detector when the Void Overflow was enable. Since GetTankInfo is used by many mods, I had to use this approach to make sure it does not break anything.
Issue : https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/11569