### PR TITLE
Yet another round of ra2 conversions

### DIFF
--- a/src/main/java/gregtech/api/util/GT_RecipeMapUtil.java
+++ b/src/main/java/gregtech/api/util/GT_RecipeMapUtil.java
@@ -92,10 +92,33 @@ public class GT_RecipeMapUtil {
         TIntList chances = b.getChances() != null ? new TIntArrayList(b.getChances()) : null;
         cellToFluid(itemInputs, fluidInputs, removeIntegratedCircuit, null);
         cellToFluid(itemOutputs, fluidOutputs, removeIntegratedCircuit, chances);
-        return b.itemInputs(itemInputs.toArray(new ItemStack[0]))
-            .itemOutputs(itemOutputs.toArray(new ItemStack[0]), chances != null ? chances.toArray() : null)
-            .fluidInputs(fluidInputs.toArray(new FluidStack[0]))
-            .fluidOutputs(fluidOutputs.toArray(new FluidStack[0]));
+        itemInputs.removeIf(Objects::isNull);
+        if (chances == null) {
+            itemOutputs.removeIf(Objects::isNull);
+        }
+        fluidInputs.removeIf(Objects::isNull);
+        fluidOutputs.removeIf(Objects::isNull);
+        if (itemInputs.size() == 0) {
+            b.noItemInputs();
+        } else {
+            b.itemInputs(itemInputs.toArray(new ItemStack[0]));
+        }
+        if (itemOutputs.size() == 0) {
+            b.noItemOutputs();
+        } else {
+            b.itemOutputs(itemOutputs.toArray(new ItemStack[0]), chances != null ? chances.toArray() : null);
+        }
+        if (fluidInputs.size() == 0) {
+            b.noFluidInputs();
+        } else {
+            b.fluidInputs(fluidInputs.toArray(new FluidStack[0]));
+        }
+        if (fluidOutputs.size() == 0) {
+            b.noFluidOutputs();
+        } else {
+            b.fluidOutputs(fluidOutputs.toArray(new FluidStack[0]));
+        }
+        return b;
     }
 
     private static void cellToFluid(List<ItemStack> items, List<FluidStack> fluids, boolean removeIntegratedCircuit,

--- a/src/main/java/gregtech/api/util/GT_RecipeRegistrator.java
+++ b/src/main/java/gregtech/api/util/GT_RecipeRegistrator.java
@@ -4,6 +4,7 @@ import static gregtech.api.enums.GT_Values.*;
 import static gregtech.api.enums.Materials.*;
 import static gregtech.api.enums.Materials.Void;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sHammerRecipes;
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sMaceratorRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sWiremillRecipes;
 import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
 import static gregtech.api.util.GT_RecipeBuilder.TICKS;
@@ -358,19 +359,38 @@ public class GT_RecipeRegistrator {
         if (!aData.hasValidMaterialData()) return;
 
         long tAmount = 0;
-        for (MaterialStack tMaterial : aData.getAllMaterialStacks())
+        for (MaterialStack tMaterial : aData.getAllMaterialStacks()) {
             tAmount += tMaterial.mAmount * tMaterial.mMaterial.getMass();
-        boolean tHide = (aData.mMaterial.mMaterial != Materials.Iron) && (GT_Mod.gregtechproxy.mHideRecyclingRecipes);
-        RA.addPulveriserRecipe(
-            aStack,
-            new ItemStack[] { GT_OreDictUnificator.getDust(aData.mMaterial),
-                GT_OreDictUnificator.getDust(aData.getByProduct(0)),
-                GT_OreDictUnificator.getDust(aData.getByProduct(1)),
-                GT_OreDictUnificator.getDust(aData.getByProduct(2)) },
-            null,
-            aData.mMaterial.mMaterial == Materials.Marble ? 1 : (int) Math.max(16, tAmount / M),
-            4,
-            tHide);
+        }
+
+        {
+            boolean tHide = (aData.mMaterial.mMaterial != Materials.Iron)
+                && (GT_Mod.gregtechproxy.mHideRecyclingRecipes);
+            ArrayList<ItemStack> outputs = new ArrayList<ItemStack>();
+            if (GT_OreDictUnificator.getDust(aData.mMaterial) != null) {
+                outputs.add(GT_OreDictUnificator.getDust(aData.mMaterial));
+            }
+            for (int i = 0; i < 3; i++) {
+                if (GT_OreDictUnificator.getDust(aData.getByProduct(i)) != null) {
+                    outputs.add(GT_OreDictUnificator.getDust(aData.getByProduct(i)));
+                }
+            }
+            if (outputs.size() != 0) {
+                ItemStack[] outputsArray = outputs.toArray(new ItemStack[outputs.size()]);
+                GT_RecipeBuilder recipeBuilder = GT_Values.RA.stdBuilder();
+                recipeBuilder.itemInputs(aStack)
+                    .itemOutputs(outputsArray)
+                    .noFluidInputs()
+                    .noFluidOutputs()
+                    .duration(
+                        (aData.mMaterial.mMaterial == Materials.Marble ? 1 : (int) Math.max(16, tAmount / M)) * TICKS)
+                    .eut(4);
+                if (tHide) {
+                    recipeBuilder.hidden();
+                }
+                recipeBuilder.addTo(sMaceratorRecipes);
+            }
+        }
 
         if (!aAllowHammer) {
             return;

--- a/src/main/java/gregtech/common/items/GT_MetaGenerated_Item_01.java
+++ b/src/main/java/gregtech/common/items/GT_MetaGenerated_Item_01.java
@@ -2,10 +2,12 @@ package gregtech.common.items;
 
 import static gregtech.api.enums.Mods.GalacticraftMars;
 import static gregtech.api.enums.Textures.BlockIcons.*;
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAssemblerRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCannerRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCompressorRecipes;
 import static gregtech.api.util.GT_RecipeBuilder.MINUTES;
 import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
+import static gregtech.api.util.GT_RecipeBuilder.TICKS;
 import static gregtech.client.GT_TooltipHandler.Tier.*;
 import static gregtech.client.GT_TooltipHandler.registerTieredTooltip;
 
@@ -35,6 +37,7 @@ import gregtech.api.enums.OreDictNames;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.enums.SubTag;
 import gregtech.api.enums.TC_Aspects;
+import gregtech.api.enums.TierEU;
 import gregtech.api.interfaces.IItemBehaviour;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.items.GT_MetaBase_Item;
@@ -839,13 +842,17 @@ public class GT_MetaGenerated_Item_01 extends GT_MetaGenerated_Item_X32 {
                 new TC_Aspects.TC_AspectStack(TC_Aspects.VACUOS, 1L),
                 new TC_Aspects.TC_AspectStack(TC_Aspects.MOTUS, 1L)));
 
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Redstone, 1L),
-                GT_OreDictUnificator.get(OrePrefixes.cell, Materials.Empty, 1L), GT_Utility.getIntegratedCircuit(1) },
-            GT_Values.NF,
-            ItemList.Spray_Empty.get(1L),
-            800,
-            1);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Redstone, 1L),
+                GT_OreDictUnificator.get(OrePrefixes.cell, Materials.Empty, 1L),
+                GT_Utility.getIntegratedCircuit(1))
+            .itemOutputs(ItemList.Spray_Empty.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(40 * SECONDS)
+            .eut(1)
+            .addTo(sAssemblerRecipes);
 
         ItemList.Crate_Empty.set(
             addItem(
@@ -879,14 +886,17 @@ public class GT_MetaGenerated_Item_01 extends GT_MetaGenerated_Item_X32 {
                 new TC_Aspects.TC_AspectStack(TC_Aspects.IGNIS, 1L),
                 new TC_Aspects.TC_AspectStack(TC_Aspects.GELUM, 1L)));
 
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.plateDouble, Materials.Aluminium, 1L),
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                GT_OreDictUnificator.get(OrePrefixes.plateDouble, Materials.Aluminium, 1L),
                 GT_OreDictUnificator.get(OrePrefixes.ring, Materials.Aluminium, 2L),
-                GT_Utility.getIntegratedCircuit(1) },
-            GT_Values.NF,
-            ItemList.ThermosCan_Empty.get(1L),
-            800,
-            1);
+                GT_Utility.getIntegratedCircuit(1))
+            .itemOutputs(ItemList.ThermosCan_Empty.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(40 * SECONDS)
+            .eut(1)
+            .addTo(sAssemblerRecipes);
 
         ItemList.Large_Fluid_Cell_Steel.set(
             addItem(
@@ -901,14 +911,17 @@ public class GT_MetaGenerated_Item_01 extends GT_MetaGenerated_Item_X32 {
                 new TC_Aspects.TC_AspectStack(TC_Aspects.AQUA, 2L)));
         setFluidContainerStats(32000 + tLastID, 8000L, 64L);
 
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.plateDouble, Materials.Steel, 4L),
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                GT_OreDictUnificator.get(OrePrefixes.plateDouble, Materials.Steel, 4L),
                 GT_OreDictUnificator.get(OrePrefixes.ring, Materials.AnyBronze, 4L),
-                GT_Utility.getIntegratedCircuit(1) },
-            GT_Values.NF,
-            ItemList.Large_Fluid_Cell_Steel.get(1L),
-            200,
-            30);
+                GT_Utility.getIntegratedCircuit(1))
+            .itemOutputs(ItemList.Large_Fluid_Cell_Steel.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(10 * SECONDS)
+            .eut(TierEU.RECIPE_LV)
+            .addTo(sAssemblerRecipes);
 
         ItemList.Large_Fluid_Cell_TungstenSteel.set(
             addItem(
@@ -923,14 +936,17 @@ public class GT_MetaGenerated_Item_01 extends GT_MetaGenerated_Item_X32 {
                 new TC_Aspects.TC_AspectStack(TC_Aspects.AQUA, 7L)));
         setFluidContainerStats(32000 + tLastID, 512000L, 32L);
 
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.plateDouble, Materials.TungstenSteel, 4L),
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                GT_OreDictUnificator.get(OrePrefixes.plateDouble, Materials.TungstenSteel, 4L),
                 GT_OreDictUnificator.get(OrePrefixes.ring, Materials.Platinum, 4L),
-                GT_Utility.getIntegratedCircuit(1) },
-            GT_Values.NF,
-            ItemList.Large_Fluid_Cell_TungstenSteel.get(1L),
-            200,
-            480);
+                GT_Utility.getIntegratedCircuit(1))
+            .itemOutputs(ItemList.Large_Fluid_Cell_TungstenSteel.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(10 * SECONDS)
+            .eut(TierEU.RECIPE_HV)
+            .addTo(sAssemblerRecipes);
 
         ItemList.Large_Fluid_Cell_Aluminium.set(
             addItem(
@@ -945,13 +961,17 @@ public class GT_MetaGenerated_Item_01 extends GT_MetaGenerated_Item_X32 {
                 new TC_Aspects.TC_AspectStack(TC_Aspects.AQUA, 3L)));
         setFluidContainerStats(32000 + tLastID, 32000L, 64L);
 
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.plateDouble, Materials.Aluminium, 4L),
-                GT_OreDictUnificator.get(OrePrefixes.ring, Materials.Silver, 4L), GT_Utility.getIntegratedCircuit(1) },
-            GT_Values.NF,
-            ItemList.Large_Fluid_Cell_Aluminium.get(1L),
-            200,
-            64);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                GT_OreDictUnificator.get(OrePrefixes.plateDouble, Materials.Aluminium, 4L),
+                GT_OreDictUnificator.get(OrePrefixes.ring, Materials.Silver, 4L),
+                GT_Utility.getIntegratedCircuit(1))
+            .itemOutputs(ItemList.Large_Fluid_Cell_Aluminium.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(10 * SECONDS)
+            .eut(64)
+            .addTo(sAssemblerRecipes);
 
         ItemList.Large_Fluid_Cell_StainlessSteel.set(
             addItem(
@@ -966,14 +986,17 @@ public class GT_MetaGenerated_Item_01 extends GT_MetaGenerated_Item_X32 {
                 new TC_Aspects.TC_AspectStack(TC_Aspects.AQUA, 4L)));
         setFluidContainerStats(32000 + tLastID, 64000L, 64L);
 
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.plateDouble, Materials.StainlessSteel, 4L),
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                GT_OreDictUnificator.get(OrePrefixes.plateDouble, Materials.StainlessSteel, 4L),
                 GT_OreDictUnificator.get(OrePrefixes.ring, Materials.Electrum, 4L),
-                GT_Utility.getIntegratedCircuit(1) },
-            GT_Values.NF,
-            ItemList.Large_Fluid_Cell_StainlessSteel.get(1L),
-            200,
-            120);
+                GT_Utility.getIntegratedCircuit(1))
+            .itemOutputs(ItemList.Large_Fluid_Cell_StainlessSteel.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(10 * SECONDS)
+            .eut(TierEU.RECIPE_MV)
+            .addTo(sAssemblerRecipes);
 
         ItemList.Large_Fluid_Cell_Titanium.set(
             addItem(
@@ -988,14 +1011,17 @@ public class GT_MetaGenerated_Item_01 extends GT_MetaGenerated_Item_X32 {
                 new TC_Aspects.TC_AspectStack(TC_Aspects.AQUA, 5L)));
         setFluidContainerStats(32000 + tLastID, 128000L, 64L);
 
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.plateDouble, Materials.Titanium, 4L),
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                GT_OreDictUnificator.get(OrePrefixes.plateDouble, Materials.Titanium, 4L),
                 GT_OreDictUnificator.get(OrePrefixes.ring, Materials.RoseGold, 4L),
-                GT_Utility.getIntegratedCircuit(1) },
-            GT_Values.NF,
-            ItemList.Large_Fluid_Cell_Titanium.get(1L),
-            200,
-            256);
+                GT_Utility.getIntegratedCircuit(1))
+            .itemOutputs(ItemList.Large_Fluid_Cell_Titanium.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(10 * SECONDS)
+            .eut(256)
+            .addTo(sAssemblerRecipes);
 
         ItemList.Large_Fluid_Cell_Chrome.set(
             addItem(
@@ -1010,14 +1036,17 @@ public class GT_MetaGenerated_Item_01 extends GT_MetaGenerated_Item_X32 {
                 new TC_Aspects.TC_AspectStack(TC_Aspects.AQUA, 6L)));
         setFluidContainerStats(32000 + tLastID, 2048000L, 8L);
 
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.plateDouble, Materials.Chrome, 4L),
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                GT_OreDictUnificator.get(OrePrefixes.plateDouble, Materials.Chrome, 4L),
                 GT_OreDictUnificator.get(OrePrefixes.ring, Materials.Palladium, 4L),
-                GT_Utility.getIntegratedCircuit(1) },
-            GT_Values.NF,
-            ItemList.Large_Fluid_Cell_Chrome.get(1L),
-            200,
-            1024);
+                GT_Utility.getIntegratedCircuit(1))
+            .itemOutputs(ItemList.Large_Fluid_Cell_Chrome.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(10 * SECONDS)
+            .eut(1024)
+            .addTo(sAssemblerRecipes);
 
         ItemList.Large_Fluid_Cell_Iridium.set(
             addItem(
@@ -1032,14 +1061,17 @@ public class GT_MetaGenerated_Item_01 extends GT_MetaGenerated_Item_X32 {
                 new TC_Aspects.TC_AspectStack(TC_Aspects.AQUA, 8L)));
         setFluidContainerStats(32000 + tLastID, 8192000L, 2L);
 
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.plateDouble, Materials.Iridium, 4L),
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                GT_OreDictUnificator.get(OrePrefixes.plateDouble, Materials.Iridium, 4L),
                 GT_OreDictUnificator.get(OrePrefixes.ring, Materials.Naquadah, 4L),
-                GT_Utility.getIntegratedCircuit(1) },
-            GT_Values.NF,
-            ItemList.Large_Fluid_Cell_Iridium.get(1L),
-            200,
-            1920);
+                GT_Utility.getIntegratedCircuit(1))
+            .itemOutputs(ItemList.Large_Fluid_Cell_Iridium.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(10 * SECONDS)
+            .eut(TierEU.RECIPE_EV)
+            .addTo(sAssemblerRecipes);
 
         ItemList.Large_Fluid_Cell_Osmium.set(
             addItem(
@@ -1054,14 +1086,17 @@ public class GT_MetaGenerated_Item_01 extends GT_MetaGenerated_Item_X32 {
                 new TC_Aspects.TC_AspectStack(TC_Aspects.AQUA, 9L)));
         setFluidContainerStats(32000 + tLastID, 32768000L, 1L);
 
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.plateDouble, Materials.Osmium, 4L),
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                GT_OreDictUnificator.get(OrePrefixes.plateDouble, Materials.Osmium, 4L),
                 GT_OreDictUnificator.get(OrePrefixes.ring, Materials.ElectrumFlux, 4L),
-                GT_Utility.getIntegratedCircuit(1) },
-            GT_Values.NF,
-            ItemList.Large_Fluid_Cell_Osmium.get(1L),
-            200,
-            4096);
+                GT_Utility.getIntegratedCircuit(1))
+            .itemOutputs(ItemList.Large_Fluid_Cell_Osmium.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(10 * SECONDS)
+            .eut(4096)
+            .addTo(sAssemblerRecipes);
 
         ItemList.Large_Fluid_Cell_Neutronium.set(
             addItem(
@@ -1076,14 +1111,17 @@ public class GT_MetaGenerated_Item_01 extends GT_MetaGenerated_Item_X32 {
                 new TC_Aspects.TC_AspectStack(TC_Aspects.AQUA, 10L)));
         setFluidContainerStats(32000 + tLastID, 131072000L, 1L);
 
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.plateDouble, Materials.Neutronium, 4L),
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                GT_OreDictUnificator.get(OrePrefixes.plateDouble, Materials.Neutronium, 4L),
                 GT_OreDictUnificator.get(OrePrefixes.ring, Materials.Draconium, 4L),
-                GT_Utility.getIntegratedCircuit(1) },
-            GT_Values.NF,
-            ItemList.Large_Fluid_Cell_Neutronium.get(1L),
-            200,
-            7680);
+                GT_Utility.getIntegratedCircuit(1))
+            .itemOutputs(ItemList.Large_Fluid_Cell_Neutronium.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(10 * SECONDS)
+            .eut(TierEU.RECIPE_IV)
+            .addTo(sAssemblerRecipes);
         for (byte i = 0; i < 16; i = (byte) (i + 1)) {
             ItemList.SPRAY_CAN_DYES[i].set(
                 addItem(
@@ -1144,38 +1182,50 @@ public class GT_MetaGenerated_Item_01 extends GT_MetaGenerated_Item_X32 {
         addItemBehavior(32472, tBehaviour);
         addItemBehavior(32473, tBehaviour);
 
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.bolt, Materials.Wood, 1L),
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                GT_OreDictUnificator.get(OrePrefixes.bolt, Materials.Wood, 1L),
                 GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.Phosphorus, 1L),
-                GT_Utility.getIntegratedCircuit(1) },
-            GT_Values.NF,
-            ItemList.Tool_Matches.get(1L),
-            16,
-            16);
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.bolt, Materials.Wood, 1L),
+                GT_Utility.getIntegratedCircuit(1))
+            .itemOutputs(ItemList.Tool_Matches.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(16 * TICKS)
+            .eut(16)
+            .addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                GT_OreDictUnificator.get(OrePrefixes.bolt, Materials.Wood, 1L),
                 GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.TricalciumPhosphate, 1L),
