### PR TITLE
Fix server crash with RecipeFilter

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_SpecialFilter.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_SpecialFilter.java
@@ -40,8 +40,6 @@ public abstract class GT_MetaTileEntity_SpecialFilter extends GT_MetaTileEntity_
         super(aName, aTier, aInvSlotCount, aDescription, aTextures);
     }
 
-    public abstract void clickTypeIcon(boolean aRightClick, ItemStack aHandStack);
-
     @Override
     public void saveNBTData(NBTTagCompound aNBT) {
         super.saveNBTData(aNBT);
@@ -88,29 +86,10 @@ public abstract class GT_MetaTileEntity_SpecialFilter extends GT_MetaTileEntity_
                 new DrawableWidget().setDrawable(GT_UITextures.PICTURE_ARROW_24_RED.apply(19, true))
                     .setPos(152, 19)
                     .setSize(19, 24))
-            .widget(new SlotWidget(BaseSlot.phantom(inventoryHandler, 9)) {
-
-                @Override
-                protected void phantomClick(ClickData clickData, ItemStack cursorStack) {
-                    clickTypeIcon(clickData.mouseButton != 0, cursorStack);
-                }
-
-                @Override
-                public void buildTooltip(List<Text> tooltip) {
-                    super.buildTooltip(tooltip);
-                    List<Text> emptySlotTooltip = getEmptySlotTooltip();
-                    if (emptySlotTooltip != null) {
-                        tooltip.addAll(emptySlotTooltip);
-                    }
-                }
-
-                @Override
-                public Function<List<String>, List<String>> getOverwriteItemStackTooltip() {
-                    return getItemStackReplacementTooltip();
-                }
-            }.disableShiftInsert()
-                .setPos(34, 22)
-                .setBackground(GT_UITextures.BUTTON_STANDARD))
+            .widget(
+                createFilterIconSlot(BaseSlot.phantom(inventoryHandler, 9)).disableShiftInsert()
+                    .setPos(34, 22)
+                    .setBackground(GT_UITextures.BUTTON_STANDARD))
             .widget(
                 SlotGroup.ofItemHandler(inventoryHandler, 3)
                     .endAtSlot(8)
@@ -125,5 +104,31 @@ public abstract class GT_MetaTileEntity_SpecialFilter extends GT_MetaTileEntity_
                 val -> allowNbt = val,
                 GT_UITextures.OVERLAY_BUTTON_NBT,
                 () -> mTooltipCache.getData(ALLOW_NBT_TOOLTIP)));
+    }
+
+    protected abstract SlotWidget createFilterIconSlot(BaseSlot slot);
+
+    protected abstract class FilterIconSlotWidget extends SlotWidget {
+
+        public FilterIconSlotWidget(BaseSlot slot) {
+            super(slot);
+        }
+
+        @Override
+        protected abstract void phantomClick(ClickData clickData, ItemStack cursorStack);
+
+        @Override
+        public void buildTooltip(List<Text> tooltip) {
+            super.buildTooltip(tooltip);
+            List<Text> emptySlotTooltip = getEmptySlotTooltip();
+            if (emptySlotTooltip != null) {
+                tooltip.addAll(emptySlotTooltip);
+            }
+        }
+
+        @Override
+        public Function<List<String>, List<String>> getOverwriteItemStackTooltip() {
+            return getItemStackReplacementTooltip();
+        }
     }
 }

--- a/src/main/java/gregtech/common/tileentities/automation/GT_MetaTileEntity_RecipeFilter.java
+++ b/src/main/java/gregtech/common/tileentities/automation/GT_MetaTileEntity_RecipeFilter.java
@@ -7,7 +7,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -21,11 +20,12 @@ import com.gtnewhorizons.modularui.api.screen.ModularWindow;
 import com.gtnewhorizons.modularui.api.screen.UIBuildContext;
 import com.gtnewhorizons.modularui.common.widget.FakeSyncWidget;
 
