### PR TITLE
Next round of Ra2 conversions 

### DIFF
--- a/src/main/java/gregtech/common/items/GT_MetaGenerated_Item_02.java
+++ b/src/main/java/gregtech/common/items/GT_MetaGenerated_Item_02.java
@@ -464,7 +464,6 @@ public class GT_MetaGenerated_Item_02 extends GT_MetaGenerated_Item_X32 {
                 tLastID = 106,
                 "Leninade",
                 "Let the Communism flow through you!",
-                SubTag.INVISIBLE,
                 new GT_FoodStat(
                     2,
                     0.2F,

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingCrop.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingCrop.java
@@ -1,9 +1,16 @@
 package gregtech.loaders.oreprocessing;
 
+import static gregtech.api.enums.Mods.IndustrialCraft2;
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sBrewingRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCompressorRecipes;
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sMaceratorRecipes;
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sSlicerRecipes;
 import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
+import static gregtech.api.util.GT_RecipeBuilder.TICKS;
 
+import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
+import net.minecraftforge.fluids.FluidStack;
 
 import gregtech.api.enums.GT_Values;
 import gregtech.api.enums.ItemList;
@@ -33,87 +40,140 @@ public class ProcessingCrop implements gregtech.api.interfaces.IOreRecipeRegistr
                 .addTo(sCompressorRecipes);
         }
 
+        Fluid[] waterArray;
+
+        if (IndustrialCraft2.isModLoaded()) {
+            waterArray = new Fluid[] { FluidRegistry.WATER, GT_ModHandler.getDistilledWater(1L)
+                .getFluid() };
+        } else {
+            waterArray = new Fluid[] { FluidRegistry.WATER };
+        }
+
         switch (aOreDictName) {
             case "cropTea" -> {
-                GT_Values.RA.addBrewingRecipe(aStack, FluidRegistry.WATER, FluidRegistry.getFluid("potion.tea"), false);
-                GT_Values.RA.addBrewingRecipe(
-                    aStack,
-                    GT_ModHandler.getDistilledWater(1L)
-                        .getFluid(),
-                    FluidRegistry.getFluid("potion.tea"),
-                    false);
+                for (Fluid tFluid : waterArray) {
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(aStack)
+                        .noItemOutputs()
+                        .fluidInputs(new FluidStack(tFluid, 750))
+                        .fluidOutputs(new FluidStack(FluidRegistry.getFluid("potion.tea"), 750))
+                        .duration(6 * SECONDS + 8 * TICKS)
+                        .eut(4)
+                        .addTo(sBrewingRecipes);
+                }
             }
             case "cropGrape" -> {
-                GT_Values.RA
-                    .addBrewingRecipe(aStack, FluidRegistry.WATER, FluidRegistry.getFluid("potion.grapejuice"), false);
-                GT_Values.RA.addBrewingRecipe(
-                    aStack,
-                    GT_ModHandler.getDistilledWater(1L)
-                        .getFluid(),
-                    FluidRegistry.getFluid("potion.grapejuice"),
-                    false);
+                for (Fluid tFluid : waterArray) {
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(aStack)
+                        .noItemOutputs()
+                        .fluidInputs(new FluidStack(tFluid, 750))
+                        .fluidOutputs(new FluidStack(FluidRegistry.getFluid("potion.grapejuice"), 750))
+                        .duration(6 * SECONDS + 8 * TICKS)
+                        .eut(4)
+                        .addTo(sBrewingRecipes);
+                }
             }
-            case "cropChilipepper" -> GT_ModHandler
-                .addPulverisationRecipe(aStack, GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Chili, 1L));
-            case "cropCoffee" -> GT_ModHandler
-                .addPulverisationRecipe(aStack, GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Coffee, 1L));
+            case "cropChilipepper" -> GT_Values.RA.stdBuilder()
+                .itemInputs(aStack)
+                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Chili, 1L))
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(20 * SECONDS)
+                .eut(2)
+                .addTo(sMaceratorRecipes);
+            case "cropCoffee" -> GT_Values.RA.stdBuilder()
+                .itemInputs(aStack)
+                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Coffee, 1L))
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(20 * SECONDS)
+                .eut(2)
+                .addTo(sMaceratorRecipes);
             case "cropPotato" -> {
-                GT_Values.RA.addSlicerRecipe(
-                    aStack,
-                    ItemList.Shape_Slicer_Flat.get(0L),
-                    ItemList.Food_Raw_PotatoChips.get(1L),
-                    64,
-                    4);
-                GT_Values.RA.addSlicerRecipe(
-                    aStack,
-                    ItemList.Shape_Slicer_Stripes.get(0L),
-                    ItemList.Food_Raw_Fries.get(1L),
-                    64,
-                    4);
-                GT_Values.RA
-                    .addBrewingRecipe(aStack, FluidRegistry.WATER, FluidRegistry.getFluid("potion.potatojuice"), true);
-                GT_Values.RA.addBrewingRecipe(
-                    aStack,
-                    GT_ModHandler.getDistilledWater(1L)
-                        .getFluid(),
-                    FluidRegistry.getFluid("potion.potatojuice"),
-                    true);
+                GT_Values.RA.stdBuilder()
+                    .itemInputs(aStack, ItemList.Shape_Slicer_Flat.get(0))
+                    .itemOutputs(ItemList.Food_Raw_PotatoChips.get(1L))
+                    .noFluidInputs()
+                    .noFluidOutputs()
+                    .duration(3 * SECONDS + 4 * TICKS)
+                    .eut(4)
+                    .addTo(sSlicerRecipes);
+
+                GT_Values.RA.stdBuilder()
+                    .itemInputs(aStack, ItemList.Shape_Slicer_Stripes.get(0L))
+                    .itemOutputs(ItemList.Food_Raw_Fries.get(1L))
+                    .noFluidInputs()
+                    .noFluidOutputs()
+                    .duration(3 * SECONDS + 4 * TICKS)
+                    .eut(4)
+                    .addTo(sSlicerRecipes);
+
+                for (Fluid tFluid : waterArray) {
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(aStack)
+                        .noItemOutputs()
+                        .fluidInputs(new FluidStack(tFluid, 750))
+                        .fluidOutputs(new FluidStack(FluidRegistry.getFluid("potion.potatojuice"), 750))
+                        .duration(6 * SECONDS + 8 * TICKS)
+                        .eut(4)
+                        .addTo(sBrewingRecipes);
+                }
             }
             case "cropLemon" -> {
-                GT_Values.RA.addSlicerRecipe(
-                    aStack,
-                    ItemList.Shape_Slicer_Flat.get(0L),
-                    ItemList.Food_Sliced_Lemon.get(4L),
-                    64,
-                    4);
-                GT_Values.RA
-                    .addBrewingRecipe(aStack, FluidRegistry.WATER, FluidRegistry.getFluid("potion.lemonjuice"), false);
-                GT_Values.RA.addBrewingRecipe(
-                    aStack,
-                    GT_ModHandler.getDistilledWater(1L)
-                        .getFluid(),
-                    FluidRegistry.getFluid("potion.lemonjuice"),
-                    false);
-                GT_Values.RA.addBrewingRecipe(
-                    aStack,
-                    FluidRegistry.getFluid("potion.vodka"),
-                    FluidRegistry.getFluid("potion.leninade"),
-                    true);
+                GT_Values.RA.stdBuilder()
+                    .itemInputs(aStack, ItemList.Shape_Slicer_Flat.get(0))
+                    .itemOutputs(ItemList.Food_Sliced_Lemon.get(4L))
+                    .noFluidInputs()
+                    .noFluidOutputs()
+                    .duration(3 * SECONDS + 4 * TICKS)
+                    .eut(4)
+                    .addTo(sSlicerRecipes);
+
+                for (Fluid tFluid : waterArray) {
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(aStack)
+                        .noItemOutputs()
+                        .fluidInputs(new FluidStack(tFluid, 750))
+                        .fluidOutputs(new FluidStack(FluidRegistry.getFluid("potion.lemonjuice"), 750))
+                        .duration(6 * SECONDS + 8 * TICKS)
+                        .eut(4)
+                        .addTo(sBrewingRecipes);
+                }
+
+                GT_Values.RA.stdBuilder()
+                    .itemInputs(aStack)
+                    .noItemOutputs()
+                    .fluidInputs(new FluidStack(FluidRegistry.getFluid("potion.vodka"), 750))
+                    .fluidOutputs(new FluidStack(FluidRegistry.getFluid("potion.leninade"), 750))
+                    .duration(6 * SECONDS + 8 * TICKS)
+                    .eut(4)
+                    .addTo(sBrewingRecipes);
             }
