### PR TITLE
Added getter for average voltage

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_ExtendedPowerMultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_ExtendedPowerMultiBlockBase.java
@@ -175,6 +175,10 @@ public abstract class GT_MetaTileEntity_ExtendedPowerMultiBlockBase<
         return GT_ExoticEnergyInputHelper.getMaxInputVoltageMulti(getExoticAndNormalEnergyHatchList());
     }
 
+    public long getAverageInputVoltage() {
+        return GT_ExoticEnergyInputHelper.getAverageInputVoltageMulti(getExoticAndNormalEnergyHatchList());
+    }
+
     public long getMaxInputAmps() {
         return GT_ExoticEnergyInputHelper.getMaxWorkingInputAmpsMulti(getExoticAndNormalEnergyHatchList());
     }

--- a/src/main/java/gregtech/api/util/GT_ExoticEnergyInputHelper.java
+++ b/src/main/java/gregtech/api/util/GT_ExoticEnergyInputHelper.java
@@ -58,7 +58,7 @@ public class GT_ExoticEnergyInputHelper {
     }
 
     public static long getTotalEuMulti(Collection<? extends GT_MetaTileEntity_Hatch> hatches) {
-        return getMaxWorkingInputAmpsMulti(hatches) * getMaxInputVoltageMulti(hatches);
+        return getMaxWorkingInputAmpsMulti(hatches) * getAverageInputVoltageMulti(hatches);
     }
 
     public static long getMaxInputVoltageMulti(Collection<? extends GT_MetaTileEntity_Hatch> hatches) {
@@ -67,6 +67,17 @@ public class GT_ExoticEnergyInputHelper {
             if (isValidMetaTileEntity(tHatch))
                 rVoltage += tHatch.getBaseMetaTileEntity().getInputVoltage();
         return rVoltage;
+    }
+
+    public static long getAverageInputVoltageMulti(Collection<? extends GT_MetaTileEntity_Hatch> hatches) {
+        long rVoltage = 0;
+        if (hatches.size() <= 0) {
+            return rVoltage;
+        }
+        for (GT_MetaTileEntity_Hatch tHatch : hatches)
+            if (isValidMetaTileEntity(tHatch))
+                rVoltage += tHatch.getBaseMetaTileEntity().getInputVoltage();
+        return rVoltage / hatches.size();
     }
 
     public static long getMaxInputAmpsMulti(Collection<? extends GT_MetaTileEntity_Hatch> hatches) {

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_PlasmaForge.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_PlasmaForge.java
@@ -1276,15 +1276,15 @@ public class GT_MetaTileEntity_PlasmaForge extends GT_MetaTileEntity_AbstractMul
                     + GT_Utility.formatNumbers(-EU_per_tick) + EnumChatFormatting.RESET + " EU/t",
             StatCollector.translateToLocal("GT5U.multiblock.mei") + ": " + EnumChatFormatting.YELLOW
                     + GT_Utility.formatNumbers(
-                            GT_ExoticEnergyInputHelper.getMaxInputVoltageMulti(getExoticAndNormalEnergyHatchList()))
+                            GT_ExoticEnergyInputHelper.getAverageInputVoltageMulti(getExoticAndNormalEnergyHatchList()))
                     + EnumChatFormatting.RESET + " EU/t(*" + EnumChatFormatting.YELLOW
                     + GT_Utility.formatNumbers(
                             GT_ExoticEnergyInputHelper.getMaxWorkingInputAmpsMulti(getExoticAndNormalEnergyHatchList()))
                     + EnumChatFormatting.RESET + "A) " + StatCollector.translateToLocal("GT5U.machines.tier")
                     + ": " + EnumChatFormatting.YELLOW
                     + VN[
-                            GT_Utility.getTier(GT_ExoticEnergyInputHelper.getMaxInputVoltageMulti(
-                                    getExoticAndNormalEnergyHatchList()))]
+                            GT_Utility.getTier(
+                                    GT_ExoticEnergyInputHelper.getTotalEuMulti(getExoticAndNormalEnergyHatchList()))]
                     + EnumChatFormatting.RESET,
             StatCollector.translateToLocal("GT5U.EBF.heat") + ": " + EnumChatFormatting.GREEN
                     + GT_Utility.formatNumbers(mHeatingCapacity) + EnumChatFormatting.RESET + " K",


### PR DESCRIPTION
Missed this before when adding the total EU getter. The DTPF used max voltage * max amperage when it should really only be average voltage * max amperage. I added it as a getter to the long base since I plan on replacing this math in the addons multis too.