### PR TITLE
Various GT recipe fixes

### DIFF
--- a/src/main/java/gregtech/api/enums/OrePrefixes.java
+++ b/src/main/java/gregtech/api/enums/OrePrefixes.java
@@ -970,7 +970,6 @@ public enum OrePrefixes {
         oreRich.mSecondaryMaterial = new MaterialStack(Materials.Stone, dust.mMaterialAmount * 2);
         ore.mSecondaryMaterial = new MaterialStack(Materials.Stone, dust.mMaterialAmount);
         crushed.mSecondaryMaterial = new MaterialStack(Materials.Stone, dust.mMaterialAmount);
-        toolHeadDrill.mSecondaryMaterial = new MaterialStack(Materials.Steel, plate.mMaterialAmount * 4);
         toolHeadChainsaw.mSecondaryMaterial = new MaterialStack(
             Materials.Steel,
             plate.mMaterialAmount * 4 + ring.mMaterialAmount * 2);

--- a/src/main/java/gregtech/api/util/GT_RecipeRegistrator.java
+++ b/src/main/java/gregtech/api/util/GT_RecipeRegistrator.java
@@ -194,8 +194,8 @@ public class GT_RecipeRegistrator {
         // }
         RA.addFluidSmelterRecipe(
             GT_Utility.copyAmount(1, aStack),
-            aByproduct == null
-                || (tData != null && tData.hasValidPrefixData() && tData.mPrefix == OrePrefixes.toolHeadDrill)
+            aByproduct
+                == null
                     ? null
                     : aByproduct.mMaterial.contains(SubTag.NO_SMELTING) || !aByproduct.mMaterial.contains(SubTag.METAL)
                         ? aByproduct.mMaterial.contains(SubTag.FLAMMABLE)
@@ -305,11 +305,20 @@ public class GT_RecipeRegistrator {
             tAmount += tMaterial.mAmount * tMaterial.mMaterial.getMass();
 
         boolean tHide = !tIron && GT_Mod.gregtechproxy.mHideRecyclingRecipes;
-        if (aData.mPrefix == OrePrefixes.toolHeadDrill) {
+        ArrayList<ItemStack> outputs = new ArrayList<ItemStack>();
+        if (GT_OreDictUnificator.getIngotOrDust(aData.mMaterial) != null) {
+            outputs.add(GT_OreDictUnificator.getIngotOrDust(aData.mMaterial));
+        }
+        for (int i = 0; i < 8; i++) {
+            if (GT_OreDictUnificator.getIngotOrDust(aData.getByProduct(i)) != null) {
+                outputs.add(GT_OreDictUnificator.getIngotOrDust(aData.getByProduct(i)));
+            }
+        }
+        if (outputs.size() != 0) {
+            ItemStack[] outputsArray = outputs.toArray(new ItemStack[outputs.size()]);
             GT_RecipeBuilder recipeBuilder = GT_Values.RA.stdBuilder();
-
             recipeBuilder.itemInputs(aStack)
-                .itemOutputs(GT_OreDictUnificator.getIngotOrDust(aData.mMaterial))
+                .itemOutputs(outputsArray)
                 .fluidInputs(Materials.Oxygen.getGas((int) Math.max(16, tAmount / M)))
                 .noFluidOutputs()
                 .duration(((int) Math.max(16, tAmount / M)) * TICKS)
@@ -318,31 +327,8 @@ public class GT_RecipeRegistrator {
                 recipeBuilder.hidden();
             }
             recipeBuilder.addTo(UniversalArcFurnace);
-        } else {
-            ArrayList<ItemStack> outputs = new ArrayList<ItemStack>();
-            if (GT_OreDictUnificator.getIngotOrDust(aData.mMaterial) != null) {
-                outputs.add(GT_OreDictUnificator.getIngotOrDust(aData.mMaterial));
-            }
-            for (int i = 0; i < 8; i++) {
-                if (GT_OreDictUnificator.getIngotOrDust(aData.getByProduct(i)) != null) {
-                    outputs.add(GT_OreDictUnificator.getIngotOrDust(aData.getByProduct(i)));
-                }
-            }
-            if (outputs.size() != 0) {
-                ItemStack[] outputsArray = outputs.toArray(new ItemStack[outputs.size()]);
-                GT_RecipeBuilder recipeBuilder = GT_Values.RA.stdBuilder();
-                recipeBuilder.itemInputs(aStack)
-                    .itemOutputs(outputsArray)
-                    .fluidInputs(Materials.Oxygen.getGas((int) Math.max(16, tAmount / M)))
-                    .noFluidOutputs()
-                    .duration(((int) Math.max(16, tAmount / M)) * TICKS)
-                    .eut(90);
-                if (tHide) {
-                    recipeBuilder.hidden();
-                }
-                recipeBuilder.addTo(UniversalArcFurnace);
-            }
         }
+
     }
 
     public static void registerReverseMacerating(ItemStack aStack, Materials aMaterial, long aMaterialAmount,
@@ -374,26 +360,16 @@ public class GT_RecipeRegistrator {
         for (MaterialStack tMaterial : aData.getAllMaterialStacks())
             tAmount += tMaterial.mAmount * tMaterial.mMaterial.getMass();
         boolean tHide = (aData.mMaterial.mMaterial != Materials.Iron) && (GT_Mod.gregtechproxy.mHideRecyclingRecipes);
-        if (aData.mPrefix == OrePrefixes.toolHeadDrill) {
-            RA.addPulveriserRecipe(
-                aStack,
-                new ItemStack[] { GT_OreDictUnificator.getDust(aData.mMaterial) },
-                null,
-                aData.mMaterial.mMaterial == Materials.Marble ? 1 : (int) Math.max(16, tAmount / M),
-                4,
-                tHide);
-        } else {
-            RA.addPulveriserRecipe(
-                aStack,
-                new ItemStack[] { GT_OreDictUnificator.getDust(aData.mMaterial),
-                    GT_OreDictUnificator.getDust(aData.getByProduct(0)),
-                    GT_OreDictUnificator.getDust(aData.getByProduct(1)),
-                    GT_OreDictUnificator.getDust(aData.getByProduct(2)) },
-                null,
-                aData.mMaterial.mMaterial == Materials.Marble ? 1 : (int) Math.max(16, tAmount / M),
-                4,
-                tHide);
-        }
+        RA.addPulveriserRecipe(
+            aStack,
+            new ItemStack[] { GT_OreDictUnificator.getDust(aData.mMaterial),
+                GT_OreDictUnificator.getDust(aData.getByProduct(0)),
+                GT_OreDictUnificator.getDust(aData.getByProduct(1)),
+                GT_OreDictUnificator.getDust(aData.getByProduct(2)) },
+            null,
+            aData.mMaterial.mMaterial == Materials.Marble ? 1 : (int) Math.max(16, tAmount / M),
+            4,
+            tHide);
 
         if (!aAllowHammer) {
             return;

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingWire.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingWire.java
@@ -303,7 +303,7 @@ public class ProcessingWire implements gregtech.api.interfaces.IOreRecipeRegistr
                     .eut(TierEU.RECIPE_LV)
                     .addTo(sAlloySmelterRecipes);
             }
-            case "Iron", "Nickel", "Cupronickel", "Copper", "AnnealedCopper", "Kanthal", "Gold", "Electrum", "Silver", "Blue Alloy", "Nichrome", "Steel", "BlackSteel", "Titanium", "Aluminium", "BlueAlloy":
+            case "Iron", "Nickel", "Cupronickel", "Copper", "AnnealedCopper", "Kanthal", "Gold", "Electrum", "Silver", "Nichrome", "Steel", "BlackSteel", "Titanium", "Aluminium", "BlueAlloy", "NetherStar":
             // Assembler recipes
             {
                 if (GT_OreDictUnificator.get(correspondingCable, aMaterial, 1L) != null) {

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingWire.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingWire.java
@@ -253,22 +253,22 @@ public class ProcessingWire implements gregtech.api.interfaces.IOreRecipeRegistr
                     craftingListRubber.add(OrePrefixes.plate.get(Materials.Rubber));
                 }
 
-            // shapeless crafting
-            {
-                GT_ModHandler.addShapelessCraftingRecipe(
-                    GT_OreDictUnificator.get(correspondingCable, aMaterial, 1L),
-                    craftingListRubber.toArray());
-            }
+                // shapeless crafting
+                if (GT_OreDictUnificator.get(correspondingCable, aMaterial, 1L) != null) {
+                    GT_ModHandler.addShapelessCraftingRecipe(
+                        GT_OreDictUnificator.get(correspondingCable, aMaterial, 1L),
+                        craftingListRubber.toArray());
+                }
 
-            // Packer recipe
-            {
-                GT_Values.RA.addBoxingRecipe(
-                    GT_Utility.copyAmount(1L, aStack),
-                    GT_OreDictUnificator.get(OrePrefixes.plate.get(Materials.Rubber), costMultiplier),
-                    GT_OreDictUnificator.get(correspondingCable, aMaterial, 1L),
-                    100,
-                    8);
-            }
+                // Packer recipe
+                if (GT_OreDictUnificator.get(correspondingCable, aMaterial, 1L) != null) {
+                    GT_Values.RA.addBoxingRecipe(
+                        GT_Utility.copyAmount(1L, aStack),
+                        GT_OreDictUnificator.get(OrePrefixes.plate.get(Materials.Rubber), costMultiplier),
+                        GT_OreDictUnificator.get(correspondingCable, aMaterial, 1L),
+                        100,
+                        8);
+                }
 
             // alloy smelter recipes
             {
@@ -306,53 +306,55 @@ public class ProcessingWire implements gregtech.api.interfaces.IOreRecipeRegistr
             case "Iron", "Nickel", "Cupronickel", "Copper", "AnnealedCopper", "Kanthal", "Gold", "Electrum", "Silver", "Blue Alloy", "Nichrome", "Steel", "BlackSteel", "Titanium", "Aluminium", "BlueAlloy":
             // Assembler recipes
             {
-                GT_Values.RA.stdBuilder()
-                    .itemInputs(aStack, GT_Utility.getIntegratedCircuit(24))
-                    .itemOutputs(GT_OreDictUnificator.get(correspondingCable, aMaterial, 1L))
-                    .fluidInputs(Materials.Rubber.getMolten(144 * costMultiplier))
-                    .noFluidOutputs()
-                    .duration(5 * SECONDS)
-                    .eut(8)
-                    .addTo(sAssemblerRecipes);
+                if (GT_OreDictUnificator.get(correspondingCable, aMaterial, 1L) != null) {
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(aStack, GT_Utility.getIntegratedCircuit(24))
+                        .itemOutputs(GT_OreDictUnificator.get(correspondingCable, aMaterial, 1L))
+                        .fluidInputs(Materials.Rubber.getMolten(144 * costMultiplier))
+                        .noFluidOutputs()
+                        .duration(5 * SECONDS)
+                        .eut(8)
+                        .addTo(sAssemblerRecipes);
 
-                GT_Values.RA.stdBuilder()
-                    .itemInputs(aStack, GT_Utility.getIntegratedCircuit(24))
-                    .itemOutputs(GT_OreDictUnificator.get(correspondingCable, aMaterial, 1L))
-                    .fluidInputs(Materials.StyreneButadieneRubber.getMolten(108 * costMultiplier))
-                    .noFluidOutputs()
-                    .duration(5 * SECONDS)
-                    .eut(8)
-                    .addTo(sAssemblerRecipes);
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(aStack, GT_Utility.getIntegratedCircuit(24))
+                        .itemOutputs(GT_OreDictUnificator.get(correspondingCable, aMaterial, 1L))
+                        .fluidInputs(Materials.StyreneButadieneRubber.getMolten(108 * costMultiplier))
+                        .noFluidOutputs()
+                        .duration(5 * SECONDS)
+                        .eut(8)
+                        .addTo(sAssemblerRecipes);
 
-                GT_Values.RA.stdBuilder()
-                    .itemInputs(aStack, GT_Utility.getIntegratedCircuit(24))
-                    .itemOutputs(GT_OreDictUnificator.get(correspondingCable, aMaterial, 1L))
-                    .fluidInputs(Materials.Silicone.getMolten(72 * costMultiplier))
-                    .noFluidOutputs()
-                    .duration(5 * SECONDS)
-                    .eut(8)
-                    .addTo(sAssemblerRecipes);
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(aStack, GT_Utility.getIntegratedCircuit(24))
+                        .itemOutputs(GT_OreDictUnificator.get(correspondingCable, aMaterial, 1L))
+                        .fluidInputs(Materials.Silicone.getMolten(72 * costMultiplier))
+                        .noFluidOutputs()
+                        .duration(5 * SECONDS)
+                        .eut(8)
+                        .addTo(sAssemblerRecipes);
 
-                for (Materials dielectric : dielectrics) {
-                    for (Materials syntheticRubber : syntheticRubbers) {
+                    for (Materials dielectric : dielectrics) {
+                        for (Materials syntheticRubber : syntheticRubbers) {
 
-                        GT_Values.RA.stdBuilder()
-                            .itemInputs(GT_Utility.copyAmount(4, aStack), dielectric.getDust(costMultiplier))
-                            .itemOutputs(GT_OreDictUnificator.get(correspondingCable, aMaterial, 4L))
-                            .fluidInputs(syntheticRubber.getMolten(costMultiplier * 144))
-                            .noFluidOutputs()
-                            .duration(20 * SECONDS)
-                            .eut(8)
-                            .addTo(sAssemblerRecipes);
+                            GT_Values.RA.stdBuilder()
+                                .itemInputs(GT_Utility.copyAmount(4, aStack), dielectric.getDust(costMultiplier))
+                                .itemOutputs(GT_OreDictUnificator.get(correspondingCable, aMaterial, 4L))
+                                .fluidInputs(syntheticRubber.getMolten(costMultiplier * 144))
+                                .noFluidOutputs()
+                                .duration(20 * SECONDS)
+                                .eut(8)
+                                .addTo(sAssemblerRecipes);
 
-                        GT_Values.RA.stdBuilder()
-                            .itemInputs(aStack, dielectric.getDustSmall(costMultiplier))
-                            .itemOutputs(GT_OreDictUnificator.get(correspondingCable, aMaterial, 1L))
-                            .fluidInputs(syntheticRubber.getMolten(costMultiplier * 36))
-                            .noFluidOutputs()
-                            .duration(5 * SECONDS)
-                            .eut(8)
-                            .addTo(sAssemblerRecipes);
+                            GT_Values.RA.stdBuilder()
+                                .itemInputs(aStack, dielectric.getDustSmall(costMultiplier))
+                                .itemOutputs(GT_OreDictUnificator.get(correspondingCable, aMaterial, 1L))
+                                .fluidInputs(syntheticRubber.getMolten(costMultiplier * 36))
+                                .noFluidOutputs()
+                                .duration(5 * SECONDS)
+                                .eut(8)
+                                .addTo(sAssemblerRecipes);
+                        }
                     }
                 }
             }
@@ -360,52 +362,54 @@ public class ProcessingWire implements gregtech.api.interfaces.IOreRecipeRegistr
             case "RedstoneAlloy":
             // Assembler recipes
             {
-                GT_Values.RA.stdBuilder()
-                    .itemInputs(aStack, GT_Utility.getIntegratedCircuit(24))
-                    .itemOutputs(GT_OreDictUnificator.get(correspondingCable, aMaterial, 1L))
-                    .fluidInputs(Materials.Rubber.getMolten(144 * costMultiplier))
-                    .noFluidOutputs()
-                    .duration(5 * SECONDS)
-                    .eut(8)
-                    .addTo(sAssemblerRecipes);
+                if (GT_OreDictUnificator.get(correspondingCable, aMaterial, 1L) != null) {
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(aStack, GT_Utility.getIntegratedCircuit(24))
+                        .itemOutputs(GT_OreDictUnificator.get(correspondingCable, aMaterial, 1L))
+                        .fluidInputs(Materials.Rubber.getMolten(144 * costMultiplier))
+                        .noFluidOutputs()
+                        .duration(5 * SECONDS)
+                        .eut(8)
+                        .addTo(sAssemblerRecipes);
 
-                GT_Values.RA.stdBuilder()
-                    .itemInputs(aStack, GT_Utility.getIntegratedCircuit(24))
-                    .itemOutputs(GT_OreDictUnificator.get(correspondingCable, aMaterial, 1L))
-                    .fluidInputs(Materials.StyreneButadieneRubber.getMolten(108 * costMultiplier))
-                    .noFluidOutputs()
-                    .duration(5 * SECONDS)
-                    .eut(8)
-                    .addTo(sAssemblerRecipes);
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(aStack, GT_Utility.getIntegratedCircuit(24))
+                        .itemOutputs(GT_OreDictUnificator.get(correspondingCable, aMaterial, 1L))
+                        .fluidInputs(Materials.StyreneButadieneRubber.getMolten(108 * costMultiplier))
+                        .noFluidOutputs()
+                        .duration(5 * SECONDS)
+                        .eut(8)
+                        .addTo(sAssemblerRecipes);
 
-                GT_Values.RA.stdBuilder()
-                    .itemInputs(aStack, GT_Utility.getIntegratedCircuit(24))
-                    .itemOutputs(GT_OreDictUnificator.get(correspondingCable, aMaterial, 1L))
-                    .fluidInputs(Materials.Silicone.getMolten(72 * costMultiplier))
-                    .noFluidOutputs()
-                    .duration(5 * SECONDS)
-                    .eut(8)
-                    .addTo(sAssemblerRecipes);
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(aStack, GT_Utility.getIntegratedCircuit(24))
+                        .itemOutputs(GT_OreDictUnificator.get(correspondingCable, aMaterial, 1L))
+                        .fluidInputs(Materials.Silicone.getMolten(72 * costMultiplier))
+                        .noFluidOutputs()
+                        .duration(5 * SECONDS)
+                        .eut(8)
+                        .addTo(sAssemblerRecipes);
 
-                for (Materials dielectric : dielectrics) {
-                    for (Materials syntheticRubber : syntheticRubbers) {
-                        GT_Values.RA.stdBuilder()
-                            .itemInputs(GT_Utility.copyAmount(4, aStack), dielectric.getDust(costMultiplier))
-                            .itemOutputs(GT_OreDictUnificator.get(correspondingCable, aMaterial, 4L))
-                            .fluidInputs(syntheticRubber.getMolten(costMultiplier * 144))
-                            .noFluidOutputs()
-                            .duration(20 * SECONDS)
-                            .eut(8)
-                            .addTo(sAssemblerRecipes);
+                    for (Materials dielectric : dielectrics) {
+                        for (Materials syntheticRubber : syntheticRubbers) {
+                            GT_Values.RA.stdBuilder()
+                                .itemInputs(GT_Utility.copyAmount(4, aStack), dielectric.getDust(costMultiplier))
+                                .itemOutputs(GT_OreDictUnificator.get(correspondingCable, aMaterial, 4L))
+                                .fluidInputs(syntheticRubber.getMolten(costMultiplier * 144))
+                                .noFluidOutputs()
+                                .duration(20 * SECONDS)
+                                .eut(8)
+                                .addTo(sAssemblerRecipes);
 
-                        GT_Values.RA.stdBuilder()
-                            .itemInputs(aStack, dielectric.getDustSmall(costMultiplier))
-                            .itemOutputs(GT_OreDictUnificator.get(correspondingCable, aMaterial, 1L))
-                            .fluidInputs(syntheticRubber.getMolten(costMultiplier * 36))
-                            .noFluidOutputs()
-                            .duration(5 * SECONDS)
-                            .eut(8)
-                            .addTo(sAssemblerRecipes);
+                            GT_Values.RA.stdBuilder()
+                                .itemInputs(aStack, dielectric.getDustSmall(costMultiplier))
+                                .itemOutputs(GT_OreDictUnificator.get(correspondingCable, aMaterial, 1L))
+                                .fluidInputs(syntheticRubber.getMolten(costMultiplier * 36))
+                                .noFluidOutputs()
+                                .duration(5 * SECONDS)
+                                .eut(8)
+                                .addTo(sAssemblerRecipes);
+                        }
                     }
                 }
             }
@@ -413,79 +417,81 @@ public class ProcessingWire implements gregtech.api.interfaces.IOreRecipeRegistr
             default:
             // Assembler recipes
             {
-                GT_Values.RA.stdBuilder()
-                    .itemInputs(
-                        aStack,
-                        GT_OreDictUnificator.get(OrePrefixes.foil, aMaterial, costMultiplier),
-                        GT_Utility.getIntegratedCircuit(24))
-                    .itemOutputs(GT_OreDictUnificator.get(correspondingCable, aMaterial, 1L))
-                    .fluidInputs(Materials.Silicone.getMolten(costMultiplier * 72))
-                    .noFluidOutputs()
-                    .duration(5 * SECONDS)
-                    .eut(calculateRecipeEU(aMaterial, 8))
-                    .addTo(sAssemblerRecipes);
+                if (GT_OreDictUnificator.get(correspondingCable, aMaterial, 1L) != null) {
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(
+                            aStack,
+                            GT_OreDictUnificator.get(OrePrefixes.foil, aMaterial, costMultiplier),
+                            GT_Utility.getIntegratedCircuit(24))
+                        .itemOutputs(GT_OreDictUnificator.get(correspondingCable, aMaterial, 1L))
+                        .fluidInputs(Materials.Silicone.getMolten(costMultiplier * 72))
+                        .noFluidOutputs()
+                        .duration(5 * SECONDS)
+                        .eut(calculateRecipeEU(aMaterial, 8))
+                        .addTo(sAssemblerRecipes);
 
-                GT_Values.RA.stdBuilder()
-                    .itemInputs(
-                        aStack,
-                        GT_OreDictUnificator.get(OrePrefixes.foil, Materials.PolyphenyleneSulfide, costMultiplier),
-                        GT_Utility.getIntegratedCircuit(24))
-                    .itemOutputs(GT_OreDictUnificator.get(correspondingCable, aMaterial, 1L))
-                    .fluidInputs(Materials.Silicone.getMolten(costMultiplier * 72))
-                    .noFluidOutputs()
-                    .duration(5 * SECONDS)
-                    .eut(calculateRecipeEU(aMaterial, 8))
-                    .addTo(sAssemblerRecipes);
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(
+                            aStack,
+                            GT_OreDictUnificator.get(OrePrefixes.foil, Materials.PolyphenyleneSulfide, costMultiplier),
+                            GT_Utility.getIntegratedCircuit(24))
+                        .itemOutputs(GT_OreDictUnificator.get(correspondingCable, aMaterial, 1L))
+                        .fluidInputs(Materials.Silicone.getMolten(costMultiplier * 72))
+                        .noFluidOutputs()
+                        .duration(5 * SECONDS)
+                        .eut(calculateRecipeEU(aMaterial, 8))
+                        .addTo(sAssemblerRecipes);
 
-                for (Materials dielectric : dielectrics) {
-                    for (Materials syntheticRubber : syntheticRubbers) {
+                    for (Materials dielectric : dielectrics) {
+                        for (Materials syntheticRubber : syntheticRubbers) {
 
-                        GT_Values.RA.stdBuilder()
-                            .itemInputs(
-                                GT_Utility.copyAmount(4, aStack),
-                                dielectric.getDust(costMultiplier),
-                                GT_OreDictUnificator.get(OrePrefixes.foil, aMaterial, costMultiplier * 4))
-                            .itemOutputs(GT_OreDictUnificator.get(correspondingCable, aMaterial, 4L))
-                            .fluidInputs(syntheticRubber.getMolten(costMultiplier * 144))
-                            .noFluidOutputs()
-                            .duration(20 * SECONDS)
-                            .eut(calculateRecipeEU(aMaterial, 8))
-                            .addTo(sAssemblerRecipes);
-                        GT_Values.RA.stdBuilder()
-                            .itemInputs(
-                                GT_Utility.copyAmount(4, aStack),
-                                dielectric.getDust(costMultiplier),
-                                GT_OreDictUnificator
-                                    .get(OrePrefixes.foil, Materials.PolyphenyleneSulfide, costMultiplier * 4))
-                            .itemOutputs(GT_OreDictUnificator.get(correspondingCable, aMaterial, 4L))
-                            .fluidInputs(syntheticRubber.getMolten(costMultiplier * 144))
-                            .noFluidOutputs()
-                            .duration(20 * SECONDS)
-                            .eut(calculateRecipeEU(aMaterial, 8))
-                            .addTo(sAssemblerRecipes);
-                        GT_Values.RA.stdBuilder()
-                            .itemInputs(
-                                aStack,
-                                dielectric.getDustSmall(costMultiplier),
-                                GT_OreDictUnificator.get(OrePrefixes.foil, aMaterial, costMultiplier))
-                            .itemOutputs(GT_OreDictUnificator.get(correspondingCable, aMaterial, 1L))
-                            .fluidInputs(syntheticRubber.getMolten(costMultiplier * 36))
-                            .noFluidOutputs()
-                            .duration(5 * SECONDS)
-                            .eut(calculateRecipeEU(aMaterial, 8))
-                            .addTo(sAssemblerRecipes);
-                        GT_Values.RA.stdBuilder()
-                            .itemInputs(
-                                aStack,
-                                dielectric.getDustSmall(costMultiplier),
-                                GT_OreDictUnificator
-                                    .get(OrePrefixes.foil, Materials.PolyphenyleneSulfide, costMultiplier))
-                            .itemOutputs(GT_OreDictUnificator.get(correspondingCable, aMaterial, 1L))
-                            .fluidInputs(syntheticRubber.getMolten(costMultiplier * 36))
-                            .noFluidOutputs()
-                            .duration(5 * SECONDS)
-                            .eut(calculateRecipeEU(aMaterial, 8))
-                            .addTo(sAssemblerRecipes);
+                            GT_Values.RA.stdBuilder()
+                                .itemInputs(
+                                    GT_Utility.copyAmount(4, aStack),
+                                    dielectric.getDust(costMultiplier),
+                                    GT_OreDictUnificator.get(OrePrefixes.foil, aMaterial, costMultiplier * 4))
+                                .itemOutputs(GT_OreDictUnificator.get(correspondingCable, aMaterial, 4L))
+                                .fluidInputs(syntheticRubber.getMolten(costMultiplier * 144))
+                                .noFluidOutputs()
+                                .duration(20 * SECONDS)
+                                .eut(calculateRecipeEU(aMaterial, 8))
+                                .addTo(sAssemblerRecipes);
+                            GT_Values.RA.stdBuilder()
+                                .itemInputs(
+                                    GT_Utility.copyAmount(4, aStack),
+                                    dielectric.getDust(costMultiplier),
+                                    GT_OreDictUnificator
+                                        .get(OrePrefixes.foil, Materials.PolyphenyleneSulfide, costMultiplier * 4))
+                                .itemOutputs(GT_OreDictUnificator.get(correspondingCable, aMaterial, 4L))
+                                .fluidInputs(syntheticRubber.getMolten(costMultiplier * 144))
+                                .noFluidOutputs()
+                                .duration(20 * SECONDS)
+                                .eut(calculateRecipeEU(aMaterial, 8))
+                                .addTo(sAssemblerRecipes);
+                            GT_Values.RA.stdBuilder()
+                                .itemInputs(
+                                    aStack,
+                                    dielectric.getDustSmall(costMultiplier),
+                                    GT_OreDictUnificator.get(OrePrefixes.foil, aMaterial, costMultiplier))
+                                .itemOutputs(GT_OreDictUnificator.get(correspondingCable, aMaterial, 1L))
+                                .fluidInputs(syntheticRubber.getMolten(costMultiplier * 36))
+                                .noFluidOutputs()
+                                .duration(5 * SECONDS)
+                                .eut(calculateRecipeEU(aMaterial, 8))
+                                .addTo(sAssemblerRecipes);
+                            GT_Values.RA.stdBuilder()
+                                .itemInputs(
+                                    aStack,
+                                    dielectric.getDustSmall(costMultiplier),
+                                    GT_OreDictUnificator
+                                        .get(OrePrefixes.foil, Materials.PolyphenyleneSulfide, costMultiplier))
+                                .itemOutputs(GT_OreDictUnificator.get(correspondingCable, aMaterial, 1L))
+                                .fluidInputs(syntheticRubber.getMolten(costMultiplier * 36))
+                                .noFluidOutputs()
+                                .duration(5 * SECONDS)
+                                .eut(calculateRecipeEU(aMaterial, 8))
+                                .addTo(sAssemblerRecipes);
+                        }
                     }
                 }
             }
@@ -493,14 +499,17 @@ public class ProcessingWire implements gregtech.api.interfaces.IOreRecipeRegistr
         }
 
         // Honestly when can this machine be removed? );
-        GT_Values.RA.addUnboxingRecipe(
-            GT_OreDictUnificator.get(correspondingCable, aMaterial, 1L),
-            GT_Utility.copyAmount(1L, aStack),
-            null,
-            100,
-            calculateRecipeEU(aMaterial, 8));
+        if (GT_OreDictUnificator.get(correspondingCable, aMaterial, 1L) != null) {
+            GT_Values.RA.addUnboxingRecipe(
+                GT_OreDictUnificator.get(correspondingCable, aMaterial, 1L),
+                GT_Utility.copyAmount(1L, aStack),
+                null,
+                100,
+                calculateRecipeEU(aMaterial, 8));
+        }
 
-        if (GT_Mod.gregtechproxy.mAE2Integration) {
+        if (GT_Mod.gregtechproxy.mAE2Integration
+            && GT_OreDictUnificator.get(correspondingCable, aMaterial, 1L) != null) {
             AE2AddNetAttunementCable(aStack, correspondingCable, aMaterial);
         }
     }


### PR DESCRIPTION
- add null checks for cables in wire oredict recipes (RA2 really needs them, clears up a lot in the debug log)
- fix netherstar cables (not a RA2 fix, this is an older problem as netherstar does not have foils)
- actually fix drillhead recycling steel exploit
- revert the old hacky fix attempt [here](https://github.com/GTNewHorizons/GT5-Unofficial/pull/1773) that never worked.

all tested with latest nightly.

context:
this was how nether star cables looked like with the null item before the circuit:
![image](https://github.com/GTNewHorizons/GT5-Unofficial/assets/40274384/b873efa4-fb56-4272-a41c-b7713b343208)

this was how drill recycling looked like:
![image](https://github.com/GTNewHorizons/GT5-Unofficial/assets/40274384/df4a246c-a587-4aeb-8b8c-829c5a1202fa)

