### PR TITLE
Overhaul stretchy materials (aka bending recipes for Polyethylene)

### DIFF
--- a/src/main/java/gregtech/api/enums/Materials.java
+++ b/src/main/java/gregtech/api/enums/Materials.java
@@ -2230,10 +2230,14 @@ public class Materials implements IColorModulationContainer, ISubTagContainer {
 
         Rubber.add(SubTag.FLAMMABLE, SubTag.NO_SMASHING, SubTag.BOUNCY, SubTag.STRETCHY);
         StyreneButadieneRubber.add(SubTag.FLAMMABLE, SubTag.NO_SMASHING, SubTag.BOUNCY, SubTag.STRETCHY);
-        Plastic.add(SubTag.FLAMMABLE, SubTag.NO_SMASHING, SubTag.BOUNCY);
-        PolyvinylChloride.add(SubTag.FLAMMABLE, SubTag.NO_SMASHING, SubTag.BOUNCY);
-        Polystyrene.add(SubTag.FLAMMABLE, SubTag.NO_SMASHING, SubTag.BOUNCY);
+        Plastic.add(SubTag.FLAMMABLE, SubTag.NO_SMASHING, SubTag.BOUNCY, SubTag.STRETCHY);
+        PolyvinylChloride.add(SubTag.FLAMMABLE, SubTag.NO_SMASHING, SubTag.BOUNCY, SubTag.STRETCHY);
+        Polystyrene.add(SubTag.FLAMMABLE, SubTag.NO_SMASHING, SubTag.BOUNCY, SubTag.STRETCHY);
         Silicone.add(SubTag.FLAMMABLE, SubTag.NO_SMASHING, SubTag.BOUNCY, SubTag.STRETCHY);
+        Polytetrafluoroethylene.add(SubTag.FLAMMABLE, SubTag.NO_SMASHING, SubTag.STRETCHY);
+        Polybenzimidazole.add(SubTag.FLAMMABLE, SubTag.NO_SMASHING, SubTag.STRETCHY);
+        PolyphenyleneSulfide.add(SubTag.FLAMMABLE, SubTag.NO_SMASHING, SubTag.STRETCHY);
+        MaterialsKevlar.Kevlar.add(SubTag.FLAMMABLE, SubTag.NO_SMASHING, SubTag.STRETCHY);
 
         TNT.add(SubTag.FLAMMABLE, SubTag.EXPLOSIVE, SubTag.NO_SMELTING, SubTag.NO_SMASHING);
         Gunpowder.add(SubTag.FLAMMABLE, SubTag.EXPLOSIVE, SubTag.NO_SMELTING, SubTag.NO_SMASHING);

--- a/src/main/java/gregtech/api/enums/OrePrefixes.java
+++ b/src/main/java/gregtech/api/enums/OrePrefixes.java
@@ -926,17 +926,29 @@ public enum OrePrefixes {
             SubTag.MAGICAL,
             new ICondition.And<>(SubTag.TRANSPARENT, SubTag.HAS_COLOR));
 
-        plateDouble.mCondition = new ICondition.Or<>(SubTag.PAPER, new ICondition.Not<>(SubTag.NO_SMASHING));
-        plateTriple.mCondition = new ICondition.Or<>(SubTag.PAPER, new ICondition.Not<>(SubTag.NO_SMASHING));
-        plateQuadruple.mCondition = new ICondition.Or<>(SubTag.PAPER, new ICondition.Not<>(SubTag.NO_SMASHING));
-        plateQuintuple.mCondition = new ICondition.Or<>(SubTag.PAPER, new ICondition.Not<>(SubTag.NO_SMASHING));
+        plateDouble.mCondition = new ICondition.Or<>(
+            SubTag.PAPER,
+            new ICondition.Not<>(SubTag.NO_SMASHING),
+            SubTag.STRETCHY);
+        plateTriple.mCondition = new ICondition.Or<>(
+            SubTag.PAPER,
+            new ICondition.Not<>(SubTag.NO_SMASHING),
+            SubTag.STRETCHY);
+        plateQuadruple.mCondition = new ICondition.Or<>(
+            SubTag.PAPER,
+            new ICondition.Not<>(SubTag.NO_SMASHING),
+            SubTag.STRETCHY);
+        plateQuintuple.mCondition = new ICondition.Or<>(
+            SubTag.PAPER,
+            new ICondition.Not<>(SubTag.NO_SMASHING),
+            SubTag.STRETCHY);
 
-        plateDense.mCondition = new ICondition.Not<>(SubTag.NO_SMASHING);
+        plateDense.mCondition = new ICondition.Or<>(new ICondition.Not<>(SubTag.NO_SMASHING), SubTag.STRETCHY);
 
-        ingotDouble.mCondition = new ICondition.Not<>(SubTag.NO_SMASHING);
-        ingotTriple.mCondition = new ICondition.Not<>(SubTag.NO_SMASHING);
-        ingotQuadruple.mCondition = new ICondition.Not<>(SubTag.NO_SMASHING);
-        ingotQuintuple.mCondition = new ICondition.Not<>(SubTag.NO_SMASHING);
+        ingotDouble.mCondition = new ICondition.Or<>(new ICondition.Not<>(SubTag.NO_SMASHING), SubTag.STRETCHY);
+        ingotTriple.mCondition = new ICondition.Or<>(new ICondition.Not<>(SubTag.NO_SMASHING), SubTag.STRETCHY);
+        ingotQuadruple.mCondition = new ICondition.Or<>(new ICondition.Not<>(SubTag.NO_SMASHING), SubTag.STRETCHY);
+        ingotQuintuple.mCondition = new ICondition.Or<>(new ICondition.Not<>(SubTag.NO_SMASHING), SubTag.STRETCHY);
 
         wireFine.mCondition = SubTag.METAL;
 

--- a/src/main/java/gregtech/api/enums/SubTag.java
+++ b/src/main/java/gregtech/api/enums/SubTag.java
@@ -83,7 +83,7 @@ public final class SubTag implements ICondition<ISubTagContainer> {
      */
     public static final SubTag NO_WORKING = getNewSubTag("NO_WORKING");
     /**
-     * This Material cannot be used for regular Metal working techniques since it is not possible to bend it. Already
+     * This Material cannot be used for regular Metal working techniques. Already
      * listed are: Rubber, Plastic, Paper, Wood, Stone
      */
     public static final SubTag NO_SMASHING = getNewSubTag("NO_SMASHING");

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingIngot.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingIngot.java
@@ -43,6 +43,7 @@ public class ProcessingIngot implements gregtech.api.interfaces.IOreRecipeRegist
     public void registerOre(OrePrefixes aPrefix, Materials aMaterial, String aOreDictName, String aModName,
         ItemStack aStack) {
         boolean aNoSmashing = aMaterial.contains(SubTag.NO_SMASHING);
+        boolean aStretchy = aMaterial.contains(SubTag.STRETCHY);
         boolean aNoSmelting = aMaterial.contains(SubTag.NO_SMELTING);
         long aMaterialMass = aMaterial.getMass();
         boolean aSpecialRecipeReq = aMaterial.mUnificatable && (aMaterial.mMaterialInto == aMaterial)
@@ -105,7 +106,7 @@ public class ProcessingIngot implements gregtech.api.interfaces.IOreRecipeRegist
                         GT_Proxy.tBits,
                         new Object[] { ToolDictNames.craftingToolMortar, OrePrefixes.ingot.get(aMaterial) });
                 }
-                if (!aNoSmashing) {
+                if (!aNoSmashing || aStretchy) {
                     // Forge hammer recipes
                     if (aMaterial.getProcessingMaterialTierEU() < TierEU.IV) {
                         GT_Values.RA.stdBuilder()
@@ -200,7 +201,7 @@ public class ProcessingIngot implements gregtech.api.interfaces.IOreRecipeRegist
                 }
             }
             case ingotDouble -> {
-                if (!aNoSmashing) {
+                if (!aNoSmashing || aStretchy) {
                     // bender recipes
                     {
                         GT_Values.RA.stdBuilder()
@@ -234,7 +235,7 @@ public class ProcessingIngot implements gregtech.api.interfaces.IOreRecipeRegist
                 }
             }
             case ingotTriple -> {
-                if (!aNoSmashing) {
+                if (!aNoSmashing || aStretchy) {
                     // Bender recipes
                     {
                         GT_Values.RA.stdBuilder()
@@ -268,7 +269,7 @@ public class ProcessingIngot implements gregtech.api.interfaces.IOreRecipeRegist
                 }
             }
             case ingotQuadruple -> {
-                if (!aNoSmashing) {
+                if (!aNoSmashing || aStretchy) {
                     // Bender recipes
                     {
                         GT_Values.RA.stdBuilder()
@@ -294,7 +295,7 @@ public class ProcessingIngot implements gregtech.api.interfaces.IOreRecipeRegist
                 }
             }
             case ingotQuintuple -> {
-                if (!aNoSmashing) {
+                if (!aNoSmashing || aStretchy) {
                     // Bender recipes
                     {
                         GT_Values.RA.stdBuilder()

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingPlate.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingPlate.java
@@ -191,7 +191,7 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
 
         GT_ModHandler.removeRecipeByOutputDelayed(aStack);
 
-        if (!aNoSmashing) {
+        if (!aNoSmashing || aMaterial.contains(SubTag.STRETCHY)) {
             // 2 double -> 1 quadruple plate
             if (GT_OreDictUnificator.get(OrePrefixes.plateQuadruple, aMaterial, 1L) != null) {
                 GT_Values.RA.stdBuilder()
@@ -203,7 +203,31 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
                     .eut(calculateRecipeEU(aMaterial, 96))
                     .addTo(sBenderRecipes);
             }
+            // 2 plates -> 1 double plate
+            GT_Values.RA.stdBuilder()
+                .itemInputs(
+                    GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 2L),
+                    GT_Utility.getIntegratedCircuit(2))
+                .itemOutputs(GT_Utility.copyAmount(1L, aStack))
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(Math.max(aMaterialMass * 2L, 1L))
+                .eut(calculateRecipeEU(aMaterial, 96))
+                .addTo(sBenderRecipes);
+        } else {
+            GT_Values.RA.stdBuilder()
+                .itemInputs(
+                    GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 2L),
+                    GT_Utility.getIntegratedCircuit(2))
+                .itemOutputs(GT_Utility.copyAmount(1L, aStack))
+                .fluidInputs(Materials.Glue.getFluid(10L))
+                .noFluidOutputs()
+                .duration(3 * SECONDS + 4 * TICKS)
+                .eut(8)
+                .addTo(sAssemblerRecipes);
+        }
 
+        if (!aNoSmashing) {
             if (GregTech_API.sRecipeFile.get(
                 gregtech.api.enums.ConfigCategories.Tools.hammerdoubleplate,
                 OrePrefixes.plate.get(aMaterial)
@@ -220,30 +244,6 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
                             'I', aPlateStack, 'B', aPlateStack });
                 }
             }
-
-            // 2 plates -> 1 double plate
-            GT_Values.RA.stdBuilder()
-                .itemInputs(
-                    GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 2L),
-                    GT_Utility.getIntegratedCircuit(2))
-                .itemOutputs(GT_Utility.copyAmount(1L, aStack))
-                .noFluidInputs()
-                .noFluidOutputs()
-                .duration(Math.max(aMaterialMass * 2L, 1L))
-                .eut(calculateRecipeEU(aMaterial, 96))
-                .addTo(sBenderRecipes);
-
-        } else {
-            GT_Values.RA.stdBuilder()
-                .itemInputs(
-                    GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 2L),
-                    GT_Utility.getIntegratedCircuit(2))
-                .itemOutputs(GT_Utility.copyAmount(1L, aStack))
-                .fluidInputs(Materials.Glue.getFluid(10L))
-                .noFluidOutputs()
-                .duration(3 * SECONDS + 4 * TICKS)
-                .eut(8)
-                .addTo(sAssemblerRecipes);
         }
     }
 
@@ -254,18 +254,43 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
 
         GT_ModHandler.removeRecipeByOutputDelayed(aStack);
 
-        if (!aNoSmashing) {
+        if (!aNoSmashing || aMaterial.contains(SubTag.STRETCHY)) {
+            if (GT_OreDictUnificator.get(OrePrefixes.plateDense, aMaterial, 1L) != null) {
+                // 3 triple plates -> 1 dense plate
+                GT_Values.RA.stdBuilder()
+                    .itemInputs(GT_Utility.copyAmount(3L, aStack), GT_Utility.getIntegratedCircuit(3))
+                    .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plateDense, aMaterial, 1L))
+                    .noFluidInputs()
+                    .noFluidOutputs()
+                    .duration(Math.max(aMaterialMass * 3L, 1L))
+                    .eut(calculateRecipeEU(aMaterial, 96))
+                    .addTo(sBenderRecipes);
+            }
 
-            // 3 triple plates -> 1 dense plate
             GT_Values.RA.stdBuilder()
-                .itemInputs(GT_Utility.copyAmount(3L, aStack), GT_Utility.getIntegratedCircuit(3))
-                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plateDense, aMaterial, 1L))
+                .itemInputs(
+                    GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 3L),
+                    GT_Utility.getIntegratedCircuit(3))
+                .itemOutputs(GT_Utility.copyAmount(1L, aStack))
                 .noFluidInputs()
                 .noFluidOutputs()
                 .duration(Math.max(aMaterialMass * 3L, 1L))
                 .eut(calculateRecipeEU(aMaterial, 96))
                 .addTo(sBenderRecipes);
+        } else {
+            GT_Values.RA.stdBuilder()
+                .itemInputs(
+                    GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 3L),
+                    GT_Utility.getIntegratedCircuit(3))
+                .itemOutputs(GT_Utility.copyAmount(1L, aStack))
+                .fluidInputs(Materials.Glue.getFluid(20L))
+                .noFluidOutputs()
+                .duration(4 * SECONDS + 16 * TICKS)
+                .eut(8)
+                .addTo(sAssemblerRecipes);
+        }
 
+        if (!aNoSmashing) {
             if (GregTech_API.sRecipeFile.get(
                 gregtech.api.enums.ConfigCategories.Tools.hammertripleplate,
                 OrePrefixes.plate.get(aMaterial)
@@ -289,29 +314,6 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
                             aPlateStack, aPlateStack });
                 }
             }
