### PR TITLE
More frequent recipe checks after machine just shuts down

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
@@ -123,6 +123,8 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
     @SideOnly(Side.CLIENT)
     protected GT_SoundLoop activitySoundLoop;
 
+    private long mLastWorkingTick = 0;
+
     protected static final byte INTERRUPT_SOUND_INDEX = 8;
     protected static final byte PROCESS_START_SOUND_INDEX = 1;
 
@@ -452,6 +454,22 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
         return result;
     }
 
+    private boolean shouldCheckRecipeThisTick(long aTick) {
+        // Perform more frequent recipe change after the machine just shuts down.
+        long timeElapsed = aTick - mLastWorkingTick;
+
+        if (timeElapsed >= 100) return aTick % 100 == 0;
+
+        return timeElapsed == 1 ||
+            timeElapsed == 2 ||
+            timeElapsed == 5 ||
+            timeElapsed == 10 ||
+            timeElapsed == 20 ||
+            timeElapsed == 40 ||
+            timeElapsed == 60 ||
+            timeElapsed == 80;
+    }
+
     protected void runMachine(IGregTechTileEntity aBaseMetaTileEntity, long aTick) {
         if (mMaxProgresstime > 0 && doRandomMaintenanceDamage()) {
             if (onRunningTick(mInventory[1])) {
@@ -481,6 +499,7 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
                     mProgresstime = 0;
                     mMaxProgresstime = 0;
                     mEfficiencyIncrease = 0;
+                    mLastWorkingTick = aTick;
                     if (aBaseMetaTileEntity.isAllowedToWork()) {
                         checkRecipe();
                     }
@@ -497,7 +516,7 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
                 }
             }
         } else {
-            if (aTick % 100 == 0 || aBaseMetaTileEntity.hasWorkJustBeenEnabled()
+            if (shouldCheckRecipeThisTick(aTick) || aBaseMetaTileEntity.hasWorkJustBeenEnabled()
                 || aBaseMetaTileEntity.hasInventoryBeenModified()) {
 
                 if (aBaseMetaTileEntity.isAllowedToWork()) {

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
@@ -460,14 +460,13 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
 
         if (timeElapsed >= 100) return aTick % 100 == 0;
 
-        return timeElapsed == 1 ||
-            timeElapsed == 2 ||
-            timeElapsed == 5 ||
-            timeElapsed == 10 ||
-            timeElapsed == 20 ||
-            timeElapsed == 40 ||
-            timeElapsed == 60 ||
-            timeElapsed == 80;
+        return timeElapsed == 1 || timeElapsed == 2
+            || timeElapsed == 5
+            || timeElapsed == 10
+            || timeElapsed == 20
+            || timeElapsed == 40
+            || timeElapsed == 60
+            || timeElapsed == 80;
     }
 
     protected void runMachine(IGregTechTileEntity aBaseMetaTileEntity, long aTick) {

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
@@ -460,13 +460,13 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
 
         if (timeElapsed >= 100) return aTick % 100 == 0;
 
-        return timeElapsed == 1 || timeElapsed == 2
-            || timeElapsed == 5
-            || timeElapsed == 10
+        return timeElapsed == 5 || timeElapsed == 12
             || timeElapsed == 20
+            || timeElapsed == 30
             || timeElapsed == 40
-            || timeElapsed == 60
-            || timeElapsed == 80;
+            || timeElapsed == 55
+            || timeElapsed == 70
+            || timeElapsed == 85;
     }
 
     protected void runMachine(IGregTechTileEntity aBaseMetaTileEntity, long aTick) {


### PR DESCRIPTION
This might perform up to 8 extra checks, but will be able to increase crafting efficiency significantly.