### PR TITLE
Fix fluid registry related bugs

### DIFF
--- a/src/main/java/gregtech/api/GregTech_API.java
+++ b/src/main/java/gregtech/api/GregTech_API.java
@@ -33,7 +33,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ChunkCoordinates;
 import net.minecraft.world.World;
-import net.minecraftforge.fluids.Fluid;
 
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
@@ -109,7 +108,6 @@ public class GregTech_API {
      */
     public static final Collection<Map<? extends GT_ItemStack, ?>> sItemStackMappings = new ArrayList<>();
 
-    public static final Collection<Map<Fluid, ?>> sFluidMappings = new ArrayList<>();
     /**
      * The MetaTileEntity-ID-List-Length
      */

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_Output.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_Output.java
@@ -13,7 +13,6 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.StatCollector;
 import net.minecraftforge.common.util.ForgeDirection;
-import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidContainerRegistry;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
@@ -162,10 +161,6 @@ public class GT_MetaTileEntity_Hatch_Output extends GT_MetaTileEntity_Hatch
         mMode = aNBT.getByte("mMode");
         lockedFluidName = aNBT.getString("lockedFluidName");
         lockedFluidName = lockedFluidName.length() == 0 ? null : lockedFluidName;
-        if (GT_Utility.getFluidFromUnlocalizedName(lockedFluidName) != null) {
-            lockedFluidName = GT_Utility.getFluidFromUnlocalizedName(lockedFluidName)
-                .getName();
-        }
     }
 
     @Override

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
@@ -70,6 +70,7 @@ import gregtech.api.util.GT_Recipe.GT_Recipe_Map;
 import gregtech.api.util.GT_Single_Recipe_Check;
 import gregtech.api.util.GT_Utility;
 import gregtech.api.util.GT_Waila;
+import gregtech.api.util.OutputHatchWrapper;
 import gregtech.api.util.VoidProtectionHelper;
 import gregtech.client.GT_SoundLoop;
 import gregtech.common.GT_Pollution;

--- a/src/main/java/gregtech/api/util/GT_Recipe.java
+++ b/src/main/java/gregtech/api/util/GT_Recipe.java
@@ -3246,7 +3246,6 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
             mUsualOutputCount = aUsualOutputCount;
             mMinimalInputItems = aMinimalInputItems;
             mMinimalInputFluids = aMinimalInputFluids;
