### PR TITLE
Remove duplicate obsidian long rod

### DIFF
--- a/src/main/java/gregtech/api/enums/Materials.java
+++ b/src/main/java/gregtech/api/enums/Materials.java
@@ -2436,6 +2436,7 @@ public class Materials implements IColorModulationContainer, ISubTagContainer {
             OrePrefixes.ingotHot.disableComponent(Materials.PulsatingIron);
             OrePrefixes.ingotHot.disableComponent(Materials.CrudeSteel);
             OrePrefixes.dust.disableComponent(Materials.CertusQuartzCharged);
+            OrePrefixes.stickLong.disableComponent(Materials.Obsidian);
         }
 
         fillGeneratedMaterialsMap();

--- a/src/main/java/gregtech/api/enums/Materials.java
+++ b/src/main/java/gregtech/api/enums/Materials.java
@@ -2435,8 +2435,6 @@ public class Materials implements IColorModulationContainer, ISubTagContainer {
             OrePrefixes.ingotHot.disableComponent(Materials.EnergeticAlloy);
             OrePrefixes.ingotHot.disableComponent(Materials.PulsatingIron);
             OrePrefixes.ingotHot.disableComponent(Materials.CrudeSteel);
-            OrePrefixes.dust.disableComponent(Materials.CertusQuartzCharged);
-            OrePrefixes.stickLong.disableComponent(Materials.Obsidian);
         }
 
         fillGeneratedMaterialsMap();

--- a/src/main/java/gregtech/api/enums/OrePrefixes.java
+++ b/src/main/java/gregtech/api/enums/OrePrefixes.java
@@ -795,6 +795,8 @@ public enum OrePrefixes {
         arrowGtPlastic.mNotGeneratedItems.add(MaterialsUEVplus.TranscendentMetal);
         arrow.mNotGeneratedItems.add(MaterialsUEVplus.TranscendentMetal);
         arrowGtWood.mNotGeneratedItems.add(MaterialsUEVplus.TranscendentMetal);
+        stickLong.mNotGeneratedItems.add(Materials.Obsidian);
+        dust.mNotGeneratedItems.add(Materials.CertusQuartzCharged);
 
         // -----
 


### PR DESCRIPTION
Remove the duplicate obsidian long rod gt generates now.

Goes together with a https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/720. Together they fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14362.

with both PRs, the materials page now has the coremod one and it is the one in all recipes (usage and creation)
![image](https://github.com/GTNewHorizons/GT5-Unofficial/assets/40274384/68a93cbd-52a6-41b9-abb8-39162b4bcc7b)
