### PR TITLE
Crafting input hatches QoLs

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -33,9 +33,6 @@
  *
  * For more details, see https://docs.gradle.org/8.0.1/userguide/java_library_plugin.html#sec:java_library_configurations_graph
  */
-repositories {
-    mavenLocal()
-}
 dependencies {
     api("com.github.GTNewHorizons:StructureLib:1.2.7:dev")
     api("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev")
@@ -43,7 +40,7 @@ dependencies {
     api("com.github.GTNewHorizons:GTNHLib:0.0.13:dev")
     api("com.github.GTNewHorizons:ModularUI:1.1.16:dev")
     api("com.github.GTNewHorizons:waila:1.6.0:dev")
-    api("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-243-GTNH-4-g7e29860.dirty:dev")
+    api("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-247-GTNH:dev")
     api("com.github.GTNewHorizons:AE2FluidCraft-Rework:1.1.29-gtnh-pre:dev")
     implementation("com.github.GTNewHorizons:Eternal-Singularity:1.1.0:dev")
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -34,33 +34,33 @@
  * For more details, see https://docs.gradle.org/8.0.1/userguide/java_library_plugin.html#sec:java_library_configurations_graph
  */
 dependencies {
-    api("com.github.GTNewHorizons:StructureLib:1.2.7:dev")
+    api("com.github.GTNewHorizons:StructureLib:1.2.8:dev")
     api("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev")
-    api("com.github.GTNewHorizons:NotEnoughItems:2.3.70-GTNH:dev")
+    api("com.github.GTNewHorizons:NotEnoughItems:2.3.83-GTNH:dev")
     api("com.github.GTNewHorizons:GTNHLib:0.0.13:dev")
     api("com.github.GTNewHorizons:ModularUI:1.1.16:dev")
     api("com.github.GTNewHorizons:waila:1.6.0:dev")
-    api("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-247-GTNH:dev")
-    api("com.github.GTNewHorizons:AE2FluidCraft-Rework:1.1.29-gtnh-pre:dev")
+    api("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-250-GTNH:dev")
+    api("com.github.GTNewHorizons:AE2FluidCraft-Rework:1.1.41-gtnh:dev")
     implementation("com.github.GTNewHorizons:Eternal-Singularity:1.1.0:dev")
 
-    compileOnlyApi("com.github.GTNewHorizons:AppleCore:3.2.10:dev") { transitive = false }
-    compileOnlyApi("com.github.GTNewHorizons:BuildCraft:7.1.34:dev") { transitive = false }
-    compileOnlyApi("com.github.GTNewHorizons:EnderIO:2.4.21:dev") { transitive = false }
-    compileOnlyApi("com.github.GTNewHorizons:ForestryMC:4.6.10:dev") { transitive = false }
-    compileOnlyApi("com.github.GTNewHorizons:ProjectRed:4.7.10-GTNH:dev") { transitive = false }
-    compileOnlyApi("com.github.GTNewHorizons:Railcraft:9.14.5:dev") { transitive = false }
+    compileOnlyApi("com.github.GTNewHorizons:AppleCore:3.2.11:dev") { transitive = false }
+    compileOnlyApi("com.github.GTNewHorizons:BuildCraft:7.1.36:dev") { transitive = false }
+    compileOnlyApi("com.github.GTNewHorizons:EnderIO:2.4.24:dev") { transitive = false }
+    compileOnlyApi("com.github.GTNewHorizons:ForestryMC:4.6.14:dev") { transitive = false }
+    compileOnlyApi("com.github.GTNewHorizons:ProjectRed:4.7.12-GTNH:dev") { transitive = false }
+    compileOnlyApi("com.github.GTNewHorizons:Railcraft:9.14.9:dev") { transitive = false }
 
-    compileOnly("com.github.GTNewHorizons:EnderCore:0.2.16:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:Galacticraft:3.0.71-GTNH:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:TinkersConstruct:1.9.38-GTNH:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:Chisel:2.11.3-GTNH:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:EnderCore:0.2.17:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:Galacticraft:3.0.73-GTNH:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:TinkersConstruct:1.9.39-GTNH:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:Chisel:2.11.4-GTNH:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:Translocators:1.1.2.21:dev") { transitive = false }
     compileOnly("curse.maven:cofh-core-69162:2388751") { transitive = false }
     compileOnly("com.github.GTNewHorizons:Nuclear-Control:2.4.19:dev") { transitive = false }
     compileOnly("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:Hodgepodge:2.2.23:dev") { transitive = false }
-    compileOnly('com.github.GTNewHorizons:Botania:1.9.23-GTNH:dev') { transitive = false }
+    compileOnly("com.github.GTNewHorizons:Hodgepodge:2.2.30:dev") { transitive = false }
+    compileOnly('com.github.GTNewHorizons:Botania:1.9.24-GTNH:dev') { transitive = false }
 
     compileOnly("com.google.auto.value:auto-value-annotations:1.10.1") { transitive = false }
     annotationProcessor("com.google.auto.value:auto-value:1.10.1")

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -33,6 +33,9 @@
  *
  * For more details, see https://docs.gradle.org/8.0.1/userguide/java_library_plugin.html#sec:java_library_configurations_graph
  */
+repositories {
+    mavenLocal()
+}
 dependencies {
     api("com.github.GTNewHorizons:StructureLib:1.2.7:dev")
     api("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev")
@@ -40,7 +43,7 @@ dependencies {
     api("com.github.GTNewHorizons:GTNHLib:0.0.13:dev")
     api("com.github.GTNewHorizons:ModularUI:1.1.16:dev")
     api("com.github.GTNewHorizons:waila:1.6.0:dev")
-    api("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-235-GTNH:dev")
+    api("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-243-GTNH-4-g7e29860.dirty:dev")
     api("com.github.GTNewHorizons:AE2FluidCraft-Rework:1.1.29-gtnh-pre:dev")
     implementation("com.github.GTNewHorizons:Eternal-Singularity:1.1.0:dev")
 

--- a/src/main/java/gregtech/GT_Mod.java
+++ b/src/main/java/gregtech/GT_Mod.java
@@ -4,7 +4,6 @@ import static gregtech.GT_Version.VERSION_MAJOR;
 import static gregtech.GT_Version.VERSION_MINOR;
 import static gregtech.GT_Version.VERSION_PATCH;
 import static gregtech.api.GregTech_API.registerCircuitProgrammer;
-import static gregtech.api.enums.Mods.AppliedEnergistics2;
 import static gregtech.api.enums.Mods.Forestry;
 
 import java.io.PrintWriter;
@@ -15,8 +14,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.function.Predicate;
 
-import appeng.helpers.InterfaceTerminalSupportedClassProvider;
-import gregtech.common.tileentities.machines.GT_MetaTileEntity_Hatch_CraftingInput_ME;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
@@ -36,6 +33,7 @@ import org.apache.logging.log4j.Logger;
 import com.google.common.base.Stopwatch;
 
 import appeng.api.AEApi;
+import appeng.helpers.InterfaceTerminalSupportedClassProvider;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.Mod;
 import cpw.mods.fml.common.SidedProxy;
@@ -87,6 +85,7 @@ import gregtech.common.entities.GT_Entity_Arrow_Potion;
 import gregtech.common.misc.GT_Command;
 import gregtech.common.misc.spaceprojects.commands.SPM_Command;
 import gregtech.common.misc.spaceprojects.commands.SP_Command;
+import gregtech.common.tileentities.machines.GT_MetaTileEntity_Hatch_CraftingInput_ME;
 import gregtech.common.tileentities.storage.GT_MetaTileEntity_DigitalChestBase;
 import gregtech.crossmod.Waila;
 import gregtech.loaders.load.GT_CoverBehaviorLoader;

--- a/src/main/java/gregtech/GT_Mod.java
+++ b/src/main/java/gregtech/GT_Mod.java
@@ -4,6 +4,7 @@ import static gregtech.GT_Version.VERSION_MAJOR;
 import static gregtech.GT_Version.VERSION_MINOR;
 import static gregtech.GT_Version.VERSION_PATCH;
 import static gregtech.api.GregTech_API.registerCircuitProgrammer;
+import static gregtech.api.enums.Mods.AppliedEnergistics2;
 import static gregtech.api.enums.Mods.Forestry;
 
 import java.io.PrintWriter;
@@ -14,6 +15,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.function.Predicate;
 
+import appeng.helpers.InterfaceTerminalSupportedClassProvider;
+import gregtech.common.tileentities.machines.GT_MetaTileEntity_Hatch_CraftingInput_ME;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
@@ -272,6 +275,7 @@ public class GT_Mod implements IGT_Mod {
         EntityRegistry.registerModEntity(GT_Entity_Arrow.class, "GT_Entity_Arrow", 1, GT_Values.GT, 160, 1, true);
         EntityRegistry
             .registerModEntity(GT_Entity_Arrow_Potion.class, "GT_Entity_Arrow_Potion", 2, GT_Values.GT, 160, 1, true);
+        InterfaceTerminalSupportedClassProvider.register(GT_MetaTileEntity_Hatch_CraftingInput_ME.class);
 
         GT_PreLoad.runMineTweakerCompat();
 

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
@@ -44,6 +44,7 @@ import appeng.api.networking.IGridNode;
 import appeng.api.networking.security.IActionHost;
 import appeng.api.util.AECableType;
 import appeng.api.util.DimensionalCoord;
+import appeng.helpers.ICustomNameObject;
 import appeng.me.helpers.AENetworkProxy;
 import appeng.me.helpers.IGridProxyable;
 import appeng.tile.TileEvent;
@@ -87,7 +88,7 @@ import mcp.mobius.waila.api.IWailaDataAccessor;
  */
 public class BaseMetaTileEntity extends CommonMetaTileEntity
     implements IGregTechTileEntity, IActionHost, IGridProxyable, IAlignmentProvider, IConstructableProvider,
-    IDebugableTileEntity, IGregtechWailaProvider, ICleanroomReceiver {
+    IDebugableTileEntity, IGregtechWailaProvider, ICleanroomReceiver, ICustomNameObject {
 
     private static final Field ENTITY_ITEM_HEALTH_FIELD = ReflectionHelper
         .findField(EntityItem.class, "health", "field_70291_e");
@@ -2445,5 +2446,21 @@ public class BaseMetaTileEntity extends CommonMetaTileEntity
     @Override
     public int[] getTimeStatistics() {
         return mTimeStatistics;
+    }
+
+    @Override
+    public String getCustomName() {
+        return getMetaTileEntity() instanceof ICustomNameObject customNameObject ? customNameObject.getCustomName()
+            : null;
+    }
+
+    @Override
+    public boolean hasCustomName() {
+        return getMetaTileEntity() instanceof ICustomNameObject customNameObject && customNameObject.hasCustomName();
+    }
+
+    @Override
+    public void setCustomName(String name) {
+        if (getMetaTileEntity() instanceof ICustomNameObject customNameObject) customNameObject.setCustomName(name);
     }
 }

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
@@ -587,7 +587,8 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
                         var output = patternItem.getOutput(stack);
                         return output != null ? output : stack;
                     }
-                }.setFilter(itemStack -> itemStack.getItem() instanceof ICraftingPatternItem))
+                }.setFilter(itemStack -> itemStack.getItem() instanceof ICraftingPatternItem)
+                    .setChangeListener(() -> onPatternChange(slot.getSlotIndex(), slot.getStack())))
                 .build()
                 .setPos(7, 9))
             .widget(
@@ -797,7 +798,7 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
     @Override
     public boolean onRightclick(IGregTechTileEntity aBaseMetaTileEntity, EntityPlayer aPlayer, ForgeDirection side, float aX, float aY, float aZ) {
         final ItemStack is = aPlayer.inventory.getCurrentItem();
-        if (is.getItem() instanceof ToolQuartzCuttingKnife) {
+        if (is != null && is.getItem() instanceof ToolQuartzCuttingKnife) {
             if (ForgeEventFactory.onItemUseStart(aPlayer, is, 1) <= 0) return false;
             var te = getBaseMetaTileEntity();
             aPlayer.openGui(

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
@@ -803,4 +803,9 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
         return true;
     }
 
+    @Override
+    public void setInventorySlotContents(int aIndex, ItemStack aStack) {
+        super.setInventorySlotContents(aIndex, aStack);
+        needPatternSync = true;
+    }
 }

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
@@ -722,7 +722,7 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
     private ItemStack[] getSharedItems() {
         ItemStack[] sharedItems = new ItemStack[SLOT_MANUAL_SIZE + 1];
         sharedItems[0] = mInventory[SLOT_CIRCUIT];
-        System.arraycopy(mInventory, SLOT_MANUAL_START, sharedItems, 0, SLOT_MANUAL_SIZE);
+        System.arraycopy(mInventory, SLOT_MANUAL_START, sharedItems, 1, SLOT_MANUAL_SIZE);
         return sharedItems;
     }
 

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
@@ -7,8 +7,6 @@ import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
-import com.gtnewhorizons.modularui.api.math.Alignment;
-import com.gtnewhorizons.modularui.api.math.Size;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.inventory.IInventory;
@@ -31,6 +29,8 @@ import org.jetbrains.annotations.NotNull;
 
 import com.glodblock.github.common.item.ItemFluidPacket;
 import com.google.common.collect.ImmutableList;
+import com.gtnewhorizons.modularui.api.math.Alignment;
+import com.gtnewhorizons.modularui.api.math.Size;
 import com.gtnewhorizons.modularui.api.screen.ModularWindow;
 import com.gtnewhorizons.modularui.api.screen.UIBuildContext;
 import com.gtnewhorizons.modularui.common.widget.ButtonWidget;
@@ -635,42 +635,42 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
     public void addUIWidgets(ModularWindow.@NotNull Builder builder, UIBuildContext buildContext) {
         buildContext.addSyncedWindow(MANUAL_SLOT_WINDOW, this::createSlotManualWindow);
         builder.widget(
-                SlotGroup.ofItemHandler(inventoryHandler, 9)
-                    .startFromSlot(0)
-                    .endAtSlot(MAX_PATTERN_COUNT - 1)
-                    .phantom(false)
-                    .background(getGUITextureSet().getItemSlot(), GT_UITextures.OVERLAY_SLOT_PATTERN_ME)
-                    .widgetCreator(slot -> new SlotWidget(slot) {
+            SlotGroup.ofItemHandler(inventoryHandler, 9)
+                .startFromSlot(0)
+                .endAtSlot(MAX_PATTERN_COUNT - 1)
+                .phantom(false)
+                .background(getGUITextureSet().getItemSlot(), GT_UITextures.OVERLAY_SLOT_PATTERN_ME)
+                .widgetCreator(slot -> new SlotWidget(slot) {
 
-                        @Override
-                        protected ItemStack getItemStackForRendering(Slot slotIn) {
-                            var stack = slot.getStack();
-                            if (stack == null || !(stack.getItem() instanceof ItemEncodedPattern patternItem)) {
-                                return stack;
-                            }
-                            var output = patternItem.getOutput(stack);
-                            return output != null ? output : stack;
+                    @Override
+                    protected ItemStack getItemStackForRendering(Slot slotIn) {
+                        var stack = slot.getStack();
+                        if (stack == null || !(stack.getItem() instanceof ItemEncodedPattern patternItem)) {
+                            return stack;
                         }
-                    }.setFilter(itemStack -> itemStack.getItem() instanceof ICraftingPatternItem)
-                        .setChangeListener(() -> onPatternChange(slot.getSlotIndex(), slot.getStack())))
-                    .build()
-                    .setPos(7, 9))
-            .widget(
-                new ButtonWidget().setOnClick((clickData, widget) -> {
-                        if (clickData.mouseButton == 0) {
-                            widget.getContext().openSyncedWindow(MANUAL_SLOT_WINDOW);
-                        }
-                    })
-                    .setPlayClickSound(true)
-                    .setBackground(GT_UITextures.BUTTON_STANDARD, GT_UITextures.OVERLAY_BUTTON_PLUS_LARGE)
-                    .addTooltips(ImmutableList.of("Place manual items"))
-                    .setSize(16, 16)
-                    .setPos(170, 45))
-            .widget(new ButtonWidget().setOnClick((clickData, widget) -> {
-                    if (clickData.mouseButton == 0) {
-                        refundAll();
+                        var output = patternItem.getOutput(stack);
+                        return output != null ? output : stack;
                     }
-                })
+                }.setFilter(itemStack -> itemStack.getItem() instanceof ICraftingPatternItem)
+                    .setChangeListener(() -> onPatternChange(slot.getSlotIndex(), slot.getStack())))
+                .build()
+                .setPos(7, 9))
+            .widget(new ButtonWidget().setOnClick((clickData, widget) -> {
+                if (clickData.mouseButton == 0) {
+                    widget.getContext()
+                        .openSyncedWindow(MANUAL_SLOT_WINDOW);
+                }
+            })
+                .setPlayClickSound(true)
+                .setBackground(GT_UITextures.BUTTON_STANDARD, GT_UITextures.OVERLAY_BUTTON_PLUS_LARGE)
+                .addTooltips(ImmutableList.of("Place manual items"))
+                .setSize(16, 16)
+                .setPos(170, 45))
+            .widget(new ButtonWidget().setOnClick((clickData, widget) -> {
+                if (clickData.mouseButton == 0) {
+                    refundAll();
+                }
+            })
                 .setPlayClickSound(true)
                 .setBackground(GT_UITextures.BUTTON_STANDARD, GT_UITextures.OVERLAY_BUTTON_EXPORT)
                 .addTooltips(ImmutableList.of("Return all internally stored items back to AE"))
@@ -681,8 +681,7 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
     @Override
     public void updateSlots() {
         for (int slotId = SLOT_MANUAL_START; slotId < SLOT_MANUAL_START + SLOT_MANUAL_SIZE; ++slotId) {
-            if (mInventory[slotId] != null && mInventory[slotId].stackSize <= 0)
-                mInventory[slotId] = null;
+            if (mInventory[slotId] != null && mInventory[slotId].stackSize <= 0) mInventory[slotId] = null;
         }
     }
 
@@ -908,7 +907,6 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
         return true;
     }
 
-
     protected ModularWindow createSlotManualWindow(final EntityPlayer player) {
         final int WIDTH = 68;
         final int HEIGHT = 68;
@@ -923,21 +921,17 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
         // See GuiContainer.java flag1
         builder.setPos(
             (size, window) -> Alignment.Center.getAlignedPos(size, new Size(PARENT_WIDTH, PARENT_HEIGHT))
-                .add(
-                    Alignment.TopRight.getAlignedPos(new Size(PARENT_WIDTH, PARENT_HEIGHT), new Size(WIDTH, HEIGHT))));
-        builder
-            .widget(
-                SlotGroup.ofItemHandler(inventoryHandler, 3)
+                .add(Alignment.TopRight.getAlignedPos(new Size(PARENT_WIDTH, PARENT_HEIGHT), new Size(WIDTH, HEIGHT))));
+        builder.widget(
+            SlotGroup.ofItemHandler(inventoryHandler, 3)
                 .startFromSlot(SLOT_MANUAL_START)
                 .endAtSlot(SLOT_MANUAL_START + SLOT_MANUAL_SIZE - 1)
                 .phantom(false)
                 .background(getGUITextureSet().getItemSlot())
                 .build()
-                .setPos(7, 7)
-            );
+                .setPos(7, 7));
         return builder.build();
     }
-
 
     @Override
     public void setInventorySlotContents(int aIndex, ItemStack aStack) {

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
@@ -7,7 +7,6 @@ import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
-import appeng.helpers.IInterfaceTerminalSupport;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.inventory.IInventory;
@@ -56,6 +55,7 @@ import appeng.api.util.DimensionalCoord;
 import appeng.core.AppEng;
 import appeng.core.sync.GuiBridge;
 import appeng.helpers.ICustomNameObject;
+import appeng.helpers.IInterfaceTerminalSupport;
 import appeng.items.misc.ItemEncodedPattern;
 import appeng.items.tools.quartz.ToolQuartzCuttingKnife;
 import appeng.me.GridAccessException;
@@ -407,12 +407,8 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
 
     @Override
     public PatternsConfiguration[] getPatternsConfigurations() {
-        return new PatternsConfiguration[] {
-            new PatternsConfiguration(0, 8),
-            new PatternsConfiguration(8, 8),
-            new PatternsConfiguration(16, 8),
-            new PatternsConfiguration(24, 8),
-        };
+        return new PatternsConfiguration[] { new PatternsConfiguration(0, 8), new PatternsConfiguration(8, 8),
+            new PatternsConfiguration(16, 8), new PatternsConfiguration(24, 8), };
     }
 
     @Override

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
@@ -434,7 +434,7 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
         if (getCrafterIcon() != null) {
             name.append(getCrafterIcon().getDisplayName());
         } else {
-            name.append(getInventoryName());
+            name.append(super.getInventoryName());
         }
 
         if (mInventory[SLOT_CIRCUIT] != null) {
@@ -733,12 +733,13 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
     public void getWailaBody(ItemStack itemStack, List<String> currenttip, IWailaDataAccessor accessor,
         IWailaConfigHandler config) {
         NBTTagCompound tag = accessor.getNBTData();
+        currenttip.add(EnumChatFormatting.AQUA + tag.getString("name") + EnumChatFormatting.RESET);
         if (tag.hasKey("inventory")) {
             var inventory = tag.getTagList("inventory", Constants.NBT.TAG_COMPOUND);
             for (int i = 0; i < inventory.tagCount(); ++i) {
                 var item = inventory.getCompoundTagAt(i);
                 var name = item.getString("name");
-                var amount = item.getInteger("amount");
+                var amount = item.getLong("amount");
                 currenttip.add(
                     name + ": "
                         + EnumChatFormatting.GOLD
@@ -754,20 +755,20 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
         int z) {
 
         NBTTagList inventory = new NBTTagList();
-        HashMap<String, Integer> nameToAmount = new HashMap<>();
+        HashMap<String, Long> nameToAmount = new HashMap<>();
         for (Iterator<PatternSlot> it = inventories(); it.hasNext();) {
             var i = it.next();
             for (var item : i.itemInventory) {
                 if (item != null && item.stackSize > 0) {
                     var name = item.getDisplayName();
-                    var amount = nameToAmount.getOrDefault(name, 0);
+                    var amount = nameToAmount.getOrDefault(name, 0L);
                     nameToAmount.put(name, amount + item.stackSize);
                 }
             }
             for (var fluid : i.fluidInventory) {
                 if (fluid != null && fluid.amount > 0) {
                     var name = fluid.getLocalizedName();
-                    var amount = nameToAmount.getOrDefault(name, 0);
+                    var amount = nameToAmount.getOrDefault(name, 0L);
                     nameToAmount.put(name, amount + fluid.amount);
                 }
             }
@@ -775,11 +776,12 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
         for (var entry : nameToAmount.entrySet()) {
             var item = new NBTTagCompound();
             item.setString("name", entry.getKey());
-            item.setInteger("amount", entry.getValue());
+            item.setLong("amount", entry.getValue());
             inventory.appendTag(item);
         }
 
         tag.setTag("inventory", inventory);
+        tag.setString("name", getName());
         super.getWailaNBTData(player, tile, tag, world, x, y, z);
     }
 
@@ -946,7 +948,7 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
 
     @Override
     public String getCustomName() {
-        return customName != null ? customName : null;
+        return customName;
     }
 
     @Override

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
@@ -7,12 +7,6 @@ import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
-import appeng.block.networking.BlockCableBus;
-import appeng.core.AppEng;
-import appeng.core.sync.GuiBridge;
-import appeng.helpers.ICustomNameObject;
-import appeng.items.tools.quartz.ToolQuartzCuttingKnife;
-import appeng.tile.AEBaseTile;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.inventory.InventoryCrafting;
@@ -36,7 +30,6 @@ import com.glodblock.github.common.item.ItemFluidPacket;
 import com.google.common.collect.ImmutableList;
 import com.gtnewhorizons.modularui.api.screen.ModularWindow;
 import com.gtnewhorizons.modularui.api.screen.UIBuildContext;
-import com.gtnewhorizons.modularui.common.internal.wrapper.BaseSlot;
 import com.gtnewhorizons.modularui.common.widget.ButtonWidget;
 import com.gtnewhorizons.modularui.common.widget.SlotGroup;
 import com.gtnewhorizons.modularui.common.widget.SlotWidget;
@@ -58,7 +51,11 @@ import appeng.api.storage.data.IAEFluidStack;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.api.util.AECableType;
 import appeng.api.util.DimensionalCoord;
+import appeng.core.AppEng;
+import appeng.core.sync.GuiBridge;
+import appeng.helpers.ICustomNameObject;
 import appeng.items.misc.ItemEncodedPattern;
+import appeng.items.tools.quartz.ToolQuartzCuttingKnife;
 import appeng.me.GridAccessException;
 import appeng.me.helpers.AENetworkProxy;
 import appeng.me.helpers.IGridProxyable;
@@ -474,7 +471,7 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
             }
         }
 
-        if(aNBT.hasKey("customName")) customName = aNBT.getString("customName");
+        if (aNBT.hasKey("customName")) customName = aNBT.getString("customName");
 
         if (GregTech_API.mAE2) {
             getProxy().readFromNBT(aNBT);
@@ -796,7 +793,8 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
     }
 
     @Override
-    public boolean onRightclick(IGregTechTileEntity aBaseMetaTileEntity, EntityPlayer aPlayer, ForgeDirection side, float aX, float aY, float aZ) {
+    public boolean onRightclick(IGregTechTileEntity aBaseMetaTileEntity, EntityPlayer aPlayer, ForgeDirection side,
+        float aX, float aY, float aZ) {
         final ItemStack is = aPlayer.inventory.getCurrentItem();
         if (is != null && is.getItem() instanceof ToolQuartzCuttingKnife) {
             if (ForgeEventFactory.onItemUseStart(aPlayer, is, 1) <= 0) return false;
@@ -804,8 +802,10 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
             aPlayer.openGui(
                 AppEng.instance(),
                 GuiBridge.GUI_RENAMER.ordinal() << 5 | (side.ordinal()),
-                te.getWorld(), te.getXCoord(), te.getYCoord(), te.getZCoord()
-            );
+                te.getWorld(),
+                te.getXCoord(),
+                te.getYCoord(),
+                te.getZCoord());
             return true;
         }
         return super.onRightclick(aBaseMetaTileEntity, aPlayer, side, aX, aY, aZ);

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
@@ -858,6 +858,7 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
     @Override
     public void setInventorySlotContents(int aIndex, ItemStack aStack) {
         super.setInventorySlotContents(aIndex, aStack);
+        if (aIndex >= MAX_PATTERN_COUNT) return;
         onPatternChange(aIndex, aStack);
         needPatternSync = true;
     }

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
@@ -156,9 +156,14 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
         private boolean isEmpty() {
             // if one item / fluid is empty then it should be safe to assume all other is empty,
             // or at least won't require a recipe check, as long as the pattern is sane
-            if (!itemInventory.isEmpty()) return itemInventory.get(0) == null || itemInventory.get(0).stackSize <= 0;
+            if (!itemInventory.isEmpty()) {
+                return itemInventory.get(0) == null || itemInventory.get(0).stackSize <= 0;
+            }
 
-            return fluidInventory.get(0) == null || fluidInventory.get(0).amount <= 0;
+            if (!fluidInventory.isEmpty()) {
+                return fluidInventory.get(0) == null || fluidInventory.get(0).amount <= 0;
+            }
+            return true;
         }
 
         @Override

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
@@ -434,7 +434,7 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
         if (getCrafterIcon() != null) {
             name.append(getCrafterIcon().getDisplayName());
         } else {
-            name.append(super.getInventoryName());
+            name.append(getInventoryName());
         }
 
         if (mInventory[SLOT_CIRCUIT] != null) {

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
@@ -297,7 +297,7 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
     }
 
     // mInventory is used for storing patterns, circuit and manual slot (typically NC items)
-    private static final int MAX_PATTERN_COUNT = 4 * 8;
+    private static final int MAX_PATTERN_COUNT = 4 * 9;
     private static final int MAX_INV_COUNT = MAX_PATTERN_COUNT + 2;
     private static final int SLOT_MANUAL = MAX_INV_COUNT - 1;
     private static final int SLOT_CIRCUIT = MAX_INV_COUNT - 2;
@@ -407,8 +407,8 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
 
     @Override
     public PatternsConfiguration[] getPatternsConfigurations() {
-        return new PatternsConfiguration[] { new PatternsConfiguration(0, 8), new PatternsConfiguration(8, 8),
-            new PatternsConfiguration(16, 8), new PatternsConfiguration(24, 8), };
+        return new PatternsConfiguration[] { new PatternsConfiguration(0, 9), new PatternsConfiguration(9, 9),
+            new PatternsConfiguration(18, 9), new PatternsConfiguration(27, 9), };
     }
 
     @Override
@@ -418,7 +418,25 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
 
     @Override
     public String getName() {
-        return hasCustomName() ? getCustomName() : getInventoryName();
+        if (hasCustomName()) {
+            return getCustomName();
+        }
+        StringBuilder name = new StringBuilder();
+        if (getCrafterIcon() != null) {
+            name.append(getCrafterIcon().getDisplayName());
+        } else {
+            name.append(getInventoryName());
+        }
+
+        if (mInventory[SLOT_CIRCUIT] != null) {
+            name.append(" - ");
+            name.append(mInventory[SLOT_CIRCUIT].getItemDamage());
+        }
+        if (mInventory[SLOT_MANUAL] != null) {
+            name.append(" - ");
+            name.append(mInventory[SLOT_MANUAL].getDisplayName());
+        }
+        return name.toString();
     }
 
     @Override
@@ -484,6 +502,20 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
                     "An error occurred while loading contents of ME Crafting Input Bus. This pattern has been voided: "
                         + patternSlotNBT);
             }
+        }
+
+        // Migrate from 4x8 to 4x9 pattern inventory
+        int oldPatternCount = 4*8;
+        int oldSlotManual = oldPatternCount - 1;
+        int oldSlotCircuit = oldPatternCount - 2;
+
+        if (internalInventory[oldSlotManual] == null && mInventory[oldSlotManual] != null) {
+            mInventory[SLOT_MANUAL] = mInventory[oldSlotManual];
+            mInventory[oldSlotManual] = null;
+        }
+        if (internalInventory[oldSlotCircuit] == null && mInventory[oldSlotCircuit] != null) {
+            mInventory[SLOT_CIRCUIT] = mInventory[oldSlotCircuit];
+            mInventory[oldSlotCircuit] = null;
         }
 
         // reconstruct patternDetailsPatternSlotMap
@@ -575,7 +607,7 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
 
     @Override
     public int getCircuitSlotX() {
-        return 152;
+        return 170;
     }
 
     @Override
@@ -589,9 +621,14 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
     }
 
     @Override
+    public int getGUIWidth() {
+        return super.getGUIWidth() + 16;
+    }
+
+    @Override
     public void addUIWidgets(ModularWindow.@NotNull Builder builder, UIBuildContext buildContext) {
         builder.widget(
-            SlotGroup.ofItemHandler(inventoryHandler, 8)
+            SlotGroup.ofItemHandler(inventoryHandler, 9)
                 .startFromSlot(0)
                 .endAtSlot(MAX_PATTERN_COUNT - 1)
                 .phantom(false)
@@ -614,7 +651,7 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
             .widget(
                 new SlotWidget(inventoryHandler, SLOT_MANUAL).setShiftClickPriority(11)
                     .setBackground(getGUITextureSet().getItemSlot())
-                    .setPos(151, 45))
+                    .setPos(169, 45))
             .widget(new ButtonWidget().setOnClick((clickData, widget) -> {
                 if (clickData.mouseButton == 0) {
                     refundAll();
@@ -624,7 +661,7 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
                 .setBackground(GT_UITextures.BUTTON_STANDARD, GT_UITextures.OVERLAY_BUTTON_EXPORT)
                 .addTooltips(ImmutableList.of("Return all internally stored items back to AE"))
                 .setSize(16, 16)
-                .setPos(152, 28));
+                .setPos(170, 28));
     }
 
     @Override
@@ -861,12 +898,12 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
 
     @Override
     public String getCustomName() {
-        return customName != null ? customName : getCrafterIcon() != null ? getCrafterIcon().getDisplayName() : null;
+        return customName != null ? customName : null;
     }
 
     @Override
     public boolean hasCustomName() {
-        return customName != null || getCrafterIcon() != null;
+        return customName != null;
     }
 
     @Override

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
@@ -158,9 +158,7 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
             // or at least won't require a recipe check, as long as the pattern is sane
             if (!itemInventory.isEmpty()) return itemInventory.get(0) == null || itemInventory.get(0).stackSize <= 0;
 
-            if (!fluidInventory.isEmpty()) return fluidInventory.get(0) == null || fluidInventory.get(0).amount <= 0;
-
-            return true;
+            return fluidInventory.get(0) == null || fluidInventory.get(0).amount <= 0;
         }
 
         @Override

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
@@ -505,7 +505,7 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
         }
 
         // Migrate from 4x8 to 4x9 pattern inventory
-        int oldPatternCount = 4*8;
+        int oldPatternCount = 4 * 8;
         int oldSlotManual = oldPatternCount - 1;
         int oldSlotCircuit = oldPatternCount - 2;
 

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
@@ -7,8 +7,10 @@ import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
+import appeng.helpers.IInterfaceTerminalSupport;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.InventoryCrafting;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
@@ -80,7 +82,7 @@ import mcp.mobius.waila.api.IWailaDataAccessor;
 
 public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_Hatch_InputBus
     implements IConfigurationCircuitSupport, IAddGregtechLogo, IAddUIWidgets, IPowerChannelState, ICraftingProvider,
-    IGridProxyable, IDualInputHatch, ICustomNameObject {
+    IGridProxyable, IDualInputHatch, ICustomNameObject, IInterfaceTerminalSupport {
 
     // Each pattern slot in the crafting input hatch has its own internal inventory
     public static class PatternSlot implements IDualInputInventory {
@@ -401,6 +403,31 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
             getBaseMetaTileEntity().getXCoord(),
             getBaseMetaTileEntity().getYCoord(),
             getBaseMetaTileEntity().getZCoord());
+    }
+
+    @Override
+    public PatternsConfiguration[] getPatternsConfigurations() {
+        return new PatternsConfiguration[] {
+            new PatternsConfiguration(0, 8),
+            new PatternsConfiguration(8, 8),
+            new PatternsConfiguration(16, 8),
+            new PatternsConfiguration(24, 8),
+        };
+    }
+
+    @Override
+    public IInventory getPatterns(int i) {
+        return this;
+    }
+
+    @Override
+    public String getName() {
+        return hasCustomName() ? getCustomName() : getInventoryName();
+    }
+
+    @Override
+    public TileEntity getTileEntity() {
+        return (TileEntity) getBaseMetaTileEntity();
     }
 
     @Override

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
@@ -311,6 +311,10 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
     // a hash map for faster lookup of pattern slots, not necessarily all valid.
     private Map<ICraftingPatternDetails, PatternSlot> patternDetailsPatternSlotMap = new HashMap<>(MAX_PATTERN_COUNT);
 
+    static private PatternsConfiguration[] patternConfigurations = new PatternsConfiguration[] {
+        new PatternsConfiguration(0, 9), new PatternsConfiguration(9, 9), new PatternsConfiguration(18, 9),
+        new PatternsConfiguration(27, 9) };
+
     private boolean needPatternSync = true;
     private boolean justHadNewItems = false;
 
@@ -407,8 +411,7 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
 
     @Override
     public PatternsConfiguration[] getPatternsConfigurations() {
-        return new PatternsConfiguration[] { new PatternsConfiguration(0, 9), new PatternsConfiguration(9, 9),
-            new PatternsConfiguration(18, 9), new PatternsConfiguration(27, 9), };
+        return patternConfigurations;
     }
 
     @Override

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_Slave.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_Slave.java
@@ -8,7 +8,10 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ChatComponentText;
+import net.minecraft.util.EnumChatFormatting;
+import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import gregtech.api.enums.ItemList;
@@ -17,6 +20,8 @@ import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_InputBus;
 import gregtech.api.render.TextureFactory;
+import mcp.mobius.waila.api.IWailaConfigHandler;
+import mcp.mobius.waila.api.IWailaDataAccessor;
 
 public class GT_MetaTileEntity_Hatch_CraftingInput_Slave extends GT_MetaTileEntity_Hatch_InputBus
     implements IDualInputHatch {
@@ -177,5 +182,39 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_Slave extends GT_MetaTileEnti
         }
         aPlayer.addChatMessage(new ChatComponentText("Link failed"));
         return false;
+    }
+
+    @Override
+    public void getWailaBody(ItemStack itemStack, List<String> currenttip, IWailaDataAccessor accessor,
+        IWailaConfigHandler config) {
+        NBTTagCompound tag = accessor.getNBTData();
+        currenttip.add((tag.getBoolean("linked") ? "Linked" : "Not linked"));
+
+        if (tag.hasKey("masterX")) {
+            currenttip.add(
+                "Bound to " + tag
+                    .getInteger("masterX") + ", " + tag.getInteger("masterY") + ", " + tag.getInteger("masterZ"));
+        }
+
+        if (tag.hasKey("masterName")) {
+            currenttip.add(EnumChatFormatting.GOLD + tag.getString("masterName") + EnumChatFormatting.RESET);
+        }
+
+        super.getWailaBody(itemStack, currenttip, accessor, config);
+    }
+
+    @Override
+    public void getWailaNBTData(EntityPlayerMP player, TileEntity tile, NBTTagCompound tag, World world, int x, int y,
+        int z) {
+
+        tag.setBoolean("linked", getMaster() != null);
+        if (masterSet) {
+            tag.setInteger("masterX", masterX);
+            tag.setInteger("masterY", masterY);
+            tag.setInteger("masterZ", masterZ);
+        }
+        if (getMaster() != null) tag.setString("masterName", getMaster().getName());
+
+        super.getWailaNBTData(player, tile, tag, world, x, y, z);
     }
 }

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_Slave.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_Slave.java
@@ -162,7 +162,8 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_Slave extends GT_MetaTileEnti
     public boolean onRightclick(IGregTechTileEntity aBaseMetaTileEntity, EntityPlayer aPlayer) {
         if (!(aPlayer instanceof EntityPlayerMP)) return false;
         ItemStack dataStick = aPlayer.inventory.getCurrentItem();
-        if (!ItemList.Tool_DataStick.isStackEqual(dataStick, true, true)) return false;
+        if (!ItemList.Tool_DataStick.isStackEqual(dataStick, true, true))
+            return false;
         if (!dataStick.hasTagCompound() || !"CraftingInputBuffer".equals(dataStick.stackTagCompound.getString("type")))
             return false;
 

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_Slave.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_Slave.java
@@ -162,8 +162,7 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_Slave extends GT_MetaTileEnti
     public boolean onRightclick(IGregTechTileEntity aBaseMetaTileEntity, EntityPlayer aPlayer) {
         if (!(aPlayer instanceof EntityPlayerMP)) return false;
         ItemStack dataStick = aPlayer.inventory.getCurrentItem();
-        if (!ItemList.Tool_DataStick.isStackEqual(dataStick, true, true))
-            return false;
+        if (!ItemList.Tool_DataStick.isStackEqual(dataStick, true, true)) return false;
         if (!dataStick.hasTagCompound() || !"CraftingInputBuffer".equals(dataStick.stackTagCompound.getString("type")))
             return false;
 

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_Slave.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_Slave.java
@@ -163,14 +163,16 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_Slave extends GT_MetaTileEnti
         return master;
     }
 
-    @Override
-    public boolean onRightclick(IGregTechTileEntity aBaseMetaTileEntity, EntityPlayer aPlayer) {
-        if (!(aPlayer instanceof EntityPlayerMP)) return false;
+    private boolean tryLinkDataStick(EntityPlayer aPlayer) {
         ItemStack dataStick = aPlayer.inventory.getCurrentItem();
-        if (!ItemList.Tool_DataStick.isStackEqual(dataStick, true, true))
+
+        if (!ItemList.Tool_DataStick.isStackEqual(dataStick, true, true)) {
             return false;
-        if (!dataStick.hasTagCompound() || !"CraftingInputBuffer".equals(dataStick.stackTagCompound.getString("type")))
+        }
+        if (!dataStick.hasTagCompound() || !dataStick.stackTagCompound.getString("type")
+            .equals("CraftingInputBuffer")) {
             return false;
+        }
 
         NBTTagCompound nbt = dataStick.stackTagCompound;
         int x = nbt.getInteger("x");
@@ -181,6 +183,21 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_Slave extends GT_MetaTileEnti
             return true;
         }
         aPlayer.addChatMessage(new ChatComponentText("Link failed"));
+        return true;
+    }
+
+    @Override
+    public boolean onRightclick(IGregTechTileEntity aBaseMetaTileEntity, EntityPlayer aPlayer) {
+        if (!(aPlayer instanceof EntityPlayerMP)) {
+            return false;
+        }
+        if (tryLinkDataStick(aPlayer)) {
+            return true;
+        }
+        var master = getMaster();
+        if (master != null) {
+            return master.onRightclick(master.getBaseMetaTileEntity(), aPlayer);
+        }
         return false;
     }
 


### PR DESCRIPTION
* Support custom name
* Support interface terminal
* WAILA for slave hatches
* https://github.com/GTNewHorizons/GT5-Unofficial/pull/2212
    * 4 extra pattern slots (=4*9=36 now)
    * Auto-generated name
*  9 manual slots for all your laser engraver, nano forge and dtpf needs
* https://github.com/GTNewHorizons/GT5-Unofficial/pull/2221

Other half in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/368

Note that this modifies `BaseMetaTileEntity` so every `BaseMetaTileEntity` is an `ICustomNameObject`. I don't like doing this so let me know if there is a better way.

![image](https://github.com/GTNewHorizons/GT5-Unofficial/assets/7413706/5613672a-32b7-4211-a11e-73edaeb9cbbf)
![image](https://github.com/GTNewHorizons/GT5-Unofficial/assets/7413706/a1a6acdc-5387-4bb3-9f40-a0db9ef97387)
![image](https://github.com/GTNewHorizons/GT5-Unofficial/assets/7413706/b11f369a-64f1-498b-a3e9-3c926574205c)

