### PR TITLE
Crafting input - Optimize isEmpty check to reduce lag

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
@@ -146,13 +146,13 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
         }
 
         private boolean isEmpty() {
-            if (itemInventory.isEmpty() && fluidInventory.isEmpty()) return true;
-
             // if one item / fluid is empty then it should be safe to assume all other is empty,
             // or at least won't require a recipe check, as long as the pattern is sane
             if (!itemInventory.isEmpty()) return itemInventory.get(0) == null || itemInventory.get(0).stackSize <= 0;
 
-            return fluidInventory.get(0) == null || fluidInventory.get(0).amount <= 0;
+            if (!fluidInventory.isEmpty()) return fluidInventory.get(0) == null || fluidInventory.get(0).amount <= 0;
+
+            return true;
         }
 
         @Override

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
@@ -148,15 +148,11 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
         private boolean isEmpty() {
             if (itemInventory.isEmpty() && fluidInventory.isEmpty()) return true;
 
-            for (ItemStack itemStack : itemInventory) {
-                if (itemStack != null && itemStack.stackSize > 0) return false;
-            }
+            // if one item / fluid is empty then it should be safe to assume all other is empty,
+            // or at least won't require a recipe check, as long as the pattern is sane
+            if (!itemInventory.isEmpty()) return itemInventory.get(0) == null || itemInventory.get(0).stackSize <= 0;
 
-            for (FluidStack fluidStack : fluidInventory) {
-                if (fluidStack != null && fluidStack.amount > 0) return false;
-            }
-
-            return true;
+            return fluidInventory.get(0) == null || fluidInventory.get(0).amount <= 0;
         }
 
         @Override


### PR DESCRIPTION
After a large craft there could be a lot of slots with 0 stack size and so this check would be slow. This optimizes it to `O(1)` to reduce lag when the server has been running for a while.

Will test it later when I can restart my server to be sure