### PR TITLE
Debug for recipe collisions

### DIFF
--- a/src/main/java/gregtech/api/util/GT_Recipe.java
+++ b/src/main/java/gregtech/api/util/GT_Recipe.java
@@ -3763,12 +3763,8 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
                             continue;
                         }
                         String s = iStack.getDisplayName();
-                        if (s == null) {
-                            continue;
-                        }
                         if (hasAnEntry) {
-                            errorInfo.append("+")
-                                .append(s);
+                            errorInfo.append("+" + s);
                         } else {
                             errorInfo.append(s);
                         }

--- a/src/main/java/gregtech/api/util/GT_Recipe.java
+++ b/src/main/java/gregtech/api/util/GT_Recipe.java
@@ -3744,7 +3744,7 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
                     boolean hasAnEntry = false;
                     for (FluidStack fStack : r.mFluidInputs) {
                         if (fStack != null) {
-                            String s = fStack.getUnlocalizedName();
+                            String s = fStack.getLocalizedName();
                             if (s != null) {
                                 if (hasAnEntry) {
                                     errorInfo.append("+")
@@ -3758,7 +3758,7 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
                     }
                     for (ItemStack iStack : r.mInputs) {
                         if (iStack != null) {
-                            String s = iStack.getUnlocalizedName();
+                            String s = iStack.getDisplayName();
                             if (s != null) {
                                 if (hasAnEntry) {
                                     errorInfo.append("+")

--- a/src/main/java/gregtech/api/util/GT_Recipe.java
+++ b/src/main/java/gregtech/api/util/GT_Recipe.java
@@ -3743,18 +3743,20 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
                     StringBuilder errorInfo = new StringBuilder();
                     boolean hasAnEntry = false;
                     for (FluidStack fStack : r.mFluidInputs) {
-                        if (fStack != null) {
-                            String s = fStack.getLocalizedName();
-                            if (s != null) {
-                                if (hasAnEntry) {
-                                    errorInfo.append("+")
-                                        .append(s);
-                                } else {
-                                    errorInfo.append(s);
-                                }
-                                hasAnEntry = true;
-                            }
+                        if (fStack == null) {
+                            continue;
                         }
+                        String s = fStack.getLocalizedName();
+                        if (s == null) {
+                            continue;
+                        }
+                        if (hasAnEntry) {
+                            errorInfo.append("+")
+                                .append(s);
+                        } else {
+                            errorInfo.append(s);
+                        }
+                        hasAnEntry = true;
                     }
                     for (ItemStack iStack : r.mInputs) {
                         if (iStack != null) {

--- a/src/main/java/gregtech/api/util/GT_Recipe.java
+++ b/src/main/java/gregtech/api/util/GT_Recipe.java
@@ -5,6 +5,7 @@ import static gregtech.api.enums.Mods.GTPlusPlus;
 import static gregtech.api.enums.Mods.GregTech;
 import static gregtech.api.enums.Mods.NEICustomDiagrams;
 import static gregtech.api.enums.Mods.Railcraft;
+import static gregtech.api.util.GT_RecipeBuilder.handleRecipeCollision;
 import static gregtech.api.util.GT_RecipeConstants.ADDITIVE_AMOUNT;
 import static gregtech.api.util.GT_RecipeMapUtil.*;
 import static gregtech.api.util.GT_Utility.formatNumbers;
@@ -3738,7 +3739,36 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
                 if (specialHandler != null) r = specialHandler.apply(r);
                 if (r == null) continue;
                 if (checkForCollision
-                    && findRecipe(null, false, true, Long.MAX_VALUE, r.mFluidInputs, r.mInputs) != null) continue;
+                    && findRecipe(null, false, true, Long.MAX_VALUE, r.mFluidInputs, r.mInputs) != null) {
+                    StringBuilder errorInfo = new StringBuilder();
+                    boolean hasAnEntry = false;
+                    for (FluidStack f : r.mFluidInputs) {
+                        String s = f.getUnlocalizedName();
+                        if (s != null) {
+                            if (hasAnEntry) {
+                                errorInfo.append("+")
+                                    .append(s);
+                            } else {
+                                errorInfo.append(s);
+                            }
+                            hasAnEntry = true;
+                        }
+                    }
+                    for (ItemStack f : r.mInputs) {
+                        String s = f.getUnlocalizedName();
+                        if (s != null) {
+                            if (hasAnEntry) {
+                                errorInfo.append("+")
+                                    .append(s);
+                            } else {
+                                errorInfo.append(s);
+                            }
+                            hasAnEntry = true;
+                        }
+                    }
+                    handleRecipeCollision(errorInfo.toString());
+                    continue;
+                }
                 ret.add(add(r));
             }
             if (!ret.isEmpty()) {

--- a/src/main/java/gregtech/api/util/GT_Recipe.java
+++ b/src/main/java/gregtech/api/util/GT_Recipe.java
@@ -3759,18 +3759,20 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
                         hasAnEntry = true;
                     }
                     for (ItemStack iStack : r.mInputs) {
-                        if (iStack != null) {
-                            String s = iStack.getDisplayName();
-                            if (s != null) {
-                                if (hasAnEntry) {
-                                    errorInfo.append("+")
-                                        .append(s);
-                                } else {
-                                    errorInfo.append(s);
-                                }
-                                hasAnEntry = true;
-                            }
+                        if (iStack == null) {
+                            continue;
                         }
+                        String s = iStack.getDisplayName();
+                        if (s == null) {
+                            continue;
+                        }
+                        if (hasAnEntry) {
+                            errorInfo.append("+")
+                                .append(s);
+                        } else {
+                            errorInfo.append(s);
+                        }
+                        hasAnEntry = true;
                     }
                     handleRecipeCollision(errorInfo.toString());
                     continue;

--- a/src/main/java/gregtech/api/util/GT_Recipe.java
+++ b/src/main/java/gregtech/api/util/GT_Recipe.java
@@ -3742,28 +3742,32 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
                     && findRecipe(null, false, true, Long.MAX_VALUE, r.mFluidInputs, r.mInputs) != null) {
                     StringBuilder errorInfo = new StringBuilder();
                     boolean hasAnEntry = false;
-                    for (FluidStack f : r.mFluidInputs) {
-                        String s = f.getUnlocalizedName();
-                        if (s != null) {
-                            if (hasAnEntry) {
-                                errorInfo.append("+")
-                                    .append(s);
-                            } else {
-                                errorInfo.append(s);
+                    for (FluidStack fStack : r.mFluidInputs) {
+                        if (fStack != null) {
+                            String s = fStack.getUnlocalizedName();
+                            if (s != null) {
+                                if (hasAnEntry) {
+                                    errorInfo.append("+")
+                                        .append(s);
+                                } else {
+                                    errorInfo.append(s);
+                                }
+                                hasAnEntry = true;
                             }
-                            hasAnEntry = true;
                         }
                     }
-                    for (ItemStack f : r.mInputs) {
-                        String s = f.getUnlocalizedName();
-                        if (s != null) {
-                            if (hasAnEntry) {
-                                errorInfo.append("+")
-                                    .append(s);
-                            } else {
-                                errorInfo.append(s);
+                    for (ItemStack iStack : r.mInputs) {
+                        if (iStack != null) {
+                            String s = iStack.getUnlocalizedName();
+                            if (s != null) {
+                                if (hasAnEntry) {
+                                    errorInfo.append("+")
+                                        .append(s);
+                                } else {
+                                    errorInfo.append(s);
+                                }
+                                hasAnEntry = true;
                             }
-                            hasAnEntry = true;
                         }
                     }
                     handleRecipeCollision(errorInfo.toString());

--- a/src/main/java/gregtech/api/util/GT_RecipeBuilder.java
+++ b/src/main/java/gregtech/api/util/GT_RecipeBuilder.java
@@ -1,6 +1,14 @@
 package gregtech.api.util;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Function;
 
 import javax.annotation.Nonnull;
@@ -123,6 +131,17 @@ public class GT_RecipeBuilder {
             GT_Log.err.print("null detected in ");
             GT_Log.err.println(componentType);
             new NullPointerException().printStackTrace(GT_Log.err);
+        }
+    }
+
+    public static void handleRecipeCollision(String details) {
+        if (PANIC_MODE) {
+            throw new IllegalArgumentException("Recipe Collision");
+        } else if (DEBUG_MODE) {
+            // place a breakpoint here to catch all these issues
+            GT_Log.err.print("Recipe collision resulting in recipe loss detected with ");
+            GT_Log.err.println(details);
+            new IllegalArgumentException().printStackTrace(GT_Log.err);
         }
     }
 

--- a/src/main/java/gregtech/api/util/GT_RecipeBuilder.java
+++ b/src/main/java/gregtech/api/util/GT_RecipeBuilder.java
@@ -136,6 +136,8 @@ public class GT_RecipeBuilder {
 
     public static void handleRecipeCollision(String details) {
         if (PANIC_MODE) {
+            GT_Log.err.print("Recipe collision resulting in recipe loss detected with ");
+            GT_Log.err.println(details);
             throw new IllegalArgumentException("Recipe Collision");
         } else if (DEBUG_MODE) {
             // place a breakpoint here to catch all these issues

--- a/src/main/java/gregtech/api/util/GT_RecipeBuilder.java
+++ b/src/main/java/gregtech/api/util/GT_RecipeBuilder.java
@@ -135,14 +135,15 @@ public class GT_RecipeBuilder {
     }
 
     public static void handleRecipeCollision(String details) {
+        if (!PANIC_MODE && !DEBUG_MODE) {
+            return;
+        }
+        GT_Log.err.print("Recipe collision resulting in recipe loss detected with ");
+        GT_Log.err.println(details);
         if (PANIC_MODE) {
-            GT_Log.err.print("Recipe collision resulting in recipe loss detected with ");
-            GT_Log.err.println(details);
             throw new IllegalArgumentException("Recipe Collision");
-        } else if (DEBUG_MODE) {
+        } else {
             // place a breakpoint here to catch all these issues
-            GT_Log.err.print("Recipe collision resulting in recipe loss detected with ");
-            GT_Log.err.println(details);
             new IllegalArgumentException().printStackTrace(GT_Log.err);
         }
     }


### PR DESCRIPTION
Adds info to the GT log for recipe collisions when in recipe debug mode. (java arg: -Dgt.recipebuilder.debug=true)