### PR TITLE
Add Kevlar Bee and remove autoclave recipes

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -11,6 +11,7 @@ dependencies {
     compile("com.github.GTNewHorizons:GTNHLib:0.0.1:dev")
     compile("com.github.GTNewHorizons:ModularUI:1.0.24:dev")
     compile("com.github.GTNewHorizons:waila:1.5.21:dev")
+    compile("com.github.GTNewHorizons:ForestryMC:4.5.6:dev")
 
     compile("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev")
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -11,7 +11,6 @@ dependencies {
     compile("com.github.GTNewHorizons:GTNHLib:0.0.1:dev")
     compile("com.github.GTNewHorizons:ModularUI:1.0.24:dev")
     compile("com.github.GTNewHorizons:waila:1.5.21:dev")
-    compile("com.github.GTNewHorizons:ForestryMC:4.5.6:dev")
 
     compile("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev")
 

--- a/src/main/java/gregtech/common/items/CombType.java
+++ b/src/main/java/gregtech/common/items/CombType.java
@@ -201,6 +201,7 @@ public enum CombType {
     ESSENTIA(158, "essentia", true, Materials._NULL, 100, 0xED3601, 0xFF6D50, ItemComb.Voltage.MV),
     INDIUM(159, "indium", true, Materials.Indium, 100, 0x8F5D99, 0xFFA9FF, ItemComb.Voltage.ZPM),
     BLIZZ(160, "cryotheum", true, Materials.Blizz, 50, 0xFF99A5, 0x5af7ff, ItemComb.Voltage.MV),
+    KEVLAR(161, "kevlar", true, Materials._NULL, 50, 0xa2baa3, 0x2d542f, ItemComb.Voltage.MV),
 
     // ALWAYS KEEP _NULL AT THE BOTTOM
     _NULL(-1, "INVALIDCOMB", false, Materials._NULL, 0, 0, 0);

--- a/src/main/java/gregtech/common/items/ItemComb.java
+++ b/src/main/java/gregtech/common/items/ItemComb.java
@@ -13,7 +13,6 @@ import forestry.api.recipes.RecipeManagers;
 import gregtech.GT_Mod;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
-import gregtech.api.enums.MaterialsKevlar;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_OreDictUnificator;

--- a/src/main/java/gregtech/common/items/ItemComb.java
+++ b/src/main/java/gregtech/common/items/ItemComb.java
@@ -1756,16 +1756,6 @@ public class ItemComb extends Item {
             if (GT_OreDictUnificator.get(OrePrefixes.crushedPurified, aMaterial[i], 4) != NI) {
                 switch (comb) {
                     case NEUTRONIUM:
-                        // RA.addAutoclaveRecipe(
-                        //        GT_Utility.copyAmount(9, tComb),
-                        //         GT_Utility.getIntegratedCircuit(i + 1),
-                        //         Materials.UUMatter.getFluid(
-                        //                 Math.max(1, ((aMaterial[i].getMass() + volt.getUUAmplifier()) / 10))),
-                        //         GT_OreDictUnificator.get(OrePrefixes.crushedPurified, aMaterial[i], 4),
-                        //          10000,
-                        //         (int) (aMaterial[i].getMass() * 128),
-                        //         volt.getAutoClaveEnergy(),
-                        //         volt.compareTo(Voltage.HV) > 0);
                         RA.addChemicalRecipe(
                                 GT_Utility.copyAmount(4, tComb),
                                 null,
@@ -1777,16 +1767,6 @@ public class ItemComb extends Item {
                                 volt.getChemicalEnergy(),
                                 volt.compareTo(Voltage.IV) > 0);
                     case OSMIUM:
-                        // RA.addAutoclaveRecipe(
-                        //         GT_Utility.copyAmount(9, tComb),
-                        //         GT_Utility.getIntegratedCircuit(i + 1),
-                        //         Materials.UUMatter.getFluid(
-                        //                 Math.max(1, ((aMaterial[i].getMass() + volt.getUUAmplifier()) / 10))),
-                        //        GT_OreDictUnificator.get(OrePrefixes.crushedPurified, aMaterial[i], 4),
-                        //         10000,
-                        //         (int) (aMaterial[i].getMass() * 128),
-                        //         volt.getAutoClaveEnergy(),
-                        //         volt.compareTo(Voltage.HV) > 0);
                         RA.addChemicalRecipe(
                                 GT_Utility.copyAmount(4, tComb),
                                 null,
@@ -1798,16 +1778,6 @@ public class ItemComb extends Item {
                                 volt.getChemicalEnergy(),
                                 volt.compareTo(Voltage.IV) > 0);
                     case PLATINUM:
-                        // RA.addAutoclaveRecipe(
-                        //         GT_Utility.copyAmount(9, tComb),
-                        //         GT_Utility.getIntegratedCircuit(i + 1),
-                        //         Materials.UUMatter.getFluid(
-                        //                 Math.max(1, ((aMaterial[i].getMass() + volt.getUUAmplifier()) / 10))),
-                        //        GT_OreDictUnificator.get(OrePrefixes.crushedPurified, aMaterial[i], 4),
-                        //        10000,
-                        //         (int) (aMaterial[i].getMass() * 128),
-                        //          volt.getAutoClaveEnergy(),
-                        //          volt.compareTo(Voltage.HV) > 0);
                         RA.addChemicalRecipe(
                                 GT_Utility.copyAmount(4, tComb),
                                 null,
@@ -1819,16 +1789,6 @@ public class ItemComb extends Item {
                                 volt.getChemicalEnergy(),
                                 volt.compareTo(Voltage.HV) > 0);
                     case IRIDIUM:
-                        // RA.addAutoclaveRecipe(
-                        //        GT_Utility.copyAmount(9, tComb),
-                        //        GT_Utility.getIntegratedCircuit(i + 1),
-                        //        Materials.UUMatter.getFluid(
-                        //                Math.max(1, ((aMaterial[i].getMass() + volt.getUUAmplifier()) / 10))),
-                        //        GT_OreDictUnificator.get(OrePrefixes.crushedPurified, aMaterial[i], 4),
-                        //        10000,
-                        //        (int) (aMaterial[i].getMass() * 128),
-                        //        volt.getAutoClaveEnergy(),
-                        //        volt.compareTo(Voltage.HV) > 0);
                         RA.addChemicalRecipe(
                                 GT_Utility.copyAmount(4, tComb),
                                 null,
@@ -1850,16 +1810,6 @@ public class ItemComb extends Item {
                                 volt.getComplexTime(),
                                 volt.getChemicalEnergy(),
                                 volt.compareTo(Voltage.IV) > 0);
-                        // RA.addAutoclaveRecipe(
-                        //        GT_Utility.copyAmount(9, tComb),
-                        //        GT_Utility.getIntegratedCircuit(i + 1),
-                        //        Materials.UUMatter.getFluid(
-                        //                Math.max(1, ((aMaterial[i].getMass() + volt.getUUAmplifier()) / 10))),
-                        //        GT_OreDictUnificator.get(OrePrefixes.crushedPurified, aMaterial[i], 4),
-                        //        10000,
-                        //        (int) (aMaterial[i].getMass() * 128),
-                        //        volt.getAutoClaveEnergy(),
-                        //        volt.compareTo(Voltage.HV) > 0);
                         break;
                 }
             }

--- a/src/main/java/gregtech/common/items/ItemComb.java
+++ b/src/main/java/gregtech/common/items/ItemComb.java
@@ -1033,7 +1033,7 @@ public class ItemComb extends Item {
         addProcessGT(CombType.TUNGSTEN, new Materials[] {Materials.Tungsten}, Voltage.IV);
         addProcessGT(CombType.PLATINUM, new Materials[] {Materials.Platinum}, Voltage.HV);
         addProcessGT(CombType.MOLYBDENUM, new Materials[] {Materials.Molybdenum}, Voltage.LV);
-       // addAutoclaveProcess(CombType.MOLYBDENUM, Materials.Osmium, Voltage.IV, 5);
+        // addAutoclaveProcess(CombType.MOLYBDENUM, Materials.Osmium, Voltage.IV, 5);
         addProcessGT(CombType.IRIDIUM, new Materials[] {Materials.Iridium}, Voltage.IV);
         addProcessGT(CombType.OSMIUM, new Materials[] {Materials.Osmium}, Voltage.IV);
         addProcessGT(CombType.LITHIUM, new Materials[] {Materials.Lithium}, Voltage.MV);
@@ -1756,16 +1756,16 @@ public class ItemComb extends Item {
             if (GT_OreDictUnificator.get(OrePrefixes.crushedPurified, aMaterial[i], 4) != NI) {
                 switch (comb) {
                     case NEUTRONIUM:
-                       // RA.addAutoclaveRecipe(
+                        // RA.addAutoclaveRecipe(
                         //        GT_Utility.copyAmount(9, tComb),
-                       //         GT_Utility.getIntegratedCircuit(i + 1),
-                       //         Materials.UUMatter.getFluid(
-                       //                 Math.max(1, ((aMaterial[i].getMass() + volt.getUUAmplifier()) / 10))),
-                       //         GT_OreDictUnificator.get(OrePrefixes.crushedPurified, aMaterial[i], 4),
-                      //          10000,
-                       //         (int) (aMaterial[i].getMass() * 128),
-                       //         volt.getAutoClaveEnergy(),
-                       //         volt.compareTo(Voltage.HV) > 0);
+                        //         GT_Utility.getIntegratedCircuit(i + 1),
+                        //         Materials.UUMatter.getFluid(
+                        //                 Math.max(1, ((aMaterial[i].getMass() + volt.getUUAmplifier()) / 10))),
+                        //         GT_OreDictUnificator.get(OrePrefixes.crushedPurified, aMaterial[i], 4),
+                        //          10000,
+                        //         (int) (aMaterial[i].getMass() * 128),
+                        //         volt.getAutoClaveEnergy(),
+                        //         volt.compareTo(Voltage.HV) > 0);
                         RA.addChemicalRecipe(
                                 GT_Utility.copyAmount(4, tComb),
                                 null,
@@ -1777,16 +1777,16 @@ public class ItemComb extends Item {
                                 volt.getChemicalEnergy(),
                                 volt.compareTo(Voltage.IV) > 0);
                     case OSMIUM:
-                       // RA.addAutoclaveRecipe(
-                       //         GT_Utility.copyAmount(9, tComb),
-                       //         GT_Utility.getIntegratedCircuit(i + 1),
-                       //         Materials.UUMatter.getFluid(
-                       //                 Math.max(1, ((aMaterial[i].getMass() + volt.getUUAmplifier()) / 10))),
+                        // RA.addAutoclaveRecipe(
+                        //         GT_Utility.copyAmount(9, tComb),
+                        //         GT_Utility.getIntegratedCircuit(i + 1),
+                        //         Materials.UUMatter.getFluid(
+                        //                 Math.max(1, ((aMaterial[i].getMass() + volt.getUUAmplifier()) / 10))),
                         //        GT_OreDictUnificator.get(OrePrefixes.crushedPurified, aMaterial[i], 4),
-                       //         10000,
-                       //         (int) (aMaterial[i].getMass() * 128),
-                       //         volt.getAutoClaveEnergy(),
-                       //         volt.compareTo(Voltage.HV) > 0);
+                        //         10000,
+                        //         (int) (aMaterial[i].getMass() * 128),
+                        //         volt.getAutoClaveEnergy(),
+                        //         volt.compareTo(Voltage.HV) > 0);
                         RA.addChemicalRecipe(
                                 GT_Utility.copyAmount(4, tComb),
                                 null,
@@ -1798,16 +1798,16 @@ public class ItemComb extends Item {
                                 volt.getChemicalEnergy(),
                                 volt.compareTo(Voltage.IV) > 0);
                     case PLATINUM:
-                       // RA.addAutoclaveRecipe(
-                       //         GT_Utility.copyAmount(9, tComb),
-                       //         GT_Utility.getIntegratedCircuit(i + 1),
-                       //         Materials.UUMatter.getFluid(
-                       //                 Math.max(1, ((aMaterial[i].getMass() + volt.getUUAmplifier()) / 10))),
+                        // RA.addAutoclaveRecipe(
+                        //         GT_Utility.copyAmount(9, tComb),
+                        //         GT_Utility.getIntegratedCircuit(i + 1),
+                        //         Materials.UUMatter.getFluid(
+                        //                 Math.max(1, ((aMaterial[i].getMass() + volt.getUUAmplifier()) / 10))),
                         //        GT_OreDictUnificator.get(OrePrefixes.crushedPurified, aMaterial[i], 4),
                         //        10000,
-                       //         (int) (aMaterial[i].getMass() * 128),
-                      //          volt.getAutoClaveEnergy(),
-                      //          volt.compareTo(Voltage.HV) > 0);
+                        //         (int) (aMaterial[i].getMass() * 128),
+                        //          volt.getAutoClaveEnergy(),
+                        //          volt.compareTo(Voltage.HV) > 0);
                         RA.addChemicalRecipe(
                                 GT_Utility.copyAmount(4, tComb),
                                 null,
@@ -1819,7 +1819,7 @@ public class ItemComb extends Item {
                                 volt.getChemicalEnergy(),
                                 volt.compareTo(Voltage.HV) > 0);
                     case IRIDIUM:
-                        //RA.addAutoclaveRecipe(
+                        // RA.addAutoclaveRecipe(
                         //        GT_Utility.copyAmount(9, tComb),
                         //        GT_Utility.getIntegratedCircuit(i + 1),
                         //        Materials.UUMatter.getFluid(
@@ -1850,7 +1850,7 @@ public class ItemComb extends Item {
                                 volt.getComplexTime(),
                                 volt.getChemicalEnergy(),
                                 volt.compareTo(Voltage.IV) > 0);
-                        //RA.addAutoclaveRecipe(
+                        // RA.addAutoclaveRecipe(
                         //        GT_Utility.copyAmount(9, tComb),
                         //        GT_Utility.getIntegratedCircuit(i + 1),
                         //        Materials.UUMatter.getFluid(

--- a/src/main/java/gregtech/common/items/ItemComb.java
+++ b/src/main/java/gregtech/common/items/ItemComb.java
@@ -13,6 +13,7 @@ import forestry.api.recipes.RecipeManagers;
 import gregtech.GT_Mod;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
+import gregtech.api.enums.MaterialsKevlar;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_OreDictUnificator;
@@ -189,7 +190,6 @@ public class ItemComb extends Item {
                     NI,
                     30 * 100);
         }
-
         // ic2
         addCentrifugeToItemStack(
                 CombType.COOLANT,
@@ -235,7 +235,6 @@ public class ItemComb extends Item {
                 new ItemStack[] {ItemList.FR_RefractoryWax.get(1), Materials.Blizz.getDust(1)},
                 new int[] {50 * 100, 100 * 100},
                 Voltage.MV);
-
         // Alloy
         addProcessGT(CombType.REDALLOY, new Materials[] {Materials.RedAlloy}, Voltage.LV);
         addProcessGT(CombType.REDSTONEALLOY, new Materials[] {Materials.RedstoneAlloy}, Voltage.LV);
@@ -1035,7 +1034,7 @@ public class ItemComb extends Item {
         addProcessGT(CombType.TUNGSTEN, new Materials[] {Materials.Tungsten}, Voltage.IV);
         addProcessGT(CombType.PLATINUM, new Materials[] {Materials.Platinum}, Voltage.HV);
         addProcessGT(CombType.MOLYBDENUM, new Materials[] {Materials.Molybdenum}, Voltage.LV);
-        addAutoclaveProcess(CombType.MOLYBDENUM, Materials.Osmium, Voltage.IV, 5);
+       // addAutoclaveProcess(CombType.MOLYBDENUM, Materials.Osmium, Voltage.IV, 5);
         addProcessGT(CombType.IRIDIUM, new Materials[] {Materials.Iridium}, Voltage.IV);
         addProcessGT(CombType.OSMIUM, new Materials[] {Materials.Osmium}, Voltage.IV);
         addProcessGT(CombType.LITHIUM, new Materials[] {Materials.Lithium}, Voltage.MV);
@@ -1758,16 +1757,16 @@ public class ItemComb extends Item {
             if (GT_OreDictUnificator.get(OrePrefixes.crushedPurified, aMaterial[i], 4) != NI) {
                 switch (comb) {
                     case NEUTRONIUM:
-                        RA.addAutoclaveRecipe(
-                                GT_Utility.copyAmount(9, tComb),
-                                GT_Utility.getIntegratedCircuit(i + 1),
-                                Materials.UUMatter.getFluid(
-                                        Math.max(1, ((aMaterial[i].getMass() + volt.getUUAmplifier()) / 10))),
-                                GT_OreDictUnificator.get(OrePrefixes.crushedPurified, aMaterial[i], 4),
-                                10000,
-                                (int) (aMaterial[i].getMass() * 128),
-                                volt.getAutoClaveEnergy(),
-                                volt.compareTo(Voltage.HV) > 0);
+                       // RA.addAutoclaveRecipe(
+                        //        GT_Utility.copyAmount(9, tComb),
+                       //         GT_Utility.getIntegratedCircuit(i + 1),
+                       //         Materials.UUMatter.getFluid(
+                       //                 Math.max(1, ((aMaterial[i].getMass() + volt.getUUAmplifier()) / 10))),
+                       //         GT_OreDictUnificator.get(OrePrefixes.crushedPurified, aMaterial[i], 4),
+                      //          10000,
+                       //         (int) (aMaterial[i].getMass() * 128),
+                       //         volt.getAutoClaveEnergy(),
+                       //         volt.compareTo(Voltage.HV) > 0);
                         RA.addChemicalRecipe(
                                 GT_Utility.copyAmount(4, tComb),
                                 null,
@@ -1779,16 +1778,16 @@ public class ItemComb extends Item {
                                 volt.getChemicalEnergy(),
                                 volt.compareTo(Voltage.IV) > 0);
                     case OSMIUM:
-                        RA.addAutoclaveRecipe(
-                                GT_Utility.copyAmount(9, tComb),
-                                GT_Utility.getIntegratedCircuit(i + 1),
-                                Materials.UUMatter.getFluid(
-                                        Math.max(1, ((aMaterial[i].getMass() + volt.getUUAmplifier()) / 10))),
-                                GT_OreDictUnificator.get(OrePrefixes.crushedPurified, aMaterial[i], 4),
-                                10000,
-                                (int) (aMaterial[i].getMass() * 128),
-                                volt.getAutoClaveEnergy(),
-                                volt.compareTo(Voltage.HV) > 0);
+                       // RA.addAutoclaveRecipe(
+                       //         GT_Utility.copyAmount(9, tComb),
+                       //         GT_Utility.getIntegratedCircuit(i + 1),
+                       //         Materials.UUMatter.getFluid(
+                       //                 Math.max(1, ((aMaterial[i].getMass() + volt.getUUAmplifier()) / 10))),
+                        //        GT_OreDictUnificator.get(OrePrefixes.crushedPurified, aMaterial[i], 4),
+                       //         10000,
+                       //         (int) (aMaterial[i].getMass() * 128),
+                       //         volt.getAutoClaveEnergy(),
+                       //         volt.compareTo(Voltage.HV) > 0);
                         RA.addChemicalRecipe(
                                 GT_Utility.copyAmount(4, tComb),
                                 null,
@@ -1800,16 +1799,16 @@ public class ItemComb extends Item {
                                 volt.getChemicalEnergy(),
                                 volt.compareTo(Voltage.IV) > 0);
                     case PLATINUM:
-                        RA.addAutoclaveRecipe(
-                                GT_Utility.copyAmount(9, tComb),
-                                GT_Utility.getIntegratedCircuit(i + 1),
-                                Materials.UUMatter.getFluid(
-                                        Math.max(1, ((aMaterial[i].getMass() + volt.getUUAmplifier()) / 10))),
-                                GT_OreDictUnificator.get(OrePrefixes.crushedPurified, aMaterial[i], 4),
-                                10000,
-                                (int) (aMaterial[i].getMass() * 128),
-                                volt.getAutoClaveEnergy(),
-                                volt.compareTo(Voltage.HV) > 0);
+                       // RA.addAutoclaveRecipe(
+                       //         GT_Utility.copyAmount(9, tComb),
+                       //         GT_Utility.getIntegratedCircuit(i + 1),
+                       //         Materials.UUMatter.getFluid(
+                       //                 Math.max(1, ((aMaterial[i].getMass() + volt.getUUAmplifier()) / 10))),
+                        //        GT_OreDictUnificator.get(OrePrefixes.crushedPurified, aMaterial[i], 4),
+                        //        10000,
+                       //         (int) (aMaterial[i].getMass() * 128),
+                      //          volt.getAutoClaveEnergy(),
+                      //          volt.compareTo(Voltage.HV) > 0);
                         RA.addChemicalRecipe(
                                 GT_Utility.copyAmount(4, tComb),
                                 null,
@@ -1821,16 +1820,16 @@ public class ItemComb extends Item {
                                 volt.getChemicalEnergy(),
                                 volt.compareTo(Voltage.HV) > 0);
                     case IRIDIUM:
-                        RA.addAutoclaveRecipe(
-                                GT_Utility.copyAmount(9, tComb),
-                                GT_Utility.getIntegratedCircuit(i + 1),
-                                Materials.UUMatter.getFluid(
-                                        Math.max(1, ((aMaterial[i].getMass() + volt.getUUAmplifier()) / 10))),
-                                GT_OreDictUnificator.get(OrePrefixes.crushedPurified, aMaterial[i], 4),
-                                10000,
-                                (int) (aMaterial[i].getMass() * 128),
-                                volt.getAutoClaveEnergy(),
-                                volt.compareTo(Voltage.HV) > 0);
+                        //RA.addAutoclaveRecipe(
+                        //        GT_Utility.copyAmount(9, tComb),
+                        //        GT_Utility.getIntegratedCircuit(i + 1),
+                        //        Materials.UUMatter.getFluid(
+                        //                Math.max(1, ((aMaterial[i].getMass() + volt.getUUAmplifier()) / 10))),
+                        //        GT_OreDictUnificator.get(OrePrefixes.crushedPurified, aMaterial[i], 4),
+                        //        10000,
+                        //        (int) (aMaterial[i].getMass() * 128),
+                        //        volt.getAutoClaveEnergy(),
+                        //        volt.compareTo(Voltage.HV) > 0);
                         RA.addChemicalRecipe(
                                 GT_Utility.copyAmount(4, tComb),
                                 null,
@@ -1852,16 +1851,16 @@ public class ItemComb extends Item {
                                 volt.getComplexTime(),
                                 volt.getChemicalEnergy(),
                                 volt.compareTo(Voltage.IV) > 0);
-                        RA.addAutoclaveRecipe(
-                                GT_Utility.copyAmount(9, tComb),
-                                GT_Utility.getIntegratedCircuit(i + 1),
-                                Materials.UUMatter.getFluid(
-                                        Math.max(1, ((aMaterial[i].getMass() + volt.getUUAmplifier()) / 10))),
-                                GT_OreDictUnificator.get(OrePrefixes.crushedPurified, aMaterial[i], 4),
-                                10000,
-                                (int) (aMaterial[i].getMass() * 128),
-                                volt.getAutoClaveEnergy(),
-                                volt.compareTo(Voltage.HV) > 0);
+                        //RA.addAutoclaveRecipe(
+                        //        GT_Utility.copyAmount(9, tComb),
+                        //        GT_Utility.getIntegratedCircuit(i + 1),
+                        //        Materials.UUMatter.getFluid(
+                        //                Math.max(1, ((aMaterial[i].getMass() + volt.getUUAmplifier()) / 10))),
+                        //        GT_OreDictUnificator.get(OrePrefixes.crushedPurified, aMaterial[i], 4),
+                        //        10000,
+                        //        (int) (aMaterial[i].getMass() * 128),
+                        //        volt.getAutoClaveEnergy(),
+                        //        volt.compareTo(Voltage.HV) > 0);
                         break;
                 }
             }

--- a/src/main/java/gregtech/common/items/ItemComb.java
+++ b/src/main/java/gregtech/common/items/ItemComb.java
@@ -1033,7 +1033,6 @@ public class ItemComb extends Item {
         addProcessGT(CombType.TUNGSTEN, new Materials[] {Materials.Tungsten}, Voltage.IV);
         addProcessGT(CombType.PLATINUM, new Materials[] {Materials.Platinum}, Voltage.HV);
         addProcessGT(CombType.MOLYBDENUM, new Materials[] {Materials.Molybdenum}, Voltage.LV);
-        // addAutoclaveProcess(CombType.MOLYBDENUM, Materials.Osmium, Voltage.IV, 5);
         addProcessGT(CombType.IRIDIUM, new Materials[] {Materials.Iridium}, Voltage.IV);
         addProcessGT(CombType.OSMIUM, new Materials[] {Materials.Osmium}, Voltage.IV);
         addProcessGT(CombType.LITHIUM, new Materials[] {Materials.Lithium}, Voltage.MV);

--- a/src/main/java/gregtech/loaders/misc/GT_BeeDefinition.java
+++ b/src/main/java/gregtech/loaders/misc/GT_BeeDefinition.java
@@ -997,7 +997,7 @@ public enum GT_BeeDefinition implements IBeeDefinition {
             template -> AlleleHelper.instance.set(template, SPEED, Speed.SLOWER),
             dis -> {
                 IBeeMutationCustom tMutation = dis.registerMutation(SALTY, ALUMINIUM, 5);
-                tMutation.requireResource("blockLithium");
+                tMutation.requireResource("frameGtLithium");
             }),
     ELECTROTINE(
             GT_BranchDefinition.RAREMETAL,
@@ -1219,6 +1219,32 @@ public enum GT_BeeDefinition implements IBeeDefinition {
             dis -> {
                 IBeeMutationCustom tMutation = dis.registerMutation(FIRESTONE, COAL, 4);
                 tMutation.requireResource(GameRegistry.findBlock("IC2", "blockITNT"), 0);
+            }),
+    KEVLAR(
+            GT_BranchDefinition.IC2,
+            "kevlar",
+            false,
+            new Color(0x2d542f),
+            new Color(0xa2baa3),
+            beeSpecies -> {
+                beeSpecies.addSpecialty(GT_Bees.combs.getStackForType(CombType.KEVLAR), 0.075f);
+                beeSpecies.setHumidity(DAMP);
+                beeSpecies.setTemperature(COLD);
+                beeSpecies.setHasEffect();
+                beeSpecies.setJubilanceProvider(GT_JubilanceMegaApiary.instance);
+            },
+            template -> {
+                AlleleHelper.instance.set(template, SPEED, Speed.SLOWEST);
+                AlleleHelper.instance.set(template, LIFESPAN, Lifespan.LONGEST);
+                AlleleHelper.instance.set(template, EFFECT, AlleleEffect.effectSnowing);
+                AlleleHelper.instance.set(template, TEMPERATURE_TOLERANCE, Tolerance.NONE);
+                AlleleHelper.instance.set(template, NOCTURNAL, true);
+                AlleleHelper.instance.set(template, FLOWER_PROVIDER, Flowers.SNOW);
+                AlleleHelper.instance.set(template, FLOWERING, Flowering.AVERAGE);
+            },
+            dis -> {
+                IBeeMutationCustom tMutation = dis.registerMutation(OIL, ENERGY, 4);
+                tMutation.requireResource("frameGtKevlar");
             }),
     // Alloy
     REDALLOY(


### PR DESCRIPTION
Autoclave recipes removed  becase we don't need them anymore. Needs to be revorked, in the meantime we can get rid of 500+ recipes temporarily.

Added Kevlar bee to be used in QFT as a bonus items to get more kevlar and concentrate on purely getting kevlar.

Fixed lithium bee needing the proper block fixes: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/11812