### PR TITLE
Balance adjustment for the LCR Nitrobenzene recipe.

### DIFF
--- a/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
@@ -11334,15 +11334,19 @@ public class GT_MachineRecipeLoader implements Runnable {
                     900,
                     1920);
             // C6H6 + HNO3 =H2SO4= C6H5NO2 + H2O
-            GT_Values.RA.addChemicalRecipe(
-                    GT_OreDictUnificator.get(OrePrefixes.cell, Materials.NitrationMixture, 10),
-                    GT_OreDictUnificator.get(OrePrefixes.cell, Materials.Benzene, 5),
-                    Materials.Water.getFluid(10000),
-                    Materials.DilutedSulfuricAcid.getFluid(5000),
-                    GT_ModHandler.getModItem("miscutils", "nitrobenzene", 5L),
-                    ItemList.Cell_Empty.get(10L),
-                    200,
-                    1920);
+			GT_Values.RA.addMultiblockChemicalRecipe(
+                    new ItemStack[] {GT_Utility.getIntegratedCircuit(1)},
+                    new FluidStack[] {
+                        Materials.Benzene.getFluid(5000),
+						Materials.SulfuricAcid.getFluid(3000),
+						Materials.NitricAcid.getFluid(5000),
+                        GT_ModHandler.getDistilledWater(10000)
+                    },
+                    new FluidStack[] {new FluidStack(FluidRegistry.getFluid("nitrobenzene"), 5000), 
+                    Materials.DilutedSulfuricAcid.getFluid(3000)},
+                    null,
+                    100,
+                    7680);
             // C13H14N2(HCl) + 2COCl2 = C15H10N2O2(5HCl)
             GT_Values.RA.addMultiblockChemicalRecipe(
                     new ItemStack[] {GT_Utility.getIntegratedCircuit(1)},

--- a/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
@@ -11334,16 +11334,18 @@ public class GT_MachineRecipeLoader implements Runnable {
                     900,
                     1920);
             // C6H6 + HNO3 =H2SO4= C6H5NO2 + H2O
-			GT_Values.RA.addMultiblockChemicalRecipe(
+            GT_Values.RA.addMultiblockChemicalRecipe(
                     new ItemStack[] {GT_Utility.getIntegratedCircuit(1)},
                     new FluidStack[] {
                         Materials.Benzene.getFluid(5000),
-						Materials.SulfuricAcid.getFluid(3000),
-						Materials.NitricAcid.getFluid(5000),
+                        Materials.SulfuricAcid.getFluid(3000),
+                        Materials.NitricAcid.getFluid(5000),
                         GT_ModHandler.getDistilledWater(10000)
                     },
-                    new FluidStack[] {new FluidStack(FluidRegistry.getFluid("nitrobenzene"), 5000), 
-                    Materials.DilutedSulfuricAcid.getFluid(3000)},
+                    new FluidStack[] {
+                        new FluidStack(FluidRegistry.getFluid("nitrobenzene"), 5000),
+                        Materials.DilutedSulfuricAcid.getFluid(3000)
+                    },
                     null,
                     100,
                     7680);

--- a/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
@@ -11347,8 +11347,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                         Materials.DilutedSulfuricAcid.getFluid(3000)
                     },
                     null,
-                    100,
-                    7680);
+                    8,
+                    122880);
             // C13H14N2(HCl) + 2COCl2 = C15H10N2O2(5HCl)
             GT_Values.RA.addMultiblockChemicalRecipe(
                     new ItemStack[] {GT_Utility.getIntegratedCircuit(1)},


### PR DESCRIPTION
Adjusts the LCR nitrobenzene recipe. So that it:
- has the same inputs and outputs as the chemplant recipe.
- is not tiered lower as before but higher instead, namely ZPM power. It also is a bit more expensive EU wise. But its available when you get to Kevlar in UV.

The last part is a deliberate downside to counterbalance the 2 major upsides that 1) the multi is much cheaper than a chemplant 2) LCR has perfect OCs and even the MCR eventually.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/10650.

![image](https://user-images.githubusercontent.com/40274384/210593988-d5384f5f-d6ad-4a8f-8644-2b4e27e339cd.png)
