### PR TITLE
remove compat with IC2 fuel can

### DIFF
--- a/src/main/java/gregtech/api/enums/ItemList.java
+++ b/src/main/java/gregtech/api/enums/ItemList.java
@@ -5,6 +5,7 @@ import static gregtech.api.enums.GT_Values.W;
 
 import gregtech.api.interfaces.IItemContainer;
 import gregtech.api.util.GT_LanguageManager;
+import gregtech.api.util.GT_Log;
 import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_OreDictUnificator;
 import gregtech.api.util.GT_Utility;
@@ -87,8 +88,10 @@ public enum ItemList implements IItemContainer {
     IC2_Compressed_Coal_Ball,
     IC2_Compressed_Coal_Chunk,
     IC2_Fuel_Rod_Empty,
-    IC2_Fuel_Can_Empty,
-    IC2_Fuel_Can_Filled,
+    @Deprecated
+    IC2_Fuel_Can_Empty(true),
+    @Deprecated
+    IC2_Fuel_Can_Filled(true),
     IC2_Food_Can_Empty,
     IC2_Food_Can_Filled,
     IC2_Food_Can_Spoiled,
@@ -2111,7 +2114,20 @@ public enum ItemList implements IItemContainer {
             sLeadZincSolution,
             sHydrochloricAcid;
     private ItemStack mStack;
-    private boolean mHasNotBeenSet = true;
+    private boolean mHasNotBeenSet;
+    private boolean mDeprecated;
+    private boolean mWarned;
+
+    ItemList() {
+        mHasNotBeenSet = true;
+    }
+
+    ItemList(boolean aDeprecated) {
+        if (aDeprecated) {
+            mDeprecated = true;
+            mHasNotBeenSet = true;
+        }
+    }
 
     @Override
     public IItemContainer set(Item aItem) {
@@ -2131,16 +2147,14 @@ public enum ItemList implements IItemContainer {
 
     @Override
     public Item getItem() {
-        if (mHasNotBeenSet)
-            throw new IllegalAccessError("The Enum '" + name() + "' has not been set to an Item at this time!");
+        sanityCheck();
         if (GT_Utility.isStackInvalid(mStack)) return null;
         return mStack.getItem();
     }
 
     @Override
     public Block getBlock() {
-        if (mHasNotBeenSet)
-            throw new IllegalAccessError("The Enum '" + name() + "' has not been set to an Item at this time!");
+        sanityCheck();
         return GT_Utility.getBlockFromItem(getItem());
     }
 
@@ -2156,38 +2170,39 @@ public enum ItemList implements IItemContainer {
 
     @Override
     public boolean isStackEqual(Object aStack, boolean aWildcard, boolean aIgnoreNBT) {
+        if (mDeprecated && !mWarned) {
+            new Exception(this + " is now deprecated").printStackTrace(GT_Log.err);
+            // warn only once
+            mWarned = true;
+        }
         if (GT_Utility.isStackInvalid(aStack)) return false;
         return GT_Utility.areUnificationsEqual((ItemStack) aStack, aWildcard ? getWildcard(1) : get(1), aIgnoreNBT);
     }
 
     @Override
     public ItemStack get(long aAmount, Object... aReplacements) {
-        if (mHasNotBeenSet)
-            throw new IllegalAccessError("The Enum '" + name() + "' has not been set to an Item at this time!");
+        sanityCheck();
         if (GT_Utility.isStackInvalid(mStack)) return GT_Utility.copyAmount(aAmount, aReplacements);
         return GT_Utility.copyAmount(aAmount, GT_OreDictUnificator.get(mStack));
     }
 
     @Override
     public ItemStack getWildcard(long aAmount, Object... aReplacements) {
-        if (mHasNotBeenSet)
-            throw new IllegalAccessError("The Enum '" + name() + "' has not been set to an Item at this time!");
+        sanityCheck();
         if (GT_Utility.isStackInvalid(mStack)) return GT_Utility.copyAmount(aAmount, aReplacements);
         return GT_Utility.copyAmountAndMetaData(aAmount, W, GT_OreDictUnificator.get(mStack));
     }
 
     @Override
     public ItemStack getUndamaged(long aAmount, Object... aReplacements) {
-        if (mHasNotBeenSet)
-            throw new IllegalAccessError("The Enum '" + name() + "' has not been set to an Item at this time!");
+        sanityCheck();
         if (GT_Utility.isStackInvalid(mStack)) return GT_Utility.copyAmount(aAmount, aReplacements);
         return GT_Utility.copyAmountAndMetaData(aAmount, 0, GT_OreDictUnificator.get(mStack));
     }
 
     @Override
     public ItemStack getAlmostBroken(long aAmount, Object... aReplacements) {
-        if (mHasNotBeenSet)
-            throw new IllegalAccessError("The Enum '" + name() + "' has not been set to an Item at this time!");
+        sanityCheck();
         if (GT_Utility.isStackInvalid(mStack)) return GT_Utility.copyAmount(aAmount, aReplacements);
         return GT_Utility.copyAmountAndMetaData(aAmount, mStack.getMaxDamage() - 1, GT_OreDictUnificator.get(mStack));
     }
@@ -2228,24 +2243,21 @@ public enum ItemList implements IItemContainer {
 
     @Override
     public ItemStack getWithDamage(long aAmount, long aMetaValue, Object... aReplacements) {
-        if (mHasNotBeenSet)
-            throw new IllegalAccessError("The Enum '" + name() + "' has not been set to an Item at this time!");
+        sanityCheck();
         if (GT_Utility.isStackInvalid(mStack)) return GT_Utility.copyAmount(aAmount, aReplacements);
         return GT_Utility.copyAmountAndMetaData(aAmount, aMetaValue, GT_OreDictUnificator.get(mStack));
     }
 
     @Override
     public IItemContainer registerOre(Object... aOreNames) {
-        if (mHasNotBeenSet)
-            throw new IllegalAccessError("The Enum '" + name() + "' has not been set to an Item at this time!");
+        sanityCheck();
         for (Object tOreName : aOreNames) GT_OreDictUnificator.registerOre(tOreName, get(1));
         return this;
     }
 
     @Override
     public IItemContainer registerWildcardAsOre(Object... aOreNames) {
-        if (mHasNotBeenSet)
-            throw new IllegalAccessError("The Enum '" + name() + "' has not been set to an Item at this time!");
+        sanityCheck();
         for (Object tOreName : aOreNames) GT_OreDictUnificator.registerOre(tOreName, getWildcard(1));
         return this;
     }
@@ -2257,5 +2269,15 @@ public enum ItemList implements IItemContainer {
      */
     public ItemStack getInternalStack_unsafe() {
         return mStack;
+    }
+
+    private void sanityCheck() {
+        if (mHasNotBeenSet)
+            throw new IllegalAccessError("The Enum '" + name() + "' has not been set to an Item at this time!");
+        if (mDeprecated && !mWarned) {
+            new Exception(this + " is now deprecated").printStackTrace(GT_Log.err);
+            // warn only once
+            mWarned = true;
+        }
     }
 }

--- a/src/main/java/gregtech/api/util/GT_ModHandler.java
+++ b/src/main/java/gregtech/api/util/GT_ModHandler.java
@@ -282,8 +282,9 @@ public class GT_ModHandler {
         return FluidRegistry.getFluidStack("milk", (int) aAmount);
     }
 
+    @Deprecated
     public static ItemStack getEmptyFuelCan(long aAmount) {
-        return ItemList.IC2_Fuel_Can_Empty.get(aAmount);
+        return null;
     }
 
     public static ItemStack getEmptyCell(long aAmount) {
@@ -320,25 +321,18 @@ public class GT_ModHandler {
     /**
      * @param aValue Fuel value in EU
      */
+    @Deprecated
     public static ItemStack getFuelCan(int aValue) {
-        if (aValue < 5) return ItemList.IC2_Fuel_Can_Empty.get(1);
-        ItemStack rFuelCanStack = ItemList.IC2_Fuel_Can_Filled.get(1);
-        if (rFuelCanStack == null) return null;
-        NBTTagCompound tNBT = new NBTTagCompound();
-        tNBT.setInteger("value", aValue / 5);
-        rFuelCanStack.setTagCompound(tNBT);
-        return rFuelCanStack;
+        return null;
     }
 
     /**
      * @param aFuelCan the Item you want to check
      * @return the exact Value in EU the Fuel Can is worth if its even a Fuel Can.
      */
+    @Deprecated
     public static int getFuelCanValue(ItemStack aFuelCan) {
-        if (GT_Utility.isStackInvalid(aFuelCan) || !ItemList.IC2_Fuel_Can_Filled.isStackEqual(aFuelCan, false, true))
-            return 0;
-        NBTTagCompound tNBT = aFuelCan.getTagCompound();
-        return tNBT == null ? 0 : tNBT.getInteger("value") * 5;
+        return 0;
     }
 
     /**

--- a/src/main/java/gregtech/api/util/GT_Utility.java
+++ b/src/main/java/gregtech/api/util/GT_Utility.java
@@ -1996,7 +1996,6 @@ public class GT_Utility {
         if (aStack.getItem().hasContainerItem(aStack)) return aStack.getItem().getContainerItem(aStack);
         /** These are all special Cases, in which it is intended to have only GT Blocks outputting those Container Items */
         if (ItemList.Cell_Empty.isStackEqual(aStack, false, true)) return null;
-        if (ItemList.IC2_Fuel_Can_Filled.isStackEqual(aStack, false, true)) return ItemList.IC2_Fuel_Can_Empty.get(1);
         if (aStack.getItem() == Items.potionitem
                 || aStack.getItem() == Items.experience_bottle
                 || ItemList.TF_Vial_FieryBlood.isStackEqual(aStack)

--- a/src/main/java/gregtech/common/GT_Proxy.java
+++ b/src/main/java/gregtech/common/GT_Proxy.java
@@ -849,11 +849,6 @@ public abstract class GT_Proxy implements IGT_Mod, IGuiHandler, IFuelHandler, IG
         ItemList.IC2_Item_Casing_Lead.set(GT_ModHandler.getIC2Item("casinglead", 1L));
         ItemList.IC2_Item_Casing_Steel.set(GT_ModHandler.getIC2Item("casingadviron", 1L));
         ItemList.IC2_Spray_WeedEx.set(GT_ModHandler.getIC2Item("weedEx", 1L));
-        ItemList.IC2_Fuel_Can_Empty.set(GT_ModHandler.getIC2Item(
-                "fuelCan",
-                1L,
-                GT_ModHandler.getIC2Item("fuelCanEmpty", 1L, GT_ModHandler.getIC2Item("emptyFuelCan", 1L))));
-        ItemList.IC2_Fuel_Can_Filled.set(GT_ModHandler.getIC2Item("filledFuelCan", 1L));
         ItemList.IC2_Mixed_Metal_Ingot.set(GT_ModHandler.getIC2Item("mixedMetalIngot", 1L));
         ItemList.IC2_Fertilizer.set(GT_ModHandler.getIC2Item("fertilizer", 1L));
         ItemList.IC2_CoffeeBeans.set(GT_ModHandler.getIC2Item("coffeeBeans", 1L));

--- a/src/main/java/gregtech/common/GT_RecipeAdder.java
+++ b/src/main/java/gregtech/common/GT_RecipeAdder.java
@@ -102,9 +102,7 @@ public class GT_RecipeAdder implements IGT_RecipeAdder {
             int aDuration) {
         return addCentrifugeRecipe(
                 aInput1,
-                aInput2 < 0
-                        ? null
-                        : aInput2 > 0 ? ItemList.Cell_Empty.get(aInput2) : null,
+                aInput2 < 0 ? null : aInput2 > 0 ? ItemList.Cell_Empty.get(aInput2) : null,
                 null,
                 null,
                 aOutput1,
@@ -132,9 +130,7 @@ public class GT_RecipeAdder implements IGT_RecipeAdder {
             int aEUt) {
         return addCentrifugeRecipe(
                 aInput1,
-                aInput2 < 0
-                        ? null
-                        : aInput2 > 0 ? ItemList.Cell_Empty.get(aInput2) : null,
+                aInput2 < 0 ? null : aInput2 > 0 ? ItemList.Cell_Empty.get(aInput2) : null,
                 null,
                 null,
                 aOutput1,
@@ -293,9 +289,7 @@ public class GT_RecipeAdder implements IGT_RecipeAdder {
             int aEUt) {
         return addElectrolyzerRecipe(
                 aInput1,
-                aInput2 < 0
-                        ? null
-                        : aInput2 > 0 ? ItemList.Cell_Empty.get(aInput2) : null,
+                aInput2 < 0 ? null : aInput2 > 0 ? ItemList.Cell_Empty.get(aInput2) : null,
                 null,
                 null,
                 aOutput1,

--- a/src/main/java/gregtech/common/GT_RecipeAdder.java
+++ b/src/main/java/gregtech/common/GT_RecipeAdder.java
@@ -103,8 +103,8 @@ public class GT_RecipeAdder implements IGT_RecipeAdder {
         return addCentrifugeRecipe(
                 aInput1,
                 aInput2 < 0
-                        ? ItemList.IC2_Fuel_Can_Empty.get(-aInput2, new Object[0])
-                        : aInput2 > 0 ? ItemList.Cell_Empty.get(aInput2, new Object[0]) : null,
+                        ? null
+                        : aInput2 > 0 ? ItemList.Cell_Empty.get(aInput2) : null,
                 null,
                 null,
                 aOutput1,
@@ -133,8 +133,8 @@ public class GT_RecipeAdder implements IGT_RecipeAdder {
         return addCentrifugeRecipe(
                 aInput1,
                 aInput2 < 0
-                        ? ItemList.IC2_Fuel_Can_Empty.get(-aInput2, new Object[0])
-                        : aInput2 > 0 ? ItemList.Cell_Empty.get(aInput2, new Object[0]) : null,
+                        ? null
+                        : aInput2 > 0 ? ItemList.Cell_Empty.get(aInput2) : null,
                 null,
                 null,
                 aOutput1,
@@ -294,8 +294,8 @@ public class GT_RecipeAdder implements IGT_RecipeAdder {
         return addElectrolyzerRecipe(
                 aInput1,
                 aInput2 < 0
-                        ? ItemList.IC2_Fuel_Can_Empty.get(-aInput2, new Object[0])
-                        : aInput2 > 0 ? ItemList.Cell_Empty.get(aInput2, new Object[0]) : null,
+                        ? null
+                        : aInput2 > 0 ? ItemList.Cell_Empty.get(aInput2) : null,
                 null,
                 null,
                 aOutput1,

--- a/src/main/java/gregtech/common/tileentities/generators/GT_MetaTileEntity_DieselGenerator.java
+++ b/src/main/java/gregtech/common/tileentities/generators/GT_MetaTileEntity_DieselGenerator.java
@@ -17,7 +17,6 @@ import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_BasicGenerator;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GT_Log;
-import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_Recipe;
 import gregtech.api.util.GT_Utility;
 import gregtech.api.util.WorldSpawnedEventBuilder.ParticleEventBuilder;
@@ -85,7 +84,7 @@ public class GT_MetaTileEntity_DieselGenerator extends GT_MetaTileEntity_BasicGe
     @Override
     public int getFuelValue(ItemStack aStack) {
         if (GT_Utility.isStackInvalid(aStack) || getRecipes() == null) return 0;
-        long rValue = Math.max(GT_ModHandler.getFuelCanValue(aStack) * 6 / 5, super.getFuelValue(aStack));
+        long rValue = super.getFuelValue(aStack);
         if (ItemList.Fuel_Can_Plastic_Filled.isStackEqual(aStack, false, true)) {
             rValue = Math.max(rValue, GameRegistry.getFuelValue(aStack) * 3L);
         }

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingSand.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingSand.java
@@ -16,18 +16,7 @@ public class ProcessingSand implements gregtech.api.interfaces.IOreRecipeRegistr
     @Override
     public void registerOre(
             OrePrefixes aPrefix, Materials aMaterial, String aOreDictName, String aModName, ItemStack aStack) {
-        if (aOreDictName.equals("sandCracked")) {
-            GT_Values.RA.addCentrifugeRecipe(
-                    GT_Utility.copyAmount(16L, aStack),
-                    -1,
-                    gregtech.api.util.GT_ModHandler.getFuelCan(25000),
-                    GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Saltpeter, 8L),
-                    null,
-                    null,
-                    null,
-                    new ItemStack(Blocks.sand, 10),
-                    2500);
-        } else if (aOreDictName.equals("sandOil")) {
+        if (aOreDictName.equals("sandOil")) {
             GT_Values.RA.addCentrifugeRecipe(
                     GT_Utility.copyAmount(2L, aStack),
                     1,

--- a/src/main/java/gregtech/loaders/preload/GT_Loader_ItemData.java
+++ b/src/main/java/gregtech/loaders/preload/GT_Loader_ItemData.java
@@ -151,7 +151,6 @@ public class GT_Loader_ItemData implements Runnable {
                 GT_ModHandler.getIC2Item("ironFurnace", 1L), new ItemData(Materials.Iron, 18144000L));
         GT_OreDictUnificator.addItemData(ItemList.IC2_Food_Can_Empty.get(1L), new ItemData(Materials.Tin, 1814400L));
         GT_OreDictUnificator.addItemData(ItemList.IC2_Fuel_Rod_Empty.get(1L), new ItemData(Materials.Iron, 3628800L));
-        GT_OreDictUnificator.addItemData(ItemList.IC2_Fuel_Can_Empty.get(1L), new ItemData(Materials.Tin, 25401600L));
         GT_OreDictUnificator.addItemData(
                 new ItemStack(Blocks.light_weighted_pressure_plate, 1, 32767), new ItemData(Materials.Gold, 7257600L));
         GT_OreDictUnificator.addItemData(


### PR DESCRIPTION
IC2 fuel can is no longer with us, so will the compat code in GT.

API methods are left with `@Deprecated` warnings in case someone is STILL using these ancient stuff.