### PR TITLE
Adjust overrides to allow opening machine GUI

### DIFF
--- a/src/main/java/gregtech/api/objects/GT_Cover_None.java
+++ b/src/main/java/gregtech/api/objects/GT_Cover_None.java
@@ -200,12 +200,6 @@ public class GT_Cover_None extends GT_CoverBehavior {
     }
 
     @Override
-    protected boolean isGUIClickableImpl(ForgeDirection side, int aCoverID,
-        ISerializableObject.LegacyCoverData aCoverVariable, ICoverable aTileEntity) {
-        return true;
-    }
-
-    @Override
     protected boolean manipulatesSidedRedstoneOutputImpl(ForgeDirection side, int aCoverID,
         ISerializableObject.LegacyCoverData aCoverVariable, ICoverable aTileEntity) {
         return false;

--- a/src/main/java/gregtech/api/util/GT_CoverBehavior.java
+++ b/src/main/java/gregtech/api/util/GT_CoverBehavior.java
@@ -358,7 +358,7 @@ public abstract class GT_CoverBehavior extends GT_CoverBehaviorBase<ISerializabl
      * If it lets you rightclick the Machine normally
      */
     public boolean isGUIClickable(ForgeDirection side, int aCoverID, int aCoverVariable, ICoverable aTileEntity) {
-        return false;
+        return true;
     }
 
     /**

--- a/src/main/java/gregtech/api/util/GT_CoverBehaviorBase.java
+++ b/src/main/java/gregtech/api/util/GT_CoverBehaviorBase.java
@@ -712,7 +712,7 @@ public abstract class GT_CoverBehaviorBase<T extends ISerializableObject> {
      * If it lets you rightclick the Machine normally
      */
     protected boolean isGUIClickableImpl(ForgeDirection side, int aCoverID, T aCoverVariable, ICoverable aTileEntity) {
-        return false;
+        return true;
     }
 
     /**

--- a/src/main/java/gregtech/common/covers/GT_Cover_Arm.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_Arm.java
@@ -193,6 +193,12 @@ public class GT_Cover_Arm extends GT_CoverBehavior {
         return true;
     }
 
+    @Override
+    protected boolean isGUIClickableImpl(ForgeDirection side, int aCoverID,
+        ISerializableObject.LegacyCoverData aCoverVariable, ICoverable aTileEntity) {
+        return false;
+    }
+
     private void sendMessageToPlayer(EntityPlayer aPlayer, int var) {
         if ((var & EXPORT_MASK) != 0) GT_Utility.sendChatToPlayer(
             aPlayer,

--- a/src/main/java/gregtech/common/covers/GT_Cover_Crafting.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_Crafting.java
@@ -9,6 +9,7 @@ import net.minecraftforge.common.util.ForgeDirection;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.tileentity.ICoverable;
 import gregtech.api.util.GT_CoverBehavior;
+import gregtech.api.util.ISerializableObject;
 
 public class GT_Cover_Crafting extends GT_CoverBehavior {
 
@@ -53,5 +54,11 @@ public class GT_Cover_Crafting extends GT_CoverBehavior {
             aPlayer.openContainer.addCraftingToCrafters((EntityPlayerMP) aPlayer);
         }
         return true;
+    }
+
+    @Override
+    protected boolean isGUIClickableImpl(ForgeDirection side, int aCoverID,
+        ISerializableObject.LegacyCoverData aCoverVariable, ICoverable aTileEntity) {
+        return false;
     }
 }

--- a/src/main/java/gregtech/common/covers/GT_Cover_RedstoneWirelessBase.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_RedstoneWirelessBase.java
@@ -82,6 +82,12 @@ public abstract class GT_Cover_RedstoneWirelessBase extends GT_CoverBehavior {
     }
 
     @Override
+    protected boolean isGUIClickableImpl(ForgeDirection side, int aCoverID,
+        ISerializableObject.LegacyCoverData aCoverVariable, ICoverable aTileEntity) {
+        return false;
+    }
+
+    @Override
     public int onCoverScrewdriverclick(ForgeDirection side, int aCoverID, int aCoverVariable, ICoverable aTileEntity,
         EntityPlayer aPlayer, float aX, float aY, float aZ) {
         if (((aX > 0.375D) && (aX < 0.625D))

--- a/src/main/java/gregtech/common/covers/GT_Cover_SolarPanel.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_SolarPanel.java
@@ -122,6 +122,12 @@ public class GT_Cover_SolarPanel extends GT_CoverBehavior {
     }
 
     @Override
+    protected boolean isGUIClickableImpl(ForgeDirection side, int aCoverID,
+        ISerializableObject.LegacyCoverData aCoverVariable, ICoverable aTileEntity) {
+        return false;
+    }
+
+    @Override
     public boolean alwaysLookConnected(ForgeDirection side, int aCoverID, int aCoverVariable, ICoverable aTileEntity) {
         return true;
     }


### PR DESCRIPTION
Makes covers that have no rightclick behavior open the GUI of the machine its on