### PR TITLE
WIP using Forge Direction instead of byte ordinal

### DIFF
--- a/src/main/java/gregtech/api/enums/GT_Values.java
+++ b/src/main/java/gregtech/api/enums/GT_Values.java
@@ -9,6 +9,7 @@ import java.util.*;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTankInfo;
 import net.minecraftforge.fluids.IFluidTank;
@@ -377,22 +378,63 @@ public class GT_Values {
 
     /**
      * Side->Offset Mappings.
+     * 
+     * @deprecated Use {@link ForgeDirection#VALID_DIRECTIONS} {@link ForgeDirection#offsetX}
      */
-    public static final byte[] OFFX = { 0, 0, 0, 0, -1, +1, 0 }, OFFY = { -1, +1, 0, 0, 0, 0, 0 },
-        OFFZ = { 0, 0, -1, +1, 0, 0, 0 };
+    @Deprecated
+    // spotless:off
+    public static final byte[]
+            OFFX = {
+                (byte) ForgeDirection.DOWN.offsetX,     (byte) ForgeDirection.UP.offsetX,
+                (byte) ForgeDirection.NORTH.offsetX,    (byte) ForgeDirection.SOUTH.offsetX,
+                (byte) ForgeDirection.WEST.offsetX,     (byte) ForgeDirection.EAST.offsetX,
+                (byte) ForgeDirection.UNKNOWN.offsetX },
+    /**
+     * @deprecated Use {@link ForgeDirection#VALID_DIRECTIONS} {@link ForgeDirection#offsetY}
+     */
+            OFFY = {
+                (byte) ForgeDirection.DOWN.offsetY,     (byte) ForgeDirection.UP.offsetY,
+                (byte) ForgeDirection.NORTH.offsetY,    (byte) ForgeDirection.SOUTH.offsetY,
+                (byte) ForgeDirection.WEST.offsetY,     (byte) ForgeDirection.EAST.offsetY,
+                (byte) ForgeDirection.UNKNOWN.offsetY },
+    /**
+     * @deprecated Use {@link ForgeDirection#VALID_DIRECTIONS} {@link ForgeDirection#offsetZ}
+     */
+            OFFZ = {
+                (byte) ForgeDirection.DOWN.offsetZ,     (byte) ForgeDirection.UP.offsetZ,
+                (byte) ForgeDirection.NORTH.offsetZ,    (byte) ForgeDirection.SOUTH.offsetZ,
+                (byte) ForgeDirection.WEST.offsetZ,     (byte) ForgeDirection.EAST.offsetZ,
+                (byte) ForgeDirection.UNKNOWN.offsetZ };
 
     /**
      * Side->Opposite Mappings.
+     * 
+     * @deprecated Use {@link ForgeDirection#OPPOSITES}
      **/
-    public static final byte[] OPOS = { 1, 0, 3, 2, 5, 4, 6 };
+    public static final byte[] OPOS = {
+            (byte) ForgeDirection.OPPOSITES[ForgeDirection.DOWN.ordinal()],
+            (byte) ForgeDirection.OPPOSITES[ForgeDirection.UP.ordinal()],
+            (byte) ForgeDirection.OPPOSITES[ForgeDirection.NORTH.ordinal()],
+            (byte) ForgeDirection.OPPOSITES[ForgeDirection.SOUTH.ordinal()],
+            (byte) ForgeDirection.OPPOSITES[ForgeDirection.WEST.ordinal()],
+            (byte) ForgeDirection.OPPOSITES[ForgeDirection.EAST.ordinal()],
+            (byte) ForgeDirection.OPPOSITES[ForgeDirection.UNKNOWN.ordinal()] };
 
+    // spotless:off
     /**
      * [Facing,Side]->Side Mappings for Blocks, which don't face up- and downwards. 0 = bottom, 1 = top, 2 = left, 3 =
      * front, 4 = right, 5 = back, 6 = undefined.
      */
-    public static final byte[][] FACING_ROTATIONS = { { 0, 1, 2, 3, 4, 5, 6 }, { 0, 1, 2, 3, 4, 5, 6 },
-        { 0, 1, 3, 5, 4, 2, 6 }, { 0, 1, 5, 3, 2, 4, 6 }, { 0, 1, 2, 4, 3, 5, 6 }, { 0, 1, 4, 2, 5, 3, 6 },
-        { 0, 1, 2, 3, 4, 5, 6 } };
+    public static final byte[][] FACING_ROTATIONS = {
+            { 0, 1, 2, 3, 4, 5, 6 }, // bottom
+            { 0, 1, 2, 3, 4, 5, 6 }, // top
+            { 0, 1, 3, 5, 4, 2, 6 }, // left
+            { 0, 1, 5, 3, 2, 4, 6 }, // front
+            { 0, 1, 2, 4, 3, 5, 6 }, // right
+            { 0, 1, 4, 2, 5, 3, 6 }, // back
+            { 0, 1, 2, 3, 4, 5, 6 }  // undefined
+    };
+    // spotless:on
 
     /**
      * The Mod Object itself. That is the GT_Mod-Object. It's needed to open GUI's and similar.

--- a/src/main/java/gregtech/api/enums/Textures.java
+++ b/src/main/java/gregtech/api/enums/Textures.java
@@ -1349,28 +1349,18 @@ public class Textures {
         /**
          * Icon for Fresh CFoam
          */
-        public static final ITexture[] FRESHFOAM = { TextureFactory.of(CFOAM_FRESH) };
+        public static final ITexture FRESHFOAM = TextureFactory.of(CFOAM_FRESH);
         /**
          * Icons for Hardened CFoam 0 = No Color 1 - 16 = Colors
          */
-        public static final ITexture[][] HARDENEDFOAMS = {
-            new ITexture[] { TextureFactory.of(CFOAM_HARDENED, Dyes.CONSTRUCTION_FOAM.mRGBa) },
-            new ITexture[] { TextureFactory.of(CFOAM_HARDENED, Dyes.VALUES[0].mRGBa) },
-            new ITexture[] { TextureFactory.of(CFOAM_HARDENED, Dyes.VALUES[1].mRGBa) },
-            new ITexture[] { TextureFactory.of(CFOAM_HARDENED, Dyes.VALUES[2].mRGBa) },
-            new ITexture[] { TextureFactory.of(CFOAM_HARDENED, Dyes.VALUES[3].mRGBa) },
-            new ITexture[] { TextureFactory.of(CFOAM_HARDENED, Dyes.VALUES[4].mRGBa) },
-            new ITexture[] { TextureFactory.of(CFOAM_HARDENED, Dyes.VALUES[5].mRGBa) },
-            new ITexture[] { TextureFactory.of(CFOAM_HARDENED, Dyes.VALUES[6].mRGBa) },
-            new ITexture[] { TextureFactory.of(CFOAM_HARDENED, Dyes.VALUES[7].mRGBa) },
-            new ITexture[] { TextureFactory.of(CFOAM_HARDENED, Dyes.VALUES[8].mRGBa) },
-            new ITexture[] { TextureFactory.of(CFOAM_HARDENED, Dyes.VALUES[9].mRGBa) },
-            new ITexture[] { TextureFactory.of(CFOAM_HARDENED, Dyes.VALUES[10].mRGBa) },
-            new ITexture[] { TextureFactory.of(CFOAM_HARDENED, Dyes.VALUES[11].mRGBa) },
-            new ITexture[] { TextureFactory.of(CFOAM_HARDENED, Dyes.VALUES[12].mRGBa) },
-            new ITexture[] { TextureFactory.of(CFOAM_HARDENED, Dyes.VALUES[13].mRGBa) },
-            new ITexture[] { TextureFactory.of(CFOAM_HARDENED, Dyes.VALUES[14].mRGBa) },
-            new ITexture[] { TextureFactory.of(CFOAM_HARDENED, Dyes.VALUES[15].mRGBa) } };
+        public static final ITexture[] HARDENEDFOAMS = new ITexture[1 + Dyes.VALUES.length];
+        static {
+            HARDENEDFOAMS[0] = TextureFactory.of(CFOAM_HARDENED, Dyes.CONSTRUCTION_FOAM.mRGBa);
+            for (Dyes dye : Dyes.VALUES) {
+                HARDENEDFOAMS[dye.ordinal() + 1] = TextureFactory.of(CFOAM_HARDENED, dye.mRGBa);
+            }
+        }
+
         /**
          * Machine Casings by Tier 0 = 8V, 1 = LV, 2 = MV, 3 = HV, 4 = EV, 5 = IV, 6 = IV, 7 = IV, 8 = IV, 9 = IV
          */
@@ -1491,11 +1481,11 @@ public class Textures {
                 BLOCK_TRANSCENDENTMETAL, BLOCK_ORIHARUKON, BLOCK_WHITEDWARFMATTER, BLOCK_BLACKDWARFMATTER,
                 BLOCK_UNIVERSIUM };
 
-        public static final ITexture[] HIDDEN_TEXTURE = { TextureFactory.builder()
+        public static final ITexture HIDDEN_TEXTURE = TextureFactory.builder()
             .addIcon(HIDDEN_FACE)
             .stdOrient()
-            .build() };
-        public static final ITexture[] ERROR_RENDERING = { TextureFactory.of(RENDERING_ERROR) };
+            .build();
+        public static final ITexture ERROR_RENDERING = TextureFactory.of(RENDERING_ERROR);
         public static final ITexture[] OVERLAYS_ENERGY_IN = {
             TextureFactory.of(OVERLAY_ENERGY_IN, new short[] { 180, 180, 180, 0 }),
             TextureFactory.of(OVERLAY_ENERGY_IN, new short[] { 220, 220, 220, 0 }),
@@ -1672,7 +1662,7 @@ public class Textures {
             // adds some known pages, modders also can do it...
             GT_Utility.addTexturePage((byte) 1);
             GT_Utility.addTexturePage((byte) 8);
-            setCasingTextureForId(ERROR_TEXTURE_INDEX, ERROR_RENDERING[0]);
+            setCasingTextureForId(ERROR_TEXTURE_INDEX, ERROR_RENDERING);
         }
 
         protected IIcon mIcon;

--- a/src/main/java/gregtech/api/interfaces/ILayeredTexture.java
+++ b/src/main/java/gregtech/api/interfaces/ILayeredTexture.java
@@ -1,0 +1,51 @@
+package gregtech.api.interfaces;
+
+/**
+ * Interface to a list of bottom-up layered {@link ITexture}
+ */
+public interface ILayeredTexture extends ITexture, Iterable<ITexture> {
+
+    /**
+     * Adds an {@link ITexture} layer atop
+     *
+     * @param iTexture the texture as top layer
+     * @return self for chaining
+     */
+    ILayeredTexture add(ITexture iTexture);
+
+    /**
+     * Adds the {@link ITexture} at layer index
+     *
+     * @param index    the {@link ITexture} to add
+     * @param iTexture the texture layer to add
+     * @return self for chaining
+     */
+    ILayeredTexture add(int index, ITexture iTexture);
+
+    /**
+     * Adds all the {@link ITexture} layers atop
+     *
+     * @param iTexture the {@link ITexture} layers
+     * @return self for chaining
+     */
+    ILayeredTexture addAll(ITexture... iTexture);
+
+    /**
+     * Adds all the {@link ITexture} layers starting at index
+     *
+     * @param index    the index to add the layers at
+     * @param iTexture the {@link ITexture} layers to add
+     * @return self for chaining
+     */
+    ILayeredTexture addAll(int index, ITexture... iTexture);
+
+    /**
+     * @return the number of {@link ITexture} layers
+     */
+    int size();
+
+    /**
+     * @return true if there is no layer
+     */
+    boolean isEmpty();
+}

--- a/src/main/java/gregtech/api/interfaces/ITexture.java
+++ b/src/main/java/gregtech/api/interfaces/ITexture.java
@@ -3,19 +3,92 @@ package gregtech.api.interfaces;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.client.renderer.Tessellator;
+import net.minecraftforge.common.util.ForgeDirection;
 
 public interface ITexture {
 
+    /**
+     * Renders the {@link Block}'s face at the given axis sign
+     *
+     * @param aRenderer the Minecraft {@link RenderBlocks} renderer
+     * @param aBlock    the {@link Block} to render
+     * @param aX        the x coordinate of the {@link Block}
+     * @param aY        y
+     * @param aZ        z
+     *
+     * @deprecated use {@link #render(RenderBlocks, Block, int, int, int, ForgeDirection)} instead
+     */
+    @Deprecated
     void renderXPos(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ);
 
+    /**
+     * Renders the {@link Block}'s face at the given axis sign
+     *
+     * @param aRenderer the Minecraft {@link RenderBlocks} renderer
+     * @param aBlock    the {@link Block} to render
+     * @param aX        the x coordinate of the {@link Block}
+     * @param aY        y
+     * @param aZ        z
+     *
+     * @deprecated use {@link #render(RenderBlocks, Block, int, int, int, ForgeDirection)} instead
+     */
+    @Deprecated
     void renderXNeg(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ);
 
+    /**
+     * Renders the {@link Block}'s face at the given axis sign
+     *
+     * @param aRenderer the Minecraft {@link RenderBlocks} renderer
+     * @param aBlock    the {@link Block} to render
+     * @param aX        the x coordinate of the {@link Block}
+     * @param aY        y
+     * @param aZ        z
+     *
+     * @deprecated use {@link #render(RenderBlocks, Block, int, int, int, ForgeDirection)} instead
+     */
+    @Deprecated
     void renderYPos(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ);
 
+    /**
+     * Renders the {@link Block}'s face at the given axis sign
+     *
+     * @param aRenderer the Minecraft {@link RenderBlocks} renderer
+     * @param aBlock    the {@link Block} to render
+     * @param aX        the x coordinate of the {@link Block}
+     * @param aY        y
+     * @param aZ        z
+     *
+     * @deprecated use {@link #render(RenderBlocks, Block, int, int, int, ForgeDirection)} instead
+     */
+    @Deprecated
     void renderYNeg(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ);
 
+    /**
+     * Renders the {@link Block}'s face at the given axis sign
+     *
+     * @param aRenderer the Minecraft {@link RenderBlocks} renderer
+     * @param aBlock    the {@link Block} to render
+     * @param aX        the x coordinate of the {@link Block}
+     * @param aY        y
+     * @param aZ        z
+     *
+     * @deprecated use {@link #render(RenderBlocks, Block, int, int, int, ForgeDirection)} instead
+     */
+    @Deprecated
     void renderZPos(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ);
 
+    /**
+     * Renders the {@link Block}'s face at the given axis sign
+     *
+     * @param aRenderer the Minecraft {@link RenderBlocks} renderer
+     * @param aBlock    the {@link Block} to render
+     * @param aX        the x coordinate of the {@link Block}
+     * @param aY        y
+     * @param aZ        z
+     *
+     * @deprecated use {@link #render(RenderBlocks, Block, int, int, int, ForgeDirection)} instead
+     */
+    @Deprecated
     void renderZNeg(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ);
 
     boolean isValidTexture();
@@ -50,6 +123,28 @@ public interface ITexture {
     default void draw(RenderBlocks aRenderer) {
         if (aRenderer.useInventoryTint && !isOldTexture()) {
             Tessellator.instance.draw();
+        }
+    }
+
+    /**
+     * Renders the {@link Block}'s face at the given {@link ForgeDirection}
+     *
+     * @param renderer  the Minecraft {@link RenderBlocks} renderer
+     * @param block     the {@link Block} to render
+     * @param x         the x coordinate of the {@link Block}
+     * @param y         y
+     * @param z         z
+     * @param direction the {@link ForgeDirection} of the face
+     */
+    @SuppressWarnings("MethodWithTooManyParameters")
+    default void render(RenderBlocks renderer, Block block, int x, int y, int z, ForgeDirection direction) {
+        switch (direction) {
+            case DOWN -> renderYNeg(renderer, block, x, y, z);
+            case UP -> renderYPos(renderer, block, x, y, z);
+            case NORTH -> renderZNeg(renderer, block, x, y, z);
+            case SOUTH -> renderZPos(renderer, block, x, y, z);
+            case WEST -> renderXNeg(renderer, block, x, y, z);
+            case EAST -> renderXPos(renderer, block, x, y, z);
         }
     }
 }

--- a/src/main/java/gregtech/api/interfaces/metatileentity/IConnectable.java
+++ b/src/main/java/gregtech/api/interfaces/metatileentity/IConnectable.java
@@ -5,6 +5,7 @@ package gregtech.api.interfaces.metatileentity;
  */
 public interface IConnectable {
 
+    // spotless:off
     int NO_CONNECTION = 0b00000000;
     int CONNECTED_DOWN = 0b00000001;
     int CONNECTED_UP = 0b00000010;
@@ -12,10 +13,11 @@ public interface IConnectable {
     int CONNECTED_SOUTH = 0b00001000;
     int CONNECTED_WEST = 0b00010000;
     int CONNECTED_EAST = 0b00100000;
-    int CONNECTED_ALL = 0b00111111;
+    int CONNECTED_ALL = CONNECTED_DOWN|CONNECTED_UP|CONNECTED_NORTH|CONNECTED_SOUTH|CONNECTED_WEST|CONNECTED_EAST;
     int HAS_FRESHFOAM = 0b01000000;
     int HAS_HARDENEDFOAM = 0b10000000;
-    int HAS_FOAM = 0b11000000;
+    int HAS_FOAM = HAS_FRESHFOAM|HAS_HARDENEDFOAM;
+    // spotless:on
 
     /**
      * Try to connect to the Block at the specified side returns the connection state. Non-positive values for failed,

--- a/src/main/java/gregtech/api/interfaces/metatileentity/IConnectable.java
+++ b/src/main/java/gregtech/api/interfaces/metatileentity/IConnectable.java
@@ -1,5 +1,9 @@
 package gregtech.api.interfaces.metatileentity;
 
+import static net.minecraftforge.common.util.ForgeDirection.*;
+
+import net.minecraftforge.common.util.ForgeDirection;
+
 /**
  * For pipes, wires, and other MetaTiles which need to be decided whether they should connect to the block at each side.
  */
@@ -30,5 +34,13 @@ public interface IConnectable {
      */
     void disconnect(byte aSide);
 
-    boolean isConnectedAtSide(int aSide);
+    /**
+     * @deprecated use {@link #isConnectedAtSide(ForgeDirection)}
+     */
+    @Deprecated
+    default boolean isConnectedAtSide(int aSide) {
+        throw new UnsupportedOperationException();
+    }
+
+    boolean isConnectedAtSide(ForgeDirection dir);
 }

--- a/src/main/java/gregtech/api/interfaces/metatileentity/IMetaTileEntity.java
+++ b/src/main/java/gregtech/api/interfaces/metatileentity/IMetaTileEntity.java
@@ -16,6 +16,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.IFluidHandler;
 import net.minecraftforge.fluids.IFluidTank;
 
@@ -372,9 +373,16 @@ public interface IMetaTileEntity extends ISidedInventory, IFluidTank, IFluidHand
      *                    to something or not.
      * @param aRedstone   if the Machine is currently outputting a RedstoneSignal (use this instead of calling
      *                    mBaseMetaTileEntity.mRedstone!!!)
+     * @deprecated
      */
-    ITexture[] getTexture(IGregTechTileEntity aBaseMetaTileEntity, byte aSide, byte aFacing, byte aColorIndex,
-        boolean aActive, boolean aRedstone);
+    @Deprecated
+    default ITexture[] getTexture(IGregTechTileEntity aBaseMetaTileEntity, byte aSide, byte aFacing, byte aColorIndex,
+        boolean aActive, boolean aRedstone) {
+        throw new UnsupportedOperationException();
+    }
+
+    ITexture getTexture(IGregTechTileEntity baseMetaTileEntity, ForgeDirection side, byte facing,
+        byte colorIndex, boolean active, boolean redstone);
 
     /**
      * The Textures used for the Item rendering. Return null if you want the regular 3D Block Rendering.

--- a/src/main/java/gregtech/api/interfaces/tileentity/ICoverable.java
+++ b/src/main/java/gregtech/api/interfaces/tileentity/ICoverable.java
@@ -2,6 +2,7 @@ package gregtech.api.interfaces.tileentity;
 
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.common.util.ForgeDirection;
 
 import gregtech.api.util.GT_CoverBehavior;
 import gregtech.api.util.GT_CoverBehaviorBase;
@@ -43,7 +44,15 @@ public interface ICoverable extends IRedstoneTileEntity, IHasInventory, IBasicEn
         return new ISerializableObject.LegacyCoverData(getCoverDataAtSide(aSide));
     }
 
+    /**
+     * @deprecated use {@link #getCoverIDAtDirection(ForgeDirection)}
+     */
+    @Deprecated
     int getCoverIDAtSide(byte aSide);
+
+    default int getCoverIDAtDirection(ForgeDirection direction) {
+        return getCoverIDAtSide((byte) direction.ordinal());
+    }
 
     ItemStack getCoverItemAtSide(byte aSide);
 

--- a/src/main/java/gregtech/api/interfaces/tileentity/ICoverable.java
+++ b/src/main/java/gregtech/api/interfaces/tileentity/ICoverable.java
@@ -45,12 +45,12 @@ public interface ICoverable extends IRedstoneTileEntity, IHasInventory, IBasicEn
     }
 
     /**
-     * @deprecated use {@link #getCoverIDAtDirection(ForgeDirection)}
+     * @deprecated use {@link #getCoverIDAtSide(ForgeDirection)}
      */
     @Deprecated
     int getCoverIDAtSide(byte aSide);
 
-    default int getCoverIDAtDirection(ForgeDirection direction) {
+    default int getCoverIDAtSide(ForgeDirection direction) {
         return getCoverIDAtSide((byte) direction.ordinal());
     }
 
@@ -59,9 +59,15 @@ public interface ICoverable extends IRedstoneTileEntity, IHasInventory, IBasicEn
     @Deprecated
     GT_CoverBehavior getCoverBehaviorAtSide(byte aSide);
 
+    @Deprecated
     default GT_CoverBehaviorBase<?> getCoverBehaviorAtSideNew(byte aSide) {
-        return getCoverBehaviorAtSide(aSide);
+        throw new UnsupportedOperationException();
     }
+
+    default GT_CoverBehaviorBase<?> getCoverBehaviorAtSideNew(ForgeDirection side) {
+        return getCoverBehaviorAtSide(side);
+    }
+
 
     /**
      * For use by the regular MetaTileEntities. Returns the Cover Manipulated input Redstone. Don't use this if you are

--- a/src/main/java/gregtech/api/interfaces/tileentity/IPipeRenderedTileEntity.java
+++ b/src/main/java/gregtech/api/interfaces/tileentity/IPipeRenderedTileEntity.java
@@ -1,6 +1,13 @@
 package gregtech.api.interfaces.tileentity;
 
+import static net.minecraftforge.common.util.ForgeDirection.VALID_DIRECTIONS;
+
+import java.util.EnumMap;
+
+import net.minecraftforge.common.util.ForgeDirection;
+
 import gregtech.api.interfaces.ITexture;
+import gregtech.api.render.TextureFactory;
 
 public interface IPipeRenderedTileEntity extends ICoverable, ITexturedTileEntity {
 
@@ -8,9 +15,61 @@ public interface IPipeRenderedTileEntity extends ICoverable, ITexturedTileEntity
 
     byte getConnections();
 
+    /**
+     * Gets the {@link ITexture} layers of Pipe without a Cover as an array for Side
+     *
+     * @param aSide the ordinal side
+     * @return the {@link ITexture} array of layers
+     * @deprecated {@link #getTextureUncovered(ForgeDirection)}
+     */
+    @Deprecated
     ITexture[] getTextureUncovered(byte aSide);
 
+    /**
+     * Gets the texture of a pipe without a cover as an array for side
+     *
+     * @param side the {@link ForgeDirection} side
+     * @return the {@link ITexture} array of layers
+     */
+    default ITexture getTextureUncovered(ForgeDirection side) {
+        return TextureFactory.of(getTextureUncovered((byte) side.ordinal()));
+    }
+
+    /**
+     * Gets the uncovered textures for all side directions of the pipe
+     *
+     * @return the <code>{@link EnumMap}&lt;{@link ForgeDirection}, {@link ITexture}&gt;</code>
+     *         containing textures for each direction
+     */
+    default EnumMap<ForgeDirection, ITexture> getTexturesMapUncovered() {
+        EnumMap<ForgeDirection, ITexture> textureMap = new EnumMap<>(ForgeDirection.class);
+        for (ForgeDirection direction : VALID_DIRECTIONS) {
+            textureMap.put(direction, getTextureUncovered(direction));
+        }
+        return textureMap;
+    }
+
+    /**
+     * Gets the {@link ITexture} layers of Pipe with a Cover texture at top layer as an array for Side
+     *
+     * @param aSide the ordinal side
+     * @return the {@link ITexture} array of layers
+     * @deprecated {@link #getTextureUncovered(ForgeDirection)}
+     */
+    @Deprecated
     default ITexture[] getTextureCovered(byte aSide) {
         return getTextureUncovered(aSide);
+    }
+
+    default ITexture getTextureCovered(ForgeDirection direction) {
+        return TextureFactory.of(getTextureCovered((byte) direction.ordinal()));
+    }
+
+    default EnumMap<ForgeDirection, ITexture> getTexturesMapCovered() {
+        EnumMap<ForgeDirection, ITexture> textureMap = new EnumMap<>(ForgeDirection.class);
+        for (ForgeDirection direction : VALID_DIRECTIONS) {
+            textureMap.put(direction, getTextureCovered(direction));
+        }
+        return textureMap;
     }
 }

--- a/src/main/java/gregtech/api/interfaces/tileentity/IPipeRenderedTileEntity.java
+++ b/src/main/java/gregtech/api/interfaces/tileentity/IPipeRenderedTileEntity.java
@@ -7,7 +7,6 @@ import java.util.EnumMap;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import gregtech.api.interfaces.ITexture;
-import gregtech.api.render.TextureFactory;
 
 public interface IPipeRenderedTileEntity extends ICoverable, ITexturedTileEntity {
 
@@ -23,7 +22,9 @@ public interface IPipeRenderedTileEntity extends ICoverable, ITexturedTileEntity
      * @deprecated {@link #getTextureUncovered(ForgeDirection)}
      */
     @Deprecated
-    ITexture[] getTextureUncovered(byte aSide);
+    default ITexture[] getTextureUncovered(byte aSide) {
+        throw new UnsupportedOperationException();
+    }
 
     /**
      * Gets the texture of a pipe without a cover as an array for side
@@ -31,9 +32,7 @@ public interface IPipeRenderedTileEntity extends ICoverable, ITexturedTileEntity
      * @param side the {@link ForgeDirection} side
      * @return the {@link ITexture} array of layers
      */
-    default ITexture getTextureUncovered(ForgeDirection side) {
-        return TextureFactory.of(getTextureUncovered((byte) side.ordinal()));
-    }
+    ITexture getTextureUncovered(ForgeDirection side);
 
     /**
      * Gets the uncovered textures for all side directions of the pipe
@@ -41,13 +40,7 @@ public interface IPipeRenderedTileEntity extends ICoverable, ITexturedTileEntity
      * @return the <code>{@link EnumMap}&lt;{@link ForgeDirection}, {@link ITexture}&gt;</code>
      *         containing textures for each direction
      */
-    default EnumMap<ForgeDirection, ITexture> getTexturesMapUncovered() {
-        EnumMap<ForgeDirection, ITexture> textureMap = new EnumMap<>(ForgeDirection.class);
-        for (ForgeDirection direction : VALID_DIRECTIONS) {
-            textureMap.put(direction, getTextureUncovered(direction));
-        }
-        return textureMap;
-    }
+    EnumMap<ForgeDirection, ITexture> getTexturesMapUncovered();
 
     /**
      * Gets the {@link ITexture} layers of Pipe with a Cover texture at top layer as an array for Side
@@ -58,12 +51,10 @@ public interface IPipeRenderedTileEntity extends ICoverable, ITexturedTileEntity
      */
     @Deprecated
     default ITexture[] getTextureCovered(byte aSide) {
-        return getTextureUncovered(aSide);
+        throw new UnsupportedOperationException();
     }
 
-    default ITexture getTextureCovered(ForgeDirection direction) {
-        return TextureFactory.of(getTextureCovered((byte) direction.ordinal()));
-    }
+    ITexture getTextureCovered(ForgeDirection side);
 
     default EnumMap<ForgeDirection, ITexture> getTexturesMapCovered() {
         EnumMap<ForgeDirection, ITexture> textureMap = new EnumMap<>(ForgeDirection.class);

--- a/src/main/java/gregtech/api/interfaces/tileentity/IRedstoneEmitter.java
+++ b/src/main/java/gregtech/api/interfaces/tileentity/IRedstoneEmitter.java
@@ -1,5 +1,7 @@
 package gregtech.api.interfaces.tileentity;
 
+import net.minecraftforge.common.util.ForgeDirection;
+
 /**
  * This File has just internal Information about the Redstone State of a TileEntity
  */
@@ -7,8 +9,21 @@ public interface IRedstoneEmitter extends IHasWorldObjectAndCoords {
 
     /**
      * gets the Redstone Level the TileEntity should emit to the given Output Side
+     * 
+     * @deprecated use {@link #getOutputRedstoneSignal(ForgeDirection)}
      */
-    byte getOutputRedstoneSignal(byte aSide);
+    @Deprecated
+    default byte getOutputRedstoneSignal(byte ignoredASide) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * gets the Redstone Level the TileEntity should emit to the given Output Side
+     * 
+     * @param side the {@link ForgeDirection} side
+     * @return the Redstone Level the TileEntity
+     */
+    byte getOutputRedstoneSignal(ForgeDirection side);
 
     /**
      * sets the Redstone Level the TileEntity should emit to the given Output Side

--- a/src/main/java/gregtech/api/interfaces/tileentity/ITexturedTileEntity.java
+++ b/src/main/java/gregtech/api/interfaces/tileentity/ITexturedTileEntity.java
@@ -1,6 +1,11 @@
 package gregtech.api.interfaces.tileentity;
 
+import static net.minecraftforge.common.util.ForgeDirection.VALID_DIRECTIONS;
+
+import java.util.EnumMap;
+
 import net.minecraft.block.Block;
+import net.minecraftforge.common.util.ForgeDirection;
 
 import gregtech.api.interfaces.ITexture;
 
@@ -8,6 +13,36 @@ public interface ITexturedTileEntity {
 
     /**
      * @return the Textures rendered by the GT Rendering
+     * @deprecated use {@link #getTexture(Block, ForgeDirection)
      */
-    ITexture[] getTexture(Block aBlock, byte aSide);
+    @Deprecated
+    default ITexture getTexture(Block aBlock, byte aSide) {
+        return getTexture(aBlock, ForgeDirection.getOrientation(aSide));
+    }
+
+    /**
+     * Gets the texture to be rendered for the block's side at given direction
+     *
+     * @param block the {@link Block} being textured
+     * @param dir   the {@link ForgeDirection} of the side being textured
+     * @return the {@link ITexture} to be rendered
+     */
+    default ITexture getTexture(Block block, ForgeDirection dir) {
+        return getTexture(block, (byte) dir.ordinal());
+    }
+
+    /**
+     * Gets the textures to be rendered for all side directions of the block
+     *
+     * @param block the {@link Block} being textured
+     * @return the <code>{@link EnumMap}&lt;{@link ForgeDirection}, {@link ITexture}&gt;</code>
+     *         containing textures for each direction
+     */
+    default EnumMap<ForgeDirection, ITexture> getTexturesMap(Block block) {
+        EnumMap<ForgeDirection, ITexture> directionLayeredTextures = new EnumMap<>(ForgeDirection.class);
+        for (ForgeDirection direction : VALID_DIRECTIONS) {
+            directionLayeredTextures.put(direction, getTexture(block, direction));
+        }
+        return directionLayeredTextures;
+    }
 }

--- a/src/main/java/gregtech/api/interfaces/tileentity/ITexturedTileEntity.java
+++ b/src/main/java/gregtech/api/interfaces/tileentity/ITexturedTileEntity.java
@@ -8,6 +8,7 @@ import net.minecraft.block.Block;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import gregtech.api.interfaces.ITexture;
+import gregtech.api.render.TextureFactory;
 
 public interface ITexturedTileEntity {
 
@@ -16,19 +17,19 @@ public interface ITexturedTileEntity {
      * @deprecated use {@link #getTexture(Block, ForgeDirection)
      */
     @Deprecated
-    default ITexture getTexture(Block aBlock, byte aSide) {
-        return getTexture(aBlock, ForgeDirection.getOrientation(aSide));
+    default ITexture[] getTexture(Block aBlock, byte aSide) {
+        throw new UnsupportedOperationException();
     }
 
     /**
      * Gets the texture to be rendered for the block's side at given direction
      *
      * @param block the {@link Block} being textured
-     * @param dir   the {@link ForgeDirection} of the side being textured
+     * @param side  the {@link ForgeDirection} of the side being textured
      * @return the {@link ITexture} to be rendered
      */
-    default ITexture getTexture(Block block, ForgeDirection dir) {
-        return getTexture(block, (byte) dir.ordinal());
+    default ITexture getTexture(Block block, ForgeDirection side) {
+        return TextureFactory.of(getTexture(block, (byte) side.ordinal()));
     }
 
     /**

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
@@ -69,6 +69,7 @@ import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_BasicMachin
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch;
 import gregtech.api.net.GT_Packet_TileEntity;
 import gregtech.api.objects.GT_ItemStack;
+import gregtech.api.render.TextureFactory;
 import gregtech.api.util.*;
 import gregtech.common.GT_Pollution;
 import gregtech.common.covers.CoverInfo;
@@ -1199,16 +1200,15 @@ public class BaseMetaTileEntity extends CommonMetaTileEntity implements IGregTec
     }
 
     @Override
-    public ITexture[] getTexture(Block aBlock, byte aSide) {
-        final ITexture coverTexture = getCoverTexture(aSide);
-        final ITexture[] textureUncovered = hasValidMetaTileEntity()
+    public ITexture getTexture(Block block, ForgeDirection side) {
+        final ITexture coverTexture = getCoverTexture(side);
+        final ITexture textureUncovered = hasValidMetaTileEntity()
             ? mMetaTileEntity
-                .getTexture(this, aSide, mFacing, (byte) (mColor - 1), mActive, getOutputRedstoneSignal(aSide) > 0)
+                .getTexture(this, side, mFacing, (byte) (mColor - 1), mActive, getOutputRedstoneSignal(side) > 0)
             : Textures.BlockIcons.ERROR_RENDERING;
-        final ITexture[] textureCovered;
+        final ITexture textureCovered;
         if (coverTexture != null) {
-            textureCovered = Arrays.copyOf(textureUncovered, textureUncovered.length + 1);
-            textureCovered[textureUncovered.length] = coverTexture;
+            textureCovered = TextureFactory.of(textureUncovered, coverTexture);
             return textureCovered;
         } else {
             return textureUncovered;

--- a/src/main/java/gregtech/api/metatileentity/CoverableTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/CoverableTileEntity.java
@@ -236,8 +236,27 @@ public abstract class CoverableTileEntity extends BaseTileEntity implements ICov
         if (worldObj == null || (isServerSide() && coverInfo.isDataNeededOnClient())) coverInfo.setNeedsUpdate(true);
     }
 
+    /**
+     * Gets the cover texture for the given side
+     * 
+     * @deprecated use {@link #getCoverTexture(ForgeDirection)}
+     *
+     * @param aSide the {@code byte} ordinal side direction
+     * @return the {@link ITexture} of the cover at this side
+     */
+    @Deprecated
     public final ITexture getCoverTexture(byte aSide) {
-        final CoverInfo coverInfo = getCoverInfoAtSide(aSide);
+        return getCoverTexture(ForgeDirection.getOrientation(aSide));
+    }
+
+    /**
+     * Gets the cover texture for the given side
+     *
+     * @param dir the {@link ForgeDirection} of the side
+     * @return the {@link ITexture} of the cover at this side
+     */
+    public final ITexture getCoverTexture(ForgeDirection dir) {
+        final CoverInfo coverInfo = getCoverInfoAtSide((byte) dir.ordinal());
         if (!coverInfo.isValid()) return null;
         if (GT_Mod.instance.isClientSide() && (GT_Client.hideValue & 0x1) != 0) {
             return Textures.BlockIcons.HIDDEN_TEXTURE[0]; // See through
@@ -246,7 +265,7 @@ public abstract class CoverableTileEntity extends BaseTileEntity implements ICov
             : coverInfo.getSpecialCoverTexture();
 
         return coverTexture != null ? coverTexture
-            : GregTech_API.sCovers.get(new GT_ItemStack(getCoverIDAtSide(aSide)));
+            : GregTech_API.sCovers.get(new GT_ItemStack(getCoverIDAtSide((byte) dir.ordinal())));
     }
 
     protected void requestCoverDataIfNeeded() {

--- a/src/main/java/gregtech/api/metatileentity/CoverableTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/CoverableTileEntity.java
@@ -373,6 +373,12 @@ public abstract class CoverableTileEntity extends BaseTileEntity implements ICov
         return getCoverInfoAtSide(aSide).getCoverBehavior();
     }
 
+    @Override
+    public GT_CoverBehaviorBase<?> getCoverBehaviorAtSideNew(ForgeDirection side) {
+        return getCoverInfoAtSide(side).getCoverBehavior();
+    }
+
+
     public void setCoverInfoAtSide(byte aSide, CoverInfo coverInfo) {
         if (aSide >= 0 && aSide < 6) coverInfos[aSide] = coverInfo;
     }
@@ -504,12 +510,13 @@ public abstract class CoverableTileEntity extends BaseTileEntity implements ICov
             .getIndirectPowerLevelTo(getOffsetX(aSide, 1), getOffsetY(aSide, 1), getOffsetZ(aSide, 1), aSide) & 15);
     }
 
+
     @Override
-    public byte getOutputRedstoneSignal(byte aSide) {
-        return getCoverBehaviorAtSideNew(aSide)
-            .manipulatesSidedRedstoneOutput(aSide, getCoverIDAtSide(aSide), getComplexCoverDataAtSide(aSide), this)
-                ? mSidedRedstone[aSide]
-                : getGeneralRS(aSide);
+    public byte getOutputRedstoneSignal(ForgeDirection side) {
+        return getCoverBehaviorAtSideNew((byte) side.ordinal())
+            .manipulatesSidedRedstoneOutput(side, getCoverIDAtSide(side), getComplexCoverDataAtSide(side), this)
+                ? mSidedRedstone[side]
+                : getGeneralRS(side);
     }
 
     protected void updateOutputRedstoneSignal(byte aSide) {

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Cable.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Cable.java
@@ -2,6 +2,12 @@ package gregtech.api.metatileentity.implementations;
 
 import static gregtech.api.enums.GT_Values.ALL_VALID_SIDES;
 import static gregtech.api.enums.Mods.GalacticraftCore;
+import static net.minecraftforge.common.util.ForgeDirection.DOWN;
+import static net.minecraftforge.common.util.ForgeDirection.EAST;
+import static net.minecraftforge.common.util.ForgeDirection.NORTH;
+import static net.minecraftforge.common.util.ForgeDirection.SOUTH;
+import static net.minecraftforge.common.util.ForgeDirection.UP;
+import static net.minecraftforge.common.util.ForgeDirection.WEST;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -110,54 +116,52 @@ public class GT_MetaPipeEntity_Cable extends MetaPipeEntity implements IMetaTile
     }
 
     @Override
-    public ITexture[] getTexture(IGregTechTileEntity aBaseMetaTileEntity, byte aSide, byte aConnections,
-        byte aColorIndex, boolean aConnected, boolean aRedstone) {
-        if (!mInsulated) return new ITexture[] { TextureFactory.of(
-            mMaterial.mIconSet.mTextures[TextureSet.INDEX_wire],
-            Dyes.getModulation(aColorIndex, mMaterial.mRGBa)) };
+    public ITexture getTexture(IGregTechTileEntity aBaseMetaTileEntity, ForgeDirection aSide,
+        byte aConnections, byte aColorIndex, boolean aConnected, boolean aRedstone) {
+        if (!mInsulated) return TextureFactory
+            .of(mMaterial.mIconSet.mTextures[TextureSet.INDEX_wire], Dyes.getModulation(aColorIndex, mMaterial.mRGBa));
         if (aConnected) {
             float tThickNess = getThickNess();
-            if (tThickNess < 0.124F) return new ITexture[] { TextureFactory.of(
-                Textures.BlockIcons.INSULATION_FULL,
-                Dyes.getModulation(aColorIndex, Dyes.CABLE_INSULATION.mRGBa)) };
+            if (tThickNess < 0.124F) return TextureFactory
+                .of(Textures.BlockIcons.INSULATION_FULL, Dyes.getModulation(aColorIndex, Dyes.CABLE_INSULATION.mRGBa));
             if (tThickNess < 0.374F) // 0.375 x1
-                return new ITexture[] {
+                return TextureFactory.of(
                     TextureFactory.of(mMaterial.mIconSet.mTextures[TextureSet.INDEX_wire], mMaterial.mRGBa),
                     TextureFactory.of(
                         Textures.BlockIcons.INSULATION_TINY,
-                        Dyes.getModulation(aColorIndex, Dyes.CABLE_INSULATION.mRGBa)) };
+                        Dyes.getModulation(aColorIndex, Dyes.CABLE_INSULATION.mRGBa)));
             if (tThickNess < 0.499F) // 0.500 x2
-                return new ITexture[] {
+                return TextureFactory.of(
                     TextureFactory.of(mMaterial.mIconSet.mTextures[TextureSet.INDEX_wire], mMaterial.mRGBa),
                     TextureFactory.of(
                         Textures.BlockIcons.INSULATION_SMALL,
-                        Dyes.getModulation(aColorIndex, Dyes.CABLE_INSULATION.mRGBa)) };
+                        Dyes.getModulation(aColorIndex, Dyes.CABLE_INSULATION.mRGBa)));
             if (tThickNess < 0.624F) // 0.625 x4
-                return new ITexture[] {
+                return TextureFactory.of(
                     TextureFactory.of(mMaterial.mIconSet.mTextures[TextureSet.INDEX_wire], mMaterial.mRGBa),
                     TextureFactory.of(
                         Textures.BlockIcons.INSULATION_MEDIUM,
-                        Dyes.getModulation(aColorIndex, Dyes.CABLE_INSULATION.mRGBa)) };
+                        Dyes.getModulation(aColorIndex, Dyes.CABLE_INSULATION.mRGBa)));
             if (tThickNess < 0.749F) // 0.750 x8
-                return new ITexture[] {
+                return TextureFactory.of(
                     TextureFactory.of(mMaterial.mIconSet.mTextures[TextureSet.INDEX_wire], mMaterial.mRGBa),
                     TextureFactory.of(
                         Textures.BlockIcons.INSULATION_MEDIUM_PLUS,
-                        Dyes.getModulation(aColorIndex, Dyes.CABLE_INSULATION.mRGBa)) };
+                        Dyes.getModulation(aColorIndex, Dyes.CABLE_INSULATION.mRGBa)));
             if (tThickNess < 0.874F) // 0.825 x12
-                return new ITexture[] {
+                return TextureFactory.of(
                     TextureFactory.of(mMaterial.mIconSet.mTextures[TextureSet.INDEX_wire], mMaterial.mRGBa),
                     TextureFactory.of(
                         Textures.BlockIcons.INSULATION_LARGE,
-                        Dyes.getModulation(aColorIndex, Dyes.CABLE_INSULATION.mRGBa)) };
-            return new ITexture[] {
+                        Dyes.getModulation(aColorIndex, Dyes.CABLE_INSULATION.mRGBa)));
+            return TextureFactory.of(
                 TextureFactory.of(mMaterial.mIconSet.mTextures[TextureSet.INDEX_wire], mMaterial.mRGBa),
                 TextureFactory.of(
                     Textures.BlockIcons.INSULATION_HUGE,
-                    Dyes.getModulation(aColorIndex, Dyes.CABLE_INSULATION.mRGBa)) };
+                    Dyes.getModulation(aColorIndex, Dyes.CABLE_INSULATION.mRGBa)));
         }
-        return new ITexture[] { TextureFactory
-            .of(Textures.BlockIcons.INSULATION_FULL, Dyes.getModulation(aColorIndex, Dyes.CABLE_INSULATION.mRGBa)) };
+        return TextureFactory
+            .of(Textures.BlockIcons.INSULATION_FULL, Dyes.getModulation(aColorIndex, Dyes.CABLE_INSULATION.mRGBa));
     }
 
     @Override
@@ -498,10 +502,10 @@ public class GT_MetaPipeEntity_Cable extends MetaPipeEntity implements IMetaTile
     public AxisAlignedBB getCollisionBoundingBoxFromPool(World aWorld, int aX, int aY, int aZ) {
         if (GT_Mod.instance.isClientSide() && (GT_Client.hideValue & 0x2) != 0)
             return AxisAlignedBB.getBoundingBox(aX, aY, aZ, aX + 1, aY + 1, aZ + 1);
-        else return getActualCollisionBoundingBoxFromPool(aWorld, aX, aY, aZ);
+        else return getActualCollisionBoundingBoxFromPool(aX, aY, aZ);
     }
 
-    private AxisAlignedBB getActualCollisionBoundingBoxFromPool(World aWorld, int aX, int aY, int aZ) {
+    private AxisAlignedBB getActualCollisionBoundingBoxFromPool(int aX, int aY, int aZ) {
         float tSpace = (1f - mThickNess) / 2;
         float tSide0 = tSpace;
         float tSide1 = 1f - tSpace;
@@ -510,38 +514,40 @@ public class GT_MetaPipeEntity_Cable extends MetaPipeEntity implements IMetaTile
         float tSide4 = tSpace;
         float tSide5 = 1f - tSpace;
 
-        if (getBaseMetaTileEntity().getCoverIDAtSide((byte) 0) != 0) {
+        if (getBaseMetaTileEntity().getCoverIDAtSide(DOWN) != 0) {
             tSide0 = tSide2 = tSide4 = 0;
             tSide3 = tSide5 = 1;
         }
-        if (getBaseMetaTileEntity().getCoverIDAtSide((byte) 1) != 0) {
+        if (getBaseMetaTileEntity().getCoverIDAtSide(UP) != 0) {
             tSide2 = tSide4 = 0;
             tSide1 = tSide3 = tSide5 = 1;
         }
-        if (getBaseMetaTileEntity().getCoverIDAtSide((byte) 2) != 0) {
+        if (getBaseMetaTileEntity().getCoverIDAtSide(NORTH) != 0) {
             tSide0 = tSide2 = tSide4 = 0;
             tSide1 = tSide5 = 1;
         }
-        if (getBaseMetaTileEntity().getCoverIDAtSide((byte) 3) != 0) {
+        if (getBaseMetaTileEntity().getCoverIDAtSide(SOUTH) != 0) {
             tSide0 = tSide4 = 0;
             tSide1 = tSide3 = tSide5 = 1;
         }
-        if (getBaseMetaTileEntity().getCoverIDAtSide((byte) 4) != 0) {
+        if (getBaseMetaTileEntity().getCoverIDAtSide(WEST) != 0) {
             tSide0 = tSide2 = tSide4 = 0;
             tSide1 = tSide3 = 1;
         }
-        if (getBaseMetaTileEntity().getCoverIDAtSide((byte) 5) != 0) {
+        if (getBaseMetaTileEntity().getCoverIDAtSide(EAST) != 0) {
             tSide0 = tSide2 = 0;
             tSide1 = tSide3 = tSide5 = 1;
         }
 
         byte tConn = ((BaseMetaPipeEntity) getBaseMetaTileEntity()).mConnections;
-        if ((tConn & (1 << ForgeDirection.DOWN.ordinal())) != 0) tSide0 = 0f;
-        if ((tConn & (1 << ForgeDirection.UP.ordinal())) != 0) tSide1 = 1f;
-        if ((tConn & (1 << ForgeDirection.NORTH.ordinal())) != 0) tSide2 = 0f;
-        if ((tConn & (1 << ForgeDirection.SOUTH.ordinal())) != 0) tSide3 = 1f;
-        if ((tConn & (1 << ForgeDirection.WEST.ordinal())) != 0) tSide4 = 0f;
-        if ((tConn & (1 << ForgeDirection.EAST.ordinal())) != 0) tSide5 = 1f;
+        BaseMetaPipeEntity metaPipeEntity = (BaseMetaPipeEntity) getBaseMetaTileEntity();
+        if (metaPipeEntity.isConnectedAtSide(DOWN)) tSide0 = 0f;
+        if ((tConn & CONNECTED_DOWN) != 0) tSide0 = 0f;
+        if ((tConn & CONNECTED_UP) != 0) tSide1 = 1f;
+        if ((tConn & CONNECTED_NORTH) != 0) tSide2 = 0f;
+        if ((tConn & CONNECTED_SOUTH) != 0) tSide3 = 1f;
+        if ((tConn & CONNECTED_WEST) != 0) tSide4 = 0f;
+        if ((tConn & CONNECTED_EAST) != 0) tSide5 = 1f;
 
         return AxisAlignedBB
             .getBoundingBox(aX + tSide4, aY + tSide0, aZ + tSide2, aX + tSide5, aY + tSide1, aZ + tSide3);
@@ -552,7 +558,7 @@ public class GT_MetaPipeEntity_Cable extends MetaPipeEntity implements IMetaTile
         List<AxisAlignedBB> outputAABB, Entity collider) {
         super.addCollisionBoxesToList(aWorld, aX, aY, aZ, inputAABB, outputAABB, collider);
         if (GT_Mod.instance.isClientSide() && (GT_Client.hideValue & 0x2) != 0) {
-            final AxisAlignedBB aabb = getActualCollisionBoundingBoxFromPool(aWorld, aX, aY, aZ);
+            final AxisAlignedBB aabb = getActualCollisionBoundingBoxFromPool(aX, aY, aZ);
             if (inputAABB.intersectsWith(aabb)) outputAABB.add(aabb);
         }
     }

--- a/src/main/java/gregtech/api/multitileentity/MultiTileEntityBlock.java
+++ b/src/main/java/gregtech/api/multitileentity/MultiTileEntityBlock.java
@@ -1,9 +1,6 @@
 package gregtech.api.multitileentity;
 
 import static gregtech.api.enums.GT_Values.ALL_VALID_SIDES;
-import static gregtech.api.enums.GT_Values.OFFX;
-import static gregtech.api.enums.GT_Values.OFFY;
-import static gregtech.api.enums.GT_Values.OFFZ;
 import static gregtech.api.util.GT_Util.LAST_BROKEN_TILEENTITY;
 import static gregtech.api.util.GT_Util.getTileEntity;
 import static gregtech.api.util.GT_Util.setTileEntity;
@@ -425,7 +422,11 @@ public class MultiTileEntityBlock extends Block
 
     @Override
     public final boolean shouldSideBeRendered(IBlockAccess aWorld, int aX, int aY, int aZ, int aSide) {
-        final TileEntity aTileEntity = aWorld.getTileEntity(aX - OFFX[aSide], aY - OFFY[aSide], aZ - OFFZ[aSide]);
+        final TileEntity aTileEntity = aWorld.getTileEntity(
+            aX - ForgeDirection.VALID_DIRECTIONS[aSide].offsetX,
+            aY - ForgeDirection.VALID_DIRECTIONS[aSide].offsetY,
+            aZ - ForgeDirection.VALID_DIRECTIONS[aSide].offsetZ);
+
         return aTileEntity instanceof IMultiTileEntity
             ? ((IMultiTileEntity) aTileEntity).shouldSideBeRendered((byte) aSide)
             : super.shouldSideBeRendered(aWorld, aX, aY, aZ, aSide);

--- a/src/main/java/gregtech/api/multitileentity/MultiTileEntityItemInternal.java
+++ b/src/main/java/gregtech/api/multitileentity/MultiTileEntityItemInternal.java
@@ -19,13 +19,13 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.IFluidContainerItem;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import gregtech.api.GregTech_API;
-import gregtech.api.enums.GT_Values;
 import gregtech.api.metatileentity.CoverableTileEntity;
 import gregtech.api.multitileentity.interfaces.IItemUpdatable;
 import gregtech.api.multitileentity.interfaces.IMultiTileEntity;
@@ -93,9 +93,9 @@ public class MultiTileEntityItemInternal extends ItemBlock implements IFluidCont
             } else if (tClickedBlock != Blocks.vine && tClickedBlock != Blocks.tallgrass
                 && tClickedBlock != Blocks.deadbush
                 && !tClickedBlock.isReplaceable(aWorld, aX, aY, aZ)) {
-                    aX += GT_Values.OFFX[aSide];
-                    aY += GT_Values.OFFY[aSide];
-                    aZ += GT_Values.OFFZ[aSide];
+                    aX += ForgeDirection.VALID_DIRECTIONS[aSide].offsetX;
+                    aY += ForgeDirection.VALID_DIRECTIONS[aSide].offsetY;
+                    aZ += ForgeDirection.VALID_DIRECTIONS[aSide].offsetZ;
                 }
             final Block tReplacedBlock = aWorld.getBlock(aX, aY, aZ);
 

--- a/src/main/java/gregtech/api/multitileentity/base/MultiTileEntity.java
+++ b/src/main/java/gregtech/api/multitileentity/base/MultiTileEntity.java
@@ -2,7 +2,6 @@ package gregtech.api.multitileentity.base;
 
 import static gregtech.GT_Mod.GT_FML_LOGGER;
 import static gregtech.api.enums.GT_Values.NBT;
-import static gregtech.api.enums.GT_Values.OPOS;
 import static gregtech.api.enums.GT_Values.SIDE_WEST;
 import static gregtech.api.enums.GT_Values.VALID_SIDES;
 import static gregtech.api.enums.GT_Values.emptyIconContainerArray;
@@ -293,15 +292,15 @@ public abstract class MultiTileEntity extends CoverableTileEntity implements IMu
         if (this instanceof IMTE_IsProvidingStrongPower) for (byte tSide : GT_Values.ALL_VALID_SIDES) {
             if (getBlockAtSide(tSide).isNormalCube(
                 worldObj,
-                xCoord + GT_Values.OFFX[tSide],
-                yCoord + GT_Values.OFFY[tSide],
-                zCoord + GT_Values.OFFZ[tSide])) {
+                xCoord + ForgeDirection.VALID_DIRECTIONS[tSide].offsetX,
+                yCoord + ForgeDirection.VALID_DIRECTIONS[tSide].offsetY,
+                zCoord + ForgeDirection.VALID_DIRECTIONS[tSide].offsetZ)) {
                 worldObj.notifyBlocksOfNeighborChange(
-                    xCoord + GT_Values.OFFX[tSide],
-                    yCoord + GT_Values.OFFY[tSide],
-                    zCoord + GT_Values.OFFZ[tSide],
+                    xCoord + ForgeDirection.VALID_DIRECTIONS[tSide].offsetX,
+                    yCoord + ForgeDirection.VALID_DIRECTIONS[tSide].offsetY,
+                    zCoord + ForgeDirection.VALID_DIRECTIONS[tSide].offsetZ,
                     tBlock,
-                    OPOS[tSide]);
+                    ForgeDirection.OPPOSITES[tSide]);
             }
         }
         needsBlockUpdate = false;
@@ -312,7 +311,8 @@ public abstract class MultiTileEntity extends CoverableTileEntity implements IMu
         final TileEntity tTileEntity = getTileEntityAtSideAndDistance(aSide, 1);
         // TODO: check to an interface
         // if (getBlockAtSide(aSide) == Blocks.glass) return false;
-        return tTileEntity instanceof IMultiTileEntity ? !((IMultiTileEntity) tTileEntity).isSurfaceOpaque(OPOS[aSide])
+        return tTileEntity instanceof IMultiTileEntity
+            ? !((IMultiTileEntity) tTileEntity).isSurfaceOpaque((byte) ForgeDirection.OPPOSITES[aSide])
             : !getBlockAtSide(aSide).isOpaqueCube();
     }
 

--- a/src/main/java/gregtech/api/objects/GT_SidedTexture.java
+++ b/src/main/java/gregtech/api/objects/GT_SidedTexture.java
@@ -1,5 +1,7 @@
 package gregtech.api.objects;
 
+import java.util.Arrays;
+
 import gregtech.api.enums.Dyes;
 import gregtech.api.interfaces.IColorModulationContainer;
 import gregtech.api.interfaces.IIconContainer;
@@ -15,28 +17,33 @@ public class GT_SidedTexture extends gregtech.common.render.GT_SidedTexture
     @Deprecated
     public short[] mRGBa;
 
+    @Deprecated
     public GT_SidedTexture(IIconContainer aIcon0, IIconContainer aIcon1, IIconContainer aIcon2, IIconContainer aIcon3,
         IIconContainer aIcon4, IIconContainer aIcon5, short[] aRGBa, boolean aAllowAlpha) {
-        super(aIcon0, aIcon1, aIcon2, aIcon3, aIcon4, aIcon5, aRGBa, aAllowAlpha);
+        super(Arrays.asList(aIcon0, aIcon1, aIcon2, aIcon3, aIcon4, aIcon5), aRGBa, aAllowAlpha);
 
         // Backwards Compat
         GT_SidedTexture.this.mRGBa = aRGBa;
     }
 
+    @Deprecated
     public GT_SidedTexture(IIconContainer aIcon0, IIconContainer aIcon1, IIconContainer aIcon2, IIconContainer aIcon3,
         IIconContainer aIcon4, IIconContainer aIcon5, short[] aRGBa) {
         this(aIcon0, aIcon1, aIcon2, aIcon3, aIcon4, aIcon5, aRGBa, true);
     }
 
+    @Deprecated
     public GT_SidedTexture(IIconContainer aIcon0, IIconContainer aIcon1, IIconContainer aIcon2, IIconContainer aIcon3,
         IIconContainer aIcon4, IIconContainer aIcon5) {
         this(aIcon0, aIcon1, aIcon2, aIcon3, aIcon4, aIcon5, Dyes._NULL.mRGBa);
     }
 
+    @Deprecated
     public GT_SidedTexture(IIconContainer aBottom, IIconContainer aTop, IIconContainer aSides, short[] aRGBa) {
         this(aBottom, aTop, aSides, aSides, aSides, aSides, aRGBa);
     }
 
+    @Deprecated
     public GT_SidedTexture(IIconContainer aBottom, IIconContainer aTop, IIconContainer aSides) {
         this(aBottom, aTop, aSides, Dyes._NULL.mRGBa);
     }

--- a/src/main/java/gregtech/common/blocks/GT_Block_Machines.java
+++ b/src/main/java/gregtech/common/blocks/GT_Block_Machines.java
@@ -485,8 +485,9 @@ public class GT_Block_Machines extends GT_Generic_Block implements IDebugableBlo
             return 0;
         }
         final TileEntity tTileEntity = aWorld.getTileEntity(aX, aY, aZ);
-        if (tTileEntity instanceof IGregTechTileEntity) {
-            return ((IGregTechTileEntity) tTileEntity).getOutputRedstoneSignal(GT_Utility.getOppositeSide(aSide));
+        if (tTileEntity instanceof IGregTechTileEntity iGregTechTileEntity) {
+            return iGregTechTileEntity.getOutputRedstoneSignal(ForgeDirection.getOrientation(aSide)
+                    .getOpposite());
         }
         return 0;
     }

--- a/src/main/java/gregtech/common/render/GT_MultiTexture.java
+++ b/src/main/java/gregtech/common/render/GT_MultiTexture.java
@@ -1,9 +1,24 @@
 package gregtech.common.render;
 
+import static net.minecraftforge.common.util.ForgeDirection.DOWN;
+import static net.minecraftforge.common.util.ForgeDirection.EAST;
+import static net.minecraftforge.common.util.ForgeDirection.NORTH;
+import static net.minecraftforge.common.util.ForgeDirection.SOUTH;
+import static net.minecraftforge.common.util.ForgeDirection.UP;
+import static net.minecraftforge.common.util.ForgeDirection.WEST;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.Spliterator;
+import java.util.function.Consumer;
+
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
+import net.minecraftforge.common.util.ForgeDirection;
 
 import gregtech.GT_Mod;
+import gregtech.api.interfaces.ILayeredTexture;
 import gregtech.api.interfaces.ITexture;
 
 /**
@@ -14,56 +29,125 @@ import gregtech.api.interfaces.ITexture;
  * I should have done this much earlier...
  * </p>
  */
-public class GT_MultiTexture extends GT_TextureBase implements ITexture {
+public class GT_MultiTexture extends GT_TextureBase implements ILayeredTexture {
 
-    protected final ITexture[] mTextures;
+    protected final ArrayList<ITexture> mTextures;
+
+    protected GT_MultiTexture(ITexture... aTextures) {
+        mTextures = new ArrayList<>(Arrays.asList(aTextures));
+    }
 
     public static GT_MultiTexture get(ITexture... aTextures) {
         return GT_Mod.instance.isClientSide() ? new GT_MultiTexture(aTextures) : null;
     }
 
-    protected GT_MultiTexture(ITexture... aTextures) {
-        mTextures = aTextures;
-    }
+    // ITexture methods
 
     @Override
+    @Deprecated
     public void renderXPos(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
         for (ITexture tTexture : mTextures)
-            if (tTexture != null && tTexture.isValidTexture()) tTexture.renderXPos(aRenderer, aBlock, aX, aY, aZ);
+            if (tTexture != null && tTexture.isValidTexture()) tTexture.render(aRenderer, aBlock, aX, aY, aZ, EAST);
     }
 
     @Override
+    @Deprecated
     public void renderXNeg(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
         for (ITexture tTexture : mTextures)
-            if (tTexture != null && tTexture.isValidTexture()) tTexture.renderXNeg(aRenderer, aBlock, aX, aY, aZ);
+            if (tTexture != null && tTexture.isValidTexture()) tTexture.render(aRenderer, aBlock, aX, aY, aZ, WEST);
     }
 
     @Override
+    @Deprecated
     public void renderYPos(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
         for (ITexture tTexture : mTextures)
-            if (tTexture != null && tTexture.isValidTexture()) tTexture.renderYPos(aRenderer, aBlock, aX, aY, aZ);
+            if (tTexture != null && tTexture.isValidTexture()) tTexture.render(aRenderer, aBlock, aX, aY, aZ, UP);
     }
 
     @Override
+    @Deprecated
     public void renderYNeg(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
         for (ITexture tTexture : mTextures)
-            if (tTexture != null && tTexture.isValidTexture()) tTexture.renderYNeg(aRenderer, aBlock, aX, aY, aZ);
+            if (tTexture != null && tTexture.isValidTexture()) tTexture.render(aRenderer, aBlock, aX, aY, aZ, DOWN);
     }
 
     @Override
+    @Deprecated
     public void renderZPos(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
         for (ITexture tTexture : mTextures)
-            if (tTexture != null && tTexture.isValidTexture()) tTexture.renderZPos(aRenderer, aBlock, aX, aY, aZ);
+            if (tTexture != null && tTexture.isValidTexture()) tTexture.render(aRenderer, aBlock, aX, aY, aZ, SOUTH);
     }
 
     @Override
+    @Deprecated
     public void renderZNeg(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
         for (ITexture tTexture : mTextures)
-            if (tTexture != null && tTexture.isValidTexture()) tTexture.renderZNeg(aRenderer, aBlock, aX, aY, aZ);
+            if (tTexture != null && tTexture.isValidTexture()) tTexture.render(aRenderer, aBlock, aX, aY, aZ, NORTH);
     }
 
     @Override
     public boolean isValidTexture() {
-        return true;
+        return mTextures.stream()
+            .allMatch(ITexture::isValidTexture);
+    }
+
+    @Override
+    public void render(RenderBlocks renderer, Block block, int x, int y, int z, ForgeDirection sideDirection) {
+        for (ITexture iTexture : mTextures) {
+            if (iTexture != null && iTexture.isValidTexture()) iTexture.render(renderer, block, x, y, z, sideDirection);
+        }
+    }
+
+    // ILayeredTexture methods
+
+    @Override
+    public ILayeredTexture add(ITexture iTexture) {
+        mTextures.add(iTexture);
+        return this;
+    }
+
+    @Override
+    public ILayeredTexture add(int index, ITexture iTexture) {
+        mTextures.add(index, iTexture);
+        return this;
+    }
+
+    @Override
+    public ILayeredTexture addAll(ITexture... iTexture) {
+        mTextures.addAll(Arrays.asList(iTexture));
+        return this;
+    }
+
+    @Override
+    public ILayeredTexture addAll(int index, ITexture... iTexture) {
+        mTextures.addAll(index, Arrays.asList(iTexture));
+        return this;
+    }
+
+    @Override
+    public int size() {
+        return mTextures.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return mTextures.size() == 0;
+    }
+
+    // Iterable<ITexture> methods
+
+    @Override
+    public Iterator<ITexture> iterator() {
+        return mTextures.iterator();
+    }
+
+    @Override
+    public void forEach(Consumer<? super ITexture> action) {
+        mTextures.forEach(action);
+    }
+
+    @Override
+    public Spliterator<ITexture> spliterator() {
+        return mTextures.spliterator();
     }
 }

--- a/src/main/java/gregtech/common/render/GT_Renderer_Block.java
+++ b/src/main/java/gregtech/common/render/GT_Renderer_Block.java
@@ -135,7 +135,7 @@ public class GT_Renderer_Block implements ISimpleBlockRenderingHandler {
         final float pipeMax = blockMax - pipeMin;
         final EnumMap<ForgeDirection, Boolean> directionIsCovered = new EnumMap<>(ForgeDirection.class);
         for (ForgeDirection dir : VALID_DIRECTIONS) {
-            directionIsCovered.put(dir, aTileEntity.getCoverIDAtDirection(dir) != 0);
+            directionIsCovered.put(dir, aTileEntity.getCoverIDAtSide(dir) != 0);
         }
 
         final var coverTextureMap = aTileEntity.getTexturesMap(aBlock);
@@ -147,7 +147,7 @@ public class GT_Renderer_Block implements ISimpleBlockRenderingHandler {
                 aRenderer.setRenderBoundsFromBlock(aBlock);
                 renderCuboid(aWorld, aRenderer, aBlock, aX, aY, aZ, pipeTextureMap);
             }
-            case CONNECTED_EAST | CONNECTED_WEST -> {
+            case CONNECTED_WEST | CONNECTED_EAST -> {
                 // EAST - WEST Pipe Sides
                 aBlock.setBlockBounds(blockMin, pipeMin, pipeMin, blockMax, pipeMax, pipeMax);
                 aRenderer.setRenderBoundsFromBlock(aBlock);
@@ -633,7 +633,7 @@ public class GT_Renderer_Block implements ISimpleBlockRenderingHandler {
 
             aBlock.setBlockBounds(blockMin, pipeMin, pipeMin, blockMax, pipeMax, pipeMax);
             aRenderer.setRenderBoundsFromBlock(aBlock);
-            renderNegativeYFacing(
+            renderFace(
                 null,
                 aRenderer,
                 aBlock,
@@ -642,13 +642,13 @@ public class GT_Renderer_Block implements ISimpleBlockRenderingHandler {
                 0,
                 tMetaTileEntity.getTexture(
                     iGregTechTileEntity,
-                    (byte) DOWN.ordinal(),
+                    DOWN,
                     (byte) (CONNECTED_WEST | CONNECTED_EAST),
                     (byte) -1,
                     false,
                     false),
-                true);
-            renderPositiveYFacing(
+                true, DOWN);
+            renderFace(
                 null,
                 aRenderer,
                 aBlock,
@@ -657,13 +657,13 @@ public class GT_Renderer_Block implements ISimpleBlockRenderingHandler {
                 0,
                 tMetaTileEntity.getTexture(
                     iGregTechTileEntity,
-                    (byte) UP.ordinal(),
+                    UP,
                     (byte) (CONNECTED_WEST | CONNECTED_EAST),
                     (byte) -1,
                     false,
                     false),
-                true);
-            renderNegativeZFacing(
+                true, UP);
+            renderFace(
                 null,
                 aRenderer,
                 aBlock,
@@ -672,13 +672,13 @@ public class GT_Renderer_Block implements ISimpleBlockRenderingHandler {
                 0,
                 tMetaTileEntity.getTexture(
                     iGregTechTileEntity,
-                    (byte) NORTH.ordinal(),
+                    NORTH,
                     (byte) (CONNECTED_WEST | CONNECTED_EAST),
                     (byte) -1,
                     false,
                     false),
-                true);
-            renderPositiveZFacing(
+                true, NORTH);
+            renderFace(
                 null,
                 aRenderer,
                 aBlock,
@@ -687,13 +687,13 @@ public class GT_Renderer_Block implements ISimpleBlockRenderingHandler {
                 0,
                 tMetaTileEntity.getTexture(
                     iGregTechTileEntity,
-                    (byte) SOUTH.ordinal(),
+                        SOUTH,
                     (byte) (CONNECTED_WEST | CONNECTED_EAST),
                     (byte) -1,
                     false,
                     false),
-                true);
-            renderNegativeXFacing(
+                true, SOUTH);
+            renderFace(
                 null,
                 aRenderer,
                 aBlock,
@@ -702,13 +702,13 @@ public class GT_Renderer_Block implements ISimpleBlockRenderingHandler {
                 0,
                 tMetaTileEntity.getTexture(
                     iGregTechTileEntity,
-                    (byte) WEST.ordinal(),
+                        WEST,
                     (byte) (CONNECTED_WEST | CONNECTED_EAST),
                     (byte) -1,
                     true,
                     false),
-                true);
-            renderPositiveXFacing(
+                true,WEST);
+            renderFace(
                 null,
                 aRenderer,
                 aBlock,
@@ -717,14 +717,14 @@ public class GT_Renderer_Block implements ISimpleBlockRenderingHandler {
                 0,
                 tMetaTileEntity.getTexture(
                     iGregTechTileEntity,
-                    (byte) EAST.ordinal(),
+                        EAST,
                     (byte) (CONNECTED_WEST | CONNECTED_EAST),
                     (byte) -1,
                     true,
                     false),
-                true);
+                true,EAST);
         } else {
-            renderNegativeYFacing(
+            renderFace(
                 null,
                 aRenderer,
                 aBlock,
@@ -733,12 +733,12 @@ public class GT_Renderer_Block implements ISimpleBlockRenderingHandler {
                 0,
                 tMetaTileEntity.getTexture(
                     iGregTechTileEntity,
-                    (byte) DOWN.ordinal(),
+                        DOWN,
                     (byte) WEST.ordinal(),
                     (byte) -1,
                     true,
                     false),
-                true);
+                true, DOWN);
             renderPositiveYFacing(
                 null,
                 aRenderer,

--- a/src/main/java/gregtech/common/render/GT_SidedTexture.java
+++ b/src/main/java/gregtech/common/render/GT_SidedTexture.java
@@ -1,7 +1,18 @@
 package gregtech.common.render;
 
+import static net.minecraftforge.common.util.ForgeDirection.DOWN;
+import static net.minecraftforge.common.util.ForgeDirection.EAST;
+import static net.minecraftforge.common.util.ForgeDirection.NORTH;
+import static net.minecraftforge.common.util.ForgeDirection.SOUTH;
+import static net.minecraftforge.common.util.ForgeDirection.UP;
+import static net.minecraftforge.common.util.ForgeDirection.WEST;
+
+import java.util.EnumMap;
+import java.util.List;
+
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
+import net.minecraftforge.common.util.ForgeDirection;
 
 import gregtech.api.interfaces.IColorModulationContainer;
 import gregtech.api.interfaces.IIconContainer;
@@ -10,22 +21,90 @@ import gregtech.api.render.TextureFactory;
 
 public class GT_SidedTexture extends GT_TextureBase implements ITexture, IColorModulationContainer {
 
-    protected final ITexture[] mTextures;
+    protected final EnumMap<ForgeDirection, ITexture> directionTextures = new EnumMap<>(ForgeDirection.class);
     /**
      * DO NOT MANIPULATE THE VALUES INSIDE THIS ARRAY!!!
      * <p/>
-     * Just set this variable to another different Array instead. Otherwise some colored things will get Problems.
+     * Just set this variable to another different Array instead. Otherwise, some colored things will get Problems.
      */
     private final short[] mRGBa;
 
-    protected GT_SidedTexture(IIconContainer aIcon0, IIconContainer aIcon1, IIconContainer aIcon2,
-        IIconContainer aIcon3, IIconContainer aIcon4, IIconContainer aIcon5, short[] aRGBa, boolean aAllowAlpha) {
+    /**
+     * @deprecated use {@link #GT_SidedTexture(List, short[], boolean)} instead
+     */
+    @SuppressWarnings("ConstructorWithTooManyParameters")
+    @Deprecated
+    protected GT_SidedTexture(IIconContainer iconDown, IIconContainer iconUp, IIconContainer iconNorth,
+        IIconContainer iconSouth, IIconContainer iconWest, IIconContainer iconEast, short[] aRGBa,
+        boolean aAllowAlpha) {
         if (aRGBa.length != 4) throw new IllegalArgumentException("RGBa doesn't have 4 Values @ GT_RenderedTexture");
-        mTextures = new ITexture[] { TextureFactory.of(aIcon0, aRGBa, aAllowAlpha),
-            TextureFactory.of(aIcon1, aRGBa, aAllowAlpha), TextureFactory.of(aIcon2, aRGBa, aAllowAlpha),
-            TextureFactory.of(aIcon3, aRGBa, aAllowAlpha), TextureFactory.of(aIcon4, aRGBa, aAllowAlpha),
-            TextureFactory.of(aIcon5, aRGBa, aAllowAlpha) };
+        directionTextures.put(DOWN, TextureFactory.of(iconDown, aRGBa, aAllowAlpha));
+        directionTextures.put(UP, TextureFactory.of(iconUp, aRGBa, aAllowAlpha));
+        directionTextures.put(NORTH, TextureFactory.of(iconNorth, aRGBa, aAllowAlpha));
+        directionTextures.put(SOUTH, TextureFactory.of(iconSouth, aRGBa, aAllowAlpha));
+        directionTextures.put(WEST, TextureFactory.of(iconWest, aRGBa, aAllowAlpha));
+        directionTextures.put(EAST, TextureFactory.of(iconEast, aRGBa, aAllowAlpha));
         mRGBa = aRGBa;
+    }
+
+    protected GT_SidedTexture(List<IIconContainer> sideIcons, short[] aRGBa, boolean aAllowAlpha) {
+        if (sideIcons.size() != 6)
+            throw new IllegalArgumentException("sideIcons doesn't have 6 icons @ GT_SidedTexture");
+        if (aRGBa.length != 4) throw new IllegalArgumentException("RGBa doesn't have 4 Values @ GT_SidedTexture");
+        for (int side = 0; side < sideIcons.size(); side++) {
+            directionTextures
+                .put(ForgeDirection.VALID_DIRECTIONS[side], TextureFactory.of(sideIcons.get(side), aRGBa, aAllowAlpha));
+        }
+        mRGBa = aRGBa;
+    }
+
+    @Override
+    @Deprecated
+    public void renderXPos(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
+        directionTextures.get(EAST)
+            .render(aRenderer, aBlock, aX, aY, aZ, EAST);
+    }
+
+    @Override
+    @Deprecated
+    public void renderXNeg(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
+        directionTextures.get(WEST)
+            .render(aRenderer, aBlock, aX, aY, aZ, WEST);
+    }
+
+    @Override
+    @Deprecated
+    public void renderYPos(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
+        directionTextures.get(UP)
+            .render(aRenderer, aBlock, aX, aY, aZ, UP);
+    }
+
+    @Override
+    @Deprecated
+    public void renderYNeg(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
+        directionTextures.get(DOWN)
+            .render(aRenderer, aBlock, aX, aY, aZ, DOWN);
+    }
+
+    @Override
+    @Deprecated
+    public void renderZPos(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
+        directionTextures.get(SOUTH)
+            .render(aRenderer, aBlock, aX, aY, aZ, SOUTH);
+    }
+
+    @Override
+    @Deprecated
+    public void renderZNeg(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
+        directionTextures.get(NORTH)
+            .render(aRenderer, aBlock, aX, aY, aZ, NORTH);
+    }
+
+    @Override
+    public boolean isValidTexture() {
+        return directionTextures.values()
+            .stream()
+            .allMatch(ITexture::isValidTexture);
     }
 
     @Override
@@ -34,45 +113,13 @@ public class GT_SidedTexture extends GT_TextureBase implements ITexture, IColorM
     }
 
     @Override
-    public void renderXPos(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
-        mTextures[5].renderXPos(aRenderer, aBlock, aX, aY, aZ);
-    }
-
-    @Override
-    public void renderXNeg(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
-        mTextures[4].renderXNeg(aRenderer, aBlock, aX, aY, aZ);
-    }
-
-    @Override
-    public void renderYPos(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
-        mTextures[1].renderYPos(aRenderer, aBlock, aX, aY, aZ);
-    }
-
-    @Override
-    public void renderYNeg(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
-        mTextures[0].renderYNeg(aRenderer, aBlock, aX, aY, aZ);
-    }
-
-    @Override
-    public void renderZPos(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
-        mTextures[3].renderZPos(aRenderer, aBlock, aX, aY, aZ);
-    }
-
-    @Override
-    public void renderZNeg(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
-        mTextures[2].renderZNeg(aRenderer, aBlock, aX, aY, aZ);
+    public void render(RenderBlocks renderer, Block block, int x, int y, int z, ForgeDirection sideDirection) {
+        directionTextures.get(sideDirection)
+            .render(renderer, block, x, y, z, sideDirection);
     }
 
     @Override
     public short[] getRGBA() {
         return mRGBa;
-    }
-
-    @Override
-    public boolean isValidTexture() {
-        for (ITexture renderedTexture : mTextures) {
-            if (!renderedTexture.isValidTexture()) return false;
-        }
-        return true;
     }
 }

--- a/src/main/java/gregtech/common/render/GT_TextureBuilder.java
+++ b/src/main/java/gregtech/common/render/GT_TextureBuilder.java
@@ -11,6 +11,7 @@ import gregtech.GT_Mod;
 import gregtech.api.enums.Dyes;
 import gregtech.api.enums.GT_Values;
 import gregtech.api.interfaces.IIconContainer;
+import gregtech.api.interfaces.ILayeredTexture;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.ITextureBuilder;
 
@@ -18,7 +19,7 @@ import gregtech.api.interfaces.ITextureBuilder;
 public class GT_TextureBuilder implements ITextureBuilder {
 
     private final List<IIconContainer> iconContainerList;
-    private final List<ITexture> textureLayers;
+    private final ILayeredTexture textureLayers;
     private Block fromBlock;
     private int fromMeta;
     private ForgeDirection fromSide;
@@ -30,7 +31,7 @@ public class GT_TextureBuilder implements ITextureBuilder {
     private Boolean worldCoord = null;
 
     public GT_TextureBuilder() {
-        textureLayers = new ArrayList<>();
+        textureLayers = new GT_MultiTexture();
         iconContainerList = new ArrayList<>();
         rgba = Dyes._NULL.mRGBa;
         allowAlpha = true;
@@ -66,7 +67,7 @@ public class GT_TextureBuilder implements ITextureBuilder {
 
     @Override
     public ITextureBuilder addLayer(final ITexture... iTextures) {
-        this.textureLayers.addAll(Arrays.asList(iTextures));
+        this.textureLayers.addAll(iTextures);
         return this;
     }
 
@@ -117,18 +118,10 @@ public class GT_TextureBuilder implements ITextureBuilder {
             else return new GT_CopiedBlockTexture(fromBlock, fromSide.ordinal(), fromMeta, rgba, allowAlpha);
         }
         if (worldCoord != null) throw new IllegalStateException("worldCoord without from block");
-        if (!textureLayers.isEmpty()) return new GT_MultiTexture(textureLayers.toArray(new ITexture[0]));
+        if (!textureLayers.isEmpty()) return textureLayers;
         return switch (iconContainerList.size()) {
             case 1 -> new GT_RenderedTexture(iconContainerList.get(0), rgba, allowAlpha, glow, stdOrient, extFacing);
-            case 6 -> new GT_SidedTexture(
-                iconContainerList.get(ForgeDirection.DOWN.ordinal()),
-                iconContainerList.get(ForgeDirection.UP.ordinal()),
-                iconContainerList.get(ForgeDirection.NORTH.ordinal()),
-                iconContainerList.get(ForgeDirection.SOUTH.ordinal()),
-                iconContainerList.get(ForgeDirection.WEST.ordinal()),
-                iconContainerList.get(ForgeDirection.EAST.ordinal()),
-                rgba,
-                allowAlpha);
+            case 6 -> new GT_SidedTexture(iconContainerList, rgba, allowAlpha);
             default -> throw new IllegalStateException("Invalid sideIconContainer count");
         };
     }

--- a/src/main/java/gregtech/common/render/IRenderedBlock.java
+++ b/src/main/java/gregtech/common/render/IRenderedBlock.java
@@ -4,11 +4,14 @@ import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.IBlockAccess;
+import net.minecraftforge.common.util.ForgeDirection;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import gregtech.api.enums.Textures;
+import gregtech.api.interfaces.ILayeredTexture;
 import gregtech.api.interfaces.ITexture;
+import gregtech.api.render.TextureFactory;
 
 public interface IRenderedBlock {
 
@@ -18,6 +21,12 @@ public interface IRenderedBlock {
 
     @SideOnly(Side.CLIENT)
     ITexture[] getTexture(Block aBlock, byte aSide, boolean isActive, int aRenderPass);
+
+    @SideOnly(Side.CLIENT)
+    default ILayeredTexture getTexture(Block block, ForgeDirection sideDirection, boolean isActive, int renderPass) {
+        return (ILayeredTexture) TextureFactory
+            .of(getTexture(block, (byte) sideDirection.ordinal(), isActive, renderPass));
+    }
 
     /** gets the Amount of Render Passes for this TileEntity or similar Handler. Only gets called once per Rendering. */
     @SideOnly(Side.CLIENT)


### PR DESCRIPTION
Changes to use ForgeDirection instead of `(byte) ForgeDirection.ordinal()`

Very WIP, does not compile. Here to deal with merge conflict. 