### PR TITLE
Further RA2 recipe fixes

### DIFF
--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingLog.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingLog.java
@@ -100,7 +100,7 @@ public class ProcessingLog implements gregtech.api.interfaces.IOreRecipeRegistra
         GT_Values.RA.addChemicalBathRecipe(
             GT_Utility.copyAmount(1L, aStack),
             Materials.Creosote.getFluid(1000L),
-            GT_ModHandler.getModItem(Railcraft.ID, "tile.railcraft.cube", 1L, 8),
+            GT_ModHandler.getModItem(Railcraft.ID, "cube", 1L, 8),
             null,
             null,
             null,

--- a/src/main/java/gregtech/loaders/postload/recipes/CuttingRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/CuttingRecipes.java
@@ -62,14 +62,6 @@ public class CuttingRecipes implements Runnable {
 
         }
 
-        // doesnt seem to be in game?
-        recipeWithClassicFluids(
-            new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.block, Materials.Graphite, 1) },
-            new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.ingot, Materials.Graphite, 9) },
-            25 * SECONDS,
-            48,
-            true);
-
         // glass pane recipes
         {
             // stained-glass -> glass pane recipes

--- a/src/main/java/gregtech/loaders/postload/recipes/DistilleryRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/DistilleryRecipes.java
@@ -1271,7 +1271,7 @@ public class DistilleryRecipes implements Runnable {
         for (int i = 0; i < Math.min(aOutputs.length, 11); i++) {
             GT_RecipeBuilder buildDistillation = GT_Values.RA.stdBuilder()
                 .itemInputs(GT_Utility.getIntegratedCircuit(i + 1));
-            if (aOutput2 == GT_Values.NI) {
+            if (aOutput2 == GT_Values.NI || aOutput2 == null) {
                 buildDistillation.noItemOutputs();
             } else {
                 buildDistillation.itemOutputs(aOutput2);
@@ -1284,7 +1284,7 @@ public class DistilleryRecipes implements Runnable {
         }
         GT_RecipeBuilder buildDT = GT_Values.RA.stdBuilder()
             .itemInputs(aCircuit);
-        if (aOutput2 == GT_Values.NI) {
+        if (aOutput2 == GT_Values.NI || aOutput2 == null) {
             buildDT.noItemOutputs();
         } else {
             buildDT.itemOutputs(aOutput2);
@@ -1298,34 +1298,28 @@ public class DistilleryRecipes implements Runnable {
 
     public void addUniversalDistillationRecipe(FluidStack aInput, FluidStack[] aOutputs, ItemStack aOutput2,
         int aDuration, int aEUt) {
-        if (aOutput2 == null) {
-            for (int i = 0; i < Math.min(aOutputs.length, 11); i++) {
-                GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.getIntegratedCircuit(i + 1))
-                    .noItemOutputs()
-                    .fluidInputs(aInput)
-                    .fluidOutputs(aOutputs[i])
-                    .duration(2 * aDuration)
-                    .eut(aEUt / 4)
-                    .addTo(sDistilleryRecipes);
+        for (int i = 0; i < Math.min(aOutputs.length, 11); i++) {
+            GT_RecipeBuilder buildDistillation = GT_Values.RA.stdBuilder()
+                .itemInputs(GT_Utility.getIntegratedCircuit(i + 1));
+            if (aOutput2 == GT_Values.NI || aOutput2 == null) {
+                buildDistillation.noItemOutputs();
+            } else {
+                buildDistillation.itemOutputs(aOutput2);
             }
-        } else {
-            for (int i = 0; i < Math.min(aOutputs.length, 11); i++) {
-                GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.getIntegratedCircuit(i + 1))
-                    .itemOutputs(aOutput2)
-                    .fluidInputs(aInput)
-                    .fluidOutputs(aOutputs[i])
-                    .duration(2 * aDuration)
-                    .eut(aEUt / 4)
-                    .addTo(sDistilleryRecipes);
-            }
+            buildDistillation.fluidInputs(aInput)
+                .fluidOutputs(aOutputs[i])
+                .duration(2 * aDuration)
+                .eut(aEUt / 4)
+                .addTo(sDistilleryRecipes);
         }
-
-        GT_Values.RA.stdBuilder()
-            .noItemInputs()
-            .itemOutputs(aOutput2)
-            .fluidInputs(aInput)
+        GT_RecipeBuilder buildDT = GT_Values.RA.stdBuilder()
+            .noItemInputs();
+        if (aOutput2 == GT_Values.NI || aOutput2 == null) {
+            buildDT.noItemOutputs();
+        } else {
+            buildDT.itemOutputs(aOutput2);
+        }
+        buildDT.fluidInputs(aInput)
             .fluidOutputs(aOutputs)
             .duration(20 * SECONDS)
             .eut(TierEU.RECIPE_MV)

--- a/src/main/java/gregtech/loaders/postload/recipes/DistilleryRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/DistilleryRecipes.java
@@ -16,6 +16,7 @@ import gregtech.api.GregTech_API;
 import gregtech.api.enums.*;
 import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_OreDictUnificator;
+import gregtech.api.util.GT_RecipeBuilder;
 import gregtech.api.util.GT_Utility;
 
 public class DistilleryRecipes implements Runnable {
@@ -504,7 +505,7 @@ public class DistilleryRecipes implements Runnable {
 
         GT_Values.RA.stdBuilder()
             .noItemInputs()
-            .itemOutputs(GT_Values.NI)
+            .noItemOutputs()
             .fluidInputs(Materials.WoodTar.getFluid(1000))
             .fluidOutputs(
                 Materials.Creosote.getFluid(250),
@@ -546,7 +547,7 @@ public class DistilleryRecipes implements Runnable {
 
         GT_Values.RA.stdBuilder()
             .noItemInputs()
-            .itemOutputs(GT_Values.NI)
+            .noItemOutputs()
             .fluidInputs(Materials.WoodTar.getFluid(1000))
             .fluidOutputs(
                 Materials.Creosote.getFluid(250),
@@ -1268,20 +1269,27 @@ public class DistilleryRecipes implements Runnable {
     public void addUniversalDistillationRecipewithCircuit(FluidStack aInput, ItemStack[] aCircuit,
         FluidStack[] aOutputs, ItemStack aOutput2, int aDuration, int aEUt) {
         for (int i = 0; i < Math.min(aOutputs.length, 11); i++) {
-            GT_Values.RA.stdBuilder()
-                .itemInputs(GT_Utility.getIntegratedCircuit(i + 1))
-                .itemOutputs(aOutput2)
-                .fluidInputs(aInput)
+            GT_RecipeBuilder buildDistillation = GT_Values.RA.stdBuilder()
+                .itemInputs(GT_Utility.getIntegratedCircuit(i + 1));
+            if (aOutput2 == GT_Values.NI) {
+                buildDistillation.noItemOutputs();
+            } else {
+                buildDistillation.itemOutputs(aOutput2);
+            }
+            buildDistillation.fluidInputs(aInput)
                 .fluidOutputs(aOutputs[i])
                 .duration(2 * aDuration)
                 .eut(aEUt / 4)
                 .addTo(sDistilleryRecipes);
         }
-
-        GT_Values.RA.stdBuilder()
-            .itemInputs(aCircuit)
-            .itemOutputs(aOutput2)
-            .fluidInputs(aInput)
+        GT_RecipeBuilder buildDT = GT_Values.RA.stdBuilder()
+            .itemInputs(aCircuit);
+        if (aOutput2 == GT_Values.NI) {
+            buildDT.noItemOutputs();
+        } else {
+            buildDT.itemOutputs(aOutput2);
+        }
+        buildDT.fluidInputs(aInput)
             .fluidOutputs(aOutputs)
             .duration(20 * SECONDS)
             .eut(TierEU.RECIPE_MV)

--- a/src/main/java/gregtech/loaders/postload/recipes/FermenterRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/FermenterRecipes.java
@@ -326,24 +326,6 @@ public class FermenterRecipes implements Runnable {
         GT_Values.RA.stdBuilder()
             .noItemInputs()
             .noItemOutputs()
-            .fluidInputs(getFluidStack("potion.speed.strong", 50))
-            .fluidOutputs(getFluidStack("potion.slowness.strong", 10))
-            .duration(1 * MINUTES + 42 * SECONDS + 8 * TICKS)
-            .eut(2)
-            .addTo(sFermentingRecipes);
-
-        GT_Values.RA.stdBuilder()
-            .noItemInputs()
-            .noItemOutputs()
-            .fluidInputs(getFluidStack("potion.strength.strong", 50))
-            .fluidOutputs(getFluidStack("potion.weakness.strong", 10))
-            .duration(1 * MINUTES + 42 * SECONDS + 8 * TICKS)
-            .eut(2)
-            .addTo(sFermentingRecipes);
-
-        GT_Values.RA.stdBuilder()
-            .noItemInputs()
-            .noItemOutputs()
             .fluidInputs(getFluidStack("potion.nightvision.long", 50))
             .fluidOutputs(getFluidStack("potion.invisibility.long", 10))
             .duration(1 * MINUTES + 42 * SECONDS + 8 * TICKS)
@@ -355,24 +337,6 @@ public class FermenterRecipes implements Runnable {
             .noItemOutputs()
             .fluidInputs(getFluidStack("potion.regen.strong", 50))
             .fluidOutputs(getFluidStack("potion.poison.strong", 10))
-            .duration(1 * MINUTES + 42 * SECONDS + 8 * TICKS)
-            .eut(2)
-            .addTo(sFermentingRecipes);
-
-        GT_Values.RA.stdBuilder()
-            .noItemInputs()
-            .noItemOutputs()
-            .fluidInputs(getFluidStack("potion.poison.long", 50))
-            .fluidOutputs(getFluidStack("potion.damage.long", 10))
-            .duration(1 * MINUTES + 42 * SECONDS + 8 * TICKS)
-            .eut(2)
-            .addTo(sFermentingRecipes);
-
-        GT_Values.RA.stdBuilder()
-            .noItemInputs()
-            .noItemOutputs()
-            .fluidInputs(getFluidStack("potion.waterbreathing.long", 50))
-            .fluidOutputs(getFluidStack("potion.damage.long", 10))
             .duration(1 * MINUTES + 42 * SECONDS + 8 * TICKS)
             .eut(2)
             .addTo(sFermentingRecipes);

--- a/src/main/java/gregtech/loaders/postload/recipes/FluidSolidifierRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/FluidSolidifierRecipes.java
@@ -347,7 +347,7 @@ public class FluidSolidifierRecipes implements Runnable {
 
         GT_Values.RA.stdBuilder()
             .itemInputs(ItemList.Shape_Mold_Anvil.get(0L))
-            .itemOutputs(getModItem(Railcraft.ID, "tile.railcraft.anvil", 1L, 0))
+            .itemOutputs(getModItem(Railcraft.ID, "anvil", 1L, 0))
             .fluidInputs(Materials.Steel.getMolten(4464L))
             .noFluidOutputs()
             .duration(6 * SECONDS + 8 * TICKS)

--- a/src/main/java/gregtech/loaders/postload/recipes/FuelRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/FuelRecipes.java
@@ -155,7 +155,7 @@ public class FuelRecipes implements Runnable {
             .addTo(GT_RecipeConstants.Fuel);
 
         GT_Values.RA.stdBuilder()
-            .itemInputs(getModItem(TaintedMagic.ID, "WarpedShard", 1L))
+            .itemInputs(getModItem(TaintedMagic.ID, "ItemMaterial", 1L, 3))
             .noItemOutputs()
             .noFluidInputs()
             .noFluidOutputs()
@@ -166,7 +166,7 @@ public class FuelRecipes implements Runnable {
             .addTo(GT_RecipeConstants.Fuel);
 
         GT_Values.RA.stdBuilder()
-            .itemInputs(getModItem(TaintedMagic.ID, "FluxShard", 1L))
+            .itemInputs(getModItem(TaintedMagic.ID, "ItemMaterial", 1L, 4))
             .noItemOutputs()
             .noFluidInputs()
             .noFluidOutputs()
@@ -177,7 +177,7 @@ public class FuelRecipes implements Runnable {
             .addTo(GT_RecipeConstants.Fuel);
 
         GT_Values.RA.stdBuilder()
-            .itemInputs(getModItem(TaintedMagic.ID, "EldritchShard", 1L))
+            .itemInputs(getModItem(TaintedMagic.ID, "ItemMaterial", 1L, 5))
             .noItemOutputs()
             .noFluidInputs()
             .noFluidOutputs()

--- a/src/main/java/gregtech/loaders/preload/GT_Loader_ItemData.java
+++ b/src/main/java/gregtech/loaders/preload/GT_Loader_ItemData.java
@@ -167,13 +167,13 @@ public class GT_Loader_ItemData implements Runnable {
             new ItemStack(Blocks.heavy_weighted_pressure_plate, 1, 32767),
             new ItemData(Materials.Iron, 7257600L));
         GT_OreDictUnificator.addItemData(
-            GT_ModHandler.getModItem(Railcraft.ID, "tile.railcraft.anvil", 1L, 0),
+            GT_ModHandler.getModItem(Railcraft.ID, "anvil", 1L, 0),
             new ItemData(Materials.Steel, 108864000L));
         GT_OreDictUnificator.addItemData(
-            GT_ModHandler.getModItem(Railcraft.ID, "tile.railcraft.anvil", 1L, 1),
+            GT_ModHandler.getModItem(Railcraft.ID, "anvil", 1L, 1),
             new ItemData(Materials.Steel, 72576000L));
         GT_OreDictUnificator.addItemData(
-            GT_ModHandler.getModItem(Railcraft.ID, "tile.railcraft.anvil", 1L, 2),
+            GT_ModHandler.getModItem(Railcraft.ID, "anvil", 1L, 2),
             new ItemData(Materials.Steel, 36288000L));
         GT_OreDictUnificator.addItemData(new ItemStack(Blocks.anvil, 1, 0), new ItemData(Materials.Iron, 108864000L));
         GT_OreDictUnificator.addItemData(new ItemStack(Blocks.anvil, 1, 1), new ItemData(Materials.Iron, 72576000L));


### PR DESCRIPTION
- remove graphite block cutting (doesnt exist)
- fix old RA1 remnants in distilling recipes
- fix some nulls in distilling recipes
- fix railcraft anvil (fluid solidifying, autogenerated fluid extracting/recycling)
- fix fuel values of tainted magic shards in magic energy absorber (probably never worked before)
- fix wrong registry name for creosote wood block