### PR TITLE
MuTE casing structure element

### DIFF
--- a/src/main/java/gregtech/api/multitileentity/enums/GT_MultiTileCasing.java
+++ b/src/main/java/gregtech/api/multitileentity/enums/GT_MultiTileCasing.java
@@ -1,21 +1,36 @@
 package gregtech.api.multitileentity.enums;
 
+import static gregtech.api.util.GT_StructureUtilityMuTE.createMuTEStructureCasing;
+import static gregtech.loaders.preload.GT_Loader_MultiTileEntities.CASING_REGISTRY_NAME;
+
 import gregtech.api.enums.GT_Values;
+import gregtech.api.util.GT_StructureUtilityMuTE;
 
 public enum GT_MultiTileCasing {
 
     CokeOven(0),
     Chemical(1),
     Distillation(2),
+    Macerator(18000),
     NONE(GT_Values.W);
 
     private final int meta;
+    private final GT_StructureUtilityMuTE.MuTEStructureCasing casing;
 
     GT_MultiTileCasing(int meta) {
         this.meta = meta;
+        casing = createMuTEStructureCasing(CASING_REGISTRY_NAME, meta);
     }
 
     public int getId() {
         return meta;
+    }
+
+    public short getRegistryId() {
+        return (short) casing.getRegistryId();
+    }
+
+    public GT_StructureUtilityMuTE.MuTEStructureCasing getCasing() {
+        return casing;
     }
 }

--- a/src/main/java/gregtech/api/multitileentity/multiblock/base/Controller.java
+++ b/src/main/java/gregtech/api/multitileentity/multiblock/base/Controller.java
@@ -1,10 +1,7 @@
 package gregtech.api.multitileentity.multiblock.base;
 
-import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofChain;
-import static gregtech.GT_Mod.GT_FML_LOGGER;
 import static gregtech.api.multitileentity.enums.GT_MultiTileComponentCasing.*;
 import static gregtech.api.util.GT_Utility.moveMultipleItemStacks;
-import static gregtech.loaders.preload.GT_Loader_MultiTileEntities.COMPONENT_CASING_REGISTRY_NAME;
 import static mcp.mobius.waila.api.SpecialChars.*;
 
 import java.lang.ref.WeakReference;
@@ -18,7 +15,6 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
-import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.inventory.IInventory;
@@ -26,7 +22,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.IIcon;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.Constants;
 import net.minecraftforge.common.util.ForgeDirection;
@@ -49,8 +44,6 @@ import com.gtnewhorizon.structurelib.alignment.enumerable.ExtendedFacing;
 import com.gtnewhorizon.structurelib.alignment.enumerable.Flip;
 import com.gtnewhorizon.structurelib.alignment.enumerable.Rotation;
 import com.gtnewhorizon.structurelib.structure.IStructureDefinition;
-import com.gtnewhorizon.structurelib.structure.IStructureElement;
-import com.gtnewhorizon.structurelib.structure.IStructureElementChain;
 import com.gtnewhorizon.structurelib.structure.ISurvivalBuildEnvironment;
 import com.gtnewhorizon.structurelib.util.Vec3Impl;
 import com.gtnewhorizons.modularui.api.ModularUITextures;
@@ -76,8 +69,6 @@ import gnu.trove.list.TIntList;
 import gnu.trove.list.array.TIntArrayList;
 import gregtech.api.enums.GT_Values;
 import gregtech.api.enums.GT_Values.NBT;
-import gregtech.api.enums.OrePrefixes;
-import gregtech.api.enums.TextureSet;
 import gregtech.api.enums.VoidingMode;
 import gregtech.api.fluid.FluidTankGT;
 import gregtech.api.gui.modularui.GT_UITextures;
@@ -89,12 +80,9 @@ import gregtech.api.logic.PowerLogic;
 import gregtech.api.logic.ProcessingLogic;
 import gregtech.api.logic.interfaces.PowerLogicHost;
 import gregtech.api.logic.interfaces.ProcessingLogicHost;
-import gregtech.api.multitileentity.MultiTileEntityContainer;
-import gregtech.api.multitileentity.MultiTileEntityRegistry;
 import gregtech.api.multitileentity.enums.MultiTileCasingPurpose;
 import gregtech.api.multitileentity.interfaces.IMultiBlockController;
 import gregtech.api.multitileentity.interfaces.IMultiBlockPart;
-import gregtech.api.multitileentity.interfaces.IMultiTileEntity;
 import gregtech.api.multitileentity.interfaces.IMultiTileEntity.IMTE_AddToolTips;
 import gregtech.api.multitileentity.machine.MultiTileBasicMachine;
 import gregtech.api.multitileentity.multiblock.casing.FunctionalCasing;
@@ -908,230 +896,7 @@ public abstract class Controller<T extends Controller<T>> extends MultiTileBasic
         }
     }
 
