### PR TITLE
Only print meta TE IDs when a debug flag is on.

### DIFF
--- a/src/main/java/gregtech/common/GT_Client.java
+++ b/src/main/java/gregtech/common/GT_Client.java
@@ -587,19 +587,21 @@ public class GT_Client extends GT_Proxy implements Runnable {
     public void onPostLoad() {
         super.onPostLoad();
 
-        try {
-            for (int i = 1; i < GregTech_API.METATILEENTITIES.length; i++) {
-                try {
-                    if (GregTech_API.METATILEENTITIES[i] != null) {
-                        GregTech_API.METATILEENTITIES[i].getStackForm(1L).getTooltip(null, true);
-                        GT_Log.out.println("META " + i + " " + GregTech_API.METATILEENTITIES[i].getMetaName());
+        if (GregTech_API.sClientDataFile.get("debug", "PrintMetaIDs", false)) {
+            try {
+                for (int i = 1; i < GregTech_API.METATILEENTITIES.length; i++) {
+                    try {
+                        if (GregTech_API.METATILEENTITIES[i] != null) {
+                            GregTech_API.METATILEENTITIES[i].getStackForm(1L).getTooltip(null, true);
+                            GT_Log.out.println("META " + i + " " + GregTech_API.METATILEENTITIES[i].getMetaName());
+                        }
+                    } catch (Throwable e) {
+                        e.printStackTrace(GT_Log.err);
                     }
-                } catch (Throwable e) {
-                    e.printStackTrace(GT_Log.err);
                 }
+            } catch (Throwable e) {
+                e.printStackTrace(GT_Log.err);
             }
-        } catch (Throwable e) {
-            e.printStackTrace(GT_Log.err);
         }
 
         if (Loader.isModLoaded("Avaritia")) {


### PR DESCRIPTION
It seems to cause loading lag with completely silent logs in the full pack