### PR TITLE
make lightning rod more cumbersome to use

### DIFF
--- a/src/main/java/gregtech/common/tileentities/generators/GT_MetaTileEntity_LightningRod.java
+++ b/src/main/java/gregtech/common/tileentities/generators/GT_MetaTileEntity_LightningRod.java
@@ -101,8 +101,9 @@ public class GT_MetaTileEntity_LightningRod extends GT_MetaTileEntity_TieredMach
                         .increaseStoredEnergyUnits(maxEUStore() - aBaseMetaTileEntity.getStoredEU(), false);
                     aWorld.addWeatherEffect(new EntityLightningBolt(aWorld, aX, aY + aRodValue, aZ));
                     // randomly break a rod
-                    if (aWorld.isThundering())
+                    if (aWorld.isThundering()) {
                         aWorld.setBlockToAir(aX, aY + XSTR_INSTANCE.nextInt(aRodValue) + 1, aZ);
+                    }
                 }
             }
         }

--- a/src/main/java/gregtech/common/tileentities/generators/GT_MetaTileEntity_LightningRod.java
+++ b/src/main/java/gregtech/common/tileentities/generators/GT_MetaTileEntity_LightningRod.java
@@ -101,7 +101,8 @@ public class GT_MetaTileEntity_LightningRod extends GT_MetaTileEntity_TieredMach
                         .increaseStoredEnergyUnits(maxEUStore() - aBaseMetaTileEntity.getStoredEU(), false);
                     aWorld.addWeatherEffect(new EntityLightningBolt(aWorld, aX, aY + aRodValue, aZ));
                     // randomly break a rod
-                    aWorld.setBlockToAir(aX, aY + XSTR_INSTANCE.nextInt(aRodValue) + 1, aZ);
+                    if (aWorld.isThundering())
+                        aWorld.setBlockToAir(aX, aY + XSTR_INSTANCE.nextInt(aRodValue) + 1, aZ);
                 }
             }
         }

--- a/src/main/java/gregtech/common/tileentities/generators/GT_MetaTileEntity_LightningRod.java
+++ b/src/main/java/gregtech/common/tileentities/generators/GT_MetaTileEntity_LightningRod.java
@@ -100,6 +100,8 @@ public class GT_MetaTileEntity_LightningRod extends GT_MetaTileEntity_TieredMach
                     aBaseMetaTileEntity
                         .increaseStoredEnergyUnits(maxEUStore() - aBaseMetaTileEntity.getStoredEU(), false);
                     aWorld.addWeatherEffect(new EntityLightningBolt(aWorld, aX, aY + aRodValue, aZ));
+                    // randomly break a rod
+                    aWorld.setBlockToAir(aX, aY + XSTR_INSTANCE.nextInt(aRodValue) + 1, aZ);
                 }
             }
         }


### PR DESCRIPTION
with this change, one of the iron fence above the lightning rod will be broken when it is struck by a lighnting during thunder storms. replacements of rods should be trivial with piston based automation.

lore wise the iron fence are burnt due to high current flowing through it. this change makes the lightning rod 
1. less of a wind kinectics clone and more of a unique generator. 
2. less scalable as you need to build more automation around a single rod, instead of slap down a single block and build up 5~30 iron fence.
3. have a neligable running cost, instead of 0 running cost.

For the performance of this generator, see https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/5880

you can also use [this small python script](https://gist.github.com/Glease/b6b02a882a91e7e27c0b90ff6144adb1) to evaluate the performance of this generator. tweak the numbers at top to see performance for other tier. mTier=3 is HV. amp is the output amp from lightning rod. output figure does not account for any wire loss or transformer loss.