### PR TITLE
Added getter for working amperes of a hatch

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_ExtendedPowerMultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_ExtendedPowerMultiBlockBase.java
@@ -179,6 +179,10 @@ public abstract class GT_MetaTileEntity_ExtendedPowerMultiBlockBase<
         return GT_ExoticEnergyInputHelper.getMaxInputAmpsMulti(getExoticAndNormalEnergyHatchList());
     }
 
+    public long getMaxWorkingInputAmps() {
+        return GT_ExoticEnergyInputHelper.getMaxWorkingInputAmpsMulti(getExoticAndNormalEnergyHatchList());
+    }
+
     @Override
     public void clearHatches() {
         super.clearHatches();

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_ExtendedPowerMultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_ExtendedPowerMultiBlockBase.java
@@ -176,10 +176,6 @@ public abstract class GT_MetaTileEntity_ExtendedPowerMultiBlockBase<
     }
 
     public long getMaxInputAmps() {
-        return GT_ExoticEnergyInputHelper.getMaxInputAmpsMulti(getExoticAndNormalEnergyHatchList());
-    }
-
-    public long getMaxWorkingInputAmps() {
         return GT_ExoticEnergyInputHelper.getMaxWorkingInputAmpsMulti(getExoticAndNormalEnergyHatchList());
     }
 

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_Energy.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_Energy.java
@@ -106,6 +106,14 @@ public class GT_MetaTileEntity_Hatch_Energy extends GT_MetaTileEntity_Hatch {
         return 2;
     }
 
+    /** Get the maximum amount of amperes to work with, which excludes the additional amps in for loss
+     *
+     * @return Working amps
+     */
+    public long maxWorkingAmperesIn() {
+        return maxAmperesIn();
+    }
+
     @Override
     public MetaTileEntity newMetaEntity(IGregTechTileEntity aTileEntity) {
         return new GT_MetaTileEntity_Hatch_Energy(mName, mTier, mDescriptionArray, mTextures);

--- a/src/main/java/gregtech/api/util/GT_ExoticEnergyInputHelper.java
+++ b/src/main/java/gregtech/api/util/GT_ExoticEnergyInputHelper.java
@@ -4,6 +4,7 @@ import static gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Mult
 
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch;
+import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_Energy;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -70,6 +71,19 @@ public class GT_ExoticEnergyInputHelper {
         for (GT_MetaTileEntity_Hatch tHatch : hatches)
             if (isValidMetaTileEntity(tHatch))
                 rAmp += tHatch.getBaseMetaTileEntity().getInputAmperage();
+        return rAmp;
+    }
+
+    public static long getMaxWorkingInputAmpsMulti(Collection<? extends GT_MetaTileEntity_Hatch> hatches) {
+        long rAmp = 0;
+        for (GT_MetaTileEntity_Hatch tHatch : hatches)
+            if (isValidMetaTileEntity(tHatch)) {
+                if (tHatch instanceof GT_MetaTileEntity_Hatch_Energy) {
+                    rAmp += ((GT_MetaTileEntity_Hatch_Energy) tHatch).maxWorkingAmperesIn();
+                } else {
+                    rAmp += tHatch.getBaseMetaTileEntity().getInputAmperage();
+                }
+            }
         return rAmp;
     }
 


### PR DESCRIPTION
This is intended as a proper fix to fix too much energy use on TT hatches. Working amperage of a 64A energy hatch for example will be 64A instead of the 80A max input it currently returns.
After this is merged I'll override `maxWorkingAmperesIn()` in TT with proper values.