### PR TITLE
Fix GT_ParallelHelper always doing batch mode parallels instead of focusing on normal parallels

### DIFF
--- a/src/main/java/gregtech/api/util/GT_ParallelHelper.java
+++ b/src/main/java/gregtech/api/util/GT_ParallelHelper.java
@@ -320,6 +320,7 @@ public class GT_ParallelHelper {
             }
         }
 
+        int maxParallelBeforeBatchMode = mMaxParallel;
         if (mBatchMode) {
             mMaxParallel *= mBatchModifier;
         }
@@ -353,16 +354,17 @@ public class GT_ParallelHelper {
             mMaxParallel = Math.min(voidProtectionHelper.getMaxParallel(), mMaxParallel);
         }
 
+        maxParallelBeforeBatchMode = Math.min(mMaxParallel, maxParallelBeforeBatchMode);
+
         final int tRecipeEUt = (int) Math.ceil(mRecipe.mEUt * mEUtModifier);
-        final int batchCorrectedMaxParallel = mMaxParallel / mBatchModifier;
         // Consume inputs to determine normal parallel
         if (recipeCheck != null) {
-            int actualMaxParallel = (int) Math.min(batchCorrectedMaxParallel, mAvailableEUt / tRecipeEUt);
+            int actualMaxParallel = (int) Math.min(maxParallelBeforeBatchMode, mAvailableEUt / tRecipeEUt);
             mCurrentParallel = recipeCheck.checkRecipeInputs(true, actualMaxParallel, tItemInputs, tFluidInputs);
         } else {
             long tCurrentUsage = 0;
             boolean builtRecipeCheck = false;
-            for (; mCurrentParallel < batchCorrectedMaxParallel
+            for (; mCurrentParallel < maxParallelBeforeBatchMode
                 && tCurrentUsage < (mAvailableEUt - tRecipeEUt); mCurrentParallel++) {
                 if (!mRecipe.isRecipeInputEqual(true, false, tFluidInputs, tItemInputs)) {
                     break;

--- a/src/main/java/gregtech/api/util/GT_ParallelHelper.java
+++ b/src/main/java/gregtech/api/util/GT_ParallelHelper.java
@@ -382,7 +382,8 @@ public class GT_ParallelHelper {
         // If Batch Mode is enabled determine how many extra parallels we can get
         if (mBatchMode && mCurrentParallel > 0) {
             int tExtraParallels = 0;
-            final int maxExtraParallels = mCurrentParallel * (mBatchModifier - 1);
+            final int maxExtraParallels = Math
+                .min(mCurrentParallel * (mBatchModifier - 1), mMaxParallel - mCurrentParallel);
             if (recipeCheck != null) {
                 tExtraParallels = recipeCheck.checkRecipeInputs(true, maxExtraParallels, tItemInputs, tFluidInputs);
             } else {


### PR DESCRIPTION
This is the actual fix, as currently batch mode will make sure it can also be fully run along with the normal parallels with void protection on.