### PR TITLE
Crafting Input bus/buffer Overflow fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ src/main/resources/mixins.*.json
 .DS_Store
 classes
 .factorypath
+/.vs

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
@@ -180,7 +180,8 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
             }
         }
 
-        public void insertItemsAndFluids(InventoryCrafting inventoryCrafting) {
+        public boolean insertItemsAndFluids(InventoryCrafting inventoryCrafting) {
+            int errorIndex = -1; // overflow may occur at this index
             for (int i = 0; i < inventoryCrafting.getSizeInventory(); ++i) {
                 ItemStack itemStack = inventoryCrafting.getStackInSlot(i);
                 if (itemStack == null) continue;
@@ -190,28 +191,63 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
                     var fluidStack = ItemFluidPacket.getFluidStack(itemStack);
                     if (fluidStack == null) continue;
                     for (var fluid : fluidInventory) {
-                        if (fluid.isFluidEqual(fluidStack)) {
-                            fluid.amount += fluidStack.amount;
-                            inserted = true;
+                        if (!fluid.isFluidEqual(fluidStack)) continue;
+                        if (Integer.MAX_VALUE - fluidStack.amount < fluid.amount) {
+                            // Overflow detected
+                            errorIndex = i;
                             break;
                         }
+                        fluid.amount += fluidStack.amount;
+                        inserted = true;
+                        break;
                     }
+                    if (errorIndex != -1) break;
                     if (!inserted) {
                         fluidInventory.add(fluidStack);
                     }
                 } else { // insert item
                     for (var item : itemInventory) {
-                        if (itemStack.isItemEqual(item)) {
-                            item.stackSize += itemStack.stackSize;
-                            inserted = true;
+                        if (!itemStack.isItemEqual(item)) continue;
+                        if (Integer.MAX_VALUE - itemStack.stackSize < item.stackSize) {
+                            // Overflow detected
+                            errorIndex = i;
                             break;
                         }
+                        item.stackSize += itemStack.stackSize;
+                        inserted = true;
+                        break;
                     }
+                    if (errorIndex != -1) break;
                     if (!inserted) {
                         itemInventory.add(itemStack);
                     }
                 }
             }
+            if (errorIndex != -1) { // need to rollback
+                // Clean up the inserted items/liquids
+                for (int i = 0; i < errorIndex; ++i) {
+                    var itemStack = inventoryCrafting.getStackInSlot(i);
+                    if (itemStack.getItem() instanceof ItemFluidPacket) { // remove fluid
+                        var fluidStack = ItemFluidPacket.getFluidStack(itemStack);
+                        if (fluidStack == null) continue;
+                        for (var fluid : fluidInventory) {
+                            if (fluid.isFluidEqual(fluidStack)) {
+                                fluid.amount -= fluidStack.amount;
+                                break;
+                            }
+                        }
+                    } else { // remove item
+                        for (var item : itemInventory) {
+                            if (item.isItemEqual(itemStack)) {
+                                item.stackSize -= itemStack.stackSize;
+                                break;
+                            }
+                        }
+                    }
+                }
+                return false;
+            }
+            return true;
         }
 
         public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
@@ -646,9 +682,10 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
                 if (itemStack.getItem() instanceof ItemFluidPacket) return false;
             }
         }
-
-        patternDetailsPatternSlotMap.get(patternDetails)
-            .insertItemsAndFluids(table);
+        if (!patternDetailsPatternSlotMap.get(patternDetails)
+            .insertItemsAndFluids(table)) {
+            return false;
+        }
         justHadNewItems = true;
         return true;
     }


### PR DESCRIPTION
In current implementation of Crafting Input bus/buffer, when a large amount of item/liquid is present, the stored numbers can overflow and present a negative value:

![6e20f8f05607198203177bf1b0b88ab](https://github.com/GTNewHorizons/GT5-Unofficial/assets/36905103/6835c0e8-70dd-479b-a080-79934c31b9ab)

This pull request fixes the problem by detecting if inserting the items/fluids will cause an overflow, otherwise prevent the insertion. The buffer now then will have an 2147483647 upper bound for everything inside each slots.

![4b6bf18e40b3ff633fe30b7c93fd73f](https://github.com/GTNewHorizons/GT5-Unofficial/assets/36905103/d1ab9ed3-44c8-4cd2-8b5b-0a3892c7dbf7)

![71a5920ed8182763fe0edfb85c5c182](https://github.com/GTNewHorizons/GT5-Unofficial/assets/36905103/56ab90ac-49c5-4897-ab79-79c4f118d08b)
