### PR TITLE
Some more ra2 fixes

### DIFF
--- a/src/main/java/gregtech/api/util/GT_RecipeRegistrator.java
+++ b/src/main/java/gregtech/api/util/GT_RecipeRegistrator.java
@@ -399,7 +399,8 @@ public class GT_RecipeRegistrator {
 
         for (MaterialStack tMaterial : aData.getAllMaterialStacks()) {
             if (tMaterial.mMaterial.contains(SubTag.CRYSTAL) && !tMaterial.mMaterial.contains(SubTag.METAL)
-                && tMaterial.mMaterial != Materials.Glass) {
+                && tMaterial.mMaterial != Materials.Glass
+                && GT_OreDictUnificator.getDust(aData.mMaterial) != null) {
                 GT_Values.RA.stdBuilder()
                     .itemInputs(GT_Utility.copyAmount(1, aStack))
                     .itemOutputs(GT_OreDictUnificator.getDust(aData.mMaterial))

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingCrystallized.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingCrystallized.java
@@ -23,7 +23,8 @@ public class ProcessingCrystallized implements gregtech.api.interfaces.IOreRecip
     public void registerOre(OrePrefixes aPrefix, Materials aMaterial, String aOreDictName, String aModName,
         ItemStack aStack) {
 
-        if (GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial.mMacerateInto, 1L) != null) {
+        if (aMaterial.mMacerateInto != null
+            && GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial.mMacerateInto, 1L) != null) {
             GT_Values.RA.stdBuilder()
                 .itemInputs(GT_Utility.copyAmount(1L, aStack))
                 .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial.mMacerateInto, 1L))
@@ -32,13 +33,13 @@ public class ProcessingCrystallized implements gregtech.api.interfaces.IOreRecip
                 .duration(10 * TICKS)
                 .eut(16)
                 .addTo(sHammerRecipes);
-        }
 
-        GT_ModHandler.addPulverisationRecipe(
-            GT_Utility.copyAmount(1L, aStack),
-            GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial.mMacerateInto, 1L),
-            null,
-            10,
-            false);
+            GT_ModHandler.addPulverisationRecipe(
+                GT_Utility.copyAmount(1L, aStack),
+                GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial.mMacerateInto, 1L),
+                null,
+                10,
+                false);
+        }
     }
 }

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingCrystallized.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingCrystallized.java
@@ -23,14 +23,16 @@ public class ProcessingCrystallized implements gregtech.api.interfaces.IOreRecip
     public void registerOre(OrePrefixes aPrefix, Materials aMaterial, String aOreDictName, String aModName,
         ItemStack aStack) {
 
-        GT_Values.RA.stdBuilder()
-            .itemInputs(GT_Utility.copyAmount(1L, aStack))
-            .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial.mMacerateInto, 1L))
-            .noFluidInputs()
-            .noFluidOutputs()
-            .duration(10 * TICKS)
-            .eut(16)
-            .addTo(sHammerRecipes);
+        if (GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial.mMacerateInto, 1L) != null) {
+            GT_Values.RA.stdBuilder()
+                .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial.mMacerateInto, 1L))
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(10 * TICKS)
+                .eut(16)
+                .addTo(sHammerRecipes);
+        }
 
         GT_ModHandler.addPulverisationRecipe(
             GT_Utility.copyAmount(1L, aStack),

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingGem.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingGem.java
@@ -258,16 +258,19 @@ public class ProcessingGem implements gregtech.api.interfaces.IOreRecipeRegistra
                 for (ItemStack is : OreDictionary.getOres("craftingLens" + aMaterial.mColor.mName.replace(" ", ""))) { // Engraver
                     // Laser engraver recipes
                     {
-                        is.stackSize = 0;
 
-                        GT_Values.RA.stdBuilder()
-                            .itemInputs(GT_Utility.copyAmount(3L, aStack), is)
-                            .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.gemFlawless, aMaterial, 1L))
-                            .noFluidInputs()
-                            .noFluidOutputs()
-                            .duration(60 * SECONDS)
-                            .eut(TierEU.RECIPE_HV)
-                            .addTo(sLaserEngraverRecipes);
+                        if (GT_OreDictUnificator.get(OrePrefixes.gemFlawless, aMaterial, 1L) != null) {
+                            is.stackSize = 0;
+
+                            GT_Values.RA.stdBuilder()
+                                .itemInputs(GT_Utility.copyAmount(3L, aStack), is)
+                                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.gemFlawless, aMaterial, 1L))
+                                .noFluidInputs()
+                                .noFluidOutputs()
+                                .duration(60 * SECONDS)
+                                .eut(TierEU.RECIPE_HV)
+                                .addTo(sLaserEngraverRecipes);
+                        }
 
                     }
                 }

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingPlate.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingPlate.java
@@ -164,14 +164,16 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
 
         if (!aNoSmashing) {
             // 2 double -> 1 quadruple plate
-            GT_Values.RA.stdBuilder()
-                .itemInputs(GT_Utility.copyAmount(2L, aStack), GT_Utility.getIntegratedCircuit(2))
-                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plateQuadruple, aMaterial, 1L))
-                .noFluidInputs()
-                .noFluidOutputs()
-                .duration(Math.max(aMaterialMass * 2L, 1L))
-                .eut(calculateRecipeEU(aMaterial, 96))
-                .addTo(sBenderRecipes);
+            if (GT_OreDictUnificator.get(OrePrefixes.plateQuadruple, aMaterial, 1L) != null) {
+                GT_Values.RA.stdBuilder()
+                    .itemInputs(GT_Utility.copyAmount(2L, aStack), GT_Utility.getIntegratedCircuit(2))
+                    .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plateQuadruple, aMaterial, 1L))
+                    .noFluidInputs()
+                    .noFluidOutputs()
+                    .duration(Math.max(aMaterialMass * 2L, 1L))
+                    .eut(calculateRecipeEU(aMaterial, 96))
+                    .addTo(sBenderRecipes);
+            }
 
             if (GregTech_API.sRecipeFile.get(
                 gregtech.api.enums.ConfigCategories.Tools.hammerdoubleplate,

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingStickLong.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingStickLong.java
@@ -50,14 +50,16 @@ public class ProcessingStickLong implements gregtech.api.interfaces.IOreRecipeRe
         if (!aMaterial.contains(SubTag.NO_SMASHING)) {
             // Bender recipes
             {
-                GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack), GT_Utility.getIntegratedCircuit(1))
-                    .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.spring, aMaterial, 1L))
-                    .noFluidInputs()
-                    .noFluidOutputs()
-                    .duration(10 * SECONDS)
-                    .eut(calculateRecipeEU(aMaterial, 16))
-                    .addTo(sBenderRecipes);
+                if (GT_OreDictUnificator.get(OrePrefixes.spring, aMaterial, 1L) != null) {
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(GT_Utility.copyAmount(1L, aStack), GT_Utility.getIntegratedCircuit(1))
+                        .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.spring, aMaterial, 1L))
+                        .noFluidInputs()
+                        .noFluidOutputs()
+                        .duration(10 * SECONDS)
+                        .eut(calculateRecipeEU(aMaterial, 16))
+                        .addTo(sBenderRecipes);
+                }
             }
 
             if (aMaterial.mUnificatable && (aMaterial.mMaterialInto == aMaterial))

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingTransforming.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingTransforming.java
@@ -33,7 +33,8 @@ public class ProcessingTransforming implements IOreRecipeRegistrator {
             case "Wood" ->
             // Chemical bath recipes
             {
-                GT_Values.RA.stdBuilder()
+                if (GT_OreDictUnificator.get(aPrefix, Materials.WoodSealed, 1L) != null) {
+				GT_Values.RA.stdBuilder()
                     .itemInputs(GT_Utility.copyAmount(1L, aStack))
                     .itemOutputs(GT_OreDictUnificator.get(aPrefix, Materials.WoodSealed, 1L))
                     .fluidInputs(
@@ -64,7 +65,7 @@ public class ProcessingTransforming implements IOreRecipeRegistrator {
                     .noFluidOutputs()
                     .duration(5 * SECONDS)
                     .eut(TierEU.ULV)
-                    .addTo(sChemicalBathRecipes);
+				.addTo(sChemicalBathRecipes);}
 
             }
             case "Iron" -> {
@@ -96,7 +97,8 @@ public class ProcessingTransforming implements IOreRecipeRegistrator {
             case "WroughtIron" -> {
                 // Chemical bath recipes
                 {
-                    GT_Values.RA.stdBuilder()
+                    if (GT_OreDictUnificator.get(aPrefix, Materials.FierySteel, 1L) != null) {
+					GT_Values.RA.stdBuilder()
                         .itemInputs(GT_Utility.copyAmount(1L, aStack))
                         .itemOutputs(GT_OreDictUnificator.get(aPrefix, Materials.FierySteel, 1L))
                         .fluidInputs(
@@ -105,7 +107,7 @@ public class ProcessingTransforming implements IOreRecipeRegistrator {
                         .noFluidOutputs()
                         .duration(5 * SECONDS)
                         .eut(TierEU.ULV)
-                        .addTo(sChemicalBathRecipes);
+					.addTo(sChemicalBathRecipes);}
                 }
 
                 // Polarizer recipes
@@ -120,7 +122,8 @@ public class ProcessingTransforming implements IOreRecipeRegistrator {
             case "Steel" -> {
                 // Chemical Bath recipes
                 {
-                    GT_Values.RA.stdBuilder()
+                    if (GT_OreDictUnificator.get(aPrefix, Materials.FierySteel, 1L) != null) {
+					GT_Values.RA.stdBuilder()
                         .itemInputs(GT_Utility.copyAmount(1L, aStack))
                         .itemOutputs(GT_OreDictUnificator.get(aPrefix, Materials.FierySteel, 1L))
                         .fluidInputs(
@@ -129,7 +132,7 @@ public class ProcessingTransforming implements IOreRecipeRegistrator {
                         .noFluidOutputs()
                         .duration(5 * SECONDS)
                         .eut(TierEU.ULV)
-                        .addTo(sChemicalBathRecipes);
+					.addTo(sChemicalBathRecipes);}
                 }
 
                 // polarizer recipes

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingTransforming.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingTransforming.java
@@ -34,16 +34,17 @@ public class ProcessingTransforming implements IOreRecipeRegistrator {
             // Chemical bath recipes
             {
                 if (GT_OreDictUnificator.get(aPrefix, Materials.WoodSealed, 1L) != null) {
-				GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack))
-                    .itemOutputs(GT_OreDictUnificator.get(aPrefix, Materials.WoodSealed, 1L))
-                    .fluidInputs(
-                        Materials.SeedOil
-                            .getFluid(GT_Utility.translateMaterialToAmount(aPrefix.mMaterialAmount, 120L, true)))
-                    .noFluidOutputs()
-                    .duration(5 * SECONDS)
-                    .eut(TierEU.ULV)
-                    .addTo(sChemicalBathRecipes);}
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                        .itemOutputs(GT_OreDictUnificator.get(aPrefix, Materials.WoodSealed, 1L))
+                        .fluidInputs(
+                            Materials.SeedOil
+                                .getFluid(GT_Utility.translateMaterialToAmount(aPrefix.mMaterialAmount, 120L, true)))
+                        .noFluidOutputs()
+                        .duration(5 * SECONDS)
+                        .eut(TierEU.ULV)
+                        .addTo(sChemicalBathRecipes);
+                }
 
             }
             case "Iron" -> {
@@ -76,16 +77,17 @@ public class ProcessingTransforming implements IOreRecipeRegistrator {
                 // Chemical bath recipes
                 {
                     if (GT_OreDictUnificator.get(aPrefix, Materials.FierySteel, 1L) != null) {
-					GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(1L, aStack))
-                        .itemOutputs(GT_OreDictUnificator.get(aPrefix, Materials.FierySteel, 1L))
-                        .fluidInputs(
-                            Materials.FierySteel
-                                .getFluid(GT_Utility.translateMaterialToAmount(aPrefix.mMaterialAmount, 225L, true)))
-                        .noFluidOutputs()
-                        .duration(5 * SECONDS)
-                        .eut(TierEU.ULV)
-					.addTo(sChemicalBathRecipes);}
+                        GT_Values.RA.stdBuilder()
+                            .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                            .itemOutputs(GT_OreDictUnificator.get(aPrefix, Materials.FierySteel, 1L))
+                            .fluidInputs(
+                                Materials.FierySteel.getFluid(
+                                    GT_Utility.translateMaterialToAmount(aPrefix.mMaterialAmount, 225L, true)))
+                            .noFluidOutputs()
+                            .duration(5 * SECONDS)
+                            .eut(TierEU.ULV)
+                            .addTo(sChemicalBathRecipes);
+                    }
                 }
 
                 // Polarizer recipes
@@ -101,16 +103,17 @@ public class ProcessingTransforming implements IOreRecipeRegistrator {
                 // Chemical Bath recipes
                 {
                     if (GT_OreDictUnificator.get(aPrefix, Materials.FierySteel, 1L) != null) {
-					GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(1L, aStack))
-                        .itemOutputs(GT_OreDictUnificator.get(aPrefix, Materials.FierySteel, 1L))
-                        .fluidInputs(
-                            Materials.FierySteel
-                                .getFluid(GT_Utility.translateMaterialToAmount(aPrefix.mMaterialAmount, 200L, true)))
-                        .noFluidOutputs()
-                        .duration(5 * SECONDS)
-                        .eut(TierEU.ULV)
-					.addTo(sChemicalBathRecipes);}
+                        GT_Values.RA.stdBuilder()
+                            .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                            .itemOutputs(GT_OreDictUnificator.get(aPrefix, Materials.FierySteel, 1L))
+                            .fluidInputs(
+                                Materials.FierySteel.getFluid(
+                                    GT_Utility.translateMaterialToAmount(aPrefix.mMaterialAmount, 200L, true)))
+                            .noFluidOutputs()
+                            .duration(5 * SECONDS)
+                            .eut(TierEU.ULV)
+                            .addTo(sChemicalBathRecipes);
+                    }
                 }
 
                 // polarizer recipes

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingTransforming.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingTransforming.java
@@ -70,16 +70,18 @@ public class ProcessingTransforming implements IOreRecipeRegistrator {
             case "Iron" -> {
                 // Chemical bath recipes
                 {
-                    GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(1L, aStack))
-                        .itemOutputs(GT_OreDictUnificator.get(aPrefix, Materials.FierySteel, 1L))
-                        .fluidInputs(
-                            Materials.FierySteel
-                                .getFluid(GT_Utility.translateMaterialToAmount(aPrefix.mMaterialAmount, 250L, true)))
-                        .noFluidOutputs()
-                        .duration(5 * SECONDS)
-                        .eut(TierEU.ULV)
-                        .addTo(sChemicalBathRecipes);
+                    if (GT_OreDictUnificator.get(aPrefix, Materials.FierySteel, 1L) != null) {
+                        GT_Values.RA.stdBuilder()
+                            .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                            .itemOutputs(GT_OreDictUnificator.get(aPrefix, Materials.FierySteel, 1L))
+                            .fluidInputs(
+                                Materials.FierySteel.getFluid(
+                                    GT_Utility.translateMaterialToAmount(aPrefix.mMaterialAmount, 250L, true)))
+                            .noFluidOutputs()
+                            .duration(5 * SECONDS)
+                            .eut(TierEU.ULV)
+                            .addTo(sChemicalBathRecipes);
+                    }
                 }
 
                 // Polarizer recipes

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingTransforming.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingTransforming.java
@@ -43,29 +43,7 @@ public class ProcessingTransforming implements IOreRecipeRegistrator {
                     .noFluidOutputs()
                     .duration(5 * SECONDS)
                     .eut(TierEU.ULV)
-                    .addTo(sChemicalBathRecipes);
-
-                GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack))
-                    .itemOutputs(GT_OreDictUnificator.get(aPrefix, Materials.WoodSealed, 1L))
-                    .fluidInputs(
-                        Materials.SeedOilLin
-                            .getFluid(GT_Utility.translateMaterialToAmount(aPrefix.mMaterialAmount, 80L, true)))
-                    .noFluidOutputs()
-                    .duration(5 * SECONDS)
-                    .eut(TierEU.ULV)
-                    .addTo(sChemicalBathRecipes);
-
-                GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack))
-                    .itemOutputs(GT_OreDictUnificator.get(aPrefix, Materials.WoodSealed, 1L))
-                    .fluidInputs(
-                        Materials.SeedOilHemp
-                            .getFluid(GT_Utility.translateMaterialToAmount(aPrefix.mMaterialAmount, 80L, true)))
-                    .noFluidOutputs()
-                    .duration(5 * SECONDS)
-                    .eut(TierEU.ULV)
-				.addTo(sChemicalBathRecipes);}
+                    .addTo(sChemicalBathRecipes);}
 
             }
             case "Iron" -> {

--- a/src/main/java/gregtech/loaders/postload/recipes/BreweryRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/BreweryRecipes.java
@@ -11,7 +11,9 @@ import static net.minecraftforge.fluids.FluidRegistry.getFluidStack;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
+import net.minecraftforge.fluids.FluidStack;
 
 import gregtech.api.enums.*;
 import gregtech.api.util.GT_ModHandler;
@@ -88,25 +90,23 @@ public class BreweryRecipes implements Runnable {
 
         // water based recipe input
         {
-            String[] waterArray;
+            Fluid[] waterArray;
 
             /*
              * if IC2 isn't loaded, getDistilledWater returns the base minecraft water, so no need to do the recipe
              * loading twice.
              */
             if (IndustrialCraft2.isModLoaded()) {
-                waterArray = new String[] { FluidRegistry.WATER.getUnlocalizedName(),
-                    GT_ModHandler.getDistilledWater(1L)
-                        .getFluid()
-                        .getUnlocalizedName() };
+                waterArray = new Fluid[] { FluidRegistry.WATER, GT_ModHandler.getDistilledWater(1L)
+                    .getFluid() };
             } else {
-                waterArray = new String[] { FluidRegistry.WATER.getUnlocalizedName(), };
+                waterArray = new Fluid[] { FluidRegistry.WATER };
             }
-            for (String fluid : waterArray) {
+            for (Fluid tFluid : waterArray) {
                 GT_Values.RA.stdBuilder()
                     .itemInputs(GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Milk, 1L))
                     .noItemOutputs()
-                    .fluidInputs(getFluidStack(fluid, 750))
+                    .fluidInputs(new FluidStack(tFluid, 750))
                     .fluidOutputs(getFluidStack("milk", 750))
                     .duration(6 * SECONDS + 8 * TICKS)
                     .eut(4)
@@ -115,7 +115,7 @@ public class BreweryRecipes implements Runnable {
                 GT_Values.RA.stdBuilder()
                     .itemInputs(GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wheat, 1L))
                     .noItemOutputs()
-                    .fluidInputs(getFluidStack(fluid, 750))
+                    .fluidInputs(new FluidStack(tFluid, 750))
                     .fluidOutputs(getFluidStack("potion.wheatyjuice", 750))
                     .duration(6 * SECONDS + 8 * TICKS)
                     .eut(4)
@@ -124,7 +124,7 @@ public class BreweryRecipes implements Runnable {
                 GT_Values.RA.stdBuilder()
                     .itemInputs(GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Potassium, 1L))
                     .noItemOutputs()
-                    .fluidInputs(getFluidStack(fluid, 750))
+                    .fluidInputs(new FluidStack(tFluid, 750))
                     .fluidOutputs(getFluidStack("potion.mineralwater", 750))
                     .duration(6 * SECONDS + 8 * TICKS)
                     .eut(4)
@@ -133,7 +133,7 @@ public class BreweryRecipes implements Runnable {
                 GT_Values.RA.stdBuilder()
                     .itemInputs(GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Sodium, 1L))
                     .noItemOutputs()
-                    .fluidInputs(getFluidStack(fluid, 750))
+                    .fluidInputs(new FluidStack(tFluid, 750))
                     .fluidOutputs(getFluidStack("potion.mineralwater", 750))
                     .duration(6 * SECONDS + 8 * TICKS)
                     .eut(4)
@@ -142,7 +142,7 @@ public class BreweryRecipes implements Runnable {
                 GT_Values.RA.stdBuilder()
                     .itemInputs(GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Calcium, 1L))
                     .noItemOutputs()
-                    .fluidInputs(getFluidStack(fluid, 750))
+                    .fluidInputs(new FluidStack(tFluid, 750))
                     .fluidOutputs(getFluidStack("potion.mineralwater", 750))
                     .duration(6 * SECONDS + 8 * TICKS)
                     .eut(4)
@@ -151,7 +151,7 @@ public class BreweryRecipes implements Runnable {
                 GT_Values.RA.stdBuilder()
                     .itemInputs(GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Magnesium, 1L))
                     .noItemOutputs()
-                    .fluidInputs(getFluidStack(fluid, 750))
+                    .fluidInputs(new FluidStack(tFluid, 750))
                     .fluidOutputs(getFluidStack("potion.mineralwater", 750))
                     .duration(6 * SECONDS + 8 * TICKS)
                     .eut(4)
@@ -160,7 +160,7 @@ public class BreweryRecipes implements Runnable {
                 GT_Values.RA.stdBuilder()
                     .itemInputs(GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Glowstone, 1L))
                     .noItemOutputs()
-                    .fluidInputs(getFluidStack(fluid, 750))
+                    .fluidInputs(new FluidStack(tFluid, 750))
                     .fluidOutputs(getFluidStack("potion.thick", 750))
                     .duration(6 * SECONDS + 8 * TICKS)
                     .eut(4)
@@ -169,7 +169,7 @@ public class BreweryRecipes implements Runnable {
                 GT_Values.RA.stdBuilder()
                     .itemInputs(GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Redstone, 1L))
                     .noItemOutputs()
-                    .fluidInputs(getFluidStack(fluid, 750))
+                    .fluidInputs(new FluidStack(tFluid, 750))
                     .fluidOutputs(getFluidStack("potion.mundane", 750))
                     .duration(6 * SECONDS + 8 * TICKS)
                     .eut(4)
@@ -178,7 +178,7 @@ public class BreweryRecipes implements Runnable {
                 GT_Values.RA.stdBuilder()
                     .itemInputs(GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Sugar, 1L))
                     .noItemOutputs()
-                    .fluidInputs(getFluidStack(fluid, 750))
+                    .fluidInputs(new FluidStack(tFluid, 750))
                     .fluidOutputs(getFluidStack("potion.mundane", 750))
                     .duration(6 * SECONDS + 8 * TICKS)
                     .eut(4)
@@ -187,7 +187,7 @@ public class BreweryRecipes implements Runnable {
                 GT_Values.RA.stdBuilder()
                     .itemInputs(GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Blaze, 1L))
                     .noItemOutputs()
-                    .fluidInputs(getFluidStack(fluid, 750))
+                    .fluidInputs(new FluidStack(tFluid, 750))
                     .fluidOutputs(getFluidStack("potion.mundane", 750))
                     .duration(6 * SECONDS + 8 * TICKS)
                     .eut(4)
@@ -196,7 +196,7 @@ public class BreweryRecipes implements Runnable {
                 GT_Values.RA.stdBuilder()
                     .itemInputs(new ItemStack(Items.magma_cream, 1, 0))
                     .noItemOutputs()
-                    .fluidInputs(getFluidStack(fluid, 750))
+                    .fluidInputs(new FluidStack(tFluid, 750))
                     .fluidOutputs(getFluidStack("potion.mundane", 750))
                     .duration(6 * SECONDS + 8 * TICKS)
                     .eut(4)
@@ -205,7 +205,7 @@ public class BreweryRecipes implements Runnable {
                 GT_Values.RA.stdBuilder()
                     .itemInputs(new ItemStack(Items.fermented_spider_eye, 1, 0))
                     .noItemOutputs()
-                    .fluidInputs(getFluidStack(fluid, 750))
+                    .fluidInputs(new FluidStack(tFluid, 750))
                     .fluidOutputs(getFluidStack("potion.mundane", 750))
                     .duration(6 * SECONDS + 8 * TICKS)
                     .eut(4)
@@ -214,7 +214,7 @@ public class BreweryRecipes implements Runnable {
                 GT_Values.RA.stdBuilder()
                     .itemInputs(new ItemStack(Items.spider_eye, 1, 0))
                     .noItemOutputs()
-                    .fluidInputs(getFluidStack(fluid, 750))
+                    .fluidInputs(new FluidStack(tFluid, 750))
                     .fluidOutputs(getFluidStack("potion.mundane", 750))
                     .duration(6 * SECONDS + 8 * TICKS)
                     .eut(4)
@@ -223,7 +223,7 @@ public class BreweryRecipes implements Runnable {
                 GT_Values.RA.stdBuilder()
                     .itemInputs(new ItemStack(Items.speckled_melon, 1, 0))
                     .noItemOutputs()
-                    .fluidInputs(getFluidStack(fluid, 750))
+                    .fluidInputs(new FluidStack(tFluid, 750))
                     .fluidOutputs(getFluidStack("potion.mundane", 750))
                     .duration(6 * SECONDS + 8 * TICKS)
                     .eut(4)
@@ -232,7 +232,7 @@ public class BreweryRecipes implements Runnable {
                 GT_Values.RA.stdBuilder()
                     .itemInputs(new ItemStack(Items.ghast_tear, 1, 0))
                     .noItemOutputs()
-                    .fluidInputs(getFluidStack(fluid, 750))
+                    .fluidInputs(new FluidStack(tFluid, 750))
                     .fluidOutputs(getFluidStack("potion.mundane", 750))
                     .duration(6 * SECONDS + 8 * TICKS)
                     .eut(4)
@@ -241,7 +241,7 @@ public class BreweryRecipes implements Runnable {
                 GT_Values.RA.stdBuilder()
                     .itemInputs(new ItemStack(Items.nether_wart, 1, 0))
                     .noItemOutputs()
-                    .fluidInputs(getFluidStack(fluid, 750))
+                    .fluidInputs(new FluidStack(tFluid, 750))
                     .fluidOutputs(getFluidStack("potion.awkward", 750))
                     .duration(6 * SECONDS + 8 * TICKS)
                     .eut(4)
@@ -250,7 +250,7 @@ public class BreweryRecipes implements Runnable {
                 GT_Values.RA.stdBuilder()
                     .itemInputs(new ItemStack(Blocks.red_mushroom, 1, 0))
                     .noItemOutputs()
-                    .fluidInputs(getFluidStack(fluid, 750))
+                    .fluidInputs(new FluidStack(tFluid, 750))
                     .fluidOutputs(getFluidStack("potion.poison", 750))
                     .duration(6 * SECONDS + 8 * TICKS)
                     .eut(4)
@@ -259,7 +259,7 @@ public class BreweryRecipes implements Runnable {
                 GT_Values.RA.stdBuilder()
                     .itemInputs(new ItemStack(Items.fish, 1, 3))
                     .noItemOutputs()
-                    .fluidInputs(getFluidStack(fluid, 750))
+                    .fluidInputs(new FluidStack(tFluid, 750))
                     .fluidOutputs(getFluidStack("potion.poison.strong", 750))
                     .duration(6 * SECONDS + 8 * TICKS)
                     .eut(4)
@@ -269,7 +269,7 @@ public class BreweryRecipes implements Runnable {
                 GT_Values.RA.stdBuilder()
                     .itemInputs(ItemList.IC2_Grin_Powder.get(1L))
                     .noItemOutputs()
-                    .fluidInputs(getFluidStack(fluid, 750))
+                    .fluidInputs(new FluidStack(tFluid, 750))
                     .fluidOutputs(getFluidStack("potion.poison.strong", 750))
                     .duration(6 * SECONDS + 8 * TICKS)
                     .eut(4)
@@ -278,7 +278,7 @@ public class BreweryRecipes implements Runnable {
                 GT_Values.RA.stdBuilder()
                     .itemInputs(new ItemStack(Items.reeds, 1, 0))
                     .noItemOutputs()
-                    .fluidInputs(getFluidStack(fluid, 750))
+                    .fluidInputs(new FluidStack(tFluid, 750))
                     .fluidOutputs(getFluidStack("potion.reedwater", 750))
                     .duration(6 * SECONDS + 8 * TICKS)
                     .eut(4)
@@ -287,7 +287,7 @@ public class BreweryRecipes implements Runnable {
                 GT_Values.RA.stdBuilder()
                     .itemInputs(new ItemStack(Items.apple, 1, 0))
                     .noItemOutputs()
-                    .fluidInputs(getFluidStack(fluid, 750))
+                    .fluidInputs(new FluidStack(tFluid, 750))
                     .fluidOutputs(getFluidStack("potion.applejuice", 750))
                     .duration(6 * SECONDS + 8 * TICKS)
                     .eut(4)
@@ -296,7 +296,7 @@ public class BreweryRecipes implements Runnable {
                 GT_Values.RA.stdBuilder()
                     .itemInputs(new ItemStack(Items.golden_apple, 1, 0))
                     .noItemOutputs()
-                    .fluidInputs(getFluidStack(fluid, 750))
+                    .fluidInputs(new FluidStack(tFluid, 750))
                     .fluidOutputs(getFluidStack("potion.goldenapplejuice", 750))
                     .duration(6 * SECONDS + 8 * TICKS)
                     .eut(4)
@@ -306,7 +306,7 @@ public class BreweryRecipes implements Runnable {
                 GT_Values.RA.stdBuilder()
                     .itemInputs(new ItemStack(Items.golden_apple, 1, 1))
                     .noItemOutputs()
-                    .fluidInputs(getFluidStack(fluid, 750))
+                    .fluidInputs(new FluidStack(tFluid, 750))
                     .fluidOutputs(getFluidStack("potion.idunsapplejuice", 750))
                     .duration(6 * SECONDS + 8 * TICKS)
                     .eut(4)
@@ -316,7 +316,7 @@ public class BreweryRecipes implements Runnable {
                 GT_Values.RA.stdBuilder()
                     .itemInputs(ItemList.IC2_Hops.get(1L))
                     .noItemOutputs()
-                    .fluidInputs(getFluidStack(fluid, 750))
+                    .fluidInputs(new FluidStack(tFluid, 750))
                     .fluidOutputs(getFluidStack("potion.hopsjuice", 750))
                     .duration(6 * SECONDS + 8 * TICKS)
                     .eut(4)
@@ -325,7 +325,7 @@ public class BreweryRecipes implements Runnable {
                 GT_Values.RA.stdBuilder()
                     .itemInputs(GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Coffee, 1L))
                     .noItemOutputs()
-                    .fluidInputs(getFluidStack(fluid, 750))
+                    .fluidInputs(new FluidStack(tFluid, 750))
                     .fluidOutputs(getFluidStack("potion.darkcoffee", 750))
                     .duration(6 * SECONDS + 8 * TICKS)
                     .eut(4)
@@ -334,7 +334,7 @@ public class BreweryRecipes implements Runnable {
                 GT_Values.RA.stdBuilder()
                     .itemInputs(GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Chili, 1L))
                     .noItemOutputs()
-                    .fluidInputs(getFluidStack(fluid, 750))
+                    .fluidInputs(new FluidStack(tFluid, 750))
                     .fluidOutputs(getFluidStack("potion.chillysauce", 750))
                     .duration(6 * SECONDS + 8 * TICKS)
                     .eut(4)
@@ -520,7 +520,7 @@ public class BreweryRecipes implements Runnable {
             GT_Values.RA.stdBuilder()
                 .itemInputs(getModItem(Forestry.ID, "fertilizerBio", 4L, 0))
                 .noItemOutputs()
-                .fluidInputs(getFluidStack(FluidRegistry.WATER.getUnlocalizedName(), 750))
+                .fluidInputs(GT_ModHandler.getWater(750L))
                 .fluidOutputs(getFluidStack("biomass", 750))
                 .duration(6 * SECONDS + 8 * TICKS)
                 .eut(4)
@@ -529,12 +529,7 @@ public class BreweryRecipes implements Runnable {
             GT_Values.RA.stdBuilder()
                 .itemInputs(getModItem(Forestry.ID, "mulch", 16L, 0))
                 .noItemOutputs()
-                .fluidInputs(
-                    getFluidStack(
-                        GT_ModHandler.getDistilledWater(750L)
-                            .getFluid()
-                            .getUnlocalizedName(),
-                        750))
+                .fluidInputs(GT_ModHandler.getDistilledWater(750L))
                 .fluidOutputs(getFluidStack("biomass", 750))
                 .duration(6 * SECONDS + 8 * TICKS)
                 .eut(4)
@@ -600,24 +595,28 @@ public class BreweryRecipes implements Runnable {
             .addTo(sBrewingRecipes);
 
         // strong
-        GT_Values.RA.stdBuilder()
-            .itemInputs(aItem)
-            .noItemOutputs()
-            .fluidInputs(getFluidStack("potion.thick", 750))
-            .fluidOutputs(getFluidStack("potion." + aName + ".strong", 750))
-            .duration(6 * SECONDS + 8 * TICKS)
-            .eut(4)
-            .addTo(sBrewingRecipes);
+        if (aName == "regen" || aName == "speed" || aName == "health" || aName == "strength" || aName == "poison") {
+            GT_Values.RA.stdBuilder()
+                .itemInputs(aItem)
+                .noItemOutputs()
+                .fluidInputs(getFluidStack("potion.thick", 750))
+                .fluidOutputs(getFluidStack("potion." + aName + ".strong", 750))
+                .duration(6 * SECONDS + 8 * TICKS)
+                .eut(4)
+                .addTo(sBrewingRecipes);
+        }
 
         // long
-        GT_Values.RA.stdBuilder()
-            .itemInputs(GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Redstone, 1L))
-            .noItemOutputs()
-            .fluidInputs(getFluidStack("potion." + aName, 750))
-            .fluidOutputs(getFluidStack("potion." + aName + ".long", 750))
-            .duration(6 * SECONDS + 8 * TICKS)
-            .eut(4)
-            .addTo(sBrewingRecipes);
+        if (aName != "health") {
+            GT_Values.RA.stdBuilder()
+                .itemInputs(GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Redstone, 1L))
+                .noItemOutputs()
+                .fluidInputs(getFluidStack("potion." + aName, 750))
+                .fluidOutputs(getFluidStack("potion." + aName + ".long", 750))
+                .duration(6 * SECONDS + 8 * TICKS)
+                .eut(4)
+                .addTo(sBrewingRecipes);
+        }
 
         MixerRecipes.addMixerPotionRecipes(aName);
     }

--- a/src/main/java/gregtech/loaders/postload/recipes/ChemicalRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/ChemicalRecipes.java
@@ -2679,7 +2679,7 @@ public class ChemicalRecipes implements Runnable {
             .itemInputs(
                 GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Tin, 1),
                 GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Saltpeter, 1))
-            .itemOutputs(getModItem(Railcraft.ID, "tile.railcraft.glass", 6))
+            .itemOutputs(getModItem(Railcraft.ID, "glass", 6))
             .fluidInputs(Materials.Glass.getMolten(864))
             .noFluidOutputs()
             .duration(2 * SECONDS + 10 * TICKS)


### PR DESCRIPTION
more ra2 fixes:
- fixed: literally the entire brewing recipe file was reverted by mistake. reverted the revert to refix all the water and distilled water being broken and missing. As well as all the potions creating nulls because they dont exist.
- fixed missing quadruple plates creating nulls
- fixed missing springs creating nulls
- fixed wrong item name of railcraft glass creating broken chem recipe
- fixed missing flawless gems creating nulls in laser engraver
- fixed many broken recipes from missing fiery variants creating nulls
- fixed many broken recipes from missing seed oil types creating nulls
- fixed many broken recipes from missing sealed wood items creating nulls
- fixed reverse macerating creating nulls if there is no small dust