### PR TITLE
Fix GT Ore Gen

### DIFF
--- a/src/main/java/gregtech/common/GT_Proxy.java
+++ b/src/main/java/gregtech/common/GT_Proxy.java
@@ -84,6 +84,7 @@ import net.minecraft.world.ChunkCoordIntPair;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldSettings.GameType;
 import net.minecraft.world.gen.feature.WorldGenMinable;
+import net.minecraftforge.common.DimensionManager;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.event.ForgeEventFactory;
@@ -1364,6 +1365,13 @@ public abstract class GT_Proxy implements IGT_Mod, IGuiHandler, IFuelHandler, IG
                 }
             }
         }
+        World world = DimensionManager.getWorld(0);
+        if (world.getWorldInfo()
+            .getWorldTotalTime() == 0L) {
+            // The world has just been created
+            GT_Worldgenerator.useNewOregenPattern = true;
+        }
+        GT_Worldgenerator.OregenPatternSavedData.loadData(world);
     }
 
     public void onServerStopping() {

--- a/src/main/java/gregtech/common/GT_Proxy.java
+++ b/src/main/java/gregtech/common/GT_Proxy.java
@@ -84,7 +84,6 @@ import net.minecraft.world.ChunkCoordIntPair;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldSettings.GameType;
 import net.minecraft.world.gen.feature.WorldGenMinable;
-import net.minecraftforge.common.DimensionManager;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.event.ForgeEventFactory;
@@ -1093,6 +1092,7 @@ public abstract class GT_Proxy implements IGT_Mod, IGuiHandler, IFuelHandler, IG
 
         MinecraftForge.EVENT_BUS.register(new GlobalEnergyWorldSavedData(""));
         MinecraftForge.EVENT_BUS.register(new SpaceProjectWorldSavedData());
+        MinecraftForge.EVENT_BUS.register(new GT_Worldgenerator.OregenPatternSavedData(""));
 
         // IC2 Hazmat
         addFullHazmatToIC2Item("hazmatHelmet");
@@ -1365,13 +1365,6 @@ public abstract class GT_Proxy implements IGT_Mod, IGuiHandler, IFuelHandler, IG
                 }
             }
         }
