### PR TITLE
Adds Borax to Salt Bee

### DIFF
--- a/src/main/java/gregtech/loaders/misc/GT_BeeDefinition.java
+++ b/src/main/java/gregtech/loaders/misc/GT_BeeDefinition.java
@@ -608,6 +608,7 @@ public enum GT_BeeDefinition implements IBeeDefinition {
         beeSpecies.addProduct(GT_Bees.combs.getStackForType(CombType.SLAG), 0.30f);
         beeSpecies.addSpecialty(GT_Bees.combs.getStackForType(CombType.SALT), 0.35f);
         beeSpecies.addSpecialty(GT_Bees.combs.getStackForType(CombType.LITHIUM), 0.05f);
+        beeSpecies.addSpecialty(GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Borax, 1L), 0.1f);
         beeSpecies.setHumidity(ARID);
         beeSpecies.setTemperature(WARM);
     }, template -> AlleleHelper.instance.set(template, SPEED, Speed.SLOWER), dis -> {


### PR DESCRIPTION
Borax is a natural byproduct of salt and Salt bee is more difficult to get working than force bee (Warm/Aridvs normal/normal). Adds 1 Borax dust to Salt bee specialty with a 10% chance.