### PR TITLE
Reset outputs after outputting them

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
@@ -517,17 +517,31 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
                     stopMachine();
                 }
                 if (mMaxProgresstime > 0 && ++mProgresstime >= mMaxProgresstime) {
-                    if (mOutputItems != null) for (ItemStack tStack : mOutputItems) if (tStack != null) {
-                        try {
-                            GT_Mod.achievements.issueAchivementHatch(
-                                aBaseMetaTileEntity.getWorld()
-                                    .getPlayerEntityByName(aBaseMetaTileEntity.getOwnerName()),
-                                tStack);
-                        } catch (Exception ignored) {}
-                        addOutput(tStack);
+                    if (mOutputItems != null) {
+                        for (ItemStack tStack : mOutputItems) {
+                            if (tStack != null) {
+                                try {
+                                    GT_Mod.achievements.issueAchivementHatch(
+                                        aBaseMetaTileEntity.getWorld()
+                                            .getPlayerEntityByName(aBaseMetaTileEntity.getOwnerName()),
+                                        tStack);
+                                } catch (Exception ignored) {}
+                                addOutput(tStack);
+                            }
+                        }
+                        mOutputItems = null;
                     }
                     if (mOutputFluids != null) {
                         addFluidOutputs(mOutputFluids);
+                        if (mOutputFluids.length > 1) {
+                            try {
+                                GT_Mod.achievements.issueAchievement(
+                                    aBaseMetaTileEntity.getWorld()
+                                        .getPlayerEntityByName(aBaseMetaTileEntity.getOwnerName()),
+                                    "oilplant");
+                            } catch (Exception ignored) {}
+                        }
+                        mOutputFluids = null;
                     }
                     mEfficiency = Math.max(
                         0,
@@ -541,16 +555,6 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
                     mLastWorkingTick = aTick;
                     if (aBaseMetaTileEntity.isAllowedToWork()) {
                         checkRecipe();
-                    }
-                    if (mOutputFluids != null && mOutputFluids.length > 0) {
-                        if (mOutputFluids.length > 1) {
-                            try {
-                                GT_Mod.achievements.issueAchievement(
-                                    aBaseMetaTileEntity.getWorld()
-                                        .getPlayerEntityByName(aBaseMetaTileEntity.getOwnerName()),
-                                    "oilplant");
-                            } catch (Exception ignored) {}
-                        }
                     }
                 }
             }


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14041
I am not sure why this has been on for so long. in TT it seems to be reset already. But maybe someone knows if there is a reason and this fix will break other machines, please point it out.