-            GregTech_API.sFluidMappings.add(mRecipeFluidMap);
             GregTech_API.sItemStackMappings.add(mRecipeItemMap);
             GT_LanguageManager.addStringLocalization(mUnlocalizedName = aUnlocalizedName, aLocalName);
             mUniqueIdentifier = String.format(

--- a/src/main/java/gregtech/api/util/GT_Utility.java
+++ b/src/main/java/gregtech/api/util/GT_Utility.java
@@ -182,11 +182,8 @@ public class GT_Utility {
     private static final List<FluidContainerData> sFluidContainerList = new ArrayList<>();
 
     private static final Map<GT_ItemStack, FluidContainerData> sFilledContainerToData = new /* Concurrent */ HashMap<>();
-    private static final Map<GT_ItemStack, Map<Fluid, FluidContainerData>> sEmptyContainerToFluidToData = new /*
-                                                                                                               * Concurrent
-                                                                                                               */ HashMap<>();
-    private static final Map<Fluid, List<ItemStack>> sFluidToContainers = new HashMap<>();
-    private static final Map<String, Fluid> sFluidUnlocalizedNameToFluid = new HashMap<>();
+    private static final Map<GT_ItemStack, Map<String, FluidContainerData>> sEmptyContainerToFluidToData = new HashMap<>();
+    private static final Map<String, List<ItemStack>> sFluidToContainers = new HashMap<>();
     /** Must use {@code Supplier} here because the ore prefixes have not yet been registered at class load time. */
     private static final Map<OrePrefixes, Supplier<ItemStack>> sOreToCobble = new HashMap<>();
 
@@ -1770,56 +1767,51 @@ public class GT_Utility {
         sFilledContainerToData.clear();
         sEmptyContainerToFluidToData.clear();
         sFluidToContainers.clear();
-        sFluidUnlocalizedNameToFluid.clear();
         for (FluidContainerData tData : sFluidContainerList) {
+            String fluidName = tData.fluid.getFluid()
+                .getName();
             sFilledContainerToData.put(new GT_ItemStack(tData.filledContainer), tData);
-            Map<Fluid, FluidContainerData> tFluidToContainer = sEmptyContainerToFluidToData
+            Map<String, FluidContainerData> tFluidToContainer = sEmptyContainerToFluidToData
                 .get(new GT_ItemStack(tData.emptyContainer));
-            List<ItemStack> tContainers = sFluidToContainers.get(tData.fluid.getFluid());
+            List<ItemStack> tContainers = sFluidToContainers.get(fluidName);
             if (tFluidToContainer == null) {
                 sEmptyContainerToFluidToData
                     .put(new GT_ItemStack(tData.emptyContainer), tFluidToContainer = new /* Concurrent */ HashMap<>());
-                GregTech_API.sFluidMappings.add(tFluidToContainer);
             }
-            tFluidToContainer.put(tData.fluid.getFluid(), tData);
+            tFluidToContainer.put(fluidName, tData);
             if (tContainers == null) {
                 tContainers = new ArrayList<>();
                 tContainers.add(tData.filledContainer);
-                sFluidToContainers.put(tData.fluid.getFluid(), tContainers);
+                sFluidToContainers.put(fluidName, tContainers);
             } else tContainers.add(tData.filledContainer);
         }
-        for (Fluid tFluid : FluidRegistry.getRegisteredFluids()
-            .values()) {
-            sFluidUnlocalizedNameToFluid.put(tFluid.getUnlocalizedName(), tFluid);
-        }
-    }
-
-    public static Fluid getFluidFromUnlocalizedName(String aUnlocalizedName) {
-        return sFluidUnlocalizedNameToFluid.get(aUnlocalizedName);
     }
 
     public static void addFluidContainerData(FluidContainerData aData) {
+        String fluidName = aData.fluid.getFluid()
+            .getName();
         sFluidContainerList.add(aData);
         sFilledContainerToData.put(new GT_ItemStack(aData.filledContainer), aData);
-        Map<Fluid, FluidContainerData> tFluidToContainer = sEmptyContainerToFluidToData
+        Map<String, FluidContainerData> tFluidToContainer = sEmptyContainerToFluidToData
             .get(new GT_ItemStack(aData.emptyContainer));
-        List<ItemStack> tContainers = sFluidToContainers.get(aData.fluid.getFluid());
+        List<ItemStack> tContainers = sFluidToContainers.get(fluidName);
         if (tFluidToContainer == null) {
             sEmptyContainerToFluidToData
                 .put(new GT_ItemStack(aData.emptyContainer), tFluidToContainer = new /* Concurrent */ HashMap<>());
-            GregTech_API.sFluidMappings.add(tFluidToContainer);
         }
-        tFluidToContainer.put(aData.fluid.getFluid(), aData);
+        tFluidToContainer.put(fluidName, aData);
         if (tContainers == null) {
             tContainers = new ArrayList<>();
             tContainers.add(aData.filledContainer);
-            sFluidToContainers.put(aData.fluid.getFluid(), tContainers);
+            sFluidToContainers.put(fluidName, tContainers);
         } else tContainers.add(aData.filledContainer);
     }
 
     public static List<ItemStack> getContainersFromFluid(FluidStack tFluidStack) {
         if (tFluidStack != null) {
-            List<ItemStack> tContainers = sFluidToContainers.get(tFluidStack.getFluid());
+            List<ItemStack> tContainers = sFluidToContainers.get(
+                tFluidStack.getFluid()
+                    .getName());
             if (tContainers == null) return new ArrayList<>();
             return tContainers;
         }
@@ -1844,9 +1836,11 @@ public class GT_Utility {
             else((IFluidContainerItem) aStack.getItem()).fill(aStack = copyAmount(1, aStack), aFluid, true);
             return aStack;
         }
-        Map<Fluid, FluidContainerData> tFluidToContainer = sEmptyContainerToFluidToData.get(new GT_ItemStack(aStack));
+        Map<String, FluidContainerData> tFluidToContainer = sEmptyContainerToFluidToData.get(new GT_ItemStack(aStack));
         if (tFluidToContainer == null) return null;
-        FluidContainerData tData = tFluidToContainer.get(aFluid.getFluid());
+        FluidContainerData tData = tFluidToContainer.get(
+            aFluid.getFluid()
+                .getName());
         if (tData == null || tData.fluid.amount > aFluid.amount) return null;
         if (aRemoveFluidDirectly) aFluid.amount -= tData.fluid.amount;
         return copyAmount(1, tData.filledContainer);

--- a/src/main/java/gregtech/common/fluid/GT_Fluid.java
+++ b/src/main/java/gregtech/common/fluid/GT_Fluid.java
@@ -97,8 +97,6 @@ public class GT_Fluid extends Fluid implements IGT_Fluid, IGT_RegisteredFluid, R
         if (FluidRegistry.registerFluid(GT_Fluid.this)) {
             // Registered as a new Fluid
             registeredFluid = this;
-            // Schedules the gtFluid for the block icons loader run() tasks
-            GregTech_API.sGTBlockIconload.add(this);
             // Adds a server-side localized-name
             GT_LanguageManager.addStringLocalization(getUnlocalizedName(), localizedName);
         } else {
@@ -109,6 +107,8 @@ public class GT_Fluid extends Fluid implements IGT_Fluid, IGT_RegisteredFluid, R
                 registeredFluid.setTemperature(GT_Fluid.this.temperature);
             }
         }
+        // Schedules the fluid for the block icons loader run() tasks
+        GregTech_API.sGTBlockIconload.add(this);
         return this;
     }
 


### PR DESCRIPTION
- Fix missing icon for `GT_Fluid`
  - Currently `GT_Fluid#addFluid` does not load icon if its fluid name is already registered. However, the fluid still might be referenced after `FluidRegistry#loadFluidDefaults` selected it as default.
  - This explains why people on server are experiencing the issue but not for most of the SP players; Default fluids are stored per world save, not code.
  - I'm still not sure if `GT_Fluid#registeredFluid` can cause problem, but things are working fine for me at least.
- Fix fluid container data
  - For the same reason as above, storing `Fluid` before world load and using it after will cause problem. Replaced with String fluid name. ~~Ironically "I made my own registry because Forge is doing bad thing" is worse than that~~
  - I wonder why it didn't cause issues before...
- Remove backward compatibility for super tank locked fluid name saved with unlocalized name
  - It's been 1.5 years since https://github.com/GTNewHorizons/GT5-Unofficial/pull/796, version bumped from 2.1.2.0 to > 2.3.3
- Remove `GregTech_API.sFluidMappings` as it does nothing now due to https://github.com/GTNewHorizons/GT5-Unofficial/pull/2040