### PR TITLE
Allow resource packs to override individual progressbar textures

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -9,7 +9,7 @@ dependencies {
     compile("com.github.GTNewHorizons:NotEnoughItems:2.3.12-GTNH:dev")
     compile("com.github.GTNewHorizons:CodeChickenLib:1.1.5.4:dev")
     compile("com.github.GTNewHorizons:GTNHLib:0.0.8:dev")
-    compile("com.github.GTNewHorizons:ModularUI:1.0.24:dev")
+    compile("com.github.GTNewHorizons:ModularUI:1.0.32:dev")
     compile("com.github.GTNewHorizons:waila:1.5.21:dev")
 
     compile("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev")

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -9,7 +9,7 @@ dependencies {
     compile("com.github.GTNewHorizons:NotEnoughItems:2.3.12-GTNH:dev")
     compile("com.github.GTNewHorizons:CodeChickenLib:1.1.5.4:dev")
     compile("com.github.GTNewHorizons:GTNHLib:0.0.8:dev")
-    compile("com.github.GTNewHorizons:ModularUI:1.0.32:dev")
+    compile("com.github.GTNewHorizons:ModularUI:1.0.33:dev")
     compile("com.github.GTNewHorizons:waila:1.5.21:dev")
 
     compile("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev")

--- a/src/main/java/gregtech/api/gui/modularui/FallbackableSteamTexture.java
+++ b/src/main/java/gregtech/api/gui/modularui/FallbackableSteamTexture.java
@@ -1,0 +1,84 @@
+package gregtech.api.gui.modularui;
+
+import com.gtnewhorizons.modularui.api.drawable.UITexture;
+import com.gtnewhorizons.modularui.common.internal.network.NetworkUtils;
+import gregtech.api.enums.SteamVariant;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import net.minecraft.client.Minecraft;
+
+public class FallbackableSteamTexture {
+
+    private final SteamTexture candidate;
+    private final Object fallback;
+    private final Map<SteamVariant, Boolean> useFallbackMap = new HashMap<>();
+
+    private static final List<FallbackableSteamTexture> ALL_INSTANCES = new ArrayList<>();
+
+    public FallbackableSteamTexture(SteamTexture candidate, SteamTexture fallback) {
+        this(candidate, (Object) fallback);
+    }
+
+    public FallbackableSteamTexture(SteamTexture candidate, FallbackableSteamTexture fallback) {
+        this(candidate, (Object) fallback);
+    }
+
+    public FallbackableSteamTexture(SteamTexture fallback) {
+        this(null, fallback);
+    }
+
+    private FallbackableSteamTexture(SteamTexture candidate, Object fallback) {
+        this.candidate = candidate;
+        this.fallback = fallback;
+        ALL_INSTANCES.add(this);
+    }
+
+    public UITexture get(SteamVariant steamVariant) {
+        verifyCandidate(steamVariant);
+        if (useFallbackMap.get(steamVariant)) {
+            return castFallback(steamVariant);
+        } else {
+            return candidate.get(steamVariant);
+        }
+    }
+
+    private void verifyCandidate(SteamVariant steamVariant) {
+        if (useFallbackMap.get(steamVariant) == null) {
+            boolean useFallback;
+            if (NetworkUtils.isDedicatedClient()) {
+                if (candidate == null) {
+                    useFallback = true;
+                } else {
+                    try {
+                        Minecraft.getMinecraft().getResourceManager().getResource(candidate.get(steamVariant).location);
+                        useFallback = false;
+                    } catch (IOException e) {
+                        useFallback = true;
+                    }
+                }
+            } else {
+                useFallback = false;
+            }
+            useFallbackMap.put(steamVariant, useFallback);
+        }
+    }
+
+    private UITexture castFallback(SteamVariant steamVariant) {
+        if (fallback instanceof SteamTexture) {
+            return ((SteamTexture) fallback).get(steamVariant);
+        } else if (fallback instanceof FallbackableSteamTexture) {
+            return ((FallbackableSteamTexture) fallback).get(steamVariant);
+        } else {
+            throw new RuntimeException("Unexpected type found for fallback: " + fallback.getClass());
+        }
+    }
+
+    public static void reload() {
+        for (FallbackableSteamTexture t : ALL_INSTANCES) {
+            t.useFallbackMap.clear();
+        }
+    }
+}

--- a/src/main/java/gregtech/api/gui/modularui/FallbackableSteamTexture.java
+++ b/src/main/java/gregtech/api/gui/modularui/FallbackableSteamTexture.java
@@ -60,7 +60,7 @@ public class FallbackableSteamTexture {
                     }
                 }
             } else {
-                useFallback = false;
+                useFallback = true;
             }
             useFallbackMap.put(steamVariant, useFallback);
         }

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicMachine.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicMachine.java
@@ -1341,8 +1341,8 @@ public abstract class GT_MetaTileEntity_BasicMachine extends GT_MetaTileEntity_B
             builder.widget(setNEITransferRect(
                     createProgressBar(
                             isSteampowered()
-                                    ? getRecipeList().progressBarTextureSteam.get(getSteamVariant())
-                                    : getRecipeList().progressBarTexture,
+                                    ? getRecipeList().getProgressBarTextureSteam(getSteamVariant())
+                                    : getRecipeList().getProgressBarTexture(),
                             getRecipeList().getProgressBarImageSize(),
                             getRecipeList().progressBarDirection,
                             getRecipeList().progressBarPos,

--- a/src/main/java/gregtech/api/util/GT_Recipe.java
+++ b/src/main/java/gregtech/api/util/GT_Recipe.java
@@ -2784,7 +2784,7 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
         /**
          * Some resource packs want to use custom progress bar textures even for plain arrow.
          * This method allows them to add unique textures, yet other packs don't need to make textures
-         * for every recipemaps.
+         * for every recipemap.
          */
         public GT_Recipe_Map setProgressBarWithFallback(
                 FallbackableUITexture progressBarTexture, ProgressBar.Direction progressBarDirection) {

--- a/src/main/java/gregtech/api/util/GT_Recipe.java
+++ b/src/main/java/gregtech/api/util/GT_Recipe.java
@@ -4,6 +4,7 @@ import static gregtech.api.enums.GT_Values.*;
 
 import codechicken.nei.PositionedStack;
 import com.gtnewhorizons.modularui.api.ModularUITextures;
+import com.gtnewhorizons.modularui.api.drawable.FallbackableUITexture;
 import com.gtnewhorizons.modularui.api.drawable.IDrawable;
 import com.gtnewhorizons.modularui.api.drawable.UITexture;
 import com.gtnewhorizons.modularui.api.forge.IItemHandlerModifiable;
@@ -21,6 +22,7 @@ import gregtech.GT_Mod;
 import gregtech.api.GregTech_API;
 import gregtech.api.enums.*;
 import gregtech.api.enums.SteamVariant;
+import gregtech.api.gui.modularui.FallbackableSteamTexture;
 import gregtech.api.gui.modularui.GT_UITextures;
 import gregtech.api.gui.modularui.SteamTexture;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
@@ -2579,7 +2581,7 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
          * First is (20, 18) size of "empty" image at the top,
          * Second is (20, 18) size of "filled" image at the bottom.
          */
-        public UITexture progressBarTexture = GT_UITextures.PROGRESSBAR_ARROW;
+        private FallbackableUITexture progressBarTexture;
 
         /**
          * Progressbar used for steam machine GUI and/or NEI.
@@ -2587,7 +2589,7 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
          * First is (20, 18) size of "empty" image at the top,
          * Second is (20, 18) size of "filled" image at the bottom.
          */
-        public SteamTexture progressBarTextureSteam;
+        private FallbackableSteamTexture progressBarTextureSteam;
 
         public ProgressBar.Direction progressBarDirection = ProgressBar.Direction.RIGHT;
 
@@ -2678,6 +2680,9 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
                     aUsualOutputCount,
                     aMinimalInputFluids,
                     aMinimalInputItems);
+            progressBarTexture = new FallbackableUITexture(
+                    UITexture.fullImage("gregtech", "gui/progressbar/" + mUnlocalizedName),
+                    GT_UITextures.PROGRESSBAR_ARROW);
             if (sIndexedMappings.put(mUniqueIdentifier, this) != null)
                 throw new IllegalArgumentException("Duplicate recipe map registered: " + mUniqueIdentifier);
         }
@@ -2766,17 +2771,36 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
         }
 
         public GT_Recipe_Map setProgressBar(UITexture progressBarTexture, ProgressBar.Direction progressBarDirection) {
-            useModularUI(true);
-            this.progressBarTexture = progressBarTexture;
-            this.progressBarDirection = progressBarDirection;
-            return this;
+            return setProgressBarWithFallback(
+                    new FallbackableUITexture(
+                            UITexture.fullImage("gregtech", "gui/progressbar/" + mUnlocalizedName), progressBarTexture),
+                    progressBarDirection);
         }
 
         public GT_Recipe_Map setProgressBar(UITexture progressBarTexture) {
             return setProgressBar(progressBarTexture, ProgressBar.Direction.RIGHT);
         }
 
+        /**
+         * Some resource packs want to use custom progress bar textures even for plain arrow.
+         * This method allows them to add unique textures, yet other packs don't need to make textures
+         * for every recipemaps.
+         */
+        public GT_Recipe_Map setProgressBarWithFallback(
+                FallbackableUITexture progressBarTexture, ProgressBar.Direction progressBarDirection) {
+            useModularUI(true);
+            this.progressBarTexture = progressBarTexture;
+            this.progressBarDirection = progressBarDirection;
+            return this;
+        }
+
         public GT_Recipe_Map setProgressBarSteam(SteamTexture progressBarTexture) {
+            return setProgressBarSteamWithFallback(new FallbackableSteamTexture(
+                    SteamTexture.fullImage("gregtech", "gui/progressbar/" + mUnlocalizedName + "_%s"),
+                    progressBarTexture));
+        }
+
+        public GT_Recipe_Map setProgressBarSteamWithFallback(FallbackableSteamTexture progressBarTexture) {
             this.progressBarTextureSteam = progressBarTexture;
             return this;
         }
@@ -3332,6 +3356,14 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
             return null;
         }
 
