### PR TITLE
Unify sodium persulfate amount

### DIFF
--- a/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
@@ -17434,7 +17434,7 @@ public class GT_MachineRecipeLoader implements Runnable {
         // Custom Sodium Persulfate Ore Processing Recipes
         GT_Values.RA.addChemicalBathRecipe(
                 GT_OreDictUnificator.get(OrePrefixes.crushed, Materials.Tantalite, 1),
-                Materials.SodiumPersulfate.getFluid(500L),
+                Materials.SodiumPersulfate.getFluid(100L),
                 GT_OreDictUnificator.get(OrePrefixes.crushedPurified, Materials.Tantalite, 1),
                 Materials.Tantalum.getDust(1),
                 GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Stone, 1L),
@@ -17443,7 +17443,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                 8);
         GT_Values.RA.addChemicalBathRecipe(
                 GT_OreDictUnificator.get(OrePrefixes.crushed, Materials.Pyrolusite, 1),
-                Materials.SodiumPersulfate.getFluid(500L),
+                Materials.SodiumPersulfate.getFluid(100L),
                 GT_OreDictUnificator.get(OrePrefixes.crushedPurified, Materials.Pyrolusite, 1),
                 Materials.Manganese.getDust(1),
                 GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Stone, 1L),
@@ -17452,7 +17452,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                 8);
         GT_Values.RA.addChemicalBathRecipe(
                 GT_OreDictUnificator.get(OrePrefixes.crushed, Materials.Quartzite, 1),
-                Materials.SodiumPersulfate.getFluid(500L),
+                Materials.SodiumPersulfate.getFluid(100L),
                 GT_OreDictUnificator.get(OrePrefixes.crushedPurified, Materials.Quartzite, 1),
                 Materials.CertusQuartz.getDust(1),
                 GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Stone, 1L),
@@ -17461,7 +17461,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                 8);
         GT_Values.RA.addChemicalBathRecipe(
                 GT_OreDictUnificator.get(OrePrefixes.crushed, Materials.CertusQuartz, 1),
-                Materials.SodiumPersulfate.getFluid(500L),
+                Materials.SodiumPersulfate.getFluid(100L),
                 GT_OreDictUnificator.get(OrePrefixes.crushedPurified, Materials.CertusQuartz, 1),
                 Materials.Barium.getDust(1),
                 GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Stone, 1L),
@@ -17470,7 +17470,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                 8);
         GT_Values.RA.addChemicalBathRecipe(
                 GT_OreDictUnificator.get(OrePrefixes.crushed, Materials.Bauxite, 1),
-                Materials.SodiumPersulfate.getFluid(500L),
+                Materials.SodiumPersulfate.getFluid(100L),
                 GT_OreDictUnificator.get(OrePrefixes.crushedPurified, Materials.Bauxite, 1),
                 Materials.Rutile.getDust(1),
                 GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Stone, 1L),
@@ -17479,7 +17479,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                 8);
         GT_Values.RA.addChemicalBathRecipe(
                 GT_OreDictUnificator.get(OrePrefixes.crushed, Materials.Thorium, 1),
-                Materials.SodiumPersulfate.getFluid(500L),
+                Materials.SodiumPersulfate.getFluid(100L),
                 GT_OreDictUnificator.get(OrePrefixes.crushedPurified, Materials.Thorium, 1),
                 Materials.Uranium.getDust(1),
                 GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Stone, 1L),
@@ -17488,7 +17488,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                 8);
         GT_Values.RA.addChemicalBathRecipe(
                 GT_OreDictUnificator.get(OrePrefixes.crushed, Materials.Stibnite, 1),
-                Materials.SodiumPersulfate.getFluid(500L),
+                Materials.SodiumPersulfate.getFluid(100L),
                 GT_OreDictUnificator.get(OrePrefixes.crushedPurified, Materials.Stibnite, 1),
                 Materials.Antimony.getDust(1),
                 GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Stone, 1L),


### PR DESCRIPTION
Modify recipes added in https://github.com/GTNewHorizons/GT5-Unofficial/pull/1063 to use 100L sodium persulfate instead of 500L. 100L is what the other recipes use, so this makes the amounts consistent.

See https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/11842#issuecomment-1364870167 for some additional context. This PR will also fix that issue, but https://github.com/GTNewHorizons/nei-custom-diagram/pull/15 is a more proper fix for it.