### PR TITLE
Make recipe check less intensive with batch mode

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
@@ -501,14 +501,19 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
         long timeElapsed = aTick - mLastWorkingTick;
 
         if (timeElapsed >= 100) return aTick % 100 == 0;
-
-        return timeElapsed == 5 || timeElapsed == 12
-            || timeElapsed == 20
-            || timeElapsed == 30
-            || timeElapsed == 40
-            || timeElapsed == 55
-            || timeElapsed == 70
-            || timeElapsed == 85;
+        if (!isBatchModeEnabled()) {
+            return timeElapsed == 5 || timeElapsed == 12
+                || timeElapsed == 20
+                || timeElapsed == 30
+                || timeElapsed == 40
+                || timeElapsed == 55
+                || timeElapsed == 70
+                || timeElapsed == 85;
+        } else {
+            // Batch mode should be a lot less aggressive at recipe checking (Implement a GUI-configurable time here)
+            if (timeElapsed >= 100) return aTick % 100 == 0;
+        }
+        return false;
     }
 
     protected void runMachine(IGregTechTileEntity aBaseMetaTileEntity, long aTick) {

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
@@ -501,6 +501,7 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
         long timeElapsed = aTick - mLastWorkingTick;
 
         if (timeElapsed >= 100) return aTick % 100 == 0;
+        // Batch mode should be a lot less aggressive at recipe checking
         if (!isBatchModeEnabled()) {
             return timeElapsed == 5 || timeElapsed == 12
                 || timeElapsed == 20
@@ -509,9 +510,6 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
                 || timeElapsed == 55
                 || timeElapsed == 70
                 || timeElapsed == 85;
-        } else {
-            // Batch mode should be a lot less aggressive at recipe checking (Implement a GUI-configurable time here)
-            if (timeElapsed >= 100) return aTick % 100 == 0;
         }
         return false;
     }


### PR DESCRIPTION
https://github.com/GTNewHorizons/GT5-Unofficial/pull/2125 made recipe checks very aggressive, which makes batch mode less effective at reducing lag. This makes batch mode-enabled machines revert to old behavior, providing large tick time savings on passive setups that are input limited and would otherwise constantly turn on and off.