### PR TITLE
more Ra2 recipe conversions and some small fixes/improvements in GT recipe generation

### DIFF
--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingCell.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingCell.java
@@ -18,6 +18,7 @@ import gregtech.api.interfaces.IOreRecipeRegistrator;
 import gregtech.api.objects.MaterialStack;
 import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_OreDictUnificator;
+import gregtech.api.util.GT_RecipeBuilder;
 import gregtech.api.util.GT_Utility;
 
 public class ProcessingCell implements IOreRecipeRegistrator {
@@ -103,20 +104,21 @@ public class ProcessingCell implements IOreRecipeRegistrator {
                                 // Electrolyzer recipe
                                 {
                                     if (GT_Utility.getFluidForFilledItem(aStack, true) == null) {
-                                        int capsuleCount = tCapsuleCount <= 0L ? 0 : (int) tCapsuleCount;
-                                        ItemStack cells = capsuleCount <= 0 ? null
-                                            : ItemList.Cell_Empty.get(capsuleCount);
                                         // dust stuffed cell e.g. Phosphate, Phosphorous Pentoxide
-                                        GT_Values.RA.stdBuilder()
-                                            .itemInputs(GT_Utility.copyAmount(tItemAmount, aStack), cells)
-                                            .itemOutputs(
-                                                tList.get(0),
-                                                tList.size() >= 2 ? tList.get(1) : null,
-                                                tList.size() >= 3 ? tList.get(2) : null,
-                                                tList.size() >= 4 ? tList.get(3) : null,
-                                                tList.size() >= 5 ? tList.get(4) : null,
-                                                tCapsuleCount >= 0L ? tList.size() >= 6 ? tList.get(5) : null
-                                                    : ItemList.Cell_Empty.get(-tCapsuleCount))
+                                        GT_RecipeBuilder recipeBuilder = GT_Values.RA.stdBuilder();
+                                        if (tCapsuleCount > 0L) {
+                                            recipeBuilder.itemInputs(
+                                                GT_Utility.copyAmount(tItemAmount, aStack),
+                                                ItemList.Cell_Empty.get(tCapsuleCount));
+                                        } else {
+                                            recipeBuilder.itemInputs(GT_Utility.copyAmount(tItemAmount, aStack));
+                                        }
+                                        if (tCapsuleCount < 0L) {
+                                            tList.add(ItemList.Cell_Empty.get(-tCapsuleCount));
+                                        }
+                                        ItemStack[] outputsArray = tList
+                                            .toArray(new ItemStack[Math.min(tList.size(), 6)]);
+                                        recipeBuilder.itemOutputs(outputsArray)
                                             .noFluidInputs()
                                             .noFluidOutputs()
                                             .duration(Math.max(1L, Math.abs(aMaterial.getProtons() * 2L * tItemAmount)))
@@ -124,20 +126,18 @@ public class ProcessingCell implements IOreRecipeRegistrator {
                                             .addTo(sElectrolyzerRecipes);
                                     } else {
                                         long tCellBalance = tCapsuleCount + tItemAmount - 1;
-                                        int capsuleCount = tCellBalance <= 0L ? 0 : (int) tCellBalance;
-                                        ItemStack cells = capsuleCount <= 0 ? null
-                                            : ItemList.Cell_Empty.get(capsuleCount);
-
-                                        GT_Values.RA.stdBuilder()
-                                            .itemInputs(aStack, cells)
-                                            .itemOutputs(
-                                                tList.get(0),
-                                                tList.size() >= 2 ? tList.get(1) : null,
-                                                tList.size() >= 3 ? tList.get(2) : null,
-                                                tList.size() >= 4 ? tList.get(3) : null,
-                                                tList.size() >= 5 ? tList.get(4) : null,
-                                                tCapsuleCount >= 0L ? tList.size() >= 6 ? tList.get(5) : null
-                                                    : tCellBalance < 0 ? ItemList.Cell_Empty.get(-tCellBalance) : null)
+                                        GT_RecipeBuilder recipeBuilder = GT_Values.RA.stdBuilder();
+                                        if (tCellBalance > 0L) {
+                                            recipeBuilder.itemInputs(aStack, ItemList.Cell_Empty.get(tCellBalance));
+                                        } else {
+                                            recipeBuilder.itemInputs(GT_Utility.copyAmount(tItemAmount, aStack));
+                                        }
+                                        if (tCellBalance < 0L) {
+                                            tList.add(ItemList.Cell_Empty.get(-tCellBalance));
+                                        }
+                                        ItemStack[] outputsArray = tList
+                                            .toArray(new ItemStack[Math.min(tList.size(), 6)]);
+                                        recipeBuilder.itemOutputs(outputsArray)
                                             .noFluidInputs()
                                             .noFluidOutputs()
                                             .duration(Math.max(1L, Math.abs(aMaterial.getProtons() * 8L * tItemAmount)))
@@ -147,19 +147,19 @@ public class ProcessingCell implements IOreRecipeRegistrator {
                                 }
                             }
                             if ((aMaterial.mExtraData & 0x2) != 0) {
-                                ItemStack emptyCells = tCapsuleCount > 0 ? ItemList.Cell_Empty.get(tCapsuleCount)
-                                    : null;
-
-                                GT_Values.RA.stdBuilder()
-                                    .itemInputs(GT_Utility.copyAmount(tItemAmount, aStack), emptyCells)
-                                    .itemOutputs(
-                                        tList.get(0),
-                                        tList.size() >= 2 ? tList.get(1) : null,
-                                        tList.size() >= 3 ? tList.get(2) : null,
-                                        tList.size() >= 4 ? tList.get(3) : null,
-                                        tList.size() >= 5 ? tList.get(4) : null,
-                                        tCapsuleCount >= 0L ? tList.size() >= 6 ? tList.get(5) : null
-                                            : ItemList.Cell_Empty.get(-tCapsuleCount))
+                                GT_RecipeBuilder recipeBuilder = GT_Values.RA.stdBuilder();
+                                if (tCapsuleCount > 0L) {
+                                    recipeBuilder.itemInputs(
+                                        GT_Utility.copyAmount(tItemAmount, aStack),
+                                        ItemList.Cell_Empty.get(tCapsuleCount));
+                                } else {
+                                    recipeBuilder.itemInputs(GT_Utility.copyAmount(tItemAmount, aStack));
+                                }
+                                if (tCapsuleCount < 0L) {
+                                    tList.add(ItemList.Cell_Empty.get(-tCapsuleCount));
+                                }
+                                ItemStack[] outputsArray = tList.toArray(new ItemStack[Math.min(tList.size(), 6)]);
+                                recipeBuilder.itemOutputs(outputsArray)
                                     .noFluidInputs()
                                     .noFluidOutputs()
                                     .duration(Math.max(1L, Math.abs(aMaterial.getMass() * 2L * tItemAmount)))

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingDust.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingDust.java
@@ -258,7 +258,8 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                         }
                     }
                 }
-                if (aMaterial.contains(SubTag.CRYSTALLISABLE)) {
+                if (aMaterial.contains(SubTag.CRYSTALLISABLE)
+                    && GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 1L) != null) {
                     GT_Values.RA.stdBuilder()
                         .itemInputs(GT_Utility.copyAmount(1L, aStack), GT_Utility.getIntegratedCircuit(1))
                         .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 1L))
@@ -531,7 +532,8 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                             .addTo(sElectroMagneticSeparatorRecipes);
                     }
                 }
-                if (aMaterial.contains(SubTag.CRYSTALLISABLE)) {
+                if (aMaterial.contains(SubTag.CRYSTALLISABLE)
+                    && GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 1L) != null) {
                     GT_Values.RA.stdBuilder()
                         .itemInputs(GT_Utility.copyAmount(1L, aStack), GT_Utility.getIntegratedCircuit(1))
                         .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 1L))

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingDust.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingDust.java
@@ -28,6 +28,7 @@ import gregtech.api.enums.TierEU;
 import gregtech.api.objects.MaterialStack;
 import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_OreDictUnificator;
+import gregtech.api.util.GT_RecipeBuilder;
 import gregtech.api.util.GT_RecipeConstants;
 import gregtech.api.util.GT_RecipeRegistrator;
 import gregtech.api.util.GT_Utility;
@@ -168,9 +169,9 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                             if (tDustStack != null) {
                                 tDustStack.stackSize = ((int) (tDustStack.stackSize * tDensityMultiplier));
                                 while ((tDustStack.stackSize > 64) && (tList.size() < 6)
-                                    && (tCapsuleCount + GT_ModHandler.getCapsuleCellContainerCount(tDustStack) * 64
+                                    && (tCapsuleCount + GT_ModHandler.getCapsuleCellContainerCount(tDustStack) * 64L
                                         <= 64L)) {
-                                    tCapsuleCount += GT_ModHandler.getCapsuleCellContainerCount(tDustStack) * 64;
+                                    tCapsuleCount += GT_ModHandler.getCapsuleCellContainerCount(tDustStack) * 64L;
                                     tList.add(GT_Utility.copyAmount(64L, tDustStack));
                                     tDustStack.stackSize -= 64;
                                 }
@@ -201,40 +202,59 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                             }
                         }
                         if ((aMaterial.mExtraData & 0x1) != 0) {
-                            ItemStack cells = tCapsuleCount > 0L ? ItemList.Cell_Empty.get(tCapsuleCount) : null;
-
-                            GT_Values.RA.stdBuilder()
-                                .itemInputs(GT_Utility.copyAmount(tItemAmount, aStack), cells)
-                                .itemOutputs(
-                                    tList.size() < 1 ? null : tList.get(0),
-                                    tList.size() < 2 ? null : tList.get(1),
-                                    tList.size() < 3 ? null : tList.get(2),
-                                    tList.size() < 4 ? null : tList.get(3),
-                                    tList.size() < 5 ? null : tList.get(4),
-                                    tList.size() < 6 ? null : tList.get(5))
-                                .noFluidInputs()
-                                .fluidOutputs(tFluid)
-                                .duration(Math.max(1L, Math.abs(aMaterial.getProtons() * 2L * tItemAmount)))
-                                .eut(Math.min(4, tList.size()) * 30)
-                                .addTo(sElectrolyzerRecipes);
+                            if (tList.size() > 0 || tFluid != null) {
+                                GT_RecipeBuilder recipeBuilder = GT_Values.RA.stdBuilder();
+                                if (tCapsuleCount > 0L) {
+                                    recipeBuilder.itemInputs(
+                                        GT_Utility.copyAmount(tItemAmount, aStack),
+                                        ItemList.Cell_Empty.get(tCapsuleCount));
+                                } else {
+                                    recipeBuilder.itemInputs(GT_Utility.copyAmount(tItemAmount, aStack));
+                                }
+                                if (tList.size() > 0) {
+                                    ItemStack[] outputsArray = tList.toArray(new ItemStack[Math.min(tList.size(), 6)]);
+                                    recipeBuilder.itemOutputs(outputsArray);
+                                } else {
+                                    recipeBuilder.noItemOutputs();
+                                }
+                                recipeBuilder.noFluidInputs();
+                                if (tFluid != null) {
+                                    recipeBuilder.fluidOutputs(tFluid);
+                                } else {
+                                    recipeBuilder.noFluidOutputs();
+                                }
+                                recipeBuilder
+                                    .duration(Math.max(1L, Math.abs(aMaterial.getProtons() * 2L * tItemAmount)))
+                                    .eut(Math.min(4, tList.size()) * 30)
+                                    .addTo(sElectrolyzerRecipes);
+                            }
                         }
                         if ((aMaterial.mExtraData & 0x2) != 0) {
-                            GT_Values.RA.stdBuilder()
-                                .itemInputs(
-                                    GT_Utility.copyAmount(tItemAmount, aStack),
-                                    tCapsuleCount > 0L ? ItemList.Cell_Empty.get(tCapsuleCount) : null)
-                                .itemOutputs(
-                                    tList.size() < 1 ? null : tList.get(0),
-                                    tList.size() < 2 ? null : tList.get(1),
-                                    tList.size() < 3 ? null : tList.get(2),
-                                    tList.size() < 4 ? null : tList.get(3),
-                                    tList.size() < 5 ? null : tList.get(4),
-                                    tList.size() < 6 ? null : tList.get(5))
-                                .noFluidInputs()
-                                .fluidOutputs(tFluid)
-                                .duration(Math.max(1L, Math.abs(aMaterial.getMass() * 4L * tItemAmount)))
-                                .eut(Math.min(4, tList.size()) * 5)
-                                .addTo(sCentrifugeRecipes);
+                            if (tList.size() > 0 || tFluid != null) {
+                                GT_RecipeBuilder recipeBuilder = GT_Values.RA.stdBuilder();
+                                if (tCapsuleCount > 0L) {
+                                    recipeBuilder.itemInputs(
+                                        GT_Utility.copyAmount(tItemAmount, aStack),
+                                        ItemList.Cell_Empty.get(tCapsuleCount));
+                                } else {
+                                    recipeBuilder.itemInputs(GT_Utility.copyAmount(tItemAmount, aStack));
+                                }
+                                if (tList.size() > 0) {
+                                    ItemStack[] outputsArray = tList.toArray(new ItemStack[Math.min(tList.size(), 6)]);
+                                    recipeBuilder.itemOutputs(outputsArray);
+                                } else {
+                                    recipeBuilder.noItemOutputs();
+                                }
+                                recipeBuilder.noFluidInputs();
+                                if (tFluid != null) {
+                                    recipeBuilder.fluidOutputs(tFluid);
+                                } else {
+                                    recipeBuilder.noFluidOutputs();
+                                }
+                                recipeBuilder.duration(Math.max(1L, Math.abs(aMaterial.getMass() * 4L * tItemAmount)))
+                                    .eut(Math.min(4, tList.size()) * 5)
+                                    .addTo(sCentrifugeRecipes);
+                            }
                         }
                     }
                 }

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingDust.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingDust.java
@@ -1,19 +1,34 @@
 package gregtech.loaders.oreprocessing;
 
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAutoclaveRecipes;
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCannerRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCentrifugeRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCompressorRecipes;
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sElectroMagneticSeparatorRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sElectrolyzerRecipes;
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sImplosionRecipes;
+import static gregtech.api.util.GT_RecipeBuilder.MINUTES;
 import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
+import static gregtech.api.util.GT_RecipeConstants.FUEL_TYPE;
+import static gregtech.api.util.GT_RecipeConstants.FUEL_VALUE;
 
 import java.util.ArrayList;
 
+import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
-import gregtech.api.enums.*;
+import gregtech.api.enums.GT_Values;
+import gregtech.api.enums.ItemList;
+import gregtech.api.enums.Materials;
+import gregtech.api.enums.MaterialsUEVplus;
+import gregtech.api.enums.OrePrefixes;
+import gregtech.api.enums.SubTag;
+import gregtech.api.enums.TierEU;
 import gregtech.api.objects.MaterialStack;
 import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_OreDictUnificator;
+import gregtech.api.util.GT_RecipeConstants;
 import gregtech.api.util.GT_RecipeRegistrator;
 import gregtech.api.util.GT_Utility;
 
@@ -33,17 +48,29 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
         ItemStack aStack) {
         switch (aPrefix) {
             case dust -> {
-                if (aMaterial.mFuelPower > 0) GT_Values.RA
-                    .addFuel(GT_Utility.copyAmount(1L, aStack), null, aMaterial.mFuelPower, aMaterial.mFuelType);
-                if (GT_Utility.getFluidForFilledItem(GT_OreDictUnificator.get(OrePrefixes.cell, aMaterial, 1L), true)
-                    == null)
-                    GT_Values.RA.addCannerRecipe(
-                        aStack,
-                        ItemList.Cell_Empty.get(1L),
-                        GT_OreDictUnificator.get(OrePrefixes.cell, aMaterial, 1L),
-                        null,
-                        100,
-                        1);
+                if (aMaterial.mFuelPower > 0) {
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                        .noItemOutputs()
+                        .noFluidInputs()
+                        .noFluidOutputs()
+                        .metadata(FUEL_VALUE, aMaterial.mFuelPower)
+                        .metadata(FUEL_TYPE, aMaterial.mFuelType)
+                        .duration(0)
+                        .eut(0)
+                        .addTo(GT_RecipeConstants.Fuel);
+                }
+                if ((GT_Utility.getFluidForFilledItem(GT_OreDictUnificator.get(OrePrefixes.cell, aMaterial, 1L), true)
+                    == null) && (GT_OreDictUnificator.get(OrePrefixes.cell, aMaterial, 1L) != null)) {
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(aStack, ItemList.Cell_Empty.get(1L))
+                        .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.cell, aMaterial, 1L))
+                        .noFluidInputs()
+                        .noFluidOutputs()
+                        .duration(5 * SECONDS)
+                        .eut(1)
+                        .addTo(sCannerRecipes);
+                }
                 if (!aMaterial.mBlastFurnaceRequired) {
                     GT_RecipeRegistrator.registerReverseFluidSmelting(aStack, aMaterial, aPrefix.mMaterialAmount, null);
                     if (aMaterial.mSmeltInto.mArcSmeltInto != aMaterial) {
@@ -212,33 +239,33 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                     }
                 }
                 if (aMaterial.contains(SubTag.CRYSTALLISABLE)) {
-                    GT_Values.RA.addAutoclaveRecipe(
-                        GT_Utility.copyAmount(1L, aStack),
-                        GT_Utility.getIntegratedCircuit(1),
-                        Materials.Water.getFluid(200L),
-                        GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 1L),
-                        7000,
-                        2000,
-                        24,
-                        false);
-                    GT_Values.RA.addAutoclaveRecipe(
-                        GT_Utility.copyAmount(1L, aStack),
-                        GT_Utility.getIntegratedCircuit(2),
-                        GT_ModHandler.getDistilledWater(100L),
-                        GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 1L),
-                        9000,
-                        1500,
-                        24,
-                        false);
-                    GT_Values.RA.addAutoclaveRecipe(
-                        GT_Utility.copyAmount(1L, aStack),
-                        GT_Utility.getIntegratedCircuit(3),
-                        Materials.Void.getMolten(36L),
-                        GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 1L),
-                        10000,
-                        1200,
-                        24,
-                        false);
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(GT_Utility.copyAmount(1L, aStack), GT_Utility.getIntegratedCircuit(1))
+                        .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 1L))
+                        .outputChances(7000)
+                        .fluidInputs(Materials.Water.getFluid(200L))
+                        .noFluidOutputs()
+                        .duration(1 * MINUTES + 40 * SECONDS)
+                        .eut(24)
+                        .addTo(sAutoclaveRecipes);
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(GT_Utility.copyAmount(1L, aStack), GT_Utility.getIntegratedCircuit(2))
+                        .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 1L))
+                        .outputChances(9000)
+                        .fluidInputs(GT_ModHandler.getDistilledWater(100L))
+                        .noFluidOutputs()
+                        .duration(1 * MINUTES + 15 * SECONDS)
+                        .eut(24)
+                        .addTo(sAutoclaveRecipes);
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(GT_Utility.copyAmount(1L, aStack), GT_Utility.getIntegratedCircuit(3))
+                        .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 1L))
+                        .outputChances(10000)
+                        .fluidInputs(Materials.Void.getMolten(36L))
+                        .noFluidOutputs()
+                        .duration(1 * MINUTES)
+                        .eut(24)
+                        .addTo(sAutoclaveRecipes);
                 }
                 switch (aMaterial.mName) {
                     case "NULL":
@@ -282,12 +309,50 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                             GT_Utility.copyAmount(1L, aStack),
                             GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Coal, 1L));
                         break;
-                    case "Diamond":
-                        GT_Values.RA.addImplosionRecipe(
-                            GT_Utility.copyAmount(4L, aStack),
-                            32,
-                            ItemList.IC2_Industrial_Diamond.get(3L),
-                            GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 16L));
+                    case "Diamond": {
+                        GT_Values.RA.stdBuilder()
+                            .itemInputs(GT_Utility.copyAmount(4L, aStack), ItemList.Block_Powderbarrel.get(64))
+                            .itemOutputs(
+                                ItemList.IC2_Industrial_Diamond.get(3L),
+                                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 16L))
+                            .noFluidInputs()
+                            .noFluidOutputs()
+                            .duration(1 * SECONDS)
+                            .eut(TierEU.RECIPE_LV)
+                            .addTo(sImplosionRecipes);
+                        GT_Values.RA.stdBuilder()
+                            .itemInputs(
+                                GT_Utility.copyAmount(4L, aStack),
+                                GT_ModHandler.getIC2Item("dynamite", 16, null))
+                            .itemOutputs(
+                                ItemList.IC2_Industrial_Diamond.get(3L),
+                                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 16L))
+                            .noFluidInputs()
+                            .noFluidOutputs()
+                            .duration(1 * SECONDS)
+                            .eut(TierEU.RECIPE_LV)
+                            .addTo(sImplosionRecipes);
+                        GT_Values.RA.stdBuilder()
+                            .itemInputs(GT_Utility.copyAmount(4L, aStack), new ItemStack(Blocks.tnt, 32))
+                            .itemOutputs(
+                                ItemList.IC2_Industrial_Diamond.get(3L),
+                                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 16L))
+                            .noFluidInputs()
+                            .noFluidOutputs()
+                            .duration(1 * SECONDS)
+                            .eut(TierEU.RECIPE_LV)
+                            .addTo(sImplosionRecipes);
+                        GT_Values.RA.stdBuilder()
+                            .itemInputs(GT_Utility.copyAmount(4L, aStack), GT_ModHandler.getIC2Item("industrialTnt", 8))
+                            .itemOutputs(
+                                ItemList.IC2_Industrial_Diamond.get(3L),
+                                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 16L))
+                            .noFluidInputs()
+                            .noFluidOutputs()
+                            .duration(1 * SECONDS)
+                            .eut(TierEU.RECIPE_LV)
+                            .addTo(sImplosionRecipes);
+                    }
                         break;
                     case "Opal":
                     case "Olivine":
@@ -298,12 +363,50 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                     case "Topaz":
                     case "BlueTopaz":
                     case "Tanzanite":
-                    case "Amethyst":
-                        GT_Values.RA.addImplosionRecipe(
-                            GT_Utility.copyAmount(4L, aStack),
-                            24,
-                            GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 3L),
-                            GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 12L));
+                    case "Amethyst": {
+                        GT_Values.RA.stdBuilder()
+                            .itemInputs(GT_Utility.copyAmount(4L, aStack), ItemList.Block_Powderbarrel.get(48))
+                            .itemOutputs(
+                                GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 3L),
+                                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 12L))
+                            .noFluidInputs()
+                            .noFluidOutputs()
+                            .duration(1 * SECONDS)
+                            .eut(TierEU.RECIPE_LV)
+                            .addTo(sImplosionRecipes);
+                        GT_Values.RA.stdBuilder()
+                            .itemInputs(
+                                GT_Utility.copyAmount(4L, aStack),
+                                GT_ModHandler.getIC2Item("dynamite", 12, null))
+                            .itemOutputs(
+                                GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 3L),
+                                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 12L))
+                            .noFluidInputs()
+                            .noFluidOutputs()
+                            .duration(1 * SECONDS)
+                            .eut(TierEU.RECIPE_LV)
+                            .addTo(sImplosionRecipes);
+                        GT_Values.RA.stdBuilder()
+                            .itemInputs(GT_Utility.copyAmount(4L, aStack), new ItemStack(Blocks.tnt, 24))
+                            .itemOutputs(
+                                GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 3L),
+                                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 12L))
+                            .noFluidInputs()
+                            .noFluidOutputs()
+                            .duration(1 * SECONDS)
+                            .eut(TierEU.RECIPE_LV)
+                            .addTo(sImplosionRecipes);
+                        GT_Values.RA.stdBuilder()
+                            .itemInputs(GT_Utility.copyAmount(4L, aStack), GT_ModHandler.getIC2Item("industrialTnt", 6))
+                            .itemOutputs(
+                                GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 3L),
+                                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 12L))
+                            .noFluidInputs()
+                            .noFluidOutputs()
+                            .duration(1 * SECONDS)
+                            .eut(TierEU.RECIPE_LV)
+                            .addTo(sImplosionRecipes);
+                    }
                         break;
                     case "FoolsRuby":
                     case "GarnetRed":
@@ -313,12 +416,50 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                     case "Monazite":
                     case "Forcicium":
                     case "Forcillium":
-                    case "Force":
-                        GT_Values.RA.addImplosionRecipe(
-                            GT_Utility.copyAmount(4L, aStack),
-                            16,
-                            GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 3L),
-                            GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 8L));
+                    case "Force": {
+                        GT_Values.RA.stdBuilder()
+                            .itemInputs(GT_Utility.copyAmount(4L, aStack), ItemList.Block_Powderbarrel.get(32))
+                            .itemOutputs(
+                                GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 3L),
+                                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 8L))
+                            .noFluidInputs()
+                            .noFluidOutputs()
+                            .duration(1 * SECONDS)
+                            .eut(TierEU.RECIPE_LV)
+                            .addTo(sImplosionRecipes);
+                        GT_Values.RA.stdBuilder()
+                            .itemInputs(
+                                GT_Utility.copyAmount(4L, aStack),
+                                GT_ModHandler.getIC2Item("dynamite", 8, null))
+                            .itemOutputs(
+                                GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 3L),
+                                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 8L))
+                            .noFluidInputs()
+                            .noFluidOutputs()
+                            .duration(1 * SECONDS)
+                            .eut(TierEU.RECIPE_LV)
+                            .addTo(sImplosionRecipes);
+                        GT_Values.RA.stdBuilder()
+                            .itemInputs(GT_Utility.copyAmount(4L, aStack), new ItemStack(Blocks.tnt, 16))
+                            .itemOutputs(
+                                GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 3L),
+                                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 8L))
+                            .noFluidInputs()
+                            .noFluidOutputs()
+                            .duration(1 * SECONDS)
+                            .eut(TierEU.RECIPE_LV)
+                            .addTo(sImplosionRecipes);
+                        GT_Values.RA.stdBuilder()
+                            .itemInputs(GT_Utility.copyAmount(4L, aStack), GT_ModHandler.getIC2Item("industrialTnt", 4))
+                            .itemOutputs(
+                                GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 3L),
+                                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 8L))
+                            .noFluidInputs()
+                            .noFluidOutputs()
+                            .duration(1 * SECONDS)
+                            .eut(TierEU.RECIPE_LV)
+                            .addTo(sImplosionRecipes);
+                    }
                 }
             }
             case dustPure, dustImpure, dustRefined -> {
@@ -327,63 +468,77 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                     aMaterial,
                     aMaterial.mOreByProducts);
                 if (aPrefix == OrePrefixes.dustPure) {
-                    if (aMaterial.contains(SubTag.ELECTROMAGNETIC_SEPERATION_GOLD))
-                        GT_Values.RA.addElectromagneticSeparatorRecipe(
-                            GT_Utility.copyAmount(1L, aStack),
-                            GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial, 1L),
-                            GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.Gold, 1L),
-                            GT_OreDictUnificator.get(OrePrefixes.nugget, Materials.Gold, 1L),
-                            new int[] { 10000, 4000, 2000 },
-                            400,
-                            24);
-                    if (aMaterial.contains(SubTag.ELECTROMAGNETIC_SEPERATION_IRON))
-                        GT_Values.RA.addElectromagneticSeparatorRecipe(
-                            GT_Utility.copyAmount(1L, aStack),
-                            GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial, 1L),
-                            GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.Iron, 1L),
-                            GT_OreDictUnificator.get(OrePrefixes.nugget, Materials.Iron, 1L),
-                            new int[] { 10000, 4000, 2000 },
-                            400,
-                            24);
+                    if (aMaterial.contains(SubTag.ELECTROMAGNETIC_SEPERATION_GOLD)) {
+                        GT_Values.RA.stdBuilder()
+                            .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                            .itemOutputs(
+                                GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial, 1L),
+                                GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.Gold, 1L),
+                                GT_OreDictUnificator.get(OrePrefixes.nugget, Materials.Gold, 1L))
+                            .outputChances(10000, 4000, 2000)
+                            .noFluidInputs()
+                            .noFluidOutputs()
+                            .duration(20 * SECONDS)
+                            .eut(24)
+                            .addTo(sElectroMagneticSeparatorRecipes);
+                    }
+                    if (aMaterial.contains(SubTag.ELECTROMAGNETIC_SEPERATION_IRON)) {
+                        GT_Values.RA.stdBuilder()
+                            .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                            .itemOutputs(
+                                GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial, 1L),
+                                GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.Iron, 1L),
+                                GT_OreDictUnificator.get(OrePrefixes.nugget, Materials.Iron, 1L))
+                            .outputChances(10000, 4000, 2000)
+                            .noFluidInputs()
+                            .noFluidOutputs()
+                            .duration(20 * SECONDS)
+                            .eut(24)
+                            .addTo(sElectroMagneticSeparatorRecipes);
+                    }
                     if (aMaterial.contains(SubTag.ELECTROMAGNETIC_SEPERATION_NEODYMIUM)) {
-                        GT_Values.RA.addElectromagneticSeparatorRecipe(
-                            GT_Utility.copyAmount(1L, aStack),
-                            GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial, 1L),
-                            GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.Neodymium, 1L),
-                            GT_OreDictUnificator.get(OrePrefixes.nugget, Materials.Neodymium, 1L),
-                            new int[] { 10000, 4000, 2000 },
-                            400,
-                            24);
+                        GT_Values.RA.stdBuilder()
+                            .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                            .itemOutputs(
+                                GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial, 1L),
+                                GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.Neodymium, 1L),
+                                GT_OreDictUnificator.get(OrePrefixes.nugget, Materials.Neodymium, 1L))
+                            .outputChances(10000, 4000, 2000)
+                            .noFluidInputs()
+                            .noFluidOutputs()
+                            .duration(20 * SECONDS)
+                            .eut(24)
+                            .addTo(sElectroMagneticSeparatorRecipes);
                     }
                 }
                 if (aMaterial.contains(SubTag.CRYSTALLISABLE)) {
-                    GT_Values.RA.addAutoclaveRecipe(
-                        GT_Utility.copyAmount(1L, aStack),
-                        GT_Utility.getIntegratedCircuit(1),
-                        Materials.Water.getFluid(200L),
-                        GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 1L),
-                        9000,
-                        2000,
-                        24,
-                        false);
-                    GT_Values.RA.addAutoclaveRecipe(
-                        GT_Utility.copyAmount(1L, aStack),
-                        GT_Utility.getIntegratedCircuit(2),
-                        GT_ModHandler.getDistilledWater(100L),
-                        GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 1L),
-                        9500,
-                        1500,
-                        24,
-                        false);
-                    GT_Values.RA.addAutoclaveRecipe(
-                        GT_Utility.copyAmount(1L, aStack),
-                        GT_Utility.getIntegratedCircuit(3),
-                        Materials.Void.getMolten(36L),
-                        GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 1L),
-                        10000,
-                        1200,
-                        24,
-                        false);
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(GT_Utility.copyAmount(1L, aStack), GT_Utility.getIntegratedCircuit(1))
+                        .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 1L))
+                        .outputChances(9000)
+                        .fluidInputs(Materials.Water.getFluid(200L))
+                        .noFluidOutputs()
+                        .duration(1 * MINUTES + 40 * SECONDS)
+                        .eut(24)
+                        .addTo(sAutoclaveRecipes);
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(GT_Utility.copyAmount(1L, aStack), GT_Utility.getIntegratedCircuit(2))
+                        .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 1L))
+                        .outputChances(9500)
+                        .fluidInputs(GT_ModHandler.getDistilledWater(100L))
+                        .noFluidOutputs()
+                        .duration(1 * MINUTES + 15 * SECONDS)
+                        .eut(24)
+                        .addTo(sAutoclaveRecipes);
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(GT_Utility.copyAmount(1L, aStack), GT_Utility.getIntegratedCircuit(3))
+                        .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 1L))
+                        .outputChances(10000)
+                        .fluidInputs(Materials.Void.getMolten(36L))
+                        .noFluidOutputs()
+                        .duration(1 * MINUTES)
+                        .eut(24)
+                        .addTo(sAutoclaveRecipes);
                 }
                 ItemStack tImpureStack = GT_OreDictUnificator.get(
                     OrePrefixes.dustTiny,

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingOre.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingOre.java
@@ -9,7 +9,6 @@ import java.util.ArrayList;
 import net.minecraft.item.ItemStack;
 
 import gregtech.api.enums.GT_Values;
-import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.enums.SubTag;
@@ -161,8 +160,7 @@ public class ProcessingOre implements gregtech.api.interfaces.IOreRecipeRegistra
                         null,
                         null,
                         GT_Utility.mul(aMultiplier * 3 * aMaterial.mSmeltingMultiplier, tSmeltInto),
-                        ItemList.TE_Slag
-                            .get(1L, GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.DarkAsh, 1L)),
+                        GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.DarkAsh, 1L),
                         tSmeltInto.stackSize * 500,
                         120,
                         1500);
@@ -172,8 +170,7 @@ public class ProcessingOre implements gregtech.api.interfaces.IOreRecipeRegistra
                         null,
                         null,
                         GT_Utility.mul(aMultiplier * 3 * aMaterial.mSmeltingMultiplier, tSmeltInto),
-                        ItemList.TE_Slag
-                            .get(1L, GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.DarkAsh, 1L)),
+                        GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.DarkAsh, 1L),
                         tSmeltInto.stackSize * 500,
                         120,
                         1500);
@@ -186,8 +183,7 @@ public class ProcessingOre implements gregtech.api.interfaces.IOreRecipeRegistra
                         null,
                         null,
                         GT_Utility.mul(aMultiplier * 2 * aMaterial.mSmeltingMultiplier, tSmeltInto),
-                        ItemList.TE_Slag
-                            .get(1L, GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.DarkAsh, 1L)),
+                        GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.DarkAsh, 1L),
                         tSmeltInto.stackSize * 500,
                         120,
                         1500);
@@ -197,8 +193,7 @@ public class ProcessingOre implements gregtech.api.interfaces.IOreRecipeRegistra
                         null,
                         null,
                         GT_Utility.mul(aMultiplier * 2 * aMaterial.mSmeltingMultiplier, tSmeltInto),
-                        ItemList.TE_Slag
-                            .get(1L, GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.DarkAsh, 1L)),
+                        GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.DarkAsh, 1L),
                         tSmeltInto.stackSize * 500,
                         120,
                         1500);

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingPlate.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingPlate.java
@@ -3,11 +3,21 @@ package gregtech.loaders.oreprocessing;
 import static gregtech.api.enums.ConfigCategories.Recipes.harderrecipes;
 import static gregtech.api.enums.GT_Values.L;
 import static gregtech.api.enums.GT_Values.NI;
-import static gregtech.api.enums.GT_Values.RA;
 import static gregtech.api.enums.GT_Values.W;
 import static gregtech.api.util.GT_ModHandler.RecipeBits.BUFFERED;
 import static gregtech.api.util.GT_ModHandler.RecipeBits.DO_NOT_CHECK_FOR_COLLISIONS;
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAlloySmelterRecipes;
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAssemblerRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sBenderRecipes;
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCutterRecipes;
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sExtruderRecipes;
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sFluidSolidficationRecipes;
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sImplosionRecipes;
+import static gregtech.api.util.GT_RecipeBuilder.MINUTES;
+import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
+import static gregtech.api.util.GT_RecipeBuilder.TICKS;
+import static gregtech.api.util.GT_RecipeConstants.FUEL_TYPE;
+import static gregtech.api.util.GT_RecipeConstants.FUEL_VALUE;
 import static gregtech.api.util.GT_Utility.calculateRecipeEU;
 import static gregtech.common.GT_Proxy.tBits;
 
@@ -17,10 +27,19 @@ import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 
 import gregtech.api.GregTech_API;
-import gregtech.api.enums.*;
+import gregtech.api.enums.ConfigCategories;
+import gregtech.api.enums.GT_Values;
+import gregtech.api.enums.ItemList;
+import gregtech.api.enums.Materials;
+import gregtech.api.enums.OrePrefixes;
+import gregtech.api.enums.SubTag;
+import gregtech.api.enums.TextureSet;
+import gregtech.api.enums.TierEU;
+import gregtech.api.enums.ToolDictNames;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_OreDictUnificator;
+import gregtech.api.util.GT_RecipeConstants;
 import gregtech.api.util.GT_RecipeRegistrator;
 import gregtech.api.util.GT_Utility;
 
@@ -81,18 +100,28 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
             GT_OreDictUnificator.get(OrePrefixes.plateDense, aMaterial, 1L));
 
         if (aMaterial.mFuelPower > 0) {
-            RA.addFuel(GT_Utility.copyAmount(1L, aStack), NI, aMaterial.mFuelPower, aMaterial.mFuelType);
+            GT_Values.RA.stdBuilder()
+                .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                .noItemOutputs()
+                .noFluidInputs()
+                .noFluidOutputs()
+                .metadata(FUEL_VALUE, aMaterial.mFuelPower)
+                .metadata(FUEL_TYPE, aMaterial.mFuelType)
+                .duration(0)
+                .eut(0)
+                .addTo(GT_RecipeConstants.Fuel);
         }
 
         if (aMaterial.mStandardMoltenFluid != null
             && !(aMaterial == Materials.AnnealedCopper || aMaterial == Materials.WroughtIron)) {
-
-            RA.addFluidSolidifierRecipe(
-                ItemList.Shape_Mold_Plate.get(0L),
-                aMaterial.getMolten(L),
-                aMaterial.getPlates(1),
-                32,
-                calculateRecipeEU(aMaterial, 8));
+            GT_Values.RA.stdBuilder()
+                .itemInputs(ItemList.Shape_Mold_Plate.get(0L))
+                .itemOutputs(aMaterial.getPlates(1))
+                .fluidInputs(aMaterial.getMolten(L))
+                .noFluidOutputs()
+                .duration(1 * SECONDS + 12 * TICKS)
+                .eut(calculateRecipeEU(aMaterial, 8))
+                .addTo(sFluidSolidficationRecipes);
         }
 
         GT_ModHandler.addCraftingRecipe(
@@ -205,14 +234,16 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
                 .addTo(sBenderRecipes);
 
         } else {
-
-            RA.addAssemblerRecipe(
-                GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 2L),
-                GT_Utility.getIntegratedCircuit(2),
-                Materials.Glue.getFluid(10L),
-                GT_Utility.copyAmount(1L, aStack),
-                64,
-                8);
+            GT_Values.RA.stdBuilder()
+                .itemInputs(
+                    gregtech.api.util.GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 2L),
+                    GT_Utility.getIntegratedCircuit(2))
+                .itemOutputs(GT_Utility.copyAmount(1L, aStack))
+                .fluidInputs(Materials.Glue.getFluid(10L))
+                .noFluidOutputs()
+                .duration(3 * SECONDS + 4 * TICKS)
+                .eut(8)
+                .addTo(sAssemblerRecipes);
         }
     }
 
@@ -271,21 +302,60 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
                 .addTo(sBenderRecipes);
 
         } else {
-
-            RA.addAssemblerRecipe(
-                GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 3L),
-                GT_Utility.getIntegratedCircuit(3),
-                Materials.Glue.getFluid(20L),
-                GT_Utility.copyAmount(1L, aStack),
-                96,
-                8);
+            GT_Values.RA.stdBuilder()
+                .itemInputs(
+                    gregtech.api.util.GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 3L),
+                    GT_Utility.getIntegratedCircuit(3))
+                .itemOutputs(GT_Utility.copyAmount(1L, aStack))
+                .fluidInputs(Materials.Glue.getFluid(20L))
+                .noFluidOutputs()
+                .duration(4 * SECONDS + 16 * TICKS)
+                .eut(8)
+                .addTo(sAssemblerRecipes);
         }
 
-        RA.addImplosionRecipe(
-            GT_Utility.copyAmount(1L, aStack),
-            2,
-            GT_OreDictUnificator.get(OrePrefixes.compressed, aMaterial, 1L),
-            GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 1L));
+        if (GT_OreDictUnificator.get(OrePrefixes.compressed, aMaterial, 1L) != null) {
+            GT_Values.RA.stdBuilder()
+                .itemInputs(GT_Utility.copyAmount(1L, aStack), ItemList.Block_Powderbarrel.get(4))
+                .itemOutputs(
+                    GT_OreDictUnificator.get(OrePrefixes.compressed, aMaterial, 1L),
+                    GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 1L))
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(1 * SECONDS)
+                .eut(TierEU.RECIPE_LV)
+                .addTo(sImplosionRecipes);
+            GT_Values.RA.stdBuilder()
+                .itemInputs(GT_Utility.copyAmount(1L, aStack), GT_ModHandler.getIC2Item("dynamite", 1, null))
+                .itemOutputs(
+                    GT_OreDictUnificator.get(OrePrefixes.compressed, aMaterial, 1L),
+                    GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 1L))
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(1 * SECONDS)
+                .eut(TierEU.RECIPE_LV)
+                .addTo(sImplosionRecipes);
+            GT_Values.RA.stdBuilder()
+                .itemInputs(GT_Utility.copyAmount(1L, aStack), new ItemStack(Blocks.tnt, 2))
+                .itemOutputs(
+                    GT_OreDictUnificator.get(OrePrefixes.compressed, aMaterial, 1L),
+                    GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 1L))
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(1 * SECONDS)
+                .eut(TierEU.RECIPE_LV)
+                .addTo(sImplosionRecipes);
+            GT_Values.RA.stdBuilder()
+                .itemInputs(GT_Utility.copyAmount(1L, aStack), GT_ModHandler.getIC2Item("industrialTnt", 1))
+                .itemOutputs(
+                    GT_OreDictUnificator.get(OrePrefixes.compressed, aMaterial, 1L),
+                    GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 1L))
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(1 * SECONDS)
+                .eut(TierEU.RECIPE_LV)
+                .addTo(sImplosionRecipes);
+        }
     }
 
     private void registerPlateQuadruple(final Materials aMaterial, final ItemStack aStack, final boolean aNoSmashing,
@@ -294,12 +364,6 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
         registerCover(aMaterial, aStack);
 
         GT_ModHandler.removeRecipeByOutputDelayed(aStack);
-
-        if (!aNoWorking) RA.addCNCRecipe(
-            GT_Utility.copyAmount(1L, aStack),
-            GT_OreDictUnificator.get(OrePrefixes.gearGt, aMaterial, 1L),
-            (int) Math.max(aMaterialMass * 2L, 1L),
-            30);
 
         if (!aNoSmashing) {
 
@@ -339,14 +403,16 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
                 .addTo(sBenderRecipes);
 
         } else {
-
-            RA.addAssemblerRecipe(
-                GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 4L),
-                GT_Utility.getIntegratedCircuit(4),
-                Materials.Glue.getFluid(30L),
-                GT_Utility.copyAmount(1L, aStack),
-                128,
-                8);
+            GT_Values.RA.stdBuilder()
+                .itemInputs(
+                    gregtech.api.util.GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 4L),
+                    GT_Utility.getIntegratedCircuit(4))
+                .itemOutputs(GT_Utility.copyAmount(1L, aStack))
+                .fluidInputs(Materials.Glue.getFluid(30L))
+                .noFluidOutputs()
+                .duration(6 * SECONDS + 8 * TICKS)
+                .eut(8)
+                .addTo(sAssemblerRecipes);
         }
     }
 
@@ -395,14 +461,16 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
                 .addTo(sBenderRecipes);
 
         } else {
-
-            RA.addAssemblerRecipe(
-                gregtech.api.util.GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 5L),
-                ItemList.Circuit_Integrated.getWithDamage(0L, 5L),
-                Materials.Glue.getFluid(40L),
-                GT_Utility.copyAmount(1L, aStack),
-                160,
-                8);
+            GT_Values.RA.stdBuilder()
+                .itemInputs(
+                    gregtech.api.util.GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 5L),
+                    GT_Utility.getIntegratedCircuit(5))
+                .itemOutputs(GT_Utility.copyAmount(1L, aStack))
+                .fluidInputs(Materials.Glue.getFluid(40L))
+                .noFluidOutputs()
+                .duration(8 * SECONDS)
+                .eut(8)
+                .addTo(sAssemblerRecipes);
         }
     }
 
@@ -434,13 +502,14 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
         GT_ModHandler.removeRecipeByOutputDelayed(aStack);
 
         if (aMaterial.mStandardMoltenFluid != null) {
-
-            RA.addFluidSolidifierRecipe(
-                ItemList.Shape_Mold_Casing.get(0L),
-                aMaterial.getMolten(L / 2),
-                GT_OreDictUnificator.get(OrePrefixes.itemCasing, aMaterial, 1L),
-                16,
-                calculateRecipeEU(aMaterial, 8));
+            GT_Values.RA.stdBuilder()
+                .itemInputs(ItemList.Shape_Mold_Casing.get(0L))
+                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.itemCasing, aMaterial, 1L))
+                .fluidInputs(aMaterial.getMolten(L / 2))
+                .noFluidOutputs()
+                .duration(16 * TICKS)
+                .eut(calculateRecipeEU(aMaterial, 8))
+                .addTo(sFluidSolidficationRecipes);
         }
 
         if (aMaterial.mUnificatable && aMaterial.mMaterialInto == aMaterial
@@ -462,27 +531,77 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
             }
         }
 
-        RA.addAlloySmelterRecipe(
-            GT_OreDictUnificator.get(OrePrefixes.ingot, aMaterial, 2L),
-            ItemList.Shape_Mold_Casing.get(0L),
-            GT_Utility.copyAmount(3L, aStack),
-            128,
-            calculateRecipeEU(aMaterial, 15));
+        if (GT_OreDictUnificator.get(OrePrefixes.ingot, aMaterial, 1L) != null) {
+            GT_Values.RA.stdBuilder()
+                .itemInputs(
+                    GT_OreDictUnificator.get(OrePrefixes.ingot, aMaterial, 2L),
+                    ItemList.Shape_Mold_Casing.get(0L))
+                .itemOutputs(GT_Utility.copyAmount(3L, aStack))
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(6 * SECONDS + 8 * TICKS)
+                .eut(calculateRecipeEU(aMaterial, 15))
+                .addTo(sAlloySmelterRecipes);
 
-        RA.addCutterRecipe(
-            GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L),
-            GT_OreDictUnificator.get(OrePrefixes.itemCasing, aMaterial, 2L),
-            NI,
-            (int) Math.max(aMaterial.getMass(), 1L),
-            calculateRecipeEU(aMaterial, 16));
+            GT_Values.RA.stdBuilder()
+                .itemInputs(
+                    GT_OreDictUnificator.get(OrePrefixes.ingot, aMaterial, 1L),
+                    ItemList.Shape_Extruder_Casing.get(0L))
+                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.itemCasing, aMaterial, 2L))
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(((int) Math.max(aMaterial.getMass(), 1L)) * TICKS)
+                .eut(calculateRecipeEU(aMaterial, 45))
+                .addTo(sExtruderRecipes);
+        }
 
-        RA.addExtruderRecipe(
-            GT_OreDictUnificator.get(OrePrefixes.ingot, aMaterial, 1L),
-            ItemList.Shape_Extruder_Casing.get(0L),
-            GT_OreDictUnificator.get(OrePrefixes.itemCasing, aMaterial, 2L),
-            (int) Math.max(aMaterial.getMass(), 1L),
-            calculateRecipeEU(aMaterial, 45));
+        if (GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L) != null) {
+            GT_Values.RA.stdBuilder()
+                .itemInputs(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L))
+                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.itemCasing, aMaterial, 2L))
+                .fluidInputs(
+                    Materials.Water.getFluid(
+                        Math.max(
+                            4,
+                            Math.min(
+                                1000,
+                                ((int) Math.max(aMaterial.getMass(), 1L)) * (calculateRecipeEU(aMaterial, 16)) / 320))))
+                .noFluidOutputs()
+                .duration(2 * ((int) Math.max(aMaterial.getMass(), 1L)) * TICKS)
+                .eut(calculateRecipeEU(aMaterial, 16))
+                .addTo(sCutterRecipes);
 
+            GT_Values.RA.stdBuilder()
+                .itemInputs(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L))
+                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.itemCasing, aMaterial, 2L))
+                .fluidInputs(
+                    GT_ModHandler.getDistilledWater(
+                        Math.max(
+                            3,
+                            Math.min(
+                                750,
+                                ((int) Math.max(aMaterial.getMass(), 1L)) * (calculateRecipeEU(aMaterial, 16)) / 426))))
+                .noFluidOutputs()
+                .duration(2 * ((int) Math.max(aMaterial.getMass(), 1L)) * TICKS)
+                .eut(calculateRecipeEU(aMaterial, 16))
+                .addTo(sCutterRecipes);
+
+            GT_Values.RA.stdBuilder()
+                .itemInputs(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L))
+                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.itemCasing, aMaterial, 2L))
+                .fluidInputs(
+                    Materials.Lubricant.getFluid(
+                        Math.max(
+                            1,
+                            Math.min(
+                                250,
+                                ((int) Math.max(aMaterial.getMass(), 1L)) * (calculateRecipeEU(aMaterial, 16))
+                                    / 1280))))
+                .noFluidOutputs()
+                .duration(((int) Math.max(aMaterial.getMass(), 1L)) * TICKS)
+                .eut(calculateRecipeEU(aMaterial, 16))
+                .addTo(sCutterRecipes);
+        }
         GT_RecipeRegistrator.registerReverseFluidSmelting(aStack, aMaterial, aPrefix.mMaterialAmount, null);
     }
 
@@ -490,26 +609,31 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
 
         switch (aOreDictName) {
             case "plateAlloyCarbon" -> {
-                RA.addAssemblerRecipe(
-                    GT_ModHandler.getIC2Item("generator", 1L),
-                    GT_Utility.copyAmount(4L, aStack),
-                    GT_ModHandler.getIC2Item("windMill", 1L),
-                    6400,
-                    8);
-                GT_ModHandler.addAlloySmelterRecipe(
-                    GT_Utility.copyAmount(1L, aStack),
-                    new ItemStack(Blocks.glass, 3, W),
-                    GT_ModHandler.getIC2Item("reinforcedGlass", 4L),
-                    400,
-                    4,
-                    false);
-                GT_ModHandler.addAlloySmelterRecipe(
-                    GT_Utility.copyAmount(1L, aStack),
-                    Materials.Glass.getDust(3),
-                    GT_ModHandler.getIC2Item("reinforcedGlass", 4L),
-                    400,
-                    4,
-                    false);
+                GT_Values.RA.stdBuilder()
+                    .itemInputs(GT_ModHandler.getIC2Item("generator", 1L), GT_Utility.copyAmount(4L, aStack))
+                    .itemOutputs(GT_ModHandler.getIC2Item("windMill", 1L))
+                    .noFluidInputs()
+                    .noFluidOutputs()
+                    .duration(5 * MINUTES + 20 * SECONDS)
+                    .eut(8)
+                    .addTo(sAssemblerRecipes);
+
+                GT_Values.RA.stdBuilder()
+                    .itemInputs(GT_Utility.copyAmount(1L, aStack), new ItemStack(Blocks.glass, 3, W))
+                    .itemOutputs(GT_ModHandler.getIC2Item("reinforcedGlass", 4L))
+                    .noFluidInputs()
+                    .noFluidOutputs()
+                    .duration(20 * SECONDS)
+                    .eut(4)
+                    .addTo(sAlloySmelterRecipes);
+                GT_Values.RA.stdBuilder()
+                    .itemInputs(GT_Utility.copyAmount(1L, aStack), Materials.Glass.getDust(3))
+                    .itemOutputs(GT_ModHandler.getIC2Item("reinforcedGlass", 4L))
+                    .noFluidInputs()
+                    .noFluidOutputs()
+                    .duration(20 * SECONDS)
+                    .eut(4)
+                    .addTo(sAlloySmelterRecipes);
             }
             case "plateAlloyAdvanced" -> {
                 GT_ModHandler.addAlloySmelterRecipe(

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingRecycling.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingRecycling.java
@@ -1,5 +1,8 @@
 package gregtech.loaders.oreprocessing;
 
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCannerRecipes;
+import static gregtech.api.util.GT_RecipeBuilder.TICKS;
+
 import net.minecraft.item.ItemStack;
 
 import gregtech.api.enums.GT_Values;
@@ -21,13 +24,18 @@ public class ProcessingRecycling implements gregtech.api.interfaces.IOreRecipeRe
     public void registerOre(OrePrefixes aPrefix, Materials aMaterial, String aOreDictName, String aModName,
         ItemStack aStack) {
         if ((aMaterial != Materials.Empty) && (GT_Utility.getFluidForFilledItem(aStack, true) == null)
-            && !aMaterial.contains(SubTag.SMELTING_TO_FLUID))
-            GT_Values.RA.addCannerRecipe(
-                aStack,
-                null,
-                GT_Utility.getContainerItem(aStack, true),
-                GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial, aPrefix.mMaterialAmount / 3628800L),
-                (int) Math.max(aMaterial.getMass() / 2L, 1L),
-                2);
+            && !aMaterial.contains(SubTag.SMELTING_TO_FLUID)
+            && (GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial, 1L) != null)) {
+            GT_Values.RA.stdBuilder()
+                .itemInputs(aStack)
+                .itemOutputs(
+                    GT_Utility.getContainerItem(aStack, true),
+                    GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial, aPrefix.mMaterialAmount / 3628800L))
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(((int) Math.max(aMaterial.getMass() / 2L, 1L)) * TICKS)
+                .eut(2)
+                .addTo(sCannerRecipes);
+        }
     }
 }

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingShaping.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingShaping.java
@@ -1,5 +1,10 @@
 package gregtech.loaders.oreprocessing;
 
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAlloySmelterRecipes;
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sExtruderRecipes;
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sFluidSolidficationRecipes;
+import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
+import static gregtech.api.util.GT_RecipeBuilder.TICKS;
 import static gregtech.api.util.GT_Utility.calculateRecipeEU;
 
 import net.minecraft.init.Blocks;
@@ -37,440 +42,673 @@ public class ProcessingShaping implements gregtech.api.interfaces.IOreRecipeRegi
                         return;
                     }
 
-                if (!OrePrefixes.block.isIgnored(aMaterial.mSmeltInto)) {
-                    GT_Values.RA.addExtruderRecipe(
-                        GT_Utility.copyAmount(9L, aStack),
-                        ItemList.Shape_Extruder_Block.get(0L),
-                        GT_OreDictUnificator.get(OrePrefixes.block, aMaterial.mSmeltInto, tAmount),
-                        10 * tAmount,
-                        calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier));
+                if (!OrePrefixes.block.isIgnored(aMaterial.mSmeltInto)
+                    && (GT_OreDictUnificator.get(OrePrefixes.block, aMaterial.mSmeltInto, 1L) != null)) {
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(GT_Utility.copyAmount(9L, aStack), ItemList.Shape_Extruder_Block.get(0L))
+                        .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.block, aMaterial.mSmeltInto, tAmount))
+                        .noFluidInputs()
+                        .noFluidOutputs()
+                        .duration((10 * tAmount) * TICKS)
+                        .eut(calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier))
+                        .addTo(sExtruderRecipes);
 
                     // Allow creation of alloy smelter recipes for material recycling if < IV tier.
                     if (tTrueVoltage < TierEU.IV) {
-                        GT_Values.RA.addAlloySmelterRecipe(
-                            GT_Utility.copyAmount(9L, aStack),
-                            ItemList.Shape_Mold_Block.get(0L),
-                            GT_OreDictUnificator.get(OrePrefixes.block, aMaterial.mSmeltInto, tAmount),
-                            5 * tAmount,
-                            calculateRecipeEU(aMaterial, 4 * tVoltageMultiplier));
+                        GT_Values.RA.stdBuilder()
+                            .itemInputs(GT_Utility.copyAmount(9L, aStack), ItemList.Shape_Mold_Block.get(0L))
+                            .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.block, aMaterial.mSmeltInto, tAmount))
+                            .noFluidInputs()
+                            .noFluidOutputs()
+                            .duration((5 * tAmount) * TICKS)
+                            .eut(calculateRecipeEU(aMaterial, 4 * tVoltageMultiplier))
+                            .addTo(sAlloySmelterRecipes);
                     }
                 }
-                if (((aPrefix != OrePrefixes.ingot) || (aMaterial != aMaterial.mSmeltInto))) {
-                    GT_Values.RA.addExtruderRecipe(
-                        GT_Utility.copyAmount(1L, aStack),
-                        ItemList.Shape_Extruder_Ingot.get(0L),
-                        GT_OreDictUnificator.get(OrePrefixes.ingot, aMaterial.mSmeltInto, tAmount),
-                        10,
-                        calculateRecipeEU(aMaterial, 4 * tVoltageMultiplier));
+                if ((aPrefix != OrePrefixes.ingot || aMaterial != aMaterial.mSmeltInto)
+                    && GT_OreDictUnificator.get(OrePrefixes.ingot, aMaterial.mSmeltInto, 1L) != null) {
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(GT_Utility.copyAmount(1L, aStack), ItemList.Shape_Extruder_Ingot.get(0L))
+                        .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.ingot, aMaterial.mSmeltInto, tAmount))
+                        .noFluidInputs()
+                        .noFluidOutputs()
+                        .duration(10 * TICKS)
+                        .eut(calculateRecipeEU(aMaterial, 4 * tVoltageMultiplier))
+                        .addTo(sExtruderRecipes);
                 }
-
-                GT_Values.RA.addExtruderRecipe(
-                    GT_Utility.copyAmount(1L, aStack),
-                    ItemList.Shape_Extruder_Pipe_Tiny.get(0L),
-                    GT_OreDictUnificator.get(OrePrefixes.pipeTiny, aMaterial.mSmeltInto, tAmount * 2),
-                    4 * tAmount,
-                    calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier));
-
-                if (!(aMaterial == Materials.Redstone || aMaterial == Materials.Glowstone)) {
-                    GT_Values.RA.addExtruderRecipe(
-                        GT_Utility.copyAmount(1L, aStack),
-                        ItemList.Shape_Extruder_Pipe_Small.get(0L),
-                        GT_OreDictUnificator.get(OrePrefixes.pipeSmall, aMaterial.mSmeltInto, tAmount),
-                        8 * tAmount,
-                        calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier));
-
-                    GT_Values.RA.addExtruderRecipe(
-                        GT_Utility.copyAmount(3L, aStack),
-                        ItemList.Shape_Extruder_Pipe_Medium.get(0L),
-                        GT_OreDictUnificator.get(OrePrefixes.pipeMedium, aMaterial.mSmeltInto, tAmount),
-                        24 * tAmount,
-                        calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier));
-
-                    GT_Values.RA.addExtruderRecipe(
-                        GT_Utility.copyAmount(6L, aStack),
-                        ItemList.Shape_Extruder_Pipe_Large.get(0L),
-                        GT_OreDictUnificator.get(OrePrefixes.pipeLarge, aMaterial.mSmeltInto, tAmount),
-                        48 * tAmount,
-                        calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier));
+                if (GT_OreDictUnificator.get(OrePrefixes.pipeTiny, aMaterial.mSmeltInto, 1L) != null) {
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(GT_Utility.copyAmount(1L, aStack), ItemList.Shape_Extruder_Pipe_Tiny.get(0L))
+                        .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.pipeTiny, aMaterial.mSmeltInto, tAmount * 2))
+                        .noFluidInputs()
+                        .noFluidOutputs()
+                        .duration((4 * tAmount) * TICKS)
+                        .eut(calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier))
+                        .addTo(sExtruderRecipes);
                 }
-
-                GT_Values.RA.addExtruderRecipe(
-                    GT_Utility.copyAmount(12L, aStack),
-                    ItemList.Shape_Extruder_Pipe_Huge.get(0L),
-                    GT_OreDictUnificator.get(OrePrefixes.pipeHuge, aMaterial.mSmeltInto, tAmount),
-                    96 * tAmount,
-                    calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier));
-                GT_Values.RA.addExtruderRecipe(
-                    GT_Utility.copyAmount(1L, aStack),
-                    ItemList.Shape_Extruder_Plate.get(0L),
-                    GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial.mSmeltInto, tAmount),
-                    (int) Math.max(aMaterialMass * tAmount, tAmount),
-                    calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier));
-                GT_Values.RA.addExtruderRecipe(
-                    GT_OreDictUnificator.get(OrePrefixes.ingot, aMaterial, 1L),
-                    ItemList.Shape_Extruder_Small_Gear.get(0L),
-                    GT_OreDictUnificator.get(OrePrefixes.gearGtSmall, aMaterial.mSmeltInto, tAmount),
-                    (int) Math.max(aMaterialMass * tAmount, tAmount),
-                    calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier));
-                GT_Values.RA.addExtruderRecipe(
-                    GT_Utility.copyAmount(6L, aStack),
-                    ItemList.Shape_Extruder_Turbine_Blade.get(0L),
-                    GT_OreDictUnificator.get(OrePrefixes.turbineBlade, aMaterial.mSmeltInto, tAmount),
-                    (int) Math.max(aMaterialMass * tAmount, tAmount),
-                    calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier));
+                if (GT_OreDictUnificator.get(OrePrefixes.pipeSmall, aMaterial.mSmeltInto, 1L) != null) {
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(GT_Utility.copyAmount(1L, aStack), ItemList.Shape_Extruder_Pipe_Small.get(0L))
+                        .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.pipeSmall, aMaterial.mSmeltInto, tAmount))
+                        .noFluidInputs()
+                        .noFluidOutputs()
+                        .duration((8 * tAmount) * TICKS)
+                        .eut(calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier))
+                        .addTo(sExtruderRecipes);
+                }
+                if (GT_OreDictUnificator.get(OrePrefixes.pipeMedium, aMaterial.mSmeltInto, 1L) != null) {
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(GT_Utility.copyAmount(3L, aStack), ItemList.Shape_Extruder_Pipe_Medium.get(0L))
+                        .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.pipeMedium, aMaterial.mSmeltInto, tAmount))
+                        .noFluidInputs()
+                        .noFluidOutputs()
+                        .duration((24 * tAmount) * TICKS)
+                        .eut(calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier))
+                        .addTo(sExtruderRecipes);
+                }
+                if (GT_OreDictUnificator.get(OrePrefixes.pipeLarge, aMaterial.mSmeltInto, 1L) != null) {
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(GT_Utility.copyAmount(6L, aStack), ItemList.Shape_Extruder_Pipe_Large.get(0L))
+                        .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.pipeLarge, aMaterial.mSmeltInto, tAmount))
+                        .noFluidInputs()
+                        .noFluidOutputs()
+                        .duration((48 * tAmount) * TICKS)
+                        .eut(calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier))
+                        .addTo(sExtruderRecipes);
+                }
+                if (GT_OreDictUnificator.get(OrePrefixes.pipeHuge, aMaterial.mSmeltInto, 1L) != null) {
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(GT_Utility.copyAmount(12L, aStack), ItemList.Shape_Extruder_Pipe_Huge.get(0L))
+                        .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.pipeHuge, aMaterial.mSmeltInto, tAmount))
+                        .noFluidInputs()
+                        .noFluidOutputs()
+                        .duration((96 * tAmount) * TICKS)
+                        .eut(calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier))
+                        .addTo(sExtruderRecipes);
+                }
+                if (GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial.mSmeltInto, 1L) != null) {
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(GT_Utility.copyAmount(1L, aStack), ItemList.Shape_Extruder_Plate.get(0L))
+                        .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial.mSmeltInto, tAmount))
+                        .noFluidInputs()
+                        .noFluidOutputs()
+                        .duration(((int) Math.max(aMaterialMass * tAmount, tAmount)) * TICKS)
+                        .eut(calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier))
+                        .addTo(sExtruderRecipes);
+                }
+                if (GT_OreDictUnificator.get(OrePrefixes.gearGtSmall, aMaterial.mSmeltInto, 1L) != null) {
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(GT_Utility.copyAmount(1L, aStack), ItemList.Shape_Extruder_Small_Gear.get(0L))
+                        .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.gearGtSmall, aMaterial.mSmeltInto, tAmount))
+                        .noFluidInputs()
+                        .noFluidOutputs()
+                        .duration(((int) Math.max(aMaterialMass * tAmount, tAmount)) * TICKS)
+                        .eut(calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier))
+                        .addTo(sExtruderRecipes);
+                }
+                if (GT_OreDictUnificator.get(OrePrefixes.turbineBlade, aMaterial.mSmeltInto, 1L) != null) {
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(GT_Utility.copyAmount(6L, aStack), ItemList.Shape_Extruder_Turbine_Blade.get(0L))
+                        .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.turbineBlade, aMaterial.mSmeltInto, tAmount))
+                        .noFluidInputs()
+                        .noFluidOutputs()
+                        .duration(((int) Math.max(aMaterialMass * tAmount, tAmount)) * TICKS)
+                        .eut(calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier))
+                        .addTo(sExtruderRecipes);
+                }
 
                 if (!(aMaterial == Materials.AnnealedCopper || aMaterial == Materials.WroughtIron)) {
-                    GT_Values.RA.addFluidSolidifierRecipe(
-                        ItemList.Shape_Mold_Ring.get(0L),
-                        aMaterial.getMolten(36L),
-                        GT_OreDictUnificator.get(OrePrefixes.ring, aMaterial, 1L),
-                        100,
-                        calculateRecipeEU(aMaterial, 4 * tVoltageMultiplier));
-                    GT_Values.RA.addFluidSolidifierRecipe(
-                        ItemList.Shape_Mold_Screw.get(0L),
-                        aMaterial.getMolten(18L),
-                        GT_OreDictUnificator.get(OrePrefixes.screw, aMaterial, 1L),
-                        50,
-                        calculateRecipeEU(aMaterial, 2 * tVoltageMultiplier));
-                    GT_Values.RA.addFluidSolidifierRecipe(
-                        ItemList.Shape_Mold_Rod.get(0L),
-                        aMaterial.getMolten(72L),
-                        GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial, 1L),
-                        150,
-                        calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier));
-                    GT_Values.RA.addFluidSolidifierRecipe(
-                        ItemList.Shape_Mold_Bolt.get(0L),
-                        aMaterial.getMolten(18L),
-                        GT_OreDictUnificator.get(OrePrefixes.bolt, aMaterial, 1L),
-                        50,
-                        calculateRecipeEU(aMaterial, 2 * tVoltageMultiplier));
-                    GT_Values.RA.addFluidSolidifierRecipe(
-                        ItemList.Shape_Mold_Round.get(0L),
-                        aMaterial.getMolten(18L),
-                        GT_OreDictUnificator.get(OrePrefixes.round, aMaterial, 1L),
-                        50,
-                        calculateRecipeEU(aMaterial, 2 * tVoltageMultiplier));
-                    GT_Values.RA.addFluidSolidifierRecipe(
-                        ItemList.Shape_Mold_Rod_Long.get(0L),
-                        aMaterial.getMolten(144L),
-                        GT_OreDictUnificator.get(OrePrefixes.stickLong, aMaterial, 1L),
-                        300,
-                        calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier));
-                    GT_Values.RA.addFluidSolidifierRecipe(
-                        ItemList.Shape_Mold_Turbine_Blade.get(0L),
-                        aMaterial.getMolten(864L),
-                        GT_OreDictUnificator.get(OrePrefixes.turbineBlade, aMaterial, 1L),
-                        400,
-                        calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier));
-                    GT_Values.RA.addFluidSolidifierRecipe(
-                        ItemList.Shape_Mold_Pipe_Tiny.get(0L),
-                        aMaterial.getMolten(72L),
-                        GT_OreDictUnificator.get(OrePrefixes.pipeTiny, aMaterial, 1L),
-                        20,
-                        calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier));
-                    GT_Values.RA.addFluidSolidifierRecipe(
-                        ItemList.Shape_Mold_Pipe_Small.get(0L),
-                        aMaterial.getMolten(144L),
-                        GT_OreDictUnificator.get(OrePrefixes.pipeSmall, aMaterial, 1L),
-                        40,
-                        calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier));
-                    GT_Values.RA.addFluidSolidifierRecipe(
-                        ItemList.Shape_Mold_Pipe_Medium.get(0L),
-                        aMaterial.getMolten(432L),
-                        GT_OreDictUnificator.get(OrePrefixes.pipeMedium, aMaterial, 1L),
-                        80,
-                        calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier));
-                    GT_Values.RA.addFluidSolidifierRecipe(
-                        ItemList.Shape_Mold_Pipe_Large.get(0L),
-                        aMaterial.getMolten(864L),
-                        GT_OreDictUnificator.get(OrePrefixes.pipeLarge, aMaterial, 1L),
-                        160,
-                        calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier));
-                    GT_Values.RA.addFluidSolidifierRecipe(
-                        ItemList.Shape_Mold_Pipe_Huge.get(0L),
-                        aMaterial.getMolten(1728L),
-                        GT_OreDictUnificator.get(OrePrefixes.pipeHuge, aMaterial, 1L),
-                        320,
-                        calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier));
+                    if (GT_OreDictUnificator.get(OrePrefixes.ring, aMaterial, 1L) != null) {
+                        GT_Values.RA.stdBuilder()
+                            .itemInputs(ItemList.Shape_Mold_Ring.get(0L))
+                            .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.ring, aMaterial, 1L))
+                            .fluidInputs(aMaterial.getMolten(36L))
+                            .noFluidOutputs()
+                            .duration(5 * SECONDS)
+                            .eut(calculateRecipeEU(aMaterial, 4 * tVoltageMultiplier))
+                            .addTo(sFluidSolidficationRecipes);
+                    }
+                    if (GT_OreDictUnificator.get(OrePrefixes.screw, aMaterial, 1L) != null) {
+                        GT_Values.RA.stdBuilder()
+                            .itemInputs(ItemList.Shape_Mold_Screw.get(0L))
+                            .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.screw, aMaterial, 1L))
+                            .fluidInputs(aMaterial.getMolten(18L))
+                            .noFluidOutputs()
+                            .duration(2 * SECONDS + 10 * TICKS)
+                            .eut(calculateRecipeEU(aMaterial, 2 * tVoltageMultiplier))
+                            .addTo(sFluidSolidficationRecipes);
+                    }
+                    if (GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial, 1L) != null) {
+                        GT_Values.RA.stdBuilder()
+                            .itemInputs(ItemList.Shape_Mold_Rod.get(0L))
+                            .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial, 1L))
+                            .fluidInputs(aMaterial.getMolten(72L))
+                            .noFluidOutputs()
+                            .duration(7 * SECONDS + 10 * TICKS)
+                            .eut(calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier))
+                            .addTo(sFluidSolidficationRecipes);
+                    }
+                    if (GT_OreDictUnificator.get(OrePrefixes.bolt, aMaterial, 1L) != null) {
+                        GT_Values.RA.stdBuilder()
+                            .itemInputs(ItemList.Shape_Mold_Bolt.get(0L))
+                            .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.bolt, aMaterial, 1L))
+                            .fluidInputs(aMaterial.getMolten(18L))
+                            .noFluidOutputs()
+                            .duration(2 * SECONDS + 10 * TICKS)
+                            .eut(calculateRecipeEU(aMaterial, 2 * tVoltageMultiplier))
+                            .addTo(sFluidSolidficationRecipes);
+                    }
+                    if (GT_OreDictUnificator.get(OrePrefixes.round, aMaterial, 1L) != null) {
+                        GT_Values.RA.stdBuilder()
+                            .itemInputs(ItemList.Shape_Mold_Round.get(0L))
+                            .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.round, aMaterial, 1L))
+                            .fluidInputs(aMaterial.getMolten(18L))
+                            .noFluidOutputs()
+                            .duration(2 * SECONDS + 10 * TICKS)
+                            .eut(calculateRecipeEU(aMaterial, 2 * tVoltageMultiplier))
+                            .addTo(sFluidSolidficationRecipes);
+                    }
+                    if (GT_OreDictUnificator.get(OrePrefixes.stickLong, aMaterial, 1L) != null) {
+                        GT_Values.RA.stdBuilder()
+                            .itemInputs(ItemList.Shape_Mold_Rod_Long.get(0L))
+                            .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.stickLong, aMaterial, 1L))
+                            .fluidInputs(aMaterial.getMolten(144L))
+                            .noFluidOutputs()
+                            .duration(15 * SECONDS)
+                            .eut(calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier))
+                            .addTo(sFluidSolidficationRecipes);
+                    }
+                    if (GT_OreDictUnificator.get(OrePrefixes.turbineBlade, aMaterial, 1L) != null) {
+                        GT_Values.RA.stdBuilder()
+                            .itemInputs(ItemList.Shape_Mold_Turbine_Blade.get(0L))
+                            .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.turbineBlade, aMaterial, 1L))
+                            .fluidInputs(aMaterial.getMolten(864L))
+                            .noFluidOutputs()
+                            .duration(20 * SECONDS)
+                            .eut(calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier))
+                            .addTo(sFluidSolidficationRecipes);
+                    }
+                    if (GT_OreDictUnificator.get(OrePrefixes.pipeTiny, aMaterial, 1L) != null) {
+                        GT_Values.RA.stdBuilder()
+                            .itemInputs(ItemList.Shape_Mold_Pipe_Tiny.get(0L))
+                            .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.pipeTiny, aMaterial, 1L))
+                            .fluidInputs(aMaterial.getMolten(72L))
+                            .noFluidOutputs()
+                            .duration(1 * SECONDS)
+                            .eut(calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier))
+                            .addTo(sFluidSolidficationRecipes);
+                    }
+                    if (GT_OreDictUnificator.get(OrePrefixes.pipeSmall, aMaterial, 1L) != null) {
+                        GT_Values.RA.stdBuilder()
+                            .itemInputs(ItemList.Shape_Mold_Pipe_Small.get(0L))
+                            .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.pipeSmall, aMaterial, 1L))
+                            .fluidInputs(aMaterial.getMolten(144L))
+                            .noFluidOutputs()
+                            .duration(2 * SECONDS)
+                            .eut(calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier))
+                            .addTo(sFluidSolidficationRecipes);
+                    }
+                    if (GT_OreDictUnificator.get(OrePrefixes.pipeMedium, aMaterial, 1L) != null) {
+                        GT_Values.RA.stdBuilder()
+                            .itemInputs(ItemList.Shape_Mold_Pipe_Medium.get(0L))
+                            .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.pipeMedium, aMaterial, 1L))
+                            .fluidInputs(aMaterial.getMolten(432L))
+                            .noFluidOutputs()
+                            .duration(4 * SECONDS)
+                            .eut(calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier))
+                            .addTo(sFluidSolidficationRecipes);
+                    }
+                    if (GT_OreDictUnificator.get(OrePrefixes.pipeLarge, aMaterial, 1L) != null) {
+                        GT_Values.RA.stdBuilder()
+                            .itemInputs(ItemList.Shape_Mold_Pipe_Large.get(0L))
+                            .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.pipeLarge, aMaterial, 1L))
+                            .fluidInputs(aMaterial.getMolten(864L))
+                            .noFluidOutputs()
+                            .duration(8 * SECONDS)
+                            .eut(calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier))
+                            .addTo(sFluidSolidficationRecipes);
+                    }
+                    if (GT_OreDictUnificator.get(OrePrefixes.pipeHuge, aMaterial, 1L) != null) {
+                        GT_Values.RA.stdBuilder()
+                            .itemInputs(ItemList.Shape_Mold_Pipe_Huge.get(0L))
+                            .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.pipeHuge, aMaterial, 1L))
+                            .fluidInputs(aMaterial.getMolten(1728L))
+                            .noFluidOutputs()
+                            .duration(16 * SECONDS)
+                            .eut(calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier))
+                            .addTo(sFluidSolidficationRecipes);
+                    }
                 }
                 if (tAmount * 2 <= 64) {
                     if (!(aMaterial == Materials.Aluminium)) {
-                        GT_Values.RA.addExtruderRecipe(
-                            GT_Utility.copyAmount(1L, aStack),
-                            ItemList.Shape_Extruder_Rod.get(0L),
-                            GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial.mSmeltInto, tAmount * 2),
-                            (int) Math.max(aMaterialMass * 2L * tAmount, tAmount),
-                            calculateRecipeEU(aMaterial, 6 * tVoltageMultiplier));
+                        if (GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial.mSmeltInto, 1L) != null) {
+                            GT_Values.RA.stdBuilder()
+                                .itemInputs(GT_Utility.copyAmount(1L, aStack), ItemList.Shape_Extruder_Rod.get(0L))
+                                .itemOutputs(
+                                    GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial.mSmeltInto, tAmount * 2))
+                                .noFluidInputs()
+                                .noFluidOutputs()
+                                .duration(((int) Math.max(aMaterialMass * 2L * tAmount, tAmount)) * TICKS)
+                                .eut(calculateRecipeEU(aMaterial, 6 * tVoltageMultiplier))
+                                .addTo(sExtruderRecipes);
+                        }
                     } else {
-                        GT_Values.RA.addExtruderRecipe(
-                            GT_Utility.copyAmount(1L, aStack),
-                            ItemList.Shape_Extruder_Rod.get(0L),
-                            GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial.mSmeltInto, tAmount * 2),
-                            200,
-                            calculateRecipeEU(aMaterial, 2 * tVoltageMultiplier));
+                        if (GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial.mSmeltInto, 1L) != null) {
+                            GT_Values.RA.stdBuilder()
+                                .itemInputs(GT_Utility.copyAmount(1L, aStack), ItemList.Shape_Extruder_Rod.get(0L))
+                                .itemOutputs(
+                                    GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial.mSmeltInto, tAmount * 2))
+                                .noFluidInputs()
+                                .noFluidOutputs()
+                                .duration(10 * SECONDS)
+                                .eut(calculateRecipeEU(aMaterial, 2 * tVoltageMultiplier))
+                                .addTo(sExtruderRecipes);
+                        }
                     }
                 }
-                if (tAmount * 2 <= 64) GT_Values.RA.addExtruderRecipe(
-                    GT_Utility.copyAmount(1L, aStack),
-                    ItemList.Shape_Extruder_Wire.get(0L),
-                    GT_OreDictUnificator.get(OrePrefixes.wireGt01, aMaterial.mSmeltInto, tAmount * 2),
-                    (int) Math.max(aMaterialMass * 2L * tAmount, tAmount),
-                    calculateRecipeEU(aMaterial, 6 * tVoltageMultiplier));
-                if (tAmount * 8 <= 64) GT_Values.RA.addExtruderRecipe(
-                    GT_Utility.copyAmount(1L, aStack),
-                    ItemList.Shape_Extruder_Bolt.get(0L),
-                    GT_OreDictUnificator.get(OrePrefixes.bolt, aMaterial.mSmeltInto, tAmount * 8),
-                    (int) Math.max(aMaterialMass * 2L * tAmount, tAmount),
-                    calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier));
+                if (tAmount * 2 <= 64) {
+                    if (GT_OreDictUnificator.get(OrePrefixes.wireGt01, aMaterial.mSmeltInto, 1L) != null) {
+                        GT_Values.RA.stdBuilder()
+                            .itemInputs(GT_Utility.copyAmount(1L, aStack), ItemList.Shape_Extruder_Wire.get(0L))
+                            .itemOutputs(
+                                GT_OreDictUnificator.get(OrePrefixes.wireGt01, aMaterial.mSmeltInto, tAmount * 2))
+                            .noFluidInputs()
+                            .noFluidOutputs()
+                            .duration(((int) Math.max(aMaterialMass * 2L * tAmount, tAmount)) * TICKS)
+                            .eut(calculateRecipeEU(aMaterial, 6 * tVoltageMultiplier))
+                            .addTo(sExtruderRecipes);
+                    }
+                }
+                if (tAmount * 8 <= 64) {
+                    if (GT_OreDictUnificator.get(OrePrefixes.bolt, aMaterial.mSmeltInto, 1L) != null) {
+                        GT_Values.RA.stdBuilder()
+                            .itemInputs(GT_Utility.copyAmount(1L, aStack), ItemList.Shape_Extruder_Bolt.get(0L))
+                            .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.bolt, aMaterial.mSmeltInto, tAmount * 8))
+                            .noFluidInputs()
+                            .noFluidOutputs()
+                            .duration(((int) Math.max(aMaterialMass * 2L * tAmount, tAmount)) * TICKS)
+                            .eut(calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier))
+                            .addTo(sExtruderRecipes);
+                    }
+                }
                 if (tAmount * 4 <= 64) {
-                    GT_Values.RA.addExtruderRecipe(
-                        GT_Utility.copyAmount(1L, aStack),
-                        ItemList.Shape_Extruder_Ring.get(0L),
-                        GT_OreDictUnificator.get(OrePrefixes.ring, aMaterial.mSmeltInto, tAmount * 4),
-                        (int) Math.max(aMaterialMass * 2L * tAmount, tAmount),
-                        calculateRecipeEU(aMaterial, 6 * tVoltageMultiplier));
+                    if (GT_OreDictUnificator.get(OrePrefixes.ring, aMaterial.mSmeltInto, 1L) != null) {
+                        GT_Values.RA.stdBuilder()
+                            .itemInputs(GT_Utility.copyAmount(1L, aStack), ItemList.Shape_Extruder_Ring.get(0L))
+                            .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.ring, aMaterial.mSmeltInto, tAmount * 4))
+                            .noFluidInputs()
+                            .noFluidOutputs()
+                            .duration(((int) Math.max(aMaterialMass * 2L * tAmount, tAmount)) * TICKS)
+                            .eut(calculateRecipeEU(aMaterial, 6 * tVoltageMultiplier))
+                            .addTo(sExtruderRecipes);
+                    }
                     if ((aMaterial.mUnificatable) && (aMaterial.mMaterialInto == aMaterial)
-                        && !aMaterial.contains(SubTag.NO_SMASHING))
-
+                        && !aMaterial.contains(SubTag.NO_SMASHING)) {
                         // If material tier < IV then add manual recipe.
-                        if (aMaterial.getProcessingMaterialTierEU() < TierEU.IV) {
+                        if (aMaterial.getProcessingMaterialTierEU() < TierEU.IV
+                            && GT_OreDictUnificator.get(OrePrefixes.ring, aMaterial, 1L) != null) {
                             GT_ModHandler.addCraftingRecipe(
                                 GT_OreDictUnificator.get(OrePrefixes.ring, aMaterial, 1L),
                                 GT_Proxy.tBits,
                                 new Object[] { "h ", "fX", 'X', OrePrefixes.stick.get(aMaterial) });
                         }
+                    }
                 }
 
-                GT_Values.RA.addExtruderRecipe(
-                    GT_Utility.copyAmount(2L, aStack),
-                    ItemList.Shape_Extruder_Sword.get(0L),
-                    GT_OreDictUnificator.get(OrePrefixes.toolHeadSword, aMaterial.mSmeltInto, tAmount),
-                    (int) Math.max(aMaterialMass * 2L * tAmount, tAmount),
-                    calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier));
-                GT_Values.RA.addExtruderRecipe(
-                    GT_Utility.copyAmount(3L, aStack),
-                    ItemList.Shape_Extruder_Pickaxe.get(0L),
-                    GT_OreDictUnificator.get(OrePrefixes.toolHeadPickaxe, aMaterial.mSmeltInto, tAmount),
-                    (int) Math.max(aMaterialMass * 3L * tAmount, tAmount),
-                    calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier));
-                GT_Values.RA.addExtruderRecipe(
-                    GT_Utility.copyAmount(1L, aStack),
-                    ItemList.Shape_Extruder_Shovel.get(0L),
-                    GT_OreDictUnificator.get(OrePrefixes.toolHeadShovel, aMaterial.mSmeltInto, tAmount),
-                    (int) Math.max(aMaterialMass * 1L * tAmount, tAmount),
-                    calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier));
-                GT_Values.RA.addExtruderRecipe(
-                    GT_Utility.copyAmount(3L, aStack),
-                    ItemList.Shape_Extruder_Axe.get(0L),
-                    GT_OreDictUnificator.get(OrePrefixes.toolHeadAxe, aMaterial.mSmeltInto, tAmount),
-                    (int) Math.max(aMaterialMass * 3L * tAmount, tAmount),
-                    calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier));
-                GT_Values.RA.addExtruderRecipe(
-                    GT_Utility.copyAmount(2L, aStack),
-                    ItemList.Shape_Extruder_Hoe.get(0L),
-                    GT_OreDictUnificator.get(OrePrefixes.toolHeadHoe, aMaterial.mSmeltInto, tAmount),
-                    (int) Math.max(aMaterialMass * 2L * tAmount, tAmount),
-                    calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier));
-                GT_Values.RA.addExtruderRecipe(
-                    GT_Utility.copyAmount(6L, aStack),
-                    ItemList.Shape_Extruder_Hammer.get(0L),
-                    GT_OreDictUnificator.get(OrePrefixes.toolHeadHammer, aMaterial.mSmeltInto, tAmount),
-                    (int) Math.max(aMaterialMass * 6L * tAmount, tAmount),
-                    calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier));
-                GT_Values.RA.addExtruderRecipe(
-                    GT_Utility.copyAmount(2L, aStack),
-                    ItemList.Shape_Extruder_File.get(0L),
-                    GT_OreDictUnificator.get(OrePrefixes.toolHeadFile, aMaterial.mSmeltInto, tAmount),
-                    (int) Math.max(aMaterialMass * 2L * tAmount, tAmount),
-                    calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier));
-                GT_Values.RA.addExtruderRecipe(
-                    GT_Utility.copyAmount(2L, aStack),
-                    ItemList.Shape_Extruder_Saw.get(0L),
-                    GT_OreDictUnificator.get(OrePrefixes.toolHeadSaw, aMaterial.mSmeltInto, tAmount),
-                    (int) Math.max(aMaterialMass * 2L * tAmount, tAmount),
-                    calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier));
-                GT_Values.RA.addExtruderRecipe(
-                    GT_Utility.copyAmount(4L, aStack),
-                    ItemList.Shape_Extruder_Gear.get(0L),
-                    GT_OreDictUnificator.get(OrePrefixes.gearGt, aMaterial.mSmeltInto, tAmount),
-                    (int) Math.max(aMaterialMass * 5L * tAmount, tAmount),
-                    calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier));
+                if (GT_OreDictUnificator.get(OrePrefixes.toolHeadSword, aMaterial.mSmeltInto, 1L) != null) {
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(GT_Utility.copyAmount(2L, aStack), ItemList.Shape_Extruder_Sword.get(0L))
+                        .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.toolHeadSword, aMaterial.mSmeltInto, tAmount))
+                        .noFluidInputs()
+                        .noFluidOutputs()
+                        .duration(((int) Math.max(aMaterialMass * 2L * tAmount, tAmount)) * TICKS)
+                        .eut(calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier))
+                        .addTo(sExtruderRecipes);
+                }
+                if (GT_OreDictUnificator.get(OrePrefixes.toolHeadPickaxe, aMaterial.mSmeltInto, 1L) != null) {
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(GT_Utility.copyAmount(3L, aStack), ItemList.Shape_Extruder_Pickaxe.get(0L))
+                        .itemOutputs(
+                            GT_OreDictUnificator.get(OrePrefixes.toolHeadPickaxe, aMaterial.mSmeltInto, tAmount))
+                        .noFluidInputs()
+                        .noFluidOutputs()
+                        .duration(((int) Math.max(aMaterialMass * 3L * tAmount, tAmount)) * TICKS)
+                        .eut(calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier))
+                        .addTo(sExtruderRecipes);
+                }
+                if (GT_OreDictUnificator.get(OrePrefixes.toolHeadShovel, aMaterial.mSmeltInto, 1L) != null) {
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(GT_Utility.copyAmount(1L, aStack), ItemList.Shape_Extruder_Shovel.get(0L))
+                        .itemOutputs(
+                            GT_OreDictUnificator.get(OrePrefixes.toolHeadShovel, aMaterial.mSmeltInto, tAmount))
+                        .noFluidInputs()
+                        .noFluidOutputs()
+                        .duration(((int) Math.max(aMaterialMass * 1L * tAmount, tAmount)) * TICKS)
+                        .eut(calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier))
+                        .addTo(sExtruderRecipes);
+                }
+                if (GT_OreDictUnificator.get(OrePrefixes.toolHeadAxe, aMaterial.mSmeltInto, 1L) != null) {
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(GT_Utility.copyAmount(3L, aStack), ItemList.Shape_Extruder_Axe.get(0L))
+                        .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.toolHeadAxe, aMaterial.mSmeltInto, tAmount))
+                        .noFluidInputs()
+                        .noFluidOutputs()
+                        .duration(((int) Math.max(aMaterialMass * 3L * tAmount, tAmount)) * TICKS)
+                        .eut(calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier))
+                        .addTo(sExtruderRecipes);
+                }
+                if (GT_OreDictUnificator.get(OrePrefixes.toolHeadHoe, aMaterial.mSmeltInto, 1L) != null) {
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(GT_Utility.copyAmount(2L, aStack), ItemList.Shape_Extruder_Hoe.get(0L))
+                        .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.toolHeadHoe, aMaterial.mSmeltInto, tAmount))
+                        .noFluidInputs()
+                        .noFluidOutputs()
+                        .duration(((int) Math.max(aMaterialMass * 2L * tAmount, tAmount)) * TICKS)
+                        .eut(calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier))
+                        .addTo(sExtruderRecipes);
+                }
+                if (GT_OreDictUnificator.get(OrePrefixes.toolHeadHammer, aMaterial.mSmeltInto, 1L) != null) {
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(GT_Utility.copyAmount(6L, aStack), ItemList.Shape_Extruder_Hammer.get(0L))
+                        .itemOutputs(
+                            GT_OreDictUnificator.get(OrePrefixes.toolHeadHammer, aMaterial.mSmeltInto, tAmount))
+                        .noFluidInputs()
+                        .noFluidOutputs()
+                        .duration(((int) Math.max(aMaterialMass * 6L * tAmount, tAmount)) * TICKS)
+                        .eut(calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier))
+                        .addTo(sExtruderRecipes);
+                }
+                if (GT_OreDictUnificator.get(OrePrefixes.toolHeadFile, aMaterial.mSmeltInto, 1L) != null) {
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(GT_Utility.copyAmount(2L, aStack), ItemList.Shape_Extruder_File.get(0L))
+                        .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.toolHeadFile, aMaterial.mSmeltInto, tAmount))
+                        .noFluidInputs()
+                        .noFluidOutputs()
+                        .duration(((int) Math.max(aMaterialMass * 2L * tAmount, tAmount)) * TICKS)
+                        .eut(calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier))
+                        .addTo(sExtruderRecipes);
+                }
+                if (GT_OreDictUnificator.get(OrePrefixes.toolHeadSaw, aMaterial.mSmeltInto, 1L) != null) {
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(GT_Utility.copyAmount(2L, aStack), ItemList.Shape_Extruder_Saw.get(0L))
+                        .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.toolHeadSaw, aMaterial.mSmeltInto, tAmount))
+                        .noFluidInputs()
+                        .noFluidOutputs()
+                        .duration(((int) Math.max(aMaterialMass * 2L * tAmount, tAmount)) * TICKS)
+                        .eut(calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier))
+                        .addTo(sExtruderRecipes);
+                }
+                if (GT_OreDictUnificator.get(OrePrefixes.gearGt, aMaterial.mSmeltInto, 1L) != null) {
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(GT_Utility.copyAmount(4L, aStack), ItemList.Shape_Extruder_Gear.get(0L))
+                        .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.gearGt, aMaterial.mSmeltInto, tAmount))
+                        .noFluidInputs()
+                        .noFluidOutputs()
+                        .duration(((int) Math.max(aMaterialMass * 5L * tAmount, tAmount)) * TICKS)
+                        .eut(calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier))
+                        .addTo(sExtruderRecipes);
+                }
 
                 if (!(aMaterial == Materials.StyreneButadieneRubber || aMaterial == Materials.Silicone)) {
                     if (aMaterial.getProcessingMaterialTierEU() < TierEU.IV) {
-                        GT_Values.RA.addAlloySmelterRecipe(
-                            GT_Utility.copyAmount(2L, aStack),
-                            ItemList.Shape_Mold_Plate.get(0L),
-                            GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial.mSmeltInto, tAmount),
-                            (int) Math.max(aMaterialMass * 2L * tAmount, tAmount),
-                            calculateRecipeEU(aMaterial, 2 * tVoltageMultiplier));
+                        if (GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial.mSmeltInto, 1L) != null) {
+                            GT_Values.RA.stdBuilder()
+                                .itemInputs(GT_Utility.copyAmount(2L, aStack), ItemList.Shape_Mold_Plate.get(0L))
+                                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial.mSmeltInto, tAmount))
+                                .noFluidInputs()
+                                .noFluidOutputs()
+                                .duration(((int) Math.max(aMaterialMass * 2L * tAmount, tAmount)) * TICKS)
+                                .eut(calculateRecipeEU(aMaterial, 2 * tVoltageMultiplier))
+                                .addTo(sAlloySmelterRecipes);
+                        }
                     }
                 } else {
                     // If tier < IV then add ability to turn ingots into plates via alloy smelter.
                     if (tTrueVoltage < TierEU.IV) {
-                        GT_Values.RA.addAlloySmelterRecipe(
-                            GT_Utility.copyAmount(1L, aStack),
-                            ItemList.Shape_Mold_Plate.get(0L),
-                            GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial.mSmeltInto, tAmount),
-                            (int) Math.max(aMaterialMass * 2L * tAmount, tAmount),
-                            calculateRecipeEU(aMaterial, 2 * tVoltageMultiplier));
+                        if (GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial.mSmeltInto, 1L) != null) {
+                            GT_Values.RA.stdBuilder()
+                                .itemInputs(GT_Utility.copyAmount(1L, aStack), ItemList.Shape_Mold_Plate.get(0L))
+                                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial.mSmeltInto, tAmount))
+                                .noFluidInputs()
+                                .noFluidOutputs()
+                                .duration(((int) Math.max(aMaterialMass * 2L * tAmount, tAmount)) * TICKS)
+                                .eut(calculateRecipeEU(aMaterial, 2 * tVoltageMultiplier))
+                                .addTo(sAlloySmelterRecipes);
+                        }
                     }
                 }
 
                 // If tier < IV then add ability to turn ingots into gears via alloy smelter.
                 if (tTrueVoltage < TierEU.IV) {
-                    GT_Values.RA.addAlloySmelterRecipe(
-                        GT_Utility.copyAmount(8L, aStack),
-                        ItemList.Shape_Mold_Gear.get(0L),
-                        GT_OreDictUnificator.get(OrePrefixes.gearGt, aMaterial.mSmeltInto, tAmount),
-                        (int) Math.max(aMaterialMass * 10L * tAmount, tAmount),
-                        calculateRecipeEU(aMaterial, 2 * tVoltageMultiplier));
+                    if (GT_OreDictUnificator.get(OrePrefixes.gearGt, aMaterial.mSmeltInto, 1L) != null) {
+                        GT_Values.RA.stdBuilder()
+                            .itemInputs(GT_Utility.copyAmount(8L, aStack), ItemList.Shape_Mold_Gear.get(0L))
+                            .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.gearGt, aMaterial.mSmeltInto, tAmount))
+                            .noFluidInputs()
+                            .noFluidOutputs()
+                            .duration(((int) Math.max(aMaterialMass * 10L * tAmount, tAmount)) * TICKS)
+                            .eut(calculateRecipeEU(aMaterial, 2 * tVoltageMultiplier))
+                            .addTo(sAlloySmelterRecipes);
+                    }
                 }
 
                 switch (aMaterial.mSmeltInto.mName) {
                     case "Glass" -> {
-                        GT_Values.RA.addExtruderRecipe(
-                            GT_Utility.copyAmount(1L, aStack),
-                            ItemList.Shape_Extruder_Bottle.get(0L),
-                            new ItemStack(Items.glass_bottle, 1),
-                            tAmount * 32,
-                            16);
-                        GT_Values.RA.addAlloySmelterRecipe(
-                            GT_Utility.copyAmount(1L, aStack),
-                            ItemList.Shape_Mold_Bottle.get(0L),
-                            new ItemStack(Items.glass_bottle, 1),
-                            tAmount * 64,
-                            4);
+                        GT_Values.RA.stdBuilder()
+                            .itemInputs(GT_Utility.copyAmount(1L, aStack), ItemList.Shape_Extruder_Bottle.get(0L))
+                            .itemOutputs(new ItemStack(Items.glass_bottle, 1))
+                            .noFluidInputs()
+                            .noFluidOutputs()
+                            .duration((tAmount * 32) * TICKS)
+                            .eut(16)
+                            .addTo(sExtruderRecipes);
+                        GT_Values.RA.stdBuilder()
+                            .itemInputs(GT_Utility.copyAmount(1L, aStack), ItemList.Shape_Mold_Bottle.get(0L))
+                            .itemOutputs(new ItemStack(Items.glass_bottle, 1))
+                            .noFluidInputs()
+                            .noFluidOutputs()
+                            .duration((tAmount * 64) * TICKS)
+                            .eut(4)
+                            .addTo(sAlloySmelterRecipes);
                     }
                     case "Steel" -> {
-                        GT_Values.RA.addExtruderRecipe(
-                            GT_Utility.copyAmount(1L, aStack),
-                            ItemList.Shape_Extruder_Cell.get(0L),
-                            ItemList.Cell_Empty.get(tAmount),
-                            tAmount * 128,
-                            30);
-                        if (tAmount * 2 <= 64) GT_Values.RA.addExtruderRecipe(
-                            GT_Utility.copyAmount(1L, aStack),
-                            ItemList.Shape_Extruder_Casing.get(0L),
-                            GT_ModHandler.getIC2Item("casingadviron", tAmount * 2),
-                            tAmount * 32,
-                            3 * tVoltageMultiplier);
-                        if (tAmount * 2 <= 64) GT_Values.RA.addAlloySmelterRecipe(
-                            GT_Utility.copyAmount(2L, aStack),
-                            ItemList.Shape_Mold_Casing.get(0L),
-                            GT_ModHandler.getIC2Item("casingadviron", tAmount * 3),
-                            tAmount * 128,
-                            1 * tVoltageMultiplier);
+                        GT_Values.RA.stdBuilder()
+                            .itemInputs(GT_Utility.copyAmount(1L, aStack), ItemList.Shape_Extruder_Cell.get(0L))
+                            .itemOutputs(ItemList.Cell_Empty.get(tAmount))
+                            .noFluidInputs()
+                            .noFluidOutputs()
+                            .duration((tAmount * 128) * TICKS)
+                            .eut(TierEU.RECIPE_LV)
+                            .addTo(sExtruderRecipes);
+                        if (tAmount * 2 <= 64) {
+                            GT_Values.RA.stdBuilder()
+                                .itemInputs(GT_Utility.copyAmount(1L, aStack), ItemList.Shape_Extruder_Casing.get(0L))
+                                .itemOutputs(GT_ModHandler.getIC2Item("casingadviron", tAmount * 2))
+                                .noFluidInputs()
+                                .noFluidOutputs()
+                                .duration((tAmount * 32) * TICKS)
+                                .eut(3 * tVoltageMultiplier)
+                                .addTo(sExtruderRecipes);
+                        }
+                        if (tAmount * 2 <= 64) {
+                            GT_Values.RA.stdBuilder()
+                                .itemInputs(GT_Utility.copyAmount(2L, aStack), ItemList.Shape_Mold_Casing.get(0L))
+                                .itemOutputs(GT_ModHandler.getIC2Item("casingadviron", tAmount * 3))
+                                .noFluidInputs()
+                                .noFluidOutputs()
+                                .duration((tAmount * 128) * TICKS)
+                                .eut(1 * tVoltageMultiplier)
+                                .addTo(sAlloySmelterRecipes);
+                        }
                     }
                     case "Iron", "WroughtIron" -> {
-                        GT_Values.RA.addExtruderRecipe(
-                            GT_Utility.copyAmount(1L, aStack),
-                            ItemList.Shape_Extruder_Cell.get(0L),
-                            GT_ModHandler.getIC2Item("fuelRod", tAmount),
-                            tAmount * 128,
-                            30);
-                        if (tAmount * 2 <= 64) GT_Values.RA.addExtruderRecipe(
-                            GT_Utility.copyAmount(1L, aStack),
-                            ItemList.Shape_Extruder_Casing.get(0L),
-                            GT_ModHandler.getIC2Item("casingiron", tAmount * 2),
-                            tAmount * 32,
-                            3 * tVoltageMultiplier);
-                        if (tAmount * 2 <= 64) GT_Values.RA.addAlloySmelterRecipe(
-                            GT_Utility.copyAmount(2L, aStack),
-                            ItemList.Shape_Mold_Casing.get(0L),
-                            GT_ModHandler.getIC2Item("casingiron", tAmount * 3),
-                            tAmount * 128,
-                            1 * tVoltageMultiplier);
-                        if (tAmount * 31 <= 64) GT_Values.RA.addAlloySmelterRecipe(
-                            GT_Utility.copyAmount(31L, aStack),
-                            ItemList.Shape_Mold_Anvil.get(0L),
-                            new ItemStack(Blocks.anvil, 1, 0),
-                            tAmount * 512,
-                            4 * tVoltageMultiplier);
+                        GT_Values.RA.stdBuilder()
+                            .itemInputs(GT_Utility.copyAmount(1L, aStack), ItemList.Shape_Extruder_Cell.get(0L))
+                            .itemOutputs(GT_ModHandler.getIC2Item("fuelRod", tAmount))
+                            .noFluidInputs()
+                            .noFluidOutputs()
+                            .duration((tAmount * 128) * TICKS)
+                            .eut(TierEU.RECIPE_LV)
+                            .addTo(sExtruderRecipes);
+                        if (tAmount * 2 <= 64) {
+                            GT_Values.RA.stdBuilder()
+                                .itemInputs(GT_Utility.copyAmount(1L, aStack), ItemList.Shape_Extruder_Casing.get(0L))
+                                .itemOutputs(GT_ModHandler.getIC2Item("casingiron", tAmount * 2))
+                                .noFluidInputs()
+                                .noFluidOutputs()
+                                .duration((tAmount * 32) * TICKS)
+                                .eut(3 * tVoltageMultiplier)
+                                .addTo(sExtruderRecipes);
+                        }
+                        if (tAmount * 2 <= 64) {
+                            GT_Values.RA.stdBuilder()
+                                .itemInputs(GT_Utility.copyAmount(2L, aStack), ItemList.Shape_Mold_Casing.get(0L))
+                                .itemOutputs(GT_ModHandler.getIC2Item("casingiron", tAmount * 3))
+                                .noFluidInputs()
+                                .noFluidOutputs()
+                                .duration((tAmount * 128) * TICKS)
+                                .eut(1 * tVoltageMultiplier)
+                                .addTo(sAlloySmelterRecipes);
+                        }
+                        if (tAmount * 31 <= 64) {
+                            GT_Values.RA.stdBuilder()
+                                .itemInputs(GT_Utility.copyAmount(31L, aStack), ItemList.Shape_Mold_Anvil.get(0L))
+                                .itemOutputs(new ItemStack(Blocks.anvil, 1, 0))
+                                .noFluidInputs()
+                                .noFluidOutputs()
+                                .duration((tAmount * 512) * TICKS)
+                                .eut(4 * tVoltageMultiplier)
+                                .addTo(sAlloySmelterRecipes);
+                        }
                     }
                     case "Tin" -> {
-                        GT_Values.RA.addExtruderRecipe(
-                            GT_Utility.copyAmount(2L, aStack),
-                            ItemList.Shape_Extruder_Cell.get(0L),
-                            ItemList.Cell_Empty.get(tAmount),
-                            tAmount * 128,
-                            30);
-                        if (tAmount * 2 <= 64) GT_Values.RA.addExtruderRecipe(
-                            GT_Utility.copyAmount(1L, aStack),
-                            ItemList.Shape_Extruder_Casing.get(0L),
-                            GT_ModHandler.getIC2Item("casingtin", tAmount * 2),
-                            tAmount * 32,
-                            3 * tVoltageMultiplier);
-                        if (tAmount * 2 <= 64) GT_Values.RA.addAlloySmelterRecipe(
-                            GT_Utility.copyAmount(2L, aStack),
-                            ItemList.Shape_Mold_Casing.get(0L),
-                            GT_ModHandler.getIC2Item("casingtin", tAmount * 3),
-                            tAmount * 128,
-                            1 * tVoltageMultiplier);
+                        GT_Values.RA.stdBuilder()
+                            .itemInputs(GT_Utility.copyAmount(2L, aStack), ItemList.Shape_Extruder_Cell.get(0L))
+                            .itemOutputs(ItemList.Cell_Empty.get(tAmount))
+                            .noFluidInputs()
+                            .noFluidOutputs()
+                            .duration((tAmount * 128) * TICKS)
+                            .eut(TierEU.RECIPE_LV)
+                            .addTo(sExtruderRecipes);
+                        if (tAmount * 2 <= 64) {
+                            GT_Values.RA.stdBuilder()
+                                .itemInputs(GT_Utility.copyAmount(1L, aStack), ItemList.Shape_Extruder_Casing.get(0L))
+                                .itemOutputs(GT_ModHandler.getIC2Item("casingtin", tAmount * 2))
+                                .noFluidInputs()
+                                .noFluidOutputs()
+                                .duration((tAmount * 32) * TICKS)
+                                .eut(3 * tVoltageMultiplier)
+                                .addTo(sExtruderRecipes);
+                        }
+                        if (tAmount * 2 <= 64) {
+                            GT_Values.RA.stdBuilder()
+                                .itemInputs(GT_Utility.copyAmount(2L, aStack), ItemList.Shape_Mold_Casing.get(0L))
+                                .itemOutputs(GT_ModHandler.getIC2Item("casingtin", tAmount * 3))
+                                .noFluidInputs()
+                                .noFluidOutputs()
+                                .duration((tAmount * 128) * TICKS)
+                                .eut(1 * tVoltageMultiplier)
+                                .addTo(sAlloySmelterRecipes);
+                        }
                     }
                     case "Lead" -> {
-                        if (tAmount * 2 <= 64) GT_Values.RA.addExtruderRecipe(
-                            GT_Utility.copyAmount(1L, aStack),
-                            ItemList.Shape_Extruder_Casing.get(0L),
-                            GT_ModHandler.getIC2Item("casinglead", tAmount * 2),
-                            tAmount * 32,
-                            3 * tVoltageMultiplier);
-                        if (tAmount * 2 <= 64) GT_Values.RA.addAlloySmelterRecipe(
-                            GT_Utility.copyAmount(2L, aStack),
-                            ItemList.Shape_Mold_Casing.get(0L),
-                            GT_ModHandler.getIC2Item("casinglead", tAmount * 3),
-                            tAmount * 128,
-                            1 * tVoltageMultiplier);
+                        if (tAmount * 2 <= 64) {
+                            GT_Values.RA.stdBuilder()
+                                .itemInputs(GT_Utility.copyAmount(1L, aStack), ItemList.Shape_Extruder_Casing.get(0L))
+                                .itemOutputs(GT_ModHandler.getIC2Item("casinglead", tAmount * 2))
+                                .noFluidInputs()
+                                .noFluidOutputs()
+                                .duration((tAmount * 32) * TICKS)
+                                .eut(3 * tVoltageMultiplier)
+                                .addTo(sExtruderRecipes);
+                        }
+                        if (tAmount * 2 <= 64) {
+                            GT_Values.RA.stdBuilder()
+                                .itemInputs(GT_Utility.copyAmount(2L, aStack), ItemList.Shape_Mold_Casing.get(0L))
+                                .itemOutputs(GT_ModHandler.getIC2Item("casinglead", tAmount * 3))
+                                .noFluidInputs()
+                                .noFluidOutputs()
+                                .duration((tAmount * 128) * TICKS)
+                                .eut(1 * tVoltageMultiplier)
+                                .addTo(sAlloySmelterRecipes);
+                        }
                     }
                     case "Copper", "AnnealedCopper" -> {
-                        if (tAmount * 2 <= 64) GT_Values.RA.addExtruderRecipe(
-                            GT_Utility.copyAmount(1L, aStack),
-                            ItemList.Shape_Extruder_Casing.get(0L),
-                            GT_ModHandler.getIC2Item("casingcopper", tAmount * 2),
-                            tAmount * 32,
-                            3 * tVoltageMultiplier);
-                        if (tAmount * 2 <= 64) GT_Values.RA.addAlloySmelterRecipe(
-                            GT_Utility.copyAmount(2L, aStack),
-                            ItemList.Shape_Mold_Casing.get(0L),
-                            GT_ModHandler.getIC2Item("casingcopper", tAmount * 3),
-                            tAmount * 128,
-                            1 * tVoltageMultiplier);
+                        if (tAmount * 2 <= 64) {
+                            GT_Values.RA.stdBuilder()
+                                .itemInputs(GT_Utility.copyAmount(1L, aStack), ItemList.Shape_Extruder_Casing.get(0L))
+                                .itemOutputs(GT_ModHandler.getIC2Item("casingcopper", tAmount * 2))
+                                .noFluidInputs()
+                                .noFluidOutputs()
+                                .duration((tAmount * 32) * TICKS)
+                                .eut(3 * tVoltageMultiplier)
+                                .addTo(sExtruderRecipes);
+                        }
+                        if (tAmount * 2 <= 64) {
+                            GT_Values.RA.stdBuilder()
+                                .itemInputs(GT_Utility.copyAmount(2L, aStack), ItemList.Shape_Mold_Casing.get(0L))
+                                .itemOutputs(GT_ModHandler.getIC2Item("casingcopper", tAmount * 3))
+                                .noFluidInputs()
+                                .noFluidOutputs()
+                                .duration((tAmount * 128) * TICKS)
+                                .eut(1 * tVoltageMultiplier)
+                                .addTo(sAlloySmelterRecipes);
+                        }
                     }
                     case "Bronze" -> {
-                        if (tAmount * 2 <= 64) GT_Values.RA.addExtruderRecipe(
-                            GT_Utility.copyAmount(1L, aStack),
-                            ItemList.Shape_Extruder_Casing.get(0L),
-                            GT_ModHandler.getIC2Item("casingbronze", tAmount * 2),
-                            tAmount * 32,
-                            3 * tVoltageMultiplier);
-                        if (tAmount * 2 <= 64) GT_Values.RA.addAlloySmelterRecipe(
-                            GT_Utility.copyAmount(2L, aStack),
-                            ItemList.Shape_Mold_Casing.get(0L),
-                            GT_ModHandler.getIC2Item("casingbronze", tAmount * 3),
-                            tAmount * 128,
-                            1 * tVoltageMultiplier);
+                        if (tAmount * 2 <= 64) {
+                            GT_Values.RA.stdBuilder()
+                                .itemInputs(GT_Utility.copyAmount(1L, aStack), ItemList.Shape_Extruder_Casing.get(0L))
+                                .itemOutputs(GT_ModHandler.getIC2Item("casingbronze", tAmount * 2))
+                                .noFluidInputs()
+                                .noFluidOutputs()
+                                .duration((tAmount * 32) * TICKS)
+                                .eut(3 * tVoltageMultiplier)
+                                .addTo(sExtruderRecipes);
+                        }
+                        if (tAmount * 2 <= 64) {
+                            GT_Values.RA.stdBuilder()
+                                .itemInputs(GT_Utility.copyAmount(2L, aStack), ItemList.Shape_Mold_Casing.get(0L))
+                                .itemOutputs(GT_ModHandler.getIC2Item("casingbronze", tAmount * 3))
+                                .noFluidInputs()
+                                .noFluidOutputs()
+                                .duration((tAmount * 128) * TICKS)
+                                .eut(1 * tVoltageMultiplier)
+                                .addTo(sAlloySmelterRecipes);
+                        }
                     }
                     case "Gold" -> {
-                        if (tAmount * 2 <= 64) GT_Values.RA.addExtruderRecipe(
-                            GT_Utility.copyAmount(1L, aStack),
-                            ItemList.Shape_Extruder_Casing.get(0L),
-                            GT_ModHandler.getIC2Item("casinggold", tAmount * 2),
-                            tAmount * 32,
-                            3 * tVoltageMultiplier);
-                        if (tAmount * 2 <= 64) GT_Values.RA.addAlloySmelterRecipe(
-                            GT_Utility.copyAmount(2L, aStack),
-                            ItemList.Shape_Mold_Casing.get(0L),
-                            GT_ModHandler.getIC2Item("casinggold", tAmount * 3),
-                            tAmount * 128,
-                            1 * tVoltageMultiplier);
+                        if (tAmount * 2 <= 64) {
+                            GT_Values.RA.stdBuilder()
+                                .itemInputs(GT_Utility.copyAmount(1L, aStack), ItemList.Shape_Extruder_Casing.get(0L))
+                                .itemOutputs(GT_ModHandler.getIC2Item("casinggold", tAmount * 2))
+                                .noFluidInputs()
+                                .noFluidOutputs()
+                                .duration((tAmount * 32) * TICKS)
+                                .eut(3 * tVoltageMultiplier)
+                                .addTo(sExtruderRecipes);
+                        }
+                        if (tAmount * 2 <= 64) {
+                            GT_Values.RA.stdBuilder()
+                                .itemInputs(GT_Utility.copyAmount(2L, aStack), ItemList.Shape_Mold_Casing.get(0L))
+                                .itemOutputs(GT_ModHandler.getIC2Item("casinggold", tAmount * 3))
+                                .noFluidInputs()
+                                .noFluidOutputs()
+                                .duration((tAmount * 128) * TICKS)
+                                .eut(1 * tVoltageMultiplier)
+                                .addTo(sAlloySmelterRecipes);
+                        }
                     }
-                    case "Polytetrafluoroethylene" -> // Recipe for cells from PTFE, why is it here?
-                        GT_Values.RA.addExtruderRecipe(
-                            GT_Utility.copyAmount(1L, aStack),
-                            ItemList.Shape_Extruder_Cell.get(0L),
-                            ItemList.Cell_Empty.get(tAmount * 4),
-                            tAmount * 128,
-                            30);
+                    case "Polytetrafluoroethylene" -> {
+                        GT_Values.RA.stdBuilder()
+                            .itemInputs(GT_Utility.copyAmount(1L, aStack), ItemList.Shape_Extruder_Cell.get(0L))
+                            .itemOutputs(ItemList.Cell_Empty.get(tAmount * 4))
+                            .noFluidInputs()
+                            .noFluidOutputs()
+                            .duration((tAmount * 128) * TICKS)
+                            .eut(TierEU.RECIPE_LV)
+                            .addTo(sExtruderRecipes);
+                    }
                 }
             }
         }


### PR DESCRIPTION
- convert oredict plate recipes to RA2
- convert oredict dust recipes to RA2
- convert oredict recycling recipes to RA2
- convert shaping recipes to RA2
- improve handling of automatic electrolysis and centrifuging recipes to avoid nulls and fit in with RA2
- remove the TE slag search from calcite smelting, that was just bloat