-        World world = DimensionManager.getWorld(0);
-        if (world.getWorldInfo()
-            .getWorldTotalTime() == 0L) {
-            // The world has just been created
-            GT_Worldgenerator.useNewOregenPattern = true;
-        }
-        GT_Worldgenerator.OregenPatternSavedData.loadData(world);
     }
 
     public void onServerStopping() {

--- a/src/main/java/gregtech/common/GT_Worldgenerator.java
+++ b/src/main/java/gregtech/common/GT_Worldgenerator.java
@@ -131,7 +131,9 @@ public class GT_Worldgenerator implements IWorldGenerator {
         if (oregenPattern == OregenPattern.EQUAL_SPACING) {
             return Math.floorMod(chunkX, 3) == 1 && Math.floorMod(chunkZ, 3) == 1;
         }
-        // AXISSYMMETRICAL - and next if statement here or convert to switch when expanding OregenPattern enum
+        // add next if statement here or convert to switch when expanding OregenPattern enum
+
+        // AXISSYMMETRICAL
         return Math.abs(chunkX) % 3 == 1 && Math.abs(chunkZ) % 3 == 1;
     }
 
@@ -145,6 +147,17 @@ public class GT_Worldgenerator implements IWorldGenerator {
         }
 
         public static void loadData(World world) {
+            if (world.getWorldInfo()
+                .getWorldTotalTime() == 0L) {
+                // The world has just been created -> use newest pattern
+                oregenPattern = OregenPattern.values()[OregenPattern.values().length - 1];
+            } else {
+                // This is an old world. Use legacy pattern for now, readFromNBT may change this if
+                // GregTech_OregenPattern.dat is present
+                oregenPattern = OregenPattern.AXISSYMMETRICAL;
+            }
+
+            // load OregenPatternSavedData
             WorldSavedData instance = world.mapStorage
                 .loadData(OregenPatternSavedData.class, OregenPatternSavedData.NAME);
             if (instance == null) {
@@ -156,14 +169,8 @@ public class GT_Worldgenerator implements IWorldGenerator {
 
         @SubscribeEvent
         public void onWorldLoad(WorldEvent.Load event) {
-            oregenPattern = OregenPattern.AXISSYMMETRICAL;
-            World world = event.world;
+            final World world = event.world;
             if (!world.isRemote && world.provider.dimensionId == 0) {
-                if (world.getWorldInfo()
-                    .getWorldTotalTime() == 0L) {
-                    // The world has just been created
-                    oregenPattern = OregenPattern.values()[OregenPattern.values().length - 1];
-                }
                 loadData(world);
             }
         }
@@ -186,6 +193,7 @@ public class GT_Worldgenerator implements IWorldGenerator {
     }
 
     public enum OregenPattern {
+        // The last value is used when creating a new world
         AXISSYMMETRICAL,
         EQUAL_SPACING;
     }

--- a/src/main/java/gregtech/common/GT_Worldgenerator.java
+++ b/src/main/java/gregtech/common/GT_Worldgenerator.java
@@ -156,6 +156,7 @@ public class GT_Worldgenerator implements IWorldGenerator {
 
         @SubscribeEvent
         public void onWorldLoad(WorldEvent.Load event) {
+            oregenPattern = OregenPattern.AXISSYMMETRICAL;
             World world = event.world;
             if (!world.isRemote && world.provider.dimensionId == 0) {
                 if (world.getWorldInfo()

--- a/src/main/java/gregtech/common/GT_Worldgenerator.java
+++ b/src/main/java/gregtech/common/GT_Worldgenerator.java
@@ -454,7 +454,8 @@ public class GT_Worldgenerator implements IWorldGenerator {
             for (int x = wXbox; x < eXbox; x++) {
                 for (int z = nZbox; z < sZbox; z++) {
                     // Determine if this X/Z is an orevein seed
-                    if (((Math.abs(x) % 3) == 1) && ((Math.abs(z) % 3) == 1)) {
+                    // use floorMod because java was written by idiots
+                    if ((Math.floorMod(x, 3) == 1) && (Math.floorMod(z, 3) == 1)) {
                         if (debugWorldGen) GT_Log.out.println("Adding seed x=" + x + " z=" + z);
                         seedList.add(new NearbySeeds(x, z));
                     }

--- a/src/main/java/gregtech/common/GT_Worldgenerator.java
+++ b/src/main/java/gregtech/common/GT_Worldgenerator.java
@@ -19,8 +19,10 @@ import net.minecraft.world.World;
 import net.minecraft.world.WorldSavedData;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.IChunkProvider;
+import net.minecraftforge.event.world.WorldEvent;
 
 import cpw.mods.fml.common.IWorldGenerator;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.registry.GameRegistry;
 import gregtech.api.GregTech_API;
 import gregtech.api.enums.Materials;
@@ -150,6 +152,19 @@ public class GT_Worldgenerator implements IWorldGenerator {
                 world.mapStorage.setData(OregenPatternSavedData.NAME, instance);
             }
             instance.markDirty();
+        }
+
+        @SubscribeEvent
+        public void onWorldLoad(WorldEvent.Load event) {
+            World world = event.world;
+            if (!world.isRemote && world.provider.dimensionId == 0) {
+                if (world.getWorldInfo()
+                    .getWorldTotalTime() == 0L) {
+                    // The world has just been created
+                    oregenPattern = OregenPattern.values()[OregenPattern.values().length - 1];
+                }
+                loadData(world);
+            }
         }
 
         @Override


### PR DESCRIPTION
Follow-up of #2070 with backwards compat. In other mods use `GT_Worldgenerator#useNewOregenPattern` and/or `GT_Worldgenerator#isOreChunk(int, int)`.


edit by chochem:
fixes the _oldest bug in the pack_. This makes oreveins always 3 chunks apart - even when crossing x=0 or z=0. closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/8912.

needs to be followed by https://github.com/GTNewHorizons/VisualProspecting/pull/35, https://github.com/GTNewHorizons/InGame-Info-XML/pull/18, https://github.com/GTNewHorizons/NotEnoughItems/pull/391, https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/pull/13700