### PR TITLE
Fix GT Ore Gen

### DIFF
--- a/src/main/java/gregtech/common/GT_Worldgenerator.java
+++ b/src/main/java/gregtech/common/GT_Worldgenerator.java
@@ -454,7 +454,8 @@ public class GT_Worldgenerator implements IWorldGenerator {
             for (int x = wXbox; x < eXbox; x++) {
                 for (int z = nZbox; z < sZbox; z++) {
                     // Determine if this X/Z is an orevein seed
-                    if (((Math.abs(x) % 3) == 1) && ((Math.abs(z) % 3) == 1)) {
+                    // use floorMod because java was written by idiots
+                    if ((Math.floorMod(x, 3) == 1) && (Math.floorMod(z, 3) == 1)) {
                         if (debugWorldGen) GT_Log.out.println("Adding seed x=" + x + " z=" + z);
                         seedList.add(new NearbySeeds(x, z));
                     }


### PR DESCRIPTION
fixes the oldest bug in the pack. This makes oreveins 3 chunks apart - even when crossing x=0 or z=0. closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/8912.

goes together with the following PRs: https://github.com/GTNewHorizons/VisualProspecting/pull/34, https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/pull/13638, https://github.com/GTNewHorizons/NotEnoughItems/pull/389.
quests/wiki should also get a follow-up.