### PR TITLE
Add Very heavy oil recipe to distillation tower

### DIFF
--- a/src/main/java/gregtech/loaders/postload/recipes/DistilleryRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/DistilleryRecipes.java
@@ -602,6 +602,13 @@ public class DistilleryRecipes implements Runnable {
             .eut(TierEU.RECIPE_MV)
             .addTo(sDistillationRecipes);
 
+        GT_Values.RA.stdBuilder()
+            .fluidInputs(new FluidStack(ItemList.sOilExtraHeavy, 1000))
+            .fluidOutputs(Materials.OilHeavy.getFluid(1500))
+            .duration(16 * TICKS)
+            .eut(2400)
+            .addTo(sDistillationRecipes);
+
         if (!GregTech_API.mIC2Classic) {
 
             GT_Values.RA.stdBuilder()


### PR DESCRIPTION
This will remove the need to use PAs if you want to use very heavy oil
Recipe is the same as in distillery just multiplied by 100 (1000 input, 1500 output)