### PR TITLE
Steel bee + Salt bee change

### DIFF
--- a/src/main/java/gregtech/loaders/misc/GT_BeeDefinition.java
+++ b/src/main/java/gregtech/loaders/misc/GT_BeeDefinition.java
@@ -439,7 +439,6 @@ public enum GT_BeeDefinition implements IBeeDefinition {
     }, template -> AlleleHelper.instance.set(template, SPEED, Speed.SLOWER), dis -> {
         IBeeMutationCustom tMutation = dis.registerMutation(IRON, COAL, 10);
         tMutation.requireResource(GregTech_API.sBlockMetal6, 13);
-        tMutation.restrictTemperature(HOT);
     }),
     NICKEL(GT_BranchDefinition.METAL, "Nickel", true, new Color(0x8585AD), new Color(0x8585AD), beeSpecies -> {
         beeSpecies.addProduct(GT_Bees.combs.getStackForType(CombType.SLAG), 0.30f);
@@ -611,7 +610,7 @@ public enum GT_BeeDefinition implements IBeeDefinition {
         beeSpecies.addSpecialty(GT_Bees.combs.getStackForType(CombType.SALT), 0.35f);
         beeSpecies.addSpecialty(GT_Bees.combs.getStackForType(CombType.LITHIUM), 0.05f);
         beeSpecies.setHumidity(EnumHumidity.NORMAL);
-        beeSpecies.setTemperature(WARM);
+        beeSpecies.setTemperature(NORMAL);
     }, template -> AlleleHelper.instance.set(template, SPEED, Speed.SLOWER), dis -> {
         IBeeMutationCustom tMutation = dis.registerMutation(CLAY, ALUMINIUM, 5);
         tMutation.requireResource("blockSalt");

--- a/src/main/java/gregtech/loaders/misc/GT_BeeDefinition.java
+++ b/src/main/java/gregtech/loaders/misc/GT_BeeDefinition.java
@@ -609,8 +609,8 @@ public enum GT_BeeDefinition implements IBeeDefinition {
         beeSpecies.addProduct(GT_Bees.combs.getStackForType(CombType.SLAG), 0.30f);
         beeSpecies.addSpecialty(GT_Bees.combs.getStackForType(CombType.SALT), 0.35f);
         beeSpecies.addSpecialty(GT_Bees.combs.getStackForType(CombType.LITHIUM), 0.05f);
-        beeSpecies.setHumidity(EnumHumidity.NORMAL);
-        beeSpecies.setTemperature(NORMAL);
+        beeSpecies.setHumidity(ARID);
+        beeSpecies.setTemperature(WARM);
     }, template -> AlleleHelper.instance.set(template, SPEED, Speed.SLOWER), dis -> {
         IBeeMutationCustom tMutation = dis.registerMutation(CLAY, ALUMINIUM, 5);
         tMutation.requireResource("blockSalt");


### PR DESCRIPTION
Removes hot breeding requirement on steel bee (makes its incredibly difficult to the point its not a valid early game bee)

changed salt bee temp to normal.