### PR TITLE
fix annoying rawtype warnings in item tooltip

### DIFF
--- a/src/main/java/gregtech/api/items/GT_BreederCell_Item.java
+++ b/src/main/java/gregtech/api/items/GT_BreederCell_Item.java
@@ -53,7 +53,7 @@ public class GT_BreederCell_Item extends GT_Generic_Item implements IReactorComp
     }
 
     @Override
-    public void addAdditionalToolTips(List aList, ItemStack aStack, EntityPlayer aPlayer) {
+    public void addAdditionalToolTips(List<String> aList, ItemStack aStack, EntityPlayer aPlayer) {
         aList.add(transItem("019", "Bath with neutron in a hot reactor"));
         int rDmg = aStack.getItemDamage() * 4 / getMaxDamage();
         EnumChatFormatting color2;

--- a/src/main/java/gregtech/api/items/GT_CoolantCell_Item.java
+++ b/src/main/java/gregtech/api/items/GT_CoolantCell_Item.java
@@ -48,7 +48,7 @@ public class GT_CoolantCell_Item extends GT_Generic_Item {
     }
 
     @Override
-    public void addAdditionalToolTips(List aList, ItemStack aStack, EntityPlayer aPlayer) {
+    public void addAdditionalToolTips(List<String> aList, ItemStack aStack, EntityPlayer aPlayer) {
         super.addAdditionalToolTips(aList, aStack, aPlayer);
         int rHeat = getHeatOfStack(aStack) * 10 / this.heatStorage;
         EnumChatFormatting color;

--- a/src/main/java/gregtech/api/items/GT_Generic_Item.java
+++ b/src/main/java/gregtech/api/items/GT_Generic_Item.java
@@ -90,6 +90,7 @@ public class GT_Generic_Item extends Item implements IProjectileItem {
         return 0;
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public void addInformation(ItemStack aStack, EntityPlayer aPlayer, List aList, boolean aF3_H) {
         if (getMaxDamage() > 0 && !getHasSubtypes())
@@ -99,7 +100,7 @@ public class GT_Generic_Item extends Item implements IProjectileItem {
         addAdditionalToolTips(aList, aStack, aPlayer);
     }
 
-    protected void addAdditionalToolTips(List aList, ItemStack aStack, EntityPlayer aPlayer) {
+    protected void addAdditionalToolTips(List<String> aList, ItemStack aStack, EntityPlayer aPlayer) {
         //
     }
 

--- a/src/main/java/gregtech/api/items/GT_MetaBase_Item.java
+++ b/src/main/java/gregtech/api/items/GT_MetaBase_Item.java
@@ -221,6 +221,7 @@ public abstract class GT_MetaBase_Item extends GT_Generic_Item
         return aStack;
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public final void addInformation(ItemStack aStack, EntityPlayer aPlayer, List aList, boolean aF3_H) {
         String tKey = getUnlocalizedName(aStack) + ".tooltip";

--- a/src/main/java/gregtech/api/items/GT_MetaGenerated_Tool.java
+++ b/src/main/java/gregtech/api/items/GT_MetaGenerated_Tool.java
@@ -423,7 +423,7 @@ public abstract class GT_MetaGenerated_Tool extends GT_MetaBase_Item
     }
 
     @Override
-    public void addAdditionalToolTips(List aList, ItemStack aStack, EntityPlayer aPlayer) {
+    public void addAdditionalToolTips(List<String> aList, ItemStack aStack, EntityPlayer aPlayer) {
         long tMaxDamage = getToolMaxDamage(aStack);
         Materials tMaterial = getPrimaryMaterial(aStack);
         IToolStats tStats = getToolStats(aStack);

--- a/src/main/java/gregtech/api/items/GT_RadioactiveCell_Item.java
+++ b/src/main/java/gregtech/api/items/GT_RadioactiveCell_Item.java
@@ -131,7 +131,7 @@ public class GT_RadioactiveCell_Item extends GT_Generic_Item implements IBoxable
     }
 
     @Override
-    public void addAdditionalToolTips(List aList, ItemStack aStack, EntityPlayer aPlayer) {
+    public void addAdditionalToolTips(List<String> aList, ItemStack aStack, EntityPlayer aPlayer) {
         super.addAdditionalToolTips(aList, aStack, aPlayer);
         // aList.add("Time left: " + (this.maxDelay - getDurabilityOfStack(aStack)) + " secs");
         int rDmg = getDurabilityOfStack(aStack) * 6 / this.maxDmg;

--- a/src/main/java/gregtech/api/items/GT_SolderingTool_Item.java
+++ b/src/main/java/gregtech/api/items/GT_SolderingTool_Item.java
@@ -32,7 +32,7 @@ public class GT_SolderingTool_Item extends GT_Tool_Item {
     }
 
     @Override
-    public void addAdditionalToolTips(List aList, ItemStack aStack, EntityPlayer aPlayer) {
+    public void addAdditionalToolTips(List<String> aList, ItemStack aStack, EntityPlayer aPlayer) {
         aList.add(GT_LanguageManager.addStringLocalization(
                 getUnlocalizedName() + ".tooltip_1", "Sets the Strength of outputted Redstone"));
         aList.add(GT_LanguageManager.addStringLocalization(

--- a/src/main/java/gregtech/api/items/GT_Spray_Pepper_Item.java
+++ b/src/main/java/gregtech/api/items/GT_Spray_Pepper_Item.java
@@ -17,7 +17,7 @@ public class GT_Spray_Pepper_Item extends GT_Tool_Item {
     }
 
     @Override
-    public void addAdditionalToolTips(List aList, ItemStack aStack, EntityPlayer aPlayer) {
+    public void addAdditionalToolTips(List<String> aList, ItemStack aStack, EntityPlayer aPlayer) {
         aList.add(GT_LanguageManager.addStringLocalization(
                 getUnlocalizedName() + ".tooltip_1", "especially Pedobears, Care Bears,"));
         aList.add(GT_LanguageManager.addStringLocalization(

--- a/src/main/java/gregtech/common/items/GT_FluidDisplayItem.java
+++ b/src/main/java/gregtech/common/items/GT_FluidDisplayItem.java
@@ -36,7 +36,7 @@ public class GT_FluidDisplayItem extends GT_Generic_Item {
     }
 
     @Override
-    protected void addAdditionalToolTips(List aList, ItemStack aStack, EntityPlayer aPlayer) {
+    protected void addAdditionalToolTips(List<String> aList, ItemStack aStack, EntityPlayer aPlayer) {
         if (FluidRegistry.getFluid(aStack.getItemDamage()) != null) {
             String tChemicalFormula =
                     getChemicalFormula(new FluidStack(FluidRegistry.getFluid(aStack.getItemDamage()), 1));

--- a/src/main/java/gregtech/common/items/GT_IntegratedCircuit_Item.java
+++ b/src/main/java/gregtech/common/items/GT_IntegratedCircuit_Item.java
@@ -162,7 +162,7 @@ public class GT_IntegratedCircuit_Item extends GT_Generic_Item implements INetwo
     }
 
     @Override
-    public void addAdditionalToolTips(List aList, ItemStack aStack, EntityPlayer aPlayer) {
+    public void addAdditionalToolTips(List<String> aList, ItemStack aStack, EntityPlayer aPlayer) {
         super.addAdditionalToolTips(aList, aStack, aPlayer);
         aList.add(GT_LanguageManager.addStringLocalization(
                         new StringBuilder()

--- a/src/main/java/gregtech/common/items/GT_MetaGenerated_Item_01.java
+++ b/src/main/java/gregtech/common/items/GT_MetaGenerated_Item_01.java
@@ -4855,7 +4855,7 @@ public class GT_MetaGenerated_Item_01 extends GT_MetaGenerated_Item_X32 {
     }
 
     @Override
-    protected void addAdditionalToolTips(List aList, ItemStack aStack, EntityPlayer aPlayer) {
+    protected void addAdditionalToolTips(List<String> aList, ItemStack aStack, EntityPlayer aPlayer) {
         super.addAdditionalToolTips(aList, aStack, aPlayer);
         int aDamage = aStack.getItemDamage();
         if ((aDamage < 32000) && (aDamage >= 0)) {

--- a/src/main/java/gregtech/common/items/GT_SensorCard_Item.java
+++ b/src/main/java/gregtech/common/items/GT_SensorCard_Item.java
@@ -30,7 +30,7 @@ public class GT_SensorCard_Item extends GT_Generic_Item implements IRemoteSensor
     }
 
     @Override
-    public void addAdditionalToolTips(List aList, ItemStack aStack, EntityPlayer aPlayer) {
+    public void addAdditionalToolTips(List<String> aList, ItemStack aStack, EntityPlayer aPlayer) {
         super.addAdditionalToolTips(aList, aStack, aPlayer);
         if (aStack != null) {
             NBTTagCompound tNBT = aStack.getTagCompound();

--- a/src/main/java/gregtech/common/items/GT_VolumetricFlask.java
+++ b/src/main/java/gregtech/common/items/GT_VolumetricFlask.java
@@ -207,9 +207,7 @@ public class GT_VolumetricFlask extends GT_Generic_Item implements IFluidContain
     }
 
     @Override
-    @SideOnly(Side.CLIENT)
-    public void addInformation(ItemStack stack, EntityPlayer player, List info, boolean b) {
-        super.addInformation(stack, player, info, b);
+    protected void addAdditionalToolTips(List<String> info, ItemStack stack, EntityPlayer aPlayer) {
         FluidStack fs = getFluid(stack);
         if (fs != null) {
             info.add(String.format("< %s, %s mB >", GT_Utility.getFluidName(fs, true), formatNumbers(fs.amount)));


### PR DESCRIPTION
... and suppress it when necessary 

this should be compatible with all addons without code changes, as a subclass can override it with the existing rawtype parameter.