-            case "cropTomato" -> GT_Values.RA.addSlicerRecipe(
-                aStack,
-                ItemList.Shape_Slicer_Flat.get(0L),
-                ItemList.Food_Sliced_Tomato.get(4L),
-                64,
-                4);
-            case "cropCucumber" -> GT_Values.RA.addSlicerRecipe(
-                aStack,
-                ItemList.Shape_Slicer_Flat.get(0L),
-                ItemList.Food_Sliced_Cucumber.get(4L),
-                64,
-                4);
-            case "cropOnion" -> GT_Values.RA
-                .addSlicerRecipe(aStack, ItemList.Shape_Slicer_Flat.get(0L), ItemList.Food_Sliced_Onion.get(4L), 64, 4);
+            case "cropTomato" -> GT_Values.RA.stdBuilder()
+                .itemInputs(aStack, ItemList.Shape_Slicer_Flat.get(0))
+                .itemOutputs(ItemList.Food_Sliced_Tomato.get(4L))
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(3 * SECONDS + 4 * TICKS)
+                .eut(4)
+                .addTo(sSlicerRecipes);
+            case "cropCucumber" -> GT_Values.RA.stdBuilder()
+                .itemInputs(aStack, ItemList.Shape_Slicer_Flat.get(0))
+                .itemOutputs(ItemList.Food_Sliced_Cucumber.get(4L))
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(3 * SECONDS + 4 * TICKS)
+                .eut(4)
+                .addTo(sSlicerRecipes);
+            case "cropOnion" -> GT_Values.RA.stdBuilder()
+                .itemInputs(aStack, ItemList.Shape_Slicer_Flat.get(0))
+                .itemOutputs(ItemList.Food_Sliced_Onion.get(4L))
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(3 * SECONDS + 4 * TICKS)
+                .eut(4)
+                .addTo(sSlicerRecipes);
         }
     }
 }

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingGear.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingGear.java
@@ -1,5 +1,8 @@
 package gregtech.loaders.oreprocessing;
 
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sFluidSolidficationRecipes;
+import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
+import static gregtech.api.util.GT_RecipeBuilder.TICKS;
 import static gregtech.api.util.GT_Utility.calculateRecipeEU;
 
 import net.minecraft.init.Blocks;
