### PR TITLE
Add a way to enable or disable the crafting buffer on GPL multiblocks

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
@@ -756,6 +756,10 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
         logic.setAmperageOC(mEnergyHatches.size() != 1);
     }
 
+    protected boolean supportsCraftingMEBuffer() {
+        return true;
+    }
+
     /**
      * Iterates over hatches and tries to find recipe. Assume {@link #processingLogic} is already set up for use.
      * If return value is successful, inputs are consumed.
@@ -764,18 +768,20 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
     protected CheckRecipeResult doCheckRecipe() {
         CheckRecipeResult result = CheckRecipeResultRegistry.NO_RECIPE;
         // check crafting input hatches first
-        for (IDualInputHatch dualInputHatch : mDualInputHatches) {
-            for (var it = dualInputHatch.inventories(); it.hasNext();) {
-                IDualInputInventory slot = it.next();
-                processingLogic.setInputItems(slot.getItemInputs());
-                processingLogic.setInputFluids(slot.getFluidInputs());
-                result = processingLogic.process();
+        if (supportsCraftingMEBuffer()) {
+            for (IDualInputHatch dualInputHatch : mDualInputHatches) {
+                for (var it = dualInputHatch.inventories(); it.hasNext();) {
+                    IDualInputInventory slot = it.next();
+                    processingLogic.setInputItems(slot.getItemInputs());
+                    processingLogic.setInputFluids(slot.getFluidInputs());
+                    result = processingLogic.process();
+                    if (result.wasSuccessful()) {
+                        return result;
+                    }
+                }
                 if (result.wasSuccessful()) {
                     return result;
                 }
-            }
-            if (result.wasSuccessful()) {
-                return result;
             }
         }
 

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
@@ -779,9 +779,6 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
                         return result;
                     }
                 }
-                if (result.wasSuccessful()) {
-                    return result;
-                }
             }
         }
 
@@ -1531,6 +1528,7 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
         IMetaTileEntity aMetaTileEntity = aTileEntity.getMetaTileEntity();
         if (aMetaTileEntity == null) return false;
         if (aMetaTileEntity instanceof IDualInputHatch hatch) {
+            if (!supportsCraftingMEBuffer()) return false;
             hatch.updateTexture(aBaseCasingIndex);
             hatch.updateCraftingIcon(this.getMachineCraftingIcon());
             return mDualInputHatches.add(hatch);


### PR DESCRIPTION
Adds a method to override when a multi isn't wanted to be able to use the Crafting ME Buffer