### PR TITLE
ForgeDirections fix for GT Boilers

### DIFF
--- a/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler.java
+++ b/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler.java
@@ -328,14 +328,14 @@ public abstract class GT_MetaTileEntity_Boiler extends GT_MetaTileEntity_BasicTa
     }
 
     /**
-     * Pushes steam to Fluid inventories at all sides except Front.
+     * Pushes steam to Fluid inventories at all sides except Front and Bottom.
      *
      * @param aBaseMetaTileEntity The tile-entity instance of this Boiler
      */
     protected void pushSteamToInventories(IGregTechTileEntity aBaseMetaTileEntity) {
         if (mSteam == null || mSteam.amount == 0) return;
         for (final ForgeDirection direction : ForgeDirection.VALID_DIRECTIONS) {
-            if (direction == aBaseMetaTileEntity.getFrontFacing()) continue;
+            if (direction == aBaseMetaTileEntity.getFrontFacing() || direction == ForgeDirection.DOWN) continue;
             if (this.mSteam == null) break;
             pushSteamToSide(aBaseMetaTileEntity, direction);
         }


### PR DESCRIPTION
was caused by https://github.com/GTNewHorizons/GT5-Unofficial/pull/1895 from what I can tell but the code documentation was wrong too.

fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13783