@@ -24,15 +27,18 @@ public class ProcessingGear implements gregtech.api.interfaces.IOreRecipeRegistr
         switch (aPrefix) {
             case gearGt -> {
                 GT_ModHandler.removeRecipeByOutputDelayed(aStack);
-                if (aMaterial.mStandardMoltenFluid != null)
+                if (aMaterial.mStandardMoltenFluid != null) {
                     if (!(aMaterial == Materials.AnnealedCopper || aMaterial == Materials.WroughtIron)) {
-                        GT_Values.RA.addFluidSolidifierRecipe(
-                            ItemList.Shape_Mold_Gear.get(0L),
-                            aMaterial.getMolten(576L),
-                            GT_OreDictUnificator.get(aPrefix, aMaterial, 1L),
-                            128,
-                            calculateRecipeEU(aMaterial, 8));
+                        GT_Values.RA.stdBuilder()
+                            .itemInputs(ItemList.Shape_Mold_Gear.get(0L))
+                            .itemOutputs(GT_OreDictUnificator.get(aPrefix, aMaterial, 1L))
+                            .fluidInputs(aMaterial.getMolten(576L))
+                            .noFluidOutputs()
+                            .duration(6 * SECONDS + 8 * TICKS)
+                            .eut(calculateRecipeEU(aMaterial, 8))
+                            .addTo(sFluidSolidficationRecipes);
                     }
+                }
                 if (aMaterial.mUnificatable && (aMaterial.mMaterialInto == aMaterial)
                     && !aMaterial.contains(SubTag.NO_WORKING)) {
                     switch (aMaterial.mName) {
@@ -59,15 +65,18 @@ public class ProcessingGear implements gregtech.api.interfaces.IOreRecipeRegistr
                 }
             }
             case gearGtSmall -> {
-                if (aMaterial.mStandardMoltenFluid != null)
+                if (aMaterial.mStandardMoltenFluid != null) {
                     if (!(aMaterial == Materials.AnnealedCopper || aMaterial == Materials.WroughtIron)) {
-                        GT_Values.RA.addFluidSolidifierRecipe(
-                            ItemList.Shape_Mold_Gear_Small.get(0L),
-                            aMaterial.getMolten(144L),
-                            GT_Utility.copyAmount(1L, aStack),
-                            16,
-                            calculateRecipeEU(aMaterial, 8));
+                        GT_Values.RA.stdBuilder()
+                            .itemInputs(ItemList.Shape_Mold_Gear_Small.get(0L))
+                            .itemOutputs(GT_Utility.copyAmount(1L, aStack))
+                            .fluidInputs(aMaterial.getMolten(144L))
+                            .noFluidOutputs()
+                            .duration(16 * TICKS)
+                            .eut(calculateRecipeEU(aMaterial, 8))
+                            .addTo(sFluidSolidficationRecipes);
                     }
+                }
                 if (aMaterial.mUnificatable && (aMaterial.mMaterialInto == aMaterial)
                     && !aMaterial.contains(SubTag.NO_WORKING)) {
                     switch (aMaterial.mName) {

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingLog.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingLog.java
@@ -1,8 +1,13 @@
 package gregtech.loaders.oreprocessing;
 
 import static gregtech.api.enums.Mods.Railcraft;
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAssemblerRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCentrifugeRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sChemicalBathRecipes;
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sExtractorRecipes;
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sLatheRecipes;
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sMaceratorRecipes;
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sPyrolyseRecipes;
 import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
 import static gregtech.api.util.GT_RecipeBuilder.TICKS;
 
@@ -40,19 +45,24 @@ public class ProcessingLog implements gregtech.api.interfaces.IOreRecipeRegistra
                 .eut(20)
                 .addTo(sCentrifugeRecipes);
 
-            GT_ModHandler.addSawmillRecipe(
-                GT_Utility.copyAmount(1L, aStack),
-                ItemList.IC2_Resin.get(1L),
-                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 16L));
-            GT_ModHandler.addExtractionRecipe(
-                GT_Utility.copyAmount(1L, aStack),
-                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.RawRubber, 1L));
-            GT_ModHandler.addPulverisationRecipe(
-                GT_Utility.copyAmount(1L, aStack),
-                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 6L),
-                ItemList.IC2_Resin.get(1L),
-                33,
-                false);
+            GT_Values.RA.stdBuilder()
+                .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.dust, Materials.RawRubber, 1L))
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(15 * SECONDS)
+                .eut(2)
+                .addTo(sExtractorRecipes);
+
+            GT_Values.RA.stdBuilder()
+                .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 6L), ItemList.IC2_Resin.get(1L))
+                .outputChances(10000, 3300)
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(20 * SECONDS)
+                .eut(2)
+                .addTo(sMaceratorRecipes);
         } else {
             GT_Values.RA.stdBuilder()
                 .itemInputs(GT_Utility.copyAmount(1L, aStack), GT_Utility.getIntegratedCircuit(1))
@@ -63,12 +73,17 @@ public class ProcessingLog implements gregtech.api.interfaces.IOreRecipeRegistra
                 .eut(20)
                 .addTo(sCentrifugeRecipes);
 
-            GT_ModHandler.addPulverisationRecipe(
-                GT_Utility.copyAmount(1L, aStack),
-                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 6L),
-                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 1L),
-                80,
-                false);
+            GT_Values.RA.stdBuilder()
+                .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                .itemOutputs(
+                    GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 6L),
+                    GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 1L))
+                .outputChances(10000, 8000)
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(20 * SECONDS)
+                .eut(2)
+                .addTo(sMaceratorRecipes);
         }
 
         GT_ModHandler.addCraftingRecipe(
@@ -76,26 +91,35 @@ public class ProcessingLog implements gregtech.api.interfaces.IOreRecipeRegistra
             gregtech.api.util.GT_ModHandler.RecipeBits.DO_NOT_CHECK_FOR_COLLISIONS
                 | gregtech.api.util.GT_ModHandler.RecipeBits.BUFFERED,
             new Object[] { "sLf", 'L', GT_Utility.copyAmount(1L, aStack) });
