### PR TITLE
Added Activity Monitor Cover, WIP

### DIFF
--- a/src/main/java/gregtech/api/enums/ItemList.java
+++ b/src/main/java/gregtech/api/enums/ItemList.java
@@ -1935,7 +1935,9 @@ public enum ItemList implements IItemContainer {
 
     Hatch_Input_Bus_ME,
     Hatch_CraftingInput_Bus_ME,
-    AdvDebugStructureWriter;
+    AdvDebugStructureWriter,
+
+    Cover_ActivityMonitor;
     public static final ItemList[]
             DYE_ONLY_ITEMS =
                     {

--- a/src/main/java/gregtech/api/enums/Textures.java
+++ b/src/main/java/gregtech/api/enums/Textures.java
@@ -1280,7 +1280,9 @@ public class Textures {
         OVERLAY_ME_FLUID_HATCH,
         OVERLAY_ME_FLUID_HATCH_ACTIVE,
 
-        STRUCTURE_MARK;
+        STRUCTURE_MARK,
+
+        OVERLAY_ACTIVITY_MONITOR;
 
         /**
          * Icon for Fresh CFoam

--- a/src/main/java/gregtech/common/covers/GT_Cover_ActivityMonitor.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_ActivityMonitor.java
@@ -42,7 +42,8 @@ public class GT_Cover_ActivityMonitor extends GT_CoverBehavior {
     }
 
     @Override
-    public int doCoverThings(byte aSide, byte aInputRedstone, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
+    public int doCoverThings(
+            byte aSide, byte aInputRedstone, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
         if (aTileEntity instanceof IMachineProgress) {
             aCoverVariable += 1 << aliveOffset;
             IMachineProgress machine = (IMachineProgress) aTileEntity;
@@ -93,7 +94,6 @@ public class GT_Cover_ActivityMonitor extends GT_CoverBehavior {
             this.tileEntity = aTileEntity;
 
             new GT_GuiIconButton(this, 0, startX, startY + spaceY * 3, GT_GuiIcon.CROSS);
-
         }
 
         private int getCurrentCoverVariable() {
@@ -106,9 +106,7 @@ public class GT_Cover_ActivityMonitor extends GT_CoverBehavior {
         }
 
         @Override
-        protected void onInitGui(int guiLeft, int guiTop, int gui_width, int gui_height) {
-
-        }
+        protected void onInitGui(int guiLeft, int guiTop, int gui_width, int gui_height) {}
 
         @Override
         public void drawExtras(int mouseX, int mouseY, float parTicks) {
@@ -124,45 +122,39 @@ public class GT_Cover_ActivityMonitor extends GT_CoverBehavior {
             int ticksActive = getTicksActive(getCurrentCoverVariable());
             double uptimePercentage = ticksActive / (double) ticksAlive * 100.0;
             this.fontRendererObj.drawString(
-                String.format("Active/Alive: %d/%d (%.2f %%)", ticksActive, ticksAlive, uptimePercentage),
-                3 + startX,
-                4 + startY,
-                textColor
-            );
+                    String.format("Active/Alive: %d/%d (%.2f %%)", ticksActive, ticksAlive, uptimePercentage),
+                    3 + startX,
+                    4 + startY,
+                    textColor);
         }
 
         private void renderRecipesCompleted() {
             this.fontRendererObj.drawString(
-                String.format("Recipes Completed: %d", getRecipeCount(getCurrentCoverVariable())),
-                3 + startX,
-                4 + startY + spaceY,
-                textColor
-            );
+                    String.format("Recipes Completed: %d", getRecipeCount(getCurrentCoverVariable())),
+                    3 + startX,
+                    4 + startY + spaceY,
+                    textColor);
         }
 
         private void renderRecipesPerMinute() {
             this.fontRendererObj.drawString(
-                String.format("Recipes per Minute: %.2f", getRecipeCount(getCurrentCoverVariable()) / (double)getTicksAlive(getCurrentCoverVariable()) * 1200),
-                3 + startX,
-                4 + startY + spaceY * 2,
-                textColor
-            );
+                    String.format(
+                            "Recipes per Minute: %.2f",
+                            getRecipeCount(getCurrentCoverVariable())
+                                    / (double) getTicksAlive(getCurrentCoverVariable())
+                                    * 1200),
+                    3 + startX,
+                    4 + startY + spaceY * 2,
+                    textColor);
         }
 
         private void renderButtonText() {
-            this.fontRendererObj.drawString(
-                "Reset",
-                3 + startX + spaceX * 1,
-                4 + startY + spaceY * 3,
-                textColor
-            );
+            this.fontRendererObj.drawString("Reset", 3 + startX + spaceX * 1, 4 + startY + spaceY * 3, textColor);
         }
 
         @Override
         public void buttonClicked(GuiButton button) {
             GT_Values.NW.sendToServer(new GT_Packet_TileEntityCover(side, coverID, 0, tile));
         }
-
     }
-
 }

--- a/src/main/java/gregtech/common/covers/GT_Cover_ActivityMonitor.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_ActivityMonitor.java
@@ -1,0 +1,168 @@
+package gregtech.common.covers;
+
+import gregtech.api.enums.GT_Values;
+import gregtech.api.gui.GT_GUICover;
+import gregtech.api.gui.widgets.GT_GuiIcon;
+import gregtech.api.gui.widgets.GT_GuiIconButton;
+import gregtech.api.interfaces.ITexture;
+import gregtech.api.interfaces.tileentity.ICoverable;
+import gregtech.api.interfaces.tileentity.IMachineProgress;
+import gregtech.api.net.GT_Packet_TileEntityCover;
+import gregtech.api.util.GT_CoverBehavior;
+import gregtech.api.util.GT_Utility;
+import net.minecraft.client.gui.GuiButton;
+
+public class GT_Cover_ActivityMonitor extends GT_CoverBehavior {
+
+    public static final int aliveWidth = 13;
+    public static final int aliveOffset = 32 - aliveWidth;
+    public static final int activeWidth = 13;
+    public static final int activeOffset = aliveOffset - activeWidth;
+    public static final int recipeWidth = 32 - (aliveWidth + activeWidth);
+    public static final int recipeOffset = 0;
+
+    public GT_Cover_ActivityMonitor() {
+        this(null);
+    }
+
+    public GT_Cover_ActivityMonitor(ITexture coverTexture) {
+        super(coverTexture);
+    }
+
+    private static int getTicksAlive(int aCoverVariable) {
+        return (aCoverVariable & 0xFFF80000) >> aliveOffset;
+    }
+
+    private static int getTicksActive(int aCoverVariable) {
+        return (aCoverVariable & 0x0007FFC0) >> activeOffset;
+    }
+
+    private static int getRecipeCount(int aCoverVariable) {
+        return (aCoverVariable & 0x0000003F) >> recipeOffset;
+    }
+
+    @Override
+    public int doCoverThings(byte aSide, byte aInputRedstone, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
+        if (aTileEntity instanceof IMachineProgress) {
+            aCoverVariable += 1 << aliveOffset;
+            IMachineProgress machine = (IMachineProgress) aTileEntity;
+            if (machine.isActive()) {
+                aCoverVariable += 1 << activeOffset;
+                if (machine.getProgress() >= machine.getMaxProgress()) {
+                    aCoverVariable += 1 << recipeOffset;
+                }
+            }
+        }
+        return aCoverVariable;
+    }
+
+    @Override
+    public int getTickRate(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity) {
+        return 1;
+    }
+
+    @Override
+    public boolean hasCoverGUI() {
+        return true;
+    }
+
+    @Override
+    public Object getClientGUI(byte aSide, int aCoverID, int coverData, ICoverable aTileEntity) {
+        return new GT_Cover_ActivityMonitor.GUI(aSide, aCoverID, coverData, aTileEntity);
+    }
+
+    private class GUI extends GT_GUICover {
+
+        private static final int startX = 10;
+        private static final int startY = 25;
+        private static final int spaceX = 18;
+        private static final int spaceY = 18;
+        private final byte side;
+        private final int coverID;
+        private final int textColor = this.getTextColorOrDefault("text", 0xFF555555);
+        private final int coverVariable;
+
+        private final ICoverable tileEntity;
+
+        public GUI(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity) {
+
+            super(aTileEntity, 176, 107, GT_Utility.intToStack(aCoverID));
+            this.side = aSide;
+            this.coverID = aCoverID;
+            this.coverVariable = aCoverVariable;
+            this.tileEntity = aTileEntity;
+
+            new GT_GuiIconButton(this, 0, startX, startY + spaceY * 3, GT_GuiIcon.CROSS);
+
+        }
+
+        private int getCurrentCoverVariable() {
+            GT_CoverBehavior behavior = (GT_CoverBehavior) tile.getCoverBehaviorAtSideNew(side);
+            if (behavior instanceof GT_Cover_ActivityMonitor) {
+                GT_Cover_ActivityMonitor monitor = (GT_Cover_ActivityMonitor) behavior;
+                return monitor.doCoverThings(side, (byte) 0, coverID, coverVariable, tile, 0);
+            }
+            return 0;
+        }
+
+        @Override
+        protected void onInitGui(int guiLeft, int guiTop, int gui_width, int gui_height) {
+
+        }
+
+        @Override
+        public void drawExtras(int mouseX, int mouseY, float parTicks) {
+            super.drawExtras(mouseX, mouseY, parTicks);
+            renderTime();
+            renderRecipesCompleted();
+            renderRecipesPerMinute();
+            renderButtonText();
+        }
+
+        private void renderTime() {
+            int ticksAlive = getTicksAlive(getCurrentCoverVariable());
+            int ticksActive = getTicksActive(getCurrentCoverVariable());
+            double uptimePercentage = ticksActive / (double) ticksAlive * 100.0;
+            this.fontRendererObj.drawString(
+                String.format("Active/Alive: %d/%d (%.2f %%)", ticksActive, ticksAlive, uptimePercentage),
+                3 + startX,
+                4 + startY,
+                textColor
+            );
+        }
+
+        private void renderRecipesCompleted() {
+            this.fontRendererObj.drawString(
+                String.format("Recipes Completed: %d", getRecipeCount(getCurrentCoverVariable())),
+                3 + startX,
+                4 + startY + spaceY,
+                textColor
+            );
+        }
+
+        private void renderRecipesPerMinute() {
+            this.fontRendererObj.drawString(
+                String.format("Recipes per Minute: %.2f", getRecipeCount(getCurrentCoverVariable()) / (double)getTicksAlive(getCurrentCoverVariable()) * 1200),
+                3 + startX,
+                4 + startY + spaceY * 2,
+                textColor
+            );
+        }
+
+        private void renderButtonText() {
+            this.fontRendererObj.drawString(
+                "Reset",
+                3 + startX + spaceX * 1,
+                4 + startY + spaceY * 3,
+                textColor
+            );
+        }
+
+        @Override
+        public void buttonClicked(GuiButton button) {
+            GT_Values.NW.sendToServer(new GT_Packet_TileEntityCover(side, coverID, 0, tile));
+        }
+
+    }
+
+}

--- a/src/main/java/gregtech/common/items/GT_MetaGenerated_Item_01.java
+++ b/src/main/java/gregtech/common/items/GT_MetaGenerated_Item_01.java
@@ -4732,14 +4732,12 @@ public class GT_MetaGenerated_Item_01 extends GT_MetaGenerated_Item_X32 {
                 600,
                 24);
 
-        ItemList.Cover_ActivityMonitor.set(addItem(
-            tLastID = 749,
-            "Activity Monitor Cover",
-            "Keeps track of the performance of a machine"));
+        ItemList.Cover_ActivityMonitor.set(
+                addItem(tLastID = 749, "Activity Monitor Cover", "Keeps track of the performance of a machine"));
         GregTech_API.registerCover(
-            ItemList.Cover_ActivityMonitor.get(1L),
-            TextureFactory.of(MACHINE_CASINGS[2][0], TextureFactory.of(OVERLAY_ACTIVITY_MONITOR)),
-            new GT_Cover_ActivityMonitor(TextureFactory.of(OVERLAY_ACTIVITY_MONITOR)));
+                ItemList.Cover_ActivityMonitor.get(1L),
+                TextureFactory.of(MACHINE_CASINGS[2][0], TextureFactory.of(OVERLAY_ACTIVITY_MONITOR)),
+                new GT_Cover_ActivityMonitor(TextureFactory.of(OVERLAY_ACTIVITY_MONITOR)));
 
         GT_ModHandler.addCraftingRecipe(ItemList.ItemFilter_Export.get(1L), new Object[] {
             "SPS",

--- a/src/main/java/gregtech/common/items/GT_MetaGenerated_Item_01.java
+++ b/src/main/java/gregtech/common/items/GT_MetaGenerated_Item_01.java
@@ -4227,6 +4227,7 @@ public class GT_MetaGenerated_Item_01 extends GT_MetaGenerated_Item_X32 {
                 "Displays the fluid stored in the Tank",
                 new TC_Aspects.TC_AspectStack(TC_Aspects.SENSUS, 2L),
                 new TC_Aspects.TC_AspectStack(TC_Aspects.AQUA, 1L)));
+
         GT_Values.RA.addAssemblerRecipe(
                 new ItemStack[] {
                     ItemList.Sensor_EV.get(1L),
@@ -4730,6 +4731,15 @@ public class GT_MetaGenerated_Item_01 extends GT_MetaGenerated_Item_X32 {
                 ItemList.Cover_NeedsMaintainance.get(1L),
                 600,
                 24);
+
+        ItemList.Cover_ActivityMonitor.set(addItem(
+            tLastID = 749,
+            "Activity Monitor Cover",
+            "Keeps track of the performance of a machine"));
+        GregTech_API.registerCover(
+            ItemList.Cover_ActivityMonitor.get(1L),
+            TextureFactory.of(MACHINE_CASINGS[2][0], TextureFactory.of(OVERLAY_ACTIVITY_MONITOR)),
+            new GT_Cover_ActivityMonitor(TextureFactory.of(OVERLAY_ACTIVITY_MONITOR)));
 
         GT_ModHandler.addCraftingRecipe(ItemList.ItemFilter_Export.get(1L), new Object[] {
             "SPS",

--- a/src/main/java/gregtech/loaders/preload/GT_Loader_MetaTileEntities.java
+++ b/src/main/java/gregtech/loaders/preload/GT_Loader_MetaTileEntities.java
@@ -8,6 +8,7 @@ import gregtech.api.enums.*;
 import gregtech.api.metatileentity.implementations.*;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_BasicMachine_GT_Recipe.SpecialEffects;
 import gregtech.api.util.*;
+import gregtech.common.covers.GT_Cover_ActivityMonitor;
 import gregtech.common.tileentities.automation.*;
 import gregtech.common.tileentities.boilers.*;
 import gregtech.common.tileentities.debug.*;

--- a/src/main/java/gregtech/loaders/preload/GT_Loader_MetaTileEntities.java
+++ b/src/main/java/gregtech/loaders/preload/GT_Loader_MetaTileEntities.java
@@ -8,7 +8,6 @@ import gregtech.api.enums.*;
 import gregtech.api.metatileentity.implementations.*;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_BasicMachine_GT_Recipe.SpecialEffects;
 import gregtech.api.util.*;
-import gregtech.common.covers.GT_Cover_ActivityMonitor;
 import gregtech.common.tileentities.automation.*;
 import gregtech.common.tileentities.boilers.*;
 import gregtech.common.tileentities.debug.*;


### PR DESCRIPTION
I'm trying to add a cover that keeps track of useful stats about a machine. It currently keeps track of how many ticks it has been measuring, how many ticks the machine has been active, and how many recipes have been executed in that time frame.
TODO: Make the GUI live update

One issue I'm having is that the 32 bit int is a bit small for what I'm trying to do.