### PR TITLE
Adds 1 manual slot to Stocking Input Bus for lenses/molds

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_InputBus_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_InputBus_ME.java
@@ -78,7 +78,7 @@ public class GT_MetaTileEntity_Hatch_InputBus_ME extends GT_MetaTileEntity_Hatch
             aName,
             aNameRegional,
             1,
-            SLOT_COUNT * 2 + 1,
+            SLOT_COUNT * 2 + 2,
             new String[] { "Advanced item input for Multiblocks", "Retrieves directly from ME",
                 "Keeps 16 item types in stock",
                 "Auto-Pull from ME mode will automatically stock the first 16 items in the ME system, updated every 5 seconds.",
@@ -90,7 +90,7 @@ public class GT_MetaTileEntity_Hatch_InputBus_ME extends GT_MetaTileEntity_Hatch
 
     public GT_MetaTileEntity_Hatch_InputBus_ME(String aName, int aTier, String[] aDescription,
         ITexture[][][] aTextures) {
-        super(aName, aTier, SLOT_COUNT * 2 + 1, aDescription, aTextures);
+        super(aName, aTier, SLOT_COUNT * 2 + 2, aDescription, aTextures);
         disableSort = true;
     }
 
@@ -239,7 +239,10 @@ public class GT_MetaTileEntity_Hatch_InputBus_ME extends GT_MetaTileEntity_Hatch
     }
 
     @Override
-    public void updateSlots() {}
+    public void updateSlots() {
+        if (mInventory[getManualSlot()] != null && mInventory[getManualSlot()].stackSize <= 0)
+            mInventory[getManualSlot()] = null;
+    }
 
     @Override
     public boolean onRightclick(IGregTechTileEntity aBaseMetaTileEntity, EntityPlayer aPlayer, ForgeDirection side,
@@ -295,6 +298,10 @@ public class GT_MetaTileEntity_Hatch_InputBus_ME extends GT_MetaTileEntity_Hatch
         aPlayer.addChatMessage(new ChatComponentText("Saved Config to Data Stick"));
     }
 
+    private int getManualSlot() {
+        return SLOT_COUNT * 2 + 1;
+    }
+
     @Override
     public int getCircuitSlot() {
         return SLOT_COUNT * 2;
@@ -307,12 +314,12 @@ public class GT_MetaTileEntity_Hatch_InputBus_ME extends GT_MetaTileEntity_Hatch
 
     @Override
     public int getCircuitSlotY() {
-        return 63;
+        return 64;
     }
 
     @Override
     public boolean setStackToZeroInsteadOfNull(int aIndex) {
-        return true;
+        return aIndex != getManualSlot();
     }
 
     @Override
@@ -323,6 +330,7 @@ public class GT_MetaTileEntity_Hatch_InputBus_ME extends GT_MetaTileEntity_Hatch
             // Display slots
             return null;
         if (aIndex == getCircuitSlot()) return mInventory[aIndex];
+        if (aIndex == getManualSlot()) return mInventory[aIndex];
         if (GregTech_API.mAE2 && mInventory[aIndex] != null) {
             AENetworkProxy proxy = getProxy();
             if (proxy == null) {
@@ -508,7 +516,7 @@ public class GT_MetaTileEntity_Hatch_InputBus_ME extends GT_MetaTileEntity_Hatch
                     .setPos(97, 9))
             .widget(
                 new DrawableWidget().setDrawable(GT_UITextures.PICTURE_ARROW_DOUBLE)
-                    .setPos(82, 40)
+                    .setPos(82, 30)
                     .setSize(12, 12))
             .widget(new ButtonWidget().setOnClick((clickData, widget) -> {
                 if (clickData.mouseButton == 0) {
@@ -532,7 +540,14 @@ public class GT_MetaTileEntity_Hatch_InputBus_ME extends GT_MetaTileEntity_Hatch
                         "Right-Click to edit minimum stack size for item pulling."))
                 .setSize(16, 16)
                 .setPos(80, 10))
-            .widget(new FakeSyncWidget.BooleanSyncer(() -> autoPullItemList, this::setAutoPullItemList));
+            .widget(new FakeSyncWidget.BooleanSyncer(() -> autoPullItemList, this::setAutoPullItemList))
+            .widget(
+                SlotGroup.ofItemHandler(inventoryHandler, 1)
+                    .startFromSlot(getManualSlot())
+                    .endAtSlot(getManualSlot())
+                    .background(getGUITextureSet().getItemSlot())
+                    .build()
+                    .setPos(79, 45));
     }
 
     protected ModularWindow createStackSizeConfigurationWindow(final EntityPlayer player) {

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_InputBus_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_InputBus_ME.java
@@ -329,8 +329,7 @@ public class GT_MetaTileEntity_Hatch_InputBus_ME extends GT_MetaTileEntity_Hatch
         if (aIndex >= SLOT_COUNT && aIndex < SLOT_COUNT * 2)
             // Display slots
             return null;
-        if (aIndex == getCircuitSlot()) return mInventory[aIndex];
-        if (aIndex == getManualSlot()) return mInventory[aIndex];
+        if (aIndex == getCircuitSlot() || aIndex == getManualSlot()) return mInventory[aIndex];
         if (GregTech_API.mAE2 && mInventory[aIndex] != null) {
             AENetworkProxy proxy = getProxy();
             if (proxy == null) {
@@ -463,7 +462,7 @@ public class GT_MetaTileEntity_Hatch_InputBus_ME extends GT_MetaTileEntity_Hatch
 
     @Override
     public boolean isValidSlot(int aIndex) {
-        return false;
+        return aIndex == getManualSlot();
     }
 
     @Override

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_InputBus_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_InputBus_ME.java
@@ -542,11 +542,7 @@ public class GT_MetaTileEntity_Hatch_InputBus_ME extends GT_MetaTileEntity_Hatch
                 .setPos(80, 10))
             .widget(new FakeSyncWidget.BooleanSyncer(() -> autoPullItemList, this::setAutoPullItemList))
             .widget(
-                SlotGroup.ofItemHandler(inventoryHandler, 1)
-                    .startFromSlot(getManualSlot())
-                    .endAtSlot(getManualSlot())
-                    .background(getGUITextureSet().getItemSlot())
-                    .build()
+                new SlotWidget(inventoryHandler, getManualSlot()).setBackground(getGUITextureSet().getItemSlot())
                     .setPos(79, 45));
     }
 


### PR DESCRIPTION
While Stocking Input Busses got auto-pull, allowing them to be used as input for some auto crafting machines, they don't really work for extruders or laser engravers. 

These GT++ multi's don't allow sharing input busses. Therefore there is no way to set a mold or lens for a recipe when using a stocking input bus in auto-pull mode. 

To rectify this, I added a single normal (non-automatable) slot intended to be used for lenses and extruder molds. 

![Capture](https://user-images.githubusercontent.com/109012629/235831176-b0d80bf3-d63f-4e24-a133-324b7eff407e.PNG)
