### PR TITLE
Don't panic over collisions

### DIFF
--- a/src/main/java/gregtech/api/util/GT_RecipeBuilder.java
+++ b/src/main/java/gregtech/api/util/GT_RecipeBuilder.java
@@ -157,12 +157,9 @@ public class GT_RecipeBuilder {
         }
         GT_Log.err.print("Recipe collision resulting in recipe loss detected with ");
         GT_Log.err.println(details);
-        if (PANIC_MODE) {
-            throw new IllegalArgumentException("Recipe Collision");
-        } else {
-            // place a breakpoint here to catch all these issues
-            new IllegalArgumentException().printStackTrace(GT_Log.err);
-        }
+        // place a breakpoint here to catch all these issues
+        new IllegalArgumentException().printStackTrace(GT_Log.err);
+        // at least for now, do not crash in panic mode over collisions.
     }
 
     // endregion


### PR DESCRIPTION
With this I can actually run the game in panic mode for the first time (with the latest nightly + the gt++ pr that was merged earlier)

The 10k collisions that make recipes disappear are still something to be looked at but in the mean time we actually want to be able to use this mode to not miss invalid recipes and nulls in recipes. The precise nature of how we use it needs to be discussed I suppose.