### PR TITLE
Makes boilers "getSteamCapacity() aware"

### DIFF
--- a/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler.java
+++ b/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler.java
@@ -278,9 +278,9 @@ public abstract class GT_MetaTileEntity_Boiler extends GT_MetaTileEntity_BasicTa
     }
 
     protected void ventSteamIfTankIsFull() {
-        if ((this.mSteam != null) && (this.mSteam.amount > getCapacity())) {
+        if ((this.mSteam != null) && (this.mSteam.amount > getSteamCapacity())) {
             sendSound(SOUND_EVENT_LET_OFF_EXCESS_STEAM);
-            this.mSteam.amount = getCapacity() * 3 / 4;
+            this.mSteam.amount = getSteamCapacity() * 3 / 4;
         }
     }
 
@@ -391,6 +391,8 @@ public abstract class GT_MetaTileEntity_Boiler extends GT_MetaTileEntity_BasicTa
         return 16000;
     }
 
+    protected int getSteamCapacity() { return getCapacity(); }
+
     protected abstract int getProductionPerSecond();
 
     protected abstract int getMaxTemperature();
@@ -440,7 +442,7 @@ public abstract class GT_MetaTileEntity_Boiler extends GT_MetaTileEntity_BasicTa
             .widget(createFuelSlot())
             .widget(createAshSlot())
             .widget(
-                new ProgressBar().setProgress(() -> mSteam == null ? 0 : (float) mSteam.amount / getCapacity())
+                new ProgressBar().setProgress(() -> mSteam == null ? 0 : (float) mSteam.amount / getSteamCapacity())
                     .setTexture(getProgressbarEmpty(), GT_UITextures.PROGRESSBAR_BOILER_STEAM, 10)
                     .setDirection(ProgressBar.Direction.UP)
                     .setPos(70, 25)

--- a/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler.java
+++ b/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler.java
@@ -391,7 +391,9 @@ public abstract class GT_MetaTileEntity_Boiler extends GT_MetaTileEntity_BasicTa
         return 16000;
     }
 
-    protected int getSteamCapacity() { return getCapacity(); }
+    protected int getSteamCapacity() {
+        return getCapacity();
+    }
 
     protected abstract int getProductionPerSecond();
 

--- a/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Lava.java
+++ b/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Lava.java
@@ -456,7 +456,7 @@ public class GT_MetaTileEntity_Boiler_Lava extends GT_MetaTileEntity_Boiler {
     public FluidTankInfo[] getTankInfo(ForgeDirection side) {
         return new FluidTankInfo[] { super.getTankInfo(side)[0],
             new FluidTankInfo(this.lavaTank.getFluid(), this.lavaTank.getCapacity()),
-            new FluidTankInfo(getDrainableStack(), getCapacity()) };
+            new FluidTankInfo(getDrainableStack(), getSteamCapacity()) };
     }
 
     @Override
@@ -479,7 +479,7 @@ public class GT_MetaTileEntity_Boiler_Lava extends GT_MetaTileEntity_Boiler {
                     .setPos(115, 61))
             .widget(createAshSlot())
             .widget(
-                new ProgressBar().setProgress(() -> mSteam == null ? 0 : (float) mSteam.amount / getCapacity())
+                new ProgressBar().setProgress(() -> mSteam == null ? 0 : (float) mSteam.amount / getSteamCapacity())
                     .setTexture(getProgressbarEmpty(), GT_UITextures.PROGRESSBAR_BOILER_STEAM, 10)
                     .setDirection(ProgressBar.Direction.UP)
                     .setPos(70, 25)


### PR DESCRIPTION
As discussed with wlhlm/rot13 this converts GT5 to use `getSteamCapacity()` for boilers. Also makes it easier to control steam capacity if any future subclasses need it.
Needed for: https://github.com/GTNewHorizons/GTplusplus/pull/686