### PR TITLE
Fix and cleanup ammonia recipes

### DIFF
--- a/src/main/java/gregtech/loaders/postload/recipes/ChemicalRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/ChemicalRecipes.java
@@ -4430,7 +4430,7 @@ public class ChemicalRecipes implements Runnable {
             .fluidInputs(Materials.Hydrogen.getGas(3000))
             .fluidOutputs(Materials.Ammonia.getGas(1000))
             .duration(16 * SECONDS)
-            .eut(384)
+            .eut(TierEU.HV * 3 / 4)
             .addTo(sChemicalRecipes);
 
         GT_Values.RA.stdBuilder()
@@ -4439,7 +4439,7 @@ public class ChemicalRecipes implements Runnable {
             .fluidInputs(Materials.Nitrogen.getGas(1000))
             .fluidOutputs(Materials.Ammonia.getGas(1000))
             .duration(16 * SECONDS)
-            .eut(384)
+            .eut(TierEU.HV * 3 / 4)
             .addTo(sChemicalRecipes);
 
         GT_Values.RA.stdBuilder()
@@ -4448,7 +4448,7 @@ public class ChemicalRecipes implements Runnable {
             .fluidInputs(Materials.Hydrogen.getGas(3000))
             .noFluidOutputs()
             .duration(16 * SECONDS)
-            .eut(384)
+            .eut(TierEU.HV * 3 / 4)
             .addTo(sChemicalRecipes);
 
         GT_Values.RA.stdBuilder()
@@ -4457,7 +4457,7 @@ public class ChemicalRecipes implements Runnable {
             .fluidInputs(Materials.Nitrogen.getGas(1000))
             .noFluidOutputs()
             .duration(16 * SECONDS)
-            .eut(384)
+            .eut(TierEU.HV * 3 / 4)
             .addTo(sChemicalRecipes);
 
         GT_Values.RA.stdBuilder()
@@ -5446,12 +5446,21 @@ public class ChemicalRecipes implements Runnable {
             .addTo(sMultiblockChemicalRecipes);
 
         GT_Values.RA.stdBuilder()
+            .itemInputs(GT_Utility.getIntegratedCircuit(1))
+            .noItemOutputs()
+            .fluidInputs(Materials.Nitrogen.getGas(1000), Materials.Hydrogen.getGas(3000))
+            .fluidOutputs(Materials.Ammonia.getGas(1000))
+            .duration(16 * SECONDS)
+            .eut(TierEU.HV * 3 / 4)
+            .addTo(sMultiblockChemicalRecipes);
+
+        GT_Values.RA.stdBuilder()
             .itemInputs(GT_Utility.getIntegratedCircuit(24))
             .noItemOutputs()
             .fluidInputs(Materials.Nitrogen.getGas(10000), Materials.Hydrogen.getGas(30000))
             .fluidOutputs(Materials.Ammonia.getGas(10000))
-            .duration(40 * SECONDS)
-            .eut(TierEU.RECIPE_HV)
+            .duration(2 * MINUTES + 40 * SECONDS)
+            .eut(TierEU.HV * 3 / 4)
             .addTo(sMultiblockChemicalRecipes);
 
         // 2NH3 + 7O = N2O4 + 3H2O


### PR DESCRIPTION
fixes https://discord.com/channels/181078474394566657/401118216228831252/1137722614564016138 (+subsequent discussion).

Basically we had 2 broken ammonia LCR recipe (one had a broken input, the other didnt even show up in the game) and no correctly working ones. Fixing the first in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/695 made the second one also show up and they are kind of conflicting with each other another. As we dont want multiple conflicting recipes the best way to fix this is a small cleanup.

This needs to be merged together with https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/697 which removes the coremod recipe, so that the clean up can happen here.

The recipes now are as close to possible to the old, but with circuits to avoid conflicts and with a working batch-variant recipe. In particular no magnetite catalyst is involved.

multiblock:
![image](https://github.com/GTNewHorizons/GT5-Unofficial/assets/40274384/2f5b15e6-1dd3-4a04-b028-555a655ca6ea)
![image](https://github.com/GTNewHorizons/GT5-Unofficial/assets/40274384/e48d2f12-039f-45db-aabc-16a905e40293)

singleblock:
![image](https://github.com/GTNewHorizons/GT5-Unofficial/assets/40274384/0310c465-4343-4bf5-8e54-ca30b542fbb0)
![image](https://github.com/GTNewHorizons/GT5-Unofficial/assets/40274384/c3122a3d-b078-4284-b77b-ad87f3537315)
![image](https://github.com/GTNewHorizons/GT5-Unofficial/assets/40274384/114cec38-e0b5-4f1a-bbdb-9a1d3062dd1f)

