### PR TITLE
Fix Recipes starting because of discount

### DIFF
--- a/src/main/java/gregtech/api/util/GT_ParallelHelper.java
+++ b/src/main/java/gregtech/api/util/GT_ParallelHelper.java
@@ -228,7 +228,10 @@ public class GT_ParallelHelper {
     /**
      * Called by build(). Determines the parallels and everything else that needs to be done at build time
      */
-    private void determineParallel() {
+    protected void determineParallel() {
+        if (mRecipe.mEUt > mAvailableEUt) {
+            return;
+        }
         ItemStack[] tItemInputs = null;
         FluidStack[] tFluidInputs = null;
         boolean tMEOutputBus = false;


### PR DESCRIPTION
fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12903

This fix will disallow multis without two hatches to do a recipe 1 tier higher because of discounts!