### PR TITLE
Partially revert gtrecipebuilder deprecations and fix hundreds of recipes

### DIFF
--- a/src/main/java/gregtech/api/util/GT_RecipeBuilder.java
+++ b/src/main/java/gregtech/api/util/GT_RecipeBuilder.java
@@ -227,7 +227,8 @@ public class GT_RecipeBuilder {
     }
 
     /**
-     * You don't need to call this method for new recipes as RecipeBuilder takes empty item input array by default. But it is needed for manipulation of existing recipes.
+     * You don't need to call this method for new recipes as RecipeBuilder takes empty item input array by default. But
+     * it is needed for manipulation of existing recipes.
      */
     public GT_RecipeBuilder noItemInputs() {
         inputsBasic = new ItemStack[0];
@@ -260,7 +261,8 @@ public class GT_RecipeBuilder {
     }
 
     /**
-     * You don't need to call this method for new recipes as RecipeBuilder takes empty item output array by default. But it is needed for manipulation of existing recipes.
+     * You don't need to call this method for new recipes as RecipeBuilder takes empty item output array by default. But
+     * it is needed for manipulation of existing recipes.
      */
     public GT_RecipeBuilder noItemOutputs() {
         chances = null;

--- a/src/main/java/gregtech/api/util/GT_RecipeBuilder.java
+++ b/src/main/java/gregtech/api/util/GT_RecipeBuilder.java
@@ -227,10 +227,12 @@ public class GT_RecipeBuilder {
     }
 
     /**
-     * @deprecated You don't need to call this method, RecipeBuilder now takes empty item input array by default.
+     * You don't need to call this method for new recipes as RecipeBuilder takes empty item input array by default. But it is needed for manipulation of existing recipes.
      */
-    @Deprecated
     public GT_RecipeBuilder noItemInputs() {
+        inputsBasic = new ItemStack[0];
+        inputsOreDict = null;
+        alts = null;
         return this;
     }
 
@@ -258,11 +260,11 @@ public class GT_RecipeBuilder {
     }
 
     /**
-     * @deprecated You don't need to call this method, RecipeBuilder now takes empty item output array by default.
+     * You don't need to call this method for new recipes as RecipeBuilder takes empty item output array by default. But it is needed for manipulation of existing recipes.
      */
-    @Deprecated
     public GT_RecipeBuilder noItemOutputs() {
-        return this;
+        chances = null;
+        return itemOutputs();
     }
 
     public GT_RecipeBuilder fluidInputs(FluidStack... fluidInputs) {
@@ -271,12 +273,8 @@ public class GT_RecipeBuilder {
         return this;
     }
 
-    /**
-     * @deprecated You don't need to call this method, RecipeBuilder now takes empty fluid input array by default.
-     */
-    @Deprecated
     public GT_RecipeBuilder noFluidInputs() {
-        return this;
+        return fluidInputs == null ? fluidInputs() : this;
     }
 
     public GT_RecipeBuilder fluidOutputs(FluidStack... fluidOutputs) {
@@ -285,20 +283,12 @@ public class GT_RecipeBuilder {
         return this;
     }
 
-    /**
-     * @deprecated You don't need to call this method, RecipeBuilder now takes empty fluid output array by default.
-     */
-    @Deprecated
     public GT_RecipeBuilder noFluidOutputs() {
-        return this;
+        return fluidOutputs();
     }
 
-    /**
-     * @deprecated You don't need to call this method, RecipeBuilder now takes empty arrays by default.
-     */
-    @Deprecated
     public GT_RecipeBuilder noOutputs() {
-        return this;
+        return noFluidOutputs().noItemOutputs();
     }
 
     public GT_RecipeBuilder outputChances(int... chances) {

--- a/src/main/java/gregtech/api/util/GT_RecipeMapUtil.java
+++ b/src/main/java/gregtech/api/util/GT_RecipeMapUtil.java
@@ -107,16 +107,24 @@ public class GT_RecipeMapUtil {
         }
         fluidInputs.removeIf(Objects::isNull);
         fluidOutputs.removeIf(Objects::isNull);
-        if (!itemInputs.isEmpty()) {
+        if (itemInputs.size() == 0) {
+            b.noItemInputs();
+        } else {
             b.itemInputs(itemInputs.toArray(new ItemStack[0]));
         }
-        if (!itemOutputs.isEmpty()) {
+        if (itemOutputs.size() == 0) {
+            b.noItemOutputs();
+        } else {
             b.itemOutputs(itemOutputs.toArray(new ItemStack[0]), chances != null ? chances.toArray() : null);
         }
-        if (!fluidInputs.isEmpty()) {
+        if (fluidInputs.size() == 0) {
+            b.noFluidInputs();
+        } else {
             b.fluidInputs(fluidInputs.toArray(new FluidStack[0]));
         }
-        if (!fluidOutputs.isEmpty()) {
+        if (fluidOutputs.size() == 0) {
+            b.noFluidOutputs();
+        } else {
             b.fluidOutputs(fluidOutputs.toArray(new FluidStack[0]));
         }
         return b;


### PR DESCRIPTION
We need the explicit noinput/nooutput overrides for recipe manipulation so they can not just be trivialized and deprecated. I reverted that part but kept the null defaults, so they remain optional for recipe declarations.

Then I also reinstated their usage in the cell->fluid method that makes recipes for multiblocks. Thus fixing hundreds of recipes.

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14512