### PR TITLE
Fixing mixing

### DIFF
--- a/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
@@ -398,15 +398,15 @@ public class GT_MachineRecipeLoader implements Runnable {
                 (int) (500L * OrePrefixes.dust.mMaterialAmount / 3628800L),
                 8);
         GT_Values.RA.addMixerRecipe(
-                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.SterlingSilver, 1L),
-                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.BismuthBronze, 1L),
-                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.BlackSteel, 4L),
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.SterlingSilver, 5L),
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.BismuthBronze, 5L),
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.BlackSteel, 36L),
                 GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Steel, 2L),
                 GT_Values.NI,
                 GT_Utility.getIntegratedCircuit(1),
                 GT_Values.NF,
                 GT_Values.NF,
-                GT_OreDictUnificator.getDust(Materials.RedSteel, 8L * OrePrefixes.dust.mMaterialAmount),
+                GT_OreDictUnificator.getDust(Materials.RedSteel, 48L * OrePrefixes.dust.mMaterialAmount),
                 (int) (800L * OrePrefixes.dust.mMaterialAmount / 3628800L),
                 8);
         GT_Values.RA.addMixerRecipe(
@@ -438,14 +438,14 @@ public class GT_MachineRecipeLoader implements Runnable {
                 GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Silver, 4L),
                 GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Bismuth, 1L),
                 GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Zinc, 1L),
-                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.BlackSteel, 20L),
-                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Steel, 10L),
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.BlackSteel, 36L),
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Steel, 2L),
                 GT_Values.NI,
                 GT_Values.NI,
                 GT_Utility.getIntegratedCircuit(15),
                 GT_Values.NF,
                 GT_Values.NF,
-                GT_OreDictUnificator.getDust(Materials.RedSteel, 40L * OrePrefixes.dust.mMaterialAmount),
+                GT_OreDictUnificator.getDust(Materials.RedSteel, 48L * OrePrefixes.dust.mMaterialAmount),
                 (int) (1200L * OrePrefixes.dust.mMaterialAmount / 3628800L),
                 480);
         GT_Values.RA.addMixerRecipe(

--- a/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
@@ -410,15 +410,15 @@ public class GT_MachineRecipeLoader implements Runnable {
                 (int) (800L * OrePrefixes.dust.mMaterialAmount / 3628800L),
                 8);
         GT_Values.RA.addMixerRecipe(
-                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.RoseGold, 1L),
-                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Brass, 1L),
-                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.BlackSteel, 4L),
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.RoseGold, 5L),
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Brass, 4L),
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.BlackSteel, 36L),
                 GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Steel, 2L),
                 GT_Values.NI,
                 GT_Utility.getIntegratedCircuit(1),
                 GT_Values.NF,
                 GT_Values.NF,
-                GT_OreDictUnificator.getDust(Materials.BlueSteel, 8L * OrePrefixes.dust.mMaterialAmount),
+                GT_OreDictUnificator.getDust(Materials.BlueSteel, 47L * OrePrefixes.dust.mMaterialAmount),
                 (int) (800L * OrePrefixes.dust.mMaterialAmount / 3628800L),
                 8);
         GT_Values.RA.addMixerRecipe(
@@ -449,21 +449,15 @@ public class GT_MachineRecipeLoader implements Runnable {
                 (int) (1200L * OrePrefixes.dust.mMaterialAmount / 3628800L),
                 480);
         GT_Values.RA.addMixerRecipe(
-                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Copper, 31L),
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Copper, 4L),
                 GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Gold, 4L),
-                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Zinc, 5L),
-                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.BlackSteel, 64L),
-                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.BlackSteel, 16L),
-                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Steel, 40L),
-                GT_Values.NI,
-                GT_Values.NI,
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Zinc, 1L),
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.BlackSteel, 36L),
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Steel, 2L),
                 GT_Utility.getIntegratedCircuit(16),
                 GT_Values.NF,
                 GT_Values.NF,
-                GT_OreDictUnificator.getDust(Materials.BlueSteel, 64L * OrePrefixes.dust.mMaterialAmount),
-                GT_OreDictUnificator.getDust(Materials.BlueSteel, 64L * OrePrefixes.dust.mMaterialAmount),
-                GT_OreDictUnificator.getDust(Materials.BlueSteel, 32L * OrePrefixes.dust.mMaterialAmount),
-                GT_Values.NI,
+                GT_OreDictUnificator.getDust(Materials.BlueSteel, 47L * OrePrefixes.dust.mMaterialAmount),
                 (int) (3600L * OrePrefixes.dust.mMaterialAmount / 3628800L),
                 480);
         GT_Values.RA.addMixerRecipe(

--- a/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
@@ -386,7 +386,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                 (int) (500L * OrePrefixes.dust.mMaterialAmount / 3628800L),
                 8);
         GT_Values.RA.addMixerRecipe(
-                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.BlackBronze, 1L),
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.BlackBronze, 5L),
                 GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Nickel, 1L),
                 GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Steel, 3L),
                 GT_Values.NI,
@@ -394,7 +394,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                 GT_Utility.getIntegratedCircuit(1),
                 GT_Values.NF,
                 GT_Values.NF,
-                GT_OreDictUnificator.getDust(Materials.BlackSteel, 5L * OrePrefixes.dust.mMaterialAmount),
+                GT_OreDictUnificator.getDust(Materials.BlackSteel, 9L * OrePrefixes.dust.mMaterialAmount),
                 (int) (500L * OrePrefixes.dust.mMaterialAmount / 3628800L),
                 8);
         GT_Values.RA.addMixerRecipe(
@@ -425,12 +425,12 @@ public class GT_MachineRecipeLoader implements Runnable {
                 GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Copper, 3L),
                 GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Gold, 1L),
                 GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Silver, 1L),
-                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Nickel, 5L),
-                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Steel, 15L),
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Nickel, 1L),
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Steel, 3L),
                 GT_Utility.getIntegratedCircuit(14),
                 GT_Values.NF,
                 GT_Values.NF,
-                GT_OreDictUnificator.getDust(Materials.BlackSteel, 25L * OrePrefixes.dust.mMaterialAmount),
+                GT_OreDictUnificator.getDust(Materials.BlackSteel, 9L * OrePrefixes.dust.mMaterialAmount),
                 (int) (800L * OrePrefixes.dust.mMaterialAmount / 3628800L),
                 480);
         GT_Values.RA.addMixerRecipe(

--- a/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
@@ -375,14 +375,14 @@ public class GT_MachineRecipeLoader implements Runnable {
                 8);
         GT_Values.RA.addMixerRecipe(
                 GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Bismuth, 1L),
-                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Brass, 1L),
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Brass, 4L),
                 GT_Values.NI,
                 GT_Values.NI,
                 GT_Values.NI,
                 GT_Utility.getIntegratedCircuit(1),
                 GT_Values.NF,
                 GT_Values.NF,
-                GT_OreDictUnificator.getDust(Materials.BismuthBronze, 2L * OrePrefixes.dust.mMaterialAmount),
+                GT_OreDictUnificator.getDust(Materials.BismuthBronze, 5L * OrePrefixes.dust.mMaterialAmount),
                 (int) (500L * OrePrefixes.dust.mMaterialAmount / 3628800L),
                 8);
         GT_Values.RA.addMixerRecipe(


### PR DESCRIPTION
Among other things, fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12115

Fixes various incorrect mixing and centrifuging recipes (bismuth bronze, red steel, blue steel, black steel)