-    public <S> IStructureElement<S> addMultiTileCasing(String registryName, int meta, int modes) {
-        MultiTileEntityRegistry registry = MultiTileEntityRegistry.getRegistry(registryName);
-        int registryID = Block.getIdFromBlock(registry.mBlock);
-        return addMultiTileCasing(registryID, meta, modes);
-    }
-
-    public <S> IStructureElement<S> addMultiTileCasing(int registryID, int meta, int modes) {
-        return new IStructureElement<S>() {
-
-            private final short[] DEFAULT = new short[] { 255, 255, 255, 0 };
-            private IIcon[] mIcons = null;
-
-            @Override
-            public boolean check(S t, World world, int x, int y, int z) {
-                final TileEntity tileEntity = world.getTileEntity(x, y, z);
-                if (!(tileEntity instanceof MultiBlockPart part)) return false;
-
-                if (registryID != part.getMultiTileEntityRegistryID() || meta != part.getMultiTileEntityID())
-                    return false;
-
-                final IMultiBlockController tTarget = part.getTarget(false);
-                if (tTarget != null && tTarget != t) return false;
-
-                part.setTarget((IMultiBlockController) t, modes);
-
-                ((Controller<?>) t).registerSpecialCasings(part);
-                return true;
-            }
-
-            @Override
-            public boolean spawnHint(S t, World world, int x, int y, int z, ItemStack trigger) {
-                if (mIcons == null) {
-                    mIcons = new IIcon[6];
-                    Arrays.fill(mIcons, TextureSet.SET_NONE.mTextures[OrePrefixes.block.mTextureIndex].getIcon());
-                    // Arrays.fill(mIcons, getTexture(aCasing);
-                    // for (byte i : ALL_VALID_SIDES) {
-                    // mIcons[i] = aCasing.getIcon(i, aMeta);
-                    // }
-                }
-                final short[] RGBA = DEFAULT;
-                StructureLibAPI.hintParticleTinted(world, x, y, z, mIcons, RGBA);
-                // StructureLibAPI.hintParticle(world, x, y, z, aCasing, aMeta);
-                return true;
-            }
-
-            @Override
-            public boolean placeBlock(S t, World world, int x, int y, int z, ItemStack trigger) {
-                final MultiTileEntityRegistry tRegistry = MultiTileEntityRegistry.getRegistry(registryID);
-                if (tRegistry == null) {
-                    GT_FML_LOGGER.error("NULL REGISTRY");
-                    return false;
-                }
-                final MultiTileEntityContainer tContainer = tRegistry
-                    .getNewTileEntityContainer(world, x, y, z, meta, null);
-                if (tContainer == null) {
-                    GT_FML_LOGGER.error("NULL CONTAINER");
-                    return false;
-                }
-                final IMultiTileEntity te = ((IMultiTileEntity) tContainer.mTileEntity);
-                if (!(te instanceof MultiBlockPart)) {
-                    GT_FML_LOGGER.error("Not a multiblock part");
-                    return false;
-                }
-                if (world.setBlock(x, y, z, tContainer.mBlock, 15 - tContainer.mBlockMetaData, 2)) {
-                    tContainer.setMultiTile(world, x, y, z);
-                    ((MultiBlockPart) te).setTarget((IMultiBlockController) t, modes);
-
-                    ((Controller<?>) t).registerSpecialCasings((MultiBlockPart) te);
-                }
-
-                return false;
-            }
-
-            public IIcon getTexture(OrePrefixes aBlock) {
-                return TextureSet.SET_NONE.mTextures[OrePrefixes.block.mTextureIndex].getIcon();
-            }
-        };
-    }
-
-    protected <S> IStructureElementChain<S> addMotorCasings(int modes) {
-        return ofChain(
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, LV_Motor.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, MV_Motor.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, HV_Motor.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, EV_Motor.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, IV_Motor.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, LuV_Motor.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, ZPM_Motor.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, UV_Motor.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, UHV_Motor.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, UEV_Motor.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, UIV_Motor.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, UMV_Motor.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, UXV_Motor.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, MAX_Motor.getId(), modes));
-    }
-
-    protected <S> IStructureElementChain<S> addPumpCasings(int modes) {
-        return ofChain(
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, LV_Pump.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, MV_Pump.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, HV_Pump.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, EV_Pump.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, IV_Pump.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, LuV_Pump.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, ZPM_Pump.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, UV_Pump.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, UHV_Pump.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, UEV_Pump.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, UIV_Pump.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, UMV_Pump.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, UXV_Pump.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, MAX_Pump.getId(), modes));
-    }
-
-    protected <S> IStructureElementChain<S> addPistonCasings(int modes) {
-        return ofChain(
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, LV_Piston.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, MV_Piston.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, HV_Piston.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, EV_Piston.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, IV_Piston.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, LuV_Piston.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, ZPM_Piston.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, UV_Piston.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, UHV_Piston.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, UEV_Piston.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, UIV_Piston.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, UMV_Piston.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, UXV_Piston.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, MAX_Piston.getId(), modes));
-    }
-
-    protected <S> IStructureElementChain<S> addConveyorCasings(int modes) {
-        return ofChain(
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, LV_Conveyor.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, MV_Conveyor.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, HV_Conveyor.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, EV_Conveyor.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, IV_Conveyor.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, LuV_Conveyor.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, ZPM_Conveyor.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, UV_Conveyor.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, UHV_Conveyor.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, UEV_Conveyor.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, UIV_Conveyor.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, UMV_Conveyor.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, UXV_Conveyor.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, MAX_Conveyor.getId(), modes));
-    }
-
-    protected <S> IStructureElementChain<S> addRobotArmCasings(int modes) {
-        return ofChain(
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, LV_RobotArm.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, MV_RobotArm.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, HV_RobotArm.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, EV_RobotArm.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, IV_RobotArm.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, LuV_RobotArm.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, ZPM_RobotArm.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, UV_RobotArm.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, UHV_RobotArm.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, UEV_RobotArm.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, UIV_RobotArm.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, UMV_RobotArm.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, UXV_RobotArm.getId(), modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, MAX_RobotArm.getId(), modes));
-    }
-
-    protected <S> IStructureElementChain<S> addSensorCasings(int Modes) {
-        return ofChain(
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, LV_Sensor.getId(), Modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, MV_Sensor.getId(), Modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, HV_Sensor.getId(), Modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, EV_Sensor.getId(), Modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, IV_Sensor.getId(), Modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, LuV_Sensor.getId(), Modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, ZPM_Sensor.getId(), Modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, UV_Sensor.getId(), Modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, UHV_Sensor.getId(), Modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, UEV_Sensor.getId(), Modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, UIV_Sensor.getId(), Modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, UMV_Sensor.getId(), Modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, UXV_Sensor.getId(), Modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, MAX_Sensor.getId(), Modes));
-    }
-
-    protected <S> IStructureElementChain<S> addEmitterCasings(int Modes) {
-        return ofChain(
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, LV_Emitter.getId(), Modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, MV_Emitter.getId(), Modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, HV_Emitter.getId(), Modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, EV_Emitter.getId(), Modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, IV_Emitter.getId(), Modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, LuV_Emitter.getId(), Modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, ZPM_Emitter.getId(), Modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, UV_Emitter.getId(), Modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, UHV_Emitter.getId(), Modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, UEV_Emitter.getId(), Modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, UIV_Emitter.getId(), Modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, UMV_Emitter.getId(), Modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, UXV_Emitter.getId(), Modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, MAX_Emitter.getId(), Modes));
-    }
-
-    protected <S> IStructureElementChain<S> addFieldGeneratorCasings(int Modes) {
-        return ofChain(
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, LV_FieldGenerator.getId(), Modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, MV_FieldGenerator.getId(), Modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, HV_FieldGenerator.getId(), Modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, EV_FieldGenerator.getId(), Modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, IV_FieldGenerator.getId(), Modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, LuV_FieldGenerator.getId(), Modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, ZPM_FieldGenerator.getId(), Modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, UV_FieldGenerator.getId(), Modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, UHV_FieldGenerator.getId(), Modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, UEV_FieldGenerator.getId(), Modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, UIV_FieldGenerator.getId(), Modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, UMV_FieldGenerator.getId(), Modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, UXV_FieldGenerator.getId(), Modes),
-            addMultiTileCasing(COMPONENT_CASING_REGISTRY_NAME, MAX_FieldGenerator.getId(), Modes));
-    }
-
-    protected void registerSpecialCasings(MultiBlockPart part) {
+    public void registerSpecialCasings(MultiBlockPart part) {
         if (part instanceof UpgradeCasing) {
             upgradeCasings.add((UpgradeCasing) part);
         }

--- a/src/main/java/gregtech/api/util/GT_StructureUtilityMuTE.java
+++ b/src/main/java/gregtech/api/util/GT_StructureUtilityMuTE.java
@@ -6,7 +6,6 @@ import static gregtech.api.multitileentity.enums.GT_MultiTileUpgradeCasing.*;
 import static gregtech.loaders.preload.GT_Loader_MultiTileEntities.*;
 
 import java.util.Arrays;
-import java.util.HashSet;
 
 import net.minecraft.block.Block;
 import net.minecraft.item.ItemStack;
@@ -228,7 +227,7 @@ public class GT_StructureUtilityMuTE {
         private String registryName;
         private int registryId = GT_Values.W;
         private final int defaultMeta;
-        private final HashSet<Integer> validIds;
+        private final Integer[] validIds;
 
         public MuTEStructureCasing(String registryName, Integer... validIds) {
             MultiTileEntityRegistry registry = MultiTileEntityRegistry.getRegistry(registryName);
@@ -236,7 +235,7 @@ public class GT_StructureUtilityMuTE {
                 throw new IllegalArgumentException();
             }
             this.registryName = registryName;
-            this.validIds = new HashSet<>(Arrays.asList(validIds));
+            this.validIds = validIds;
             this.defaultMeta = validIds[0];
         }
 
@@ -244,7 +243,12 @@ public class GT_StructureUtilityMuTE {
             if (getRegistryId() != registryId) {
                 return false;
             }
-            return validIds.contains(id);
+            for (Integer validId : validIds) {
+                if (validId == id) {
+                    return true;
+                }
+            }
+            return false;
         }
 
         public int getDefaultMeta() {

--- a/src/main/java/gregtech/api/util/GT_StructureUtilityMuTE.java
+++ b/src/main/java/gregtech/api/util/GT_StructureUtilityMuTE.java
@@ -173,14 +173,9 @@ public class GT_StructureUtilityMuTE {
                 if (mIcons == null) {
                     mIcons = new IIcon[6];
                     Arrays.fill(mIcons, TextureSet.SET_NONE.mTextures[OrePrefixes.block.mTextureIndex].getIcon());
-                    // Arrays.fill(mIcons, getTexture(aCasing);
-                    // for (byte i : ALL_VALID_SIDES) {
-                    // mIcons[i] = aCasing.getIcon(i, aMeta);
-                    // }
                 }
                 final short[] RGBA = DEFAULT;
                 StructureLibAPI.hintParticleTinted(world, x, y, z, mIcons, RGBA);
-                // StructureLibAPI.hintParticle(world, x, y, z, aCasing, aMeta);
                 return true;
             }
 

--- a/src/main/java/gregtech/api/util/GT_StructureUtilityMuTE.java
+++ b/src/main/java/gregtech/api/util/GT_StructureUtilityMuTE.java
@@ -1,0 +1,248 @@
+package gregtech.api.util;
+
+import static gregtech.GT_Mod.GT_FML_LOGGER;
+import static gregtech.api.multitileentity.enums.GT_MultiTileComponentCasing.*;
+import static gregtech.api.multitileentity.enums.GT_MultiTileUpgradeCasing.*;
+import static gregtech.loaders.preload.GT_Loader_MultiTileEntities.*;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+import net.minecraft.block.Block;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.IIcon;
+import net.minecraft.world.World;
+
+import com.gtnewhorizon.structurelib.StructureLibAPI;
+import com.gtnewhorizon.structurelib.structure.IStructureElement;
+
+import gregtech.api.enums.OrePrefixes;
+import gregtech.api.enums.TextureSet;
+import gregtech.api.multitileentity.MultiTileEntityContainer;
+import gregtech.api.multitileentity.MultiTileEntityRegistry;
+import gregtech.api.multitileentity.enums.GT_MultiTileUpgradeCasing;
+import gregtech.api.multitileentity.interfaces.IMultiBlockController;
+import gregtech.api.multitileentity.interfaces.IMultiTileEntity;
+import gregtech.api.multitileentity.multiblock.base.Controller;
+import gregtech.api.multitileentity.multiblock.base.MultiBlockPart;
+
+public class GT_StructureUtilityMuTE {
+
+    public static final MuTEStructureCasing MOTOR_CASINGS = FunctionalCasings.Motor.getCasing();
+    public static final MuTEStructureCasing PUMP_CASINGS = FunctionalCasings.Pump.getCasing();
+    public static final MuTEStructureCasing CONVEYOR_CASINGS = FunctionalCasings.Conveyor.getCasing();
+    public static final MuTEStructureCasing PISTON_CASINGS = FunctionalCasings.Piston.getCasing();
+    public static final MuTEStructureCasing ROBOT_ARM_CASINGS = FunctionalCasings.RobotArm.getCasing();
+    public static final MuTEStructureCasing EMITTER_CASINGS = FunctionalCasings.Emitter.getCasing();
+    public static final MuTEStructureCasing SENSOR_CASINGS = FunctionalCasings.Sensor.getCasing();
+    public static final MuTEStructureCasing FIELD_GENERATOR_CASINGS = FunctionalCasings.FieldGenerator.getCasing();
+    public static final MuTEStructureCasing INVENTORY_CASINGS = UpgradeCasings.Inventory.getCasing();
+    public static final MuTEStructureCasing TANK_CASINGS = UpgradeCasings.Tank.getCasing();
+    public static final MuTEStructureCasing AMPERAGE_CASINGS = UpgradeCasings.Amperage.getCasing();
+    public static final MuTEStructureCasing LASER_CASINGS = UpgradeCasings.Laser.getCasing();
+    public static final MuTEStructureCasing WIRELESS_CASINGS = UpgradeCasings.Wireless.getCasing();
+    public static final MuTEStructureCasing CLEANROOM_CASINGS = UpgradeCasings.Cleanroom.getCasing();
+
+    public enum FunctionalCasings {
+
+        Motor(COMPONENT_CASING_REGISTRY_NAME, LV_Motor.getId(), MV_Motor.getId(), HV_Motor.getId(), EV_Motor.getId(),
+            IV_Motor.getId(), LuV_Motor.getId(), ZPM_Motor.getId(), UV_Motor.getId(), UHV_Motor.getId(),
+            UEV_Motor.getId(), UIV_Motor.getId(), UMV_Motor.getId(), UXV_Motor.getId(), MAX_Motor.getId()),
+
+        Pump(COMPONENT_CASING_REGISTRY_NAME, LV_Pump.getId(), MV_Pump.getId(), HV_Pump.getId(), EV_Pump.getId(),
+            IV_Pump.getId(), LuV_Pump.getId(), ZPM_Pump.getId(), UV_Pump.getId(), UHV_Pump.getId(), UEV_Pump.getId(),
+            UIV_Pump.getId(), UMV_Pump.getId(), UXV_Pump.getId(), MAX_Pump.getId()),
+
+        Conveyor(COMPONENT_CASING_REGISTRY_NAME, LV_Conveyor.getId(), MV_Conveyor.getId(), HV_Conveyor.getId(),
+            EV_Conveyor.getId(), IV_Conveyor.getId(), LuV_Conveyor.getId(), ZPM_Conveyor.getId(), UV_Conveyor.getId(),
+            UHV_Conveyor.getId(), UEV_Conveyor.getId(), UIV_Conveyor.getId(), UMV_Conveyor.getId(),
+            UXV_Conveyor.getId(), MAX_Conveyor.getId()),
+
+        Piston(COMPONENT_CASING_REGISTRY_NAME, LV_Piston.getId(), MV_Piston.getId(), HV_Piston.getId(),
+            EV_Piston.getId(), IV_Piston.getId(), LuV_Piston.getId(), ZPM_Piston.getId(), UV_Piston.getId(),
+            UHV_Piston.getId(), UEV_Piston.getId(), UIV_Piston.getId(), UMV_Piston.getId(), UXV_Piston.getId(),
+            MAX_Piston.getId()),
+
+        RobotArm(COMPONENT_CASING_REGISTRY_NAME, LV_RobotArm.getId(), MV_RobotArm.getId(), HV_RobotArm.getId(),
+            EV_RobotArm.getId(), IV_RobotArm.getId(), LuV_RobotArm.getId(), ZPM_RobotArm.getId(), UV_RobotArm.getId(),
+            UHV_RobotArm.getId(), UEV_RobotArm.getId(), UIV_RobotArm.getId(), UMV_RobotArm.getId(),
+            UXV_RobotArm.getId(), MAX_RobotArm.getId()),
+
+        Emitter(COMPONENT_CASING_REGISTRY_NAME, LV_Emitter.getId(), MV_Emitter.getId(), HV_Emitter.getId(),
+            EV_Emitter.getId(), IV_Emitter.getId(), LuV_Emitter.getId(), ZPM_Emitter.getId(), UV_Emitter.getId(),
+            UHV_Emitter.getId(), UEV_Emitter.getId(), UIV_Emitter.getId(), UMV_Emitter.getId(), UXV_Emitter.getId(),
+            MAX_Emitter.getId()),
+
+        Sensor(COMPONENT_CASING_REGISTRY_NAME, LV_Sensor.getId(), MV_Sensor.getId(), HV_Sensor.getId(),
+            EV_Sensor.getId(), IV_Sensor.getId(), LuV_Sensor.getId(), ZPM_Sensor.getId(), UV_Sensor.getId(),
+            UHV_Sensor.getId(), UEV_Sensor.getId(), UIV_Sensor.getId(), UMV_Sensor.getId(), UXV_Sensor.getId(),
+            MAX_Sensor.getId()),
+
+        FieldGenerator(COMPONENT_CASING_REGISTRY_NAME, LV_FieldGenerator.getId(), MV_FieldGenerator.getId(),
+            HV_FieldGenerator.getId(), EV_FieldGenerator.getId(), IV_FieldGenerator.getId(), LuV_FieldGenerator.getId(),
+            ZPM_FieldGenerator.getId(), UV_FieldGenerator.getId(), UHV_FieldGenerator.getId(),
+            UEV_FieldGenerator.getId(), UIV_FieldGenerator.getId(), UMV_FieldGenerator.getId(),
+            UXV_FieldGenerator.getId(), MAX_FieldGenerator.getId());
+
+        private final MuTEStructureCasing casing;
+
+        FunctionalCasings(String registryName, Integer... validIds) {
+            casing = createMuTEStructureCasing(registryName, validIds);
+        }
+
+        public MuTEStructureCasing getCasing() {
+            return casing;
+        }
+    }
+
+    public enum UpgradeCasings {
+
+        Inventory(UPGRADE_CASING_REGISTRY_NAME, ULV_Inventory.getId(), LV_Inventory.getId(), MV_Inventory.getId(),
+            HV_Inventory.getId(), EV_Inventory.getId(), IV_Inventory.getId(), LuV_Inventory.getId(),
+            ZPM_Inventory.getId(), UV_Inventory.getId(), UHV_Inventory.getId(), UEV_Inventory.getId(),
+            UIV_Inventory.getId(), UMV_Inventory.getId(), UXV_Inventory.getId(), MAX_Inventory.getId()),
+
+        Tank(UPGRADE_CASING_REGISTRY_NAME, ULV_Tank.getId(), LV_Tank.getId(), MV_Tank.getId(), HV_Tank.getId(),
+            EV_Tank.getId(), IV_Tank.getId(), LuV_Tank.getId(), ZPM_Tank.getId(), UV_Tank.getId(), UHV_Tank.getId(),
+            UEV_Tank.getId(), UIV_Tank.getId(), UMV_Tank.getId(), UXV_Tank.getId(), MAX_Tank.getId()),
+
+        Amperage(UPGRADE_CASING_REGISTRY_NAME, Amp_4.getId(), Amp_16.getId(), Amp_64.getId(), Amp_256.getId(),
+            Amp_1_024.getId(), Amp_4_096.getId(), Amp_16_384.getId(), Amp_65_536.getId(), Amp_262_144.getId(),
+            Amp_1_048_576.getId()),
+
+        Laser(UPGRADE_CASING_REGISTRY_NAME, GT_MultiTileUpgradeCasing.Laser.getId()),
+
+        Wireless(UPGRADE_CASING_REGISTRY_NAME, GT_MultiTileUpgradeCasing.Wireless.getId()),
+
+        Cleanroom(UPGRADE_CASING_REGISTRY_NAME, GT_MultiTileUpgradeCasing.Cleanroom.getId());
+
+        private final MuTEStructureCasing casing;
+
+        UpgradeCasings(String registryName, Integer... validIds) {
+            casing = createMuTEStructureCasing(registryName, validIds);
+        }
+
+        public MuTEStructureCasing getCasing() {
+            return casing;
+        }
+    }
+
+    /**
+     * Specify all casing sets that are valid for a multiblock structure position. The first casing will be used as
+     * default when doing auto place
+     *
+     * @param modes        Allowed modes on the casings
+     * @param validCasings Allowed casing sets
+     * @return Structure Element
+     * @param <T> Multiblock class
+     */
+    public static <T> IStructureElement<T> ofMuTECasings(int modes, MuTEStructureCasing... validCasings) {
+        if (validCasings == null || validCasings.length == 0) {
+            throw new IllegalArgumentException();
+        }
+        return new IStructureElement<>() {
+
+            final MuTEStructureCasing[] allowedCasings = validCasings;
+            private final static short[] DEFAULT = new short[] { 255, 255, 255, 0 };
+            private static IIcon[] mIcons = null;
+
+            @Override
+            public boolean check(T t, World world, int x, int y, int z) {
+                final TileEntity tileEntity = world.getTileEntity(x, y, z);
+                if (!(tileEntity instanceof MultiBlockPart part)) return false;
+
+                for (MuTEStructureCasing casing : allowedCasings) {
+                    if (casing.isCasingValid(part.getMultiTileEntityRegistryID(), part.getMultiTileEntityID())) {
+                        final IMultiBlockController tTarget = part.getTarget(false);
+                        if (tTarget != null && tTarget != t) return false;
+
+                        part.setTarget((IMultiBlockController) t, modes);
+
+                        ((Controller<?>) t).registerSpecialCasings(part);
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
+            @Override
+            public boolean spawnHint(T t, World world, int x, int y, int z, ItemStack trigger) {
+                // Moved here from Controller. TODO: Proper implementation
+                if (mIcons == null) {
+                    mIcons = new IIcon[6];
+                    Arrays.fill(mIcons, TextureSet.SET_NONE.mTextures[OrePrefixes.block.mTextureIndex].getIcon());
+                    // Arrays.fill(mIcons, getTexture(aCasing);
+                    // for (byte i : ALL_VALID_SIDES) {
+                    // mIcons[i] = aCasing.getIcon(i, aMeta);
+                    // }
+                }
+                final short[] RGBA = DEFAULT;
+                StructureLibAPI.hintParticleTinted(world, x, y, z, mIcons, RGBA);
+                // StructureLibAPI.hintParticle(world, x, y, z, aCasing, aMeta);
+                return true;
+            }
+
+            @Override
+            public boolean placeBlock(T t, World world, int x, int y, int z, ItemStack trigger) {
+                final MultiTileEntityRegistry tRegistry = MultiTileEntityRegistry
+                    .getRegistry(validCasings[0].registryId);
+                if (tRegistry == null) {
+                    GT_FML_LOGGER.error("NULL REGISTRY");
+                    return false;
+                }
+                final MultiTileEntityContainer tContainer = tRegistry
+                    .getNewTileEntityContainer(world, x, y, z, validCasings[0].defaultMeta, null);
+                if (tContainer == null) {
+                    GT_FML_LOGGER.error("NULL CONTAINER");
+                    return false;
+                }
+                final IMultiTileEntity te = ((IMultiTileEntity) tContainer.mTileEntity);
+                if (!(te instanceof MultiBlockPart)) {
+                    GT_FML_LOGGER.error("Not a multiblock part");
+                    return false;
+                }
+                if (world.setBlock(x, y, z, tContainer.mBlock, 15 - tContainer.mBlockMetaData, 2)) {
+                    tContainer.setMultiTile(world, x, y, z);
+                    ((MultiBlockPart) te).setTarget((IMultiBlockController) t, modes);
+
+                    ((Controller<?>) t).registerSpecialCasings((MultiBlockPart) te);
+                }
+
+                return false;
+            }
+        };
+    }
+
+    public static MuTEStructureCasing createMuTEStructureCasing(String registryName, Integer... validIds) {
+        return new MuTEStructureCasing(registryName, validIds);
+    }
+
+    /**
+     * Object used to store a set of casings (e.g. all motor casings)
+     */
+    public static class MuTEStructureCasing {
+
+        private final int registryId;
+        private final int defaultMeta;
+        private final HashSet<Integer> validIds;
+
+        public MuTEStructureCasing(String registryName, Integer... validIds) {
+            MultiTileEntityRegistry registry = MultiTileEntityRegistry.getRegistry(registryName);
+            if (validIds == null || validIds.length == 0 || registry == null) {
+                throw new IllegalArgumentException();
+            }
+            registryId = Block.getIdFromBlock(registry.mBlock);
+            this.validIds = new HashSet<>(Arrays.asList(validIds));
+            this.defaultMeta = validIds[0];
+        }
+
+        public boolean isCasingValid(int registryId, int id) {
+            if (this.registryId != registryId) {
+                return false;
+            }
+            return validIds.contains(id);
+        }
+    }
+}

--- a/src/main/java/gregtech/api/util/GT_StructureUtilityMuTE.java
+++ b/src/main/java/gregtech/api/util/GT_StructureUtilityMuTE.java
@@ -17,6 +17,7 @@ import net.minecraft.world.World;
 import com.gtnewhorizon.structurelib.StructureLibAPI;
 import com.gtnewhorizon.structurelib.structure.IStructureElement;
 
+import gregtech.api.enums.GT_Values;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.enums.TextureSet;
 import gregtech.api.multitileentity.MultiTileEntityContainer;
@@ -187,7 +188,7 @@ public class GT_StructureUtilityMuTE {
             @Override
             public boolean placeBlock(T t, World world, int x, int y, int z, ItemStack trigger) {
                 final MultiTileEntityRegistry tRegistry = MultiTileEntityRegistry
-                    .getRegistry(validCasings[0].registryId);
+                    .getRegistry(validCasings[0].getRegistryId());
                 if (tRegistry == null) {
                     GT_FML_LOGGER.error("NULL REGISTRY");
                     return false;
@@ -224,7 +225,8 @@ public class GT_StructureUtilityMuTE {
      */
     public static class MuTEStructureCasing {
 
-        private final int registryId;
+        private String registryName;
+        private int registryId = GT_Values.W;
         private final int defaultMeta;
         private final HashSet<Integer> validIds;
 
@@ -233,16 +235,30 @@ public class GT_StructureUtilityMuTE {
             if (validIds == null || validIds.length == 0 || registry == null) {
                 throw new IllegalArgumentException();
             }
-            registryId = Block.getIdFromBlock(registry.mBlock);
+            this.registryName = registryName;
             this.validIds = new HashSet<>(Arrays.asList(validIds));
             this.defaultMeta = validIds[0];
         }
 
         public boolean isCasingValid(int registryId, int id) {
-            if (this.registryId != registryId) {
+            if (getRegistryId() != registryId) {
                 return false;
             }
             return validIds.contains(id);
+        }
+
+        public int getDefaultMeta() {
+            return defaultMeta;
+        }
+
+        public int getRegistryId() {
+            // TODO: MuTE registry seems to somehow shift, probably due to NBT shenanigans. Lazy init circumvents this
+            // but it should be properly fixed in the future
+            if (registryId == GT_Values.W) {
+                MultiTileEntityRegistry registry = MultiTileEntityRegistry.getRegistry(registryName);
+                registryId = Block.getIdFromBlock(registry.mBlock);
+            }
+            return registryId;
         }
     }
 }

--- a/src/main/java/gregtech/common/tileentities/machines/multiblock/AdvChemicalProcessor.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multiblock/AdvChemicalProcessor.java
@@ -4,14 +4,13 @@ import static com.google.common.primitives.Ints.saturatedCast;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.*;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofBlock;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.transpose;
-import static gregtech.api.enums.Mods.*;
 import static gregtech.api.multitileentity.multiblock.base.MultiBlockPart.ENERGY_IN;
 import static gregtech.api.multitileentity.multiblock.base.MultiBlockPart.FLUID_IN;
 import static gregtech.api.multitileentity.multiblock.base.MultiBlockPart.FLUID_OUT;
 import static gregtech.api.multitileentity.multiblock.base.MultiBlockPart.ITEM_IN;
 import static gregtech.api.multitileentity.multiblock.base.MultiBlockPart.ITEM_OUT;
 import static gregtech.api.multitileentity.multiblock.base.MultiBlockPart.NOTHING;
-import static gregtech.loaders.preload.GT_Loader_MultiTileEntities.UPGRADE_CASING_REGISTRY_NAME;
+import static gregtech.api.util.GT_StructureUtilityMuTE.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -50,12 +49,12 @@ import gregtech.api.fluid.FluidTankGT;
 import gregtech.api.gui.modularui.GT_UITextures;
 import gregtech.api.logic.ComplexParallelProcessingLogic;
 import gregtech.api.multitileentity.enums.GT_MultiTileCasing;
-import gregtech.api.multitileentity.enums.GT_MultiTileUpgradeCasing;
 import gregtech.api.multitileentity.multiblock.base.ComplexParallelController;
 import gregtech.api.multitileentity.multiblock.casing.Glasses;
 import gregtech.api.util.GT_Multiblock_Tooltip_Builder;
 import gregtech.api.util.GT_Recipe;
 import gregtech.api.util.GT_StructureUtility;
+import gregtech.api.util.GT_StructureUtilityMuTE;
 import gregtech.common.tileentities.casings.upgrade.Inventory;
 
 public class AdvChemicalProcessor extends ComplexParallelController<AdvChemicalProcessor> {
@@ -174,7 +173,7 @@ public class AdvChemicalProcessor extends ComplexParallelController<AdvChemicalP
 
     @Override
     public short getCasingRegistryID() {
-        return 0;
+        return GT_MultiTileCasing.Chemical.getRegistryId();
     }
 
     @Override
@@ -350,12 +349,11 @@ public class AdvChemicalProcessor extends ComplexParallelController<AdvChemicalP
                         { "       ", "       ", "       ", "       ", "       ", "  F F  ", "       " } })
                 .addElement(
                     'C',
-                    addMultiTileCasing(
-                        "gt.multitileentity.casings",
-                        getCasingMeta(),
-                        FLUID_IN | ITEM_IN | FLUID_OUT | ITEM_OUT | ENERGY_IN))
+                    ofMuTECasings(
+                        FLUID_IN | ITEM_IN | FLUID_OUT | ITEM_OUT | ENERGY_IN,
+                        GT_MultiTileCasing.Chemical.getCasing()))
                 .addElement('P', ofBlock(GregTech_API.sBlockCasings8, 1))
-                .addElement('T', addMotorCasings(NOTHING))
+                .addElement('T', ofMuTECasings(NOTHING, MOTOR_CASINGS))
                 .addElement(
                     'W',
                     GT_StructureUtility.ofCoil(AdvChemicalProcessor::setCoilTier, AdvChemicalProcessor::getCoilTier))
@@ -364,15 +362,10 @@ public class AdvChemicalProcessor extends ComplexParallelController<AdvChemicalP
                 .addElement('G', Glasses.chainAllGlasses())
                 .addElement(
                     'U',
-                    ofChain(
-                        addMultiTileCasing(
-                            UPGRADE_CASING_REGISTRY_NAME,
-                            GT_MultiTileUpgradeCasing.IV_Inventory.getId(),
-                            NOTHING),
-                        addMultiTileCasing(
-                            "gt.multitileentity.casings",
-                            getCasingMeta(),
-                            FLUID_IN | ITEM_IN | FLUID_OUT | ITEM_OUT | ENERGY_IN)))
+                    ofMuTECasings(
+                        FLUID_IN | ITEM_IN | FLUID_OUT | ITEM_OUT | ENERGY_IN,
+                        GT_MultiTileCasing.Chemical.getCasing(),
+                        GT_StructureUtilityMuTE.INVENTORY_CASINGS))
                 .build();
         }
         return STRUCTURE_DEFINITION;

--- a/src/main/java/gregtech/common/tileentities/machines/multiblock/CokeOven.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multiblock/CokeOven.java
@@ -2,6 +2,7 @@ package gregtech.common.tileentities.machines.multiblock;
 
 import static gregtech.api.multitileentity.multiblock.base.MultiBlockPart.ITEM_IN;
 import static gregtech.api.multitileentity.multiblock.base.MultiBlockPart.ITEM_OUT;
+import static gregtech.api.util.GT_StructureUtilityMuTE.ofMuTECasings;
 
 import java.util.List;
 
@@ -98,7 +99,7 @@ public class CokeOven extends Controller<CokeOven> implements PollutionLogicHost
                 .addShape(
                     MAIN,
                     new String[][] { { "AAA", "A~A", "AAA" }, { "AAA", "A-A", "AAA" }, { "AAA", "AAA", "AAA" } })
-                .addElement('A', addMultiTileCasing("gt.multitileentity.casings", getCasingMeta(), ITEM_IN | ITEM_OUT))
+                .addElement('A', ofMuTECasings(ITEM_IN | ITEM_OUT, GT_MultiTileCasing.CokeOven.getCasing()))
                 .build();
         }
         return STRUCTURE_DEFINITION;

--- a/src/main/java/gregtech/common/tileentities/machines/multiblock/DistillationTower.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multiblock/DistillationTower.java
@@ -112,10 +112,8 @@ public class DistillationTower extends StackableController<DistillationTower> {
                 .addElement(
                     'C',
                     ofMuTECasings(
-
                         FLUID_IN | ITEM_IN | FLUID_OUT | ITEM_OUT | ENERGY_IN,
                         GT_MultiTileCasing.Distillation.getCasing()))
-
                 .addElement('E', GT_StructureUtility.ofFrame(Materials.StainlessSteel))
                 .addElement('A', ofBlock(GregTech_API.sBlockCasings2, 0))
                 .addElement('B', ofBlock(GregTech_API.sBlockCasings2, 13))

--- a/src/main/java/gregtech/common/tileentities/machines/multiblock/DistillationTower.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multiblock/DistillationTower.java
@@ -2,6 +2,8 @@ package gregtech.common.tileentities.machines.multiblock;
 
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.*;
 import static gregtech.api.multitileentity.multiblock.base.MultiBlockPart.*;
+import static gregtech.api.util.GT_StructureUtilityMuTE.MOTOR_CASINGS;
+import static gregtech.api.util.GT_StructureUtilityMuTE.ofMuTECasings;
 
 import java.util.Arrays;
 import java.util.List;
@@ -109,15 +111,15 @@ public class DistillationTower extends StackableController<DistillationTower> {
                         // spotless:on
                 .addElement(
                     'C',
-                    addMultiTileCasing(
-                        "gt.multitileentity.casings",
-                        getCasingMeta(),
-                        FLUID_IN | ITEM_IN | FLUID_OUT | ITEM_OUT | ENERGY_IN))
+                    ofMuTECasings(
+
+                        FLUID_IN | ITEM_IN | FLUID_OUT | ITEM_OUT | ENERGY_IN,
+                        GT_MultiTileCasing.Distillation.getCasing()))
 
                 .addElement('E', GT_StructureUtility.ofFrame(Materials.StainlessSteel))
                 .addElement('A', ofBlock(GregTech_API.sBlockCasings2, 0))
                 .addElement('B', ofBlock(GregTech_API.sBlockCasings2, 13))
-                .addElement('X', addMotorCasings(NOTHING))
+                .addElement('X', ofMuTECasings(NOTHING, MOTOR_CASINGS))
                 .addElement('D', GT_StructureUtility.ofCoil((tile, meta) -> {}, (tile) -> HeatingCoilLevel.None))
                 .build();
         }

--- a/src/main/java/gregtech/common/tileentities/machines/multiblock/LayeredCokeBattery.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multiblock/LayeredCokeBattery.java
@@ -8,6 +8,8 @@ import static gregtech.api.multitileentity.multiblock.base.MultiBlockPart.FLUID_
 import static gregtech.api.multitileentity.multiblock.base.MultiBlockPart.ITEM_IN;
 import static gregtech.api.multitileentity.multiblock.base.MultiBlockPart.ITEM_OUT;
 import static gregtech.api.multitileentity.multiblock.base.MultiBlockPart.NOTHING;
+import static gregtech.api.util.GT_StructureUtilityMuTE.MOTOR_CASINGS;
+import static gregtech.api.util.GT_StructureUtilityMuTE.ofMuTECasings;
 
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
@@ -126,19 +128,18 @@ public class LayeredCokeBattery extends StackableController<LayeredCokeBattery> 
                             { "AAAAAAAAAAAAA", "AAAAAAAAAAAAA", "AAAAAAAAAAAAA" } }))
                 .addElement(
                     'A',
-                    addMultiTileCasing(
-                        "gt.multitileentity.casings",
-                        GT_MultiTileCasing.Chemical.getId(),
-                        FLUID_IN | ITEM_IN | FLUID_OUT | ITEM_OUT | ENERGY_IN))
+                    ofMuTECasings(
+
+                        FLUID_IN | ITEM_IN | FLUID_OUT | ITEM_OUT | ENERGY_IN,
+                        GT_MultiTileCasing.Chemical.getCasing()))
                 .addElement(
                     'B',
-                    addMultiTileCasing(
-                        "gt.multitileentity.casings",
-                        getCasingMeta(),
-                        FLUID_IN | ITEM_IN | FLUID_OUT | ITEM_OUT | ENERGY_IN))
+                    ofMuTECasings(
+                        FLUID_IN | ITEM_IN | FLUID_OUT | ITEM_OUT | ENERGY_IN,
+                        GT_MultiTileCasing.Distillation.getCasing()))
                 .addElement('C', ofBlock(GregTech_API.sBlockCasings4, 1))
                 .addElement('D', GT_StructureUtility.ofFrame(Materials.Steel))
-                .addElement('E', addMotorCasings(NOTHING))
+                .addElement('E', ofMuTECasings(NOTHING, MOTOR_CASINGS))
                 .addElement(
                     'F',
                     ofChain(

--- a/src/main/java/gregtech/common/tileentities/machines/multiblock/LayeredCokeBattery.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multiblock/LayeredCokeBattery.java
@@ -129,7 +129,6 @@ public class LayeredCokeBattery extends StackableController<LayeredCokeBattery> 
                 .addElement(
                     'A',
                     ofMuTECasings(
-
                         FLUID_IN | ITEM_IN | FLUID_OUT | ITEM_OUT | ENERGY_IN,
                         GT_MultiTileCasing.Chemical.getCasing()))
                 .addElement(

--- a/src/main/java/gregtech/common/tileentities/machines/multiblock/Macerator.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multiblock/Macerator.java
@@ -1,6 +1,5 @@
 package gregtech.common.tileentities.machines.multiblock;
 
-import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofChain;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.transpose;
 import static gregtech.api.multitileentity.multiblock.base.MultiBlockPart.ENERGY_IN;
 import static gregtech.api.multitileentity.multiblock.base.MultiBlockPart.FLUID_IN;
@@ -8,6 +7,7 @@ import static gregtech.api.multitileentity.multiblock.base.MultiBlockPart.FLUID_
 import static gregtech.api.multitileentity.multiblock.base.MultiBlockPart.ITEM_IN;
 import static gregtech.api.multitileentity.multiblock.base.MultiBlockPart.ITEM_OUT;
 import static gregtech.api.multitileentity.multiblock.base.MultiBlockPart.NOTHING;
+import static gregtech.api.util.GT_StructureUtilityMuTE.*;
 
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
@@ -22,6 +22,7 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import gregtech.api.enums.SoundResource;
 import gregtech.api.enums.TierEU;
+import gregtech.api.multitileentity.enums.GT_MultiTileCasing;
 import gregtech.api.multitileentity.multiblock.base.StackableController;
 import gregtech.api.util.GT_Multiblock_Tooltip_Builder;
 import gregtech.api.util.GT_Recipe;
@@ -53,18 +54,15 @@ public class Macerator extends StackableController<Macerator> {
                 .addShape(
                     STACKABLE_START,
                     transpose(new String[][] { { " G~F ", "AAAAA", "AAAAA", "AAAAA", " AAA " }, }))
-                .addElement('A', ofChain(addMultiTileCasing("gt.multitileentity.casings", getCasingMeta(), ENERGY_IN)))
+                .addElement('A', ofMuTECasings(ENERGY_IN, GT_MultiTileCasing.Macerator.getCasing()))
                 .addElement(
                     'B',
-                    ofChain(
-                        addMultiTileCasing(
-                            "gt.multitileentity.casings",
-                            getCasingMeta(),
-                            FLUID_IN | ITEM_IN | FLUID_OUT | ITEM_OUT)))
-                .addElement('C', addMultiTileCasing("gt.multitileentity.casings", getCasingMeta(), NOTHING))
-                .addElement('D', addMultiTileCasing("gt.multitileentity.casings", getCasingMeta(), NOTHING))
-                .addElement('F', addMotorCasings(NOTHING))
-                .addElement('G', addMultiTileCasing("gt.multitileentity.component.casings", 10000, NOTHING))
+
+                    ofMuTECasings(FLUID_IN | ITEM_IN | FLUID_OUT | ITEM_OUT, GT_MultiTileCasing.Macerator.getCasing()))
+                .addElement('C', ofMuTECasings(NOTHING, GT_MultiTileCasing.Macerator.getCasing()))
+                .addElement('D', ofMuTECasings(NOTHING, GT_MultiTileCasing.Macerator.getCasing()))
+                .addElement('F', ofMuTECasings(NOTHING, MOTOR_CASINGS))
+                .addElement('G', ofMuTECasings(NOTHING, INVENTORY_CASINGS))
                 .build();
         }
         return STRUCTURE_DEFINITION;

--- a/src/main/java/gregtech/common/tileentities/machines/multiblock/Macerator.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multiblock/Macerator.java
@@ -57,7 +57,6 @@ public class Macerator extends StackableController<Macerator> {
                 .addElement('A', ofMuTECasings(ENERGY_IN, GT_MultiTileCasing.Macerator.getCasing()))
                 .addElement(
                     'B',
-
                     ofMuTECasings(FLUID_IN | ITEM_IN | FLUID_OUT | ITEM_OUT, GT_MultiTileCasing.Macerator.getCasing()))
                 .addElement('C', ofMuTECasings(NOTHING, GT_MultiTileCasing.Macerator.getCasing()))
                 .addElement('D', ofMuTECasings(NOTHING, GT_MultiTileCasing.Macerator.getCasing()))


### PR DESCRIPTION
Adds new structure element for MuTEs. In this structure element you can specify an array of valid casing sets. A set would for example be all motor casings. This allows ease of use when one wants to allow upgrade/functional casings as optional casings.