### PR TITLE
implement drain for stocking input hatch

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_Input_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_Input_ME.java
@@ -208,6 +208,21 @@ public class GT_MetaTileEntity_Hatch_Input_ME extends GT_MetaTileEntity_Hatch_In
     }
 
     @Override
+    public FluidStack drain(ForgeDirection side, FluidStack aFluid, boolean doDrain) {
+        if (false) {
+            return super.drain(side, aFluid, doDrain);
+        }
+        if (side != ForgeDirection.UNKNOWN) return null;
+        FluidStack stored = getMatchingFluidStack(aFluid);
+        if (stored == null) return null;
+        FluidStack drained = GT_Utility.copyAmount(Math.min(stored.amount, aFluid.amount), stored);
+        if (doDrain) {
+            stored.amount -= drained.amount;
+        }
+        return drained;
+    }
+
+    @Override
     public void startRecipeProcessing() {
         processingRecipe = true;
     }

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_Input_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_Input_ME.java
@@ -209,9 +209,8 @@ public class GT_MetaTileEntity_Hatch_Input_ME extends GT_MetaTileEntity_Hatch_In
 
     @Override
     public FluidStack drain(ForgeDirection side, FluidStack aFluid, boolean doDrain) {
-        if (false) {
-            return super.drain(side, aFluid, doDrain);
-        }
+        // this is an ME output hatch. allowing draining via logistics would be very wrong (and against canTankbeEmptied())
+        // but we do need to support draining from controller, which uses the UNKNOWN direction.
         if (side != ForgeDirection.UNKNOWN) return null;
         FluidStack stored = getMatchingFluidStack(aFluid);
         if (stored == null) return null;

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_Input_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_Input_ME.java
@@ -209,8 +209,8 @@ public class GT_MetaTileEntity_Hatch_Input_ME extends GT_MetaTileEntity_Hatch_In
 
     @Override
     public FluidStack drain(ForgeDirection side, FluidStack aFluid, boolean doDrain) {
-        // this is an ME output hatch. allowing draining via logistics would be very wrong (and against canTankbeEmptied())
-        // but we do need to support draining from controller, which uses the UNKNOWN direction.
+        // this is an ME output hatch. allowing draining via logistics would be very wrong (and against
+        // canTankbeEmptied()) but we do need to support draining from controller, which uses the UNKNOWN direction.
         if (side != ForgeDirection.UNKNOWN) return null;
         FluidStack stored = getMatchingFluidStack(aFluid);
         if (stored == null) return null;

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_Input_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_Input_ME.java
@@ -209,8 +209,8 @@ public class GT_MetaTileEntity_Hatch_Input_ME extends GT_MetaTileEntity_Hatch_In
 
     @Override
     public FluidStack drain(ForgeDirection side, FluidStack aFluid, boolean doDrain) {
-        // this is an ME output hatch. allowing draining via logistics would be very wrong (and against
-        // canTankbeEmptied()) but we do need to support draining from controller, which uses the UNKNOWN direction.
+        // this is an ME input hatch. allowing draining via logistics would be very wrong (and against
+        // canTankBeEmptied()) but we do need to support draining from controller, which uses the UNKNOWN direction.
         if (side != ForgeDirection.UNKNOWN) return null;
         FluidStack stored = getMatchingFluidStack(aFluid);
         if (stored == null) return null;

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_HeatExchanger.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_HeatExchanger.java
@@ -273,6 +273,7 @@ public class GT_MetaTileEntity_HeatExchanger extends
                 // 1:160 ratio with distilled water consumption
 
                 FluidStack distilledStack = GT_ModHandler.getDistilledWater(distilledConsumed);
+                startRecipeProcessing();
                 if (depleteInput(distilledStack)) // Consume the distilled water
                 {
                     if (superheated) {
@@ -291,6 +292,7 @@ public class GT_MetaTileEntity_HeatExchanger extends
                         explodeMultiblock(); // Generate crater
                     }
                 }
+                endRecipeProcessing();
             }
             return true;
         }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeBoiler.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeBoiler.java
@@ -364,6 +364,7 @@ public abstract class GT_MetaTileEntity_LargeBoiler
                 excessWater += amount * STEAM_PER_WATER - tGeneratedEU;
                 amount -= excessWater / STEAM_PER_WATER;
                 excessWater %= STEAM_PER_WATER;
+                startRecipeProcessing();
                 if (isSuperheated()) {
                     // Consumes only one third of the water if producing Superheated Steam, to maintain water in the
                     // chain.
@@ -386,6 +387,7 @@ public abstract class GT_MetaTileEntity_LargeBoiler
                         explodeMultiblock();
                     }
                 }
+                endRecipeProcessing();
             }
             return true;
         }


### PR DESCRIPTION
This is primarily used by depleteInput() from controller. only drain from internal source (i.e. ForgeDirection.UNKNOWN) is allowed.