### PR TITLE
Add circuit to Solid Machine Casing Recipe

### DIFF
--- a/src/main/java/gregtech/loaders/postload/recipes/AssemblerRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/AssemblerRecipes.java
@@ -2204,7 +2204,8 @@ public class AssemblerRecipes implements Runnable {
         GT_Values.RA.stdBuilder()
             .itemInputs(
                 GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Steel, 6),
-                GT_OreDictUnificator.get(OrePrefixes.frameGt, Materials.Steel, 1))
+                GT_OreDictUnificator.get(OrePrefixes.frameGt, Materials.Steel, 1),
+                GT_Utility.getIntegratedCircuit(1))
             .itemOutputs(ItemList.Casing_SolidSteel.get(1))
             .noFluidInputs()
             .noFluidOutputs()


### PR DESCRIPTION
Adds circuit 1 to the Solid Machine Casing recipe. This is to avoid a recipe conflict with the Steel Gear Box Casing recipe added in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/680.