### PR TITLE
Fix warnings about ModularUI methods that can only be overridden

### DIFF
--- a/src/main/java/gregtech/common/gui/modularui/widget/DataControllerWidget.java
+++ b/src/main/java/gregtech/common/gui/modularui/widget/DataControllerWidget.java
@@ -25,7 +25,7 @@ import gregtech.api.util.ISerializableObject;
  * This widget wraps data and handles validation, e.g. tell client to close GUI when tile is broken or cover is removed.
  * <br>
  * Data can be anything, e.g. {@link ISerializableObject} or machine recipe mode.
- * 
+ *
  * @param <T> Data type stored in this widget
  * @see IDataFollowerWidget
  */
@@ -53,7 +53,6 @@ public abstract class DataControllerWidget<T> extends MultiChildWidget implement
 
     @Override
     public void onPostInit() {
-        super.onPostInit();
         // client _should_ have received initial cover data from `GT_UIInfos#openCoverUI`
         lastData = dataGetter.get();
         if (NetworkUtils.isClient()) {

--- a/src/main/java/gregtech/nei/GT_NEI_DefaultHandler.java
+++ b/src/main/java/gregtech/nei/GT_NEI_DefaultHandler.java
@@ -448,7 +448,6 @@ public class GT_NEI_DefaultHandler extends RecipeMapHandler {
             GlStateManager.popMatrix();
         }
 
-        // noinspection RedundantSuppression //IntelliJ incorrectly thinks that OverrideOnly suppression is redundant
         for (Widget widget : window.getChildren()) {
             // NEI already did translation, so we can't use Widget#drawInternal here
             GlStateManager.pushMatrix();

--- a/src/main/java/gregtech/nei/GT_NEI_DefaultHandler.java
+++ b/src/main/java/gregtech/nei/GT_NEI_DefaultHandler.java
@@ -447,14 +447,19 @@ public class GT_NEI_DefaultHandler extends RecipeMapHandler {
             background.draw(Pos2d.ZERO, window.getSize(), 0);
             GlStateManager.popMatrix();
         }
+
+        // noinspection RedundantSuppression //IntelliJ incorrectly thinks that OverrideOnly suppression is redundant
         for (Widget widget : window.getChildren()) {
             // NEI already did translation, so we can't use Widget#drawInternal here
             GlStateManager.pushMatrix();
             GlStateManager.translate(widget.getPos().x, widget.getPos().y, 0);
             GlStateManager.color(1, 1, 1, window.getAlpha());
             GlStateManager.enableBlend();
+
             // maybe we can use Minecraft#timer but none of the IDrawables use partialTicks
             widget.drawBackground(0);
+
+            // noinspection OverrideOnly // It's either suppressing this warning or changing ModularUI
             widget.draw(0);
             GlStateManager.popMatrix();
         }


### PR DESCRIPTION
A call of `super.onPostInit()` was safely deleted because it is empty for `DataControllerWidget` and is labeled as `OverrideOnly` in `super`.

A call of `draw()` is legit because it is implied that actually the children of the `Widget` class are called, but `Widget::draw()` is labeled as `OverrideOnly` in ModularUI, so IntelliJ considers it incorrect to call `draw()`.  
This warning was suppressed. On top of that, IntelliJ incorrectly says that this suppression is redundant, so that was addressed too.

From one side, it can be argued that piling suppressions on the code reduces readability.  
From the other side, having thousands unaddressed warnings in the project is bound to backfire spectacularly.  
I chose to address the second concern. It's up to the reviewers to judge whether my choice is correct.

Fixing the issue without suppressing the warning entails changing the architecture of ModularUI, which is too much work for one warning.

The blank lines were added to improve readability.

The whitespace change is done by Spotless, although it did not detect the problem before the changes to the file.