### PR TITLE
Modularize the isBlockUnder check in GT_BaseCrop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ src/main/resources/mixins.*.json
 classes
 .factorypath
 /.vs
+layout.json


### PR DESCRIPTION
This is to help with some changes related to the EIG stuff I'm working on. I already have a functional workaround using mixins and interfaces that effectively does this but a proper implementation would be nice.

- Add layout.json from idea to gitignore
- Modularizes the code for the isBlockBelow check
- No functionality changes should appear to the end user