### PR TITLE
Fix PCB Factory not voiding output when trace size is above 100

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_PCBFactory.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_PCBFactory.java
@@ -587,18 +587,23 @@ public class GT_MetaTileEntity_PCBFactory extends
 
                 mOutputItems = new ItemStack[tRecipe.mOutputs.length];
                 ArrayList<ItemStack> tOutputs = new ArrayList<ItemStack>();
-                int repeats = (int) Math.ceil(getMaxEfficiency(aStack) / 10000.0f);
-                for (int k = 0; k < mCurrentParallel; k++) {
-                    int remainingEfficiency = getMaxEfficiency(aStack) < 10000 ? 10000 : getMaxEfficiency(aStack);
-                    for (int j = 0; j < repeats; j++) {
-                        int chanced = getBaseMetaTileEntity().getRandomNumber(10000);
-                        for (int i = 0; i < tRecipe.mOutputs.length; i++) {
-                            if (chanced < remainingEfficiency) {
-                                tOutputs.add(tRecipe.getOutput(i));
-                            }
-                        }
-                        remainingEfficiency -= 10000;
+                int remainingEfficiency = getMaxEfficiency(aStack);
+                for (int j = 0; j < (int) Math.ceil(getMaxEfficiency(aStack) / 10000.0f); j++) {
+                    int chanced = getBaseMetaTileEntity().getRandomNumber(10000);
+                    if (chanced >= remainingEfficiency) {
+                        continue;
                     }
+                    for (ItemStack tOutput : tRecipe.mOutputs) {
+                        if (tOutput == null) {
+                            break;
+                        }
+                        tOutputs.add(tOutput);
+                    }
+                    remainingEfficiency -= 10000;
+                }
+
+                for (ItemStack itemStack : tOutputs) {
+                    itemStack.stackSize *= mCurrentParallel;
                 }
 
                 mOutputItems = tOutputs.toArray(new ItemStack[0]);


### PR DESCRIPTION
BlueWeaBo try to use machine efficiency to void output when trace size is above 100, but by my testing this is not working as intended, with 64 stack of input both 100 and 200 trace size PCB factory produce the same result.
![image](https://user-images.githubusercontent.com/39846845/228277107-1370dc98-33c1-495e-91e7-428d019db2c9.png)

With this patch 200 trace PCB will sometimes (50% of the time) void the output correctly.

Here is the result of 200 trace:
![image](https://user-images.githubusercontent.com/39846845/228276658-36214fb0-6a19-49d6-848a-fabd84556595.png)
Here is the result of 100 trace:
![image](https://user-images.githubusercontent.com/39846845/228276912-9742f57d-fc21-4b94-a80c-91066fd29995.png)

Also refactor the code to cache result for CurrentParallel.
