### PR TITLE
Fix propene recipe conflict

### DIFF
--- a/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
@@ -17281,14 +17281,14 @@ public class GT_MachineRecipeLoader implements Runnable {
                 120);
         GT_Values.RA.addChemicalRecipe(
                 Materials.Empty.getCells(1),
-                GT_Utility.getIntegratedCircuit(2),
+                GT_Utility.getIntegratedCircuit(5),
                 Materials.Propene.getGas(2000),
                 Materials.Isoprene.getFluid(1000),
                 Materials.Methane.getCells(1),
                 120);
         GT_Values.RA.addChemicalRecipe(
                 Materials.Propene.getCells(2),
-                GT_Utility.getIntegratedCircuit(3),
+                GT_Utility.getIntegratedCircuit(5),
                 GT_Values.NF,
                 Materials.Isoprene.getFluid(1000),
                 Materials.Methane.getCells(1),
@@ -17296,14 +17296,14 @@ public class GT_MachineRecipeLoader implements Runnable {
                 120);
         GT_Values.RA.addChemicalRecipe(
                 Materials.Empty.getCells(1),
-                GT_Utility.getIntegratedCircuit(12),
+                GT_Utility.getIntegratedCircuit(15),
                 Materials.Propene.getGas(2000),
                 Materials.Methane.getGas(1000),
                 Materials.Isoprene.getCells(1),
                 120);
         GT_Values.RA.addChemicalRecipe(
                 Materials.Propene.getCells(2),
-                GT_Utility.getIntegratedCircuit(12),
+                GT_Utility.getIntegratedCircuit(15),
                 GT_Values.NF,
                 Materials.Methane.getGas(1000),
                 Materials.Isoprene.getCells(1),


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12228.
Circuit 1, 2, 3, 4, 9, 11, 23, 24 would all give conflicts, so 5 and 15 are the natural choices.