### PR TITLE
CoverInfo refactor

### DIFF
--- a/src/main/java/gregtech/api/enums/GT_Values.java
+++ b/src/main/java/gregtech/api/enums/GT_Values.java
@@ -257,8 +257,9 @@ public class GT_Values {
     /**
      * NBT String Keys
      */
-    public static class NBT {
+    public static final class NBT {
         public static final String COLOR = "gt.color", // Integer
+                COVERS = "gt.covers", // String
                 CUSTOM_NAME = "name", // String
                 DISPAY = "gt.display", // String
                 FACING = "gt.facing", // Byte

--- a/src/main/java/gregtech/api/graphs/GenerateNodeMap.java
+++ b/src/main/java/gregtech/api/graphs/GenerateNodeMap.java
@@ -1,5 +1,6 @@
 package gregtech.api.graphs;
 
+import static gregtech.api.enums.GT_Values.ALL_VALID_SIDES;
 import static gregtech.api.util.GT_Utility.getOppositeSide;
 
 import gregtech.api.graphs.consumers.ConsumerNode;
@@ -15,7 +16,7 @@ public abstract class GenerateNodeMap {
     // clearing the node map to make sure it is gone on reset
     public static void clearNodeMap(Node aNode, int aReturnNodeValue) {
         if (aNode.mTileEntity instanceof BaseMetaPipeEntity) {
-            BaseMetaPipeEntity tPipe = (BaseMetaPipeEntity) aNode.mTileEntity;
+            final BaseMetaPipeEntity tPipe = (BaseMetaPipeEntity) aNode.mTileEntity;
             tPipe.setNode(null);
             tPipe.setNodePath(null);
             if (aNode.mSelfPath != null) {
@@ -23,24 +24,24 @@ public abstract class GenerateNodeMap {
                 aNode.mSelfPath = null;
             }
         }
-        for (int i = 0; i < 6; i++) {
-            NodePath tPath = aNode.mNodePaths[i];
+        for (byte side : ALL_VALID_SIDES) {
+            final NodePath tPath = aNode.mNodePaths[side];
             if (tPath != null) {
                 tPath.clearPath();
-                aNode.mNodePaths[i] = null;
+                aNode.mNodePaths[side] = null;
             }
-            Node tNextNode = aNode.mNeighbourNodes[i];
+            final Node tNextNode = aNode.mNeighbourNodes[side];
             if (tNextNode == null) continue;
             if (tNextNode.mNodeValue != aReturnNodeValue) clearNodeMap(tNextNode, aNode.mNodeValue);
-            aNode.mNeighbourNodes[i] = null;
+            aNode.mNeighbourNodes[side] = null;
         }
     }
 
     // get how many connections the pipe have
     private static int getNumberOfConnections(MetaPipeEntity aPipe) {
         int tCons = 0;
-        for (int i = 0; i < 6; i++) {
-            if (aPipe.isConnectedAtSide(i)) tCons++;
+        for (byte side : ALL_VALID_SIDES) {
+            if (aPipe.isConnectedAtSide(side)) tCons++;
         }
         return tCons;
     }
@@ -53,17 +54,17 @@ public abstract class GenerateNodeMap {
             int aNextNodeValue,
             ArrayList<ConsumerNode> tConsumers,
             HashSet<Node> tNodeMap) {
-        MetaPipeEntity tMetaPipe = (MetaPipeEntity) aPipe.getMetaTileEntity();
-        for (byte i = 0; i < 6; i++) {
-            if (i == aInvalidSide) {
+        final MetaPipeEntity tMetaPipe = (MetaPipeEntity) aPipe.getMetaTileEntity();
+        for (byte side : ALL_VALID_SIDES) {
+            if (side == aInvalidSide) {
                 continue;
             }
-            TileEntity tNextTileEntity = aPipe.getTileEntityAtSide(i);
-            if (tNextTileEntity == null || (tMetaPipe != null && !tMetaPipe.isConnectedAtSide(i))) continue;
-            ArrayList<MetaPipeEntity> tNewPipes = new ArrayList<>();
-            Pair nextTileEntity = getNextValidTileEntity(tNextTileEntity, tNewPipes, i, tNodeMap);
+            final TileEntity tNextTileEntity = aPipe.getTileEntityAtSide(side);
+            if (tNextTileEntity == null || (tMetaPipe != null && !tMetaPipe.isConnectedAtSide(side))) continue;
+            final ArrayList<MetaPipeEntity> tNewPipes = new ArrayList<>();
+            final Pair nextTileEntity = getNextValidTileEntity(tNextTileEntity, tNewPipes, side, tNodeMap);
             if (nextTileEntity != null) {
-                Node tNextNode = generateNode(
+                final Node tNextNode = generateNode(
                         nextTileEntity.mTileEntity,
                         aPipeNode,
                         aNextNodeValue + 1,
@@ -74,10 +75,10 @@ public abstract class GenerateNodeMap {
                 if (tNextNode != null) {
                     aNextNodeValue = tNextNode.mHighestNodeValue;
                     aPipeNode.mHighestNodeValue = tNextNode.mHighestNodeValue;
-                    aPipeNode.mNeighbourNodes[i] = tNextNode;
-                    aPipeNode.mNodePaths[i] = aPipeNode.returnValues.mReturnPath;
-                    aPipeNode.locks[i] = aPipeNode.returnValues.returnLock;
-                    aPipeNode.mNodePaths[i].reloadLocks();
+                    aPipeNode.mNeighbourNodes[side] = tNextNode;
+                    aPipeNode.mNodePaths[side] = aPipeNode.returnValues.mReturnPath;
+                    aPipeNode.locks[side] = aPipeNode.returnValues.returnLock;
+                    aPipeNode.mNodePaths[side].reloadLocks();
                 }
             }
         }
@@ -94,14 +95,14 @@ public abstract class GenerateNodeMap {
             ArrayList<ConsumerNode> aConsumers,
             HashSet<Node> aNodeMap) {
         if (aTileEntity.isInvalid()) return null;
-        byte tSideOp = getOppositeSide(aSide);
-        byte tInvalidSide = aPreviousNode == null ? -1 : tSideOp;
+        final byte tSideOp = getOppositeSide(aSide);
+        final byte tInvalidSide = aPreviousNode == null ? -1 : tSideOp;
         Node tThisNode = null;
         if (isPipe(aTileEntity)) {
-            BaseMetaPipeEntity tPipe = (BaseMetaPipeEntity) aTileEntity;
-            MetaPipeEntity tMetaPipe = (MetaPipeEntity) tPipe.getMetaTileEntity();
-            int tConnections = getNumberOfConnections(tMetaPipe);
-            Node tPipeNode;
+            final BaseMetaPipeEntity tPipe = (BaseMetaPipeEntity) aTileEntity;
+            final MetaPipeEntity tMetaPipe = (MetaPipeEntity) tPipe.getMetaTileEntity();
+            final int tConnections = getNumberOfConnections(tMetaPipe);
+            final Node tPipeNode;
             if (tConnections == 1) {
                 tPipeNode = getEmptyNode(aNextNodeValue, tSideOp, aTileEntity, aConsumers);
                 if (tPipeNode == null) return null;
@@ -115,7 +116,7 @@ public abstract class GenerateNodeMap {
             if (tInvalidSide > -1) {
                 tPipeNode.mNeighbourNodes[tInvalidSide] = aPreviousNode;
                 tPipeNode.mNodePaths[tInvalidSide] = getNewPath(aPipes.toArray(new MetaPipeEntity[0]));
-                Lock lock = new Lock();
+                final Lock lock = new Lock();
                 tPipeNode.mNodePaths[tSideOp].lock = lock;
                 tPipeNode.locks[tInvalidSide] = lock;
                 aPreviousNode.returnValues.mReturnPath = tPipeNode.mNodePaths[tInvalidSide];
@@ -124,10 +125,10 @@ public abstract class GenerateNodeMap {
             if (tConnections > 1)
                 generateNextNode(tPipe, tPipeNode, tInvalidSide, aNextNodeValue, aConsumers, aNodeMap);
         } else if (addConsumer(aTileEntity, tSideOp, aNextNodeValue, aConsumers)) {
-            ConsumerNode tConsumeNode = aConsumers.get(aConsumers.size() - 1);
+            final ConsumerNode tConsumeNode = aConsumers.get(aConsumers.size() - 1);
             tConsumeNode.mNeighbourNodes[tSideOp] = aPreviousNode;
             tConsumeNode.mNodePaths[tSideOp] = getNewPath(aPipes.toArray(new MetaPipeEntity[0]));
-            Lock lock = new Lock();
+            final Lock lock = new Lock();
             tConsumeNode.mNodePaths[tSideOp].lock = lock;
             aPreviousNode.returnValues.mReturnPath = tConsumeNode.mNodePaths[tSideOp];
             aPreviousNode.returnValues.returnLock = lock;
@@ -140,18 +141,18 @@ public abstract class GenerateNodeMap {
     protected Pair getNextValidTileEntity(
             TileEntity aTileEntity, ArrayList<MetaPipeEntity> aPipes, byte aSide, HashSet<Node> aNodeMap) {
         if (isPipe(aTileEntity)) {
-            BaseMetaPipeEntity tPipe = (BaseMetaPipeEntity) aTileEntity;
-            MetaPipeEntity tMetaPipe = (MetaPipeEntity) tPipe.getMetaTileEntity();
-            Node tNode = tPipe.getNode();
+            final BaseMetaPipeEntity tPipe = (BaseMetaPipeEntity) aTileEntity;
+            final MetaPipeEntity tMetaPipe = (MetaPipeEntity) tPipe.getMetaTileEntity();
+            final Node tNode = tPipe.getNode();
             if (tNode != null) {
                 if (aNodeMap.contains(tNode)) return null;
             }
-            int tConnections = getNumberOfConnections(tMetaPipe);
+            final int tConnections = getNumberOfConnections(tMetaPipe);
             if (tConnections == 2) {
-                byte tSideOp = getOppositeSide(aSide);
-                for (byte i = 0; i < 6; i++) {
+                final byte tSideOp = getOppositeSide(aSide);
+                for (byte i : ALL_VALID_SIDES) {
                     if (i == tSideOp || !(tMetaPipe.isConnectedAtSide(i))) continue;
-                    TileEntity tNewTileEntity = tPipe.getTileEntityAtSide(i);
+                    final TileEntity tNewTileEntity = tPipe.getTileEntityAtSide(i);
                     if (tNewTileEntity == null) continue;
                     if (isPipe(tNewTileEntity)) {
                         aPipes.add(tMetaPipe);

--- a/src/main/java/gregtech/api/gui/modularui/GT_UIInfos.java
+++ b/src/main/java/gregtech/api/gui/modularui/GT_UIInfos.java
@@ -70,9 +70,9 @@ public class GT_UIInfos {
                     side,
                     UIBuilder.of()
                             .container((player, world, x, y, z) -> {
-                                TileEntity te = world.getTileEntity(x, y, z);
+                                final TileEntity te = world.getTileEntity(x, y, z);
                                 if (!(te instanceof ICoverable)) return null;
-                                ICoverable gtTileEntity = (ICoverable) te;
+                                final ICoverable gtTileEntity = (ICoverable) te;
                                 GT_CoverBehaviorBase<?> cover = gtTileEntity.getCoverBehaviorAtSideNew(side);
                                 return createCoverContainer(
                                         player,
@@ -84,10 +84,10 @@ public class GT_UIInfos {
                             })
                             .gui((player, world, x, y, z) -> {
                                 if (!world.isRemote) return null;
-                                TileEntity te = world.getTileEntity(x, y, z);
+                                final TileEntity te = world.getTileEntity(x, y, z);
                                 if (!(te instanceof ICoverable)) return null;
-                                ICoverable gtTileEntity = (ICoverable) te;
-                                GT_CoverBehaviorBase<?> cover = gtTileEntity.getCoverBehaviorAtSideNew(side);
+                                final ICoverable gtTileEntity = (ICoverable) te;
+                                final GT_CoverBehaviorBase<?> cover = gtTileEntity.getCoverBehaviorAtSideNew(side);
                                 return createCoverGuiContainer(
                                         player,
                                         cover::createWindow,

--- a/src/main/java/gregtech/api/gui/widgets/GT_GuiCoverTabLine.java
+++ b/src/main/java/gregtech/api/gui/widgets/GT_GuiCoverTabLine.java
@@ -79,7 +79,7 @@ public class GT_GuiCoverTabLine extends GT_GuiTabLine {
      */
     private void setupTabs() {
         for (byte tSide = 0; tSide < 6; tSide++) {
-            ItemStack cover = tile.getCoverItemAtSide(tSide);
+            final ItemStack cover = tile.getCoverItemAtSide(tSide);
             if (cover != null) {
                 addCoverToTabs(tSide, cover);
             }
@@ -114,7 +114,7 @@ public class GT_GuiCoverTabLine extends GT_GuiTabLine {
      * @param cover
      */
     private void addCoverToTabs(byte side, ItemStack cover) {
-        boolean enabled = this.tile.getCoverBehaviorAtSideNew(side).hasCoverGUI();
+        final boolean enabled = this.tile.getCoverBehaviorAtSideNew(side).hasCoverGUI();
         this.setTab(side, cover, null, getTooltipForCoverTab(side, cover, enabled));
         this.setTabEnabled(side, enabled);
     }
@@ -127,7 +127,7 @@ public class GT_GuiCoverTabLine extends GT_GuiTabLine {
      * @return This cover tab's tooltip
      */
     private String[] getTooltipForCoverTab(byte side, ItemStack cover, boolean enabled) {
-        List<String> tooltip = cover.getTooltip(Minecraft.getMinecraft().thePlayer, true);
+        final List<String> tooltip = cover.getTooltip(Minecraft.getMinecraft().thePlayer, true);
         tooltip.set(
                 0,
                 (enabled ? EnumChatFormatting.UNDERLINE : EnumChatFormatting.DARK_GRAY)
@@ -158,9 +158,9 @@ public class GT_GuiCoverTabLine extends GT_GuiTabLine {
     static class CoverTabLineNEIHandler extends INEIGuiAdapter {
         @Override
         public boolean hideItemPanelSlot(GuiContainer gui, int x, int y, int w, int h) {
-            Rectangle neiSlotArea = new Rectangle(x, y, w, h);
+            final Rectangle neiSlotArea = new Rectangle(x, y, w, h);
             if (gui instanceof GT_GUIContainerMetaTile_Machine) {
-                GT_GuiTabLine tabLine = ((GT_GUIContainerMetaTile_Machine) gui).coverTabs;
+                final GT_GuiTabLine tabLine = ((GT_GUIContainerMetaTile_Machine) gui).coverTabs;
                 if (!tabLine.visible) {
                     return false;
                 }

--- a/src/main/java/gregtech/api/interfaces/covers/IControlsWorkCover.java
+++ b/src/main/java/gregtech/api/interfaces/covers/IControlsWorkCover.java
@@ -3,6 +3,8 @@ package gregtech.api.interfaces.covers;
 import gregtech.api.interfaces.tileentity.ICoverable;
 import gregtech.api.interfaces.tileentity.IMachineProgress;
 
+import static gregtech.api.enums.GT_Values.ALL_VALID_SIDES;
+
 /**
  * Marker interface for covers that might control whether the work can start on a {@link IMachineProgress}.
  */
@@ -15,9 +17,9 @@ public interface IControlsWorkCover {
      * @return true if the cover is the first (side) one
      **/
     static boolean makeSureOnlyOne(byte aMySide, ICoverable aTileEntity) {
-        for (byte i = 0; i < 6; i++) {
-            if (aTileEntity.getCoverBehaviorAtSideNew(i) instanceof IControlsWorkCover && i < aMySide) {
-                aTileEntity.dropCover(i, i, true);
+        for (byte tSide : ALL_VALID_SIDES) {
+            if (aTileEntity.getCoverBehaviorAtSideNew(tSide) instanceof IControlsWorkCover && tSide < aMySide) {
+                aTileEntity.dropCover(tSide, tSide, true);
                 aTileEntity.markDirty();
                 return false;
             }

--- a/src/main/java/gregtech/api/interfaces/covers/IControlsWorkCover.java
+++ b/src/main/java/gregtech/api/interfaces/covers/IControlsWorkCover.java
@@ -1,9 +1,9 @@
 package gregtech.api.interfaces.covers;
 
+import static gregtech.api.enums.GT_Values.ALL_VALID_SIDES;
+
 import gregtech.api.interfaces.tileentity.ICoverable;
 import gregtech.api.interfaces.tileentity.IMachineProgress;
-
-import static gregtech.api.enums.GT_Values.ALL_VALID_SIDES;
 
 /**
  * Marker interface for covers that might control whether the work can start on a {@link IMachineProgress}.

--- a/src/main/java/gregtech/api/interfaces/metatileentity/IMetaTileEntityItemPipe.java
+++ b/src/main/java/gregtech/api/interfaces/metatileentity/IMetaTileEntityItemPipe.java
@@ -56,39 +56,26 @@ public interface IMetaTileEntityItemPipe extends IMetaTileEntity {
             aStep += aMetaTileEntity.getStepSize();
             if (aIgnoreCapacity || aMetaTileEntity.pipeCapacityCheck())
                 if (aMap.get(aMetaTileEntity) == null || aMap.get(aMetaTileEntity) > aStep) {
-                    IGregTechTileEntity aBaseMetaTileEntity = aMetaTileEntity.getBaseMetaTileEntity();
+                    final IGregTechTileEntity aBaseMetaTileEntity = aMetaTileEntity.getBaseMetaTileEntity();
                     aMap.put(aMetaTileEntity, aStep);
                     for (byte i = 0, j = 0; i < 6; i++) {
                         if (aMetaTileEntity instanceof IConnectable
                                 && !((IConnectable) aMetaTileEntity).isConnectedAtSide(i)) continue;
                         j = GT_Utility.getOppositeSide(i);
                         if (aSuckItems) {
-                            if (aBaseMetaTileEntity
-                                    .getCoverBehaviorAtSideNew(i)
-                                    .letsItemsIn(
-                                            i,
-                                            aBaseMetaTileEntity.getCoverIDAtSide(i),
-                                            aBaseMetaTileEntity.getComplexCoverDataAtSide(i),
-                                            -2,
-                                            aBaseMetaTileEntity)) {
-                                IGregTechTileEntity tItemPipe = aBaseMetaTileEntity.getIGregTechTileEntityAtSide(i);
+                            if (aBaseMetaTileEntity.getCoverInfoAtSide(i).letsItemsIn(-2)) {
+                                final IGregTechTileEntity tItemPipe =
+                                        aBaseMetaTileEntity.getIGregTechTileEntityAtSide(i);
                                 if (aBaseMetaTileEntity.getColorization() >= 0) {
-                                    byte tColor = tItemPipe.getColorization();
+                                    final byte tColor = tItemPipe.getColorization();
                                     if (tColor >= 0 && tColor != aBaseMetaTileEntity.getColorization()) {
                                         continue;
                                     }
                                 }
                                 if (tItemPipe instanceof BaseMetaPipeEntity) {
-                                    IMetaTileEntity tMetaTileEntity = tItemPipe.getMetaTileEntity();
+                                    final IMetaTileEntity tMetaTileEntity = tItemPipe.getMetaTileEntity();
                                     if (tMetaTileEntity instanceof IMetaTileEntityItemPipe
-                                            && tItemPipe
-                                                    .getCoverBehaviorAtSideNew(j)
-                                                    .letsItemsOut(
-                                                            j,
-                                                            tItemPipe.getCoverIDAtSide(j),
-                                                            tItemPipe.getComplexCoverDataAtSide(j),
-                                                            -2,
-                                                            tItemPipe)) {
+                                            && tItemPipe.getCoverInfoAtSide(j).letsItemsOut(-2)) {
                                         scanPipes(
                                                 (IMetaTileEntityItemPipe) tMetaTileEntity,
                                                 aMap,
@@ -99,33 +86,22 @@ public interface IMetaTileEntityItemPipe extends IMetaTileEntity {
                                 }
                             }
                         } else {
-                            if (aBaseMetaTileEntity
-                                    .getCoverBehaviorAtSideNew(i)
-                                    .letsItemsOut(
-                                            i,
-                                            aBaseMetaTileEntity.getCoverIDAtSide(i),
-                                            aBaseMetaTileEntity.getComplexCoverDataAtSide(i),
-                                            -2,
-                                            aBaseMetaTileEntity)) {
-                                IGregTechTileEntity tItemPipe = aBaseMetaTileEntity.getIGregTechTileEntityAtSide(i);
+                            if (aBaseMetaTileEntity.getCoverInfoAtSide(i).letsItemsOut(-2)) {
+                                final IGregTechTileEntity tItemPipe =
+                                        aBaseMetaTileEntity.getIGregTechTileEntityAtSide(i);
                                 if (tItemPipe != null) {
                                     if (aBaseMetaTileEntity.getColorization() >= 0) {
-                                        byte tColor = tItemPipe.getColorization();
+                                        final byte tColor = tItemPipe.getColorization();
                                         if (tColor >= 0 && tColor != aBaseMetaTileEntity.getColorization()) {
                                             continue;
                                         }
                                     }
                                     if (tItemPipe instanceof BaseMetaPipeEntity) {
-                                        IMetaTileEntity tMetaTileEntity = tItemPipe.getMetaTileEntity();
+                                        final IMetaTileEntity tMetaTileEntity = tItemPipe.getMetaTileEntity();
                                         if (tMetaTileEntity instanceof IMetaTileEntityItemPipe
                                                 && tItemPipe
-                                                        .getCoverBehaviorAtSideNew(j)
-                                                        .letsItemsIn(
-                                                                j,
-                                                                tItemPipe.getCoverIDAtSide(j),
-                                                                tItemPipe.getComplexCoverDataAtSide(j),
-                                                                -2,
-                                                                tItemPipe)) {
+                                                        .getCoverInfoAtSide(i)
+                                                        .letsItemsIn(-2)) {
                                             scanPipes(
                                                     (IMetaTileEntityItemPipe) tMetaTileEntity,
                                                     aMap,

--- a/src/main/java/gregtech/api/interfaces/metatileentity/IMetaTileEntityItemPipe.java
+++ b/src/main/java/gregtech/api/interfaces/metatileentity/IMetaTileEntityItemPipe.java
@@ -1,11 +1,11 @@
 package gregtech.api.interfaces.metatileentity;
 
+import static gregtech.api.enums.GT_Values.ALL_VALID_SIDES;
+
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.BaseMetaPipeEntity;
 import gregtech.api.util.GT_Utility;
 import java.util.Map;
-
-import static gregtech.api.enums.GT_Values.ALL_VALID_SIDES;
 
 public interface IMetaTileEntityItemPipe extends IMetaTileEntity {
     /**
@@ -78,7 +78,9 @@ public interface IMetaTileEntityItemPipe extends IMetaTileEntity {
                                 if (tItemPipe instanceof BaseMetaPipeEntity) {
                                     final IMetaTileEntity tMetaTileEntity = tItemPipe.getMetaTileEntity();
                                     if (tMetaTileEntity instanceof IMetaTileEntityItemPipe
-                                            && tItemPipe.getCoverInfoAtSide(oppositeSide).letsItemsOut(-2)) {
+                                            && tItemPipe
+                                                    .getCoverInfoAtSide(oppositeSide)
+                                                    .letsItemsOut(-2)) {
                                         scanPipes(
                                                 (IMetaTileEntityItemPipe) tMetaTileEntity,
                                                 aMap,

--- a/src/main/java/gregtech/api/interfaces/metatileentity/IMetaTileEntityItemPipe.java
+++ b/src/main/java/gregtech/api/interfaces/metatileentity/IMetaTileEntityItemPipe.java
@@ -5,6 +5,8 @@ import gregtech.api.metatileentity.BaseMetaPipeEntity;
 import gregtech.api.util.GT_Utility;
 import java.util.Map;
 
+import static gregtech.api.enums.GT_Values.ALL_VALID_SIDES;
+
 public interface IMetaTileEntityItemPipe extends IMetaTileEntity {
     /**
      * @return if this Pipe can still be used.
@@ -58,14 +60,15 @@ public interface IMetaTileEntityItemPipe extends IMetaTileEntity {
                 if (aMap.get(aMetaTileEntity) == null || aMap.get(aMetaTileEntity) > aStep) {
                     final IGregTechTileEntity aBaseMetaTileEntity = aMetaTileEntity.getBaseMetaTileEntity();
                     aMap.put(aMetaTileEntity, aStep);
-                    for (byte i = 0, j = 0; i < 6; i++) {
+                    byte oppositeSide;
+                    for (byte side : ALL_VALID_SIDES) {
                         if (aMetaTileEntity instanceof IConnectable
-                                && !((IConnectable) aMetaTileEntity).isConnectedAtSide(i)) continue;
-                        j = GT_Utility.getOppositeSide(i);
+                                && !((IConnectable) aMetaTileEntity).isConnectedAtSide(side)) continue;
+                        oppositeSide = GT_Utility.getOppositeSide(side);
                         if (aSuckItems) {
-                            if (aBaseMetaTileEntity.getCoverInfoAtSide(i).letsItemsIn(-2)) {
+                            if (aBaseMetaTileEntity.getCoverInfoAtSide(side).letsItemsIn(-2)) {
                                 final IGregTechTileEntity tItemPipe =
-                                        aBaseMetaTileEntity.getIGregTechTileEntityAtSide(i);
+                                        aBaseMetaTileEntity.getIGregTechTileEntityAtSide(side);
                                 if (aBaseMetaTileEntity.getColorization() >= 0) {
                                     final byte tColor = tItemPipe.getColorization();
                                     if (tColor >= 0 && tColor != aBaseMetaTileEntity.getColorization()) {
@@ -75,7 +78,7 @@ public interface IMetaTileEntityItemPipe extends IMetaTileEntity {
                                 if (tItemPipe instanceof BaseMetaPipeEntity) {
                                     final IMetaTileEntity tMetaTileEntity = tItemPipe.getMetaTileEntity();
                                     if (tMetaTileEntity instanceof IMetaTileEntityItemPipe
-                                            && tItemPipe.getCoverInfoAtSide(j).letsItemsOut(-2)) {
+                                            && tItemPipe.getCoverInfoAtSide(oppositeSide).letsItemsOut(-2)) {
                                         scanPipes(
                                                 (IMetaTileEntityItemPipe) tMetaTileEntity,
                                                 aMap,
@@ -86,9 +89,9 @@ public interface IMetaTileEntityItemPipe extends IMetaTileEntity {
                                 }
                             }
                         } else {
-                            if (aBaseMetaTileEntity.getCoverInfoAtSide(i).letsItemsOut(-2)) {
+                            if (aBaseMetaTileEntity.getCoverInfoAtSide(side).letsItemsOut(-2)) {
                                 final IGregTechTileEntity tItemPipe =
-                                        aBaseMetaTileEntity.getIGregTechTileEntityAtSide(i);
+                                        aBaseMetaTileEntity.getIGregTechTileEntityAtSide(side);
                                 if (tItemPipe != null) {
                                     if (aBaseMetaTileEntity.getColorization() >= 0) {
                                         final byte tColor = tItemPipe.getColorization();
@@ -100,7 +103,7 @@ public interface IMetaTileEntityItemPipe extends IMetaTileEntity {
                                         final IMetaTileEntity tMetaTileEntity = tItemPipe.getMetaTileEntity();
                                         if (tMetaTileEntity instanceof IMetaTileEntityItemPipe
                                                 && tItemPipe
-                                                        .getCoverInfoAtSide(i)
+                                                        .getCoverInfoAtSide(oppositeSide)
                                                         .letsItemsIn(-2)) {
                                             scanPipes(
                                                     (IMetaTileEntityItemPipe) tMetaTileEntity,

--- a/src/main/java/gregtech/api/interfaces/tileentity/ICoverable.java
+++ b/src/main/java/gregtech/api/interfaces/tileentity/ICoverable.java
@@ -3,6 +3,7 @@ package gregtech.api.interfaces.tileentity;
 import gregtech.api.util.GT_CoverBehavior;
 import gregtech.api.util.GT_CoverBehaviorBase;
 import gregtech.api.util.ISerializableObject;
+import gregtech.common.covers.CoverInfo;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 
@@ -31,6 +32,10 @@ public interface ICoverable extends IRedstoneTileEntity, IHasInventory, IBasicEn
 
     @Deprecated
     int getCoverDataAtSide(byte aSide);
+
+    default CoverInfo getCoverInfoAtSide(byte aSide) {
+        return null;
+    }
 
     default ISerializableObject getComplexCoverDataAtSide(byte aSide) {
         return new ISerializableObject.LegacyCoverData(getCoverDataAtSide(aSide));

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
@@ -41,6 +41,7 @@ import gregtech.api.net.GT_Packet_TileEntity;
 import gregtech.api.objects.GT_ItemStack;
 import gregtech.api.util.*;
 import gregtech.common.GT_Pollution;
+import gregtech.common.covers.CoverInfo;
 import ic2.api.Direction;
 import java.lang.reflect.Field;
 import java.util.*;
@@ -1240,8 +1241,7 @@ public class BaseMetaTileEntity extends CommonMetaTileEntity
 
     private boolean isEnergyInputSide(byte aSide) {
         if (aSide >= 0 && aSide < 6) {
-            if (!getCoverBehaviorAtSideNew(aSide)
-                    .letsEnergyIn(aSide, getCoverIDAtSide(aSide), getComplexCoverDataAtSide(aSide), this)) return false;
+            if (!getCoverInfoAtSide(aSide).letsEnergyIn()) return false;
             if (isInvalid() || mReleaseEnergy) return false;
             if (canAccessData() && mMetaTileEntity.isElectric() && mMetaTileEntity.isEnetInput())
                 return mMetaTileEntity.isInputFacing(aSide);
@@ -1251,9 +1251,7 @@ public class BaseMetaTileEntity extends CommonMetaTileEntity
 
     private boolean isEnergyOutputSide(byte aSide) {
         if (aSide >= 0 && aSide < 6) {
-            if (!getCoverBehaviorAtSideNew(aSide)
-                    .letsEnergyOut(aSide, getCoverIDAtSide(aSide), getComplexCoverDataAtSide(aSide), this))
-                return false;
+            if (!getCoverInfoAtSide(aSide).letsEnergyOut()) return false;
             if (isInvalid() || mReleaseEnergy) return mReleaseEnergy;
             if (canAccessData() && mMetaTileEntity.isElectric() && mMetaTileEntity.isEnetOutput())
                 return mMetaTileEntity.isOutputFacing(aSide);
@@ -1448,9 +1446,7 @@ public class BaseMetaTileEntity extends CommonMetaTileEntity
                 return true;
             }
 
-            if (!getCoverBehaviorAtSideNew(aSide)
-                    .isGUIClickable(aSide, getCoverIDAtSide(aSide), getComplexCoverDataAtSide(aSide), this))
-                return false;
+            if (!getCoverInfoAtSide(aSide).isGUIClickable()) return false;
         }
 
         if (isServerSide()) {
@@ -1637,9 +1633,7 @@ public class BaseMetaTileEntity extends CommonMetaTileEntity
                                 aY,
                                 aZ)) return true;
 
-                if (!getCoverBehaviorAtSideNew(aSide)
-                        .isGUIClickable(aSide, getCoverIDAtSide(aSide), getComplexCoverDataAtSide(aSide), this))
-                    return false;
+                if (!getCoverInfoAtSide(aSide).isGUIClickable()) return false;
 
                 if (isUpgradable() && tCurrentItem != null) {
                     if (ItemList.Upgrade_Muffler.isStackEqual(aPlayer.inventory.getCurrentItem())) {
@@ -1726,21 +1720,9 @@ public class BaseMetaTileEntity extends CommonMetaTileEntity
      */
     @Override
     public int[] getAccessibleSlotsFromSide(int aSide) {
-        if (canAccessData()
-                && (getCoverBehaviorAtSideNew((byte) aSide)
-                                .letsItemsOut(
-                                        (byte) aSide,
-                                        getCoverIDAtSide((byte) aSide),
-                                        getComplexCoverDataAtSide((byte) aSide),
-                                        -1,
-                                        this)
-                        || getCoverBehaviorAtSideNew((byte) aSide)
-                                .letsItemsIn(
-                                        (byte) aSide,
-                                        getCoverIDAtSide((byte) aSide),
-                                        getComplexCoverDataAtSide((byte) aSide),
-                                        -1,
-                                        this))) return mMetaTileEntity.getAccessibleSlotsFromSide(aSide);
+        final CoverInfo coverInfo = getCoverInfoAtSide((byte) aSide);
+        if (canAccessData() && (coverInfo.letsItemsOut(-1) || coverInfo.letsItemsIn(-1)))
+            return mMetaTileEntity.getAccessibleSlotsFromSide(aSide);
         return GT_Values.emptyIntArray;
     }
 
@@ -1751,13 +1733,7 @@ public class BaseMetaTileEntity extends CommonMetaTileEntity
     public boolean canInsertItem(int aIndex, ItemStack aStack, int aSide) {
         return canAccessData()
                 && (mRunningThroughTick || !mInputDisabled)
-                && getCoverBehaviorAtSideNew((byte) aSide)
-                        .letsItemsIn(
-                                (byte) aSide,
-                                getCoverIDAtSide((byte) aSide),
-                                getComplexCoverDataAtSide((byte) aSide),
-                                aIndex,
-                                this)
+                && getCoverInfoAtSide((byte) aSide).letsItemsIn(aIndex)
                 && mMetaTileEntity.canInsertItem(aIndex, aStack, aSide);
     }
 
@@ -1988,13 +1964,9 @@ public class BaseMetaTileEntity extends CommonMetaTileEntity
                 && (mRunningThroughTick || !mInputDisabled)
                 && (aSide == ForgeDirection.UNKNOWN
                         || (mMetaTileEntity.isLiquidInput((byte) aSide.ordinal())
-                                && getCoverBehaviorAtSideNew((byte) aSide.ordinal())
-                                        .letsFluidIn(
-                                                (byte) aSide.ordinal(),
-                                                getCoverIDAtSide((byte) aSide.ordinal()),
-                                                getComplexCoverDataAtSide((byte) aSide.ordinal()),
-                                                aFluid == null ? null : aFluid.getFluid(),
-                                                this)))) return mMetaTileEntity.fill(aSide, aFluid, doFill);
+                                && getCoverInfoAtSide((byte) aSide.ordinal())
+                                        .letsFluidIn(aFluid == null ? null : aFluid.getFluid()))))
+            return mMetaTileEntity.fill(aSide, aFluid, doFill);
         return 0;
     }
 
@@ -2005,17 +1977,14 @@ public class BaseMetaTileEntity extends CommonMetaTileEntity
                 && (mRunningThroughTick || !mOutputDisabled)
                 && (aSide == ForgeDirection.UNKNOWN
                         || (mMetaTileEntity.isLiquidOutput((byte) aSide.ordinal())
-                                && getCoverBehaviorAtSideNew((byte) aSide.ordinal())
+                                && getCoverInfoAtSide((byte) aSide.ordinal())
                                         .letsFluidOut(
-                                                (byte) aSide.ordinal(),
-                                                getCoverIDAtSide((byte) aSide.ordinal()),
-                                                getComplexCoverDataAtSide((byte) aSide.ordinal()),
                                                 mMetaTileEntity.getFluid() == null
                                                         ? null
                                                         : mMetaTileEntity
                                                                 .getFluid()
-                                                                .getFluid(),
-                                                this)))) return mMetaTileEntity.drain(aSide, maxDrain, doDrain);
+                                                                .getFluid()))))
+            return mMetaTileEntity.drain(aSide, maxDrain, doDrain);
         return null;
     }
 
@@ -2026,13 +1995,9 @@ public class BaseMetaTileEntity extends CommonMetaTileEntity
                 && (mRunningThroughTick || !mOutputDisabled)
                 && (aSide == ForgeDirection.UNKNOWN
                         || (mMetaTileEntity.isLiquidOutput((byte) aSide.ordinal())
-                                && getCoverBehaviorAtSideNew((byte) aSide.ordinal())
-                                        .letsFluidOut(
-                                                (byte) aSide.ordinal(),
-                                                getCoverIDAtSide((byte) aSide.ordinal()),
-                                                getComplexCoverDataAtSide((byte) aSide.ordinal()),
-                                                aFluid == null ? null : aFluid.getFluid(),
-                                                this)))) return mMetaTileEntity.drain(aSide, aFluid, doDrain);
+                                && getCoverInfoAtSide((byte) aSide.ordinal())
+                                        .letsFluidOut(aFluid == null ? null : aFluid.getFluid()))))
+            return mMetaTileEntity.drain(aSide, aFluid, doDrain);
         return null;
     }
 
@@ -2043,13 +2008,8 @@ public class BaseMetaTileEntity extends CommonMetaTileEntity
                 && (mRunningThroughTick || !mInputDisabled)
                 && (aSide == ForgeDirection.UNKNOWN
                         || (mMetaTileEntity.isLiquidInput((byte) aSide.ordinal())
-                                && getCoverBehaviorAtSideNew((byte) aSide.ordinal())
-                                        .letsFluidIn(
-                                                (byte) aSide.ordinal(),
-                                                getCoverIDAtSide((byte) aSide.ordinal()),
-                                                getComplexCoverDataAtSide((byte) aSide.ordinal()),
-                                                aFluid,
-                                                this)))) return mMetaTileEntity.canFill(aSide, aFluid);
+                                && getCoverInfoAtSide((byte) aSide.ordinal()).letsFluidIn(aFluid))))
+            return mMetaTileEntity.canFill(aSide, aFluid);
         return false;
     }
 
@@ -2060,13 +2020,8 @@ public class BaseMetaTileEntity extends CommonMetaTileEntity
                 && (mRunningThroughTick || !mOutputDisabled)
                 && (aSide == ForgeDirection.UNKNOWN
                         || (mMetaTileEntity.isLiquidOutput((byte) aSide.ordinal())
-                                && getCoverBehaviorAtSideNew((byte) aSide.ordinal())
-                                        .letsFluidOut(
-                                                (byte) aSide.ordinal(),
-                                                getCoverIDAtSide((byte) aSide.ordinal()),
-                                                getComplexCoverDataAtSide((byte) aSide.ordinal()),
-                                                aFluid,
-                                                this)))) return mMetaTileEntity.canDrain(aSide, aFluid);
+                                && getCoverInfoAtSide((byte) aSide.ordinal()).letsFluidOut(aFluid))))
+            return mMetaTileEntity.canDrain(aSide, aFluid);
         return false;
     }
 
@@ -2077,21 +2032,10 @@ public class BaseMetaTileEntity extends CommonMetaTileEntity
         if (canAccessData()
                 && (aSide == ForgeDirection.UNKNOWN
                         || (mMetaTileEntity.isLiquidInput(tSide)
-                                && getCoverBehaviorAtSideNew(tSide)
-                                        .letsFluidIn(
-                                                tSide,
-                                                getCoverIDAtSide(tSide),
-                                                getComplexCoverDataAtSide(tSide),
-                                                null,
-                                                this))
+                                && getCoverInfoAtSide(tSide).letsFluidIn(null))
                         || (mMetaTileEntity.isLiquidOutput(tSide)
-                                && getCoverBehaviorAtSideNew(tSide)
-                                        .letsFluidOut(
-                                                tSide,
-                                                getCoverIDAtSide(tSide),
-                                                getComplexCoverDataAtSide(tSide),
-                                                null,
-                                                this)))) return mMetaTileEntity.getTankInfo(aSide);
+                                && getCoverInfoAtSide(tSide).letsFluidOut(null))))
+            return mMetaTileEntity.getTankInfo(aSide);
         return new FluidTankInfo[] {};
     }
 

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
@@ -1,6 +1,7 @@
 package gregtech.api.metatileentity;
 
 import static gregtech.GT_Mod.GT_FML_LOGGER;
+import static gregtech.api.enums.GT_Values.ALL_VALID_SIDES;
 import static gregtech.api.enums.GT_Values.NW;
 import static gregtech.api.enums.GT_Values.V;
 import static gregtech.api.objects.XSTR.XSTR_INSTANCE;
@@ -215,8 +216,6 @@ public class BaseMetaTileEntity extends CommonMetaTileEntity
             loadMetaTileNBT(aNBT);
         }
 
-        if (mCoverData == null || mCoverData.length != 6) mCoverData = new ISerializableObject[6];
-        if (mCoverSides.length != 6) mCoverSides = new int[] {0, 0, 0, 0, 0, 0};
         if (mSidedRedstone.length != 6)
             if (hasValidMetaTileEntity() && mMetaTileEntity.hasSidedRedstoneOutputBehavior())
                 mSidedRedstone = new byte[] {0, 0, 0, 0, 0, 0};
@@ -375,7 +374,7 @@ public class BaseMetaTileEntity extends CommonMetaTileEntity
                         }
 
                         if (mMetaTileEntity.isEnetOutput() || mMetaTileEntity.isEnetInput()) {
-                            for (byte i = 0; i < 6; i++) {
+                            for (byte i : ALL_VALID_SIDES) {
                                 boolean temp = isEnergyInputSide(i);
                                 if (temp != mActiveEUInputs[i]) {
                                     mActiveEUInputs[i] = temp;
@@ -645,12 +644,12 @@ public class BaseMetaTileEntity extends CommonMetaTileEntity
                             (short) yCoord,
                             zCoord,
                             mID,
-                            mCoverSides[0],
-                            mCoverSides[1],
-                            mCoverSides[2],
-                            mCoverSides[3],
-                            mCoverSides[4],
-                            mCoverSides[5],
+                            getCoverInfoAtSide((byte) 0).getCoverID(),
+                            getCoverInfoAtSide((byte) 1).getCoverID(),
+                            getCoverInfoAtSide((byte) 2).getCoverID(),
+                            getCoverInfoAtSide((byte) 3).getCoverID(),
+                            getCoverInfoAtSide((byte) 4).getCoverID(),
+                            getCoverInfoAtSide((byte) 5).getCoverID(),
                             oTextureData = (byte) ((mFacing & 7)
                                     | (mActive ? 8 : 0)
                                     | (mRedstone ? 16 : 0)
@@ -1136,7 +1135,7 @@ public class BaseMetaTileEntity extends CommonMetaTileEntity
     public void generatePowerNodes() {
         if (isServerSide() && (isEnetInput() || isEnetOutput())) {
             final int time = MinecraftServer.getServer().getTickCounter();
-            for (byte i = 0; i < 6; i++) {
+            for (byte i : ALL_VALID_SIDES) {
                 if (outputsEnergyTo(i, false) || inputEnergyFrom(i, false)) {
                     final IGregTechTileEntity TE = getIGregTechTileEntityAtSide(i);
                     if (TE instanceof BaseMetaPipeEntity) {

--- a/src/main/java/gregtech/api/metatileentity/CoverableTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/CoverableTileEntity.java
@@ -1,5 +1,6 @@
 package gregtech.api.metatileentity;
 
+import static gregtech.GT_Mod.GT_FML_LOGGER;
 import static gregtech.api.enums.GT_Values.ALL_VALID_SIDES;
 import static gregtech.api.enums.GT_Values.E;
 import static gregtech.api.enums.GT_Values.NW;
@@ -34,6 +35,7 @@ import gregtech.api.util.GT_CoverBehavior;
 import gregtech.api.util.GT_CoverBehaviorBase;
 import gregtech.api.util.ISerializableObject;
 import gregtech.common.GT_Client;
+import gregtech.common.covers.CoverInfo;
 import gregtech.common.covers.GT_Cover_Fluidfilter;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -49,6 +51,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.StatCollector;
@@ -61,6 +64,16 @@ public abstract class CoverableTileEntity extends BaseTileEntity implements ICov
             .mapToInt(Enum::ordinal)
             .mapToObj(i -> "mCoverData" + i)
             .toArray(String[]::new);
+
+    // New Cover Information
+    protected final CoverInfo[] coverInfos = new CoverInfo[] {null, null, null, null, null, null};
+
+    protected byte[] mSidedRedstone = new byte[] {15, 15, 15, 15, 15, 15};
+    protected boolean mRedstone = false;
+    protected byte mStrongRedstone = 0;
+
+    /* Deprecated Cover Variables */
+    @Deprecated
     protected final GT_CoverBehaviorBase<?>[] mCoverBehaviors = new GT_CoverBehaviorBase<?>[] {
         GregTech_API.sNoBehavior,
         GregTech_API.sNoBehavior,
@@ -69,26 +82,29 @@ public abstract class CoverableTileEntity extends BaseTileEntity implements ICov
         GregTech_API.sNoBehavior,
         GregTech_API.sNoBehavior
     };
-    protected byte[] mSidedRedstone = new byte[] {15, 15, 15, 15, 15, 15};
-    protected boolean mRedstone = false;
-    protected byte mStrongRedstone = 0;
-
+    @Deprecated
     protected int[] mCoverSides = new int[] {0, 0, 0, 0, 0, 0};
+
+    @Deprecated
     protected ISerializableObject[] mCoverData = new ISerializableObject[6];
+
+    @Deprecated
     protected final boolean[] mCoverNeedUpdate = new boolean[] {false, false, false, false, false, false};
+    /* End Deprecated Cover Variables */
+
     protected short mID = 0;
     public long mTickTimer = 0;
 
     protected void writeCoverNBT(NBTTagCompound aNBT, boolean isDrop) {
-        boolean hasCover = false;
-        for (int i = 0; i < mCoverData.length; i++) {
-            if (mCoverSides[i] != 0 && mCoverData[i] != null) {
-                aNBT.setTag(COVER_DATA_NBT_KEYS[i], mCoverData[i].saveDataToNBT());
-                hasCover = true;
-            }
+        final NBTTagList tList = new NBTTagList();
+        for (byte i = 0; i < coverInfos.length; i++) {
+            final CoverInfo coverInfo = getCoverInfoAtSide(i);
+            if (!coverInfo.isValid()) continue;
+            tList.appendTag(coverInfo.writeToNBT(new NBTTagCompound()));
         }
+        if (tList.tagCount() > 0) aNBT.setTag(GT_Values.NBT.COVERS, tList);
+
         if (mStrongRedstone > 0) aNBT.setByte("mStrongRedstone", mStrongRedstone);
-        if (hasCover) aNBT.setIntArray("mCoverSides", mCoverSides);
 
         if (!isDrop) {
             aNBT.setByteArray("mRedstoneSided", mSidedRedstone);
@@ -97,40 +113,64 @@ public abstract class CoverableTileEntity extends BaseTileEntity implements ICov
     }
 
     protected void readCoverNBT(NBTTagCompound aNBT) {
-        mCoverSides = aNBT.hasKey("mCoverSides") ? aNBT.getIntArray("mCoverSides") : new int[] {0, 0, 0, 0, 0, 0};
         mRedstone = aNBT.getBoolean("mRedstone");
         mSidedRedstone = aNBT.hasKey("mRedstoneSided")
                 ? aNBT.getByteArray("mRedstoneSided")
                 : new byte[] {15, 15, 15, 15, 15, 15};
         mStrongRedstone = aNBT.getByte("mStrongRedstone");
 
-        for (byte i = 0; i < 6; i++) mCoverBehaviors[i] = GregTech_API.getCoverBehaviorNew(mCoverSides[i]);
+        if (aNBT.hasKey(GT_Values.NBT.COVERS)) {
+            readCoverInfoNBT(aNBT);
+        }
+        else if (aNBT.hasKey("mCoverSides")) {
+            readLegacyCoverInfoNBT(aNBT);
+        }
+    }
 
-        // check old form of data
-        mCoverData = new ISerializableObject[6];
-        if (aNBT.hasKey("mCoverData", 11) && aNBT.getIntArray("mCoverData").length == 6) {
-            final int[] tOldData = aNBT.getIntArray("mCoverData");
-            for (int i = 0; i < tOldData.length; i++) {
-                if (mCoverBehaviors[i] instanceof GT_Cover_Fluidfilter) {
+    public void readCoverInfoNBT(NBTTagCompound aNBT) {
+        final NBTTagList tList = aNBT.getTagList(GT_Values.NBT.COVERS, 10);
+        for (byte i = 0; i < tList.tagCount(); i++) {
+            final NBTTagCompound tNBT = tList.getCompoundTagAt(i);
+            final CoverInfo coverInfo = new CoverInfo(this, tNBT);
+            this.setCoverInfoAtSide(coverInfo.getSide(), coverInfo);
+            if (coverInfo.isDataNeededOnClient()) issueCoverUpdate(i);
+        }
+    }
+
+    public void readLegacyCoverInfoNBT(NBTTagCompound aNBT) {
+        final int[] coverIDs =
+                aNBT.hasKey("mCoverSides") ? aNBT.getIntArray("mCoverSides") : new int[] {0, 0, 0, 0, 0, 0};
+        final boolean hasOldCoverData = (aNBT.hasKey("mCoverData", 11) && aNBT.getIntArray("mCoverData").length == 6);
+        final int[] tOldData = hasOldCoverData ? aNBT.getIntArray("mCoverData") : new int[] {};
+
+        for (byte i : ALL_VALID_SIDES) {
+            if (coverIDs[i] == 0) continue;
+
+            final CoverInfo coverInfo = new CoverInfo(i, coverIDs[i], this, null);
+            final GT_CoverBehaviorBase<?> coverBehavior = coverInfo.getCoverBehavior();
+            if (coverBehavior == GregTech_API.sNoBehavior) continue;
+
+            ISerializableObject coverData = null;
+            if (hasOldCoverData) {
+                if (coverBehavior instanceof GT_Cover_Fluidfilter) {
                     final String filterKey = String.format("fluidFilter%d", i);
                     if (aNBT.hasKey(filterKey)) {
-                        mCoverData[i] = mCoverBehaviors[i].createDataObject(
-                                (tOldData[i] & 7) | (FluidRegistry.getFluidID(aNBT.getString(filterKey)) << 3));
+                        coverData = coverInfo
+                                .getCoverBehavior()
+                                .createDataObject(
+                                        (tOldData[i] & 7) | (FluidRegistry.getFluidID(aNBT.getString(filterKey)) << 3));
                     }
-                } else if (mCoverBehaviors[i] != null && mCoverBehaviors[i] != GregTech_API.sNoBehavior) {
-                    mCoverData[i] = mCoverBehaviors[i].createDataObject(tOldData[i]);
+                } else {
+                    coverData = coverBehavior.createDataObject(tOldData[i]);
                 }
-            }
-        } else {
-            // no old data
-            for (byte i = 0; i < 6; i++) {
-                if (mCoverBehaviors[i] == null) continue;
+            } else {
                 if (aNBT.hasKey(COVER_DATA_NBT_KEYS[i]))
-                    mCoverData[i] = mCoverBehaviors[i].createDataObject(aNBT.getTag(COVER_DATA_NBT_KEYS[i]));
-                else mCoverData[i] = mCoverBehaviors[i].createDataObject();
-                if (mCoverBehaviors[i].isDataNeededOnClient(i, mCoverSides[i], mCoverData[i], this))
-                    issueCoverUpdate(i);
+                    coverData = coverBehavior.createDataObject(aNBT.getTag(COVER_DATA_NBT_KEYS[i]));
             }
+
+            if (coverData != null) coverInfo.setCoverData(coverData);
+            setCoverInfoAtSide(i, coverInfo);
+            if (coverInfo.isDataNeededOnClient()) issueCoverUpdate(i);
         }
     }
 
@@ -147,33 +187,36 @@ public abstract class CoverableTileEntity extends BaseTileEntity implements ICov
         return tickCoverAtSide(aSide, mTickTimer);
     }
 
+    /**
+     * Returns false if the cover/tile is no longer valid
+     */
     public boolean tickCoverAtSide(byte aSide, long aTickTimer) {
-        final int coverId = getCoverIDAtSide(aSide);
-        if (coverId == 0) return false;
-        final ISerializableObject coverData = mCoverData[aSide];
-        final GT_CoverBehaviorBase<?> tCover = getCoverBehaviorAtSideNew(aSide);
-        final int tCoverTickRate = tCover.getTickRate(aSide, coverId, coverData, this);
-
-        if (tCoverTickRate > 0 && mTickTimer % tCoverTickRate == 0) {
-            final byte tRedstone = tCover.isRedstoneSensitive(aSide, coverId, coverData, this, aTickTimer)
-                    ? getInputRedstoneSignal(aSide)
-                    : 0;
-            mCoverData[aSide] = tCover.doCoverThings(aSide, tRedstone, coverId, coverData, this, aTickTimer);
-            if (!isStillValid()) return false;
+        final CoverInfo coverInfo = getCoverInfoAtSide(aSide);
+        if (!coverInfo.isValid()) return true;
+        final int tCoverTickRate = coverInfo.getTickRate();
+        if (tCoverTickRate > 0 && aTickTimer % tCoverTickRate == 0) {
+            final byte tRedstone = coverInfo.isRedstoneSensitive(aTickTimer) ? getInputRedstoneSignal(aSide) : 0;
+            coverInfo.setCoverData(coverInfo.doCoverThings(aTickTimer, tRedstone));
+            return isStillValid();
         }
+
         return true;
     }
 
     public abstract boolean allowCoverOnSide(byte aSide, GT_ItemStack aCoverID);
 
     protected void checkDropCover() {
-        for (byte i : ALL_VALID_SIDES)
-            if (getCoverIDAtSide(i) != 0)
-                if (!allowCoverOnSide(i, new GT_ItemStack(getCoverIDAtSide(i)))) dropCover(i, i, true);
+        for (byte i : ALL_VALID_SIDES) {
+            final int coverId = getCoverIDAtSide(i);
+            if (coverId != 0) if (!allowCoverOnSide(i, new GT_ItemStack(coverId))) dropCover(i, i, true);
+        }
     }
 
     protected void updateCoverBehavior() {
-        for (byte i : ALL_VALID_SIDES) mCoverBehaviors[i] = GregTech_API.getCoverBehaviorNew(mCoverSides[i]);
+        for (byte i : ALL_VALID_SIDES) {
+            final CoverInfo coverInfo = getCoverInfoAtSide(i);
+            if (coverInfo.isValid()) coverInfo.updateCoverBehavior();
+        }
     }
 
     @Override
@@ -181,32 +224,20 @@ public abstract class CoverableTileEntity extends BaseTileEntity implements ICov
         // If we've got a null worldObj we're getting called as a part of readingNBT from a non tickable MultiTileEntity
         // on chunk load before the world is set
         // so we'll want to send a cover update.
-        if (worldObj == null
-                || (isServerSide()
-                        && getCoverBehaviorAtSideNew(aSide)
-                                .isDataNeededOnClient(
-                                        aSide, getCoverIDAtSide(aSide), getComplexCoverDataAtSide(aSide), this)))
-            mCoverNeedUpdate[aSide] = true;
+        final CoverInfo coverInfo = getCoverInfoAtSide(aSide);
+        if (worldObj == null || (isServerSide() && coverInfo.isDataNeededOnClient())) coverInfo.setNeedsUpdate(true);
     }
 
     public final ITexture getCoverTexture(byte aSide) {
-        if (getCoverIDAtSide(aSide) == 0) return null;
+        final CoverInfo coverInfo = getCoverInfoAtSide(aSide);
+        if (!coverInfo.isValid()) return null;
         if (GT_Mod.instance.isClientSide() && (GT_Client.hideValue & 0x1) != 0) {
             return Textures.BlockIcons.HIDDEN_TEXTURE[0]; // See through
         }
-        GT_CoverBehaviorBase<?> coverBehavior = getCoverBehaviorAtSideNew(aSide);
-        final ITexture coverTexture;
-        if (coverBehavior != null) {
-            if (!(this instanceof BaseMetaPipeEntity)) {
-                coverTexture = coverBehavior.getSpecialCoverFGTexture(
-                        aSide, getCoverIDAtSide(aSide), getComplexCoverDataAtSide(aSide), this);
-            } else {
-                coverTexture = coverBehavior.getSpecialCoverTexture(
-                        aSide, getCoverIDAtSide(aSide), getComplexCoverDataAtSide(aSide), this);
-            }
-        } else {
-            coverTexture = null;
-        }
+        final ITexture coverTexture = (!(this instanceof BaseMetaPipeEntity))
+                ? coverInfo.getSpecialCoverFGTexture()
+                : coverInfo.getSpecialCoverTexture();
+
         return coverTexture != null
                 ? coverTexture
                 : GregTech_API.sCovers.get(new GT_ItemStack(getCoverIDAtSide(aSide)));
@@ -215,16 +246,15 @@ public abstract class CoverableTileEntity extends BaseTileEntity implements ICov
     protected void requestCoverDataIfNeeded() {
         if (worldObj == null || !worldObj.isRemote) return;
         for (byte i : ALL_VALID_SIDES) {
-            if (getCoverBehaviorAtSideNew(i)
-                    .isDataNeededOnClient(i, getCoverIDAtSide(i), getComplexCoverDataAtSide(i), this))
-                NW.sendToServer(new GT_Packet_RequestCoverData(i, getCoverIDAtSide(i), this));
+            final CoverInfo coverInfo = getCoverInfoAtSide(i);
+            if (coverInfo.isDataNeededOnClient())
+                NW.sendToServer(new GT_Packet_RequestCoverData(coverInfo, this));
         }
     }
 
     @Override
     public void setCoverIdAndDataAtSide(byte aSide, int aId, ISerializableObject aData) {
-        if (setCoverIDAtSideNoUpdate(aSide, aId)) {
-            setCoverDataAtSide(aSide, aData);
+        if (setCoverIDAtSideNoUpdate(aSide, aId, aData)) {
             issueCoverUpdate(aSide);
             issueBlockUpdate();
         }
@@ -232,20 +262,19 @@ public abstract class CoverableTileEntity extends BaseTileEntity implements ICov
 
     @Override
     public void setCoverIDAtSide(byte aSide, int aID) {
-        if (setCoverIDAtSideNoUpdate(aSide, aID)) {
-            issueCoverUpdate(aSide);
-            issueBlockUpdate();
-        }
+        setCoverIdAndDataAtSide(aSide, aID, null);
     }
 
     @Override
     public boolean setCoverIDAtSideNoUpdate(byte aSide, int aID) {
-        if (aSide >= 0 && aSide < 6 && mCoverSides[aSide] != aID) {
-            if (aID == 0 && isClientSide())
-                mCoverBehaviors[aSide].onDropped(aSide, mCoverSides[aSide], mCoverData[aSide], this);
-            mCoverSides[aSide] = aID;
-            mCoverBehaviors[aSide] = GregTech_API.getCoverBehaviorNew(aID);
-            mCoverData[aSide] = mCoverBehaviors[aSide].createDataObject();
+        return setCoverIDAtSideNoUpdate(aSide, aID, null);
+    }
+
+    public boolean setCoverIDAtSideNoUpdate(byte aSide, int aID, ISerializableObject aData) {
+        final CoverInfo oldCoverInfo = getCoverInfoAtSide(aSide);
+        if (aSide >= 0 && aSide < 6 && oldCoverInfo.getCoverID() != aID) {
+            if (aID == 0 && isClientSide()) oldCoverInfo.onDropped();
+            setCoverInfoAtSide(aSide, new CoverInfo(aSide, aID, this, aData));
             return true;
         }
         return false;
@@ -254,23 +283,24 @@ public abstract class CoverableTileEntity extends BaseTileEntity implements ICov
     @Override
     @Deprecated
     public void setCoverDataAtSide(byte aSide, int aData) {
-        if (aSide >= 0 && aSide < 6 && mCoverData[aSide] instanceof ISerializableObject.LegacyCoverData)
-            mCoverData[aSide] = new ISerializableObject.LegacyCoverData(aData);
+        final CoverInfo coverInfo = getCoverInfoAtSide(aSide);
+        if (coverInfo.isValid() && coverInfo.getCoverData() instanceof ISerializableObject.LegacyCoverData)
+            coverInfo.setCoverData(new ISerializableObject.LegacyCoverData(aData));
     }
 
     @Override
     public void setCoverDataAtSide(byte aSide, ISerializableObject aData) {
-        if (aSide >= 0
-                && aSide < 6
-                && getCoverBehaviorAtSideNew(aSide) != null
-                && getCoverBehaviorAtSideNew(aSide).cast(aData) != null) mCoverData[aSide] = aData;
+        final CoverInfo coverInfo = getCoverInfoAtSide(aSide);
+        if (coverInfo.isValid() && coverInfo.getCoverBehavior().cast(aData) != null)
+            coverInfo.setCoverData(aData);
     }
 
     @Override
     @Deprecated
     public GT_CoverBehavior getCoverBehaviorAtSide(byte aSide) {
-        if (aSide >= 0 && aSide < mCoverBehaviors.length && mCoverBehaviors[aSide] instanceof GT_CoverBehavior)
-            return (GT_CoverBehavior) mCoverBehaviors[aSide];
+        final GT_CoverBehaviorBase<?> behavior = getCoverInfoAtSide(aSide).getCoverBehavior();
+        if (behavior instanceof GT_CoverBehavior)
+            return (GT_CoverBehavior) behavior;
         return GregTech_API.sNoBehavior;
     }
 
@@ -281,14 +311,12 @@ public abstract class CoverableTileEntity extends BaseTileEntity implements ICov
 
     @Override
     public int getCoverIDAtSide(byte aSide) {
-        if (aSide >= 0 && aSide < 6) return mCoverSides[aSide];
-        return 0;
+        return getCoverInfoAtSide(aSide).getCoverID();
     }
 
     @Override
     public ItemStack getCoverItemAtSide(byte aSide) {
-        return getCoverBehaviorAtSideNew(aSide)
-                .getDisplayStack(getCoverIDAtSide(aSide), getComplexCoverDataAtSide(aSide));
+        return getCoverInfoAtSide(aSide).getDisplayStack();
     }
 
     @Override
@@ -304,57 +332,72 @@ public abstract class CoverableTileEntity extends BaseTileEntity implements ICov
     @Override
     @Deprecated
     public int getCoverDataAtSide(byte aSide) {
-        if (aSide >= 0 && aSide < 6 && mCoverData[aSide] instanceof ISerializableObject.LegacyCoverData)
-            return ((ISerializableObject.LegacyCoverData) mCoverData[aSide]).get();
+        final ISerializableObject coverData = getCoverInfoAtSide(aSide).getCoverData();
+        if (coverData instanceof ISerializableObject.LegacyCoverData) {
+            return ((ISerializableObject.LegacyCoverData) coverData).get();
+        }
         return 0;
     }
 
     @Override
     public ISerializableObject getComplexCoverDataAtSide(byte aSide) {
-        if (aSide >= 0 && aSide < 6 && getCoverBehaviorAtSideNew(aSide) != null) return mCoverData[aSide];
-        return GregTech_API.sNoBehavior.createDataObject();
+        return getCoverInfoAtSide(aSide).getCoverData();
     }
 
     @Override
     public GT_CoverBehaviorBase<?> getCoverBehaviorAtSideNew(byte aSide) {
-        if (aSide >= 0 && aSide < 6) return mCoverBehaviors[aSide];
-        return GregTech_API.sNoBehavior;
+        return getCoverInfoAtSide(aSide).getCoverBehavior();
+    }
+
+    public void setCoverInfoAtSide(byte aSide, CoverInfo coverInfo) {
+        if (aSide >= 0 && aSide < 6)
+            coverInfos[aSide] = coverInfo;
+    }
+
+    public CoverInfo getCoverInfoAtSide(byte aSide) {
+        if (aSide >= 0 && aSide < 6) {
+            if (coverInfos[aSide] == null)
+                coverInfos[aSide] = new CoverInfo(aSide, this);
+            return coverInfos[aSide];
+        }
+        return null;
+    }
+
+    public void clearCoverInfoAtSide(byte aSide) {
+        if (aSide >= 0 && aSide < 6) {
+            setCoverIDAtSide(aSide, 0);
+        }
     }
 
     @Override
     public boolean dropCover(byte aSide, byte aDroppedSide, boolean aForced) {
-        if (getCoverBehaviorAtSideNew(aSide)
-                        .onCoverRemoval(aSide, getCoverIDAtSide(aSide), mCoverData[aSide], this, aForced)
-                || aForced) {
-            final ItemStack tStack = getCoverBehaviorAtSideNew(aSide)
-                    .getDrop(aSide, getCoverIDAtSide(aSide), getComplexCoverDataAtSide(aSide), this);
-            if (tStack != null) {
-                getCoverBehaviorAtSideNew(aSide)
-                        .onDropped(aSide, getCoverIDAtSide(aSide), getComplexCoverDataAtSide(aSide), this);
-                final EntityItem tEntity = new EntityItem(
-                        worldObj,
-                        getOffsetX(aDroppedSide, 1) + 0.5,
-                        getOffsetY(aDroppedSide, 1) + 0.5,
-                        getOffsetZ(aDroppedSide, 1) + 0.5,
-                        tStack);
-                tEntity.motionX = 0;
-                tEntity.motionY = 0;
-                tEntity.motionZ = 0;
-                worldObj.spawnEntityInWorld(tEntity);
-            }
-            setCoverIDAtSide(aSide, 0);
-            updateOutputRedstoneSignal(aSide);
-
-            return true;
+        final CoverInfo coverInfo = getCoverInfoAtSide(aSide);
+        if (!coverInfo.isValid()) return false;
+        if (!coverInfo.onCoverRemoval(aForced) && !aForced) return false;
+        final ItemStack tStack = coverInfo.getDrop();
+        if (tStack != null) {
+            coverInfo.onDropped();
+            final EntityItem tEntity = new EntityItem(
+                    worldObj,
+                    getOffsetX(aDroppedSide, 1) + 0.5,
+                    getOffsetY(aDroppedSide, 1) + 0.5,
+                    getOffsetZ(aDroppedSide, 1) + 0.5,
+                    tStack);
+            tEntity.motionX = 0;
+            tEntity.motionY = 0;
+            tEntity.motionZ = 0;
+            worldObj.spawnEntityInWorld(tEntity);
         }
-        return false;
+        clearCoverInfoAtSide(aSide);
+        updateOutputRedstoneSignal(aSide);
+
+        return true;
     }
 
     protected void onBaseTEDestroyed() {
         for (byte side = 0; side < 6; ++side) {
-            GT_CoverBehaviorBase<?> behavior = getCoverBehaviorAtSideNew(side);
-            if (behavior != GregTech_API.sNoBehavior)
-                behavior.onBaseTEDestroyed(side, getCoverIDAtSide(side), mCoverData[side], this);
+            final CoverInfo coverInfo = getCoverInfoAtSide(side);
+            if (coverInfo.isValid()) coverInfo.onBaseTEDestroyed();
         }
     }
 
@@ -444,49 +487,37 @@ public abstract class CoverableTileEntity extends BaseTileEntity implements ICov
 
     @Override
     public void receiveCoverData(byte aCoverSide, int aCoverID, int aCoverData) {
-        if ((aCoverSide >= 0 && aCoverSide < 6)) {
-            GT_CoverBehaviorBase<?> behaviorBase = getCoverBehaviorAtSideNew(aCoverSide);
-            if (behaviorBase == GregTech_API.sNoBehavior) return;
+        if (aCoverSide < 0 || aCoverSide >= 6) return;
+        final CoverInfo oldCoverInfo = getCoverInfoAtSide(aCoverSide);
+        if(!oldCoverInfo.isValid()) return;
 
-            setCoverIDAtSideNoUpdate(aCoverSide, aCoverID);
-            setCoverDataAtSide(aCoverSide, aCoverData);
-        }
+        setCoverIDAtSideNoUpdate(aCoverSide, aCoverID);
+        setCoverDataAtSide(aCoverSide, aCoverData);
     }
 
     @Override
-    public void receiveCoverData(
-            byte aCoverSide, int aCoverID, ISerializableObject aCoverData, EntityPlayerMP aPlayer) {
-        if ((aCoverSide >= 0 && aCoverSide < 6)) {
-            GT_CoverBehaviorBase<?> behaviorBase = getCoverBehaviorAtSideNew(aCoverSide);
-            if (behaviorBase == GregTech_API.sNoBehavior) return;
+    public void receiveCoverData(byte aCoverSide, int aCoverID, ISerializableObject aCoverData, EntityPlayerMP aPlayer) {
+        if (aCoverSide < 0 || aCoverSide >= 6) return;
 
-            behaviorBase.preDataChanged(
-                    aCoverSide,
-                    getCoverIDAtSide(aCoverSide),
-                    aCoverID,
-                    getComplexCoverDataAtSide(aCoverSide),
-                    aCoverData,
-                    this);
+        final CoverInfo oldCoverInfo = getCoverInfoAtSide(aCoverSide);
 
-            setCoverIDAtSideNoUpdate(aCoverSide, aCoverID);
-            setCoverDataAtSide(aCoverSide, aCoverData);
-            if (isClientSide()) {
-                behaviorBase.onDataChanged(aCoverSide, aCoverID, aCoverData, this);
-            }
+        if(!oldCoverInfo.isValid()) return;
+        oldCoverInfo.preDataChanged(aCoverID, aCoverData);
+        setCoverIDAtSideNoUpdate(aCoverSide, aCoverID, aCoverData);
+
+        if (isClientSide()) {
+            getCoverInfoAtSide(aCoverSide).onDataChanged();
         }
     }
 
     protected void sendCoverDataIfNeeded() {
         if (worldObj == null || worldObj.isRemote) return;
-        final int mCoverNeedUpdateLength = mCoverNeedUpdate.length;
-        for (byte i = 0; i < mCoverNeedUpdateLength; i++) {
-            if (mCoverNeedUpdate[i]) {
+        for (byte i : ALL_VALID_SIDES) {
+            final CoverInfo coverInfo = getCoverInfoAtSide(i);
+            if (coverInfo.needsUpdate()) {
                 NW.sendPacketToAllPlayersInRange(
-                        worldObj,
-                        new GT_Packet_SendCoverData(i, getCoverIDAtSide(i), getComplexCoverDataAtSide(i), this),
-                        xCoord,
-                        zCoord);
-                mCoverNeedUpdate[i] = false;
+                        worldObj, new GT_Packet_SendCoverData(coverInfo, this), xCoord, zCoord);
+                coverInfo.setNeedsUpdate(false);
             }
         }
     }
@@ -497,31 +528,24 @@ public abstract class CoverableTileEntity extends BaseTileEntity implements ICov
         final NBTTagCompound tag = accessor.getNBTData();
         final byte currentFacing = (byte) accessor.getSide().ordinal();
 
-        final int[] coverSides = tag.getIntArray("mCoverSides");
-        // Not all data is available on the client, so get it from the NBT packet
-        if (coverSides != null && coverSides.length == 6) {
-            for (ForgeDirection direction : ForgeDirection.VALID_DIRECTIONS) {
-                final byte side = (byte) direction.ordinal();
-                final int coverId = coverSides[side];
-                final GT_CoverBehaviorBase<?> behavior = GregTech_API.getCoverBehaviorNew(coverId);
+        final NBTTagList tList = tag.getTagList(GT_Values.NBT.COVERS, 10);
+        for (byte i = 0; i < tList.tagCount(); i++) {
+            final NBTTagCompound tNBT = tList.getCompoundTagAt(i);
+            final CoverInfo coverInfo = new CoverInfo(this, tNBT);
+            if(!coverInfo.isValid() || coverInfo.getCoverBehavior() == GregTech_API.sNoBehavior) continue;
 
-                if (coverId != 0 && behavior != null && behavior != GregTech_API.sNoBehavior) {
-                    if (tag.hasKey(CoverableTileEntity.COVER_DATA_NBT_KEYS[side])) {
-                        final ISerializableObject dataObject =
-                                behavior.createDataObject(tag.getTag(CoverableTileEntity.COVER_DATA_NBT_KEYS[side]));
-                        final ItemStack coverStack = behavior.getDisplayStack(coverId, dataObject);
-                        if (coverStack != null)
-                            currenttip.add(StatCollector.translateToLocalFormatted(
-                                    "GT5U.waila.cover",
-                                    currentFacing == side
-                                            ? StatCollector.translateToLocal("GT5U.waila.cover.current_facing")
-                                            : StatCollector.translateToLocal("GT5U.interface.coverTabs."
-                                                    + direction.toString().toLowerCase()),
-                                    coverStack.getDisplayName()));
-                        final String behaviorDesc = behavior.getDescription(side, coverId, dataObject, null);
-                        if (!Objects.equals(behaviorDesc, E)) currenttip.add(behaviorDesc);
-                    }
-                }
+            final ItemStack coverStack = coverInfo.getDisplayStack();
+            if (coverStack != null) {
+                currenttip.add(StatCollector.translateToLocalFormatted(
+                    "GT5U.waila.cover",
+                    currentFacing == coverInfo.getSide()
+                    ? StatCollector.translateToLocal("GT5U.waila.cover.current_facing")
+                    : StatCollector.translateToLocal("GT5U.interface.coverTabs."
+                                                         + ForgeDirection.getOrientation(coverInfo.getSide()).toString().toLowerCase()),
+                    coverStack.getDisplayName()
+                ));
+                final String behaviorDesc = coverInfo.getBehaviorDescription();
+                if (!Objects.equals(behaviorDesc, E)) currenttip.add(behaviorDesc);
             }
         }
 
@@ -536,8 +560,7 @@ public abstract class CoverableTileEntity extends BaseTileEntity implements ICov
         // super.getWailaNBTData(player, tile, tag, world, x, y, z);
 
         // While we have some cover data on the client (enough to render it); we don't have all the information we want,
-        // such as
-        // details on the fluid filter, so send it all here.
+        // such as details on the fluid filter, so send it all here.
         writeCoverNBT(tag, false);
     }
 
@@ -547,6 +570,19 @@ public abstract class CoverableTileEntity extends BaseTileEntity implements ICov
      * @param aList - List to add the information to
      */
     public static void addInstalledCoversInformation(NBTTagCompound aNBT, List<String> aList) {
+        final NBTTagList tList = aNBT.getTagList(GT_Values.NBT.COVERS, 10);
+        for (byte i = 0; i < tList.tagCount(); i++) {
+            final NBTTagCompound tNBT = tList.getCompoundTagAt(i);
+            final CoverInfo coverInfo = new CoverInfo(null, tNBT);
+            if(!coverInfo.isValid() || coverInfo.getCoverBehavior() == GregTech_API.sNoBehavior) continue;
+
+            final ItemStack coverStack = coverInfo.getDisplayStack();
+            if (coverStack != null) {
+                aList.add(String.format(
+                    "Cover on %s side: %s", getTranslation(FACES[coverInfo.getSide()]), coverStack.getDisplayName()));
+            }
+        }
+
         if (aNBT.hasKey("mCoverSides")) {
             final int[] mCoverSides = aNBT.getIntArray("mCoverSides");
             if (mCoverSides != null && mCoverSides.length == 6) {
@@ -569,10 +605,7 @@ public abstract class CoverableTileEntity extends BaseTileEntity implements ICov
     }
 
     protected ModularWindow createCoverWindow(EntityPlayer player, byte side) {
-        final GT_CoverBehaviorBase<?> coverBehavior = getCoverBehaviorAtSideNew(side);
-        final GT_CoverUIBuildContext buildContext =
-                new GT_CoverUIBuildContext(player, getCoverIDAtSide(side), side, this, true);
-        return coverBehavior.createWindow(buildContext);
+        return getCoverInfoAtSide(side).createWindow(player);
     }
 
     protected static final int COVER_WINDOW_ID_START = 1;
@@ -611,21 +644,12 @@ public abstract class CoverableTileEntity extends BaseTileEntity implements ICov
 
                                     if (getCoverBehaviorAtSideNew(side).hasCoverGUI()) {
                                         if (isHovering()) {
-                                            backgrounds.add(
-                                                    flipHorizontally
-                                                            ? tabIconSet.getCoverTabHighlightFlipped()
-                                                            : tabIconSet.getCoverTabHighlight());
+                                            backgrounds.add(flipHorizontally ? tabIconSet.getCoverTabHighlightFlipped() : tabIconSet.getCoverTabHighlight());
                                         } else {
-                                            backgrounds.add(
-                                                    flipHorizontally
-                                                            ? tabIconSet.getCoverTabNormalFlipped()
-                                                            : tabIconSet.getCoverTabNormal());
+                                            backgrounds.add(flipHorizontally ? tabIconSet.getCoverTabNormalFlipped() : tabIconSet.getCoverTabNormal());
                                         }
                                     } else {
-                                        backgrounds.add(
-                                                flipHorizontally
-                                                        ? tabIconSet.getCoverTabDisabledFlipped()
-                                                        : tabIconSet.getCoverTabDisabled());
+                                        backgrounds.add(flipHorizontally ? tabIconSet.getCoverTabDisabledFlipped() : tabIconSet.getCoverTabDisabled());
                                     }
                                     return backgrounds.toArray(new IDrawable[] {});
                                 }
@@ -639,9 +663,7 @@ public abstract class CoverableTileEntity extends BaseTileEntity implements ICov
                             .setPos(
                                     (COVER_TAB_WIDTH - ICON_SIZE) / 2 + (flipHorizontally ? -1 : 1),
                                     (COVER_TAB_HEIGHT - ICON_SIZE) / 2))
-                    .setEnabled(widget -> {
-                        return getCoverItemAtSide(side) != null;
-                    }));
+                    .setEnabled(widget -> getCoverItemAtSide(side) != null));
         }
     }
 
@@ -655,20 +677,16 @@ public abstract class CoverableTileEntity extends BaseTileEntity implements ICov
             "GT5U.interface.coverTabs.west",
             "GT5U.interface.coverTabs.east"
         };
-        final ItemStack coverItem = getCoverItemAtSide(side);
+        final CoverInfo coverInfo = getCoverInfoAtSide(side);
+        final ItemStack coverItem = coverInfo.getDisplayStack();
         if (coverItem == null) return Collections.emptyList();
-        boolean coverHasGUI = getCoverBehaviorAtSideNew(side).hasCoverGUI();
+        final boolean coverHasGUI = coverInfo.hasCoverGUI();
 
         //noinspection unchecked
-        List<String> tooltip = coverItem.getTooltip(Minecraft.getMinecraft().thePlayer, true);
+        final List<String> tooltip = coverItem.getTooltip(Minecraft.getMinecraft().thePlayer, true);
         for (int i = 0; i < tooltip.size(); i++) {
             if (i == 0) {
-                tooltip.set(
-                        0,
-                        (coverHasGUI ? EnumChatFormatting.UNDERLINE : EnumChatFormatting.DARK_GRAY)
-                                + StatCollector.translateToLocal(SIDE_TOOLTIPS[side])
-                                + (coverHasGUI ? EnumChatFormatting.RESET + ": " : ": " + EnumChatFormatting.RESET)
-                                + tooltip.get(0));
+                tooltip.set(0, (coverHasGUI ? EnumChatFormatting.UNDERLINE : EnumChatFormatting.DARK_GRAY) + StatCollector.translateToLocal(SIDE_TOOLTIPS[side]) + (coverHasGUI ? EnumChatFormatting.RESET + ": " : ": " + EnumChatFormatting.RESET) + tooltip.get(0));
             } else {
                 tooltip.set(i, EnumChatFormatting.GRAY + tooltip.get(i));
             }
@@ -678,23 +696,16 @@ public abstract class CoverableTileEntity extends BaseTileEntity implements ICov
 
     protected void onTabClicked(Widget.ClickData clickData, Widget widget, byte side) {
         if (isClientSide()) return;
-
-        final GT_CoverBehaviorBase<?> coverBehavior = getCoverBehaviorAtSideNew(side);
-        if (coverBehavior.useModularUI()) {
+        final CoverInfo coverInfo = getCoverInfoAtSide(side);
+        if (coverInfo.useModularUI()) {
             widget.getContext().openSyncedWindow(side + COVER_WINDOW_ID_START);
         } else {
             final GT_Packet_TileEntityCoverGUI packet = new GT_Packet_TileEntityCoverGUI(
-                    getXCoord(),
-                    getYCoord(),
-                    getZCoord(),
-                    side,
-                    getCoverIDAtSide(side),
-                    getComplexCoverDataAtSide(side),
+                    coverInfo,
                     getWorld().provider.dimensionId,
                     widget.getContext().getPlayer().getEntityId(),
                     0);
-            GT_Values.NW.sendToPlayer(
-                    packet, (EntityPlayerMP) widget.getContext().getPlayer());
+            GT_Values.NW.sendToPlayer(packet, (EntityPlayerMP) widget.getContext().getPlayer());
         }
     }
 }

--- a/src/main/java/gregtech/api/metatileentity/CoverableTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/CoverableTileEntity.java
@@ -186,7 +186,7 @@ public abstract class CoverableTileEntity extends BaseTileEntity implements ICov
     }
 
     /**
-     * Returns false if the cover/tile is no longer valid
+     * Returns false if the tile is no longer valid after ticking the cover
      */
     public boolean tickCoverAtSide(byte aSide, long aTickTimer) {
         final CoverInfo coverInfo = getCoverInfoAtSide(aSide);
@@ -389,7 +389,7 @@ public abstract class CoverableTileEntity extends BaseTileEntity implements ICov
     }
 
     protected void onBaseTEDestroyed() {
-        for (byte side = 0; side < 6; ++side) {
+        for (byte side : ALL_VALID_SIDES) {
             final CoverInfo coverInfo = getCoverInfoAtSide(side);
             if (coverInfo.isValid()) coverInfo.onBaseTEDestroyed();
         }

--- a/src/main/java/gregtech/api/metatileentity/CoverableTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/CoverableTileEntity.java
@@ -1,6 +1,5 @@
 package gregtech.api.metatileentity;
 
-import static gregtech.GT_Mod.GT_FML_LOGGER;
 import static gregtech.api.enums.GT_Values.ALL_VALID_SIDES;
 import static gregtech.api.enums.GT_Values.E;
 import static gregtech.api.enums.GT_Values.NW;
@@ -22,7 +21,6 @@ import gregtech.GT_Mod;
 import gregtech.api.GregTech_API;
 import gregtech.api.enums.GT_Values;
 import gregtech.api.enums.Textures;
-import gregtech.api.gui.modularui.GT_CoverUIBuildContext;
 import gregtech.api.gui.modularui.GUITextureSet;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.tileentity.ICoverable;
@@ -82,6 +80,7 @@ public abstract class CoverableTileEntity extends BaseTileEntity implements ICov
         GregTech_API.sNoBehavior,
         GregTech_API.sNoBehavior
     };
+
     @Deprecated
     protected int[] mCoverSides = new int[] {0, 0, 0, 0, 0, 0};
 
@@ -121,8 +120,7 @@ public abstract class CoverableTileEntity extends BaseTileEntity implements ICov
 
         if (aNBT.hasKey(GT_Values.NBT.COVERS)) {
             readCoverInfoNBT(aNBT);
-        }
-        else if (aNBT.hasKey("mCoverSides")) {
+        } else if (aNBT.hasKey("mCoverSides")) {
             readLegacyCoverInfoNBT(aNBT);
         }
     }
@@ -247,8 +245,7 @@ public abstract class CoverableTileEntity extends BaseTileEntity implements ICov
         if (worldObj == null || !worldObj.isRemote) return;
         for (byte i : ALL_VALID_SIDES) {
             final CoverInfo coverInfo = getCoverInfoAtSide(i);
-            if (coverInfo.isDataNeededOnClient())
-                NW.sendToServer(new GT_Packet_RequestCoverData(coverInfo, this));
+            if (coverInfo.isDataNeededOnClient()) NW.sendToServer(new GT_Packet_RequestCoverData(coverInfo, this));
         }
     }
 
@@ -291,16 +288,14 @@ public abstract class CoverableTileEntity extends BaseTileEntity implements ICov
     @Override
     public void setCoverDataAtSide(byte aSide, ISerializableObject aData) {
         final CoverInfo coverInfo = getCoverInfoAtSide(aSide);
-        if (coverInfo.isValid() && coverInfo.getCoverBehavior().cast(aData) != null)
-            coverInfo.setCoverData(aData);
+        if (coverInfo.isValid() && coverInfo.getCoverBehavior().cast(aData) != null) coverInfo.setCoverData(aData);
     }
 
     @Override
     @Deprecated
     public GT_CoverBehavior getCoverBehaviorAtSide(byte aSide) {
         final GT_CoverBehaviorBase<?> behavior = getCoverInfoAtSide(aSide).getCoverBehavior();
-        if (behavior instanceof GT_CoverBehavior)
-            return (GT_CoverBehavior) behavior;
+        if (behavior instanceof GT_CoverBehavior) return (GT_CoverBehavior) behavior;
         return GregTech_API.sNoBehavior;
     }
 
@@ -350,14 +345,13 @@ public abstract class CoverableTileEntity extends BaseTileEntity implements ICov
     }
 
     public void setCoverInfoAtSide(byte aSide, CoverInfo coverInfo) {
-        if (aSide >= 0 && aSide < 6)
-            coverInfos[aSide] = coverInfo;
+        if (aSide >= 0 && aSide < 6) coverInfos[aSide] = coverInfo;
     }
 
+    @Override
     public CoverInfo getCoverInfoAtSide(byte aSide) {
         if (aSide >= 0 && aSide < 6) {
-            if (coverInfos[aSide] == null)
-                coverInfos[aSide] = new CoverInfo(aSide, this);
+            if (coverInfos[aSide] == null) coverInfos[aSide] = new CoverInfo(aSide, this);
             return coverInfos[aSide];
         }
         return null;
@@ -489,19 +483,20 @@ public abstract class CoverableTileEntity extends BaseTileEntity implements ICov
     public void receiveCoverData(byte aCoverSide, int aCoverID, int aCoverData) {
         if (aCoverSide < 0 || aCoverSide >= 6) return;
         final CoverInfo oldCoverInfo = getCoverInfoAtSide(aCoverSide);
-        if(!oldCoverInfo.isValid()) return;
+        if (!oldCoverInfo.isValid()) return;
 
         setCoverIDAtSideNoUpdate(aCoverSide, aCoverID);
         setCoverDataAtSide(aCoverSide, aCoverData);
     }
 
     @Override
-    public void receiveCoverData(byte aCoverSide, int aCoverID, ISerializableObject aCoverData, EntityPlayerMP aPlayer) {
+    public void receiveCoverData(
+            byte aCoverSide, int aCoverID, ISerializableObject aCoverData, EntityPlayerMP aPlayer) {
         if (aCoverSide < 0 || aCoverSide >= 6) return;
 
         final CoverInfo oldCoverInfo = getCoverInfoAtSide(aCoverSide);
 
-        if(!oldCoverInfo.isValid()) return;
+        if (!oldCoverInfo.isValid()) return;
         oldCoverInfo.preDataChanged(aCoverID, aCoverData);
         setCoverIDAtSideNoUpdate(aCoverSide, aCoverID, aCoverData);
 
@@ -532,18 +527,19 @@ public abstract class CoverableTileEntity extends BaseTileEntity implements ICov
         for (byte i = 0; i < tList.tagCount(); i++) {
             final NBTTagCompound tNBT = tList.getCompoundTagAt(i);
             final CoverInfo coverInfo = new CoverInfo(this, tNBT);
-            if(!coverInfo.isValid() || coverInfo.getCoverBehavior() == GregTech_API.sNoBehavior) continue;
+            if (!coverInfo.isValid() || coverInfo.getCoverBehavior() == GregTech_API.sNoBehavior) continue;
 
             final ItemStack coverStack = coverInfo.getDisplayStack();
             if (coverStack != null) {
                 currenttip.add(StatCollector.translateToLocalFormatted(
-                    "GT5U.waila.cover",
-                    currentFacing == coverInfo.getSide()
-                    ? StatCollector.translateToLocal("GT5U.waila.cover.current_facing")
-                    : StatCollector.translateToLocal("GT5U.interface.coverTabs."
-                                                         + ForgeDirection.getOrientation(coverInfo.getSide()).toString().toLowerCase()),
-                    coverStack.getDisplayName()
-                ));
+                        "GT5U.waila.cover",
+                        currentFacing == coverInfo.getSide()
+                                ? StatCollector.translateToLocal("GT5U.waila.cover.current_facing")
+                                : StatCollector.translateToLocal("GT5U.interface.coverTabs."
+                                        + ForgeDirection.getOrientation(coverInfo.getSide())
+                                                .toString()
+                                                .toLowerCase()),
+                        coverStack.getDisplayName()));
                 final String behaviorDesc = coverInfo.getBehaviorDescription();
                 if (!Objects.equals(behaviorDesc, E)) currenttip.add(behaviorDesc);
             }
@@ -574,12 +570,13 @@ public abstract class CoverableTileEntity extends BaseTileEntity implements ICov
         for (byte i = 0; i < tList.tagCount(); i++) {
             final NBTTagCompound tNBT = tList.getCompoundTagAt(i);
             final CoverInfo coverInfo = new CoverInfo(null, tNBT);
-            if(!coverInfo.isValid() || coverInfo.getCoverBehavior() == GregTech_API.sNoBehavior) continue;
+            if (!coverInfo.isValid() || coverInfo.getCoverBehavior() == GregTech_API.sNoBehavior) continue;
 
             final ItemStack coverStack = coverInfo.getDisplayStack();
             if (coverStack != null) {
                 aList.add(String.format(
-                    "Cover on %s side: %s", getTranslation(FACES[coverInfo.getSide()]), coverStack.getDisplayName()));
+                        "Cover on %s side: %s",
+                        getTranslation(FACES[coverInfo.getSide()]), coverStack.getDisplayName()));
             }
         }
 
@@ -644,12 +641,21 @@ public abstract class CoverableTileEntity extends BaseTileEntity implements ICov
 
                                     if (getCoverBehaviorAtSideNew(side).hasCoverGUI()) {
                                         if (isHovering()) {
-                                            backgrounds.add(flipHorizontally ? tabIconSet.getCoverTabHighlightFlipped() : tabIconSet.getCoverTabHighlight());
+                                            backgrounds.add(
+                                                    flipHorizontally
+                                                            ? tabIconSet.getCoverTabHighlightFlipped()
+                                                            : tabIconSet.getCoverTabHighlight());
                                         } else {
-                                            backgrounds.add(flipHorizontally ? tabIconSet.getCoverTabNormalFlipped() : tabIconSet.getCoverTabNormal());
+                                            backgrounds.add(
+                                                    flipHorizontally
+                                                            ? tabIconSet.getCoverTabNormalFlipped()
+                                                            : tabIconSet.getCoverTabNormal());
                                         }
                                     } else {
-                                        backgrounds.add(flipHorizontally ? tabIconSet.getCoverTabDisabledFlipped() : tabIconSet.getCoverTabDisabled());
+                                        backgrounds.add(
+                                                flipHorizontally
+                                                        ? tabIconSet.getCoverTabDisabledFlipped()
+                                                        : tabIconSet.getCoverTabDisabled());
                                     }
                                     return backgrounds.toArray(new IDrawable[] {});
                                 }
@@ -686,7 +692,12 @@ public abstract class CoverableTileEntity extends BaseTileEntity implements ICov
         final List<String> tooltip = coverItem.getTooltip(Minecraft.getMinecraft().thePlayer, true);
         for (int i = 0; i < tooltip.size(); i++) {
             if (i == 0) {
-                tooltip.set(0, (coverHasGUI ? EnumChatFormatting.UNDERLINE : EnumChatFormatting.DARK_GRAY) + StatCollector.translateToLocal(SIDE_TOOLTIPS[side]) + (coverHasGUI ? EnumChatFormatting.RESET + ": " : ": " + EnumChatFormatting.RESET) + tooltip.get(0));
+                tooltip.set(
+                        0,
+                        (coverHasGUI ? EnumChatFormatting.UNDERLINE : EnumChatFormatting.DARK_GRAY)
+                                + StatCollector.translateToLocal(SIDE_TOOLTIPS[side])
+                                + (coverHasGUI ? EnumChatFormatting.RESET + ": " : ": " + EnumChatFormatting.RESET)
+                                + tooltip.get(0));
             } else {
                 tooltip.set(i, EnumChatFormatting.GRAY + tooltip.get(i));
             }
@@ -705,7 +716,8 @@ public abstract class CoverableTileEntity extends BaseTileEntity implements ICov
                     getWorld().provider.dimensionId,
                     widget.getContext().getPlayer().getEntityId(),
                     0);
-            GT_Values.NW.sendToPlayer(packet, (EntityPlayerMP) widget.getContext().getPlayer());
+            GT_Values.NW.sendToPlayer(
+                    packet, (EntityPlayerMP) widget.getContext().getPlayer());
         }
     }
 }

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -32,6 +32,7 @@ import gregtech.api.util.GT_TooltipDataCache;
 import gregtech.api.util.GT_Util;
 import gregtech.api.util.GT_Utility;
 import gregtech.common.GT_Client;
+import gregtech.common.covers.CoverInfo;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
@@ -862,43 +863,15 @@ public abstract class MetaTileEntity implements IMetaTileEntity, IMachineCallbac
 
     @Override
     public int[] getAccessibleSlotsFromSide(int aSide) {
-        TIntList tList = new TIntArrayList();
-        IGregTechTileEntity tTileEntity = getBaseMetaTileEntity();
-        boolean tSkip = tTileEntity
-                        .getCoverBehaviorAtSideNew((byte) aSide)
-                        .letsItemsIn(
-                                (byte) aSide,
-                                tTileEntity.getCoverIDAtSide((byte) aSide),
-                                tTileEntity.getComplexCoverDataAtSide((byte) aSide),
-                                -2,
-                                tTileEntity)
-                || tTileEntity
-                        .getCoverBehaviorAtSideNew((byte) aSide)
-                        .letsItemsOut(
-                                (byte) aSide,
-                                tTileEntity.getCoverIDAtSide((byte) aSide),
-                                tTileEntity.getComplexCoverDataAtSide((byte) aSide),
-                                -2,
-                                tTileEntity);
-        for (int i = 0; i < getSizeInventory(); i++)
-            if (isValidSlot(i)
-                    && (tSkip
-                            || tTileEntity
-                                    .getCoverBehaviorAtSideNew((byte) aSide)
-                                    .letsItemsOut(
-                                            (byte) aSide,
-                                            tTileEntity.getCoverIDAtSide((byte) aSide),
-                                            tTileEntity.getComplexCoverDataAtSide((byte) aSide),
-                                            i,
-                                            tTileEntity)
-                            || tTileEntity
-                                    .getCoverBehaviorAtSideNew((byte) aSide)
-                                    .letsItemsIn(
-                                            (byte) aSide,
-                                            tTileEntity.getCoverIDAtSide((byte) aSide),
-                                            tTileEntity.getComplexCoverDataAtSide((byte) aSide),
-                                            i,
-                                            tTileEntity))) tList.add(i);
+        final TIntList tList = new TIntArrayList();
+        final IGregTechTileEntity tTileEntity = getBaseMetaTileEntity();
+        final CoverInfo tileCoverInfo = tTileEntity.getCoverInfoAtSide((byte) aSide);
+        final boolean tSkip = tileCoverInfo.letsItemsIn(-2) || tileCoverInfo.letsItemsOut(-2);
+        for (int i = 0; i < getSizeInventory(); i++) {
+            if (isValidSlot(i) && (tSkip || tileCoverInfo.letsItemsOut(i) || tileCoverInfo.letsItemsIn(i))) {
+                tList.add(i);
+            }
+        }
         return tList.toArray();
     }
 

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Cable.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Cable.java
@@ -1,5 +1,7 @@
 package gregtech.api.metatileentity.implementations;
 
+import static gregtech.api.enums.GT_Values.ALL_VALID_SIDES;
+
 import cofh.api.energy.IEnergyReceiver;
 import cpw.mods.fml.common.Loader;
 import gregtech.GT_Mod;
@@ -47,8 +49,6 @@ import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
-
-import static gregtech.api.enums.GT_Values.ALL_VALID_SIDES;
 
 public class GT_MetaPipeEntity_Cable extends MetaPipeEntity implements IMetaTileEntityCable {
     public final float mThickNess;

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Cable.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Cable.java
@@ -26,6 +26,7 @@ import gregtech.api.objects.GT_Cover_None;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.*;
 import gregtech.common.GT_Client;
+import gregtech.common.covers.CoverInfo;
 import gregtech.common.covers.GT_Cover_SolarPanel;
 import ic2.api.energy.EnergyNet;
 import ic2.api.energy.tile.IEnergyEmitter;
@@ -231,14 +232,8 @@ public class GT_MetaPipeEntity_Cable extends MetaPipeEntity implements IMetaTile
     @Override
     public long injectEnergyUnits(byte aSide, long aVoltage, long aAmperage) {
         if (!isConnectedAtSide(aSide) && aSide != 6) return 0;
-        if (!getBaseMetaTileEntity()
-                .getCoverBehaviorAtSideNew(aSide)
-                .letsEnergyIn(
-                        aSide,
-                        getBaseMetaTileEntity().getCoverIDAtSide(aSide),
-                        getBaseMetaTileEntity().getComplexCoverDataAtSide(aSide),
-                        getBaseMetaTileEntity())) return 0;
-        HashSet<TileEntity> nul = null;
+        if (!getBaseMetaTileEntity().getCoverInfoAtSide(aSide).letsEnergyIn()) return 0;
+        final HashSet<TileEntity> nul = null;
         return transferElectricity(aSide, aVoltage, aAmperage, nul);
     }
 
@@ -252,12 +247,12 @@ public class GT_MetaPipeEntity_Cable extends MetaPipeEntity implements IMetaTile
     @Override
     public long transferElectricity(byte aSide, long aVoltage, long aAmperage, HashSet<TileEntity> aAlreadyPassedSet) {
         if (!getBaseMetaTileEntity().isServerSide() || !isConnectedAtSide(aSide) && aSide != 6) return 0;
-        BaseMetaPipeEntity tBase = (BaseMetaPipeEntity) getBaseMetaTileEntity();
+        final BaseMetaPipeEntity tBase = (BaseMetaPipeEntity) getBaseMetaTileEntity();
         if (!(tBase.getNode() instanceof PowerNode)) return 0;
-        PowerNode tNode = (PowerNode) tBase.getNode();
+        final PowerNode tNode = (PowerNode) tBase.getNode();
         if (tNode != null) {
             int tPlace = 0;
-            Node[] tToPower = new Node[tNode.mConsumers.size()];
+            final Node[] tToPower = new Node[tNode.mConsumers.size()];
             if (tNode.mHadVoltage) {
                 for (ConsumerNode consumer : tNode.mConsumers) {
                     if (consumer.needsEnergy()) tToPower[tPlace++] = consumer;
@@ -356,6 +351,16 @@ public class GT_MetaPipeEntity_Cable extends MetaPipeEntity implements IMetaTile
             ISerializableObject aCoverVariable,
             ICoverable aTileEntity) {
         return coverBehavior.letsEnergyOut(aSide, aCoverID, aCoverVariable, aTileEntity);
+    }
+
+    @Override
+    public boolean letsIn(CoverInfo coverInfo) {
+        return coverInfo.letsEnergyIn();
+    }
+
+    @Override
+    public boolean letsOut(CoverInfo coverInfo) {
+        return coverInfo.letsEnergyOut();
     }
 
     @Override
@@ -472,8 +477,8 @@ public class GT_MetaPipeEntity_Cable extends MetaPipeEntity implements IMetaTile
 
     @Override
     public String[] getInfoData() {
-        BaseMetaPipeEntity base = (BaseMetaPipeEntity) getBaseMetaTileEntity();
-        PowerNodePath path = (PowerNodePath) base.getNodePath();
+        final BaseMetaPipeEntity base = (BaseMetaPipeEntity) getBaseMetaTileEntity();
+        final PowerNodePath path = (PowerNodePath) base.getNodePath();
         long amps = 0;
         long volts = 0;
         if (path != null) {
@@ -562,7 +567,7 @@ public class GT_MetaPipeEntity_Cable extends MetaPipeEntity implements IMetaTile
             Entity collider) {
         super.addCollisionBoxesToList(aWorld, aX, aY, aZ, inputAABB, outputAABB, collider);
         if (GT_Mod.instance.isClientSide() && (GT_Client.hideValue & 0x2) != 0) {
-            AxisAlignedBB aabb = getActualCollisionBoundingBoxFromPool(aWorld, aX, aY, aZ);
+            final AxisAlignedBB aabb = getActualCollisionBoundingBoxFromPool(aWorld, aX, aY, aZ);
             if (inputAABB.intersectsWith(aabb)) outputAABB.add(aabb);
         }
     }
@@ -593,16 +598,13 @@ public class GT_MetaPipeEntity_Cable extends MetaPipeEntity implements IMetaTile
 
     @Override
     public void reloadLocks() {
-        BaseMetaPipeEntity pipe = (BaseMetaPipeEntity) getBaseMetaTileEntity();
+        final BaseMetaPipeEntity pipe = (BaseMetaPipeEntity) getBaseMetaTileEntity();
         if (pipe.getNode() != null) {
             for (byte i = 0; i < 6; i++) {
                 if (isConnectedAtSide(i)) {
-                    final GT_CoverBehaviorBase<?> coverBehavior = pipe.getCoverBehaviorAtSideNew(i);
-                    if (coverBehavior instanceof GT_Cover_None) continue;
-                    final int coverId = pipe.getCoverIDAtSide(i);
-                    ISerializableObject coverData = pipe.getComplexCoverDataAtSide(i);
-                    if (!letsIn(coverBehavior, i, coverId, coverData, pipe)
-                            || !letsOut(coverBehavior, i, coverId, coverData, pipe)) {
+                    final CoverInfo coverInfo = pipe.getCoverInfoAtSide(i);
+                    if (coverInfo.getCoverBehavior() instanceof GT_Cover_None) continue;
+                    if (!letsIn(coverInfo) || !letsOut(coverInfo)) {
                         pipe.addToLock(pipe, i);
                     } else {
                         pipe.removeFromLock(pipe, i);
@@ -613,12 +615,10 @@ public class GT_MetaPipeEntity_Cable extends MetaPipeEntity implements IMetaTile
             boolean dontAllow = false;
             for (byte i = 0; i < 6; i++) {
                 if (isConnectedAtSide(i)) {
-                    final GT_CoverBehaviorBase<?> coverBehavior = pipe.getCoverBehaviorAtSideNew(i);
-                    if (coverBehavior instanceof GT_Cover_None) continue;
-                    final int coverId = pipe.getCoverIDAtSide(i);
-                    ISerializableObject coverData = pipe.getComplexCoverDataAtSide(i);
-                    if (!letsIn(coverBehavior, i, coverId, coverData, pipe)
-                            || !letsOut(coverBehavior, i, coverId, coverData, pipe)) {
+                    final CoverInfo coverInfo = pipe.getCoverInfoAtSide(i);
+                    if (coverInfo.getCoverBehavior() instanceof GT_Cover_None) continue;
+
+                    if (!letsIn(coverInfo) || !letsOut(coverInfo)) {
                         dontAllow = true;
                     }
                 }

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Cable.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Cable.java
@@ -48,6 +48,8 @@ import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import static gregtech.api.enums.GT_Values.ALL_VALID_SIDES;
+
 public class GT_MetaPipeEntity_Cable extends MetaPipeEntity implements IMetaTileEntityCable {
     public final float mThickNess;
     public final Materials mMaterial;
@@ -600,22 +602,22 @@ public class GT_MetaPipeEntity_Cable extends MetaPipeEntity implements IMetaTile
     public void reloadLocks() {
         final BaseMetaPipeEntity pipe = (BaseMetaPipeEntity) getBaseMetaTileEntity();
         if (pipe.getNode() != null) {
-            for (byte i = 0; i < 6; i++) {
-                if (isConnectedAtSide(i)) {
-                    final CoverInfo coverInfo = pipe.getCoverInfoAtSide(i);
+            for (byte tSide : ALL_VALID_SIDES) {
+                if (isConnectedAtSide(tSide)) {
+                    final CoverInfo coverInfo = pipe.getCoverInfoAtSide(tSide);
                     if (coverInfo.getCoverBehavior() instanceof GT_Cover_None) continue;
                     if (!letsIn(coverInfo) || !letsOut(coverInfo)) {
-                        pipe.addToLock(pipe, i);
+                        pipe.addToLock(pipe, tSide);
                     } else {
-                        pipe.removeFromLock(pipe, i);
+                        pipe.removeFromLock(pipe, tSide);
                     }
                 }
             }
         } else {
             boolean dontAllow = false;
-            for (byte i = 0; i < 6; i++) {
-                if (isConnectedAtSide(i)) {
-                    final CoverInfo coverInfo = pipe.getCoverInfoAtSide(i);
+            for (byte tSide : ALL_VALID_SIDES) {
+                if (isConnectedAtSide(tSide)) {
+                    final CoverInfo coverInfo = pipe.getCoverInfoAtSide(tSide);
                     if (coverInfo.getCoverBehavior() instanceof GT_Cover_None) continue;
 
                     if (!letsIn(coverInfo) || !letsOut(coverInfo)) {

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Item.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Item.java
@@ -1,5 +1,6 @@
 package gregtech.api.metatileentity.implementations;
 
+import static gregtech.api.enums.GT_Values.ALL_VALID_SIDES;
 import static gregtech.api.enums.Textures.BlockIcons.PIPE_RESTRICTOR;
 
 import gregtech.GT_Mod;
@@ -390,7 +391,7 @@ public class GT_MetaPipeEntity_Item extends MetaPipeEntity implements IMetaTileE
         if (pipeCapacityCheck()) {
             final byte tOffset = (byte) getBaseMetaTileEntity().getRandomNumber(6);
             byte tSide = 0;
-            for (byte i = 0; i < 6; i++) {
+            for (byte i : ALL_VALID_SIDES) {
                 tSide = (byte) ((i + tOffset) % 6);
                 if (isConnectedAtSide(tSide)
                         && (isInventoryEmpty() || (tSide != mLastReceivedFrom || aSender != getBaseMetaTileEntity()))) {

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Item.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Item.java
@@ -20,6 +20,7 @@ import gregtech.api.util.GT_CoverBehaviorBase;
 import gregtech.api.util.GT_Utility;
 import gregtech.api.util.ISerializableObject;
 import gregtech.common.GT_Client;
+import gregtech.common.covers.CoverInfo;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -264,7 +265,7 @@ public class GT_MetaPipeEntity_Item extends MetaPipeEntity implements IMetaTileE
             if (oLastReceivedFrom == mLastReceivedFrom) {
                 doTickProfilingInThisTick = false;
 
-                ArrayList<IMetaTileEntityItemPipe> tPipeList = new ArrayList<IMetaTileEntityItemPipe>();
+                final ArrayList<IMetaTileEntityItemPipe> tPipeList = new ArrayList<>();
 
                 for (boolean temp = true; temp && !isInventoryEmpty() && pipeCapacityCheck(); ) {
                     temp = false;
@@ -290,7 +291,7 @@ public class GT_MetaPipeEntity_Item extends MetaPipeEntity implements IMetaTileE
     public boolean onWrenchRightClick(
             byte aSide, byte aWrenchingSide, EntityPlayer aPlayer, float aX, float aY, float aZ) {
         if (GT_Mod.gregtechproxy.gt6Pipe) {
-            byte tSide = GT_Utility.determineWrenchingSide(aSide, aX, aY, aZ);
+            final byte tSide = GT_Utility.determineWrenchingSide(aSide, aX, aY, aZ);
             if (isConnectedAtSide(tSide)) {
                 disconnect(tSide);
                 GT_Utility.sendChatToPlayer(aPlayer, GT_Utility.trans("215", "Disconnected"));
@@ -335,6 +336,16 @@ public class GT_MetaPipeEntity_Item extends MetaPipeEntity implements IMetaTileE
     }
 
     @Override
+    public boolean letsIn(CoverInfo coverInfo) {
+        return coverInfo.letsItemsOut(-1);
+    }
+
+    @Override
+    public boolean letsOut(CoverInfo coverInfo) {
+        return coverInfo.letsItemsOut(-1);
+    }
+
+    @Override
     public boolean canConnect(byte aSide, TileEntity tTileEntity) {
         if (tTileEntity == null) return false;
 
@@ -354,7 +365,7 @@ public class GT_MetaPipeEntity_Item extends MetaPipeEntity implements IMetaTileE
             connectable = true;
         }
         if (tTileEntity instanceof ISidedInventory) {
-            int[] tSlots = ((ISidedInventory) tTileEntity).getAccessibleSlotsFromSide(tSide);
+            final int[] tSlots = ((ISidedInventory) tTileEntity).getAccessibleSlotsFromSide(tSide);
             if (tSlots == null || tSlots.length <= 0) return false;
             connectable = true;
         }
@@ -377,7 +388,8 @@ public class GT_MetaPipeEntity_Item extends MetaPipeEntity implements IMetaTileE
     @Override
     public boolean sendItemStack(Object aSender) {
         if (pipeCapacityCheck()) {
-            byte tOffset = (byte) getBaseMetaTileEntity().getRandomNumber(6), tSide = 0;
+            final byte tOffset = (byte) getBaseMetaTileEntity().getRandomNumber(6);
+            byte tSide = 0;
             for (byte i = 0; i < 6; i++) {
                 tSide = (byte) ((i + tOffset) % 6);
                 if (isConnectedAtSide(tSide)
@@ -391,15 +403,8 @@ public class GT_MetaPipeEntity_Item extends MetaPipeEntity implements IMetaTileE
 
     @Override
     public boolean insertItemStackIntoTileEntity(Object aSender, byte aSide) {
-        if (getBaseMetaTileEntity()
-                .getCoverBehaviorAtSideNew(aSide)
-                .letsItemsOut(
-                        aSide,
-                        getBaseMetaTileEntity().getCoverIDAtSide(aSide),
-                        getBaseMetaTileEntity().getComplexCoverDataAtSide(aSide),
-                        -1,
-                        getBaseMetaTileEntity())) {
-            TileEntity tInventory = getBaseMetaTileEntity().getTileEntityAtSide(aSide);
+        if (getBaseMetaTileEntity().getCoverInfoAtSide(aSide).letsItemsOut(-1)) {
+            final TileEntity tInventory = getBaseMetaTileEntity().getTileEntityAtSide(aSide);
             if (tInventory != null && !(tInventory instanceof BaseMetaPipeEntity)) {
                 if ((!(tInventory instanceof TileEntityHopper) && !(tInventory instanceof TileEntityDispenser))
                         || getBaseMetaTileEntity().getMetaIDAtSide(aSide) != GT_Utility.getOppositeSide(aSide)) {
@@ -459,23 +464,9 @@ public class GT_MetaPipeEntity_Item extends MetaPipeEntity implements IMetaTileE
 
     @Override
     public int[] getAccessibleSlotsFromSide(int aSide) {
-        IGregTechTileEntity tTileEntity = getBaseMetaTileEntity();
-        boolean tAllow = tTileEntity
-                        .getCoverBehaviorAtSideNew((byte) aSide)
-                        .letsItemsIn(
-                                (byte) aSide,
-                                tTileEntity.getCoverIDAtSide((byte) aSide),
-                                tTileEntity.getComplexCoverDataAtSide((byte) aSide),
-                                -2,
-                                tTileEntity)
-                || tTileEntity
-                        .getCoverBehaviorAtSideNew((byte) aSide)
-                        .letsItemsOut(
-                                (byte) aSide,
-                                tTileEntity.getCoverIDAtSide((byte) aSide),
-                                tTileEntity.getComplexCoverDataAtSide((byte) aSide),
-                                -2,
-                                tTileEntity);
+        final IGregTechTileEntity tTileEntity = getBaseMetaTileEntity();
+        final CoverInfo coverInfo = tTileEntity.getCoverInfoAtSide((byte) aSide);
+        final boolean tAllow = coverInfo.letsItemsIn(-2) || coverInfo.letsItemsOut(-2);
         if (tAllow) {
             if (cacheSides == null) cacheSides = super.getAccessibleSlotsFromSide(aSide);
             return cacheSides;
@@ -534,7 +525,7 @@ public class GT_MetaPipeEntity_Item extends MetaPipeEntity implements IMetaTileE
     }
 
     private AxisAlignedBB getActualCollisionBoundingBoxFromPool(World aWorld, int aX, int aY, int aZ) {
-        float tSpace = (1f - mThickNess) / 2;
+        final float tSpace = (1f - mThickNess) / 2;
         float tSide0 = tSpace;
         float tSide1 = 1f - tSpace;
         float tSide2 = tSpace;
@@ -567,7 +558,7 @@ public class GT_MetaPipeEntity_Item extends MetaPipeEntity implements IMetaTileE
             tSide1 = tSide3 = tSide5 = 1;
         }
 
-        byte tConn = ((BaseMetaPipeEntity) getBaseMetaTileEntity()).mConnections;
+        final byte tConn = ((BaseMetaPipeEntity) getBaseMetaTileEntity()).mConnections;
         if ((tConn & (1 << ForgeDirection.DOWN.ordinal())) != 0) tSide0 = 0f;
         if ((tConn & (1 << ForgeDirection.UP.ordinal())) != 0) tSide1 = 1f;
         if ((tConn & (1 << ForgeDirection.NORTH.ordinal())) != 0) tSide2 = 0f;
@@ -590,7 +581,7 @@ public class GT_MetaPipeEntity_Item extends MetaPipeEntity implements IMetaTileE
             Entity collider) {
         super.addCollisionBoxesToList(aWorld, aX, aY, aZ, inputAABB, outputAABB, collider);
         if (GT_Mod.instance.isClientSide() && (GT_Client.hideValue & 0x2) != 0) {
-            AxisAlignedBB aabb = getActualCollisionBoundingBoxFromPool(aWorld, aX, aY, aZ);
+            final AxisAlignedBB aabb = getActualCollisionBoundingBoxFromPool(aWorld, aX, aY, aZ);
             if (inputAABB.intersectsWith(aabb)) outputAABB.add(aabb);
         }
     }

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicMachine.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicMachine.java
@@ -1,5 +1,6 @@
 package gregtech.api.metatileentity.implementations;
 
+import static gregtech.api.enums.GT_Values.ALL_VALID_SIDES;
 import static gregtech.api.enums.GT_Values.V;
 import static gregtech.api.enums.GT_Values.debugCleanroom;
 import static gregtech.api.enums.Textures.BlockIcons.MACHINE_CASINGS;
@@ -527,8 +528,8 @@ public abstract class GT_MetaTileEntity_BasicMachine extends GT_MetaTileEntity_B
             }
             return true;
         }
-        for (byte i = 0; i < 6; i++) {
-            if (aBaseMetaTileEntity.getAirAtSide(i)) {
+        for (byte tSide : ALL_VALID_SIDES) {
+            if (aBaseMetaTileEntity.getAirAtSide(tSide)) {
                 if (useModularUI()) {
                     GT_UIInfos.openGTTileEntityUI(aBaseMetaTileEntity, aPlayer);
                 } else {

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_InputBus.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_InputBus.java
@@ -197,13 +197,7 @@ public class GT_MetaTileEntity_Hatch_InputBus extends GT_MetaTileEntity_Hatch
 
     @Override
     public void onScrewdriverRightClick(byte aSide, EntityPlayer aPlayer, float aX, float aY, float aZ) {
-        if (!getBaseMetaTileEntity()
-                .getCoverBehaviorAtSideNew(aSide)
-                .isGUIClickable(
-                        aSide,
-                        getBaseMetaTileEntity().getCoverIDAtSide(aSide),
-                        getBaseMetaTileEntity().getComplexCoverDataAtSide(aSide),
-                        getBaseMetaTileEntity())) return;
+        if (!getBaseMetaTileEntity().getCoverInfoAtSide(aSide).isGUIClickable()) return;
         if (aPlayer.isSneaking()) {
             if (disableSort) {
                 disableSort = false;

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_Output.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_Output.java
@@ -230,19 +230,13 @@ public class GT_MetaTileEntity_Hatch_Output extends GT_MetaTileEntity_Hatch impl
 
     @Override
     public void onScrewdriverRightClick(byte aSide, EntityPlayer aPlayer, float aX, float aY, float aZ) {
-        if (!getBaseMetaTileEntity()
-                .getCoverBehaviorAtSideNew(aSide)
-                .isGUIClickable(
-                        aSide,
-                        getBaseMetaTileEntity().getCoverIDAtSide(aSide),
-                        getBaseMetaTileEntity().getComplexCoverDataAtSide(aSide),
-                        getBaseMetaTileEntity())) return;
+        if (!getBaseMetaTileEntity().getCoverInfoAtSide(aSide).isGUIClickable()) return;
         if (aPlayer.isSneaking()) {
             mMode = (byte) ((mMode + 9) % 10);
         } else {
             mMode = (byte) ((mMode + 1) % 10);
         }
-        String inBrackets;
+        final String inBrackets;
         switch (mMode) {
             case 0:
                 GT_Utility.sendChatToPlayer(aPlayer, GT_Utility.trans("108", "Outputs misc. Fluids, Steam and Items"));
@@ -312,15 +306,9 @@ public class GT_MetaTileEntity_Hatch_Output extends GT_MetaTileEntity_Hatch impl
     }
 
     private boolean tryToLockHatch(EntityPlayer aPlayer, byte aSide) {
-        if (!getBaseMetaTileEntity()
-                .getCoverBehaviorAtSideNew(aSide)
-                .isGUIClickable(
-                        aSide,
-                        getBaseMetaTileEntity().getCoverIDAtSide(aSide),
-                        getBaseMetaTileEntity().getComplexCoverDataAtSide(aSide),
-                        getBaseMetaTileEntity())) return false;
+        if (!getBaseMetaTileEntity().getCoverInfoAtSide(aSide).isGUIClickable()) return false;
         if (!isFluidLocked()) return false;
-        ItemStack tCurrentItem = aPlayer.inventory.getCurrentItem();
+        final ItemStack tCurrentItem = aPlayer.inventory.getCurrentItem();
         if (tCurrentItem == null) return false;
         FluidStack tFluid = FluidContainerRegistry.getFluidForFilledItem(tCurrentItem);
         if (tFluid == null && tCurrentItem.getItem() instanceof IFluidContainerItem)
@@ -432,7 +420,7 @@ public class GT_MetaTileEntity_Hatch_Output extends GT_MetaTileEntity_Hatch impl
     protected void onEmptyingContainerWhenEmpty() {
         if (this.lockedFluidName == null && this.mFluid != null && isFluidLocked()) {
             this.setLockedFluidName(this.mFluid.getFluid().getName());
-            EntityPlayer player;
+            final EntityPlayer player;
             if (playerThatLockedfluid == null || (player = playerThatLockedfluid.get()) == null) return;
             GT_Utility.sendChatToPlayer(
                     player,
@@ -496,7 +484,7 @@ public class GT_MetaTileEntity_Hatch_Output extends GT_MetaTileEntity_Hatch impl
                         .setDefaultColor(COLOR_TEXT_WHITE.get())
                         .setPos(101, 20))
                 .widget(TextWidget.dynamicString(() -> {
-                            ItemStack lockedDisplayStack = mInventory[getLockedDisplaySlot()];
+                            final ItemStack lockedDisplayStack = mInventory[getLockedDisplaySlot()];
                             return lockedDisplayStack == null ? "None" : lockedDisplayStack.getDisplayName();
                         })
                         .setSynced(false)

--- a/src/main/java/gregtech/api/multitileentity/MultiTileEntityBlock.java
+++ b/src/main/java/gregtech/api/multitileentity/MultiTileEntityBlock.java
@@ -1,5 +1,6 @@
 package gregtech.api.multitileentity;
 
+import static gregtech.api.enums.GT_Values.ALL_VALID_SIDES;
 import static gregtech.api.enums.GT_Values.OFFX;
 import static gregtech.api.enums.GT_Values.OFFY;
 import static gregtech.api.enums.GT_Values.OFFZ;
@@ -456,8 +457,8 @@ public class MultiTileEntityBlock extends Block
             } else {
                 // we do not allow more than one type of facade per block, so no need to check every side
                 // see comment in gregtech.common.covers.GT_Cover_FacadeBase.isCoverPlaceable
-                for (byte i = 0; i < 6; i++) {
-                    final Block facadeBlock = tile.getCoverInfoAtSide(i).getFacadeBlock();
+                for (byte tSide : ALL_VALID_SIDES) {
+                    final Block facadeBlock = tile.getCoverInfoAtSide(tSide).getFacadeBlock();
                     if (facadeBlock != null) {
                         return facadeBlock;
                     }
@@ -480,8 +481,8 @@ public class MultiTileEntityBlock extends Block
             } else {
                 // we do not allow more than one type of facade per block, so no need to check every side
                 // see comment in gregtech.common.covers.GT_Cover_FacadeBase.isCoverPlaceable
-                for (byte i = 0; i < 6; i++) {
-                    final CoverInfo coverInfo = tile.getCoverInfoAtSide(i);
+                for (byte tSide : ALL_VALID_SIDES) {
+                    final CoverInfo coverInfo = tile.getCoverInfoAtSide(tSide);
                     final Block facadeBlock = coverInfo.getFacadeBlock();
                     if (facadeBlock != null) {
                         return coverInfo.getFacadeMeta();

--- a/src/main/java/gregtech/api/multitileentity/MultiTileEntityBlock.java
+++ b/src/main/java/gregtech/api/multitileentity/MultiTileEntityBlock.java
@@ -34,6 +34,7 @@ import gregtech.api.objects.XSTR;
 import gregtech.api.util.GT_Log;
 import gregtech.api.util.GT_Util;
 import gregtech.api.util.GT_Utility;
+import gregtech.common.covers.CoverInfo;
 import gregtech.common.render.GT_Renderer_Block;
 import gregtech.common.render.IRenderedBlock;
 import java.util.ArrayList;
@@ -450,16 +451,13 @@ public class MultiTileEntityBlock extends Block
             final byte aSide = (byte) side;
             final CoverableTileEntity tile = (CoverableTileEntity) tTileEntity;
             if (side != -1) {
-                final Block facadeBlock = tile.getCoverBehaviorAtSideNew(aSide)
-                        .getFacadeBlock(
-                                aSide, tile.getCoverIDAtSide(aSide), tile.getComplexCoverDataAtSide(aSide), tile);
+                final Block facadeBlock = tile.getCoverInfoAtSide(aSide).getFacadeBlock();
                 if (facadeBlock != null) return facadeBlock;
             } else {
                 // we do not allow more than one type of facade per block, so no need to check every side
                 // see comment in gregtech.common.covers.GT_Cover_FacadeBase.isCoverPlaceable
                 for (byte i = 0; i < 6; i++) {
-                    final Block facadeBlock = tile.getCoverBehaviorAtSideNew(i)
-                            .getFacadeBlock(i, tile.getCoverIDAtSide(i), tile.getComplexCoverDataAtSide(i), tile);
+                    final Block facadeBlock = tile.getCoverInfoAtSide(i).getFacadeBlock();
                     if (facadeBlock != null) {
                         return facadeBlock;
                     }
@@ -476,22 +474,17 @@ public class MultiTileEntityBlock extends Block
             final byte aSide = (byte) side;
             final CoverableTileEntity tile = (CoverableTileEntity) tTileEntity;
             if (side != -1) {
-                final Block facadeBlock = tile.getCoverBehaviorAtSideNew(aSide)
-                        .getFacadeBlock(
-                                aSide, tile.getCoverIDAtSide(aSide), tile.getComplexCoverDataAtSide(aSide), tile);
-                if (facadeBlock != null)
-                    return tile.getCoverBehaviorAtSideNew(aSide)
-                            .getFacadeMeta(
-                                    aSide, tile.getCoverIDAtSide(aSide), tile.getComplexCoverDataAtSide(aSide), tile);
+                final CoverInfo coverInfo = tile.getCoverInfoAtSide(aSide);
+                final Block facadeBlock = coverInfo.getFacadeBlock();
+                if (facadeBlock != null) return coverInfo.getFacadeMeta();
             } else {
                 // we do not allow more than one type of facade per block, so no need to check every side
                 // see comment in gregtech.common.covers.GT_Cover_FacadeBase.isCoverPlaceable
                 for (byte i = 0; i < 6; i++) {
-                    final Block facadeBlock = tile.getCoverBehaviorAtSideNew(i)
-                            .getFacadeBlock(i, tile.getCoverIDAtSide(i), tile.getComplexCoverDataAtSide(i), tile);
+                    final CoverInfo coverInfo = tile.getCoverInfoAtSide(i);
+                    final Block facadeBlock = coverInfo.getFacadeBlock();
                     if (facadeBlock != null) {
-                        return tile.getCoverBehaviorAtSideNew(i)
-                                .getFacadeMeta(i, tile.getCoverIDAtSide(i), tile.getComplexCoverDataAtSide(i), tile);
+                        return coverInfo.getFacadeMeta();
                     }
                 }
             }

--- a/src/main/java/gregtech/api/multitileentity/base/BaseMultiTileEntity.java
+++ b/src/main/java/gregtech/api/multitileentity/base/BaseMultiTileEntity.java
@@ -749,9 +749,7 @@ public abstract class BaseMultiTileEntity extends CoverableTileEntity
                 return true;
             }
 
-            if (!getCoverBehaviorAtSideNew(aSide)
-                    .isGUIClickable(aSide, getCoverIDAtSide(aSide), getComplexCoverDataAtSide(aSide), this))
-                return false;
+            if (!getCoverInfoAtSide(aSide).isGUIClickable()) return false;
         }
         if (isServerSide()) {
             if (!privateAccess() || aPlayer.getDisplayName().equalsIgnoreCase(getOwnerName())) {
@@ -828,9 +826,7 @@ public abstract class BaseMultiTileEntity extends CoverableTileEntity
                                 aY,
                                 aZ)) return true;
 
-                if (!getCoverBehaviorAtSideNew(aSide)
-                        .isGUIClickable(aSide, getCoverIDAtSide(aSide), getComplexCoverDataAtSide(aSide), this))
-                    return false;
+                if (!getCoverInfoAtSide(aSide).isGUIClickable()) return false;
 
                 return openModularUi(aPlayer, aSide);
             }
@@ -1377,33 +1373,27 @@ public abstract class BaseMultiTileEntity extends CoverableTileEntity
      */
 
     public boolean coverLetsFluidIn(byte aSide, Fluid aFluid) {
-        return getCoverBehaviorAtSideNew(aSide)
-                .letsFluidIn(aSide, getCoverIDAtSide(aSide), getComplexCoverDataAtSide(aSide), aFluid, this);
+        return getCoverInfoAtSide(aSide).letsFluidIn(aFluid);
     }
 
     public boolean coverLetsFluidOut(byte aSide, Fluid aFluid) {
-        return getCoverBehaviorAtSideNew(aSide)
-                .letsFluidOut(aSide, getCoverIDAtSide(aSide), getComplexCoverDataAtSide(aSide), aFluid, this);
+        return getCoverInfoAtSide(aSide).letsFluidOut(aFluid);
     }
 
     public boolean coverLetsEnergyIn(byte aSide) {
-        return getCoverBehaviorAtSideNew(aSide)
-                .letsEnergyIn(aSide, getCoverIDAtSide(aSide), getComplexCoverDataAtSide(aSide), this);
+        return getCoverInfoAtSide(aSide).letsEnergyIn();
     }
 
     public boolean coverLetsEnergyOut(byte aSide) {
-        return getCoverBehaviorAtSideNew(aSide)
-                .letsEnergyOut(aSide, getCoverIDAtSide(aSide), getComplexCoverDataAtSide(aSide), this);
+        return getCoverInfoAtSide(aSide).letsEnergyOut();
     }
 
     public boolean coverLetsItemsIn(byte aSide, int aSlot) {
-        return getCoverBehaviorAtSideNew(aSide)
-                .letsItemsIn(aSide, getCoverIDAtSide(aSide), getComplexCoverDataAtSide(aSide), aSlot, this);
+        return getCoverInfoAtSide(aSide).letsItemsIn(aSlot);
     }
 
     public boolean coverLetsItemsOut(byte aSide, int aSlot) {
-        return getCoverBehaviorAtSideNew(aSide)
-                .letsItemsOut(aSide, getCoverIDAtSide(aSide), getComplexCoverDataAtSide(aSide), aSlot, this);
+        return getCoverInfoAtSide(aSide).letsItemsOut(aSlot);
     }
 
     @Override

--- a/src/main/java/gregtech/api/multitileentity/base/BaseMultiTileEntity.java
+++ b/src/main/java/gregtech/api/multitileentity/base/BaseMultiTileEntity.java
@@ -36,7 +36,6 @@ import gregtech.api.util.GT_Log;
 import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_Util;
 import gregtech.api.util.GT_Utility;
-import gregtech.api.util.ISerializableObject;
 import gregtech.common.render.GT_MultiTexture;
 import gregtech.common.render.IRenderedBlock;
 import java.util.ArrayList;
@@ -196,8 +195,6 @@ public abstract class BaseMultiTileEntity extends CoverableTileEntity
                 copyTextures();
             }
 
-            if (mCoverData == null || mCoverData.length != 6) mCoverData = new ISerializableObject[6];
-            if (mCoverSides.length != 6) mCoverSides = new int[] {0, 0, 0, 0, 0, 0};
             if (mSidedRedstone.length != 6) mSidedRedstone = new byte[] {15, 15, 15, 15, 15, 15};
 
             updateCoverBehavior();
@@ -993,7 +990,12 @@ public abstract class BaseMultiTileEntity extends CoverableTileEntity
                 mColor);
 
         packet.setCoverData(
-                mCoverSides[0], mCoverSides[1], mCoverSides[2], mCoverSides[3], mCoverSides[4], mCoverSides[5]);
+                getCoverInfoAtSide((byte) 0).getCoverID(),
+                getCoverInfoAtSide((byte) 1).getCoverID(),
+                getCoverInfoAtSide((byte) 2).getCoverID(),
+                getCoverInfoAtSide((byte) 3).getCoverID(),
+                getCoverInfoAtSide((byte) 4).getCoverID(),
+                getCoverInfoAtSide((byte) 5).getCoverID());
 
         packet.setRedstoneData((byte) (((mSidedRedstone[0] > 0) ? 1 : 0)
                 | ((mSidedRedstone[1] > 0) ? 2 : 0)

--- a/src/main/java/gregtech/api/multitileentity/base/BaseNontickableMultiTileEntity.java
+++ b/src/main/java/gregtech/api/multitileentity/base/BaseNontickableMultiTileEntity.java
@@ -4,6 +4,7 @@ import static gregtech.api.enums.GT_Values.NW;
 
 import gregtech.api.net.GT_Packet_SendCoverData;
 import gregtech.api.util.ISerializableObject;
+import gregtech.common.covers.CoverInfo;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.network.Packet;
 
@@ -37,13 +38,11 @@ public abstract class BaseNontickableMultiTileEntity extends BaseMultiTileEntity
             super.issueCoverUpdate(aSide);
         } else {
             // Otherwise, send the data right away
-            NW.sendPacketToAllPlayersInRange(
-                    worldObj,
-                    new GT_Packet_SendCoverData(aSide, getCoverIDAtSide(aSide), getComplexCoverDataAtSide(aSide), this),
-                    xCoord,
-                    zCoord);
+            final CoverInfo coverInfo = getCoverInfoAtSide(aSide);
+            NW.sendPacketToAllPlayersInRange(worldObj, new GT_Packet_SendCoverData(coverInfo, this), xCoord, zCoord);
+
             // Just in case
-            mCoverNeedUpdate[aSide] = false;
+            coverInfo.setNeedsUpdate(false);
         }
     }
 

--- a/src/main/java/gregtech/api/multitileentity/machine/MultiTileBasicMachine.java
+++ b/src/main/java/gregtech/api/multitileentity/machine/MultiTileBasicMachine.java
@@ -331,8 +331,7 @@ public class MultiTileBasicMachine extends BaseTickableMultiTileEntity {
         if (aSide == GT_Values.SIDE_UNKNOWN) return true;
         if (aSide >= 0 && aSide < 6) {
             if (isInvalid()) return false;
-            if (!getCoverBehaviorAtSideNew(aSide)
-                    .letsEnergyIn(aSide, getCoverIDAtSide(aSide), getComplexCoverDataAtSide(aSide), this)) return false;
+            if (!getCoverInfoAtSide(aSide).letsEnergyIn()) return false;
             if (isEnetInput()) return isEnergyInputSide(aSide);
         }
         return false;
@@ -343,9 +342,7 @@ public class MultiTileBasicMachine extends BaseTickableMultiTileEntity {
         if (aSide == GT_Values.SIDE_UNKNOWN) return true;
         if (aSide >= 0 && aSide < 6) {
             if (isInvalid()) return false;
-            if (!getCoverBehaviorAtSideNew(aSide)
-                    .letsEnergyOut(aSide, getCoverIDAtSide(aSide), getComplexCoverDataAtSide(aSide), this))
-                return false;
+            if (!getCoverInfoAtSide(aSide).letsEnergyOut()) return false;
             if (isEnetOutput()) return isEnergyOutputSide(aSide);
         }
         return false;

--- a/src/main/java/gregtech/api/multitileentity/multiblock/base/MultiBlockController.java
+++ b/src/main/java/gregtech/api/multitileentity/multiblock/base/MultiBlockController.java
@@ -339,9 +339,9 @@ public abstract class MultiBlockController<T extends MultiBlockController<T>> ex
     }
 
     private boolean tickCovers() {
-        for (byte i : ALL_VALID_SIDES) {
+        for (byte side : ALL_VALID_SIDES) {
             // TODO: Tick controller covers, if any
-            final LinkedList<WeakReference<IMultiBlockPart>> coveredParts = this.registeredCoveredParts.get(i);
+            final LinkedList<WeakReference<IMultiBlockPart>> coveredParts = this.registeredCoveredParts.get(side);
             final Iterator<WeakReference<IMultiBlockPart>> it = coveredParts.iterator();
             while (it.hasNext()) {
                 final IMultiBlockPart part = (it.next()).get();
@@ -349,7 +349,7 @@ public abstract class MultiBlockController<T extends MultiBlockController<T>> ex
                     it.remove();
                     continue;
                 }
-                if (!part.tickCoverAtSide(i, mTickTimer)) it.remove();
+                if (!part.tickCoverAtSide(side, mTickTimer)) it.remove();
             }
         }
 
@@ -560,7 +560,7 @@ public abstract class MultiBlockController<T extends MultiBlockController<T>> ex
                     mIcons = new IIcon[6];
                     Arrays.fill(mIcons, TextureSet.SET_NONE.mTextures[OrePrefixes.block.mTextureIndex].getIcon());
                     //                    Arrays.fill(mIcons, getTexture(aCasing);
-                    //                    for (int i = 0; i < 6; i++) {
+                    //                    for (byte i : ALL_VALID_SIDES) {
                     //                        mIcons[i] = aCasing.getIcon(i, aMeta);
                     //                    }
                 }

--- a/src/main/java/gregtech/api/multitileentity/multiblock/base/MultiBlockController.java
+++ b/src/main/java/gregtech/api/multitileentity/multiblock/base/MultiBlockController.java
@@ -964,11 +964,9 @@ public abstract class MultiBlockController<T extends MultiBlockController<T>> ex
 
     @Override
     public List<String> getInventoryNames(MultiBlockPart aPart) {
-        List<String> inventoryNames = new ArrayList<String>();
+        final List<String> inventoryNames = new ArrayList<>();
         inventoryNames.add("all");
-        for (String invName : getMultiBlockInventory(aPart).keySet()) {
-            inventoryNames.add(invName);
-        }
+        inventoryNames.addAll(getMultiBlockInventory(aPart).keySet());
         return inventoryNames;
     }
 
@@ -1132,7 +1130,7 @@ public abstract class MultiBlockController<T extends MultiBlockController<T>> ex
         final IItemHandlerModifiable inv = getInventoriesForInput();
         final Scrollable scrollable = new Scrollable().setVerticalScroll();
         for (int rows = 0; rows * 4 < Math.min(inv.getSlots(), 128); rows++) {
-            int columnsToMake = Math.min(Math.min(inv.getSlots(), 128) - rows * 4, 4);
+            final int columnsToMake = Math.min(Math.min(inv.getSlots(), 128) - rows * 4, 4);
             for (int column = 0; column < columnsToMake; column++) {
                 scrollable.widget(new SlotWidget(inv, rows * 4 + column)
                         .setPos(column * 18, rows * 18)
@@ -1146,7 +1144,7 @@ public abstract class MultiBlockController<T extends MultiBlockController<T>> ex
         final IItemHandlerModifiable inv = getInventoriesForOutput();
         final Scrollable scrollable = new Scrollable().setVerticalScroll();
         for (int rows = 0; rows * 4 < Math.min(inv.getSlots(), 128); rows++) {
-            int columnsToMake = Math.min(Math.min(inv.getSlots(), 128) - rows * 4, 4);
+            final int columnsToMake = Math.min(Math.min(inv.getSlots(), 128) - rows * 4, 4);
             for (int column = 0; column < columnsToMake; column++) {
                 scrollable.widget(new SlotWidget(inv, rows * 4 + column)
                         .setPos(column * 18, rows * 18)
@@ -1168,9 +1166,9 @@ public abstract class MultiBlockController<T extends MultiBlockController<T>> ex
         final IFluidTank[] tanks = mTanksInput;
         final Scrollable scrollable = new Scrollable().setVerticalScroll();
         for (int rows = 0; rows * 4 < tanks.length; rows++) {
-            int columnsToMake = Math.min(tanks.length - rows * 4, 4);
+            final int columnsToMake = Math.min(tanks.length - rows * 4, 4);
             for (int column = 0; column < columnsToMake; column++) {
-                FluidSlotWidget fluidSlot = new FluidSlotWidget(tanks[rows * 4 + column]);
+                final FluidSlotWidget fluidSlot = new FluidSlotWidget(tanks[rows * 4 + column]);
                 scrollable.widget(fluidSlot.setPos(column * 18, rows * 18).setSize(18, 18));
             }
         }
@@ -1181,9 +1179,9 @@ public abstract class MultiBlockController<T extends MultiBlockController<T>> ex
         final IFluidTank[] tanks = mTanksOutput;
         final Scrollable scrollable = new Scrollable().setVerticalScroll();
         for (int rows = 0; rows * 4 < tanks.length; rows++) {
-            int columnsToMake = Math.min(tanks.length - rows * 4, 4);
+            final int columnsToMake = Math.min(tanks.length - rows * 4, 4);
             for (int column = 0; column < columnsToMake; column++) {
-                FluidSlotWidget fluidSlot = new FluidSlotWidget(tanks[rows * 4 + column]);
+                final FluidSlotWidget fluidSlot = new FluidSlotWidget(tanks[rows * 4 + column]);
                 fluidSlot.setInteraction(true, false);
                 scrollable.widget(fluidSlot.setPos(column * 18, rows * 18).setSize(18, 18));
             }

--- a/src/main/java/gregtech/api/multitileentity/multiblock/base/MultiBlockPart.java
+++ b/src/main/java/gregtech/api/multitileentity/multiblock/base/MultiBlockPart.java
@@ -35,15 +35,12 @@ import gregtech.api.multitileentity.interfaces.IMultiBlockPart;
 import gregtech.api.multitileentity.interfaces.IMultiTileEntity.IMTE_BreakBlock;
 import gregtech.api.multitileentity.interfaces.IMultiTileEntity.IMTE_HasModes;
 import gregtech.api.render.TextureFactory;
-import gregtech.api.util.GT_CoverBehaviorBase;
 import gregtech.api.util.GT_Utility;
-import gregtech.api.util.ISerializableObject;
+import gregtech.common.covers.CoverInfo;
 import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
-import gregtech.common.covers.CoverInfo;
 import mcp.mobius.waila.api.IWailaConfigHandler;
 import mcp.mobius.waila.api.IWailaDataAccessor;
 import net.minecraft.block.Block;
@@ -140,7 +137,7 @@ public class MultiBlockPart extends BaseNontickableMultiTileEntity
     public void registerCovers(IMultiBlockController controller) {
         for (byte i : ALL_VALID_SIDES) {
             final CoverInfo coverInfo = getCoverInfoAtSide(i);
-            if(coverInfo.isValid() && coverInfo.getTickRate() > 0) {
+            if (coverInfo.isValid() && coverInfo.getTickRate() > 0) {
                 controller.registerCoveredPartOnSide(i, this);
             }
         }
@@ -153,7 +150,7 @@ public class MultiBlockPart extends BaseNontickableMultiTileEntity
         final IMultiBlockController tTarget = getTarget(true);
         if (tTarget != null) {
             final CoverInfo coverInfo = getCoverInfoAtSide(aSide);
-            if(coverInfo.isValid() && coverInfo.getTickRate() > 0) {
+            if (coverInfo.isValid() && coverInfo.getTickRate() > 0) {
                 tTarget.registerCoveredPartOnSide(aSide, this);
             }
         }
@@ -462,13 +459,10 @@ public class MultiBlockPart extends BaseNontickableMultiTileEntity
         final IMultiBlockController controller = getTarget(true);
         if (controller == null) return GT_Values.emptyFluidTankInfo;
 
-        final GT_CoverBehaviorBase<?> tCover = getCoverBehaviorAtSideNew(aSide);
-        final int coverId = getCoverIDAtSide(aSide);
-        final ISerializableObject complexCoverData = getComplexCoverDataAtSide(aSide);
+        final CoverInfo coverInfo = getCoverInfoAtSide(aSide);
 
-        if ((controller.isLiquidInput(aSide) && tCover.letsFluidIn(aSide, coverId, complexCoverData, null, controller))
-                || (controller.isLiquidOutput(aSide)
-                        && tCover.letsFluidOut(aSide, coverId, complexCoverData, null, controller)))
+        if ((controller.isLiquidInput(aSide) && coverInfo.letsFluidIn(null, controller))
+                || (controller.isLiquidOutput(aSide) && coverInfo.letsFluidOut(null, controller)))
             return controller.getTankInfo(this, aDirection);
 
         return GT_Values.emptyFluidTankInfo;

--- a/src/main/java/gregtech/api/multitileentity/multiblock/base/MultiBlockPart.java
+++ b/src/main/java/gregtech/api/multitileentity/multiblock/base/MultiBlockPart.java
@@ -42,6 +42,8 @@ import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
+import gregtech.common.covers.CoverInfo;
 import mcp.mobius.waila.api.IWailaConfigHandler;
 import mcp.mobius.waila.api.IWailaDataAccessor;
 import net.minecraft.block.Block;
@@ -137,11 +139,9 @@ public class MultiBlockPart extends BaseNontickableMultiTileEntity
 
     public void registerCovers(IMultiBlockController controller) {
         for (byte i : ALL_VALID_SIDES) {
-            final int coverId = getCoverIDAtSide(i);
-            if (coverId != 0) {
-                if (getCoverBehaviorAtSideNew(i).getTickRate(i, coverId, getComplexCoverDataAtSide(i), this) > 0) {
-                    controller.registerCoveredPartOnSide(i, this);
-                }
+            final CoverInfo coverInfo = getCoverInfoAtSide(i);
+            if(coverInfo.isValid() && coverInfo.getTickRate() > 0) {
+                controller.registerCoveredPartOnSide(i, this);
             }
         }
     }
@@ -152,19 +152,16 @@ public class MultiBlockPart extends BaseNontickableMultiTileEntity
         // TODO: Filter on tickable covers
         final IMultiBlockController tTarget = getTarget(true);
         if (tTarget != null) {
-            final int coverId = getCoverIDAtSide(aSide);
-            if (coverId != 0) {
-                if (getCoverBehaviorAtSideNew(aSide).getTickRate(aSide, coverId, getComplexCoverDataAtSide(aSide), this)
-                        > 0) {
-                    tTarget.registerCoveredPartOnSide(aSide, this);
-                }
+            final CoverInfo coverInfo = getCoverInfoAtSide(aSide);
+            if(coverInfo.isValid() && coverInfo.getTickRate() > 0) {
+                tTarget.registerCoveredPartOnSide(aSide, this);
             }
         }
     }
 
     public void unregisterCovers(IMultiBlockController controller) {
         for (byte i : ALL_VALID_SIDES) {
-            if (getCoverIDAtSide(i) != 0) {
+            if (getCoverInfoAtSide(i).isValid()) {
                 controller.unregisterCoveredPartOnSide(i, this);
             }
         }

--- a/src/main/java/gregtech/api/net/GT_Packet_RequestCoverData.java
+++ b/src/main/java/gregtech/api/net/GT_Packet_RequestCoverData.java
@@ -3,6 +3,7 @@ package gregtech.api.net;
 import com.google.common.io.ByteArrayDataInput;
 import gregtech.api.interfaces.tileentity.ICoverable;
 import gregtech.api.metatileentity.CoverableTileEntity;
+import gregtech.common.covers.CoverInfo;
 import io.netty.buffer.ByteBuf;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.network.INetHandler;
@@ -29,6 +30,15 @@ public class GT_Packet_RequestCoverData extends GT_Packet_New {
         super(true);
     }
 
+    public GT_Packet_RequestCoverData(CoverInfo info, ICoverable tile) {
+        super(false);
+        this.mX = tile.getXCoord();
+        this.mY = tile.getYCoord();
+        this.mZ = tile.getZCoord();
+
+        this.side = info.getSide();
+        this.coverID = info.getCoverID();
+    }
     public GT_Packet_RequestCoverData(int mX, short mY, int mZ, byte coverSide, int coverID) {
         super(false);
         this.mX = mX;
@@ -79,9 +89,9 @@ public class GT_Packet_RequestCoverData extends GT_Packet_New {
 
     @Override
     public void process(IBlockAccess aWorld) {
-        if (mPlayer == null) // impossible, but who knows
-        return;
-        World world = DimensionManager.getWorld(mPlayer.dimension);
+        // impossible, but who knows
+        if (mPlayer == null) return;
+        final World world = DimensionManager.getWorld(mPlayer.dimension);
         if (world != null) {
             final TileEntity tile = world.getTileEntity(mX, mY, mZ);
             if (tile instanceof CoverableTileEntity) {

--- a/src/main/java/gregtech/api/net/GT_Packet_RequestCoverData.java
+++ b/src/main/java/gregtech/api/net/GT_Packet_RequestCoverData.java
@@ -39,6 +39,7 @@ public class GT_Packet_RequestCoverData extends GT_Packet_New {
         this.side = info.getSide();
         this.coverID = info.getCoverID();
     }
+
     public GT_Packet_RequestCoverData(int mX, short mY, int mZ, byte coverSide, int coverID) {
         super(false);
         this.mX = mX;

--- a/src/main/java/gregtech/api/net/GT_Packet_SendCoverData.java
+++ b/src/main/java/gregtech/api/net/GT_Packet_SendCoverData.java
@@ -5,6 +5,7 @@ import gregtech.api.GregTech_API;
 import gregtech.api.interfaces.tileentity.ICoverable;
 import gregtech.api.metatileentity.CoverableTileEntity;
 import gregtech.api.util.ISerializableObject;
+import gregtech.common.covers.CoverInfo;
 import io.netty.buffer.ByteBuf;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.IBlockAccess;
@@ -37,6 +38,17 @@ public class GT_Packet_SendCoverData extends GT_Packet_New {
         this.coverData = coverData;
     }
 
+    public GT_Packet_SendCoverData(CoverInfo info, ICoverable tile) {
+        super(false);
+        this.mX = tile.getXCoord();
+        this.mY = tile.getYCoord();
+        this.mZ = tile.getZCoord();
+
+        this.side = info.getSide();
+        this.coverID = info.getCoverID();
+        this.coverData = info.getCoverData();
+    }
+
     public GT_Packet_SendCoverData(byte coverSide, int coverID, ISerializableObject coverData, ICoverable tile) {
         super(false);
         this.mX = tile.getXCoord();
@@ -66,7 +78,7 @@ public class GT_Packet_SendCoverData extends GT_Packet_New {
 
     @Override
     public GT_Packet_New decode(ByteArrayDataInput aData) {
-        int coverId;
+        final int coverId;
         return new GT_Packet_SendCoverData(
                 aData.readInt(),
                 aData.readShort(),
@@ -79,7 +91,7 @@ public class GT_Packet_SendCoverData extends GT_Packet_New {
     @Override
     public void process(IBlockAccess aWorld) {
         if (aWorld != null) {
-            TileEntity tile = aWorld.getTileEntity(mX, mY, mZ);
+            final TileEntity tile = aWorld.getTileEntity(mX, mY, mZ);
             if (tile instanceof CoverableTileEntity && !((CoverableTileEntity) tile).isDead()) {
                 ((CoverableTileEntity) tile).receiveCoverData(side, coverID, coverData, null);
             }

--- a/src/main/java/gregtech/api/net/GT_Packet_TileEntityCoverGUI.java
+++ b/src/main/java/gregtech/api/net/GT_Packet_TileEntityCoverGUI.java
@@ -72,9 +72,8 @@ public class GT_Packet_TileEntityCoverGUI extends GT_Packet_New {
         this.playerID = playerID;
         this.parentGuiId = -1;
     }
-    public GT_Packet_TileEntityCoverGUI(CoverInfo coverInfo,            int dimID,
-                                        int playerID,
-                                        int parentGuiId) {
+
+    public GT_Packet_TileEntityCoverGUI(CoverInfo coverInfo, int dimID, int playerID, int parentGuiId) {
         super(false);
         final ICoverable tile = coverInfo.getTile();
         this.mX = tile.getXCoord();
@@ -200,15 +199,15 @@ public class GT_Packet_TileEntityCoverGUI extends GT_Packet_New {
     public void process(IBlockAccess aWorld) {
         if (aWorld instanceof World) {
             // Using EntityPlayer instead of EntityClientPlayerMP so both client and server can load this
-            EntityPlayer thePlayer = ((EntityPlayer) ((World) aWorld).getEntityByID(playerID));
-            TileEntity tile = aWorld.getTileEntity(mX, mY, mZ);
+            final EntityPlayer thePlayer = ((EntityPlayer) ((World) aWorld).getEntityByID(playerID));
+            final TileEntity tile = aWorld.getTileEntity(mX, mY, mZ);
             if (tile instanceof IGregTechTileEntity && !((IGregTechTileEntity) tile).isDead()) {
-                IGregTechTileEntity gtTile = ((IGregTechTileEntity) tile);
+                final IGregTechTileEntity gtTile = ((IGregTechTileEntity) tile);
                 gtTile.setCoverDataAtSide(side, coverData); // Set it client side to read later.
 
                 GT_CoverBehaviorBase<?> cover = gtTile.getCoverBehaviorAtSideNew(side);
                 if (cover.hasCoverGUI()) {
-                    GuiScreen gui = (GuiScreen) cover.getClientGUI(
+                    final GuiScreen gui = (GuiScreen) cover.getClientGUI(
                             side,
                             gtTile.getCoverIDAtSide(side),
                             gtTile.getComplexCoverDataAtSide(side),

--- a/src/main/java/gregtech/api/net/GT_Packet_TileEntityCoverGUI.java
+++ b/src/main/java/gregtech/api/net/GT_Packet_TileEntityCoverGUI.java
@@ -7,6 +7,7 @@ import gregtech.api.interfaces.tileentity.ICoverable;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.util.GT_CoverBehaviorBase;
 import gregtech.api.util.ISerializableObject;
+import gregtech.common.covers.CoverInfo;
 import io.netty.buffer.ByteBuf;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
@@ -70,6 +71,23 @@ public class GT_Packet_TileEntityCoverGUI extends GT_Packet_New {
         this.dimID = dimID;
         this.playerID = playerID;
         this.parentGuiId = -1;
+    }
+    public GT_Packet_TileEntityCoverGUI(CoverInfo coverInfo,            int dimID,
+                                        int playerID,
+                                        int parentGuiId) {
+        super(false);
+        final ICoverable tile = coverInfo.getTile();
+        this.mX = tile.getXCoord();
+        this.mY = tile.getYCoord();
+        this.mZ = tile.getZCoord();
+
+        this.side = coverInfo.getSide();
+        this.coverID = coverInfo.getCoverID();
+        this.coverData = coverInfo.getCoverData();
+
+        this.dimID = dimID;
+        this.playerID = playerID;
+        this.parentGuiId = parentGuiId;
     }
 
     public GT_Packet_TileEntityCoverGUI(

--- a/src/main/java/gregtech/api/threads/GT_Runnable_Cable_Update.java
+++ b/src/main/java/gregtech/api/threads/GT_Runnable_Cable_Update.java
@@ -10,6 +10,8 @@ import net.minecraft.util.ChunkCoordinates;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import static gregtech.api.enums.GT_Values.ALL_VALID_SIDES;
+
 public class GT_Runnable_Cable_Update extends GT_Runnable_MachineBlockUpdate {
     protected GT_Runnable_Cable_Update(World aWorld, ChunkCoordinates aCoords) {
         super(aWorld, aCoords);
@@ -50,10 +52,10 @@ public class GT_Runnable_Cable_Update extends GT_Runnable_MachineBlockUpdate {
                 if (tTileEntity instanceof BaseMetaPipeEntity
                         && ((BaseMetaPipeEntity) tTileEntity).getMetaTileEntity() instanceof GT_MetaPipeEntity_Cable) {
                     ChunkCoordinates tCoords;
-                    for (byte i = 0; i < 6; i++) {
+                    for (byte tSide : ALL_VALID_SIDES) {
                         if (((GT_MetaPipeEntity_Cable) ((BaseMetaPipeEntity) tTileEntity).getMetaTileEntity())
-                                .isConnectedAtSide(i)) {
-                            ForgeDirection offset = ForgeDirection.getOrientation(i);
+                                .isConnectedAtSide(tSide)) {
+                            final ForgeDirection offset = ForgeDirection.getOrientation(tSide);
                             if (visited.add(
                                     tCoords = new ChunkCoordinates(
                                             aCoords.posX + offset.offsetX,

--- a/src/main/java/gregtech/api/threads/GT_Runnable_Cable_Update.java
+++ b/src/main/java/gregtech/api/threads/GT_Runnable_Cable_Update.java
@@ -1,5 +1,7 @@
 package gregtech.api.threads;
 
+import static gregtech.api.enums.GT_Values.ALL_VALID_SIDES;
+
 import gregtech.GT_Mod;
 import gregtech.api.interfaces.tileentity.IMachineBlockUpdateable;
 import gregtech.api.metatileentity.BaseMetaPipeEntity;
@@ -9,8 +11,6 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ChunkCoordinates;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
-
-import static gregtech.api.enums.GT_Values.ALL_VALID_SIDES;
 
 public class GT_Runnable_Cable_Update extends GT_Runnable_MachineBlockUpdate {
     protected GT_Runnable_Cable_Update(World aWorld, ChunkCoordinates aCoords) {

--- a/src/main/java/gregtech/api/util/GT_CircuitryBehavior.java
+++ b/src/main/java/gregtech/api/util/GT_CircuitryBehavior.java
@@ -5,6 +5,8 @@ import cpw.mods.fml.relauncher.SideOnly;
 import gregtech.api.GregTech_API;
 import gregtech.api.interfaces.IRedstoneCircuitBlock;
 
+import static gregtech.api.enums.GT_Values.ALL_VALID_SIDES;
+
 /**
  * Redstone Circuit Control Code
  * <p/>
@@ -31,17 +33,17 @@ public abstract class GT_CircuitryBehavior {
     /**
      * returns if there is Redstone applied to any of the valid Inputs (OR)
      */
-    public static final boolean getAnyRedstone(IRedstoneCircuitBlock aRedstoneCircuitBlock) {
-        for (byte i = 0; i < 6; i++) {
-            if (i != aRedstoneCircuitBlock.getOutputFacing()
+    public static boolean getAnyRedstone(IRedstoneCircuitBlock aRedstoneCircuitBlock) {
+        for (byte side : ALL_VALID_SIDES) {
+            if (side != aRedstoneCircuitBlock.getOutputFacing()
                     && aRedstoneCircuitBlock
-                            .getCover(i)
+                            .getCover(side)
                             .letsRedstoneGoIn(
-                                    i,
-                                    aRedstoneCircuitBlock.getCoverID(i),
-                                    aRedstoneCircuitBlock.getCoverVariable(i),
+                                    side,
+                                    aRedstoneCircuitBlock.getCoverID(side),
+                                    aRedstoneCircuitBlock.getCoverVariable(side),
                                     aRedstoneCircuitBlock.getOwnTileEntity())) {
-                if (aRedstoneCircuitBlock.getInputRedstone(i) > 0) {
+                if (aRedstoneCircuitBlock.getInputRedstone(side) > 0) {
                     return true;
                 }
             }
@@ -52,17 +54,17 @@ public abstract class GT_CircuitryBehavior {
     /**
      * returns if there is Redstone applied to all the valid Inputs (AND)
      */
-    public static final boolean getAllRedstone(IRedstoneCircuitBlock aRedstoneCircuitBlock) {
-        for (byte i = 0; i < 6; i++) {
-            if (i != aRedstoneCircuitBlock.getOutputFacing()
+    public static boolean getAllRedstone(IRedstoneCircuitBlock aRedstoneCircuitBlock) {
+        for (byte side : ALL_VALID_SIDES) {
+            if (side != aRedstoneCircuitBlock.getOutputFacing()
                     && aRedstoneCircuitBlock
-                            .getCover(i)
+                            .getCover(side)
                             .letsRedstoneGoIn(
-                                    i,
-                                    aRedstoneCircuitBlock.getCoverID(i),
-                                    aRedstoneCircuitBlock.getCoverVariable(i),
+                                    side,
+                                    aRedstoneCircuitBlock.getCoverID(side),
+                                    aRedstoneCircuitBlock.getCoverVariable(side),
                                     aRedstoneCircuitBlock.getOwnTileEntity())) {
-                if (aRedstoneCircuitBlock.getInputRedstone(i) == 0) {
+                if (aRedstoneCircuitBlock.getInputRedstone(side) == 0) {
                     return false;
                 }
             }
@@ -73,18 +75,18 @@ public abstract class GT_CircuitryBehavior {
     /**
      * returns if there is Redstone applied to exactly one of the valid Inputs (XOR)
      */
-    public static final boolean getOneRedstone(IRedstoneCircuitBlock aRedstoneCircuitBlock) {
+    public static boolean getOneRedstone(IRedstoneCircuitBlock aRedstoneCircuitBlock) {
         int tRedstoneAmount = 0;
-        for (byte i = 0; i < 6; i++) {
-            if (i != aRedstoneCircuitBlock.getOutputFacing()
+        for (byte side : ALL_VALID_SIDES) {
+            if (side != aRedstoneCircuitBlock.getOutputFacing()
                     && aRedstoneCircuitBlock
-                            .getCover(i)
+                            .getCover(side)
                             .letsRedstoneGoIn(
-                                    i,
-                                    aRedstoneCircuitBlock.getCoverID(i),
-                                    aRedstoneCircuitBlock.getCoverVariable(i),
+                                    side,
+                                    aRedstoneCircuitBlock.getCoverID(side),
+                                    aRedstoneCircuitBlock.getCoverVariable(side),
                                     aRedstoneCircuitBlock.getOwnTileEntity())) {
-                if (aRedstoneCircuitBlock.getInputRedstone(i) > 0) {
+                if (aRedstoneCircuitBlock.getInputRedstone(side) > 0) {
                     tRedstoneAmount++;
                 }
             }
@@ -95,18 +97,18 @@ public abstract class GT_CircuitryBehavior {
     /**
      * returns the strongest incoming RS-Power
      */
-    public static final byte getStrongestRedstone(IRedstoneCircuitBlock aRedstoneCircuitBlock) {
+    public static byte getStrongestRedstone(IRedstoneCircuitBlock aRedstoneCircuitBlock) {
         byte tRedstoneAmount = 0;
-        for (byte i = 0; i < 6; i++) {
-            if (i != aRedstoneCircuitBlock.getOutputFacing()
+        for (byte side : ALL_VALID_SIDES) {
+            if (side != aRedstoneCircuitBlock.getOutputFacing()
                     && aRedstoneCircuitBlock
-                            .getCover(i)
+                            .getCover(side)
                             .letsRedstoneGoIn(
-                                    i,
-                                    aRedstoneCircuitBlock.getCoverID(i),
-                                    aRedstoneCircuitBlock.getCoverVariable(i),
+                                    side,
+                                    aRedstoneCircuitBlock.getCoverID(side),
+                                    aRedstoneCircuitBlock.getCoverVariable(side),
                                     aRedstoneCircuitBlock.getOwnTileEntity())) {
-                tRedstoneAmount = (byte) Math.max(tRedstoneAmount, aRedstoneCircuitBlock.getInputRedstone(i));
+                tRedstoneAmount = (byte) Math.max(tRedstoneAmount, aRedstoneCircuitBlock.getInputRedstone(side));
             }
         }
         return tRedstoneAmount;
@@ -119,20 +121,20 @@ public abstract class GT_CircuitryBehavior {
     /**
      * returns the weakest incoming non-zero RS-Power
      */
-    public static final byte getWeakestNonZeroRedstone(IRedstoneCircuitBlock aRedstoneCircuitBlock) {
+    public static byte getWeakestNonZeroRedstone(IRedstoneCircuitBlock aRedstoneCircuitBlock) {
         if (!getAnyRedstone(aRedstoneCircuitBlock)) return 0;
         byte tRedstoneAmount = 15;
-        for (byte i = 0; i < 6; i++) {
-            if (i != aRedstoneCircuitBlock.getOutputFacing()
+        for (byte side : ALL_VALID_SIDES) {
+            if (side != aRedstoneCircuitBlock.getOutputFacing()
                     && aRedstoneCircuitBlock
-                            .getCover(i)
+                            .getCover(side)
                             .letsRedstoneGoIn(
-                                    i,
-                                    aRedstoneCircuitBlock.getCoverID(i),
-                                    aRedstoneCircuitBlock.getCoverVariable(i),
+                                    side,
+                                    aRedstoneCircuitBlock.getCoverID(side),
+                                    aRedstoneCircuitBlock.getCoverVariable(side),
                                     aRedstoneCircuitBlock.getOwnTileEntity())) {
-                if (aRedstoneCircuitBlock.getInputRedstone(i) > 0)
-                    tRedstoneAmount = (byte) Math.min(tRedstoneAmount, aRedstoneCircuitBlock.getInputRedstone(i));
+                if (aRedstoneCircuitBlock.getInputRedstone(side) > 0)
+                    tRedstoneAmount = (byte) Math.min(tRedstoneAmount, aRedstoneCircuitBlock.getInputRedstone(side));
             }
         }
         return tRedstoneAmount;
@@ -141,19 +143,19 @@ public abstract class GT_CircuitryBehavior {
     /**
      * returns the weakest incoming RS-Power
      */
-    public static final byte getWeakestRedstone(IRedstoneCircuitBlock aRedstoneCircuitBlock) {
+    public static byte getWeakestRedstone(IRedstoneCircuitBlock aRedstoneCircuitBlock) {
         if (!getAnyRedstone(aRedstoneCircuitBlock)) return 0;
         byte tRedstoneAmount = 15;
-        for (byte i = 0; i < 6; i++) {
-            if (i != aRedstoneCircuitBlock.getOutputFacing()
+        for (byte side : ALL_VALID_SIDES) {
+            if (side != aRedstoneCircuitBlock.getOutputFacing()
                     && aRedstoneCircuitBlock
-                            .getCover(i)
+                            .getCover(side)
                             .letsRedstoneGoIn(
-                                    i,
-                                    aRedstoneCircuitBlock.getCoverID(i),
-                                    aRedstoneCircuitBlock.getCoverVariable(i),
+                                    side,
+                                    aRedstoneCircuitBlock.getCoverID(side),
+                                    aRedstoneCircuitBlock.getCoverVariable(side),
                                     aRedstoneCircuitBlock.getOwnTileEntity())) {
-                tRedstoneAmount = (byte) Math.min(tRedstoneAmount, aRedstoneCircuitBlock.getInputRedstone(i));
+                tRedstoneAmount = (byte) Math.min(tRedstoneAmount, aRedstoneCircuitBlock.getInputRedstone(side));
             }
         }
         return tRedstoneAmount;

--- a/src/main/java/gregtech/api/util/GT_CircuitryBehavior.java
+++ b/src/main/java/gregtech/api/util/GT_CircuitryBehavior.java
@@ -1,11 +1,11 @@
 package gregtech.api.util;
 
+import static gregtech.api.enums.GT_Values.ALL_VALID_SIDES;
+
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import gregtech.api.GregTech_API;
 import gregtech.api.interfaces.IRedstoneCircuitBlock;
-
-import static gregtech.api.enums.GT_Values.ALL_VALID_SIDES;
 
 /**
  * Redstone Circuit Control Code

--- a/src/main/java/gregtech/api/util/GT_CoverBehaviorBase.java
+++ b/src/main/java/gregtech/api/util/GT_CoverBehaviorBase.java
@@ -62,7 +62,7 @@ public abstract class GT_CoverBehaviorBase<T extends ISerializableObject> {
             return createDataObject(((NBTTagInt) aNBT).func_150287_d());
         }
 
-        T ret = createDataObject();
+        final T ret = createDataObject();
         ret.loadDataFromNBT(aNBT);
         return ret;
     }

--- a/src/main/java/gregtech/api/util/GT_Utility.java
+++ b/src/main/java/gregtech/api/util/GT_Utility.java
@@ -3337,12 +3337,8 @@ public class GT_Utility {
                 if (tTileEntity instanceof ICoverable) {
                     rEUAmount += 300;
                     final String tString = ((ICoverable) tTileEntity)
-                            .getCoverBehaviorAtSideNew((byte) aSide)
-                            .getDescription(
-                                    (byte) aSide,
-                                    ((ICoverable) tTileEntity).getCoverIDAtSide((byte) aSide),
-                                    ((ICoverable) tTileEntity).getComplexCoverDataAtSide((byte) aSide),
-                                    (ICoverable) tTileEntity);
+                            .getCoverInfoAtSide((byte) aSide)
+                            .getBehaviorDescription();
                     if (tString != null && !tString.equals(E)) tList.add(tString);
                 }
             } catch (Throwable e) {

--- a/src/main/java/gregtech/common/GT_Client.java
+++ b/src/main/java/gregtech/common/GT_Client.java
@@ -5,6 +5,7 @@
 
 package gregtech.common;
 
+import static gregtech.api.enums.GT_Values.ALL_VALID_SIDES;
 import static gregtech.api.enums.GT_Values.calculateMaxPlasmaTurbineEfficiency;
 import static org.lwjgl.opengl.GL11.GL_LINE_LOOP;
 
@@ -328,16 +329,16 @@ public class GT_Client extends GT_Proxy implements Runnable {
         byte tConnections = 0;
         if (tTile instanceof ICoverable) {
             if (showCoverConnections) {
-                for (byte i = 0; i < 6; i++) {
-                    if (((ICoverable) tTile).getCoverIDAtSide(i) > 0) tConnections = (byte) (tConnections + (1 << i));
+                for (byte tSide : ALL_VALID_SIDES) {
+                    if (((ICoverable) tTile).getCoverIDAtSide(tSide) > 0) tConnections = (byte) (tConnections + (1 << tSide));
                 }
             } else if (tTile instanceof BaseMetaPipeEntity) tConnections = ((BaseMetaPipeEntity) tTile).mConnections;
         }
 
         if (tConnections > 0) {
-            for (byte i = 0; i < 6; i++) {
-                if ((tConnections & (1 << i)) != 0) {
-                    switch (GRID_SWITCH_TABLE[aEvent.target.sideHit][i]) {
+            for (byte tSide : ALL_VALID_SIDES) {
+                if ((tConnections & (1 << tSide)) != 0) {
+                    switch (GRID_SWITCH_TABLE[aEvent.target.sideHit][tSide]) {
                         case 0:
                             GL11.glVertex3d(+.25D, .0D, +.25D);
                             GL11.glVertex3d(-.25D, .0D, -.25D);
@@ -787,8 +788,8 @@ public class GT_Client extends GT_Proxy implements Runnable {
                 || GT_Utility.isStackInList(aEvent.currentItem, GregTech_API.sCrowbarList)
                 || GT_Utility.isStackInList(aEvent.currentItem, GregTech_API.sScrewdriverList)) {
             if (((ICoverable) aTileEntity).getCoverIDAtSide((byte) aEvent.target.sideHit) == 0)
-                for (byte i = 0; i < 6; i++)
-                    if (((ICoverable) aTileEntity).getCoverIDAtSide(i) > 0) {
+                for (byte tSide : ALL_VALID_SIDES)
+                    if (((ICoverable) aTileEntity).getCoverIDAtSide(tSide) > 0) {
                         drawGrid(aEvent, true, false, true);
                         return;
                     }

--- a/src/main/java/gregtech/common/GT_Client.java
+++ b/src/main/java/gregtech/common/GT_Client.java
@@ -330,7 +330,8 @@ public class GT_Client extends GT_Proxy implements Runnable {
         if (tTile instanceof ICoverable) {
             if (showCoverConnections) {
                 for (byte tSide : ALL_VALID_SIDES) {
-                    if (((ICoverable) tTile).getCoverIDAtSide(tSide) > 0) tConnections = (byte) (tConnections + (1 << tSide));
+                    if (((ICoverable) tTile).getCoverIDAtSide(tSide) > 0)
+                        tConnections = (byte) (tConnections + (1 << tSide));
                 }
             } else if (tTile instanceof BaseMetaPipeEntity) tConnections = ((BaseMetaPipeEntity) tTile).mConnections;
         }

--- a/src/main/java/gregtech/common/GT_Proxy.java
+++ b/src/main/java/gregtech/common/GT_Proxy.java
@@ -2191,16 +2191,16 @@ public abstract class GT_Proxy implements IGT_Mod, IGuiHandler, IFuelHandler, IG
                                     GT_MetaGenerated_Tool_01.AXE, 1, Materials.Flint, Materials.Wood, null)));
                 }
             }
-            boolean tHungerEffect = (this.mHungerEffect) && (aEvent.player.ticksExisted % 2400 == 1200);
+            final boolean tHungerEffect = (this.mHungerEffect) && (aEvent.player.ticksExisted % 2400 == 1200);
             if (aEvent.player.ticksExisted % 120 == 0) {
                 int tCount = 64;
                 for (int i = 0; i < 36; i++) {
-                    ItemStack tStack;
+                    final ItemStack tStack;
                     if ((tStack = aEvent.player.inventory.getStackInSlot(i)) != null) {
                         if (!aEvent.player.capabilities.isCreativeMode) {
                             GT_Utility.applyRadioactivity(
                                     aEvent.player, GT_Utility.getRadioactivityLevel(tStack), tStack.stackSize);
-                            float tHeat = GT_Utility.getHeatDamageFromItem(tStack);
+                            final float tHeat = GT_Utility.getHeatDamageFromItem(tStack);
                             if (tHeat != 0.0F) {
                                 if (tHeat > 0.0F) {
                                     GT_Utility.applyHeatDamageFromItem(aEvent.player, tHeat, tStack);
@@ -2218,12 +2218,12 @@ public abstract class GT_Proxy implements IGT_Mod, IGuiHandler, IFuelHandler, IG
                     }
                 }
                 for (int i = 0; i < 4; i++) {
-                    ItemStack tStack;
+                    final ItemStack tStack;
                     if ((tStack = aEvent.player.inventory.armorInventory[i]) != null) {
                         if (!aEvent.player.capabilities.isCreativeMode) {
                             GT_Utility.applyRadioactivity(
                                     aEvent.player, GT_Utility.getRadioactivityLevel(tStack), tStack.stackSize);
-                            float tHeat = GT_Utility.getHeatDamageFromItem(tStack);
+                            final float tHeat = GT_Utility.getHeatDamageFromItem(tStack);
                             if (tHeat != 0.0F) {
                                 if (tHeat > 0.0F) {
                                     GT_Utility.applyHeatDamageFromItem(aEvent.player, tHeat, tStack);
@@ -2257,12 +2257,12 @@ public abstract class GT_Proxy implements IGT_Mod, IGuiHandler, IFuelHandler, IG
         if (aID >= 1000) {
             return null;
         }
-        TileEntity tTileEntity = aWorld.getTileEntity(aX, aY, aZ);
+        final TileEntity tTileEntity = aWorld.getTileEntity(aX, aY, aZ);
         if ((tTileEntity instanceof IGregTechTileEntity)) {
             if (GUI_ID_COVER_SIDE_BASE <= aID && aID < GUI_ID_COVER_SIDE_BASE + 6) {
                 return null;
             }
-            IMetaTileEntity tMetaTileEntity = ((IGregTechTileEntity) tTileEntity).getMetaTileEntity();
+            final IMetaTileEntity tMetaTileEntity = ((IGregTechTileEntity) tTileEntity).getMetaTileEntity();
             if (tMetaTileEntity != null && !tMetaTileEntity.useModularUI()) {
                 return tMetaTileEntity.getServerGUI(aID, aPlayer.inventory, (IGregTechTileEntity) tTileEntity);
             }
@@ -2275,12 +2275,12 @@ public abstract class GT_Proxy implements IGT_Mod, IGuiHandler, IFuelHandler, IG
         if (aID >= 1000) {
             return null;
         }
-        TileEntity tTileEntity = aWorld.getTileEntity(aX, aY, aZ);
+        final TileEntity tTileEntity = aWorld.getTileEntity(aX, aY, aZ);
         if ((tTileEntity instanceof IGregTechTileEntity)) {
-            IGregTechTileEntity tile = (IGregTechTileEntity) tTileEntity;
+            final IGregTechTileEntity tile = (IGregTechTileEntity) tTileEntity;
 
             if (GUI_ID_COVER_SIDE_BASE <= aID && aID < GUI_ID_COVER_SIDE_BASE + 6) {
-                byte side = (byte) (aID - GT_Proxy.GUI_ID_COVER_SIDE_BASE);
+                final byte side = (byte) (aID - GT_Proxy.GUI_ID_COVER_SIDE_BASE);
                 GT_CoverBehaviorBase<?> cover = tile.getCoverBehaviorAtSideNew(side);
 
                 if (cover.hasCoverGUI() && !cover.useModularUI()) {
@@ -2294,7 +2294,7 @@ public abstract class GT_Proxy implements IGT_Mod, IGuiHandler, IFuelHandler, IG
                 }
                 return null;
             }
-            IMetaTileEntity tMetaTileEntity = tile.getMetaTileEntity();
+            final IMetaTileEntity tMetaTileEntity = tile.getMetaTileEntity();
             if (tMetaTileEntity != null && !tMetaTileEntity.useModularUI()) {
                 return tMetaTileEntity.getClientGUI(aID, aPlayer.inventory, tile);
             }
@@ -2315,15 +2315,16 @@ public abstract class GT_Proxy implements IGT_Mod, IGuiHandler, IFuelHandler, IG
         }
         int rFuelValue = 0;
         if ((aFuel.getItem() instanceof GT_MetaGenerated_Item)) {
-            Short tFuelValue = ((GT_MetaGenerated_Item) aFuel.getItem()).mBurnValues.get((short) aFuel.getItemDamage());
+            final Short tFuelValue =
+                    ((GT_MetaGenerated_Item) aFuel.getItem()).mBurnValues.get((short) aFuel.getItemDamage());
             if (tFuelValue != null) {
                 rFuelValue = Math.max(rFuelValue, tFuelValue);
             }
         }
-        NBTTagCompound tNBT = aFuel.getTagCompound();
+        final NBTTagCompound tNBT = aFuel.getTagCompound();
         if (tNBT != null) {
             // See if we have something defined by NBT
-            short tValue = tNBT.getShort("GT.ItemFuelValue");
+            final short tValue = tNBT.getShort("GT.ItemFuelValue");
             rFuelValue = Math.max(rFuelValue, tValue);
         } else {
             // If not check the ore dict

--- a/src/main/java/gregtech/common/blocks/GT_Block_Machines.java
+++ b/src/main/java/gregtech/common/blocks/GT_Block_Machines.java
@@ -23,6 +23,7 @@ import gregtech.api.metatileentity.CoverableTileEntity;
 import gregtech.api.util.GT_BaseCrop;
 import gregtech.api.util.GT_Log;
 import gregtech.api.util.GT_Utility;
+import gregtech.common.covers.CoverInfo;
 import gregtech.common.render.GT_Renderer_Block;
 import gregtech.common.tileentities.storage.GT_MetaTileEntity_QuantumChest;
 import java.util.ArrayList;
@@ -658,16 +659,13 @@ public class GT_Block_Machines extends GT_Generic_Block implements IDebugableBlo
             final byte aSide = (byte) side;
             final CoverableTileEntity tile = (CoverableTileEntity) tTileEntity;
             if (side != -1) {
-                final Block facadeBlock = tile.getCoverBehaviorAtSideNew(aSide)
-                        .getFacadeBlock(
-                                aSide, tile.getCoverIDAtSide(aSide), tile.getComplexCoverDataAtSide(aSide), tile);
+                final Block facadeBlock = tile.getCoverInfoAtSide(aSide).getFacadeBlock();
                 if (facadeBlock != null) return facadeBlock;
             } else {
                 // we do not allow more than one type of facade per block, so no need to check every side
                 // see comment in gregtech.common.covers.GT_Cover_FacadeBase.isCoverPlaceable
                 for (byte i = 0; i < 6; i++) {
-                    final Block facadeBlock = tile.getCoverBehaviorAtSideNew(i)
-                            .getFacadeBlock(i, tile.getCoverIDAtSide(i), tile.getComplexCoverDataAtSide(i), tile);
+                    final Block facadeBlock = tile.getCoverInfoAtSide(i).getFacadeBlock();
                     if (facadeBlock != null) {
                         return facadeBlock;
                     }
@@ -684,22 +682,17 @@ public class GT_Block_Machines extends GT_Generic_Block implements IDebugableBlo
             final byte aSide = (byte) side;
             final CoverableTileEntity tile = (CoverableTileEntity) tTileEntity;
             if (side != -1) {
-                final Block facadeBlock = tile.getCoverBehaviorAtSideNew(aSide)
-                        .getFacadeBlock(
-                                aSide, tile.getCoverIDAtSide(aSide), tile.getComplexCoverDataAtSide(aSide), tile);
-                if (facadeBlock != null)
-                    return tile.getCoverBehaviorAtSideNew(aSide)
-                            .getFacadeMeta(
-                                    aSide, tile.getCoverIDAtSide(aSide), tile.getComplexCoverDataAtSide(aSide), tile);
+                final CoverInfo coverInfo = tile.getCoverInfoAtSide(aSide);
+                final Block facadeBlock = coverInfo.getFacadeBlock();
+                if (facadeBlock != null) return coverInfo.getFacadeMeta();
             } else {
                 // we do not allow more than one type of facade per block, so no need to check every side
                 // see comment in gregtech.common.covers.GT_Cover_FacadeBase.isCoverPlaceable
                 for (byte i = 0; i < 6; i++) {
-                    final Block facadeBlock = tile.getCoverBehaviorAtSideNew(i)
-                            .getFacadeBlock(i, tile.getCoverIDAtSide(i), tile.getComplexCoverDataAtSide(i), tile);
+                    final CoverInfo coverInfo = tile.getCoverInfoAtSide(i);
+                    final Block facadeBlock = coverInfo.getFacadeBlock();
                     if (facadeBlock != null) {
-                        return tile.getCoverBehaviorAtSideNew(i)
-                                .getFacadeMeta(i, tile.getCoverIDAtSide(i), tile.getComplexCoverDataAtSide(i), tile);
+                        return coverInfo.getFacadeMeta();
                     }
                 }
             }

--- a/src/main/java/gregtech/common/blocks/GT_Block_Machines.java
+++ b/src/main/java/gregtech/common/blocks/GT_Block_Machines.java
@@ -1,6 +1,7 @@
 package gregtech.common.blocks;
 
 import static gregtech.GT_Mod.GT_FML_LOGGER;
+import static gregtech.api.enums.GT_Values.ALL_VALID_SIDES;
 import static gregtech.api.enums.GT_Values.SIDE_UP;
 import static gregtech.api.objects.XSTR.XSTR_INSTANCE;
 
@@ -664,8 +665,8 @@ public class GT_Block_Machines extends GT_Generic_Block implements IDebugableBlo
             } else {
                 // we do not allow more than one type of facade per block, so no need to check every side
                 // see comment in gregtech.common.covers.GT_Cover_FacadeBase.isCoverPlaceable
-                for (byte i = 0; i < 6; i++) {
-                    final Block facadeBlock = tile.getCoverInfoAtSide(i).getFacadeBlock();
+                for (byte tSide : ALL_VALID_SIDES) {
+                    final Block facadeBlock = tile.getCoverInfoAtSide(tSide).getFacadeBlock();
                     if (facadeBlock != null) {
                         return facadeBlock;
                     }
@@ -688,8 +689,8 @@ public class GT_Block_Machines extends GT_Generic_Block implements IDebugableBlo
             } else {
                 // we do not allow more than one type of facade per block, so no need to check every side
                 // see comment in gregtech.common.covers.GT_Cover_FacadeBase.isCoverPlaceable
-                for (byte i = 0; i < 6; i++) {
-                    final CoverInfo coverInfo = tile.getCoverInfoAtSide(i);
+                for (byte tSide : ALL_VALID_SIDES) {
+                    final CoverInfo coverInfo = tile.getCoverInfoAtSide(tSide);
                     final Block facadeBlock = coverInfo.getFacadeBlock();
                     if (facadeBlock != null) {
                         return coverInfo.getFacadeMeta();

--- a/src/main/java/gregtech/common/covers/CoverInfo.java
+++ b/src/main/java/gregtech/common/covers/CoverInfo.java
@@ -1,0 +1,169 @@
+package gregtech.common.covers;
+
+import static gregtech.api.enums.GT_Values.SIDE_UNKNOWN;
+
+import com.gtnewhorizons.modularui.api.screen.ModularWindow;
+import gregtech.api.GregTech_API;
+import gregtech.api.gui.modularui.GT_CoverUIBuildContext;
+import gregtech.api.interfaces.ITexture;
+import gregtech.api.interfaces.tileentity.ICoverable;
+import gregtech.api.util.GT_CoverBehaviorBase;
+import gregtech.api.util.ISerializableObject;
+import java.lang.ref.WeakReference;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+
+public final class CoverInfo {
+    private static final String NBT_SIDE = "s", NBT_ID = "id", NBT_DATA = "d";
+
+    private byte coverSide = SIDE_UNKNOWN;
+    private int coverID = 0;
+    private GT_CoverBehaviorBase<?> coverBehavior = null;
+    private ISerializableObject coverData = null;
+    private WeakReference<ICoverable> coveredTile;
+    private boolean needsUpdate = false;
+
+    public CoverInfo(byte aSide, ICoverable aTile) {
+        coverSide = aSide;
+        coveredTile = new WeakReference<>(aTile);
+    }
+
+    public CoverInfo(byte aSide, int aID, ICoverable aTile, ISerializableObject aCoverData) {
+        coverSide = aSide;
+        coverID = aID;
+        coverBehavior = GregTech_API.getCoverBehaviorNew(aID);
+        coverData = aCoverData == null ? coverBehavior.createDataObject() : aCoverData;
+        coveredTile = new WeakReference<>(aTile);
+    }
+
+    public CoverInfo(ICoverable aTile, NBTTagCompound aNBT) {
+        coverSide = aNBT.getByte(NBT_SIDE);
+        coverID = aNBT.getInteger(NBT_ID);
+        coverBehavior = GregTech_API.getCoverBehaviorNew(coverID);
+        coverData = aNBT.hasKey(NBT_DATA)
+                ? coverBehavior.createDataObject(aNBT.getTag(NBT_DATA))
+                : coverBehavior.createDataObject();
+        coveredTile = new WeakReference<>(aTile);
+    }
+
+    public boolean isValid() {
+        return coverID != 0 && coverSide != SIDE_UNKNOWN;
+    }
+
+    public NBTTagCompound writeToNBT(NBTTagCompound aNBT) {
+        aNBT.setByte(NBT_SIDE, coverSide);
+        aNBT.setInteger(NBT_ID, coverID);
+        if (coverData != null) aNBT.setTag(NBT_DATA, coverData.saveDataToNBT());
+
+        return aNBT;
+    }
+
+    public int getCoverID() {
+        return coverID;
+    }
+
+    public boolean needsUpdate() {
+        return needsUpdate;
+    }
+
+    public void setNeedsUpdate(boolean aUpdate) {
+        needsUpdate = aUpdate;
+    }
+
+    public GT_CoverBehaviorBase<?> getCoverBehavior() {
+        if (coverBehavior != null) return coverBehavior;
+        return GregTech_API.sNoBehavior;
+    }
+
+    public ISerializableObject getCoverData() {
+        if (coverData != null) return coverData;
+        return GregTech_API.sNoBehavior.createDataObject();
+    }
+
+    public boolean onCoverRemoval(boolean aForced) {
+        return getCoverBehavior().onCoverRemoval(coverSide, coverID, coverData, coveredTile.get(), aForced);
+    }
+
+    public ItemStack getDrop() {
+        return getCoverBehavior().getDrop(coverSide, coverID, coverData, coveredTile.get());
+    }
+
+    public ItemStack getDisplayStack() {
+        return getCoverBehavior().getDisplayStack(coverID, coverData);
+    }
+
+    public boolean isDataNeededOnClient() {
+        return getCoverBehavior().isDataNeededOnClient(coverSide, coverID, coverData, coveredTile.get());
+    }
+
+    public void onDropped() {
+        getCoverBehavior().onDropped(coverSide, coverID, coverData, coveredTile.get());
+    }
+
+    public void setCoverData(ISerializableObject aData) {
+        coverData = aData;
+    }
+
+    public ITexture getSpecialCoverFGTexture() {
+        return getCoverBehavior().getSpecialCoverFGTexture(coverSide, coverID, coverData, coveredTile.get());
+    }
+
+    public ITexture getSpecialCoverTexture() {
+        return getCoverBehavior().getSpecialCoverTexture(coverSide, coverID, coverData, coveredTile.get());
+    }
+
+    public int getTickRate() {
+        return getCoverBehavior().getTickRate(coverSide, coverID, coverData, coveredTile.get());
+    }
+
+    public byte getSide() {
+        return coverSide;
+    }
+
+    public ICoverable getTile() {
+        return coveredTile.get();
+    }
+
+    public boolean isRedstoneSensitive(long aTickTimer) {
+        return getCoverBehavior().isRedstoneSensitive(coverSide, coverID, coverData, coveredTile.get(), aTickTimer);
+    }
+
+    public ISerializableObject doCoverThings(long aTickTimer, byte aRedstone) {
+        return getCoverBehavior()
+                .doCoverThings(coverSide, aRedstone, coverID, coverData, coveredTile.get(), aTickTimer);
+    }
+
+    public void onBaseTEDestroyed() {
+        getCoverBehavior().onBaseTEDestroyed(coverSide, coverID, coverData, coveredTile.get());
+    }
+
+    public void updateCoverBehavior() {
+        coverBehavior = GregTech_API.getCoverBehaviorNew(coverID);
+    }
+
+    public void preDataChanged(int aCoverID, ISerializableObject aCoverData) {
+        getCoverBehavior().preDataChanged(coverSide, coverID, aCoverID, coverData, aCoverData, coveredTile.get());
+    }
+    public void onDataChanged() {
+        getCoverBehavior().onDataChanged(coverSide, coverID, coverData, coveredTile.get());
+    }
+
+    public String getBehaviorDescription() {
+        return getCoverBehavior().getDescription(coverSide, coverID, coverData, null);
+    }
+
+    public ModularWindow createWindow(EntityPlayer player) {
+        final GT_CoverUIBuildContext buildContext = new GT_CoverUIBuildContext(player, coverID, coverSide, coveredTile.get(), true);
+        return getCoverBehavior().createWindow(buildContext);
+    }
+
+    public boolean hasCoverGUI() {
+        return getCoverBehavior().hasCoverGUI();
+    }
+
+    public boolean useModularUI() {
+        return getCoverBehavior().useModularUI();
+    }
+}

--- a/src/main/java/gregtech/common/covers/CoverInfo.java
+++ b/src/main/java/gregtech/common/covers/CoverInfo.java
@@ -10,10 +10,11 @@ import gregtech.api.interfaces.tileentity.ICoverable;
 import gregtech.api.util.GT_CoverBehaviorBase;
 import gregtech.api.util.ISerializableObject;
 import java.lang.ref.WeakReference;
-
+import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraftforge.fluids.Fluid;
 
 public final class CoverInfo {
     private static final String NBT_SIDE = "s", NBT_ID = "id", NBT_DATA = "d";
@@ -146,6 +147,7 @@ public final class CoverInfo {
     public void preDataChanged(int aCoverID, ISerializableObject aCoverData) {
         getCoverBehavior().preDataChanged(coverSide, coverID, aCoverID, coverData, aCoverData, coveredTile.get());
     }
+
     public void onDataChanged() {
         getCoverBehavior().onDataChanged(coverSide, coverID, coverData, coveredTile.get());
     }
@@ -155,8 +157,13 @@ public final class CoverInfo {
     }
 
     public ModularWindow createWindow(EntityPlayer player) {
-        final GT_CoverUIBuildContext buildContext = new GT_CoverUIBuildContext(player, coverID, coverSide, coveredTile.get(), true);
+        final GT_CoverUIBuildContext buildContext =
+                new GT_CoverUIBuildContext(player, coverID, coverSide, coveredTile.get(), true);
         return getCoverBehavior().createWindow(buildContext);
+    }
+
+    public boolean isGUIClickable() {
+        return getCoverBehavior().isGUIClickable(coverSide, coverID, coverData, coveredTile.get());
     }
 
     public boolean hasCoverGUI() {
@@ -165,5 +172,63 @@ public final class CoverInfo {
 
     public boolean useModularUI() {
         return getCoverBehavior().useModularUI();
+    }
+
+    public boolean letsItemsIn(int aSlot) {
+        return getCoverBehavior().letsItemsIn(coverSide, coverID, coverData, aSlot, coveredTile.get());
+    }
+
+    public boolean letsItemsOut(int aSlot) {
+        return getCoverBehavior().letsItemsOut(coverSide, coverID, coverData, aSlot, coveredTile.get());
+    }
+
+    public boolean letsFluidIn(Fluid aFluid) {
+        return letsFluidIn(aFluid, coveredTile.get());
+    }
+
+    public boolean letsFluidOut(Fluid aFluid) {
+        return letsFluidOut(aFluid, coveredTile.get());
+    }
+
+    public boolean letsFluidIn(Fluid aFluid, ICoverable tile) {
+        return getCoverBehavior().letsFluidIn(coverSide, coverID, coverData, aFluid, tile);
+    }
+
+    public boolean letsFluidOut(Fluid aFluid, ICoverable tile) {
+        return getCoverBehavior().letsFluidOut(coverSide, coverID, coverData, aFluid, tile);
+    }
+
+    public boolean letsEnergyIn() {
+        return getCoverBehavior().letsEnergyIn(coverSide, coverID, coverData, coveredTile.get());
+    }
+
+    public boolean letsEnergyOut() {
+        return getCoverBehavior().letsEnergyOut(coverSide, coverID, coverData, coveredTile.get());
+    }
+
+    public boolean alwaysLookConnected() {
+        return getCoverBehavior().alwaysLookConnected(coverSide, coverID, coverData, coveredTile.get());
+    }
+
+    public boolean onCoverRightClick(EntityPlayer aPlayer, float aX, float aY, float aZ) {
+        return getCoverBehavior()
+                .onCoverRightClick(coverSide, coverID, coverData, coveredTile.get(), aPlayer, aX, aY, aZ);
+    }
+
+    public boolean onCoverShiftRightClick(EntityPlayer aPlayer) {
+        return getCoverBehavior().onCoverShiftRightClick(coverSide, coverID, coverData, coveredTile.get(), aPlayer);
+    }
+
+    public ISerializableObject onCoverScrewdriverClick(EntityPlayer aPlayer, float aX, float aY, float aZ) {
+        return getCoverBehavior()
+                .onCoverScrewdriverClick(coverSide, coverID, coverData, coveredTile.get(), aPlayer, aX, aY, aZ);
+    }
+
+    public Block getFacadeBlock() {
+        return getCoverBehavior().getFacadeBlock(coverSide, coverID, coverData, coveredTile.get());
+    }
+
+    public int getFacadeMeta() {
+        return getCoverBehavior().getFacadeMeta(coverSide, coverID, coverData, coveredTile.get());
     }
 }

--- a/src/main/java/gregtech/common/covers/GT_Cover_ControlsWork.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_ControlsWork.java
@@ -1,5 +1,7 @@
 package gregtech.common.covers;
 
+import static gregtech.api.enums.GT_Values.ALL_VALID_SIDES;
+
 import com.gtnewhorizons.modularui.api.screen.ModularWindow;
 import com.gtnewhorizons.modularui.common.widget.TextWidget;
 import gregtech.api.gui.modularui.GT_CoverUIBuildContext;
@@ -16,8 +18,6 @@ import gregtech.common.gui.modularui.widget.CoverDataFollower_ToggleButtonWidget
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.Fluid;
-
-import static gregtech.api.enums.GT_Values.ALL_VALID_SIDES;
 
 public class GT_Cover_ControlsWork extends GT_CoverBehavior implements IControlsWorkCover {
 

--- a/src/main/java/gregtech/common/covers/GT_Cover_ControlsWork.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_ControlsWork.java
@@ -17,6 +17,8 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.Fluid;
 
+import static gregtech.api.enums.GT_Values.ALL_VALID_SIDES;
+
 public class GT_Cover_ControlsWork extends GT_CoverBehavior implements IControlsWorkCover {
 
     /**
@@ -168,8 +170,8 @@ public class GT_Cover_ControlsWork extends GT_CoverBehavior implements IControls
     @Override
     public boolean isCoverPlaceable(byte aSide, ItemStack aStack, ICoverable aTileEntity) {
         if (!super.isCoverPlaceable(aSide, aStack, aTileEntity)) return false;
-        for (byte i = 0; i < 6; i++) {
-            if (aTileEntity.getCoverBehaviorAtSideNew(i) instanceof IControlsWorkCover) {
+        for (byte tSide : ALL_VALID_SIDES) {
+            if (aTileEntity.getCoverBehaviorAtSideNew(tSide) instanceof IControlsWorkCover) {
                 return false;
             }
         }

--- a/src/main/java/gregtech/common/covers/GT_Cover_FacadeBase.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_FacadeBase.java
@@ -1,5 +1,7 @@
 package gregtech.common.covers;
 
+import static gregtech.api.enums.GT_Values.ALL_VALID_SIDES;
+
 import com.google.common.io.ByteArrayDataInput;
 import com.gtnewhorizons.modularui.api.drawable.ItemDrawable;
 import com.gtnewhorizons.modularui.api.screen.ModularWindow;
@@ -26,8 +28,6 @@ import net.minecraft.nbt.NBTBase;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.Fluid;
-
-import static gregtech.api.enums.GT_Values.ALL_VALID_SIDES;
 
 public abstract class GT_Cover_FacadeBase extends GT_CoverBehaviorBase<GT_Cover_FacadeBase.FacadeData> {
     /**
@@ -234,7 +234,7 @@ public abstract class GT_Cover_FacadeBase extends GT_CoverBehaviorBase<GT_Cover_
         // to render it correctly require changing GT_Block_Machine to render in both pass, which is not really a good
         // idea...
         if (!super.isCoverPlaceable(aSide, aStack, aTileEntity)) return false;
-        Block targetBlock = getTargetBlock(aStack);
+        final Block targetBlock = getTargetBlock(aStack);
         if (targetBlock == null) return false;
         // we allow one single type of facade on the same block for now
         // otherwise it's not clear which block this block should impersonate
@@ -242,15 +242,12 @@ public abstract class GT_Cover_FacadeBase extends GT_CoverBehaviorBase<GT_Cover_
         // class
         for (byte i : ALL_VALID_SIDES) {
             if (i == aSide) continue;
-            GT_CoverBehaviorBase<?> behavior = aTileEntity.getCoverBehaviorAtSideNew(i);
-            if (behavior == null) continue;
-            Block facadeBlock = behavior.getFacadeBlock(
-                    i, aTileEntity.getCoverIDAtSide(i), aTileEntity.getComplexCoverDataAtSide(i), aTileEntity);
+            final CoverInfo coverInfo = aTileEntity.getCoverInfoAtSide(i);
+            if (!coverInfo.isValid()) continue;
+            final Block facadeBlock = coverInfo.getFacadeBlock();
             if (facadeBlock == null) continue;
             if (facadeBlock != targetBlock) return false;
-            if (behavior.getFacadeMeta(
-                            i, aTileEntity.getCoverIDAtSide(i), aTileEntity.getComplexCoverDataAtSide(i), aTileEntity)
-                    != getTargetMeta(aStack)) return false;
+            if (coverInfo.getFacadeMeta() != getTargetMeta(aStack)) return false;
         }
         return true;
     }
@@ -275,7 +272,7 @@ public abstract class GT_Cover_FacadeBase extends GT_CoverBehaviorBase<GT_Cover_
         @Nonnull
         @Override
         public NBTBase saveDataToNBT() {
-            NBTTagCompound tag = new NBTTagCompound();
+            final NBTTagCompound tag = new NBTTagCompound();
             if (mStack != null) tag.setTag("mStack", mStack.writeToNBT(new NBTTagCompound()));
             tag.setByte("mFlags", (byte) mFlags);
             return tag;
@@ -289,7 +286,7 @@ public abstract class GT_Cover_FacadeBase extends GT_CoverBehaviorBase<GT_Cover_
 
         @Override
         public void loadDataFromNBT(NBTBase aNBT) {
-            NBTTagCompound tag = (NBTTagCompound) aNBT;
+            final NBTTagCompound tag = (NBTTagCompound) aNBT;
             mStack = ItemStack.loadItemStackFromNBT(tag.getCompoundTag("mStack"));
             mFlags = tag.getByte("mFlags");
         }

--- a/src/main/java/gregtech/common/covers/GT_Cover_FacadeBase.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_FacadeBase.java
@@ -27,6 +27,8 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.Fluid;
 
+import static gregtech.api.enums.GT_Values.ALL_VALID_SIDES;
+
 public abstract class GT_Cover_FacadeBase extends GT_CoverBehaviorBase<GT_Cover_FacadeBase.FacadeData> {
     /**
      * This is the Dummy, if there is a generic Cover without behavior
@@ -120,6 +122,7 @@ public abstract class GT_Cover_FacadeBase extends GT_CoverBehaviorBase<GT_Cover_
     public void placeCover(byte aSide, ItemStack aCover, ICoverable aTileEntity) {
         aTileEntity.setCoverIdAndDataAtSide(
                 aSide, GT_Utility.stackToInt(aCover), new FacadeData(GT_Utility.copyAmount(1, aCover), 0));
+
         if (aTileEntity.isClientSide())
             GT_RenderingWorld.getInstance()
                     .register(
@@ -193,7 +196,7 @@ public abstract class GT_Cover_FacadeBase extends GT_CoverBehaviorBase<GT_Cover_
     @Override
     protected void onDroppedImpl(byte aSide, int aCoverID, FacadeData aCoverVariable, ICoverable aTileEntity) {
         if (aTileEntity.isClientSide()) {
-            for (byte i = 0; i < 6; i++) {
+            for (byte i : ALL_VALID_SIDES) {
                 if (i == aSide) continue;
                 // since we do not allow multiple type of facade per block, this check would be enough.
                 if (aTileEntity.getCoverBehaviorAtSideNew(i) instanceof GT_Cover_FacadeBase) return;
@@ -237,7 +240,7 @@ public abstract class GT_Cover_FacadeBase extends GT_CoverBehaviorBase<GT_Cover_
         // otherwise it's not clear which block this block should impersonate
         // this restriction can be lifted later by specifying a certain facade as dominate one as an extension to this
         // class
-        for (byte i = 0; i < 6; i++) {
+        for (byte i : ALL_VALID_SIDES) {
             if (i == aSide) continue;
             GT_CoverBehaviorBase<?> behavior = aTileEntity.getCoverBehaviorAtSideNew(i);
             if (behavior == null) continue;

--- a/src/main/java/gregtech/common/covers/GT_Cover_RedstoneTransmitterExternal.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_RedstoneTransmitterExternal.java
@@ -7,6 +7,8 @@ import gregtech.api.interfaces.tileentity.ICoverable;
 import gregtech.api.util.ISerializableObject;
 import net.minecraft.item.ItemStack;
 
+import static gregtech.api.enums.GT_Values.ALL_VALID_SIDES;
+
 public class GT_Cover_RedstoneTransmitterExternal extends GT_Cover_RedstoneWirelessBase {
 
     /**
@@ -53,8 +55,8 @@ public class GT_Cover_RedstoneTransmitterExternal extends GT_Cover_RedstoneWirel
     @Override
     public boolean isCoverPlaceable(byte aSide, ItemStack aStack, ICoverable aTileEntity) {
         if (!super.isCoverPlaceable(aSide, aStack, aTileEntity)) return false;
-        for (byte i = 0; i < 6; i++) {
-            if (aTileEntity.getCoverBehaviorAtSideNew(i) instanceof IControlsWorkCover) {
+        for (byte tSide : ALL_VALID_SIDES) {
+            if (aTileEntity.getCoverBehaviorAtSideNew(tSide) instanceof IControlsWorkCover) {
                 return false;
             }
         }

--- a/src/main/java/gregtech/common/covers/GT_Cover_RedstoneTransmitterExternal.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_RedstoneTransmitterExternal.java
@@ -1,13 +1,13 @@
 package gregtech.common.covers;
 
+import static gregtech.api.enums.GT_Values.ALL_VALID_SIDES;
+
 import gregtech.api.GregTech_API;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.covers.IControlsWorkCover;
 import gregtech.api.interfaces.tileentity.ICoverable;
 import gregtech.api.util.ISerializableObject;
 import net.minecraft.item.ItemStack;
-
-import static gregtech.api.enums.GT_Values.ALL_VALID_SIDES;
 
 public class GT_Cover_RedstoneTransmitterExternal extends GT_Cover_RedstoneWirelessBase {
 

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_OutputBus_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_OutputBus_ME.java
@@ -129,13 +129,7 @@ public class GT_MetaTileEntity_Hatch_OutputBus_ME extends GT_MetaTileEntity_Hatc
 
     @Override
     public void onScrewdriverRightClick(byte aSide, EntityPlayer aPlayer, float aX, float aY, float aZ) {
-        if (!getBaseMetaTileEntity()
-                .getCoverBehaviorAtSideNew(aSide)
-                .isGUIClickable(
-                        aSide,
-                        getBaseMetaTileEntity().getCoverIDAtSide(aSide),
-                        getBaseMetaTileEntity().getComplexCoverDataAtSide(aSide),
-                        getBaseMetaTileEntity())) return;
+        if (!getBaseMetaTileEntity().getCoverInfoAtSide(aSide).isGUIClickable()) return;
         infiniteCache = !infiniteCache;
         GT_Utility.sendChatToPlayer(
                 aPlayer, StatCollector.translateToLocal("GT5U.hatch.infiniteCache." + infiniteCache));

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_Output_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_Output_ME.java
@@ -151,13 +151,7 @@ public class GT_MetaTileEntity_Hatch_Output_ME extends GT_MetaTileEntity_Hatch_O
     @Override
     public void onScrewdriverRightClick(byte aSide, EntityPlayer aPlayer, float aX, float aY, float aZ) {
         // Don't allow to lock fluid in me fluid hatch
-        if (!getBaseMetaTileEntity()
-                .getCoverBehaviorAtSideNew(aSide)
-                .isGUIClickable(
-                        aSide,
-                        getBaseMetaTileEntity().getCoverIDAtSide(aSide),
-                        getBaseMetaTileEntity().getComplexCoverDataAtSide(aSide),
-                        getBaseMetaTileEntity())) return;
+        if (!getBaseMetaTileEntity().getCoverInfoAtSide(aSide).isGUIClickable()) return;
         infiniteCache = !infiniteCache;
         GT_Utility.sendChatToPlayer(
                 aPlayer, StatCollector.translateToLocal("GT5U.hatch.infiniteCacheFluid." + infiniteCache));

--- a/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_IndustrialApiary.java
+++ b/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_IndustrialApiary.java
@@ -1,5 +1,6 @@
 package gregtech.common.tileentities.machines.basic;
 
+import static gregtech.api.enums.GT_Values.ALL_VALID_SIDES;
 import static gregtech.api.enums.GT_Values.AuthorKuba;
 import static gregtech.api.enums.GT_Values.V;
 import static gregtech.api.enums.Textures.BlockIcons.*;
@@ -179,8 +180,8 @@ public class GT_MetaTileEntity_IndustrialApiary extends GT_MetaTileEntity_BasicM
             openGUI(aBaseMetaTileEntity, aPlayer);
             return true;
         }
-        for (byte i = 0; i < 6; i++) {
-            if (aBaseMetaTileEntity.getAirAtSide(i)) {
+        for (byte tSide : ALL_VALID_SIDES) {
+            if (aBaseMetaTileEntity.getAirAtSide(tSide)) {
                 openGUI(aBaseMetaTileEntity, aPlayer);
                 return true;
             }
@@ -230,38 +231,38 @@ public class GT_MetaTileEntity_IndustrialApiary extends GT_MetaTileEntity_BasicM
         updateModifiers();
         if (canWork()) {
 
-            ItemStack queen = getQueen();
+            final ItemStack queen = getQueen();
             usedQueen = queen.copy();
             if (beeRoot.getType(queen) == EnumBeeType.QUEEN) {
-                IBee bee = beeRoot.getMember(queen);
+                final IBee bee = beeRoot.getMember(queen);
                 usedQueenBee = bee;
 
                 // LIFE CYCLES
 
                 float mod = this.getLifespanModifier(null, null, 1.f);
-                IBeekeepingMode mode = beeRoot.getBeekeepingMode(this.getWorld());
-                IBeeModifier beemodifier = mode.getBeeModifier();
+                final IBeekeepingMode mode = beeRoot.getBeekeepingMode(this.getWorld());
+                final IBeeModifier beemodifier = mode.getBeeModifier();
                 mod *= beemodifier.getLifespanModifier(null, null, 1.f);
-                int h = bee.getHealth();
+                final int h = bee.getHealth();
                 mod = 1.f / mod;
-                float cycles = h / mod;
+                final float cycles = h / mod;
 
                 // PRODUCTS
 
-                HashMap<GT_Utility.ItemId, ItemStack> pollen = new HashMap<>();
+                final HashMap<GT_Utility.ItemId, ItemStack> pollen = new HashMap<>();
 
                 if (isRetrievingPollen && floweringMod > 0f) {
-                    int icycles =
+                    final int icycles =
                             (int) cycles + (getWorld().rand.nextFloat() < (cycles - (float) ((int) cycles)) ? 1 : 0);
                     for (int z = 0; z < icycles; z++) {
-                        IIndividual p = bee.retrievePollen(this);
+                        final IIndividual p = bee.retrievePollen(this);
                         if (p != null) {
-                            ItemStack s =
+                            final ItemStack s =
                                     p.getGenome().getSpeciesRoot().getMemberStack(p, EnumGermlingType.POLLEN.ordinal());
                             if (s != null) {
-                                GT_Utility.ItemId id = GT_Utility.ItemId.createNoCopy(s);
+                                final GT_Utility.ItemId id = GT_Utility.ItemId.createNoCopy(s);
                                 pollen.computeIfAbsent(id, k -> {
-                                    ItemStack ns = s.copy();
+                                    final ItemStack ns = s.copy();
                                     ns.stackSize = 0;
                                     return ns;
                                 });
@@ -274,19 +275,19 @@ public class GT_MetaTileEntity_IndustrialApiary extends GT_MetaTileEntity_BasicM
                 retrievedpollen = null;
                 retrievingPollenInThisOperation = isRetrievingPollen;
 
-                IBeeGenome genome = bee.getGenome();
-                IAlleleBeeSpecies primary = genome.getPrimary();
-                IAlleleBeeSpecies secondary = genome.getSecondary();
+                final IBeeGenome genome = bee.getGenome();
+                final IAlleleBeeSpecies primary = genome.getPrimary();
+                final IAlleleBeeSpecies secondary = genome.getSecondary();
 
-                float speed = genome.getSpeed();
-                float prodMod = getProductionModifier(null, 1f) * beemodifier.getProductionModifier(null, 1.f);
+                final float speed = genome.getSpeed();
+                final float prodMod = getProductionModifier(null, 1f) * beemodifier.getProductionModifier(null, 1.f);
 
-                HashMap<GT_Utility.ItemId, Float> drops = new HashMap<>();
-                HashMap<GT_Utility.ItemId, ItemStack> dropstacks = new HashMap<>();
+                final HashMap<GT_Utility.ItemId, Float> drops = new HashMap<>();
+                final HashMap<GT_Utility.ItemId, ItemStack> dropstacks = new HashMap<>();
 
                 for (Map.Entry<ItemStack, Float> entry :
                         primary.getProductChances().entrySet()) {
-                    GT_Utility.ItemId id = GT_Utility.ItemId.createNoCopy(entry.getKey());
+                    final GT_Utility.ItemId id = GT_Utility.ItemId.createNoCopy(entry.getKey());
                     drops.merge(
                             id,
                             Bee.getFinalChance(entry.getValue(), speed, prodMod, 8f)
@@ -297,7 +298,7 @@ public class GT_MetaTileEntity_IndustrialApiary extends GT_MetaTileEntity_BasicM
                 }
                 for (Map.Entry<ItemStack, Float> entry :
                         secondary.getProductChances().entrySet()) {
-                    GT_Utility.ItemId id = GT_Utility.ItemId.createNoCopy(entry.getKey());
+                    final GT_Utility.ItemId id = GT_Utility.ItemId.createNoCopy(entry.getKey());
                     drops.merge(
                             id,
                             Bee.getFinalChance(entry.getValue() / 2f, speed, prodMod, 8f)
@@ -309,7 +310,7 @@ public class GT_MetaTileEntity_IndustrialApiary extends GT_MetaTileEntity_BasicM
                 if (primary.isJubilant(genome, this) && secondary.isJubilant(genome, this))
                     for (Map.Entry<ItemStack, Float> entry :
                             primary.getSpecialtyChances().entrySet()) {
-                        GT_Utility.ItemId id = GT_Utility.ItemId.createNoCopy(entry.getKey());
+                        final GT_Utility.ItemId id = GT_Utility.ItemId.createNoCopy(entry.getKey());
                         drops.merge(
                                 id,
                                 Bee.getFinalChance(entry.getValue(), speed, prodMod, 8f)
@@ -320,30 +321,30 @@ public class GT_MetaTileEntity_IndustrialApiary extends GT_MetaTileEntity_BasicM
                     }
 
                 int i = 0;
-                int imax = mOutputItems.length;
+                final int imax = mOutputItems.length;
 
-                IApiaristTracker breedingTracker = beeRoot.getBreedingTracker(getWorld(), getOwner());
+                final IApiaristTracker breedingTracker = beeRoot.getBreedingTracker(getWorld(), getOwner());
 
                 if (!bee.canSpawn()) {
-                    ItemStack convert = new ItemStack(PluginApiculture.items.beePrincessGE);
-                    NBTTagCompound nbttagcompound = new NBTTagCompound();
+                    final ItemStack convert = new ItemStack(PluginApiculture.items.beePrincessGE);
+                    final NBTTagCompound nbttagcompound = new NBTTagCompound();
                     queen.writeToNBT(nbttagcompound);
                     convert.setTagCompound(nbttagcompound);
                     this.mOutputItems[i++] = convert;
                 } else {
-                    IBee b = bee.spawnPrincess(this);
+                    final IBee b = bee.spawnPrincess(this);
                     if (b != null) {
-                        ItemStack princess = beeRoot.getMemberStack(b, EnumBeeType.PRINCESS.ordinal());
+                        final ItemStack princess = beeRoot.getMemberStack(b, EnumBeeType.PRINCESS.ordinal());
                         breedingTracker.registerPrincess(b);
                         this.mOutputItems[i++] = princess;
                     }
-                    IBee[] d = bee.spawnDrones(this);
+                    final IBee[] d = bee.spawnDrones(this);
                     if (d != null && d.length > 0) {
-                        HashMap<GT_Utility.ItemId, ItemStack> drones = new HashMap<>(d.length);
+                        final HashMap<GT_Utility.ItemId, ItemStack> drones = new HashMap<>(d.length);
                         for (IBee dr : d) {
-                            ItemStack drone = beeRoot.getMemberStack(dr, EnumBeeType.DRONE.ordinal());
+                            final ItemStack drone = beeRoot.getMemberStack(dr, EnumBeeType.DRONE.ordinal());
                             breedingTracker.registerDrone(dr);
-                            GT_Utility.ItemId drid = GT_Utility.ItemId.createNoCopy(drone);
+                            final GT_Utility.ItemId drid = GT_Utility.ItemId.createNoCopy(drone);
                             if (drones.containsKey(drid)) drones.get(drid).stackSize += drone.stackSize;
                             else {
                                 this.mOutputItems[i++] = drone;
@@ -353,12 +354,12 @@ public class GT_MetaTileEntity_IndustrialApiary extends GT_MetaTileEntity_BasicM
                     }
                 }
 
-                int imin = i;
+                final int imin = i;
 
                 setQueen(null);
 
                 for (Map.Entry<GT_Utility.ItemId, Float> entry : drops.entrySet()) {
-                    ItemStack s = dropstacks.get(entry.getKey()).copy();
+                    final ItemStack s = dropstacks.get(entry.getKey()).copy();
                     s.stackSize = entry.getValue().intValue()
                             + (getWorld().rand.nextFloat()
                                             < (entry.getValue()
@@ -383,8 +384,8 @@ public class GT_MetaTileEntity_IndustrialApiary extends GT_MetaTileEntity_BasicM
 
                 usedBeeLife = cycles * (float) beeCycleLength;
                 this.mMaxProgresstime = (int) usedBeeLife;
-                int timemaxdivider = this.mMaxProgresstime / 100;
-                int useddivider = 1 << this.mSpeed;
+                final int timemaxdivider = this.mMaxProgresstime / 100;
+                final int useddivider = 1 << this.mSpeed;
                 int actualdivider = useddivider;
                 this.mMaxProgresstime /= Math.min(actualdivider, timemaxdivider);
                 actualdivider /= Math.min(actualdivider, timemaxdivider);
@@ -403,17 +404,17 @@ public class GT_MetaTileEntity_IndustrialApiary extends GT_MetaTileEntity_BasicM
 
                 this.mMaxProgresstime = 100;
                 this.mProgresstime = 0;
-                int useddivider = Math.min(100, 1 << this.mSpeed);
+                final int useddivider = Math.min(100, 1 << this.mSpeed);
                 this.mMaxProgresstime /= useddivider;
                 this.mEUt = (int) ((float) baseEUtUsage * this.energyMod * useddivider);
                 if (useddivider == 2) this.mEUt += 32;
                 else if (useddivider > 2) this.mEUt += (32 * (useddivider << (this.mSpeed - 2)));
 
-                IBee princess = beeRoot.getMember(getQueen());
+                final IBee princess = beeRoot.getMember(getQueen());
                 usedQueenBee = princess;
-                IBee drone = beeRoot.getMember(getDrone());
+                final IBee drone = beeRoot.getMember(getDrone());
                 princess.mate(drone);
-                NBTTagCompound nbttagcompound = new NBTTagCompound();
+                final NBTTagCompound nbttagcompound = new NBTTagCompound();
                 princess.writeToNBT(nbttagcompound);
                 this.mOutputItems[0] = new ItemStack(PluginApiculture.items.beeQueenGE);
                 this.mOutputItems[0].setTagCompound(nbttagcompound);
@@ -446,8 +447,8 @@ public class GT_MetaTileEntity_IndustrialApiary extends GT_MetaTileEntity_BasicM
     }
 
     private void doEffect() {
-        IBeeGenome genome = usedQueenBee.getGenome();
-        IAlleleBeeEffect effect = genome.getEffect();
+        final IBeeGenome genome = usedQueenBee.getGenome();
+        final IAlleleBeeEffect effect = genome.getEffect();
         if (!(effect instanceof IAlleleBeeAcceleratableEffect)) {
             effectData[0] = effect.validateStorage(effectData[0]);
             effect.doEffect(genome, effectData[0], this);
@@ -455,7 +456,7 @@ public class GT_MetaTileEntity_IndustrialApiary extends GT_MetaTileEntity_BasicM
 
         if (!effect.isCombinable()) return;
 
-        IAlleleBeeEffect secondary = (IAlleleBeeEffect) genome.getInactiveAllele(EnumBeeChromosome.EFFECT);
+        final IAlleleBeeEffect secondary = (IAlleleBeeEffect) genome.getInactiveAllele(EnumBeeChromosome.EFFECT);
         if (!secondary.isCombinable()) return;
 
         if (!(secondary instanceof IAlleleBeeAcceleratableEffect)) {
@@ -465,8 +466,8 @@ public class GT_MetaTileEntity_IndustrialApiary extends GT_MetaTileEntity_BasicM
     }
 
     private void doAcceleratedEffects() {
-        IBeeGenome genome = usedQueenBee.getGenome();
-        IAlleleBeeEffect effect = genome.getEffect();
+        final IBeeGenome genome = usedQueenBee.getGenome();
+        final IAlleleBeeEffect effect = genome.getEffect();
         try {
             if (AlleleBeeEffectThrottledField == null) {
                 AlleleBeeEffectThrottledField = AlleleEffectThrottled.class.getDeclaredField("throttle");
@@ -487,7 +488,7 @@ public class GT_MetaTileEntity_IndustrialApiary extends GT_MetaTileEntity_BasicM
 
             if (!effect.isCombinable()) return;
 
-            IAlleleBeeEffect secondary = (IAlleleBeeEffect) genome.getInactiveAllele(EnumBeeChromosome.EFFECT);
+            final IAlleleBeeEffect secondary = (IAlleleBeeEffect) genome.getInactiveAllele(EnumBeeChromosome.EFFECT);
             if (!secondary.isCombinable()) return;
 
             if (secondary instanceof IAlleleBeeAcceleratableEffect) {
@@ -521,7 +522,7 @@ public class GT_MetaTileEntity_IndustrialApiary extends GT_MetaTileEntity_BasicM
                 if (usedQueen != null) {
                     if (aTick % 2 == 0) {
                         // FX on client, effect on server
-                        IBee bee = beeRoot.getMember(usedQueen);
+                        final IBee bee = beeRoot.getMember(usedQueen);
                         effectData = bee.doFX(effectData, this);
                     }
                 }
@@ -540,7 +541,7 @@ public class GT_MetaTileEntity_IndustrialApiary extends GT_MetaTileEntity_BasicM
                                 || aTick % 600 == 0
                                 || aBaseMetaTileEntity.hasWorkJustBeenEnabled())
                         && hasEnoughEnergyToCheckRecipe()) {
-                    int check = checkRecipe();
+                    final int check = checkRecipe();
                     if (check == FOUND_AND_SUCCESSFULLY_USED_RECIPE) {
                         aBaseMetaTileEntity.setActive(true);
                     }
@@ -615,9 +616,9 @@ public class GT_MetaTileEntity_IndustrialApiary extends GT_MetaTileEntity_BasicM
                     aBaseMetaTileEntity.setActive(false);
 
                     if (doesAutoOutput() && !isOutputEmpty() && aBaseMetaTileEntity.getFrontFacing() != mMainFacing) {
-                        TileEntity tTileEntity2 =
+                        final TileEntity tTileEntity2 =
                                 aBaseMetaTileEntity.getTileEntityAtSide(aBaseMetaTileEntity.getFrontFacing());
-                        long tStoredEnergy = aBaseMetaTileEntity.getUniversalEnergyStored();
+                        final long tStoredEnergy = aBaseMetaTileEntity.getUniversalEnergyStored();
                         int tMaxStacks = (int) (tStoredEnergy / 64L);
                         if (tMaxStacks > mOutputItems.length) tMaxStacks = mOutputItems.length;
 
@@ -670,7 +671,7 @@ public class GT_MetaTileEntity_IndustrialApiary extends GT_MetaTileEntity_BasicM
             if (!GT_ApiaryUpgrade.isUpgrade(aStack)) return false;
             for (int i = drone + 1; i < drone + 1 + 4; i++) {
                 if (aIndex == i) continue;
-                ItemStack s = getStackInSlot(i);
+                final ItemStack s = getStackInSlot(i);
                 if (s == null) continue;
                 if (GT_Utility.areStacksEqual(getStackInSlot(i), aStack)) return false;
                 if (GT_ApiaryUpgrade.isUpgrade(aStack)) {
@@ -860,7 +861,7 @@ public class GT_MetaTileEntity_IndustrialApiary extends GT_MetaTileEntity_BasicM
     private int flowerBlockMeta;
 
     private boolean checkFlower(IBee bee) {
-        String flowerType = bee.getGenome().getFlowerProvider().getFlowerType();
+        final String flowerType = bee.getGenome().getFlowerProvider().getFlowerType();
         if (!this.flowerType.equals(flowerType)) flowercoords = null;
         if (flowercoords != null) {
             if (getWorld().getBlock(flowercoords.posX, flowercoords.posY, flowercoords.posZ) != flowerBlock
@@ -890,7 +891,7 @@ public class GT_MetaTileEntity_IndustrialApiary extends GT_MetaTileEntity_BasicM
         clearErrors();
         if (queen == null) return true; // Reloaded the chunk ?
         if (beeRoot.isMember(queen, EnumBeeType.PRINCESS.ordinal())) return true;
-        IBee bee = beeRoot.getMember(queen);
+        final IBee bee = beeRoot.getMember(queen);
         for (IErrorState err : bee.getCanWork(this)) setCondition(true, err);
         setCondition(!checkFlower(bee), EnumErrorCode.NO_FLOWER);
         return !hasErrors();
@@ -898,13 +899,13 @@ public class GT_MetaTileEntity_IndustrialApiary extends GT_MetaTileEntity_BasicM
 
     private boolean canWork() {
         clearErrors();
-        EnumBeeType beeType = beeRoot.getType(getQueen());
+        final EnumBeeType beeType = beeRoot.getType(getQueen());
         if (beeType == EnumBeeType.PRINCESS) {
             setCondition(!beeRoot.isDrone(getDrone()), EnumErrorCode.NO_DRONE);
             return !hasErrors();
         }
         if (beeType == EnumBeeType.QUEEN) {
-            IBee bee = beeRoot.getMember(getQueen());
+            final IBee bee = beeRoot.getMember(getQueen());
             for (IErrorState err : bee.getCanWork(this)) setCondition(true, err);
             setCondition(!checkFlower(bee), EnumErrorCode.NO_FLOWER);
             return !hasErrors();
@@ -936,12 +937,12 @@ public class GT_MetaTileEntity_IndustrialApiary extends GT_MetaTileEntity_BasicM
     private int maxspeed = 0;
 
     public void updateModifiers() {
-        GT_ApiaryModifier mods = new GT_ApiaryModifier();
+        final GT_ApiaryModifier mods = new GT_ApiaryModifier();
         for (int i = 2; i < 2 + 4; i++) {
-            ItemStack s = getInputAt(i);
+            final ItemStack s = getInputAt(i);
             if (s == null) continue;
             if (GT_ApiaryUpgrade.isUpgrade(s)) {
-                GT_ApiaryUpgrade upgrade = GT_ApiaryUpgrade.getUpgrade(s);
+                final GT_ApiaryUpgrade upgrade = GT_ApiaryUpgrade.getUpgrade(s);
                 upgrade.applyModifiers(mods, s);
             }
         }
@@ -1124,25 +1125,25 @@ public class GT_MetaTileEntity_IndustrialApiary extends GT_MetaTileEntity_BasicM
                 .widget(new DrawableWidget()
                         .setDrawable(GT_UITextures.PICTURE_INFORMATION)
                         .setGTTooltip(() -> {
-                            String energyreq = GT_Utility.formatNumbers(
+                            final String energyreq = GT_Utility.formatNumbers(
                                     (int) ((float) GT_MetaTileEntity_IndustrialApiary.baseEUtUsage
                                                     * getEnergyModifier()
                                                     * getAcceleration())
                                             + getAdditionalEnergyUsage());
-                            String Temp = StatCollector.translateToLocal(
+                            final String Temp = StatCollector.translateToLocal(
                                     getTemperature().getName());
-                            String Hum =
+                            final String Hum =
                                     StatCollector.translateToLocal(getHumidity().getName());
                             if (getUsedQueen() != null
                                     && BeeManager.beeRoot.isMember(getUsedQueen(), EnumBeeType.QUEEN.ordinal())) {
-                                IBee bee = BeeManager.beeRoot.getMember(getUsedQueen());
+                                final IBee bee = BeeManager.beeRoot.getMember(getUsedQueen());
                                 if (bee.isAnalyzed()) {
-                                    IBeeGenome genome = bee.getGenome();
-                                    IBeeModifier mod = BeeManager.beeRoot
+                                    final IBeeGenome genome = bee.getGenome();
+                                    final IBeeModifier mod = BeeManager.beeRoot
                                             .getBeekeepingMode(getWorld())
                                             .getBeeModifier();
-                                    float tmod = getTerritoryModifier(null, 1f) * mod.getTerritoryModifier(null, 1f);
-                                    int[] t = Arrays.stream(genome.getTerritory())
+                                    final float tmod = getTerritoryModifier(null, 1f) * mod.getTerritoryModifier(null, 1f);
+                                    final int[] t = Arrays.stream(genome.getTerritory())
                                             .map(i -> (int) ((float) i * tmod))
                                             .toArray();
                                     return mTooltipCache.getUncachedTooltipData(
@@ -1279,7 +1280,7 @@ public class GT_MetaTileEntity_IndustrialApiary extends GT_MetaTileEntity_BasicM
     }
 
     private int getAdditionalEnergyUsage() {
-        int accelerated = getAcceleration();
+        final int accelerated = getAcceleration();
         int energyusage = 0;
         if (accelerated == 2) energyusage = 32;
         else if (accelerated > 2) energyusage = 32 * accelerated << (mSpeed - 2);
@@ -1322,10 +1323,10 @@ public class GT_MetaTileEntity_IndustrialApiary extends GT_MetaTileEntity_BasicM
             if (aShifthold == 5) return null;
             if (aShifthold != 0) return super.slotClick(aSlotNumber, aMouseclick, aShifthold, aPlayer);
             if (aMouseclick > 1) return super.slotClick(aSlotNumber, aMouseclick, aShifthold, aPlayer);
-            ItemStack s = aPlayer.inventory.getItemStack();
+            final ItemStack s = aPlayer.inventory.getItemStack();
             if (s == null) return super.slotClick(aSlotNumber, aMouseclick, aShifthold, aPlayer);
-            Slot slot = getSlot(aSlotNumber);
-            ItemStack slotStack = slot.getStack();
+            final Slot slot = getSlot(aSlotNumber);
+            final ItemStack slotStack = slot.getStack();
             if (slotStack != null && !GT_Utility.areStacksEqual(slotStack, s)) return null; // super would replace item
             if (slotStack == null && !slot.isItemValid(s))
                 return super.slotClick(aSlotNumber, aMouseclick, aShifthold, aPlayer);
@@ -1336,23 +1337,23 @@ public class GT_MetaTileEntity_IndustrialApiary extends GT_MetaTileEntity_BasicM
             if (max == 0) return null;
             if (aMouseclick == 1) max = 1;
             if (max == s.stackSize) return super.slotClick(aSlotNumber, aMouseclick, aShifthold, aPlayer);
-            ItemStack newStack = s.splitStack(s.stackSize - max);
-            ItemStack result = super.slotClick(aSlotNumber, aMouseclick, aShifthold, aPlayer);
+            final ItemStack newStack = s.splitStack(s.stackSize - max);
+            final ItemStack result = super.slotClick(aSlotNumber, aMouseclick, aShifthold, aPlayer);
             aPlayer.inventory.setItemStack(newStack);
             return result;
         }
 
         @Override
         public ItemStack transferStackInSlot(EntityPlayer aPlayer, int aSlotIndex) {
-            Slot s = getSlot(aSlotIndex);
+            final Slot s = getSlot(aSlotIndex);
             if (s == null) return super.transferStackInSlot(aPlayer, aSlotIndex);
             if (aSlotIndex >= playerInventorySlot) return super.transferStackInSlot(aPlayer, aSlotIndex);
-            ItemStack aStack = s.getStack();
+            final ItemStack aStack = s.getStack();
             if (aStack == null) return super.transferStackInSlot(aPlayer, aSlotIndex);
             if (!GT_ApiaryUpgrade.isUpgrade(aStack)) return super.transferStackInSlot(aPlayer, aSlotIndex);
             for (int i = playerInventorySlot + 2; i < playerInventorySlot + 2 + 4; i++) {
-                Slot iSlot = getSlot(i);
-                ItemStack iStack = iSlot.getStack();
+                final Slot iSlot = getSlot(i);
+                final ItemStack iStack = iSlot.getStack();
                 if (iStack == null) {
                     if (!iSlot.isItemValid(aStack)) continue;
                 } else {
@@ -1361,7 +1362,7 @@ public class GT_MetaTileEntity_IndustrialApiary extends GT_MetaTileEntity_BasicM
                 int max = GT_ApiaryUpgrade.getUpgrade(aStack).getMaxNumber();
                 if (iStack == null) {
                     max = Math.min(max, aStack.stackSize);
-                    ItemStack newstack = aStack.splitStack(max);
+                    final ItemStack newstack = aStack.splitStack(max);
                     iSlot.putStack(newstack);
                 } else {
                     max = Math.max(0, max - iStack.stackSize);

--- a/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_IndustrialApiary.java
+++ b/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_IndustrialApiary.java
@@ -1142,7 +1142,8 @@ public class GT_MetaTileEntity_IndustrialApiary extends GT_MetaTileEntity_BasicM
                                     final IBeeModifier mod = BeeManager.beeRoot
                                             .getBeekeepingMode(getWorld())
                                             .getBeeModifier();
-                                    final float tmod = getTerritoryModifier(null, 1f) * mod.getTerritoryModifier(null, 1f);
+                                    final float tmod =
+                                            getTerritoryModifier(null, 1f) * mod.getTerritoryModifier(null, 1f);
                                     final int[] t = Arrays.stream(genome.getTerritory())
                                             .map(i -> (int) ((float) i * tmod))
                                             .toArray();

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_Cleanroom.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_Cleanroom.java
@@ -1,5 +1,6 @@
 package gregtech.common.tileentities.machines.multi;
 
+import static gregtech.api.enums.GT_Values.ALL_VALID_SIDES;
 import static gregtech.api.enums.GT_Values.debugCleanroom;
 import static gregtech.api.enums.Textures.BlockIcons.*;
 
@@ -45,6 +46,7 @@ public class GT_MetaTileEntity_Cleanroom extends GT_MetaTileEntity_TooltipMultiB
         return new GT_MetaTileEntity_Cleanroom(mName);
     }
 
+    @Override
     protected GT_Multiblock_Tooltip_Builder createTooltip() {
         final GT_Multiblock_Tooltip_Builder tt = new GT_Multiblock_Tooltip_Builder();
         tt.addMachineType("Cleanroom")
@@ -104,7 +106,7 @@ public class GT_MetaTileEntity_Cleanroom extends GT_MetaTileEntity_TooltipMultiB
         int mDoorCount = 0;
         int mHullCount = 0;
         int mPlascreteCount = 0;
-        HashMap<String, Integer> otherBlocks = new HashMap<>();
+        final HashMap<String, Integer> otherBlocks = new HashMap<>();
         boolean doorState = false;
         this.mUpdate = 100;
 
@@ -112,8 +114,8 @@ public class GT_MetaTileEntity_Cleanroom extends GT_MetaTileEntity_TooltipMultiB
             GT_Log.out.println("Cleanroom: Checking machine");
         }
         for (int i = 1; i < 8; i++) {
-            Block tBlock = aBaseMetaTileEntity.getBlockOffset(i, 0, 0);
-            int tMeta = aBaseMetaTileEntity.getMetaIDOffset(i, 0, 0);
+            final Block tBlock = aBaseMetaTileEntity.getBlockOffset(i, 0, 0);
+            final int tMeta = aBaseMetaTileEntity.getMetaIDOffset(i, 0, 0);
             if (tBlock != GregTech_API.sBlockCasings3 || tMeta != 11) {
                 if (tBlock == GregTech_API.sBlockReinforced || tMeta == 2) {
                     x = i;
@@ -127,8 +129,8 @@ public class GT_MetaTileEntity_Cleanroom extends GT_MetaTileEntity_TooltipMultiB
             }
         }
         for (int i = 1; i < 8; i++) {
-            Block tBlock = aBaseMetaTileEntity.getBlockOffset(0, 0, i);
-            int tMeta = aBaseMetaTileEntity.getMetaIDOffset(0, 0, i);
+            final Block tBlock = aBaseMetaTileEntity.getBlockOffset(0, 0, i);
+            final int tMeta = aBaseMetaTileEntity.getMetaIDOffset(0, 0, i);
             if (tBlock != GregTech_API.sBlockCasings3 || tMeta != 11) {
                 if (tBlock == GregTech_API.sBlockReinforced || tMeta == 2) {
                     z = i;
@@ -145,8 +147,8 @@ public class GT_MetaTileEntity_Cleanroom extends GT_MetaTileEntity_TooltipMultiB
         for (int i = -x + 1; i < x; i++) {
             for (int j = -z + 1; j < z; j++) {
                 if (i == 0 && j == 0) continue;
-                Block tBlock = aBaseMetaTileEntity.getBlockOffset(j, 0, i);
-                int tMeta = aBaseMetaTileEntity.getMetaIDOffset(j, 0, i);
+                final Block tBlock = aBaseMetaTileEntity.getBlockOffset(j, 0, i);
+                final int tMeta = aBaseMetaTileEntity.getMetaIDOffset(j, 0, i);
                 if (tBlock != GregTech_API.sBlockCasings3 && tMeta != 11) {
                     return false;
                 }
@@ -154,8 +156,8 @@ public class GT_MetaTileEntity_Cleanroom extends GT_MetaTileEntity_TooltipMultiB
         }
 
         for (int i = -1; i > -16; i--) {
-            Block tBlock = aBaseMetaTileEntity.getBlockOffset(x, i, z);
-            int tMeta = aBaseMetaTileEntity.getMetaIDOffset(x, i, z);
+            final Block tBlock = aBaseMetaTileEntity.getBlockOffset(x, i, z);
+            final int tMeta = aBaseMetaTileEntity.getMetaIDOffset(x, i, z);
             if (tBlock != GregTech_API.sBlockReinforced || tMeta != 2) {
                 y = i + 1;
                 break;
@@ -193,7 +195,7 @@ public class GT_MetaTileEntity_Cleanroom extends GT_MetaTileEntity_TooltipMultiB
                         } else if (tBlock == GregTech_API.sBlockReinforced && tMeta == 2) {
                             mPlascreteCount++;
                         } else {
-                            IGregTechTileEntity tTileEntity =
+                            final IGregTechTileEntity tTileEntity =
                                     aBaseMetaTileEntity.getIGregTechTileEntityOffset(dX, dY, dZ);
                             if ((!this.addMaintenanceToMachineList(tTileEntity, 210))
                                     && (!this.addEnergyInputToMachineList(tTileEntity, 210))) {
@@ -209,7 +211,7 @@ public class GT_MetaTileEntity_Cleanroom extends GT_MetaTileEntity_TooltipMultiB
                                     mDoorCount++;
                                 } else {
                                     if (tTileEntity != null) {
-                                        IMetaTileEntity aMetaTileEntity = tTileEntity.getMetaTileEntity();
+                                        final IMetaTileEntity aMetaTileEntity = tTileEntity.getMetaTileEntity();
                                         if (aMetaTileEntity == null) {
                                             if (debugCleanroom) {
                                                 GT_Log.out.println("Cleanroom: Missing block? Not a aMetaTileEntity");
@@ -255,9 +257,9 @@ public class GT_MetaTileEntity_Cleanroom extends GT_MetaTileEntity_TooltipMultiB
             return false;
         }
         if (mPlascreteCount < 20) return false;
-        float ratio = (((float) mPlascreteCount) / 100f);
+        final float ratio = (((float) mPlascreteCount) / 100f);
         for (Map.Entry<String, Integer> e : otherBlocks.entrySet()) {
-            ConfigEntry ce = config.get(e.getKey());
+            final ConfigEntry ce = config.get(e.getKey());
             if (ce.allowedCount > 0) { // count has priority
                 if (e.getValue() > ce.allowedCount) return false;
             } else if (e.getValue() > ratio * ce.percentage) return false;
@@ -268,9 +270,9 @@ public class GT_MetaTileEntity_Cleanroom extends GT_MetaTileEntity_TooltipMultiB
         if (doorState) {
             this.mEfficiency = Math.max(0, this.mEfficiency - 200);
         }
-        for (byte i = 0; i < 6; i++) {
-            byte t = (byte) Math.max(1, (byte) (15 / (10000f / this.mEfficiency)));
-            aBaseMetaTileEntity.setInternalOutputRedstoneSignal(i, t);
+        for (byte tSide : ALL_VALID_SIDES) {
+            final byte t = (byte) Math.max(1, (byte) (15 / (10000f / this.mEfficiency)));
+            aBaseMetaTileEntity.setInternalOutputRedstoneSignal(tSide, t);
         }
         this.mHeight = -y;
         return true;
@@ -430,7 +432,7 @@ public class GT_MetaTileEntity_Cleanroom extends GT_MetaTileEntity_TooltipMultiB
     public static void loadConfig(Configuration cfg) {
         if (!cfg.hasCategory(category)) setDefaultConfigValues(cfg);
         for (ConfigCategory cc : cfg.getCategory(category).getChildren()) {
-            String name = cc.get("Name").getString();
+            final String name = cc.get("Name").getString();
             if (cc.containsKey("Count")) {
                 if (cc.containsKey("Meta"))
                     config.put(


### PR DESCRIPTION
Refactor cover usage; add `CoverInfo`.    Currently targeting the `mte_inventory` branch, which is mostly isolated; unlike this change - hence the review request.

TODO:
- [x] Verify  legacy NBT cover loading works
- [x] Verify it works in the full pack (other GT addons)