### PR TITLE
Fix breaking drawer voids items

### DIFF
--- a/src/main/java/gregtech/api/util/GT_OreDictUnificator.java
+++ b/src/main/java/gregtech/api/util/GT_OreDictUnificator.java
@@ -176,9 +176,12 @@ public class GT_OreDictUnificator {
     }
 
     public static ItemStack get(boolean aUseBlackList, ItemStack aStack) {
+        return get(aUseBlackList, aStack, false);
+    }
+
+    public static ItemStack get(boolean aUseBlackList, ItemStack aStack, boolean unsafe) {
         if (GT_Utility.isStackInvalid(aStack)) return null;
         ItemData tPrefixMaterial = getAssociation(aStack);
-        ItemStack rStack = null;
         if (tPrefixMaterial == null
                 || !tPrefixMaterial.hasValidPrefixMaterialData()
                 || (aUseBlackList && tPrefixMaterial.mBlackListed)) return GT_Utility.copyOrNull(aStack);
@@ -188,11 +191,14 @@ public class GT_OreDictUnificator {
         }
         if (tPrefixMaterial.mUnificationTarget == null)
             tPrefixMaterial.mUnificationTarget = sName2StackMap.get(tPrefixMaterial.toString());
-        rStack = tPrefixMaterial.mUnificationTarget;
+        ItemStack rStack = tPrefixMaterial.mUnificationTarget;
         if (GT_Utility.isStackInvalid(rStack)) return GT_Utility.copyOrNull(aStack);
-        assert rStack != null;
         rStack.setTagCompound(aStack.getTagCompound());
-        return GT_Utility.copyAmount(aStack.stackSize, rStack);
+        if (unsafe) {
+            return GT_Utility.copyAmountUnsafe(aStack.stackSize, rStack);
+        } else {
+            return GT_Utility.copyAmount(aStack.stackSize, rStack);
+        }
     }
 
     /** Doesn't copy the returned stack or set quantity. Be careful and do not mutate it;

--- a/src/main/java/gregtech/common/GT_Proxy.java
+++ b/src/main/java/gregtech/common/GT_Proxy.java
@@ -1415,7 +1415,8 @@ public abstract class GT_Proxy implements IGT_Mod, IGuiHandler, IFuelHandler, IG
         if ((aEvent.entity != null) && (!aEvent.entity.worldObj.isRemote)) {
             if ((aEvent.entity instanceof EntityItem)) {
                 ((EntityItem) aEvent.entity)
-                        .setEntityItemStack(GT_OreDictUnificator.get(((EntityItem) aEvent.entity).getEntityItem()));
+                        .setEntityItemStack(
+                                GT_OreDictUnificator.get(true, ((EntityItem) aEvent.entity).getEntityItem(), true));
             }
             if ((this.mSkeletonsShootGTArrows > 0)
                     && (aEvent.entity.getClass() == EntityArrow.class)


### PR DESCRIPTION
Close https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/11940
Due to the fact `get` is used in so many places, I don't think we can make it always use `copyAmountUnsafe` without breaking other stuff.