### PR TITLE
Untangle IEnergyConnected and IHasWorldObjectAndCoords

### DIFF
--- a/src/main/java/gregtech/api/interfaces/tileentity/IBasicEnergyContainer.java
+++ b/src/main/java/gregtech/api/interfaces/tileentity/IBasicEnergyContainer.java
@@ -3,7 +3,7 @@ package gregtech.api.interfaces.tileentity;
 /**
  * Interface for internal Code, which is mainly used for independent Energy conversion.
  */
-public interface IBasicEnergyContainer extends IEnergyConnected {
+public interface IBasicEnergyContainer extends IEnergyConnected, IHasWorldObjectAndCoords {
 
     /**
      * Gets if that Amount of Energy is stored inside the Machine. It is used for checking the contained Energy before

--- a/src/main/java/gregtech/api/interfaces/tileentity/IEnergyConductor.java
+++ b/src/main/java/gregtech/api/interfaces/tileentity/IEnergyConductor.java
@@ -7,7 +7,7 @@ import gregtech.api.enums.Materials;
  * <p/>
  * Not all Data might be reliable. This is just for Information sake.
  */
-public interface IEnergyConductor extends IEnergyConnected {
+public interface IEnergyConductor extends IEnergyConnected, IHasWorldObjectAndCoords {
 
     /**
      * @return if this is actually a Cable. (you must check this)

--- a/src/main/java/gregtech/api/interfaces/tileentity/IEnergyConnected.java
+++ b/src/main/java/gregtech/api/interfaces/tileentity/IEnergyConnected.java
@@ -15,7 +15,7 @@ import ic2.api.energy.tile.IEnergySink;
  * coloured Blocks to each other. IHasWorldObjectAndCoords is needed for the InWorld related Stuff. @BaseTileEntity does
  * implement most of that Interface.
  */
-public interface IEnergyConnected extends IColoredTileEntity, IHasWorldObjectAndCoords {
+public interface IEnergyConnected extends IColoredTileEntity {
 
     /**
      * Inject Energy Call for Electricity. Gets called by EnergyEmitters to inject Energy into your Block
@@ -58,33 +58,36 @@ public interface IEnergyConnected extends IColoredTileEntity, IHasWorldObjectAnd
          */
         public static long emitEnergyToNetwork(long aVoltage, long aAmperage, IEnergyConnected aEmitter) {
             long rUsedAmperes = 0;
-            for (byte i = 0, j = 0; i < 6 && aAmperage > rUsedAmperes; i++) {
-                if (aEmitter.outputsEnergyTo(i)) {
-                    j = GT_Utility.getOppositeSide(i);
-                    final TileEntity tTileEntity = aEmitter.getTileEntityAtSide(i);
-                    if (tTileEntity instanceof IEnergyConnected) {
-                        if (aEmitter.getColorization() >= 0) {
-                            final byte tColor = ((IEnergyConnected) tTileEntity).getColorization();
-                            if (tColor >= 0 && tColor != aEmitter.getColorization()) continue;
-                        }
-                        rUsedAmperes += ((IEnergyConnected) tTileEntity)
-                                .injectEnergyUnits(j, aVoltage, aAmperage - rUsedAmperes);
+            if (aEmitter instanceof IHasWorldObjectAndCoords) {
+                IHasWorldObjectAndCoords emitterTile = (IHasWorldObjectAndCoords) aEmitter;
+                for (byte i = 0, j = 0; i < 6 && aAmperage > rUsedAmperes; i++) {
+                    if (aEmitter.outputsEnergyTo(i)) {
+                        j = GT_Utility.getOppositeSide(i);
+                        final TileEntity tTileEntity = emitterTile.getTileEntityAtSide(i);
+                        if (tTileEntity instanceof IEnergyConnected) {
+                            if (aEmitter.getColorization() >= 0) {
+                                final byte tColor = ((IEnergyConnected) tTileEntity).getColorization();
+                                if (tColor >= 0 && tColor != aEmitter.getColorization()) continue;
+                            }
+                            rUsedAmperes += ((IEnergyConnected) tTileEntity)
+                                    .injectEnergyUnits(j, aVoltage, aAmperage - rUsedAmperes);
 
-                    } else if (tTileEntity instanceof IEnergySink) {
-                        if (((IEnergySink) tTileEntity)
-                                .acceptsEnergyFrom((TileEntity) aEmitter, ForgeDirection.getOrientation(j))) {
-                            while (aAmperage > rUsedAmperes && ((IEnergySink) tTileEntity).getDemandedEnergy() > 0
-                                    && ((IEnergySink) tTileEntity)
-                                            .injectEnergy(ForgeDirection.getOrientation(j), aVoltage, aVoltage)
-                                            < aVoltage)
+                        } else if (tTileEntity instanceof IEnergySink) {
+                            if (((IEnergySink) tTileEntity)
+                                    .acceptsEnergyFrom((TileEntity) aEmitter, ForgeDirection.getOrientation(j))) {
+                                while (aAmperage > rUsedAmperes && ((IEnergySink) tTileEntity).getDemandedEnergy() > 0
+                                        && ((IEnergySink) tTileEntity)
+                                                .injectEnergy(ForgeDirection.getOrientation(j), aVoltage, aVoltage)
+                                                < aVoltage)
+                                    rUsedAmperes++;
+                            }
+                        } else if (GregTech_API.mOutputRF && tTileEntity instanceof IEnergyReceiver) {
+                            final ForgeDirection tDirection = ForgeDirection.getOrientation(i).getOpposite();
+                            final int rfOut = GT_Utility.safeInt(aVoltage * GregTech_API.mEUtoRF / 100);
+                            if (((IEnergyReceiver) tTileEntity).receiveEnergy(tDirection, rfOut, true) == rfOut) {
+                                ((IEnergyReceiver) tTileEntity).receiveEnergy(tDirection, rfOut, false);
                                 rUsedAmperes++;
-                        }
-                    } else if (GregTech_API.mOutputRF && tTileEntity instanceof IEnergyReceiver) {
-                        final ForgeDirection tDirection = ForgeDirection.getOrientation(i).getOpposite();
-                        final int rfOut = GT_Utility.safeInt(aVoltage * GregTech_API.mEUtoRF / 100);
-                        if (((IEnergyReceiver) tTileEntity).receiveEnergy(tDirection, rfOut, true) == rfOut) {
-                            ((IEnergyReceiver) tTileEntity).receiveEnergy(tDirection, rfOut, false);
-                            rUsedAmperes++;
+                            }
                         }
                     }
                 }

--- a/src/main/java/gregtech/api/multitileentity/interfaces/IMultiTileEntity.java
+++ b/src/main/java/gregtech/api/multitileentity/interfaces/IMultiTileEntity.java
@@ -21,14 +21,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.fluids.IFluidHandler;
 
 import cpw.mods.fml.common.Optional;
-import gregtech.api.interfaces.tileentity.IBasicEnergyContainer;
-import gregtech.api.interfaces.tileentity.ICoverable;
-import gregtech.api.interfaces.tileentity.IDebugableTileEntity;
-import gregtech.api.interfaces.tileentity.IEnergyConnected;
-import gregtech.api.interfaces.tileentity.IHasInventory;
-import gregtech.api.interfaces.tileentity.IHasWorldObjectAndCoords;
-import gregtech.api.interfaces.tileentity.ITexturedTileEntity;
-import gregtech.api.interfaces.tileentity.ITurnable;
+import gregtech.api.interfaces.tileentity.*;
 import gregtech.api.multitileentity.MultiTileEntityBlockInternal;
 import gregtech.api.multitileentity.MultiTileEntityItemInternal;
 import gregtech.api.multitileentity.MultiTileEntityRegistry;
@@ -36,8 +29,9 @@ import gregtech.api.multitileentity.MultiTileEntityRegistry;
 /*
  * Heavily inspired by GT6
  */
-public interface IMultiTileEntity extends IHasWorldObjectAndCoords, ICoverable, ITurnable, IHasInventory,
-        IEnergyConnected, IBasicEnergyContainer, IFluidHandler, ITexturedTileEntity, IDebugableTileEntity {
+public interface IMultiTileEntity
+        extends IHasWorldObjectAndCoords, ICoverable, ITurnable, IHasInventory, IEnergyConnected, IBasicEnergyContainer,
+        IFluidHandler, ITexturedTileEntity, IDebugableTileEntity, IColoredTileEntity {
 
     /**
      * Those two IDs HAVE to be saved inside the NBT of the TileEntity itself. They get set by the Registry itself, when
@@ -138,7 +132,7 @@ public interface IMultiTileEntity extends IHasWorldObjectAndCoords, ICoverable, 
 
     /**
      * Sets the main facing to {aSide} and update as appropriately
-     * 
+     *
      * @return Whether the facing was changed
      */
     boolean setMainFacing(byte aSide);


### PR DESCRIPTION
(to allow FMP tiles to support IEnergyConnected)
Since that may affect only GT addons (implementors of the API) and not the users of the API, I don't think this will break anything.
I checked BartWorks, TecTech, GoodGenerators and KekzTech, and looks like no one implements IEnergyConnected directly