### PR TITLE
Add isMachineBlock support to metal blocks

### DIFF
--- a/src/main/java/gregtech/common/blocks/GT_Block_Metal.java
+++ b/src/main/java/gregtech/common/blocks/GT_Block_Metal.java
@@ -2,10 +2,13 @@ package gregtech.common.blocks;
 
 import static gregtech.api.enums.Mods.NotEnoughItems;
 
+import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
+import net.minecraft.world.World;
 
+import gregtech.api.GregTech_API;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.interfaces.IIconContainer;
@@ -47,4 +50,19 @@ public class GT_Block_Metal extends GT_Block_Storage {
         }
         return null;
     }
+
+    @Override
+    public void onBlockAdded(World aWorld, int aX, int aY, int aZ) {
+        if (GregTech_API.isMachineBlock(this, aWorld.getBlockMetadata(aX, aY, aZ))) {
+            GregTech_API.causeMachineUpdate(aWorld, aX, aY, aZ);
+        }
+    }
+
+    @Override
+    public void breakBlock(World aWorld, int aX, int aY, int aZ, Block aBlock, int aMetaData) {
+        if (GregTech_API.isMachineBlock(this, aWorld.getBlockMetadata(aX, aY, aZ))) {
+            GregTech_API.causeMachineUpdate(aWorld, aX, aY, aZ);
+        }
+    }
+
 }


### PR DESCRIPTION
Related to https://github.com/GTNewHorizons/bartworks/pull/273 which is incomplete on its own as GT metal blocks did not cause machine updates before.

Prevent shenanigans
https://discord.com/channels/181078474394566657/181078474394566657/1094027892641501324