### PR TITLE
Titaniumtetrachloride Fix

### DIFF
--- a/src/main/java/gregtech/loaders/postload/recipes/ChemicalRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/ChemicalRecipes.java
@@ -716,18 +716,18 @@ public class ChemicalRecipes implements Runnable {
 
         GT_Values.RA.stdBuilder()
             .itemInputs(
-                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Rutile, 1),
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Rutile, 3),
                 GT_OreDictUnificator.get(OrePrefixes.cell, Materials.Carbon, 2))
             .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.cell, Materials.CarbonMonoxide, 2))
             .fluidInputs(Materials.Chlorine.getGas(4000))
             .fluidOutputs(Materials.Titaniumtetrachloride.getFluid(1000))
             .duration(20 * SECONDS)
             .eut(TierEU.RECIPE_HV)
-            .addTo(UniversalChemical);
+            .addTo(sChemicalRecipes);
 
         GT_Values.RA.stdBuilder()
             .itemInputs(
-                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Rutile, 1),
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Rutile, 3),
                 GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Carbon, 2))
             .noItemOutputs()
             .fluidInputs(Materials.Chlorine.getGas(4000))
@@ -735,6 +735,17 @@ public class ChemicalRecipes implements Runnable {
             .duration(20 * SECONDS)
             .eut(TierEU.RECIPE_HV)
             .addTo(sChemicalRecipes);
+
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Rutile, 3),
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Carbon, 2))
+            .noItemOutputs()
+            .fluidInputs(Materials.Chlorine.getGas(4000))
+            .fluidOutputs(Materials.CarbonMonoxide.getFluid(2000), Materials.Titaniumtetrachloride.getFluid(1000))
+            .duration(20 * SECONDS)
+            .eut(TierEU.RECIPE_HV)
+            .addTo(sMultiblockChemicalRecipes);
 
         // 4Na + 2MgCl2 = 2Mg + 4NaCl
 

--- a/src/main/java/gregtech/loaders/postload/recipes/ChemicalRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/ChemicalRecipes.java
@@ -742,7 +742,7 @@ public class ChemicalRecipes implements Runnable {
                 GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Carbon, 2))
             .noItemOutputs()
             .fluidInputs(Materials.Chlorine.getGas(4000))
-            .fluidOutputs(Materials.CarbonMonoxide.getFluid(2000), Materials.Titaniumtetrachloride.getFluid(1000))
+            .fluidOutputs(Materials.CarbonMonoxide.getGas(2000), Materials.Titaniumtetrachloride.getFluid(1000))
             .duration(20 * SECONDS)
             .eut(TierEU.RECIPE_HV)
             .addTo(sMultiblockChemicalRecipes);

--- a/src/main/java/gregtech/loaders/postload/recipes/ChemicalRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/ChemicalRecipes.java
@@ -734,7 +734,7 @@ public class ChemicalRecipes implements Runnable {
             .fluidOutputs(Materials.Titaniumtetrachloride.getFluid(1000))
             .duration(20 * SECONDS)
             .eut(TierEU.RECIPE_HV)
-            .addTo(UniversalChemical);
+            .addTo(sChemicalRecipes);
 
         // 4Na + 2MgCl2 = 2Mg + 4NaCl
 


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13334

Additionally, this also applies chem balance to the recipe by setting the rutile dusts to 3. This has the effect that the player needs to use more rutile, but this is balanced out by 1) applying chembalance in the rutile ebf recipe which improves the yield there (https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/576), 2) the new ilmenite and bauxite processes that give huge amounts of rutile, and 3) chem balance also removed the chlorine loss already earlier

![image](https://user-images.githubusercontent.com/40274384/234840803-255cf90f-325b-4711-9474-e68e94cdcd3d.png)
