### PR TITLE
Nerf Phosphorus Bee, Buff Fluid bees

### DIFF
--- a/src/main/java/gregtech/common/items/ItemComb.java
+++ b/src/main/java/gregtech/common/items/ItemComb.java
@@ -165,9 +165,9 @@ public class ItemComb extends Item implements IGT_ItemWithMaterialRenderer {
             50 * 100);
         addCentrifugeToItemStack(
             CombType.PHOSPHORUS,
-            new ItemStack[] { Materials.Phosphorus.getDust(3), Materials.TricalciumPhosphate.getDust(2),
+            new ItemStack[] { Materials.Phosphorus.getDust(1), Materials.TricalciumPhosphate.getDust(2),
                 ItemList.FR_Wax.get(1) },
-            new int[] { 100 * 100, 75 * 100, 100 * 100 },
+            new int[] { 100 * 100, 100 * 100, 100 * 100 },
             Voltage.HV);
         addCentrifugeToItemStack(
             CombType.MICA,
@@ -1537,10 +1537,10 @@ public class ItemComb extends Item implements IGT_ItemWithMaterialRenderer {
         // (Noble)gas Line
         addFluidExtractorProcess(CombType.HELIUM, Materials.Helium.getGas(250), Voltage.HV);
         addFluidExtractorProcess(CombType.ARGON, Materials.Argon.getGas(250), Voltage.MV);
-        addFluidExtractorProcess(CombType.NITROGEN, Materials.Nitrogen.getGas(250), Voltage.MV);
-        addFluidExtractorProcess(CombType.HYDROGEN, Materials.Hydrogen.getGas(250), Voltage.MV);
+        addFluidExtractorProcess(CombType.NITROGEN, Materials.Nitrogen.getGas(500), Voltage.MV);
+        addFluidExtractorProcess(CombType.HYDROGEN, Materials.Hydrogen.getGas(500), Voltage.MV);
         addFluidExtractorProcess(CombType.FLUORINE, Materials.Fluorine.getGas(250), Voltage.MV);
-        addFluidExtractorProcess(CombType.OXYGEN, Materials.Oxygen.getGas(250), Voltage.MV);
+        addFluidExtractorProcess(CombType.OXYGEN, Materials.Oxygen.getGas(500), Voltage.MV);
         // Organic part 2, unknown liquid
         // yes, unknowwater. Its not my typo, its how it is spelled. Stupid game.
         addFluidExtractorProcess(CombType.UNKNOWNWATER, FluidRegistry.getFluidStack("unknowwater", 250), Voltage.ZPM);

--- a/src/main/java/gregtech/loaders/misc/GT_BeeDefinition.java
+++ b/src/main/java/gregtech/loaders/misc/GT_BeeDefinition.java
@@ -224,7 +224,7 @@ public enum GT_BeeDefinition implements IBeeDefinition {
     // Phosphorus bee, Humidity: normal, Temperature: Hot, Parents: Apatite & Ash, Mutationrate: 12%, Combrate: 55%
     PHOSPHORUS(GT_BranchDefinition.ORGANIC, "Phosphorus", false, new Color(0xFFC826), new Color(0xC1C1F6),
         beeSpecies -> {
-            beeSpecies.addProduct(GT_Bees.combs.getStackForType(CombType.PHOSPHORUS), 0.55f);
+            beeSpecies.addSpecialty(GT_Bees.combs.getStackForType(CombType.PHOSPHORUS), 0.35f);
             beeSpecies.setHumidity(EnumHumidity.NORMAL);
             beeSpecies.setTemperature(HOT);
             beeSpecies.setNocturnal();
@@ -2342,7 +2342,8 @@ public enum GT_BeeDefinition implements IBeeDefinition {
     }),
     // Oxygen bee, Humidity: normal, Temperature: Icy, Parents: Space & Callisto, Mutationrate: 15%, Combrate: 50%
     OXYGEN(GT_BranchDefinition.NOBLEGAS, "Oxygen", false, new Color(0xFFFFFF), new Color(0x8F8FFF), beeSpecies -> {
-        beeSpecies.addProduct(GT_Bees.combs.getStackForType(CombType.OXYGEN), 0.35f);
+        beeSpecies.addProduct(GT_Bees.combs.getStackForType(CombType.OXYGEN), 0.45f);
+        beeSpecies.addSpecialty(GT_Bees.combs.getStackForType(CombType.HYDROGEN), 0.20f);
         beeSpecies.setHumidity(EnumHumidity.NORMAL);
         beeSpecies.setTemperature(ICY);
         beeSpecies.setNocturnal();
@@ -2353,7 +2354,8 @@ public enum GT_BeeDefinition implements IBeeDefinition {
     }),
     // Hydrogen bee, Humidity: normal, Temperature: Icy, Parents: Oxygen & Watery, Mutationrate: 15%, Combrate: 50%
     HYDROGEN(GT_BranchDefinition.NOBLEGAS, "Oxygen", false, new Color(0xFFFFFF), new Color(0xFF1493), beeSpecies -> {
-        beeSpecies.addProduct(GT_Bees.combs.getStackForType(CombType.HYDROGEN), 0.35f);
+        beeSpecies.addProduct(GT_Bees.combs.getStackForType(CombType.HYDROGEN), 0.45f);
+        beeSpecies.addSpecialty(GT_Bees.combs.getStackForType(CombType.NITROGEN), 0.20f);
         beeSpecies.setHumidity(EnumHumidity.NORMAL);
         beeSpecies.setTemperature(ICY);
         beeSpecies.setNocturnal();
@@ -2364,7 +2366,8 @@ public enum GT_BeeDefinition implements IBeeDefinition {
     }),
     // Nitrogen bee, Humidity: normal, Temperature: Icy, Parents: Oxygen & Hydrogen, Mutationrate: 15%, Combrate: 50%
     NITROGEN(GT_BranchDefinition.NOBLEGAS, "Nitrogen", false, new Color(0xFFC832), new Color(0xA52A2A), beeSpecies -> {
-        beeSpecies.addProduct(GT_Bees.combs.getStackForType(CombType.NITROGEN), 0.35f);
+        beeSpecies.addProduct(GT_Bees.combs.getStackForType(CombType.NITROGEN), 0.45f);
+        beeSpecies.addSpecialty(GT_Bees.combs.getStackForType(CombType.FLUORINE), 0.20f);
         beeSpecies.setHumidity(EnumHumidity.NORMAL);
         beeSpecies.setTemperature(ICY);
         beeSpecies.setNocturnal();
@@ -2375,7 +2378,8 @@ public enum GT_BeeDefinition implements IBeeDefinition {
     }),
     // Fluorine bee, Humidity: normal, Temperature: Icy, Parents: Nitrogen & Hydrogen, Mutationrate: 15%, Combrate: 50%
     FLUORINE(GT_BranchDefinition.NOBLEGAS, "Fluorine", false, new Color(0x86AFF0), new Color(0xFF6D00), beeSpecies -> {
-        beeSpecies.addProduct(GT_Bees.combs.getStackForType(CombType.FLUORINE), 0.35f);
+        beeSpecies.addProduct(GT_Bees.combs.getStackForType(CombType.FLUORINE), 0.45f);
+        beeSpecies.addSpecialty(GT_Bees.combs.getStackForType(CombType.OXYGEN), 0.20f);
         beeSpecies.setHumidity(EnumHumidity.NORMAL);
         beeSpecies.setTemperature(ICY);
         beeSpecies.setNocturnal();


### PR DESCRIPTION
Nerfed Phosphorus bee 
Previously:
- 55% Primarly comb chance, garanteed 3 phosphorus and 75% tricalciumphosphate

now:
20% specialty comb with 1 garantueed phosphorus and 2 garantueed tricalciumphosphate

Increased primary comb chance of Oxygen, Hydrogen, Nitrogen and FLuorine comb by 10%, added specialty combs
(Oxygen has Hydrogen, Hydrogen has Nitrogen, Nitrogen has Fluorine and Fluorine has oxygen) and increased the fluid output from 250 to 500