-import codechicken.nei.recipe.RecipeCatalysts;
+import gregtech.api.GregTech_API;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.interfaces.tileentity.IRecipeLockable;
+import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_BasicGenerator;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_BasicMachine;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_SpecialFilter;
 import gregtech.api.multitileentity.MultiTileEntityContainer;
@@ -93,6 +93,8 @@ public class GT_MetaTileEntity_RecipeFilter extends GT_MetaTileEntity_SpecialFil
             return machine.getRecipeList();
         } else if (metaTileEntity instanceof IRecipeLockable recipeLockable) {
             return recipeLockable.getRecipeMap();
+        } else if (metaTileEntity instanceof GT_MetaTileEntity_BasicGenerator generator) {
+            return generator.getRecipes();
         }
         return null;
     }
@@ -107,10 +109,13 @@ public class GT_MetaTileEntity_RecipeFilter extends GT_MetaTileEntity_SpecialFil
     }
 
     private static List<ItemStack> getFilteredMachines(GT_Recipe.GT_Recipe_Map recipeMap) {
-        return RecipeCatalysts.getRecipeCatalysts(recipeMap.mNEIName)
-            .stream()
-            .map(positionedStack -> positionedStack.item)
-            .collect(Collectors.toList());
+        List<ItemStack> result = new ArrayList<>();
+        for (IMetaTileEntity mte : GregTech_API.METATILEENTITIES) {
+            if (getMetaTileEntityRecipeMap(mte) == recipeMap) {
+                result.add(mte.getStackForm(1));
+            }
+        }
+        return result;
     }
 
     @Override

--- a/src/main/java/gregtech/common/tileentities/automation/GT_MetaTileEntity_TypeFilter.java
+++ b/src/main/java/gregtech/common/tileentities/automation/GT_MetaTileEntity_TypeFilter.java
@@ -14,7 +14,9 @@ import net.minecraft.nbt.NBTTagCompound;
 import com.google.common.collect.ImmutableList;
 import com.gtnewhorizons.modularui.api.screen.ModularWindow;
 import com.gtnewhorizons.modularui.api.screen.UIBuildContext;
+import com.gtnewhorizons.modularui.common.internal.wrapper.BaseSlot;
 import com.gtnewhorizons.modularui.common.widget.FakeSyncWidget;
+import com.gtnewhorizons.modularui.common.widget.SlotWidget;
 
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.interfaces.ITexture;
@@ -86,7 +88,6 @@ public class GT_MetaTileEntity_TypeFilter extends GT_MetaTileEntity_SpecialFilte
                 .build());
     }
 
-    @Override
     public void clickTypeIcon(boolean aRightClick, ItemStack aHandStack) {
         if (getBaseMetaTileEntity().isServerSide()) {
             if (aHandStack != null) {
@@ -191,5 +192,22 @@ public class GT_MetaTileEntity_TypeFilter extends GT_MetaTileEntity_SpecialFilte
             replacementTooltip.addAll(mTooltipCache.getData(REPRESENTATION_SLOT_TOOLTIP).text);
             return replacementTooltip;
         };
+    }
+
+    @Override
+    protected SlotWidget createFilterIconSlot(BaseSlot slot) {
+        return new TypeFilterIconSlotWidget(slot);
+    }
+
+    private class TypeFilterIconSlotWidget extends FilterIconSlotWidget {
+
+        public TypeFilterIconSlotWidget(BaseSlot slot) {
+            super(slot);
+        }
+
+        @Override
+        protected void phantomClick(ClickData clickData, ItemStack cursorStack) {
+            clickTypeIcon(clickData.mouseButton != 0, cursorStack);
+        }
     }
 }


### PR DESCRIPTION
Close https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14216

Recipe catalysts and recipe handlers are stored only on client, so we can't just use it on server side. I'm not sure how to iterate over MuTEs, so I just leave it untouched.
This doesn't work well with machines that have multiple recipemaps; It needs some more work but it should be after stable release.