### PR TITLE
Make Crafting Input Bus / Hatch compatible with some non-GPL multis

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
@@ -78,11 +78,7 @@ import gregtech.client.GT_SoundLoop;
 import gregtech.common.GT_Pollution;
 import gregtech.common.gui.modularui.widget.CheckRecipeResultSyncer;
 import gregtech.common.items.GT_MetaGenerated_Tool_01;
-import gregtech.common.tileentities.machines.GT_MetaTileEntity_Hatch_InputBus_ME;
-import gregtech.common.tileentities.machines.GT_MetaTileEntity_Hatch_OutputBus_ME;
-import gregtech.common.tileentities.machines.GT_MetaTileEntity_Hatch_Output_ME;
-import gregtech.common.tileentities.machines.IDualInputHatch;
-import gregtech.common.tileentities.machines.IDualInputInventory;
+import gregtech.common.tileentities.machines.*;
 import gregtech.common.tileentities.machines.multi.GT_MetaTileEntity_LargeTurbine;
 import mcp.mobius.waila.api.IWailaConfigHandler;
 import mcp.mobius.waila.api.IWailaDataAccessor;
@@ -1351,6 +1347,8 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
     public ArrayList<ItemStack> getStoredInputs() {
         ArrayList<ItemStack> rList = new ArrayList<>();
         HashMap<String, ItemStack> rInputBusMeList = new HashMap<>();
+        HashMap<String, ItemStack> rCraftingInputBusList = new HashMap<>();
+
         for (GT_MetaTileEntity_Hatch_InputBus tHatch : mInputBusses) {
             tHatch.mRecipeMap = getRecipeMap();
             if (isValidMetaTileEntity(tHatch)) {
@@ -1368,9 +1366,20 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
                 }
             }
         }
+
+        for (IDualInputHatch tHatch : mDualInputHatches) {
+            if (supportsCraftingMEBuffer() && tHatch instanceof GT_MetaTileEntity_Hatch_CraftingInput_ME) {
+                for (ItemStack itemStack : ((GT_MetaTileEntity_Hatch_CraftingInput_ME) tHatch)
+                    .getCombinedItemInputs()) {
+                    if (itemStack != null) rCraftingInputBusList.put(itemStack.toString(), itemStack);
+                }
+            }
+        }
+
         if (getStackInSlot(1) != null && getStackInSlot(1).getUnlocalizedName()
             .startsWith("gt.integrated_circuit")) rList.add(getStackInSlot(1));
         if (!rInputBusMeList.isEmpty()) rList.addAll(rInputBusMeList.values());
+        if (!rCraftingInputBusList.isEmpty()) rList.addAll(rCraftingInputBusList.values());
         return rList;
     }
 

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
@@ -1323,6 +1323,7 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
 
     public ArrayList<FluidStack> getStoredFluids() {
         ArrayList<FluidStack> rList = new ArrayList<>();
+        HashMap<String, FluidStack> rInputHatchMeList = new HashMap<>();
         for (GT_MetaTileEntity_Hatch_Input tHatch : mInputHatches) {
             tHatch.mRecipeMap = getRecipeMap();
             if (tHatch instanceof GT_MetaTileEntity_Hatch_MultiInput) {
@@ -1341,6 +1342,17 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
                 }
             }
         }
+
+        for (IDualInputHatch tHatch : mDualInputHatches) {
+            if (supportsCraftingMEBuffer() && tHatch instanceof GT_MetaTileEntity_Hatch_CraftingInput_ME) {
+                for (FluidStack fluidStack : ((GT_MetaTileEntity_Hatch_CraftingInput_ME) tHatch)
+                    .getCombinedFluidInputs()) {
+                    if (fluidStack != null) rInputHatchMeList.put(fluidStack.toString(), fluidStack);
+                }
+            }
+        }
+
+        if (!rInputHatchMeList.isEmpty()) rList.addAll(rInputHatchMeList.values());
         return rList;
     }
 

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
@@ -1365,7 +1365,7 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
                 IDualInputInventory inventory = dualInputHatch.getFirstNonEmptyInventory();
                 if (inventory != null) {
                     ArrayList<ItemStack> itemStacks = Lists.newArrayList(inventory.getItemInputs());
-                    itemStacks.addAll(List.of(dualInputHatch.getSharedItems()));
+                    itemStacks.addAll(Arrays.asList(dualInputHatch.getSharedItems()));
                     return itemStacks;
                 }
             }

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
@@ -1327,9 +1327,11 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
             if (supportsCraftingMEBuffer() && tHatch instanceof GT_MetaTileEntity_Hatch_CraftingInput_ME) {
                 GT_MetaTileEntity_Hatch_CraftingInput_ME dualInputHatch = (GT_MetaTileEntity_Hatch_CraftingInput_ME) tHatch;
 
-                IDualInputInventory inventory = dualInputHatch.getFirstNonEmptyInventory();
-                if (inventory != null) {
-                    return Lists.newArrayList(inventory.getFluidInputs());
+                if (dualInputHatch.supportsFluids()) {
+                    IDualInputInventory inventory = dualInputHatch.getFirstNonEmptyInventory();
+                    if (inventory != null) {
+                        return Lists.newArrayList(inventory.getFluidInputs());
+                    }
                 }
             }
         }

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
@@ -32,6 +32,7 @@ import org.jetbrains.annotations.TestOnly;
 import org.lwjgl.input.Keyboard;
 
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import com.gtnewhorizons.modularui.api.math.Alignment;
 import com.gtnewhorizons.modularui.api.math.Pos2d;
 import com.gtnewhorizons.modularui.api.screen.ModularWindow;
