### PR TITLE
Make private fields final where possible

### DIFF
--- a/src/main/java/gregtech/api/enums/MaterialBuilder.java
+++ b/src/main/java/gregtech/api/enums/MaterialBuilder.java
@@ -10,15 +10,15 @@ public class MaterialBuilder {
 
     public static final int DIESEL = 0, GAS = 1, THERMAL = 2, SEMIFLUID = 3, PLASMA = 4, MAGIC = 5;
 
-    private int metaItemSubID;
-    private TextureSet iconSet;
+    private final int metaItemSubID;
+    private final TextureSet iconSet;
     private float toolSpeed = 1.0f;
     private int durability = 0;
     private int toolQuality = 0;
     private int types = 0;
     private int r = 255, g = 255, b = 255, a = 0;
     private String name;
-    private String defaultLocalName;
+    private final String defaultLocalName;
     private int fuelType = 0;
     private int fuelPower = 0;
     private int meltingPoint = 0;

--- a/src/main/java/gregtech/api/gui/GT_GUIScreen.java
+++ b/src/main/java/gregtech/api/gui/GT_GUIScreen.java
@@ -35,7 +35,7 @@ public abstract class GT_GUIScreen extends GuiScreen implements GT_IToolTipRende
     protected ResourceLocation mGUIbackgroundLocation;
 
     private GuiButton selectedButton;
-    private GT_GUIColorOverride colorOverride;
+    private final GT_GUIColorOverride colorOverride;
     private final int textColor;
     private static final String guiTexturePath = "gregtech:textures/gui/GuiCover.png";
 

--- a/src/main/java/gregtech/api/gui/widgets/GT_GuiCoverTabLine.java
+++ b/src/main/java/gregtech/api/gui/widgets/GT_GuiCoverTabLine.java
@@ -30,10 +30,10 @@ public class GT_GuiCoverTabLine extends GT_GuiTabLine {
         "GT5U.interface.coverTabs.north", "GT5U.interface.coverTabs.south", "GT5U.interface.coverTabs.west",
         "GT5U.interface.coverTabs.east" };
 
-    // Not sure there's a point in JIT translation but that's what this is
-    private String[] translatedSides;
-    private IGregTechTileEntity tile;
-    private int colorization;
+    // Not sure if there's a point in JIT translation but that's what this is
+    private final String[] translatedSides;
+    private final IGregTechTileEntity tile;
+    private final int colorization;
 
     /**
      * Let's you access an IGregTechTileEntity's covers as tabs on the GUI's sides

--- a/src/main/java/gregtech/api/gui/widgets/GT_GuiFakeItemButton.java
+++ b/src/main/java/gregtech/api/gui/widgets/GT_GuiFakeItemButton.java
@@ -18,7 +18,7 @@ public class GT_GuiFakeItemButton implements IGuiScreen.IGuiElement {
 
     private GT_GuiIcon bgIcon;
     private ItemStack item;
-    private IGuiScreen gui;
+    private final IGuiScreen gui;
     private int xPosition, yPosition;
     private List<String> itemTooltips;
     private final GT_GuiTooltip tooltip = new GT_GuiTooltip(null) {

--- a/src/main/java/gregtech/api/gui/widgets/GT_GuiIconButton.java
+++ b/src/main/java/gregtech/api/gui/widgets/GT_GuiIconButton.java
@@ -15,7 +15,8 @@ public class GT_GuiIconButton extends GuiButton implements IGuiScreen.IGuiElemen
     public static final int DEFAULT_HEIGHT = 16;
 
     protected GT_GuiIcon icon;
-    private int x0, y0;
+    private final int x0;
+    private final int y0;
     protected IGuiScreen gui;
 
     private GT_GuiTooltip tooltip;

--- a/src/main/java/gregtech/api/gui/widgets/GT_GuiTab.java
+++ b/src/main/java/gregtech/api/gui/widgets/GT_GuiTab.java
@@ -23,12 +23,12 @@ public class GT_GuiTab {
     public boolean visible = true, mousedOver, enabled = true;
 
     private Rectangle bounds;
-    private GT_GuiTabIconSet tabBackground;
-    private ItemStack item;
-    private GT_ITabRenderer gui;
+    private final GT_GuiTabIconSet tabBackground;
+    private final ItemStack item;
+    private final GT_ITabRenderer gui;
     private GT_GuiTooltip tooltip;
-    private IGuiIcon overlay;
-    private boolean flipHorizontally;
+    private final IGuiIcon overlay;
+    private final boolean flipHorizontally;
 
     /**
      * A tab to be attached to a tab line

--- a/src/main/java/gregtech/api/gui/widgets/GT_GuiTabLine.java
+++ b/src/main/java/gregtech/api/gui/widgets/GT_GuiTabLine.java
@@ -40,7 +40,7 @@ public class GT_GuiTabLine {
         NORMAL((byte) 1),
         INVERSE((byte) -1);
 
-        private byte value;
+        private final byte value;
 
         DisplayStyle(byte value) {
             this.value = value;
@@ -75,16 +75,21 @@ public class GT_GuiTabLine {
     // The tabs are arranged according to their index in this array
     protected final GT_GuiTab[] mTabs;
 
-    private int tabLineLeft, tabLineTop, tabHeight, tabWidth, tabSpacing;
+    private final int tabLineLeft;
+    private final int tabLineTop;
+    private final int tabHeight;
+    private final int tabWidth;
+    private final int tabSpacing;
 
     // In which direction to draw the tab line
-    private DisplayStyle xDir, yDir;
+    private final DisplayStyle xDir;
+    private final DisplayStyle yDir;
 
     // Whether to display on the right side of the GT_ITabRenderer instead of left
     protected boolean flipHorizontally, visible;
 
-    private GT_GuiTabIconSet tabBackground;
-    private GT_ITabRenderer gui;
+    private final GT_GuiTabIconSet tabBackground;
+    private final GT_ITabRenderer gui;
 
     /**
      * Draws clickable and configurable tabs on the left or right side of a GT_ITabRenderer

--- a/src/main/java/gregtech/api/metatileentity/TileIC2EnergySink.java
+++ b/src/main/java/gregtech/api/metatileentity/TileIC2EnergySink.java
@@ -15,7 +15,7 @@ import ic2.api.energy.tile.IEnergySink;
 
 public class TileIC2EnergySink extends TileEntity implements IEnergySink {
 
-    private IGregTechTileEntity myMeta;
+    private final IGregTechTileEntity myMeta;
     private GT_MetaPipeEntity_Cable cableMeta = null;
 
     public TileIC2EnergySink(IGregTechTileEntity meta) {

--- a/src/main/java/gregtech/api/objects/GT_ChunkManager.java
+++ b/src/main/java/gregtech/api/objects/GT_ChunkManager.java
@@ -25,7 +25,7 @@ import gregtech.api.util.GT_Log;
 public class GT_ChunkManager
     implements ForgeChunkManager.OrderedLoadingCallback, ForgeChunkManager.PlayerOrderedLoadingCallback {
 
-    private Map<TileEntity, Ticket> registeredTickets = new HashMap<>();
+    private final Map<TileEntity, Ticket> registeredTickets = new HashMap<>();
     public static GT_ChunkManager instance = new GT_ChunkManager();
 
     public static void init() {

--- a/src/main/java/gregtech/api/objects/GT_FluidStack.java
+++ b/src/main/java/gregtech/api/objects/GT_FluidStack.java
@@ -21,7 +21,7 @@ public class GT_FluidStack extends FluidStack {
     private static final Collection<GT_FluidStack> sAllFluidStacks = Collections
         .newSetFromMap(new WeakHashMap<>(10000));
     private static volatile boolean lock = false;
-    private Fluid mFluid;
+    private final Fluid mFluid;
 
     public GT_FluidStack(Fluid aFluid, int aAmount) {
         super(aFluid, aAmount);

--- a/src/main/java/gregtech/api/objects/GT_UO_Dimension.java
+++ b/src/main/java/gregtech/api/objects/GT_UO_Dimension.java
@@ -9,7 +9,7 @@ import com.google.common.collect.HashBiMap;
 
 public class GT_UO_Dimension {
 
-    private BiMap<String, GT_UO_Fluid> fFluids;
+    private final BiMap<String, GT_UO_Fluid> fFluids;
     private int maxChance;
     public String Dimension = "null";
 

--- a/src/main/java/gregtech/api/objects/GT_UO_DimensionList.java
+++ b/src/main/java/gregtech/api/objects/GT_UO_DimensionList.java
@@ -11,7 +11,7 @@ public class GT_UO_DimensionList {
 
     private Configuration fConfig;
     private String fCategory;
-    private BiMap<String, GT_UO_Dimension> fDimensionList;
+    private final BiMap<String, GT_UO_Dimension> fDimensionList;
 
     public int[] blackList = new int[0];
 

--- a/src/main/java/gregtech/api/util/GT_AssemblyLineUtils.java
+++ b/src/main/java/gregtech/api/util/GT_AssemblyLineUtils.java
@@ -28,11 +28,11 @@ public class GT_AssemblyLineUtils {
     /**
      * A cache of Recipes using the Output as Key.
      */
-    private static HashMap<GT_ItemStack, GT_Recipe_AssemblyLine> sRecipeCacheByOutput = new HashMap<>();
+    private static final HashMap<GT_ItemStack, GT_Recipe_AssemblyLine> sRecipeCacheByOutput = new HashMap<>();
     /**
      * A cache of Recipes using the Recipe Hash String as Key.
      */
-    private static HashMap<String, GT_Recipe_AssemblyLine> sRecipeCacheByRecipeHash = new HashMap<>();
+    private static final HashMap<String, GT_Recipe_AssemblyLine> sRecipeCacheByRecipeHash = new HashMap<>();
 
     /**
      * Checks the DataStick for deprecated/invalid recipes, updating them as required.

--- a/src/main/java/gregtech/api/util/GT_BaseCrop.java
+++ b/src/main/java/gregtech/api/util/GT_BaseCrop.java
@@ -36,8 +36,8 @@ public class GT_BaseCrop extends CropCard implements ICropCardInfo {
     private int mMaxSize = 0;
     private int mAfterHarvestSize = 0;
     private int mHarvestSize = 0;
-    private int[] mStats = new int[5];
-    private int mGrowthSpeed = 0;
+    private final int[] mStats = new int[5];
+    private final int mGrowthSpeed = 0;
     private ItemStack mDrop = null;
     private ItemStack[] mSpecialDrops = null;
     private Materials mBlock = null;

--- a/src/main/java/gregtech/api/util/GT_ItsNotMyFaultException.java
+++ b/src/main/java/gregtech/api/util/GT_ItsNotMyFaultException.java
@@ -4,7 +4,7 @@ public class GT_ItsNotMyFaultException extends RuntimeException {
 
     private static final long serialVersionUID = -8752778866486460495L;
 
-    private String mError;
+    private final String mError;
 
     public GT_ItsNotMyFaultException(String aError) {
         mError = aError;

--- a/src/main/java/gregtech/api/util/GT_Recipe.java
+++ b/src/main/java/gregtech/api/util/GT_Recipe.java
@@ -3160,7 +3160,11 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
         private int neiTextColorOverride = -1;
 
         private INEISpecialInfoFormatter neiSpecialInfoFormatter;
-        private boolean checkForCollision = true, allowNoInput, allowNoInputFluid, allowNoOutput, allowNoOutputFluid;
+        private final boolean checkForCollision = true;
+        private boolean allowNoInput;
+        private boolean allowNoInputFluid;
+        private boolean allowNoOutput;
+        private boolean allowNoOutputFluid;
         private boolean disableOptimize = false;
         private Function<? super GT_RecipeBuilder, ? extends Iterable<? extends GT_Recipe>> recipeEmitter = this::defaultBuildRecipe;
         private Function<? super GT_Recipe, ? extends GT_Recipe> specialHandler;

--- a/src/main/java/gregtech/common/GT_Pollution.java
+++ b/src/main/java/gregtech/common/GT_Pollution.java
@@ -79,7 +79,7 @@ public class GT_Pollution {
     private boolean blank = true;
     public static int mPlayerPollution;
 
-    private static int POLLUTIONPACKET_MINVALUE = 1000;
+    private static final int POLLUTIONPACKET_MINVALUE = 1000;
 
     private static GT_PollutionEventHandler EVENT_HANDLER;
 

--- a/src/main/java/gregtech/common/items/DropType.java
+++ b/src/main/java/gregtech/common/items/DropType.java
@@ -15,13 +15,13 @@ public enum DropType {
     LAPIS("lapis coolant", true),
     ENDERGOO("ender goo", true);
 
-    private static int[][] colours = new int[][] { { 0x19191B, 0x303032 }, { 0xffc100, 0x00ff11 },
+    private static final int[][] colours = new int[][] { { 0x19191B, 0x303032 }, { 0xffc100, 0x00ff11 },
         { 0x144F5A, 0x2494A2 }, { 0xC11F1F, 0xEBB9B9 }, { 0x872836, 0xB8132C }, { 0xD02001, 0x9C0018 },
         { 0x003366, 0x0066BB }, { 0x1727b1, 0x008ce3 }, { 0xA005E7, 0x161616 }, };
     public boolean showInList;
     public Materials material;
     public int chance;
-    private String name;
+    private final String name;
 
     DropType(String pName, boolean show) {
         this.name = pName;

--- a/src/main/java/gregtech/common/items/GT_MetaGenerated_Item_99.java
+++ b/src/main/java/gregtech/common/items/GT_MetaGenerated_Item_99.java
@@ -49,7 +49,7 @@ public class GT_MetaGenerated_Item_99 extends GT_MetaGenerated_Item {
      * Assignment of metadata IDs: 0 - 999: Molten cells 10_000 - 15_999: Cracked fluid cells (# IDs used is
      * NUM_CRACKED_CELL_TYPES * 1_000; update this if you add any)
      */
-    private BitSet enabled = new BitSet();
+    private final BitSet enabled = new BitSet();
 
     public GT_MetaGenerated_Item_99() {
         super("metaitem.99", (short) (10_000 + NUM_CRACKED_CELL_TYPES * 1_000), (short) 0);

--- a/src/main/java/gregtech/common/items/PollenType.java
+++ b/src/main/java/gregtech/common/items/PollenType.java
@@ -7,11 +7,11 @@ public enum PollenType {
 
     MATRIX("matrix", true);
 
-    private static int[][] colours = new int[][] { { 0x19191B, 0x303032 }, };
+    private static final int[][] colours = new int[][] { { 0x19191B, 0x303032 }, };
     public boolean showInList;
     public Materials material;
     public int chance;
-    private String name;
+    private final String name;
 
     PollenType(String pName, boolean show) {
         this.name = pName;

--- a/src/main/java/gregtech/common/items/PropolisType.java
+++ b/src/main/java/gregtech/common/items/PropolisType.java
@@ -15,13 +15,13 @@ public enum PropolisType {
     Endium("Endium", true),
     Fireessence("Fireessence", true);
 
-    private static int[] colours = new int[] { 0xCC00FA, 0xDCB0E5, 0x9010AD, 0xFFFF00, 0x911ECE, 0x161616, 0xEE053D,
-        0xa0ffff, 0xD41238 };
+    private static final int[] colours = new int[] { 0xCC00FA, 0xDCB0E5, 0x9010AD, 0xFFFF00, 0x911ECE, 0x161616,
+        0xEE053D, 0xa0ffff, 0xD41238 };
 
     public boolean showInList;
     public Materials material;
     public int chance;
-    private String name;
+    private final String name;
 
     PropolisType(String pName, boolean show) {
         this.name = pName;

--- a/src/main/java/gregtech/common/misc/spaceprojects/commands/SP_Command.java
+++ b/src/main/java/gregtech/common/misc/spaceprojects/commands/SP_Command.java
@@ -19,8 +19,9 @@ import gregtech.common.misc.spaceprojects.SpaceProjectManager;
  */
 public class SP_Command extends CommandBase {
 
-    private static Set<Pair<EntityPlayerMP, EntityPlayerMP>> invite = Collections.newSetFromMap(new WeakHashMap<>());
-    private static Set<EntityPlayerMP> confirm = Collections.newSetFromMap(new WeakHashMap<>());
+    private static final Set<Pair<EntityPlayerMP, EntityPlayerMP>> invite = Collections
+        .newSetFromMap(new WeakHashMap<>());
+    private static final Set<EntityPlayerMP> confirm = Collections.newSetFromMap(new WeakHashMap<>());
 
     private static final String INVITE = "invite";
     private static final String ACCEPT = "accept";

--- a/src/main/java/gregtech/common/misc/spaceprojects/enums/SolarSystem.java
+++ b/src/main/java/gregtech/common/misc/spaceprojects/enums/SolarSystem.java
@@ -55,9 +55,9 @@ public enum SolarSystem implements ISpaceBody {
     KuiperBelt(AsteroidBelt),
     NONE(SpaceBodyType.NONE);
 
-    private SpaceBodyType spaceBody;
-    private StarType star;
-    private UITexture texture;
+    private final SpaceBodyType spaceBody;
+    private final StarType star;
+    private final UITexture texture;
 
     SolarSystem(SpaceBodyType aType) {
         this(aType, NotAStar);

--- a/src/main/java/gregtech/common/misc/spaceprojects/enums/StarType.java
+++ b/src/main/java/gregtech/common/misc/spaceprojects/enums/StarType.java
@@ -14,8 +14,8 @@ public enum StarType {
     MClass(0.08, 0.1f),
     NotAStar(0, 0);
 
-    private double solarLuminosity;
-    private float costMultiplier;
+    private final double solarLuminosity;
+    private final float costMultiplier;
 
     StarType(double solarLuminosity, float costMultiplier) {
         this.solarLuminosity = solarLuminosity;

--- a/src/main/java/gregtech/common/render/GT_PollutionRenderer.java
+++ b/src/main/java/gregtech/common/render/GT_PollutionRenderer.java
@@ -31,7 +31,7 @@ public class GT_PollutionRenderer {
     private static GT_ClientPollutionMap pollutionMap;
     private static int playerPollution = 0;
 
-    private static boolean DEBUG = false;
+    private static final boolean DEBUG = false;
 
     // PARTICLES_POLLUTION_START + PARTICLES_POLLUTION_END -> Max Particles
     private static final int PARTICLES_MAX_NUM = 100;

--- a/src/main/java/gregtech/common/tileentities/casings/upgrade/Inventory.java
+++ b/src/main/java/gregtech/common/tileentities/casings/upgrade/Inventory.java
@@ -22,7 +22,7 @@ public class Inventory extends UpgradeCasing {
     public static final int BOTH = 2;
     private String mInventoryName = "inventory";
     private int mInventorySize;
-    private int mType = BOTH;
+    private final int mType = BOTH;
 
     public String getInventoryName() {
         return mInventoryName;

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_PCBFactory.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_PCBFactory.java
@@ -85,8 +85,9 @@ public class GT_MetaTileEntity_PCBFactory extends
     private float mRoughnessMultiplier = 1;
     private int mTier = 1, mSetTier = 1, mUpgradesInstalled = 0, mCurrentParallel = 0, mMaxParallel = 0;
     private boolean mBioUpgrade = false, mBioRotate = false, mOCTier1 = false, mOCTier2 = false;
-    private int[] mBioOffsets = new int[] { -5, -1 }, mOCTier1Offsets = new int[] { 2, -11 },
-        mOCTier2Offsets = new int[] { 2, -11 };
+    private final int[] mBioOffsets = new int[] { -5, -1 };
+    private final int[] mOCTier1Offsets = new int[] { 2, -11 };
+    private final int[] mOCTier2Offsets = new int[] { 2, -11 };
     private GT_MetaTileEntity_Hatch_Input mCoolantInputHatch;
     private static final int mBioRotateBitMap = 0b1000000;
     private static final int mOCTier2BitMap = 0b100000;

--- a/src/main/java/gregtech/common/tools/GT_Tool_Plow.java
+++ b/src/main/java/gregtech/common/tools/GT_Tool_Plow.java
@@ -21,7 +21,7 @@ import gregtech.api.util.GT_ToolHarvestHelper;
 
 public class GT_Tool_Plow extends GT_Tool {
 
-    private ThreadLocal<Object> sIsHarvestingRightNow = new ThreadLocal<>();
+    private final ThreadLocal<Object> sIsHarvestingRightNow = new ThreadLocal<>();
 
     @Override
     public float getNormalDamageAgainstEntity(float aOriginalDamage, Entity aEntity, ItemStack aStack,

--- a/src/main/java/gregtech/common/tools/GT_Tool_Sense.java
+++ b/src/main/java/gregtech/common/tools/GT_Tool_Sense.java
@@ -20,7 +20,7 @@ import gregtech.common.items.behaviors.Behaviour_Sense;
 
 public class GT_Tool_Sense extends GT_Tool {
 
-    private ThreadLocal<Object> sIsHarvestingRightNow = new ThreadLocal<>();
+    private final ThreadLocal<Object> sIsHarvestingRightNow = new ThreadLocal<>();
 
     @Override
     public float getBaseDamage() {

--- a/src/main/java/gregtech/loaders/misc/GT_Bees.java
+++ b/src/main/java/gregtech/loaders/misc/GT_Bees.java
@@ -82,7 +82,7 @@ public class GT_Bees {
 
     private static class AlleleFloat extends Allele implements IAlleleFloat {
 
-        private float value;
+        private final float value;
 
         public AlleleFloat(String id, float val, boolean isDominant) {
             super("gregtech." + id, "gregtech." + id, isDominant);
@@ -98,7 +98,7 @@ public class GT_Bees {
 
     private static class AlleleInteger extends Allele implements IAlleleInteger {
 
-        private int value;
+        private final int value;
 
         public AlleleInteger(String id, int val, boolean isDominant, EnumBeeChromosome c) {
             super("gregtech." + id, "gregtech." + id, isDominant);
@@ -114,7 +114,7 @@ public class GT_Bees {
 
     private static class AlleleArea extends Allele implements IAlleleArea {
 
-        private int[] value;
+        private final int[] value;
 
         public AlleleArea(String id, int rangeXZ, int rangeY, boolean isDominant) {
             super("gregtech." + id, "gregtech." + id, isDominant);

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingOre.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingOre.java
@@ -19,7 +19,7 @@ import gregtech.api.util.GT_Utility;
 
 public class ProcessingOre implements gregtech.api.interfaces.IOreRecipeRegistrator {
 
-    private ArrayList<Materials> mAlreadyListedOres = new ArrayList<>(1000);
+    private final ArrayList<Materials> mAlreadyListedOres = new ArrayList<>(1000);
 
     public ProcessingOre() {
         for (OrePrefixes tPrefix : OrePrefixes.values()) if ((tPrefix.name()

--- a/src/main/java/gregtech/loaders/postload/recipes/AssemblyLineRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/AssemblyLineRecipes.java
@@ -17,8 +17,8 @@ import gregtech.api.util.GT_OreDictUnificator;
 
 public class AssemblyLineRecipes implements Runnable {
 
-    private Fluid solderIndalloy;
-    private Materials LuVMat;
+    private final Fluid solderIndalloy;
+    private final Materials LuVMat;
 
     public AssemblyLineRecipes() {
         solderIndalloy = GTPlusPlus.isModLoaded() ? FluidRegistry.getFluid("molten.indalloy140")


### PR DESCRIPTION
It was tested that the pack successfully launches with this patch.

The `final` keyword is the equivalent of suggesting that if the reassignment of a variable became necessary, its usages need to be checked for potential side-effects because it was previously assigned only once.