### PR TITLE
Change osmiridium to ruridit in gt directly

### DIFF
--- a/src/main/java/gregtech/loaders/postload/recipes/AssemblerRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/AssemblerRecipes.java
@@ -25,6 +25,8 @@ public class AssemblerRecipes implements Runnable {
     @Override
     public void run() {
 
+        Materials LuVMat = isBartWorksLoaded ? Materials.get("Ruridit") : Materials.Osmiridium;
+
         this.withBartWorks();
         this.withGalacticraftMars();
         this.withoutGTPPRecipes();
@@ -1162,7 +1164,7 @@ public class AssemblerRecipes implements Runnable {
                 (int) TierEU.RECIPE_IV);
         GT_Values.RA.addAssemblerRecipe(
                 new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.stick, Materials.SamariumMagnetic, 1L),
-                        GT_OreDictUnificator.get(OrePrefixes.wireFine, Materials.Osmiridium, 16L),
+                        GT_OreDictUnificator.get(OrePrefixes.wireFine, LuVMat, 16L),
                         GT_Utility.getIntegratedCircuit(1) },
                 GT_Values.NF,
                 ItemList.LuV_Coil.get(1L),

--- a/src/main/java/gregtech/loaders/postload/recipes/AssemblyLineRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/AssemblyLineRecipes.java
@@ -24,6 +24,9 @@ public class AssemblyLineRecipes implements Runnable {
         // addAssemblylineRecipe(ItemStack aResearchItem, int aResearchTime, ItemStack[] aInputs, FluidStack[]
         // aFluidInputs, ItemStack aOutput1, int aDuration, int aEUt);
 
+
+		// indalloy and ruridit are from gt++ and bartworks which are not dependencies
+		
         Fluid solderIndalloy = FluidRegistry.getFluid("molten.indalloy140") != null
                 ? FluidRegistry.getFluid("molten.indalloy140")
                 : FluidRegistry.getFluid("molten.solderingalloy");
@@ -58,7 +61,7 @@ public class AssemblyLineRecipes implements Runnable {
                 new FluidStack[] { new FluidStack(solderIndalloy, 288), Materials.Lubricant.getFluid(750) },
                 ItemList.Electric_Motor_ZPM.get(1),
                 600,
-                24000);
+                (int) TierEU.RECIPE_LuV);
 
         GT_Values.RA.addAssemblylineRecipe(
                 ItemList.Electric_Motor_ZPM.get(1, new Object() {}),
@@ -78,7 +81,7 @@ public class AssemblyLineRecipes implements Runnable {
                         Materials.Lubricant.getFluid(2000) },
                 ItemList.Electric_Motor_UV.get(1),
                 600,
-                100000);
+                (int) TierEU.RECIPE_ZPM);
 
         // Pumps
         GT_Values.RA.addAssemblylineRecipe(
@@ -94,7 +97,7 @@ public class AssemblyLineRecipes implements Runnable {
                 new FluidStack[] { new FluidStack(solderIndalloy, 144), Materials.Lubricant.getFluid(250) },
                 ItemList.Electric_Pump_LuV.get(1),
                 600,
-                6000);
+                (int) TierEU.RECIPE_IV);
 
         GT_Values.RA.addAssemblylineRecipe(
                 ItemList.Electric_Pump_LuV.get(1, new Object() {}),
@@ -109,7 +112,7 @@ public class AssemblyLineRecipes implements Runnable {
                 new FluidStack[] { new FluidStack(solderIndalloy, 288), Materials.Lubricant.getFluid(750) },
                 ItemList.Electric_Pump_ZPM.get(1),
                 600,
-                24000);
+                (int) TierEU.RECIPE_LuV);
 
         GT_Values.RA.addAssemblylineRecipe(
                 ItemList.Electric_Pump_ZPM.get(1, new Object() {}),
@@ -125,7 +128,7 @@ public class AssemblyLineRecipes implements Runnable {
                         Materials.Lubricant.getFluid(2000) },
                 ItemList.Electric_Pump_UV.get(1),
                 600,
-                100000);
+                (int) TierEU.RECIPE_ZPM);
 
         // Conveyors
         GT_Values.RA.addAssemblylineRecipe(
@@ -140,7 +143,7 @@ public class AssemblyLineRecipes implements Runnable {
                 new FluidStack[] { new FluidStack(solderIndalloy, 144), Materials.Lubricant.getFluid(250) },
                 ItemList.Conveyor_Module_LuV.get(1),
                 600,
-                6000);
+                (int) TierEU.RECIPE_IV);
 
         GT_Values.RA.addAssemblylineRecipe(
                 ItemList.Conveyor_Module_LuV.get(1, new Object() {}),
@@ -154,7 +157,7 @@ public class AssemblyLineRecipes implements Runnable {
                 new FluidStack[] { new FluidStack(solderIndalloy, 288), Materials.Lubricant.getFluid(750) },
                 ItemList.Conveyor_Module_ZPM.get(1),
                 600,
-                24000);
+                (int) TierEU.RECIPE_LuV);
 
         GT_Values.RA.addAssemblylineRecipe(
                 ItemList.Conveyor_Module_ZPM.get(1, new Object() {}),
@@ -169,7 +172,7 @@ public class AssemblyLineRecipes implements Runnable {
                         Materials.Lubricant.getFluid(2000) },
                 ItemList.Conveyor_Module_UV.get(1),
                 600,
-                100000);
+                (int) TierEU.RECIPE_ZPM);
 
         // Pistons
         GT_Values.RA.addAssemblylineRecipe(
@@ -186,7 +189,7 @@ public class AssemblyLineRecipes implements Runnable {
                 new FluidStack[] { new FluidStack(solderIndalloy, 144), Materials.Lubricant.getFluid(250) },
                 ItemList.Electric_Piston_LuV.get(1),
                 600,
-                6000);
+                (int) TierEU.RECIPE_IV);
 
         GT_Values.RA.addAssemblylineRecipe(
                 ItemList.Electric_Piston_LuV.get(1, new Object() {}),
@@ -202,7 +205,7 @@ public class AssemblyLineRecipes implements Runnable {
                 new FluidStack[] { new FluidStack(solderIndalloy, 288), Materials.Lubricant.getFluid(750) },
                 ItemList.Electric_Piston_ZPM.get(1),
                 600,
-                24000);
+                (int) TierEU.RECIPE_LuV);
 
         GT_Values.RA.addAssemblylineRecipe(
                 ItemList.Electric_Piston_ZPM.get(1, new Object() {}),
@@ -219,7 +222,7 @@ public class AssemblyLineRecipes implements Runnable {
                         Materials.Lubricant.getFluid(2000) },
                 ItemList.Electric_Piston_UV.get(1),
                 600,
-                100000);
+                (int) TierEU.RECIPE_ZPM);
 
         // RobotArms
         GT_Values.RA.addAssemblylineRecipe(
@@ -237,7 +240,7 @@ public class AssemblyLineRecipes implements Runnable {
                 new FluidStack[] { new FluidStack(solderIndalloy, 576), Materials.Lubricant.getFluid(250) },
                 ItemList.Robot_Arm_LuV.get(1),
                 600,
-                6000);
+                (int) TierEU.RECIPE_IV);
 
         GT_Values.RA.addAssemblylineRecipe(
                 ItemList.Robot_Arm_LuV.get(1, new Object() {}),
@@ -254,7 +257,7 @@ public class AssemblyLineRecipes implements Runnable {
                 new FluidStack[] { new FluidStack(solderIndalloy, 1152), Materials.Lubricant.getFluid(750) },
                 ItemList.Robot_Arm_ZPM.get(1),
                 600,
-                24000);
+                (int) TierEU.RECIPE_LuV);
 
         GT_Values.RA.addAssemblylineRecipe(
                 ItemList.Robot_Arm_ZPM.get(1, new Object() {}),
@@ -272,7 +275,7 @@ public class AssemblyLineRecipes implements Runnable {
                         Materials.Lubricant.getFluid(2000) },
                 ItemList.Robot_Arm_UV.get(1),
                 600,
-                100000);
+                (int) TierEU.RECIPE_ZPM);
 
         // Emitters
         GT_Values.RA.addAssemblylineRecipe(
@@ -280,7 +283,7 @@ public class AssemblyLineRecipes implements Runnable {
                 144000,
                 new Object[] { GT_OreDictUnificator.get(OrePrefixes.frameGt, Materials.HSSS, 1L),
                         ItemList.Electric_Motor_LuV.get(1, new Object() {}),
-                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Osmiridium, 8L),
+                        GT_OreDictUnificator.get(OrePrefixes.stick, LuVMat, 8L),
                         ItemList.QuantumStar.get(1, new Object() {}),
                         new Object[] { OrePrefixes.circuit.get(Materials.Master), 4 },
                         GT_OreDictUnificator.get(OrePrefixes.foil, Materials.Gallium, 64L),
@@ -290,7 +293,7 @@ public class AssemblyLineRecipes implements Runnable {
                 new FluidStack[] { new FluidStack(solderIndalloy, 576) },
                 ItemList.Emitter_LuV.get(1),
                 600,
-                6000);
+                (int) TierEU.RECIPE_IV);
 
         GT_Values.RA.addAssemblylineRecipe(
                 ItemList.Emitter_LuV.get(1, new Object() {}),
@@ -307,7 +310,7 @@ public class AssemblyLineRecipes implements Runnable {
                 new FluidStack[] { new FluidStack(solderIndalloy, 1152) },
                 ItemList.Emitter_ZPM.get(1),
                 600,
-                24000);
+                (int) TierEU.RECIPE_LuV);
 
         GT_Values.RA.addAssemblylineRecipe(
                 ItemList.Emitter_ZPM.get(1, new Object() {}),
@@ -324,7 +327,7 @@ public class AssemblyLineRecipes implements Runnable {
                 new FluidStack[] { Materials.Naquadria.getMolten(1296), new FluidStack(solderIndalloy, 2304) },
                 ItemList.Emitter_UV.get(1),
                 600,
-                100000);
+                (int) TierEU.RECIPE_ZPM);
 
         // Sensors
         GT_Values.RA.addAssemblylineRecipe(
@@ -332,7 +335,7 @@ public class AssemblyLineRecipes implements Runnable {
                 144000,
                 new Object[] { GT_OreDictUnificator.get(OrePrefixes.frameGt, Materials.HSSS, 1L),
                         ItemList.Electric_Motor_LuV.get(1, new Object() {}),
-                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Osmiridium, 8L),
+                        GT_OreDictUnificator.get(OrePrefixes.plate, LuVMat, 8L),
                         ItemList.QuantumStar.get(1, new Object() {}),
                         new Object[] { OrePrefixes.circuit.get(Materials.Master), 4 },
                         GT_OreDictUnificator.get(OrePrefixes.foil, Materials.Gallium, 64L),
@@ -342,7 +345,7 @@ public class AssemblyLineRecipes implements Runnable {
                 new FluidStack[] { new FluidStack(solderIndalloy, 576) },
                 ItemList.Sensor_LuV.get(1),
                 600,
-                6000);
+                (int) TierEU.RECIPE_IV);
 
         GT_Values.RA.addAssemblylineRecipe(
                 ItemList.Sensor_LuV.get(1, new Object() {}),
@@ -359,7 +362,7 @@ public class AssemblyLineRecipes implements Runnable {
                 new FluidStack[] { new FluidStack(solderIndalloy, 1152) },
                 ItemList.Sensor_ZPM.get(1),
                 600,
-                24000);
+                (int) TierEU.RECIPE_LuV);
 
         GT_Values.RA.addAssemblylineRecipe(
                 ItemList.Sensor_ZPM.get(1, new Object() {}),
@@ -376,7 +379,7 @@ public class AssemblyLineRecipes implements Runnable {
                 new FluidStack[] { Materials.Naquadria.getMolten(1296), new FluidStack(solderIndalloy, 2304) },
                 ItemList.Sensor_UV.get(1),
                 600,
-                100000);
+                (int) TierEU.RECIPE_ZPM);
 
         // Field Generators
         GT_Values.RA.addAssemblylineRecipe(
@@ -386,15 +389,15 @@ public class AssemblyLineRecipes implements Runnable {
                         GT_OreDictUnificator.get(OrePrefixes.plate, Materials.HSSS, 6L),
                         ItemList.QuantumStar.get(2, new Object() {}), ItemList.Emitter_LuV.get(4, new Object() {}),
                         new Object[] { OrePrefixes.circuit.get(Materials.Ultimate), 4 },
-                        GT_OreDictUnificator.get(OrePrefixes.wireFine, Materials.Osmiridium, 64L),
-                        GT_OreDictUnificator.get(OrePrefixes.wireFine, Materials.Osmiridium, 64L),
-                        GT_OreDictUnificator.get(OrePrefixes.wireFine, Materials.Osmiridium, 64L),
-                        GT_OreDictUnificator.get(OrePrefixes.wireFine, Materials.Osmiridium, 64L),
+                        GT_OreDictUnificator.get(OrePrefixes.wireFine, LuVMat, 64L),
+                        GT_OreDictUnificator.get(OrePrefixes.wireFine, LuVMat, 64L),
+                        GT_OreDictUnificator.get(OrePrefixes.wireFine, LuVMat, 64L),
+                        GT_OreDictUnificator.get(OrePrefixes.wireFine, LuVMat, 64L),
                         GT_OreDictUnificator.get(OrePrefixes.cableGt01, Materials.YttriumBariumCuprate, 8L) },
                 new FluidStack[] { new FluidStack(solderIndalloy, 576) },
                 ItemList.Field_Generator_LuV.get(1),
                 600,
-                6000);
+                (int) TierEU.RECIPE_IV);
 
         GT_Values.RA.addAssemblylineRecipe(
                 ItemList.Field_Generator_LuV.get(1, new Object() {}),
@@ -411,7 +414,7 @@ public class AssemblyLineRecipes implements Runnable {
                 new FluidStack[] { new FluidStack(solderIndalloy, 1152) },
                 ItemList.Field_Generator_ZPM.get(1),
                 600,
-                24000);
+                (int) TierEU.RECIPE_LuV);
 
         GT_Values.RA.addAssemblylineRecipe(
                 ItemList.Field_Generator_ZPM.get(1, new Object() {}),
@@ -430,7 +433,7 @@ public class AssemblyLineRecipes implements Runnable {
                 new FluidStack[] { Materials.Naquadria.getMolten(1296), new FluidStack(solderIndalloy, 2304) },
                 ItemList.Field_Generator_UV.get(1),
                 600,
-                100000);
+                (int) TierEU.RECIPE_ZPM);
 
         // Energy Hatches Luv-UV
         GT_Values.RA.addAssemblylineRecipe(
@@ -500,7 +503,7 @@ public class AssemblyLineRecipes implements Runnable {
                         new FluidStack(solderIndalloy, 2880) },
                 ItemList.Hatch_Energy_UV.get(1),
                 800,
-                500000);
+                (int) TierEU.RECIPE_UV);
 
         // Dynamo Hatches Luv-UV
         GT_Values.RA.addAssemblylineRecipe(
@@ -574,7 +577,7 @@ public class AssemblyLineRecipes implements Runnable {
                         new FluidStack(solderIndalloy, 2880) },
                 ItemList.Hatch_Dynamo_UV.get(1),
                 800,
-                500000);
+                (int) TierEU.RECIPE_UV);
 
         GT_Values.RA.addAssemblylineRecipe(
                 ItemList.Energy_LapotronicOrb2.get(1),
@@ -592,7 +595,7 @@ public class AssemblyLineRecipes implements Runnable {
                         new FluidStack(FluidRegistry.getFluid("ic2coolant"), 16000) },
                 ItemList.Energy_Module.get(1),
                 2000,
-                100000);
+                (int) TierEU.RECIPE_ZPM);
 
         GT_Values.RA.addAssemblylineRecipe(
                 ItemList.Energy_Module.get(1),
@@ -627,7 +630,7 @@ public class AssemblyLineRecipes implements Runnable {
                 new FluidStack[] { new FluidStack(solderIndalloy, 2880), Materials.VanadiumGallium.getMolten(1152L), },
                 ItemList.FusionComputer_LuV.get(1),
                 1000,
-                30000);
+                (int) TierEU.RECIPE_LuV);
 
         GT_Values.RA.addAssemblylineRecipe(
                 GT_OreDictUnificator.get(OrePrefixes.block, Materials.Europium, 1),

--- a/src/main/java/gregtech/loaders/postload/recipes/AssemblyLineRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/AssemblyLineRecipes.java
@@ -8,6 +8,8 @@ import net.minecraftforge.fluids.FluidStack;
 import gregtech.api.enums.*;
 import gregtech.api.util.GT_OreDictUnificator;
 
+import static gregtech.loaders.postload.GT_MachineRecipeLoader.isBartWorksLoaded;
+
 public class AssemblyLineRecipes implements Runnable {
 
     @Override
@@ -25,6 +27,8 @@ public class AssemblyLineRecipes implements Runnable {
         Fluid solderIndalloy = FluidRegistry.getFluid("molten.indalloy140") != null
                 ? FluidRegistry.getFluid("molten.indalloy140")
                 : FluidRegistry.getFluid("molten.solderingalloy");
+		
+		Materials LuVMat = isBartWorksLoaded ? Materials.Ruridit : Materials.Osmiridium;
 
         // Motors
         GT_Values.RA.addAssemblylineRecipe(
@@ -32,13 +36,13 @@ public class AssemblyLineRecipes implements Runnable {
                 144000,
                 new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.stick, Materials.SamariumMagnetic, 1L),
                         GT_OreDictUnificator.get(OrePrefixes.stickLong, Materials.HSSS, 2L),
-                        GT_OreDictUnificator.get(OrePrefixes.wireFine, Materials.Osmiridium, 64L),
-                        GT_OreDictUnificator.get(OrePrefixes.wireFine, Materials.Osmiridium, 64L),
+                        GT_OreDictUnificator.get(OrePrefixes.wireFine, LuVMat, 64L),
+                        GT_OreDictUnificator.get(OrePrefixes.wireFine, LuVMat, 64L),
                         GT_OreDictUnificator.get(OrePrefixes.cableGt01, Materials.YttriumBariumCuprate, 2L) },
                 new FluidStack[] { new FluidStack(solderIndalloy, 144), Materials.Lubricant.getFluid(250) },
                 ItemList.Electric_Motor_LuV.get(1),
                 600,
-                6000);
+                (int) TierEU.RECIPE_IV);
 
         GT_Values.RA.addAssemblylineRecipe(
                 ItemList.Electric_Motor_LuV.get(1, new Object() {}),

--- a/src/main/java/gregtech/loaders/postload/recipes/AssemblyLineRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/AssemblyLineRecipes.java
@@ -28,7 +28,7 @@ public class AssemblyLineRecipes implements Runnable {
                 ? FluidRegistry.getFluid("molten.indalloy140")
                 : FluidRegistry.getFluid("molten.solderingalloy");
 
-        Materials LuVMat = isBartWorksLoaded ? Materials.Ruridit : Materials.Osmiridium;
+        Materials LuVMat = isBartWorksLoaded ? Materials.get("Ruridit") : Materials.Osmiridium;
 
         // Motors
         GT_Values.RA.addAssemblylineRecipe(

--- a/src/main/java/gregtech/loaders/postload/recipes/AssemblyLineRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/AssemblyLineRecipes.java
@@ -1,5 +1,7 @@
 package gregtech.loaders.postload.recipes;
 
+import static gregtech.loaders.postload.GT_MachineRecipeLoader.isBartWorksLoaded;
+
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
@@ -7,8 +9,6 @@ import net.minecraftforge.fluids.FluidStack;
 
 import gregtech.api.enums.*;
 import gregtech.api.util.GT_OreDictUnificator;
-
-import static gregtech.loaders.postload.GT_MachineRecipeLoader.isBartWorksLoaded;
 
 public class AssemblyLineRecipes implements Runnable {
 
@@ -27,8 +27,8 @@ public class AssemblyLineRecipes implements Runnable {
         Fluid solderIndalloy = FluidRegistry.getFluid("molten.indalloy140") != null
                 ? FluidRegistry.getFluid("molten.indalloy140")
                 : FluidRegistry.getFluid("molten.solderingalloy");
-		
-		Materials LuVMat = isBartWorksLoaded ? Materials.Ruridit : Materials.Osmiridium;
+
+        Materials LuVMat = isBartWorksLoaded ? Materials.Ruridit : Materials.Osmiridium;
 
         // Motors
         GT_Values.RA.addAssemblylineRecipe(

--- a/src/main/java/gregtech/loaders/postload/recipes/AssemblyLineRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/AssemblyLineRecipes.java
@@ -24,9 +24,8 @@ public class AssemblyLineRecipes implements Runnable {
         // addAssemblylineRecipe(ItemStack aResearchItem, int aResearchTime, ItemStack[] aInputs, FluidStack[]
         // aFluidInputs, ItemStack aOutput1, int aDuration, int aEUt);
 
+        // indalloy and ruridit are from gt++ and bartworks which are not dependencies
 
-		// indalloy and ruridit are from gt++ and bartworks which are not dependencies
-		
         Fluid solderIndalloy = FluidRegistry.getFluid("molten.indalloy140") != null
                 ? FluidRegistry.getFluid("molten.indalloy140")
                 : FluidRegistry.getFluid("molten.solderingalloy");


### PR DESCRIPTION
use ruridit for luv motor, emitter, sensor, field gen, coil directly instead of waiting for BW to replace it later.

also unified some eu/t numbers as that is now possible without BW replacements.