### PR TITLE
Fix memory leak of player instances in CoverBehavior

### DIFF
--- a/src/main/java/gregtech/api/util/GT_CoverBehavior.java
+++ b/src/main/java/gregtech/api/util/GT_CoverBehavior.java
@@ -22,7 +22,6 @@ import gregtech.api.net.GT_Packet_TileEntityCoverGUI;
  */
 public abstract class GT_CoverBehavior extends GT_CoverBehaviorBase<ISerializableObject.LegacyCoverData> {
 
-    public WeakReference<EntityPlayer> lastPlayer = null;
     public boolean mPlayerNotified = false;
 
     public GT_CoverBehavior() {

--- a/src/main/java/gregtech/api/util/GT_CoverBehavior.java
+++ b/src/main/java/gregtech/api/util/GT_CoverBehavior.java
@@ -2,6 +2,8 @@ package gregtech.api.util;
 
 import static gregtech.api.enums.GT_Values.E;
 
+import java.lang.ref.WeakReference;
+
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
@@ -20,7 +22,7 @@ import gregtech.api.net.GT_Packet_TileEntityCoverGUI;
  */
 public abstract class GT_CoverBehavior extends GT_CoverBehaviorBase<ISerializableObject.LegacyCoverData> {
 
-    public EntityPlayer lastPlayer = null;
+    public WeakReference<EntityPlayer> lastPlayer = null;
     public boolean mPlayerNotified = false;
 
     public GT_CoverBehavior() {
@@ -241,7 +243,7 @@ public abstract class GT_CoverBehavior extends GT_CoverBehaviorBase<ISerializabl
     public boolean onCoverShiftRightclick(ForgeDirection side, int aCoverID, int aCoverVariable, ICoverable aTileEntity,
         EntityPlayer aPlayer) {
         if (hasCoverGUI() && aPlayer instanceof EntityPlayerMP) {
-            lastPlayer = aPlayer;
+            lastPlayer = new WeakReference<>(aPlayer);
             mPlayerNotified = false;
             if (useModularUI()) {
                 GT_UIInfos.openCoverUI(aTileEntity, aPlayer, side);

--- a/src/main/java/gregtech/api/util/GT_CoverBehaviorBase.java
+++ b/src/main/java/gregtech/api/util/GT_CoverBehaviorBase.java
@@ -2,6 +2,7 @@ package gregtech.api.util;
 
 import static gregtech.api.enums.GT_Values.E;
 
+import java.lang.ref.WeakReference;
 import java.util.List;
 import java.util.function.Supplier;
 
@@ -45,7 +46,7 @@ import gregtech.common.covers.CoverInfo;
  */
 public abstract class GT_CoverBehaviorBase<T extends ISerializableObject> {
 
-    public EntityPlayer lastPlayer = null;
+    public WeakReference<EntityPlayer> lastPlayer = null;
     private final Class<T> typeToken;
     private final ITexture coverFGTexture;
 
@@ -620,7 +621,7 @@ public abstract class GT_CoverBehaviorBase<T extends ISerializableObject> {
     protected boolean onCoverShiftRightClickImpl(ForgeDirection side, int aCoverID, T aCoverVariable,
         ICoverable aTileEntity, EntityPlayer aPlayer) {
         if (hasCoverGUI() && aPlayer instanceof EntityPlayerMP) {
-            lastPlayer = aPlayer;
+            lastPlayer = new WeakReference<>(aPlayer);
             if (useModularUI()) {
                 GT_UIInfos.openCoverUI(aTileEntity, aPlayer, side);
             } else {

--- a/src/main/java/gregtech/common/covers/GT_Cover_ControlsWork.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_ControlsWork.java
@@ -50,16 +50,20 @@ public class GT_Cover_ControlsWork extends GT_CoverBehavior implements IControls
                 if (machine.wasShutdown()) {
                     machine.disableWorking();
                     if (!mPlayerNotified) {
-                        mPlayerNotified = true;
-                        GT_Utility.sendChatToPlayer(
-                            lastPlayer,
-                            aTileEntity.getInventoryName() + "at "
-                                + String.format(
-                                    "(%d,%d,%d)",
-                                    aTileEntity.getXCoord(),
-                                    aTileEntity.getYCoord(),
-                                    aTileEntity.getZCoord())
-                                + " shut down.");
+                        EntityPlayer player = lastPlayer == null ? null : lastPlayer.get();
+                        if (player != null) {
+                            lastPlayer = null;
+                            mPlayerNotified = true;
+                            GT_Utility.sendChatToPlayer(
+                                player,
+                                aTileEntity.getInventoryName() + "at "
+                                    + String.format(
+                                        "(%d,%d,%d)",
+                                        aTileEntity.getXCoord(),
+                                        aTileEntity.getYCoord(),
+                                        aTileEntity.getZCoord())
+                                    + " shut down.");
+                        }
                     }
                     return 2;
                 } else {


### PR DESCRIPTION
Simply shift-right clicking a cover, leaving and then joining again will "duplicate" player instances. This happens because covers store a reference to the last player that used them, without ever clearing that reference.