### PR TITLE
add denisty for ore clusters

### DIFF
--- a/src/main/java/gregtech/api/world/GT_Worldgen_Ore.java
+++ b/src/main/java/gregtech/api/world/GT_Worldgen_Ore.java
@@ -27,6 +27,7 @@ public abstract class GT_Worldgen_Ore extends GT_Worldgen {
         mSize = GregTech_API.sWorldgenFile.get(aTextWorldgen + mWorldGenName, "Size", aSize);
         mMinY = GregTech_API.sWorldgenFile.get(aTextWorldgen + mWorldGenName, "MinHeight", aMinY);
         mMaxY = GregTech_API.sWorldgenFile.get(aTextWorldgen + mWorldGenName, "MaxHeight", aMaxY);
+        mDeinsity = GregTech_API.sWorldgenFile.get(aTextWorldgen + mWorldGenName,"DensityPercent", aDensity);
         if (aBiomeList == null) mBiomeList = new ArrayList<>();
         else mBiomeList = aBiomeList;
         mAllowToGenerateinVoid = aAllowToGenerateinVoid;


### PR DESCRIPTION
add ability to generate dense ore clusters like in geolosys
![](https://www.minecraft-france.fr/wp-content/uploads/2018/06/filon_bauxite-575x300.png)