-                GT_Utility.getIntegratedCircuit(1) },
-            GT_Values.NF,
-            ItemList.Tool_Matches.get(1L),
-            16,
-            16);
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.bolt, Materials.Wood, 4L),
+                GT_Utility.getIntegratedCircuit(1))
+            .itemOutputs(ItemList.Tool_Matches.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(16 * TICKS)
+            .eut(16)
+            .addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                GT_OreDictUnificator.get(OrePrefixes.bolt, Materials.Wood, 4L),
                 GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Phosphorus, 1L),
-                GT_Utility.getIntegratedCircuit(1) },
-            GT_Values.NF,
-            ItemList.Tool_Matches.get(4L),
-            64,
-            16);
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.bolt, Materials.Wood, 4L),
+                GT_Utility.getIntegratedCircuit(1))
+            .itemOutputs(ItemList.Tool_Matches.get(4L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(3 * SECONDS + 4 * TICKS)
+            .eut(16)
+            .addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                GT_OreDictUnificator.get(OrePrefixes.bolt, Materials.Wood, 4L),
                 GT_OreDictUnificator.get(OrePrefixes.dust, Materials.TricalciumPhosphate, 1L),
-                GT_Utility.getIntegratedCircuit(1) },
-            GT_Values.NF,
-            ItemList.Tool_Matches.get(4L),
-            64,
-            16);
+                GT_Utility.getIntegratedCircuit(1))
+            .itemOutputs(ItemList.Tool_Matches.get(4L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(3 * SECONDS + 4 * TICKS)
+            .eut(16)
+            .addTo(sAssemblerRecipes);
         GT_Values.RA.addBoxingRecipe(
             ItemList.Tool_Matches.get(16L),
             GT_OreDictUnificator.get(OrePrefixes.plateDouble, Materials.Paper, 1L),
@@ -1219,13 +1269,17 @@ public class GT_MetaGenerated_Item_01 extends GT_MetaGenerated_Item_X32 {
         addItemBehavior(32475, tBehaviour);
         addItemBehavior(32476, tBehaviour);
 
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Invar, 2L),
-                new ItemStack(Items.flint, 1), GT_Utility.getIntegratedCircuit(1) },
-            GT_Values.NF,
-            ItemList.Tool_Lighter_Invar_Empty.get(1L),
-            256,
-            16);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Invar, 2L),
+                new ItemStack(Items.flint, 1),
+                GT_Utility.getIntegratedCircuit(1))
+            .itemOutputs(ItemList.Tool_Lighter_Invar_Empty.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(12 * SECONDS + 16 * TICKS)
+            .eut(16)
+            .addTo(sAssemblerRecipes);
 
         ItemList.Tool_Lighter_Platinum_Empty.set(
             addItem(
@@ -1264,13 +1318,17 @@ public class GT_MetaGenerated_Item_01 extends GT_MetaGenerated_Item_X32 {
         addItemBehavior(32478, tBehaviour);
         addItemBehavior(32479, tBehaviour);
 
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Platinum, 2L),
-                new ItemStack(Items.flint, 1), GT_Utility.getIntegratedCircuit(1) },
-            GT_Values.NF,
-            ItemList.Tool_Lighter_Platinum_Empty.get(1L),
-            256,
-            256);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Platinum, 2L),
+                new ItemStack(Items.flint, 1),
+                GT_Utility.getIntegratedCircuit(1))
+            .itemOutputs(ItemList.Tool_Lighter_Platinum_Empty.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(12 * SECONDS + 16 * TICKS)
+            .eut(256)
+            .addTo(sAssemblerRecipes);
 
         if (GalacticraftMars.isModLoaded()) {
             ItemList.Ingot_Heavy1
@@ -3644,72 +3702,105 @@ public class GT_MetaGenerated_Item_01 extends GT_MetaGenerated_Item_X32 {
                 "Protects your Machines",
                 new TC_Aspects.TC_AspectStack(TC_Aspects.TUTAMEN, 4L)));
 
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Aluminium, 1L),
-                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Plastic, 2L), GT_Utility.getIntegratedCircuit(1) },
-            GT_Values.NF,
-            ItemList.Upgrade_Muffler.get(1L),
-            1600,
-            2);
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Aluminium, 1L),
-                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 2L), GT_Utility.getIntegratedCircuit(1) },
-            GT_Values.NF,
-            ItemList.Upgrade_Muffler.get(1L),
-            1600,
-            2);
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Iron, 1L),
-                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Plastic, 2L), GT_Utility.getIntegratedCircuit(1) },
-            GT_Values.NF,
-            ItemList.Upgrade_Muffler.get(1L),
-            1600,
-            2);
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Iron, 1L),
-                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 2L), GT_Utility.getIntegratedCircuit(1) },
-            GT_Values.NF,
-            ItemList.Upgrade_Muffler.get(1L),
-            1600,
-            2);
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.plate, Materials.WroughtIron, 1L),
-                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Plastic, 2L), GT_Utility.getIntegratedCircuit(1) },
-            GT_Values.NF,
-            ItemList.Upgrade_Muffler.get(1L),
-            1600,
-            2);
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.plate, Materials.WroughtIron, 1L),
-                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 2L), GT_Utility.getIntegratedCircuit(1) },
-            GT_Values.NF,
-            ItemList.Upgrade_Muffler.get(1L),
-            1600,
-            2);
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Aluminium, 1L),
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Aluminium, 1L),
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Plastic, 2L),
+                GT_Utility.getIntegratedCircuit(1))
+            .itemOutputs(ItemList.Upgrade_Muffler.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(1 * MINUTES + 20 * SECONDS)
+            .eut(2)
+            .addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Aluminium, 1L),
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 2L),
+                GT_Utility.getIntegratedCircuit(1))
+            .itemOutputs(ItemList.Upgrade_Muffler.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(1 * MINUTES + 20 * SECONDS)
+            .eut(2)
+            .addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Iron, 1L),
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Plastic, 2L),
+                GT_Utility.getIntegratedCircuit(1))
+            .itemOutputs(ItemList.Upgrade_Muffler.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(1 * MINUTES + 20 * SECONDS)
+            .eut(2)
+            .addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Iron, 1L),
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 2L),
+                GT_Utility.getIntegratedCircuit(1))
+            .itemOutputs(ItemList.Upgrade_Muffler.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(1 * MINUTES + 20 * SECONDS)
+            .eut(2)
+            .addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                GT_OreDictUnificator.get(OrePrefixes.plate, Materials.WroughtIron, 1L),
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Plastic, 2L),
+                GT_Utility.getIntegratedCircuit(1))
+            .itemOutputs(ItemList.Upgrade_Muffler.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(1 * MINUTES + 20 * SECONDS)
+            .eut(2)
+            .addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                GT_OreDictUnificator.get(OrePrefixes.plate, Materials.WroughtIron, 1L),
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 2L),
+                GT_Utility.getIntegratedCircuit(1))
+            .itemOutputs(ItemList.Upgrade_Muffler.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(1 * MINUTES + 20 * SECONDS)
+            .eut(2)
+            .addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Aluminium, 1L),
                 GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Iridium, 1L),
-                GT_Utility.getIntegratedCircuit(1) },
-            GT_Values.NF,
-            ItemList.Upgrade_Lock.get(1L),
-            6400,
-            16);
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Iron, 1L),
+                GT_Utility.getIntegratedCircuit(1))
+            .itemOutputs(ItemList.Upgrade_Lock.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(5 * MINUTES + 20 * SECONDS)
+            .eut(16)
+            .addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Iron, 1L),
                 GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Iridium, 1L),
-                GT_Utility.getIntegratedCircuit(1) },
-            GT_Values.NF,
-            ItemList.Upgrade_Lock.get(1L),
-            6400,
-            16);
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.plate, Materials.WroughtIron, 1L),
+                GT_Utility.getIntegratedCircuit(1))
+            .itemOutputs(ItemList.Upgrade_Lock.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(5 * MINUTES + 20 * SECONDS)
+            .eut(16)
+            .addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                GT_OreDictUnificator.get(OrePrefixes.plate, Materials.WroughtIron, 1L),
                 GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Iridium, 1L),
