### PR TITLE
Fix wrong Oregen Pattern on Servers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1689409577
+//version: 1690104383
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -69,7 +69,7 @@ plugins {
     id 'com.diffplug.spotless' version '6.13.0' apply false // 6.13.0 is the last jvm8 supporting version
     id 'com.modrinth.minotaur' version '2.+' apply false
     id 'com.matthewprenger.cursegradle' version '1.4.0' apply false
-    id 'com.gtnewhorizons.retrofuturagradle' version '1.3.19'
+    id 'com.gtnewhorizons.retrofuturagradle' version '1.3.21'
 }
 
 print("You might want to check out './gradlew :faq' if your build fails.\n")
@@ -575,11 +575,26 @@ repositories {
         }
     }
     if (includeWellKnownRepositories.toBoolean()) {
-        maven {
-            name "CurseMaven"
-            url "https://cursemaven.com"
-            content {
+        exclusiveContent {
+            forRepository {
+                maven {
+                    name "CurseMaven"
+                    url "https://cursemaven.com"
+                }
+            }
+            filter {
                 includeGroup "curse.maven"
+            }
+        }
+        exclusiveContent {
+            forRepository {
+                maven {
+                    name = "Modrinth"
+                    url = "https://api.modrinth.com/maven"
+                }
+            }
+            filter {
+                includeGroup "maven.modrinth"
             }
         }
         maven {
@@ -623,7 +638,7 @@ dependencies {
         }
     }
     if (usesMixins.toBoolean()) {
-        implementation(mixinProviderSpec)
+        implementation(modUtils.enableMixins(mixinProviderSpec))
     } else if (forceEnableMixins.toBoolean()) {
         runtimeOnlyNonPublishable(mixinProviderSpec)
     }
@@ -677,9 +692,6 @@ if (file('dependencies.gradle.kts').exists()) {
 }
 
 def mixingConfigRefMap = 'mixins.' + modId + '.refmap.json'
-def mixinTmpDir = buildDir.path + File.separator + 'tmp' + File.separator + 'mixins'
-def refMap = "${mixinTmpDir}" + File.separator + mixingConfigRefMap
-def mixinSrg = "${mixinTmpDir}" + File.separator + "mixins.srg"
 
 tasks.register('generateAssets') {
     group = "GTNH Buildscript"
@@ -711,46 +723,17 @@ tasks.register('generateAssets') {
 }
 
 if (usesMixins.toBoolean()) {
-    tasks.named("reobfJar", ReobfuscatedJar).configure {
-        extraSrgFiles.from(mixinSrg)
-    }
-
     tasks.named("processResources").configure {
         dependsOn("generateAssets")
     }
 
     tasks.named("compileJava", JavaCompile).configure {
-        doFirst {
-            new File(mixinTmpDir).mkdirs()
-        }
         options.compilerArgs += [
-            "-AreobfSrgFile=${tasks.reobfJar.srg.get().asFile}",
-            "-AoutSrgFile=${mixinSrg}",
-            "-AoutRefMapFile=${refMap}",
             // Elan: from what I understand they are just some linter configs so you get some warning on how to properly code
             "-XDenableSunApiLintControl",
             "-XDignore.symbol.file"
         ]
     }
-
-    pluginManager.withPlugin('org.jetbrains.kotlin.kapt') {
-        kapt {
-            correctErrorTypes = true
-            javacOptions {
-                option("-AreobfSrgFile=${tasks.reobfJar.srg.get().asFile}")
-                option("-AoutSrgFile=$mixinSrg")
-                option("-AoutRefMapFile=$refMap")
-            }
-        }
-        tasks.configureEach { task ->
-            if (task.name == "kaptKotlin") {
-                task.doFirst {
-                    new File(mixinTmpDir).mkdirs()
-                }
-            }
-        }
-    }
-
 }
 
 tasks.named("processResources", ProcessResources).configure {
@@ -768,7 +751,6 @@ tasks.named("processResources", ProcessResources).configure {
     }
 
     if (usesMixins.toBoolean()) {
-        from refMap
         dependsOn("compileJava", "compileScala")
     }
 }
@@ -1311,7 +1293,7 @@ def addCurseForgeRelation(String type, String name) {
 
 // Updating
 
-def buildscriptGradleVersion = "8.1.1"
+def buildscriptGradleVersion = "8.2.1"
 
 tasks.named('wrapper', Wrapper).configure {
     gradleVersion = buildscriptGradleVersion

--- a/src/main/java/gregtech/api/net/GT_Packet_SendOregenPattern.java
+++ b/src/main/java/gregtech/api/net/GT_Packet_SendOregenPattern.java
@@ -1,0 +1,56 @@
+package gregtech.api.net;
+
+import net.minecraft.world.IBlockAccess;
+
+import com.google.common.io.ByteArrayDataInput;
+
+import gregtech.api.util.GT_Log;
+import gregtech.common.GT_Worldgenerator;
+import gregtech.common.GT_Worldgenerator.OregenPattern;
+import io.netty.buffer.ByteBuf;
+
+public class GT_Packet_SendOregenPattern extends GT_Packet_New {
+
+    protected OregenPattern pattern = OregenPattern.AXISSYMMETRICAL;
+
+    public GT_Packet_SendOregenPattern() {
+        super(true);
+    }
+
+    public GT_Packet_SendOregenPattern(OregenPattern pattern) {
+        super(false);
+        this.pattern = pattern;
+    }
+
+    @Override
+    public void encode(ByteBuf aOut) {
+        aOut.writeInt(this.pattern.ordinal());
+    }
+
+    @Override
+    public GT_Packet_New decode(ByteArrayDataInput aData) {
+        int ordinal = aData.readInt();
+        // make sure we get valid data:
+        if (ordinal >= 0 && ordinal < OregenPattern.values().length) {
+            return new GT_Packet_SendOregenPattern(OregenPattern.values()[ordinal]);
+        }
+        // invalid data, default to AXISSYMMETRICAL:
+        GT_Log.err.println(
+            String.format(
+                "Received invalid data! Received %d but value must be between 0 and %d! Default (0) will be used.",
+                ordinal,
+                OregenPattern.values().length - 1));
+        return new GT_Packet_SendOregenPattern();
+    }
+
+    @Override
+    public byte getPacketID() {
+        return 19;
+    }
+
+    @Override
+    public void process(IBlockAccess aWorld) {
+        GT_Worldgenerator.oregenPattern = this.pattern;
+    }
+
+}

--- a/src/main/java/gregtech/common/GT_Network.java
+++ b/src/main/java/gregtech/common/GT_Network.java
@@ -27,6 +27,7 @@ import gregtech.api.net.GT_Packet_MultiTileEntity;
 import gregtech.api.net.GT_Packet_Pollution;
 import gregtech.api.net.GT_Packet_RequestCoverData;
 import gregtech.api.net.GT_Packet_SendCoverData;
+import gregtech.api.net.GT_Packet_SendOregenPattern;
 import gregtech.api.net.GT_Packet_SetConfigurationCircuit;
 import gregtech.api.net.GT_Packet_Sound;
 import gregtech.api.net.GT_Packet_TileEntity;
@@ -73,7 +74,8 @@ public class GT_Network extends MessageToMessageCodec<FMLProxyPacket, GT_Packet>
             new GT_Packet_GtTileEntityGuiRequest(), // 15
             new GT_Packet_SendCoverData(), // 16
             new GT_Packet_RequestCoverData(), // 17
-            new GT_Packet_MultiTileEntity() // 18
+            new GT_Packet_MultiTileEntity(), // 18
+            new GT_Packet_SendOregenPattern() // 19
         );
     }
 

--- a/src/main/java/gregtech/common/GT_Proxy.java
+++ b/src/main/java/gregtech/common/GT_Proxy.java
@@ -1093,6 +1093,9 @@ public abstract class GT_Proxy implements IGT_Mod, IGuiHandler, IFuelHandler, IG
         MinecraftForge.EVENT_BUS.register(new GlobalEnergyWorldSavedData(""));
         MinecraftForge.EVENT_BUS.register(new SpaceProjectWorldSavedData());
         MinecraftForge.EVENT_BUS.register(new GT_Worldgenerator.OregenPatternSavedData(""));
+        FMLCommonHandler.instance()
+            .bus()
+            .register(new GT_Worldgenerator.OregenPatternSavedData(""));
 
         // IC2 Hazmat
         addFullHazmatToIC2Item("hazmatHelmet");

--- a/src/main/java/gregtech/common/GT_Worldgenerator.java
+++ b/src/main/java/gregtech/common/GT_Worldgenerator.java
@@ -12,6 +12,7 @@ import java.util.Hashtable;
 import java.util.List;
 import java.util.Random;
 
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.Blocks;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.MathHelper;
@@ -23,9 +24,12 @@ import net.minecraftforge.event.world.WorldEvent;
 
 import cpw.mods.fml.common.IWorldGenerator;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import cpw.mods.fml.common.gameevent.PlayerEvent;
 import cpw.mods.fml.common.registry.GameRegistry;
 import gregtech.api.GregTech_API;
+import gregtech.api.enums.GT_Values;
 import gregtech.api.enums.Materials;
+import gregtech.api.net.GT_Packet_SendOregenPattern;
 import gregtech.api.objects.XSTR;
 import gregtech.api.util.GT_Log;
 import gregtech.api.world.GT_Worldgen;
@@ -172,6 +176,13 @@ public class GT_Worldgenerator implements IWorldGenerator {
             final World world = event.world;
             if (!world.isRemote && world.provider.dimensionId == 0) {
                 loadData(world);
+            }
+        }
+
+        @SubscribeEvent
+        public void onPlayerLoggedIn(PlayerEvent.PlayerLoggedInEvent event) {
+            if (event.player instanceof EntityPlayerMP player) {
+                GT_Values.NW.sendToPlayer(new GT_Packet_SendOregenPattern(oregenPattern), player);
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13992

### The Problem
`OregenPatternSavedData#loadData()` is only called in SP. This is intentional, as the client can't simply access the server's `GregTech_OregenPattern.dat` file. As a result, `GT_Worldgenerator#oregenPattern` stays as default (`AXISSYMMETRICAL`). The default is correct for all worlds created *before* the new pattern was introduced, which is currently nearly all of them.

### The Solution
On player login, the server tells the client the oregen pattern in use (via a custom GT packet). If the client receives an invalid packet, it uses the default pattern.