### PR TITLE
Use Avaritia for Universium renderer

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -42,7 +42,7 @@ dependencies {
     api("com.github.GTNewHorizons:waila:1.6.0:dev")
     api("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-254-GTNH:dev")
     api("com.github.GTNewHorizons:AE2FluidCraft-Rework:1.1.42-gtnh:dev")
-    implementation("com.github.GTNewHorizons:Eternal-Singularity:1.1.2:dev")
+    implementation("com.github.GTNewHorizons:Avaritia:1.46:dev")
 
     compileOnlyApi("com.github.GTNewHorizons:AppleCore:3.2.11:dev") { transitive = false }
     compileOnlyApi("com.github.GTNewHorizons:BuildCraft:7.1.36:dev") { transitive = false }

--- a/src/main/java/gregtech/api/GregTech_API.java
+++ b/src/main/java/gregtech/api/GregTech_API.java
@@ -280,7 +280,7 @@ public class GregTech_API {
         sMachineWireFire = true, mOutputRF = false, mInputRF = false, meIOLoaded = false, mRFExplosions = false,
         mServerStarted = false, mIC2Classic = false, mMagneticraft = false, mImmersiveEngineering = false,
         mGTPlusPlus = false, mTranslocator = false, mTConstruct = false, mGalacticraft = false, mAE2 = false,
-        mHodgepodge = false, mEternalSingularity = false;
+        mHodgepodge = false, mAvaritia = false;
 
     public static int mEUtoRF = 360, mRFtoEU = 20;
 

--- a/src/main/java/gregtech/common/render/items/UniversiumRenderer.java
+++ b/src/main/java/gregtech/common/render/items/UniversiumRenderer.java
@@ -16,10 +16,10 @@ import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
 
 import codechicken.lib.render.TextureUtils;
+import fox.spiteful.avaritia.render.CosmicRenderShenanigans;
 import gregtech.api.GregTech_API;
 import gregtech.api.enums.ItemList;
 import gregtech.api.interfaces.IGT_ItemWithMaterialRenderer;
-import singulariteam.eternalsingularity.render.CosmicRenderStuffs;
 
 @SuppressWarnings("RedundantLabeledSwitchRuleCodeBlock")
 public class UniversiumRenderer extends GT_GeneratedMaterial_Renderer {
@@ -81,7 +81,7 @@ public class UniversiumRenderer extends GT_GeneratedMaterial_Renderer {
 
     private void magicRenderMethod(ItemRenderType type, ItemStack aStack, IIcon tIcon, boolean fluidDisplay,
         Object... data) {
-        if (!GregTech_API.mEternalSingularity) return;
+        if (!GregTech_API.mAvaritia) return;
 
         RenderItem r = RenderItem.getInstance();
         Minecraft mc = Minecraft.getMinecraft();
@@ -130,9 +130,9 @@ public class UniversiumRenderer extends GT_GeneratedMaterial_Renderer {
                     GL11.glDisable(GL11.GL_BLEND);
                 }
 
-                CosmicRenderStuffs.cosmicOpacity = cosmicOpacity;
-                CosmicRenderStuffs.inventoryRender = true;
-                CosmicRenderStuffs.useShader();
+                CosmicRenderShenanigans.cosmicOpacity = cosmicOpacity;
+                CosmicRenderShenanigans.inventoryRender = true;
+                CosmicRenderShenanigans.useShader();
 
                 GL11.glColor4d(1, 1, 1, 1);
 
@@ -149,8 +149,8 @@ public class UniversiumRenderer extends GT_GeneratedMaterial_Renderer {
                 t.addVertexWithUV(16, 0, 0, maxu, minv);
                 t.draw();
 
-                CosmicRenderStuffs.releaseShader();
-                CosmicRenderStuffs.inventoryRender = false;
+                CosmicRenderShenanigans.releaseShader();
+                CosmicRenderShenanigans.inventoryRender = false;
 
                 GL11.glEnable(GL11.GL_ALPHA_TEST);
                 GL11.glEnable(GL12.GL_RESCALE_NORMAL);
@@ -187,8 +187,8 @@ public class UniversiumRenderer extends GT_GeneratedMaterial_Renderer {
 
         GL11.glDisable(GL11.GL_ALPHA_TEST);
         GL11.glDepthFunc(GL11.GL_EQUAL);
-        CosmicRenderStuffs.cosmicOpacity = cosmicOpacity;
-        CosmicRenderStuffs.useShader();
+        CosmicRenderShenanigans.cosmicOpacity = cosmicOpacity;
+        CosmicRenderShenanigans.useShader();
 
         float minu = icon.getMinU();
         float maxu = icon.getMaxU();
@@ -205,7 +205,7 @@ public class UniversiumRenderer extends GT_GeneratedMaterial_Renderer {
             icon.getIconWidth(),
             icon.getIconHeight(),
             scale);
-        CosmicRenderStuffs.releaseShader();
+        CosmicRenderShenanigans.releaseShader();
         GL11.glDepthFunc(GL11.GL_LEQUAL);
         GL11.glEnable(GL11.GL_ALPHA_TEST);
 
@@ -220,7 +220,7 @@ public class UniversiumRenderer extends GT_GeneratedMaterial_Renderer {
             case ENTITY -> {
                 EntityItem ent = (EntityItem) (data[1]);
                 if (ent != null) {
-                    CosmicRenderStuffs.setLightFromLocation(
+                    CosmicRenderShenanigans.setLightFromLocation(
                         ent.worldObj,
                         MathHelper.floor_double(ent.posX),
                         MathHelper.floor_double(ent.posY),
@@ -230,7 +230,7 @@ public class UniversiumRenderer extends GT_GeneratedMaterial_Renderer {
             case EQUIPPED, EQUIPPED_FIRST_PERSON -> {
                 EntityLivingBase ent = (EntityLivingBase) (data[1]);
                 if (ent != null) {
-                    CosmicRenderStuffs.setLightFromLocation(
+                    CosmicRenderShenanigans.setLightFromLocation(
                         ent.worldObj,
                         MathHelper.floor_double(ent.posX),
                         MathHelper.floor_double(ent.posY),
@@ -238,10 +238,10 @@ public class UniversiumRenderer extends GT_GeneratedMaterial_Renderer {
                 }
             }
             case INVENTORY -> {
-                CosmicRenderStuffs.setLightLevel(10.2f);
+                CosmicRenderShenanigans.setLightLevel(10.2f);
             }
             default -> {
-                CosmicRenderStuffs.setLightLevel(1.0f);
+                CosmicRenderShenanigans.setLightLevel(1.0f);
             }
         }
     }

--- a/src/main/java/gregtech/loaders/preload/GT_PreLoad.java
+++ b/src/main/java/gregtech/loaders/preload/GT_PreLoad.java
@@ -2,9 +2,9 @@ package gregtech.loaders.preload;
 
 import static gregtech.GT_Mod.GT_FML_LOGGER;
 import static gregtech.api.enums.Mods.AppliedEnergistics2;
+import static gregtech.api.enums.Mods.Avaritia;
 import static gregtech.api.enums.Mods.CraftTweaker;
 import static gregtech.api.enums.Mods.EnderIO;
-import static gregtech.api.enums.Mods.EternalSingularity;
 import static gregtech.api.enums.Mods.GTPlusPlus;
 import static gregtech.api.enums.Mods.GalacticraftCore;
 import static gregtech.api.enums.Mods.GregTech;
@@ -139,7 +139,7 @@ public class GT_PreLoad {
         GregTech_API.mGalacticraft = GalacticraftCore.isModLoaded();
         GregTech_API.mAE2 = AppliedEnergistics2.isModLoaded();
         GregTech_API.mHodgepodge = HodgePodge.isModLoaded();
-        GregTech_API.mEternalSingularity = EternalSingularity.isModLoaded();
+        GregTech_API.mAvaritia = Avaritia.isModLoaded();
     }
 
     public static void createLogFiles(File parentFile, Configuration tMainConfig) {


### PR DESCRIPTION
Eternal Singularities'es renderer is almost identical to Avaritia's one. This PR shaves 3 dependencies off from GT: Universal Singularities, Eternal Singularity and WanionLib.
`mEternalSingularity` is not used by any of the addons.