### PR TITLE
Add soft material subtag

### DIFF
--- a/src/main/java/gregtech/api/enums/MaterialsBotania.java
+++ b/src/main/java/gregtech/api/enums/MaterialsBotania.java
@@ -211,6 +211,7 @@ public class MaterialsBotania {
         Dreamwood.add(SubTag.WOOD, SubTag.FLAMMABLE, SubTag.NO_SMELTING, SubTag.NO_SMASHING);
         ManaDiamond.add(SubTag.CRYSTAL, SubTag.NO_SMASHING, SubTag.NO_SMELTING);
         BotaniaDragonstone.add(SubTag.CRYSTAL, SubTag.NO_SMASHING, SubTag.NO_SMELTING);
+        GaiaSpirit.add(SubTag.SOFT);
 
         // Botania native items
         ingot.mNotGeneratedItems.add(Manasteel);

--- a/src/main/java/gregtech/api/enums/SubTag.java
+++ b/src/main/java/gregtech/api/enums/SubTag.java
@@ -189,6 +189,10 @@ public final class SubTag implements ICondition<ISubTagContainer> {
      */
     public static final SubTag STRETCHY = getNewSubTag("STRETCHY");
     /**
+     * If this Material is soft (and can be made into a Soft Mallet even if it's not wooden or bouncy)
+     */
+    public static final SubTag SOFT = getNewSubTag("SOFT");
+    /**
      * If this Material is grindable with a simple Mortar
      */
     public static final SubTag MORTAR_GRINDABLE = getNewSubTag("MORTAR_GRINDABLE");

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingToolHead.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingToolHead.java
@@ -55,6 +55,8 @@ public class ProcessingToolHead implements gregtech.api.interfaces.IOreRecipeReg
         boolean aSpecialRecipeReq2 = aMaterial.mUnificatable && (aMaterial.mMaterialInto == aMaterial)
             && !aMaterial.contains(SubTag.NO_WORKING);
         boolean aNoWorking = aMaterial.contains(SubTag.NO_WORKING);
+        boolean aProducesSoftMallet = aMaterial.contains(SubTag.BOUNCY) || aMaterial.contains(SubTag.WOOD)
+            || aMaterial.contains(SubTag.SOFT);
         switch (aPrefix) {
             case toolHeadArrow -> {
                 if (aMaterial.mStandardMoltenFluid != null)
@@ -1177,7 +1179,7 @@ public class ProcessingToolHead implements gregtech.api.interfaces.IOreRecipeReg
                             GT_Utility.getIntegratedCircuit(14))
                         .itemOutputs(
                             GT_MetaGenerated_Tool_01.INSTANCE.getToolWithStats(
-                                (aMaterial.contains(SubTag.BOUNCY)) || (aMaterial.contains(SubTag.WOOD))
+                                aProducesSoftMallet
                                     ? GT_MetaGenerated_Tool_01.SOFTMALLET
                                     : GT_MetaGenerated_Tool_01.HARDHAMMER,
                                 1,
@@ -1193,7 +1195,7 @@ public class ProcessingToolHead implements gregtech.api.interfaces.IOreRecipeReg
                 if ((aMaterial != Materials.Stone) && (aMaterial != Materials.Flint)) {
                     GT_ModHandler.addShapelessCraftingRecipe(
                         GT_MetaGenerated_Tool_01.INSTANCE.getToolWithStats(
-                            (aMaterial.contains(SubTag.BOUNCY)) || (aMaterial.contains(SubTag.WOOD))
+                            aProducesSoftMallet
                                 ? GT_MetaGenerated_Tool_01.SOFTMALLET
                                 : GT_MetaGenerated_Tool_01.HARDHAMMER,
                             1,
@@ -1204,7 +1206,7 @@ public class ProcessingToolHead implements gregtech.api.interfaces.IOreRecipeReg
                         new Object[] { aOreDictName, OrePrefixes.stick.get(aMaterial.mHandleMaterial) });
                     GT_ModHandler.addCraftingRecipe(
                         GT_MetaGenerated_Tool_01.INSTANCE.getToolWithStats(
-                            (aMaterial.contains(SubTag.BOUNCY)) || (aMaterial.contains(SubTag.WOOD))
+                            aProducesSoftMallet
                                 ? GT_MetaGenerated_Tool_01.SOFTMALLET
                                 : GT_MetaGenerated_Tool_01.HARDHAMMER,
                             1,
@@ -1218,7 +1220,7 @@ public class ProcessingToolHead implements gregtech.api.interfaces.IOreRecipeReg
                             'S', OrePrefixes.stick.get(aMaterial.mHandleMaterial) });
                     GT_ModHandler.addCraftingRecipe(
                         GT_MetaGenerated_Tool_01.INSTANCE.getToolWithStats(
-                            (aMaterial.contains(SubTag.BOUNCY)) || (aMaterial.contains(SubTag.WOOD))
+                            aProducesSoftMallet
                                 ? GT_MetaGenerated_Tool_01.SOFTMALLET
                                 : GT_MetaGenerated_Tool_01.HARDHAMMER,
                             1,

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingToolHead.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingToolHead.java
@@ -1179,8 +1179,7 @@ public class ProcessingToolHead implements gregtech.api.interfaces.IOreRecipeReg
                             GT_Utility.getIntegratedCircuit(14))
                         .itemOutputs(
                             GT_MetaGenerated_Tool_01.INSTANCE.getToolWithStats(
-                                aProducesSoftMallet
-                                    ? GT_MetaGenerated_Tool_01.SOFTMALLET
+                                aProducesSoftMallet ? GT_MetaGenerated_Tool_01.SOFTMALLET
                                     : GT_MetaGenerated_Tool_01.HARDHAMMER,
                                 1,
                                 aMaterial,
@@ -1195,8 +1194,7 @@ public class ProcessingToolHead implements gregtech.api.interfaces.IOreRecipeReg
                 if ((aMaterial != Materials.Stone) && (aMaterial != Materials.Flint)) {
                     GT_ModHandler.addShapelessCraftingRecipe(
                         GT_MetaGenerated_Tool_01.INSTANCE.getToolWithStats(
-                            aProducesSoftMallet
-                                ? GT_MetaGenerated_Tool_01.SOFTMALLET
+                            aProducesSoftMallet ? GT_MetaGenerated_Tool_01.SOFTMALLET
                                 : GT_MetaGenerated_Tool_01.HARDHAMMER,
                             1,
                             aMaterial,
@@ -1206,8 +1204,7 @@ public class ProcessingToolHead implements gregtech.api.interfaces.IOreRecipeReg
                         new Object[] { aOreDictName, OrePrefixes.stick.get(aMaterial.mHandleMaterial) });
                     GT_ModHandler.addCraftingRecipe(
                         GT_MetaGenerated_Tool_01.INSTANCE.getToolWithStats(
-                            aProducesSoftMallet
-                                ? GT_MetaGenerated_Tool_01.SOFTMALLET
+                            aProducesSoftMallet ? GT_MetaGenerated_Tool_01.SOFTMALLET
                                 : GT_MetaGenerated_Tool_01.HARDHAMMER,
                             1,
                             aMaterial,
@@ -1220,8 +1217,7 @@ public class ProcessingToolHead implements gregtech.api.interfaces.IOreRecipeReg
                             'S', OrePrefixes.stick.get(aMaterial.mHandleMaterial) });
                     GT_ModHandler.addCraftingRecipe(
                         GT_MetaGenerated_Tool_01.INSTANCE.getToolWithStats(
-                            aProducesSoftMallet
-                                ? GT_MetaGenerated_Tool_01.SOFTMALLET
+                            aProducesSoftMallet ? GT_MetaGenerated_Tool_01.SOFTMALLET
                                 : GT_MetaGenerated_Tool_01.HARDHAMMER,
                             1,
                             aMaterial,


### PR DESCRIPTION
Requested change from https://github.com/GTNewHorizons/GT5-Unofficial/pull/2123

Basically adds a new subtag for making soft mallets even if "wood" or "bouncy" doesn't apply. For now just to add it to Gaia Spirit.

In my opinion, the designation of Steeleaf as "wood" seems to have been a bit of a stretch in the first place, since it's technically about leaves, not wood, so it's not the first time we've added a soft mallet out of something non-woody and non-bouncy.