### PR TITLE
Integrate BW material replacements (WIP)

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicMachine_GT_Recipe.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicMachine_GT_Recipe.java
@@ -397,7 +397,7 @@ public class GT_MetaTileEntity_BasicMachine_GT_Recipe extends GT_MetaTileEntity_
                         case 3    -> OrePrefixes.rotor.get(Materials.Steel);
                         case 4    -> OrePrefixes.rotor.get(Materials.StainlessSteel);
                         case 5    -> OrePrefixes.rotor.get(Materials.TungstenSteel);
-                        case 6    -> OrePrefixes.rotor.get(Materials.Chrome);
+                        case 6    -> OrePrefixes.rotor.get(BartWorks.isModLoaded() ? Materials.get("Rhodium-PlatedPalladium") : Materials.Chrome);
                         case 7    -> OrePrefixes.rotor.get(Materials.Iridium);
                         default   -> OrePrefixes.rotor.get(Materials.Osmium);
                     };

--- a/src/main/java/gregtech/loaders/postload/GT_CraftingRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/postload/GT_CraftingRecipeLoader.java
@@ -35,14 +35,17 @@ public class GT_CraftingRecipeLoader implements Runnable {
 
     private static final String aTextIron1 = "X X";
     private static final String aTextIron2 = "XXX";
+    private static final String aTextPlate = "PPP";
+    private static final String aTextPlateWrench = "PwP";
+    private static final String aTextCableHull = "CMC";
     private static final long bits_no_remove_buffered = GT_ModHandler.RecipeBits.NOT_REMOVABLE
         | GT_ModHandler.RecipeBits.BUFFERED;
     private static final long bits = GT_ModHandler.RecipeBits.NOT_REMOVABLE | GT_ModHandler.RecipeBits.REVERSIBLE
         | GT_ModHandler.RecipeBits.BUFFERED;
-    private static final String aTextPlateWrench = "PwP";
 
     @Override
     public void run() {
+
         GT_Log.out.println("GT_Mod: Adding nerfed Vanilla Recipes.");
         GT_ModHandler.addCraftingRecipe(
             new ItemStack(Items.bucket, 1),

--- a/src/main/java/gregtech/loaders/postload/recipes/AssemblerRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/AssemblerRecipes.java
@@ -36,6 +36,9 @@ public class AssemblerRecipes implements Runnable {
         this.loadOutputHatchesRecipes();
         this.withIC2NuclearControl();
 
+        Materials LuVMat = BartWorks.isModLoaded() ? Materials.get("Ruridit") : Materials.Osmiridium;
+        Materials LuVMat2 = BartWorks.isModLoaded() ? Materials.get("Rhodium-PlatedPalladium") : Materials.Chrome;
+
         GT_Values.RA.stdBuilder()
             .itemInputs(
                 GT_OreDictUnificator.get(OrePrefixes.frameGt, Materials.BlackSteel, 1),
@@ -1580,7 +1583,6 @@ public class AssemblerRecipes implements Runnable {
             .eut(TierEU.RECIPE_IV)
             .addTo(sAssemblerRecipes);
 
-        Materials LuVMat = BartWorks.isModLoaded() ? Materials.get("Ruridit") : Materials.Osmiridium;
         GT_Values.RA.stdBuilder()
             .itemInputs(
                 GT_OreDictUnificator.get(OrePrefixes.stick, Materials.SamariumMagnetic, 1),
@@ -2090,9 +2092,7 @@ public class AssemblerRecipes implements Runnable {
             .addTo(sAssemblerRecipes);
 
         GT_Values.RA.stdBuilder()
-            .itemInputs(
-                GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Chrome, 8),
-                GT_Utility.getIntegratedCircuit(8))
+            .itemInputs(GT_OreDictUnificator.get(OrePrefixes.plate, LuVMat2, 8), GT_Utility.getIntegratedCircuit(8))
             .itemOutputs(ItemList.Casing_LuV.get(1))
             .noFluidInputs()
             .noFluidOutputs()

--- a/src/main/java/gregtech/loaders/preload/GT_Loader_MetaTileEntities.java
+++ b/src/main/java/gregtech/loaders/preload/GT_Loader_MetaTileEntities.java
@@ -250,6 +250,11 @@ public class GT_Loader_MetaTileEntities implements Runnable { // TODO CHECK CIRC
     private static final long bitsd = GT_ModHandler.RecipeBits.DISMANTLEABLE | bits;
 
     private static void run1() {
+
+        Materials LuVMat2 = Materials.get("Rhodium-PlatedPalladium") == Materials._NULL
+            || Materials.get("Rhodium-PlatedPalladium") == null ? Materials.Chrome
+                : Materials.get("Rhodium-PlatedPalladium");
+
         GT_ModHandler.addCraftingRecipe(
             ItemList.Casing_Pipe_Polytetrafluoroethylene.get(1L),
             bits,
@@ -293,7 +298,7 @@ public class GT_Loader_MetaTileEntities implements Runnable { // TODO CHECK CIRC
         GT_ModHandler.addCraftingRecipe(
             ItemList.Casing_LuV.get(1L),
             bits,
-            new Object[] { aTextPlate, aTextPlateWrench, aTextPlate, 'P', OrePrefixes.plate.get(Materials.Chrome) });
+            new Object[] { aTextPlate, aTextPlateWrench, aTextPlate, 'P', OrePrefixes.plate.get(LuVMat2) });
         GT_ModHandler.addCraftingRecipe(
             ItemList.Casing_ZPM.get(1L),
             bits,
@@ -658,7 +663,7 @@ public class GT_Loader_MetaTileEntities implements Runnable { // TODO CHECK CIRC
             ItemList.Hull_LuV.get(1L),
             GT_ModHandler.RecipeBits.REVERSIBLE,
             new Object[] { aTextCableHull, 'M', ItemList.Casing_LuV, 'C',
-                OrePrefixes.cableGt01.get(Materials.VanadiumGallium), 'H', OrePrefixes.plate.get(Materials.Chrome), 'P',
+                OrePrefixes.cableGt01.get(Materials.VanadiumGallium), 'H', OrePrefixes.plate.get(LuVMat2), 'P',
                 OrePrefixes.plate.get(Materials.Polytetrafluoroethylene) });
         GT_ModHandler.addCraftingRecipe(
             ItemList.Hull_ZPM.get(1L),
@@ -731,8 +736,8 @@ public class GT_Loader_MetaTileEntities implements Runnable { // TODO CHECK CIRC
                 ItemList.Hull_LuV.get(1L),
                 GT_ModHandler.RecipeBits.NOT_REMOVABLE | GT_ModHandler.RecipeBits.BUFFERED,
                 new Object[] { "PHP", aTextCableHull, 'M', ItemList.Casing_LuV, 'C',
-                    OrePrefixes.cableGt01.get(Materials.VanadiumGallium), 'H', OrePrefixes.plate.get(Materials.Chrome),
-                    'P', OrePrefixes.plate.get(Materials.Polytetrafluoroethylene) });
+                    OrePrefixes.cableGt01.get(Materials.VanadiumGallium), 'H', OrePrefixes.plate.get(LuVMat2), 'P',
+                    OrePrefixes.plate.get(Materials.Polytetrafluoroethylene) });
             GT_ModHandler.addCraftingRecipe(
                 ItemList.Hull_ZPM.get(1L),
                 GT_ModHandler.RecipeBits.NOT_REMOVABLE | GT_ModHandler.RecipeBits.BUFFERED,


### PR DESCRIPTION
Directly change chrome to rhodium palladium if BW exists.

This is currently not working. Please help if you know how.
The recipes for the LuV machine hull and casing are in preload and rhodium palladium doesnt exist there. Just moving the 2-3 recipes to postload breaks the recycling pretty badly (including all LuV machines).