### PR TITLE
Added method to add instance specific information to an MTE tooltip

### DIFF
--- a/src/main/java/gregtech/api/interfaces/metatileentity/IMetaTileEntity.java
+++ b/src/main/java/gregtech/api/interfaces/metatileentity/IMetaTileEntity.java
@@ -513,4 +513,12 @@ public interface IMetaTileEntity extends ISidedInventory, IFluidTank, IFluidHand
      * Called before block is destroyed. This is before inventory dropping code has executed.
      */
     default void onBlockDestroyed() {}
+
+    /**
+     * Allows to add additional data to the tooltip, which is specific to an instance of the machine
+     *
+     * @param stack   Item stack of this MTE
+     * @param tooltip Tooltip to which can be added
+     */
+    default void addAdditionalTooltipInformation(ItemStack stack, List<String> tooltip) {}
 }

--- a/src/main/java/gregtech/common/blocks/GT_Item_Machines.java
+++ b/src/main/java/gregtech/common/blocks/GT_Item_Machines.java
@@ -81,6 +81,7 @@ public class GT_Item_Machines extends ItemBlock implements IFluidContainerItem {
                             tDamage,
                             tSuffix,
                             !GregTech_API.sPostloadFinished);
+                    tMetaTileEntity.addAdditionalTooltipInformation(aStack, aList);
                 }
                 if (tTileEntity.getEUCapacity() > 0L) {
                     if (tTileEntity.getInputVoltage() > 0L) {
@@ -128,53 +129,6 @@ public class GT_Item_Machines extends ItemBlock implements IFluidContainerItem {
                                     + GT_Utility.formatNumbers(tTileEntity.getEUCapacity())
                                     + EnumChatFormatting.GRAY
                                     + " EU");
-                }
-                if (GregTech_API.METATILEENTITIES[tDamage] instanceof GT_MetaTileEntity_QuantumTank
-                        || GregTech_API.METATILEENTITIES[tDamage] instanceof GT_MetaTileEntity_SuperTank) {
-                    if (aStack.hasTagCompound() && aStack.stackTagCompound.hasKey("mFluid")) {
-                        final FluidStack tContents = FluidStack.loadFluidStackFromNBT(
-                                aStack.stackTagCompound.getCompoundTag("mFluid"));
-                        if (tContents != null && tContents.amount > 0) {
-                            aList.add(
-                                    GT_LanguageManager.addStringLocalization(
-                                            "TileEntity_TANK_INFO",
-                                            "Contains Fluid: ",
-                                            !GregTech_API.sPostloadFinished) + EnumChatFormatting.YELLOW
-                                            + tContents.getLocalizedName()
-                                            + EnumChatFormatting.GRAY);
-                            aList.add(
-                                    GT_LanguageManager.addStringLocalization(
-                                            "TileEntity_TANK_AMOUNT",
-                                            "Fluid Amount: ",
-                                            !GregTech_API.sPostloadFinished) + EnumChatFormatting.GREEN
-                                            + GT_Utility.formatNumbers(tContents.amount)
-                                            + " L"
-                                            + EnumChatFormatting.GRAY);
-                        }
-                    }
-                }
-                if (GregTech_API.METATILEENTITIES[tDamage] instanceof GT_MetaTileEntity_DigitalChestBase) {
-                    if (aStack.hasTagCompound() && aStack.stackTagCompound.hasKey("mItemStack")) {
-                        final ItemStack tContents = ItemStack.loadItemStackFromNBT(
-                                aStack.stackTagCompound.getCompoundTag("mItemStack"));
-                        final int tSize = aStack.stackTagCompound.getInteger("mItemCount");
-                        if (tContents != null && tSize > 0) {
-                            aList.add(
-                                    GT_LanguageManager.addStringLocalization(
-                                            "TileEntity_CHEST_INFO",
-                                            "Contains Item: ",
-                                            !GregTech_API.sPostloadFinished) + EnumChatFormatting.YELLOW
-                                            + tContents.getDisplayName()
-                                            + EnumChatFormatting.GRAY);
-                            aList.add(
-                                    GT_LanguageManager.addStringLocalization(
-                                            "TileEntity_CHEST_AMOUNT",
-                                            "Item Amount: ",
-                                            !GregTech_API.sPostloadFinished) + EnumChatFormatting.GREEN
-                                            + GT_Utility.formatNumbers(tSize)
-                                            + EnumChatFormatting.GRAY);
-                        }
-                    }
                 }
             }
             final NBTTagCompound aNBT = aStack.getTagCompound();

--- a/src/main/java/gregtech/common/tileentities/storage/GT_MetaTileEntity_DigitalChestBase.java
+++ b/src/main/java/gregtech/common/tileentities/storage/GT_MetaTileEntity_DigitalChestBase.java
@@ -37,6 +37,7 @@ import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_TieredMachineBlock;
 import gregtech.api.objects.AE2DigitalChestHandler;
 import gregtech.api.render.TextureFactory;
