### PR TITLE
Adds item and charging info to Locker WAILA panel

### DIFF
--- a/src/main/java/gregtech/api/util/GT_ModHandler.java
+++ b/src/main/java/gregtech/api/util/GT_ModHandler.java
@@ -2342,20 +2342,17 @@ public class GT_ModHandler {
         }
 
         final Item item = aStack.getItem();
-        if (item == null) {
-            return Optional.empty();
-        }
 
-        if (item instanceof GT_MetaBase_Item) {
-            final Long[] stats = ((GT_MetaBase_Item) item).getElectricStats(aStack);
+        if (item instanceof final GT_MetaBase_Item metaBaseItem) {
+            final Long[] stats = metaBaseItem.getElectricStats(aStack);
             if (stats != null && stats.length > 0) {
-                return Optional.of(new Long[] { ((GT_MetaBase_Item) item).getRealCharge(aStack), stats[0] });
+                return Optional.of(new Long[] { metaBaseItem.getRealCharge(aStack), stats[0] });
             }
 
-        } else if (item instanceof IElectricItem) {
+        } else if (item instanceof final IElectricItem ic2ElectricItem) {
             return Optional.of(
                 new Long[] { (long) ic2.api.item.ElectricItem.manager.getCharge(aStack),
-                    (long) ((IElectricItem) aStack.getItem()).getMaxCharge(aStack) });
+                    (long) ic2ElectricItem.getMaxCharge(aStack) });
         }
 
         return Optional.empty();

--- a/src/main/java/gregtech/api/util/GT_ModHandler.java
+++ b/src/main/java/gregtech/api/util/GT_ModHandler.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -63,6 +64,7 @@ import gregtech.api.enums.ToolDictNames;
 import gregtech.api.interfaces.IDamagableItem;
 import gregtech.api.interfaces.IItemContainer;
 import gregtech.api.interfaces.internal.IGT_CraftingRecipe;
+import gregtech.api.items.GT_MetaBase_Item;
 import gregtech.api.objects.GT_HashSet;
 import gregtech.api.objects.GT_ItemStack;
 import gregtech.api.objects.ItemData;
@@ -2325,6 +2327,38 @@ public class GT_ModHandler {
             /* Do nothing */
         }
         return false;
+    }
+
+    /**
+     * Returns the current charge and maximum charge of an ItemStack.
+     *
+     * @param aStack Any ItemStack.
+     * @return Optional.empty() if the stack is null or not an electric item, or an Optional containing a payload of an
+     *         array containing [ current_charge, maximum_charge ] on success.
+     */
+    public static Optional<Long[]> getElectricItemCharge(ItemStack aStack) {
+        if (aStack == null || !isElectricItem(aStack)) {
+            return Optional.empty();
+        }
+
+        final Item item = aStack.getItem();
+        if (item == null) {
+            return Optional.empty();
+        }
+
+        if (item instanceof GT_MetaBase_Item) {
+            final Long[] stats = ((GT_MetaBase_Item) item).getElectricStats(aStack);
+            if (stats != null && stats.length > 0) {
+                return Optional.of(new Long[] { ((GT_MetaBase_Item) item).getRealCharge(aStack), stats[0] });
+            }
+
+        } else if (item instanceof IElectricItem) {
+            return Optional.of(
+                new Long[] { (long) ic2.api.item.ElectricItem.manager.getCharge(aStack),
+                    (long) ((IElectricItem) aStack.getItem()).getMaxCharge(aStack) });
+        }
+
+        return Optional.empty();
     }
 
     /**

--- a/src/main/resources/assets/gregtech/lang/en_US.lang
+++ b/src/main/resources/assets/gregtech/lang/en_US.lang
@@ -1324,3 +1324,7 @@ gt.solar.system.phobos=Phobos
 gt.specialvalue.stages=Stages:
 
 gt.multiBlock.controller.cokeOven=Coke Oven
+
+gt.locker.waila_armor_slot_none=Slot %s: §7None
+gt.locker.waila_armor_slot_generic=Slot %s: §e%s
+gt.locker.waila_armor_slot_charged=Slot %s: §e%s§r (%s%s%%§r)


### PR DESCRIPTION
This is a new feature, and doesn't need to be in 2.4.0 right away if a feature freeze is in place.

This PR adds more information to the WAILA readout for GT Lockers. Includes charge level for each item, if appropriate. 

![image](https://github.com/GTNewHorizons/GT5-Unofficial/assets/33518699/4fc4ae41-7073-4d99-81c3-8255d1a27a95)

![image](https://github.com/GTNewHorizons/GT5-Unofficial/assets/33518699/14f63071-ea96-483c-9cf6-839eb0195123)
