### PR TITLE
Halve Tin Plasma Fuel Value and Double Fusion Output

### DIFF
--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingCell.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingCell.java
@@ -193,13 +193,26 @@ public class ProcessingCell implements IOreRecipeRegistrator {
                     } else {
                         recipeBuilder.noItemOutputs();
                     }
-                    recipeBuilder.noFluidInputs()
-                        .noFluidOutputs()
-                        .metadata(FUEL_VALUE, (int) Math.max(1024L, 1024L * aMaterial.getMass()))
-                        .metadata(FUEL_TYPE, 4)
-                        .duration(0)
-                        .eut(0)
-                        .addTo(GT_RecipeConstants.Fuel);
+                    // Switch case to set manual values for specific plasmas and escape the formula based on mass
+                    // when it doesn't make sense for powergen balance.
+                    switch (aMaterial.mName) {
+                        case "Tin":
+                            recipeBuilder.noFluidInputs()
+                                .noFluidOutputs()
+                                .metadata(FUEL_VALUE, 150_000)
+                                .metadata(FUEL_TYPE, 4)
+                                .duration(0)
+                                .eut(0)
+                                .addTo(GT_RecipeConstants.Fuel);
+                        default:
+                            recipeBuilder.noFluidInputs()
+                                .noFluidOutputs()
+                                .metadata(FUEL_VALUE, (int) Math.max(1024L, 1024L * aMaterial.getMass()))
+                                .metadata(FUEL_TYPE, 4)
+                                .duration(0)
+                                .eut(0)
+                                .addTo(GT_RecipeConstants.Fuel);
+                    }
                     if (GT_OreDictUnificator.get(OrePrefixes.cell, aMaterial, 1L) != null) {
                         GT_Values.RA.stdBuilder()
                             .itemInputs(GT_Utility.copyAmount(1L, aStack))

--- a/src/main/java/gregtech/loaders/postload/recipes/FusionReactorRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/FusionReactorRecipes.java
@@ -295,7 +295,7 @@ public class FusionReactorRecipes implements Runnable {
             .noItemInputs()
             .noItemOutputs()
             .fluidInputs(Materials.Silver.getMolten(144), Materials.Helium_3.getGas(375))
-            .fluidOutputs(Materials.Tin.getPlasma(144))
+            .fluidOutputs(Materials.Tin.getPlasma(288))
             .duration(16 * TICKS)
             .eut(49152)
             .metadata(FUSION_THRESHOLD, 280000000)


### PR DESCRIPTION
Refer to [GTPP #656](https://github.com/GTNewHorizons/GTplusplus/pull/656) for the formula change.

The purpose of this change is to further reduce the EU/t of Tin Plasma spam on infinity XLs, since it's only about 2.5x lower than before, even with the new formula, and it can very well be spammed in the same way as before. However, the Tin Plasma change should not affect existing setups, since output amount on the reactor setup is doubled while fuel value is halved.