### PR TITLE
General Crafting Input Hatch QoL fixes

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
@@ -279,7 +279,7 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
     }
 
     // mInventory is used for storing patterns, circuit and manual slot (typically NC items)
-    private static final int MAX_PATTERN_COUNT = 4 * 8;
+    private static final int MAX_PATTERN_COUNT = 4 * 9;
     private static final int MAX_INV_COUNT = MAX_PATTERN_COUNT + 2;
     private static final int SLOT_MANUAL = MAX_INV_COUNT - 1;
     private static final int SLOT_CIRCUIT = MAX_INV_COUNT - 2;
@@ -389,8 +389,8 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
 
     @Override
     public PatternsConfiguration[] getPatternsConfigurations() {
-        return new PatternsConfiguration[] { new PatternsConfiguration(0, 8), new PatternsConfiguration(8, 8),
-            new PatternsConfiguration(16, 8), new PatternsConfiguration(24, 8), };
+        return new PatternsConfiguration[] { new PatternsConfiguration(0, 9), new PatternsConfiguration(9, 9),
+            new PatternsConfiguration(18, 9), new PatternsConfiguration(27, 9), };
     }
 
     @Override
@@ -571,7 +571,7 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
 
     @Override
     public int getCircuitSlotX() {
-        return 152;
+        return 170;
     }
 
     @Override
@@ -585,32 +585,37 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
     }
 
     @Override