-                GT_Utility.getIntegratedCircuit(1) },
-            GT_Values.NF,
-            ItemList.Upgrade_Lock.get(1L),
-            6400,
-            16);
+                GT_Utility.getIntegratedCircuit(1))
+            .itemOutputs(ItemList.Upgrade_Lock.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(5 * MINUTES + 20 * SECONDS)
+            .eut(16)
+            .addTo(sAssemblerRecipes);
 
         ItemList.Component_Filter.set(
             addItem(
@@ -3771,14 +3862,17 @@ public class GT_MetaGenerated_Item_01 extends GT_MetaGenerated_Item_X32 {
                 "Displays the fluid stored in the Tank",
                 new TC_Aspects.TC_AspectStack(TC_Aspects.SENSUS, 2L),
                 new TC_Aspects.TC_AspectStack(TC_Aspects.AQUA, 1L)));
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] { ItemList.Sensor_EV.get(1L),
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                ItemList.Sensor_EV.get(1L),
                 GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Titanium, 1L),
-                GT_Utility.getIntegratedCircuit(1) },
-            GT_Values.NF,
-            ItemList.Cover_PlayerDetector.get(1L),
-            3200,
-            128);
+                GT_Utility.getIntegratedCircuit(1))
+            .itemOutputs(ItemList.Cover_PlayerDetector.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(2 * MINUTES + 40 * SECONDS)
+            .eut(TierEU.RECIPE_MV)
+            .addTo(sAssemblerRecipes);
 
         GregTech_API.registerCover(
             ItemList.Cover_Controller.get(1L),
@@ -3861,83 +3955,127 @@ public class GT_MetaGenerated_Item_01 extends GT_MetaGenerated_Item_X32 {
                 OrePrefixes.dust.get(Materials.Glowstone), 'R', Dyes.dyeRed, 'G', Dyes.dyeLime, 'B', Dyes.dyeBlue, 'P',
                 OrePrefixes.plate.get(Materials.Glass) });
 
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Aluminium, 1L),
-                ItemList.Cover_Drain.get(1L), GT_Utility.getIntegratedCircuit(1) },
-            GT_Values.NF,
-            ItemList.Cover_Shutter.get(1L),
-            200,
-            64);
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Iron, 1L),
-                ItemList.Cover_Drain.get(1L), GT_Utility.getIntegratedCircuit(1) },
-            GT_Values.NF,
-            ItemList.Cover_Shutter.get(1L),
-            800,
-            16);
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.plate, Materials.WroughtIron, 1L),
-                ItemList.Cover_Drain.get(1L), GT_Utility.getIntegratedCircuit(1) },
-            GT_Values.NF,
-            ItemList.Cover_Shutter.get(1L),
-            400,
-            30);
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Aluminium, 2L),
-                new ItemStack(Blocks.iron_bars, 2), GT_Utility.getIntegratedCircuit(1) },
-            GT_Values.NF,
-            ItemList.Cover_Drain.get(1L),
-            200,
-            64);
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Iron, 2L),
-                new ItemStack(Blocks.iron_bars, 2), GT_Utility.getIntegratedCircuit(1) },
-            GT_Values.NF,
-            ItemList.Cover_Drain.get(1L),
-            800,
-            16);
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.plate, Materials.WroughtIron, 2L),
-                new ItemStack(Blocks.iron_bars, 2), GT_Utility.getIntegratedCircuit(1) },
-            GT_Values.NF,
-            ItemList.Cover_Drain.get(1L),
-            400,
-            30);
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Aluminium, 1L),
-                new ItemStack(Blocks.crafting_table, 1), GT_Utility.getIntegratedCircuit(1) },
-            GT_Values.NF,
-            ItemList.Cover_Crafting.get(1L),
-            200,
-            64);
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Iron, 1L),
-                new ItemStack(Blocks.crafting_table, 1), GT_Utility.getIntegratedCircuit(1) },
-            GT_Values.NF,
-            ItemList.Cover_Crafting.get(1L),
-            800,
-            16);
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.plate, Materials.WroughtIron, 1L),
-                new ItemStack(Blocks.crafting_table, 1), GT_Utility.getIntegratedCircuit(1) },
-            GT_Values.NF,
-            ItemList.Cover_Crafting.get(1L),
-            800,
-            16);
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] { ItemList.Cover_Shutter.get(1L),
-                GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Basic, 1), GT_Utility.getIntegratedCircuit(1) },
-            GT_Values.NF,
-            ItemList.FluidFilter.get(1L),
-            800,
-            4);
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] { ItemList.Cover_Screen.get(1L), ItemList.Cover_FluidDetector.get(1L),
-                GT_Utility.getIntegratedCircuit(1) },
-            GT_Values.NF,
-            ItemList.Cover_FluidStorageMonitor.get(1L),
-            1200,
-            128);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Aluminium, 1L),
+                ItemList.Cover_Drain.get(1L),
+                GT_Utility.getIntegratedCircuit(1))
+            .itemOutputs(ItemList.Cover_Shutter.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(10 * SECONDS)
+            .eut(64)
+            .addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Iron, 1L),
+                ItemList.Cover_Drain.get(1L),
+                GT_Utility.getIntegratedCircuit(1))
+            .itemOutputs(ItemList.Cover_Shutter.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(10 * SECONDS)
+            .eut(64)
+            .addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                GT_OreDictUnificator.get(OrePrefixes.plate, Materials.WroughtIron, 1L),
+                ItemList.Cover_Drain.get(1L),
+                GT_Utility.getIntegratedCircuit(1))
+            .itemOutputs(ItemList.Cover_Shutter.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(10 * SECONDS)
+            .eut(64)
+            .addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Aluminium, 2L),
+                new ItemStack(Blocks.iron_bars, 2),
+                GT_Utility.getIntegratedCircuit(1))
+            .itemOutputs(ItemList.Cover_Drain.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(10 * SECONDS)
+            .eut(64)
+            .addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Iron, 2L),
+                new ItemStack(Blocks.iron_bars, 2),
+                GT_Utility.getIntegratedCircuit(1))
+            .itemOutputs(ItemList.Cover_Drain.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(10 * SECONDS)
+            .eut(64)
+            .addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                GT_OreDictUnificator.get(OrePrefixes.plate, Materials.WroughtIron, 2L),
+                new ItemStack(Blocks.iron_bars, 2),
+                GT_Utility.getIntegratedCircuit(1))
+            .itemOutputs(ItemList.Cover_Drain.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(10 * SECONDS)
+            .eut(64)
+            .addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Aluminium, 1L),
+                new ItemStack(Blocks.crafting_table, 1),
+                GT_Utility.getIntegratedCircuit(1))
+            .itemOutputs(ItemList.Cover_Crafting.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(10 * SECONDS)
+            .eut(64)
+            .addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Iron, 1L),
+                new ItemStack(Blocks.crafting_table, 1),
+                GT_Utility.getIntegratedCircuit(1))
+            .itemOutputs(ItemList.Cover_Crafting.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(10 * SECONDS)
+            .eut(64)
+            .addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                GT_OreDictUnificator.get(OrePrefixes.plate, Materials.WroughtIron, 1L),
+                new ItemStack(Blocks.crafting_table, 1),
+                GT_Utility.getIntegratedCircuit(1))
+            .itemOutputs(ItemList.Cover_Crafting.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(10 * SECONDS)
+            .eut(64)
+            .addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                ItemList.Cover_Shutter.get(1L),
+                GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Basic, 1),
+                GT_Utility.getIntegratedCircuit(1))
+            .itemOutputs(ItemList.FluidFilter.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(40 * SECONDS)
+            .eut(4)
+            .addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                ItemList.Cover_Screen.get(1L),
+                ItemList.Cover_FluidDetector.get(1L),
+                GT_Utility.getIntegratedCircuit(1))
+            .itemOutputs(ItemList.Cover_FluidStorageMonitor.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(40 * SECONDS)
+            .eut(4)
+            .addTo(sAssemblerRecipes);
 
         final ITexture screenCoverTexture = TextureFactory.of(
             TextureFactory.of(OVERLAY_SCREEN),
@@ -4140,13 +4278,14 @@ public class GT_MetaGenerated_Item_01 extends GT_MetaGenerated_Item_X32 {
                 new TC_Aspects.TC_AspectStack(TC_Aspects.NEBRISUM, 8L),
                 new TC_Aspects.TC_AspectStack(TC_Aspects.STRONTIO, 8L)));
 
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] { ItemList.Sensor_LV.get(1L), ItemList.Emitter_LV.get(1L),
-                GT_Utility.getIntegratedCircuit(1) },
-            GT_Values.NF,
-            ItemList.NC_SensorKit.get(1L),
-            1600,
-            2);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(ItemList.Sensor_LV.get(1L), ItemList.Emitter_LV.get(1L), GT_Utility.getIntegratedCircuit(1))
+            .itemOutputs(ItemList.NC_SensorKit.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(1 * MINUTES + 20 * SECONDS)
+            .eut(2)
+            .addTo(sAssemblerRecipes);
 
         ItemList.Cover_RedstoneTransmitterExternal.set(
             addItem(
@@ -4194,22 +4333,29 @@ public class GT_MetaGenerated_Item_01 extends GT_MetaGenerated_Item_X32 {
             TextureFactory.of(MACHINE_CASINGS[2][0], TextureFactory.of(OVERLAY_REDSTONE_RECEIVER)),
             new GT_Cover_RedstoneReceiverInternal(TextureFactory.of(OVERLAY_REDSTONE_RECEIVER)));
 
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] { ItemList.Emitter_EV.get(1L),
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                ItemList.Emitter_EV.get(1L),
                 GT_OreDictUnificator.get(OrePrefixes.plate, Materials.StainlessSteel, 1L),
-                GT_Utility.getIntegratedCircuit(1) },
-            GT_Values.NF,
-            ItemList.Cover_RedstoneTransmitterExternal.get(1L),
-            3200,
-            128);
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] { ItemList.Sensor_EV.get(1L),
+                GT_Utility.getIntegratedCircuit(1))
+            .itemOutputs(ItemList.Cover_RedstoneTransmitterExternal.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(2 * MINUTES + 40 * SECONDS)
+            .eut(TierEU.RECIPE_MV)
+            .addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                ItemList.Sensor_EV.get(1L),
                 GT_OreDictUnificator.get(OrePrefixes.plate, Materials.StainlessSteel, 1L),
-                GT_Utility.getIntegratedCircuit(1) },
-            GT_Values.NF,
-            ItemList.Cover_RedstoneReceiverExternal.get(1L),
-            3200,
-            128);
+                GT_Utility.getIntegratedCircuit(1))
+            .itemOutputs(ItemList.Cover_RedstoneReceiverExternal.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(2 * MINUTES + 40 * SECONDS)
+            .eut(TierEU.RECIPE_MV)
+            .addTo(sAssemblerRecipes);
+
         GT_ModHandler.addShapelessCraftingRecipe(
             ItemList.Cover_RedstoneTransmitterInternal.get(1L),
             new Object[] { ItemList.Cover_RedstoneTransmitterExternal.get(1L) });
@@ -4235,14 +4381,17 @@ public class GT_MetaGenerated_Item_01 extends GT_MetaGenerated_Item_X32 {
             TextureFactory.of(MACHINE_CASINGS[2][0], TextureFactory.of(OVERLAY_MAINTENANCE_DETECTOR)),
             new GT_Cover_NeedMaintainance(TextureFactory.of(OVERLAY_MAINTENANCE_DETECTOR)));
 
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] { ItemList.Emitter_MV.get(1L),
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                ItemList.Emitter_MV.get(1L),
                 GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Aluminium, 1L),
