### PR TITLE
Remove limit of 1 recipe/t on batch mode

### DIFF
--- a/src/main/java/gregtech/api/logic/ProcessingLogic.java
+++ b/src/main/java/gregtech/api/logic/ProcessingLogic.java
@@ -331,7 +331,7 @@ public class ProcessingLogic {
      */
     protected double calculateDuration(@Nonnull GT_Recipe recipe, @Nonnull GT_ParallelHelper helper,
         @Nonnull GT_OverclockCalculator calculator) {
-        return calculator.getDuration() * helper.getDurationMultiplierDouble();
+        return calculator.getDuration();
     }
 
     /**
@@ -378,7 +378,7 @@ public class ProcessingLogic {
         @Nonnull GT_ParallelHelper helper) {
         return new GT_OverclockCalculator().setRecipeEUt(recipe.mEUt)
             .setParallel((int) Math.floor(helper.getCurrentParallel() / helper.getDurationMultiplierDouble()))
-            .setDuration(recipe.mDuration)
+            .setDuration((int) Math.floor(recipe.mDuration * helper.getDurationMultiplierDouble()))
             .setAmperage(availableAmperage)
             .setEUt(availableVoltage)
             .setSpeedBoost(speedBoost)

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_ProcessingArray.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_ProcessingArray.java
@@ -245,19 +245,6 @@ public class GT_MetaTileEntity_ProcessingArray extends
 
             @Nonnull
             @Override
-            protected GT_OverclockCalculator createOverclockCalculator(@Nonnull GT_Recipe recipe,
-                @Nonnull GT_ParallelHelper helper) {
-                return new GT_OverclockCalculator().setRecipeEUt(recipe.mEUt)
-                    .setParallel((int) Math.floor(helper.getCurrentParallel() / helper.getDurationMultiplierDouble()))
-                    .setDuration((int) Math.ceil(recipe.mDuration * helper.getDurationMultiplierDouble()))
-                    .setAmperage(availableAmperage)
-                    .setEUt(availableVoltage)
-                    .setDurationDecreasePerOC(overClockTimeReduction)
-                    .setEUtIncreasePerOC(overClockPowerIncrease);
-            }
-
-            @Nonnull
-            @Override
             protected CheckRecipeResult validateRecipe(@Nonnull GT_Recipe recipe) {
                 if (GT_Mod.gregtechproxy.mLowGravProcessing && recipe.mSpecialValue == -100
                     && !isValidForLowGravity(recipe, getBaseMetaTileEntity().getWorld().provider.dimensionId)) {


### PR DESCRIPTION
Currently batch mode on all machines except the Processing Array are capped at 1 x Batch Multiplier ticks, essentially making batch mode a tool purely for lag reduction. This PR removes the limit, allowing you to keep overclocking as long as the machine still has EU/t available.

Essentially what this does is removes the artificial limit imposed by the game engine running at 20 ticks per second that the overclocking formula currently has.

Some notable balancing considerations:

- High EU/t, high time recipes are unaffected. Those are already unfeasible to 1-tick even without batch mode.
- Low EU/t, high time recipes become exponentially more power expensive to speed up, but allows you to do so instead of having to make dozens of the identical machine to increase thoroughput.
- Low EU/t, low time recipes are the main target of this change, such as ingots in the MEBF and MVF. They already have trillions of EU/t pumped into them in the late game to produce the high-tier ingots (atleast for now), but can only use a miniscule fraction of that when creating basic things like steel, titanium and samarium which are needed in the hundreds of millions even later on.

Changing this primarily affects low-tier materials made in high tiers where the speed is dictated more by how many machines you can have 1-ticking instead of how much energy you are providing the machines.
