### PR TITLE
Allow SMD inductor for MV transformer

### DIFF
--- a/src/main/java/gregtech/loaders/preload/GT_Loader_MetaTileEntities.java
+++ b/src/main/java/gregtech/loaders/preload/GT_Loader_MetaTileEntities.java
@@ -882,7 +882,8 @@ public class GT_Loader_MetaTileEntities implements Runnable { // TODO CHECK CIRC
             ItemList.Transformer_HV_MV.get(1L),
             bitsd,
             new Object[] { "KBB", "CM ", "KBB", 'M', ItemList.Hull_MV, 'C', OrePrefixes.cableGt01.get(Materials.Gold),
-                'B', OrePrefixes.cableGt01.get(Materials.AnyCopper), 'K', ItemList.Circuit_Parts_Coil });
+                'B', OrePrefixes.cableGt01.get(Materials.AnyCopper), 'K',
+                OrePrefixes.componentCircuit.get(Materials.Inductor) });
         GT_ModHandler.addCraftingRecipe(
             ItemList.Transformer_EV_HV.get(1L),
             bitsd,


### PR DESCRIPTION
Allows SMD inductor for MV transformer instead of just small coil. Adresses one aspect of https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13250.