### PR TITLE
add callhook for pre block destroy

### DIFF
--- a/src/main/java/gregtech/api/interfaces/metatileentity/IMetaTileEntity.java
+++ b/src/main/java/gregtech/api/interfaces/metatileentity/IMetaTileEntity.java
@@ -523,5 +523,5 @@ public interface IMetaTileEntity
     /**
      * Called before block is destroyed. This is before inventory dropping code has executed.
      */
-	default void onBlockDestroyed() {}
+    default void onBlockDestroyed() {}
 }

--- a/src/main/java/gregtech/api/interfaces/metatileentity/IMetaTileEntity.java
+++ b/src/main/java/gregtech/api/interfaces/metatileentity/IMetaTileEntity.java
@@ -519,4 +519,9 @@ public interface IMetaTileEntity
     default int getTextColorOrDefault(String textType, int defaultColor) {
         return defaultColor;
     }
+
+    /**
+     * Called before block is destroyed. This is before inventory dropping code has executed.
+     */
+	default void onBlockDestroyed() {}
 }

--- a/src/main/java/gregtech/api/interfaces/tileentity/IGregTechTileEntity.java
+++ b/src/main/java/gregtech/api/interfaces/tileentity/IGregTechTileEntity.java
@@ -140,6 +140,8 @@ public interface IGregTechTileEntity
 
     float getBlastResistance(byte aSide);
 
+    default void onBlockDestroyed() {}
+
     ArrayList<ItemStack> getDrops();
 
     /** Check if the item at the specific index should be dropped or not

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
@@ -1359,6 +1359,12 @@ public class BaseMetaPipeEntity extends CommonMetaTileEntity
     }
 
     @Override
+    public void onBlockDestroyed() {
+        if (canAccessData())
+            getMetaTileEntity().onBlockDestroyed();
+    }
+
+    @Override
     public boolean isMufflerUpgradable() {
         return false;
     }

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
@@ -1360,8 +1360,7 @@ public class BaseMetaPipeEntity extends CommonMetaTileEntity
 
     @Override
     public void onBlockDestroyed() {
-        if (canAccessData())
-            getMetaTileEntity().onBlockDestroyed();
+        if (canAccessData()) getMetaTileEntity().onBlockDestroyed();
     }
 
     @Override

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
@@ -2235,6 +2235,12 @@ public class BaseMetaTileEntity extends CommonMetaTileEntity
     }
 
     @Override
+    public void onBlockDestroyed() {
+        if (canAccessData())
+            getMetaTileEntity().onBlockDestroyed();
+    }
+
+    @Override
     public boolean isUniversalEnergyStored(long aEnergyAmount) {
         if (getUniversalEnergyStored() >= aEnergyAmount) return true;
         mHasEnoughEnergy = false;

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
@@ -2236,8 +2236,7 @@ public class BaseMetaTileEntity extends CommonMetaTileEntity
 
     @Override
     public void onBlockDestroyed() {
-        if (canAccessData())
-            getMetaTileEntity().onBlockDestroyed();
+        if (canAccessData()) getMetaTileEntity().onBlockDestroyed();
     }
 
     @Override

--- a/src/main/java/gregtech/common/blocks/GT_Block_Machines.java
+++ b/src/main/java/gregtech/common/blocks/GT_Block_Machines.java
@@ -410,6 +410,7 @@ public class GT_Block_Machines extends GT_Generic_Block implements IDebugableBlo
         final TileEntity tTileEntity = aWorld.getTileEntity(aX, aY, aZ);
         if (tTileEntity instanceof IGregTechTileEntity) {
             final IGregTechTileEntity tGregTechTileEntity = (IGregTechTileEntity) tTileEntity;
+            tGregTechTileEntity.onBlockDestroyed();
             mTemporaryTileEntity.set(tGregTechTileEntity);
             if (!(tGregTechTileEntity.getMetaTileEntity() instanceof GT_MetaTileEntity_QuantumChest)) {
                 for (int i = 0; i < tGregTechTileEntity.getSizeInventory(); i++) {


### PR DESCRIPTION
does nothing on its own, but is required for more complex features.

I cannot imagine a lifecycle hook like this hasn't been added yet. 