### PR TITLE
Remove recipe modifying code for matching input and output stacks

### DIFF
--- a/src/main/java/gregtech/api/util/GT_Recipe.java
+++ b/src/main/java/gregtech/api/util/GT_Recipe.java
@@ -261,18 +261,6 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
         for (int i = 0; i < aFluidInputs.length; i++) aFluidInputs[i] = aFluidInputs[i].copy();
         for (int i = 0; i < aFluidOutputs.length; i++) aFluidOutputs[i] = aFluidOutputs[i].copy();
 
-        for (ItemStack aInput : aInputs)
-            if (aInput != null && Items.feather.getDamage(aInput) != W) for (int j = 0; j < aOutputs.length; j++) {
-                if (GT_Utility.areStacksEqual(aInput, aOutputs[j]) && aChances[j] >= 10000) {
-                    if (aInput.stackSize >= aOutputs[j].stackSize) {
-                        aInput.stackSize -= aOutputs[j].stackSize;
-                        aOutputs[j] = null;
-                    } else {
-                        aOutputs[j].stackSize -= aInput.stackSize;
-                    }
-                }
-            }
-
         if (aOptimize && aDuration >= 32) {
             ArrayList<ItemStack> tList = new ArrayList<>();
             tList.addAll(Arrays.asList(aInputs));


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14539

Removed code functions as described in discord here: https://discord.com/channels/181078474394566657/603348502637969419/1153249987803762708

This code removal could cause issues, since it is very old code in a very root level constructor for recipes. However, I can't think of any cases where this code is either useful, or even being used at all, aside from the case in the above issue where it is causing a bug. Additionally, at least one of the three potential cases in this code seems to do the incorrect thing, though again I'm not sure of any recipes where it actually occurs since this is a very small corner case