### PR TITLE
Added check to API if the block should drop its inventory on break

### DIFF
--- a/src/main/java/gregtech/api/interfaces/metatileentity/IMetaTileEntity.java
+++ b/src/main/java/gregtech/api/interfaces/metatileentity/IMetaTileEntity.java
@@ -217,6 +217,11 @@ public interface IMetaTileEntity
     boolean isValidSlot(int aIndex);
 
     /**
+     * @return True if this MTE should drop its inventory content on block break
+     */
+    boolean shouldDropInventory();
+
+    /**
      * @return if aIndex can be set to Zero stackSize, when being removed.
      */
     boolean setStackToZeroInsteadOfNull(int aIndex);

--- a/src/main/java/gregtech/api/interfaces/metatileentity/IMetaTileEntity.java
+++ b/src/main/java/gregtech/api/interfaces/metatileentity/IMetaTileEntity.java
@@ -216,10 +216,12 @@ public interface IMetaTileEntity
      */
     boolean isValidSlot(int aIndex);
 
-    /**
-     * @return True if this MTE should drop its inventory content on block break
+    /** Check if the item at the specified index should be dropped
+     *
+     * @param index Index that will be checked
+     * @return True if the item at the index should be dropped, else false
      */
-    boolean shouldDropInventory();
+    boolean shouldDropItemAt(int index);
 
     /**
      * @return if aIndex can be set to Zero stackSize, when being removed.

--- a/src/main/java/gregtech/api/interfaces/tileentity/IGregTechTileEntity.java
+++ b/src/main/java/gregtech/api/interfaces/tileentity/IGregTechTileEntity.java
@@ -138,6 +138,12 @@ public interface IGregTechTileEntity
 
     ArrayList<ItemStack> getDrops();
 
+    /** Check if this block should drop its inventory content
+     *
+     * @return True if it should drop, else false
+     */
+    boolean shouldDropInventory();
+
     /**
      * 255 = 100%
      */

--- a/src/main/java/gregtech/api/interfaces/tileentity/IGregTechTileEntity.java
+++ b/src/main/java/gregtech/api/interfaces/tileentity/IGregTechTileEntity.java
@@ -138,11 +138,12 @@ public interface IGregTechTileEntity
 
     ArrayList<ItemStack> getDrops();
 
-    /** Check if this block should drop its inventory content
+    /** Check if the item at the specific index should be dropped or not
      *
+     * @param index Index that will be checked
      * @return True if it should drop, else false
      */
