### PR TITLE
Overwrite setStackToZeroInsteadOfNull in me input bus

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_InputBus_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_InputBus_ME.java
@@ -195,6 +195,11 @@ public class GT_MetaTileEntity_Hatch_InputBus_ME extends GT_MetaTileEntity_Hatch
     }
 
     @Override
+    public boolean setStackToZeroInsteadOfNull(int aIndex) {
+        return true;
+    }
+
+    @Override
     public ItemStack getStackInSlot(int aIndex) {
         if (!processingRecipe) return super.getStackInSlot(aIndex);
         if (aIndex < 0 || aIndex > mInventory.length) return null;


### PR DESCRIPTION
Setting the stack to null leads to the ghost item being consumed, leaving the actual contents of the me untouched.

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/11497