### PR TITLE
Lower the Hydrogen Cost of Hydrocracking

### DIFF
--- a/src/main/java/gregtech/common/GT_Proxy.java
+++ b/src/main/java/gregtech/common/GT_Proxy.java
@@ -2439,6 +2439,8 @@ public abstract class GT_Proxy implements IGT_Mod, IGuiHandler, IFuelHandler, IG
             OrePrefixes.cellHydroCracked1, OrePrefixes.cellHydroCracked2, OrePrefixes.cellHydroCracked3
         };
         final Fluid uncrackedFluid;
+        // Hydrogen is much more expensive than Steam, they should not be used in similar quantities
+        final int hydrogenDivideAmount = 40;
         if (aMaterial.mFluid != null) {
             uncrackedFluid = aMaterial.mFluid;
         } else if (aMaterial.mGas != null) {
@@ -2455,26 +2457,26 @@ public abstract class GT_Proxy implements IGT_Mod, IGuiHandler, IFuelHandler, IG
                             GT_OreDictUnificator.get(orePrefixes[i], aMaterial, 1L), ItemList.Cell_Empty.get(1L))
                     .asFluid();
 
-            int hydrogenAmount = 2 * i + 2;
+            int hydrogenAmount = i + 1;
             GT_Values.RA.addCrackingRecipe(
                     i + 1,
                     new FluidStack(uncrackedFluid, 1000),
-                    Materials.Hydrogen.getGas(hydrogenAmount * 800),
+                    Materials.Hydrogen.getGas(hydrogenAmount * 800 / hydrogenDivideAmount),
                     new FluidStack(crackedFluids[i], 1000),
                     20 + 20 * i,
                     240);
             GT_Values.RA.addChemicalRecipe(
                     Materials.Hydrogen.getCells(hydrogenAmount),
                     GT_Utility.getIntegratedCircuit(i + 1),
-                    new FluidStack(uncrackedFluid, 1000),
-                    new FluidStack(crackedFluids[i], 800),
+                    new FluidStack(uncrackedFluid, 1000 * hydrogenDivideAmount),
+                    new FluidStack(crackedFluids[i], 800 * hydrogenDivideAmount),
                     Materials.Empty.getCells(hydrogenAmount),
-                    160 + 80 * i,
+                    160 * hydrogenDivideAmount + 80 * i,
                     30);
             GT_Values.RA.addChemicalRecipe(
                     aMaterial.getCells(1),
                     GT_Utility.getIntegratedCircuit(i + 1),
-                    Materials.Hydrogen.getGas(hydrogenAmount * 1000),
+                    Materials.Hydrogen.getGas(hydrogenAmount * 1000 / hydrogenDivideAmount),
                     new FluidStack(crackedFluids[i], 800),
                     Materials.Empty.getCells(1),
                     160 + 80 * i,

--- a/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
@@ -18034,7 +18034,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                 120);
         GT_Values.RA.addUniversalDistillationRecipe(
                 Materials.Ethylene.getSeverelyHydroCracked(1000),
-                new FluidStack[] {Materials.Methane.getGas(2000), Materials.Hydrogen.getGas(2000)},
+                new FluidStack[] {Materials.Methane.getGas(2000), Materials.Hydrogen.getGas(20)},
                 GT_Values.NI,
                 120,
                 120);
@@ -18065,13 +18065,13 @@ public class GT_MachineRecipeLoader implements Runnable {
                 120);
         GT_Values.RA.addUniversalDistillationRecipe(
                 Materials.Ethane.getModeratelyHydroCracked(1000),
-                new FluidStack[] {Materials.Methane.getGas(2000), Materials.Hydrogen.getGas(2000)},
+                new FluidStack[] {Materials.Methane.getGas(2000), Materials.Hydrogen.getGas(20)},
                 GT_Values.NI,
                 120,
                 120);
         GT_Values.RA.addUniversalDistillationRecipe(
                 Materials.Ethane.getSeverelyHydroCracked(1000),
-                new FluidStack[] {Materials.Methane.getGas(2000), Materials.Hydrogen.getGas(4000)},
+                new FluidStack[] {Materials.Methane.getGas(2000), Materials.Hydrogen.getGas(40)},
                 GT_Values.NI,
                 120,
                 120);
@@ -18147,7 +18147,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                 120);
         GT_Values.RA.addUniversalDistillationRecipe(
                 Materials.Propane.getSeverelyHydroCracked(1000),
-                new FluidStack[] {Materials.Methane.getGas(3000), Materials.Hydrogen.getGas(2000)},
+                new FluidStack[] {Materials.Methane.getGas(3000), Materials.Hydrogen.getGas(20)},
                 GT_Values.NI,
                 120,
                 120);
@@ -18335,7 +18335,7 @@ public class GT_MachineRecipeLoader implements Runnable {
         GT_Values.RA.addUniversalDistillationRecipe(
                 Materials.Gas.getLightlyHydroCracked(1000),
                 new FluidStack[] {
-                    Materials.Methane.getGas(1300), Materials.Hydrogen.getGas(1500), Materials.Helium.getGas(100)
+                    Materials.Methane.getGas(1300), Materials.Hydrogen.getGas(15), Materials.Helium.getGas(100)
                 },
                 GT_Values.NI,
                 120,
@@ -18343,7 +18343,7 @@ public class GT_MachineRecipeLoader implements Runnable {
         GT_Values.RA.addUniversalDistillationRecipe(
                 Materials.Gas.getModeratelyHydroCracked(1000),
                 new FluidStack[] {
-                    Materials.Methane.getGas(1400), Materials.Hydrogen.getGas(3000), Materials.Helium.getGas(150)
+                    Materials.Methane.getGas(1400), Materials.Hydrogen.getGas(30), Materials.Helium.getGas(150)
                 },
                 GT_Values.NI,
                 120,
@@ -18351,7 +18351,7 @@ public class GT_MachineRecipeLoader implements Runnable {
         GT_Values.RA.addUniversalDistillationRecipe(
                 Materials.Gas.getSeverelyHydroCracked(1000),
                 new FluidStack[] {
-                    Materials.Methane.getGas(1500), Materials.Hydrogen.getGas(4000), Materials.Helium.getGas(200)
+                    Materials.Methane.getGas(1500), Materials.Hydrogen.getGas(40), Materials.Helium.getGas(200)
                 },
                 GT_Values.NI,
                 120,


### PR DESCRIPTION
This is an overall change to hydrocracking, to lower the huge difference in costs between the Hydrogen and Steam inputs. As is known, Water converts to Steam at a 1:120 ratio, whereas Water electrolyzer to Hydrogen at a 1:2 ratio. The former is incredibly cheap and is produced from Bronze Age, whereas the latter needs about 30k EU per bucket, with cheaper and more expensive alternatives depending on the Hydrogen source and overclocking.

That said, the cracking input of Hydrogen is even higher (2000/4000/6000 for light/moderate/severe cracking) than its Steam equivalent (1000 for all types). Given that, the point of this change is to drastically lower the Hydrogen inputs to 20/40/60 per 1000L of fluid to crack and approximate the cost of Steam for cracking, which is vastly cheaper per bucket.