### PR TITLE
Fix comparision logic

### DIFF
--- a/src/main/java/gregtech/common/power/Power.java
+++ b/src/main/java/gregtech/common/power/Power.java
@@ -65,7 +65,7 @@ public abstract class Power {
     public abstract String getAmperageString();
 
     public int compareTo(byte tier, int specialValue) {
-        if (this.tier != tier) {
+        if (this.tier < tier) {
             return this.tier - tier;
         }
         return this.specialValue - specialValue;


### PR DESCRIPTION
In my last PR I accidently checked for unequal voltage tier, which is wrong. Higher voltage tier needs to be checked because after that the special value also needs to be checked.