-                GT_Utility.getIntegratedCircuit(1) },
-            GT_Values.NF,
-            ItemList.Cover_NeedsMaintainance.get(1L),
-            600,
-            24);
+                GT_Utility.getIntegratedCircuit(1))
+            .itemOutputs(ItemList.Cover_NeedsMaintainance.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(30 * SECONDS)
+            .eut(TierEU.RECIPE_LV)
+            .addTo(sAssemblerRecipes);
 
         GT_ModHandler.addCraftingRecipe(
             ItemList.ItemFilter_Export.get(1L),
@@ -4261,22 +4410,30 @@ public class GT_MetaGenerated_Item_01 extends GT_MetaGenerated_Item_X32 {
             ItemList.ItemFilter_Import.get(1L),
             new Object[] { ItemList.ItemFilter_Export.get(1L) });
 
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Tin, 2L),
-                ItemList.Component_Filter.get(1L), ItemList.Conveyor_Module_LV.get(1L),
-                GT_Utility.getIntegratedCircuit(1) },
-            null,
-            ItemList.ItemFilter_Export.get(1L),
-            100,
-            30);
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Tin, 2L),
-                ItemList.Component_Filter.get(1L), ItemList.Conveyor_Module_LV.get(1L),
-                GT_Utility.getIntegratedCircuit(2) },
-            null,
-            ItemList.ItemFilter_Import.get(1L),
-            100,
-            30);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Tin, 2L),
+                ItemList.Component_Filter.get(1L),
+                ItemList.Conveyor_Module_LV.get(1L),
+                GT_Utility.getIntegratedCircuit(1))
+            .itemOutputs(ItemList.ItemFilter_Export.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(5 * SECONDS)
+            .eut(TierEU.RECIPE_LV)
+            .addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Tin, 2L),
+                ItemList.Component_Filter.get(1L),
+                ItemList.Conveyor_Module_LV.get(1L),
+                GT_Utility.getIntegratedCircuit(2))
+            .itemOutputs(ItemList.ItemFilter_Import.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(5 * SECONDS)
+            .eut(TierEU.RECIPE_LV)
+            .addTo(sAssemblerRecipes);
 
         GT_ModHandler.addCraftingRecipe(
             ItemList.Tool_Cover_Copy_Paste.get(1L),

--- a/src/main/java/gregtech/common/items/GT_MetaGenerated_Item_02.java
+++ b/src/main/java/gregtech/common/items/GT_MetaGenerated_Item_02.java
@@ -2,7 +2,9 @@ package gregtech.common.items;
 
 import static gregtech.api.enums.Mods.Forestry;
 import static gregtech.api.enums.Textures.BlockIcons.*;
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAssemblerRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCompressorRecipes;
+import static gregtech.api.util.GT_RecipeBuilder.MINUTES;
 import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
 
 import net.minecraft.dispenser.IBlockSource;
@@ -2442,45 +2444,61 @@ public class GT_MetaGenerated_Item_02 extends GT_MetaGenerated_Item_X32 {
             TextureFactory.of(MACHINE_CASINGS[2][0], TextureFactory.of(OVERLAY_WIRELESS_MAINTENANCE_DETECTOR)),
             new GT_Cover_WirelessMaintenanceDetector(TextureFactory.of(OVERLAY_WIRELESS_MAINTENANCE_DETECTOR)));
 
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] { ItemList.Cover_RedstoneTransmitterExternal.get(1L),
-                GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Data, 1L), GT_Utility.getIntegratedCircuit(1) },
-            GT_Values.NF,
-            ItemList.Cover_AdvancedRedstoneTransmitterExternal.get(1L),
-            3200,
-            128);
-
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] { ItemList.Cover_RedstoneReceiverExternal.get(1L),
-                GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Data, 1L), GT_Utility.getIntegratedCircuit(1) },
-            GT_Values.NF,
-            ItemList.Cover_AdvancedRedstoneReceiverExternal.get(1L),
-            3200,
-            128);
-
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] { ItemList.Cover_FluidDetector.get(1L), ItemList.Emitter_EV.get(1L),
-                GT_Utility.getIntegratedCircuit(1) },
-            GT_Values.NF,
-            ItemList.Cover_WirelessFluidDetector.get(1L),
-            3200,
-            128);
-
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] { ItemList.Cover_ItemDetector.get(1L), ItemList.Emitter_EV.get(1L),
-                GT_Utility.getIntegratedCircuit(1) },
-            GT_Values.NF,
-            ItemList.Cover_WirelessItemDetector.get(1L),
-            3200,
-            128);
-
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] { ItemList.Cover_NeedsMaintainance.get(1L), ItemList.Emitter_EV.get(1L),
-                GT_Utility.getIntegratedCircuit(1) },
-            GT_Values.NF,
-            ItemList.Cover_WirelessNeedsMaintainance.get(1L),
-            3200,
-            128);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                ItemList.Cover_RedstoneTransmitterExternal.get(1L),
+                GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Data, 1L),
+                GT_Utility.getIntegratedCircuit(1))
+            .itemOutputs(ItemList.Cover_AdvancedRedstoneTransmitterExternal.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(2 * MINUTES + 40 * SECONDS)
+            .eut(TierEU.RECIPE_MV)
+            .addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                ItemList.Cover_RedstoneReceiverExternal.get(1L),
+                GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Data, 1L),
+                GT_Utility.getIntegratedCircuit(1))
+            .itemOutputs(ItemList.Cover_AdvancedRedstoneReceiverExternal.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(2 * MINUTES + 40 * SECONDS)
+            .eut(TierEU.RECIPE_MV)
+            .addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                ItemList.Cover_FluidDetector.get(1L),
+                ItemList.Emitter_EV.get(1L),
+                GT_Utility.getIntegratedCircuit(1))
+            .itemOutputs(ItemList.Cover_WirelessFluidDetector.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(2 * MINUTES + 40 * SECONDS)
+            .eut(TierEU.RECIPE_MV)
+            .addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                ItemList.Cover_ItemDetector.get(1L),
+                ItemList.Emitter_EV.get(1L),
+                GT_Utility.getIntegratedCircuit(1))
+            .itemOutputs(ItemList.Cover_WirelessItemDetector.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(2 * MINUTES + 40 * SECONDS)
+            .eut(TierEU.RECIPE_MV)
+            .addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                ItemList.Cover_NeedsMaintainance.get(1L),
+                ItemList.Emitter_EV.get(1L),
+                GT_Utility.getIntegratedCircuit(1))
+            .itemOutputs(ItemList.Cover_WirelessNeedsMaintainance.get(1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(2 * MINUTES + 40 * SECONDS)
+            .eut(TierEU.RECIPE_MV)
+            .addTo(sAssemblerRecipes);
 
         GT_ModHandler.addShapelessCraftingRecipe(
             ItemList.Cover_AdvancedRedstoneReceiverExternal.get(1L),

--- a/src/main/java/gregtech/common/items/ItemComb.java
+++ b/src/main/java/gregtech/common/items/ItemComb.java
@@ -1,9 +1,21 @@
 package gregtech.common.items;
 
-import static gregtech.api.enums.GT_Values.*;
-import static gregtech.api.enums.Mods.*;
+import static gregtech.api.enums.GT_Values.L;
+import static gregtech.api.enums.GT_Values.NF;
+import static gregtech.api.enums.GT_Values.NI;
+import static gregtech.api.enums.GT_Values.V;
+import static gregtech.api.enums.Mods.AE2FluidCraft;
+import static gregtech.api.enums.Mods.ExtraUtilities;
+import static gregtech.api.enums.Mods.GalaxySpace;
+import static gregtech.api.enums.Mods.GregTech;
+import static gregtech.api.enums.Mods.MagicBees;
+import static gregtech.api.enums.Mods.NewHorizonsCoreMod;
+import static gregtech.api.enums.Mods.Thaumcraft;
+import static gregtech.api.enums.Mods.ThaumicBases;
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAutoclaveRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCentrifugeRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sFluidExtractionRecipes;
+import static gregtech.api.util.GT_RecipeBuilder.TICKS;
 import static gregtech.api.util.GT_RecipeConstants.CLEANROOM;
 import static gregtech.api.util.GT_RecipeConstants.UniversalChemical;
 
@@ -37,6 +49,7 @@ import gregtech.api.enums.OrePrefixes;
 import gregtech.api.interfaces.IGT_ItemWithMaterialRenderer;
 import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_OreDictUnificator;
+import gregtech.api.util.GT_RecipeBuilder;
 import gregtech.api.util.GT_Utility;
 import gregtech.common.render.items.GT_GeneratedMaterial_Renderer;
 import gregtech.loaders.misc.GT_Bees;
@@ -1557,16 +1570,21 @@ public class ItemComb extends Item implements IGT_ItemWithMaterialRenderer {
      *
      **/
     public void addAutoclaveProcess(CombType comb, Materials aMaterial, Voltage volt, int circuitNumber) {
-        if (GT_OreDictUnificator.get(OrePrefixes.crushedPurified, aMaterial, 4) == NI) return;
-        RA.addAutoclaveRecipe(
-            GT_Utility.copyAmount(9, getStackForType(comb)),
-            GT_Utility.getIntegratedCircuit(circuitNumber),
-            Materials.UUMatter.getFluid(Math.max(1, ((aMaterial.getMass() + volt.getUUAmplifier()) / 10))),
-            GT_OreDictUnificator.get(OrePrefixes.crushedPurified, aMaterial, 4),
-            10000,
-            (int) (aMaterial.getMass() * 128),
-            volt.getAutoClaveEnergy(),
-            volt.compareTo(Voltage.HV) > 0);
+        if (GT_OreDictUnificator.get(OrePrefixes.crushedPurified, aMaterial, 4) == NI) {
+            return;
+        }
+        GT_RecipeBuilder recipeBuilder = GT_Values.RA.stdBuilder();
+        recipeBuilder
+            .itemInputs(GT_Utility.copyAmount(9, getStackForType(comb)), GT_Utility.getIntegratedCircuit(circuitNumber))
+            .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.crushedPurified, aMaterial, 4))
+            .fluidInputs(Materials.UUMatter.getFluid(Math.max(1, ((aMaterial.getMass() + volt.getUUAmplifier()) / 10))))
+            .noFluidOutputs()
+            .duration(((int) (aMaterial.getMass() * 128)) * TICKS)
+            .eut(volt.getAutoClaveEnergy());
+        if (volt.compareTo(Voltage.HV) > 0) {
+            recipeBuilder.requiresCleanRoom();
+        }
+        recipeBuilder.addTo(sAutoclaveRecipes);
     }
 
     public void addFluidExtractorProcess(CombType comb, FluidStack fluid, Voltage volt) {

--- a/src/main/java/gregtech/common/items/ItemComb.java
+++ b/src/main/java/gregtech/common/items/ItemComb.java
@@ -1676,12 +1676,16 @@ public class ItemComb extends Item implements IGT_ItemWithMaterialRenderer {
                         requiresCleanroom = volt.compareTo(Voltage.IV) > 0;
                     }
                 }
-                GT_Values.RA.stdBuilder()
-                    .itemInputs(combInput)
+                GT_RecipeBuilder recipeBuilder = GT_Values.RA.stdBuilder();
+                recipeBuilder.itemInputs(combInput)
                     .itemOutputs(combOutput)
-                    .fluidInputs(fluidInput)
-                    .fluidOutputs(fluidOutput)
-                    .duration(durationTicks)
+                    .fluidInputs(fluidInput);
+                if (fluidOutput == null) {
+                    recipeBuilder.noFluidOutputs();
+                } else {
+                    recipeBuilder.fluidOutputs(fluidOutput);
+                }
+                recipeBuilder.duration(durationTicks)
                     .eut(eut)
                     .metadata(CLEANROOM, requiresCleanroom)
                     .addTo(UniversalChemical);

--- a/src/main/java/gregtech/common/items/ItemDrop.java
+++ b/src/main/java/gregtech/common/items/ItemDrop.java
@@ -29,6 +29,7 @@ import gregtech.api.enums.GT_Values;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.TierEU;
 import gregtech.api.util.GT_ModHandler;
+import gregtech.api.util.GT_RecipeBuilder;
 
 public class ItemDrop extends Item {
 
@@ -229,11 +230,15 @@ public class ItemDrop extends Item {
     }
 
     public void addProcessHV(ItemStack tDrop, FluidStack aOutput, ItemStack aOutput2, int aChance) {
-        GT_Values.RA.stdBuilder()
-            .itemInputs(tDrop)
-            .itemOutputs(aOutput2)
-            .outputChances(aChance)
-            .noFluidInputs()
+        GT_RecipeBuilder recipeBuilder = GT_Values.RA.stdBuilder();
+        recipeBuilder.itemInputs(tDrop);
+        if (aOutput2 == GT_Values.NI) {
+            recipeBuilder.noItemOutputs();
+        } else {
+            recipeBuilder.itemOutputs(aOutput2)
+                .outputChances(aChance);
+        }
+        recipeBuilder.noFluidInputs()
             .fluidOutputs(aOutput)
             .duration(24 * SECONDS)
             .eut(TierEU.RECIPE_HV)

--- a/src/main/java/gregtech/loaders/load/GT_ItemIterator.java
+++ b/src/main/java/gregtech/loaders/load/GT_ItemIterator.java
@@ -24,6 +24,7 @@ import gregtech.api.items.GT_Generic_Item;
 import gregtech.api.util.GT_Log;
 import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_OreDictUnificator;
+import gregtech.api.util.GT_RecipeBuilder;
 import gregtech.api.util.GT_Utility;
 import mods.railcraft.api.core.items.IToolCrowbar;
 
@@ -212,14 +213,18 @@ public class GT_ItemIterator implements Runnable {
                             && (tItem != ItemList.IC2_Food_Can_Spoiled.getItem())) {
                             int tFoodValue = ((ItemFood) tItem).func_150905_g(new ItemStack(tItem, 1, 0));
                             if (tFoodValue > 0) {
-                                GT_Values.RA.stdBuilder()
-                                    .itemInputs(
-                                        new ItemStack(tItem, 1, 32767),
-                                        ItemList.IC2_Food_Can_Empty.get(tFoodValue))
-                                    .itemOutputs(
+                                GT_RecipeBuilder recipeBuilder = GT_Values.RA.stdBuilder();
+                                recipeBuilder.itemInputs(
+                                    new ItemStack(tItem, 1, 32767),
+                                    ItemList.IC2_Food_Can_Empty.get(tFoodValue));
+                                if (GT_Utility.getContainerItem(new ItemStack(tItem, 1, 0), true) == null) {
+                                    recipeBuilder.itemOutputs(ItemList.IC2_Food_Can_Filled.get(tFoodValue));
+                                } else {
+                                    recipeBuilder.itemOutputs(
                                         ItemList.IC2_Food_Can_Filled.get(tFoodValue),
-                                        GT_Utility.getContainerItem(new ItemStack(tItem, 1, 0), true))
-                                    .noFluidInputs()
+                                        GT_Utility.getContainerItem(new ItemStack(tItem, 1, 0), true));
+                                }
+                                recipeBuilder.noFluidInputs()
                                     .noFluidOutputs()
                                     .duration(tFoodValue * 5 * SECONDS)
                                     .eut(1)

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingFood.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingFood.java
@@ -3,6 +3,7 @@ package gregtech.loaders.oreprocessing;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sBenderRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sMixerRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sPressRecipes;
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sSlicerRecipes;
 import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
 import static gregtech.api.util.GT_RecipeBuilder.TICKS;
 
@@ -40,8 +41,14 @@ public class ProcessingFood implements gregtech.api.interfaces.IOreRecipeRegistr
     }
 
     private void registerSlicerRecipes(ItemStack stack) {
-        GT_Values.RA
-            .addSlicerRecipe(stack, ItemList.Shape_Slicer_Flat.get(0L), ItemList.Food_Sliced_Cheese.get(4L), 64, 4);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(stack, ItemList.Shape_Slicer_Flat.get(0L))
+            .itemOutputs(ItemList.Food_Sliced_Cheese.get(4L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(3 * SECONDS + 4 * TICKS)
+            .eut(4)
+            .addTo(sSlicerRecipes);
     }
 
     private void registerBenderRecipes(ItemStack stack) {

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingGem.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingGem.java
@@ -5,6 +5,7 @@ import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sBenderRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCompressorRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sElectrolyzerRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sHammerRecipes;
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sImplosionRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sLaserEngraverRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sLatheRecipes;
 import static gregtech.api.util.GT_RecipeBuilder.MINUTES;
@@ -12,11 +13,18 @@ import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
 import static gregtech.api.util.GT_RecipeBuilder.TICKS;
 import static gregtech.api.util.GT_Utility.calculateRecipeEU;
 
+import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.oredict.OreDictionary;
 
 import gregtech.api.GregTech_API;
-import gregtech.api.enums.*;
+import gregtech.api.enums.ConfigCategories;
+import gregtech.api.enums.GT_Values;
+import gregtech.api.enums.ItemList;
+import gregtech.api.enums.Materials;
+import gregtech.api.enums.OrePrefixes;
+import gregtech.api.enums.SubTag;
+import gregtech.api.enums.TierEU;
 import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_OreDictUnificator;
 import gregtech.api.util.GT_Utility;
@@ -202,11 +210,52 @@ public class ProcessingGem implements gregtech.api.interfaces.IOreRecipeRegistra
                     if (aMaterial.mUnificatable && (aMaterial.mMaterialInto == aMaterial)) {
                         // Implosion compressor recipes
                         {
-                            GT_Values.RA.addImplosionRecipe(
-                                GT_Utility.copyAmount(3L, aStack),
-                                8,
-                                GT_OreDictUnificator.get(OrePrefixes.gemFlawless, aMaterial, 1),
-                                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 2));
+                            if (GT_OreDictUnificator.get(OrePrefixes.gemFlawless, aMaterial, 1) != null) {
+                                GT_Values.RA.stdBuilder()
+                                    .itemInputs(GT_Utility.copyAmount(3L, aStack), ItemList.Block_Powderbarrel.get(16))
+                                    .itemOutputs(
+                                        GT_OreDictUnificator.get(OrePrefixes.gemFlawless, aMaterial, 1),
+                                        GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 2))
+                                    .noFluidInputs()
+                                    .noFluidOutputs()
+                                    .duration(1 * SECONDS)
+                                    .eut(TierEU.RECIPE_LV)
+                                    .addTo(sImplosionRecipes);
+                                GT_Values.RA.stdBuilder()
+                                    .itemInputs(
+                                        GT_Utility.copyAmount(3L, aStack),
+                                        GT_ModHandler.getIC2Item("dynamite", 4, null))
+                                    .itemOutputs(
+                                        GT_OreDictUnificator.get(OrePrefixes.gemFlawless, aMaterial, 1),
+                                        GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 2))
+                                    .noFluidInputs()
+                                    .noFluidOutputs()
+                                    .duration(1 * SECONDS)
+                                    .eut(TierEU.RECIPE_LV)
+                                    .addTo(sImplosionRecipes);
+                                GT_Values.RA.stdBuilder()
+                                    .itemInputs(GT_Utility.copyAmount(3L, aStack), new ItemStack(Blocks.tnt, 8))
+                                    .itemOutputs(
+                                        GT_OreDictUnificator.get(OrePrefixes.gemFlawless, aMaterial, 1),
+                                        GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 2))
+                                    .noFluidInputs()
+                                    .noFluidOutputs()
+                                    .duration(1 * SECONDS)
+                                    .eut(TierEU.RECIPE_LV)
+                                    .addTo(sImplosionRecipes);
+                                GT_Values.RA.stdBuilder()
+                                    .itemInputs(
+                                        GT_Utility.copyAmount(3L, aStack),
+                                        GT_ModHandler.getIC2Item("industrialTnt", 2))
+                                    .itemOutputs(
+                                        GT_OreDictUnificator.get(OrePrefixes.gemFlawless, aMaterial, 1),
+                                        GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 2))
+                                    .noFluidInputs()
+                                    .noFluidOutputs()
+                                    .duration(1 * SECONDS)
+                                    .eut(TierEU.RECIPE_LV)
+                                    .addTo(sImplosionRecipes);
+                            }
                         }
 
                         // Crafting recipes
@@ -310,11 +359,52 @@ public class ProcessingGem implements gregtech.api.interfaces.IOreRecipeRegistra
                     if (aMaterial.mUnificatable && (aMaterial.mMaterialInto == aMaterial)) {
                         // Implosion compressor recipes
                         {
-                            GT_Values.RA.addImplosionRecipe(
-                                GT_Utility.copyAmount(3L, aStack),
-                                8,
-                                GT_OreDictUnificator.get(OrePrefixes.gemFlawed, aMaterial, 1),
-                                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 2));
+                            if (GT_OreDictUnificator.get(OrePrefixes.gemFlawed, aMaterial, 1) != null) {
+                                GT_Values.RA.stdBuilder()
+                                    .itemInputs(GT_Utility.copyAmount(3L, aStack), ItemList.Block_Powderbarrel.get(16))
+                                    .itemOutputs(
+                                        GT_OreDictUnificator.get(OrePrefixes.gemFlawed, aMaterial, 1),
+                                        GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 2))
+                                    .noFluidInputs()
+                                    .noFluidOutputs()
+                                    .duration(1 * SECONDS)
+                                    .eut(TierEU.RECIPE_LV)
+                                    .addTo(sImplosionRecipes);
+                                GT_Values.RA.stdBuilder()
+                                    .itemInputs(
+                                        GT_Utility.copyAmount(3L, aStack),
+                                        GT_ModHandler.getIC2Item("dynamite", 4, null))
+                                    .itemOutputs(
+                                        GT_OreDictUnificator.get(OrePrefixes.gemFlawed, aMaterial, 1),
+                                        GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 2))
+                                    .noFluidInputs()
+                                    .noFluidOutputs()
+                                    .duration(1 * SECONDS)
+                                    .eut(TierEU.RECIPE_LV)
+                                    .addTo(sImplosionRecipes);
+                                GT_Values.RA.stdBuilder()
+                                    .itemInputs(GT_Utility.copyAmount(3L, aStack), new ItemStack(Blocks.tnt, 8))
+                                    .itemOutputs(
+                                        GT_OreDictUnificator.get(OrePrefixes.gemFlawed, aMaterial, 1),
+                                        GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 2))
+                                    .noFluidInputs()
+                                    .noFluidOutputs()
+                                    .duration(1 * SECONDS)
+                                    .eut(TierEU.RECIPE_LV)
+                                    .addTo(sImplosionRecipes);
+                                GT_Values.RA.stdBuilder()
+                                    .itemInputs(
+                                        GT_Utility.copyAmount(3L, aStack),
+                                        GT_ModHandler.getIC2Item("industrialTnt", 2))
+                                    .itemOutputs(
+                                        GT_OreDictUnificator.get(OrePrefixes.gemFlawed, aMaterial, 1),
+                                        GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 2))
+                                    .noFluidInputs()
+                                    .noFluidOutputs()
+                                    .duration(1 * SECONDS)
+                                    .eut(TierEU.RECIPE_LV)
+                                    .addTo(sImplosionRecipes);
+                            }
                         }
 
                         // Crafting recipes
