### PR TITLE
Make enum fields final where possible

### DIFF
--- a/src/main/java/gregtech/api/enums/Element.java
+++ b/src/main/java/gregtech/api/enums/Element.java
@@ -285,6 +285,8 @@ public enum Element {
     /**
      * Links to every pure Material containing just this Element.
      */
+    // bartworks.system.material.werkstoff_loaders.registration.BridgeMaterialsLoader reassigns it, so no final here
+    @SuppressWarnings("NonFinalFieldInEnum")
     public ArrayList<Materials> mLinkedMaterials = new ArrayList<>();
 
     /**

--- a/src/main/java/gregtech/api/enums/OrePrefixes.java
+++ b/src/main/java/gregtech/api/enums/OrePrefixes.java
@@ -1007,7 +1007,7 @@ public enum OrePrefixes {
     public OrePrefixes mPrefixInto = this;
     public float mHeatDamage = 0.0F; // Negative for Frost Damage
     private final GT_HashSet<GT_ItemStack2> mContainsTestCache = new GT_HashSet<>(512, 0.5f);
-    public static List<OrePrefixes> mPreventableComponents = new LinkedList<>(
+    public static final List<OrePrefixes> mPreventableComponents = new LinkedList<>(
         Arrays.asList(
             OrePrefixes.gem,
             OrePrefixes.ingotHot,

--- a/src/main/java/gregtech/api/enums/TC_Aspects.java
+++ b/src/main/java/gregtech/api/enums/TC_Aspects.java
@@ -64,7 +64,7 @@ public enum TC_Aspects {
      */
     public Object mAspect;
 
-    public int mValue;
+    public final int mValue;
 
     TC_Aspects(int aValue) {
         mValue = aValue;

--- a/src/main/java/gregtech/api/enums/Textures.java
+++ b/src/main/java/gregtech/api/enums/Textures.java
@@ -1649,7 +1649,7 @@ public class Textures {
          * USE casingTexturePages[page] instead of CASING_BLOCKS since it is casingTexturePages[0]
          */
         @Deprecated
-        public static ITexture[] CASING_BLOCKS = new ITexture[128]; // original variable still limited to 128
+        public static final ITexture[] CASING_BLOCKS = new ITexture[128]; // original variable still limited to 128
 
         public static ITexture[][] MACHINE_CASINGS = new ITexture[15][17];
         /**

--- a/src/main/java/gregtech/common/items/CombType.java
+++ b/src/main/java/gregtech/common/items/CombType.java
@@ -211,9 +211,9 @@ public enum CombType {
     _NULL(-1, "INVALIDCOMB", false, Materials._NULL, 0, 0, 0);
 
     public boolean showInList;
-    public ItemComb.Voltage voltage;
-    public Materials material;
-    public int chance;
+    public final ItemComb.Voltage voltage;
+    public final Materials material;
+    public final int chance;
 
     private final int id;
     private final String name;


### PR DESCRIPTION
Non-final enum fields make a global mutable state, which should be used only when necessary. Let's make the enum fields final where possible.

As usual, it was tested that the pack launches successfully with this patch.