### PR TITLE
add slot migration to disassembler

### DIFF
--- a/addon.gradle
+++ b/addon.gradle
@@ -7,3 +7,11 @@ test {
         events "passed", "skipped", "failed"
     }
 }
+
+minecraft {
+    String version = project.version
+    def (five,major,minor,patch)= version.split("[.-]", 5)
+    injectedTags.put 'VERSION_MAJOR', 500 + major.toInteger()
+    injectedTags.put 'VERSION_MINOR', minor.toInteger()
+    injectedTags.put 'VERSION_PATCH', patch.toInteger()
+}

--- a/src/main/java/gregtech/GT_Mod.java
+++ b/src/main/java/gregtech/GT_Mod.java
@@ -1,5 +1,8 @@
 package gregtech;
 
+import static gregtech.GT_Version.VERSION_MAJOR;
+import static gregtech.GT_Version.VERSION_MINOR;
+import static gregtech.GT_Version.VERSION_PATCH;
 import static gregtech.api.GregTech_API.registerCircuitProgrammer;
 import static gregtech.api.enums.Mods.Forestry;
 
@@ -137,11 +140,11 @@ import ic2.api.recipe.RecipeOutput;
 public class GT_Mod implements IGT_Mod {
 
     @Deprecated // Keep for use in BaseMetaTileEntity
-    public static final int VERSION = 509, SUBVERSION = 42;
+    public static final int VERSION = VERSION_MAJOR, SUBVERSION = VERSION_MINOR;
 
-    @SuppressWarnings("DeprecatedIsStillUsed") // Need initialization until it is deleted
     @Deprecated
     public static final int TOTAL_VERSION = calculateTotalGTVersion(VERSION, SUBVERSION);
+    public static final int NBT_VERSION = calculateTotalGTVersion(VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH);
 
     @Deprecated
     public static final int REQUIRED_IC2 = 624;
@@ -203,7 +206,11 @@ public class GT_Mod implements IGT_Mod {
     }
 
     public static int calculateTotalGTVersion(int majorVersion, int minorVersion) {
-        return majorVersion * 1000 + minorVersion;
+        return calculateTotalGTVersion(majorVersion, minorVersion, 0);
+    }
+
+    public static int calculateTotalGTVersion(int majorVersion, int minorVersion, int patchVersion) {
+        return majorVersion * 1000000 + minorVersion * 1000 + patchVersion;
     }
 
     @Mod.EventHandler

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
@@ -141,7 +141,6 @@ public class BaseMetaTileEntity extends CommonMetaTileEntity implements IGregTec
             aNBT.setBoolean("mInputDisabled", mInputDisabled);
             aNBT.setBoolean("mOutputDisabled", mOutputDisabled);
             aNBT.setTag("GT.CraftingComponents", mRecipeStuff);
-            aNBT.setInteger("nbtVersion", GT_Mod.TOTAL_VERSION);
         } catch (Throwable e) {
             GT_FML_LOGGER.error("Encountered CRITICAL ERROR while saving MetaTileEntity.", e);
         }
@@ -2268,6 +2267,8 @@ public class BaseMetaTileEntity extends CommonMetaTileEntity implements IGregTec
         final int chemistryUpdateVersion = GT_Mod.calculateTotalGTVersion(509, 31);
         final int configCircuitAdditionVersion = GT_Mod.calculateTotalGTVersion(509, 40);
         final int wireAdditionVersion = GT_Mod.calculateTotalGTVersion(509, 41);
+        final int disassemblerRemoveVersion = GT_Mod.calculateTotalGTVersion(509, 42, 44);
+        if (nbtVersion < 1000000) nbtVersion *= 1000;
         // 4 is old GT_MetaTileEntity_BasicMachine.OTHER_SLOT_COUNT
         if (nbtVersion < configCircuitAdditionVersion && getMetaTileEntity() instanceof GT_MetaTileEntity_BasicMachine
                 && slotIndex >= 4)
@@ -2320,6 +2321,16 @@ public class BaseMetaTileEntity extends CommonMetaTileEntity implements IGregTec
             }
             newInputSize = 2;
             newOutputSize = 1;
+
+        } else if (mID >= 654 && mID <= 655 || mID >= 11070 && mID <= 11076) { // arc furnace
+            if (nbtVersion < disassemblerRemoveVersion) {
+                oldInputSize = 1;
+                oldOutputSize = 4;
+            } else {
+                return slotIndex;
+            }
+            newInputSize = 1;
+            newOutputSize = 9;
 
         } else {
             return slotIndex;

--- a/src/main/java/gregtech/api/metatileentity/CommonMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/CommonMetaTileEntity.java
@@ -46,6 +46,7 @@ public abstract class CommonMetaTileEntity extends CoverableTileEntity implement
     protected void saveMetaTileNBT(NBTTagCompound aNBT) {
         try {
             if (hasValidMetaTileEntity()) {
+                aNBT.setInteger("nbtVersion", GT_Mod.NBT_VERSION);
                 final NBTTagList tItemList = new NBTTagList();
                 for (int i = 0; i < getMetaTileEntity().getRealInventory().length; i++) {
                     final ItemStack tStack = getMetaTileEntity().getRealInventory()[i];


### PR DESCRIPTION
also changed how nbtVersion is computed. it now considers patch version as part of its cycle. technically breaking change should only happen when minor version changes, but given we do breaking changes all the time but we rarely change minor version, depending on that is a bit too fragile. might as well just give up semver and use whatever dev do.