### PR TITLE
Fix ore factory stocking bus integration

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_IntegratedOreFactory.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_IntegratedOreFactory.java
@@ -289,7 +289,7 @@ public class GT_MetaTileEntity_IntegratedOreFactory
                     ore.stackSize = 0;
                 } else {
                     tRealUsed = tCharged;
-                    tOres.add(GT_Utility.copyAmount(tCharged, ore));
+                    tOres.add(GT_Utility.copyAmountUnsafe(tCharged, ore));
                     ore.stackSize -= tCharged;
                     tCharged = 0;
                     break;


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/11490

GT Utils `copyAmount` limits stack size to 64, use `copyAmountUnsafe` instead for limit of INT_MAX

https://user-images.githubusercontent.com/73182109/207743379-770d9339-5145-4e93-aae3-96f2e5b94d57.mp4

