### PR TITLE
Fix GT_RecipeConstants.Fuel

### DIFF
--- a/src/main/java/gregtech/api/util/GT_RecipeConstants.java
+++ b/src/main/java/gregtech/api/util/GT_RecipeConstants.java
@@ -268,7 +268,7 @@ public class GT_RecipeConstants {
     public static IGT_RecipeMap Fuel = IGT_RecipeMap.newRecipeMap(builder -> {
         builder.validateInputCount(1, 1)
             .validateNoInputFluid()
-            .validateOutputCount(-1, 0)
+            .validateOutputCount(-1, 1)
             .validateNoOutputFluid();
         if (!builder.isValid()) return Collections.emptyList();
         int fuelType = builder.getMetadata(FUEL_TYPE);


### PR DESCRIPTION
There are fuel recipes with item outputs, example from GT5:
https://github.com/GTNewHorizons/GT5-Unofficial/blob/3d8dd7cb3583f8773a723fad4ac96443a68ddf2a/src/main/java/gregtech/loaders/load/GT_ItemIterator.java#L277-L286