### PR TITLE
Fixes distilled water recipe conflict

### DIFF
--- a/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
@@ -7500,7 +7500,7 @@ public class GT_MachineRecipeLoader implements Runnable {
         // O + 2H = H2O
         GT_Values.RA.addChemicalRecipeForBasicMachineOnly(
                 GT_OreDictUnificator.get(OrePrefixes.cell, Materials.Oxygen, 1L),
-                GT_Values.NI,
+                GT_Utility.getIntegratedCircuit(22),
                 Materials.Hydrogen.getGas(2000L),
                 GT_ModHandler.getDistilledWater(1000L),
                 ItemList.Cell_Empty.get(1L),
@@ -7509,7 +7509,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                 30);
         GT_Values.RA.addChemicalRecipeForBasicMachineOnly(
                 GT_OreDictUnificator.get(OrePrefixes.cell, Materials.Hydrogen, 1L),
-                GT_Values.NI,
+                GT_Utility.getIntegratedCircuit(22),
                 Materials.Oxygen.getGas(500L),
                 GT_ModHandler.getDistilledWater(500L),
                 ItemList.Cell_Empty.get(1L),


### PR DESCRIPTION
Fixes recipe conflict between distilled water and hydroxide in the CR by adding the circuit 22. This circuit specifically because it is already used in the LCR.

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12238.