### PR TITLE
Speedup Recycler recipe lookup

### DIFF
--- a/src/main/java/gregtech/api/util/GT_Recipe.java
+++ b/src/main/java/gregtech/api/util/GT_Recipe.java
@@ -5161,13 +5161,12 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
         @Override
         public GT_Recipe findRecipe(IHasWorldObjectAndCoords aTileEntity, GT_Recipe aRecipe, boolean aNotUnificated,
             long aVoltage, FluidStack[] aFluids, ItemStack aSpecialSlot, ItemStack... aInputs) {
-            if (aInputs == null || aInputs.length <= 0 || aInputs[0] == null) return null;
+            if (aInputs == null || aInputs.length == 0 || aInputs[0] == null) return null;
             if (aRecipe != null && aRecipe.isRecipeInputEqual(false, true, aFluids, aInputs)) return aRecipe;
             return new GT_Recipe(
                 false,
                 new ItemStack[] { GT_Utility.copyAmount(1, aInputs[0]) },
-                GT_ModHandler.getRecyclerOutput(GT_Utility.copyAmount(64, aInputs[0]), 0) == null ? null
-                    : new ItemStack[] { ItemList.IC2_Scrap.get(1) },
+                new ItemStack[] { GT_ModHandler.getRecyclerOutput(aInputs[0], 0) },
                 null,
                 new int[] { 1250 },
                 null,
@@ -5179,7 +5178,7 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
 
         @Override
         public boolean containsInput(ItemStack aStack) {
-            return GT_ModHandler.getRecyclerOutput(GT_Utility.copyAmount(64, aStack), 0) != null;
+            return GT_ModHandler.getRecyclerOutput(aStack, 0) != null;
         }
     }
 

--- a/src/main/java/gregtech/api/util/GT_Utility.java
+++ b/src/main/java/gregtech/api/util/GT_Utility.java
@@ -4651,7 +4651,7 @@ public class GT_Utility {
     @AutoValue
     public abstract static class ItemId {
 
-        public static AutoValue_GT_Utility_ItemId create(NBTTagCompound tag) {
+        public static ItemId create(NBTTagCompound tag) {
             return new AutoValue_GT_Utility_ItemId(
                 Item.getItemById(tag.getShort("item")),
                 tag.getShort("meta"),
@@ -4668,12 +4668,25 @@ public class GT_Utility {
             return new AutoValue_GT_Utility_ItemId(itemStack.getItem(), itemStack.getItemDamage(), nbt);
         }
 
+        /** This method copies NBT, as it is mutable. */
+        public static ItemId create(Item item, int metaData, @Nullable NBTTagCompound nbt) {
+            if (nbt != null) {
+                nbt = (NBTTagCompound) nbt.copy();
+            }
+            return new AutoValue_GT_Utility_ItemId(item, metaData, nbt);
+        }
+
         /** This method does not copy NBT in order to save time. Make sure not to mutate it! */
         public static ItemId createNoCopy(ItemStack itemStack) {
             return new AutoValue_GT_Utility_ItemId(
                 itemStack.getItem(),
                 itemStack.getItemDamage(),
                 itemStack.getTagCompound());
+        }
+
+        /** This method does not copy NBT in order to save time. Make sure not to mutate it! */
+        public static ItemId createNoCopy(Item item, int metaData, @Nullable NBTTagCompound nbt) {
+            return new AutoValue_GT_Utility_ItemId(item, metaData, nbt);
         }
 
         protected abstract Item item();


### PR DESCRIPTION
`BasicListRecipeManager#contains` takes `O(n)` where n≈2000, while `HashSet#contains` takes `O(1)`. 
Close https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13491

This PR includes a change to return type of `ItemId#create(NBTTagCompound)`, but none of the addons use this method, so it's effectively backward compatible.