### PR TITLE
Fix HOG Consumption Rate in LCE

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_DieselEngine.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_DieselEngine.java
@@ -75,9 +75,6 @@ public class GT_MetaTileEntity_DieselEngine
     protected int fuelValue = 0;
     protected int fuelRemaining = 0;
     protected boolean boostEu = false;
-    protected double boostedFuelValue = 0;
-    protected double boostedOutput = 0;
-    protected double extraFuelFraction = 0;
 
     public GT_MetaTileEntity_DieselEngine(int aID, String aName, String aNameRegional) {
         super(aID, aName, aNameRegional);
@@ -204,6 +201,9 @@ public class GT_MetaTileEntity_DieselEngine
 
         // fast track lookup
         if (!tFluids.isEmpty()) {
+            double boostedFuelValue = 0;
+            double boostedOutput = 0;
+            double extraFuelFraction = 0;
             for (FluidStack tFluid : tFluids) {
                 GT_Recipe tRecipe = getFuelMap().findFuel(tFluid);
                 if (tRecipe == null) continue;

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_DieselEngine.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_DieselEngine.java
@@ -75,6 +75,9 @@ public class GT_MetaTileEntity_DieselEngine
     protected int fuelValue = 0;
     protected int fuelRemaining = 0;
     protected boolean boostEu = false;
+    protected double boostedFuelValue = 0;
+    protected double boostedOutput = 0;
+    protected double extraFuelFraction = 0;
 
     public GT_MetaTileEntity_DieselEngine(int aID, String aName, String aNameRegional) {
         super(aID, aName, aNameRegional);
@@ -204,25 +207,44 @@ public class GT_MetaTileEntity_DieselEngine
             for (FluidStack tFluid : tFluids) {
                 GT_Recipe tRecipe = getFuelMap().findFuel(tFluid);
                 if (tRecipe == null) continue;
+                fuelValue = tRecipe.mSpecialValue;
 
                 FluidStack tLiquid = tFluid.copy();
-                fuelConsumption = tLiquid.amount = boostEu
-                        ? (getBoostFactor() * getNominalOutput() / tRecipe.mSpecialValue)
-                        : (getNominalOutput() / tRecipe.mSpecialValue); // Calc fuel consumption
+                if (boostEu) {
+                    boostedFuelValue = GT_Utility.safeInt((long) (fuelValue * 1.5));
+                    boostedOutput = getNominalOutput() * 3;
+
+                    fuelConsumption = tLiquid.amount = getBoostFactor() * getNominalOutput() / fuelValue;
+
+                    // HOG consumption rate is normally 1 L/t, when it's supposed to be around 1.64 L/t
+                    // This code increases fuel consumption by 1 at random, but with a weighted chance
+                    if (boostedFuelValue * 2 > boostedOutput) {
+                        extraFuelFraction = boostedOutput / boostedFuelValue;
+                        extraFuelFraction = extraFuelFraction - (int) extraFuelFraction;
+                        double rand = Math.random();
+                        if (rand < extraFuelFraction) {
+                            tLiquid.amount += 1;
+                        }
+                    }
+
+                } else {
+                    fuelConsumption = tLiquid.amount = getNominalOutput() / fuelValue;
+                }
+
                 // Deplete that amount
                 if (!depleteInput(tLiquid)) return false;
                 boostEu = depleteInput(getBooster().getGas(2L * getAdditiveFactor()));
+
+                // Check to prevent burning HOG without consuming it, if not boosted
+                if (!boostEu && fuelValue > getNominalOutput()) {
+                    return false;
+                }
 
                 // Deplete Lubricant. 1000L should = 1 hour of runtime (if baseEU = 2048)
                 if ((mRuntime % 72 == 0 || mRuntime == 0)
                         && !depleteInput(Materials.Lubricant.getFluid((boostEu ? 2L : 1L) * getAdditiveFactor())))
                     return false;
 
-                fuelValue = tRecipe.mSpecialValue;
-                // Check to prevent burning HOG without consuming it, if not boosted
-                if (!boostEu && fuelValue > getNominalOutput()) {
-                    return false;
-                }
                 fuelRemaining = tFluid.amount; // Record available fuel
                 this.mEUt = mEfficiency < 2000 ? 0 : getNominalOutput(); // Output 0 if startup is less than 20%
                 this.mProgresstime = 1;


### PR DESCRIPTION
HOG consumption in the LCE was set to 1L/t after rounding. However, 1L of HOG is worth 3750 EU after the LCE's fuel efficiency bonus (2500 EU base value * 1.5 efficiency), which means that 3750 EU/t of fuel was actually generating 6144 EU/t, which is the LCE's boosted EU output.

To fix this, and any other future diesels with very high fuel value, I added some code that generates a random number to set the fuel consumption for the tick from 1 to 2. This chance depends on the fuel value, and it will not work for any fuels that might have fuel value >= 4096 EU/L, should they exist in the future.