### PR TITLE
Fix Refractory Capsule

### DIFF
--- a/src/main/java/gregtech/loaders/postload/recipes/ExtruderRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/ExtruderRecipes.java
@@ -23,7 +23,7 @@ public class ExtruderRecipes implements Runnable {
 
         GT_Values.RA.stdBuilder()
             .itemInputs(ItemList.FR_RefractoryWax.get(1L), ItemList.Shape_Extruder_Cell.get(0L))
-            .itemOutputs(ItemList.FR_WaxCapsule.get(1L))
+            .itemOutputs(ItemList.FR_RefractoryCapsule.get(1L))
             .noFluidInputs()
             .noFluidOutputs()
             .duration(6 * SECONDS + 8 * TICKS)


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13973

just another small RA2 mistake.

Now its back:
![image](https://github.com/GTNewHorizons/GT5-Unofficial/assets/40274384/b5ded178-849a-491f-826d-e5ba7c5434bc)
