### PR TITLE
ensure machine controller incompatible with redstone receiver

### DIFF
--- a/src/main/java/gregtech/api/interfaces/covers/IControlsWorkCover.java
+++ b/src/main/java/gregtech/api/interfaces/covers/IControlsWorkCover.java
@@ -1,0 +1,27 @@
+package gregtech.api.interfaces.covers;
+
+import gregtech.api.interfaces.tileentity.ICoverable;
+import gregtech.api.interfaces.tileentity.IMachineProgress;
+
+/**
+ * Marker interface for covers that might control whether the work can start on a {@link IMachineProgress}.
+ */
+public interface IControlsWorkCover {
+
+    /**
+     * Make sure there is only one GT_Cover_ControlsWork on the aTileEntity
+     * TODO this is a migration thing. Remove this after 2.3.0 is released.
+     *
+     * @return true if the cover is the first (side) one
+     **/
+    static boolean makeSureOnlyOne(byte aMySide, ICoverable aTileEntity) {
+        for (byte i = 0; i < 6; i++) {
+            if (aTileEntity.getCoverBehaviorAtSideNew(i) instanceof IControlsWorkCover && i < aMySide) {
+                aTileEntity.dropCover(i, i, true);
+                aTileEntity.markDirty();
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/gregtech/common/covers/GT_Cover_ControlsWork.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_ControlsWork.java
@@ -5,6 +5,7 @@ import com.gtnewhorizons.modularui.common.widget.TextWidget;
 import gregtech.api.gui.modularui.GT_CoverUIBuildContext;
 import gregtech.api.gui.modularui.GT_UITextures;
 import gregtech.api.interfaces.ITexture;
+import gregtech.api.interfaces.covers.IControlsWorkCover;
 import gregtech.api.interfaces.tileentity.ICoverable;
 import gregtech.api.interfaces.tileentity.IMachineProgress;
 import gregtech.api.util.GT_CoverBehavior;
@@ -16,7 +17,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.Fluid;
 
-public class GT_Cover_ControlsWork extends GT_CoverBehavior {
+public class GT_Cover_ControlsWork extends GT_CoverBehavior implements IControlsWorkCover {
 
     /**
      * @deprecated use {@link #GT_Cover_ControlsWork(ITexture coverTexture)} instead
@@ -79,17 +80,11 @@ public class GT_Cover_ControlsWork extends GT_CoverBehavior {
 
     /**
      * Make sure there is only one GT_Cover_ControlsWork on the aTileEntity
+     * TODO this is a migration thing. Remove this after 2.3.0 is released.
      * @return true if the cover is the first (side) one
      **/
     private boolean makeSureOnlyOne(byte aSide, ICoverable aTileEntity) {
-        for (byte i = 0; i < 6; i++) {
-            if (aTileEntity.getCoverBehaviorAtSideNew(i) instanceof GT_Cover_ControlsWork && i < aSide) {
-                aTileEntity.dropCover(aSide, aSide, true);
-                aTileEntity.markDirty();
-                return false;
-            }
-        }
-        return true;
+        return IControlsWorkCover.makeSureOnlyOne(aSide, aTileEntity);
     }
 
     @Override
@@ -174,7 +169,7 @@ public class GT_Cover_ControlsWork extends GT_CoverBehavior {
     public boolean isCoverPlaceable(byte aSide, ItemStack aStack, ICoverable aTileEntity) {
         if (!super.isCoverPlaceable(aSide, aStack, aTileEntity)) return false;
         for (byte i = 0; i < 6; i++) {
-            if (aTileEntity.getCoverBehaviorAtSideNew(i) instanceof GT_Cover_ControlsWork) {
+            if (aTileEntity.getCoverBehaviorAtSideNew(i) instanceof IControlsWorkCover) {
                 return false;
             }
         }

--- a/src/main/java/gregtech/common/covers/GT_Cover_RedstoneTransmitterExternal.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_RedstoneTransmitterExternal.java
@@ -2,8 +2,10 @@ package gregtech.common.covers;
 
 import gregtech.api.GregTech_API;
 import gregtech.api.interfaces.ITexture;
+import gregtech.api.interfaces.covers.IControlsWorkCover;
 import gregtech.api.interfaces.tileentity.ICoverable;
 import gregtech.api.util.ISerializableObject;
+import net.minecraft.item.ItemStack;
 
 public class GT_Cover_RedstoneTransmitterExternal extends GT_Cover_RedstoneWirelessBase {
 
@@ -22,6 +24,8 @@ public class GT_Cover_RedstoneTransmitterExternal extends GT_Cover_RedstoneWirel
     @Override
     public int doCoverThings(
             byte aSide, byte aInputRedstone, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
+        // TODO remove next line after 2.3.0
+        if (!IControlsWorkCover.makeSureOnlyOne(aSide, aTileEntity)) return aCoverVariable;
         GregTech_API.sWirelessRedstone.put(aCoverVariable, aInputRedstone);
         return aCoverVariable;
     }
@@ -44,5 +48,16 @@ public class GT_Cover_RedstoneTransmitterExternal extends GT_Cover_RedstoneWirel
     @Override
     public int getTickRate(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity) {
         return 1;
+    }
+
+    @Override
+    public boolean isCoverPlaceable(byte aSide, ItemStack aStack, ICoverable aTileEntity) {
+        if (!super.isCoverPlaceable(aSide, aStack, aTileEntity)) return false;
+        for (byte i = 0; i < 6; i++) {
+            if (aTileEntity.getCoverBehaviorAtSideNew(i) instanceof IControlsWorkCover) {
+                return false;
+            }
+        }
+        return true;
     }
 }


### PR DESCRIPTION
Close https://github.com/GTNewHorizons/GT5-Unofficial/pull/1546

These twos are fundamentally incompatible. You cannot have two different mechanism controlling one variable and expect the whole contraption to work in an intuitive way. Existing setups with both of these covers will have all but the last one dropped. The last one is the one actually being effective all the time anyway.