### PR TITLE
Fix super tank output rate based on the pump used

### DIFF
--- a/src/main/java/gregtech/common/tileentities/storage/GT_MetaTileEntity_DigitalTankBase.java
+++ b/src/main/java/gregtech/common/tileentities/storage/GT_MetaTileEntity_DigitalTankBase.java
@@ -89,8 +89,8 @@ public abstract class GT_MetaTileEntity_DigitalTankBase extends GT_MetaTileEntit
                 return 0;
         }
     }
-	
-	private static int tierPump(int tier) {
+
+    private static int tierPump(int tier) {
         switch (tier) {
             case 1:
                 return 2;
@@ -116,7 +116,6 @@ public abstract class GT_MetaTileEntity_DigitalTankBase extends GT_MetaTileEntit
                 return 0;
         }
     }
-	
 
     public GT_MetaTileEntity_DigitalTankBase(String aName, int aTier, String aDescription, ITexture[][][] aTextures) {
         super(aName, aTier, 3, aDescription, aTextures);
@@ -400,7 +399,7 @@ public abstract class GT_MetaTileEntity_DigitalTankBase extends GT_MetaTileEntit
             if (mOutputFluid && getDrainableStack() != null && (aTick % 20 == 0)) {
                 IFluidHandler tTank = aBaseMetaTileEntity.getITankContainerAtSide(aBaseMetaTileEntity.getFrontFacing());
                 if (tTank != null) {
-                    FluidStack tDrained = drain(20*(1<<(3+2*tierPump(mTier))), false);
+                    FluidStack tDrained = drain(20 * (1 << (3 + 2 * tierPump(mTier))), false);
                     if (tDrained != null) {
                         int tFilledAmount = tTank.fill(
                                 ForgeDirection.getOrientation(aBaseMetaTileEntity.getBackFacing()),

--- a/src/main/java/gregtech/common/tileentities/storage/GT_MetaTileEntity_DigitalTankBase.java
+++ b/src/main/java/gregtech/common/tileentities/storage/GT_MetaTileEntity_DigitalTankBase.java
@@ -89,6 +89,34 @@ public abstract class GT_MetaTileEntity_DigitalTankBase extends GT_MetaTileEntit
                 return 0;
         }
     }
+	
+	private static int tierPump(int tier) {
+        switch (tier) {
+            case 1:
+                return 2;
+            case 2:
+                return 3;
+            case 3:
+                return 3;
+            case 4:
+                return 4;
+            case 5:
+                return 4;
+            case 6:
+                return 5;
+            case 7:
+                return 5;
+            case 8:
+                return 6;
+            case 9:
+                return 7;
+            case 10:
+                return 8;
+            default:
+                return 0;
+        }
+    }
+	
 
     public GT_MetaTileEntity_DigitalTankBase(String aName, int aTier, String aDescription, ITexture[][][] aTextures) {
         super(aName, aTier, 3, aDescription, aTextures);
@@ -372,7 +400,7 @@ public abstract class GT_MetaTileEntity_DigitalTankBase extends GT_MetaTileEntit
             if (mOutputFluid && getDrainableStack() != null && (aTick % 20 == 0)) {
                 IFluidHandler tTank = aBaseMetaTileEntity.getITankContainerAtSide(aBaseMetaTileEntity.getFrontFacing());
                 if (tTank != null) {
-                    FluidStack tDrained = drain(commonSizeCompute(mTier) / 100, false);
+                    FluidStack tDrained = drain(20*(1<<(3+2*tierPump(mTier))), false);
                     if (tDrained != null) {
                         int tFilledAmount = tTank.fill(
                                 ForgeDirection.getOrientation(aBaseMetaTileEntity.getBackFacing()),


### PR DESCRIPTION
When the auto-output functionality for super/quantum tanks was ported over from _impact_, the output rates were chosen completely arbitrary and extremely high (might make sense in _impact_), specifically volume/100. Way higher than any pump the player can craft. This was not considered at the time. E.g. the super tank I outputs 40000L/s compared to the MV pump with 2560L/s.

Thank you for the players on discord that brought this to our attention.

However, there is a very clearly defined way to determine the output rate they should have: each one is crafted with a pump. It should just have the rate of this pump. This is not just logical, but also balanced as it directly corresponds to the tier of the player. That is implemented here.