### PR TITLE
Show energy flow amperage and correct voltage tier in WAILA for machine blocks

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicBatteryBuffer.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicBatteryBuffer.java
@@ -348,14 +348,16 @@ public class GT_MetaTileEntity_BasicBatteryBuffer extends GT_MetaTileEntity_Tier
         long avgOut = tag.getLong("AvgOut");
         currenttip.add(
             StatCollector.translateToLocalFormatted(
-                "GT5U.waila.energy.avg_in",
+                "GT5U.waila.energy.avg_in_with_amperage",
                 GT_Utility.formatNumbers(avgIn),
-                GT_Utility.getColoredTierNameFromVoltage(avgIn)));
+                GT_Utility.getAmperageForTier(avgIn, (byte) getInputTier()),
+                GT_Utility.getColoredTierNameFromTier((byte) getInputTier())));
         currenttip.add(
             StatCollector.translateToLocalFormatted(
-                "GT5U.waila.energy.avg_out",
+                "GT5U.waila.energy.avg_out_with_amperage",
                 GT_Utility.formatNumbers(avgOut),
-                GT_Utility.getColoredTierNameFromVoltage(avgOut)));
+                GT_Utility.getAmperageForTier(avgOut, (byte) getOutputTier()),
+                GT_Utility.getColoredTierNameFromTier((byte) getOutputTier())));
         super.getWailaBody(itemStack, currenttip, accessor, config);
     }
 

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicMachine.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicMachine.java
@@ -1222,18 +1222,36 @@ public abstract class GT_MetaTileEntity_BasicMachine extends GT_MetaTileEntity_B
             boolean isActive = tag.getBoolean("isActiveSingleBlock");
             if (isActive) {
                 int mEUt = tag.getInteger("eut");
-                if (mEUt > 0) {
-                    currenttip.add(
-                        StatCollector.translateToLocalFormatted(
-                            "GT5U.waila.energy.use",
-                            GT_Utility.formatNumbers(mEUt),
-                            GT_Utility.getColoredTierNameFromVoltage(mEUt)));
-                } else if (mEUt < 0) {
-                    currenttip.add(
-                        StatCollector.translateToLocalFormatted(
-                            "GT5U.waila.energy.produce",
-                            GT_Utility.formatNumbers(-mEUt),
-                            GT_Utility.getColoredTierNameFromVoltage(-mEUt)));
+                if (!isSteampowered()) {
+                    if (mEUt > 0) {
+                        currenttip.add(
+                            StatCollector.translateToLocalFormatted(
+                                "GT5U.waila.energy.use_with_amperage",
+                                GT_Utility.formatNumbers(mEUt),
+                                GT_Utility.getAmperageForTier(mEUt, (byte) getInputTier()),
+                                GT_Utility.getColoredTierNameFromTier((byte) getInputTier())));
+                    } else if (mEUt < 0) {
+                        currenttip.add(
+                            StatCollector.translateToLocalFormatted(
+                                "GT5U.waila.energy.produce_with_amperage",
+                                GT_Utility.formatNumbers(-mEUt),
+                                GT_Utility.getAmperageForTier(-mEUt, (byte) getOutputTier()),
+                                GT_Utility.getColoredTierNameFromTier((byte) getOutputTier())));
+                    }
+                } else {
+                    if (mEUt > 0) {
+                        currenttip.add(
+                            StatCollector.translateToLocalFormatted(
+                                "GT5U.waila.energy.use",
+                                GT_Utility.formatNumbers(mEUt),
+                                GT_Utility.getColoredTierNameFromVoltage(mEUt)));
+                    } else if (mEUt < 0) {
+                        currenttip.add(
+                            StatCollector.translateToLocalFormatted(
+                                "GT5U.waila.energy.produce",
+                                GT_Utility.formatNumbers(-mEUt),
+                                GT_Utility.getColoredTierNameFromVoltage(-mEUt)));
+                    }
                 }
             }
             currenttip.add(

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
@@ -799,6 +799,20 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
         return rVoltage;
     }
 
+    public long getInputVoltageTier() {
+        long rTier = 0;
+        if (mEnergyHatches.size() > 0) {
+            rTier = mEnergyHatches.get(0)
+                .getInputTier();
+            for (int i = 1; i < mEnergyHatches.size(); i++) {
+                if (mEnergyHatches.get(i)
+                    .getInputTier() != rTier) return 0;
+            }
+        }
+
+        return rTier;
+    }
+
     /**
      * Calcualtes the overclockedness using long integers
      *
@@ -1391,19 +1405,38 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
 
         boolean isActive = tag.getBoolean("isActive");
         if (isActive) {
+            long energyTier = tag.getLong("energyTier");
             long actualEnergyUsage = tag.getLong("energyUsage");
-            if (actualEnergyUsage > 0) {
-                currentTip.add(
-                    StatCollector.translateToLocalFormatted(
-                        "GT5U.waila.energy.use",
-                        GT_Utility.formatNumbers(actualEnergyUsage),
-                        GT_Utility.getColoredTierNameFromVoltage(actualEnergyUsage)));
-            } else if (actualEnergyUsage < 0) {
-                currentTip.add(
-                    StatCollector.translateToLocalFormatted(
-                        "GT5U.waila.energy.produce",
-                        GT_Utility.formatNumbers(-actualEnergyUsage),
-                        GT_Utility.getColoredTierNameFromVoltage(-actualEnergyUsage)));
+            if (energyTier > 0) {
+                if (actualEnergyUsage > 0) {
+                    currentTip.add(
+                        StatCollector.translateToLocalFormatted(
+                            "GT5U.waila.energy.use_with_amperage",
+                            GT_Utility.formatNumbers(actualEnergyUsage),
+                            GT_Utility.getAmperageForTier(actualEnergyUsage, (byte) energyTier),
+                            GT_Utility.getColoredTierNameFromTier((byte) energyTier)));
+                } else if (actualEnergyUsage < 0) {
+                    currentTip.add(
+                        StatCollector.translateToLocalFormatted(
+                            "GT5U.waila.energy.produce_with_amperage",
+                            GT_Utility.formatNumbers(-actualEnergyUsage),
+                            GT_Utility.getAmperageForTier(-actualEnergyUsage, (byte) energyTier),
+                            GT_Utility.getColoredTierNameFromTier((byte) energyTier)));
+                }
+            } else {
+                if (actualEnergyUsage > 0) {
+                    currentTip.add(
+                        StatCollector.translateToLocalFormatted(
+                            "GT5U.waila.energy.use",
+                            GT_Utility.formatNumbers(actualEnergyUsage),
+                            GT_Utility.getColoredTierNameFromVoltage(actualEnergyUsage)));
+                } else if (actualEnergyUsage < 0) {
+                    currentTip.add(
+                        StatCollector.translateToLocalFormatted(
+                            "GT5U.waila.energy.produce",
+                            GT_Utility.formatNumbers(-actualEnergyUsage),
+                            GT_Utility.getColoredTierNameFromVoltage(-actualEnergyUsage)));
+                }
             }
         }
         currentTip.add(
@@ -1429,6 +1462,7 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
             if (tileEntity.isActive()) {
                 if (mEUt < 0) tag.setLong("energyUsage", getActualEnergyUsage());
                 else tag.setLong("energyUsage", (long) -mEUt * mEfficiency / 10000);
+                tag.setLong("energyTier", getInputVoltageTier());
             }
         }
     }

--- a/src/main/java/gregtech/api/multitileentity/multiblock/base/PowerController.java
+++ b/src/main/java/gregtech/api/multitileentity/multiblock/base/PowerController.java
@@ -59,6 +59,7 @@ public abstract class PowerController<T extends PowerController<T>> extends Cont
         tag.setBoolean("isActive", isActive());
         if (isActive()) {
             tag.setLong("energyUsage", eut);
+            tag.setLong("energyTier", tier);
         }
     }
 
@@ -69,19 +70,22 @@ public abstract class PowerController<T extends PowerController<T>> extends Cont
         final NBTTagCompound tag = accessor.getNBTData();
         boolean isActive = tag.getBoolean("isActive");
         if (isActive) {
+            long energyTier = tag.getLong("energyTier");
             long actualEnergyUsage = tag.getLong("energyUsage");
             if (actualEnergyUsage > 0) {
                 currentTip.add(
                     StatCollector.translateToLocalFormatted(
-                        "GT5U.waila.energy.use",
+                        "GT5U.waila.energy.use_with_amperage",
                         GT_Utility.formatNumbers(actualEnergyUsage),
-                        GT_Utility.getColoredTierNameFromVoltage(actualEnergyUsage)));
+                        GT_Utility.getAmperageForTier(actualEnergyUsage, (byte) energyTier),
+                        GT_Utility.getColoredTierNameFromTier((byte) energyTier)));
             } else if (actualEnergyUsage < 0) {
                 currentTip.add(
                     StatCollector.translateToLocalFormatted(
-                        "GT5U.waila.energy.produce",
+                        "GT5U.waila.energy.produce_with_amperage",
                         GT_Utility.formatNumbers(-actualEnergyUsage),
-                        GT_Utility.getColoredTierNameFromVoltage(-actualEnergyUsage)));
+                        GT_Utility.getAmperageForTier(-actualEnergyUsage, (byte) energyTier),
+                        GT_Utility.getColoredTierNameFromTier((byte) energyTier)));
             }
         }
     }

--- a/src/main/java/gregtech/api/util/GT_Utility.java
+++ b/src/main/java/gregtech/api/util/GT_Utility.java
@@ -465,6 +465,10 @@ public class GT_Utility {
         return (byte) (V.length - 1);
     }
 
+    public static long getAmperageForTier(long voltage, byte tier) {
+        return ceilDiv(voltage, GT_Values.V[tier]);
+    }
+
     public static String getColoredTierNameFromVoltage(long voltage) {
         return getColoredTierNameFromTier(getTier(voltage));
     }

--- a/src/main/resources/assets/gregtech/lang/en_US.lang
+++ b/src/main/resources/assets/gregtech/lang/en_US.lang
@@ -333,10 +333,12 @@ nei.options.tools.dump.gt5u.mode.1=Used
 GT5U.waila.cover=Cover (%s): %s
 GT5U.waila.cover.current_facing=Current Facing
 GT5U.waila.energy.stored=Stored: §a%s§r EU / §e%s§r EU
-GT5U.waila.energy.avg_in=Average Input: §a%s§r EU/t (%s)
-GT5U.waila.energy.avg_out=Average Output: §c%s§r EU/t (%s)
+GT5U.waila.energy.avg_in_with_amperage=Average Input: §a%s§r EU/t (%sA %s)
+GT5U.waila.energy.avg_out_with_amperage=Average Output: §c%s§r EU/t (%sA %s)
 GT5U.waila.energy.use=Probably uses: §e%s§r EU/t (%s)
+GT5U.waila.energy.use_with_amperage=Probably uses: §e%s§r EU/t (%sA %s)
 GT5U.waila.energy.produce=Probably generates: §a%s§r EU/t (%s)
+GT5U.waila.energy.produce_with_amperage=Probably generates: §a%s§r EU/t (%sA %s)
 
 achievement.flintpick=First Tools
 achievement.flintpick.desc=Craft a flint pick


### PR DESCRIPTION
Previously, WAILA just showed voltage tier based on total energy flow. This was problematic for machines that accept multiple amps such as the Arc Furnace. Even though it can accept up to 3A of input, increasing the total input voltage by one tier, it obviously cannot accept that voltage from a single source. Should hopefully reduce confusion.

Should apply to singles, multis, and MuTEs.

Suggested by @chill-was-taken

![2023-05-05_21 44 33](https://user-images.githubusercontent.com/1928113/236622447-8a0b2ba3-5f8b-4e7c-8071-ffef3e386409.png)