@@ -1322,8 +1323,18 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
     }
 
     public ArrayList<FluidStack> getStoredFluids() {
+        for (IDualInputHatch tHatch : mDualInputHatches) {
+            if (supportsCraftingMEBuffer() && tHatch instanceof GT_MetaTileEntity_Hatch_CraftingInput_ME) {
+                GT_MetaTileEntity_Hatch_CraftingInput_ME dualInputHatch = (GT_MetaTileEntity_Hatch_CraftingInput_ME) tHatch;
+
+                IDualInputInventory inventory = dualInputHatch.getFirstNonEmptyInventory();
+                if (inventory != null) {
+                    return Lists.newArrayList(inventory.getFluidInputs());
+                }
+            }
+        }
+
         ArrayList<FluidStack> rList = new ArrayList<>();
-        HashMap<String, FluidStack> rInputHatchMeList = new HashMap<>();
         for (GT_MetaTileEntity_Hatch_Input tHatch : mInputHatches) {
             tHatch.mRecipeMap = getRecipeMap();
             if (tHatch instanceof GT_MetaTileEntity_Hatch_MultiInput) {
@@ -1343,23 +1354,25 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
             }
         }
 
-        for (IDualInputHatch tHatch : mDualInputHatches) {
-            if (supportsCraftingMEBuffer() && tHatch instanceof GT_MetaTileEntity_Hatch_CraftingInput_ME) {
-                for (FluidStack fluidStack : ((GT_MetaTileEntity_Hatch_CraftingInput_ME) tHatch)
-                    .getCombinedFluidInputs()) {
-                    if (fluidStack != null) rInputHatchMeList.put(fluidStack.toString(), fluidStack);
-                }
-            }
-        }
-
-        if (!rInputHatchMeList.isEmpty()) rList.addAll(rInputHatchMeList.values());
         return rList;
     }
 
     public ArrayList<ItemStack> getStoredInputs() {
+        for (IDualInputHatch tHatch : mDualInputHatches) {
+            if (supportsCraftingMEBuffer() && tHatch instanceof GT_MetaTileEntity_Hatch_CraftingInput_ME) {
+                GT_MetaTileEntity_Hatch_CraftingInput_ME dualInputHatch = (GT_MetaTileEntity_Hatch_CraftingInput_ME) tHatch;
+
+                IDualInputInventory inventory = dualInputHatch.getFirstNonEmptyInventory();
+                if (inventory != null) {
+                    ArrayList<ItemStack> itemStacks = Lists.newArrayList(inventory.getItemInputs());
+                    itemStacks.addAll(List.of(dualInputHatch.getSharedItems()));
+                    return itemStacks;
+                }
+            }
+        }
+
         ArrayList<ItemStack> rList = new ArrayList<>();
         HashMap<String, ItemStack> rInputBusMeList = new HashMap<>();
-        HashMap<String, ItemStack> rCraftingInputBusList = new HashMap<>();
 
         for (GT_MetaTileEntity_Hatch_InputBus tHatch : mInputBusses) {
             tHatch.mRecipeMap = getRecipeMap();
@@ -1379,19 +1392,9 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
             }
         }
 
-        for (IDualInputHatch tHatch : mDualInputHatches) {
-            if (supportsCraftingMEBuffer() && tHatch instanceof GT_MetaTileEntity_Hatch_CraftingInput_ME) {
-                for (ItemStack itemStack : ((GT_MetaTileEntity_Hatch_CraftingInput_ME) tHatch)
-                    .getCombinedItemInputs()) {
-                    if (itemStack != null) rCraftingInputBusList.put(itemStack.toString(), itemStack);
-                }
-            }
-        }
-
         if (getStackInSlot(1) != null && getStackInSlot(1).getUnlocalizedName()
             .startsWith("gt.integrated_circuit")) rList.add(getStackInSlot(1));
         if (!rInputBusMeList.isEmpty()) rList.addAll(rInputBusMeList.values());
