### PR TITLE
Fix advanced external redstone transmitter cover

### DIFF
--- a/src/main/java/gregtech/common/covers/redstone/GT_Cover_AdvancedRedstoneTransmitterExternal.java
+++ b/src/main/java/gregtech/common/covers/redstone/GT_Cover_AdvancedRedstoneTransmitterExternal.java
@@ -36,6 +36,12 @@ public class GT_Cover_AdvancedRedstoneTransmitterExternal
     }
 
     @Override
+    protected boolean isRedstoneSensitiveImpl(byte aSide, int aCoverID, TransmitterData aCoverVariable,
+            ICoverable aTileEntity, long aTimer) {
+        return true;
+    }
+
+    @Override
     public boolean letsRedstoneGoInImpl(byte aSide, int aCoverID, TransmitterData aCoverVariable,
             ICoverable aTileEntity) {
         return true;


### PR DESCRIPTION
Due to the previous addition of the `GT_CoverBehaviorBase#isRedstoneSensitive`, the functionality of the advanced external redstone transmitter cover has been disrupted. This pull request aims to resolve the issue and restore its proper functioning.