### PR TITLE
Make Parallel Helper do better chanced output calculation for paralleled chanced recipes

### DIFF
--- a/src/main/java/gregtech/api/util/GT_ParallelHelper.java
+++ b/src/main/java/gregtech/api/util/GT_ParallelHelper.java
@@ -400,16 +400,16 @@ public class GT_ParallelHelper {
             if (mRecipe.mOutputs != null) {
                 mItemOutputs = new ItemStack[mRecipe.mOutputs.length];
                 for (int i = 0; i < mRecipe.mOutputs.length; i++) {
-                    if (mRecipe.getOutputChance(i) >= XSTR.XSTR_INSTANCE.nextInt(10000)) {
-                        if (mRecipe.getOutput(i) == null) {
-                            mItemOutputs[i] = null;
-                        } else {
-                            ItemStack tItem = mRecipe.getOutput(i)
-                                .copy();
-                            tItem.stackSize *= mCurrentParallel;
-                            mItemOutputs[i] = tItem;
-                        }
+                    int totalChance = mRecipe.getOutputChance(i) * mCurrentParallel;
+                    int items = totalChance / 10000;
+                    int leftChance = totalChance % 10000;
+                    if (leftChance > 0 && leftChance >= XSTR.XSTR_INSTANCE.nextInt(10000)) {
+                        items++;
                     }
+                    ItemStack item = mRecipe.getOutput(i)
+                        .copy();
+                    item.stackSize = items;
+                    mItemOutputs[i] = item;
                 }
             }
             if (mRecipe.mFluidOutputs != null) {

--- a/src/main/java/gregtech/api/util/GT_ParallelHelper.java
+++ b/src/main/java/gregtech/api/util/GT_ParallelHelper.java
@@ -400,11 +400,12 @@ public class GT_ParallelHelper {
             if (mRecipe.mOutputs != null) {
                 mItemOutputs = new ItemStack[mRecipe.mOutputs.length];
                 for (int i = 0; i < mRecipe.mOutputs.length; i++) {
-                    int totalChance = mRecipe.getOutputChance(i) * mCurrentParallel;
-                    int items = totalChance / 10000;
-                    int leftChance = totalChance % 10000;
-                    if (leftChance > 0 && leftChance >= XSTR.XSTR_INSTANCE.nextInt(10000)) {
-                        items++;
+                    int items = 0;
+                    int itemStackSize = mRecipe.getOutput(i).stackSize;
+                    for (int roll = 0; roll < mCurrentParallel; roll++) {
+                        if (mRecipe.getOutputChance(i) >= XSTR.XSTR_INSTANCE.nextInt(10000)) {
+                            items += itemStackSize;
+                        }
                     }
                     ItemStack item = mRecipe.getOutput(i)
                         .copy();

--- a/src/main/java/gregtech/api/util/GT_ParallelHelper.java
+++ b/src/main/java/gregtech/api/util/GT_ParallelHelper.java
@@ -435,7 +435,11 @@ public class GT_ParallelHelper {
             }
             ItemStack item = mRecipe.getOutput(i)
                 .copy();
-            item.stackSize = items;
+            if (items == 0) {
+                item = null;
+            } else {
+                item.stackSize = items;
+            }
             mItemOutputs[i] = item;
         }
     }

--- a/src/main/java/gregtech/api/util/GT_ParallelHelper.java
+++ b/src/main/java/gregtech/api/util/GT_ParallelHelper.java
@@ -398,20 +398,7 @@ public class GT_ParallelHelper {
         // If we want to calculate outputs we do it here
         if (mCalculateOutputs && mCurrentParallel > 0) {
             if (mRecipe.mOutputs != null) {
-                mItemOutputs = new ItemStack[mRecipe.mOutputs.length];
-                for (int i = 0; i < mRecipe.mOutputs.length; i++) {
-                    int items = 0;
-                    int itemStackSize = mRecipe.getOutput(i).stackSize;
-                    for (int roll = 0; roll < mCurrentParallel; roll++) {
-                        if (mRecipe.getOutputChance(i) >= XSTR.XSTR_INSTANCE.nextInt(10000)) {
-                            items += itemStackSize;
-                        }
-                    }
-                    ItemStack item = mRecipe.getOutput(i)
-                        .copy();
-                    item.stackSize = items;
-                    mItemOutputs[i] = item;
-                }
+                calculateItemOutputs();
             }
             if (mRecipe.mFluidOutputs != null) {
                 mFluidOutputs = new FluidStack[mRecipe.mFluidOutputs.length];
@@ -426,6 +413,30 @@ public class GT_ParallelHelper {
                     }
                 }
             }
+        }
+    }
+
+    protected void calculateItemOutputs() {
+        mItemOutputs = new ItemStack[mRecipe.mOutputs.length];
+        for (int i = 0; i < mRecipe.mOutputs.length; i++) {
+            if (mRecipe.getOutputChance(i) >= 10000) {
+                ItemStack item = mRecipe.getOutput(i)
+                    .copy();
+                item.stackSize *= mCurrentParallel;
+                mItemOutputs[i] = item;
+                continue;
+            }
+            int items = 0;
+            int itemStackSize = mRecipe.getOutput(i).stackSize;
+            for (int roll = 0; roll < mCurrentParallel; roll++) {
+                if (mRecipe.getOutputChance(i) >= XSTR.XSTR_INSTANCE.nextInt(10000)) {
+                    items += itemStackSize;
+                }
+            }
+            ItemStack item = mRecipe.getOutput(i)
+                .copy();
+            item.stackSize = items;
+            mItemOutputs[i] = item;
         }
     }
 }


### PR DESCRIPTION
What changed:
- Multiply the chance by the amount of parallels to get a chance over 100%, which will determine how many items are certain to be gotten.
- This will still average out normally as it only makes it so one could spend 100% more resources on a 1% craft  to be certain to get something in the same time.
closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13594

If wanted it can be rolled for each parallel instead.