### PR TITLE
Fix server crash with Teleporter

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_Teleporter.java
+++ b/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_Teleporter.java
@@ -12,7 +12,6 @@ import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_TELEPORTER_SIDES_GL
 import java.util.List;
 import java.util.function.Consumer;
 
-import net.minecraft.client.particle.EntityFX;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityHanging;
 import net.minecraft.entity.EntityLiving;
@@ -97,9 +96,6 @@ public class GT_MetaTileEntity_Teleporter extends GT_MetaTileEntity_BasicTank
     }
 
     private static float calculateWeight(Entity aEntity) {
-        if ((aEntity instanceof EntityFX)) {
-            return -1.0F;
-        }
         if ((aEntity instanceof EntityFishHook)) {
             return -1.0F;
         }


### PR DESCRIPTION
Close https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14670
Blame https://github.com/GTNewHorizons/GT5-Unofficial/pull/2040/commits/2dd2b934a52bf733d7ff653a19a717e43713bfaa
This method is always executed on server