-
-            GT_Values.RA.stdBuilder()
-                .itemInputs(
-                    GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 3L),
-                    GT_Utility.getIntegratedCircuit(3))
-                .itemOutputs(GT_Utility.copyAmount(1L, aStack))
-                .noFluidInputs()
-                .noFluidOutputs()
-                .duration(Math.max(aMaterialMass * 3L, 1L))
-                .eut(calculateRecipeEU(aMaterial, 96))
-                .addTo(sBenderRecipes);
-
-        } else {
-            GT_Values.RA.stdBuilder()
-                .itemInputs(
-                    GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 3L),
-                    GT_Utility.getIntegratedCircuit(3))
-                .itemOutputs(GT_Utility.copyAmount(1L, aStack))
-                .fluidInputs(Materials.Glue.getFluid(20L))
-                .noFluidOutputs()
-                .duration(4 * SECONDS + 16 * TICKS)
-                .eut(8)
-                .addTo(sAssemblerRecipes);
         }
 
         if (GT_OreDictUnificator.get(OrePrefixes.compressed, aMaterial, 1L) != null) {
@@ -365,8 +367,31 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
 
         GT_ModHandler.removeRecipeByOutputDelayed(aStack);
 
+        if (!aNoSmashing || aMaterial.contains(SubTag.STRETCHY)) {
+            // Quadruple plate
+            GT_Values.RA.stdBuilder()
+                .itemInputs(
+                    GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 4L),
+                    GT_Utility.getIntegratedCircuit(4))
+                .itemOutputs(GT_Utility.copyAmount(1L, aStack))
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(Math.max(aMaterialMass * 4L, 1L))
+                .eut(calculateRecipeEU(aMaterial, 96))
+                .addTo(sBenderRecipes);
+        } else {
+            GT_Values.RA.stdBuilder()
+                .itemInputs(
+                    GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 4L),
+                    GT_Utility.getIntegratedCircuit(4))
+                .itemOutputs(GT_Utility.copyAmount(1L, aStack))
+                .fluidInputs(Materials.Glue.getFluid(30L))
+                .noFluidOutputs()
+                .duration(6 * SECONDS + 8 * TICKS)
+                .eut(8)
+                .addTo(sAssemblerRecipes);
+        }
         if (!aNoSmashing) {
-
             if (GregTech_API.sRecipeFile.get(
                 gregtech.api.enums.ConfigCategories.Tools.hammerquadrupleplate,
                 OrePrefixes.plate.get(aMaterial)
@@ -389,30 +414,6 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
                             aPlateStack, aPlateStack, aPlateStack });
                 }
             }