-        GT_Values.RA.addLatheRecipe(
-            GT_Utility.copyAmount(1L, aStack),
-            GT_OreDictUnificator.get(OrePrefixes.stickLong, Materials.Wood, 4L),
-            GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 2L),
-            160,
-            8);
-        GT_Values.RA.addAssemblerRecipe(
-            GT_Utility.copyAmount(1L, aStack),
-            ItemList.Circuit_Integrated.getWithDamage(0L, 2L),
-            Materials.SeedOil.getFluid(50L),
-            ItemList.FR_Stick.get(1L),
-            16,
-            8);
-        GT_Values.RA.addAssemblerRecipe(
-            GT_Utility.copyAmount(8L, aStack),
-            ItemList.Circuit_Integrated.getWithDamage(0L, 8L),
-            Materials.SeedOil.getFluid(250L),
-            ItemList.FR_Casing_Impregnated.get(1L),
-            64,
-            16);
+
+        GT_Values.RA.stdBuilder()
+            .itemInputs(GT_Utility.copyAmount(1L, aStack))
+            .itemOutputs(
+                GT_OreDictUnificator.get(OrePrefixes.stickLong, Materials.Wood, 4L),
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 2L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(8 * SECONDS)
+            .eut(7)
+            .addTo(sLatheRecipes);
+
+        GT_Values.RA.stdBuilder()
+            .itemInputs(GT_Utility.copyAmount(1L, aStack), GT_Utility.getIntegratedCircuit(2))
+            .itemOutputs(ItemList.FR_Stick.get(1L))
+            .fluidInputs(Materials.SeedOil.getFluid(50L))
+            .noFluidOutputs()
+            .duration(16 * TICKS)
+            .eut(7)
+            .addTo(sAssemblerRecipes);
+
+        GT_Values.RA.stdBuilder()
+            .itemInputs(GT_Utility.copyAmount(8L, aStack), GT_Utility.getIntegratedCircuit(8))
+            .itemOutputs(ItemList.FR_Casing_Impregnated.get(1L))
+            .fluidInputs(Materials.SeedOil.getFluid(250L))
+            .noFluidOutputs()
+            .duration(3 * SECONDS + 4 * TICKS)
+            .eut(16)
+            .addTo(sAssemblerRecipes);
 
         GT_Values.RA.stdBuilder()
             .itemInputs(GT_Utility.copyAmount(1L, aStack))
@@ -224,93 +248,104 @@ public class ProcessingLog implements gregtech.api.interfaces.IOreRecipeRegistra
     }
 
     public static void addPyrolyeOvenRecipes(ItemStack logStack) {
-        GT_Values.RA.addPyrolyseRecipe(
-            GT_Utility.copyAmount(16L, logStack),
-            GT_Values.NF,
-            1,
-            Materials.Charcoal.getGems(20),
-            Materials.Creosote.getFluid(4000),
-            640,
-            64);
-        GT_Values.RA.addPyrolyseRecipe(
-            GT_Utility.copyAmount(16L, logStack),
-            Materials.Nitrogen.getGas(1000),
-            2,
-            Materials.Charcoal.getGems(20),
-            Materials.Creosote.getFluid(4000),
-            320,
-            96);
-        GT_Values.RA.addPyrolyseRecipe(
-            GT_Utility.copyAmount(16L, logStack),
-            GT_Values.NF,
-            3,
-            Materials.Ash.getDust(4),
-            Materials.OilHeavy.getFluid(200),
-            320,
-            192);
-        GT_Values.RA.addPyrolyseRecipe(
-            GT_Utility.copyAmount(16L, logStack),
-            GT_Values.NF,
-            3,
-            Materials.Charcoal.getGems(20),
-            Materials.CharcoalByproducts.getGas(4000),
-            640,
-            64);
-        GT_Values.RA.addPyrolyseRecipe(
-            GT_Utility.copyAmount(16L, logStack),
-            Materials.Nitrogen.getGas(1000),
-            4,
-            Materials.Charcoal.getGems(20),
-            Materials.CharcoalByproducts.getGas(4000),
-            320,
-            96);
-        GT_Values.RA.addPyrolyseRecipe(
-            GT_Utility.copyAmount(16L, logStack),
-            GT_Values.NF,
-            5,
-            Materials.Charcoal.getGems(20),
-            Materials.WoodGas.getGas(1500),
-            640,
-            64);
-        GT_Values.RA.addPyrolyseRecipe(
-            GT_Utility.copyAmount(16L, logStack),
-            Materials.Nitrogen.getGas(1000),
-            6,
-            Materials.Charcoal.getGems(20),
-            Materials.WoodGas.getGas(1500),
-            320,
-            96);
-        GT_Values.RA.addPyrolyseRecipe(
-            GT_Utility.copyAmount(16L, logStack),
-            GT_Values.NF,
-            7,
-            Materials.Charcoal.getGems(20),
-            Materials.WoodVinegar.getFluid(3000),
-            640,
-            64);
-        GT_Values.RA.addPyrolyseRecipe(
-            GT_Utility.copyAmount(16L, logStack),
-            Materials.Nitrogen.getGas(1000),
-            8,
-            Materials.Charcoal.getGems(20),
-            Materials.WoodVinegar.getFluid(3000),
-            320,
-            96);
-        GT_Values.RA.addPyrolyseRecipe(
-            GT_Utility.copyAmount(16L, logStack),
-            GT_Values.NF,
-            9,
-            Materials.Charcoal.getGems(20),
-            Materials.WoodTar.getFluid(1500),
-            640,
-            64);
-        GT_Values.RA.addPyrolyseRecipe(
-            GT_Utility.copyAmount(16L, logStack),
-            Materials.Nitrogen.getGas(1000),
-            10,
-            Materials.Charcoal.getGems(20),
-            Materials.WoodTar.getFluid(1500),
-            320,
-            96);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(GT_Utility.copyAmount(16L, logStack), GT_Utility.getIntegratedCircuit(1))
+            .itemOutputs(Materials.Charcoal.getGems(20))
+            .noFluidInputs()
+            .fluidOutputs(Materials.Creosote.getFluid(4000))
+            .duration(32 * SECONDS)
+            .eut(64)
+            .noOptimize()
+            .addTo(sPyrolyseRecipes);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(GT_Utility.copyAmount(16L, logStack), GT_Utility.getIntegratedCircuit(2))
+            .itemOutputs(Materials.Charcoal.getGems(20))
+            .fluidInputs(Materials.Nitrogen.getGas(1000))
+            .fluidOutputs(Materials.Creosote.getFluid(4000))
+            .duration(16 * SECONDS)
+            .eut(96)
+            .noOptimize()
+            .addTo(sPyrolyseRecipes);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(GT_Utility.copyAmount(16L, logStack), GT_Utility.getIntegratedCircuit(3))
+            .itemOutputs(Materials.Charcoal.getGems(20))
+            .noFluidInputs()
+            .fluidOutputs(Materials.CharcoalByproducts.getGas(4000))
+            .duration(32 * SECONDS)
+            .eut(64)
+            .noOptimize()
+            .addTo(sPyrolyseRecipes);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(GT_Utility.copyAmount(16L, logStack), GT_Utility.getIntegratedCircuit(4))
+            .itemOutputs(Materials.Charcoal.getGems(20))
+            .fluidInputs(Materials.Nitrogen.getGas(1000))
+            .fluidOutputs(Materials.CharcoalByproducts.getGas(4000))
+            .duration(16 * SECONDS)
+            .eut(96)
+            .noOptimize()
+            .addTo(sPyrolyseRecipes);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(GT_Utility.copyAmount(16L, logStack), GT_Utility.getIntegratedCircuit(5))
+            .itemOutputs(Materials.Charcoal.getGems(20))
+            .noFluidInputs()
+            .fluidOutputs(Materials.WoodGas.getGas(1500))
+            .duration(32 * SECONDS)
+            .eut(64)
+            .noOptimize()
+            .addTo(sPyrolyseRecipes);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(GT_Utility.copyAmount(16L, logStack), GT_Utility.getIntegratedCircuit(6))
+            .itemOutputs(Materials.Charcoal.getGems(20))
+            .fluidInputs(Materials.Nitrogen.getGas(1000))
+            .fluidOutputs(Materials.WoodGas.getGas(1500))
+            .duration(16 * SECONDS)
+            .eut(96)
+            .noOptimize()
+            .addTo(sPyrolyseRecipes);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(GT_Utility.copyAmount(16L, logStack), GT_Utility.getIntegratedCircuit(7))
+            .itemOutputs(Materials.Charcoal.getGems(20))
+            .noFluidInputs()
+            .fluidOutputs(Materials.WoodVinegar.getFluid(3000))
+            .duration(32 * SECONDS)
+            .eut(64)
+            .noOptimize()
+            .addTo(sPyrolyseRecipes);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(GT_Utility.copyAmount(16L, logStack), GT_Utility.getIntegratedCircuit(8))
+            .itemOutputs(Materials.Charcoal.getGems(20))
+            .fluidInputs(Materials.Nitrogen.getGas(1000))
+            .fluidOutputs(Materials.WoodVinegar.getFluid(3000))
+            .duration(16 * SECONDS)
+            .eut(96)
+            .noOptimize()
+            .addTo(sPyrolyseRecipes);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(GT_Utility.copyAmount(16L, logStack), GT_Utility.getIntegratedCircuit(9))
+            .itemOutputs(Materials.Charcoal.getGems(20))
+            .noFluidInputs()
+            .fluidOutputs(Materials.WoodTar.getFluid(1500))
+            .duration(32 * SECONDS)
+            .eut(64)
+            .noOptimize()
+            .addTo(sPyrolyseRecipes);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(GT_Utility.copyAmount(16L, logStack), GT_Utility.getIntegratedCircuit(10))
+            .itemOutputs(Materials.Charcoal.getGems(20))
+            .fluidInputs(Materials.Nitrogen.getGas(1000))
+            .fluidOutputs(Materials.WoodTar.getFluid(1500))
+            .duration(16 * SECONDS)
+            .eut(96)
+            .noOptimize()
+            .addTo(sPyrolyseRecipes);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(GT_Utility.copyAmount(16L, logStack), GT_Utility.getIntegratedCircuit(11))
+            .itemOutputs(Materials.Ash.getDust(4))
+            .noFluidInputs()
+            .fluidOutputs(Materials.OilHeavy.getFluid(200))
+            .duration(16 * SECONDS)
+            .eut(192)
+            .noOptimize()
+            .addTo(sPyrolyseRecipes);
     }
 }

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingNugget.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingNugget.java
@@ -1,5 +1,9 @@
 package gregtech.loaders.oreprocessing;
 
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAlloySmelterRecipes;
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sFluidSolidficationRecipes;
+import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
+import static gregtech.api.util.GT_RecipeBuilder.TICKS;
 import static gregtech.api.util.GT_Utility.calculateRecipeEU;
 
 import net.minecraft.item.ItemStack;
