### PR TITLE
Make GT_FluidDisplayItem.getChemicalFormula static

### DIFF
--- a/src/main/java/gregtech/common/items/GT_FluidDisplayItem.java
+++ b/src/main/java/gregtech/common/items/GT_FluidDisplayItem.java
@@ -108,7 +108,7 @@ public class GT_FluidDisplayItem extends GT_Generic_Item {
     }
 
     @SideOnly(Side.CLIENT)
-    public String getChemicalFormula(FluidStack aRealFluid) {
+    public static String getChemicalFormula(FluidStack aRealFluid) {
         return sFluidTooltips.computeIfAbsent(aRealFluid.getFluid(), fluid -> {
             for (ItemStack tContainer : GT_Utility.getContainersFromFluid(aRealFluid)) {
                 if (isCell(tContainer)) {


### PR DESCRIPTION
To be used by other mods.
It's currently not used by any of the addons, so it's effectively compatible change.