@@ -408,11 +498,52 @@ public class ProcessingGem implements gregtech.api.interfaces.IOreRecipeRegistra
                     if (aMaterial.mUnificatable && (aMaterial.mMaterialInto == aMaterial)) {
                         // Implosion compressor recipes
                         {
-                            GT_Values.RA.addImplosionRecipe(
-                                GT_Utility.copyAmount(3L, aStack),
-                                8,
-                                GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 1),
-                                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 2));
+                            if (GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 1) != null) {
+                                GT_Values.RA.stdBuilder()
+                                    .itemInputs(GT_Utility.copyAmount(3L, aStack), ItemList.Block_Powderbarrel.get(16))
+                                    .itemOutputs(
+                                        GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 1),
+                                        GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 2))
+                                    .noFluidInputs()
+                                    .noFluidOutputs()
+                                    .duration(1 * SECONDS)
+                                    .eut(TierEU.RECIPE_LV)
+                                    .addTo(sImplosionRecipes);
+                                GT_Values.RA.stdBuilder()
+                                    .itemInputs(
+                                        GT_Utility.copyAmount(3L, aStack),
+                                        GT_ModHandler.getIC2Item("dynamite", 4, null))
+                                    .itemOutputs(
+                                        GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 1),
+                                        GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 2))
+                                    .noFluidInputs()
+                                    .noFluidOutputs()
+                                    .duration(1 * SECONDS)
+                                    .eut(TierEU.RECIPE_LV)
+                                    .addTo(sImplosionRecipes);
+                                GT_Values.RA.stdBuilder()
+                                    .itemInputs(GT_Utility.copyAmount(3L, aStack), new ItemStack(Blocks.tnt, 8))
+                                    .itemOutputs(
+                                        GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 1),
+                                        GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 2))
+                                    .noFluidInputs()
+                                    .noFluidOutputs()
+                                    .duration(1 * SECONDS)
+                                    .eut(TierEU.RECIPE_LV)
+                                    .addTo(sImplosionRecipes);
+                                GT_Values.RA.stdBuilder()
+                                    .itemInputs(
+                                        GT_Utility.copyAmount(3L, aStack),
+                                        GT_ModHandler.getIC2Item("industrialTnt", 2))
+                                    .itemOutputs(
+                                        GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 1),
+                                        GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 2))
+                                    .noFluidInputs()
+                                    .noFluidOutputs()
+                                    .duration(1 * SECONDS)
+                                    .eut(TierEU.RECIPE_LV)
+                                    .addTo(sImplosionRecipes);
+                            }
                         }
 
                         // Crafting recipes
@@ -486,11 +617,52 @@ public class ProcessingGem implements gregtech.api.interfaces.IOreRecipeRegistra
                     if (aMaterial.mUnificatable && (aMaterial.mMaterialInto == aMaterial)) {
                         // Implosion compressor recipes
                         {
-                            GT_Values.RA.addImplosionRecipe(
-                                GT_Utility.copyAmount(3L, aStack),
-                                8,
-                                GT_OreDictUnificator.get(OrePrefixes.gemExquisite, aMaterial, 1),
-                                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 2));
+                            if (GT_OreDictUnificator.get(OrePrefixes.gemExquisite, aMaterial, 1) != null) {
+                                GT_Values.RA.stdBuilder()
+                                    .itemInputs(GT_Utility.copyAmount(3L, aStack), ItemList.Block_Powderbarrel.get(16))
+                                    .itemOutputs(
+                                        GT_OreDictUnificator.get(OrePrefixes.gemExquisite, aMaterial, 1),
+                                        GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 2))
+                                    .noFluidInputs()
+                                    .noFluidOutputs()
+                                    .duration(1 * SECONDS)
+                                    .eut(TierEU.RECIPE_LV)
+                                    .addTo(sImplosionRecipes);
+                                GT_Values.RA.stdBuilder()
+                                    .itemInputs(
+                                        GT_Utility.copyAmount(3L, aStack),
+                                        GT_ModHandler.getIC2Item("dynamite", 4, null))
+                                    .itemOutputs(
+                                        GT_OreDictUnificator.get(OrePrefixes.gemExquisite, aMaterial, 1),
+                                        GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 2))
+                                    .noFluidInputs()
+                                    .noFluidOutputs()
+                                    .duration(1 * SECONDS)
+                                    .eut(TierEU.RECIPE_LV)
+                                    .addTo(sImplosionRecipes);
+                                GT_Values.RA.stdBuilder()
+                                    .itemInputs(GT_Utility.copyAmount(3L, aStack), new ItemStack(Blocks.tnt, 8))
+                                    .itemOutputs(
+                                        GT_OreDictUnificator.get(OrePrefixes.gemExquisite, aMaterial, 1),
+                                        GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 2))
+                                    .noFluidInputs()
+                                    .noFluidOutputs()
+                                    .duration(1 * SECONDS)
+                                    .eut(TierEU.RECIPE_LV)
+                                    .addTo(sImplosionRecipes);
+                                GT_Values.RA.stdBuilder()
+                                    .itemInputs(
+                                        GT_Utility.copyAmount(3L, aStack),
+                                        GT_ModHandler.getIC2Item("industrialTnt", 2))
+                                    .itemOutputs(
+                                        GT_OreDictUnificator.get(OrePrefixes.gemExquisite, aMaterial, 1),
+                                        GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 2))
+                                    .noFluidInputs()
+                                    .noFluidOutputs()
+                                    .duration(1 * SECONDS)
+                                    .eut(TierEU.RECIPE_LV)
+                                    .addTo(sImplosionRecipes);
+                            }
                         }
 
                         // Crafting recipes

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingLens.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingLens.java
@@ -15,6 +15,7 @@ import gregtech.api.enums.TierEU;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GT_OreDictUnificator;
+import gregtech.api.util.GT_RecipeBuilder;
 
 public class ProcessingLens implements gregtech.api.interfaces.IOreRecipeRegistrator {
 
@@ -61,24 +62,32 @@ public class ProcessingLens implements gregtech.api.interfaces.IOreRecipeRegistr
             }
             default -> {
                 if (GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L) != null) {
-                    GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L))
-                        .itemOutputs(
+                    GT_RecipeBuilder recipeBuilder = GT_Values.RA.stdBuilder();
+                    recipeBuilder.itemInputs(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L));
+                    if (GT_OreDictUnificator.get(OrePrefixes.dustSmall, aMaterial, 1L) == null) {
+                        recipeBuilder.itemOutputs(GT_OreDictUnificator.get(OrePrefixes.lens, aMaterial, 1L));
+                    } else {
+                        recipeBuilder.itemOutputs(
                             GT_OreDictUnificator.get(OrePrefixes.lens, aMaterial, 1L),
-                            GT_OreDictUnificator.get(OrePrefixes.dustSmall, aMaterial, 1L))
-                        .noFluidInputs()
+                            GT_OreDictUnificator.get(OrePrefixes.dustSmall, aMaterial, 1L));
+                    }
+                    recipeBuilder.noFluidInputs()
                         .noFluidOutputs()
                         .duration(1 * MINUTES)
                         .eut(TierEU.RECIPE_MV)
                         .addTo(sLatheRecipes);
                 }
                 if (GT_OreDictUnificator.get(OrePrefixes.gemExquisite, aMaterial, 1L) != null) {
-                    GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_OreDictUnificator.get(OrePrefixes.gemExquisite, aMaterial, 1L))
-                        .itemOutputs(
+                    GT_RecipeBuilder recipeBuilder = GT_Values.RA.stdBuilder();
+                    recipeBuilder.itemInputs(GT_OreDictUnificator.get(OrePrefixes.gemExquisite, aMaterial, 1L));
+                    if (GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial, 1L) == null) {
+                        recipeBuilder.itemOutputs(GT_OreDictUnificator.get(OrePrefixes.lens, aMaterial, 1L));
+                    } else {
+                        recipeBuilder.itemOutputs(
                             GT_OreDictUnificator.get(OrePrefixes.lens, aMaterial, 1L),
-                            GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial, 2L))
-                        .noFluidInputs()
+                            GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial, 2L));
+                    }
+                    recipeBuilder.noFluidInputs()
                         .noFluidOutputs()
                         .duration(2 * MINUTES)
                         .eut(TierEU.RECIPE_LV)

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingRecycling.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingRecycling.java
@@ -10,6 +10,7 @@ import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.enums.SubTag;
 import gregtech.api.util.GT_OreDictUnificator;
+import gregtech.api.util.GT_RecipeBuilder;
 import gregtech.api.util.GT_Utility;
 
 public class ProcessingRecycling implements gregtech.api.interfaces.IOreRecipeRegistrator {
@@ -26,12 +27,17 @@ public class ProcessingRecycling implements gregtech.api.interfaces.IOreRecipeRe
         if ((aMaterial != Materials.Empty) && (GT_Utility.getFluidForFilledItem(aStack, true) == null)
             && !aMaterial.contains(SubTag.SMELTING_TO_FLUID)
             && (GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial, 1L) != null)) {
-            GT_Values.RA.stdBuilder()
-                .itemInputs(aStack)
-                .itemOutputs(
+            GT_RecipeBuilder recipeBuilder = GT_Values.RA.stdBuilder();
+            recipeBuilder.itemInputs(aStack);
+            if (GT_Utility.getContainerItem(aStack, true) == null) {
+                recipeBuilder.itemOutputs(
+                    GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial, aPrefix.mMaterialAmount / 3628800L));
+            } else {
+                recipeBuilder.itemOutputs(
                     GT_Utility.getContainerItem(aStack, true),
-                    GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial, aPrefix.mMaterialAmount / 3628800L))
-                .noFluidInputs()
+                    GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial, aPrefix.mMaterialAmount / 3628800L));
+            }
+            recipeBuilder.noFluidInputs()
                 .noFluidOutputs()
                 .duration(((int) Math.max(aMaterial.getMass() / 2L, 1L)) * TICKS)
                 .eut(2)

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingRound.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingRound.java
@@ -1,5 +1,8 @@
 package gregtech.loaders.oreprocessing;
 
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sLatheRecipes;
+import static gregtech.api.util.GT_RecipeBuilder.TICKS;
+
 import net.minecraft.item.ItemStack;
 
 import appeng.core.Api;
@@ -23,12 +26,17 @@ public class ProcessingRound implements gregtech.api.interfaces.IOreRecipeRegist
     public void registerOre(OrePrefixes aPrefix, Materials aMaterial, String aOreDictName, String aModName,
         ItemStack aStack) {
         if (!aMaterial.contains(SubTag.NO_WORKING)) {
-            GT_Values.RA.addLatheRecipe(
-                GT_OreDictUnificator.get(OrePrefixes.nugget, aMaterial, 1L),
-                GT_Utility.copyAmount(1L, aStack),
-                null,
-                (int) Math.max(aMaterial.getMass() / 4L, 1L),
-                8);
+            if (GT_OreDictUnificator.get(OrePrefixes.nugget, aMaterial, 1L) != null) {
+                GT_Values.RA.stdBuilder()
+                    .itemInputs(GT_OreDictUnificator.get(OrePrefixes.nugget, aMaterial, 1L))
+                    .itemOutputs(GT_Utility.copyAmount(1L, aStack))
+                    .noFluidInputs()
+                    .noFluidOutputs()
+                    .duration(((int) Math.max(aMaterial.getMass() / 4L, 1L)) * TICKS)
+                    .eut(8)
+                    .addTo(sLatheRecipes);
+            }
+
             if ((aMaterial.mUnificatable) && (aMaterial.mMaterialInto == aMaterial)) {
                 GT_ModHandler.addCraftingRecipe(
                     GT_OreDictUnificator.get(OrePrefixes.round, aMaterial, 1L),

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingSaplings.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingSaplings.java
@@ -1,7 +1,10 @@
 package gregtech.loaders.oreprocessing;
 
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCompressorRecipes;
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sLatheRecipes;
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sMaceratorRecipes;
 import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
+import static gregtech.api.util.GT_RecipeBuilder.TICKS;
 
 import net.minecraft.item.ItemStack;
 
@@ -21,12 +24,14 @@ public class ProcessingSaplings implements gregtech.api.interfaces.IOreRecipeReg
     @Override
     public void registerOre(OrePrefixes aPrefix, Materials aMaterial, String aOreDictName, String aModName,
         ItemStack aStack) {
-        GT_Values.RA.addPulveriserRecipe(
-            GT_Utility.copyAmount(1L, aStack),
-            new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.Wood, 2L) },
-            new int[] { 10000 },
-            100,
-            2);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(GT_Utility.copyAmount(1L, aStack))
+            .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.Wood, 2L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(20 * SECONDS)
+            .eut(2)
+            .addTo(sMaceratorRecipes);
 
         GT_Values.RA.stdBuilder()
             .itemInputs(GT_Utility.copyAmount(8L, aStack))
@@ -37,11 +42,15 @@ public class ProcessingSaplings implements gregtech.api.interfaces.IOreRecipeReg
             .eut(2)
             .addTo(sCompressorRecipes);
 
-        GT_Values.RA.addLatheRecipe(
-            GT_Utility.copyAmount(1L, aStack),
-            GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1L),
-            GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Wood, 1L),
-            16,
-            8);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(GT_Utility.copyAmount(1L, aStack))
+            .itemOutputs(
+                GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1L),
+                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Wood, 1L))
+            .noFluidInputs()
+            .noFluidOutputs()
+            .duration(16 * TICKS)
+            .eut(8)
+            .addTo(sLatheRecipes);
     }
 }

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingScrew.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingScrew.java
@@ -1,5 +1,7 @@
 package gregtech.loaders.oreprocessing;
 
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sLatheRecipes;
+import static gregtech.api.util.GT_RecipeBuilder.TICKS;
 import static gregtech.api.util.GT_Utility.calculateRecipeEU;
 
 import net.minecraft.item.ItemStack;
