### PR TITLE
Migrate fusion reactor to proper generic processing logic

### DIFF
--- a/src/main/java/gregtech/api/recipe/check/CheckRecipeResultRegistry.java
+++ b/src/main/java/gregtech/api/recipe/check/CheckRecipeResultRegistry.java
@@ -102,10 +102,18 @@ public final class CheckRecipeResultRegistry {
         return new ResultInsufficientMachineTier(required);
     }
 
+    /**
+     * Cannot process recipe because the machine doesn't have enough startup power.
+     */
+    public static CheckRecipeResult insufficientStartupPower(int required) {
+        return new ResultInsufficientStartupPower(required);
+    }
+
     static {
         register(new SimpleCheckRecipeResult(false, ""));
         register(new ResultInsufficientPower(0));
         register(new ResultInsufficientHeat(0));
         register(new ResultInsufficientMachineTier(0));
+        register(new ResultInsufficientStartupPower(0));
     }
 }

--- a/src/main/java/gregtech/api/recipe/check/ResultInsufficientStartupPower.java
+++ b/src/main/java/gregtech/api/recipe/check/ResultInsufficientStartupPower.java
@@ -3,7 +3,6 @@ package gregtech.api.recipe.check;
 import net.minecraft.network.PacketBuffer;
 import net.minecraft.util.StatCollector;
 
