### PR TITLE
Refactor checkExoticAndNormalEnergyHatches

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -66,4 +66,5 @@ dependencies {
 
     testImplementation(platform('org.junit:junit-bom:5.9.2'))
     testImplementation('org.junit.jupiter:junit-jupiter')
+    testImplementation("org.mockito:mockito-core:3.+")
 }

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
@@ -1506,7 +1506,7 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
             return false;
         }
 
-        if (mExoticEnergyHatches.size() >= 1) {
+        if (!mExoticEnergyHatches.isEmpty()) {
             if (!mEnergyHatches.isEmpty()) {
                 return false;
             }
@@ -1516,11 +1516,7 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
             }
         }
 
-        if (mEnergyHatches.size() > 2) {
-            return false;
-        }
-
-        return true;
+        return mEnergyHatches.size() <= 2;
     }
 
     /**

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
@@ -25,6 +25,7 @@ import net.minecraftforge.common.util.Constants;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.FluidStack;
 
+import org.jetbrains.annotations.TestOnly;
 import org.lwjgl.input.Keyboard;
 
 import com.google.common.collect.Iterables;
@@ -96,7 +97,7 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
     public ArrayList<GT_MetaTileEntity_Hatch_Muffler> mMufflerHatches = new ArrayList<>();
     public ArrayList<GT_MetaTileEntity_Hatch_Energy> mEnergyHatches = new ArrayList<>();
     public ArrayList<GT_MetaTileEntity_Hatch_Maintenance> mMaintenanceHatches = new ArrayList<>();
-    protected final List<GT_MetaTileEntity_Hatch> mExoticEnergyHatches = new ArrayList<>();
+    protected List<GT_MetaTileEntity_Hatch> mExoticEnergyHatches = new ArrayList<>();
     @SideOnly(Side.CLIENT)
     protected GT_SoundLoop activitySoundLoop;
 
@@ -1916,5 +1917,15 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
         button.addTooltip(StatCollector.translateToLocal("GT5U.gui.button.lock_recipe"))
             .setTooltipShowUpDelay(TOOLTIP_DELAY);
         return (ButtonWidget) button;
+    }
+
+    @TestOnly
+    protected void setEnergyHatches(ArrayList<GT_MetaTileEntity_Hatch_Energy> EnergyHatches) {
+        this.mEnergyHatches = EnergyHatches;
+    }
+
+    @TestOnly
+    protected void setExoticEnergyHatches(List<GT_MetaTileEntity_Hatch> ExoticEnergyHatches) {
+        this.mExoticEnergyHatches = ExoticEnergyHatches;
     }
 }

--- a/src/test/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBaseTest.java
+++ b/src/test/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBaseTest.java
@@ -1,0 +1,46 @@
+package gregtech.api.metatileentity.implementations;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Answers;
+import org.mockito.Mockito;
+
+/**
+ * Tests some functions of {@link GT_MetaTileEntity_MultiBlockBase}.
+ * <p>
+ * The classes and tests are non-public because JUnit5
+ * <a href="https://junit.org/junit5/docs/snapshot/user-guide/#writing-tests-classes-and-methods">recommends</a>
+ * to omit the {@code public} modifier.
+ */
+@SuppressWarnings("NewClassNamingConvention") /*
+                                               * The name of the original class does not fit the convention,
+                                               * but refactoring that is a story for another time.
+                                               */
+class GT_MetaTileEntity_MultiBlockBaseTest {
+
+    @ParameterizedTest
+    @CsvSource({ "0,0,false", "2,0,false", "1,0,true", "1,1,false", "0,1,true", "0,2,true", "0,3,false" })
+    void checkExoticAndNormalEnergyHatches_parametrizedTest(int exoticEnergyHatchesCount, int normalEnergyHatchesCount,
+        boolean expectedResult) {
+        GT_MetaTileEntity_MultiBlockBase testedClassInstance = Mockito
+            .mock(GT_MetaTileEntity_MultiBlockBase.class, Answers.CALLS_REAL_METHODS);
+
+        testedClassInstance.setEnergyHatches(fillList(GT_MetaTileEntity_Hatch_Energy.class, normalEnergyHatchesCount));
+        testedClassInstance.setExoticEnergyHatches(fillList(GT_MetaTileEntity_Hatch.class, exoticEnergyHatchesCount));
+
+        assertEquals(expectedResult, testedClassInstance.checkExoticAndNormalEnergyHatches());
+    }
+
+    private <T> ArrayList<T> fillList(Class<T> classData, int returnedListSize) {
+        T objectToInsert = Mockito.mock(classData);
+        ArrayList<T> listToReturn = new ArrayList<>();
+        for (int i = 0; i < returnedListSize; i++) {
+            listToReturn.add(objectToInsert);
+        }
+        return listToReturn;
+    }
+}


### PR DESCRIPTION
After the test was written, it turned out that the function `checkExoticAndNormalEnergyHatches` cannot be simplified much further.

However, as the test was already written, it would be a shame to discard it.