### PR TITLE
Fix iridium exploit

### DIFF
--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingGem.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingGem.java
@@ -74,7 +74,8 @@ public class ProcessingGem implements gregtech.api.interfaces.IOreRecipeRegistra
                 if (!OrePrefixes.block.isIgnored(aMaterial)
                     && GT_OreDictUnificator.get(OrePrefixes.block, aMaterial, 1L) != null) {
                     // Compressor recipes
-                    {
+                    // need to avoid iridium exploit
+                    if (aMaterial != Materials.Iridium) {
                         GT_Values.RA.stdBuilder()
                             .itemInputs(GT_Utility.copyAmount(9L, aStack))
                             .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.block, aMaterial, 1L))
@@ -110,7 +111,9 @@ public class ProcessingGem implements gregtech.api.interfaces.IOreRecipeRegistra
                 } else {
                     // Forge hammer recipes
                     {
-                        if (GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L) != null) {
+                        // need to avoid iridium exploit
+                        if (GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L) != null
+                            && aMaterial != Materials.Iridium) {
                             GT_Values.RA.stdBuilder()
                                 .itemInputs(GT_Utility.copyAmount(1L, aStack))
                                 .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L))


### PR DESCRIPTION
fixes https://discord.com/channels/181078474394566657/603348502637969419/1117134080887246919

Dont use sifted ic2 iridium to bypass platline.

These recipes must have been removed elsewhere in the past (probably bartworks) but that must have broken recently. Anyway its better to not generate them in the first place.