### PR TITLE
Revert "Use TierEU.RECIPE in AL recipes"

### DIFF
--- a/src/main/java/gregtech/loaders/postload/recipes/AssemblyLineRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/AssemblyLineRecipes.java
@@ -38,7 +38,7 @@ public class AssemblyLineRecipes implements Runnable {
                 new FluidStack[] { new FluidStack(solderIndalloy, 144), Materials.Lubricant.getFluid(250) },
                 ItemList.Electric_Motor_LuV.get(1),
                 600,
-                (int) TierEU.RECIPE_IV);
+                6000);
 
         GT_Values.RA.addAssemblylineRecipe(
                 ItemList.Electric_Motor_LuV.get(1, new Object() {}),
@@ -54,7 +54,7 @@ public class AssemblyLineRecipes implements Runnable {
                 new FluidStack[] { new FluidStack(solderIndalloy, 288), Materials.Lubricant.getFluid(750) },
                 ItemList.Electric_Motor_ZPM.get(1),
                 600,
-                (int) TierEU.RECIPE_LuV);
+                24000);
 
         GT_Values.RA.addAssemblylineRecipe(
                 ItemList.Electric_Motor_ZPM.get(1, new Object() {}),
@@ -74,7 +74,7 @@ public class AssemblyLineRecipes implements Runnable {
                         Materials.Lubricant.getFluid(2000) },
                 ItemList.Electric_Motor_UV.get(1),
                 600,
-                (int) TierEU.RECIPE_ZPM);
+                100000);
 
         // Pumps
         GT_Values.RA.addAssemblylineRecipe(
@@ -90,7 +90,7 @@ public class AssemblyLineRecipes implements Runnable {
                 new FluidStack[] { new FluidStack(solderIndalloy, 144), Materials.Lubricant.getFluid(250) },
                 ItemList.Electric_Pump_LuV.get(1),
                 600,
-                (int) TierEU.RECIPE_IV);
+                6000);
 
         GT_Values.RA.addAssemblylineRecipe(
                 ItemList.Electric_Pump_LuV.get(1, new Object() {}),
@@ -105,7 +105,7 @@ public class AssemblyLineRecipes implements Runnable {
                 new FluidStack[] { new FluidStack(solderIndalloy, 288), Materials.Lubricant.getFluid(750) },
                 ItemList.Electric_Pump_ZPM.get(1),
                 600,
-                (int) TierEU.RECIPE_LuV);
+                24000);
 
         GT_Values.RA.addAssemblylineRecipe(
                 ItemList.Electric_Pump_ZPM.get(1, new Object() {}),
@@ -121,7 +121,7 @@ public class AssemblyLineRecipes implements Runnable {
                         Materials.Lubricant.getFluid(2000) },
                 ItemList.Electric_Pump_UV.get(1),
                 600,
-                (int) TierEU.RECIPE_ZPM);
+                100000);
 
         // Conveyors
         GT_Values.RA.addAssemblylineRecipe(
@@ -136,7 +136,7 @@ public class AssemblyLineRecipes implements Runnable {
                 new FluidStack[] { new FluidStack(solderIndalloy, 144), Materials.Lubricant.getFluid(250) },
                 ItemList.Conveyor_Module_LuV.get(1),
                 600,
-                (int) TierEU.RECIPE_IV);
+                6000);
 
         GT_Values.RA.addAssemblylineRecipe(
                 ItemList.Conveyor_Module_LuV.get(1, new Object() {}),
@@ -150,7 +150,7 @@ public class AssemblyLineRecipes implements Runnable {
                 new FluidStack[] { new FluidStack(solderIndalloy, 288), Materials.Lubricant.getFluid(750) },
                 ItemList.Conveyor_Module_ZPM.get(1),
                 600,
-                (int) TierEU.RECIPE_LuV);
+                24000);
 
         GT_Values.RA.addAssemblylineRecipe(
                 ItemList.Conveyor_Module_ZPM.get(1, new Object() {}),
@@ -165,7 +165,7 @@ public class AssemblyLineRecipes implements Runnable {
                         Materials.Lubricant.getFluid(2000) },
                 ItemList.Conveyor_Module_UV.get(1),
                 600,
-                (int) TierEU.RECIPE_ZPM);
+                100000);
 
         // Pistons
         GT_Values.RA.addAssemblylineRecipe(
@@ -182,7 +182,7 @@ public class AssemblyLineRecipes implements Runnable {
                 new FluidStack[] { new FluidStack(solderIndalloy, 144), Materials.Lubricant.getFluid(250) },
                 ItemList.Electric_Piston_LuV.get(1),
                 600,
-                (int) TierEU.RECIPE_IV);
+                6000);
 
         GT_Values.RA.addAssemblylineRecipe(
                 ItemList.Electric_Piston_LuV.get(1, new Object() {}),
@@ -198,7 +198,7 @@ public class AssemblyLineRecipes implements Runnable {
                 new FluidStack[] { new FluidStack(solderIndalloy, 288), Materials.Lubricant.getFluid(750) },
                 ItemList.Electric_Piston_ZPM.get(1),
                 600,
-                (int) TierEU.RECIPE_LuV);
+                24000);
 
         GT_Values.RA.addAssemblylineRecipe(
                 ItemList.Electric_Piston_ZPM.get(1, new Object() {}),
@@ -215,7 +215,7 @@ public class AssemblyLineRecipes implements Runnable {
                         Materials.Lubricant.getFluid(2000) },
                 ItemList.Electric_Piston_UV.get(1),
                 600,
-                (int) TierEU.RECIPE_ZPM);
+                100000);
 
         // RobotArms
         GT_Values.RA.addAssemblylineRecipe(
@@ -233,7 +233,7 @@ public class AssemblyLineRecipes implements Runnable {
                 new FluidStack[] { new FluidStack(solderIndalloy, 576), Materials.Lubricant.getFluid(250) },
                 ItemList.Robot_Arm_LuV.get(1),
                 600,
-                (int) TierEU.RECIPE_IV);
+                6000);
 
         GT_Values.RA.addAssemblylineRecipe(
                 ItemList.Robot_Arm_LuV.get(1, new Object() {}),
@@ -250,7 +250,7 @@ public class AssemblyLineRecipes implements Runnable {
                 new FluidStack[] { new FluidStack(solderIndalloy, 1152), Materials.Lubricant.getFluid(750) },
                 ItemList.Robot_Arm_ZPM.get(1),
                 600,
-                (int) TierEU.RECIPE_LuV);
+                24000);
 
         GT_Values.RA.addAssemblylineRecipe(
                 ItemList.Robot_Arm_ZPM.get(1, new Object() {}),
@@ -268,7 +268,7 @@ public class AssemblyLineRecipes implements Runnable {
                         Materials.Lubricant.getFluid(2000) },
                 ItemList.Robot_Arm_UV.get(1),
                 600,
-                (int) TierEU.RECIPE_ZPM);
+                100000);
 
         // Emitters
         GT_Values.RA.addAssemblylineRecipe(
@@ -286,7 +286,7 @@ public class AssemblyLineRecipes implements Runnable {
                 new FluidStack[] { new FluidStack(solderIndalloy, 576) },
                 ItemList.Emitter_LuV.get(1),
                 600,
-                (int) TierEU.RECIPE_IV);
+                6000);
 
         GT_Values.RA.addAssemblylineRecipe(
                 ItemList.Emitter_LuV.get(1, new Object() {}),
@@ -303,7 +303,7 @@ public class AssemblyLineRecipes implements Runnable {
                 new FluidStack[] { new FluidStack(solderIndalloy, 1152) },
                 ItemList.Emitter_ZPM.get(1),
                 600,
-                (int) TierEU.RECIPE_LuV);
+                24000);
 
         GT_Values.RA.addAssemblylineRecipe(
                 ItemList.Emitter_ZPM.get(1, new Object() {}),
@@ -320,7 +320,7 @@ public class AssemblyLineRecipes implements Runnable {
                 new FluidStack[] { Materials.Naquadria.getMolten(1296), new FluidStack(solderIndalloy, 2304) },
                 ItemList.Emitter_UV.get(1),
                 600,
-                (int) TierEU.RECIPE_ZPM);
+                100000);
 
         // Sensors
         GT_Values.RA.addAssemblylineRecipe(
@@ -338,7 +338,7 @@ public class AssemblyLineRecipes implements Runnable {
                 new FluidStack[] { new FluidStack(solderIndalloy, 576) },
                 ItemList.Sensor_LuV.get(1),
                 600,
-                (int) TierEU.RECIPE_IV);
+                6000);
 
         GT_Values.RA.addAssemblylineRecipe(
                 ItemList.Sensor_LuV.get(1, new Object() {}),
@@ -355,7 +355,7 @@ public class AssemblyLineRecipes implements Runnable {
                 new FluidStack[] { new FluidStack(solderIndalloy, 1152) },
                 ItemList.Sensor_ZPM.get(1),
                 600,
-                (int) TierEU.RECIPE_LuV);
+                24000);
 
         GT_Values.RA.addAssemblylineRecipe(
                 ItemList.Sensor_ZPM.get(1, new Object() {}),
@@ -372,7 +372,7 @@ public class AssemblyLineRecipes implements Runnable {
                 new FluidStack[] { Materials.Naquadria.getMolten(1296), new FluidStack(solderIndalloy, 2304) },
                 ItemList.Sensor_UV.get(1),
                 600,
-                (int) TierEU.RECIPE_ZPM);
+                100000);
 
         // Field Generators
         GT_Values.RA.addAssemblylineRecipe(
@@ -390,7 +390,7 @@ public class AssemblyLineRecipes implements Runnable {
                 new FluidStack[] { new FluidStack(solderIndalloy, 576) },
                 ItemList.Field_Generator_LuV.get(1),
                 600,
-                (int) TierEU.RECIPE_IV);
+                6000);
 
         GT_Values.RA.addAssemblylineRecipe(
                 ItemList.Field_Generator_LuV.get(1, new Object() {}),
@@ -407,7 +407,7 @@ public class AssemblyLineRecipes implements Runnable {
                 new FluidStack[] { new FluidStack(solderIndalloy, 1152) },
                 ItemList.Field_Generator_ZPM.get(1),
                 600,
-                (int) TierEU.RECIPE_LuV);
+                24000);
 
         GT_Values.RA.addAssemblylineRecipe(
                 ItemList.Field_Generator_ZPM.get(1, new Object() {}),
@@ -426,7 +426,7 @@ public class AssemblyLineRecipes implements Runnable {
                 new FluidStack[] { Materials.Naquadria.getMolten(1296), new FluidStack(solderIndalloy, 2304) },
                 ItemList.Field_Generator_UV.get(1),
                 600,
-                (int) TierEU.RECIPE_ZPM);
+                100000);
 
         // Energy Hatches Luv-UV
         GT_Values.RA.addAssemblylineRecipe(
@@ -469,7 +469,7 @@ public class AssemblyLineRecipes implements Runnable {
                         new FluidStack(solderIndalloy, 1440) },
                 ItemList.Hatch_Energy_ZPM.get(1),
                 600,
-                (int) TierEU.RECIPE_ZPM);
+                (int) TierEU.ZPM);
 
         GT_Values.RA.addAssemblylineRecipe(
                 ItemList.Hatch_Energy_ZPM.get(1, new Object() {}),
@@ -496,7 +496,7 @@ public class AssemblyLineRecipes implements Runnable {
                         new FluidStack(solderIndalloy, 2880) },
                 ItemList.Hatch_Energy_UV.get(1),
                 800,
-                (int) TierEU.RECIPE_UV);
+                500000);
 
         // Dynamo Hatches Luv-UV
         GT_Values.RA.addAssemblylineRecipe(
@@ -570,7 +570,7 @@ public class AssemblyLineRecipes implements Runnable {
                         new FluidStack(solderIndalloy, 2880) },
                 ItemList.Hatch_Dynamo_UV.get(1),
                 800,
-                (int) TierEU.RECIPE_UV);
+                500000);
 
         GT_Values.RA.addAssemblylineRecipe(
                 ItemList.Energy_LapotronicOrb2.get(1),
@@ -588,7 +588,7 @@ public class AssemblyLineRecipes implements Runnable {
                         new FluidStack(FluidRegistry.getFluid("ic2coolant"), 16000) },
                 ItemList.Energy_Module.get(1),
                 2000,
-                (int) TierEU.RECIPE_ZPM);
+                100000);
 
         GT_Values.RA.addAssemblylineRecipe(
                 ItemList.Energy_Module.get(1),
@@ -623,7 +623,7 @@ public class AssemblyLineRecipes implements Runnable {
                 new FluidStack[] { new FluidStack(solderIndalloy, 2880), Materials.VanadiumGallium.getMolten(1152L), },
                 ItemList.FusionComputer_LuV.get(1),
                 1000,
-                (int) TierEU.RECIPE_LuV);
+                30000);
 
         GT_Values.RA.addAssemblylineRecipe(
                 GT_OreDictUnificator.get(OrePrefixes.block, Materials.Europium, 1),


### PR DESCRIPTION
Reverts GTNewHorizons/GT5-Unofficial#1774
thus fixing https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12729
but reintroducing https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12710