### PR TITLE
Add Failsafe for getCasingTextureForId to prevent null page.

### DIFF
--- a/src/main/java/gregtech/api/enums/Textures.java
+++ b/src/main/java/gregtech/api/enums/Textures.java
@@ -2079,7 +2079,9 @@ public class Textures {
         }
 
         public static ITexture getCasingTextureForId(int id) {
-            return casingTexturePages[(id >> 7) & 0x7f][id & 0x7f];
+            final ITexture[] page = casingTexturePages[(id >> 7) & 0x7f];
+            if (page == null) return null;
+            return page[id & 0x7f];
         }
 
         public static void setCasingTextureForId(int id, ITexture iTexture) {


### PR DESCRIPTION
Adds fail safe that prevents a crash when a null page occurs. Also is a solution to a crash involving the Precise Assembler.
"solution" used lightly here.
Close https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12077