### PR TITLE
Fix mutating ItemData NBT

### DIFF
--- a/src/main/java/gregtech/api/util/GT_OreDictUnificator.java
+++ b/src/main/java/gregtech/api/util/GT_OreDictUnificator.java
@@ -187,30 +187,29 @@ public class GT_OreDictUnificator {
             tPrefixMaterial.mUnificationTarget = sName2StackMap.get(tPrefixMaterial.toString());
         ItemStack rStack = tPrefixMaterial.mUnificationTarget;
         if (GT_Utility.isStackInvalid(rStack)) return GT_Utility.copyOrNull(aStack);
-        rStack.setTagCompound(aStack.getTagCompound());
+        ItemStack newStack;
         if (unsafe) {
-            return GT_Utility.copyAmountUnsafe(aStack.stackSize, rStack);
+            newStack = GT_Utility.copyAmountUnsafe(aStack.stackSize, rStack);
         } else {
-            return GT_Utility.copyAmount(aStack.stackSize, rStack);
+            newStack = GT_Utility.copyAmount(aStack.stackSize, rStack);
         }
+        newStack.setTagCompound(aStack.getTagCompound());
+        return newStack;
     }
 
     /**
-     * Doesn't copy the returned stack or set quantity. Be careful and do not mutate it; intended only to optimize
-     * comparisons
+     * Doesn't copy the returned stack. Be careful and do not mutate it; intended only to optimize comparisons
      */
     public static ItemStack get_nocopy(ItemStack aStack) {
         return get_nocopy(true, aStack);
     }
 
     /**
-     * Doesn't copy the returned stack or set quantity. Be careful and do not mutate it; intended only to optimize
-     * comparisons
+     * Doesn't copy the returned stack. Be careful and do not mutate it; intended only to optimize comparisons
      */
     static ItemStack get_nocopy(boolean aUseBlackList, ItemStack aStack) {
         if (GT_Utility.isStackInvalid(aStack)) return null;
         ItemData tPrefixMaterial = getAssociation(aStack);
-        ItemStack rStack = null;
         if (tPrefixMaterial == null || !tPrefixMaterial.hasValidPrefixMaterialData()
                 || (aUseBlackList && tPrefixMaterial.mBlackListed))
             return aStack;
@@ -220,11 +219,17 @@ public class GT_OreDictUnificator {
         }
         if (tPrefixMaterial.mUnificationTarget == null)
             tPrefixMaterial.mUnificationTarget = sName2StackMap.get(tPrefixMaterial.toString());
-        rStack = tPrefixMaterial.mUnificationTarget;
+        ItemStack rStack = tPrefixMaterial.mUnificationTarget;
         if (GT_Utility.isStackInvalid(rStack)) return aStack;
-        assert rStack != null;
-        rStack.setTagCompound(aStack.getTagCompound());
-        return rStack;
+        // Okay, okay, I lied, we actually do need to make a copy.
+        // This is to fix a long-standing bug where we were mutating NBT directly on rStack,
+        // which had unexpected and unpredictable ripple effects.
+        //
+        // We will do some custom copying here, to avoid ItemStack.copy(),
+        // which calls the potentially expensive NBTTagCompound.copy()
+        ItemStack newStack = new ItemStack(rStack.getItem(), aStack.stackSize, Items.feather.getDamage(rStack));
+        newStack.setTagCompound(aStack.getTagCompound());
+        return newStack;
     }
 
     /**
@@ -252,7 +257,6 @@ public class GT_OreDictUnificator {
         rStack = tPrefixMaterial.mUnificationTarget;
         if (GT_Utility.isStackInvalid(rStack))
             return !alreadyCompared && GT_Utility.areStacksEqual(aStack, unified_tStack, true);
-        rStack.setTagCompound(aStack.getTagCompound());
         return GT_Utility.areStacksEqual(rStack, unified_tStack, true);
     }
 


### PR DESCRIPTION
Fix for a very old bug where we were overwriting NBT in stored `ItemData` every time we called `GT_OreDictUnificator.get()` or `GT_OreDictUnificator.get_nocopy()`

Maybe fixes:
 * https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12678
 * https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/11153

Please review this carefully, since it's very difficult to thoroughly test changes to this part of the codebase.

In `get_nocopy()`, I removed `assert rStack != null` since it is already checked by `GT_Utility.isStackInvalid()`.

In `isInputStackEqual()`, I just deleted `rStack.setTagCompound()` since the only reference to `rStack` is in `GT_Utility.areStacksEqual()`, which has `aIgnoreNBT == true` so setting NBT does nothing.