### PR TITLE
Fix LV steam valve

### DIFF
--- a/src/main/java/gregtech/common/items/GT_MetaGenerated_Item_01.java
+++ b/src/main/java/gregtech/common/items/GT_MetaGenerated_Item_01.java
@@ -2859,7 +2859,7 @@ public class GT_MetaGenerated_Item_01 extends GT_MetaGenerated_Item_X32 {
         GregTech_API.registerCover(
                 ItemList.Steam_Valve_LV.get(1L),
                 TextureFactory.of(MACHINE_CASINGS[1][0], TextureFactory.of(OVERLAY_VALVE)),
-                new GT_Cover_SteamValve(102, TextureFactory.of(OVERLAY_VALVE)));
+                new GT_Cover_SteamValve(1024, TextureFactory.of(OVERLAY_VALVE)));
         GregTech_API.registerCover(
                 ItemList.Steam_Valve_MV.get(1L),
                 TextureFactory.of(MACHINE_CASINGS[2][0], TextureFactory.of(OVERLAY_VALVE)),


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/11535.

somehow a number got dropped in a texture update:

![image](https://user-images.githubusercontent.com/40274384/210185507-f917d09d-6836-4ee0-977f-8614dca648bd.png)