-import gregtech.api.enums.HeatingCoilLevel;
 import gregtech.api.util.GT_Utility;
 
 public class ResultInsufficientStartupPower implements CheckRecipeResult {
@@ -26,10 +25,8 @@ public class ResultInsufficientStartupPower implements CheckRecipeResult {
 
     @Override
     public String getDisplayString() {
-        return StatCollector.translateToLocalFormatted(
-            "GT5U.gui.text.insufficient_startup_power",
-            GT_Utility.formatNumbers(required),
-            HeatingCoilLevel.getDisplayNameFromHeat(required, true));
+        return StatCollector
+            .translateToLocalFormatted("GT5U.gui.text.insufficient_startup_power", GT_Utility.formatNumbers(required));
     }
 
     @Override

--- a/src/main/java/gregtech/api/recipe/check/ResultInsufficientStartupPower.java
+++ b/src/main/java/gregtech/api/recipe/check/ResultInsufficientStartupPower.java
@@ -1,0 +1,57 @@
+package gregtech.api.recipe.check;
+
+import net.minecraft.network.PacketBuffer;
+import net.minecraft.util.StatCollector;
+
+import gregtech.api.enums.HeatingCoilLevel;
+import gregtech.api.util.GT_Utility;
+
+public class ResultInsufficientStartupPower implements CheckRecipeResult {
+
+    private int required;
+
+    ResultInsufficientStartupPower(int required) {
+        this.required = required;
+    }
+
+    @Override
+    public String getID() {
+        return "insufficient_startup_power";
+    }
+
+    @Override
+    public boolean wasSuccessful() {
+        return false;
+    }
+
+    @Override
+    public String getDisplayString() {
+        return StatCollector.translateToLocalFormatted(
+            "GT5U.gui.text.insufficient_startup_power",
+            GT_Utility.formatNumbers(required),
+            HeatingCoilLevel.getDisplayNameFromHeat(required, true));
+    }
+
+    @Override
+    public CheckRecipeResult newInstance() {
+        return new ResultInsufficientStartupPower(0);
+    }
+
+    @Override
+    public void encode(PacketBuffer buffer) {
+        buffer.writeVarIntToBuffer(required);
+    }
+
+    @Override
+    public void decode(PacketBuffer buffer) {
+        required = buffer.readVarIntFromBuffer();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ResultInsufficientStartupPower that = (ResultInsufficientStartupPower) o;
+        return required == that.required;
+    }
+}

--- a/src/main/java/gregtech/api/util/GT_OverclockCalculator.java
+++ b/src/main/java/gregtech/api/util/GT_OverclockCalculator.java
@@ -40,6 +40,13 @@ public class GT_OverclockCalculator {
      */
     private boolean mHeatOC, mOneTickDiscount, calculated, mHeatDiscount;
 
+    /** If the OC calculator should only do a given amount of overclocks. Mainly used in fusion reactors */
+    private boolean limitOverclocks;
+    /** Maximum amount of overclocks to perform, when limitOverclocks = true */
+    private int maxOverclocks;
+    /** How many overclocks have been performed */
+    private int overclockCount;
+
     private static final int HEAT_DISCOUNT_THRESHOLD = 900;
     private static final int HEAT_PERFECT_OVERCLOCK_THRESHOLD = 1800;
 
@@ -213,6 +220,16 @@ public class GT_OverclockCalculator {
     }
 
     /**
+     * Limit the amount of overclocks that can be performed, regardless of how much power is available. Mainly used for
+     * fusion reactors.
+     */
+    public GT_OverclockCalculator limitOverclockCount(int maxOverclocks) {
+        this.limitOverclocks = true;
+        this.maxOverclocks = maxOverclocks;
+        return this;
+    }
+
+    /**
      * Call this when all values have been put it.
      */
     public GT_OverclockCalculator calculate() {
@@ -250,7 +267,8 @@ public class GT_OverclockCalculator {
             long tNextConsumption = ((long) Math
                 .ceil(mRecipeEUt * mParallel * mRecipeAmps * mEUtDiscount * heatDiscountMultiplier))
                 << mEUtIncreasePerOC;
-            while (tTierDifference > 0 && tNextConsumption < mEUt * mAmps) {
+            while (tTierDifference > 0 && tNextConsumption < mEUt * mAmps
+                && (!limitOverclocks || overclockCount++ < maxOverclocks)) {
                 if (mDuration <= 1) {
                     break;
                 }
@@ -263,7 +281,7 @@ public class GT_OverclockCalculator {
             long tNextConsumption = ((long) Math
                 .ceil(mRecipeEUt * mParallel * mRecipeAmps * mEUtDiscount * heatDiscountMultiplier))
                 << mEUtIncreasePerOC;
-            while (tNextConsumption < mEUt * mAmps) {
+            while (tNextConsumption < mEUt * mAmps && (!limitOverclocks || overclockCount++ < maxOverclocks)) {
                 if (mDuration <= 1) {
                     break;
                 }
@@ -306,5 +324,15 @@ public class GT_OverclockCalculator {
             calculate();
         }
         return mDuration;
+    }
+
+    /**
+     * @return Number of performed overclocks
+     */
+    public int gerPerformedOverclocks() {
+        if (!calculated) {
+            calculate();
+        }
+        return overclockCount;
     }
 }

--- a/src/main/java/gregtech/api/util/GT_OverclockCalculator.java
+++ b/src/main/java/gregtech/api/util/GT_OverclockCalculator.java
@@ -329,7 +329,7 @@ public class GT_OverclockCalculator {
     /**
      * @return Number of performed overclocks
      */
-    public int gerPerformedOverclocks() {
+    public int getPerformedOverclocks() {
         if (!calculated) {
             calculate();
         }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_FusionComputer.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_FusionComputer.java
@@ -440,11 +440,11 @@ public abstract class GT_MetaTileEntity_FusionComputer
                             if (aBaseMetaTileEntity.isAllowedToWork()) {
                                 this.mEUStore = aBaseMetaTileEntity.getStoredEU();
                                 if (checkRecipe()) {
-                                    if (this.mEUStore < this.mLastRecipe.mSpecialValue - this.mEUt) {
+                                    if (this.mEUStore < this.mLastRecipe.mSpecialValue + this.mEUt) {
                                         criticalStopMachine();
                                     }
                                     aBaseMetaTileEntity
-                                        .decreaseStoredEnergyUnits(this.mLastRecipe.mSpecialValue - this.mEUt, true);
+                                        .decreaseStoredEnergyUnits(this.mLastRecipe.mSpecialValue + this.mEUt, true);
                                 }
                             }
                             if (mMaxProgresstime <= 0) mEfficiency = Math.max(0, mEfficiency - 1000);

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_FusionComputer.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_FusionComputer.java
@@ -277,16 +277,16 @@ public abstract class GT_MetaTileEntity_FusionComputer
 
     public int overclock(int mStartEnergy) {
         if (tierOverclock() == 1) {
-            return 1;
+            return 0;
         }
         if (tierOverclock() == 2) {
-            return mStartEnergy <= 160000000 ? 2 : 1;
+            return mStartEnergy <= 160000000 ? 1 : 0;
         }
         if (this.tierOverclock() == 4) {
-            return (mStartEnergy <= 160000000 ? 4 : (mStartEnergy <= 320000000 ? 2 : 1));
+            return (mStartEnergy <= 160000000 ? 2 : (mStartEnergy <= 320000000 ? 1 : 0));
         }
-        return (mStartEnergy <= 160000000) ? 8
-            : ((mStartEnergy <= 320000000) ? 4 : (mStartEnergy <= 640000000) ? 2 : 1);
+        return (mStartEnergy <= 160000000) ? 3
+            : ((mStartEnergy <= 320000000) ? 2 : (mStartEnergy <= 640000000) ? 1 : 0);
     }
 
     @Override
@@ -320,10 +320,8 @@ public abstract class GT_MetaTileEntity_FusionComputer
             @Override
             protected GT_OverclockCalculator createOverclockCalculator(@NotNull GT_Recipe recipe,
                 @NotNull GT_ParallelHelper helper) {
-                int overclock = overclock(recipe.mSpecialValue);
-                // GT_OverclockCalculator is not suited for fusion style OC
-                return GT_OverclockCalculator
-                    .ofNoOverclock((long) recipe.mEUt * overclock, recipe.mDuration / overclock);
+                return super.createOverclockCalculator(recipe, helper)
+                    .limitOverclockCount(overclock(recipe.mSpecialValue));
             }
 
             @NotNull
@@ -348,7 +346,7 @@ public abstract class GT_MetaTileEntity_FusionComputer
                 }
                 return result;
             }
-        };
+        }.setOverclock(1, 1);
     }
 
     @Override

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_FusionComputer.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_FusionComputer.java
@@ -464,7 +464,7 @@ public abstract class GT_MetaTileEntity_FusionComputer
     @Override
     public boolean onRunningTick(ItemStack aStack) {
         if (mEUt < 0) {
-            if (!drainEnergyInput(((long) -mEUt * 10000) / Math.max(1000, mEfficiency))) {
+            if (!drainEnergyInput(((long) mEUt * 10000) / Math.max(1000, mEfficiency))) {
                 this.mLastRecipe = null;
                 criticalStopMachine();
                 return false;

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_FusionComputer.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_FusionComputer.java
@@ -171,13 +171,11 @@ public abstract class GT_MetaTileEntity_FusionComputer
     }
 
     @Override
-    public void saveNBTData(NBTTagCompound aNBT) {
-        super.saveNBTData(aNBT);
-    }
-
-    @Override
     public void loadNBTData(NBTTagCompound aNBT) {
         super.loadNBTData(aNBT);
+        if (mEUt > 0) {
+            mEUt = -mEUt;
+        }
     }
 
     @Override
@@ -410,7 +408,7 @@ public abstract class GT_MetaTileEntity_FusionComputer
                     }
                     if (mMaxProgresstime > 0) {
                         this.getBaseMetaTileEntity()
-                            .decreaseStoredEnergyUnits(mEUt, true);
+                            .decreaseStoredEnergyUnits(-mEUt, true);
                         if (mMaxProgresstime > 0 && ++mProgresstime >= mMaxProgresstime) {
                             if (mOutputItems != null)
                                 for (ItemStack tStack : mOutputItems) if (tStack != null) addOutput(tStack);
@@ -459,23 +457,6 @@ public abstract class GT_MetaTileEntity_FusionComputer
                 .setErrorDisplayID((aBaseMetaTileEntity.getErrorDisplayID() & ~127) | (mMachine ? 0 : 64));
             aBaseMetaTileEntity.setActive(mMaxProgresstime > 0);
         }
-    }
-
-    @Override
-    public boolean onRunningTick(ItemStack aStack) {
-        if (mEUt < 0) {
-            if (!drainEnergyInput(((long) mEUt * 10000) / Math.max(1000, mEfficiency))) {
-                this.mLastRecipe = null;
-                criticalStopMachine();
-                return false;
-            }
-        }
-        if (this.mEUStore <= 0) {
-            this.mLastRecipe = null;
-            criticalStopMachine();
-            return false;
-        }
-        return true;
     }
 
     @Override

--- a/src/main/resources/assets/gregtech/lang/en_US.lang
+++ b/src/main/resources/assets/gregtech/lang/en_US.lang
@@ -253,6 +253,7 @@ GT5U.gui.text.duration_overflow=§7Processing time overflowed
 GT5U.gui.text.insufficient_power=§7Recipe needs more power to start. Required: %s EU/t (%s§7)
 GT5U.gui.text.insufficient_heat=§7Recipe needs more heat to start. Required: %s K (%s§7)
 GT5U.gui.text.insufficient_machine_tier=§7Recipe needs higher structure tier. Required: %s
+GT5U.gui.text.insufficient_startup_power=§7Recipe needs higher startup power. Required: %s
 
 GT5U.item.programmed_circuit.select.header=Reprogram Circuit
 


### PR DESCRIPTION
Needs https://github.com/GTNewHorizons/GTplusplus/pull/696
I finally got around to migrating fusion reactor properly. The check recipe result will currently not be seen, but I plan on changing the GUI soon, then I will enable the buttons properly for fusion. 
~From brief look this will not break the fusion mk4/5 in gtpp and compact don't even inherit this class, so it should be safe to merge this in GT5U only for now.~
Before merging the gtpp fusion reactors will need adjustment. I will start that after I got a review on this one, if the style is good to go.
Will fix this issue in the first 3 fusion tiers: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13962
but the issue should stay open until all fusion reactors are migrated.

I removed check of complex fusion recipe map for now since its not used anyway, so it doesn't get unnecessary bloated. When there is a demand we can add it back. 