+    public int getGUIWidth() {
+        return super.getGUIWidth() + 16;
+    }
+
+    @Override
     public void addUIWidgets(ModularWindow.@NotNull Builder builder, UIBuildContext buildContext) {
         builder.widget(
-            SlotGroup.ofItemHandler(inventoryHandler, 8)
-                .startFromSlot(0)
-                .endAtSlot(MAX_PATTERN_COUNT - 1)
-                .phantom(false)
-                .background(getGUITextureSet().getItemSlot(), GT_UITextures.OVERLAY_SLOT_PATTERN_ME)
-                .widgetCreator(slot -> new SlotWidget(slot) {
+                SlotGroup.ofItemHandler(inventoryHandler, 9)
+                    .startFromSlot(0)
+                    .endAtSlot(MAX_PATTERN_COUNT - 1)
+                    .phantom(false)
+                    .background(getGUITextureSet().getItemSlot(), GT_UITextures.OVERLAY_SLOT_PATTERN_ME)
+                    .widgetCreator(slot -> new SlotWidget(slot) {
 
-                    @Override
-                    protected ItemStack getItemStackForRendering(Slot slotIn) {
-                        var stack = slot.getStack();
-                        if (stack == null || !(stack.getItem() instanceof ItemEncodedPattern patternItem)) {
-                            return stack;
+                        @Override
+                        protected ItemStack getItemStackForRendering(Slot slotIn) {
+                            var stack = slot.getStack();
+                            if (stack == null || !(stack.getItem() instanceof ItemEncodedPattern patternItem)) {
+                                return stack;
+                            }
+                            var output = patternItem.getOutput(stack);
+                            return output != null ? output : stack;
                         }
-                        var output = patternItem.getOutput(stack);
-                        return output != null ? output : stack;
-                    }
-                }.setFilter(itemStack -> itemStack.getItem() instanceof ICraftingPatternItem)
-                    .setChangeListener(() -> onPatternChange(slot.getSlotIndex(), slot.getStack())))
-                .build()
-                .setPos(7, 9))
+                    }.setFilter(itemStack -> itemStack.getItem() instanceof ICraftingPatternItem)
+                        .setChangeListener(() -> onPatternChange(slot.getSlotIndex(), slot.getStack())))
+                    .build()
+                    .setPos(7, 9))
             .widget(
                 new SlotWidget(inventoryHandler, SLOT_MANUAL).setShiftClickPriority(11)
                     .setBackground(getGUITextureSet().getItemSlot())
-                    .setPos(151, 45))
+                    .setPos(169, 45))
             .widget(new ButtonWidget().setOnClick((clickData, widget) -> {
                 if (clickData.mouseButton == 0) {
                     refundAll();
@@ -620,7 +625,7 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
                 .setBackground(GT_UITextures.BUTTON_STANDARD, GT_UITextures.OVERLAY_BUTTON_EXPORT)
                 .addTooltips(ImmutableList.of("Return all internally stored items back to AE"))
                 .setSize(16, 16)
-                .setPos(152, 28));
+                .setPos(170, 28));
     }
 
     @Override

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
@@ -400,7 +400,25 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
 
     @Override
     public String getName() {
-        return hasCustomName() ? getCustomName() : getInventoryName();
+        if (hasCustomName()) {
+            return getCustomName();
+        }
+        StringBuilder name = new StringBuilder();
+        if (getCrafterIcon() != null) {
+            name.append(getCrafterIcon().getDisplayName());
+        } else {
+            name.append(getInventoryName());
+        }
+
+        if (mInventory[SLOT_CIRCUIT] != null) {
+            name.append(" - ");
+            name.append(mInventory[SLOT_CIRCUIT].getItemDamage());
+        }
+        if (mInventory[SLOT_MANUAL] != null) {
+            name.append(" - ");
+            name.append(mInventory[SLOT_MANUAL].getDisplayName());
+        }
+        return name.toString();
     }
 
     @Override
@@ -829,12 +847,12 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
 
     @Override
     public String getCustomName() {
-        return customName != null ? customName : getCrafterIcon() != null ? getCrafterIcon().getDisplayName() : null;
+        return customName != null ? customName : null;
     }
 
     @Override
     public boolean hasCustomName() {
-        return customName != null || getCrafterIcon() != null;
+        return customName != null;
     }
 
     @Override

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
@@ -592,26 +592,26 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
     @Override
     public void addUIWidgets(ModularWindow.@NotNull Builder builder, UIBuildContext buildContext) {
         builder.widget(
-                SlotGroup.ofItemHandler(inventoryHandler, 9)
-                    .startFromSlot(0)
-                    .endAtSlot(MAX_PATTERN_COUNT - 1)
-                    .phantom(false)
-                    .background(getGUITextureSet().getItemSlot(), GT_UITextures.OVERLAY_SLOT_PATTERN_ME)
-                    .widgetCreator(slot -> new SlotWidget(slot) {
+            SlotGroup.ofItemHandler(inventoryHandler, 9)
+                .startFromSlot(0)
+                .endAtSlot(MAX_PATTERN_COUNT - 1)
+                .phantom(false)
+                .background(getGUITextureSet().getItemSlot(), GT_UITextures.OVERLAY_SLOT_PATTERN_ME)
+                .widgetCreator(slot -> new SlotWidget(slot) {
 
-                        @Override
-                        protected ItemStack getItemStackForRendering(Slot slotIn) {
-                            var stack = slot.getStack();
-                            if (stack == null || !(stack.getItem() instanceof ItemEncodedPattern patternItem)) {
-                                return stack;
-                            }
-                            var output = patternItem.getOutput(stack);
-                            return output != null ? output : stack;
+                    @Override
+                    protected ItemStack getItemStackForRendering(Slot slotIn) {
+                        var stack = slot.getStack();
+                        if (stack == null || !(stack.getItem() instanceof ItemEncodedPattern patternItem)) {
+                            return stack;
                         }
-                    }.setFilter(itemStack -> itemStack.getItem() instanceof ICraftingPatternItem)
-                        .setChangeListener(() -> onPatternChange(slot.getSlotIndex(), slot.getStack())))
-                    .build()
-                    .setPos(7, 9))
+                        var output = patternItem.getOutput(stack);
+                        return output != null ? output : stack;
+                    }
+                }.setFilter(itemStack -> itemStack.getItem() instanceof ICraftingPatternItem)
+                    .setChangeListener(() -> onPatternChange(slot.getSlotIndex(), slot.getStack())))
+                .build()
+                .setPos(7, 9))
             .widget(
                 new SlotWidget(inventoryHandler, SLOT_MANUAL).setShiftClickPriority(11)
                     .setBackground(getGUITextureSet().getItemSlot())

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
@@ -482,6 +482,20 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
                 this::getSharedItems);
         }
 
+        // Migrate from 4x8 to 4x9 pattern inventory
+        int oldPatternCount = 4*8;
+        int oldSlotManual = oldPatternCount - 1;
+        int oldSlotCircuit = oldPatternCount - 2;
+
+        if (internalInventory[oldSlotManual] == null && mInventory[oldSlotManual] != null) {
+            mInventory[SLOT_MANUAL] = mInventory[oldSlotManual];
+            mInventory[oldSlotManual] = null;
+        }
+        if (internalInventory[oldSlotCircuit] == null && mInventory[oldSlotCircuit] != null) {
+            mInventory[SLOT_CIRCUIT] = mInventory[oldSlotCircuit];
+            mInventory[oldSlotCircuit] = null;
+        }
+
         // reconstruct patternDetailsPatternSlotMap
         patternDetailsPatternSlotMap.clear();
         for (PatternSlot patternSlot : internalInventory) {


### PR DESCRIPTION
A addon to #2200 , as there is a feature freeze and that wont be merged any time soon. Maybe this can be merged as this is not merging to the main branch.

This patch introduces a few QoL feature:
* Default name now include circuit number and manual slot catalyst name. Even though some multiblock names are too long to display, you can still search for it, and that's the point.
* Change how the way that custom name work to more like vanilla AE2 (By default no name) for consistency.
* Adding 4 more slots (from 4x8 -> 4x9, i.e. the capacity of a fully upgraded interface) to address my OCD on pattern terminals and maintain consistency, as it is kinda odd to have a blank slot like the one in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/368

### Screenshot

![image](https://github.com/GTNewHorizons/GT5-Unofficial/assets/39846845/792b0e66-1a92-44b8-99a8-d1e21c24c18d)
![image](https://github.com/GTNewHorizons/GT5-Unofficial/assets/39846845/5c750203-d0e5-40aa-aff0-5150ae6e4dc9)
![image](https://github.com/GTNewHorizons/GT5-Unofficial/assets/39846845/ce056409-7947-4123-93f2-f01f260509f1)
