### PR TITLE
Pulling the hardcoded ore behavior from TypeFilter

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_ExtendedPowerMultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_ExtendedPowerMultiBlockBase.java
@@ -176,7 +176,7 @@ public abstract class GT_MetaTileEntity_ExtendedPowerMultiBlockBase<
     }
 
     public long getMaxInputAmps() {
-        return GT_ExoticEnergyInputHelper.getMaxInputAmpsMulti(getExoticAndNormalEnergyHatchList());
+        return GT_ExoticEnergyInputHelper.getMaxWorkingInputAmpsMulti(getExoticAndNormalEnergyHatchList());
     }
 
     @Override

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch.java
@@ -142,6 +142,14 @@ public abstract class GT_MetaTileEntity_Hatch extends GT_MetaTileEntity_BasicTan
         mTexturePage = 0;
     }
 
+    /** Get the maximum amount of amperes to work with, which excludes the additional amps in for loss
+     *
+     * @return Working amps
+     */
+    public long maxWorkingAmperesIn() {
+        return maxAmperesIn();
+    }
+
     @Override
     public final byte getUpdateData() {
         return (byte) (actualTexture & 0x7F);

--- a/src/main/java/gregtech/api/util/GT_ExoticEnergyInputHelper.java
+++ b/src/main/java/gregtech/api/util/GT_ExoticEnergyInputHelper.java
@@ -73,6 +73,15 @@ public class GT_ExoticEnergyInputHelper {
         return rAmp;
     }
 
+    public static long getMaxWorkingInputAmpsMulti(Collection<? extends GT_MetaTileEntity_Hatch> hatches) {
+        long rAmp = 0;
+        for (GT_MetaTileEntity_Hatch tHatch : hatches)
+            if (isValidMetaTileEntity(tHatch)) {
+                rAmp += tHatch.maxWorkingAmperesIn();
+            }
+        return rAmp;
+    }
+
     public static List<Class<? extends GT_MetaTileEntity_Hatch>> getAllClasses() {
         return Collections.unmodifiableList(sExoticEnergyHatchType);
     }

--- a/src/main/java/gregtech/common/tileentities/automation/GT_MetaTileEntity_TypeFilter.java
+++ b/src/main/java/gregtech/common/tileentities/automation/GT_MetaTileEntity_TypeFilter.java
@@ -1,5 +1,9 @@
 package gregtech.common.tileentities.automation;
 
+import static gregtech.api.enums.GT_Values.W;
+import static gregtech.api.enums.Textures.BlockIcons.AUTOMATION_TYPEFILTER;
+import static gregtech.api.enums.Textures.BlockIcons.AUTOMATION_TYPEFILTER_GLOW;
+
 import com.google.common.collect.ImmutableList;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.interfaces.ITexture;
@@ -10,37 +14,31 @@ import gregtech.api.objects.ItemData;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GT_OreDictUnificator;
 import gregtech.api.util.GT_Utility;
+import java.util.Arrays;
+import java.util.List;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.StatCollector;
-
-import java.util.Arrays;
-import java.util.List;
-
-import static gregtech.api.enums.GT_Values.W;
-import static gregtech.api.enums.Textures.BlockIcons.AUTOMATION_TYPEFILTER;
-import static gregtech.api.enums.Textures.BlockIcons.AUTOMATION_TYPEFILTER_GLOW;
 
 public class GT_MetaTileEntity_TypeFilter extends GT_MetaTileEntity_SpecialFilter {
     public int mRotationIndex = 0;
     public OrePrefixes mPrefix = OrePrefixes.ore;
 
     public static ImmutableList<OrePrefixes> OREBLOCK_PREFIXES = ImmutableList.of(
-        OrePrefixes.oreBlackgranite,
-        OrePrefixes.oreDense,
-        OrePrefixes.oreEnd,
-        OrePrefixes.oreEndstone,
-        OrePrefixes.oreNether,
-        OrePrefixes.oreNetherrack,
-        OrePrefixes.oreNormal,
-        OrePrefixes.orePoor,
-        OrePrefixes.oreRedgranite,
-        OrePrefixes.oreRich,
-        OrePrefixes.oreSmall,
-        OrePrefixes.oreBasalt,
-        OrePrefixes.oreMarble
-    );
+            OrePrefixes.oreBlackgranite,
+            OrePrefixes.oreDense,
+            OrePrefixes.oreEnd,
+            OrePrefixes.oreEndstone,
+            OrePrefixes.oreNether,
+            OrePrefixes.oreNetherrack,
+            OrePrefixes.oreNormal,
+            OrePrefixes.orePoor,
+            OrePrefixes.oreRedgranite,
+            OrePrefixes.oreRich,
+            OrePrefixes.oreSmall,
+            OrePrefixes.oreBasalt,
+            OrePrefixes.oreMarble);
 
     public GT_MetaTileEntity_TypeFilter(int aID, String aName, String aNameRegional, int aTier) {
         super(aID, aName, aNameRegional, aTier, new String[] {

--- a/src/main/java/gregtech/common/tileentities/automation/GT_MetaTileEntity_TypeFilter.java
+++ b/src/main/java/gregtech/common/tileentities/automation/GT_MetaTileEntity_TypeFilter.java
@@ -1,9 +1,6 @@
 package gregtech.common.tileentities.automation;
 
-import static gregtech.api.enums.GT_Values.W;
-import static gregtech.api.enums.Textures.BlockIcons.AUTOMATION_TYPEFILTER;
-import static gregtech.api.enums.Textures.BlockIcons.AUTOMATION_TYPEFILTER_GLOW;
-
+import com.google.common.collect.ImmutableList;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
@@ -13,16 +10,37 @@ import gregtech.api.objects.ItemData;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GT_OreDictUnificator;
 import gregtech.api.util.GT_Utility;
-import java.util.Arrays;
-import java.util.List;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.StatCollector;
 
+import java.util.Arrays;
+import java.util.List;
+
+import static gregtech.api.enums.GT_Values.W;
+import static gregtech.api.enums.Textures.BlockIcons.AUTOMATION_TYPEFILTER;
+import static gregtech.api.enums.Textures.BlockIcons.AUTOMATION_TYPEFILTER_GLOW;
+
 public class GT_MetaTileEntity_TypeFilter extends GT_MetaTileEntity_SpecialFilter {
     public int mRotationIndex = 0;
     public OrePrefixes mPrefix = OrePrefixes.ore;
+
+    public static ImmutableList<OrePrefixes> OREBLOCK_PREFIXES = ImmutableList.of(
+        OrePrefixes.oreBlackgranite,
+        OrePrefixes.oreDense,
+        OrePrefixes.oreEnd,
+        OrePrefixes.oreEndstone,
+        OrePrefixes.oreNether,
+        OrePrefixes.oreNetherrack,
+        OrePrefixes.oreNormal,
+        OrePrefixes.orePoor,
+        OrePrefixes.oreRedgranite,
+        OrePrefixes.oreRich,
+        OrePrefixes.oreSmall,
+        OrePrefixes.oreBasalt,
+        OrePrefixes.oreMarble
+    );
 
     public GT_MetaTileEntity_TypeFilter(int aID, String aName, String aNameRegional, int aTier) {
         super(aID, aName, aNameRegional, aTier, new String[] {
@@ -126,27 +144,13 @@ public class GT_MetaTileEntity_TypeFilter extends GT_MetaTileEntity_SpecialFilte
 
     @Override
     protected boolean isStackAllowed(ItemStack aStack) {
-        boolean tAllowPrefix = this.mPrefix.contains(aStack);
         if (this.mPrefix == OrePrefixes.ore) {
-            ItemData tData = GT_OreDictUnificator.getItemData(aStack);
-            if (tData != null && tData.mPrefix != null) {
-                OrePrefixes tFix = tData.mPrefix;
-                if (tFix == OrePrefixes.oreBlackgranite
-                        || tFix == OrePrefixes.oreDense
-                        || tFix == OrePrefixes.oreEnd
-                        || tFix == OrePrefixes.oreEndstone
-                        || tFix == OrePrefixes.oreNether
-                        || tFix == OrePrefixes.oreNetherrack
-                        || tFix == OrePrefixes.oreNormal
-                        || tFix == OrePrefixes.orePoor
-                        || tFix == OrePrefixes.oreRedgranite
-                        || tFix == OrePrefixes.oreRich
-                        || tFix == OrePrefixes.oreSmall
-                        || tFix == OrePrefixes.oreBasalt
-                        || tFix == OrePrefixes.oreMarble) tAllowPrefix = true;
+            ItemData data = GT_OreDictUnificator.getItemData(aStack);
+            if (data != null && data.mPrefix != null && OREBLOCK_PREFIXES.contains(data.mPrefix)) {
+                return true;
             }
         }
-        return tAllowPrefix;
+        return this.mPrefix.contains(aStack);
     }
 
     @Override


### PR DESCRIPTION
Pull request pulls hardcoded ore behavior to public variable to make it accessible and syncable in other mods.
I need it to make new TypeFilter ItemSink Module in Logistics Pipes