-
-            // Quadruple plate
-            GT_Values.RA.stdBuilder()
-                .itemInputs(
-                    GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 4L),
-                    GT_Utility.getIntegratedCircuit(4))
-                .itemOutputs(GT_Utility.copyAmount(1L, aStack))
-                .noFluidInputs()
-                .noFluidOutputs()
-                .duration(Math.max(aMaterialMass * 4L, 1L))
-                .eut(calculateRecipeEU(aMaterial, 96))
-                .addTo(sBenderRecipes);
-
-        } else {
-            GT_Values.RA.stdBuilder()
-                .itemInputs(
-                    GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 4L),
-                    GT_Utility.getIntegratedCircuit(4))
-                .itemOutputs(GT_Utility.copyAmount(1L, aStack))
-                .fluidInputs(Materials.Glue.getFluid(30L))
-                .noFluidOutputs()
-                .duration(6 * SECONDS + 8 * TICKS)
-                .eut(8)
-                .addTo(sAssemblerRecipes);
         }
     }
 
@@ -423,8 +424,31 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
 
         GT_ModHandler.removeRecipeByOutputDelayed(aStack);
 
+        if (!aNoSmashing || aMaterial.contains(SubTag.STRETCHY)) {
+            // quintuple plate
+            GT_Values.RA.stdBuilder()
+                .itemInputs(
+                    GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 5L),
+                    GT_Utility.getIntegratedCircuit(5))
+                .itemOutputs(GT_Utility.copyAmount(1L, aStack))
+                .noFluidInputs()
+                .noFluidOutputs()
+                .duration(Math.max(aMaterialMass * 5L, 1L))
+                .eut(calculateRecipeEU(aMaterial, 96))
+                .addTo(sBenderRecipes);
+        } else {
+            GT_Values.RA.stdBuilder()
+                .itemInputs(
+                    GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 5L),
+                    GT_Utility.getIntegratedCircuit(5))
+                .itemOutputs(GT_Utility.copyAmount(1L, aStack))
+                .fluidInputs(Materials.Glue.getFluid(40L))
+                .noFluidOutputs()
+                .duration(8 * SECONDS)
+                .eut(8)
+                .addTo(sAssemblerRecipes);
+        }
         if (!aNoSmashing) {
-
             if (GregTech_API.sRecipeFile.get(
                 gregtech.api.enums.ConfigCategories.Tools.hammerquintupleplate,
                 OrePrefixes.plate.get(aMaterial)
@@ -447,30 +471,6 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
                             aPlateStack, aPlateStack });
                 }
             }
