### PR TITLE
Adjust new ore lines (bauxite, ruby, etc)

### DIFF
--- a/src/main/java/gregtech/loaders/postload/chains/GT_BauxiteRefineChain.java
+++ b/src/main/java/gregtech/loaders/postload/chains/GT_BauxiteRefineChain.java
@@ -74,7 +74,7 @@ public class GT_BauxiteRefineChain {
                 Materials.Quicklime.getDust(1),
                 Materials.SiliconDioxide.getDust(1),
                 Materials.Iron.getDust(1))
-            .outputChances(8000, 6000, 2000, 9000, 8000)
+            .outputChances(8000, 3000, 2000, 9000, 8000)
             .noFluidInputs()
             .noFluidOutputs()
             .duration(2 * SECONDS)
@@ -109,7 +109,7 @@ public class GT_BauxiteRefineChain {
                 Materials.Tantalum.getDust(1),
                 Materials.Manganese.getDust(1),
                 Materials.Magnesium.getDust(1))
-            .outputChances(8000, 1000, 2000, 5000, 6000)
+            .outputChances(8000, 500, 2000, 5000, 6000)
             .noFluidInputs()
             .noFluidOutputs()
             .duration(2 * SECONDS)
@@ -194,7 +194,7 @@ public class GT_BauxiteRefineChain {
                 GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Iron, 1),
                 GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Vanadium, 1),
                 GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Magnesium, 1))
-            .outputChances(10000, 10000, 2000, 2000, 2000)
+            .outputChances(10000, 5000, 2000, 2000, 2000)
             .fluidInputs(MaterialsOreAlum.RubyJuice.getFluid(1000))
             .fluidOutputs(Materials.HydrochloricAcid.getFluid(1000))
             .duration(2 * SECONDS + 5 * TICKS)

--- a/src/main/java/gregtech/loaders/postload/chains/GT_BauxiteRefineChain.java
+++ b/src/main/java/gregtech/loaders/postload/chains/GT_BauxiteRefineChain.java
@@ -161,10 +161,10 @@ public class GT_BauxiteRefineChain {
             .itemInputs(GT_Utility.getIntegratedCircuit(1))
             .itemOutputs(
                 Materials.Aluminiumhydroxide.getDust(3),
-                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Iron, 1),
-                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Vanadium, 1),
-                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Magnesium, 1))
-            .outputChances(10000, 2000, 2000, 2000)
+                Materials.Iron.getDust(1),
+                Materials.Vanadium.getDust(1),
+                Materials.Magnesium.getDust(1))
+            .outputChances(10000, 300, 200, 200)
             .fluidInputs(MaterialsOreAlum.SapphireJuice.getFluid(1000))
             .fluidOutputs(Materials.HydrochloricAcid.getFluid(1000))
             .duration(2 * SECONDS + 5 * TICKS)
@@ -175,11 +175,11 @@ public class GT_BauxiteRefineChain {
             .itemInputs(GT_Utility.getIntegratedCircuit(1))
             .itemOutputs(
                 Materials.Aluminiumhydroxide.getDust(3),
-                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Iron, 1),
-                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Vanadium, 1),
-                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Manganese, 1),
-                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Beryllium, 1))
-            .outputChances(10000, 2000, 2000, 2000, 2000)
+                Materials.Iron.getDust(1),
+                Materials.Vanadium.getDust(1),
+                Materials.Manganese.getDust(1),
+                Materials.Beryllium.getDust(1))
+            .outputChances(10000, 300, 200, 200, 200)
             .fluidInputs(MaterialsOreAlum.GreenSapphireJuice.getFluid(1000))
             .fluidOutputs(Materials.HydrochloricAcid.getFluid(1000))
             .duration(2 * SECONDS + 5 * TICKS)
