### PR TITLE
Fix sodium fluid corrupting fluid registry

### DIFF
--- a/src/main/java/gregtech/loaders/preload/GT_Loader_Item_Block_And_Fluid.java
+++ b/src/main/java/gregtech/loaders/preload/GT_Loader_Item_Block_And_Fluid.java
@@ -1245,15 +1245,6 @@ public class GT_Loader_Item_Block_And_Fluid implements Runnable {
                     Materials.FierySteel.getFluid(250L),
                     ItemList.TF_Vial_FieryBlood.get(1L),
                     ItemList.Bottle_Empty.get(1L)));
-
-            GT_FluidFactory.builder("liquid_sodium")
-                .withLocalizedName("Liquid Sodium")
-                .withStateAndTemperature(LIQUID, 495)
-                .buildAndRegister()
-                .configureMaterials(Materials.Sodium)
-                .registerBContainers(
-                    GT_OreDictUnificator.get(OrePrefixes.cell, Materials.Sodium, 1L),
-                    ItemList.Cell_Empty.get(1L));
         }
 
         FluidContainerRegistry.registerFluidContainer(
@@ -1915,7 +1906,10 @@ public class GT_Loader_Item_Block_And_Fluid implements Runnable {
             .withLocalizedName("Liquid Sodium")
             .withStateAndTemperature(LIQUID, 495)
             .buildAndRegister()
-            .configureMaterials(Materials.Sodium);
+            .configureMaterials(Materials.Sodium)
+            .registerBContainers(
+                GT_OreDictUnificator.get(OrePrefixes.cell, Materials.Sodium, 1L),
+                ItemList.Cell_Empty.get(1L));
 
         FluidContainerRegistry.registerFluidContainer(
             new FluidContainerRegistry.FluidContainerData(


### PR DESCRIPTION
Fix sodium fluid corrupting fluid registry in 11 May nightly.

2 fixes actually:

- removed old code that I found in a unrelated if condition that was never or not always active (added in https://github.com/GTNewHorizons/GT5-Unofficial/pull/1322). dream tried to add liquid sodium to GT before it seems!
- register the fluid cells with the fluid