### PR TITLE
allow filtering what is accepted in a fluid slot

### DIFF
--- a/src/main/java/gregtech/common/gui/modularui/widget/FluidDisplaySlotWidget.java
+++ b/src/main/java/gregtech/common/gui/modularui/widget/FluidDisplaySlotWidget.java
@@ -28,7 +28,7 @@ public class FluidDisplaySlotWidget extends SlotWidget {
     private Supplier<IFluidAccess> fluidAccessConstructor;
     private Supplier<Boolean> canDrainGetter;
     private Supplier<Boolean> canFillGetter;
-    private Predicate<ItemStack> canFillFilter;
+    private Predicate<Fluid> canFillFilter;
     private Action actionRealClick = Action.NONE;
     private Action actionDragAndDrop = Action.NONE;
     private BiFunction<ClickData, FluidDisplaySlotWidget, Boolean> beforeRealClick;
@@ -179,7 +179,7 @@ public class FluidDisplaySlotWidget extends SlotWidget {
                 // no fluid to fill
                 return null;
             // apply filter here
-            if (!canFillFilter.test(tStackHeld)) return null;
+            if (!canFillFilter.test(tFluidHeld.getFluid())) return null;
             return fillFluid(aFluidAccess, aPlayer, tFluidHeld, aProcessFullStack);
         }
         // tank not empty, both action possible
@@ -405,17 +405,8 @@ public class FluidDisplaySlotWidget extends SlotWidget {
      * Add a predicate on whether a client stack will be accepted. Note this will only be called when this slot is already
      * empty. It is assumed whatever is already in the slot will pass the filter.
      */
-    public FluidDisplaySlotWidget setEmptyCanFillFilterItem(Predicate<ItemStack> canFillFilter) {
+    public FluidDisplaySlotWidget setEmptyCanFillFilter(Predicate<Fluid> canFillFilter) {
         this.canFillFilter = canFillFilter;
-        return this;
-    }
-
-    /**
-     * Add a predicate on whether a client stack will be accepted. Note this will only be called when this slot is already
-     * empty. It is assumed whatever is already in the slot will pass the filter.
-     */
-    public FluidDisplaySlotWidget setEmptyCanFillFilterFluid(Predicate<FluidStack> canFillFilter) {
-        this.canFillFilter = s -> canFillFilter.test(GT_Utility.getFluidForFilledItem(s, true));
         return this;
     }
 

--- a/src/main/java/gregtech/common/gui/modularui/widget/FluidDisplaySlotWidget.java
+++ b/src/main/java/gregtech/common/gui/modularui/widget/FluidDisplaySlotWidget.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.BiFunction;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -27,6 +28,7 @@ public class FluidDisplaySlotWidget extends SlotWidget {
     private Supplier<IFluidAccess> fluidAccessConstructor;
     private Supplier<Boolean> canDrainGetter;
     private Supplier<Boolean> canFillGetter;
+    private Predicate<ItemStack> canFillFilter;
     private Action actionRealClick = Action.NONE;
     private Action actionDragAndDrop = Action.NONE;
     private BiFunction<ClickData, FluidDisplaySlotWidget, Boolean> beforeRealClick;
@@ -176,6 +178,8 @@ public class FluidDisplaySlotWidget extends SlotWidget {
             if (tFluidHeld == null)
                 // no fluid to fill
                 return null;
+            // apply filter here
+            if (!canFillFilter.test(tStackHeld)) return null;
             return fillFluid(aFluidAccess, aPlayer, tFluidHeld, aProcessFullStack);
         }
         // tank not empty, both action possible
@@ -183,6 +187,8 @@ public class FluidDisplaySlotWidget extends SlotWidget {
             // both nonnull and have space left for filling.
             if (aCanFill)
                 // actually both pickup and fill is reasonable, but I'll go with fill here
+                // there is already fluid in here. so we assume the slot will not accept this fluid anyway if it doesn't
+                // pass the filter.
                 return fillFluid(aFluidAccess, aPlayer, tFluidHeld, aProcessFullStack);
             if (!aCanDrain)
                 // cannot take AND cannot fill, why make this call then?
@@ -392,6 +398,24 @@ public class FluidDisplaySlotWidget extends SlotWidget {
      */
     public FluidDisplaySlotWidget setActionRealClick(Action actionRealClick) {
         this.actionRealClick = actionRealClick;
+        return this;
+    }
+
+    /**
+     * Add a predicate on whether a client stack will be accepted. Note this will only be called when this slot is already
+     * empty. It is assumed whatever is already in the slot will pass the filter.
+     */
+    public FluidDisplaySlotWidget setEmptyCanFillFilterItem(Predicate<ItemStack> canFillFilter) {
+        this.canFillFilter = canFillFilter;
+        return this;
+    }
+
+    /**
+     * Add a predicate on whether a client stack will be accepted. Note this will only be called when this slot is already
+     * empty. It is assumed whatever is already in the slot will pass the filter.
+     */
+    public FluidDisplaySlotWidget setEmptyCanFillFilterFluid(Predicate<FluidStack> canFillFilter) {
+        this.canFillFilter = s -> canFillFilter.test(GT_Utility.getFluidForFilledItem(s, true));
         return this;
     }
 


### PR DESCRIPTION
This is needed in various restrictive input hatch. Theoretically, we could apply the fix across the board by simply adding `.setEmptyCanFillFilterFluid(this::isFluidInputAllowed)` to `gregtech.api.metatileentity.implementations.GT_MetaTileEntity_BasicTank#createDrainableFluidSlot`. However I doubt that'd be overly restrictive, especially when there are recipe map based input filter. It would be a great inconvenience for player if that does get in the way. My decision is to add that clause to indiviual restrictive input hatches themselves instead of adding it in the super class.