### PR TITLE
Cache MuTEs for non-instance specific actions

### DIFF
--- a/src/main/java/gregtech/api/multitileentity/MultiTileEntityItemInternal.java
+++ b/src/main/java/gregtech/api/multitileentity/MultiTileEntityItemInternal.java
@@ -51,7 +51,7 @@ public class MultiTileEntityItemInternal extends ItemBlock implements IFluidCont
     @SuppressWarnings("unchecked")
     public void addInformation(ItemStack aStack, EntityPlayer aPlayer, List<String> aList, boolean aF3_H) {
         final MultiTileEntityContainer tTileEntityContainer = mBlock.mMultiTileEntityRegistry
-            .getNewTileEntityContainer(aStack);
+            .getCachedTileEntityContainer(aStack);
         if (tTileEntityContainer == null) {
             aList.add("INVALID ITEM!");
             return;
@@ -186,7 +186,7 @@ public class MultiTileEntityItemInternal extends ItemBlock implements IFluidCont
         final MultiTileEntityClassContainer tContainer = mBlock.mMultiTileEntityRegistry.getClassContainer(aStack);
         if (tContainer == null) return;
         final MultiTileEntityContainer tTileEntityContainer = mBlock.mMultiTileEntityRegistry
-            .getNewTileEntityContainer(aStack);
+            .getCachedTileEntityContainer(aStack);
         if (tTileEntityContainer != null && tTileEntityContainer.mTileEntity instanceof IItemUpdatable itemUpdatable) {
             itemUpdatable.updateItemStack(aStack);
         }
@@ -197,7 +197,7 @@ public class MultiTileEntityItemInternal extends ItemBlock implements IFluidCont
         final MultiTileEntityClassContainer tContainer = mBlock.mMultiTileEntityRegistry.getClassContainer(aStack);
         if (tContainer == null) return;
         final MultiTileEntityContainer tTileEntityContainer = mBlock.mMultiTileEntityRegistry
-            .getNewTileEntityContainer(aStack);
+            .getCachedTileEntityContainer(aStack);
         if (tTileEntityContainer != null && tTileEntityContainer.mTileEntity instanceof IItemUpdatable itemUpdatable) {
             itemUpdatable.updateItemStack(aStack, aWorld, aX, aY, aZ);
         }
@@ -208,7 +208,7 @@ public class MultiTileEntityItemInternal extends ItemBlock implements IFluidCont
         final MultiTileEntityClassContainer tContainer = mBlock.mMultiTileEntityRegistry.getClassContainer(aStack);
         if (tContainer == null) return 1;
         final MultiTileEntityContainer tTileEntityContainer = mBlock.mMultiTileEntityRegistry
-            .getNewTileEntityContainer(aStack);
+            .getCachedTileEntityContainer(aStack);
         if (tTileEntityContainer != null
             && tTileEntityContainer.mTileEntity instanceof IMTE_GetMaxStackSize maxStackSize) {
             return maxStackSize.getMaxStackSize(aStack, tContainer.mStackSize);
@@ -224,7 +224,7 @@ public class MultiTileEntityItemInternal extends ItemBlock implements IFluidCont
     @Override
     public FluidStack getFluid(ItemStack aStack) {
         final MultiTileEntityContainer tTileEntityContainer = mBlock.mMultiTileEntityRegistry
-            .getNewTileEntityContainer(aStack);
+            .getCachedTileEntityContainer(aStack);
         if (tTileEntityContainer != null
             && tTileEntityContainer.mTileEntity instanceof IFluidContainerItem fluidContainerItem) {
             final FluidStack rFluid = fluidContainerItem.getFluid(aStack);
@@ -237,7 +237,7 @@ public class MultiTileEntityItemInternal extends ItemBlock implements IFluidCont
     @Override
     public int getCapacity(ItemStack aStack) {
         final MultiTileEntityContainer tTileEntityContainer = mBlock.mMultiTileEntityRegistry
-            .getNewTileEntityContainer(aStack);
+            .getCachedTileEntityContainer(aStack);
         if (tTileEntityContainer != null
             && tTileEntityContainer.mTileEntity instanceof IFluidContainerItem fluidContainerItem) {
             final int rCapacity = fluidContainerItem.getCapacity(aStack);
@@ -250,7 +250,7 @@ public class MultiTileEntityItemInternal extends ItemBlock implements IFluidCont
     @Override
     public int fill(ItemStack aStack, FluidStack aFluid, boolean aDoFill) {
         final MultiTileEntityContainer tTileEntityContainer = mBlock.mMultiTileEntityRegistry
-            .getNewTileEntityContainer(aStack);
+            .getCachedTileEntityContainer(aStack);
         if (tTileEntityContainer != null
             && tTileEntityContainer.mTileEntity instanceof IFluidContainerItem fluidContainerItem) {
             final int tFilled = fluidContainerItem.fill(aStack, aFluid, aDoFill);
@@ -263,7 +263,7 @@ public class MultiTileEntityItemInternal extends ItemBlock implements IFluidCont
     @Override
     public FluidStack drain(ItemStack aStack, int aMaxDrain, boolean aDoDrain) {
         final MultiTileEntityContainer tTileEntityContainer = mBlock.mMultiTileEntityRegistry
-            .getNewTileEntityContainer(aStack);
+            .getCachedTileEntityContainer(aStack);
         if (tTileEntityContainer != null
             && tTileEntityContainer.mTileEntity instanceof IFluidContainerItem fluidContainerItem) {
             final FluidStack rFluid = fluidContainerItem.drain(aStack, aMaxDrain, aDoDrain);

--- a/src/main/java/gregtech/api/multitileentity/MultiTileEntityRegistry.java
+++ b/src/main/java/gregtech/api/multitileentity/MultiTileEntityRegistry.java
@@ -38,6 +38,7 @@ public class MultiTileEntityRegistry {
     // TODO: NBT sensitive or not? Starting with not for now
     private static final ItemStackMap<MultiTileEntityRegistry> REGISTRIES = new ItemStackMap<>(false);
     private static final HashSet<Class<?>> sRegisteredTileEntities = new HashSet<>();
+    private static final HashMap<Integer, MultiTileEntityContainer> cachedTileEntityContainers = new HashMap<>();
 
     public HashMap<Short, CreativeTab> mCreativeTabs = new HashMap<>();
     public Map<Short, MultiTileEntityClassContainer> mRegistry = new HashMap<>();
@@ -265,6 +266,15 @@ public class MultiTileEntityRegistry {
             Items.feather.getDamage(aStack),
             aStack.getTagCompound());
         return tContainer == null ? null : tContainer.mTileEntity;
+    }
+
+    public MultiTileEntityContainer getCachedTileEntityContainer(ItemStack stack) {
+        MultiTileEntityContainer container = cachedTileEntityContainers.get(Items.feather.getDamage(stack));
+        if (container == null) {
+            container = getNewTileEntityContainer(stack);
+            cachedTileEntityContainers.put(Items.feather.getDamage(stack), container);
+        }
+        return container;
     }
 
     public MultiTileEntityContainer getNewTileEntityContainer(ItemStack aStack) {

--- a/src/main/java/gregtech/api/multitileentity/MultiTileEntityRegistry.java
+++ b/src/main/java/gregtech/api/multitileentity/MultiTileEntityRegistry.java
@@ -38,7 +38,7 @@ public class MultiTileEntityRegistry {
     // TODO: NBT sensitive or not? Starting with not for now
     private static final ItemStackMap<MultiTileEntityRegistry> REGISTRIES = new ItemStackMap<>(false);
     private static final HashSet<Class<?>> sRegisteredTileEntities = new HashSet<>();
-    private static final HashMap<Integer, MultiTileEntityContainer> cachedTileEntityContainers = new HashMap<>();
+    private final HashMap<Integer, MultiTileEntityContainer> cachedTileEntityContainers = new HashMap<>();
 
     public HashMap<Short, CreativeTab> mCreativeTabs = new HashMap<>();
     public Map<Short, MultiTileEntityClassContainer> mRegistry = new HashMap<>();


### PR DESCRIPTION
Adds a map-cache of MuTEs. They are for example used for getting the tooltips. Before this change a new MuTE was created every tick, just to get the tooltip. If later on instance specific information are needed we should rather pass the actual ItemStack and read from its NBT.