### PR TITLE
Fix unpredictable / inconsistent item pipe transfer rate

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Item.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Item.java
@@ -47,6 +47,7 @@ public class GT_MetaPipeEntity_Item extends MetaPipeEntity implements IMetaTileE
     public final int mStepSize;
     public final int mTickTime;
     public int mTransferredItems = 0;
+    public long mCurrentTransferStartTick = 0;
     public ForgeDirection mLastReceivedFrom = ForgeDirection.UNKNOWN, oLastReceivedFrom = ForgeDirection.UNKNOWN;
     public boolean mIsRestrictive = false;
     private int[] cacheSides;
@@ -204,8 +205,11 @@ public class GT_MetaPipeEntity_Item extends MetaPipeEntity implements IMetaTileE
     @Override
     public void onPostTick(IGregTechTileEntity aBaseMetaTileEntity, long aTick) {
         super.onPostTick(aBaseMetaTileEntity, aTick);
-        if (aBaseMetaTileEntity.isServerSide() && aTick % 10 == 0) {
-            if (aTick % mTickTime == 0) mTransferredItems = 0;
+        if (aBaseMetaTileEntity.isServerSide() && (aTick - mCurrentTransferStartTick) % 10 == 0) {
+            if ((aTick - mCurrentTransferStartTick) % mTickTime == 0) {
+                mTransferredItems = 0;
+                mCurrentTransferStartTick = 0;
+            }
 
             if (!GT_Mod.gregtechproxy.gt6Pipe || mCheckConnections) checkConnections();
 
@@ -323,6 +327,7 @@ public class GT_MetaPipeEntity_Item extends MetaPipeEntity implements IMetaTileE
 
     @Override
     public boolean incrementTransferCounter(int aIncrement) {
+        if (mTransferredItems == 0) mCurrentTransferStartTick = getBaseMetaTileEntity().getTimer();
         mTransferredItems += aIncrement;
         return pipeCapacityCheck();
     }


### PR DESCRIPTION
Hi All,

This is my first attempted contribution to GTNH, so apologies if I haven't followed proper contributor procedure. I understand that the preferred contribution procedure is to refer to an open issue in the [GT-New-Horizons-Modpack issue tracker](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack), but it seems some PRs get accepted in this repo without doing so, so I figured I'd try this approach given the limited scope / obscurity of my PR. Regardless, I'd be happy to open an issue there if needed.

Anyway, this PR addresses the unpredictable / inconsistent transfer rates of GT item pipes. Consider the following setup consisting of a hopper (1 item / second) feeding eight chests via Tiny Tin Item Pipes (1 stack / 8 seconds) and Large Tin Item Pipes (1 stack / second):

![image](https://github.com/GTNewHorizons/GT5-Unofficial/assets/102826865/7b492894-d24f-4f49-86e5-fa3017fdaafa)

Given the transfer rates of each node in the pipe network, the expected / intuitive behavior is that continuous network inputs should be evenly divided among the eight chests. However, empirical observations indicate that this is often not the case, and some chests unexpectedly receive different quantities of items.

Further investigation revealed that this unexpected behavior is due to item pipes resetting their transferred items counter on every `mTickTime`[^1] interval of their base meta-tile entity's `mTickTimer`[^2] **_regardless of when their current transfer period[^3] began, resulting in item pipes sometimes transferring more items than their transfer rate should allow_**. This is illustrated in the following figure:

![Figure 1](https://github.com/GTNewHorizons/GT5-Unofficial/assets/102826865/211d9a30-5c38-4e35-a60d-599229473553)

The PR addresses this issue with the following unobtrusive changes to `GT_MetaPipeEntity_Item`:
- New member `mCurrentTransferStartTick` to mark the `mTickTimer` value when the current transfer period started (handled in `incrementTransferCounter`).
- Appropriate modifications to `onPostTick` to take into account the current transfer period start tick. Care was taken to avoid more-frequent tick updates and significantly changing existing logic / behavior.

I've tested it quite a bit and believe to have solved the issue without introducing any new bugs or weird behavior, but I'm eager to hear others' feedback.

Thanks for the consideration,
B-Tone (also Discord name)

[^1]: Related to item pipe transfer rate, e.g., `mTickTime = 20` for Large Tin Item Pipe, `mTickTime = 160` for Tiny Tin Item Pipe, etc.

[^2]: Number of ticks the entity has been loaded for.

[^3]: Transfer period meaning the time between a quiescent pipe first receiving an input and the subsequent reset of its transferred items counter; in other words, the ticks elapsed since `mTransferredItem` last became greater than 0 and subsequently returned to 0 (which should nominally be `mTickTime` ticks).