### PR TITLE
Lower Ingot to Nugget Craft with Saw from 9 to 8 Nuggets

### DIFF
--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingNugget.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingNugget.java
@@ -78,7 +78,7 @@ public class ProcessingNugget implements gregtech.api.interfaces.IOreRecipeRegis
                 .addTo(sAlloySmelterRecipes);
             if (aMaterial.getProcessingMaterialTierEU() < TierEU.IV) {
                 GT_ModHandler.addCraftingRecipe(
-                    GT_OreDictUnificator.get(OrePrefixes.nugget, aMaterial, 9L),
+                    GT_OreDictUnificator.get(OrePrefixes.nugget, aMaterial, 8L),
                     GT_ModHandler.RecipeBits.BUFFERED,
                     new Object[] { "sI ", 'I', OrePrefixes.ingot.get(aMaterial) });
             }


### PR DESCRIPTION
This PR comes from when I noticed that a GT Saw recipe to convert ingots into nuggets outputs the same amount as the Alloy Smelter recipe. Some GT tools have the same output as the equivalent machine, but _sawing_ an ingot into nuggets should very much be a lossy process because of the dust debris caused, which is hardly recoverable. However, what really stuck to me is that the machine equivalent happens to be the Alloy Smelter, which consumes a lot of Steam and also requires a specific mold to get the craft done. All of this can be instantly skipped with any saw, which is why I made this PR.

I spoke with Dream about this change and he agreed on this small nerf. Yes, it can be annoying to get a number of nuggets smaller than 9, and that is the reason why the Alloy Smelter route is supposed to be better.

![2023-06-05_00 42 26](https://github.com/GTNewHorizons/GT5-Unofficial/assets/70096037/d808e301-2ba2-49d0-a6b9-f9f3c6f7780d)

