### PR TITLE
Fix tier display for Fusion NEI header

### DIFF
--- a/src/main/java/gregtech/common/power/FusionPower.java
+++ b/src/main/java/gregtech/common/power/FusionPower.java
@@ -46,7 +46,7 @@ public class FusionPower extends BasicMachineEUPower {
     @Override
     public String getTierString() {
         return GT_Values.TIER_COLORS[tier] + "MK "
-            + FusionSpecialValueFormatter.getFusionTier(specialValue, recipeEuPerTick)
+            + (tier - 5) // Mk1 <-> LuV
             + EnumChatFormatting.RESET;
     }
 }


### PR DESCRIPTION
It's supposed to show tier of catalyst currently focused on, not calculate tier based on specific recipe.