### PR TITLE
Fix void protection not working with MB with custom output hatch field

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1684218858
+//version: 1685785062
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -1276,12 +1276,14 @@ tasks.register('faq') {
     description = 'Prints frequently asked questions about building a project'
 
     doLast {
-        print("If your build fails to fetch dependencies, they might have been deleted and replaced by newer " +
-            "versions.\nCheck if the versions you try to fetch are still on the distributing sites.\n" +
-            "The links can be found in repositories.gradle and build.gradle:repositories, " +
-            "not build.gradle:buildscript.repositories - this one is for gradle plugin metadata.\n\n" +
+        print("If your build fails to fetch dependencies, run './gradlew updateDependencies'. " +
+            "Or you can manually check if the versions are still on the distributing sites - " +
+            "the links can be found in repositories.gradle and build.gradle:repositories, " +
+            "but not build.gradle:buildscript.repositories - those ones are for gradle plugin metadata.\n\n" +
             "If your build fails to recognize the syntax of new Java versions, enable Jabel in your " +
-            "gradle.properties. See how it's done in GTNH ExampleMod/gradle.properties.")
+            "gradle.properties. See how it's done in GTNH ExampleMod/gradle.properties. " +
+            "However, keep in mind that Jabel enables only syntax features, but not APIs that were introduced in " +
+            "Java 9 or later.")
     }
 }
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -38,7 +38,7 @@ dependencies {
     api("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev")
     api("com.github.GTNewHorizons:NotEnoughItems:2.3.53-GTNH:dev")
     api("com.github.GTNewHorizons:GTNHLib:0.0.13:dev")
-    api("com.github.GTNewHorizons:ModularUI:1.1.7:dev")
+    api("com.github.GTNewHorizons:ModularUI:1.1.8:dev")
     api("com.github.GTNewHorizons:waila:1.6.0:dev")
     api("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-213-GTNH:dev")
     implementation("com.github.GTNewHorizons:Eternal-Singularity:1.1.0:dev")

--- a/src/main/java/gregtech/api/fluid/FluidTankGT.java
+++ b/src/main/java/gregtech/api/fluid/FluidTankGT.java
@@ -6,15 +6,18 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import javax.annotation.Nonnull;
+
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTankInfo;
 import net.minecraftforge.fluids.IFluidTank;
 
+import gregtech.api.interfaces.fluid.IFluidStore;
 import gregtech.api.util.GT_Utility;
 
-public class FluidTankGT implements IFluidTank {
+public class FluidTankGT implements IFluidTank, IFluidStore {
 
     public final FluidTankGT[] AS_ARRAY = new FluidTankGT[] { this };
     private FluidStack mFluid;
@@ -468,5 +471,15 @@ public class FluidTankGT implements IFluidTank {
             }
         }
         return fluidStacks.toArray(new FluidStack[0]);
+    }
+
+    @Override
+    public boolean isEmptyAndAcceptsAnyFluid() {
+        return getFluidAmount() == 0;
+    }
+
+    @Override
+    public boolean canStoreFluid(@Nonnull FluidStack fluidStack) {
+        return GT_Utility.areFluidsEqual(mFluid, fluidStack);
     }
 }

--- a/src/main/java/gregtech/api/interfaces/fluid/IFluidStore.java
+++ b/src/main/java/gregtech/api/interfaces/fluid/IFluidStore.java
@@ -1,0 +1,22 @@
+package gregtech.api.interfaces.fluid;
+
+import javax.annotation.Nonnull;
+
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.IFluidTank;
+
+/**
+ * Objects implementing this interface can be used for storing certain fluid, especially for recipe output.
+ */
+public interface IFluidStore extends IFluidTank {
+
+    /**
+     * @return If this does not have partially filled fluid nor have restriction on what fluid to accept.
+     */
+    boolean isEmptyAndAcceptsAnyFluid();
+
+    /**
+     * @return Whether to allow given fluid to be inserted into this.
+     */
+    boolean canStoreFluid(@Nonnull FluidStack fluidStack);
+}

