### PR TITLE
Fix tooltip for required input hatches on the Nano Forge

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_NanoForge.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_NanoForge.java
@@ -431,7 +431,7 @@ public class GT_MetaTileEntity_NanoForge
                         + EnumChatFormatting.GOLD + "1" + EnumChatFormatting.GRAY + " TT energy hatch.")
                 .addStructureInfo(
                         "Requires " + EnumChatFormatting.GOLD + "1" + EnumChatFormatting.GRAY + " maintenance hatch.")
-                .addStructureInfo("Requires " + EnumChatFormatting.GOLD + 0 + EnumChatFormatting.GRAY + "+"
+                .addStructureInfo("Requires " + EnumChatFormatting.GOLD + 1 + EnumChatFormatting.GRAY + "+"
                         + EnumChatFormatting.GRAY + " input hatches.")
                 .addStructureInfo("Requires " + EnumChatFormatting.GOLD + 0 + EnumChatFormatting.GRAY + "+"
                         + EnumChatFormatting.GRAY + " output hatches.")


### PR DESCRIPTION
I was trying to build the nano forge, but it didn't form. I looked at the source and saw that it did require at least 1 input hatch, despite the controller's tooltip saying otherwise.
![image](https://user-images.githubusercontent.com/66886359/209750186-10821241-ef66-488c-b745-e7c6cd829f68.png)
