### PR TITLE
Fix sunnarium bee production rate

### DIFF
--- a/src/main/java/gregtech/loaders/misc/GT_BeeDefinition.java
+++ b/src/main/java/gregtech/loaders/misc/GT_BeeDefinition.java
@@ -592,7 +592,7 @@ public enum GT_BeeDefinition implements IBeeDefinition {
     SUNNARIUM(GT_BranchDefinition.RAREMETAL, "Sunnarium", false, new Color(0xFFBC5E), new Color(0xE5CA2A),
         beeSpecies -> {
             beeSpecies.addProduct(Materials.Glowstone.getDust(1), 0.30f);
-            beeSpecies.addSpecialty(Materials.Sunnarium.getDust(1), 0.5f);
+            beeSpecies.addSpecialty(Materials.Sunnarium.getDust(1), 0.05f);
             beeSpecies.setHumidity(EnumHumidity.NORMAL);
             beeSpecies.setNocturnal();
             beeSpecies.setHasEffect();


### PR DESCRIPTION
Actually changes sunnarium speciality rate to 5% as was intended.
It was just a typo in here https://github.com/GTNewHorizons/GT5-Unofficial/pull/2014.
