### PR TITLE
Add a config to enable seeing average ns per tick in waila

### DIFF
--- a/src/main/java/gregtech/api/interfaces/tileentity/IGregTechTileEntity.java
+++ b/src/main/java/gregtech/api/interfaces/tileentity/IGregTechTileEntity.java
@@ -189,4 +189,11 @@ public interface IGregTechTileEntity extends ITexturedTileEntity, IGearEnergyTil
             getMetaTileEntity().onRandomDisplayTick(this);
         }
     }
+
+    /**
+     * gets the time statistics used for CPU timing
+     */
+    default int[] getTimeStatistics() {
+        return null;
+    }
 }

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
@@ -2441,4 +2441,9 @@ public class BaseMetaTileEntity extends CommonMetaTileEntity
     public IConstructable getConstructable() {
         return getMetaTileEntity() instanceof IConstructable ? (IConstructable) getMetaTileEntity() : null;
     }
+
+    @Override
+    public int[] getTimeStatistics() {
+        return mTimeStatistics;
+    }
 }

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
@@ -1662,7 +1662,7 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
         // Show ns on the tooltip
         if (GT_Mod.gregtechproxy.wailaAverageNS) {
             int tAverageTime = tag.getInteger("averageNS");
-            currentTip.add("Average CPU load of ~" + GT_Utility.formatNumbers(tAverageTime));
+            currentTip.add("Average CPU load of ~" + GT_Utility.formatNumbers(tAverageTime) + "ns");
         }
         super.getWailaBody(itemStack, currentTip, accessor, config);
     }

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
@@ -1662,7 +1662,7 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
         // Show ns on the tooltip
         if (GT_Mod.gregtechproxy.wailaAverageNS) {
             int tAverageTime = tag.getInteger("averageNS");
-            currentTip.add("Average CPU load of ~" + GT_Utility.formatNumbers(tAverageTime) + "ns");
+            currentTip.add("Average CPU load of ~" + GT_Utility.formatNumbers(tAverageTime) + " ns");
         }
         super.getWailaBody(itemStack, currentTip, accessor, config);
     }

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
@@ -1659,7 +1659,11 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
         }
         currentTip.add(
             GT_Waila.getMachineProgressString(isActive, tag.getInteger("maxProgress"), tag.getInteger("progress")));
-
+        // Show ns on the tooltip
+        if (GT_Mod.gregtechproxy.wailaAverageNS) {
+            int tAverageTime = tag.getInteger("averageNS");
+            currentTip.add("Average CPU load of ~" + GT_Utility.formatNumbers(tAverageTime));
+        }
         super.getWailaBody(itemStack, currentTip, accessor, config);
     }
 
@@ -1683,6 +1687,17 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
                 tag.setLong("energyTier", getInputVoltageTier());
             }
         }
+
+        int tAverageTime = 0;
+        for (int tTime : this.getBaseMetaTileEntity()
+            .getTimeStatistics()) {
+            tAverageTime += tTime;
+        }
+
+        tag.setInteger(
+            "averageNS",
+            tAverageTime / this.getBaseMetaTileEntity()
+                .getTimeStatistics().length);
     }
 
     @Override

--- a/src/main/java/gregtech/common/GT_Proxy.java
+++ b/src/main/java/gregtech/common/GT_Proxy.java
@@ -719,6 +719,8 @@ public abstract class GT_Proxy implements IGT_Mod, IGuiHandler, IFuelHandler, IG
      */
     public Map<String, Integer> mCircuitsOrder = new HashMap<>();
 
+    public boolean wailaAverageNS = false;
+
     public static final int GUI_ID_COVER_SIDE_BASE = 10; // Takes GUI ID 10 - 15
 
     public static Map<String, Integer> oreDictBurnTimes = new HashMap<>();

--- a/src/main/java/gregtech/loaders/preload/GT_PreLoad.java
+++ b/src/main/java/gregtech/loaders/preload/GT_PreLoad.java
@@ -856,6 +856,7 @@ public class GT_PreLoad {
 
         GT_Mod.gregtechproxy.mWailaTransformerVoltageTier = GregTech_API.sClientDataFile
             .get("waila", "WailaTransformerVoltageTier", true);
+        GT_Mod.gregtechproxy.wailaAverageNS = GregTech_API.sClientDataFile.get("waila", "WailaAverageNS", false);
 
         final String[] Circuits = GregTech_API.sClientDataFile.get("interface", "CircuitsOrder");
         GT_Mod.gregtechproxy.mCircuitsOrder.clear();

--- a/src/main/resources/assets/gregtech/lang/en_US.lang
+++ b/src/main/resources/assets/gregtech/lang/en_US.lang
@@ -441,6 +441,7 @@ GT5U.config.nei.RecipeOwnerStackTrace.tooltip=[requires reboot]
 GT5U.config.nei.OriginalVoltage=Show original voltage when overclocked
 GT5U.config.waila=Waila
 GT5U.config.waila.WailaTransformerVoltageTier=Show voltage tier of transformer
+GT5U.config.waila.WailaAverageNS=Show average ns of multiblocks on waila
 
 # Cover tabs
 GT5U.interface.coverTabs.down=Bottom


### PR DESCRIPTION
Shows the CPU load (same as scanner) on WAILA tooltips of Multiblock controllers.
![image](https://github.com/GTNewHorizons/GT5-Unofficial/assets/69092953/de067f61-0d24-4a7b-95f7-584e795352ff)

Disabled by default as most people likely don't care.