### PR TITLE
Revert rutile yield from garnet processing to it's pre-nerf values

### DIFF
--- a/src/main/java/gregtech/loaders/postload/chains/GT_BauxiteRefineChain.java
+++ b/src/main/java/gregtech/loaders/postload/chains/GT_BauxiteRefineChain.java
@@ -263,7 +263,7 @@ public class GT_BauxiteRefineChain {
                 Materials.Gold.getDust(1),
                 Materials.Vanadium.getDust(1),
                 Materials.Rutile.getDust(1))
-            .outputChances(5000, 4000, 300, 300, 200, 200)
+            .outputChances(5000, 4000, 300, 300, 200, 600)
             .fluidInputs(Materials.NitricAcid.getFluid(10))
             .fluidOutputs(MaterialsOreAlum.SluiceJuice.getFluid(10))
             .duration(2 * SECONDS + 5 * TICKS)


### PR DESCRIPTION
in #1927 titaniumtetrachloride was changed to need 3 rutile instead of 1. This was the result of new processing lines for bauxite and ilmenite that yielded much higher amounts. As a result of the changes to titaniumtetrachloride all other sources of rutile were nerfed by a factor of three. This change would return rutile to the same yield of titanium as before the titaniumtetrachloride rebalance.