+        public UITexture getProgressBarTexture() {
+            return progressBarTexture.get();
+        }
+
+        public UITexture getProgressBarTextureSteam(SteamVariant steamVariant) {
+            return progressBarTextureSteam.get(steamVariant);
+        }
+
         public int getProgressBarImageSize() {
             if (progressBarImageSize != 0) {
                 return progressBarImageSize;
@@ -3411,7 +3443,7 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
         public void addProgressBarUI(
                 ModularWindow.Builder builder, Supplier<Float> progressSupplier, Pos2d windowOffset) {
             builder.widget(new ProgressBar()
-                    .setTexture(progressBarTexture, 20)
+                    .setTexture(getProgressBarTexture(), 20)
                     .setDirection(progressBarDirection)
                     .setProgress(progressSupplier)
                     .setSynced(false, false)

--- a/src/main/java/gregtech/common/GT_Client.java
+++ b/src/main/java/gregtech/common/GT_Client.java
@@ -23,6 +23,7 @@ import cpw.mods.fml.common.network.FMLNetworkEvent;
 import gregtech.api.GregTech_API;
 import gregtech.api.enums.*;
 import gregtech.api.gui.GT_GUIColorOverride;
+import gregtech.api.gui.modularui.FallbackableSteamTexture;
 import gregtech.api.interfaces.IHasFluidDisplayItem;
 import gregtech.api.interfaces.tileentity.ICoverable;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
@@ -612,6 +613,7 @@ public class GT_Client extends GT_Proxy implements Runnable {
                     @Override
                     public void onResourceManagerReload(IResourceManager l) {
                         GT_GUIColorOverride.onResourceManagerReload();
+                        FallbackableSteamTexture.reload();
                         GregTech_API.sCoverBehaviors.values().forEach(GT_CoverBehaviorBase::reloadColorOverride);
                     }
                 });


### PR DESCRIPTION
Some resource packs want to use custom progress bar textures even for plain arrow. This PR allows them to add unique textures, yet other packs don't need to make textures for every recipemap.

Usage:
Place texture with the name of `${unlocalized name of recipemap}.png` at `gregtech/textures/gui/progressbar`.
Append `_bronze`, `_steel`, or `_primitive` to apply to steam machines.

Example:
`gregtech/textures/gui/progressbar/gt.recipe.laserengraver.png`
`gregtech/textures/gui/progressbar/gt.recipe.alloysmelter_bronze.png`

Requested by @Flanisch