### PR TITLE
Mini fix for the automatic multiblock recipes

### DIFF
--- a/src/main/java/gregtech/api/util/GT_RecipeBuilder.java
+++ b/src/main/java/gregtech/api/util/GT_RecipeBuilder.java
@@ -255,6 +255,7 @@ public class GT_RecipeBuilder {
     }
 
     public GT_RecipeBuilder noItemOutputs() {
+        chances = null;
         return itemOutputs();
     }
 


### PR DESCRIPTION
required for https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/692. as that will wait for after stable, so can this.

context: there is no joint method to set chances and outputs at the same time if the case of noItemOutputs. Calling both after each other just results in a crash from mismatched lengths. However there is no reason not to just set the chances null whenever there are no outputs. 