### PR TITLE
Requested drill changes, eliminates recipe info in drill GUI

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
@@ -2289,28 +2289,30 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
                         && shouldDisplayCheckRecipeResult()))
             .widget(new CheckRecipeResultSyncer(() -> checkRecipeResult, (result) -> checkRecipeResult = result));
 
-        // Display current recipe
-        screenElements.widget(
-            TextWidget.dynamicString(this::generateCurrentRecipeInfoString)
-                .setSynced(false)
-                .setTextAlignment(Alignment.CenterLeft)
-                .setEnabled(
-                    widget -> (mOutputFluids != null && mOutputFluids.length > 0)
-                        || (mOutputItems != null && mOutputItems.length > 0)))
-            .widget(
-                new FakeSyncWidget.ListSyncer<>(
-                    () -> mOutputFluids != null ? Arrays.asList(mOutputFluids) : Collections.emptyList(),
-                    val -> mOutputFluids = val.toArray(new FluidStack[0]),
-                    NetworkUtils::writeFluidStack,
-                    NetworkUtils::readFluidStack))
-            .widget(
-                new FakeSyncWidget.ListSyncer<>(
-                    () -> mOutputItems != null ? Arrays.asList(mOutputItems) : Collections.emptyList(),
-                    val -> mOutputItems = val.toArray(new ItemStack[0]),
-                    NetworkUtils::writeItemStack,
-                    NetworkUtils::readItemStack))
-            .widget(new FakeSyncWidget.IntegerSyncer(() -> mProgresstime, val -> mProgresstime = val))
-            .widget(new FakeSyncWidget.IntegerSyncer(() -> mMaxProgresstime, val -> mMaxProgresstime = val));
+        if (showRecipeTextInGUI()) {
+            // Display current recipe
+            screenElements.widget(
+                TextWidget.dynamicString(this::generateCurrentRecipeInfoString)
+                    .setSynced(false)
+                    .setTextAlignment(Alignment.CenterLeft)
+                    .setEnabled(
+                        widget -> (mOutputFluids != null && mOutputFluids.length > 0)
+                            || (mOutputItems != null && mOutputItems.length > 0)))
+                .widget(
+                    new FakeSyncWidget.ListSyncer<>(
+                        () -> mOutputFluids != null ? Arrays.asList(mOutputFluids) : Collections.emptyList(),
+                        val -> mOutputFluids = val.toArray(new FluidStack[0]),
+                        NetworkUtils::writeFluidStack,
+                        NetworkUtils::readFluidStack))
+                .widget(
+                    new FakeSyncWidget.ListSyncer<>(
+                        () -> mOutputItems != null ? Arrays.asList(mOutputItems) : Collections.emptyList(),
+                        val -> mOutputItems = val.toArray(new ItemStack[0]),
+                        NetworkUtils::writeItemStack,
+                        NetworkUtils::readItemStack))
+                .widget(new FakeSyncWidget.IntegerSyncer(() -> mProgresstime, val -> mProgresstime = val))
+                .widget(new FakeSyncWidget.IntegerSyncer(() -> mMaxProgresstime, val -> mMaxProgresstime = val));
+        }
 
         screenElements.widget(
             new TextWidget(GT_Utility.trans("144", "Missing Turbine Rotor")).setDefaultColor(COLOR_TEXT_WHITE.get())
@@ -2326,6 +2328,10 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
                     }
                     return false;
                 }));
+    }
+
+    protected boolean showRecipeTextInGUI() {
+        return true;
     }
 
     @TestOnly

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_DrillerBase.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_DrillerBase.java
@@ -61,7 +61,7 @@ import gregtech.api.GregTech_API;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
 import gregtech.api.gui.modularui.GT_UITextures;
-import gregtech.api.gui.widgets.GT_DisabledWhileActiveButton;
+import gregtech.api.gui.widgets.GT_LockedWhileActiveButton;
 import gregtech.api.interfaces.IChunkLoader;
 import gregtech.api.interfaces.IHatchElement;
 import gregtech.api.interfaces.ITexture;
