### PR TITLE
Reenable 11 missing materials

### DIFF
--- a/src/main/java/gregtech/loaders/materialprocessing/ProcessingModSupport.java
+++ b/src/main/java/gregtech/loaders/materialprocessing/ProcessingModSupport.java
@@ -21,7 +21,6 @@ public class ProcessingModSupport implements gregtech.api.interfaces.IMaterialHa
             Materials.Atlarus.mHasParentMod = false;
             Materials.Carmot.mHasParentMod = false;
             Materials.Celenegil.mHasParentMod = false;
-            Materials.Ceruclase.mHasParentMod = false;
             Materials.Eximite.mHasParentMod = false;
             Materials.Haderoth.mHasParentMod = false;
             Materials.Hepatizon.mHasParentMod = false;
@@ -31,19 +30,9 @@ public class ProcessingModSupport implements gregtech.api.interfaces.IMaterialHa
             Materials.Kalendrite.mHasParentMod = false;
             Materials.Lemurite.mHasParentMod = false;
             Materials.Meutoite.mHasParentMod = false;
-            Materials.Orichalcum.mHasParentMod = false;
             Materials.Oureclase.mHasParentMod = false;
             Materials.Prometheum.mHasParentMod = false;
-            Materials.Rubracium.mHasParentMod = false;
             Materials.Sanguinite.mHasParentMod = false;
-            Materials.Tartarite.mHasParentMod = false;
-            Materials.Vulcanite.mHasParentMod = false;
-            Materials.Vyroxeres.mHasParentMod = false;
-            Materials.DeepIron.mHasParentMod = false;
-            Materials.ShadowIron.mHasParentMod = false;
-            Materials.ShadowSteel.mHasParentMod = false;
-            Materials.AstralSilver.mHasParentMod = false;
-            Materials.Trinium.mHasParentMod = false;
         }
 
         if (!UndergroundBiomes.isModLoaded()) {


### PR DESCRIPTION
Trinium and 10 others.

I should note that there is a hidden DD buff in here as I left 16 other useless materials disabled. They are only listed in gt5u for compatibility with the metallurgy mod and should never have been in the game (though they have been for years in the DD).

Specifically Angmallen, Atlarus, Carmot, Celenegil, Eximite, Haderoth, Hepatizon, Ignatius, Infuscolium, Inolashite, Kalendrite, Lemurite, Meutoite, Oureclase, Prometheum, and Sanguinite are gone for good now.