### PR TITLE
Make Crafting Bus work alongside fluid hatches

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
@@ -775,7 +775,11 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
                 for (var it = dualInputHatch.inventories(); it.hasNext();) {
                     IDualInputInventory slot = it.next();
                     processingLogic.setInputItems(slot.getItemInputs());
-                    processingLogic.setInputFluids(slot.getFluidInputs());
+                    if (dualInputHatch.supportsFluids()) {
+                        processingLogic.setInputFluids(slot.getFluidInputs());
+                    } else {
+                        processingLogic.setInputFluids(getStoredFluids());
+                    }
                     result = processingLogic.process();
                     if (result.wasSuccessful()) {
                         return result;


### PR DESCRIPTION
This would make the Crafting Input Bus function more like a direct upgrade from an input bus + interface for setups that rely on passively stocked fluids e.g. fluid export bus. Recipes can still use fluids so long as they're in a separate input hatch(es).

This would be a balance change that makes the Crafting Input Bus more useful and intuitive. However it devalues the Crafting Input Buffer which would now only be needed to replace dual interface -> storage + fluid storage subnet.