### PR TITLE
Centrifuge Recipes for U235 - Tweaks

### DIFF
--- a/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
@@ -10770,7 +10770,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                 new int[] {2000, 1000},
                 2000,
                 (int) GT_Values.VP[3]);
-        
+
         // Uranium Enrichment in Centrifuge by adding Fluorine (Uranium Hexafluoride)
         GT_Values.RA.addCentrifugeRecipe(
                 GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Uranium, 1L),

--- a/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
@@ -10758,18 +10758,34 @@ public class GT_MachineRecipeLoader implements Runnable {
                 500);
         GT_Values.RA.addCentrifugeRecipe(
                 GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Uranium, 1L),
-                GT_Values.NI,
+                GT_Utility.getIntegratedCircuit(10),
                 GT_Values.NF,
                 GT_Values.NF,
-                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Uranium235, 1L),
-                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Plutonium, 1L),
+                GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.Uranium235, 1L),
+                GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.Plutonium, 1L),
                 GT_Values.NI,
                 GT_Values.NI,
                 GT_Values.NI,
                 GT_Values.NI,
-                new int[] {2000, 200},
-                800,
-                320);
+                new int[] {2000, 1000},
+                2000,
+                (int) GT_Values.VP[3]);
+        
+        // Uranium Enrichment in Centrifuge by adding Fluorine (Uranium Hexafluoride)
+        GT_Values.RA.addCentrifugeRecipe(
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Uranium, 1L),
+                GT_Values.NI,
+                Materials.Fluorine.getGas(4000),
+                GT_Values.NF,
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Uranium235, 1L),
+                GT_Values.NI,
+                GT_Values.NI,
+                GT_Values.NI,
+                GT_Values.NI,
+                GT_Values.NI,
+                new int[] {10000},
+                4000,
+                (int) GT_Values.VP[4]);
         GT_Values.RA.addCentrifugeRecipe(
                 GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Plutonium, 1L),
                 GT_Values.NI,


### PR DESCRIPTION
I'm working on a change to the T2 rocket, which is to add LuV circuits to one of its recipes. However, this affects EV progression in the sense that Radon is needed to make the machines for this circuit line, but is much harder to get without t2 ores. For that purpose, I am also making changes so that Plutonium is more accessible, either from a direct recipe which is a big energy sink or an easier enrichment of U238 into U235 by using Fluorine and energy.

This PR changes one existing Centrifuge recipe and adds another. The changed one is this one:

![image](https://user-images.githubusercontent.com/70096037/213791916-3eebad15-6140-4e73-9e22-80d55e402194.png)

I changed the tiny dusts to small and increased the Plutonium chance to 10% but, at the same time, also increased the recipe time and power consumption slightly. To get 8 Plutonium ingots for the Radon cycle using only this recipe, an average of 307M EU is required, and it will take 8.88 hours with one HV Centrifuge (using more than 1 is incentivized).

The other recipe (EV tier) is a 1:1 of U238 to U235, with the addition of 4000L of Fluorine which gets consumed. To make enough U235 for the fuel rods needed to make 8 Plutonium Ingots through nuke breeding, the recipe needs to be done 24 times, which takes 1.33 hours with one EV Centrifuge and 184M EU, which is a tiny amount compared to the 3.3B EU generated by the Uranium nukes to make those 8 Plutonium ingots.
