### PR TITLE
Enable fire resistance checks for heat and hot item damage

### DIFF
--- a/src/main/java/gregtech/api/damagesources/GT_DamageSources.java
+++ b/src/main/java/gregtech/api/damagesources/GT_DamageSources.java
@@ -73,6 +73,7 @@ public class GT_DamageSources {
 
         public DamageSourceHeat() {
             super("steam");
+            setFireDamage();
             setDifficultyScaled();
         }
 

--- a/src/main/java/gregtech/api/util/GT_Utility.java
+++ b/src/main/java/gregtech/api/util/GT_Utility.java
@@ -2738,19 +2738,15 @@ public class GT_Utility {
     }
 
     private static boolean applyHeatDamage(EntityLivingBase aEntity, float aDamage, DamageSource source) {
-        if (aDamage > 0 && aEntity != null
-            && aEntity.getActivePotionEffect(Potion.fireResistance) == null
-            && !isWearingFullHeatHazmat(aEntity)) {
-            aEntity.attackEntityFrom(source, aDamage);
-            return true;
+        if (aDamage > 0 && aEntity != null && !isWearingFullHeatHazmat(aEntity)) {
+            return aEntity.attackEntityFrom(source, aDamage);
         }
         return false;
     }
 
     public static boolean applyFrostDamage(EntityLivingBase aEntity, float aDamage) {
         if (aDamage > 0 && aEntity != null && !isWearingFullFrostHazmat(aEntity)) {
-            aEntity.attackEntityFrom(GT_DamageSources.getFrostDamage(), aDamage);
-            return true;
+            return aEntity.attackEntityFrom(GT_DamageSources.getFrostDamage(), aDamage);
         }
         return false;
     }
@@ -2758,8 +2754,7 @@ public class GT_Utility {
     public static boolean applyElectricityDamage(EntityLivingBase aEntity, long aVoltage, long aAmperage) {
         long aDamage = getTier(aVoltage) * aAmperage * 4;
         if (aDamage > 0 && aEntity != null && !isWearingFullElectroHazmat(aEntity)) {
-            aEntity.attackEntityFrom(GT_DamageSources.getElectricDamage(), aDamage);
-            return true;
+            return aEntity.attackEntityFrom(GT_DamageSources.getElectricDamage(), aDamage);
         }
         return false;
     }


### PR DESCRIPTION
Vanilla uses the fire damage flag for the fire resistance check.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13620