-
-            // quintuple plate
-            GT_Values.RA.stdBuilder()
-                .itemInputs(
-                    GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 5L),
-                    GT_Utility.getIntegratedCircuit(5))
-                .itemOutputs(GT_Utility.copyAmount(1L, aStack))
-                .noFluidInputs()
-                .noFluidOutputs()
-                .duration(Math.max(aMaterialMass * 5L, 1L))
-                .eut(calculateRecipeEU(aMaterial, 96))
-                .addTo(sBenderRecipes);
-
-        } else {
-            GT_Values.RA.stdBuilder()
-                .itemInputs(
-                    GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 5L),
-                    GT_Utility.getIntegratedCircuit(5))
-                .itemOutputs(GT_Utility.copyAmount(1L, aStack))
-                .fluidInputs(Materials.Glue.getFluid(40L))
-                .noFluidOutputs()
-                .duration(8 * SECONDS)
-                .eut(8)
-                .addTo(sAssemblerRecipes);
         }
     }
 
@@ -481,7 +481,7 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
 
         GT_ModHandler.removeRecipeByOutputDelayed(aStack);
 
-        if (!aNoSmashing) {
+        if (!aNoSmashing || aMaterial.contains(SubTag.STRETCHY)) {
             // Dense plate
             GT_Values.RA.stdBuilder()
                 .itemInputs(


### PR DESCRIPTION
### Introduction
Dream asked me why Polyethylene does not have normal bending for plates, or the circuit 10 recipe for foils. So here I am. Wait, actually BlueWeabo asked me the exact same thing last week. There is clearly no good reason for it except that it always was thus. There is no reason for it to be particularly hard to form a plastic or rubber into a plate or foil.

### The Changes
- expanded the subtag STRETCHY (as well as flammable and nosmashing) to all the plastic or rubber like materials. The list currently reads: PBI, Kevlar, PolyphenyleneSulfide, PTFE, PE, PVC, Polystyrene, Silicon Rubber, Rubber, Styrene-Butadiene.
- added double plates-dense plates to all STRETCHY materials as some where already using them (most notably PBI !)
- allowed bending of plates and foils for STRETCHY material.

### The Results
Main Result:
- you can now use circuit 10 for Polyethylene or PVC Foils. and make plates from ingots in the bender (not just extruder).
- you can no longer make a PBI sawblade
- all the plastic behave similarly now. (except soft hammer recipe, that is BOUNCY tag)

side effects:
- there are now dense PE sheets, which is logical but useless for now

### What is NOT changed
- hopefully no component that is needed is missing, I did check the materials pages of course and it looks good
- I intentionally left out bending recipes for the springs and small springs of these materials. (but they are unused anyway)