@@ -190,11 +190,11 @@ public class GT_BauxiteRefineChain {
             .itemInputs(GT_Utility.getIntegratedCircuit(1))
             .itemOutputs(
                 Materials.Aluminiumhydroxide.getDust(3),
-                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Chrome, 1),
-                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Iron, 1),
-                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Vanadium, 1),
-                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Magnesium, 1))
-            .outputChances(10000, 5000, 2000, 2000, 2000)
+                Materials.Chrome.getDust(1),
+                Materials.Iron.getDust(1),
+                Materials.Vanadium.getDust(1),
+                Materials.Magnesium.getDust(1))
+            .outputChances(10000, 5000, 300, 200, 200)
             .fluidInputs(MaterialsOreAlum.RubyJuice.getFluid(1000))
             .fluidOutputs(Materials.HydrochloricAcid.getFluid(1000))
             .duration(2 * SECONDS + 5 * TICKS)
@@ -206,11 +206,11 @@ public class GT_BauxiteRefineChain {
             .itemOutputs(
                 Materials.Aluminiumoxide.getDust(1),
                 Materials.Magnesia.getDust(1),
-                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Silver, 1),
-                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Iron, 1),
-                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Calcite, 1),
-                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Vanadium, 1))
-            .outputChances(5000, 4000, 2000, 2000, 2000, 2000)
+                Materials.Silver.getDust(1),
+                Materials.Iron.getDust(1),
+                Materials.Calcite.getDust(1),
+                Materials.Vanadium.getDust(1))
+            .outputChances(5000, 4000, 300, 300, 300, 200)
             .fluidInputs(Materials.NitricAcid.getFluid(10))
             .fluidOutputs(MaterialsOreAlum.SluiceJuice.getFluid(10))
             .duration(2 * SECONDS + 5 * TICKS)
@@ -222,11 +222,11 @@ public class GT_BauxiteRefineChain {
             .itemOutputs(
                 Materials.Aluminiumoxide.getDust(1),
                 Materials.Iron.getDust(1),
-                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Gold, 1),
-                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Chrome, 1),
-                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Calcite, 1),
-                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Vanadium, 1))
-            .outputChances(5000, 4000, 2000, 2000, 2000, 2000)
+                Materials.Gold.getDust(1),
+                Materials.Calcite.getDust(1),
+                Materials.Chrome.getDust(1),
+                Materials.Vanadium.getDust(1))
+            .outputChances(5000, 4000, 300, 300, 200, 200)
             .fluidInputs(Materials.NitricAcid.getFluid(10))
             .fluidOutputs(MaterialsOreAlum.SluiceJuice.getFluid(10))
             .duration(2 * SECONDS + 5 * TICKS)
@@ -238,11 +238,11 @@ public class GT_BauxiteRefineChain {
             .itemOutputs(
                 Materials.Aluminiumoxide.getDust(1),
                 Materials.Pyrolusite.getDust(1),
-                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Tantalum, 1),
-                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Iron, 1),
-                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Calcite, 1),
-                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Magnesium, 1))
-            .outputChances(5000, 4000, 2000, 2000, 2000, 2000)
+                Materials.Iron.getDust(1),
+                Materials.Calcite.getDust(1),
+                Materials.Magnesium.getDust(1),
+                Materials.Tantalum.getDust(1))
+            .outputChances(5000, 4000, 300, 300, 300, 200)
             .fluidInputs(Materials.NitricAcid.getFluid(10))
             .fluidOutputs(MaterialsOreAlum.SluiceJuice.getFluid(10))
             .duration(2 * SECONDS + 5 * TICKS)
@@ -254,11 +254,11 @@ public class GT_BauxiteRefineChain {
             .itemOutputs(
                 Materials.Quicklime.getDust(1),
                 Materials.Iron.getDust(1),
-                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Rutile, 1),
-                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Gold, 1),
-                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Aluminiumoxide, 1),
-                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Vanadium, 1))
-            .outputChances(5000, 4000, 2000, 2000, 2000, 2000)
+                Materials.Aluminiumoxide.getDust(1),
+                Materials.Gold.getDust(1),
+                Materials.Vanadium.getDust(1),
+                Materials.Rutile.getDust(1))
+            .outputChances(5000, 4000, 300, 300, 200, 200)
             .fluidInputs(Materials.NitricAcid.getFluid(10))
             .fluidOutputs(MaterialsOreAlum.SluiceJuice.getFluid(10))
             .duration(2 * SECONDS + 5 * TICKS)
