### PR TITLE
Fix ME Output Bus and Crafting Input Bus overflow when save/load

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
@@ -70,6 +70,7 @@ import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_InputBus;
 import gregtech.api.render.TextureFactory;
+import gregtech.api.util.GT_Utility;
 import mcp.mobius.waila.api.IWailaConfigHandler;
 import mcp.mobius.waila.api.IWailaDataAccessor;
 
@@ -110,7 +111,7 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
             NBTTagList inv = nbt.getTagList("inventory", Constants.NBT.TAG_COMPOUND);
             for (int i = 0; i < inv.tagCount(); i++) {
                 NBTTagCompound tagItemStack = inv.getCompoundTagAt(i);
-                var item = ItemStack.loadItemStackFromNBT(tagItemStack);
+                var item = GT_Utility.loadItem(tagItemStack);
                 if (item != null) {
                     if (item.stackSize > 0) {
                         itemInventory.add(item);
@@ -279,7 +280,7 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
 
             NBTTagList itemInventoryNbt = new NBTTagList();
             for (ItemStack itemStack : this.itemInventory) {
-                itemInventoryNbt.appendTag(itemStack.writeToNBT(new NBTTagCompound()));
+                itemInventoryNbt.appendTag(GT_Utility.saveItem(itemStack));
             }
             nbt.setTag("inventory", itemInventoryNbt);
 

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_OutputBus_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_OutputBus_ME.java
@@ -215,10 +215,7 @@ public class GT_MetaTileEntity_Hatch_OutputBus_ME extends GT_MetaTileEntity_Hatc
             for (IAEItemStack s : itemCache) {
                 if (s.getStackSize() == 0) continue;
                 NBTTagCompound tag = new NBTTagCompound();
-                NBTTagCompound tagItemStack = new NBTTagCompound();
-                s.getItemStack()
-                    .writeToNBT(tagItemStack);
-                tag.setTag("itemStack", tagItemStack);
+                tag.setTag("itemStack", GT_Utility.saveItem(s.getItemStack()));
                 tag.setLong("size", s.getStackSize());
                 items.appendTag(tag);
             }


### PR DESCRIPTION
The vanilla ItemStack limits the number of item to at most 127, which causes items to be voided when the game restarts.

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14199