### PR TITLE
Restricting Bees to MApiary + create class

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -16,7 +16,7 @@ dependencies {
     compileOnly("com.github.GTNewHorizons:EnderCore:0.2.10:dev") {
         transitive = false
     }
-    compileOnly("com.github.GTNewHorizons:ForestryMC:4.5.2:dev") {
+    compileOnly("com.github.GTNewHorizons:ForestryMC:4.5.3:dev") {
         transitive = false
     }
     compileOnly("com.github.GTNewHorizons:gendustry:1.6.5.4-GTNH:dev") {

--- a/src/main/java/gregtech/api/util/GT_JubilanceMegaApiary.java
+++ b/src/main/java/gregtech/api/util/GT_JubilanceMegaApiary.java
@@ -7,9 +7,9 @@ import forestry.api.apiculture.IJubilanceProvider;
 
 public class GT_JubilanceMegaApiary implements IJubilanceProvider {
 
-    public static final GT_JubilanceMegaApiary instance = new GT_JubilanceMegaApiary ();
+    public static final GT_JubilanceMegaApiary instance = new GT_JubilanceMegaApiary();
 
-    protected GT_JubilanceMegaApiary () {}
+    protected GT_JubilanceMegaApiary() {}
 
     @Override
     public boolean isJubilant(IAlleleBeeSpecies species, IBeeGenome genome, IBeeHousing housing) {
@@ -18,6 +18,6 @@ public class GT_JubilanceMegaApiary implements IJubilanceProvider {
 
     @Override
     public String getDescription() {
-        return "Needs Mega Apiary";
+        return "Will only be produced in mega Apiary";
     }
 }

--- a/src/main/java/gregtech/api/util/GT_JubilanceMegaApiary.java
+++ b/src/main/java/gregtech/api/util/GT_JubilanceMegaApiary.java
@@ -1,0 +1,23 @@
+package gregtech.api.util;
+
+import forestry.api.apiculture.IAlleleBeeSpecies;
+import forestry.api.apiculture.IBeeGenome;
+import forestry.api.apiculture.IBeeHousing;
+import forestry.api.apiculture.IJubilanceProvider;
+
+public class GT_JubilanceMegaApiary implements IJubilanceProvider {
+
+    public static final GT_JubilanceMegaApiary instance = new GT_JubilanceMegaApiary ();
+
+    protected GT_JubilanceMegaApiary () {}
+
+    @Override
+    public boolean isJubilant(IAlleleBeeSpecies species, IBeeGenome genome, IBeeHousing housing) {
+        return false;
+    }
+
+    @Override
+    public String getDescription() {
+        return "Needs Mega Apiary";
+    }
+}

--- a/src/main/java/gregtech/loaders/misc/GT_BeeDefinition.java
+++ b/src/main/java/gregtech/loaders/misc/GT_BeeDefinition.java
@@ -1974,7 +1974,7 @@ public enum GT_BeeDefinition implements IBeeDefinition {
                 beeSpecies.setTemperature(EnumTemperature.NORMAL);
                 beeSpecies.setNocturnal();
                 beeSpecies.setHasEffect();
-                //Makes it only work in the Mega Apiary NOTE: COMB MUST BE SPECIALITY COMB
+                // Makes it only work in the Mega Apiary NOTE: COMB MUST BE SPECIALITY COMB
                 beeSpecies.setJubilanceProvider(GT_JubilanceMegaApiary.instance);
             },
             template -> {
@@ -3404,7 +3404,7 @@ public enum GT_BeeDefinition implements IBeeDefinition {
                 beeSpecies.setTemperature(ICY);
                 beeSpecies.setNocturnal();
                 beeSpecies.setHasEffect();
-                //Makes it only work in the Mega Apiary NOTE: COMB MUST BE SPECIALITY COMB
+                // Makes it only work in the Mega Apiary NOTE: COMB MUST BE SPECIALITY COMB
                 beeSpecies.setJubilanceProvider(GT_JubilanceMegaApiary.instance);
             },
             template -> AlleleHelper.instance.set(template, LIFESPAN, Lifespan.SHORTEST),
@@ -3425,7 +3425,7 @@ public enum GT_BeeDefinition implements IBeeDefinition {
                 beeSpecies.setTemperature(HELLISH);
                 beeSpecies.setNocturnal();
                 beeSpecies.setHasEffect();
-                //Makes it only work in the Mega Apiary NOTE: COMB MUST BE SPECIALITY COMB
+                // Makes it only work in the Mega Apiary NOTE: COMB MUST BE SPECIALITY COMB
                 beeSpecies.setJubilanceProvider(GT_JubilanceMegaApiary.instance);
             },
             template -> {
@@ -3450,7 +3450,7 @@ public enum GT_BeeDefinition implements IBeeDefinition {
                 beeSpecies.setTemperature(ICY);
                 beeSpecies.setNocturnal();
                 beeSpecies.setHasEffect();
-                //Makes it only work in the Mega Apiary NOTE: COMB MUST BE SPECIALITY COMB
+                // Makes it only work in the Mega Apiary NOTE: COMB MUST BE SPECIALITY COMB
                 beeSpecies.setJubilanceProvider(GT_JubilanceMegaApiary.instance);
             },
             template -> AlleleHelper.instance.set(template, LIFESPAN, Lifespan.SHORTEST),
@@ -3552,7 +3552,7 @@ public enum GT_BeeDefinition implements IBeeDefinition {
                 beeSpecies.setTemperature(ICY);
                 beeSpecies.setNocturnal();
                 beeSpecies.setHasEffect();
-                //Makes it only work in the Mega Apiary NOTE: COMB MUST BE SPECIALITY COMB
+                // Makes it only work in the Mega Apiary NOTE: COMB MUST BE SPECIALITY COMB
                 beeSpecies.setJubilanceProvider(GT_JubilanceMegaApiary.instance);
             },
             template -> AlleleHelper.instance.set(template, LIFESPAN, Lifespan.SHORTEST),

--- a/src/main/java/gregtech/loaders/misc/GT_BeeDefinition.java
+++ b/src/main/java/gregtech/loaders/misc/GT_BeeDefinition.java
@@ -1040,7 +1040,7 @@ public enum GT_BeeDefinition implements IBeeDefinition {
             new Color(0xFFA9FF),
             new Color(0x8F5D99),
             beeSpecies -> {
-                beeSpecies.addProduct(GT_Bees.combs.getStackForType(CombType.INDIUM), 0.05f);
+                beeSpecies.addProduct(GT_Bees.combs.getStackForType(CombType.INDIUM), 0.075f);
                 beeSpecies.setHumidity(EnumHumidity.NORMAL);
                 beeSpecies.setTemperature(HOT);
             },
@@ -1969,7 +1969,7 @@ public enum GT_BeeDefinition implements IBeeDefinition {
             new Color(0xE6E6FF),
             new Color(0xC8C8C8),
             beeSpecies -> {
-                beeSpecies.addSpecialty(GT_Bees.combs.getStackForType(CombType.AMERICIUM), 0.05f);
+                beeSpecies.addSpecialty(GT_Bees.combs.getStackForType(CombType.AMERICIUM), 0.075f);
                 beeSpecies.setHumidity(EnumHumidity.NORMAL);
                 beeSpecies.setTemperature(EnumTemperature.NORMAL);
                 beeSpecies.setNocturnal();
@@ -3399,7 +3399,7 @@ public enum GT_BeeDefinition implements IBeeDefinition {
             new Color(0x484848),
             new Color(0x323232),
             beeSpecies -> {
-                beeSpecies.addSpecialty(GT_Bees.combs.getStackForType(CombType.COSMICNEUTRONIUM), 0.25f);
+                beeSpecies.addSpecialty(GT_Bees.combs.getStackForType(CombType.COSMICNEUTRONIUM), 0.375f);
                 beeSpecies.setHumidity(DAMP);
                 beeSpecies.setTemperature(ICY);
                 beeSpecies.setNocturnal();
@@ -3420,7 +3420,7 @@ public enum GT_BeeDefinition implements IBeeDefinition {
             new Color(0xFFFFFF),
             new Color(0xFFFFFF),
             beeSpecies -> {
-                beeSpecies.addSpecialty(GT_Bees.combs.getStackForType(CombType.INFINITYCATALYST), 0.02f);
+                beeSpecies.addSpecialty(GT_Bees.combs.getStackForType(CombType.INFINITYCATALYST), 0.03f);
                 beeSpecies.setHumidity(DAMP);
                 beeSpecies.setTemperature(HELLISH);
                 beeSpecies.setNocturnal();
@@ -3445,7 +3445,7 @@ public enum GT_BeeDefinition implements IBeeDefinition {
             new Color(0xFFFFFF),
             new Color(0xFFFFFF),
             beeSpecies -> {
-                beeSpecies.addSpecialty(GT_Bees.combs.getStackForType(CombType.INFINITY), 0.02f);
+                beeSpecies.addSpecialty(GT_Bees.combs.getStackForType(CombType.INFINITY), 0.03f);
                 beeSpecies.setHumidity(EnumHumidity.NORMAL);
                 beeSpecies.setTemperature(ICY);
                 beeSpecies.setNocturnal();
@@ -3528,7 +3528,7 @@ public enum GT_BeeDefinition implements IBeeDefinition {
             new Color(0x8A97B0),
             new Color(0x160822),
             beeSpecies -> {
-                beeSpecies.addProduct(GT_Bees.combs.getStackForType(CombType.KRYPTON), 0.35f);
+                beeSpecies.addProduct(GT_Bees.combs.getStackForType(CombType.KRYPTON), 0.525f);
                 beeSpecies.setHumidity(EnumHumidity.NORMAL);
                 beeSpecies.setTemperature(ICY);
                 beeSpecies.setNocturnal();

--- a/src/main/java/gregtech/loaders/misc/GT_BeeDefinition.java
+++ b/src/main/java/gregtech/loaders/misc/GT_BeeDefinition.java
@@ -1040,11 +1040,9 @@ public enum GT_BeeDefinition implements IBeeDefinition {
             new Color(0xFFA9FF),
             new Color(0x8F5D99),
             beeSpecies -> {
-                beeSpecies.addSpecialty(GT_Bees.combs.getStackForType(CombType.INDIUM), 0.05f);
+                beeSpecies.addProduct(GT_Bees.combs.getStackForType(CombType.INDIUM), 0.05f);
                 beeSpecies.setHumidity(EnumHumidity.NORMAL);
                 beeSpecies.setTemperature(HOT);
-                //Makes it only work in the Mega Apiary NOTE: COMB MUST BE SPECIALITY COMB
-                beeSpecies.setJubilanceProvider(GT_JubilanceMegaApiary.instance);
             },
             template -> AlleleHelper.instance.set(template, SPEED, Speed.SLOWEST),
             dis -> {

--- a/src/main/java/gregtech/loaders/misc/GT_BeeDefinition.java
+++ b/src/main/java/gregtech/loaders/misc/GT_BeeDefinition.java
@@ -26,6 +26,7 @@ import gregtech.api.enums.GT_Values;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
+import gregtech.api.util.GT_JubilanceMegaApiary;
 import gregtech.api.util.GT_LanguageManager;
 import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_OreDictUnificator;
@@ -1039,9 +1040,11 @@ public enum GT_BeeDefinition implements IBeeDefinition {
             new Color(0xFFA9FF),
             new Color(0x8F5D99),
             beeSpecies -> {
-                beeSpecies.addProduct(GT_Bees.combs.getStackForType(CombType.INDIUM), 0.05f);
+                beeSpecies.addSpecialty(GT_Bees.combs.getStackForType(CombType.INDIUM), 0.05f);
                 beeSpecies.setHumidity(EnumHumidity.NORMAL);
                 beeSpecies.setTemperature(HOT);
+                //Makes it only work in the Mega Apiary NOTE: COMB MUST BE SPECIALITY COMB
+                beeSpecies.setJubilanceProvider(GT_JubilanceMegaApiary.instance);
             },
             template -> AlleleHelper.instance.set(template, SPEED, Speed.SLOWEST),
             dis -> {
@@ -1968,11 +1971,13 @@ public enum GT_BeeDefinition implements IBeeDefinition {
             new Color(0xE6E6FF),
             new Color(0xC8C8C8),
             beeSpecies -> {
-                beeSpecies.addProduct(GT_Bees.combs.getStackForType(CombType.AMERICIUM), 0.05f);
+                beeSpecies.addSpecialty(GT_Bees.combs.getStackForType(CombType.AMERICIUM), 0.05f);
                 beeSpecies.setHumidity(EnumHumidity.NORMAL);
                 beeSpecies.setTemperature(EnumTemperature.NORMAL);
                 beeSpecies.setNocturnal();
                 beeSpecies.setHasEffect();
+                //Makes it only work in the Mega Apiary NOTE: COMB MUST BE SPECIALITY COMB
+                beeSpecies.setJubilanceProvider(GT_JubilanceMegaApiary.instance);
             },
             template -> {
                 AlleleHelper.instance.set(template, SPEED, Speed.SLOWEST);
@@ -3396,11 +3401,13 @@ public enum GT_BeeDefinition implements IBeeDefinition {
             new Color(0x484848),
             new Color(0x323232),
             beeSpecies -> {
-                beeSpecies.addProduct(GT_Bees.combs.getStackForType(CombType.COSMICNEUTRONIUM), 0.25f);
+                beeSpecies.addSpecialty(GT_Bees.combs.getStackForType(CombType.COSMICNEUTRONIUM), 0.25f);
                 beeSpecies.setHumidity(DAMP);
                 beeSpecies.setTemperature(ICY);
                 beeSpecies.setNocturnal();
                 beeSpecies.setHasEffect();
+                //Makes it only work in the Mega Apiary NOTE: COMB MUST BE SPECIALITY COMB
+                beeSpecies.setJubilanceProvider(GT_JubilanceMegaApiary.instance);
             },
             template -> AlleleHelper.instance.set(template, LIFESPAN, Lifespan.SHORTEST),
             dis -> {
@@ -3415,11 +3422,13 @@ public enum GT_BeeDefinition implements IBeeDefinition {
             new Color(0xFFFFFF),
             new Color(0xFFFFFF),
             beeSpecies -> {
-                beeSpecies.addProduct(GT_Bees.combs.getStackForType(CombType.INFINITYCATALYST), 0.02f);
+                beeSpecies.addSpecialty(GT_Bees.combs.getStackForType(CombType.INFINITYCATALYST), 0.02f);
                 beeSpecies.setHumidity(DAMP);
                 beeSpecies.setTemperature(HELLISH);
                 beeSpecies.setNocturnal();
                 beeSpecies.setHasEffect();
+                //Makes it only work in the Mega Apiary NOTE: COMB MUST BE SPECIALITY COMB
+                beeSpecies.setJubilanceProvider(GT_JubilanceMegaApiary.instance);
             },
             template -> {
                 AlleleHelper.instance.set(template, LIFESPAN, Lifespan.SHORTEST);
@@ -3438,11 +3447,13 @@ public enum GT_BeeDefinition implements IBeeDefinition {
             new Color(0xFFFFFF),
             new Color(0xFFFFFF),
             beeSpecies -> {
-                beeSpecies.addProduct(GT_Bees.combs.getStackForType(CombType.INFINITY), 0.02f);
+                beeSpecies.addSpecialty(GT_Bees.combs.getStackForType(CombType.INFINITY), 0.02f);
                 beeSpecies.setHumidity(EnumHumidity.NORMAL);
                 beeSpecies.setTemperature(ICY);
                 beeSpecies.setNocturnal();
                 beeSpecies.setHasEffect();
+                //Makes it only work in the Mega Apiary NOTE: COMB MUST BE SPECIALITY COMB
+                beeSpecies.setJubilanceProvider(GT_JubilanceMegaApiary.instance);
             },
             template -> AlleleHelper.instance.set(template, LIFESPAN, Lifespan.SHORTEST),
             dis -> {
@@ -3538,11 +3549,13 @@ public enum GT_BeeDefinition implements IBeeDefinition {
             new Color(0x8A97B0),
             new Color(0x160822),
             beeSpecies -> {
-                beeSpecies.addProduct(GT_Bees.combs.getStackForType(CombType.XENON), 0.35f);
+                beeSpecies.addSpecialty(GT_Bees.combs.getStackForType(CombType.XENON), 0.35f);
                 beeSpecies.setHumidity(EnumHumidity.NORMAL);
                 beeSpecies.setTemperature(ICY);
                 beeSpecies.setNocturnal();
                 beeSpecies.setHasEffect();
+                //Makes it only work in the Mega Apiary NOTE: COMB MUST BE SPECIALITY COMB
+                beeSpecies.setJubilanceProvider(GT_JubilanceMegaApiary.instance);
             },
             template -> AlleleHelper.instance.set(template, LIFESPAN, Lifespan.SHORTEST),
             dis -> {


### PR DESCRIPTION
Blacklists the production of infinity, cosmic neutronium, infinity catalyst, americium and krypton combs in anything but mega apiary

For future reference of bees blacklisted see
https://gtnh.miraheze.org/wiki/Bees#Blacklisted_bees_from_producing_combs_other_than_in_Mega_Apiary: