### PR TITLE
More RA2 conversion for automatic gt recipes

### DIFF
--- a/src/main/java/gregtech/api/items/GT_MetaGenerated_Item.java
+++ b/src/main/java/gregtech/api/items/GT_MetaGenerated_Item.java
@@ -1,9 +1,10 @@
 package gregtech.api.items;
 
 import static gregtech.api.enums.GT_Values.D1;
-import static gregtech.api.enums.GT_Values.RA;
 import static gregtech.api.enums.Mods.AppleCore;
 import static gregtech.api.enums.Mods.GregTech;
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCannerRecipes;
+import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -25,6 +26,7 @@ import cpw.mods.fml.common.Optional;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import gregtech.api.GregTech_API;
+import gregtech.api.enums.GT_Values;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.Mods;
@@ -142,15 +144,19 @@ public abstract class GT_MetaGenerated_Item extends GT_MetaBase_Item implements 
                     setFoodBehavior(mOffset + aID, (IFoodStat) tRandomData);
                     if (((IFoodStat) tRandomData).getFoodAction(this, rStack) == EnumAction.eat) {
                         int tFoodValue = ((IFoodStat) tRandomData).getFoodLevel(this, rStack, null);
-                        if (tFoodValue > 0) RA.addCannerRecipe(
-                            rStack,
-                            ItemList.IC2_Food_Can_Empty.get(tFoodValue),
-                            ((IFoodStat) tRandomData).isRotten(this, rStack, null)
-                                ? ItemList.IC2_Food_Can_Spoiled.get(tFoodValue)
-                                : ItemList.IC2_Food_Can_Filled.get(tFoodValue),
-                            null,
-                            tFoodValue * 100,
-                            1);
+                        if (tFoodValue > 0) {
+                            GT_Values.RA.stdBuilder()
+                                .itemInputs(rStack, ItemList.IC2_Food_Can_Empty.get(tFoodValue))
+                                .itemOutputs(
+                                    ((IFoodStat) tRandomData).isRotten(this, rStack, null)
+                                        ? ItemList.IC2_Food_Can_Spoiled.get(tFoodValue)
+                                        : ItemList.IC2_Food_Can_Filled.get(tFoodValue))
+                                .noFluidInputs()
+                                .noFluidOutputs()
+                                .duration(tFoodValue * 5 * SECONDS)
+                                .eut(1)
+                                .addTo(sCannerRecipes);
+                        }
                     }
                     tUseOreDict = false;
                 }

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Frame.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Frame.java
@@ -1,13 +1,20 @@
 package gregtech.api.metatileentity.implementations;
 
-import static gregtech.api.enums.GT_Values.RA;
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAssemblerRecipes;
+import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
+import static gregtech.api.util.GT_RecipeBuilder.TICKS;
 import static gregtech.api.util.GT_Utility.calculateRecipeEU;
 
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import gregtech.api.enums.*;
+import gregtech.api.enums.Dyes;
+import gregtech.api.enums.GT_Values;
+import gregtech.api.enums.Materials;
+import gregtech.api.enums.OrePrefixes;
+import gregtech.api.enums.SubTag;
+import gregtech.api.enums.TierEU;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
@@ -17,6 +24,7 @@ import gregtech.api.util.GT_LanguageManager;
 import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_ModHandler.RecipeBits;
 import gregtech.api.util.GT_OreDictUnificator;
+import gregtech.api.util.GT_Utility;
 
 public class GT_MetaPipeEntity_Frame extends MetaPipeEntity {
 
@@ -36,14 +44,19 @@ public class GT_MetaPipeEntity_Frame extends MetaPipeEntity {
                 new Object[] { "SSS", "SwS", "SSS", 'S', OrePrefixes.stick.get(mMaterial) });
         }
 
-        if (!aMaterial.contains(SubTag.NO_RECIPES)) {
+        if (!aMaterial.contains(SubTag.NO_RECIPES)
+            && GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial, 1) != null) {
             // Auto generate frame box recipe in an assembler.
-            RA.addAssemblerRecipe(
-                GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial, 4),
-                ItemList.Circuit_Integrated.getWithDamage(0, 4),
-                getStackForm(1),
-                64,
-                calculateRecipeEU(aMaterial, 7));
+            GT_Values.RA.stdBuilder()
+                .itemInputs(
+                    GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial, 4),
+                    GT_Utility.getIntegratedCircuit(4))
+                .itemOutputs(getStackForm(1))
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(3 * SECONDS + 4 * TICKS)
+                .eut(calculateRecipeEU(aMaterial, 7))
+                .addTo(sAssemblerRecipes);
         }
     }
 

--- a/src/main/java/gregtech/api/util/GT_RecipeRegistrator.java
+++ b/src/main/java/gregtech/api/util/GT_RecipeRegistrator.java
@@ -4,6 +4,7 @@ import static gregtech.api.enums.GT_Values.*;
 import static gregtech.api.enums.Materials.*;
 import static gregtech.api.enums.Materials.Void;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sHammerRecipes;
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sWiremillRecipes;
 import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
 import static gregtech.api.util.GT_RecipeBuilder.TICKS;
 import static gregtech.api.util.GT_RecipeConstants.UniversalArcFurnace;
@@ -639,90 +640,151 @@ public class GT_RecipeRegistrator {
      */
     public static void registerWiremillRecipes(Materials aMaterial, int baseDuration, int aEUt, OrePrefixes prefix1,
         OrePrefixes prefix2, int multiplier) {
-        GT_Values.RA.addWiremillRecipe(
-            GT_OreDictUnificator.get(prefix1, aMaterial, 1L),
-            GT_Utility.getIntegratedCircuit(1),
-            GT_OreDictUnificator.get(OrePrefixes.wireGt01, aMaterial, multiplier),
-            baseDuration,
-            aEUt);
-        GT_Values.RA.addWiremillRecipe(
-            GT_OreDictUnificator.get(prefix1, aMaterial, 2L / multiplier),
-            GT_Utility.getIntegratedCircuit(2),
-            GT_OreDictUnificator.get(OrePrefixes.wireGt02, aMaterial, 1L),
-            (int) (baseDuration * 1.5f),
-            aEUt);
-        GT_Values.RA.addWiremillRecipe(
-            GT_OreDictUnificator.get(prefix1, aMaterial, 4L / multiplier),
-            GT_Utility.getIntegratedCircuit(4),
-            GT_OreDictUnificator.get(OrePrefixes.wireGt04, aMaterial, 1L),
-            baseDuration * 2,
-            aEUt);
-        GT_Values.RA.addWiremillRecipe(
-            GT_OreDictUnificator.get(prefix1, aMaterial, 8L / multiplier),
-            GT_Utility.getIntegratedCircuit(8),
-            GT_OreDictUnificator.get(OrePrefixes.wireGt08, aMaterial, 1L),
-            (int) (baseDuration * 2.5f),
-            aEUt);
-        GT_Values.RA.addWiremillRecipe(
-            GT_OreDictUnificator.get(prefix1, aMaterial, 12L / multiplier),
-            GT_Utility.getIntegratedCircuit(12),
-            GT_OreDictUnificator.get(OrePrefixes.wireGt12, aMaterial, 1L),
-            baseDuration * 3,
-            aEUt);
-        GT_Values.RA.addWiremillRecipe(
-            GT_OreDictUnificator.get(prefix1, aMaterial, 16L / multiplier),
-            GT_Utility.getIntegratedCircuit(16),
-            GT_OreDictUnificator.get(OrePrefixes.wireGt16, aMaterial, 1L),
-            (int) (baseDuration * 3.5f),
-            aEUt);
-        GT_Values.RA.addWiremillRecipe(
-            GT_OreDictUnificator.get(prefix2, aMaterial, 2L / multiplier),
-            GT_Utility.getIntegratedCircuit(1),
-            GT_OreDictUnificator.get(OrePrefixes.wireGt01, aMaterial, 1L),
-            baseDuration / 2,
-            aEUt);
-        GT_Values.RA.addWiremillRecipe(
-            GT_OreDictUnificator.get(prefix2, aMaterial, 4L / multiplier),
-            GT_Utility.getIntegratedCircuit(2),
-            GT_OreDictUnificator.get(OrePrefixes.wireGt02, aMaterial, 1L),
-            baseDuration,
-            aEUt);
-        GT_Values.RA.addWiremillRecipe(
-            GT_OreDictUnificator.get(prefix2, aMaterial, 8L / multiplier),
-            GT_Utility.getIntegratedCircuit(4),
-            GT_OreDictUnificator.get(OrePrefixes.wireGt04, aMaterial, 1L),
-            (int) (baseDuration * 1.5f),
-            aEUt);
-        GT_Values.RA.addWiremillRecipe(
-            GT_OreDictUnificator.get(prefix2, aMaterial, 16L / multiplier),
-            GT_Utility.getIntegratedCircuit(8),
-            GT_OreDictUnificator.get(OrePrefixes.wireGt08, aMaterial, 1L),
-            baseDuration * 2,
-            aEUt);
-        GT_Values.RA.addWiremillRecipe(
-            GT_OreDictUnificator.get(prefix2, aMaterial, 24L / multiplier),
-            GT_Utility.getIntegratedCircuit(12),
-            GT_OreDictUnificator.get(OrePrefixes.wireGt12, aMaterial, 1L),
-            (int) (baseDuration * 2.5f),
-            aEUt);
-        GT_Values.RA.addWiremillRecipe(
-            GT_OreDictUnificator.get(prefix2, aMaterial, 32L / multiplier),
-            GT_Utility.getIntegratedCircuit(16),
-            GT_OreDictUnificator.get(OrePrefixes.wireGt16, aMaterial, 1L),
-            baseDuration * 3,
-            aEUt);
-        GT_Values.RA.addWiremillRecipe(
-            GT_OreDictUnificator.get(prefix1, aMaterial, 1L),
-            GT_Utility.getIntegratedCircuit(3),
-            GT_OreDictUnificator.get(OrePrefixes.wireFine, aMaterial, 4L * multiplier),
-            baseDuration,
-            aEUt);
-        GT_Values.RA.addWiremillRecipe(
-            GT_OreDictUnificator.get(prefix2, aMaterial, 1L),
-            GT_Utility.getIntegratedCircuit(3),
-            GT_OreDictUnificator.get(OrePrefixes.wireFine, aMaterial, 2L * multiplier),
-            baseDuration / 2,
-            aEUt);
+        if (GT_OreDictUnificator.get(prefix1, aMaterial, 1L) != null
+            && GT_OreDictUnificator.get(OrePrefixes.wireGt01, aMaterial, 1L) != null) {
+            GT_Values.RA.stdBuilder()
+                .itemInputs(GT_OreDictUnificator.get(prefix1, aMaterial, 1L), GT_Utility.getIntegratedCircuit(1))
+                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.wireGt01, aMaterial, multiplier))
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(baseDuration * TICKS)
+                .eut(aEUt)
+                .addTo(sWiremillRecipes);
+            GT_Values.RA.stdBuilder()
+                .itemInputs(
+                    GT_OreDictUnificator.get(prefix1, aMaterial, 2L / multiplier),
+                    GT_Utility.getIntegratedCircuit(2))
+                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.wireGt02, aMaterial, 1L))
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(((int) (baseDuration * 1.5f)) * TICKS)
+                .eut(aEUt)
+                .addTo(sWiremillRecipes);
+            GT_Values.RA.stdBuilder()
+                .itemInputs(
+                    GT_OreDictUnificator.get(prefix1, aMaterial, 4L / multiplier),
+                    GT_Utility.getIntegratedCircuit(4))
+                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.wireGt04, aMaterial, 1L))
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(baseDuration * 2 * TICKS)
+                .eut(aEUt)
+                .addTo(sWiremillRecipes);
+            GT_Values.RA.stdBuilder()
+                .itemInputs(
+                    GT_OreDictUnificator.get(prefix1, aMaterial, 8L / multiplier),
+                    GT_Utility.getIntegratedCircuit(8))
+                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.wireGt08, aMaterial, 1L))
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(((int) (baseDuration * 2.5f)) * TICKS)
+                .eut(aEUt)
+                .addTo(sWiremillRecipes);
+            GT_Values.RA.stdBuilder()
+                .itemInputs(
+                    GT_OreDictUnificator.get(prefix1, aMaterial, 12L / multiplier),
+                    GT_Utility.getIntegratedCircuit(12))
+                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.wireGt12, aMaterial, 1L))
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(baseDuration * 3 * TICKS)
+                .eut(aEUt)
+                .addTo(sWiremillRecipes);
+            GT_Values.RA.stdBuilder()
+                .itemInputs(
+                    GT_OreDictUnificator.get(prefix1, aMaterial, 16L / multiplier),
+                    GT_Utility.getIntegratedCircuit(16))
+                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.wireGt16, aMaterial, 1L))
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(((int) (baseDuration * 3.5f)) * TICKS)
+                .eut(aEUt)
+                .addTo(sWiremillRecipes);
+        }
+
+        if (GT_OreDictUnificator.get(prefix2, aMaterial, 1L) != null
+            && GT_OreDictUnificator.get(OrePrefixes.wireGt01, aMaterial, 1L) != null) {
+            GT_Values.RA.stdBuilder()
+                .itemInputs(GT_OreDictUnificator.get(prefix2, aMaterial, 1L), GT_Utility.getIntegratedCircuit(1))
+                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.wireGt01, aMaterial, 2L / multiplier))
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(((int) (baseDuration * 0.5f)) * TICKS)
+                .eut(aEUt)
+                .addTo(sWiremillRecipes);
+            GT_Values.RA.stdBuilder()
+                .itemInputs(
+                    GT_OreDictUnificator.get(prefix2, aMaterial, 4L / multiplier),
+                    GT_Utility.getIntegratedCircuit(2))
+                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.wireGt02, aMaterial, 1L))
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(baseDuration * TICKS)
+                .eut(aEUt)
+                .addTo(sWiremillRecipes);
+            GT_Values.RA.stdBuilder()
+                .itemInputs(
+                    GT_OreDictUnificator.get(prefix2, aMaterial, 8L / multiplier),
+                    GT_Utility.getIntegratedCircuit(4))
+                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.wireGt04, aMaterial, 1L))
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(((int) (baseDuration * 1.5f)) * TICKS)
+                .eut(aEUt)
+                .addTo(sWiremillRecipes);
+            GT_Values.RA.stdBuilder()
+                .itemInputs(
+                    GT_OreDictUnificator.get(prefix2, aMaterial, 16L / multiplier),
+                    GT_Utility.getIntegratedCircuit(8))
+                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.wireGt08, aMaterial, 1L))
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(baseDuration * 2 * TICKS)
+                .eut(aEUt)
+                .addTo(sWiremillRecipes);
+            GT_Values.RA.stdBuilder()
+                .itemInputs(
+                    GT_OreDictUnificator.get(prefix2, aMaterial, 24L / multiplier),
+                    GT_Utility.getIntegratedCircuit(12))
+                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.wireGt12, aMaterial, 1L))
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(((int) (baseDuration * 2.5f)) * TICKS)
+                .eut(aEUt)
+                .addTo(sWiremillRecipes);
+            GT_Values.RA.stdBuilder()
+                .itemInputs(
+                    GT_OreDictUnificator.get(prefix2, aMaterial, 32L / multiplier),
+                    GT_Utility.getIntegratedCircuit(16))
+                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.wireGt16, aMaterial, 1L))
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(baseDuration * 3 * TICKS)
+                .eut(aEUt)
+                .addTo(sWiremillRecipes);
+        }
+        if (GT_OreDictUnificator.get(prefix1, aMaterial, 1L) != null
+            && GT_OreDictUnificator.get(OrePrefixes.wireFine, aMaterial, 1L) != null) {
+            GT_Values.RA.stdBuilder()
+                .itemInputs(GT_OreDictUnificator.get(prefix1, aMaterial, 1L), GT_Utility.getIntegratedCircuit(3))
+                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.wireFine, aMaterial, 4L * multiplier))
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(baseDuration * TICKS)
+                .eut(aEUt)
+                .addTo(sWiremillRecipes);
+        }
+        if (GT_OreDictUnificator.get(prefix2, aMaterial, 1L) != null
+            && GT_OreDictUnificator.get(OrePrefixes.wireFine, aMaterial, 1L) != null) {
+            GT_Values.RA.stdBuilder()
+                .itemInputs(GT_OreDictUnificator.get(prefix2, aMaterial, 1L), GT_Utility.getIntegratedCircuit(3))
+                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.wireFine, aMaterial, 2L * multiplier))
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(((int) (baseDuration * 0.5f)) * TICKS)
+                .eut(aEUt)
+                .addTo(sWiremillRecipes);
+        }
     }
 
     public static boolean hasVanillaRecipes(Materials materials) {

--- a/src/main/java/gregtech/common/GT_Proxy.java
+++ b/src/main/java/gregtech/common/GT_Proxy.java
@@ -8,6 +8,7 @@ import static gregtech.api.enums.FluidState.PLASMA;
 import static gregtech.api.enums.GT_Values.W;
 import static gregtech.api.enums.GT_Values.debugEntityCramming;
 import static gregtech.api.enums.Mods.*;
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sWiremillRecipes;
 import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
 import static gregtech.api.util.GT_RecipeConstants.UniversalChemical;
 import static gregtech.api.util.GT_Util.LAST_BROKEN_TILEENTITY;
@@ -1942,16 +1943,22 @@ public abstract class GT_Proxy implements IGT_Mod, IGuiHandler, IFuelHandler, IG
                                                         Materials.Brass,
                                                         new ItemStack(aEvent.Ore.getItem(), 1, 2));
                                                     if (!mDisableIC2Cables) {
-                                                        GT_Values.RA.addWiremillRecipe(
-                                                            GT_ModHandler.getIC2Item("copperCableItem", 3L),
-                                                            new ItemStack(aEvent.Ore.getItem(), 1, 8),
-                                                            400,
-                                                            1);
-                                                        GT_Values.RA.addWiremillRecipe(
-                                                            GT_ModHandler.getIC2Item("ironCableItem", 6L),
-                                                            new ItemStack(aEvent.Ore.getItem(), 1, 9),
-                                                            400,
-                                                            2);
+                                                        GT_Values.RA.stdBuilder()
+                                                            .itemInputs(GT_ModHandler.getIC2Item("copperCableItem", 3L))
+                                                            .itemOutputs(new ItemStack(aEvent.Ore.getItem(), 1, 8))
+                                                            .noFluidInputs()
+                                                            .noFluidOutputs()
+                                                            .duration(20 * SECONDS)
+                                                            .eut(1)
+                                                            .addTo(sWiremillRecipes);
+                                                        GT_Values.RA.stdBuilder()
+                                                            .itemInputs(GT_ModHandler.getIC2Item("ironCableItem", 6L))
+                                                            .itemOutputs(new ItemStack(aEvent.Ore.getItem(), 1, 9))
+                                                            .noFluidInputs()
+                                                            .noFluidOutputs()
+                                                            .duration(20 * SECONDS)
+                                                            .eut(2)
+                                                            .addTo(sWiremillRecipes);
                                                     }
                                                     GT_Values.RA.addCutterRecipe(
                                                         new ItemStack(aEvent.Ore.getItem(), 1, 3),

--- a/src/main/java/gregtech/common/blocks/GT_Block_Stones_Abstract.java
+++ b/src/main/java/gregtech/common/blocks/GT_Block_Stones_Abstract.java
@@ -1,5 +1,6 @@
 package gregtech.common.blocks;
 
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAssemblerRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sHammerRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sLaserEngraverRecipes;
 import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
@@ -65,18 +66,22 @@ public class GT_Block_Stones_Abstract extends GT_Generic_Block implements IOreRe
     }
 
     private void registerAssemblerRecipes() {
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack(this, 1, 0),
-            ItemList.Circuit_Integrated.getWithDamage(0L, 4L),
-            new ItemStack(this, 1, 3),
-            50,
-            4);
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack(this, 1, 8),
-            ItemList.Circuit_Integrated.getWithDamage(0L, 4L),
-            new ItemStack(this, 1, 11),
-            50,
-            4);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(new ItemStack(this, 1, 0), GT_Utility.getIntegratedCircuit(4))
+            .itemOutputs(new ItemStack(this, 1, 3))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(2 * SECONDS + 10 * TICKS)
+            .eut(4)
+            .addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(new ItemStack(this, 1, 8), GT_Utility.getIntegratedCircuit(4))
+            .itemOutputs(new ItemStack(this, 1, 11))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(2 * SECONDS + 10 * TICKS)
+            .eut(4)
+            .addTo(sAssemblerRecipes);
     }
 
     private void registerCraftingRecipes() {

--- a/src/main/java/gregtech/common/items/GT_MetaGenerated_Item_01.java
+++ b/src/main/java/gregtech/common/items/GT_MetaGenerated_Item_01.java
@@ -2,7 +2,9 @@ package gregtech.common.items;
 
 import static gregtech.api.enums.Mods.GalacticraftMars;
 import static gregtech.api.enums.Textures.BlockIcons.*;
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCannerRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCompressorRecipes;
+import static gregtech.api.util.GT_RecipeBuilder.MINUTES;
 import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
 import static gregtech.client.GT_TooltipHandler.Tier.*;
 import static gregtech.client.GT_TooltipHandler.registerTieredTooltip;
@@ -1726,69 +1728,96 @@ public class GT_MetaGenerated_Item_01 extends GT_MetaGenerated_Item_X32 {
         GT_ModHandler.addExtractionRecipe(ItemList.Battery_RE_HV_Lithium.get(1L), ItemList.Battery_Hull_HV.get(1L));
         GT_ModHandler.addExtractionRecipe(ItemList.Battery_RE_HV_Sodium.get(1L), ItemList.Battery_Hull_HV.get(1L));
 
-        GT_Values.RA.addCannerRecipe(
-            GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Cadmium, 2L),
-            ItemList.Battery_Hull_LV.get(1L),
-            ItemList.Battery_RE_LV_Cadmium.get(1L),
-            null,
-            100,
-            2);
-        GT_Values.RA.addCannerRecipe(
-            GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Lithium, 2L),
-            ItemList.Battery_Hull_LV.get(1L),
-            ItemList.Battery_RE_LV_Lithium.get(1L),
-            null,
-            100,
-            2);
-        GT_Values.RA.addCannerRecipe(
-            GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Sodium, 2L),
-            ItemList.Battery_Hull_LV.get(1L),
-            ItemList.Battery_RE_LV_Sodium.get(1L),
-            null,
-            100,
-            2);
-        GT_Values.RA.addCannerRecipe(
-            GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Cadmium, 8L),
-            ItemList.Battery_Hull_MV.get(1L),
-            ItemList.Battery_RE_MV_Cadmium.get(1L),
-            null,
-            400,
-            2);
-        GT_Values.RA.addCannerRecipe(
-            GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Lithium, 8L),
-            ItemList.Battery_Hull_MV.get(1L),
-            ItemList.Battery_RE_MV_Lithium.get(1L),
-            null,
-            400,
-            2);
-        GT_Values.RA.addCannerRecipe(
-            GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Sodium, 8L),
-            ItemList.Battery_Hull_MV.get(1L),
-            ItemList.Battery_RE_MV_Sodium.get(1L),
-            null,
-            400,
-            2);
-        GT_Values.RA.addCannerRecipe(
-            GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Cadmium, 32L),
-            ItemList.Battery_Hull_HV.get(1L),
-            ItemList.Battery_RE_HV_Cadmium.get(1L),
-            null,
-            1600,
-            2);
-        GT_Values.RA.addCannerRecipe(
-            GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Lithium, 32L),
-            ItemList.Battery_Hull_HV.get(1L),
-            ItemList.Battery_RE_HV_Lithium.get(1L),
-            null,
-            1600,
-            2);
-        GT_Values.RA.addCannerRecipe(
-            GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Sodium, 32L),
-            ItemList.Battery_Hull_HV.get(1L),
-            ItemList.Battery_RE_HV_Sodium.get(1L),
-            null,
-            1600,
-            2);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Cadmium, 2L),
+                ItemList.Battery_Hull_LV.get(1L))
+            .itemOutputs(ItemList.Battery_RE_LV_Cadmium.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(5 * SECONDS)
+            .eut(2)
+            .addTo(sCannerRecipes);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Lithium, 2L),
+                ItemList.Battery_Hull_LV.get(1L))
+            .itemOutputs(ItemList.Battery_RE_LV_Lithium.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(5 * SECONDS)
+            .eut(2)
+            .addTo(sCannerRecipes);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Sodium, 2L),
+                ItemList.Battery_Hull_LV.get(1L))
+            .itemOutputs(ItemList.Battery_RE_LV_Sodium.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(5 * SECONDS)
+            .eut(2)
+            .addTo(sCannerRecipes);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Cadmium, 8L),
+                ItemList.Battery_Hull_MV.get(1L))
+            .itemOutputs(ItemList.Battery_RE_MV_Cadmium.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(20 * SECONDS)
+            .eut(2)
+            .addTo(sCannerRecipes);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Lithium, 8L),
+                ItemList.Battery_Hull_MV.get(1L))
+            .itemOutputs(ItemList.Battery_RE_MV_Lithium.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(20 * SECONDS)
+            .eut(2)
+            .addTo(sCannerRecipes);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Sodium, 8L),
+                ItemList.Battery_Hull_MV.get(1L))
+            .itemOutputs(ItemList.Battery_RE_MV_Sodium.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(20 * SECONDS)
+            .eut(2)
+            .addTo(sCannerRecipes);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Cadmium, 32L),
+                ItemList.Battery_Hull_HV.get(1L))
+            .itemOutputs(ItemList.Battery_RE_HV_Cadmium.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(1 * MINUTES + 20 * SECONDS)
+            .eut(2)
+            .addTo(sCannerRecipes);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Lithium, 32L),
+                ItemList.Battery_Hull_HV.get(1L))
+            .itemOutputs(ItemList.Battery_RE_HV_Lithium.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(1 * MINUTES + 20 * SECONDS)
+            .eut(2)
+            .addTo(sCannerRecipes);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Sodium, 32L),
+                ItemList.Battery_Hull_HV.get(1L))
+            .itemOutputs(ItemList.Battery_RE_HV_Sodium.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(1 * MINUTES + 20 * SECONDS)
+            .eut(2)
+            .addTo(sCannerRecipes);
 
         // IV Battery
         ItemList.Energy_LapotronicOrb.set(

--- a/src/main/java/gregtech/loaders/load/GT_ItemIterator.java
+++ b/src/main/java/gregtech/loaders/load/GT_ItemIterator.java
@@ -1,5 +1,8 @@
 package gregtech.loaders.load;
 
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCannerRecipes;
+import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
+
 import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
@@ -113,41 +116,46 @@ public class GT_ItemIterator implements Runnable {
 
         GT_Log.out.println(
             "GT_Mod: Adding Food Recipes to the Automatic Canning Machine. (also during the following Item Iteration)");
-        GT_Values.RA.addCannerRecipe(
-            new ItemStack(Items.rotten_flesh, 2, 32767),
-            ItemList.IC2_Food_Can_Empty.get(1L),
-            ItemList.IC2_Food_Can_Spoiled.get(1L),
-            null,
-            200,
-            1);
-        GT_Values.RA.addCannerRecipe(
-            new ItemStack(Items.spider_eye, 2, 32767),
-            ItemList.IC2_Food_Can_Empty.get(1L),
-            ItemList.IC2_Food_Can_Spoiled.get(1L),
-            null,
-            100,
-            1);
-        GT_Values.RA.addCannerRecipe(
-            ItemList.Food_Poisonous_Potato.get(2L),
-            ItemList.IC2_Food_Can_Empty.get(1L),
-            ItemList.IC2_Food_Can_Spoiled.get(1L),
-            null,
-            100,
-            1);
-        GT_Values.RA.addCannerRecipe(
-            new ItemStack(Items.cake, 1, 32767),
-            ItemList.IC2_Food_Can_Empty.get(12L),
-            ItemList.IC2_Food_Can_Filled.get(12L),
-            null,
-            600,
-            1);
-        GT_Values.RA.addCannerRecipe(
-            new ItemStack(Items.mushroom_stew, 1, 32767),
-            ItemList.IC2_Food_Can_Empty.get(6L),
-            ItemList.IC2_Food_Can_Filled.get(6L),
-            new ItemStack(Items.bowl, 1),
-            300,
-            1);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(new ItemStack(Items.rotten_flesh, 2, 32767), ItemList.IC2_Food_Can_Empty.get(1L))
+            .itemOutputs(ItemList.IC2_Food_Can_Spoiled.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(10 * SECONDS)
+            .eut(1)
+            .addTo(sCannerRecipes);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(new ItemStack(Items.spider_eye, 2, 32767), ItemList.IC2_Food_Can_Empty.get(1L))
+            .itemOutputs(ItemList.IC2_Food_Can_Spoiled.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(5 * SECONDS)
+            .eut(1)
+            .addTo(sCannerRecipes);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(ItemList.Food_Poisonous_Potato.get(2L), ItemList.IC2_Food_Can_Empty.get(1L))
+            .itemOutputs(ItemList.IC2_Food_Can_Spoiled.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(5 * SECONDS)
+            .eut(1)
+            .addTo(sCannerRecipes);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(new ItemStack(Items.cake, 1, 32767), ItemList.IC2_Food_Can_Empty.get(12L))
+            .itemOutputs(ItemList.IC2_Food_Can_Filled.get(12L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(30 * SECONDS)
+            .eut(1)
+            .addTo(sCannerRecipes);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(new ItemStack(Items.mushroom_stew, 1, 32767), ItemList.IC2_Food_Can_Empty.get(6L))
+            .itemOutputs(ItemList.IC2_Food_Can_Filled.get(6L), new ItemStack(Items.bowl, 1))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(15 * SECONDS)
+            .eut(1)
+            .addTo(sCannerRecipes);
 
         GT_Log.out.println("GT_Mod: Scanning ItemList.");
 
@@ -204,13 +212,18 @@ public class GT_ItemIterator implements Runnable {
                             && (tItem != ItemList.IC2_Food_Can_Spoiled.getItem())) {
                             int tFoodValue = ((ItemFood) tItem).func_150905_g(new ItemStack(tItem, 1, 0));
                             if (tFoodValue > 0) {
-                                GT_Values.RA.addCannerRecipe(
-                                    new ItemStack(tItem, 1, 32767),
-                                    ItemList.IC2_Food_Can_Empty.get(tFoodValue),
-                                    ItemList.IC2_Food_Can_Filled.get(tFoodValue),
-                                    GT_Utility.getContainerItem(new ItemStack(tItem, 1, 0), true),
-                                    tFoodValue * 100,
-                                    1);
+                                GT_Values.RA.stdBuilder()
+                                    .itemInputs(
+                                        new ItemStack(tItem, 1, 32767),
+                                        ItemList.IC2_Food_Can_Empty.get(tFoodValue))
+                                    .itemOutputs(
+                                        ItemList.IC2_Food_Can_Filled.get(tFoodValue),
+                                        GT_Utility.getContainerItem(new ItemStack(tItem, 1, 0), true))
+                                    .noFluidInputs()
+                                    .noFluidOutputs()
+                                    .duration(tFoodValue * 5 * SECONDS)
+                                    .eut(1)
+                                    .addTo(sCannerRecipes);
                             }
                         }
                         if ((tItem instanceof IFluidContainerItem)) {

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingPlank.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingPlank.java
@@ -1,5 +1,11 @@
 package gregtech.loaders.oreprocessing;
 
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAssemblerRecipes;
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCutterRecipes;
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sLatheRecipes;
+import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
+import static gregtech.api.util.GT_RecipeBuilder.TICKS;
+
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
@@ -22,89 +28,127 @@ public class ProcessingPlank implements gregtech.api.interfaces.IOreRecipeRegist
     public void registerOre(OrePrefixes aPrefix, Materials aMaterial, String aOreDictName, String aModName,
         ItemStack aStack) {
         if (aOreDictName.startsWith("plankWood")) {
-            GT_Values.RA.addLatheRecipe(
-                GT_Utility.copyAmount(1L, aStack),
-                GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 2L),
-                null,
-                10,
-                8);
-            GT_Values.RA.addCNCRecipe(
-                GT_Utility.copyAmount(4L, aStack),
-                GT_OreDictUnificator.get(OrePrefixes.gearGt, Materials.Wood, 1L),
-                800,
-                1);
-            GT_Values.RA.addAssemblerRecipe(
-                GT_Utility.copyAmount(8L, aStack),
-                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Redstone, 1L),
-                new ItemStack(Blocks.noteblock, 1),
-                200,
-                4);
-            GT_Values.RA.addAssemblerRecipe(
-                GT_Utility.copyAmount(8L, aStack),
-                GT_OreDictUnificator.get(OrePrefixes.gem, Materials.Diamond, 1L),
-                new ItemStack(Blocks.jukebox, 1),
-                400,
-                4);
-            GT_Values.RA.addAssemblerRecipe(
-                GT_Utility.copyAmount(1L, aStack),
-                GT_OreDictUnificator.get(OrePrefixes.screw, Materials.Iron, 1L),
-                ItemList.Crate_Empty.get(1L),
-                200,
-                1);
-            GT_Values.RA.addAssemblerRecipe(
-                GT_Utility.copyAmount(1L, aStack),
-                GT_OreDictUnificator.get(OrePrefixes.screw, Materials.WroughtIron, 1L),
-                ItemList.Crate_Empty.get(1L),
-                200,
-                1);
-            GT_Values.RA.addAssemblerRecipe(
-                GT_Utility.copyAmount(1L, aStack),
-                GT_OreDictUnificator.get(OrePrefixes.screw, Materials.Steel, 1L),
-                ItemList.Crate_Empty.get(1L),
-                200,
-                1);
-            GT_Values.RA.addAssemblerRecipe(
-                GT_Utility.copyAmount(1L, aStack),
-                ItemList.Circuit_Integrated.getWithDamage(0L, 1L),
-                new ItemStack(Blocks.wooden_button, 1),
-                100,
-                4);
-            GT_Values.RA.addAssemblerRecipe(
-                GT_Utility.copyAmount(2L, aStack),
-                ItemList.Circuit_Integrated.getWithDamage(0L, 2L),
-                new ItemStack(Blocks.wooden_pressure_plate, 1),
-                200,
-                4);
-            GT_Values.RA.addAssemblerRecipe(
-                GT_Utility.copyAmount(3L, aStack),
-                ItemList.Circuit_Integrated.getWithDamage(0L, 3L),
-                new ItemStack(Blocks.trapdoor, 1),
-                300,
-                4);
-            GT_Values.RA.addAssemblerRecipe(
-                GT_Utility.copyAmount(4L, aStack),
-                ItemList.Circuit_Integrated.getWithDamage(0L, 4L),
-                new ItemStack(Blocks.crafting_table, 1),
-                400,
-                4);
-            GT_Values.RA.addAssemblerRecipe(
-                GT_Utility.copyAmount(6L, aStack),
-                ItemList.Circuit_Integrated.getWithDamage(0L, 6L),
-                new ItemStack(Items.wooden_door, 1),
-                600,
-                4);
-            GT_Values.RA.addAssemblerRecipe(
-                GT_Utility.copyAmount(8L, aStack),
-                ItemList.Circuit_Integrated.getWithDamage(0L, 8L),
-                new ItemStack(Blocks.chest, 1),
-                800,
-                4);
-            GT_Values.RA.addAssemblerRecipe(
-                GT_Utility.copyAmount(6L, aStack),
-                new ItemStack(Items.book, 3),
-                new ItemStack(Blocks.bookshelf, 1),
-                400,
-                4);
+            GT_Values.RA.stdBuilder()
+                .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 2L))
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(10 * TICKS)
+                .eut(8)
+                .addTo(sLatheRecipes);
+            // todo: not actually in the game. removed somewhere? better remove here then.
+            GT_Values.RA.stdBuilder()
+                .itemInputs(
+                    GT_Utility.copyAmount(8L, aStack),
+                    GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Redstone, 1L))
+                .itemOutputs(new ItemStack(Blocks.noteblock, 1))
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(10 * SECONDS)
+                .eut(4)
+                .addTo(sAssemblerRecipes);
+            // todo: not actually in the game. removed somewhere? better remove here then.
+            GT_Values.RA.stdBuilder()
+                .itemInputs(
+                    GT_Utility.copyAmount(8L, aStack),
+                    GT_OreDictUnificator.get(OrePrefixes.gem, Materials.Diamond, 1L))
+                .itemOutputs(new ItemStack(Blocks.jukebox, 1))
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(20 * SECONDS)
+                .eut(4)
+                .addTo(sAssemblerRecipes);
+            GT_Values.RA.stdBuilder()
+                .itemInputs(
+                    GT_Utility.copyAmount(1L, aStack),
+                    GT_OreDictUnificator.get(OrePrefixes.screw, Materials.Iron, 1L))
+                .itemOutputs(ItemList.Crate_Empty.get(1L))
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(10 * SECONDS)
+                .eut(1)
+                .addTo(sAssemblerRecipes);
+            GT_Values.RA.stdBuilder()
+                .itemInputs(
+                    GT_Utility.copyAmount(1L, aStack),
+                    GT_OreDictUnificator.get(OrePrefixes.screw, Materials.WroughtIron, 1L))
+                .itemOutputs(ItemList.Crate_Empty.get(1L))
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(10 * SECONDS)
+                .eut(1)
+                .addTo(sAssemblerRecipes);
+            GT_Values.RA.stdBuilder()
+                .itemInputs(
+                    GT_Utility.copyAmount(1L, aStack),
+                    GT_OreDictUnificator.get(OrePrefixes.screw, Materials.Steel, 1L))
+                .itemOutputs(ItemList.Crate_Empty.get(1L))
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(10 * SECONDS)
+                .eut(1)
+                .addTo(sAssemblerRecipes);
+            // todo: not actually in the game. removed somewhere? better remove here then.
+            GT_Values.RA.stdBuilder()
+                .itemInputs(GT_Utility.copyAmount(1L, aStack), GT_Utility.getIntegratedCircuit(1))
+                .itemOutputs(new ItemStack(Blocks.wooden_button, 1))
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(5 * SECONDS)
+                .eut(4)
+                .addTo(sAssemblerRecipes);
+            // todo: not actually in the game. removed somewhere? better remove here then.
+            GT_Values.RA.stdBuilder()
+                .itemInputs(GT_Utility.copyAmount(2L, aStack), GT_Utility.getIntegratedCircuit(2))
+                .itemOutputs(new ItemStack(Blocks.wooden_pressure_plate, 1))
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(5 * SECONDS)
+                .eut(4)
+                .addTo(sAssemblerRecipes);
+            // todo: not actually in the game. removed somewhere? better remove here then.
+            GT_Values.RA.stdBuilder()
+                .itemInputs(GT_Utility.copyAmount(3L, aStack), GT_Utility.getIntegratedCircuit(3))
+                .itemOutputs(new ItemStack(Blocks.trapdoor, 1))
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(15 * SECONDS)
+                .eut(4)
+                .addTo(sAssemblerRecipes);
+            // todo: not actually in the game. removed somewhere? better remove here then.
+            GT_Values.RA.stdBuilder()
+                .itemInputs(GT_Utility.copyAmount(4L, aStack), GT_Utility.getIntegratedCircuit(4))
+                .itemOutputs(new ItemStack(Blocks.crafting_table, 1))
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(15 * SECONDS)
+                .eut(4)
+                .addTo(sAssemblerRecipes);
+            // todo: not actually in the game. removed somewhere? better remove here then.
+            GT_Values.RA.stdBuilder()
+                .itemInputs(GT_Utility.copyAmount(6L, aStack), GT_Utility.getIntegratedCircuit(6))
+                .itemOutputs(new ItemStack(Items.wooden_door, 1))
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(30 * SECONDS)
+                .eut(4)
+                .addTo(sAssemblerRecipes);
+            GT_Values.RA.stdBuilder()
+                .itemInputs(GT_Utility.copyAmount(8L, aStack), GT_Utility.getIntegratedCircuit(8))
+                .itemOutputs(new ItemStack(Blocks.chest, 1))
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(40 * SECONDS)
+                .eut(4)
+                .addTo(sAssemblerRecipes);
+            GT_Values.RA.stdBuilder()
+                .itemInputs(GT_Utility.copyAmount(6L, aStack), new ItemStack(Items.book, 3))
+                .itemOutputs(new ItemStack(Blocks.bookshelf, 1))
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(20 * SECONDS)
+                .eut(4)
+                .addTo(sAssemblerRecipes);
 
             if (aStack.getItemDamage() == 32767) {
                 for (byte i = 0; i < 64; i = (byte) (i + 1)) {
@@ -112,12 +156,30 @@ public class ProcessingPlank implements gregtech.api.interfaces.IOreRecipeRegist
                     // Get Recipe and Output, add recipe to delayed removal
                     ItemStack tOutput = GT_ModHandler.getRecipeOutput(tStack, tStack, tStack);
                     if ((tOutput != null) && (tOutput.stackSize >= 3)) {
-                        GT_Values.RA.addCutterRecipe(
-                            GT_Utility.copyAmount(1L, tStack),
-                            GT_Utility.copyAmount(tOutput.stackSize / 3, tOutput),
-                            null,
-                            25,
-                            4);
+                        GT_Values.RA.stdBuilder()
+                            .itemInputs(GT_Utility.copyAmount(1L, tStack))
+                            .itemOutputs(GT_Utility.copyAmount(tOutput.stackSize / 3, tOutput))
+                            .fluidInputs(Materials.Water.getFluid(4))
+                            .noFluidOutputs()
+                            .duration(2 * 25 * TICKS)
+                            .eut(4)
+                            .addTo(sCutterRecipes);
+                        GT_Values.RA.stdBuilder()
+                            .itemInputs(GT_Utility.copyAmount(1L, tStack))
+                            .itemOutputs(GT_Utility.copyAmount(tOutput.stackSize / 3, tOutput))
+                            .fluidInputs(GT_ModHandler.getDistilledWater(3))
+                            .noFluidOutputs()
+                            .duration(2 * 25 * TICKS)
+                            .eut(4)
+                            .addTo(sCutterRecipes);
+                        GT_Values.RA.stdBuilder()
+                            .itemInputs(GT_Utility.copyAmount(1L, tStack))
+                            .itemOutputs(GT_Utility.copyAmount(tOutput.stackSize / 3, tOutput))
+                            .fluidInputs(Materials.Lubricant.getFluid(1))
+                            .noFluidOutputs()
+                            .duration(25 * TICKS)
+                            .eut(4)
+                            .addTo(sCutterRecipes);
                         GT_ModHandler.removeRecipeDelayed(tStack, tStack, tStack);
                         GT_ModHandler.addCraftingRecipe(
                             GT_Utility.copyAmount(tOutput.stackSize / 3, tOutput),
@@ -131,12 +193,30 @@ public class ProcessingPlank implements gregtech.api.interfaces.IOreRecipeRegist
                     ? GT_ModHandler.getRecipeOutput(aStack, aStack, aStack)
                     : GT_ModHandler.getRecipeOutputNoOreDict(aStack, aStack, aStack);
                 if ((tOutput != null) && (tOutput.stackSize >= 3)) {
-                    GT_Values.RA.addCutterRecipe(
-                        GT_Utility.copyAmount(1L, aStack),
-                        GT_Utility.copyAmount(tOutput.stackSize / 3, tOutput),
-                        null,
-                        25,
-                        4);
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                        .itemOutputs(GT_Utility.copyAmount(tOutput.stackSize / 3, tOutput))
+                        .fluidInputs(Materials.Water.getFluid(4))
+                        .noFluidOutputs()
+                        .duration(2 * 25)
+                        .eut(4)
+                        .addTo(sCutterRecipes);
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                        .itemOutputs(GT_Utility.copyAmount(tOutput.stackSize / 3, tOutput))
+                        .fluidInputs(GT_ModHandler.getDistilledWater(3))
+                        .noFluidOutputs()
+                        .duration(2 * 25)
+                        .eut(4)
+                        .addTo(sCutterRecipes);
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                        .itemOutputs(GT_Utility.copyAmount(tOutput.stackSize / 3, tOutput))
+                        .fluidInputs(Materials.Lubricant.getFluid(1))
+                        .noFluidOutputs()
+                        .duration(25)
+                        .eut(4)
+                        .addTo(sCutterRecipes);
                     GT_ModHandler.removeRecipeDelayed(aStack, aStack, aStack);
                     GT_ModHandler.addCraftingRecipe(
                         GT_Utility.copyAmount(tOutput.stackSize / 3, tOutput),

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingPlank.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingPlank.java
@@ -36,28 +36,6 @@ public class ProcessingPlank implements gregtech.api.interfaces.IOreRecipeRegist
                 .duration(10 * TICKS)
                 .eut(8)
                 .addTo(sLatheRecipes);
-            // todo: not actually in the game. removed somewhere? better remove here then.
-            GT_Values.RA.stdBuilder()
-                .itemInputs(
-                    GT_Utility.copyAmount(8L, aStack),
-                    GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Redstone, 1L))
-                .itemOutputs(new ItemStack(Blocks.noteblock, 1))
-                .noFluidInputs()
-                .noFluidOutputs()
-                .duration(10 * SECONDS)
-                .eut(4)
-                .addTo(sAssemblerRecipes);
-            // todo: not actually in the game. removed somewhere? better remove here then.
-            GT_Values.RA.stdBuilder()
-                .itemInputs(
-                    GT_Utility.copyAmount(8L, aStack),
-                    GT_OreDictUnificator.get(OrePrefixes.gem, Materials.Diamond, 1L))
-                .itemOutputs(new ItemStack(Blocks.jukebox, 1))
-                .noFluidInputs()
-                .noFluidOutputs()
-                .duration(20 * SECONDS)
-                .eut(4)
-                .addTo(sAssemblerRecipes);
             GT_Values.RA.stdBuilder()
                 .itemInputs(
                     GT_Utility.copyAmount(1L, aStack),
@@ -87,33 +65,6 @@ public class ProcessingPlank implements gregtech.api.interfaces.IOreRecipeRegist
                 .noFluidOutputs()
                 .duration(10 * SECONDS)
                 .eut(1)
-                .addTo(sAssemblerRecipes);
-            // todo: not actually in the game. removed somewhere? better remove here then.
-            GT_Values.RA.stdBuilder()
-                .itemInputs(GT_Utility.copyAmount(1L, aStack), GT_Utility.getIntegratedCircuit(1))
-                .itemOutputs(new ItemStack(Blocks.wooden_button, 1))
-                .noFluidInputs()
-                .noFluidOutputs()
-                .duration(5 * SECONDS)
-                .eut(4)
-                .addTo(sAssemblerRecipes);
-            // todo: not actually in the game. removed somewhere? better remove here then.
-            GT_Values.RA.stdBuilder()
-                .itemInputs(GT_Utility.copyAmount(3L, aStack), GT_Utility.getIntegratedCircuit(3))
-                .itemOutputs(new ItemStack(Blocks.trapdoor, 1))
-                .noFluidInputs()
-                .noFluidOutputs()
-                .duration(15 * SECONDS)
-                .eut(4)
-                .addTo(sAssemblerRecipes);
-            // todo: not actually in the game. removed somewhere? better remove here then.
-            GT_Values.RA.stdBuilder()
-                .itemInputs(GT_Utility.copyAmount(6L, aStack), GT_Utility.getIntegratedCircuit(6))
-                .itemOutputs(new ItemStack(Items.wooden_door, 1))
-                .noFluidInputs()
-                .noFluidOutputs()
-                .duration(30 * SECONDS)
-                .eut(4)
                 .addTo(sAssemblerRecipes);
             GT_Values.RA.stdBuilder()
                 .itemInputs(GT_Utility.copyAmount(8L, aStack), GT_Utility.getIntegratedCircuit(8))

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingPlank.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingPlank.java
@@ -99,26 +99,8 @@ public class ProcessingPlank implements gregtech.api.interfaces.IOreRecipeRegist
                 .addTo(sAssemblerRecipes);
             // todo: not actually in the game. removed somewhere? better remove here then.
             GT_Values.RA.stdBuilder()
-                .itemInputs(GT_Utility.copyAmount(2L, aStack), GT_Utility.getIntegratedCircuit(2))
-                .itemOutputs(new ItemStack(Blocks.wooden_pressure_plate, 1))
-                .noFluidInputs()
-                .noFluidOutputs()
-                .duration(5 * SECONDS)
-                .eut(4)
-                .addTo(sAssemblerRecipes);
-            // todo: not actually in the game. removed somewhere? better remove here then.
-            GT_Values.RA.stdBuilder()
                 .itemInputs(GT_Utility.copyAmount(3L, aStack), GT_Utility.getIntegratedCircuit(3))
                 .itemOutputs(new ItemStack(Blocks.trapdoor, 1))
-                .noFluidInputs()
-                .noFluidOutputs()
-                .duration(15 * SECONDS)
-                .eut(4)
-                .addTo(sAssemblerRecipes);
-            // todo: not actually in the game. removed somewhere? better remove here then.
-            GT_Values.RA.stdBuilder()
-                .itemInputs(GT_Utility.copyAmount(4L, aStack), GT_Utility.getIntegratedCircuit(4))
-                .itemOutputs(new ItemStack(Blocks.crafting_table, 1))
                 .noFluidInputs()
                 .noFluidOutputs()
                 .duration(15 * SECONDS)

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingStoneCobble.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingStoneCobble.java
@@ -1,11 +1,13 @@
 package gregtech.loaders.oreprocessing;
 
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAssemblerRecipes;
+import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
+
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 
 import gregtech.api.enums.GT_Values;
-import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.util.GT_OreDictUnificator;
@@ -20,30 +22,44 @@ public class ProcessingStoneCobble implements gregtech.api.interfaces.IOreRecipe
     @Override
     public void registerOre(OrePrefixes aPrefix, Materials aMaterial, String aOreDictName, String aModName,
         ItemStack aStack) {
-        GT_Values.RA.addAssemblerRecipe(
-            GT_Utility.copyAmount(1L, aStack),
-            GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1L),
-            new ItemStack(Blocks.lever, 1),
-            400,
-            1);
-        GT_Values.RA.addAssemblerRecipe(
-            GT_Utility.copyAmount(8L, aStack),
-            ItemList.Circuit_Integrated.getWithDamage(0L, 8L),
-            new ItemStack(Blocks.furnace, 1),
-            400,
-            4);
-        GT_Values.RA.addAssemblerRecipe(
-            GT_Utility.copyAmount(7L, aStack),
-            GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Redstone, 1L),
-            new ItemStack(Blocks.dropper, 1),
-            400,
-            4);
-        GT_Values.RA.addAssemblerRecipe(
-            GT_Utility.copyAmount(7L, aStack),
-            new ItemStack(Items.bow, 1, 0),
-            Materials.Redstone.getMolten(144L),
-            new ItemStack(Blocks.dispenser, 1),
-            400,
-            4);
+        // todo: not actually in the game. removed somewhere? better remove here then.
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                GT_Utility.copyAmount(1L, aStack),
+                GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1L))
+            .itemOutputs(new ItemStack(Blocks.lever, 1))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(20 * SECONDS)
+            .eut(1)
+            .addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(GT_Utility.copyAmount(8L, aStack), GT_Utility.getIntegratedCircuit(8))
+            .itemOutputs(new ItemStack(Blocks.furnace, 1))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(20 * SECONDS)
+            .eut(4)
+            .addTo(sAssemblerRecipes);
+        // todo: not actually in the game. removed somewhere? better remove here then.
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                GT_Utility.copyAmount(7L, aStack),
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Redstone, 1L))
+            .itemOutputs(new ItemStack(Blocks.dropper, 1))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(20 * SECONDS)
+            .eut(4)
+            .addTo(sAssemblerRecipes);
+        // todo: not actually in the game. removed somewhere? better remove here then.
+        GT_Values.RA.stdBuilder()
+            .itemInputs(GT_Utility.copyAmount(7L, aStack), new ItemStack(Items.bow, 1, 0))
+            .itemOutputs(new ItemStack(Blocks.dispenser, 1))
+            .fluidInputs(Materials.Redstone.getMolten(144L))
+            .noFluidOutputs()
+            .duration(20 * SECONDS)
+            .eut(4)
+            .addTo(sAssemblerRecipes);
     }
 }

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingStoneCobble.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingStoneCobble.java
@@ -4,13 +4,11 @@ import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAssemblerRecipes;
 import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
 
 import net.minecraft.init.Blocks;
-import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 
 import gregtech.api.enums.GT_Values;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
-import gregtech.api.util.GT_OreDictUnificator;
 import gregtech.api.util.GT_Utility;
 
 public class ProcessingStoneCobble implements gregtech.api.interfaces.IOreRecipeRegistrator {
@@ -22,41 +20,10 @@ public class ProcessingStoneCobble implements gregtech.api.interfaces.IOreRecipe
     @Override
     public void registerOre(OrePrefixes aPrefix, Materials aMaterial, String aOreDictName, String aModName,
         ItemStack aStack) {
-        // todo: not actually in the game. removed somewhere? better remove here then.
-        GT_Values.RA.stdBuilder()
-            .itemInputs(
-                GT_Utility.copyAmount(1L, aStack),
-                GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1L))
-            .itemOutputs(new ItemStack(Blocks.lever, 1))
-            .noFluidInputs()
-            .noFluidOutputs()
-            .duration(20 * SECONDS)
-            .eut(1)
-            .addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
             .itemInputs(GT_Utility.copyAmount(8L, aStack), GT_Utility.getIntegratedCircuit(8))
             .itemOutputs(new ItemStack(Blocks.furnace, 1))
             .noFluidInputs()
-            .noFluidOutputs()
-            .duration(20 * SECONDS)
-            .eut(4)
-            .addTo(sAssemblerRecipes);
-        // todo: not actually in the game. removed somewhere? better remove here then.
-        GT_Values.RA.stdBuilder()
-            .itemInputs(
-                GT_Utility.copyAmount(7L, aStack),
-                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Redstone, 1L))
-            .itemOutputs(new ItemStack(Blocks.dropper, 1))
-            .noFluidInputs()
-            .noFluidOutputs()
-            .duration(20 * SECONDS)
-            .eut(4)
-            .addTo(sAssemblerRecipes);
-        // todo: not actually in the game. removed somewhere? better remove here then.
-        GT_Values.RA.stdBuilder()
-            .itemInputs(GT_Utility.copyAmount(7L, aStack), new ItemStack(Items.bow, 1, 0))
-            .itemOutputs(new ItemStack(Blocks.dispenser, 1))
-            .fluidInputs(Materials.Redstone.getMolten(144L))
             .noFluidOutputs()
             .duration(20 * SECONDS)
             .eut(4)

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingToolHead.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingToolHead.java
@@ -1,6 +1,8 @@
 package gregtech.loaders.oreprocessing;
 
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAssemblerRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sPressRecipes;
+import static gregtech.api.util.GT_RecipeBuilder.MINUTES;
 import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
 import static gregtech.api.util.GT_Utility.calculateRecipeEU;
 
@@ -1132,30 +1134,46 @@ public class ProcessingToolHead implements gregtech.api.interfaces.IOreRecipeReg
                         OrePrefixes.ingot.get(aMaterial) });
             }
             case turbineBlade -> {
-                GT_Values.RA.addAssemblerRecipe(
-                    GT_OreDictUnificator.get(OrePrefixes.turbineBlade, aMaterial, 4L),
-                    GT_OreDictUnificator.get(OrePrefixes.stickLong, Materials.Magnalium, 1L),
-                    GT_MetaGenerated_Tool_01.INSTANCE.getToolWithStats(170, 1, aMaterial, aMaterial, null),
-                    160,
-                    calculateRecipeEU(aMaterial, 100));
-                GT_Values.RA.addAssemblerRecipe(
-                    GT_OreDictUnificator.get(OrePrefixes.turbineBlade, aMaterial, 8L),
-                    GT_OreDictUnificator.get(OrePrefixes.stickLong, Materials.Titanium, 1L),
-                    GT_MetaGenerated_Tool_01.INSTANCE.getToolWithStats(172, 1, aMaterial, aMaterial, null),
-                    320,
-                    calculateRecipeEU(aMaterial, 400));
-                GT_Values.RA.addAssemblerRecipe(
-                    GT_OreDictUnificator.get(OrePrefixes.turbineBlade, aMaterial, 12L),
-                    GT_OreDictUnificator.get(OrePrefixes.stickLong, Materials.TungstenSteel, 1L),
-                    GT_MetaGenerated_Tool_01.INSTANCE.getToolWithStats(174, 1, aMaterial, aMaterial, null),
-                    640,
-                    calculateRecipeEU(aMaterial, 1600));
-                GT_Values.RA.addAssemblerRecipe(
-                    GT_OreDictUnificator.get(OrePrefixes.turbineBlade, aMaterial, 16L),
-                    GT_OreDictUnificator.get(OrePrefixes.stickLong, Materials.Americium, 1L),
-                    GT_MetaGenerated_Tool_01.INSTANCE.getToolWithStats(176, 1, aMaterial, aMaterial, null),
-                    1280,
-                    calculateRecipeEU(aMaterial, 6400));
+                GT_Values.RA.stdBuilder()
+                    .itemInputs(
+                        GT_OreDictUnificator.get(OrePrefixes.turbineBlade, aMaterial, 4L),
+                        GT_OreDictUnificator.get(OrePrefixes.stickLong, Materials.Magnalium, 1L))
+                    .itemOutputs(GT_MetaGenerated_Tool_01.INSTANCE.getToolWithStats(170, 1, aMaterial, aMaterial, null))
+                    .noFluidInputs()
+                    .noFluidOutputs()
+                    .duration(8 * SECONDS)
+                    .eut(calculateRecipeEU(aMaterial, 100))
+                    .addTo(sAssemblerRecipes);
+                GT_Values.RA.stdBuilder()
+                    .itemInputs(
+                        GT_OreDictUnificator.get(OrePrefixes.turbineBlade, aMaterial, 8L),
+                        GT_OreDictUnificator.get(OrePrefixes.stickLong, Materials.Titanium, 1L))
+                    .itemOutputs(GT_MetaGenerated_Tool_01.INSTANCE.getToolWithStats(172, 1, aMaterial, aMaterial, null))
+                    .noFluidInputs()
+                    .noFluidOutputs()
+                    .duration(16 * SECONDS)
+                    .eut(calculateRecipeEU(aMaterial, 400))
+                    .addTo(sAssemblerRecipes);
+                GT_Values.RA.stdBuilder()
+                    .itemInputs(
+                        GT_OreDictUnificator.get(OrePrefixes.turbineBlade, aMaterial, 12L),
+                        GT_OreDictUnificator.get(OrePrefixes.stickLong, Materials.TungstenSteel, 1L))
+                    .itemOutputs(GT_MetaGenerated_Tool_01.INSTANCE.getToolWithStats(174, 1, aMaterial, aMaterial, null))
+                    .noFluidInputs()
+                    .noFluidOutputs()
+                    .duration(32 * SECONDS)
+                    .eut(calculateRecipeEU(aMaterial, 1600))
+                    .addTo(sAssemblerRecipes);
+                GT_Values.RA.stdBuilder()
+                    .itemInputs(
+                        GT_OreDictUnificator.get(OrePrefixes.turbineBlade, aMaterial, 16L),
+                        GT_OreDictUnificator.get(OrePrefixes.stickLong, Materials.Americium, 1L))
+                    .itemOutputs(GT_MetaGenerated_Tool_01.INSTANCE.getToolWithStats(176, 1, aMaterial, aMaterial, null))
+                    .noFluidInputs()
+                    .noFluidOutputs()
+                    .duration(1 * MINUTES + 4 * SECONDS)
+                    .eut(calculateRecipeEU(aMaterial, 6400))
+                    .addTo(sAssemblerRecipes);
                 if (aSpecialRecipeReq2) {
                     if (aMaterial.getProcessingMaterialTierEU() < TierEU.IV) {
                         GT_ModHandler.addCraftingRecipe(

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingTransforming.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingTransforming.java
@@ -1,7 +1,9 @@
 package gregtech.loaders.oreprocessing;
 
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sChemicalBathRecipes;
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sPolarizerRecipes;
 import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
+import static gregtech.api.util.GT_RecipeBuilder.TICKS;
 
 import net.minecraft.item.ItemStack;
 
@@ -66,11 +68,14 @@ public class ProcessingTransforming implements IOreRecipeRegistrator {
 
                 // Polarizer recipes
                 {
-                    GT_Values.RA.addPolarizerRecipe(
-                        GT_Utility.copyAmount(1L, aStack),
-                        GT_OreDictUnificator.get(aPrefix, Materials.IronMagnetic, 1L),
-                        (int) Math.max(16L, aPrefix.mMaterialAmount * 128L / GT_Values.M),
-                        (int) TierEU.LV / 2);
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                        .itemOutputs(GT_OreDictUnificator.get(aPrefix, Materials.IronMagnetic, 1L))
+                        .noFluidInputs()
+                        .noFluidOutputs()
+                        .duration(((int) Math.max(16L, aPrefix.mMaterialAmount * 128L / GT_Values.M)) * TICKS)
+                        .eut((int) TierEU.LV / 2)
+                        .addTo(sPolarizerRecipes);
                 }
             }
             case "WroughtIron" -> {
@@ -92,11 +97,14 @@ public class ProcessingTransforming implements IOreRecipeRegistrator {
 
                 // Polarizer recipes
                 {
-                    GT_Values.RA.addPolarizerRecipe(
-                        GT_Utility.copyAmount(1L, aStack),
-                        GT_OreDictUnificator.get(aPrefix, Materials.IronMagnetic, 1L),
-                        (int) Math.max(16L, aPrefix.mMaterialAmount * 128L / GT_Values.M),
-                        (int) TierEU.LV / 2);
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                        .itemOutputs(GT_OreDictUnificator.get(aPrefix, Materials.IronMagnetic, 1L))
+                        .noFluidInputs()
+                        .noFluidOutputs()
+                        .duration(((int) Math.max(16L, aPrefix.mMaterialAmount * 128L / GT_Values.M)) * TICKS)
+                        .eut((int) TierEU.LV / 2)
+                        .addTo(sPolarizerRecipes);
                 }
             }
             case "Steel" -> {
@@ -118,40 +126,52 @@ public class ProcessingTransforming implements IOreRecipeRegistrator {
 
                 // polarizer recipes
                 {
-                    GT_Values.RA.addPolarizerRecipe(
-                        GT_Utility.copyAmount(1L, aStack),
-                        GT_OreDictUnificator.get(aPrefix, Materials.SteelMagnetic, 1L),
-                        (int) Math.max(16L, aPrefix.mMaterialAmount * 128L / GT_Values.M),
-                        (int) TierEU.LV / 2);
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                        .itemOutputs(GT_OreDictUnificator.get(aPrefix, Materials.SteelMagnetic, 1L))
+                        .noFluidInputs()
+                        .noFluidOutputs()
+                        .duration(((int) Math.max(16L, aPrefix.mMaterialAmount * 128L / GT_Values.M)) * TICKS)
+                        .eut((int) TierEU.LV / 2)
+                        .addTo(sPolarizerRecipes);
                 }
             }
             case "Neodymium" ->
             // Polarizer recipes
             {
-                GT_Values.RA.addPolarizerRecipe(
-                    GT_Utility.copyAmount(1L, aStack),
-                    GT_OreDictUnificator.get(aPrefix, Materials.NeodymiumMagnetic, 1L),
-                    (int) Math.max(16L, aPrefix.mMaterialAmount * 128L / GT_Values.M),
-                    (int) TierEU.HV / 2);
+                GT_Values.RA.stdBuilder()
+                    .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                    .itemOutputs(GT_OreDictUnificator.get(aPrefix, Materials.NeodymiumMagnetic, 1L))
+                    .noFluidInputs()
+                    .noFluidOutputs()
+                    .duration(((int) Math.max(16L, aPrefix.mMaterialAmount * 128L / GT_Values.M)) * TICKS)
+                    .eut((int) TierEU.HV / 2)
+                    .addTo(sPolarizerRecipes);
             }
             case "Samarium" ->
             // Polarizer recipes
             {
-                GT_Values.RA.addPolarizerRecipe(
-                    GT_Utility.copyAmount(1L, aStack),
-                    GT_OreDictUnificator.get(aPrefix, Materials.SamariumMagnetic, 1L),
-                    (int) Math.max(16L, aPrefix.mMaterialAmount * 128L / GT_Values.M),
-                    (int) TierEU.IV / 2);
+                GT_Values.RA.stdBuilder()
+                    .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                    .itemOutputs(GT_OreDictUnificator.get(aPrefix, Materials.SamariumMagnetic, 1L))
+                    .noFluidInputs()
+                    .noFluidOutputs()
+                    .duration(((int) Math.max(16L, aPrefix.mMaterialAmount * 128L / GT_Values.M)) * TICKS)
+                    .eut((int) TierEU.IV / 2)
+                    .addTo(sPolarizerRecipes);
             }
 
             case "TengamPurified" ->
             // Polarizer recipes
             {
-                GT_Values.RA.addPolarizerRecipe(
-                    GT_Utility.copyAmount(1L, aStack),
-                    GT_OreDictUnificator.get(aPrefix, Materials.TengamAttuned, 1L),
-                    (int) Math.max(16L, aPrefix.mMaterialAmount * 128L / GT_Values.M),
-                    (int) TierEU.RECIPE_UHV);
+                GT_Values.RA.stdBuilder()
+                    .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                    .itemOutputs(GT_OreDictUnificator.get(aPrefix, Materials.TengamAttuned, 1L))
+                    .noFluidInputs()
+                    .noFluidOutputs()
+                    .duration(((int) Math.max(16L, aPrefix.mMaterialAmount * 128L / GT_Values.M)) * TICKS)
+                    .eut((int) TierEU.RECIPE_UHV)
+                    .addTo(sPolarizerRecipes);
             }
 
             default -> { /* NO-OP */ }

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingTransforming.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingTransforming.java
@@ -68,14 +68,16 @@ public class ProcessingTransforming implements IOreRecipeRegistrator {
 
                 // Polarizer recipes
                 {
-                    GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(1L, aStack))
-                        .itemOutputs(GT_OreDictUnificator.get(aPrefix, Materials.IronMagnetic, 1L))
-                        .noFluidInputs()
-                        .noFluidOutputs()
-                        .duration(((int) Math.max(16L, aPrefix.mMaterialAmount * 128L / GT_Values.M)) * TICKS)
-                        .eut((int) TierEU.LV / 2)
-                        .addTo(sPolarizerRecipes);
+                    if (GT_OreDictUnificator.get(aPrefix, Materials.IronMagnetic, 1L) != null) {
+                        GT_Values.RA.stdBuilder()
+                            .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                            .itemOutputs(GT_OreDictUnificator.get(aPrefix, Materials.IronMagnetic, 1L))
+                            .noFluidInputs()
+                            .noFluidOutputs()
+                            .duration(((int) Math.max(16L, aPrefix.mMaterialAmount * 128L / GT_Values.M)) * TICKS)
+                            .eut((int) TierEU.LV / 2)
+                            .addTo(sPolarizerRecipes);
+                    }
                 }
             }
             case "WroughtIron" -> {
@@ -97,14 +99,16 @@ public class ProcessingTransforming implements IOreRecipeRegistrator {
 
                 // Polarizer recipes
                 {
-                    GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(1L, aStack))
-                        .itemOutputs(GT_OreDictUnificator.get(aPrefix, Materials.IronMagnetic, 1L))
-                        .noFluidInputs()
-                        .noFluidOutputs()
-                        .duration(((int) Math.max(16L, aPrefix.mMaterialAmount * 128L / GT_Values.M)) * TICKS)
-                        .eut((int) TierEU.LV / 2)
-                        .addTo(sPolarizerRecipes);
+                    if (GT_OreDictUnificator.get(aPrefix, Materials.IronMagnetic, 1L) != null) {
+                        GT_Values.RA.stdBuilder()
+                            .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                            .itemOutputs(GT_OreDictUnificator.get(aPrefix, Materials.IronMagnetic, 1L))
+                            .noFluidInputs()
+                            .noFluidOutputs()
+                            .duration(((int) Math.max(16L, aPrefix.mMaterialAmount * 128L / GT_Values.M)) * TICKS)
+                            .eut((int) TierEU.LV / 2)
+                            .addTo(sPolarizerRecipes);
+                    }
                 }
             }
             case "Steel" -> {
@@ -124,54 +128,62 @@ public class ProcessingTransforming implements IOreRecipeRegistrator {
                     }
                 }
 
-                // polarizer recipes
+                // Polarizer recipes
                 {
-                    GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(1L, aStack))
-                        .itemOutputs(GT_OreDictUnificator.get(aPrefix, Materials.SteelMagnetic, 1L))
-                        .noFluidInputs()
-                        .noFluidOutputs()
-                        .duration(((int) Math.max(16L, aPrefix.mMaterialAmount * 128L / GT_Values.M)) * TICKS)
-                        .eut((int) TierEU.LV / 2)
-                        .addTo(sPolarizerRecipes);
+                    if (GT_OreDictUnificator.get(aPrefix, Materials.SteelMagnetic, 1L) != null) {
+                        GT_Values.RA.stdBuilder()
+                            .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                            .itemOutputs(GT_OreDictUnificator.get(aPrefix, Materials.SteelMagnetic, 1L))
+                            .noFluidInputs()
+                            .noFluidOutputs()
+                            .duration(((int) Math.max(16L, aPrefix.mMaterialAmount * 128L / GT_Values.M)) * TICKS)
+                            .eut((int) TierEU.LV / 2)
+                            .addTo(sPolarizerRecipes);
+                    }
                 }
             }
             case "Neodymium" ->
             // Polarizer recipes
             {
-                GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack))
-                    .itemOutputs(GT_OreDictUnificator.get(aPrefix, Materials.NeodymiumMagnetic, 1L))
-                    .noFluidInputs()
-                    .noFluidOutputs()
-                    .duration(((int) Math.max(16L, aPrefix.mMaterialAmount * 128L / GT_Values.M)) * TICKS)
-                    .eut((int) TierEU.HV / 2)
-                    .addTo(sPolarizerRecipes);
+                if (GT_OreDictUnificator.get(aPrefix, Materials.NeodymiumMagnetic, 1L) != null) {
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                        .itemOutputs(GT_OreDictUnificator.get(aPrefix, Materials.NeodymiumMagnetic, 1L))
+                        .noFluidInputs()
+                        .noFluidOutputs()
+                        .duration(((int) Math.max(16L, aPrefix.mMaterialAmount * 128L / GT_Values.M)) * TICKS)
+                        .eut((int) TierEU.HV / 2)
+                        .addTo(sPolarizerRecipes);
+                }
             }
             case "Samarium" ->
             // Polarizer recipes
             {
-                GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack))
-                    .itemOutputs(GT_OreDictUnificator.get(aPrefix, Materials.SamariumMagnetic, 1L))
-                    .noFluidInputs()
-                    .noFluidOutputs()
-                    .duration(((int) Math.max(16L, aPrefix.mMaterialAmount * 128L / GT_Values.M)) * TICKS)
-                    .eut((int) TierEU.IV / 2)
-                    .addTo(sPolarizerRecipes);
+                if (GT_OreDictUnificator.get(aPrefix, Materials.SamariumMagnetic, 1L) != null) {
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                        .itemOutputs(GT_OreDictUnificator.get(aPrefix, Materials.SamariumMagnetic, 1L))
+                        .noFluidInputs()
+                        .noFluidOutputs()
+                        .duration(((int) Math.max(16L, aPrefix.mMaterialAmount * 128L / GT_Values.M)) * TICKS)
+                        .eut((int) TierEU.IV / 2)
+                        .addTo(sPolarizerRecipes);
+                }
             }
 
             case "TengamPurified" ->
             // Polarizer recipes
             {
-                GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack))
-                    .itemOutputs(GT_OreDictUnificator.get(aPrefix, Materials.TengamAttuned, 1L))
-                    .noFluidInputs()
-                    .noFluidOutputs()
-                    .duration(((int) Math.max(16L, aPrefix.mMaterialAmount * 128L / GT_Values.M)) * TICKS)
-                    .eut((int) TierEU.RECIPE_UHV)
-                    .addTo(sPolarizerRecipes);
+                if (GT_OreDictUnificator.get(aPrefix, Materials.TengamAttuned, 1L) != null) {
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                        .itemOutputs(GT_OreDictUnificator.get(aPrefix, Materials.TengamAttuned, 1L))
+                        .noFluidInputs()
+                        .noFluidOutputs()
+                        .duration(((int) Math.max(16L, aPrefix.mMaterialAmount * 128L / GT_Values.M)) * TICKS)
+                        .eut((int) TierEU.RECIPE_UHV)
+                        .addTo(sPolarizerRecipes);
+                }
             }
 
             default -> { /* NO-OP */ }

--- a/src/main/java/gregtech/loaders/postload/GT_CraftingRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/postload/GT_CraftingRecipeLoader.java
@@ -1823,11 +1823,6 @@ public class GT_CraftingRecipeLoader implements Runnable {
             GT_ModHandler.getIC2Item("miningPipe", 1),
             GT_ModHandler.RecipeBits.BUFFERED,
             new Object[] { "hPf", 'P', OrePrefixes.pipeSmall.get(Materials.Steel) });
-        GT_Values.RA.addWiremillRecipe(
-            GT_OreDictUnificator.get(OrePrefixes.pipeTiny, Materials.Steel, 1),
-            GT_ModHandler.getIC2Item("miningPipe", 1),
-            200,
-            16);
 
         GT_ModHandler.addCraftingRecipe(
             GT_ModHandler.getIC2Item("luminator", 16L),

--- a/src/main/java/gregtech/loaders/postload/recipes/WiremillRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/WiremillRecipes.java
@@ -3,7 +3,7 @@ package gregtech.loaders.postload.recipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sWiremillRecipes;
 import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
 import static gregtech.api.util.GT_RecipeBuilder.TICKS;
-import static gregtech.api.util.GT_Utility.calculateRecipeEU;
+import static gregtech.api.util.GT_RecipeRegistrator.registerWiremillRecipes;
 
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
@@ -13,184 +13,18 @@ import gregtech.api.enums.GT_Values;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.MaterialsUEVplus;
 import gregtech.api.enums.OrePrefixes;
-import gregtech.api.util.*;
+import gregtech.api.enums.TierEU;
+import gregtech.api.util.GT_ModHandler;
+import gregtech.api.util.GT_OreDictUnificator;
 
 public class WiremillRecipes implements Runnable {
-
-    // directly copied from GT code but converted to RA2 format
-    void registerWiremillRecipes(Materials materials, int baseDuration, int eut, OrePrefixes prefix1,
-        OrePrefixes prefix2, int multiplier) {
-        GT_Values.RA.stdBuilder()
-            .itemInputs(GT_OreDictUnificator.get(prefix1, materials, 1L), GT_Utility.getIntegratedCircuit(1))
-            .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.wireGt01, materials, multiplier))
-            .noFluidInputs()
-            .noFluidOutputs()
-            .duration(baseDuration)
-            .eut(eut)
-            .addTo(sWiremillRecipes);
-
-        GT_Values.RA.stdBuilder()
-            .itemInputs(
-                GT_OreDictUnificator.get(prefix1, materials, 2L / multiplier),
-                GT_Utility.getIntegratedCircuit(2))
-            .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.wireGt02, materials, 1L))
-            .noFluidInputs()
-            .noFluidOutputs()
-            .duration((int) (baseDuration * 1.5f))
-            .eut(eut)
-            .addTo(sWiremillRecipes);
-
-        GT_Values.RA.stdBuilder()
-            .itemInputs(
-                GT_OreDictUnificator.get(prefix1, materials, 4L / multiplier),
-                GT_Utility.getIntegratedCircuit(4))
-            .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.wireGt04, materials, 1L))
-            .noFluidInputs()
-            .noFluidOutputs()
-            .duration(baseDuration * 2)
-            .eut(eut)
-            .addTo(sWiremillRecipes);
-
-        GT_Values.RA.stdBuilder()
-            .itemInputs(
-                GT_OreDictUnificator.get(prefix1, materials, 8L / multiplier),
-                GT_Utility.getIntegratedCircuit(8))
-            .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.wireGt08, materials, 1L))
-            .noFluidInputs()
-            .noFluidOutputs()
-            .duration((int) (baseDuration * 2.5f))
-            .eut(eut)
-            .addTo(sWiremillRecipes);
-
-        GT_Values.RA.stdBuilder()
-            .itemInputs(
-                GT_OreDictUnificator.get(prefix1, materials, 12L / multiplier),
-                GT_Utility.getIntegratedCircuit(12))
-            .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.wireGt12, materials, 1L))
-            .noFluidInputs()
-            .noFluidOutputs()
-            .duration(baseDuration * 3)
-            .eut(eut)
-            .addTo(sWiremillRecipes);
-
-        GT_Values.RA.stdBuilder()
-            .itemInputs(
-                GT_OreDictUnificator.get(prefix1, materials, 16L / multiplier),
-                GT_Utility.getIntegratedCircuit(16))
-            .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.wireGt16, materials, 1L))
-            .noFluidInputs()
-            .noFluidOutputs()
-            .duration((int) (baseDuration * 3.5f))
-            .eut(eut)
-            .addTo(sWiremillRecipes);
-
-        if (GT_OreDictUnificator.get(prefix2, materials, 1L) != null) {
-            GT_Values.RA.stdBuilder()
-                .itemInputs(
-                    GT_OreDictUnificator.get(prefix2, materials, 2L / multiplier),
-                    GT_Utility.getIntegratedCircuit(1))
-                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.wireGt01, materials, 1L))
-                .noFluidInputs()
-                .noFluidOutputs()
-                .duration(baseDuration / 2)
-                .eut(eut)
-                .addTo(sWiremillRecipes);
-
-            GT_Values.RA.stdBuilder()
-                .itemInputs(
-                    GT_OreDictUnificator.get(prefix2, materials, 4L / multiplier),
-                    GT_Utility.getIntegratedCircuit(2))
-                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.wireGt02, materials, 1L))
-                .noFluidInputs()
-                .noFluidOutputs()
-                .duration(baseDuration)
-                .eut(eut)
-                .addTo(sWiremillRecipes);
-
-            GT_Values.RA.stdBuilder()
-                .itemInputs(
-                    GT_OreDictUnificator.get(prefix2, materials, 8L / multiplier),
-                    GT_Utility.getIntegratedCircuit(4))
-                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.wireGt04, materials, 1L))
-                .noFluidInputs()
-                .noFluidOutputs()
-                .duration((int) (baseDuration * 1.5f))
-                .eut(eut)
-                .addTo(sWiremillRecipes);
-
-            GT_Values.RA.stdBuilder()
-                .itemInputs(
-                    GT_OreDictUnificator.get(prefix2, materials, 16L / multiplier),
-                    GT_Utility.getIntegratedCircuit(8))
-                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.wireGt08, materials, 1L))
-                .noFluidInputs()
-                .noFluidOutputs()
-                .duration(baseDuration * 2)
-                .eut(eut)
-                .addTo(sWiremillRecipes);
-
-            GT_Values.RA.stdBuilder()
-                .itemInputs(
-                    GT_OreDictUnificator.get(prefix2, materials, 24L / multiplier),
-                    GT_Utility.getIntegratedCircuit(12))
-                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.wireGt12, materials, 1L))
-                .noFluidInputs()
-                .noFluidOutputs()
-                .duration((int) (baseDuration * 2.5f))
-                .eut(eut)
-                .addTo(sWiremillRecipes);
-
-            GT_Values.RA.stdBuilder()
-                .itemInputs(
-                    GT_OreDictUnificator.get(prefix2, materials, 32L / multiplier),
-                    GT_Utility.getIntegratedCircuit(16))
-                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.wireGt16, materials, 1L))
-                .noFluidInputs()
-                .noFluidOutputs()
-                .duration(baseDuration * 3)
-                .eut(eut)
-                .addTo(sWiremillRecipes);
-        }
-
-        if (GT_OreDictUnificator.get(OrePrefixes.wireFine, materials, 1L) != null) {
-
-            GT_Values.RA.stdBuilder()
-                .itemInputs(GT_OreDictUnificator.get(prefix1, materials, 1L), GT_Utility.getIntegratedCircuit(3))
-                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.wireFine, materials, 4L * multiplier))
-                .noFluidInputs()
-                .noFluidOutputs()
-                .duration(baseDuration)
-                .eut(eut)
-                .addTo(sWiremillRecipes);
-            if (GT_OreDictUnificator.get(prefix2, materials, 1L) != null) {
-                GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_OreDictUnificator.get(prefix2, materials, 1L), GT_Utility.getIntegratedCircuit(3))
-                    .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.wireFine, materials, 2L * multiplier))
-                    .noFluidInputs()
-                    .noFluidOutputs()
-                    .duration(baseDuration / 2)
-                    .eut(eut)
-                    .addTo(sWiremillRecipes);
-            }
-        }
-    }
-
-    void registerWiremillRecipes(Materials aMaterial, int baseDuration, int aEUt) {
-        registerWiremillRecipes(
-            aMaterial,
-            baseDuration,
-            calculateRecipeEU(aMaterial, aEUt),
-            OrePrefixes.ingot,
-            OrePrefixes.stick,
-            2);
-    }
 
     @Override
     public void run() {
 
         registerWiremillRecipes(Materials.Graphene, 20 * SECONDS, 2, OrePrefixes.dust, OrePrefixes.stick, 1);
 
-        registerWiremillRecipes(MaterialsUEVplus.SpaceTime, 20 * SECONDS, 32_000);
+        registerWiremillRecipes(MaterialsUEVplus.SpaceTime, 20 * SECONDS, (int) TierEU.RECIPE_LuV);
 
         GT_Values.RA.stdBuilder()
             .itemInputs(GT_OreDictUnificator.get(OrePrefixes.ingot, Materials.Polycaprolactam, 1L))
@@ -199,6 +33,15 @@ public class WiremillRecipes implements Runnable {
             .noFluidOutputs()
             .duration(4 * SECONDS)
             .eut(48)
+            .addTo(sWiremillRecipes);
+
+        GT_Values.RA.stdBuilder()
+            .itemInputs(GT_OreDictUnificator.get(OrePrefixes.pipeTiny, Materials.Steel, 1))
+            .itemOutputs(GT_ModHandler.getIC2Item("miningPipe", 1))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(10 * SECONDS)
+            .eut(16)
             .addTo(sWiremillRecipes);
 
         if (!GT_Mod.gregtechproxy.mDisableIC2Cables) {


### PR DESCRIPTION
- fully convert all wiremill recipes in gt and clean up unnecessary duplicate code
- fully convert all polarizer recipes in gt
- fully convert all canner recipes in gt
- convert oredict plank recipes
- convert oredict stoneCobble recipes
- convert various assembler recipes to RA2
- removed a few recipes from the oredict plank recipes and oredict stoneCobble recipes

Regarding that last point there were 2 reasons: 1) these recipes never existed in the game, meaning they were broken anyway or got removed somewhere (though I could not find any removal like that) 2) leaving them in as RA2 broke other recipes by collision (see my naive ticket https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13513).