### PR TITLE
Optimize `denyMobSpawn` slightly.

### DIFF
--- a/src/main/java/gregtech/api/util/GT_SpawnEventHandler.java
+++ b/src/main/java/gregtech/api/util/GT_SpawnEventHandler.java
@@ -2,6 +2,7 @@ package gregtech.api.util;
 
 import cpw.mods.fml.common.eventhandler.Event;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import gregtech.api.enums.GT_Values;
 import gregtech.api.metatileentity.BaseMetaTileEntity;
 import gregtech.common.tileentities.machines.basic.GT_MetaTileEntity_MonsterRepellent;
 import java.util.List;
@@ -23,6 +24,16 @@ public class GT_SpawnEventHandler {
         MinecraftForge.EVENT_BUS.register(this);
     }
 
+    // Range of a powered repellent
+    public static int getPoweredRepellentRange(int aTier) {
+        return 16 + (48 * aTier);
+    }
+
+    // Range of an unpowered repellent
+    public static int getUnpoweredRepellentRange(int aTier) {
+        return 4 + (12 * aTier);
+    }
+
     @SubscribeEvent
     public void denyMobSpawn(CheckSpawn event) {
         if (event.getResult() == Event.Result.DENY) return;
@@ -37,10 +48,18 @@ public class GT_SpawnEventHandler {
         }
 
         if (event.entityLiving.isCreatureType(EnumCreatureType.monster, false)) {
+            final double maxRangeCheck = Math.pow(getUnpoweredRepellentRange(GT_Values.V.length - 1), 2);
             for (int[] rep : mobReps) {
                 if (rep[3] == event.entity.worldObj.provider.dimensionId) {
                     // If the chunk isn't loaded, we ignore this Repellent
                     if (!event.entity.worldObj.blockExists(rep[0], rep[1], rep[2])) continue;
+                    final double dx = rep[0] + 0.5F - event.entity.posX;
+                    final double dy = rep[1] + 0.5F - event.entity.posY;
+                    final double dz = rep[2] + 0.5F - event.entity.posZ;
+
+                    final double check = (dx * dx + dz * dz + dy * dy);
+                    // Fail early if outside of max range
+                    if (check > maxRangeCheck) continue;
 
                     final TileEntity tTile = event.entity.worldObj.getTileEntity(rep[0], rep[1], rep[2]);
                     if (tTile instanceof BaseMetaTileEntity
@@ -49,10 +68,7 @@ public class GT_SpawnEventHandler {
                         final int r = ((GT_MetaTileEntity_MonsterRepellent)
                                         ((BaseMetaTileEntity) tTile).getMetaTileEntity())
                                 .mRange;
-                        final double dx = rep[0] + 0.5F - event.entity.posX;
-                        final double dy = rep[1] + 0.5F - event.entity.posY;
-                        final double dz = rep[2] + 0.5F - event.entity.posZ;
-                        if ((dx * dx + dz * dz + dy * dy) <= Math.pow(r, 2)) {
+                        if (check <= Math.pow(r, 2)) {
                             if (event.entityLiving instanceof EntitySlime)
                                 ((EntitySlime) event.entityLiving).setCustomNameTag("DoNotSpawnSlimes");
                             event.setResult(Event.Result.DENY);

--- a/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_MonsterRepellent.java
+++ b/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_MonsterRepellent.java
@@ -88,9 +88,9 @@ public class GT_MetaTileEntity_MonsterRepellent extends GT_MetaTileEntity_Tiered
             }
             if (aBaseMetaTileEntity.isUniversalEnergyStored(getMinimumStoredEU())
                     && aBaseMetaTileEntity.decreaseStoredEnergyUnits(1L << (this.mTier * 2), false)) {
-                mRange = 16 + (48 * mTier);
+                mRange = GT_SpawnEventHandler.getPoweredRepellentRange(mTier);
             } else {
-                mRange = 4 + (12 * mTier);
+                mRange = GT_SpawnEventHandler.getUnpoweredRepellentRange(mTier);
             }
         }
     }


### PR DESCRIPTION
* Don't check (or keep checking) if it's already a DENY.
* Don't consider Mob Repellents that aren't chunk loaded (chunk doesn't exist)
* Don't consider Mob Repellents that are out of the max possible range (avoid loading the tile)