### PR TITLE
Add missing residue in quantum anomaly dtpf recipe

### DIFF
--- a/src/main/java/gregtech/loaders/postload/recipes/PlasmaForgeRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/PlasmaForgeRecipes.java
@@ -28,7 +28,6 @@ public class PlasmaForgeRecipes implements Runnable {
                 MaterialsUEVplus.ExcitedDTEC.getFluid(100_000_000),
                 MaterialsUEVplus.SpaceTime.getMolten(64 * 2 * 9 * 144))
             .itemOutputs(ItemList.GigaChad.get(1))
-            .fluidOutputs(MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(100_000_000))
             .duration(86400 * 20 * 2)
             .eut(2_000_000_000)
             .metadata(COIL_HEAT, 13500)

--- a/src/main/java/gregtech/loaders/postload/recipes/PlasmaForgeRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/PlasmaForgeRecipes.java
@@ -28,6 +28,7 @@ public class PlasmaForgeRecipes implements Runnable {
                 MaterialsUEVplus.ExcitedDTEC.getFluid(100_000_000),
                 MaterialsUEVplus.SpaceTime.getMolten(64 * 2 * 9 * 144))
             .itemOutputs(ItemList.GigaChad.get(1))
+            .fluidOutputs(MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(100_000_000))
             .duration(86400 * 20 * 2)
             .eut(2_000_000_000)
             .metadata(COIL_HEAT, 13500)
@@ -41,6 +42,7 @@ public class PlasmaForgeRecipes implements Runnable {
                 getModItem(GoodGenerator.ID, "huiCircuit", 0, 4))
             .fluidInputs(MaterialsUEVplus.ExcitedDTRC.getFluid(92), Materials.Duranium.getMolten(144))
             .itemOutputs(getModItem(GTPlusPlus.ID, "MU-metaitem.01", 1, 32105))
+            .fluidOutputs(MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(46))
             .duration(60 * SECONDS)
             .eut((int) TierEU.RECIPE_UEV)
             .metadata(COIL_HEAT, 10800)


### PR DESCRIPTION
The quantum anomaly DTPF recipe was missing the dimensionally transcendent residue output, this PR fixes that

resplendent catalyst -> residue is a 2:1 ratio 