### PR TITLE
Remove old base gt recipe that we dont want

### DIFF
--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingStoneVarious.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingStoneVarious.java
@@ -1,14 +1,8 @@
 package gregtech.loaders.oreprocessing;
 
-import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAssemblerRecipes;
-import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
-
-import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 
-import gregtech.api.enums.GT_Values;
 import gregtech.api.enums.OrePrefixes;
-import gregtech.api.util.GT_Utility;
 
 public class ProcessingStoneVarious implements gregtech.api.interfaces.IOreRecipeRegistrator {
 
@@ -26,25 +20,6 @@ public class ProcessingStoneVarious implements gregtech.api.interfaces.IOreRecip
     @Override
     public void registerOre(OrePrefixes aPrefix, gregtech.api.enums.Materials aMaterial, String aOreDictName,
         String aModName, ItemStack aStack) {
-        if (aPrefix == OrePrefixes.stoneSmooth) {
-
-            GT_Values.RA.stdBuilder()
-                .itemInputs(GT_Utility.copyAmount(1L, aStack), GT_Utility.getIntegratedCircuit(1))
-                .itemOutputs(new ItemStack(Blocks.stone_button, 1))
-                .noFluidInputs()
-                .noFluidOutputs()
-                .duration(5 * SECONDS)
-                .eut(4)
-                .addTo(sAssemblerRecipes);
-
-            GT_Values.RA.stdBuilder()
-                .itemInputs(GT_Utility.copyAmount(2L, aStack), GT_Utility.getIntegratedCircuit(2))
-                .itemOutputs(new ItemStack(Blocks.stone_pressure_plate, 1))
-                .noFluidInputs()
-                .noFluidOutputs()
-                .duration(5 * SECONDS)
-                .eut(4)
-                .addTo(sAssemblerRecipes);
-        }
+        // no recipes currently.
     }
 }


### PR DESCRIPTION
Specifically pressure plate and stone button directly from smooth stone in the assembler with circuit 1 or 2.

These recipes were in fact always disabled (I checked stable, they don't exist there). But one of them got enabled somehow (pressure plate). I assume converting them to RA2 broke a recipe removal somewhere. Anyway, the cleanest option is to just remove them properly which is what this PR does.


For comparison, here are the intended recipes that are still very much around:

![image](https://github.com/GTNewHorizons/GT5-Unofficial/assets/40274384/805e9b3e-d1af-4e0d-beff-198e133ee5af)
![image](https://github.com/GTNewHorizons/GT5-Unofficial/assets/40274384/08a1ea3c-630e-4402-8224-1265cdd26d06)

as well as some similar ones and tool based recipes in the crafting grid.