### PR TITLE
Add BarnardaC bee effect, enhance tooltip and waila for iapiary

### DIFF
--- a/src/main/java/gregtech/loaders/misc/GT_BeeDefinition.java
+++ b/src/main/java/gregtech/loaders/misc/GT_BeeDefinition.java
@@ -713,6 +713,11 @@ public enum GT_BeeDefinition implements IBeeDefinition {
         IBeeMutationCustom tMutation = dis.registerMutation(LEAD, OSMIUM, 1);
         tMutation.requireResource("blockIndium");
         tMutation.addMutationCondition(new GT_Bees.DimensionMutationCondition(39, "Venus")); // Venus Dim
+        // Harder mutation that isn't dim locked
+        tMutation = dis.registerMutation(SILVER, OSMIUM, 1);
+        tMutation.requireResource("blockCinobiteA243");
+        tMutation.addMutationCondition(new GT_Bees.DimensionMutationCondition(60, "Bedrock")); // Thaumic Tinkerer
+                                                                                               // Bedrock Dim
     }),
 
     // IC2
@@ -2224,7 +2229,10 @@ public enum GT_BeeDefinition implements IBeeDefinition {
         beeSpecies.addProduct(GT_Bees.combs.getStackForType(CombType.BARNARDA), 0.25f);
         beeSpecies.setHumidity(ARID);
         beeSpecies.setTemperature(HOT);
-    }, template -> AlleleHelper.instance.set(template, LIFESPAN, Lifespan.SHORTEST), dis -> {
+    }, template -> {
+        AlleleHelper.instance.set(template, LIFESPAN, Lifespan.SHORTEST);
+        AlleleHelper.instance.set(template, EFFECT, getEffect(GREGTECH, "Treetwister"));
+    }, dis -> {
         IBeeMutationCustom tMutation = dis.registerMutation(BARNARDA, AMERICIUM, 3, 2);
         if (GalaxySpace.isModLoaded()) {
             tMutation.requireResource(GameRegistry.findBlock(GalaxySpace.ID, "barnardaEgrunt"), 0);

--- a/src/main/java/gregtech/loaders/misc/GT_Bees.java
+++ b/src/main/java/gregtech/loaders/misc/GT_Bees.java
@@ -4,41 +4,29 @@ import static gregtech.api.enums.Mods.Forestry;
 import static gregtech.api.enums.Mods.GalaxySpace;
 import static gregtech.api.enums.Mods.TwilightForest;
 
-import java.util.Arrays;
-
-import net.minecraft.block.Block;
-import net.minecraft.item.ItemStack;
-import net.minecraft.util.ChunkCoordinates;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.BiomeGenBase;
 
-import forestry.Forestry;
-import forestry.api.apiculture.BeeManager;
 import forestry.api.apiculture.EnumBeeChromosome;
 import forestry.api.apiculture.IAlleleBeeEffect;
-import forestry.api.apiculture.IBeeGenome;
-import forestry.api.apiculture.IBeeHousing;
-import forestry.api.apiculture.IBeeModifier;
 import forestry.api.core.IClimateProvider;
 import forestry.api.genetics.AlleleManager;
 import forestry.api.genetics.IAllele;
 import forestry.api.genetics.IAlleleArea;
 import forestry.api.genetics.IAlleleFloat;
 import forestry.api.genetics.IAlleleInteger;
-import forestry.api.genetics.IEffectData;
 import forestry.api.genetics.IGenome;
 import forestry.api.genetics.IMutationCondition;
-import forestry.apiculture.genetics.alleles.AlleleEffect;
 import forestry.core.genetics.alleles.Allele;
-import forestry.core.genetics.alleles.AlleleArea;
 import forestry.core.utils.StringUtil;
 import gregtech.GT_Mod;
-import gregtech.api.util.GT_ModHandler;
 import gregtech.common.bees.GT_AlleleHelper;
 import gregtech.common.items.ItemComb;
 import gregtech.common.items.ItemDrop;
 import gregtech.common.items.ItemPollen;
 import gregtech.common.items.ItemPropolis;
+import gregtech.loaders.misc.bees.GT_AlleleEffect;
+import gregtech.loaders.misc.bees.GT_EffectTreeTwister;
 
 public class GT_Bees {
 
@@ -106,68 +94,11 @@ public class GT_Bees {
 
         if (GalaxySpace.isModLoaded() && TwilightForest.isModLoaded()) {
             GT_Mod.GT_FML_LOGGER.info("treetwisterEffect: GalaxySpace and TwilightForest loaded, using default impl");
-            // Create a custom bee effect using an anonymous subclass of AlleleEffect
-            // This and the helper class AlleleEffect are based on MagicBees' TransformationEffect
-            treetwisterEffect = new AlleleEffect("effectTreetwister", false) {
-
-                private static Integer[] allowedDims = { 2, // spectre
-                    112, // last millenium
-                    60, // bedrock
-                    69, // pocket plane
-                };
-
-                public IEffectData validateStorage(IEffectData storedData) {
-                    return storedData; // unused for this effect
-                }
-
-                public IEffectData doEffect(IBeeGenome genome, IEffectData storedData, IBeeHousing housing) {
-                    World world = housing.getWorld();
-                    if (!Arrays.asList(allowedDims)
-                        .contains(world.provider.dimensionId)) {
-                        return storedData;
-                    }
-                    ChunkCoordinates coords = housing.getCoordinates();
-                    IBeeModifier beeModifier = BeeManager.beeRoot.createBeeHousingModifier(housing);
-
-                    // Get random coords within territory
-                    int xRange = (int) (beeModifier.getTerritoryModifier(genome, 1f) * genome.getTerritory()[0]);
-                    int yRange = (int) (beeModifier.getTerritoryModifier(genome, 1f) * genome.getTerritory()[1]);
-                    int zRange = (int) (beeModifier.getTerritoryModifier(genome, 1f) * genome.getTerritory()[2]);
-
-                    int xCoord = coords.posX + world.rand.nextInt(xRange) - xRange / 2;
-                    int yCoord = coords.posY + world.rand.nextInt(yRange) - yRange / 2;
-                    int zCoord = coords.posZ + world.rand.nextInt(zRange) - zRange / 2;
-
-                    ItemStack sourceBlock = new ItemStack(
-                        world.getBlock(xCoord, yCoord, zCoord),
-                        1,
-                        world.getBlockMetadata(xCoord, yCoord, zCoord));
-                    ItemStack tfTransSapling = GT_ModHandler.getModItem(TwilightForest.ID, "tile.TFSapling", 1, 6);
-                    ItemStack barnSapling = GT_ModHandler.getModItem(GalaxySpace.ID, "barnardaCsapling", 1, 0);
-                    if (tfTransSapling == null) {
-                        GT_Mod.GT_FML_LOGGER.info(
-                            "treetwisterEffect.doEffect: Could not get ItemStack for Tree of Transformation sapling");
-                    }
-                    if (barnSapling == null) {
-                        GT_Mod.GT_FML_LOGGER
-                            .info("treetwisterEffect.doEffect: Could not get ItemStack for BarnardaC sapling");
-                    }
-                    if (tfTransSapling != null && barnSapling != null && tfTransSapling.isItemEqual(sourceBlock)) {
-                        world.setBlock(
-                            xCoord,
-                            yCoord,
-                            zCoord,
-                            Block.getBlockFromItem(barnSapling.getItem()),
-                            barnSapling.getItemDamage(),
-                            2);
-                    }
-                    return storedData;
-                }
-            };
+            treetwisterEffect = new GT_EffectTreeTwister();
         } else {
             GT_Mod.GT_FML_LOGGER
                 .info("treetwisterEffect: GalaxySpace or TwilightForest was not loaded, using fallback impl");
-            treetwisterEffect = AlleleEffect.forestryBaseEffect;
+            treetwisterEffect = GT_AlleleEffect.forestryBaseEffect;
         }
     }
 
@@ -216,43 +147,6 @@ public class GT_Bees {
         @Override
         public int[] getValue() {
             return this.value;
-        }
-    }
-
-    // helper class for implementing custom bee effects, based on MagicBees' implementation
-    private abstract static class AlleleEffect extends Allele implements IAlleleBeeEffect {
-
-        public static IAlleleBeeEffect forestryBaseEffect = (IAlleleBeeEffect) AlleleManager.alleleRegistry
-            .getAllele("forestry.effectNone");
-        protected boolean combinable;
-
-        public AlleleEffect(String id, boolean isDominant) {
-            super("gregtech." + id, "gregtech." + id, isDominant);
-            AlleleManager.alleleRegistry.registerAllele(this, EnumBeeChromosome.EFFECT);
-            combinable = false;
-        }
-
-        @Override
-        public boolean isCombinable() {
-            return combinable;
-        }
-
-        // Not used by treetwisterEffect, but may be used by other custom effects in the future
-        @SuppressWarnings("unused")
-        public AlleleEffect setIsCombinable(boolean canCombine) {
-            combinable = canCombine;
-            return this;
-        }
-
-        @Override
-        public abstract IEffectData validateStorage(IEffectData storedData);
-
-        @Override
-        public abstract IEffectData doEffect(IBeeGenome genome, IEffectData storedData, IBeeHousing housing);
-
-        @Override
-        public IEffectData doFX(IBeeGenome genome, IEffectData storedData, IBeeHousing housing) {
-            return forestryBaseEffect.doFX(genome, storedData, housing);
         }
     }
 

--- a/src/main/java/gregtech/loaders/misc/GT_Bees.java
+++ b/src/main/java/gregtech/loaders/misc/GT_Bees.java
@@ -98,7 +98,7 @@ public class GT_Bees {
         } else {
             GT_Mod.GT_FML_LOGGER
                 .info("treetwisterEffect: GalaxySpace or TwilightForest was not loaded, using fallback impl");
-            treetwisterEffect = GT_AlleleEffect.forestryBaseEffect;
+            treetwisterEffect = GT_AlleleEffect.FORESTRY_BASE_EFFECT;
         }
     }
 

--- a/src/main/java/gregtech/loaders/misc/bees/GT_AlleleEffect.java
+++ b/src/main/java/gregtech/loaders/misc/bees/GT_AlleleEffect.java
@@ -11,7 +11,7 @@ import forestry.core.genetics.alleles.Allele;
 // helper class for implementing custom bee effects, based on MagicBees' implementation
 public abstract class GT_AlleleEffect extends Allele implements IAlleleBeeEffect {
 
-    public static IAlleleBeeEffect forestryBaseEffect = (IAlleleBeeEffect) AlleleManager.alleleRegistry
+    public static final IAlleleBeeEffect FORESTRY_BASE_EFFECT = (IAlleleBeeEffect) AlleleManager.alleleRegistry
         .getAllele("forestry.effectNone");
     protected boolean combinable;
 
@@ -26,8 +26,6 @@ public abstract class GT_AlleleEffect extends Allele implements IAlleleBeeEffect
         return combinable;
     }
 
-    // Not used by treetwisterEffect, but may be used by other custom effects in the future
-    @SuppressWarnings("unused")
     public GT_AlleleEffect setIsCombinable(boolean canCombine) {
         combinable = canCombine;
         return this;
@@ -41,6 +39,6 @@ public abstract class GT_AlleleEffect extends Allele implements IAlleleBeeEffect
 
     @Override
     public IEffectData doFX(IBeeGenome genome, IEffectData storedData, IBeeHousing housing) {
-        return forestryBaseEffect.doFX(genome, storedData, housing);
+        return FORESTRY_BASE_EFFECT.doFX(genome, storedData, housing);
     }
 }

--- a/src/main/java/gregtech/loaders/misc/bees/GT_AlleleEffect.java
+++ b/src/main/java/gregtech/loaders/misc/bees/GT_AlleleEffect.java
@@ -1,0 +1,46 @@
+package gregtech.loaders.misc.bees;
+
+import forestry.api.apiculture.EnumBeeChromosome;
+import forestry.api.apiculture.IAlleleBeeEffect;
+import forestry.api.apiculture.IBeeGenome;
+import forestry.api.apiculture.IBeeHousing;
+import forestry.api.genetics.AlleleManager;
+import forestry.api.genetics.IEffectData;
+import forestry.core.genetics.alleles.Allele;
+
+// helper class for implementing custom bee effects, based on MagicBees' implementation
+public abstract class GT_AlleleEffect extends Allele implements IAlleleBeeEffect {
+
+    public static IAlleleBeeEffect forestryBaseEffect = (IAlleleBeeEffect) AlleleManager.alleleRegistry
+        .getAllele("forestry.effectNone");
+    protected boolean combinable;
+
+    public GT_AlleleEffect(String id, boolean isDominant) {
+        super("gregtech." + id, "gregtech." + id, isDominant);
+        AlleleManager.alleleRegistry.registerAllele(this, EnumBeeChromosome.EFFECT);
+        combinable = false;
+    }
+
+    @Override
+    public boolean isCombinable() {
+        return combinable;
+    }
+
+    // Not used by treetwisterEffect, but may be used by other custom effects in the future
+    @SuppressWarnings("unused")
+    public GT_AlleleEffect setIsCombinable(boolean canCombine) {
+        combinable = canCombine;
+        return this;
+    }
+
+    @Override
+    public abstract IEffectData validateStorage(IEffectData storedData);
+
+    @Override
+    public abstract IEffectData doEffect(IBeeGenome genome, IEffectData storedData, IBeeHousing housing);
+
+    @Override
+    public IEffectData doFX(IBeeGenome genome, IEffectData storedData, IBeeHousing housing) {
+        return forestryBaseEffect.doFX(genome, storedData, housing);
+    }
+}

--- a/src/main/java/gregtech/loaders/misc/bees/GT_EffectTreeTwister.java
+++ b/src/main/java/gregtech/loaders/misc/bees/GT_EffectTreeTwister.java
@@ -20,23 +20,27 @@ import gregtech.api.util.GT_ModHandler;
 
 public class GT_EffectTreeTwister extends GT_AlleleEffect {
 
-    private static final Integer[] allowedDims = { 2, // spectre
+    private static final Integer[] ALLOWED_DIMS = { 2, // spectre
         112, // last millenium
         60, // bedrock
         69, // pocket plane
     };
 
-    private static final ItemStack tfTransSapling = GT_ModHandler.getModItem(TwilightForest.ID, "tile.TFSapling", 1, 6);
-    private static final ItemStack barnSapling = GT_ModHandler.getModItem(GalaxySpace.ID, "barnardaCsapling", 1, 0);
+    private static final ItemStack TF_TRANS_SAPLING = GT_ModHandler
+        .getModItem(TwilightForest.ID, "tile.TFSapling", 1, 6);
+    private static final ItemStack BARN_SAPLING = GT_ModHandler.getModItem(GalaxySpace.ID, "barnardaCsapling", 1, 0);
+
+    static {
+        if (TF_TRANS_SAPLING == null) {
+            GT_Mod.GT_FML_LOGGER.info("GT_EffectTreeTwister(): Could not get ItemStack for BarnardaC sapling");
+        }
+        if (BARN_SAPLING == null) {
+            GT_Mod.GT_FML_LOGGER.info("GT_EffectTreeTwister(): Could not get ItemStack for BarnardaC sapling");
+        }
+    }
 
     public GT_EffectTreeTwister() {
         super("effectTreetwister", false);
-        if (tfTransSapling == null) {
-            GT_Mod.GT_FML_LOGGER.info("GT_EffectTreeTwister(): Could not get ItemStack for BarnardaC sapling");
-        }
-        if (barnSapling == null) {
-            GT_Mod.GT_FML_LOGGER.info("GT_EffectTreeTwister(): Could not get ItemStack for BarnardaC sapling");
-        }
     }
 
     public IEffectData validateStorage(IEffectData storedData) {
@@ -44,11 +48,11 @@ public class GT_EffectTreeTwister extends GT_AlleleEffect {
     }
 
     public IEffectData doEffect(IBeeGenome genome, IEffectData storedData, IBeeHousing housing) {
-        if (tfTransSapling == null || barnSapling == null) {
+        if (TF_TRANS_SAPLING == null || BARN_SAPLING == null) {
             return storedData;
         }
         World world = housing.getWorld();
-        if (!Arrays.asList(allowedDims)
+        if (!Arrays.asList(ALLOWED_DIMS)
             .contains(world.provider.dimensionId)) {
             return storedData;
         }
@@ -68,13 +72,13 @@ public class GT_EffectTreeTwister extends GT_AlleleEffect {
             world.getBlock(xCoord, yCoord, zCoord),
             1,
             world.getBlockMetadata(xCoord, yCoord, zCoord));
-        if (tfTransSapling != null && barnSapling != null && tfTransSapling.isItemEqual(sourceBlock)) {
+        if (TF_TRANS_SAPLING != null && BARN_SAPLING != null && TF_TRANS_SAPLING.isItemEqual(sourceBlock)) {
             world.setBlock(
                 xCoord,
                 yCoord,
                 zCoord,
-                Block.getBlockFromItem(barnSapling.getItem()),
-                barnSapling.getItemDamage(),
+                Block.getBlockFromItem(BARN_SAPLING.getItem()),
+                BARN_SAPLING.getItemDamage(),
                 2);
         }
         return storedData;

--- a/src/main/java/gregtech/loaders/misc/bees/GT_EffectTreeTwister.java
+++ b/src/main/java/gregtech/loaders/misc/bees/GT_EffectTreeTwister.java
@@ -1,0 +1,82 @@
+package gregtech.loaders.misc.bees;
+
+import static gregtech.api.enums.Mods.GalaxySpace;
+import static gregtech.api.enums.Mods.TwilightForest;
+
+import java.util.Arrays;
+
+import net.minecraft.block.Block;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ChunkCoordinates;
+import net.minecraft.world.World;
+
+import forestry.api.apiculture.BeeManager;
+import forestry.api.apiculture.IBeeGenome;
+import forestry.api.apiculture.IBeeHousing;
+import forestry.api.apiculture.IBeeModifier;
+import forestry.api.genetics.IEffectData;
+import gregtech.GT_Mod;
+import gregtech.api.util.GT_ModHandler;
+
+public class GT_EffectTreeTwister extends GT_AlleleEffect {
+
+    private static final Integer[] allowedDims = { 2, // spectre
+        112, // last millenium
+        60, // bedrock
+        69, // pocket plane
+    };
+
+    private static final ItemStack tfTransSapling = GT_ModHandler.getModItem(TwilightForest.ID, "tile.TFSapling", 1, 6);
+    private static final ItemStack barnSapling = GT_ModHandler.getModItem(GalaxySpace.ID, "barnardaCsapling", 1, 0);
+
+    public GT_EffectTreeTwister() {
+        super("effectTreetwister", false);
+        if (tfTransSapling == null) {
+            GT_Mod.GT_FML_LOGGER.info("GT_EffectTreeTwister(): Could not get ItemStack for BarnardaC sapling");
+        }
+        if (barnSapling == null) {
+            GT_Mod.GT_FML_LOGGER.info("GT_EffectTreeTwister(): Could not get ItemStack for BarnardaC sapling");
+        }
+    }
+
+    public IEffectData validateStorage(IEffectData storedData) {
+        return storedData; // unused for this effect
+    }
+
+    public IEffectData doEffect(IBeeGenome genome, IEffectData storedData, IBeeHousing housing) {
+        if (tfTransSapling == null || barnSapling == null) {
+            return storedData;
+        }
+        World world = housing.getWorld();
+        if (!Arrays.asList(allowedDims)
+            .contains(world.provider.dimensionId)) {
+            return storedData;
+        }
+        ChunkCoordinates coords = housing.getCoordinates();
+        IBeeModifier beeModifier = BeeManager.beeRoot.createBeeHousingModifier(housing);
+
+        // Get random coords within territory
+        int xRange = (int) (beeModifier.getTerritoryModifier(genome, 1f) * genome.getTerritory()[0]);
+        int yRange = (int) (beeModifier.getTerritoryModifier(genome, 1f) * genome.getTerritory()[1]);
+        int zRange = (int) (beeModifier.getTerritoryModifier(genome, 1f) * genome.getTerritory()[2]);
+
+        int xCoord = coords.posX + world.rand.nextInt(xRange) - xRange / 2;
+        int yCoord = coords.posY + world.rand.nextInt(yRange) - yRange / 2;
+        int zCoord = coords.posZ + world.rand.nextInt(zRange) - zRange / 2;
+
+        ItemStack sourceBlock = new ItemStack(
+            world.getBlock(xCoord, yCoord, zCoord),
+            1,
+            world.getBlockMetadata(xCoord, yCoord, zCoord));
+        if (tfTransSapling != null && barnSapling != null && tfTransSapling.isItemEqual(sourceBlock)) {
+            world.setBlock(
+                xCoord,
+                yCoord,
+                zCoord,
+                Block.getBlockFromItem(barnSapling.getItem()),
+                barnSapling.getItemDamage(),
+                2);
+        }
+        return storedData;
+    }
+}

--- a/src/main/resources/assets/gregtech/lang/en_US.lang
+++ b/src/main/resources/assets/gregtech/lang/en_US.lang
@@ -1193,7 +1193,7 @@ gregtech.speedUnproductive=Unproductive
 gregtech.speedAccelerated=Accelerated
 gregtech.lifeBlink=Blink
 gregtech.lifeEon=Eon
-gregtech.effectTreetwister=Hacatu's Tree Twister
+gregtech.effectTreetwister=Treetwister
 
 entity.gregtech.GT_Entity_Arrow.name= a GregTech arrow
 

--- a/src/main/resources/assets/gregtech/lang/en_US.lang
+++ b/src/main/resources/assets/gregtech/lang/en_US.lang
@@ -1193,6 +1193,7 @@ gregtech.speedUnproductive=Unproductive
 gregtech.speedAccelerated=Accelerated
 gregtech.lifeBlink=Blink
 gregtech.lifeEon=Eon
+gregtech.effectTreetwister=Hacatu's Tree Twister
 
 entity.gregtech.GT_Entity_Arrow.name= a GregTech arrow
 


### PR DESCRIPTION
See [here](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14245).

Adds a new effect for the BarnardaC bee, "Hacatu's Tree Twister".  This is meant to allow no space players to get Radox.  This effect changes Tree of Transformation saplings into BarnardaC saplings, but only in the Spectre, Bedrock, Pocket Plane, or Last Millenium dimensions.  I'm open to changing these requirements if someone has a better idea.  In particular, Tree of Transformation saplings are not obtainable in skyblock, so it might be good to widen the set of acceptable saplings or provide a way to get them in skyblock.

Adds alternative breeding recipe for no space players to get Indium bee: Silver Bee + Osmium Bee on Block of Cinobite A243 in the Bedrock dimension.  I chose Cinobite because I noticed Naquadria processing (including from the Naquadria Bee which is not mutatron blacklisted) gives Indium as a byproduct, but Naquadria is not a hard enough gate so I chose a ZPM alloy.  Runakai did not want me to remove the Indium Bee from the mutatron blacklist so I did this instead.  If this is not acceptable I will remove this change.

Extends industrial apiary tooltip to explain the production formula and production upgrades.

Extends industrial apiary waila hud to list the effective production modifier.