### PR TITLE
Fix missing null check

### DIFF
--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingIngot.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingIngot.java
@@ -104,7 +104,8 @@ public class ProcessingIngot implements gregtech.api.interfaces.IOreRecipeRegist
                 }
                 if (!aNoSmashing || aStretchy) {
                     // Forge hammer recipes
-                    if (aMaterial.getProcessingMaterialTierEU() < TierEU.IV) {
+                    if (aMaterial.getProcessingMaterialTierEU() < TierEU.IV
+                        && GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L) != null) {
                         GT_Values.RA.stdBuilder()
                             .itemInputs(GT_Utility.copyAmount(3L, aStack))
                             .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 2L))


### PR DESCRIPTION
Fix missing null check for ingot to plate recipes.

Brings the null detecting recipe debug down to 0 broken recipes! :partying_face: (not counting the collision debug)