### PR TITLE
GPL Special Item access

### DIFF
--- a/src/main/java/gregtech/api/logic/ProcessingLogic.java
+++ b/src/main/java/gregtech/api/logic/ProcessingLogic.java
@@ -29,6 +29,7 @@ public class ProcessingLogic {
     protected IRecipeLockable recipeLockableMachine;
     protected Supplier<GT_Recipe_Map> recipeMapSupplier;
     protected GT_Recipe lastRecipe;
+    protected ItemStack specialSlotItem;
     protected ItemStack[] inputItems;
     protected ItemStack[] outputItems;
     protected ItemStack[] currentOutputItems;
@@ -70,6 +71,11 @@ public class ProcessingLogic {
 
     public ProcessingLogic setInputFluids(List<FluidStack> fluidInputs) {
         this.inputFluids = fluidInputs.toArray(new FluidStack[0]);
+        return this;
+    }
+
+    public ProcessingLogic setSpecialSlotItem(ItemStack specialSlotItem) {
+        this.specialSlotItem = specialSlotItem;
         return this;
     }
 
@@ -213,6 +219,7 @@ public class ProcessingLogic {
     public ProcessingLogic clear() {
         this.inputItems = null;
         this.inputFluids = null;
+        this.specialSlotItem = null;
         this.outputItems = null;
         this.outputFluids = null;
         this.calculatedEut = 0;
@@ -252,8 +259,14 @@ public class ProcessingLogic {
                 recipeLockableMachine.getSingleRecipeCheck()
                     .getRecipe());
         } else {
-            findRecipeResult = recipeMap
-                .findRecipeWithResult(lastRecipe, false, false, availableVoltage, inputFluids, null, inputItems);
+            findRecipeResult = recipeMap.findRecipeWithResult(
+                lastRecipe,
+                false,
+                false,
+                availableVoltage,
+                inputFluids,
+                specialSlotItem,
+                inputItems);
         }
 
         GT_Recipe recipe;

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
@@ -2003,7 +2003,7 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
     @Override
     public void addGregTechLogo(ModularWindow.Builder builder) {}
 
-    protected boolean shouldDisplayRecipeIssue() {
+    protected boolean shouldDisplayCheckRecipeResult() {
         return true;
     }
 
@@ -2085,7 +2085,7 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
                 .setTextAlignment(Alignment.CenterLeft)
                 .setEnabled(
                     widget -> GT_Utility.isStringValid(checkRecipeResult.getDisplayString())
-                        && shouldDisplayRecipeIssue()))
+                        && shouldDisplayCheckRecipeResult()))
             .widget(new CheckRecipeResultSyncer(() -> checkRecipeResult, (result) -> checkRecipeResult = result));
 
         screenElements.widget(

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
@@ -692,14 +692,8 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
 
         CheckRecipeResult result = CheckRecipeResultRegistry.NO_RECIPE;
 
-        processingLogic.clear();
-        processingLogic.setMachine(this);
-        processingLogic.setRecipeMapSupplier(this::getRecipeMap);
-        processingLogic.setVoidProtection(protectsExcessItem(), protectsExcessFluid());
-        processingLogic.setBatchSize(isBatchModeEnabled() ? getMaxBatchSize() : 1);
-        processingLogic.setRecipeLocking(this, isRecipeLockingEnabled());
-        processingLogic.setInputFluids(getStoredFluids());
-        setProcessingLogicPower(processingLogic);
+        setupProcessingLogic(processingLogic);
+
         if (isInputSeparationEnabled()) {
             for (GT_MetaTileEntity_Hatch_InputBus bus : mInputBusses) {
                 List<ItemStack> inputItems = new ArrayList<>();
@@ -740,6 +734,17 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
         mOutputFluids = processingLogic.getOutputFluids();
 
         return result;
+    }
+
+    protected void setupProcessingLogic(ProcessingLogic logic) {
+        logic.clear();
+        logic.setMachine(this);
+        logic.setRecipeMapSupplier(this::getRecipeMap);
+        logic.setVoidProtection(protectsExcessItem(), protectsExcessFluid());
+        logic.setBatchSize(isBatchModeEnabled() ? getMaxBatchSize() : 1);
+        logic.setRecipeLocking(this, isRecipeLockingEnabled());
+        logic.setInputFluids(getStoredFluids());
+        setProcessingLogicPower(logic);
     }
 
     protected void setProcessingLogicPower(ProcessingLogic logic) {
@@ -1998,6 +2003,10 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
     @Override
     public void addGregTechLogo(ModularWindow.Builder builder) {}
 
+    protected boolean shouldDisplayRecipeIssue() {
+        return true;
+    }
+
     protected void drawTexts(DynamicPositionedColumn screenElements, SlotWidget inventorySlot) {
         screenElements.setSynced(false)
             .setSpace(0)
@@ -2074,7 +2083,9 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
             TextWidget.dynamicString(() -> checkRecipeResult.getDisplayString())
                 .setSynced(false)
                 .setTextAlignment(Alignment.CenterLeft)
-                .setEnabled(widget -> GT_Utility.isStringValid(checkRecipeResult.getDisplayString())))
+                .setEnabled(
+                    widget -> GT_Utility.isStringValid(checkRecipeResult.getDisplayString())
+                        && shouldDisplayRecipeIssue()))
             .widget(new CheckRecipeResultSyncer(() -> checkRecipeResult, (result) -> checkRecipeResult = result));
 
         screenElements.widget(


### PR DESCRIPTION
- Adds method to allow a machine to set the special item for recipe checking. Used e.g. in finding the recipe of a bacterial vat
- Added method that allows a machine to turn of the recipe result display. Needed for YOTTA