@@ -20,37 +24,58 @@ public class ProcessingNugget implements gregtech.api.interfaces.IOreRecipeRegis
     public void registerOre(OrePrefixes aPrefix, Materials aMaterial, String aOreDictName, String aModName,
         ItemStack aStack) {
 
-        GT_Values.RA.addAlloySmelterRecipe(
-            GT_Utility.copyAmount(9L, aStack),
-            aMaterial.contains(SubTag.SMELTING_TO_GEM) ? ItemList.Shape_Mold_Ball.get(0L)
-                : ItemList.Shape_Mold_Ingot.get(0L),
-            GT_OreDictUnificator.get(
-                aMaterial.contains(SubTag.SMELTING_TO_GEM) ? OrePrefixes.gem : OrePrefixes.ingot,
-                aMaterial.mSmeltInto,
-                1L),
-            200,
-            calculateRecipeEU(aMaterial, 2));
+        if (aMaterial.contains(SubTag.SMELTING_TO_GEM)
+            && GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial.mSmeltInto, 1L) != null) {
+            GT_Values.RA.stdBuilder()
+                .itemInputs(GT_Utility.copyAmount(9L, aStack), ItemList.Shape_Mold_Ball.get(0L))
+                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial.mSmeltInto, 1L))
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(10 * SECONDS)
+                .eut(calculateRecipeEU(aMaterial, 2))
+                .addTo(sAlloySmelterRecipes);
+        }
 
