### PR TITLE
Uv lock

### DIFF
--- a/src/main/java/gregtech/api/interfaces/ITextureBuilder.java
+++ b/src/main/java/gregtech/api/interfaces/ITextureBuilder.java
@@ -14,6 +14,7 @@ public interface ITextureBuilder {
      * Build the {@link ITexture}
      *
      * @return The built {@link ITexture}
+     * @throws IllegalStateException if setFromBlock has never been called.
      */
     ITexture build();
 
@@ -76,7 +77,6 @@ public interface ITextureBuilder {
      * Force using meta overload of getIcon.
      *
      * @return {@link ITextureBuilder} for chaining
-     * @throws IllegalStateException if setFromBlock has never been called.
      */
     ITextureBuilder noWorldCoord();
 

--- a/src/main/java/gregtech/common/render/GT_TextureBuilder.java
+++ b/src/main/java/gregtech/common/render/GT_TextureBuilder.java
@@ -113,7 +113,7 @@ public class GT_TextureBuilder implements ITextureBuilder {
                 return new GT_CopiedCTMBlockTexture(fromBlock, fromSide.ordinal(), fromMeta, rgba, allowAlpha);
             else return new GT_CopiedBlockTexture(fromBlock, fromSide.ordinal(), fromMeta, rgba, allowAlpha);
         }
-        if (worldCoord == Boolean.TRUE) throw new IllegalStateException("worldCoord without from block");
+        if (worldCoord != null) throw new IllegalStateException("worldCoord without from block");
         if (!textureLayers.isEmpty()) return new GT_MultiTexture(textureLayers.toArray(new ITexture[0]));
         switch (iconContainerList.size()) {
             case 1:

--- a/src/main/java/gregtech/common/render/GT_TextureBuilder.java
+++ b/src/main/java/gregtech/common/render/GT_TextureBuilder.java
@@ -12,7 +12,7 @@ import java.util.List;
 import net.minecraft.block.Block;
 import net.minecraftforge.common.util.ForgeDirection;
 
-@SuppressWarnings("unused")
+@SuppressWarnings({"unused", "ClassWithTooManyFields"})
 public class GT_TextureBuilder implements ITextureBuilder {
     private final List<IIconContainer> iconContainerList;
     private final List<ITexture> textureLayers;
@@ -81,14 +81,12 @@ public class GT_TextureBuilder implements ITextureBuilder {
 
     @Override
     public ITextureBuilder useWorldCoord() {
-        if (fromBlock == null) throw new IllegalStateException("no from block");
         this.worldCoord = true;
         return this;
     }
 
     @Override
     public ITextureBuilder noWorldCoord() {
-        if (fromBlock == null) throw new IllegalStateException("no from block");
         this.worldCoord = false;
         return this;
     }
@@ -105,6 +103,9 @@ public class GT_TextureBuilder implements ITextureBuilder {
         return this;
     }
 
+    /**
+     * @inheritDoc
+     */
     @Override
     public ITexture build() {
         if (fromBlock != null) {
@@ -112,6 +113,7 @@ public class GT_TextureBuilder implements ITextureBuilder {
                 return new GT_CopiedCTMBlockTexture(fromBlock, fromSide.ordinal(), fromMeta, rgba, allowAlpha);
             else return new GT_CopiedBlockTexture(fromBlock, fromSide.ordinal(), fromMeta, rgba, allowAlpha);
         }
+        if (worldCoord == Boolean.TRUE) throw new IllegalStateException("worldCoord without from block");
         if (!textureLayers.isEmpty()) return new GT_MultiTexture(textureLayers.toArray(new ITexture[0]));
         switch (iconContainerList.size()) {
             case 1:

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeTurbine_Gas.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeTurbine_Gas.java
@@ -41,16 +41,13 @@ public class GT_MetaTileEntity_LargeTurbine_Gas extends GT_MetaTileEntity_LargeT
                     ? (aActive
                             ? TextureFactory.builder()
                                     .addIcon(LARGETURBINE_SS_ACTIVE5)
-                                    .extFacing()
                                     .build()
                             : hasTurbine()
                                     ? TextureFactory.builder()
                                             .addIcon(LARGETURBINE_SS5)
-                                            .extFacing()
                                             .build()
                                     : TextureFactory.builder()
                                             .addIcon(LARGETURBINE_SS_EMPTY5)
-                                            .extFacing()
                                             .build())
                     : casingTexturePages[0][58]
         };

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeTurbine_GasAdvanced.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeTurbine_GasAdvanced.java
@@ -40,16 +40,13 @@ public class GT_MetaTileEntity_LargeTurbine_GasAdvanced extends GT_MetaTileEntit
                     ? (aActive
                             ? TextureFactory.builder()
                                     .addIcon(LARGETURBINE_ADVGAS_ACTIVE5)
-                                    .extFacing()
                                     .build()
                             : hasTurbine()
                                     ? TextureFactory.builder()
                                             .addIcon(LARGETURBINE_ADVGAS5)
-                                            .extFacing()
                                             .build()
                                     : TextureFactory.builder()
                                             .addIcon(LARGETURBINE_ADVGAS_EMPTY5)
-                                            .extFacing()
                                             .build())
                     : casingTexturePages[1][57]
         };

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeTurbine_HPSteam.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeTurbine_HPSteam.java
@@ -47,16 +47,13 @@ public class GT_MetaTileEntity_LargeTurbine_HPSteam extends GT_MetaTileEntity_La
                     ? (aActive
                             ? TextureFactory.builder()
                                     .addIcon(LARGETURBINE_TI_ACTIVE5)
-                                    .extFacing()
                                     .build()
                             : hasTurbine()
                                     ? TextureFactory.builder()
                                             .addIcon(LARGETURBINE_TI5)
-                                            .extFacing()
                                             .build()
                                     : TextureFactory.builder()
                                             .addIcon(LARGETURBINE_TI_EMPTY5)
-                                            .extFacing()
                                             .build())
                     : casingTexturePages[0][59]
         };

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeTurbine_Plasma.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeTurbine_Plasma.java
@@ -47,16 +47,13 @@ public class GT_MetaTileEntity_LargeTurbine_Plasma extends GT_MetaTileEntity_Lar
                     ? (aActive
                             ? TextureFactory.builder()
                                     .addIcon(LARGETURBINE_TU_ACTIVE5)
-                                    .extFacing()
                                     .build()
                             : hasTurbine()
                                     ? TextureFactory.builder()
                                             .addIcon(LARGETURBINE_TU5)
-                                            .extFacing()
                                             .build()
                                     : TextureFactory.builder()
                                             .addIcon(LARGETURBINE_TU_EMPTY5)
-                                            .extFacing()
                                             .build())
                     : casingTexturePages[0][60]
         };

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeTurbine_Steam.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeTurbine_Steam.java
@@ -48,16 +48,13 @@ public class GT_MetaTileEntity_LargeTurbine_Steam extends GT_MetaTileEntity_Larg
                     ? (aActive
                             ? TextureFactory.builder()
                                     .addIcon(LARGETURBINE_ST_ACTIVE5)
-                                    .extFacing()
                                     .build()
                             : hasTurbine()
                                     ? TextureFactory.builder()
                                             .addIcon(LARGETURBINE_ST5)
-                                            .extFacing()
                                             .build()
                                     : TextureFactory.builder()
                                             .addIcon(LARGETURBINE_ST_EMPTY5)
-                                            .extFacing()
                                             .build())
                     : casingTexturePages[0][57]
         };


### PR DESCRIPTION
- fix(GT_TextureBuilder): State check belongs to the build method.
- fix(texture): lock orientation of large turbine controller

![2022-12-18_21 01 07](https://user-images.githubusercontent.com/1111474/208316943-b58ba38c-bd0c-4f07-8bc3-bb92d912d8b6.png)

