### PR TITLE
Fix Cell-less recipe converter not always setting new arrays

### DIFF
--- a/src/main/java/gregtech/api/util/GT_RecipeMapUtil.java
+++ b/src/main/java/gregtech/api/util/GT_RecipeMapUtil.java
@@ -107,18 +107,10 @@ public class GT_RecipeMapUtil {
         }
         fluidInputs.removeIf(Objects::isNull);
         fluidOutputs.removeIf(Objects::isNull);
-        if (!itemInputs.isEmpty()) {
-            b.itemInputs(itemInputs.toArray(new ItemStack[0]));
-        }
-        if (!itemOutputs.isEmpty()) {
-            b.itemOutputs(itemOutputs.toArray(new ItemStack[0]), chances != null ? chances.toArray() : null);
-        }
-        if (!fluidInputs.isEmpty()) {
-            b.fluidInputs(fluidInputs.toArray(new FluidStack[0]));
-        }
-        if (!fluidOutputs.isEmpty()) {
-            b.fluidOutputs(fluidOutputs.toArray(new FluidStack[0]));
-        }
+        b.itemInputs(itemInputs.toArray(new ItemStack[0]));
+        b.itemOutputs(itemOutputs.toArray(new ItemStack[0]), chances != null ? chances.toArray() : null);
+        b.fluidInputs(fluidInputs.toArray(new FluidStack[0]));
+        b.fluidOutputs(fluidOutputs.toArray(new FluidStack[0]));
         return b;
     }
 


### PR DESCRIPTION
Close https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14512
Supersede https://github.com/GTNewHorizons/GT5-Unofficial/pull/2293

It used to call `noItemInputs` if transformed item input array is empty, which is essentially the same as passing empty array to `itemInputs`. My PR https://github.com/GTNewHorizons/GT5-Unofficial/pull/2284 didn't notice that and removed it blindly, which resulted in empty array not being set. Now it sets the item input array no matter if it's empty or not.