-        if (aMaterial.mStandardMoltenFluid != null)
+        if ((!aMaterial.contains(SubTag.SMELTING_TO_GEM))
+            && GT_OreDictUnificator.get(OrePrefixes.ingot, aMaterial.mSmeltInto, 1L) != null) {
+            GT_Values.RA.stdBuilder()
+                .itemInputs(GT_Utility.copyAmount(9L, aStack), ItemList.Shape_Mold_Ingot.get(0L))
+                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.ingot, aMaterial.mSmeltInto, 1L))
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(10 * SECONDS)
+                .eut(calculateRecipeEU(aMaterial, 2))
+                .addTo(sAlloySmelterRecipes);
+        }
+
+        if (aMaterial.mStandardMoltenFluid != null) {
             if (!(aMaterial == Materials.AnnealedCopper || aMaterial == Materials.WroughtIron)) {
-                GT_Values.RA.addFluidSolidifierRecipe(
-                    ItemList.Shape_Mold_Nugget.get(0L),
-                    aMaterial.getMolten(16L),
-                    GT_OreDictUnificator.get(OrePrefixes.nugget, aMaterial, 1L),
-                    16,
-                    calculateRecipeEU(aMaterial, 4));
+                GT_Values.RA.stdBuilder()
+                    .itemInputs(ItemList.Shape_Mold_Nugget.get(0L))
+                    .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.nugget, aMaterial, 1L))
+                    .fluidInputs(aMaterial.getMolten(16L))
+                    .noFluidOutputs()
+                    .duration(16 * TICKS)
+                    .eut(calculateRecipeEU(aMaterial, 4))
+                    .addTo(sFluidSolidficationRecipes);
             }
