### PR TITLE
Change Kevlar Parents

### DIFF
--- a/src/main/java/gregtech/loaders/misc/GT_BeeDefinition.java
+++ b/src/main/java/gregtech/loaders/misc/GT_BeeDefinition.java
@@ -2354,8 +2354,8 @@ public enum GT_BeeDefinition implements IBeeDefinition {
         AlleleHelper.instance.set(template, FLOWER_PROVIDER, Flowers.SNOW);
         AlleleHelper.instance.set(template, FLOWERING, Flowering.AVERAGE);
     }, dis -> {
-        IBeeMutationCustom tMutation = dis.registerMutation(OIL, INFINITY, 4);
-        tMutation.requireResource("frameGtKevlar");
+        IBeeMutationCustom tMutation = dis.registerMutation(OIL, INFINITYCATALYST, 99);
+        tMutation.requireResource(GameRegistry.findBlock(GregTech.ID, "gt.blockmachines"), 11003);
     }),
 
     // Noble Gas Line


### PR DESCRIPTION
Infinity Catalyst and UVH replicator foundation. Will also be blocked from mutatron.

needs: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/compare/KevBeeBlacklist?expand=1