### PR TITLE
Fix recipe conflict between roen 1 and sandstone

### DIFF
--- a/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
@@ -8884,7 +8884,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                 4);
         GT_Values.RA.addAssemblerRecipe(
                 new ItemStack(Blocks.sandstone, 1, 0),
-                GT_Utility.getIntegratedCircuit(1),
+                GT_Utility.getIntegratedCircuit(23),
                 new ItemStack(Blocks.sandstone, 1, 2),
                 50,
                 4);


### PR DESCRIPTION
Fix recipe conflict between roen 1 and sandstone. This is one of the conflicts of https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12300.