+        }
 
         GT_RecipeRegistrator.registerReverseFluidSmelting(aStack, aMaterial, aPrefix.mMaterialAmount, null);
         GT_RecipeRegistrator
             .registerReverseMacerating(aStack, aMaterial, aPrefix.mMaterialAmount, null, null, null, false);
-        if (!aMaterial.contains(SubTag.NO_SMELTING)) {
-            GT_Values.RA.addAlloySmelterRecipe(
-                GT_OreDictUnificator.get(OrePrefixes.ingot, aMaterial, 1L),
-                ItemList.Shape_Mold_Nugget.get(0L),
-                GT_Utility.copyAmount(9L, aStack),
-                100,
-                calculateRecipeEU(aMaterial, 1));
+        if (!aMaterial.contains(SubTag.NO_SMELTING)
+            && GT_OreDictUnificator.get(OrePrefixes.ingot, aMaterial, 1L) != null) {
+            GT_Values.RA.stdBuilder()
+                .itemInputs(
+                    GT_OreDictUnificator.get(OrePrefixes.ingot, aMaterial, 1L),
+                    ItemList.Shape_Mold_Nugget.get(0L))
+                .itemOutputs(GT_Utility.copyAmount(9L, aStack))
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(5 * SECONDS)
+                .eut(calculateRecipeEU(aMaterial, 1))
+                .addTo(sAlloySmelterRecipes);
             if (aMaterial.getProcessingMaterialTierEU() < TierEU.IV) {
                 GT_ModHandler.addCraftingRecipe(
                     GT_OreDictUnificator.get(OrePrefixes.nugget, aMaterial, 9L),

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingPipe.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingPipe.java
@@ -1,6 +1,8 @@
 package gregtech.loaders.oreprocessing;
 
-import static gregtech.api.enums.GT_Values.RA;
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAssemblerRecipes;
+import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
+import static gregtech.api.util.GT_RecipeBuilder.TICKS;
 import static gregtech.api.util.GT_Utility.calculateRecipeEU;
 
 import net.minecraft.item.ItemStack;
@@ -77,16 +79,22 @@ public class ProcessingPipe implements gregtech.api.interfaces.IOreRecipeRegistr
                         new Object[] { "DhD", "D D", "DwD", 'D', OrePrefixes.plateDouble.get(aMaterial) });
                 }
             }
-            case pipeRestrictiveHuge, pipeRestrictiveLarge, pipeRestrictiveMedium, pipeRestrictiveSmall, pipeRestrictiveTiny -> RA
-                .addAssemblerRecipe(
-                    GT_OreDictUnificator.get(aOreDictName.replaceFirst("Restrictive", ""), null, 1L, false, true),
-                    GT_OreDictUnificator.get(
-                        OrePrefixes.ring,
-                        Materials.Steel,
-                        aPrefix.mSecondaryMaterial.mAmount / OrePrefixes.ring.mMaterialAmount),
-                    GT_Utility.copyAmount(1L, aStack),
-                    (int) (aPrefix.mSecondaryMaterial.mAmount * 400L / OrePrefixes.ring.mMaterialAmount),
-                    4);
+            case pipeRestrictiveHuge, pipeRestrictiveLarge, pipeRestrictiveMedium, pipeRestrictiveSmall, pipeRestrictiveTiny -> {
+                GT_Values.RA.stdBuilder()
+                    .itemInputs(
+                        GT_OreDictUnificator.get(
+                            OrePrefixes.ring,
+                            Materials.Steel,
+                            aPrefix.mSecondaryMaterial.mAmount / OrePrefixes.ring.mMaterialAmount),
+                        GT_OreDictUnificator.get(aOreDictName.replaceFirst("Restrictive", ""), null, 1L, false, true))
+                    .itemOutputs(GT_Utility.copyAmount(1L, aStack))
+                    .noFluidInputs()
+                    .noFluidOutputs()
+                    .duration(
+                        ((int) (aPrefix.mSecondaryMaterial.mAmount * 400L / OrePrefixes.ring.mMaterialAmount)) * TICKS)
+                    .eut(4)
+                    .addTo(sAssemblerRecipes);
+            }
             case pipeQuadruple -> {
                 if (aMaterial.getProcessingMaterialTierEU() < TierEU.IV) {
 
@@ -96,12 +104,16 @@ public class ProcessingPipe implements gregtech.api.interfaces.IOreRecipeRegistr
                         new Object[] { "MM ", "MM ", "   ", 'M',
                             GT_OreDictUnificator.get(OrePrefixes.pipeMedium, aMaterial, 1) });
                 }
-                RA.addAssemblerRecipe(
-                    GT_OreDictUnificator.get(OrePrefixes.pipeMedium, aMaterial, 4),
-                    GT_Utility.getIntegratedCircuit(9),
-                    GT_OreDictUnificator.get(OrePrefixes.pipeQuadruple, aMaterial, 1),
-                    60,
-                    calculateRecipeEU(aMaterial, 4));
+                GT_Values.RA.stdBuilder()
+                    .itemInputs(
+                        GT_OreDictUnificator.get(OrePrefixes.pipeMedium, aMaterial, 4),
+                        GT_Utility.getIntegratedCircuit(9))
+                    .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.pipeQuadruple, aMaterial, 1))
+                    .noFluidInputs()
+                    .noFluidOutputs()
+                    .duration(3 * SECONDS)
+                    .eut(calculateRecipeEU(aMaterial, 4))
+                    .addTo(sAssemblerRecipes);
             }
             case pipeNonuple -> {
                 if (aMaterial.getProcessingMaterialTierEU() < TierEU.IV) {
@@ -112,12 +124,16 @@ public class ProcessingPipe implements gregtech.api.interfaces.IOreRecipeRegistr
                         new Object[] { "PPP", "PPP", "PPP", 'P', GT_OreDictUnificator
                             .get(aOreDictName.replaceFirst("Nonuple", "Small"), null, 1L, false, true) });
                 }
-                RA.addAssemblerRecipe(
-                    GT_OreDictUnificator.get(OrePrefixes.pipeSmall, aMaterial, 9),
-                    GT_Utility.getIntegratedCircuit(9),
-                    GT_OreDictUnificator.get(OrePrefixes.pipeNonuple, aMaterial, 1),
-                    60,
-                    calculateRecipeEU(aMaterial, 8));
+                GT_Values.RA.stdBuilder()
+                    .itemInputs(
+                        GT_OreDictUnificator.get(OrePrefixes.pipeSmall, aMaterial, 9),
+                        GT_Utility.getIntegratedCircuit(9))
+                    .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.pipeNonuple, aMaterial, 1))
+                    .noFluidInputs()
+                    .noFluidOutputs()
+                    .duration(3 * SECONDS)
+                    .eut(calculateRecipeEU(aMaterial, 8))
+                    .addTo(sAssemblerRecipes);
             }
             default -> {}
         }


### PR DESCRIPTION
converts more recipe files to RA2:
- pipe oredict processing
- gear oredict processing
- nuggets oredict processing
- crop oredict processing (also unhide Leninade)
- log oredict processing (partially) (also fixed a recipe conflict between gettin charcoal byproducts or heavy oil in the pyro, both were on circuit 3)