@@ -270,27 +270,11 @@ public class GT_BauxiteRefineChain {
             .itemOutputs(
                 Materials.Quicklime.getDust(1),
                 Materials.Chrome.getDust(1),
-                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Silver, 1),
-                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Iron, 1),
-                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Aluminiumoxide, 1),
-                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Manganese, 1))
-            .outputChances(5000, 1000, 2000, 2000, 2000, 2000)
-            .fluidInputs(Materials.NitricAcid.getFluid(10))
-            .fluidOutputs(MaterialsOreAlum.SluiceJuice.getFluid(10))
-            .duration(2 * SECONDS + 5 * TICKS)
-            .eut(TierEU.RECIPE_MV)
-            .addTo(sCentrifugeRecipes);
-
-        GT_Values.RA.stdBuilder()
-            .itemInputs(Materials.Uvarovite.getDust(1))
-            .itemOutputs(
-                Materials.Quicklime.getDust(1),
-                Materials.Chrome.getDust(1),
-                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Silver, 1),
-                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Iron, 1),
-                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Aluminiumoxide, 1),
-                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Manganese, 1))
-            .outputChances(5000, 1000, 2000, 2000, 2000, 2000)
+                Materials.Iron.getDust(1),
+                Materials.Silver.getDust(1),
+                Materials.Aluminiumoxide.getDust(1),
+                Materials.Manganese.getDust(1))
+            .outputChances(5000, 1000, 300, 300, 200, 200)
             .fluidInputs(Materials.NitricAcid.getFluid(10))
             .fluidOutputs(MaterialsOreAlum.SluiceJuice.getFluid(10))
             .duration(2 * SECONDS + 5 * TICKS)
@@ -302,11 +286,11 @@ public class GT_BauxiteRefineChain {
             .itemOutputs(
                 Materials.Quicklime.getDust(1),
                 Materials.Aluminiumoxide.getDust(1),
-                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Gold, 1),
-                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Iron, 1),
-                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Calcite, 1),
-                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Vanadium, 1))
-            .outputChances(5000, 4000, 2000, 2000, 2000, 2000)
+                Materials.Iron.getDust(1),
+                Materials.Gold.getDust(1),
+                Materials.Calcite.getDust(1),
+                Materials.Vanadium.getDust(1))
+            .outputChances(5000, 4000, 300, 300, 300, 200)
             .fluidInputs(Materials.NitricAcid.getFluid(10))
             .fluidOutputs(MaterialsOreAlum.SluiceJuice.getFluid(10))
             .duration(2 * SECONDS + 5 * TICKS)


### PR DESCRIPTION
- Balanced output of scarce materials
- Replaced tiny dusts by full (based on averages as they are done in large quantity, not for single dust).
- Removed a duplicate recipe (caused by RA2).

The balance adjustment has dev consensus (see https://discord.com/channels/181078474394566657/939305179524792340/1101155043421458543).

Specifics for the balancing changes:

bauxite ore -> gallium dust ratio:
wihtout line: 1 ore -> 0.2 gallium dust (until recently the only option)
with line: 1 ore -> 0.6 gallium dust
new with line: 1 ore -> 0.3 gallium dust

ruby ore -> chrome dust ratio:
without line in MV: 1 ore -> 0.6555 gallium dust (until recently the only option in MV)
without line in HV: 1 ore -> 0.8555 gallium dust (with HV macerator)
with line in MV: 1 ore -> 2 gallium dust
new with line in MV: 1 ore -> 1 gallium dust

ilmenite ore -> niobium dust ratio:
without line: 1 ore -> 0 niobium dust
with line: 1 ore -> 0.12 niobium dust
new with line: 1 ore -> 0.06 niobium dust

Rutile output of the first and third line is also very high, but this is left the same in light of the chem balance adjustments there, see https://github.com/GTNewHorizons/GT5-Unofficial/pull/1927 and https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/576.