-        if (!rCraftingInputBusList.isEmpty()) rList.addAll(rCraftingInputBusList.values());
         return rList;
     }
 

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
@@ -1323,14 +1323,14 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
     }
 
     public ArrayList<FluidStack> getStoredFluids() {
-        for (IDualInputHatch tHatch : mDualInputHatches) {
-            if (supportsCraftingMEBuffer() && tHatch instanceof GT_MetaTileEntity_Hatch_CraftingInput_ME) {
-                GT_MetaTileEntity_Hatch_CraftingInput_ME dualInputHatch = (GT_MetaTileEntity_Hatch_CraftingInput_ME) tHatch;
-
-                if (dualInputHatch.supportsFluids()) {
-                    IDualInputInventory inventory = dualInputHatch.getFirstNonEmptyInventory();
-                    if (inventory != null) {
-                        return Lists.newArrayList(inventory.getFluidInputs());
+        if (supportsCraftingMEBuffer()) {
+            for (IDualInputHatch tHatch : mDualInputHatches) {
+                if (tHatch.supportsFluids()) {
+                    Optional<IDualInputInventory> inventory = tHatch.getFirstNonEmptyInventory();
+                    if (inventory.isPresent()) {
+                        return Lists.newArrayList(
+                            inventory.get()
+                                .getFluidInputs());
                     }
                 }
             }
@@ -1360,15 +1360,13 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
     }
 
     public ArrayList<ItemStack> getStoredInputs() {
-        for (IDualInputHatch tHatch : mDualInputHatches) {
-            if (supportsCraftingMEBuffer() && tHatch instanceof GT_MetaTileEntity_Hatch_CraftingInput_ME) {
-                GT_MetaTileEntity_Hatch_CraftingInput_ME dualInputHatch = (GT_MetaTileEntity_Hatch_CraftingInput_ME) tHatch;
-
-                IDualInputInventory inventory = dualInputHatch.getFirstNonEmptyInventory();
-                if (inventory != null) {
-                    ArrayList<ItemStack> itemStacks = Lists.newArrayList(inventory.getItemInputs());
-                    itemStacks.addAll(Arrays.asList(dualInputHatch.getSharedItems()));
-                    return itemStacks;
+        if (supportsCraftingMEBuffer()) {
+            for (IDualInputHatch tHatch : mDualInputHatches) {
+                Optional<IDualInputInventory> inventory = tHatch.getFirstNonEmptyInventory();
+                if (inventory.isPresent()) {
+                    return Lists.newArrayList(
+                        inventory.get()
+                            .getItemInputs());
                 }
             }
         }

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
@@ -961,14 +961,15 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
         customName = name;
     }
 
-    @Nullable
-    public IDualInputInventory getFirstNonEmptyInventory() {
+    @Override
+    public Optional<IDualInputInventory> getFirstNonEmptyInventory() {
         for (PatternSlot slot : internalInventory) {
-            if (slot != null && !slot.isEmpty()) return slot;
+            if (slot != null && !slot.isEmpty()) return Optional.of(slot);
         }
-        return null;
+        return Optional.empty();
     }
 
+    @Override
     public boolean supportsFluids() {
         return this.supportFluids;
     }

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
@@ -722,7 +722,7 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
         needPatternSync = true;
     }
 
-    private ItemStack[] getSharedItems() {
+    public ItemStack[] getSharedItems() {
         ItemStack[] sharedItems = new ItemStack[SLOT_MANUAL_SIZE + 1];
         sharedItems[0] = mInventory[SLOT_CIRCUIT];
         System.arraycopy(mInventory, SLOT_MANUAL_START, sharedItems, 1, SLOT_MANUAL_SIZE);
@@ -961,37 +961,11 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
         customName = name;
     }
 
-    public ArrayList<ItemStack> getCombinedItemInputs() {
-        ArrayList<ItemStack> itemStacks = new ArrayList<>();
-
-        for (ItemStack itemStack : getSharedItems()) {
-            if (itemStack != null && itemStack.stackSize >= 0) {
-                itemStacks.add(itemStack);
-            }
+    @Nullable
+    public IDualInputInventory getFirstNonEmptyInventory() {
+        for (PatternSlot slot : internalInventory) {
+            if (!slot.isEmpty()) return slot;
         }
-
-        for (var slot : internalInventory) {
-            if (slot != null && !slot.isEmpty()) {
-                itemStacks.addAll(slot.itemInventory);
-            }
-        }
-
-        return itemStacks;
-    }
-
-    public ArrayList<FluidStack> getCombinedFluidInputs() {
-        ArrayList<FluidStack> fluidStacks = new ArrayList<>();
-
-        if (!this.supportFluids) {
-            return fluidStacks;
-        }
-
-        for (var slot : internalInventory) {
-            if (slot != null && !slot.isEmpty()) {
-                fluidStacks.addAll(slot.fluidInventory);
-            }
-        }
-
-        return fluidStacks;
+        return null;
     }
 }

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
@@ -960,4 +960,22 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
     public void setCustomName(String name) {
         customName = name;
     }
+
+    public ArrayList<ItemStack> getCombinedItemInputs() {
+        ArrayList<ItemStack> items = new ArrayList<>();
+
+        for (ItemStack itemStack : getSharedItems()) {
+            if (itemStack != null && itemStack.stackSize >= 0) {
+                items.add(itemStack);
+            }
+        }
+
+        for (var slot : internalInventory) {
+            if (slot != null && !slot.isEmpty()) {
+                items.addAll(slot.itemInventory);
+            }
+        }
+
+        return items;
+    }
 }

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
@@ -962,20 +962,36 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
     }
 
     public ArrayList<ItemStack> getCombinedItemInputs() {
-        ArrayList<ItemStack> items = new ArrayList<>();
+        ArrayList<ItemStack> itemStacks = new ArrayList<>();
 
         for (ItemStack itemStack : getSharedItems()) {
             if (itemStack != null && itemStack.stackSize >= 0) {
-                items.add(itemStack);
+                itemStacks.add(itemStack);
             }
         }
 
         for (var slot : internalInventory) {
             if (slot != null && !slot.isEmpty()) {
-                items.addAll(slot.itemInventory);
+                itemStacks.addAll(slot.itemInventory);
             }
         }
 
-        return items;
+        return itemStacks;
+    }
+
+    public ArrayList<FluidStack> getCombinedFluidInputs() {
+        ArrayList<FluidStack> fluidStacks = new ArrayList<>();
+
+        if (!this.supportFluids) {
+            return fluidStacks;
+        }
+
+        for (var slot : internalInventory) {
+            if (slot != null && !slot.isEmpty()) {
+                fluidStacks.addAll(slot.fluidInventory);
+            }
+        }
+
+        return fluidStacks;
     }
 }

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
@@ -968,4 +968,8 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
         }
         return null;
     }
+
+    public boolean supportsFluids() {
+        return this.supportFluids;
+    }
 }

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
@@ -964,7 +964,7 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
     @Nullable
     public IDualInputInventory getFirstNonEmptyInventory() {
         for (PatternSlot slot : internalInventory) {
-            if (!slot.isEmpty()) return slot;
+            if (slot != null && !slot.isEmpty()) return slot;
         }
         return null;
     }

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_Slave.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_Slave.java
@@ -144,6 +144,16 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_Slave extends GT_MetaTileEnti
     }
 
     @Override
+    public Optional<IDualInputInventory> getFirstNonEmptyInventory() {
+        return getMaster() != null ? getMaster().getFirstNonEmptyInventory() : Optional.empty();
+    }
+
+    @Override
+    public boolean supportsFluids() {
+        return getMaster() != null && getMaster().supportsFluids();
+    }
+
+    @Override
     public boolean justUpdated() {
         return getMaster() != null && getMaster().justUpdated();
     }

--- a/src/main/java/gregtech/common/tileentities/machines/IDualInputHatch.java
+++ b/src/main/java/gregtech/common/tileentities/machines/IDualInputHatch.java
@@ -1,6 +1,7 @@
 package gregtech.common.tileentities.machines;
 
 import java.util.Iterator;
+import java.util.Optional;
 
 import net.minecraft.item.ItemStack;
 
@@ -13,4 +14,8 @@ public interface IDualInputHatch {
     void updateTexture(int id);
 
     void updateCraftingIcon(ItemStack icon);
+
+    Optional<IDualInputInventory> getFirstNonEmptyInventory();
+
+    public boolean supportsFluids();
 }


### PR DESCRIPTION
This works by exposing the bus contents to `getStoredItems()` and `getStoredFluids()` methods. This makes the buses compatible with multis that override `checkProcessing()` with special logic and rely on the aforementioned methods.

Examples include Multi-Smelter and Industrial Arc Furnace.