### PR TITLE
GTPP Advanced boiler fix

### DIFF
--- a/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler.java
+++ b/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler.java
@@ -277,7 +277,7 @@ public abstract class GT_MetaTileEntity_Boiler extends GT_MetaTileEntity_BasicTa
             updateFuel(aBaseMetaTileEntity, aTick);
     }
 
-    private void ventSteamIfTankIsFull() {
+    protected void ventSteamIfTankIsFull() {
         if ((this.mSteam != null) && (this.mSteam.amount > getCapacity())) {
             sendSound(SOUND_EVENT_LET_OFF_EXCESS_STEAM);
             this.mSteam.amount = getCapacity() * 3 / 4;


### PR DESCRIPTION
Just makes `ventSteamIfTankIsFull()` overwritable in GTPP. Old method GTPP used was not working in the slightest. 

Should be merged with https://github.com/GTNewHorizons/GTplusplus/pull/686