### PR TITLE
Delegate blast resistance call to MetaPipeEntity to allow overriding

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
@@ -1305,7 +1305,7 @@ public class BaseMetaPipeEntity extends CommonMetaTileEntity
 
     @Override
     public float getBlastResistance(ForgeDirection side) {
-        return (mConnections & IConnectable.HAS_FOAM) != 0 ? 50.0F : 5.0F;
+        return canAccessData() ? Math.max(0, getMetaTileEntity().getExplosionResistance(side)) : 5.0F;
     }
 
     @Override

--- a/src/main/java/gregtech/api/metatileentity/MetaPipeEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaPipeEntity.java
@@ -726,7 +726,7 @@ public abstract class MetaPipeEntity implements IMetaTileEntity, IConnectable {
 
     @Override
     public float getExplosionResistance(ForgeDirection side) {
-        return 10.0F;
+        return (mConnections & IConnectable.HAS_FOAM) != 0 ? 50.0F : 5.0F;
     }
 
     @Override


### PR DESCRIPTION
Before `getExplosionResistance()` was ignored in MetaPipeEntity, now it can be properly overriden.