+import gregtech.api.util.GT_LanguageManager;
 import gregtech.api.util.GT_Utility;
 
 public abstract class GT_MetaTileEntity_DigitalChestBase extends GT_MetaTileEntity_TieredMachineBlock
@@ -81,6 +82,31 @@ public abstract class GT_MetaTileEntity_DigitalChestBase extends GT_MetaTileEnti
     public GT_MetaTileEntity_DigitalChestBase(String aName, int aTier, String[] aDescription,
             ITexture[][][] aTextures) {
         super(aName, aTier, 3, aDescription, aTextures);
+    }
+
+    @Override
+    public void addAdditionalTooltipInformation(ItemStack stack, List<String> tooltip) {
+        if (stack.hasTagCompound() && stack.stackTagCompound.hasKey("mItemStack")) {
+            final ItemStack tContents = ItemStack.loadItemStackFromNBT(
+                    stack.stackTagCompound.getCompoundTag("mItemStack"));
+            final int tSize = stack.stackTagCompound.getInteger("mItemCount");
+            if (tContents != null && tSize > 0) {
+                tooltip.add(
+                        GT_LanguageManager.addStringLocalization(
+                                "TileEntity_CHEST_INFO",
+                                "Contains Item: ",
+                                !GregTech_API.sPostloadFinished) + EnumChatFormatting.YELLOW
+                                + tContents.getDisplayName()
+                                + EnumChatFormatting.GRAY);
+                tooltip.add(
+                        GT_LanguageManager.addStringLocalization(
+                                "TileEntity_CHEST_AMOUNT",
+                                "Item Amount: ",
+                                !GregTech_API.sPostloadFinished) + EnumChatFormatting.GREEN
+                                + GT_Utility.formatNumbers(tSize)
+                                + EnumChatFormatting.GRAY);
+            }
+        }
     }
 
     public static void registerAEIntegration() {

--- a/src/main/java/gregtech/common/tileentities/storage/GT_MetaTileEntity_DigitalTankBase.java
+++ b/src/main/java/gregtech/common/tileentities/storage/GT_MetaTileEntity_DigitalTankBase.java
@@ -13,6 +13,7 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
@@ -30,6 +31,7 @@ import com.gtnewhorizons.modularui.common.widget.DrawableWidget;
 import com.gtnewhorizons.modularui.common.widget.SlotWidget;
 import com.gtnewhorizons.modularui.common.widget.TextWidget;
 
+import gregtech.api.GregTech_API;
 import gregtech.api.gui.modularui.GT_UIInfos;
 import gregtech.api.gui.modularui.GT_UITextures;
 import gregtech.api.interfaces.IFluidAccess;
@@ -39,6 +41,7 @@ import gregtech.api.interfaces.modularui.IAddUIWidgets;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_BasicTank;
 import gregtech.api.render.TextureFactory;
+import gregtech.api.util.GT_LanguageManager;
 import gregtech.api.util.GT_Utility;
 import gregtech.common.gui.modularui.widget.FluidDisplaySlotWidget;
 
@@ -106,6 +109,31 @@ public abstract class GT_MetaTileEntity_DigitalTankBase extends GT_MetaTileEntit
     @Override
     public ITexture[][][] getTextureSet(ITexture[] aTextures) {
         return new ITexture[0][0][0];
+    }
+
+    @Override
+    public void addAdditionalTooltipInformation(ItemStack stack, List<String> tooltip) {
+        if (stack.hasTagCompound() && stack.stackTagCompound.hasKey("mFluid")) {
+            final FluidStack tContents = FluidStack.loadFluidStackFromNBT(
+                    stack.stackTagCompound.getCompoundTag("mFluid"));
+            if (tContents != null && tContents.amount > 0) {
+                tooltip.add(
+                        GT_LanguageManager.addStringLocalization(
+                                "TileEntity_TANK_INFO",
+                                "Contains Fluid: ",
+                                !GregTech_API.sPostloadFinished) + EnumChatFormatting.YELLOW
+                                + tContents.getLocalizedName()
+                                + EnumChatFormatting.GRAY);
+                tooltip.add(
+                        GT_LanguageManager.addStringLocalization(
+                                "TileEntity_TANK_AMOUNT",
+                                "Fluid Amount: ",
+                                !GregTech_API.sPostloadFinished) + EnumChatFormatting.GREEN
+                                + GT_Utility.formatNumbers(tContents.amount)
+                                + " L"
+                                + EnumChatFormatting.GRAY);
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
Allows one to add data on the tooltip that is specific to an instance of the machine, like it is done on super tanks when they have content in them. Also moved that to this method to clean the tooltip handling up a bit.