### PR TITLE
More ReverseArcSmelting fixes

### DIFF
--- a/src/main/java/gregtech/api/util/GT_RecipeRegistrator.java
+++ b/src/main/java/gregtech/api/util/GT_RecipeRegistrator.java
@@ -323,7 +323,7 @@ public class GT_RecipeRegistrator {
             if (GT_OreDictUnificator.getIngotOrDust(aData.mMaterial) != null) {
                 outputs.add(GT_OreDictUnificator.getIngotOrDust(aData.mMaterial));
             }
-            for (int i = 0; i < 9; i++) {
+            for (int i = 0; i < 8; i++) {
                 if (GT_OreDictUnificator.getIngotOrDust(aData.getByProduct(i)) != null) {
                     outputs.add(GT_OreDictUnificator.getIngotOrDust(aData.getByProduct(i)));
                 }

--- a/src/main/java/gregtech/api/util/GT_RecipeRegistrator.java
+++ b/src/main/java/gregtech/api/util/GT_RecipeRegistrator.java
@@ -319,27 +319,29 @@ public class GT_RecipeRegistrator {
             }
             recipeBuilder.addTo(UniversalArcFurnace);
         } else {
-            GT_RecipeBuilder recipeBuilder = GT_Values.RA.stdBuilder();
-
-            recipeBuilder.itemInputs(aStack)
-                .itemOutputs(
-                    GT_OreDictUnificator.getIngotOrDust(aData.mMaterial),
-                    GT_OreDictUnificator.getIngotOrDust(aData.getByProduct(0)),
-                    GT_OreDictUnificator.getIngotOrDust(aData.getByProduct(1)),
-                    GT_OreDictUnificator.getIngotOrDust(aData.getByProduct(2)),
-                    GT_OreDictUnificator.getIngotOrDust(aData.getByProduct(3)),
-                    GT_OreDictUnificator.getIngotOrDust(aData.getByProduct(5)),
-                    GT_OreDictUnificator.getIngotOrDust(aData.getByProduct(6)),
-                    GT_OreDictUnificator.getIngotOrDust(aData.getByProduct(7)),
-                    GT_OreDictUnificator.getIngotOrDust(aData.getByProduct(8)))
-                .fluidInputs(Materials.Oxygen.getGas((int) Math.max(16, tAmount / M)))
-                .noFluidOutputs()
-                .duration(((int) Math.max(16, tAmount / M)) * TICKS)
-                .eut(90);
-            if (tHide) {
-                recipeBuilder.hidden();
+            ArrayList<ItemStack> outputs = new ArrayList<ItemStack>();
+            if (GT_OreDictUnificator.getIngotOrDust(aData.mMaterial) != null) {
+                outputs.add(GT_OreDictUnificator.getIngotOrDust(aData.mMaterial));
             }
-            recipeBuilder.addTo(UniversalArcFurnace);
+            for (int i = 0; i < 9; i++) {
+                if (GT_OreDictUnificator.getIngotOrDust(aData.getByProduct(i)) != null) {
+                    outputs.add(GT_OreDictUnificator.getIngotOrDust(aData.getByProduct(i)));
+                }
+            }
+            if (outputs.size() != 0) {
+                ItemStack[] outputsArray = outputs.toArray(new ItemStack[outputs.size()]);
+                GT_RecipeBuilder recipeBuilder = GT_Values.RA.stdBuilder();
+                recipeBuilder.itemInputs(aStack)
+                    .itemOutputs(outputsArray)
+                    .fluidInputs(Materials.Oxygen.getGas((int) Math.max(16, tAmount / M)))
+                    .noFluidOutputs()
+                    .duration(((int) Math.max(16, tAmount / M)) * TICKS)
+                    .eut(90);
+                if (tHide) {
+                    recipeBuilder.hidden();
+                }
+                recipeBuilder.addTo(UniversalArcFurnace);
+            }
         }
     }
 


### PR DESCRIPTION
- removes a few hundred recipes that only have null outputs (like arc furnacing a charcoal screw)
- removes null outputs in all the other reversearcsmelting recipes, thus also removing 11000 debug errors about nulls
- reduces maximum number of outputs in recycling recipes from 10 to 9. I am pretty sure 9 was what Colen intended but he set it to 1 (main)+9 (byproducts) =10. one example was the Universal Chemical Fuel Engine.