### PR TITLE
Fix Precision

### DIFF
--- a/src/main/java/gregtech/api/util/GT_ApiaryUpgrade.java
+++ b/src/main/java/gregtech/api/util/GT_ApiaryUpgrade.java
@@ -49,17 +49,17 @@ public enum GT_ApiaryUpgrade {
         mods.biomeOverride = BiomeGenBase.taiga;
         mods.energy *= 1.5f;
     }),
-    dryer(UNIQUE_INDEX.DRYER_UPGRADE, 32214, 8, (mods, n) -> {
-        mods.humidity -= 0.25f * n;
-        mods.energy *= Math.pow(1.05f, n);
+    dryer(UNIQUE_INDEX.DRYER_UPGRADE, 32214, 10, (mods, n) -> {
+        mods.humidity -= 0.125f * n;
+        mods.energy *= Math.pow(1.025f, n);
     }),
     automation(UNIQUE_INDEX.AUTOMATION_UPGRADE, 32215, 1, (mods, n) -> {
         mods.isAutomated = true;
         mods.energy *= 1.1f;
     }),
-    humidifier(UNIQUE_INDEX.HUMIDIFIER_UPGRADE, 32216, 8, (mods, n) -> {
-        mods.humidity += 0.25f * n;
-        mods.energy *= Math.pow(1.1f, n);
+    humidifier(UNIQUE_INDEX.HUMIDIFIER_UPGRADE, 32216, 10, (mods, n) -> {
+        mods.humidity += 0.125f * n;
+        mods.energy *= Math.pow(1.05f, n);
     }),
     hell(UNIQUE_INDEX.HELL_UPGRADE, 32217, 1, (mods, n) -> {
         mods.biomeOverride = BiomeGenBase.hell;
@@ -73,9 +73,9 @@ public enum GT_ApiaryUpgrade {
         mods.biomeOverride = BiomeGenBase.desert;
         mods.energy *= 1.2f;
     }),
-    cooler(UNIQUE_INDEX.COOLER_UPGRADE, 32220, 8, (mods, n) -> {
-        mods.temperature -= 0.25f * n;
-        mods.energy *= Math.pow(1.05f, n);
+    cooler(UNIQUE_INDEX.COOLER_UPGRADE, 32220, 10, (mods, n) -> {
+        mods.temperature -= 0.125f * n;
+        mods.energy *= Math.pow(1.025f, n);
     }),
     lifespan(UNIQUE_INDEX.LIFESPAN_UPGRADE, 32221, 4, (mods, n) -> {
         mods.lifespan /= Math.pow(1.5f, n);

--- a/src/main/java/gregtech/common/items/GT_MetaGenerated_Item_03.java
+++ b/src/main/java/gregtech/common/items/GT_MetaGenerated_Item_03.java
@@ -773,7 +773,7 @@ public class GT_MetaGenerated_Item_03 extends GT_MetaGenerated_Item_X32 {
             addItem(
                 214,
                 "Dryer Upgrade",
-                "Dryer upgrade for Industrial Apiary/n Maximum Installed: 8/n * Humidity -25%/n * Energy Consumption +5%",
+                "Dryer upgrade for Industrial Apiary/n Maximum Installed: 10/n * Humidity -12.5%/n * Energy Consumption +2.5%",
                 OrePrefixes.apiaryUpgrade.name()));
         ItemList.IndustrialApiary_Upgrade_AUTOMATION.set(
             addItem(
@@ -785,7 +785,7 @@ public class GT_MetaGenerated_Item_03 extends GT_MetaGenerated_Item_X32 {
             addItem(
                 216,
                 "Humidifier Upgrade",
-                "Humidifier upgrade for Industrial Apiary/n Maximum Installed: 8/n * Humidity +25%/n * Energy Consumption +5%",
+                "Humidifier upgrade for Industrial Apiary/n Maximum Installed: 10/n * Humidity +12.5%/n * Energy Consumption +2.5%",
                 OrePrefixes.apiaryUpgrade.name()));
         ItemList.IndustrialApiary_Upgrade_HELL.set(
             addItem(
@@ -809,7 +809,7 @@ public class GT_MetaGenerated_Item_03 extends GT_MetaGenerated_Item_X32 {
             addItem(
                 220,
                 "Cooler Upgrade",
-                "Cooler upgrade for Industrial Apiary/n Maximum Installed: 8/n * Temperature -25%/n * Energy Consumption +5%",
+                "Cooler upgrade for Industrial Apiary/n Maximum Installed: 10/n * Temperature -12.5%/n * Energy Consumption +2.5%",
                 OrePrefixes.apiaryUpgrade.name()));
         ItemList.IndustrialApiary_Upgrade_LIFESPAN.set(
             addItem(


### PR DESCRIPTION
This increases the maximum amount of temperature upgrades from 8 to 10 while halfing the amount of temperature boost they give to allow for more precision. Previously you were not able to simulate a warm biome in normal/normal. Doubles Boost, halfes energy consumption.