### PR TITLE
Fix fermented biomass recipes

### DIFF
--- a/src/main/java/gregtech/loaders/postload/recipes/PyrolyseRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/PyrolyseRecipes.java
@@ -111,7 +111,7 @@ public class PyrolyseRecipes implements Runnable {
             .addTo(sPyrolyseRecipes);
 
         GT_Values.RA.stdBuilder()
-            .noItemInputs()
+            .itemInputs(GT_Utility.getIntegratedCircuit(2))
             .noItemOutputs()
             .fluidInputs(new FluidStack(FluidRegistry.getFluid("ic2biomass"), 1000))
             .fluidOutputs(Materials.FermentedBiomass.getFluid(1000))
@@ -120,7 +120,7 @@ public class PyrolyseRecipes implements Runnable {
             .addTo(sPyrolyseRecipes);
 
         GT_Values.RA.stdBuilder()
-            .noItemInputs()
+            .itemInputs(GT_Utility.getIntegratedCircuit(2))
             .noItemOutputs()
             .fluidInputs(Materials.Biomass.getFluid(1000))
             .fluidOutputs(Materials.FermentedBiomass.getFluid(1000))


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13634.
Was a RA2 conversion bug since already 2.3.3. :P
these are the circuits that were used in stable.