--- a/src/main/java/gregtech/api/interfaces/modularui/ControllerWithOptionalFeatures.java
+++ b/src/main/java/gregtech/api/interfaces/modularui/ControllerWithOptionalFeatures.java
@@ -19,6 +19,7 @@ import com.gtnewhorizons.modularui.common.widget.FakeSyncWidget;
 import gregtech.api.enums.SoundResource;
 import gregtech.api.enums.VoidingMode;
 import gregtech.api.gui.modularui.GT_UITextures;
+import gregtech.api.interfaces.tileentity.IVoidable;
 
 /**
  * Machines implementing this interface can have logic and GUI buttons
@@ -31,7 +32,7 @@ import gregtech.api.gui.modularui.GT_UITextures;
  * <li>Recipe locking</li>
  * </ul>
  */
-public interface ControllerWithOptionalFeatures {
+public interface ControllerWithOptionalFeatures extends IVoidable {
 
     boolean isAllowedToWork();
 
@@ -71,29 +72,6 @@ public interface ControllerWithOptionalFeatures {
             .setSize(16, 16);
         return (ButtonWidget) button;
     }
-
-    /**
-     * @return if this machine can prevent excess item and fluid from voiding.
-     */
-    boolean supportsVoidProtection();
-
-    /**
-     * @return if this machine is configured to not void excess item.
-     */
-    default boolean protectsExcessItem() {
-        return supportsVoidProtection() && getVoidingMode().protectItem;
-    }
-
-    /**
-     * @return if this machine is configured to not void excess fluid.
-     */
-    default boolean protectsExcessFluid() {
-        return supportsVoidProtection() && getVoidingMode().protectFluid;
-    }
-
-    VoidingMode getVoidingMode();
-
-    void setVoidingMode(VoidingMode mode);
 
     Pos2d getVoidingModeButtonPos();
 

--- a/src/main/java/gregtech/api/interfaces/tileentity/IVoidable.java
+++ b/src/main/java/gregtech/api/interfaces/tileentity/IVoidable.java
@@ -1,0 +1,64 @@
+package gregtech.api.interfaces.tileentity;
+
+import java.util.List;
+
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
+
+import gregtech.api.enums.VoidingMode;
+import gregtech.api.interfaces.fluid.IFluidStore;
+
+/**
+ * Machines implementing this interface can have logic to configure whether to void excess output or not.
+ */
+public interface IVoidable {
+
+    /**
+     * @return if this machine can prevent excess item and fluid from voiding.
+     */
+    boolean supportsVoidProtection();
+
+    /**
+     * @return if this machine is configured to not void excess item.
+     */
+    default boolean protectsExcessItem() {
+        return supportsVoidProtection() && getVoidingMode().protectItem;
+    }
+
+    /**
+     * @return if this machine is configured to not void excess fluid.
+     */
+    default boolean protectsExcessFluid() {
+        return supportsVoidProtection() && getVoidingMode().protectFluid;
+    }
+
+    VoidingMode getVoidingMode();
+
+    void setVoidingMode(VoidingMode mode);
+
+    /**
+     * @param toOutput List of items this machine is going to output.
+     * @return List of slots available for item outputs. Null element represents empty slot.
+     */
+    List<ItemStack> getItemOutputSlots(ItemStack[] toOutput);
+
+    /**
+     * @param toOutput List of fluids this machine is going to output.
+     * @return List of slots available for fluid outputs.
+     */
+    List<? extends IFluidStore> getFluidOutputSlots(FluidStack[] toOutput);
+
+    /**
+     * @return If this machine has ability to dump item outputs to ME network.
+     *         This doesn't need to check if it can actually dump to ME,
+     *         as this might be called every tick and cause lag.
+     */
+    boolean canDumpItemToME();
+
+    /**
+     * @return If this machine has ability to dump fluid outputs to ME network.
+     *         This doesn't need to check if it can actually dump to ME,
+     *         as this might be called every tick and cause lag.
+     */
+    boolean canDumpFluidToME();
+}

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -173,6 +173,11 @@ public abstract class MetaTileEntity implements IMetaTileEntity, IMachineCallbac
         }
     }
 
