### PR TITLE
Adjust rutile amounts from bauxite and ilmenite

### DIFF
--- a/src/main/java/gregtech/loaders/postload/chains/GT_BauxiteRefineChain.java
+++ b/src/main/java/gregtech/loaders/postload/chains/GT_BauxiteRefineChain.java
@@ -74,7 +74,7 @@ public class GT_BauxiteRefineChain {
                 Materials.Quicklime.getDust(1),
                 Materials.SiliconDioxide.getDust(1),
                 Materials.Iron.getDust(1))
-            .outputChances(8000, 3000, 2000, 9000, 8000)
+            .outputChances(10000, 3000, 2000, 9000, 8000)
             .noFluidInputs()
             .noFluidOutputs()
             .duration(2 * SECONDS)
@@ -83,8 +83,8 @@ public class GT_BauxiteRefineChain {
 
         GT_Values.RA.stdBuilder()
             .itemInputs(GT_OreDictUnificator.get(OrePrefixes.crushedPurified, Materials.Ilmenite, 1))
-            .itemOutputs(Materials.Rutile.getDust(1), MaterialsOreAlum.IlmeniteSlag.getDust(1))
-            .outputChances(8500, 3000)
+            .itemOutputs(Materials.Rutile.getDust(2), MaterialsOreAlum.IlmeniteSlag.getDust(1))
+            .outputChances(10000, 3000)
             .fluidInputs(Materials.SulfuricAcid.getFluid(1000))
             .fluidOutputs(new FluidStack(ItemList.sGreenVitriol, 2000))
             .duration(21 * SECONDS)
@@ -93,8 +93,8 @@ public class GT_BauxiteRefineChain {
 
         GT_Values.RA.stdBuilder()
             .itemInputs(GT_OreDictUnificator.get(OrePrefixes.crushed, Materials.Ilmenite, 1))
-            .itemOutputs(Materials.Rutile.getDust(1), MaterialsOreAlum.IlmeniteSlag.getDust(1))
-            .outputChances(8500, 6000)
+            .itemOutputs(Materials.Rutile.getDust(2), MaterialsOreAlum.IlmeniteSlag.getDust(1))
+            .outputChances(10000, 6000)
             .fluidInputs(Materials.SulfuricAcid.getFluid(1000))
             .fluidOutputs(new FluidStack(ItemList.sGreenVitriol, 2000))
             .duration(21 * SECONDS)


### PR DESCRIPTION
There have been multiple changes to the amount of titanium the player gets from bauxite and ilmenite. Specifically, the new lines (https://github.com/GTNewHorizons/GT5-Unofficial/pull/1210) and the chem balance (https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/576/commits, https://github.com/GTNewHorizons/GT5-Unofficial/pull/1927, and earlier ones making the chemicals lossless)

So I decided to do some maths and adjust numbers to make sure the player isn't off worse than before all these changes. In particular for ilmenite this is important as it always used to be the main source of titanium for EV/IV:

Old ratio for titanium from ilmenite ore: 1 : 2x(0.1 + 0.1111 + 4/9) = 1.31
current: 1 : 2x0.85/3=0.57
new with this PR: 1 : 2x2/3=1.33

(current and new also has the option of 1 : 2x(0.1 + 0.1111 + 3/5)/3 = 0.54 before the EV chem bath)

Old ratio for titanium from bauxite ore: 1 : 2x(0.1111+2/39) = 0.32
current: 1 : 2x(1/4x2x0.8)/3=0.27
new with this PR: 1 :  2x(1/4x2)/3=0.33

(calculation done without chem bathing the crushed ore as the players. that of course boosts the output in all cases.)
