### PR TITLE
Chemical reactor recipe map fix

### DIFF
--- a/src/main/java/gregtech/api/util/GT_Recipe.java
+++ b/src/main/java/gregtech/api/util/GT_Recipe.java
@@ -2328,7 +2328,8 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
                 .setSlotOverlay(false, true, GT_UITextures.OVERLAY_SLOT_VIAL_1)
                 .setSlotOverlay(true, true, GT_UITextures.OVERLAY_SLOT_VIAL_2)
                 .setRecipeConfigFile("chemicalreactor", FIRST_ITEM_OR_FLUID_OUTPUT)
-                .setProgressBar(GT_UITextures.PROGRESSBAR_ARROW_MULTIPLE, ProgressBar.Direction.RIGHT);
+                .setProgressBar(GT_UITextures.PROGRESSBAR_ARROW_MULTIPLE, ProgressBar.Direction.RIGHT)
+                .setDisableOptimize(true);
         /**
          * using {@code .addTo(sMultiblockChemicalRecipes)} will cause the recipe to be added to multiblock recipe map
          * ONLY!
@@ -2462,7 +2463,8 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
             true,
             true).setSlotOverlay(false, false, GT_UITextures.OVERLAY_SLOT_CIRCUIT)
                 .setRecipeConfigFile("assembling", FIRST_ITEM_OUTPUT)
-                .setProgressBar(GT_UITextures.PROGRESSBAR_ASSEMBLE, ProgressBar.Direction.RIGHT);
+                .setProgressBar(GT_UITextures.PROGRESSBAR_ASSEMBLE, ProgressBar.Direction.RIGHT)
+                .setDisableOptimize(true);
         public static final GT_Recipe_Map sCircuitAssemblerRecipes = new GT_Recipe_Map_Assembler(
             new HashSet<>(605),
             "gt.recipe.circuitassembler",

--- a/src/main/java/gregtech/api/util/GT_Recipe.java
+++ b/src/main/java/gregtech/api/util/GT_Recipe.java
@@ -2330,7 +2330,8 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
                 .setRecipeConfigFile("chemicalreactor", FIRST_ITEM_OR_FLUID_OUTPUT)
                 .setProgressBar(GT_UITextures.PROGRESSBAR_ARROW_MULTIPLE, ProgressBar.Direction.RIGHT);
         /**
-         * using {@code .addTo(sChemicalRecipes)} will cause the recipe to be added to multiblock recipe map ONLY!
+         * using {@code .addTo(sMultiblockChemicalRecipes)} will cause the recipe to be added to multiblock recipe map
+         * ONLY!
          * use {@link GT_RecipeConstants#UniversalChemical} to add to both.
          */
         public static final GT_Recipe_Map sMultiblockChemicalRecipes = //

--- a/src/main/java/gregtech/api/util/GT_RecipeConstants.java
+++ b/src/main/java/gregtech/api/util/GT_RecipeConstants.java
@@ -2,7 +2,12 @@ package gregtech.api.util;
 
 import static gregtech.api.util.GT_RecipeMapUtil.convertCellToFluid;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Optional;
 
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
@@ -126,7 +131,7 @@ public class GT_RecipeConstants {
             builder.copy()
                 .addTo(GT_Recipe_Map.sChemicalRecipes),
             convertCellToFluid(builder, false)
-                // LCR does not need cleanroom, for now.
+                // LCR does not need cleanroom.
                 .metadata(CLEANROOM, false)
                 .addTo(GT_Recipe_Map.sMultiblockChemicalRecipes));
     });


### PR DESCRIPTION
resolves the first part of https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13605

some comments:
- the actual problem seems to be that the deepcopy done by copy() in https://github.com/GTNewHorizons/GT5-Unofficial/blob/ae5b5f3e1dc6f960f94b0e352ceb08d3822e2e9e/src/main/java/gregtech/api/util/GT_RecipeConstants.java#LL126C27-L126C27 doesnt work properly. (see https://github.com/GTNewHorizons/GT5-Unofficial/blob/ae5b5f3e1dc6f960f94b0e352ceb08d3822e2e9e/src/main/java/gregtech/api/util/GT_RecipeBuilder.java#LL394C37-L394C37).
This is pretty worrying as it is also used elsewhere.

- The fix is more local: I just disabled optimization for the singleblock. Indeed we dont want it there anyway. the SB recipe with the circuit 9 makes no sense optimized either and generally the optimize nonsense is just annoying.

- also fixes 2 lines of documentation and disables optimization for the assembler. (we probably want to disable it for 20 others too, will do when it pops up) I will jeep arguing that this should be the default everywhere. 'optimize' just changes the intended recipes for no reason and almost always for the worse.