### PR TITLE
Add a way to remove a furnace recipe using the output instead of input

### DIFF
--- a/src/main/java/gregtech/api/util/GT_ModHandler.java
+++ b/src/main/java/gregtech/api/util/GT_ModHandler.java
@@ -1444,6 +1444,22 @@ public class GT_ModHandler {
     }
 
     /**
+     * Removes a Smelting Recipe
+     */
+    public static boolean removeFurnaceSmeltingByOutput(ItemStack aOutput) {
+        if (aOutput != null) {
+            for (Object tInput : FurnaceRecipes.smelting().getSmeltingList().keySet()) {
+                Object tOutput = FurnaceRecipes.smelting().getSmeltingList().get(tInput);
+                if (GT_Utility.isStackValid(tOutput) && GT_Utility.areStacksEqual(aOutput, (ItemStack) tOutput, true)) {
+                    FurnaceRecipes.smelting().getSmeltingList().remove(tInput);
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
      * Removes a Crafting Recipe and gives you the former output of it.
      *
      * @param aRecipe The content of the Crafting Grid as ItemStackArray with length 9

--- a/src/main/java/gregtech/api/util/GT_ModHandler.java
+++ b/src/main/java/gregtech/api/util/GT_ModHandler.java
@@ -1444,17 +1444,15 @@ public class GT_ModHandler {
     }
 
     /**
-     * Removes a Smelting Recipe
+     * Removes all matching Smelting Recipes by output
      */
     public static boolean removeFurnaceSmeltingByOutput(ItemStack aOutput) {
         if (aOutput != null) {
-            for (Object tInput : FurnaceRecipes.smelting().getSmeltingList().keySet()) {
-                Object tOutput = FurnaceRecipes.smelting().getSmeltingList().get(tInput);
-                if (GT_Utility.isStackValid(tOutput) && GT_Utility.areStacksEqual(aOutput, (ItemStack) tOutput, true)) {
-                    FurnaceRecipes.smelting().getSmeltingList().remove(tInput);
-                    return true;
-                }
-            }
+            return FurnaceRecipes.smelting()
+                    .getSmeltingList()
+                    .values()
+                    .removeIf(tOutput -> GT_Utility.isStackValid(tOutput)
+                            && GT_Utility.areStacksEqual(aOutput, (ItemStack) tOutput, true));
         }
         return false;
     }


### PR DESCRIPTION
got annoyed checking the inputs of furnace recipes to remove them.