### PR TITLE
disable large turbine rotation or flip

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -34,7 +34,7 @@
  * For more details, see https://docs.gradle.org/8.0.1/userguide/java_library_plugin.html#sec:java_library_configurations_graph
  */
 dependencies {
-    api("com.github.GTNewHorizons:StructureLib:1.2.8:dev")
+    api("com.github.GTNewHorizons:StructureLib:1.2.9:dev")
     api("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev")
     api("com.github.GTNewHorizons:NotEnoughItems:2.4.2:dev")
     api("com.github.GTNewHorizons:GTNHLib:0.0.13:dev")

--- a/src/main/java/gregtech/common/GT_Client.java
+++ b/src/main/java/gregtech/common/GT_Client.java
@@ -68,16 +68,7 @@ import gregtech.api.metatileentity.MetaPipeEntity;
 import gregtech.api.multitileentity.multiblock.base.MultiBlockPart;
 import gregtech.api.net.GT_Packet_ClientPreference;
 import gregtech.api.objects.GT_ItemStack;
-import gregtech.api.util.ColorsMetadataSection;
-import gregtech.api.util.ColorsMetadataSectionSerializer;
-import gregtech.api.util.GT_ClientPreference;
-import gregtech.api.util.GT_CoverBehaviorBase;
-import gregtech.api.util.GT_Log;
-import gregtech.api.util.GT_ModHandler;
-import gregtech.api.util.GT_PlayedSound;
-import gregtech.api.util.GT_Recipe;
-import gregtech.api.util.GT_Utility;
-import gregtech.api.util.WorldSpawnedEventBuilder;
+import gregtech.api.util.*;
 import gregtech.common.blocks.GT_Item_Machines;
 import gregtech.common.entities.GT_Entity_Arrow;
 import gregtech.common.entities.GT_Entity_Arrow_Potion;
@@ -400,27 +391,34 @@ public class GT_Client extends GT_Proxy implements Runnable {
             if (tAlignment != null) {
                 final ForgeDirection direction = tAlignment.getDirection();
                 if (direction.ordinal() == tSideHit)
-                    drawExtendedRotationMarker(ROTATION_MARKER_TRANSFORM_CENTER, aIsSneaking, false);
+                    drawExtendedRotationMarker(ROTATION_MARKER_TRANSFORM_CENTER, aIsSneaking, tAlignment);
                 else if (direction.getOpposite()
                     .ordinal() == tSideHit) {
                         for (Transformation t : ROTATION_MARKER_TRANSFORMS_CORNER) {
-                            drawExtendedRotationMarker(t, aIsSneaking, true);
+                            drawExtendedRotationMarker(t, aIsSneaking, tAlignment);
                         }
                     } else {
                         drawExtendedRotationMarker(
                             ROTATION_MARKER_TRANSFORMS_SIDES_TRANSFORMS[ROTATION_MARKER_TRANSFORMS_SIDES[tSideHit * 6
                                 + direction.ordinal()]],
                             aIsSneaking,
-                            true);
+                            tAlignment);
                     }
             }
         }
         GL11.glPopMatrix(); // get back to player center
     }
 
-    private static void drawExtendedRotationMarker(Transformation transform, boolean sneaking, boolean small) {
-        if (sneaking) drawFlipMarker(transform);
-        else drawRotationMarker(transform);
+    private static void drawExtendedRotationMarker(Transformation transform, boolean sneaking, IAlignment alignment) {
+        if (sneaking) {
+            if (alignment.isFlipChangeAllowed()) {
+                drawFlipMarker(transform);
+            }
+        } else {
+            if (alignment.isRotationChangeAllowed()) {
+                drawRotationMarker(transform);
+            }
+        }
     }
 
     private static void drawRotationMarker(Transformation transform) {

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_DistillationTower.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_DistillationTower.java
@@ -232,6 +232,11 @@ public class GT_MetaTileEntity_DistillationTower extends
     }
 
     @Override
+    public boolean isRotationChangeAllowed() {
+        return false;
+    }
+
+    @Override
     public IStructureDefinition<GT_MetaTileEntity_DistillationTower> getStructureDefinition() {
         return STRUCTURE_DEFINITION;
     }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_DrillerBase.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_DrillerBase.java
@@ -601,6 +601,11 @@ public abstract class GT_MetaTileEntity_DrillerBase
     }
 
     @Override
+    public boolean isRotationChangeAllowed() {
+        return false;
+    }
+
+    @Override
     public final IStructureDefinition<GT_MetaTileEntity_DrillerBase> getStructureDefinition() {
         return STRUCTURE_DEFINITION.get(getClass());
     }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeTurbine.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeTurbine.java
@@ -30,8 +30,11 @@ import net.minecraftforge.fluids.FluidStack;
 
 import org.jetbrains.annotations.NotNull;
 
+import com.gtnewhorizon.structurelib.alignment.IAlignmentLimits;
 import com.gtnewhorizon.structurelib.alignment.constructable.ISurvivalConstructable;
 import com.gtnewhorizon.structurelib.alignment.enumerable.ExtendedFacing;
+import com.gtnewhorizon.structurelib.alignment.enumerable.Flip;
+import com.gtnewhorizon.structurelib.alignment.enumerable.Rotation;
 import com.gtnewhorizon.structurelib.structure.IStructureDefinition;
 import com.gtnewhorizon.structurelib.structure.ISurvivalBuildEnvironment;
 import com.gtnewhorizon.structurelib.structure.StructureDefinition;
@@ -112,6 +115,27 @@ public abstract class GT_MetaTileEntity_LargeTurbine
     @Override
     public IStructureDefinition<GT_MetaTileEntity_LargeTurbine> getStructureDefinition() {
         return STRUCTURE_DEFINITION.get(getClass());
+    }
+
+    @Override
+    protected IAlignmentLimits getInitialAlignmentLimits() {
+        return (d, r, f) -> r.isNotRotated() && f.isNotFlipped();
+    }
+
+    @Override
+    protected ExtendedFacing getCorrectedAlignment(ExtendedFacing aOldFacing) {
+        return aOldFacing.with(Flip.NONE)
+            .with(Rotation.NORMAL);
+    }
+
+    @Override
+    public boolean isFlipChangeAllowed() {
+        return false;
+    }
+
+    @Override
+    public boolean isRotationChangeAllowed() {
+        return false;
     }
 
     @Override


### PR DESCRIPTION
context: https://discord.com/channels/181078474394566657/939305179524792340/1151015021434896494

the turbine needs not to be rotated (as it's symmytric construct), so I just disabled the rotation.

also made the rotation and flip marker to not show up when the multi doesn't support rotating or flipping