### PR TITLE
save oversized output stacks properly

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicMachine.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicMachine.java
@@ -590,8 +590,7 @@ public abstract class GT_MetaTileEntity_BasicMachine extends GT_MetaTileEntity_B
         if (mFluidOut != null) aNBT.setTag("mFluidOut", mFluidOut.writeToNBT(new NBTTagCompound()));
 
         for (int i = 0; i < mOutputItems.length; i++)
-            if (mOutputItems[i] != null)
-                aNBT.setTag("mOutputItem" + i, mOutputItems[i].writeToNBT(new NBTTagCompound()));
+            if (mOutputItems[i] != null) GT_Utility.saveItem(aNBT, "mOutputItem" + i, mOutputItems[i]);
     }
 
     @Override

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
@@ -195,9 +195,7 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
             aNBT.setInteger("mOutputItemsLength", mOutputItems.length);
             for (int i = 0; i < mOutputItems.length; i++)
                 if (mOutputItems[i] != null) {
-                    NBTTagCompound tNBT = new NBTTagCompound();
-                    mOutputItems[i].writeToNBT(tNBT);
-                    aNBT.setTag("mOutputItem" + i, tNBT);
+                    GT_Utility.saveItem(aNBT, "mOutputItem" + i, mOutputItems[i]);
                 }
         }
         if (mOutputFluids != null) {

--- a/src/main/java/gregtech/api/util/GT_Utility.java
+++ b/src/main/java/gregtech/api/util/GT_Utility.java
@@ -103,6 +103,7 @@ import net.minecraft.world.chunk.Chunk;
 import net.minecraftforge.common.DimensionManager;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.util.BlockSnapshot;
+import net.minecraftforge.common.util.Constants;
 import net.minecraftforge.common.util.FakePlayer;
 import net.minecraftforge.common.util.FakePlayerFactory;
 import net.minecraftforge.common.util.ForgeDirection;
@@ -2904,7 +2905,29 @@ public class GT_Utility {
      */
     public static ItemStack loadItem(NBTTagCompound aNBT) {
         if (aNBT == null) return null;
-        return GT_OreDictUnificator.get(true, ItemStack.loadItemStackFromNBT(aNBT));
+        ItemStack tRawStack = ItemStack.loadItemStackFromNBT(aNBT);
+        int tRealStackSize = 0;
+        if (tRawStack != null && aNBT.hasKey("Count", Constants.NBT.TAG_INT)) {
+            tRealStackSize = aNBT.getInteger("Count");
+            tRawStack.stackSize = tRealStackSize;
+        } else if (tRawStack != null) {
+            tRealStackSize = tRawStack.stackSize;
+        }
+        ItemStack tRet = GT_OreDictUnificator.get(true, tRawStack);
+        if (tRet != null) tRet.stackSize = tRealStackSize;
+        return tRet;
+    }
+
+    public static void saveItem(NBTTagCompound aParentTag, String aTagName, ItemStack aStack) {
+        if (aStack != null) aParentTag.setTag(aTagName, saveItem(aStack));
+    }
+
+    public static NBTTagCompound saveItem(ItemStack aStack) {
+        if (aStack == null) return new NBTTagCompound();
+        NBTTagCompound t = new NBTTagCompound();
+        aStack.writeToNBT(t);
+        if (aStack.stackSize > Byte.MAX_VALUE) t.setInteger("Count", aStack.stackSize);
+        return t;
     }
 
     /**


### PR DESCRIPTION
example includes smelting a stack of crushed copper ore in multi smelter. Reloading the chunk said multi is in while it's processing such recipe will cause it to void all outputs. In practice any multi with parallel and don't split output stacks in checkRecipe will have the same issue.

addOutput can correctly handle oversized stacks, so it's just this serialization code left.