### PR TITLE
Restore PA controller recipe

### DIFF
--- a/src/main/java/gregtech/loaders/load/GT_Loader_MetaTileEntities_Recipes.java
+++ b/src/main/java/gregtech/loaders/load/GT_Loader_MetaTileEntities_Recipes.java
@@ -7046,13 +7046,6 @@ public class GT_Loader_MetaTileEntities_Recipes implements Runnable {
             new Object[] { "CTC", "FMF", "CBC", 'M', ItemList.Hull_EV, 'B',
                 OrePrefixes.pipeLarge.get(Materials.StainlessSteel), 'C', OrePrefixes.circuit.get(Materials.Elite), 'F',
                 ItemList.Robot_Arm_EV, 'T', ItemList.Energy_LapotronicOrb });
-                
-        GT_ModHandler.addCraftingRecipe(
-            ItemList.Processing_Array.get(1L),
-            bitsd,
-            new Object[] { "CTC", "FMF", "CBC", 'M', ItemList.Hull_EV, 'B',
-                OrePrefixes.pipeLarge.get(Materials.StainlessSteel), 'C', OrePrefixes.circuit.get(Materials.Elite), 'F',
-                ItemList.Robot_Arm_EV, 'T', ItemList.Energy_LapotronicOrb });
 
         GT_ProcessingArrayRecipeLoader.registerDefaultGregtechMaps();
         GT_ModHandler.addCraftingRecipe(

--- a/src/main/java/gregtech/loaders/load/GT_Loader_MetaTileEntities_Recipes.java
+++ b/src/main/java/gregtech/loaders/load/GT_Loader_MetaTileEntities_Recipes.java
@@ -7040,6 +7040,20 @@ public class GT_Loader_MetaTileEntities_Recipes implements Runnable {
                 OrePrefixes.circuit.get(Materials.Ultimate), 'W', OrePrefixes.wireGt04.get(Materials.Naquadah), 'U',
                 OrePrefixes.stick.get(Materials.Americium) });
 
+        GT_ModHandler.addCraftingRecipe(
+            ItemList.Processing_Array.get(1L),
+            bitsd,
+            new Object[] { "CTC", "FMF", "CBC", 'M', ItemList.Hull_EV, 'B',
+                OrePrefixes.pipeLarge.get(Materials.StainlessSteel), 'C', OrePrefixes.circuit.get(Materials.Elite), 'F',
+                ItemList.Robot_Arm_EV, 'T', ItemList.Energy_LapotronicOrb });
+                
+        GT_ModHandler.addCraftingRecipe(
+            ItemList.Processing_Array.get(1L),
+            bitsd,
+            new Object[] { "CTC", "FMF", "CBC", 'M', ItemList.Hull_EV, 'B',
+                OrePrefixes.pipeLarge.get(Materials.StainlessSteel), 'C', OrePrefixes.circuit.get(Materials.Elite), 'F',
+                ItemList.Robot_Arm_EV, 'T', ItemList.Energy_LapotronicOrb });
+
         GT_ProcessingArrayRecipeLoader.registerDefaultGregtechMaps();
         GT_ModHandler.addCraftingRecipe(
             ItemList.Distillation_Tower.get(1L),


### PR DESCRIPTION
Leaves the deprecated warnings but doesn't remove the recipe.