### PR TITLE
Fix Game crashes if the old Gas Turbine Config is present

### DIFF
--- a/src/main/java/gregtech/loaders/preload/GT_PreLoad.java
+++ b/src/main/java/gregtech/loaders/preload/GT_PreLoad.java
@@ -760,24 +760,37 @@ public class GT_PreLoad {
                         "PollutionBaseDieselGenerator",
                         GT_Mod.gregtechproxy.mPollutionBaseDieselGeneratorPerSecond)
                 .getInt(GT_Mod.gregtechproxy.mPollutionBaseDieselGeneratorPerSecond);
-        GT_Mod.gregtechproxy.mPollutionDieselGeneratorReleasedByTier = tMainConfig
+        double[] mPollutionDieselGeneratorReleasedByTier = tMainConfig
                 .get(
                         "Pollution",
                         "PollutionReleasedByTierDieselGenerator",
                         GT_Mod.gregtechproxy.mPollutionDieselGeneratorReleasedByTier)
                 .getDoubleList();
+        if (mPollutionDieselGeneratorReleasedByTier.length
+                == GT_Mod.gregtechproxy.mPollutionDieselGeneratorReleasedByTier.length) {
+            GT_Mod.gregtechproxy.mPollutionDieselGeneratorReleasedByTier = mPollutionDieselGeneratorReleasedByTier;
+        } else {
+            GT_FML_LOGGER.error(
+                    "The Length of the Diesel Turbine Pollution Array Config must be the same as the Default");
+        }
         GT_Mod.gregtechproxy.mPollutionBaseGasTurbinePerSecond = tMainConfig
                 .get(
                         "Pollution",
                         "PollutionBaseGasTurbineGenerator",
                         GT_Mod.gregtechproxy.mPollutionBaseGasTurbinePerSecond)
                 .getInt(GT_Mod.gregtechproxy.mPollutionBaseGasTurbinePerSecond);
-        GT_Mod.gregtechproxy.mPollutionGasTurbineReleasedByTier = tMainConfig
+        double[] mPollutionGasTurbineReleasedByTier = tMainConfig
                 .get(
                         "Pollution",
                         "PollutionReleasedByTierGasTurbineGenerator",
                         GT_Mod.gregtechproxy.mPollutionGasTurbineReleasedByTier)
                 .getDoubleList();
+        if (mPollutionGasTurbineReleasedByTier.length
+                == GT_Mod.gregtechproxy.mPollutionGasTurbineReleasedByTier.length) {
+            GT_Mod.gregtechproxy.mPollutionGasTurbineReleasedByTier = mPollutionGasTurbineReleasedByTier;
+        } else {
+            GT_FML_LOGGER.error("The Length of the Gas Turbine Pollution Array Config must be the same as the Default");
+        }
 
         GT_Mod.gregtechproxy.mUndergroundOil.getConfig(tMainConfig, "undergroundfluid");
         GT_Mod.gregtechproxy.mEnableCleanroom =


### PR DESCRIPTION
Due to the recent gas turbine update, D:PollutionReleasedByTierGasTurbineGenerator now has to be 6 size.
If you try to load the old config which only has 4 size, the game crashes at the gas turbine mte initialization.

(Forge is too dumb, if I use isListLengthFixed it will read null value from config and throw NPE)
![キャプチャ1783](https://user-images.githubusercontent.com/39122497/202073823-0624f75e-c1cb-45ac-ba72-64fdfcea2968.PNG)