@@ -20,12 +22,16 @@ public class ProcessingScrew implements gregtech.api.interfaces.IOreRecipeRegist
     public void registerOre(OrePrefixes aPrefix, Materials aMaterial, String aOreDictName, String aModName,
         ItemStack aStack) {
         if (!aMaterial.contains(SubTag.NO_WORKING)) {
-            GT_Values.RA.addLatheRecipe(
-                GT_OreDictUnificator.get(OrePrefixes.bolt, aMaterial, 1L),
-                GT_Utility.copyAmount(1L, aStack),
-                null,
-                (int) Math.max(aMaterial.getMass() / 8L, 1L),
-                calculateRecipeEU(aMaterial, 4));
+            if (GT_OreDictUnificator.get(OrePrefixes.bolt, aMaterial, 1L) != null) {
+                GT_Values.RA.stdBuilder()
+                    .itemInputs(GT_OreDictUnificator.get(OrePrefixes.bolt, aMaterial, 1L))
+                    .itemOutputs(GT_Utility.copyAmount(1L, aStack))
+                    .noFluidInputs()
+                    .noFluidOutputs()
+                    .duration(((int) Math.max(aMaterial.getMass() / 8L, 1L)) * TICKS)
+                    .eut(calculateRecipeEU(aMaterial, 4))
+                    .addTo(sLatheRecipes);
+            }
             if ((aMaterial.mUnificatable) && (aMaterial.mMaterialInto == aMaterial))
                 if (aMaterial.getProcessingMaterialTierEU() < TierEU.IV) {
                     GT_ModHandler.addCraftingRecipe(

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingToolHead.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingToolHead.java
@@ -1,9 +1,12 @@
 package gregtech.loaders.oreprocessing;
 
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAssemblerRecipes;
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sExtruderRecipes;
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sFluidSolidficationRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sPressRecipes;
 import static gregtech.api.util.GT_RecipeBuilder.MINUTES;
 import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
+import static gregtech.api.util.GT_RecipeBuilder.TICKS;
 import static gregtech.api.util.GT_Utility.calculateRecipeEU;
 
 import net.minecraft.item.ItemStack;
@@ -50,12 +53,14 @@ public class ProcessingToolHead implements gregtech.api.interfaces.IOreRecipeReg
             case toolHeadArrow -> {
                 if (aMaterial.mStandardMoltenFluid != null)
                     if (!(aMaterial == Materials.AnnealedCopper || aMaterial == Materials.WroughtIron)) {
-                        GT_Values.RA.addFluidSolidifierRecipe(
-                            ItemList.Shape_Mold_Arrow.get(0L),
-                            aMaterial.getMolten(36L),
-                            GT_Utility.copyAmount(1L, aStack),
-                            16,
-                            4);
+                        GT_Values.RA.stdBuilder()
+                            .itemInputs(ItemList.Shape_Mold_Arrow.get(0L))
+                            .itemOutputs(GT_Utility.copyAmount(1L, aStack))
+                            .fluidInputs(aMaterial.getMolten(36L))
+                            .noFluidOutputs()
+                            .duration(16 * TICKS)
+                            .eut(8)
+                            .addTo(sFluidSolidficationRecipes);
                     }
                 if (aSpecialRecipeReq2) {
                     GT_ModHandler.addCraftingRecipe(
@@ -74,15 +79,25 @@ public class ProcessingToolHead implements gregtech.api.interfaces.IOreRecipeReg
                     GT_MetaGenerated_Tool_01.INSTANCE
                         .getToolWithStats(GT_MetaGenerated_Tool_01.AXE, 1, aMaterial, aMaterial.mHandleMaterial, null),
                     new Object[] { aOreDictName, OrePrefixes.stick.get(aMaterial.mHandleMaterial) });
-                GT_Values.RA.addAssemblerRecipe(
-                    new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial.mHandleMaterial, 1L),
-                        GT_OreDictUnificator.get(OrePrefixes.toolHeadAxe, aMaterial, 1L),
-                        GT_Utility.getIntegratedCircuit(2) },
-                    GT_Values.NF,
-                    GT_MetaGenerated_Tool_01.INSTANCE
-                        .getToolWithStats(GT_MetaGenerated_Tool_01.AXE, 1, aMaterial, aMaterial.mHandleMaterial, null),
-                    200,
-                    120);
+                if (GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial.mHandleMaterial, 1L) != null) {
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(
+                            GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial.mHandleMaterial, 1L),
+                            GT_OreDictUnificator.get(OrePrefixes.toolHeadAxe, aMaterial, 1L),
+                            GT_Utility.getIntegratedCircuit(2))
+                        .itemOutputs(
+                            GT_MetaGenerated_Tool_01.INSTANCE.getToolWithStats(
+                                GT_MetaGenerated_Tool_01.AXE,
+                                1,
+                                aMaterial,
+                                aMaterial.mHandleMaterial,
+                                null))
+                        .noFluidInputs()
+                        .noFluidOutputs()
+                        .duration(10 * SECONDS)
+                        .eut(TierEU.RECIPE_MV)
+                        .addTo(sAssemblerRecipes);
+                }
                 if (aSpecialRecipeReq1) GT_ModHandler.addCraftingRecipe(
                     GT_OreDictUnificator.get(OrePrefixes.toolHeadAxe, aMaterial, 1L),
                     GT_Proxy.tBits,
@@ -505,21 +520,27 @@ public class ProcessingToolHead implements gregtech.api.interfaces.IOreRecipeReg
                         GT_Proxy.tBits,
                         new Object[] { "XSX", "XSX", "ShS", 'X', OrePrefixes.plate.get(aMaterial), 'S',
                             OrePrefixes.plate.get(Materials.Steel) });
-                    if (aMaterial.getMolten(1) != null) {
-                        GT_Values.RA.addFluidSolidifierRecipe(
-                            ItemList.Shape_Mold_ToolHeadDrill.get(0),
-                            aMaterial.getMolten(144 * 4),
-                            GT_OreDictUnificator.get(OrePrefixes.toolHeadDrill, aMaterial, 1L),
-                            5 * 20,
-                            calculateRecipeEU(aMaterial, (int) GT_Values.VP[2]));
+                    if (aMaterial.mStandardMoltenFluid != null) {
+                        GT_Values.RA.stdBuilder()
+                            .itemInputs(ItemList.Shape_Mold_ToolHeadDrill.get(0))
+                            .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.toolHeadDrill, aMaterial, 1L))
+                            .fluidInputs(aMaterial.getMolten(144 * 4))
+                            .noFluidOutputs()
+                            .duration(5 * SECONDS)
+                            .eut(calculateRecipeEU(aMaterial, (int) TierEU.RECIPE_MV))
+                            .addTo(sFluidSolidficationRecipes);
                     }
-                    if (aMaterial.getIngots(1) != null) {
-                        GT_Values.RA.addExtruderRecipe(
-                            aMaterial.getIngots(4),
-                            ItemList.Shape_Extruder_ToolHeadDrill.get(0),
-                            GT_OreDictUnificator.get(OrePrefixes.toolHeadDrill, aMaterial, 1L),
-                            5 * 20,
-                            calculateRecipeEU(aMaterial, (int) GT_Values.VP[2]));
+                    if (GT_OreDictUnificator.get(OrePrefixes.ingot, aMaterial, 1L) != null) {
+                        GT_Values.RA.stdBuilder()
+                            .itemInputs(
+                                GT_OreDictUnificator.get(OrePrefixes.ingot, aMaterial, 4L),
+                                ItemList.Shape_Extruder_ToolHeadDrill.get(0))
+                            .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.toolHeadDrill, aMaterial, 1L))
+                            .noFluidInputs()
+                            .noFluidOutputs()
+                            .duration(5 * SECONDS)
+                            .eut(calculateRecipeEU(aMaterial, (int) TierEU.RECIPE_MV))
+                            .addTo(sExtruderRecipes);
                     }
                 }
             }
@@ -550,15 +571,25 @@ public class ProcessingToolHead implements gregtech.api.interfaces.IOreRecipeReg
                         }
                     }
                 }
-                GT_Values.RA.addAssemblerRecipe(
-                    new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial.mHandleMaterial, 1L),
-                        GT_OreDictUnificator.get(OrePrefixes.toolHeadFile, aMaterial, 1L),
-                        GT_Utility.getIntegratedCircuit(15) },
-                    GT_Values.NF,
-                    GT_MetaGenerated_Tool_01.INSTANCE
-                        .getToolWithStats(GT_MetaGenerated_Tool_01.FILE, 1, aMaterial, aMaterial.mHandleMaterial, null),
-                    200,
-                    calculateRecipeEU(aMaterial, 120));
+                if (GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial.mHandleMaterial, 1L) != null) {
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(
+                            GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial.mHandleMaterial, 1L),
+                            GT_OreDictUnificator.get(OrePrefixes.toolHeadFile, aMaterial, 1L),
+                            GT_Utility.getIntegratedCircuit(15))
+                        .itemOutputs(
+                            GT_MetaGenerated_Tool_01.INSTANCE.getToolWithStats(
+                                GT_MetaGenerated_Tool_01.FILE,
+                                1,
+                                aMaterial,
+                                aMaterial.mHandleMaterial,
+                                null))
+                        .noFluidInputs()
+                        .noFluidOutputs()
+                        .duration(10 * SECONDS)
+                        .eut(calculateRecipeEU(aMaterial, (int) TierEU.RECIPE_MV))
+                        .addTo(sAssemblerRecipes);
+                }
             }
             case toolHeadHoe -> {
                 if (aMaterial.getProcessingMaterialTierEU() < TierEU.IV) {
@@ -571,15 +602,25 @@ public class ProcessingToolHead implements gregtech.api.interfaces.IOreRecipeReg
                             null),
                         new Object[] { aOreDictName, OrePrefixes.stick.get(aMaterial.mHandleMaterial) });
                 }
-                GT_Values.RA.addAssemblerRecipe(
-                    new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial.mHandleMaterial, 1L),
-                        GT_OreDictUnificator.get(OrePrefixes.toolHeadHoe, aMaterial, 1L),
-                        GT_Utility.getIntegratedCircuit(16) },
-                    GT_Values.NF,
-                    GT_MetaGenerated_Tool_01.INSTANCE
-                        .getToolWithStats(GT_MetaGenerated_Tool_01.HOE, 1, aMaterial, aMaterial.mHandleMaterial, null),
-                    200,
-                    calculateRecipeEU(aMaterial, 120));
+                if (GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial.mHandleMaterial, 1L) != null) {
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(
+                            GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial.mHandleMaterial, 1L),
+                            GT_OreDictUnificator.get(OrePrefixes.toolHeadHoe, aMaterial, 1L),
+                            GT_Utility.getIntegratedCircuit(16))
+                        .itemOutputs(
+                            GT_MetaGenerated_Tool_01.INSTANCE.getToolWithStats(
+                                GT_MetaGenerated_Tool_01.HOE,
+                                1,
+                                aMaterial,
+                                aMaterial.mHandleMaterial,
+                                null))
+                        .noFluidInputs()
+                        .noFluidOutputs()
+                        .duration(10 * SECONDS)
+                        .eut(calculateRecipeEU(aMaterial, (int) TierEU.RECIPE_MV))
+                        .addTo(sAssemblerRecipes);
+                }
                 if (aSpecialRecipeReq1) GT_ModHandler.addCraftingRecipe(
                     GT_OreDictUnificator.get(OrePrefixes.toolHeadHoe, aMaterial, 1L),
                     GT_Proxy.tBits,
@@ -613,19 +654,25 @@ public class ProcessingToolHead implements gregtech.api.interfaces.IOreRecipeReg
                         GT_Proxy.tBits,
                         new Object[] { "GGG", "f  ", 'G', OrePrefixes.gem.get(aMaterial) });
                 }
-                GT_Values.RA.addAssemblerRecipe(
-                    new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial.mHandleMaterial, 1L),
-                        GT_OreDictUnificator.get(OrePrefixes.toolHeadPickaxe, aMaterial, 1L),
-                        GT_Utility.getIntegratedCircuit(5) },
-                    GT_Values.NF,
-                    GT_MetaGenerated_Tool_01.INSTANCE.getToolWithStats(
-                        GT_MetaGenerated_Tool_01.PICKAXE,
-                        1,
-                        aMaterial,
-                        aMaterial.mHandleMaterial,
-                        null),
-                    200,
-                    120);
+                if (GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial.mHandleMaterial, 1L) != null) {
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(
+                            GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial.mHandleMaterial, 1L),
+                            GT_OreDictUnificator.get(OrePrefixes.toolHeadPickaxe, aMaterial, 1L),
+                            GT_Utility.getIntegratedCircuit(5))
+                        .itemOutputs(
+                            GT_MetaGenerated_Tool_01.INSTANCE.getToolWithStats(
+                                GT_MetaGenerated_Tool_01.PICKAXE,
+                                1,
+                                aMaterial,
+                                aMaterial.mHandleMaterial,
+                                null))
+                        .noFluidInputs()
+                        .noFluidOutputs()
+                        .duration(10 * SECONDS)
+                        .eut(calculateRecipeEU(aMaterial, (int) TierEU.RECIPE_MV))
+                        .addTo(sAssemblerRecipes);
+                }
             }
             case toolHeadPlow -> {
                 if (aMaterial.getProcessingMaterialTierEU() < TierEU.IV) {
@@ -649,15 +696,25 @@ public class ProcessingToolHead implements gregtech.api.interfaces.IOreRecipeReg
                         GT_Proxy.tBits,
                         new Object[] { "GG", "GG", " f", 'G', OrePrefixes.gem.get(aMaterial) });
                 }
-                GT_Values.RA.addAssemblerRecipe(
-                    new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial.mHandleMaterial, 1L),
-                        GT_OreDictUnificator.get(OrePrefixes.toolHeadPlow, aMaterial, 1L),
-                        GT_Utility.getIntegratedCircuit(6) },
-                    GT_Values.NF,
-                    GT_MetaGenerated_Tool_01.INSTANCE
-                        .getToolWithStats(GT_MetaGenerated_Tool_01.PLOW, 1, aMaterial, aMaterial.mHandleMaterial, null),
-                    200,
-                    calculateRecipeEU(aMaterial, 120));
+                if (GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial.mHandleMaterial, 1L) != null) {
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(
+                            GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial.mHandleMaterial, 1L),
+                            GT_OreDictUnificator.get(OrePrefixes.toolHeadPlow, aMaterial, 1L),
+                            GT_Utility.getIntegratedCircuit(6))
+                        .itemOutputs(
+                            GT_MetaGenerated_Tool_01.INSTANCE.getToolWithStats(
+                                GT_MetaGenerated_Tool_01.PLOW,
+                                1,
+                                aMaterial,
+                                aMaterial.mHandleMaterial,
+                                null))
+                        .noFluidInputs()
+                        .noFluidOutputs()
+                        .duration(10 * SECONDS)
+                        .eut(calculateRecipeEU(aMaterial, (int) TierEU.RECIPE_MV))
+                        .addTo(sAssemblerRecipes);
+                }
             }
             case toolHeadSaw -> {
                 if (aMaterial.getProcessingMaterialTierEU() < TierEU.IV) {
@@ -682,15 +739,25 @@ public class ProcessingToolHead implements gregtech.api.interfaces.IOreRecipeReg
                         GT_Proxy.tBits,
                         new Object[] { "GGf", 'G', OrePrefixes.gem.get(aMaterial) });
                 }
-                GT_Values.RA.addAssemblerRecipe(
-                    new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial.mHandleMaterial, 1L),
-                        GT_OreDictUnificator.get(OrePrefixes.toolHeadSaw, aMaterial, 1L),
-                        GT_Utility.getIntegratedCircuit(7) },
-                    GT_Values.NF,
-                    GT_MetaGenerated_Tool_01.INSTANCE
-                        .getToolWithStats(GT_MetaGenerated_Tool_01.SAW, 1, aMaterial, aMaterial.mHandleMaterial, null),
-                    200,
-                    calculateRecipeEU(aMaterial, 120));
+                if (GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial.mHandleMaterial, 1L) != null) {
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(
+                            GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial.mHandleMaterial, 1L),
+                            GT_OreDictUnificator.get(OrePrefixes.toolHeadSaw, aMaterial, 1L),
+                            GT_Utility.getIntegratedCircuit(7))
+                        .itemOutputs(
+                            GT_MetaGenerated_Tool_01.INSTANCE.getToolWithStats(
+                                GT_MetaGenerated_Tool_01.SAW,
+                                1,
+                                aMaterial,
+                                aMaterial.mHandleMaterial,
+                                null))
+                        .noFluidInputs()
+                        .noFluidOutputs()
+                        .duration(10 * SECONDS)
+                        .eut(calculateRecipeEU(aMaterial, (int) TierEU.RECIPE_MV))
+                        .addTo(sAssemblerRecipes);
+                }
             }
             case toolHeadSense -> {
                 if (aMaterial.getProcessingMaterialTierEU() < TierEU.IV) {
@@ -715,19 +782,25 @@ public class ProcessingToolHead implements gregtech.api.interfaces.IOreRecipeReg
                         GT_Proxy.tBits,
                         new Object[] { "GGG", " f ", "   ", 'G', OrePrefixes.gem.get(aMaterial) });
                 }
