### PR TITLE
Fix TPM recipes

### DIFF
--- a/src/main/java/gregtech/loaders/postload/recipes/TranscendentPlasmaMixerRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/TranscendentPlasmaMixerRecipes.java
@@ -38,10 +38,10 @@ public class TranscendentPlasmaMixerRecipes implements Runnable {
                     .itemInputs(GT_Utility.getIntegratedCircuit(1))
                     .noItemOutputs()
                     .fluidInputs(
-                        Materials.Helium.getPlasma(1000),
-                        Materials.Iron.getPlasma(1000),
-                        Materials.Calcium.getPlasma(1000),
-                        Materials.Niobium.getPlasma(1000))
+                            Materials.Helium.getPlasma(1000),
+                            Materials.Iron.getPlasma(1000),
+                            Materials.Calcium.getPlasma(1000),
+                            Materials.Niobium.getPlasma(1000))
                     .fluidOutputs(Materials.ExcitedDTCC.getFluid(1000L))
                     .duration(100)
                     .eut(CRUDE_EU_PER_L)

--- a/src/main/java/gregtech/loaders/postload/recipes/TranscendentPlasmaMixerRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/TranscendentPlasmaMixerRecipes.java
@@ -37,21 +37,21 @@ public class TranscendentPlasmaMixerRecipes implements Runnable {
         GT_Values.RA.stdBuilder()
                     .itemInputs(GT_Utility.getIntegratedCircuit(1))
                     .noItemOutputs()
-                    .fluidInputs(Materials.ExcitedDTCC.getFluid(1000L))
-                    .fluidOutputs(
-                            Materials.Helium.getPlasma(1000),
-                            Materials.Iron.getPlasma(1000),
-                            Materials.Calcium.getPlasma(1000),
-                            Materials.Niobium.getPlasma(1000))
+                    .fluidInputs(
+                        Materials.Helium.getPlasma(1000),
+                        Materials.Iron.getPlasma(1000),
+                        Materials.Calcium.getPlasma(1000),
+                        Materials.Niobium.getPlasma(1000))
+                    .fluidOutputs(Materials.ExcitedDTCC.getFluid(1000L))
                     .duration(100)
                     .eut(CRUDE_EU_PER_L)
+                    .noOptimize()
                     .addTo(sTranscendentPlasmaMixerRecipes);
 
         GT_Values.RA.stdBuilder()
                     .itemInputs(GT_Utility.getIntegratedCircuit(2))
                     .noItemOutputs()
-                    .fluidInputs(Materials.ExcitedDTPC.getFluid(1000L))
-                    .fluidOutputs(
+                    .fluidInputs(
                             Materials.Helium.getPlasma(1000),
                             Materials.Iron.getPlasma(1000),
                             Materials.Calcium.getPlasma(1000),
@@ -60,15 +60,16 @@ public class TranscendentPlasmaMixerRecipes implements Runnable {
                             Materials.Nickel.getPlasma(1000),
                             Materials.Boron.getPlasma(1000),
                             Materials.Sulfur.getPlasma(1000))
+                    .fluidOutputs(Materials.ExcitedDTPC.getFluid(1000L))
                     .duration(100)
                     .eut(PROSAIC_EU_PER_L)
+                    .noOptimize()
                     .addTo(sTranscendentPlasmaMixerRecipes);
 
         GT_Values.RA.stdBuilder()
                     .itemInputs(GT_Utility.getIntegratedCircuit(3))
                     .noItemOutputs()
-                    .fluidInputs(Materials.ExcitedDTRC.getFluid(1000L))
-                    .fluidOutputs(
+                    .fluidInputs(
                             Materials.Helium.getPlasma(1000),
                             Materials.Iron.getPlasma(1000),
                             Materials.Calcium.getPlasma(1000),
@@ -81,15 +82,16 @@ public class TranscendentPlasmaMixerRecipes implements Runnable {
                             Materials.Zinc.getPlasma(1000),
                             Materials.Silver.getPlasma(1000),
                             Materials.Titanium.getPlasma(1000))
+                    .fluidOutputs(Materials.ExcitedDTRC.getFluid(1000L))
                     .duration(100)
                     .eut(RESPLENDENT_EU_PER_L)
+                    .noOptimize()
                     .addTo(sTranscendentPlasmaMixerRecipes);
 
         GT_Values.RA.stdBuilder()
                     .itemInputs(GT_Utility.getIntegratedCircuit(4))
                     .noItemOutputs()
-                    .fluidInputs(Materials.ExcitedDTEC.getFluid(1000L))
-                    .fluidOutputs(
+                    .fluidInputs(
                             Materials.Helium.getPlasma(1000),
                             Materials.Iron.getPlasma(1000),
                             Materials.Calcium.getPlasma(1000),
@@ -106,8 +108,10 @@ public class TranscendentPlasmaMixerRecipes implements Runnable {
                             Materials.Bismuth.getPlasma(1000),
                             Materials.Oxygen.getPlasma(1000),
                             Materials.Tin.getPlasma(1000))
+                    .fluidOutputs(Materials.ExcitedDTEC.getFluid(1000L))
                     .duration(100)
                     .eut(EXOTIC_EU_PER_L)
+                    .noOptimize()
                     .addTo(sTranscendentPlasmaMixerRecipes);
 
     }


### PR DESCRIPTION
Fixes the TPM recipes having reversed inputs and outputs
also added .noOptimize because having it on would be a significant nerf to the machine's max processing speed
![image](https://user-images.githubusercontent.com/93287602/230684152-f6df6961-1b7e-44b6-a2cd-c96b532e0e06.png)
