### PR TITLE
Turbine efficiency helper

### DIFF
--- a/src/main/java/gregtech/api/enums/GT_Values.java
+++ b/src/main/java/gregtech/api/enums/GT_Values.java
@@ -6,10 +6,9 @@ import gregtech.api.interfaces.internal.IGT_Mod;
 import gregtech.api.interfaces.internal.IGT_RecipeAdder;
 import gregtech.api.net.IGT_NetworkHandler;
 import java.math.BigInteger;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Locale;
-import java.util.Set;
+import java.util.*;
+
+import gregtech.api.util.GT_Recipe;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.world.World;
@@ -188,7 +187,7 @@ public class GT_Values {
         EnumChatFormatting.DARK_GREEN.toString(), // UV,  8
         EnumChatFormatting.DARK_RED.toString(), // UHV, 9
         EnumChatFormatting.DARK_PURPLE.toString(), // UEV, 10
-        EnumChatFormatting.DARK_BLUE.toString() + EnumChatFormatting.BOLD.toString(), // UIV, 11
+        EnumChatFormatting.DARK_BLUE + EnumChatFormatting.BOLD.toString(), // UIV, 11
         EnumChatFormatting.RED.toString()
                 + EnumChatFormatting.BOLD.toString()
                 + EnumChatFormatting.UNDERLINE.toString(), // UMV, 12
@@ -406,7 +405,7 @@ public class GT_Values {
      */
     public static boolean debugDriller = false;
     /**
-     * Debug parameter for world generation. Tracks chunks added/removed from run queue.
+     * Debug parameter for world generation. Track chunks added/removed from run queue.
      */
     public static boolean debugWorldGen = false;
     /**
@@ -510,4 +509,28 @@ public class GT_Values {
 
     public static final String AuthorBlueWeabo = "Author: " + EnumChatFormatting.BLUE + EnumChatFormatting.BOLD + "Blue"
             + EnumChatFormatting.AQUA + EnumChatFormatting.BOLD + "Weabo";
+
+    // 7.5F comes from GT_Tool_Turbine_Large#getBaseDamage() given huge turbines are the most efficient now.
+    public static double getMaxPlasmaTurbineEfficiencyFromMaterial(Materials material) {
+        return (5F + (7.5F + material.mToolQuality)) / 10.0;
+    }
+
+    // Called once in GT_Client on world load, has to be called late so that Materials is populated.
+    public static void calculateMaxPlasmaTurbineEfficiency() {
+
+        ArrayList<Double> effArray = new ArrayList<>();
+
+        // Iteration seems to work but need to check turbine as all items appear null.
+        for (Materials material : Materials.values()) {
+            effArray.add(getMaxPlasmaTurbineEfficiencyFromMaterial(material));
+        }
+
+        maxPlasmaTurbineEfficiency = Collections.max(effArray);
+    }
+
+    private static double maxPlasmaTurbineEfficiency;
+
+    public static double getMaxPlasmaTurbineEfficiency() {
+        return maxPlasmaTurbineEfficiency;
+    }
 }

--- a/src/main/java/gregtech/api/enums/GT_Values.java
+++ b/src/main/java/gregtech/api/enums/GT_Values.java
@@ -7,8 +7,6 @@ import gregtech.api.interfaces.internal.IGT_RecipeAdder;
 import gregtech.api.net.IGT_NetworkHandler;
 import java.math.BigInteger;
 import java.util.*;
-
-import gregtech.api.util.GT_Recipe;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.world.World;

--- a/src/main/java/gregtech/api/util/GT_Utility.java
+++ b/src/main/java/gregtech/api/util/GT_Utility.java
@@ -4331,4 +4331,16 @@ public class GT_Utility {
         @Nullable
         protected abstract NBTTagCompound nbt();
     }
+
+    public static int getPlasmaFuelValueInEUPerLiterFromMaterial(Materials material) {
+        return getPlasmaFuelValueInEUPerLiterFromFluid(material.getPlasma(1));
+    }
+
+    public static int getPlasmaFuelValueInEUPerLiterFromFluid(FluidStack aLiquid) {
+        if (aLiquid == null) return 0;
+        GT_Recipe tFuel = GT_Recipe.GT_Recipe_Map.sPlasmaFuels.findFuel(aLiquid);
+        if (tFuel != null) return tFuel.mSpecialValue;
+        return 0;
+    }
+
 }

--- a/src/main/java/gregtech/api/util/GT_Utility.java
+++ b/src/main/java/gregtech/api/util/GT_Utility.java
@@ -4342,5 +4342,4 @@ public class GT_Utility {
         if (tFuel != null) return tFuel.mSpecialValue;
         return 0;
     }
-
 }

--- a/src/main/java/gregtech/common/GT_Client.java
+++ b/src/main/java/gregtech/common/GT_Client.java
@@ -5,6 +5,7 @@
 
 package gregtech.common;
 
+import static gregtech.api.enums.GT_Values.calculateMaxPlasmaTurbineEfficiency;
 import static org.lwjgl.opengl.GL11.GL_LINE_LOOP;
 
 import codechicken.lib.vec.Rotation;
@@ -641,6 +642,8 @@ public class GT_Client extends GT_Proxy implements Runnable {
         } catch (Throwable e) {
             e.printStackTrace(GT_Log.err);
         }
+
+        // Calculate highest plasma turbine efficiency.
     }
 
     @Override
@@ -648,6 +651,7 @@ public class GT_Client extends GT_Proxy implements Runnable {
     public void onClientConnectedToServerEvent(FMLNetworkEvent.ClientConnectedToServerEvent aEvent) {
         mFirstTick = true;
         mReloadCount++;
+        calculateMaxPlasmaTurbineEfficiency();
     }
 
     @Override

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeTurbine_Plasma.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeTurbine_Plasma.java
@@ -1,6 +1,7 @@
 package gregtech.common.tileentities.machines.multi;
 
 import static gregtech.api.enums.Textures.BlockIcons.*;
+import static gregtech.api.util.GT_Utility.getPlasmaFuelValueInEUPerLiterFromFluid;
 
 import gregtech.api.GregTech_API;
 import gregtech.api.interfaces.ITexture;
@@ -23,6 +24,7 @@ import net.minecraft.util.StatCollector;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 
+@SuppressWarnings("SpellCheckingInspection")
 public class GT_MetaTileEntity_LargeTurbine_Plasma extends GT_MetaTileEntity_LargeTurbine {
 
     public GT_MetaTileEntity_LargeTurbine_Plasma(int aID, String aName, String aNameRegional) {
@@ -81,6 +83,7 @@ public class GT_MetaTileEntity_LargeTurbine_Plasma extends GT_MetaTileEntity_Lar
         return tt;
     }
 
+    @Deprecated // See GT_Utility#getPlasmaFuelValuePerLiterFromFluid
     public int getFuelValue(FluidStack aLiquid) {
         if (aLiquid == null) return 0;
         GT_Recipe tFuel = GT_Recipe_Map.sPlasmaFuels.findFuel(aLiquid);
@@ -117,14 +120,14 @@ public class GT_MetaTileEntity_LargeTurbine_Plasma extends GT_MetaTileEntity_Lar
             float[] flowMultipliers) {
         if (aFluids.size() >= 1) {
             aOptFlow *= 800; // CHANGED THINGS HERE, check recipe runs once per 20 ticks
-            int tEU = 0;
+            int tEU;
 
-            int actualOptimalFlow = 0;
+            int actualOptimalFlow;
 
             FluidStack firstFuelType = new FluidStack(
                     aFluids.get(0),
                     0); // Identify a SINGLE type of fluid to process.  Doesn't matter which one. Ignore the rest!
-            int fuelValue = getFuelValue(firstFuelType);
+            int fuelValue = getPlasmaFuelValueInEUPerLiterFromFluid(firstFuelType);
             actualOptimalFlow =
                     GT_Utility.safeInt((long) Math.ceil((double) aOptFlow * flowMultipliers[2] / (double) fuelValue));
             this.realOptFlow = actualOptimalFlow; // For scanner info
@@ -139,7 +142,7 @@ public class GT_MetaTileEntity_LargeTurbine_Plasma extends GT_MetaTileEntity_Lar
             // - 550% if it is 3
             // Variable required outside of loop for multi-hatch scenarios.
             int remainingFlow = GT_Utility.safeInt((long) (actualOptimalFlow * (1.5f * overflowMultiplier + 1)));
-            int flow = 0;
+            int flow;
             int totalFlow = 0;
 
             storedFluid = 0;
@@ -169,13 +172,12 @@ public class GT_MetaTileEntity_LargeTurbine_Plasma extends GT_MetaTileEntity_Lar
 
             // GT_FML_LOGGER.info(totalFlow+" : "+fuelValue+" : "+aOptFlow+" : "+actualOptimalFlow+" : "+tEU);
 
-            if (totalFlow == actualOptimalFlow) {
-                tEU = GT_Utility.safeInt((long) (aBaseEff / 10000D * tEU));
-            } else {
+            if (totalFlow != actualOptimalFlow) {
                 float efficiency = getOverflowEfficiency(totalFlow, actualOptimalFlow, overflowMultiplier);
                 tEU = (int) (tEU * efficiency);
-                tEU = GT_Utility.safeInt((long) (aBaseEff / 10000D * tEU));
             }
+            // Round to the nearest EU.
+            tEU = Math.round(aBaseEff * tEU);
 
             // If next output is above the maximum the dynamo can handle, set it to the maximum instead of exploding the
             // turbine
@@ -197,7 +199,7 @@ public class GT_MetaTileEntity_LargeTurbine_Plasma extends GT_MetaTileEntity_Lar
         // fuel used
         // The bigger this number is, the slower efficiency loss happens as flow moves beyond the optimal value
         // Plasmas are the most efficient out of all turbine fuels in this regard
-        float efficiency = 0;
+        float efficiency;
 
         if (totalFlow > actualOptimalFlow) {
             efficiency = 1.0f
@@ -346,7 +348,7 @@ public class GT_MetaTileEntity_LargeTurbine_Plasma extends GT_MetaTileEntity_Lar
                     + ")", /* 5 */
             StatCollector.translateToLocal("GT5U.turbine.fuel") + ": " + EnumChatFormatting.GOLD
                     + GT_Utility.formatNumbers(storedFluid) + EnumChatFormatting.RESET + "L", /* 6 */
-            StatCollector.translateToLocal("GT5U.turbine.dmg") + ": " + EnumChatFormatting.RED + Integer.toString(tDura)
+            StatCollector.translateToLocal("GT5U.turbine.dmg") + ": " + EnumChatFormatting.RED + tDura
                     + EnumChatFormatting.RESET + "%", /* 7 */
             StatCollector.translateToLocal("GT5U.multiblock.pollution") + ": " + EnumChatFormatting.GREEN
                     + mPollutionReduction + EnumChatFormatting.RESET + " %" /* 8 */


### PR DESCRIPTION
Add value to automatically determine highest possible turbine efficiency, for use in auto generating recipes elsewhere and the DTPF when I get back around to that one.

Tested and works with value of 3.75 currently given huge spacetime turbines.