@@ -789,6 +789,11 @@ public abstract class GT_MetaTileEntity_DrillerBase
             .widget(new FakeSyncWidget.StringSyncer(() -> shutdownReason, newString -> shutdownReason = newString));
     }
 
+    @Override
+    protected boolean showRecipeTextInGUI() {
+        return false;
+    }
+
     /**
      * Adds additional buttons to the main button row. You do not need to set the position.
      *
@@ -805,7 +810,7 @@ public abstract class GT_MetaTileEntity_DrillerBase
         final int BUTTON_Y_LEVEL = 91;
 
         builder.widget(
-            new GT_DisabledWhileActiveButton(this.getBaseMetaTileEntity(), builder)
+            new GT_LockedWhileActiveButton(this.getBaseMetaTileEntity(), builder)
                 .setOnClick((clickData, widget) -> mChunkLoadingEnabled = !mChunkLoadingEnabled)
                 .setPlayClickSound(true)
                 .setBackground(() -> {

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_OreDrillingPlantBase.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_OreDrillingPlantBase.java
@@ -44,7 +44,7 @@ import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.enums.SoundResource;
 import gregtech.api.gui.modularui.GT_UITextures;
-import gregtech.api.gui.widgets.GT_DisabledWhileActiveButton;
+import gregtech.api.gui.widgets.GT_LockedWhileActiveButton;
 import gregtech.api.interfaces.IHatchElement;
 import gregtech.api.objects.GT_ChunkManager;
 import gregtech.api.objects.ItemData;
@@ -623,7 +623,7 @@ public abstract class GT_MetaTileEntity_OreDrillingPlantBase extends GT_MetaTile
     @Override
     protected List<ButtonWidget> getAdditionalButtons(ModularWindow.Builder builder, UIBuildContext buildContext) {
         return ImmutableList.of(
-            (ButtonWidget) new GT_DisabledWhileActiveButton(this.getBaseMetaTileEntity(), builder)
+            (ButtonWidget) new GT_LockedWhileActiveButton(this.getBaseMetaTileEntity(), builder)
                 .setOnClick((clickData, widget) -> adjustChunkRadius(clickData.mouseButton == 0))
                 .setPlayClickSound(true)
                 .setBackground(GT_UITextures.BUTTON_STANDARD, GT_UITextures.OVERLAY_WORK_AREA)
@@ -639,12 +639,12 @@ public abstract class GT_MetaTileEntity_OreDrillingPlantBase extends GT_MetaTile
                         StatCollector.translateToLocal("GT5U.gui.button.ore_drill_radius_2")))
                 .setTooltipShowUpDelay(TOOLTIP_DELAY)
                 .setSize(16, 16),
-            (ButtonWidget) new GT_DisabledWhileActiveButton(this.getBaseMetaTileEntity(), builder)
+            (ButtonWidget) new GT_LockedWhileActiveButton(this.getBaseMetaTileEntity(), builder)
                 .setOnClick((clickData, widget) -> replaceWithCobblestone = !replaceWithCobblestone)
                 .setPlayClickSound(true)
                 .setBackground(() -> {
                     if (replaceWithCobblestone) {
-                        return new IDrawable[] { GT_UITextures.BUTTON_STANDARD,
+                        return new IDrawable[] { GT_UITextures.BUTTON_STANDARD_PRESSED,
                             GT_UITextures.OVERLAY_REPLACE_COBBLE_ON };
                     }
                     return new IDrawable[] { GT_UITextures.BUTTON_STANDARD, GT_UITextures.OVERLAY_REPLACE_COBBLE_OFF };


### PR DESCRIPTION
This fixes the late-coming concerns levied in #2270. This also eliminates the recipe info texts on multiblock drills, since it was spammy and made little sense in context.