### PR TITLE
Automatically label pull requests targetting MuTEs

### DIFF
--- a/.github/pr-branch-labeler.yml
+++ b/.github/pr-branch-labeler.yml
@@ -1,0 +1,2 @@
+MuTE:
+  base: 'feature/MuTEMaster'

--- a/.github/workflows/label-mute-prs.yml
+++ b/.github/workflows/label-mute-prs.yml
@@ -1,0 +1,17 @@
+name: Pull request labeling
+
+on:
+  pull_request_target:
+    types:
+      - opened
+    branches:
+      - 'feature/MuTEMaster'
+
+jobs:
+  label_prs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label MuTE PRs
+        uses: ffittschen/pr-branch-labeler@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Automatically apply a label to PRs targeting the `feature/MuTEMaster` branch to keep better track of the ongoing work. This workflow should be removed once the MuTE work has been merged into `master`.

[Repo of the used action](https://github.com/ffittschen/pr-branch-labeler)

This will not target already merged PRs. I will manually apply the label to the old PRs if this is accepted.