### PR TITLE
More Additions to MUCs and the LCB

### DIFF
--- a/src/main/java/gregtech/api/multitileentity/multiblock/base/StackableModularController.java
+++ b/src/main/java/gregtech/api/multitileentity/multiblock/base/StackableModularController.java
@@ -56,8 +56,10 @@ public abstract class StackableModularController<T extends StackableModularContr
         mucCounters.forEach((type, casingCount) -> { Arrays.fill(casingCount, 0); });
     }
 
+    // Returns the cheapest MUC that is possible for the multi, which gets the minimum bonuses.
     protected abstract UpgradeCasings getBaseMucType();
 
+    // Minimum parallel bonus per MUC. Higher tier MUCs multiply with this value for even more parallels.
     protected abstract int getParallelFactor();
 
     protected void calculateParallels() {
@@ -66,9 +68,13 @@ public abstract class StackableModularController<T extends StackableModularContr
         int[] parallelCasingList = mucMap.get(getBaseMucType());
 
         for (int i = 0; i < 5; i++) {
-            parallelCount += parallelCasingList[i] * (i+1) * parallelFactor;
+            // (i * 3 + 1) -> Convert MUC tier into minimum GT tier, in groups of 3 (LV, EV, LuV, UHV, UMV)
+            // If higher than multi tier, upgrade casing has no effect
+            if (i * 3 + 1 <= tier) {
+                parallelCount += parallelCasingList[i] * (i + 1) * parallelFactor;
+            }
         }
-        maxParallel = parallelCount;
+        maxParallel = parallelCount == 0 ? 1 : parallelCount;
     }
 
     protected abstract boolean calculateMucMultipliers();
@@ -102,6 +108,7 @@ public abstract class StackableModularController<T extends StackableModularContr
                 .setCurrentOutputFluids(getOutputFluids())
                 .setVoltage(power.getVoltage())
                 .setAmperage(amperage)
+                .setMaxParallel(maxParallel)
                 .setPerfectOverclock(hasPerfectOverclock())
                 .setIsCleanroom(isCleanroom)
                 .process();

--- a/src/main/java/gregtech/api/multitileentity/multiblock/base/StackableModularController.java
+++ b/src/main/java/gregtech/api/multitileentity/multiblock/base/StackableModularController.java
@@ -16,8 +16,8 @@ import gregtech.api.util.GT_StructureUtilityMuTE.UpgradeCasings;
 
 public abstract class StackableModularController<T extends StackableModularController<T>> extends StackableController<T>
     implements UpgradableModularMuTE {
-    protected long durationMultiplier = 1;
-    protected long euTickMultiplier = 1;
+    protected double durationMultiplier = 1;
+    protected double euTickMultiplier = 1;
 
     private Map<UpgradeCasings, int[]> mucMap;
 
@@ -55,7 +55,8 @@ public abstract class StackableModularController<T extends StackableModularContr
         mucCounters.forEach((type, casingCount) -> { Arrays.fill(casingCount, 0); });
     }
 
-    protected abstract void calculateMucMultipliers();
+
+    protected abstract boolean calculateMucMultipliers();
 
     @Override
     protected boolean checkRecipe() {
@@ -90,8 +91,8 @@ public abstract class StackableModularController<T extends StackableModularContr
                 .setIsCleanroom(isCleanroom)
                 .process();
         }
-        setDuration(logic.getDuration() * durationMultiplier);
-        setEut(logic.getEut() * euTickMultiplier);
+        setDuration((long) (logic.getDuration() * durationMultiplier));
+        setEut((long) (logic.getEut() * euTickMultiplier));
         setItemOutputs(logic.getOutputItems());
         setFluidOutputs(logic.getOutputFluids());
         return result;

--- a/src/main/java/gregtech/api/multitileentity/multiblock/base/StackableModularController.java
+++ b/src/main/java/gregtech/api/multitileentity/multiblock/base/StackableModularController.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import com.gtnewhorizons.modularui.api.forge.IItemHandlerModifiable;
 import gregtech.api.logic.ProcessingLogic;
 import gregtech.api.logic.interfaces.ProcessingLogicHost;
