### PR TITLE
Add wood subtag to Gaia Spirit material

### DIFF
--- a/src/main/java/gregtech/api/enums/MaterialsBotania.java
+++ b/src/main/java/gregtech/api/enums/MaterialsBotania.java
@@ -211,6 +211,7 @@ public class MaterialsBotania {
         Dreamwood.add(SubTag.WOOD, SubTag.FLAMMABLE, SubTag.NO_SMELTING, SubTag.NO_SMASHING);
         ManaDiamond.add(SubTag.CRYSTAL, SubTag.NO_SMASHING, SubTag.NO_SMELTING);
         BotaniaDragonstone.add(SubTag.CRYSTAL, SubTag.NO_SMASHING, SubTag.NO_SMELTING);
+        GaiaSpirit.add(SubTag.WOOD);
 
         // Botania native items
         ingot.mNotGeneratedItems.add(Manasteel);


### PR DESCRIPTION
This is to make Gaia Spirit produce Soft Mallets instead of Hammers. This _might_ affect the material in other aspects but I don't think there would be anything game-breaking.

I think we should have more Soft Mallets beyond Steeleaf (at least one that would reasonably be virtually indestructible). And Gaia Spirit continues the magic theme of higher-tier Mallets, plus we already have Ichorium with the exact same tool stats, so it would be a nice counterpart to that, which gives another incentive to progress in Botania.

In case our material overlords decide on that, I could do the same to a bunch of other materials, maybe some endgame-tier stuff (in this case I'd add a separate subtag just for soft mallets, in order to not needlessly designate materials as "wood" or "bouncy").

![image](https://github.com/GTNewHorizons/GT5-Unofficial/assets/8113703/d3f9647b-5c1e-49b0-aa95-62e6e44d8c1d)
