### PR TITLE
Fix MuTE structure check and power intake

### DIFF
--- a/src/main/java/gregtech/api/multitileentity/multiblock/base/Controller.java
+++ b/src/main/java/gregtech/api/multitileentity/multiblock/base/Controller.java
@@ -401,6 +401,8 @@ public abstract class Controller<T extends Controller<T>> extends MultiTileBasic
 
         // Only trigger an update if forced (from onPostTick, generally), or if the structure has changed
         if ((structureChanged || aForceReset)) {
+            functionalCasings.clear();
+            upgradeCasings.clear();
             structureOkay = checkMachine();
         }
         structureChanged = false;
@@ -413,8 +415,6 @@ public abstract class Controller<T extends Controller<T>> extends MultiTileBasic
     }
 
     public final boolean checkPiece(String piece, Vec3Impl offset) {
-        functionalCasings.clear();
-        upgradeCasings.clear();
         return checkPiece(piece, offset.get0(), offset.get1(), offset.get2());
     }
 

--- a/src/main/java/gregtech/api/multitileentity/multiblock/base/MultiBlockPart.java
+++ b/src/main/java/gregtech/api/multitileentity/multiblock/base/MultiBlockPart.java
@@ -531,7 +531,7 @@ public abstract class MultiBlockPart extends NonTickableMultiTileEntity
 
     @Override
     public PowerLogic getPowerLogic(ForgeDirection side) {
-        if (facing == side) {
+        if (facing != side) {
             return null;
         }
 


### PR DESCRIPTION
- Stackable controllers call checkPiece for each stack, this cleared the functional casings each time. That's now fixed.
- Side check for power casings was wrong. It would take power from any side but the correct one.