+import gregtech.api.util.GT_StructureUtilityMuTE;
 import net.minecraft.item.ItemStack;
 import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.NotNull;
@@ -55,6 +56,20 @@ public abstract class StackableModularController<T extends StackableModularContr
         mucCounters.forEach((type, casingCount) -> { Arrays.fill(casingCount, 0); });
     }
 
+    protected abstract UpgradeCasings getBaseMucType();
+
+    protected abstract int getParallelFactor();
+
+    protected void calculateParallels() {
+        int parallelCount = 0;
+        int parallelFactor = getParallelFactor();
+        int[] parallelCasingList = mucMap.get(getBaseMucType());
+
+        for (int i = 0; i < 5; i++) {
+            parallelCount += parallelCasingList[i] * (i+1) * parallelFactor;
+        }
+        maxParallel = parallelCount;
+    }
 
     protected abstract boolean calculateMucMultipliers();
 

--- a/src/main/java/gregtech/api/multitileentity/multiblock/base/StackableModularController.java
+++ b/src/main/java/gregtech/api/multitileentity/multiblock/base/StackableModularController.java
@@ -78,45 +78,4 @@ public abstract class StackableModularController<T extends StackableModularContr
     }
 
     protected abstract boolean calculateMucMultipliers();
-
-    @Override
-    protected boolean checkRecipe() {
-        if (!(this instanceof ProcessingLogicHost)) {
-            return false;
-        }
-        ProcessingLogic logic = ((ProcessingLogicHost) this).getProcessingLogic();
-        logic.clear();
-        boolean result = false;
-        if (isSeparateInputs()) {
-            // TODO: Add separation with fluids
-            for (Pair<ItemStack[], String> inventory : getItemInputsForEachInventory()) {
-                IItemHandlerModifiable outputInventory = multiBlockOutputInventory
-                    .getOrDefault(inventory.getLeft(), null);
-                result = logic.setInputItems(inventory.getLeft())
-                    .setCurrentOutputItems(getOutputItems())
-                    .process();
-                if (result) {
-                    inventoryName = inventory.getRight();
-                    break;
-                }
-                logic.clear();
-            }
-        } else {
-            result = logic.setInputItems(getInputItems())
-                .setCurrentOutputItems(getOutputItems())
-                .setInputFluids(getInputFluids())
-                .setCurrentOutputFluids(getOutputFluids())
-                .setVoltage(power.getVoltage())
-                .setAmperage(amperage)
-                .setMaxParallel(maxParallel)
-                .setPerfectOverclock(hasPerfectOverclock())
-                .setIsCleanroom(isCleanroom)
-                .process();
-        }
-        setDuration((long) (logic.getDuration() * durationMultiplier));
-        setEut((long) (logic.getEut() * euTickMultiplier));
-        setItemOutputs(logic.getOutputItems());
-        setFluidOutputs(logic.getOutputFluids());
-        return result;
-    }
 }

