### PR TITLE
implement save & load for single recipe lock

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
@@ -242,6 +242,9 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
             if (mLockedToSingleRecipe && aNBT.hasKey("mSingleRecipeCheck", Constants.NBT.TAG_COMPOUND)) {
                 GT_Single_Recipe_Check c = loadSingleRecipeChecker(aNBT.getCompoundTag("mSingleRecipeCheck"));
                 if (c != null) mSingleRecipeCheck = c;
+                // the old recipe is gone. we disable the machine to prevent making garbage in case of shared inputs
+                // maybe use a better way to inform player in the future.
+                else getBaseMetaTileEntity().disableWorking();
             }
         }
         batchMode = aNBT.getBoolean(BATCH_MODE_NBT_KEY);

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
@@ -20,6 +20,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
+import net.minecraftforge.common.util.Constants;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.FluidStack;
 
@@ -195,7 +196,11 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
         aNBT.setInteger("mEfficiency", mEfficiency);
         aNBT.setInteger("mPollution", mPollution);
         aNBT.setInteger("mRuntime", mRuntime);
-        aNBT.setBoolean("mLockedToSingleRecipe", mLockedToSingleRecipe);
+        if (supportsSingleRecipeLocking()) {
+            aNBT.setBoolean("mLockedToSingleRecipe", mLockedToSingleRecipe);
+            if (mLockedToSingleRecipe && mSingleRecipeCheck != null)
+                aNBT.setTag("mSingleRecipeCheck", mSingleRecipeCheck.writeToNBT());
+        }
 
         if (mOutputItems != null) {
             aNBT.setInteger("mOutputItemsLength", mOutputItems.length);
@@ -232,7 +237,13 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
         mEfficiency = aNBT.getInteger("mEfficiency");
         mPollution = aNBT.getInteger("mPollution");
         mRuntime = aNBT.getInteger("mRuntime");
-        mLockedToSingleRecipe = aNBT.getBoolean("mLockedToSingleRecipe");
+        if (supportsSingleRecipeLocking()) {
+            mLockedToSingleRecipe = aNBT.getBoolean("mLockedToSingleRecipe");
+            if (mLockedToSingleRecipe && aNBT.hasKey("mSingleRecipeCheck", Constants.NBT.TAG_COMPOUND)) {
+                GT_Single_Recipe_Check c = loadSingleRecipeChecker(aNBT.getCompoundTag("mSingleRecipeCheck"));
+                if (c != null) mSingleRecipeCheck = c;
+            }
+        }
         batchMode = aNBT.getBoolean(BATCH_MODE_NBT_KEY);
         inputSeparation = aNBT.getBoolean(INPUT_SEPARATION_NBT_KEY);
         voidExcess = aNBT.getBoolean(VOID_EXCESS_NBT_KEY);
@@ -257,6 +268,10 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
         mHardHammer = aNBT.getBoolean("mHardHammer");
         mSolderingTool = aNBT.getBoolean("mSolderingTool");
         mCrowbar = aNBT.getBoolean("mCrowbar");
+    }
+
+    protected GT_Single_Recipe_Check loadSingleRecipeChecker(NBTTagCompound aNBT) {
+        return GT_Single_Recipe_Check.tryLoad(this, aNBT);
     }
 
     @Override

--- a/src/main/java/gregtech/api/util/GT_Single_Recipe_Check.java
+++ b/src/main/java/gregtech/api/util/GT_Single_Recipe_Check.java
@@ -9,7 +9,6 @@ import java.util.function.Function;
 
 import javax.annotation.Nullable;
 
-import gregtech.api.enums.GT_Values;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTBase;
 import net.minecraft.nbt.NBTTagCompound;
@@ -21,6 +20,8 @@ import net.minecraftforge.fluids.FluidStack;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
+
+import gregtech.api.enums.GT_Values;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_MultiBlockBase;
 
 /** Used by machines that are locked to a single recipe, for fast computation. */
