### PR TITLE
Fix startup tier for fusion NEI

### DIFF
--- a/src/main/java/gregtech/nei/FusionSpecialValueFormatter.java
+++ b/src/main/java/gregtech/nei/FusionSpecialValueFormatter.java
@@ -28,10 +28,8 @@ public class FusionSpecialValueFormatter implements INEISpecialInfoFormatter {
             tier = 2;
         } else if (startupPower <= 40 * M * 16) {
             tier = 3;
-        } else if (startupPower <= 80 * M * 16) {
-            tier = 4;
         } else {
-            tier = 5;
+            tier = 4;
         }
 
         if (voltage <= GT_Values.V[6]) {


### PR DESCRIPTION
Close https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14228
Mk4 accepts 320M per hatch, but `320 * M * 16` exceeds `Integer.MAX_VALUE`