--- a/src/main/java/gregtech/common/tileentities/machines/multiblock/LayeredCokeBattery.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multiblock/LayeredCokeBattery.java
@@ -113,34 +113,34 @@ public class LayeredCokeBattery extends StackableModularController<LayeredCokeBa
                 .addShape(
                     STACKABLE_STOP,
                     transpose(
-                        new String[][] { { "AAAAAAAAAAAAA", "AAAAAAAAAAAAA" }, { " B B B B B B ", "AFAFAFAFAFAFA" },
-                            { "CB B B B B BC", "AFAFAFAFAFAFA" }, { " B B B B B B ", "AFAFAFAFAFAFA" },
+                        new String[][] { { "AHFFFFAFFFFHA", "AAAAAAAAAAAAA" }, { " B B B B B B ", "AFAFAFAFAFAFA" },
+                            { "HB B B B B BH", "AFAFAFAFAFAFA" }, { " B B B B B B ", "AFAFAFAFAFAFA" },
                             { " B B B B B B ", "AFAFAFAFAFAFA" }, { " B B B B B B ", "AFAFAFAFAFAFA" },
                             { " B B B B B B ", "AFAFAFAFAFAFA" }, { " B B B B B B ", "AFAFAFAFAFAFA" },
-                            { " B B B B B B ", "AFAFAFAFAFAFA" }, { "CB B B B B BC", "AFAFAFAFAFAFA" },
+                            { " B B B B B B ", "AFAFAFAFAFAFA" }, { "HB B B B B BH", "AFAFAFAFAFAFA" },
                             { " B B B B B B ", "AFAFAFAFAFAFA" }, { "AAAAAAAAAAAAA", "AAAAAAAAAAAAA" } }))
                 .addShape(
                     STACKABLE_MIDDLE,
                     transpose(
-                        new String[][] { { "ADFFFFHFFFFDA", "AAAAAAAAAAAAA" }, { " B    A    B ", "AAAAAAAAAAAAA" },
-                            { "CB    A    BC", "AAAAAAAAAAAAA" }, { " B    A    B ", "AAAAAAAAAAAAA" },
+                        new String[][] { { "AHFFFFAFFFFHA", "AAAAAAAAAAAAA" }, { " B    A    B ", "AAAAAAAAAAAAA" },
+                            { "HB    A    BH", "AAAAAAAAAAAAA" }, { " B    A    B ", "AAAAAAAAAAAAA" },
                             { " B    A    B ", "AAAAAAAAAAAAA" }, { " B    A    B ", "AAAAAAAAAAAAA" },
                             { " B    A    B ", "AAAAAAAAAAAAA" }, { " B    A    B ", "AAAAAAAAAAAAA" },
-                            { " B    A    B ", "AAAAAAAAAAAAA" }, { "CB    A    BC", "AAAAAAAAAAAAA" },
+                            { " B    A    B ", "AAAAAAAAAAAAA" }, { "HB    A    BH", "AAAAAAAAAAAAA" },
                             { " B    A    B ", "AAAAAAAAAAAAA" }, { "AAAAAAAAAAAAA", "AAAAAAAAAAAAA" } }))
                 .addShape(
                     STACKABLE_START,
                     transpose(
-                        new String[][] { { "AAAAAAAAAAAAA", "AAAAAAAAAAAAA", "AAAAAAAAAAAAA" },
+                        new String[][] { { "AAAAAAAAAAAAA", "AHFFFFAFFFFHA", "AAAAAAAAAAAAA" },
                             { "AFAFAFAFAFAFA", " B B B B B B ", "AAAAAAAAAAAAA" },
-                            { "AFAFAFAFAFAFA", "CB B B B B BC", "AAAAAAAAAAAAA" },
-                            { "AFAFAFAFAFAFA", " B B B B B B ", "AAAAAAAAAAAAA" },
-                            { "AFAFAFAFAFAFA", " B B B B B B ", "AAAAAAAAAAAAA" },
+                            { "AFAFAFAFAFAFA", "HB B B B B BH", "AAAAAAAAAAAAA" },
                             { "AFAFAFAFAFAFA", " B B B B B B ", "AAAAAAAAAAAAA" },
                             { "AFAFAFAFAFAFA", " B B B B B B ", "AAAAAAAAAAAAA" },
                             { "AFAFAFAFAFAFA", " B B B B B B ", "AAAAAAAAAAAAA" },
                             { "AFAFAFAFAFAFA", " B B B B B B ", "AAAAAAAAAAAAA" },
-                            { "AFAFAFAFAFAFA", "CB B B B B BC", "AAAAAAAAAAAAA" },
+                            { "AFAFAFAFAFAFA", " B B B B B B ", "AAAAAAAAAAAAA" },
+                            { "AFAFAFAFAFAFA", " B B B B B B ", "AAAAAAAAAAAAA" },
+                            { "AFAFAFAFAFAFA", "HB B B B B BH", "AAAAAAAAAAAAA" },
                             { "AFAFAFAFAFAFA", " B B B B B B ", "AAAAAAAAAAAAA" },
                             { "AAAAAAAAAAAAA", "AAAAAAAAAAAAA", "AAAAAAAAAAAAA" } }))
                 .addElement(

--- a/src/main/java/gregtech/common/tileentities/machines/multiblock/LayeredCokeBattery.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multiblock/LayeredCokeBattery.java
@@ -216,6 +216,7 @@ public class LayeredCokeBattery extends StackableModularController<LayeredCokeBa
             return false;
         }
         if (totalInsulatorCount > 0) {
+            // To be improved later, when more MUCs are added
             // durationMultiplier = 1.0 / totalHeaterCount;
             euTickMultiplier = 1.0 / totalInsulatorCount;
         }

--- a/src/main/java/gregtech/common/tileentities/machines/multiblock/LayeredCokeBattery.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multiblock/LayeredCokeBattery.java
@@ -8,6 +8,7 @@ import static gregtech.api.multitileentity.multiblock.base.MultiBlockPart.FLUID_
 import static gregtech.api.multitileentity.multiblock.base.MultiBlockPart.ITEM_IN;
 import static gregtech.api.multitileentity.multiblock.base.MultiBlockPart.ITEM_OUT;
 import static gregtech.api.multitileentity.multiblock.base.MultiBlockPart.NOTHING;
+import static gregtech.api.util.GT_StructureUtilityMuTE.AMPERAGE_CASINGS;
 import static gregtech.api.util.GT_StructureUtilityMuTE.HEATER_CASINGS;
 import static gregtech.api.util.GT_StructureUtilityMuTE.INSULATOR_CASINGS;
 import static gregtech.api.util.GT_StructureUtilityMuTE.MOTOR_CASINGS;
@@ -106,7 +107,7 @@ public class LayeredCokeBattery extends StackableModularController<LayeredCokeBa
                 .addShape(
                     STRUCTURE_PIECE_BASE,
                     transpose(
-                        new String[][] { { " AAA ", "AAAAA", "AEEEA", "AAAAA" }, { " AAA ", "A   A", "A   A", "AAAAA" },
+                        new String[][] { { " AAA ", "AAAAA", "AEEEP", "AAAAA" }, { " AAA ", "A   A", "A   A", "AAAAA" },
                             { " A~A ", "A   A", "A   A", "AAAAA" }, { " AAA ", "A   A", "A   A", "AAAAA" },
                             { " AAA ", "AAAAA", "AAAAA", "AAAAA" } }))
                 .addShape(
@@ -163,6 +164,7 @@ public class LayeredCokeBattery extends StackableModularController<LayeredCokeBa
                         ofBlockUnlocalizedName(BartWorks.ID, "BW_GlasBlocks2", 0, true),
                         ofBlockUnlocalizedName(Thaumcraft.ID, "blockCosmeticOpaque", 2, false)))
                 .addElement('H', ofMuTECasings(NOTHING, HEATER_CASINGS, INSULATOR_CASINGS))
+                .addElement('P', ofMuTECasings(NOTHING, AMPERAGE_CASINGS))
                 .build();
         }
         return STRUCTURE_DEFINITION_MEGA;
@@ -213,8 +215,8 @@ public class LayeredCokeBattery extends StackableModularController<LayeredCokeBa
         if (totalHeaterCount + totalInsulatorCount < stackCount || totalInsulatorCount > totalHeaterCount) {
             return false;
         }
-        if (totalHeaterCount > 0 && totalInsulatorCount > 0) {
-            durationMultiplier = 1.0 / totalHeaterCount;
+        if (totalInsulatorCount > 0) {
+            // durationMultiplier = 1.0 / totalHeaterCount;
             euTickMultiplier = 1.0 / totalInsulatorCount;
         }
         return true;

--- a/src/main/java/gregtech/common/tileentities/machines/multiblock/LayeredCokeBattery.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multiblock/LayeredCokeBattery.java
@@ -33,6 +33,7 @@ import gregtech.api.multitileentity.multiblock.base.StackableModularController;
 import gregtech.api.util.GT_Multiblock_Tooltip_Builder;
 import gregtech.api.util.GT_Recipe.GT_Recipe_Map;
 import gregtech.api.util.GT_StructureUtility;
+import gregtech.api.util.GT_StructureUtilityMuTE.UpgradeCasings;
 import gregtech.common.tileentities.machines.multiblock.logic.GenericProcessingLogic;
 
 import java.util.Arrays;
@@ -63,6 +64,14 @@ public class LayeredCokeBattery extends StackableModularController<LayeredCokeBa
     @Override
     public Vec3Impl getStartingStructureOffset() {
         return STRUCTURE_OFFSET_BASE;
+    }
+
+    public UpgradeCasings getBaseMucType() {
+        return UpgradeCasings.Heater;
+    }
+
+    public int getParallelFactor() {
+        return 2;
     }
 
     @Override
@@ -190,14 +199,15 @@ public class LayeredCokeBattery extends StackableModularController<LayeredCokeBa
         if (!calculateMucMultipliers()) {
             return false;
         }
+        calculateParallels();
         updatePowerLogic();
         return tier > 0;
     }
 
     protected boolean calculateMucMultipliers() {
-        Map<GT_StructureUtilityMuTE.UpgradeCasings, int[]>  mucMap = getMucMap();
-        int[] heaterList = mucMap.get(GT_StructureUtilityMuTE.UpgradeCasings.Heater);
-        int[] insulatorList = mucMap.get(GT_StructureUtilityMuTE.UpgradeCasings.Insulator);
+        Map<UpgradeCasings, int[]>  mucMap = getMucMap();
+        int[] heaterList = mucMap.get(UpgradeCasings.Heater);
+        int[] insulatorList = mucMap.get(UpgradeCasings.Insulator);
         int totalHeaterCount = Arrays.stream(heaterList).sum();
         int totalInsulatorCount = Arrays.stream(insulatorList).sum();
         if (totalHeaterCount + totalInsulatorCount < stackCount || totalInsulatorCount > totalHeaterCount) {

--- a/src/main/java/gregtech/common/tileentities/machines/multiblock/LayeredCokeBattery.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multiblock/LayeredCokeBattery.java
@@ -13,6 +13,7 @@ import static gregtech.api.util.GT_StructureUtilityMuTE.INSULATOR_CASINGS;
 import static gregtech.api.util.GT_StructureUtilityMuTE.MOTOR_CASINGS;
 import static gregtech.api.util.GT_StructureUtilityMuTE.ofMuTECasings;
 
+import gregtech.api.util.GT_StructureUtilityMuTE;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 
@@ -33,6 +34,10 @@ import gregtech.api.util.GT_Multiblock_Tooltip_Builder;
 import gregtech.api.util.GT_Recipe.GT_Recipe_Map;
 import gregtech.api.util.GT_StructureUtility;
 import gregtech.common.tileentities.machines.multiblock.logic.GenericProcessingLogic;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.IntStream;
 
 public class LayeredCokeBattery extends StackableModularController<LayeredCokeBattery> implements ProcessingLogicHost {
 
@@ -182,8 +187,27 @@ public class LayeredCokeBattery extends StackableModularController<LayeredCokeBa
         }
 
         calculateTier();
+        if (!calculateMucMultipliers()) {
+            return false;
+        }
         updatePowerLogic();
         return tier > 0;
+    }
+
+    protected boolean calculateMucMultipliers() {
+        Map<GT_StructureUtilityMuTE.UpgradeCasings, int[]>  mucMap = getMucMap();
+        int[] heaterList = mucMap.get(GT_StructureUtilityMuTE.UpgradeCasings.Heater);
+        int[] insulatorList = mucMap.get(GT_StructureUtilityMuTE.UpgradeCasings.Insulator);
+        int totalHeaterCount = Arrays.stream(heaterList).sum();
+        int totalInsulatorCount = Arrays.stream(insulatorList).sum();
+        if (totalHeaterCount + totalInsulatorCount < stackCount || totalInsulatorCount > totalHeaterCount) {
+            return false;
+        }
+        if (totalHeaterCount > 0 && totalInsulatorCount > 0) {
+            durationMultiplier = 1.0 / totalHeaterCount;
+            euTickMultiplier = 1.0 / totalInsulatorCount;
+        }
+        return true;
     }
 
     @Override

--- a/src/main/java/gregtech/common/tileentities/machines/multiblock/LayeredCokeBattery.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multiblock/LayeredCokeBattery.java
@@ -43,7 +43,7 @@ public class LayeredCokeBattery extends StackableModularController<LayeredCokeBa
     private static final Vec3Impl STRUCTURE_OFFSET_MEGA_START = new Vec3Impl(0, 0, -3);
     private static final Vec3Impl STRUCTURE_OFFSET_MEGA_STACK = new Vec3Impl(0, 0, -2);
     private static final Vec3Impl STRUCTURE_OFFSET_MEGA_STOP = new Vec3Impl(0, 0, -1);
-    private final ProcessingLogic foundryProcessingLogic = new GenericProcessingLogic(GT_Recipe_Map.sPyrolyseRecipes);
+    private final ProcessingLogic cokeBatteryProcessingLogic = new GenericProcessingLogic(GT_Recipe_Map.sPyrolyseRecipes);
 
     @Override
     public String getTileEntityName() {
@@ -200,7 +200,7 @@ public class LayeredCokeBattery extends StackableModularController<LayeredCokeBa
     protected GT_Multiblock_Tooltip_Builder createTooltip() {
         final GT_Multiblock_Tooltip_Builder tt = new GT_Multiblock_Tooltip_Builder();
         tt.addMachineType("Coke Oven")
-            .addInfo("Controller for the Layered Coke Foundry")
+            .addInfo("Controller for the Layered Coke Battery")
             .addSeparator()
             .beginVariableStructureBlock(7, 9, 2 + getMinStacks(), 2 + getMaxStacks(), 7, 9, true)
             .addController("Bottom Front Center")
@@ -253,6 +253,6 @@ public class LayeredCokeBattery extends StackableModularController<LayeredCokeBa
 
     @Override
     public ProcessingLogic getProcessingLogic() {
-        return foundryProcessingLogic;
+        return cokeBatteryProcessingLogic;
     }
 }

--- a/src/main/java/gregtech/loaders/preload/GT_Loader_MultiTileEntities.java
+++ b/src/main/java/gregtech/loaders/preload/GT_Loader_MultiTileEntities.java
@@ -118,7 +118,7 @@ public class GT_Loader_MultiTileEntities implements Runnable {
             .tankCapacity(128000L)
             .register();
         MACHINE_REGISTRY.create(3, LayeredCokeBattery.class)
-            .name("Layered Coke Foundry")
+            .name("Layered Coke Battery")
             .category("Multiblock Controller")
             .setBlock(MACHINE_BLOCK)
             .material(Materials.Iron)


### PR DESCRIPTION
I'm making a PR now, instead of delaying it to add more stuff, in order to minimize potential conflicts.

Over the last couple of days, I added more functionalities to MUCs in the Layered Coke Battery. Now, the two types, Heater and Insulator, have different roles: Heaters add parallels, whereas Insulators reduce the EU/t consumption of recipes. There's a number of new methods to support this, in my attempts to minimize refactor need later on, using the dedicated MUC classes I implemented last time.

MUC work will continue in this fashion, defining bonuses for each MUC so that the player can choose what they want to improve on the multi, at the cost of other possible improvements.