### PR TITLE
Buff TPV-Alloy Wires

### DIFF
--- a/src/main/java/gregtech/loaders/preload/GT_Loader_MetaTileEntities.java
+++ b/src/main/java/gregtech/loaders/preload/GT_Loader_MetaTileEntities.java
@@ -13011,9 +13011,9 @@ public class GT_Loader_MetaTileEntities implements Runnable { // TODO CHECK CIRC
         makeWires(
                 Materials.TPV,
                 1840,
-                bEC ? 2L : 14L,
-                bEC ? 4L : 28L,
-                1L,
+                bEC ? 1L : 14L,
+                bEC ? 2L : 28L,
+                6L,
                 gregtech.api.enums.GT_Values.V[4],
                 true,
                 false);


### PR DESCRIPTION
There aren't many good EV cable options since 2 loss in EV is still a lot when added up with transformer loss etc. The only 1 loss EV cable is aluminium but that is just 1A cable. I thought TPV could be made into a good cable. Changing it to 6A and 1 Loss.