### PR TITLE
Fix fluid canner recipes not using correct empty container

### DIFF
--- a/src/main/java/gregtech/api/util/GT_Utility.java
+++ b/src/main/java/gregtech/api/util/GT_Utility.java
@@ -1849,13 +1849,6 @@ public class GT_Utility {
     public static ItemStack fillFluidContainer(FluidStack aFluid, ItemStack aStack, boolean aRemoveFluidDirectly,
         boolean aCheckIFluidContainerItems) {
         if (isStackInvalid(aStack) || aFluid == null) return null;
-        if (GT_ModHandler.isWater(aFluid) && ItemList.Bottle_Empty.isStackEqual(aStack)) {
-            if (aFluid.amount >= 250) {
-                if (aRemoveFluidDirectly) aFluid.amount -= 250;
-                return new ItemStack(Items.potionitem, 1, 0);
-            }
-            return null;
-        }
         if (aCheckIFluidContainerItems && aStack.getItem() instanceof IFluidContainerItem
             && ((IFluidContainerItem) aStack.getItem()).getFluid(aStack) == null
             && ((IFluidContainerItem) aStack.getItem()).getCapacity(aStack) <= aFluid.amount) {
@@ -1962,8 +1955,10 @@ public class GT_Utility {
     }
 
     /**
-     * Get general container item, not only fluid container but also non-consumable item.
-     * {@link #getContainerForFilledItem} works better for fluid container.
+     * This is NOT meant for fluid manipulation! It's for getting item container, which is generally used for
+     * crafting recipes. While it also works for many of the fluid containers, some don't.
+     * <p>
+     * Use {@link #getContainerForFilledItem} for getting empty fluid container.
      */
     public static ItemStack getContainerItem(ItemStack aStack, boolean aCheckIFluidContainerItems) {
         if (isStackInvalid(aStack)) return null;

--- a/src/main/java/gregtech/common/GT_Proxy.java
+++ b/src/main/java/gregtech/common/GT_Proxy.java
@@ -823,7 +823,7 @@ public abstract class GT_Proxy implements IGT_Mod, IGuiHandler, IFuelHandler, IG
         for (FluidContainerRegistry.FluidContainerData tData : FluidContainerRegistry
             .getRegisteredFluidContainerData()) {
             if ((tData.filledContainer.getItem() == Items.potionitem) && (tData.filledContainer.getItemDamage() == 0)) {
-                tData.fluid.amount = 0;
+                tData.fluid.amount = 250;
                 break;
             }
         }
@@ -1220,7 +1220,7 @@ public abstract class GT_Proxy implements IGT_Mod, IGuiHandler, IFuelHandler, IG
         for (FluidContainerRegistry.FluidContainerData tData : FluidContainerRegistry
             .getRegisteredFluidContainerData()) {
             if ((tData.filledContainer.getItem() == Items.potionitem) && (tData.filledContainer.getItemDamage() == 0)) {
-                tData.fluid.amount = 0;
+                tData.fluid.amount = 250;
                 break;
             }
         }
@@ -1252,7 +1252,7 @@ public abstract class GT_Proxy implements IGT_Mod, IGuiHandler, IFuelHandler, IG
         for (FluidContainerRegistry.FluidContainerData tData : FluidContainerRegistry
             .getRegisteredFluidContainerData()) {
             if ((tData.filledContainer.getItem() == Items.potionitem) && (tData.filledContainer.getItemDamage() == 0)) {
-                tData.fluid.amount = 0;
+                tData.fluid.amount = 250;
                 break;
             }
         }
@@ -1345,7 +1345,7 @@ public abstract class GT_Proxy implements IGT_Mod, IGuiHandler, IFuelHandler, IG
         for (FluidContainerRegistry.FluidContainerData tData : FluidContainerRegistry
             .getRegisteredFluidContainerData()) {
             if ((tData.filledContainer.getItem() == Items.potionitem) && (tData.filledContainer.getItemDamage() == 0)) {
-                tData.fluid.amount = 0;
+                tData.fluid.amount = 250;
                 break;
             }
         }
@@ -2146,7 +2146,7 @@ public abstract class GT_Proxy implements IGT_Mod, IGuiHandler, IFuelHandler, IG
     public void onFluidContainerRegistration(FluidContainerRegistry.FluidContainerRegisterEvent aFluidEvent) {
         if ((aFluidEvent.data.filledContainer.getItem() == Items.potionitem)
             && (aFluidEvent.data.filledContainer.getItemDamage() == 0)) {
-            aFluidEvent.data.fluid.amount = 0;
+            aFluidEvent.data.fluid.amount = 250;
         }
         GT_OreDictUnificator.addToBlacklist(aFluidEvent.data.emptyContainer);
         GT_OreDictUnificator.addToBlacklist(aFluidEvent.data.filledContainer);

--- a/src/main/java/gregtech/loaders/postload/GT_PostLoad.java
+++ b/src/main/java/gregtech/loaders/postload/GT_PostLoad.java
@@ -5,7 +5,6 @@ import static gregtech.api.enums.Mods.Forestry;
 import static gregtech.api.enums.Mods.GalacticraftCore;
 import static gregtech.api.enums.Mods.GalacticraftMars;
 import static gregtech.api.enums.Mods.GalaxySpace;
-import static gregtech.api.enums.Mods.IguanaTweaksTinkerConstruct;
 import static gregtech.api.enums.Mods.Thaumcraft;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sFluidCannerRecipes;
 import static gregtech.api.util.GT_RecipeBuilder.TICKS;
@@ -114,69 +113,22 @@ public class GT_PostLoad {
     }
 
     public static void registerFluidCannerRecipes() {
-        ItemStack iSData0 = new ItemStack(Items.potionitem, 1, 0);
-        ItemStack iLData0 = ItemList.Bottle_Empty.get(1L);
-
         for (FluidContainerRegistry.FluidContainerData tData : FluidContainerRegistry
             .getRegisteredFluidContainerData()) {
-            if ((tData.filledContainer.getItem() == Items.potionitem) && (tData.filledContainer.getItemDamage() == 0)) {
-                GT_Values.RA.stdBuilder()
-                    .itemInputs(iLData0)
-                    .itemOutputs(iSData0)
-                    .fluidInputs(Materials.Water.getFluid(250L))
-                    .duration(4 * TICKS)
-                    .eut(1)
-                    .addTo(sFluidCannerRecipes);
-                GT_Values.RA.stdBuilder()
-                    .itemInputs(iSData0)
-                    .itemOutputs(iLData0)
-                    .duration(4 * TICKS)
-                    .eut(1)
-                    .addTo(sFluidCannerRecipes);
-            } else if (IguanaTweaksTinkerConstruct.isModLoaded() && tData.emptyContainer.isItemEqual(
-                Objects.requireNonNull(
-                    GT_ModHandler.getModItem(IguanaTweaksTinkerConstruct.ID, "clayBucketFired", 1L, 0)))) {
-                        GT_Values.RA.stdBuilder()
-                            .itemInputs(
-                                GT_ModHandler.getModItem(IguanaTweaksTinkerConstruct.ID, "clayBucketFired", 1L, 0))
-                            .itemOutputs(tData.filledContainer)
-                            .fluidInputs(tData.fluid)
-                            .duration((tData.fluid.amount / 62) * TICKS)
-                            .eut(1)
-                            .addTo(sFluidCannerRecipes);
-                        GT_Values.RA.stdBuilder()
-                            .itemInputs(tData.filledContainer)
-                            .itemOutputs(
-                                GT_ModHandler.getModItem(IguanaTweaksTinkerConstruct.ID, "clayBucketFired", 1L, 0))
-                            .fluidOutputs(tData.fluid)
-                            .duration((tData.fluid.amount / 62) * TICKS)
-                            .eut(1)
-                            .addTo(sFluidCannerRecipes);
-                    } else {
-                        GT_Values.RA.stdBuilder()
-                            .itemInputs(tData.emptyContainer)
-                            .itemOutputs(tData.filledContainer)
-                            .fluidInputs(tData.fluid)
-                            .duration((tData.fluid.amount / 62) * TICKS)
-                            .eut(1)
-                            .addTo(sFluidCannerRecipes);
-                        if (GT_Utility.getContainerItem(tData.filledContainer, true) == null) {
-                            GT_Values.RA.stdBuilder()
-                                .itemInputs(tData.filledContainer)
-                                .fluidOutputs(tData.fluid)
-                                .duration((tData.fluid.amount / 62) * TICKS)
-                                .eut(1)
-                                .addTo(sFluidCannerRecipes);
-                        } else {
-                            GT_Values.RA.stdBuilder()
-                                .itemInputs(tData.filledContainer)
-                                .itemOutputs(GT_Utility.getContainerItem(tData.filledContainer, true))
-                                .fluidOutputs(tData.fluid)
-                                .duration((tData.fluid.amount / 62) * TICKS)
-                                .eut(1)
-                                .addTo(sFluidCannerRecipes);
-                        }
-                    }
+            GT_Values.RA.stdBuilder()
+                .itemInputs(tData.emptyContainer)
+                .itemOutputs(tData.filledContainer)
+                .fluidInputs(tData.fluid)
+                .duration((tData.fluid.amount / 62) * TICKS)
+                .eut(1)
+                .addTo(sFluidCannerRecipes);
+            GT_Values.RA.stdBuilder()
+                .itemInputs(tData.filledContainer)
+                .itemOutputs(tData.emptyContainer)
+                .fluidOutputs(tData.fluid)
+                .duration((tData.fluid.amount / 62) * TICKS)
+                .eut(1)
+                .addTo(sFluidCannerRecipes);
         }
     }
 

--- a/src/main/java/gregtech/loaders/postload/GT_PostLoad.java
+++ b/src/main/java/gregtech/loaders/postload/GT_PostLoad.java
@@ -44,6 +44,7 @@ import gregtech.api.util.GT_Log;
 import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_OreDictUnificator;
 import gregtech.api.util.GT_Recipe;
+import gregtech.api.util.GT_RecipeBuilder;
 import gregtech.api.util.GT_RecipeRegistrator;
 import gregtech.api.util.GT_Utility;
 import gregtech.common.items.GT_MetaGenerated_Tool_01;
@@ -115,17 +116,22 @@ public class GT_PostLoad {
     public static void registerFluidCannerRecipes() {
         for (FluidContainerRegistry.FluidContainerData tData : FluidContainerRegistry
             .getRegisteredFluidContainerData()) {
+            // lava clay bucket is registered with empty container with 0 stack size
+            ItemStack emptyContainer = tData.emptyContainer.copy();
+            emptyContainer.stackSize = 1;
             GT_Values.RA.stdBuilder()
-                .itemInputs(tData.emptyContainer)
+                .itemInputs(emptyContainer)
                 .itemOutputs(tData.filledContainer)
                 .fluidInputs(tData.fluid)
                 .duration((tData.fluid.amount / 62) * TICKS)
                 .eut(1)
                 .addTo(sFluidCannerRecipes);
-            GT_Values.RA.stdBuilder()
-                .itemInputs(tData.filledContainer)
-                .itemOutputs(tData.emptyContainer)
-                .fluidOutputs(tData.fluid)
+            GT_RecipeBuilder builder = GT_Values.RA.stdBuilder()
+                .itemInputs(tData.filledContainer);
+            if (tData.emptyContainer.stackSize > 0) {
+                builder.itemOutputs(tData.emptyContainer);
+            }
+            builder.fluidOutputs(tData.fluid)
                 .duration((tData.fluid.amount / 62) * TICKS)
                 .eut(1)
                 .addTo(sFluidCannerRecipes);


### PR DESCRIPTION
Close https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13814
Lava clay bucket now doesn't output empty bucket. I also tried to fix GT tank interaction but couldn't find a way to handle it properly.