### PR TITLE
Send cover data immediately when cover is placed

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
@@ -1614,6 +1614,7 @@ public class BaseMetaTileEntity extends CommonMetaTileEntity implements IGregTec
                                         xCoord,
                                         yCoord,
                                         zCoord);
+                                sendClientData();
                             }
                             return true;
                         }


### PR DESCRIPTION
Close https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12838

`BaseMetaTileEntity#setCoverItemAtSide` triggers `CommonMetaTileEntity#issueClientUpdate`, which only schedules update (`CommonMetaTileEntity#mSendClientData`) and doesn't send cover id immediately. Cover data is actually sent only twice per second. (`mTickTimer % 10 == 0`) If client opens GUI right after placing cover, client tries to create GUI from `GT_Cover_None`.
This PR ensures client receives correct cover id when opening GUI.