-                GT_Values.RA.addAssemblerRecipe(
-                    new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial.mHandleMaterial, 1L),
-                        GT_OreDictUnificator.get(OrePrefixes.toolHeadSense, aMaterial, 1L),
-                        GT_Utility.getIntegratedCircuit(8) },
-                    GT_Values.NF,
-                    GT_MetaGenerated_Tool_01.INSTANCE.getToolWithStats(
-                        GT_MetaGenerated_Tool_01.SENSE,
-                        1,
-                        aMaterial,
-                        aMaterial.mHandleMaterial,
-                        null),
-                    200,
-                    calculateRecipeEU(aMaterial, 120));
+                if (GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial.mHandleMaterial, 1L) != null) {
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(
+                            GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial.mHandleMaterial, 1L),
+                            GT_OreDictUnificator.get(OrePrefixes.toolHeadSense, aMaterial, 1L),
+                            GT_Utility.getIntegratedCircuit(8))
+                        .itemOutputs(
+                            GT_MetaGenerated_Tool_01.INSTANCE.getToolWithStats(
+                                GT_MetaGenerated_Tool_01.SENSE,
+                                1,
+                                aMaterial,
+                                aMaterial.mHandleMaterial,
+                                null))
+                        .noFluidInputs()
+                        .noFluidOutputs()
+                        .duration(10 * SECONDS)
+                        .eut(calculateRecipeEU(aMaterial, (int) TierEU.RECIPE_MV))
+                        .addTo(sAssemblerRecipes);
+                }
             }
             case toolHeadShovel -> {
                 GT_ModHandler.addShapelessCraftingRecipe(
@@ -738,19 +811,25 @@ public class ProcessingToolHead implements gregtech.api.interfaces.IOreRecipeReg
                         aMaterial.mHandleMaterial,
                         null),
                     new Object[] { aOreDictName, OrePrefixes.stick.get(aMaterial.mHandleMaterial) });
-                GT_Values.RA.addAssemblerRecipe(
-                    new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial.mHandleMaterial, 1L),
-                        GT_OreDictUnificator.get(OrePrefixes.toolHeadShovel, aMaterial, 1L),
-                        GT_Utility.getIntegratedCircuit(9) },
-                    GT_Values.NF,
-                    GT_MetaGenerated_Tool_01.INSTANCE.getToolWithStats(
-                        GT_MetaGenerated_Tool_01.SHOVEL,
-                        1,
-                        aMaterial,
-                        aMaterial.mHandleMaterial,
-                        null),
-                    200,
-                    120);
+                if (GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial.mHandleMaterial, 1L) != null) {
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(
+                            GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial.mHandleMaterial, 1L),
+                            GT_OreDictUnificator.get(OrePrefixes.toolHeadShovel, aMaterial, 1L),
+                            GT_Utility.getIntegratedCircuit(9))
+                        .itemOutputs(
+                            GT_MetaGenerated_Tool_01.INSTANCE.getToolWithStats(
+                                GT_MetaGenerated_Tool_01.SHOVEL,
+                                1,
+                                aMaterial,
+                                aMaterial.mHandleMaterial,
+                                null))
+                        .noFluidInputs()
+                        .noFluidOutputs()
+                        .duration(10 * SECONDS)
+                        .eut(calculateRecipeEU(aMaterial, (int) TierEU.RECIPE_MV))
+                        .addTo(sAssemblerRecipes);
+                }
                 if (aSpecialRecipeReq1) GT_ModHandler.addCraftingRecipe(
                     GT_OreDictUnificator.get(OrePrefixes.toolHeadShovel, aMaterial, 1L),
                     GT_Proxy.tBits,
@@ -784,19 +863,25 @@ public class ProcessingToolHead implements gregtech.api.interfaces.IOreRecipeReg
                         GT_Proxy.tBits,
                         new Object[] { " G", "fG", 'G', OrePrefixes.gem.get(aMaterial) });
                 }