-    boolean shouldDropInventory();
+    boolean shouldDropItemAt(int index);
 
     /**
      * 255 = 100%

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
@@ -782,8 +782,8 @@ public class BaseMetaPipeEntity extends CommonMetaTileEntity
     }
 
     @Override
-    public boolean shouldDropInventory() {
-        return this.mMetaTileEntity != null ? this.mMetaTileEntity.shouldDropInventory() : true;
+    public boolean shouldDropItemAt(int index) {
+        return this.mMetaTileEntity != null ? this.mMetaTileEntity.shouldDropItemAt(index) : true;
     }
 
     @Override

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
@@ -782,6 +782,11 @@ public class BaseMetaPipeEntity extends CommonMetaTileEntity
     }
 
     @Override
+    public boolean shouldDropInventory() {
+        return this.mMetaTileEntity != null ? this.mMetaTileEntity.shouldDropInventory() : true;
+    }
+
+    @Override
     public boolean onRightclick(EntityPlayer aPlayer, byte aSide, float aX, float aY, float aZ) {
         if (isClientSide()) {
             // Configure Cover, sneak can also be: screwdriver, wrench, side cutter, soldering iron

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
@@ -1429,8 +1429,8 @@ public class BaseMetaTileEntity extends CommonMetaTileEntity
     }
 
     @Override
-    public boolean shouldDropInventory() {
-        return this.mMetaTileEntity != null ? this.mMetaTileEntity.shouldDropInventory() : true;
+    public boolean shouldDropItemAt(int index) {
+        return this.mMetaTileEntity != null ? this.mMetaTileEntity.shouldDropItemAt(index) : true;
     }
 
     public int getUpgradeCount() {

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
@@ -1428,6 +1428,11 @@ public class BaseMetaTileEntity extends CommonMetaTileEntity
         return new ArrayList<>(Collections.singletonList(rStack));
     }
 
+    @Override
+    public boolean shouldDropInventory() {
+        return this.mMetaTileEntity != null ? this.mMetaTileEntity.shouldDropInventory() : true;
+    }
+
     public int getUpgradeCount() {
         return (mMuffler ? 1 : 0) + (mLockUpgrade ? 1 : 0) + (mSteamConverter ? 1 : 0) + mOtherUpgrades;
     }

--- a/src/main/java/gregtech/api/metatileentity/MetaPipeEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaPipeEntity.java
@@ -383,7 +383,7 @@ public abstract class MetaPipeEntity implements IMetaTileEntity, IConnectable {
     }
 
     @Override
-    public boolean shouldDropInventory() {
+    public boolean shouldDropItemAt(int index) {
         return true;
     }
 

--- a/src/main/java/gregtech/api/metatileentity/MetaPipeEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaPipeEntity.java
@@ -383,6 +383,11 @@ public abstract class MetaPipeEntity implements IMetaTileEntity, IConnectable {
     }
 
     @Override
+    public boolean shouldDropInventory() {
+        return true;
+    }
+
+    @Override
     public boolean setStackToZeroInsteadOfNull(int aIndex) {
         return false;
     }

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -482,7 +482,7 @@ public abstract class MetaTileEntity implements IMetaTileEntity, IMachineCallbac
     }
 
     @Override
-    public boolean shouldDropInventory() {
+    public boolean shouldDropItemAt(int index) {
         return true;
     }
 

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -482,6 +482,11 @@ public abstract class MetaTileEntity implements IMetaTileEntity, IMachineCallbac
     }
 
     @Override
+    public boolean shouldDropInventory() {
+        return true;
+    }
+
+    @Override
     public boolean setStackToZeroInsteadOfNull(int aIndex) {
         return false;
     }

--- a/src/main/java/gregtech/common/blocks/GT_Block_Machines.java
+++ b/src/main/java/gregtech/common/blocks/GT_Block_Machines.java
@@ -412,7 +412,7 @@ public class GT_Block_Machines extends GT_Generic_Block implements IDebugableBlo
             final IGregTechTileEntity tGregTechTileEntity = (IGregTechTileEntity) tTileEntity;
             mTemporaryTileEntity.set(tGregTechTileEntity);
             if (!(tGregTechTileEntity.getMetaTileEntity() instanceof GT_MetaTileEntity_QuantumChest)
-                && tGregTechTileEntity.shouldDropInventory()) {
+                    && tGregTechTileEntity.shouldDropInventory()) {
                 for (int i = 0; i < tGregTechTileEntity.getSizeInventory(); i++) {
                     final ItemStack tItem = tGregTechTileEntity.getStackInSlot(i);
                     if ((tItem != null) && (tItem.stackSize > 0) && (tGregTechTileEntity.isValidSlot(i))) {

--- a/src/main/java/gregtech/common/blocks/GT_Block_Machines.java
+++ b/src/main/java/gregtech/common/blocks/GT_Block_Machines.java
@@ -411,11 +411,13 @@ public class GT_Block_Machines extends GT_Generic_Block implements IDebugableBlo
         if (tTileEntity instanceof IGregTechTileEntity) {
             final IGregTechTileEntity tGregTechTileEntity = (IGregTechTileEntity) tTileEntity;
             mTemporaryTileEntity.set(tGregTechTileEntity);
-            if (!(tGregTechTileEntity.getMetaTileEntity() instanceof GT_MetaTileEntity_QuantumChest)
-                    && tGregTechTileEntity.shouldDropInventory()) {
+            if (!(tGregTechTileEntity.getMetaTileEntity() instanceof GT_MetaTileEntity_QuantumChest)) {
                 for (int i = 0; i < tGregTechTileEntity.getSizeInventory(); i++) {
                     final ItemStack tItem = tGregTechTileEntity.getStackInSlot(i);
-                    if ((tItem != null) && (tItem.stackSize > 0) && (tGregTechTileEntity.isValidSlot(i))) {
+                    if ((tItem != null)
+                            && (tItem.stackSize > 0)
+                            && (tGregTechTileEntity.isValidSlot(i))
+                            && tGregTechTileEntity.shouldDropItemAt(i)) {
                         final EntityItem tItemEntity = new EntityItem(
                                 aWorld,
                                 aX + XSTR_INSTANCE.nextFloat() * 0.8F + 0.1F,

--- a/src/main/java/gregtech/common/blocks/GT_Block_Machines.java
+++ b/src/main/java/gregtech/common/blocks/GT_Block_Machines.java
@@ -411,7 +411,8 @@ public class GT_Block_Machines extends GT_Generic_Block implements IDebugableBlo
         if (tTileEntity instanceof IGregTechTileEntity) {
             final IGregTechTileEntity tGregTechTileEntity = (IGregTechTileEntity) tTileEntity;
             mTemporaryTileEntity.set(tGregTechTileEntity);
-            if (!(tGregTechTileEntity.getMetaTileEntity() instanceof GT_MetaTileEntity_QuantumChest)) {
+            if (!(tGregTechTileEntity.getMetaTileEntity() instanceof GT_MetaTileEntity_QuantumChest)
+                && tGregTechTileEntity.shouldDropInventory()) {
                 for (int i = 0; i < tGregTechTileEntity.getSizeInventory(); i++) {
                     final ItemStack tItem = tGregTechTileEntity.getStackInSlot(i);
                     if ((tItem != null) && (tItem.stackSize > 0) && (tGregTechTileEntity.isValidSlot(i))) {


### PR DESCRIPTION
This is in preperation for a proper fix to the Assembly Line Slave Connector, so it doesn't drop its inventory content (The Data Sticks that are actually stored in the Data Bank) when broken. For all other machines this changes does nothing.