### PR TITLE
Fix scotch

### DIFF
--- a/src/main/java/gregtech/loaders/postload/recipes/DistilleryRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/DistilleryRecipes.java
@@ -357,6 +357,14 @@ public class DistilleryRecipes implements Runnable {
             .eut(30)
             .addTo(sDistilleryRecipes);
 
+        GT_Values.RA.stdBuilder()
+            .itemInputs(GT_Utility.getIntegratedCircuit(1))
+            .fluidInputs(getFluidStack("potion.wheatyjuice", 75))
+            .fluidOutputs(getFluidStack("potion.scotch", 1))
+            .duration(1 * SECONDS)
+            .eut(TierEU.RECIPE_MV)
+            .addTo(sDistilleryRecipes);
+
         if (TinkerConstruct.isModLoaded()) {
 
             GT_Values.RA.stdBuilder()

--- a/src/main/java/gregtech/loaders/postload/recipes/FermenterRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/FermenterRecipes.java
@@ -95,13 +95,6 @@ public class FermenterRecipes implements Runnable {
             .addTo(sFermentingRecipes);
 
         GT_Values.RA.stdBuilder()
-            .fluidInputs(getFluidStack("potion.wheatyjuice", 50))
-            .fluidOutputs(getFluidStack("potion.scotch", 25))
-            .duration(51 * SECONDS + 4 * TICKS)
-            .eut(2)
-            .addTo(sFermentingRecipes);
-
-        GT_Values.RA.stdBuilder()
             .fluidInputs(getFluidStack("potion.scotch", 50))
             .fluidOutputs(getFluidStack("potion.glenmckenner", 10))
             .duration(1 * MINUTES + 42 * SECONDS + 8 * TICKS)


### PR DESCRIPTION
just fixes a small recipe conflict with 'fermented wheat' which made scotch unobtainable for the last few years. Let's just say it needed some time to mature. :P

The fix is just a change of machine.  The new recipe is also more in line with some other spirits now.

fixes one point in https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14638

![image](https://github.com/GTNewHorizons/GT5-Unofficial/assets/40274384/d3396df5-a8e9-4834-8fdb-71b473c7ecff)