-                GT_Values.RA.addAssemblerRecipe(
-                    new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial.mHandleMaterial, 1L),
-                        GT_OreDictUnificator.get(OrePrefixes.toolHeadSword, aMaterial, 1L),
-                        GT_Utility.getIntegratedCircuit(10) },
-                    GT_Values.NF,
-                    GT_MetaGenerated_Tool_01.INSTANCE.getToolWithStats(
-                        GT_MetaGenerated_Tool_01.SWORD,
-                        1,
-                        aMaterial,
-                        aMaterial.mHandleMaterial,
-                        null),
-                    200,
-                    calculateRecipeEU(aMaterial, 120));
+                if (GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial.mHandleMaterial, 1L) != null) {
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(
+                            GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial.mHandleMaterial, 1L),
+                            GT_OreDictUnificator.get(OrePrefixes.toolHeadSword, aMaterial, 1L),
+                            GT_Utility.getIntegratedCircuit(10))
+                        .itemOutputs(
+                            GT_MetaGenerated_Tool_01.INSTANCE.getToolWithStats(
+                                GT_MetaGenerated_Tool_01.SWORD,
+                                1,
+                                aMaterial,
+                                aMaterial.mHandleMaterial,
+                                null))
+                        .noFluidInputs()
+                        .noFluidOutputs()
+                        .duration(10 * SECONDS)
+                        .eut(calculateRecipeEU(aMaterial, (int) TierEU.RECIPE_MV))
+                        .addTo(sAssemblerRecipes);
+                }
             }
             case toolHeadUniversalSpade -> {
                 GT_ModHandler.addShapelessCraftingRecipe(
@@ -804,20 +889,27 @@ public class ProcessingToolHead implements gregtech.api.interfaces.IOreRecipeReg
                         .getToolWithStats(GT_MetaGenerated_Tool_01.UNIVERSALSPADE, 1, aMaterial, aMaterial, null),
                     new Object[] { aOreDictName, OrePrefixes.stick.get(aMaterial), OrePrefixes.screw.get(aMaterial),
                         ToolDictNames.craftingToolScrewdriver });
-                GT_Values.RA.addAssemblerRecipe(
-                    new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial.mHandleMaterial, 1L),
-                        GT_OreDictUnificator.get(OrePrefixes.screw, aMaterial, 1L),
-                        GT_OreDictUnificator.get(OrePrefixes.toolHeadUniversalSpade, aMaterial, 1L),
-                        GT_Utility.getIntegratedCircuit(11) },
-                    GT_Values.NF,
-                    GT_MetaGenerated_Tool_01.INSTANCE.getToolWithStats(
-                        GT_MetaGenerated_Tool_01.UNIVERSALSPADE,
-                        1,
-                        aMaterial,
-                        aMaterial.mHandleMaterial,
-                        null),
-                    200,
-                    120);
+                if (GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial.mHandleMaterial, 1L) != null
+                    && GT_OreDictUnificator.get(OrePrefixes.screw, aMaterial, 1L) != null) {
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(
+                            GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial.mHandleMaterial, 1L),
+                            GT_OreDictUnificator.get(OrePrefixes.screw, aMaterial, 1L),
+                            GT_OreDictUnificator.get(OrePrefixes.toolHeadUniversalSpade, aMaterial, 1L),
+                            GT_Utility.getIntegratedCircuit(11))
+                        .itemOutputs(
+                            GT_MetaGenerated_Tool_01.INSTANCE.getToolWithStats(
+                                GT_MetaGenerated_Tool_01.UNIVERSALSPADE,
+                                1,
+                                aMaterial,
+                                aMaterial.mHandleMaterial,
+                                null))
+                        .noFluidInputs()
+                        .noFluidOutputs()
+                        .duration(10 * SECONDS)
+                        .eut(calculateRecipeEU(aMaterial, (int) TierEU.RECIPE_MV))
+                        .addTo(sAssemblerRecipes);
+                }
                 if (aSpecialRecipeReq2) GT_ModHandler.addCraftingRecipe(
                     GT_OreDictUnificator.get(OrePrefixes.toolHeadUniversalSpade, aMaterial, 1L),
                     GT_Proxy.tBits,
@@ -1071,21 +1163,27 @@ public class ProcessingToolHead implements gregtech.api.interfaces.IOreRecipeReg
                         OrePrefixes.screw.get(Materials.Steel) });
             }
             case toolHeadHammer, toolHeadMallet -> {
-                GT_Values.RA.addAssemblerRecipe(
-                    new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial.mHandleMaterial, 1L),
-                        GT_OreDictUnificator.get(OrePrefixes.toolHeadHammer, aMaterial, 1L),
-                        GT_Utility.getIntegratedCircuit(14) },
-                    GT_Values.NF,
-                    GT_MetaGenerated_Tool_01.INSTANCE.getToolWithStats(
-                        (aMaterial.contains(SubTag.BOUNCY)) || (aMaterial.contains(SubTag.WOOD))
-                            ? GT_MetaGenerated_Tool_01.SOFTMALLET
-                            : GT_MetaGenerated_Tool_01.HARDHAMMER,
-                        1,
-                        aMaterial,
-                        aMaterial.mHandleMaterial,
-                        null),
-                    200,
-                    120);
+                if (GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial.mHandleMaterial, 1L) != null) {
+                    GT_Values.RA.stdBuilder()
+                        .itemInputs(
+                            GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial.mHandleMaterial, 1L),
+                            GT_OreDictUnificator.get(OrePrefixes.toolHeadHammer, aMaterial, 1L),
+                            GT_Utility.getIntegratedCircuit(14))
+                        .itemOutputs(
+                            GT_MetaGenerated_Tool_01.INSTANCE.getToolWithStats(
+                                (aMaterial.contains(SubTag.BOUNCY)) || (aMaterial.contains(SubTag.WOOD))
+                                    ? GT_MetaGenerated_Tool_01.SOFTMALLET
+                                    : GT_MetaGenerated_Tool_01.HARDHAMMER,
+                                1,
+                                aMaterial,
+                                aMaterial.mHandleMaterial,
+                                null))
+                        .noFluidInputs()
+                        .noFluidOutputs()
+                        .duration(10 * SECONDS)
+                        .eut(calculateRecipeEU(aMaterial, (int) TierEU.RECIPE_MV))
+                        .addTo(sAssemblerRecipes);
+                }
                 if ((aMaterial != Materials.Stone) && (aMaterial != Materials.Flint)) {
                     GT_ModHandler.addShapelessCraftingRecipe(
                         GT_MetaGenerated_Tool_01.INSTANCE.getToolWithStats(

--- a/src/main/java/gregtech/loaders/postload/GT_CraftingRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/postload/GT_CraftingRecipeLoader.java
@@ -11,9 +11,6 @@ import java.util.stream.Collectors;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraftforge.fluids.FluidRegistry;
-import net.minecraftforge.fluids.FluidStack;
 
 import gregtech.GT_Mod;
 import gregtech.api.GregTech_API;
@@ -2094,17 +2091,6 @@ public class GT_CraftingRecipeLoader implements Runnable {
         GT_ModHandler.addShapelessCraftingRecipe(
             Materials.Fireclay.getDust(2),
             new Object[] { Materials.Brick.getDust(1), Materials.Clay.getDust(1) });
-
-        ItemStack flask = ItemList.VOLUMETRIC_FLASK.get(1);
-        NBTTagCompound nbtFlask = new NBTTagCompound();
-        nbtFlask.setInteger("Capacity", 1000);
-        flask.setTagCompound(nbtFlask);
-        GT_Values.RA.addFluidSolidifierRecipe(
-            ItemList.Shape_Mold_Ball.get(0),
-            new FluidStack(FluidRegistry.getFluid("molten.borosilicateglass"), 144),
-            flask,
-            44,
-            24);
 
         if (BartWorks.isModLoaded()) {
             GT_ModHandler.addCraftingRecipe(

--- a/src/main/java/gregtech/loaders/postload/chains/GT_NaniteChain.java
+++ b/src/main/java/gregtech/loaders/postload/chains/GT_NaniteChain.java
@@ -5,6 +5,12 @@ import static gregtech.api.enums.Mods.GTPlusPlus;
 import static gregtech.api.enums.Mods.GoodGenerator;
 import static gregtech.api.enums.Mods.NewHorizonsCoreMod;
 import static gregtech.api.util.GT_ModHandler.getModItem;
+import static gregtech.api.util.GT_RecipeBuilder.HOURS;
+import static gregtech.api.util.GT_RecipeBuilder.MINUTES;
+import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
+import static gregtech.api.util.GT_RecipeConstants.AssemblyLine;
+import static gregtech.api.util.GT_RecipeConstants.RESEARCH_ITEM;
+import static gregtech.api.util.GT_RecipeConstants.RESEARCH_TIME;
 
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.Fluid;
@@ -31,31 +37,43 @@ public class GT_NaniteChain {
             ? FluidRegistry.getFluid("molten.indalloy140")
             : FluidRegistry.getFluid("molten.solderingalloy");
 
-        GT_Values.RA.addAssemblylineRecipe(
-            Materials.Carbon.getNanite(1),
-            3600 * 20,
-            new Object[] { ItemList.Hull_UV.get(16), Materials.Carbon.getNanite(16),
-                ItemList.Field_Generator_ZPM.get(16), ItemList.Conveyor_Module_UV.get(16),
-                ItemList.Electric_Motor_UV.get(32), new Object[] { OrePrefixes.circuit.get(Materials.Master), 16 },
-                GT_OreDictUnificator.get(OrePrefixes.wireGt08, Materials.Naquadah, 32) },
-            new FluidStack[] { new FluidStack(solderIndalloy, 144 * 32), Materials.HSSS.getMolten(144L * 32),
-                Materials.Osmiridium.getMolten(144L * 16) },
-            ItemList.NanoForge.get(1),
-            2400 * 20,
-            (int) GT_Values.VP[7]);
+        GT_Values.RA.stdBuilder()
+            .metadata(RESEARCH_ITEM, Materials.Carbon.getNanite(1))
+            .metadata(RESEARCH_TIME, 1 * HOURS)
+            .itemInputs(
+                ItemList.Hull_UV.get(16),
+                Materials.Carbon.getNanite(16),
+                ItemList.Field_Generator_ZPM.get(16),
+                ItemList.Conveyor_Module_UV.get(16),
+                ItemList.Electric_Motor_UV.get(32),
+                new Object[] { OrePrefixes.circuit.get(Materials.Master), 16 },
+                GT_OreDictUnificator.get(OrePrefixes.wireGt08, Materials.Naquadah, 32))
+            .fluidInputs(
+                new FluidStack(solderIndalloy, 144 * 32),
+                Materials.HSSS.getMolten(144L * 32),
+                Materials.Osmiridium.getMolten(144L * 16))
+            .noFluidOutputs()
+            .itemOutputs(ItemList.NanoForge.get(1))
+            .eut(TierEU.RECIPE_ZPM)
+            .duration(40 * MINUTES)
+            .addTo(AssemblyLine);
 
-        GT_Values.RA.addAssemblylineRecipe(
-            ItemList.Circuit_Crystalmainframe.get(1),
-            144000,
-            new Object[] { new Object[] { OrePrefixes.circuit.get(Materials.SuperconductorUHV), 16 },
-                ItemList.Robot_Arm_UV.get(16), ItemList.Circuit_Chip_Stemcell.get(32),
+        GT_Values.RA.stdBuilder()
+            .metadata(RESEARCH_ITEM, ItemList.Circuit_Crystalmainframe.get(1))
+            .metadata(RESEARCH_TIME, 2 * HOURS)
+            .itemInputs(
+                new Object[] { OrePrefixes.circuit.get(Materials.SuperconductorUHV), 16 },
+                ItemList.Robot_Arm_UV.get(16),
+                ItemList.Circuit_Chip_Stemcell.get(32),
                 GT_OreDictUnificator.get(OrePrefixes.ring, Materials.NaquadahAlloy, 32),
                 GT_OreDictUnificator.get(OrePrefixes.stick, Materials.NaquadahAlloy, 16),
-                Materials.Carbon.getDust(64) },
-            new FluidStack[] { Materials.UUMatter.getFluid(10000), new FluidStack(solderIndalloy, 144 * 32) },
-            Materials.Carbon.getNanite(2),
-            50 * 20,
-            (int) GT_Values.VP[8]);
+                Materials.Carbon.getDust(64))
+            .fluidInputs(Materials.UUMatter.getFluid(10000), new FluidStack(solderIndalloy, 144 * 32))
+            .noFluidOutputs()
+            .itemOutputs(Materials.Carbon.getNanite(2))
+            .eut(TierEU.RECIPE_UV)
+            .duration(50 * SECONDS)
+            .addTo(AssemblyLine);
 
         /*
          * General Rules for making nanite recipes: 1. Never make a nanite that takes a long time to make and only gives

--- a/src/main/java/gregtech/loaders/postload/chains/GT_PCBFactoryRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/chains/GT_PCBFactoryRecipes.java
@@ -2,6 +2,8 @@ package gregtech.loaders.postload.chains;
 
 import static gregtech.api.enums.Mods.BartWorks;
 import static gregtech.api.enums.Mods.GTPlusPlus;
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAssemblerRecipes;
+import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -11,7 +13,11 @@ import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 
-import gregtech.api.enums.*;
+import gregtech.api.enums.GT_Values;
+import gregtech.api.enums.ItemList;
+import gregtech.api.enums.Materials;
+import gregtech.api.enums.OrePrefixes;
+import gregtech.api.enums.TierEU;
 import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_OreDictUnificator;
 import gregtech.api.util.GT_PCBFactoryManager;
@@ -40,37 +46,53 @@ public class GT_PCBFactoryRecipes {
             new FluidStack[] { new FluidStack(solderLuV, 144 * 36), Materials.Naquadah.getMolten(144 * 18) },
             ItemList.PCBFactory.get(1),
             6000 * 20,
-            (int) GT_Values.VP[8]);
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.frameGt, Materials.NaquadahAlloy, 1),
-                Materials.get("Artherium-Sn")
-                    .getPlates(6) },
-            null,
-            ItemList.BasicPhotolithographicFrameworkCasing.get(1),
-            30 * 20,
-            (int) GT_Values.VP[7]);
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.frameGt, Materials.Infinity, 1),
-                Materials.EnrichedHolmium.getPlates(6) },
-            null,
-            ItemList.ReinforcedPhotolithographicFrameworkCasing.get(1),
-            30 * 20,
-            (int) GT_Values.VP[9]);
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] { GT_ModHandler.getModItem(GTPlusPlus.ID, "blockFrameGtCelestialTungsten", 1),
-                Materials.get("Quantum")
-                    .getPlates(6) },
-            null,
-            ItemList.RadiationProofPhotolithographicFrameworkCasing.get(1),
-            30 * 20,
-            (int) GT_Values.VP[11]);
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] { GT_ModHandler.getModItem(GTPlusPlus.ID, "blockFrameGtHypogen", 1),
-                GT_OreDictUnificator.get(OrePrefixes.rotor, Materials.Infinity, 2), Materials.Thulium.getPlates(6) },
-            MaterialsUEVplus.SpaceTime.getMolten(144 * 8),
-            ItemList.InfinityCooledCasing.get(1),
-            10 * 20,
-            (int) GT_Values.VP[12]);
+            (int) TierEU.RECIPE_UV);
+
+        if (GTPlusPlus.isModLoaded()) {
+            GT_Values.RA.stdBuilder()
+                .itemInputs(
+                    GT_OreDictUnificator.get(OrePrefixes.frameGt, Materials.NaquadahAlloy, 1),
+                    Materials.get("Artherium-Sn")
+                        .getPlates(6))
+                .itemOutputs(ItemList.BasicPhotolithographicFrameworkCasing.get(1))
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(30 * SECONDS)
+                .eut(TierEU.RECIPE_ZPM)
+                .addTo(sAssemblerRecipes);
+            GT_Values.RA.stdBuilder()
+                .itemInputs(
+                    GT_OreDictUnificator.get(OrePrefixes.frameGt, Materials.Infinity, 1),
+                    Materials.EnrichedHolmium.getPlates(6))
+                .itemOutputs(ItemList.ReinforcedPhotolithographicFrameworkCasing.get(1))
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(30 * SECONDS)
+                .eut(TierEU.RECIPE_UHV)
+                .addTo(sAssemblerRecipes);
+            GT_Values.RA.stdBuilder()
+                .itemInputs(
+                    GT_ModHandler.getModItem(GTPlusPlus.ID, "blockFrameGtCelestialTungsten", 1),
+                    Materials.get("Quantum")
+                        .getPlates(6))
+                .itemOutputs(ItemList.RadiationProofPhotolithographicFrameworkCasing.get(1))
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(30 * SECONDS)
+                .eut(TierEU.RECIPE_UIV)
+                .addTo(sAssemblerRecipes);
+            GT_Values.RA.stdBuilder()
+                .itemInputs(
+                    GT_ModHandler.getModItem(GTPlusPlus.ID, "blockFrameGtHypogen", 1),
+                    GT_OreDictUnificator.get(OrePrefixes.rotor, Materials.Infinity, 2),
+                    Materials.Thulium.getPlates(6))
+                .itemOutputs(ItemList.InfinityCooledCasing.get(1))
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(10 * SECONDS)
+                .eut(TierEU.RECIPE_UMV)
+                .addTo(sAssemblerRecipes);
+        }
 
         // Load CircuitBoard Recipes
 

--- a/src/main/java/gregtech/loaders/postload/chains/GT_PCBFactoryRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/chains/GT_PCBFactoryRecipes.java
@@ -3,7 +3,12 @@ package gregtech.loaders.postload.chains;
 import static gregtech.api.enums.Mods.BartWorks;
 import static gregtech.api.enums.Mods.GTPlusPlus;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAssemblerRecipes;
+import static gregtech.api.util.GT_RecipeBuilder.HOURS;
+import static gregtech.api.util.GT_RecipeBuilder.MINUTES;
 import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
+import static gregtech.api.util.GT_RecipeConstants.AssemblyLine;
+import static gregtech.api.util.GT_RecipeConstants.RESEARCH_ITEM;
+import static gregtech.api.util.GT_RecipeConstants.RESEARCH_TIME;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,16 +42,20 @@ public class GT_PCBFactoryRecipes {
             : FluidRegistry.getFluid("molten.solderingalloy");
 
         // Load Multi Recipes
-        GT_Values.RA.addAssemblylineRecipe(
-            ItemList.Circuit_Board_Wetware.get(1),
-            3600,
-            new Object[] { GT_OreDictUnificator.get(OrePrefixes.frameGt, Materials.Neutronium, 32),
+        GT_Values.RA.stdBuilder()
+            .metadata(RESEARCH_ITEM, ItemList.Circuit_Board_Wetware.get(1))
+            .metadata(RESEARCH_TIME, 3 * MINUTES)
+            .itemInputs(
+                GT_OreDictUnificator.get(OrePrefixes.frameGt, Materials.Neutronium, 32),
                 ItemList.Machine_ZPM_CircuitAssembler.get(4),
-                new Object[] { OrePrefixes.circuit.get(Materials.Master), 16 }, ItemList.Robot_Arm_ZPM.get(8) },
-            new FluidStack[] { new FluidStack(solderLuV, 144 * 36), Materials.Naquadah.getMolten(144 * 18) },
-            ItemList.PCBFactory.get(1),
-            6000 * 20,
-            (int) TierEU.RECIPE_UV);
+                new Object[] { OrePrefixes.circuit.get(Materials.Master), 16 },
+                ItemList.Robot_Arm_ZPM.get(8))
+            .fluidInputs(new FluidStack(solderLuV, 144 * 36), Materials.Naquadah.getMolten(144 * 18))
+            .noFluidOutputs()
+            .itemOutputs(ItemList.PCBFactory.get(1))
+            .eut(TierEU.RECIPE_UV)
+            .duration(1 * HOURS + 40 * MINUTES)
+            .addTo(AssemblyLine);
 
         if (GTPlusPlus.isModLoaded()) {
             GT_Values.RA.stdBuilder()

--- a/src/main/java/gregtech/loaders/postload/recipes/CentrifugeRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/CentrifugeRecipes.java
@@ -1,7 +1,11 @@
 package gregtech.loaders.postload.recipes;
 
-import static gregtech.api.enums.GT_Values.NI;
-import static gregtech.api.enums.Mods.*;
+import static gregtech.api.enums.Mods.AppliedEnergistics2;
+import static gregtech.api.enums.Mods.ExtraUtilities;
+import static gregtech.api.enums.Mods.GregTech;
+import static gregtech.api.enums.Mods.Thaumcraft;
+import static gregtech.api.enums.Mods.ThaumicTinkerer;
+import static gregtech.api.enums.Mods.TwilightForest;
 import static gregtech.api.util.GT_ModHandler.getModItem;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCentrifugeRecipes;
 import static gregtech.api.util.GT_RecipeBuilder.MINUTES;
@@ -13,7 +17,12 @@ import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 
-import gregtech.api.enums.*;
+import gregtech.api.enums.GT_Values;
+import gregtech.api.enums.ItemList;
+import gregtech.api.enums.Materials;
+import gregtech.api.enums.MaterialsOreAlum;
+import gregtech.api.enums.OrePrefixes;
+import gregtech.api.enums.TierEU;
 import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_OreDictUnificator;
 import gregtech.api.util.GT_Utility;
@@ -951,8 +960,7 @@ public class CentrifugeRecipes implements Runnable {
                     getModItem(ExtraUtilities.ID, "greenscreen", 1L, 5),
                     getModItem(ExtraUtilities.ID, "greenscreen", 1L, 4),
                     getModItem(ExtraUtilities.ID, "greenscreen", 1L, 8),
-                    getModItem(ExtraUtilities.ID, "greenscreen", 1L, 0),
-                    NI)
+                    getModItem(ExtraUtilities.ID, "greenscreen", 1L, 0))
                 .noFluidInputs()
                 .noFluidOutputs()
                 .duration(25 * SECONDS + 12 * TICKS)
@@ -968,8 +976,7 @@ public class CentrifugeRecipes implements Runnable {
                     getModItem(ExtraUtilities.ID, "greenscreen", 1L, 9),
                     getModItem(ExtraUtilities.ID, "greenscreen", 1L, 11),
                     getModItem(ExtraUtilities.ID, "greenscreen", 1L, 7),
-                    getModItem(ExtraUtilities.ID, "greenscreen", 1L, 15),
-                    NI)
+                    getModItem(ExtraUtilities.ID, "greenscreen", 1L, 15))
                 .noFluidInputs()
                 .noFluidOutputs()
                 .duration(25 * SECONDS + 12 * TICKS)

--- a/src/main/java/gregtech/loaders/postload/recipes/CropProcessingRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/CropProcessingRecipes.java
@@ -15,6 +15,7 @@ import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.util.GT_OreDictUnificator;
+import gregtech.api.util.GT_RecipeBuilder;
 import gregtech.api.util.GT_Utility;
 
 public class CropProcessingRecipes implements Runnable {
@@ -131,14 +132,19 @@ public class CropProcessingRecipes implements Runnable {
                 : aMaterialOut.mOreByProducts.get(0)
                     .getMolten(144);
 
-            GT_Values.RA.stdBuilder()
+            GT_RecipeBuilder recipeBuilder = GT_Values.RA.stdBuilder();
+            recipeBuilder
                 .itemInputs(
                     GT_Utility.copyAmount(9, tCrop),
                     GT_OreDictUnificator.get(OrePrefixes.crushed, aMaterial, 1))
                 .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.crushedPurified, aMaterial, 4))
-                .fluidInputs(Materials.Water.getFluid(1000))
-                .fluidOutputs(fluidOutputChemReactor)
-                .duration(4 * SECONDS + 16 * TICKS)
+                .fluidInputs(Materials.Water.getFluid(1000));
+            if (fluidOutputChemReactor == null) {
+                recipeBuilder.noFluidOutputs();
+            } else {
+                recipeBuilder.fluidOutputs(fluidOutputChemReactor);
+            }
+            recipeBuilder.duration(4 * SECONDS + 16 * TICKS)
                 .eut(24)
                 .addTo(UniversalChemical);
 

--- a/src/main/java/gregtech/loaders/postload/recipes/FluidSolidifierRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/FluidSolidifierRecipes.java
@@ -11,6 +11,8 @@ import static net.minecraftforge.fluids.FluidRegistry.getFluidStack;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 
 import gregtech.api.GregTech_API;
@@ -45,6 +47,21 @@ public class FluidSolidifierRecipes implements Runnable {
                 .noFluidOutputs()
                 .duration(16 * TICKS)
                 .eut(8)
+                .addTo(sFluidSolidficationRecipes);
+        }
+
+        {
+            ItemStack flask = ItemList.VOLUMETRIC_FLASK.get(1);
+            NBTTagCompound nbtFlask = new NBTTagCompound();
+            nbtFlask.setInteger("Capacity", 1000);
+            flask.setTagCompound(nbtFlask);
+            GT_Values.RA.stdBuilder()
+                .itemInputs(ItemList.Shape_Mold_Ball.get(0))
+                .itemOutputs(getModItem(Thaumcraft.ID, "ItemResource", 1, 3))
+                .fluidInputs(new FluidStack(FluidRegistry.getFluid("molten.borosilicateglass"), 144))
+                .noFluidOutputs()
+                .duration(2 * SECONDS + 4 * TICKS)
+                .eut(TierEU.RECIPE_LV)
                 .addTo(sFluidSolidficationRecipes);
         }
 

--- a/src/main/java/gregtech/loaders/postload/recipes/MixerRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/MixerRecipes.java
@@ -1,7 +1,5 @@
 package gregtech.loaders.postload.recipes;
 
-import static gregtech.api.enums.GT_Values.NF;
-import static gregtech.api.enums.GT_Values.NI;
 import static gregtech.api.enums.Mods.*;
 import static gregtech.api.util.GT_ModHandler.getModItem;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sMixerRecipes;
@@ -1389,10 +1387,10 @@ public class MixerRecipes implements Runnable {
         // radiation manufacturing
 
         GT_Values.RA.stdBuilder()
-            .itemInputs(GT_ModHandler.getIC2Item("fuelRod", 1), new ItemStack(Items.glowstone_dust, 9), NI, NI)
+            .itemInputs(GT_ModHandler.getIC2Item("fuelRod", 1), new ItemStack(Items.glowstone_dust, 9))
             .itemOutputs(ItemList.GlowstoneCell.get(1))
             .fluidInputs(Materials.Helium.getGas(250))
-            .fluidOutputs(NF)
+            .noFluidOutputs()
             .duration(1 * SECONDS + 10 * TICKS)
             .eut(16)
             .addTo(sMixerRecipes);


### PR DESCRIPTION
- convert all lathe recipes
- convert all sapling oredict recipes
- convert all toolhead oredict recipes
- convert all fluid solidification recipes
- convert reverse macerating
- convert comb autoclaving
- convert all implosion compressor recipes
- convert most remaining assembler recipes
- convert all remaining assembling line recipes
- convert last slicer recipe
- a few minor fixes regarding nulls in recipes and other minor recipe fixes
- remove nulls in cell-to-fluid conversion for multiblocks. this cleans up the recipedebug and makes it very easy to spot broken recipes (see other PRs fixing them)