### PR TITLE
Rework quantum anomaly dtpf recipe

### DIFF
--- a/src/main/java/gregtech/loaders/postload/recipes/PlasmaForgeRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/PlasmaForgeRecipes.java
@@ -3,6 +3,7 @@ package gregtech.loaders.postload.recipes;
 import static gregtech.api.enums.Mods.*;
 import static gregtech.api.util.GT_ModHandler.getModItem;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sPlasmaForgeRecipes;
+import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
 import static gregtech.api.util.GT_RecipeConstants.COIL_HEAT;
 import static net.minecraftforge.fluids.FluidRegistry.getFluidStack;
 
@@ -28,20 +29,20 @@ public class PlasmaForgeRecipes implements Runnable {
                     .metadata(COIL_HEAT, 13500)
                     .addTo(sPlasmaForgeRecipes);
 
-        // Quantum anomaly recipe bypass for UXV. Avoids RNG.
+        // Quantum anomaly recipe bypass for UEV+. Avoids RNG.
         GT_Values.RA.stdBuilder()
                     .itemInputs(
-                            getModItem(NewHorizonsCoreMod.ID, "item.ChromaticLens", 1),
-                            getModItem(GoodGenerator.ID, "huiCircuit", 1, 4))
+                            getModItem(GTPlusPlus.ID, "particleBase", 1, 24),
+                            getModItem(NewHorizonsCoreMod.ID, "item.ChromaticLens", 0),
+                            getModItem(GoodGenerator.ID, "huiCircuit", 0, 4))
                     .fluidInputs(
-                            Materials.WhiteDwarfMatter.getMolten(144),
-                            getFluidStack("molten.shirabon", 72),
-                            Materials.BlackDwarfMatter.getMolten(144))
+                            Materials.ExcitedDTRC.getFluid(92),
+                            Materials.Duranium.getMolten(144))
                     .itemOutputs(getModItem(GTPlusPlus.ID, "MU-metaitem.01", 1, 32105))
                     .noFluidOutputs()
-                    .duration(50 * 20)
-                    .eut((int) TierEU.RECIPE_UXV)
-                    .metadata(COIL_HEAT, 13500)
+                    .duration(60 * SECONDS)
+                    .eut((int) TierEU.RECIPE_UEV)
+                    .metadata(COIL_HEAT, 10800)
                     .addTo(sPlasmaForgeRecipes);
     }
 }

--- a/src/main/java/gregtech/loaders/postload/recipes/PlasmaForgeRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/PlasmaForgeRecipes.java
@@ -5,7 +5,6 @@ import static gregtech.api.util.GT_ModHandler.getModItem;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sPlasmaForgeRecipes;
 import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
 import static gregtech.api.util.GT_RecipeConstants.COIL_HEAT;
-import static net.minecraftforge.fluids.FluidRegistry.getFluidStack;
 
 import gregtech.api.enums.*;
 
@@ -35,9 +34,7 @@ public class PlasmaForgeRecipes implements Runnable {
                             getModItem(GTPlusPlus.ID, "particleBase", 1, 24),
                             getModItem(NewHorizonsCoreMod.ID, "item.ChromaticLens", 0),
                             getModItem(GoodGenerator.ID, "huiCircuit", 0, 4))
-                    .fluidInputs(
-                            Materials.ExcitedDTRC.getFluid(92),
-                            Materials.Duranium.getMolten(144))
+                    .fluidInputs(Materials.ExcitedDTRC.getFluid(92), Materials.Duranium.getMolten(144))
                     .itemOutputs(getModItem(GTPlusPlus.ID, "MU-metaitem.01", 1, 32105))
                     .noFluidOutputs()
                     .duration(60 * SECONDS)


### PR DESCRIPTION
Rework of the quantum anomaly recipe to make it usable. The 92L of resplendent catalyst come from the average power cost needed for a quantum anomaly in the cyclotron 

![image](https://user-images.githubusercontent.com/93287602/230694083-ae8f8bf5-8709-4bbb-ae1d-68f247e7f143.png)