@@ -248,7 +249,9 @@ public class GT_Single_Recipe_Check {
 
     protected static ImmutableMap<Fluid, Integer> loadFluidCost(NBTTagCompound tag) {
         return GT_Utility.streamCompounds(tag.getTagList("fluidCost", Constants.NBT.TAG_COMPOUND)).collect(
-                GT_Utility.toImmutableMapSerial(t -> FluidRegistry.getFluid(t.getString("id")), t -> t.getInteger("count")));
+                GT_Utility.toImmutableMapSerial(
+                        t -> FluidRegistry.getFluid(t.getString("id")),
+                        t -> t.getInteger("count")));
     }
 
     protected static ImmutableMap<GT_Utility.ItemId, Integer> loadItemCost(NBTTagCompound tag) {
@@ -270,7 +273,12 @@ public class GT_Single_Recipe_Check {
         FluidStack[] fOutputs = GT_Utility.streamCompounds(tag.getTagList("fOutputs", Constants.NBT.TAG_COMPOUND))
                 .map(FluidStack::loadFluidStackFromNBT).toArray(FluidStack[]::new);
         int eut = tag.getInteger("eut");
-        GT_Recipe found = recipeMap.findRecipe(parent.getBaseMetaTileEntity(), false, GT_Values.V[GT_Utility.getTier(eut)], fInputs, inputs);
+        GT_Recipe found = recipeMap.findRecipe(
+                parent.getBaseMetaTileEntity(),
+                false,
+                GT_Values.V[GT_Utility.getTier(eut)],
+                fInputs,
+                inputs);
         int[] chances = tag.getIntArray("chances");
         if (found == null || !GT_Utility.equals(inputs, found.mInputs)
                 || !Arrays.equals(fInputs, found.mFluidInputs)

--- a/src/main/java/gregtech/api/util/GT_Single_Recipe_Check.java
+++ b/src/main/java/gregtech/api/util/GT_Single_Recipe_Check.java
@@ -1,11 +1,21 @@
 package gregtech.api.util;
 
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
+
+import javax.annotation.Nullable;
 
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTBase;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
+import net.minecraftforge.common.util.Constants;
 import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 
 import com.google.common.collect.ImmutableMap;
@@ -169,6 +179,107 @@ public class GT_Single_Recipe_Check {
         }
 
         return true;
+    }
+
+    public NBTTagCompound writeToNBT() {
+        // here we encode recipe input, output and all other important values
+        // at load time we do a recipe check again, so in case the recipe is gone, we can stop tracking
+        // of course the next step would be auto migrating to new recipe (if any), but given
+        // we don't yet have a mean to uniquely name a recipe, this will have to make do.
+        // consider move serialization code to GT_Recipe once this has been proven to work
+        NBTTagCompound tag = new NBTTagCompound();
+        tag.setTag("inputs", writeList(recipe.mInputs, GT_Utility::saveItem));
+        tag.setTag("outputs", writeList(recipe.mOutputs, GT_Utility::saveItem));
+        tag.setIntArray("chances", recipe.mChances);
+        tag.setTag(
+                "fInputs",
+                writeList(
+                        recipe.mFluidInputs,
+                        s -> s == null ? new NBTTagCompound() : s.writeToNBT(new NBTTagCompound())));
+        tag.setTag(
+                "fOutputs",
+                writeList(
+                        recipe.mFluidOutputs,
+                        s -> s == null ? new NBTTagCompound() : s.writeToNBT(new NBTTagCompound())));
+        tag.setInteger("eut", recipe.mEUt);
+        tag.setInteger("duration", recipe.mDuration);
+        tag.setInteger("specialValue", recipe.mSpecialValue);
+        tag.setTag("itemCost", writeList(itemCost.entrySet(), e -> {
+            NBTTagCompound ret = new NBTTagCompound();
+            ret.setTag("id", e.getKey().writeToNBT());
+            ret.setInteger("count", e.getValue());
+            return ret;
+        }));
+        tag.setTag("fluidCost", writeList(fluidCost.entrySet(), e -> {
+            NBTTagCompound ret = new NBTTagCompound();
+            ret.setString("id", e.getKey().getName());
+            ret.setInteger("count", e.getValue());
+            return ret;
+        }));
+        return tag;
+    }
+
+    private static <T, NBT extends NBTBase> NBTTagList writeList(T[] arr, Function<T, NBT> ser) {
+        return writeList(Arrays.asList(arr), ser);
+    }
+
+    private static <T, NBT extends NBTBase> NBTTagList writeList(Collection<T> arr, Function<T, NBT> ser) {
+        NBTTagList l = new NBTTagList();
+        for (T t : arr) {
+            l.appendTag(ser.apply(t));
+        }
+        return l;
+    }
+
+    @Nullable
+    public static GT_Single_Recipe_Check tryLoad(GT_MetaTileEntity_MultiBlockBase parent, NBTTagCompound tag) {
+        return tryLoad(parent, parent.getRecipeMap(), tag);
+    }
+
+    @Nullable
+
+    public static GT_Single_Recipe_Check tryLoad(GT_MetaTileEntity_MultiBlockBase parent,
+            GT_Recipe.GT_Recipe_Map recipeMap, NBTTagCompound tag) {
+        GT_Recipe found = tryFindRecipe(parent, recipeMap, tag);
+        if (found == null) return null;
+        return new GT_Single_Recipe_Check(parent, found, loadItemCost(tag), loadFluidCost(tag));
+    }
+
+    protected static ImmutableMap<Fluid, Integer> loadFluidCost(NBTTagCompound tag) {
+        return GT_Utility.stream(tag.getTagList("fluidCost", Constants.NBT.TAG_COMPOUND)).collect(
+                GT_Utility.toImmutableMap(t -> FluidRegistry.getFluid(t.getString("id")), t -> t.getInteger("count")));
+    }
+
+    protected static ImmutableMap<GT_Utility.ItemId, Integer> loadItemCost(NBTTagCompound tag) {
+        return GT_Utility.stream(tag.getTagList("itemCost", Constants.NBT.TAG_COMPOUND)).collect(
+                GT_Utility.toImmutableMap(
+                        t -> GT_Utility.ItemId.create(t.getCompoundTag("id")),
+                        t -> t.getInteger("count")));
+    }
+
+    protected static GT_Recipe tryFindRecipe(GT_MetaTileEntity_MultiBlockBase parent, GT_Recipe.GT_Recipe_Map recipeMap,
+            NBTTagCompound tag) {
+        if (tag == null || tag.hasNoTags()) return null;
+        ItemStack[] inputs = GT_Utility.stream(tag.getTagList("inputs", Constants.NBT.TAG_COMPOUND))
+                .map(GT_Utility::loadItem).toArray(ItemStack[]::new);
+        ItemStack[] outputs = GT_Utility.stream(tag.getTagList("outputs", Constants.NBT.TAG_COMPOUND))
+                .map(GT_Utility::loadItem).toArray(ItemStack[]::new);
+        FluidStack[] fInputs = GT_Utility.stream(tag.getTagList("fInputs", Constants.NBT.TAG_COMPOUND))
+                .map(FluidStack::loadFluidStackFromNBT).toArray(FluidStack[]::new);
+        FluidStack[] fOutputs = GT_Utility.stream(tag.getTagList("fOutputs", Constants.NBT.TAG_COMPOUND))
+                .map(FluidStack::loadFluidStackFromNBT).toArray(FluidStack[]::new);
+        int[] chances = tag.getIntArray("chances");
+        GT_Recipe found = recipeMap.findRecipe(parent.getBaseMetaTileEntity(), false, Long.MAX_VALUE, fInputs, inputs);
+        if (found == null || !GT_Utility.equals(inputs, found.mInputs)
+                || !Arrays.equals(fInputs, found.mFluidInputs)
+                || !GT_Utility.equals(outputs, found.mOutputs)
+                || !Arrays.equals(fOutputs, found.mFluidOutputs)
+                || !Arrays.equals(chances, found.mChances)
+                || found.mDuration != tag.getInteger("duration")
+                || found.mEUt != tag.getInteger("eut")
+                || found.mSpecialValue != tag.getInteger("specialValue"))
+            return null;
+        return found;
     }
 
     protected static Map<GT_Utility.ItemId, Integer> buildItemMap(GT_MetaTileEntity_MultiBlockBase multiBlockBase) {

--- a/src/main/java/gregtech/api/util/GT_Single_Recipe_Check_Processing_Array.java
+++ b/src/main/java/gregtech/api/util/GT_Single_Recipe_Check_Processing_Array.java
@@ -5,7 +5,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import javax.annotation.Nullable;
+
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 
@@ -129,6 +132,22 @@ public class GT_Single_Recipe_Check_Processing_Array extends GT_Single_Recipe_Ch
         }
 
         return finalParallel;
+    }
+
+    @Nullable
+
+    public static GT_Single_Recipe_Check tryLoad(GT_MetaTileEntity_MultiBlockBase parent,
+            GT_Recipe.GT_Recipe_Map recipeMap, NBTTagCompound tag, ItemStack machineStack) {
+        if (recipeMap == null || machineStack == null) return null;
+        GT_Recipe found = tryFindRecipe(parent, recipeMap, tag);
+        if (found == null) return null;
+        return new GT_Single_Recipe_Check_Processing_Array(
+                parent,
+                found,
+                loadItemCost(tag),
+                loadFluidCost(tag),
+                recipeMap.mAmperage,
+                machineStack.copy());
     }
 
     public static Builder processingArrayBuilder(GT_MetaTileEntity_MultiBlockBase multiBlockBase) {

--- a/src/main/java/gregtech/api/util/GT_Utility.java
+++ b/src/main/java/gregtech/api/util/GT_Utility.java
@@ -4383,7 +4383,7 @@ public class GT_Utility {
         return new ItemStack(aItem.getItem(), 0, aItem.getItemDamage());
     }
 
-    public static Stream<NBTTagCompound> stream(NBTTagList list) {
+    public static Stream<NBTTagCompound> streamCompounds(NBTTagList list) {
         if (list == null) return Stream.empty();
         return IntStream.range(0, list.tagCount()).mapToObj(list::getCompoundTagAt);
     }
@@ -4399,7 +4399,10 @@ public class GT_Utility {
         return true;
     }
 
-    public static <T, K, U> Collector<T, ?, ImmutableMap<K, U>> toImmutableMap(
+    /**
+     * Guava ImmutableMap variant of Collectors.toMap. Optimized for serial streams.
+     */
+    public static <T, K, U> Collector<T, ?, ImmutableMap<K, U>> toImmutableMapSerial(
             Function<? super T, ? extends K> keyMapper, Function<? super T, ? extends U> valueMapper) {
         // petty type inference cannot work out the correct type parameter
         return Collector.<T, ImmutableMap.Builder<K, U>, ImmutableMap<K, U>>of(

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeChemicalReactor.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeChemicalReactor.java
@@ -129,6 +129,11 @@ public class GT_MetaTileEntity_LargeChemicalReactor
     }
 
     @Override
+    public GT_Recipe.GT_Recipe_Map getRecipeMap() {
+        return GT_Recipe.GT_Recipe_Map.sMultiblockChemicalRecipes;
+    }
+
+    @Override
     public boolean checkRecipe(ItemStack aStack) {
         long tVoltage = getMaxInputVoltage();
         byte tier = (byte) Math.max(1, GT_Utility.getTier(tVoltage));

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_ProcessingArray.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_ProcessingArray.java
@@ -53,6 +53,7 @@ import gregtech.api.util.GT_Multiblock_Tooltip_Builder;
 import gregtech.api.util.GT_ProcessingArray_Manager;
 import gregtech.api.util.GT_Recipe;
 import gregtech.api.util.GT_Recipe.GT_Recipe_Map;
+import gregtech.api.util.GT_Single_Recipe_Check;
 import gregtech.api.util.GT_Single_Recipe_Check_Processing_Array;
 import gregtech.api.util.GT_Utility;
 import gregtech.common.blocks.GT_Item_Machines;
@@ -194,13 +195,7 @@ public class GT_MetaTileEntity_ProcessingArray
         }
 
         if (mLastRecipe == null) {
-            IMetaTileEntity aMachine = GT_Item_Machines.getMetaTileEntity(mInventory[1]);
-            if (aMachine != null) tTier = ((GT_MetaTileEntity_TieredMachineBlock) aMachine).mTier;
-            mMult = 0;
-            if (downtierUEV && tTier > 9) {
-                tTier--; // Lowers down the tier by 1 to allow for bigger parallel
-                mMult = 2; // Multiplies Parallels by 4x, keeping the energy cost
-            }
+            setTierAndMult();
         }
         ArrayList<FluidStack> tFluidList = getStoredFluids();
         FluidStack[] tFluids = tFluidList.toArray(new FluidStack[0]);
@@ -223,8 +218,23 @@ public class GT_MetaTileEntity_ProcessingArray
         return false;
     }
 
+    private void setTierAndMult() {
+        IMetaTileEntity aMachine = GT_Item_Machines.getMetaTileEntity(mInventory[1]);
+        if (aMachine != null) tTier = ((GT_MetaTileEntity_TieredMachineBlock) aMachine).mTier;
+        mMult = 0;
+        if (downtierUEV && tTier > 9) {
+            tTier--; // Lowers down the tier by 1 to allow for bigger parallel
+            mMult = 2; // Multiplies Parallels by 4x, keeping the energy cost
+        }
+    }
+
     public boolean processLockedRecipe() {
         GT_Single_Recipe_Check_Processing_Array tSingleRecipeCheck = (GT_Single_Recipe_Check_Processing_Array) mSingleRecipeCheck;
+
+        if (mLastRecipe == null) {
+            setTierAndMult();
+            mLastRecipe = tSingleRecipeCheck.getRecipe();
+        }
 
         int machines = mInventory[1].stackSize << mMult;
         int parallel = tSingleRecipeCheck.checkRecipeInputs(true, machines);
@@ -410,6 +420,11 @@ public class GT_MetaTileEntity_ProcessingArray
     }
 
     @Override
+    protected GT_Single_Recipe_Check loadSingleRecipeChecker(NBTTagCompound aNBT) {
+        return GT_Single_Recipe_Check_Processing_Array.tryLoad(this, getRecipeMap(), aNBT, mInventory[1]);
+    }
+
+    @Override
     public final void onScrewdriverRightClick(byte aSide, EntityPlayer aPlayer, float aX, float aY, float aZ) {
         if (aPlayer.isSneaking()) {
             // Lock to single recipe
@@ -418,7 +433,7 @@ public class GT_MetaTileEntity_ProcessingArray
             inputSeparation = !inputSeparation;
             GT_Utility.sendChatToPlayer(
                     aPlayer,
-                    StatCollector.translateToLocal("GT5U.machines.separatebus") + " " + inputSeparation);
+                    StatCollector.translateToLocal("GT5U.machinesx.separatebus") + " " + inputSeparation);
         }
     }
 

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_ProcessingArray.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_ProcessingArray.java
@@ -433,7 +433,7 @@ public class GT_MetaTileEntity_ProcessingArray
             inputSeparation = !inputSeparation;
             GT_Utility.sendChatToPlayer(
                     aPlayer,
-                    StatCollector.translateToLocal("GT5U.machinesx.separatebus") + " " + inputSeparation);
+                    StatCollector.translateToLocal("GT5U.machines.separatebus") + " " + inputSeparation);
         }
     }
 

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_PyrolyseOven.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_PyrolyseOven.java
@@ -130,6 +130,11 @@ public class GT_MetaTileEntity_PyrolyseOven extends
     }
 
     @Override
+    public GT_Recipe.GT_Recipe_Map getRecipeMap() {
+        return GT_Recipe.GT_Recipe_Map.sPyrolyseRecipes;
+    }
+
+    @Override
     public boolean checkRecipe(ItemStack aStack) {
         long tVoltage = getMaxInputVoltage();
         byte tTier = (byte) Math.max(1, GT_Utility.getTier(tVoltage));


### PR DESCRIPTION
Fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/11420

and makes single recipe lock actually useable overall.

no guarantee over if this feature functions properly beyond not saving/loading stuff as intended.