### PR TITLE
Added Shortcut because simply dull

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -11,6 +11,7 @@ dependencies {
     compile("com.github.GTNewHorizons:GTNHLib:0.0.8:dev")
     compile("com.github.GTNewHorizons:ModularUI:1.0.24:dev")
     compile("com.github.GTNewHorizons:waila:1.5.21:dev")
+    compile("com.github.GTNewHorizons:ForestryMC:4.5.3:dev")
 
     compile("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev")
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -11,7 +11,6 @@ dependencies {
     compile("com.github.GTNewHorizons:GTNHLib:0.0.8:dev")
     compile("com.github.GTNewHorizons:ModularUI:1.0.24:dev")
     compile("com.github.GTNewHorizons:waila:1.5.21:dev")
-    compile("com.github.GTNewHorizons:ForestryMC:4.5.3:dev")
 
     compile("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev")
 

--- a/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
@@ -19363,7 +19363,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                 Materials.NitricOxide.getGas(2000),
                 Materials.Potassiumdichromate.getDust(11),
                 GT_Values.NI,
-                100,
+                600,
                 480);
         GT_Values.RA.addChemicalRecipeForBasicMachineOnly(
                 Materials.PotassiumNitrade.getDust(10),
@@ -19372,7 +19372,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                 Materials.NitricOxide.getGas(2000),
                 Materials.Potassiumdichromate.getDust(11),
                 GT_Values.NI,
-                100,
+            600,
                 480);
         GT_Values.RA.addMultiblockChemicalRecipe(
                 new ItemStack[] {
@@ -19383,7 +19383,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                 new FluidStack[] {Materials.Oxygen.getGas(6000)},
                 new FluidStack[] {Materials.NitricOxide.getGas(2000), Materials.Oxygen.getGas(3000)},
                 new ItemStack[] {Materials.Potassiumdichromate.getDust(11)},
-                100,
+            600,
                 480);
         GT_Values.RA.addMultiblockChemicalRecipe(
                 new ItemStack[] {
@@ -19392,7 +19392,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                 new FluidStack[] {Materials.Oxygen.getGas(6000)},
                 new FluidStack[] {Materials.NitricOxide.getGas(2000), Materials.Oxygen.getGas(3000)},
                 new ItemStack[] {Materials.Potassiumdichromate.getDust(11)},
-                100,
+            600,
                 480);
 
         // Nitrochlorobenzene

--- a/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
@@ -19372,7 +19372,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                 Materials.NitricOxide.getGas(2000),
                 Materials.Potassiumdichromate.getDust(11),
                 GT_Values.NI,
-            600,
+                600,
                 480);
         GT_Values.RA.addMultiblockChemicalRecipe(
                 new ItemStack[] {
@@ -19383,7 +19383,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                 new FluidStack[] {Materials.Oxygen.getGas(6000)},
                 new FluidStack[] {Materials.NitricOxide.getGas(2000), Materials.Oxygen.getGas(3000)},
                 new ItemStack[] {Materials.Potassiumdichromate.getDust(11)},
-            600,
+                600,
                 480);
         GT_Values.RA.addMultiblockChemicalRecipe(
                 new ItemStack[] {
@@ -19392,7 +19392,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                 new FluidStack[] {Materials.Oxygen.getGas(6000)},
                 new FluidStack[] {Materials.NitricOxide.getGas(2000), Materials.Oxygen.getGas(3000)},
                 new ItemStack[] {Materials.Potassiumdichromate.getDust(11)},
-            600,
+                600,
                 480);
 
         // Nitrochlorobenzene

--- a/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
@@ -19356,44 +19356,40 @@ public class GT_MachineRecipeLoader implements Runnable {
 
         // Potassium Dichromate shortcut
         // 2 Cr + 6O + 10 Saltpeter/Potassium Dichromate = 10 K2Cr2O7 + 2NO + 3O
-        GT_Values.RA.addChemicalRecipeForBasicMachineOnly(
-                Materials.Saltpeter.getDust(10),
-                Materials.Chrome.getDust(2),
-                Materials.Oxygen.getGas(6000),
-                Materials.NitricOxide.getGas(2000),
-                Materials.Potassiumdichromate.getDust(11),
-                GT_Values.NI,
-                600,
-                480);
-        GT_Values.RA.addChemicalRecipeForBasicMachineOnly(
-                Materials.PotassiumNitrade.getDust(10),
-                Materials.Chrome.getDust(2),
-                Materials.Oxygen.getGas(6000),
-                Materials.NitricOxide.getGas(2000),
-                Materials.Potassiumdichromate.getDust(11),
-                GT_Values.NI,
-                600,
-                480);
         GT_Values.RA.addMultiblockChemicalRecipe(
                 new ItemStack[] {
-                    Materials.PotassiumNitrade.getDust(10),
-                    Materials.Chrome.getDust(2),
+                    Materials.PotassiumNitrade.getDust(64),
+                    Materials.PotassiumNitrade.getDust(64),
+                    Materials.PotassiumNitrade.getDust(32),
+                    Materials.Chrome.getDust(2 * 16),
                     GT_Utility.getIntegratedCircuit(11)
                 },
-                new FluidStack[] {Materials.Oxygen.getGas(6000)},
-                new FluidStack[] {Materials.NitricOxide.getGas(2000), Materials.Oxygen.getGas(3000)},
-                new ItemStack[] {Materials.Potassiumdichromate.getDust(11)},
-                600,
-                480);
+                new FluidStack[] {Materials.Oxygen.getGas(6000 * 16)},
+                new FluidStack[] {Materials.NitricOxide.getGas(2000 * 16), Materials.Oxygen.getGas(3000 * 16)},
+                new ItemStack[] {
+                    Materials.Potassiumdichromate.getDust(64),
+                    Materials.Potassiumdichromate.getDust(64),
+                    Materials.Potassiumdichromate.getDust(48)
+                },
+                2560,
+                (int) GT_Values.VP[7]);
         GT_Values.RA.addMultiblockChemicalRecipe(
                 new ItemStack[] {
-                    Materials.Saltpeter.getDust(10), Materials.Chrome.getDust(2), GT_Utility.getIntegratedCircuit(11)
+                    Materials.Saltpeter.getDust(64),
+                    Materials.Saltpeter.getDust(64),
+                    Materials.Saltpeter.getDust(32),
+                    Materials.Chrome.getDust(2 * 16),
+                    GT_Utility.getIntegratedCircuit(11)
                 },
-                new FluidStack[] {Materials.Oxygen.getGas(6000)},
-                new FluidStack[] {Materials.NitricOxide.getGas(2000), Materials.Oxygen.getGas(3000)},
-                new ItemStack[] {Materials.Potassiumdichromate.getDust(11)},
-                600,
-                480);
+                new FluidStack[] {Materials.Oxygen.getGas(6000 * 16)},
+                new FluidStack[] {Materials.NitricOxide.getGas(2000 * 16), Materials.Oxygen.getGas(3000 * 16)},
+                new ItemStack[] {
+                    Materials.Potassiumdichromate.getDust(64),
+                    Materials.Potassiumdichromate.getDust(64),
+                    Materials.Potassiumdichromate.getDust(48)
+                },
+                2560,
+                (int) GT_Values.VP[7]);
 
         // Nitrochlorobenzene
         // C6H5Cl + HNO3 = C6H4ClNO2 + H2O

--- a/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
@@ -19354,6 +19354,47 @@ public class GT_MachineRecipeLoader implements Runnable {
                 100,
                 480);
 
+        // Potassium Dichromate shortcut
+        // 2 Cr + 6O + 10 Saltpeter/Potassium Dichromate = 10 K2Cr2O7 + 2NO + 3O
+        GT_Values.RA.addChemicalRecipeForBasicMachineOnly(
+                Materials.Saltpeter.getDust(10),
+                Materials.Chrome.getDust(2),
+                Materials.Oxygen.getGas(6000),
+                Materials.NitricOxide.getGas(2000),
+                Materials.Potassiumdichromate.getDust(11),
+                GT_Values.NI,
+                100,
+                480);
+        GT_Values.RA.addChemicalRecipeForBasicMachineOnly(
+                Materials.PotassiumNitrade.getDust(10),
+                Materials.Chrome.getDust(2),
+                Materials.Oxygen.getGas(6000),
+                Materials.NitricOxide.getGas(2000),
+                Materials.Potassiumdichromate.getDust(11),
+                GT_Values.NI,
+                100,
+                480);
+        GT_Values.RA.addMultiblockChemicalRecipe(
+                new ItemStack[] {
+                    Materials.PotassiumNitrade.getDust(10),
+                    Materials.Chrome.getDust(2),
+                    GT_Utility.getIntegratedCircuit(11)
+                },
+                new FluidStack[] {Materials.Oxygen.getGas(6000)},
+                new FluidStack[] {Materials.NitricOxide.getGas(2000), Materials.Oxygen.getGas(3000)},
+                new ItemStack[] {Materials.Potassiumdichromate.getDust(11)},
+                100,
+                480);
+        GT_Values.RA.addMultiblockChemicalRecipe(
+                new ItemStack[] {
+                    Materials.Saltpeter.getDust(10), Materials.Chrome.getDust(2), GT_Utility.getIntegratedCircuit(11)
+                },
+                new FluidStack[] {Materials.Oxygen.getGas(6000)},
+                new FluidStack[] {Materials.NitricOxide.getGas(2000), Materials.Oxygen.getGas(3000)},
+                new ItemStack[] {Materials.Potassiumdichromate.getDust(11)},
+                100,
+                480);
+
         // Nitrochlorobenzene
         // C6H5Cl + HNO3 = C6H4ClNO2 + H2O
         GT_Values.RA.addChemicalRecipe(


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/48415331/209582233-015cf214-5b6f-4aa4-9d70-f4391b087189.png)
Adds another recipe for Potassium Dichromate to avoid Chemical Reactor spam. The only use of Chromium Trioxide is Potassium Dichromate so players should be able to avoid making 2 extra reactors simply to make a nested chain.

Also the same for saltpeter ofc because the original recipe has 2 variants
