### PR TITLE
Mask direction patches

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
@@ -736,7 +736,7 @@ public class BaseMetaPipeEntity extends CommonMetaTileEntity
             this,
             sideDirection,
             tConnections,
-            (int) (mColor - 1),
+            mColor - 1,
             tConnections == 0 || (tConnections & (1 << sideDirection.ordinal())) != 0,
             getOutputRedstoneSignal(sideDirection) > 0);
         return Textures.BlockIcons.ERROR_RENDERING;

--- a/src/main/java/gregtech/api/util/GT_Utility.java
+++ b/src/main/java/gregtech/api/util/GT_Utility.java
@@ -3696,7 +3696,7 @@ public class GT_Utility {
                 if (aX > 0.75) {
                     if (aY < 0.25) return tBack;
                     if (aY > 0.75) return tBack;
-                    return WEST;
+                    return EAST;
                 }
                 if (aY < 0.25) return DOWN;
                 if (aY > 0.75) return UP;


### PR DESCRIPTION
Fix wrong wrenching direction for EAST
Fix remove useless casting
Improve migrate from a 2d array with magic numbers to EnumMaps and remove misplaced fix that is no longer needed