### PR TITLE
Add chance to sifter method

### DIFF
--- a/src/main/java/gregtech/api/interfaces/internal/IGT_RecipeAdder.java
+++ b/src/main/java/gregtech/api/interfaces/internal/IGT_RecipeAdder.java
@@ -1187,12 +1187,13 @@ public interface IGT_RecipeAdder {
      */
     boolean addSifterRecipe(ItemStack aItemToSift, ItemStack[] aSiftedItems, int[] aChances, int aDuration, int aEUt);
     /**
-     * Adds a Generalised Laser Engraver Recipe.
+     * Adds a Generalised Sifter Recipe.
      *
      * @param ItemInputArray    Array of input items.
      * @param FluidInputArray   Array of output items.
      * @param OutputItemArray   Array of input fluids.
      * @param FluidOutputArray  Array of output items.
+     * @param aChances          Array of chances for outputs.
      * @param aDuration         Must be > 0. Duration in ticks.
      * @param aEUt              Should be > 0. EU/t.
      * @param aCleanroom        Boolean for usage of cleanroom in recipe.
@@ -1202,6 +1203,7 @@ public interface IGT_RecipeAdder {
             FluidStack[] FluidInputArray,
             ItemStack[] OutputItemArray,
             FluidStack[] FluidOutputArray,
+            int[] aChances,
             int aDuration,
             int aEUt,
             boolean aCleanroom);

--- a/src/main/java/gregtech/common/GT_RecipeAdder.java
+++ b/src/main/java/gregtech/common/GT_RecipeAdder.java
@@ -2874,6 +2874,7 @@ public class GT_RecipeAdder implements IGT_RecipeAdder {
             FluidStack[] FluidInputArray,
             ItemStack[] OutputItemArray,
             FluidStack[] FluidOutputArray,
+            int[] aChances,
             int aDuration,
             int aEUt,
             boolean aCleanroom) {
@@ -2882,7 +2883,7 @@ public class GT_RecipeAdder implements IGT_RecipeAdder {
                 ItemInputArray,
                 OutputItemArray,
                 null,
-                null,
+                aChances,
                 FluidInputArray,
                 FluidOutputArray,
                 aDuration,


### PR DESCRIPTION
Adds the possibility for chance outputs in the new sifter method, this should only break a single recipe which is part of the draft pr on optical circuits, will be fixed