+    public boolean isValid() {
+        return getBaseMetaTileEntity() != null && getBaseMetaTileEntity().getMetaTileEntity() == this
+            && !getBaseMetaTileEntity().isDead();
+    }
+
     @Override
     public ItemStack getStackForm(long aAmount) {
         return new ItemStack(GregTech_API.sBlockMachines, (int) aAmount, getBaseMetaTileEntity().getMetaTileID());

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_Output.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_Output.java
@@ -5,6 +5,8 @@ import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_PIPE_OUT;
 
 import java.lang.ref.WeakReference;
 
+import javax.annotation.Nonnull;
+
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -24,6 +26,7 @@ import gregtech.GT_Mod;
 import gregtech.api.gui.modularui.GT_UIInfos;
 import gregtech.api.gui.modularui.GT_UITextures;
 import gregtech.api.interfaces.ITexture;
+import gregtech.api.interfaces.fluid.IFluidStore;
 import gregtech.api.interfaces.metatileentity.IFluidLockable;
 import gregtech.api.interfaces.modularui.IAddUIWidgets;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
@@ -33,7 +36,8 @@ import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_Utility;
 import gregtech.common.gui.modularui.widget.FluidLockWidget;
 
-public class GT_MetaTileEntity_Hatch_Output extends GT_MetaTileEntity_Hatch implements IFluidLockable, IAddUIWidgets {
+public class GT_MetaTileEntity_Hatch_Output extends GT_MetaTileEntity_Hatch
+    implements IFluidStore, IFluidLockable, IAddUIWidgets {
 
     private String lockedFluidName = null;
     private WeakReference<EntityPlayer> playerThatLockedfluid = null;
@@ -403,12 +407,27 @@ public class GT_MetaTileEntity_Hatch_Output extends GT_MetaTileEntity_Hatch impl
         return true;
     }
 
-    public boolean canStoreFluid(Fluid fluid) {
-        if (isFluidLocked()) {
-            if (lockedFluidName == null) return true;
-            return lockedFluidName.equals(fluid.getName());
+    @Override
+    public boolean isEmptyAndAcceptsAnyFluid() {
+        return mMode == 0 && getFluidAmount() == 0;
+    }
+
+    @Override
+    public boolean canStoreFluid(@Nonnull FluidStack fluidStack) {
+        if (mFluid != null && !GT_Utility.areFluidsEqual(mFluid, fluidStack)) {
+            return false;
         }
-        if (GT_ModHandler.isSteam(new FluidStack(fluid, 0))) return outputsSteam();
+        if (isFluidLocked()) {
+            if (lockedFluidName == null) {
+                return true;
+            }
+            return lockedFluidName.equals(
+                fluidStack.getFluid()
+                    .getName());
+        }
+        if (GT_ModHandler.isSteam(fluidStack)) {
+            return outputsSteam();
+        }
         return outputsLiquids();
     }
 

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
@@ -1631,7 +1631,7 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
 
     @Override
     public boolean canDumpItemToME() {
-        for (GT_MetaTileEntity_Hatch tHatch : mOutputBusses) {
+        for (GT_MetaTileEntity_Hatch tHatch : filterValidMetaTileEntities(mOutputBusses)) {
             if (tHatch instanceof GT_MetaTileEntity_Hatch_OutputBus_ME) {
                 return true;
             }

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
@@ -1629,6 +1629,29 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
         return filterValidMetaTileEntities(mOutputHatches);
     }
 
+    /**
+     * Util method for DT-like structure to collect list of output hatches.
+     */
+    protected <T extends GT_MetaTileEntity_Hatch_Output> List<? extends IFluidStore> getFluidOutputSlotsByLayer(
+        FluidStack[] toOutput, List<List<T>> hatchesByLayer) {
+        List<IFluidStore> ret = new ArrayList<>();
+        for (int i = 0; i < toOutput.length; i++) {
+            if (i >= hatchesByLayer.size()) {
+                break;
+            }
+            FluidStack fluidOutputForLayer = toOutput[i];
+            for (GT_MetaTileEntity_Hatch_Output hatch : hatchesByLayer.get(i)) {
+                if (!hatch.isValid()) continue;
+                if (fluidOutputForLayer != null) {
+                    ret.add(new OutputHatchWrapper(hatch, f -> GT_Utility.areFluidsEqual(f, fluidOutputForLayer)));
+                } else {
+                    ret.add(hatch);
+                }
+            }
+        }
+        return ret;
+    }
+
     @Override
     public boolean canDumpItemToME() {
         for (GT_MetaTileEntity_Hatch tHatch : filterValidMetaTileEntities(mOutputBusses)) {

--- a/src/main/java/gregtech/api/multitileentity/multiblock/base/Controller.java
+++ b/src/main/java/gregtech/api/multitileentity/multiblock/base/Controller.java
@@ -52,6 +52,7 @@ import com.gtnewhorizon.structurelib.structure.ISurvivalBuildEnvironment;
 import com.gtnewhorizon.structurelib.util.Vec3Impl;
 import com.gtnewhorizons.modularui.api.ModularUITextures;
 import com.gtnewhorizons.modularui.api.drawable.ItemDrawable;
+import com.gtnewhorizons.modularui.api.forge.IItemHandler;
 import com.gtnewhorizons.modularui.api.forge.IItemHandlerModifiable;
 import com.gtnewhorizons.modularui.api.forge.ItemStackHandler;
 import com.gtnewhorizons.modularui.api.forge.ListItemHandler;
@@ -78,6 +79,7 @@ import gregtech.api.enums.VoidingMode;
 import gregtech.api.fluid.FluidTankGT;
 import gregtech.api.gui.modularui.GT_UITextures;
 import gregtech.api.interfaces.IDescribable;
+import gregtech.api.interfaces.fluid.IFluidStore;
 import gregtech.api.interfaces.modularui.ControllerWithOptionalFeatures;
 import gregtech.api.logic.PowerLogic;
 import gregtech.api.logic.ProcessingLogic;
@@ -1975,6 +1977,33 @@ public abstract class Controller<T extends Controller<T>> extends MultiTileBasic
     @Override
     public void setVoidingMode(VoidingMode mode) {
         this.voidingMode = mode;
+    }
+
+    @Override
+    public List<ItemStack> getItemOutputSlots(ItemStack[] toOutput) {
+        List<ItemStack> ret = new ArrayList<>();
+        IItemHandler inv = getOutputInventory();
+        if (inv != null && inv.getSlots() > 0) {
+            for (int i = 0; i < inv.getSlots(); i++) {
+                ret.add(inv.getStackInSlot(i));
+            }
+        }
+        return ret;
+    }
+
+    @Override
+    public List<? extends IFluidStore> getFluidOutputSlots(FluidStack[] toOutput) {
+        return Arrays.asList(getOutputTanks());
+    }
+
+    @Override
+    public boolean canDumpItemToME() {
+        return false;
+    }
+
+    @Override
+    public boolean canDumpFluidToME() {
+        return false;
     }
 
     @Override

--- a/src/main/java/gregtech/api/util/GT_ParallelHelper.java
+++ b/src/main/java/gregtech/api/util/GT_ParallelHelper.java
@@ -299,9 +299,9 @@ public class GT_ParallelHelper {
         if (protectExcessItem || protectExcessFluid) {
             VoidProtectionHelper voidProtectionHelper = new VoidProtectionHelper();
             if (mMachineMeta != null) {
-                voidProtectionHelper.setController(mMachineMeta, protectExcessItem, protectExcessFluid);
+                voidProtectionHelper.setMachine(mMachineMeta, protectExcessItem, protectExcessFluid);
             } else if (mMachineMulti != null) {
-                voidProtectionHelper.setController(mMachineMulti, protectExcessItem, protectExcessFluid);
+                voidProtectionHelper.setMachine(mMachineMulti, protectExcessItem, protectExcessFluid);
             }
             voidProtectionHelper.setItemOutputs(mRecipe.mOutputs)
                 .setFluidOutputs(mRecipe.mFluidOutputs)

--- a/src/main/java/gregtech/api/util/GT_Recipe.java
+++ b/src/main/java/gregtech/api/util/GT_Recipe.java
@@ -172,8 +172,8 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
     public List<List<StackTraceElement>> stackTraces = new ArrayList<>();
 
     private GT_Recipe(GT_Recipe aRecipe, boolean shallow) {
-        mInputs = shallow ? aRecipe.mInputs : GT_Utility.copyStackArray((Object[]) aRecipe.mInputs);
-        mOutputs = shallow ? aRecipe.mOutputs : GT_Utility.copyStackArray((Object[]) aRecipe.mOutputs);
+        mInputs = shallow ? aRecipe.mInputs : GT_Utility.copyItemArray(aRecipe.mInputs);
+        mOutputs = shallow ? aRecipe.mOutputs : GT_Utility.copyItemArray(aRecipe.mOutputs);
         mSpecialItems = aRecipe.mSpecialItems;
         mChances = aRecipe.mChances;
         mFluidInputs = shallow ? aRecipe.mFluidInputs : GT_Utility.copyFluidArray(aRecipe.mFluidInputs);

--- a/src/main/java/gregtech/api/util/GT_RecipeBuilder.java
+++ b/src/main/java/gregtech/api/util/GT_RecipeBuilder.java
@@ -1,5 +1,8 @@
 package gregtech.api.util;
 
+import static gregtech.api.util.GT_Utility.copyFluidArray;
+import static gregtech.api.util.GT_Utility.copyItemArray;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -378,26 +381,6 @@ public class GT_RecipeBuilder {
         return metadata(GT_RecipeConstants.LOW_GRAVITY, true);
     }
 
-    private static ItemStack[] copy(ItemStack[] arr) {
-        if (arr == null) return null;
-        ItemStack[] ret = new ItemStack[arr.length];
-        for (int i = 0; i < arr.length; i++) {
-            if (arr[i] == null) continue;
-            ret[i] = arr[i].copy();
-        }
-        return ret;
-    }
-
-    private static FluidStack[] copy(FluidStack[] arr) {
-        if (arr == null) return null;
-        FluidStack[] ret = new FluidStack[arr.length];
-        for (int i = 0; i < arr.length; i++) {
-            if (arr[i] == null) continue;
-            ret[i] = arr[i].copy();
-        }
-        return ret;
-    }
-
     private static <T> T[] copy(T[] arr) {
         return arr == null ? null : arr.clone();
     }
@@ -414,12 +397,12 @@ public class GT_RecipeBuilder {
      */
     public GT_RecipeBuilder copy() {
         return new GT_RecipeBuilder(
-            copy(inputsBasic),
+            copyItemArray(inputsBasic),
             copy(inputsOreDict),
-            copy(outputs),
+            copyItemArray(outputs),
             copy(alts),
-            copy(fluidInputs),
-            copy(fluidOutputs),
+            copyFluidArray(fluidInputs),
+            copyFluidArray(fluidOutputs),
             copy(chances),
             special,
             duration,
@@ -441,12 +424,12 @@ public class GT_RecipeBuilder {
      */
     public GT_RecipeBuilder copyNoMetadata() {
         return new GT_RecipeBuilder(
-            copy(inputsBasic),
+            copyItemArray(inputsBasic),
             copy(inputsOreDict),
-            copy(outputs),
+            copyItemArray(outputs),
             copy(alts),
-            copy(fluidInputs),
-            copy(fluidOutputs),
+            copyFluidArray(fluidInputs),
+            copyFluidArray(fluidOutputs),
             copy(chances),
             special,
             duration,

--- a/src/main/java/gregtech/api/util/GT_Utility.java
+++ b/src/main/java/gregtech/api/util/GT_Utility.java
@@ -2816,12 +2816,14 @@ public class GT_Utility {
     }
 
     public static FluidStack[] copyFluidArray(FluidStack... aStacks) {
+        if (aStacks == null) return null;
         FluidStack[] rStacks = new FluidStack[aStacks.length];
         for (int i = 0; i < aStacks.length; i++) if (aStacks[i] != null) rStacks[i] = aStacks[i].copy();
         return rStacks;
     }
 
-    public static ItemStack[] copyStackArray(Object... aStacks) {
+    public static ItemStack[] copyItemArray(ItemStack... aStacks) {
+        if (aStacks == null) return null;
         ItemStack[] rStacks = new ItemStack[aStacks.length];
         for (int i = 0; i < aStacks.length; i++) rStacks[i] = copy(aStacks[i]);
         return rStacks;

--- a/src/main/java/gregtech/api/util/OutputHatchWrapper.java
+++ b/src/main/java/gregtech/api/util/OutputHatchWrapper.java
@@ -1,0 +1,65 @@
+package gregtech.api.util;
+
+import java.util.function.Predicate;
+
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.FluidTankInfo;
+
+import org.jetbrains.annotations.NotNull;
+
+import gregtech.api.interfaces.fluid.IFluidStore;
+import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_Output;
+
+/**
+ * Wrapper for output hatch to allow multiblocks to apply specific filter.
+ */
+public class OutputHatchWrapper implements IFluidStore {
+
+    private final GT_MetaTileEntity_Hatch_Output outputHatch;
+    private final Predicate<FluidStack> filter;
+
+    public OutputHatchWrapper(GT_MetaTileEntity_Hatch_Output outputHatch, Predicate<FluidStack> filter) {
+        this.outputHatch = outputHatch;
+        this.filter = filter;
+    }
+
+    @Override
+    public FluidStack getFluid() {
+        return outputHatch.getFluid();
+    }
+
+    @Override
+    public int getFluidAmount() {
+        return outputHatch.getFluidAmount();
+    }
+
+    @Override
+    public int getCapacity() {
+        return outputHatch.getCapacity();
+    }
+
+    @Override
+    public FluidTankInfo getInfo() {
+        return outputHatch.getInfo();
+    }
+
+    @Override
+    public int fill(FluidStack resource, boolean doFill) {
+        return outputHatch.fill(resource, doFill);
+    }
+
+    @Override
+    public FluidStack drain(int maxDrain, boolean doDrain) {
+        return outputHatch.drain(maxDrain, doDrain);
+    }
+
+    @Override
+    public boolean isEmptyAndAcceptsAnyFluid() {
+        return outputHatch.isEmptyAndAcceptsAnyFluid();
+    }
+
+    @Override
+    public boolean canStoreFluid(@NotNull FluidStack fluidStack) {
+        return outputHatch.canStoreFluid(fluidStack) && filter.test(fluidStack);
+    }
+}

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_DistillationTower.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_DistillationTower.java
@@ -41,7 +41,6 @@ import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GT_Multiblock_Tooltip_Builder;
 import gregtech.api.util.GT_Recipe;
 import gregtech.api.util.GT_Utility;
-import gregtech.api.util.OutputHatchWrapper;
 
 public class GT_MetaTileEntity_DistillationTower extends
     GT_MetaTileEntity_EnhancedMultiBlockBase<GT_MetaTileEntity_DistillationTower> implements ISurvivalConstructable {
@@ -281,22 +280,7 @@ public class GT_MetaTileEntity_DistillationTower extends
 
     @Override
     public List<? extends IFluidStore> getFluidOutputSlots(FluidStack[] toOutput) {
-        List<IFluidStore> ret = new ArrayList<>();
-        for (int i = 0; i < toOutput.length; i++) {
-            if (i >= mOutputHatchesByLayer.size()) {
-                break;
-            }
-            FluidStack fluidOutputForLayer = toOutput[i];
-            for (GT_MetaTileEntity_Hatch_Output hatch : mOutputHatchesByLayer.get(i)) {
-                if (!hatch.isValid()) continue;
-                if (fluidOutputForLayer != null) {
-                    ret.add(new OutputHatchWrapper(hatch, f -> GT_Utility.areFluidsEqual(f, fluidOutputForLayer)));
-                } else {
-                    ret.add(hatch);
-                }
-            }
-        }
-        return ret;
+        return getFluidOutputSlotsByLayer(toOutput, mOutputHatchesByLayer);
     }
 
     @Override

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_DistillationTower.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_DistillationTower.java
@@ -32,6 +32,7 @@ import gregtech.api.enums.Textures;
 import gregtech.api.enums.Textures.BlockIcons;
 import gregtech.api.interfaces.IHatchElement;
 import gregtech.api.interfaces.ITexture;
+import gregtech.api.interfaces.fluid.IFluidStore;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_EnhancedMultiBlockBase;
@@ -40,6 +41,7 @@ import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GT_Multiblock_Tooltip_Builder;
 import gregtech.api.util.GT_Recipe;
 import gregtech.api.util.GT_Utility;
+import gregtech.api.util.OutputHatchWrapper;
 
 public class GT_MetaTileEntity_DistillationTower extends
     GT_MetaTileEntity_EnhancedMultiBlockBase<GT_MetaTileEntity_DistillationTower> implements ISurvivalConstructable {
@@ -275,6 +277,26 @@ public class GT_MetaTileEntity_DistillationTower extends
         tHatch.updateTexture(aBaseCasingIndex);
         return mOutputHatchesByLayer.get(mHeight - 1)
             .add(tHatch);
+    }
+
+    @Override
+    public List<? extends IFluidStore> getFluidOutputSlots(FluidStack[] toOutput) {
+        List<IFluidStore> ret = new ArrayList<>();
+        for (int i = 0; i < toOutput.length; i++) {
+            if (i >= mOutputHatchesByLayer.size()) {
+                break;
+            }
+            FluidStack fluidOutputForLayer = toOutput[i];
+            for (GT_MetaTileEntity_Hatch_Output hatch : mOutputHatchesByLayer.get(i)) {
+                if (!hatch.isValid()) continue;
+                if (fluidOutputForLayer != null) {
+                    ret.add(new OutputHatchWrapper(hatch, f -> GT_Utility.areFluidsEqual(f, fluidOutputForLayer)));
+                } else {
+                    ret.add(hatch);
+                }
+            }
+        }
+        return ret;
     }
 
     @Override


### PR DESCRIPTION
Close https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13607
- Move void protection related interfaces to `IVoidable` from `ControllerWithOptionalFeatures`
- Merge logic in `VoidProtectionHelper` by introducing `IVoidable` (for controller) and `IFluidStore` (for MetaTE hatches / MuTE fluid inventories)
- Fix main issues by overriding `getFluidOutputSlots`
- Introduce `OutputHatchWrapper` to fix issue with DT in the following case:
  - The recipe outputs fluid A and B. Output hatches are already filled with fluid B and A, from bottom each. `VoidProtectionHelper` doesn't care about order and thinks there's enough space. But actually DT tries to dump fluids in specific order, thus both fluids are voided even if void protection is enabled.
  - To prevent this, it applies additional fluid filter for each layer.
- Change signature: `copyStackArray(Object... aStacks)` -> `copyItemArray(ItemStack... aStacks)`, no other mods used this method
- Fix EBF outputting more gasses than the recipe outputs if UHV muffler hatch is used
- Cleanup some methods in multiblocks