### PR TITLE
Remove unwanted GT recipes for frequency transmitter

### DIFF
--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingCrafting.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingCrafting.java
@@ -42,16 +42,6 @@ public class ProcessingCrafting implements gregtech.api.interfaces.IOreRecipeReg
                     .eut(20)
                     .addTo(sAssemblerRecipes);
             }
-            case "craftingWireCopper", "craftingWireTin" -> {
-                GT_Values.RA.stdBuilder()
-                    .itemInputs(ItemList.Circuit_Basic.get(1L), GT_Utility.copyAmount(1L, aStack))
-                    .itemOutputs(GT_ModHandler.getIC2Item("frequencyTransmitter", 1L))
-                    .noFluidInputs()
-                    .noFluidOutputs()
-                    .duration(2 * SECONDS)
-                    .eut(20)
-                    .addTo(sAssemblerRecipes);
-            }
             case "craftingLensBlue" -> {
 
                 GT_Values.RA.stdBuilder()


### PR DESCRIPTION
remove unwanted recipes for frequency transmitter in gt. The intended one is in coremod.

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13991

this is the remaining one from coremod:
![image](https://github.com/GTNewHorizons/GT5-Unofficial/assets/40274384/280e7373-802f-4776-a0ad-4a492fe2d42d)
