### PR TITLE
Migrate to non-Object version Utility methods

### DIFF
--- a/src/main/java/gregtech/api/util/GT_Recipe.java
+++ b/src/main/java/gregtech/api/util/GT_Recipe.java
@@ -2210,10 +2210,10 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
                         && (aOutput1 == null || aOutput1.stackSize <= 6)
                         && (aOutput2 == null || aOutput2.stackSize <= 6)) {
                         // we don't use GT_Utility.mul() here. It does not have the truncating we need here.
-                        aInput1 = GT_Utility.multiplyStack(10L, aInput1);
-                        aInput2 = GT_Utility.multiplyStack(10L, aInput2);
-                        aOutput1 = GT_Utility.multiplyStack(10L, aOutput1);
-                        aOutput2 = GT_Utility.multiplyStack(10L, aOutput2);
+                        aInput1 = GT_Utility.multiplyStack(10, aInput1);
+                        aInput2 = GT_Utility.multiplyStack(10, aInput2);
+                        aOutput1 = GT_Utility.multiplyStack(10, aOutput1);
+                        aOutput2 = GT_Utility.multiplyStack(10, aOutput2);
                         for (Materials coal : new Materials[] { Materials.Coal, Materials.Charcoal }) {
                             coll.derive()
                                 .setInputs(aInput1, aInput2, coal.getBlocks(aCoalAmount))

--- a/src/main/java/gregtech/common/GT_Proxy.java
+++ b/src/main/java/gregtech/common/GT_Proxy.java
@@ -1767,7 +1767,7 @@ public abstract class GT_Proxy implements IGT_Mod, IGuiHandler, IFuelHandler, IG
                     GT_Log.ore.println(
                         tModToName + " is getting re-registered because the OreDict Name containing invalid spaces.");
                     GT_OreDictUnificator
-                        .registerOre(aEvent.Name.replaceAll(" ", ""), GT_Utility.copyAmount(1L, aEvent.Ore));
+                        .registerOre(aEvent.Name.replaceAll(" ", ""), GT_Utility.copyAmount(1, aEvent.Ore));
                     aEvent.Ore.setStackDisplayName("Invalid OreDictionary Tag");
                     return;
                 } else if (this.mInvalidNames.contains(aEvent.Name)) {
@@ -1826,7 +1826,7 @@ public abstract class GT_Proxy implements IGT_Mod, IGuiHandler, IFuelHandler, IG
                                 return;
                             }
                             if (!aPrefix.isIgnored(aMaterial)) {
-                                aPrefix.add(GT_Utility.copyAmount(1L, aEvent.Ore));
+                                aPrefix.add(GT_Utility.copyAmount(1, aEvent.Ore));
                             }
                             if (aMaterial != Materials._NULL) {
                                 Materials tReRegisteredMaterial;
@@ -1835,7 +1835,7 @@ public abstract class GT_Proxy implements IGT_Mod, IGuiHandler, IFuelHandler, IG
                                         .registerOre(aPrefix, tReRegisteredMaterial, aEvent.Ore)) {
                                     tReRegisteredMaterial = i$.next();
                                 }
-                                aMaterial.add(GT_Utility.copyAmount(1L, aEvent.Ore));
+                                aMaterial.add(GT_Utility.copyAmount(1, aEvent.Ore));
 
                                 if (GregTech_API.sThaumcraftCompat != null && aPrefix.doGenerateItem(aMaterial)
                                     && !aPrefix.isIgnored(aMaterial)) {
@@ -2043,11 +2043,11 @@ public abstract class GT_Proxy implements IGT_Mod, IGuiHandler, IFuelHandler, IG
                                 return;
                             }
                         } else {
-                            aPrefix.add(GT_Utility.copyAmount(1L, aEvent.Ore));
+                            aPrefix.add(GT_Utility.copyAmount(1, aEvent.Ore));
                         }
                     }
                 } else if (aPrefix.mIsSelfReferencing) {
-                    aPrefix.add(GT_Utility.copyAmount(1L, aEvent.Ore));
+                    aPrefix.add(GT_Utility.copyAmount(1, aEvent.Ore));
                 } else {
                     GT_Log.ore.println(tModToName + " uses a Prefix as full OreDict Name, and is therefor invalid.");
                     aEvent.Ore.setStackDisplayName("Invalid OreDictionary Tag");
@@ -2277,7 +2277,7 @@ public abstract class GT_Proxy implements IGT_Mod, IGuiHandler, IFuelHandler, IG
                     aOre.mMaterial == null ? Materials._NULL : aOre.mMaterial,
                     aOre.mEvent.Name,
                     aOre.mModID,
-                    GT_Utility.copyAmount(1L, aOre.mEvent.Ore));
+                    GT_Utility.copyAmount(1, aOre.mEvent.Ore));
             }
         } else {
             // GT_FML_LOGGER.info("Thingy Name: "+ aOre.mEvent.Name+ " !!!Unknown 'Thingy' detected!!! This

--- a/src/main/java/gregtech/common/GT_RecipeAdder.java
+++ b/src/main/java/gregtech/common/GT_RecipeAdder.java
@@ -712,10 +712,10 @@ public class GT_RecipeAdder implements IGT_RecipeAdder {
         if ((aInput1 == null || aInput1.stackSize <= 6) && (aInput2 == null || aInput2.stackSize <= 6)
             && (aOutput1 == null || aOutput1.stackSize <= 6)
             && (aOutput2 == null || aOutput2.stackSize <= 6)) {
-            aInput1 = aInput1 == null ? null : GT_Utility.copyAmount(aInput1.stackSize * 10L, aInput1);
-            aInput2 = aInput2 == null ? null : GT_Utility.copyAmount(aInput2.stackSize * 10L, aInput2);
-            aOutput1 = aOutput1 == null ? null : GT_Utility.copyAmount(aOutput1.stackSize * 10L, aOutput1);
-            aOutput2 = aOutput2 == null ? null : GT_Utility.copyAmount(aOutput2.stackSize * 10L, aOutput2);
+            aInput1 = aInput1 == null ? null : GT_Utility.copyAmount(aInput1.stackSize * 10, aInput1);
+            aInput2 = aInput2 == null ? null : GT_Utility.copyAmount(aInput2.stackSize * 10, aInput2);
+            aOutput1 = aOutput1 == null ? null : GT_Utility.copyAmount(aOutput1.stackSize * 10, aOutput1);
+            aOutput2 = aOutput2 == null ? null : GT_Utility.copyAmount(aOutput2.stackSize * 10, aOutput2);
             for (Materials coal : coals) {
                 GT_Recipe.GT_Recipe_Map.sPrimitiveBlastRecipes.addRecipe(
                     true,

--- a/src/main/java/gregtech/common/blocks/GT_Block_Stones_Abstract.java
+++ b/src/main/java/gregtech/common/blocks/GT_Block_Stones_Abstract.java
@@ -162,14 +162,14 @@ public class GT_Block_Stones_Abstract extends GT_Generic_Block implements IOreRe
         if (aOreDictName.equals(OreDictNames.craftingLensWhite.toString())) {
 
             GT_Values.RA.stdBuilder()
-                .itemInputs(new ItemStack(this, 1, 7), GT_Utility.copyAmount(0L, aStack))
+                .itemInputs(new ItemStack(this, 1, 7), GT_Utility.copyAmount(0, aStack))
                 .itemOutputs(new ItemStack(this, 1, 6))
                 .duration(2 * SECONDS + 10 * TICKS)
                 .eut(16)
                 .addTo(sLaserEngraverRecipes);
 
             GT_Values.RA.stdBuilder()
-                .itemInputs(new ItemStack(this, 1, 15), GT_Utility.copyAmount(0L, aStack))
+                .itemInputs(new ItemStack(this, 1, 15), GT_Utility.copyAmount(0, aStack))
                 .itemOutputs(new ItemStack(this, 1, 14))
                 .duration(2 * SECONDS + 10 * TICKS)
                 .eut(16)

--- a/src/main/java/gregtech/common/blocks/GT_TileEntity_Ores.java
+++ b/src/main/java/gregtech/common/blocks/GT_TileEntity_Ores.java
@@ -373,7 +373,7 @@ public class GT_TileEntity_Ores extends TileEntity implements ITexturedTileEntit
                     aMaterial.mOreMultiplier
                         + (aFortune > 0 ? tRandom.nextInt(1 + aFortune * aMaterial.mOreMultiplier) : 0) / 2); i
                             < j; i++) {
-                    rList.add(GT_Utility.copyAmount(1L, tSelector.get(tRandom.nextInt(tSelector.size()))));
+                    rList.add(GT_Utility.copyAmount(1, tSelector.get(tRandom.nextInt(tSelector.size()))));
                 }
             }
             if (tRandom.nextInt(3 + aFortune) > 1) {

--- a/src/main/java/gregtech/common/entities/GT_Entity_Arrow.java
+++ b/src/main/java/gregtech/common/entities/GT_Entity_Arrow.java
@@ -424,7 +424,7 @@ public class GT_Entity_Arrow extends EntityArrow {
     }
 
     public void setArrowItem(ItemStack aStack) {
-        this.mArrow = GT_Utility.updateItemStack(GT_Utility.copyAmount(1L, aStack));
+        this.mArrow = GT_Utility.updateItemStack(GT_Utility.copyAmount(1, aStack));
     }
 
     public boolean breaksOnImpact() {

--- a/src/main/java/gregtech/common/tileentities/automation/GT_MetaTileEntity_RecipeFilter.java
+++ b/src/main/java/gregtech/common/tileentities/automation/GT_MetaTileEntity_RecipeFilter.java
@@ -119,7 +119,7 @@ public class GT_MetaTileEntity_RecipeFilter extends GT_MetaTileEntity_SpecialFil
             return;
         }
         this.mInventory[FILTER_SLOT_INDEX] = GT_Utility.copyAmount(
-            1L,
+            1,
             this.filteredMachines.get(this.mRotationIndex = (this.mRotationIndex + 1) % this.filteredMachines.size()));
         if (this.mInventory[FILTER_SLOT_INDEX] == null) return;
     }

--- a/src/main/java/gregtech/common/tileentities/automation/GT_MetaTileEntity_TypeFilter.java
+++ b/src/main/java/gregtech/common/tileentities/automation/GT_MetaTileEntity_TypeFilter.java
@@ -143,7 +143,7 @@ public class GT_MetaTileEntity_TypeFilter extends GT_MetaTileEntity_SpecialFilte
             return;
         }
         this.mInventory[FILTER_SLOT_INDEX] = GT_Utility.copyAmount(
-            1L,
+            1,
             this.mPrefix.mPrefixedItems
                 .get(this.mRotationIndex = (this.mRotationIndex + 1) % this.mPrefix.mPrefixedItems.size()));
         if (this.mInventory[FILTER_SLOT_INDEX] == null) return;

--- a/src/main/java/gregtech/common/tileentities/generators/GT_MetaTileEntity_MagicalEnergyAbsorber.java
+++ b/src/main/java/gregtech/common/tileentities/generators/GT_MetaTileEntity_MagicalEnergyAbsorber.java
@@ -499,7 +499,7 @@ public class GT_MetaTileEntity_MagicalEnergyAbsorber extends GT_MetaTileEntity_B
             }
         }
 
-        ItemStack tOutputStack = GT_Utility.copyAmount(1L, tStack);
+        ItemStack tOutputStack = GT_Utility.copyAmount(1, tStack);
         if (tOutputStack != null) {
             if (isDisenchantableItem(tOutputStack)) {
                 tEU = tEU * getEfficiency() / 100;

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_InputBus_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_InputBus_ME.java
@@ -561,7 +561,7 @@ public class GT_MetaTileEntity_Hatch_InputBus_ME extends GT_MetaTileEntity_Hatch
                             getMcSlot().putStack(null);
                         } else {
                             if (containsSuchStack(cursorStack)) return;
-                            getMcSlot().putStack(GT_Utility.copyAmount(1L, cursorStack));
+                            getMcSlot().putStack(GT_Utility.copyAmount(1, cursorStack));
                         }
                         if (getBaseMetaTileEntity().isServerSide()) {
                             final ItemStack newInfo = updateInformationSlot(aSlotIndex, cursorStack);

--- a/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_Boxinator.java
+++ b/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_Boxinator.java
@@ -211,7 +211,7 @@ public class GT_MetaTileEntity_Boxinator extends GT_MetaTileEntity_BasicMachine 
                 true,
                 gregtech.api.enums.GT_Values.V[mTier],
                 null,
-                GT_Utility.copyAmount(64L, aStack),
+                GT_Utility.copyAmount(64, aStack),
                 tInput1) != null) {
                 return true;
             }

--- a/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_Scanner.java
+++ b/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_Scanner.java
@@ -182,7 +182,7 @@ public class GT_MetaTileEntity_Scanner extends GT_MetaTileEntity_BasicMachine {
                     this.mEUt = 1;
                 }
                 aStack.stackSize -= 1;
-                this.mOutputItems[0] = GT_Utility.copyAmount(1L, aStack);
+                this.mOutputItems[0] = GT_Utility.copyAmount(1, aStack);
                 assert this.mOutputItems[0] != null;
                 this.mOutputItems[0].setTagCompound(tNBT);
                 return 2;
@@ -190,7 +190,7 @@ public class GT_MetaTileEntity_Scanner extends GT_MetaTileEntity_BasicMachine {
             if (ItemList.Tool_DataOrb.isStackEqual(getSpecialSlot(), false, true)) {
                 if (ItemList.Tool_DataOrb.isStackEqual(aStack, false, true)) {
                     aStack.stackSize -= 1;
-                    this.mOutputItems[0] = GT_Utility.copyAmount(1L, getSpecialSlot());
+                    this.mOutputItems[0] = GT_Utility.copyAmount(1, getSpecialSlot());
                     calculateOverclockedNess(30, 512);
                     // In case recipe is too OP for that machine
                     if (mMaxProgresstime == Integer.MAX_VALUE - 1 && mEUt == Integer.MAX_VALUE - 1)
@@ -219,7 +219,7 @@ public class GT_MetaTileEntity_Scanner extends GT_MetaTileEntity_BasicMachine {
             if (ItemList.Tool_DataStick.isStackEqual(getSpecialSlot(), false, true)) {
                 if (ItemList.Tool_DataStick.isStackEqual(aStack, false, true)) {
                     aStack.stackSize -= 1;
-                    this.mOutputItems[0] = GT_Utility.copyAmount(1L, getSpecialSlot());
+                    this.mOutputItems[0] = GT_Utility.copyAmount(1, getSpecialSlot());
                     calculateOverclockedNess(30, 128);
                     // In case recipe is too OP for that machine
                     if (mMaxProgresstime == Integer.MAX_VALUE - 1 && mEUt == Integer.MAX_VALUE - 1)
@@ -230,7 +230,7 @@ public class GT_MetaTileEntity_Scanner extends GT_MetaTileEntity_BasicMachine {
                     getSpecialSlot().stackSize -= 1;
                     aStack.stackSize -= 1;
 
-                    this.mOutputItems[0] = GT_Utility.copyAmount(1L, getSpecialSlot());
+                    this.mOutputItems[0] = GT_Utility.copyAmount(1, getSpecialSlot());
                     assert this.mOutputItems[0] != null;
                     this.mOutputItems[0].setTagCompound(aStack.getTagCompound());
                     calculateOverclockedNess(30, 128);
@@ -243,7 +243,7 @@ public class GT_MetaTileEntity_Scanner extends GT_MetaTileEntity_BasicMachine {
                     getSpecialSlot().stackSize -= 1;
                     aStack.stackSize -= 1;
 
-                    this.mOutputItems[0] = GT_Utility.copyAmount(1L, getSpecialSlot());
+                    this.mOutputItems[0] = GT_Utility.copyAmount(1, getSpecialSlot());
                     assert this.mOutputItems[0] != null;
                     this.mOutputItems[0].setTagCompound(
                         GT_Utility
@@ -327,7 +327,7 @@ public class GT_MetaTileEntity_Scanner extends GT_MetaTileEntity_BasicMachine {
                     getSpecialSlot().stackSize -= 1;
                     aStack.stackSize -= 1;
 
-                    this.mOutputItems[0] = GT_Utility.copyAmount(1L, getSpecialSlot());
+                    this.mOutputItems[0] = GT_Utility.copyAmount(1, getSpecialSlot());
                     assert this.mOutputItems[0] != null;
                     this.mOutputItems[0].setTagCompound(
                         GT_Utility.getNBTContainingShort(new NBTTagCompound(), "rocket_tier", Short.parseShort(sTier)));
@@ -346,7 +346,7 @@ public class GT_MetaTileEntity_Scanner extends GT_MetaTileEntity_BasicMachine {
                     GT_Utility.ItemNBT.convertProspectionData(aStack);
                     aStack.stackSize -= 1;
 
-                    this.mOutputItems[0] = GT_Utility.copyAmount(1L, aStack);
+                    this.mOutputItems[0] = GT_Utility.copyAmount(1, aStack);
                     calculateOverclockedNess(30, 1000);
                     // In case recipe is too OP for that machine
                     if (mMaxProgresstime == Integer.MAX_VALUE - 1 && mEUt == Integer.MAX_VALUE - 1)
@@ -368,7 +368,7 @@ public class GT_MetaTileEntity_Scanner extends GT_MetaTileEntity_BasicMachine {
                             return FOUND_RECIPE_BUT_DID_NOT_MEET_REQUIREMENTS;
                         }
 
-                        this.mOutputItems[0] = GT_Utility.copyAmount(1L, getSpecialSlot());
+                        this.mOutputItems[0] = GT_Utility.copyAmount(1, getSpecialSlot());
 
                         // Use Assline Utils
                         if (GT_AssemblyLineUtils.setAssemblyLineRecipeOnDataStick(this.mOutputItems[0], tRecipe)) {

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_IntegratedOreFactory.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_IntegratedOreFactory.java
@@ -577,16 +577,15 @@ public class GT_MetaTileEntity_IntegratedOreFactory extends
             }
             int tChance = aRecipe.getOutputChance(i);
             if (tChance == 10000) {
-                tOutput.add(
-                    GT_Utility.copyAmountUnsafe((long) aTime * aRecipe.getOutput(i).stackSize, aRecipe.getOutput(i)));
+                tOutput.add(GT_Utility.copyAmountUnsafe(aTime * aRecipe.getOutput(i).stackSize, aRecipe.getOutput(i)));
             } else {
                 // Use Normal Distribution
                 double u = aTime * (tChance / 10000D);
                 double e = aTime * (tChance / 10000D) * (1 - (tChance / 10000D));
                 Random random = new Random();
                 int tAmount = (int) Math.ceil(Math.sqrt(e) * random.nextGaussian() + u);
-                tOutput.add(
-                    GT_Utility.copyAmountUnsafe((long) tAmount * aRecipe.getOutput(i).stackSize, aRecipe.getOutput(i)));
+                tOutput
+                    .add(GT_Utility.copyAmountUnsafe(tAmount * aRecipe.getOutput(i).stackSize, aRecipe.getOutput(i)));
             }
         }
         return tOutput.stream()

--- a/src/main/java/gregtech/common/tileentities/machines/steam/GT_MetaTileEntity_Furnace_Bronze.java
+++ b/src/main/java/gregtech/common/tileentities/machines/steam/GT_MetaTileEntity_Furnace_Bronze.java
@@ -68,7 +68,7 @@ public class GT_MetaTileEntity_Furnace_Bronze extends GT_MetaTileEntity_BasicMac
     protected boolean allowPutStackValidated(IGregTechTileEntity aBaseMetaTileEntity, int aIndex, ForgeDirection side,
         ItemStack aStack) {
         return super.allowPutStackValidated(aBaseMetaTileEntity, aIndex, side, aStack)
-            && GT_ModHandler.getSmeltingOutput(GT_Utility.copyAmount(64L, aStack), false, null) != null;
+            && GT_ModHandler.getSmeltingOutput(GT_Utility.copyAmount(64, aStack), false, null) != null;
     }
 
     @Override

--- a/src/main/java/gregtech/common/tileentities/machines/steam/GT_MetaTileEntity_Furnace_Steel.java
+++ b/src/main/java/gregtech/common/tileentities/machines/steam/GT_MetaTileEntity_Furnace_Steel.java
@@ -68,7 +68,7 @@ public class GT_MetaTileEntity_Furnace_Steel extends GT_MetaTileEntity_BasicMach
     protected boolean allowPutStackValidated(IGregTechTileEntity aBaseMetaTileEntity, int aIndex, ForgeDirection side,
         ItemStack aStack) {
         return super.allowPutStackValidated(aBaseMetaTileEntity, aIndex, side, aStack)
-            && GT_ModHandler.getSmeltingOutput(GT_Utility.copyAmount(64L, aStack), false, null) != null;
+            && GT_ModHandler.getSmeltingOutput(GT_Utility.copyAmount(64, aStack), false, null) != null;
     }
 
     @Override

--- a/src/main/java/gregtech/common/tileentities/machines/steam/GT_MetaTileEntity_Macerator_Bronze.java
+++ b/src/main/java/gregtech/common/tileentities/machines/steam/GT_MetaTileEntity_Macerator_Bronze.java
@@ -98,7 +98,7 @@ public class GT_MetaTileEntity_Macerator_Bronze extends GT_MetaTileEntity_BasicM
     protected boolean allowPutStackValidated(IGregTechTileEntity aBaseMetaTileEntity, int aIndex, ForgeDirection side,
         ItemStack aStack) {
         return super.allowPutStackValidated(aBaseMetaTileEntity, aIndex, side, aStack)
-            && GT_Recipe_Map.sMaceratorRecipes.containsInput(GT_Utility.copyAmount(64L, aStack));
+            && GT_Recipe_Map.sMaceratorRecipes.containsInput(GT_Utility.copyAmount(64, aStack));
     }
 
     @Override

--- a/src/main/java/gregtech/common/tileentities/machines/steam/GT_MetaTileEntity_Macerator_Steel.java
+++ b/src/main/java/gregtech/common/tileentities/machines/steam/GT_MetaTileEntity_Macerator_Steel.java
@@ -97,7 +97,7 @@ public class GT_MetaTileEntity_Macerator_Steel extends GT_MetaTileEntity_BasicMa
     public boolean allowPutStackValidated(IGregTechTileEntity aBaseMetaTileEntity, int aIndex, ForgeDirection side,
         ItemStack aStack) {
         return super.allowPutStackValidated(aBaseMetaTileEntity, aIndex, side, aStack)
-            && GT_Recipe_Map.sMaceratorRecipes.containsInput(GT_Utility.copyAmount(64L, aStack));
+            && GT_Recipe_Map.sMaceratorRecipes.containsInput(GT_Utility.copyAmount(64, aStack));
     }
 
     @Override

--- a/src/main/java/gregtech/common/tools/GT_Tool_HardHammer.java
+++ b/src/main/java/gregtech/common/tools/GT_Tool_HardHammer.java
@@ -137,7 +137,7 @@ public class GT_Tool_HardHammer extends GT_Tool {
         if ((tRecipe == null) || (aBlock.hasTileEntity(aMetaData))) {
             for (ItemStack tDrop : aDrops) {
                 tRecipe = GT_Recipe.GT_Recipe_Map.sHammerRecipes
-                    .findRecipe(null, true, MAX_IC2, null, GT_Utility.copyAmount(1L, tDrop));
+                    .findRecipe(null, true, MAX_IC2, null, GT_Utility.copyAmount(1, tDrop));
                 if (tRecipe != null) {
                     ItemStack tHammeringOutput = tRecipe.getOutput(0);
                     if (tHammeringOutput != null) {

--- a/src/main/java/gregtech/common/tools/GT_Tool_JackHammer.java
+++ b/src/main/java/gregtech/common/tools/GT_Tool_JackHammer.java
@@ -82,7 +82,7 @@ public class GT_Tool_JackHammer extends GT_Tool_Drill_LV {
         if ((tRecipe == null) || (aBlock.hasTileEntity(aMetaData))) {
             for (ItemStack tDrop : aDrops) {
                 tRecipe = GT_Recipe.GT_Recipe_Map.sHammerRecipes
-                    .findRecipe(null, true, 2147483647L, null, GT_Utility.copyAmount(1L, tDrop));
+                    .findRecipe(null, true, 2147483647L, null, GT_Utility.copyAmount(1, tDrop));
                 if (tRecipe != null) {
                     ItemStack tHammeringOutput = tRecipe.getOutput(0);
                     if (tHammeringOutput != null) {

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingArrows.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingArrows.java
@@ -27,7 +27,7 @@ public class ProcessingArrows implements gregtech.api.interfaces.IOreRecipeRegis
     @Override
     public void registerOre(OrePrefixes aPrefix, Materials aMaterial, String aOreDictName, String aModName,
         ItemStack aStack) {
-        ItemStack tOutput = GT_Utility.copyAmount(1L, aStack);
+        ItemStack tOutput = GT_Utility.copyAmount(1, aStack);
         GT_Utility.updateItemStack(tOutput);
         GT_Utility.ItemNBT.addEnchantment(
             tOutput,
@@ -35,14 +35,14 @@ public class ProcessingArrows implements gregtech.api.interfaces.IOreRecipeRegis
             EnchantmentHelper.getEnchantmentLevel(Enchantment.smite.effectId, tOutput) + 3);
 
         GT_Values.RA.stdBuilder()
-            .itemInputs(GT_Utility.copyAmount(1L, aStack))
+            .itemInputs(GT_Utility.copyAmount(1, aStack))
             .itemOutputs(tOutput)
             .fluidInputs(Materials.HolyWater.getFluid(25L))
             .duration(5 * SECONDS)
             .eut(2)
             .addTo(sChemicalBathRecipes);
 
-        tOutput = GT_Utility.copyAmount(1L, aStack);
+        tOutput = GT_Utility.copyAmount(1, aStack);
         GT_Utility.updateItemStack(tOutput);
         GT_Utility.ItemNBT.addEnchantment(
             tOutput,
@@ -50,14 +50,14 @@ public class ProcessingArrows implements gregtech.api.interfaces.IOreRecipeRegis
             EnchantmentHelper.getEnchantmentLevel(Enchantment.fireAspect.effectId, tOutput) + 3);
 
         GT_Values.RA.stdBuilder()
-            .itemInputs(GT_Utility.copyAmount(1L, aStack))
+            .itemInputs(GT_Utility.copyAmount(1, aStack))
             .itemOutputs(tOutput)
             .fluidInputs(Materials.FierySteel.getFluid(25L))
             .duration(5 * SECONDS)
             .eut(2)
             .addTo(sChemicalBathRecipes);
 
-        tOutput = GT_Utility.copyAmount(1L, aStack);
+        tOutput = GT_Utility.copyAmount(1, aStack);
         GT_Utility.updateItemStack(tOutput);
         GT_Utility.ItemNBT.addEnchantment(
             tOutput,
@@ -65,14 +65,14 @@ public class ProcessingArrows implements gregtech.api.interfaces.IOreRecipeRegis
             EnchantmentHelper.getEnchantmentLevel(Enchantment.fireAspect.effectId, tOutput) + 1);
 
         GT_Values.RA.stdBuilder()
-            .itemInputs(GT_Utility.copyAmount(1L, aStack))
+            .itemInputs(GT_Utility.copyAmount(1, aStack))
             .itemOutputs(tOutput)
             .fluidInputs(Materials.Blaze.getMolten(18L))
             .duration(5 * SECONDS)
             .eut(2)
             .addTo(sChemicalBathRecipes);
 
-        tOutput = GT_Utility.copyAmount(1L, aStack);
+        tOutput = GT_Utility.copyAmount(1, aStack);
         GT_Utility.updateItemStack(tOutput);
         GT_Utility.ItemNBT.addEnchantment(
             tOutput,
@@ -80,14 +80,14 @@ public class ProcessingArrows implements gregtech.api.interfaces.IOreRecipeRegis
             EnchantmentHelper.getEnchantmentLevel(Enchantment.knockback.effectId, tOutput) + 1);
 
         GT_Values.RA.stdBuilder()
-            .itemInputs(GT_Utility.copyAmount(1L, aStack))
+            .itemInputs(GT_Utility.copyAmount(1, aStack))
             .itemOutputs(tOutput)
             .fluidInputs(Materials.Rubber.getMolten(18L))
             .duration(5 * SECONDS)
             .eut(2)
             .addTo(sChemicalBathRecipes);
 
-        tOutput = GT_Utility.copyAmount(1L, aStack);
+        tOutput = GT_Utility.copyAmount(1, aStack);
         GT_Utility.updateItemStack(tOutput);
         GT_Utility.ItemNBT.addEnchantment(
             tOutput,
@@ -96,7 +96,7 @@ public class ProcessingArrows implements gregtech.api.interfaces.IOreRecipeRegis
                 .getEnchantmentLevel(gregtech.api.enchants.Enchantment_EnderDamage.INSTANCE.effectId, tOutput) + 1);
 
         GT_Values.RA.stdBuilder()
-            .itemInputs(GT_Utility.copyAmount(1L, aStack))
+            .itemInputs(GT_Utility.copyAmount(1, aStack))
             .itemOutputs(tOutput)
             .fluidInputs(Materials.Mercury.getFluid(25L))
             .duration(5 * SECONDS)

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingBeans.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingBeans.java
@@ -26,7 +26,7 @@ public class ProcessingBeans implements gregtech.api.interfaces.IOreRecipeRegist
         }
 
         GT_Values.RA.stdBuilder()
-            .itemInputs(GT_Utility.copyAmount(1L, aStack))
+            .itemInputs(GT_Utility.copyAmount(1, aStack))
             .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Cocoa, 1L))
             .duration(20 * SECONDS)
             .eut(2)

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingBlock.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingBlock.java
@@ -40,7 +40,7 @@ public class ProcessingBlock implements gregtech.api.interfaces.IOreRecipeRegist
                 || aMaterial == MaterialsBotania.Dreamwood) {
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack), GT_Utility.getIntegratedCircuit(3))
+                    .itemInputs(GT_Utility.copyAmount(1, aStack), GT_Utility.getIntegratedCircuit(3))
                     .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 9L))
                     .fluidInputs(
                         Materials.Water.getFluid(
@@ -52,7 +52,7 @@ public class ProcessingBlock implements gregtech.api.interfaces.IOreRecipeRegist
                     .addTo(sCutterRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack), GT_Utility.getIntegratedCircuit(3))
+                    .itemInputs(GT_Utility.copyAmount(1, aStack), GT_Utility.getIntegratedCircuit(3))
                     .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 9L))
                     .fluidInputs(
                         GT_ModHandler.getDistilledWater(
@@ -64,7 +64,7 @@ public class ProcessingBlock implements gregtech.api.interfaces.IOreRecipeRegist
                     .addTo(sCutterRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack), GT_Utility.getIntegratedCircuit(3))
+                    .itemInputs(GT_Utility.copyAmount(1, aStack), GT_Utility.getIntegratedCircuit(3))
                     .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 9L))
                     .fluidInputs(
                         Materials.Lubricant.getFluid(
@@ -80,7 +80,7 @@ public class ProcessingBlock implements gregtech.api.interfaces.IOreRecipeRegist
             else if (aMaterial != Materials.Clay && aMaterial != Materials.Basalt) {
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                    .itemInputs(GT_Utility.copyAmount(1, aStack))
                     .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 9L))
                     .fluidInputs(
                         Materials.Water.getFluid(
@@ -92,7 +92,7 @@ public class ProcessingBlock implements gregtech.api.interfaces.IOreRecipeRegist
                     .addTo(sCutterRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                    .itemInputs(GT_Utility.copyAmount(1, aStack))
                     .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 9L))
                     .fluidInputs(
                         GT_ModHandler.getDistilledWater(
@@ -104,7 +104,7 @@ public class ProcessingBlock implements gregtech.api.interfaces.IOreRecipeRegist
                     .addTo(sCutterRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                    .itemInputs(GT_Utility.copyAmount(1, aStack))
                     .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 9L))
                     .fluidInputs(
                         Materials.Lubricant.getFluid(
@@ -121,7 +121,7 @@ public class ProcessingBlock implements gregtech.api.interfaces.IOreRecipeRegist
         ItemStack tStack2 = GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 1L);
         ItemStack tStack3 = GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial, 1L);
 
-        GT_ModHandler.removeRecipeDelayed(GT_Utility.copyAmount(1L, aStack));
+        GT_ModHandler.removeRecipeDelayed(GT_Utility.copyAmount(1, aStack));
 
         if (tStack1 != null) GT_ModHandler
             .removeRecipeDelayed(tStack1, tStack1, tStack1, tStack1, tStack1, tStack1, tStack1, tStack1, tStack1);
@@ -203,7 +203,7 @@ public class ProcessingBlock implements gregtech.api.interfaces.IOreRecipeRegist
             case "Mercury" -> System.err.println(
                 "'blockQuickSilver'?, In which Ice Desert can you actually place this as a solid Block? On Pluto Greg :)");
             case "Iron", "WroughtIron", "Steel" -> GT_Values.RA.stdBuilder()
-                .itemInputs(ItemList.IC2_Compressed_Coal_Ball.get(8L), GT_Utility.copyAmount(1L, aStack))
+                .itemInputs(ItemList.IC2_Compressed_Coal_Ball.get(8L), GT_Utility.copyAmount(1, aStack))
                 .itemOutputs(ItemList.IC2_Compressed_Coal_Chunk.get(1L))
                 .duration(20 * SECONDS)
                 .eut(4)

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingBolt.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingBolt.java
@@ -36,7 +36,7 @@ public class ProcessingBolt implements gregtech.api.interfaces.IOreRecipeRegistr
         }
 
         GT_ModHandler.addCraftingRecipe(
-            GT_Utility.copyAmount(2L, aStack),
+            GT_Utility.copyAmount(2, aStack),
             GT_Proxy.tBits,
             new Object[] { "s ", " X", 'X', OrePrefixes.stick.get(aMaterial) });
 

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingCell.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingCell.java
@@ -44,7 +44,7 @@ public class ProcessingCell implements IOreRecipeRegistrator {
                 } else {
                     if (aMaterial.mFuelPower > 0) {
                         GT_RecipeBuilder recipeBuilder = GT_Values.RA.stdBuilder();
-                        recipeBuilder.itemInputs(GT_Utility.copyAmount(1L, aStack));
+                        recipeBuilder.itemInputs(GT_Utility.copyAmount(1, aStack));
                         if (GT_Utility.getFluidForFilledItem(aStack, true) == null
                             && GT_Utility.getContainerItem(aStack, true) != null) {
                             recipeBuilder.itemOutputs(GT_Utility.getContainerItem(aStack, true));
@@ -100,7 +100,7 @@ public class ProcessingCell implements IOreRecipeRegistrator {
                                 : tList.size() < 6)
                             && (tCapsuleCount + GT_ModHandler.getCapsuleCellContainerCount(tStack) * 64L <= 64L)) {
                             tCapsuleCount += GT_ModHandler.getCapsuleCellContainerCount(tStack) * 64L;
-                            tList.add(GT_Utility.copyAmount(64L, tStack));
+                            tList.add(GT_Utility.copyAmount(64, tStack));
                             tStack.stackSize -= 64;
                         }
                         int tThisCapsuleCount = GT_ModHandler
@@ -183,7 +183,7 @@ public class ProcessingCell implements IOreRecipeRegistrator {
                     GT_ModHandler.removeRecipeByOutputDelayed(aStack);
                 } else {
                     GT_RecipeBuilder recipeBuilder = GT_Values.RA.stdBuilder();
-                    recipeBuilder.itemInputs(GT_Utility.copyAmount(1L, aStack));
+                    recipeBuilder.itemInputs(GT_Utility.copyAmount(1, aStack));
                     if (GT_Utility.getFluidForFilledItem(aStack, true) == null
                         && GT_Utility.getContainerItem(aStack, true) != null) {
                         recipeBuilder.itemOutputs(GT_Utility.getContainerItem(aStack, true));
@@ -206,7 +206,7 @@ public class ProcessingCell implements IOreRecipeRegistrator {
                     }
                     if (GT_OreDictUnificator.get(OrePrefixes.cell, aMaterial, 1L) != null) {
                         GT_Values.RA.stdBuilder()
-                            .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                            .itemInputs(GT_Utility.copyAmount(1, aStack))
                             .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.cell, aMaterial, 1L))
                             .duration(((int) Math.max(aMaterial.getMass() * 2L, 1L)) * TICKS)
                             .eut(TierEU.RECIPE_MV)

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingCrafting.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingCrafting.java
@@ -34,7 +34,7 @@ public class ProcessingCrafting implements gregtech.api.interfaces.IOreRecipeReg
         switch (aOreDictName) {
             case "craftingQuartz" -> {
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(new ItemStack(Blocks.redstone_torch, 3, 32767), GT_Utility.copyAmount(1L, aStack))
+                    .itemInputs(new ItemStack(Blocks.redstone_torch, 3, 32767), GT_Utility.copyAmount(1, aStack))
                     .itemOutputs(new ItemStack(net.minecraft.init.Items.comparator, 1, 0))
                     .fluidInputs(Materials.Concrete.getMolten(144L))
                     .duration(2 * SECONDS)
@@ -46,7 +46,7 @@ public class ProcessingCrafting implements gregtech.api.interfaces.IOreRecipeReg
                 GT_Values.RA.stdBuilder()
                     .itemInputs(
                         GT_OreDictUnificator.get(OrePrefixes.block, Materials.Iron, 1L),
-                        GT_Utility.copyAmount(0L, aStack))
+                        GT_Utility.copyAmount(0, aStack))
                     .itemOutputs(GT_ModHandler.getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1L, 13))
                     .duration(1 * MINUTES + 40 * SECONDS)
                     .eut(TierEU.RECIPE_EV)
@@ -55,14 +55,14 @@ public class ProcessingCrafting implements gregtech.api.interfaces.IOreRecipeReg
                 GT_Values.RA.stdBuilder()
                     .itemInputs(
                         GT_OreDictUnificator.get(OrePrefixes.block, Materials.WroughtIron, 1L),
-                        GT_Utility.copyAmount(0L, aStack))
+                        GT_Utility.copyAmount(0, aStack))
                     .itemOutputs(GT_ModHandler.getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1L, 13))
                     .duration(1 * MINUTES + 40 * SECONDS)
                     .eut(TierEU.RECIPE_EV)
                     .addTo(sLaserEngraverRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(ItemList.IC2_LapotronCrystal.getWildcard(1L), GT_Utility.copyAmount(0L, aStack))
+                    .itemInputs(ItemList.IC2_LapotronCrystal.getWildcard(1L), GT_Utility.copyAmount(0, aStack))
                     .itemOutputs(ItemList.Circuit_Parts_Crystal_Chip_Master.get(3L))
                     .requiresCleanRoom()
                     .duration(45 * SECONDS)
@@ -70,7 +70,7 @@ public class ProcessingCrafting implements gregtech.api.interfaces.IOreRecipeReg
                     .addTo(sLaserEngraverRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(ItemList.Circuit_Chip_CrystalCPU.get(1L), GT_Utility.copyAmount(0L, aStack))
+                    .itemInputs(ItemList.Circuit_Chip_CrystalCPU.get(1L), GT_Utility.copyAmount(0, aStack))
                     .itemOutputs(ItemList.Circuit_Chip_CrystalSoC.get(1))
                     .requiresCleanRoom()
                     .duration(30 * SECONDS)
@@ -78,7 +78,7 @@ public class ProcessingCrafting implements gregtech.api.interfaces.IOreRecipeReg
                     .addTo(sLaserEngraverRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(ItemList.Circuit_Silicon_Wafer2.get(1), GT_Utility.copyAmount(0L, aStack))
+                    .itemInputs(ItemList.Circuit_Silicon_Wafer2.get(1), GT_Utility.copyAmount(0, aStack))
                     .itemOutputs(ItemList.Circuit_Wafer_PIC.get(1))
                     .requiresCleanRoom()
                     .duration(60 * SECONDS)
@@ -86,7 +86,7 @@ public class ProcessingCrafting implements gregtech.api.interfaces.IOreRecipeReg
                     .addTo(sLaserEngraverRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(ItemList.Circuit_Silicon_Wafer3.get(1), GT_Utility.copyAmount(0L, aStack))
+                    .itemInputs(ItemList.Circuit_Silicon_Wafer3.get(1), GT_Utility.copyAmount(0, aStack))
                     .itemOutputs(ItemList.Circuit_Wafer_PIC.get(4))
                     .requiresCleanRoom()
                     .duration(40 * SECONDS)
@@ -94,7 +94,7 @@ public class ProcessingCrafting implements gregtech.api.interfaces.IOreRecipeReg
                     .addTo(sLaserEngraverRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(ItemList.Circuit_Silicon_Wafer5.get(1), GT_Utility.copyAmount(0L, aStack))
+                    .itemInputs(ItemList.Circuit_Silicon_Wafer5.get(1), GT_Utility.copyAmount(0, aStack))
                     .itemOutputs(ItemList.Circuit_Wafer_QPIC.get(1))
                     .requiresCleanRoom()
                     .duration(2 * MINUTES)
@@ -107,7 +107,7 @@ public class ProcessingCrafting implements gregtech.api.interfaces.IOreRecipeReg
                 GT_Values.RA.stdBuilder()
                     .itemInputs(
                         GT_OreDictUnificator.get(OrePrefixes.block, Materials.Iron, 1L),
-                        GT_Utility.copyAmount(0L, aStack))
+                        GT_Utility.copyAmount(0, aStack))
                     .itemOutputs(GT_ModHandler.getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1L, 14))
                     .duration(1 * MINUTES + 40 * SECONDS)
                     .eut(TierEU.RECIPE_EV)
@@ -116,21 +116,21 @@ public class ProcessingCrafting implements gregtech.api.interfaces.IOreRecipeReg
                 GT_Values.RA.stdBuilder()
                     .itemInputs(
                         GT_OreDictUnificator.get(OrePrefixes.block, Materials.WroughtIron, 1L),
-                        GT_Utility.copyAmount(0L, aStack))
+                        GT_Utility.copyAmount(0, aStack))
                     .itemOutputs(GT_ModHandler.getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1L, 14))
                     .duration(1 * MINUTES + 40 * SECONDS)
                     .eut(TierEU.RECIPE_EV)
                     .addTo(sLaserEngraverRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(ItemList.Circuit_Silicon_Wafer.get(1), GT_Utility.copyAmount(0L, aStack))
+                    .itemInputs(ItemList.Circuit_Silicon_Wafer.get(1), GT_Utility.copyAmount(0, aStack))
                     .itemOutputs(ItemList.Circuit_Wafer_LPIC.get(1))
                     .duration(40 * SECONDS)
                     .eut(TierEU.RECIPE_MV)
                     .addTo(sLaserEngraverRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(ItemList.Circuit_Silicon_Wafer2.get(1), GT_Utility.copyAmount(0L, aStack))
+                    .itemInputs(ItemList.Circuit_Silicon_Wafer2.get(1), GT_Utility.copyAmount(0, aStack))
                     .itemOutputs(ItemList.Circuit_Wafer_LPIC.get(4))
                     .requiresCleanRoom()
                     .duration(30 * SECONDS)
@@ -138,7 +138,7 @@ public class ProcessingCrafting implements gregtech.api.interfaces.IOreRecipeReg
                     .addTo(sLaserEngraverRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(ItemList.Circuit_Silicon_Wafer3.get(1), GT_Utility.copyAmount(0L, aStack))
+                    .itemInputs(ItemList.Circuit_Silicon_Wafer3.get(1), GT_Utility.copyAmount(0, aStack))
                     .itemOutputs(ItemList.Circuit_Wafer_SoC.get(1))
                     .requiresCleanRoom()
                     .duration(45 * SECONDS)
@@ -146,7 +146,7 @@ public class ProcessingCrafting implements gregtech.api.interfaces.IOreRecipeReg
                     .addTo(sLaserEngraverRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(ItemList.Circuit_Silicon_Wafer4.get(1), GT_Utility.copyAmount(0L, aStack))
+                    .itemInputs(ItemList.Circuit_Silicon_Wafer4.get(1), GT_Utility.copyAmount(0, aStack))
                     .itemOutputs(ItemList.Circuit_Wafer_SoC.get(4))
                     .requiresCleanRoom()
                     .duration(30 * SECONDS)
@@ -154,7 +154,7 @@ public class ProcessingCrafting implements gregtech.api.interfaces.IOreRecipeReg
                     .addTo(sLaserEngraverRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(ItemList.Circuit_Silicon_Wafer5.get(1), GT_Utility.copyAmount(0L, aStack))
+                    .itemInputs(ItemList.Circuit_Silicon_Wafer5.get(1), GT_Utility.copyAmount(0, aStack))
                     .itemOutputs(ItemList.Circuit_Wafer_SoC.get(8))
                     .requiresCleanRoom()
                     .duration(15 * SECONDS)
@@ -164,28 +164,28 @@ public class ProcessingCrafting implements gregtech.api.interfaces.IOreRecipeReg
             case "craftingLensOrange" -> {
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(ItemList.Circuit_Silicon_Wafer.get(1), GT_Utility.copyAmount(0L, aStack))
+                    .itemInputs(ItemList.Circuit_Silicon_Wafer.get(1), GT_Utility.copyAmount(0, aStack))
                     .itemOutputs(ItemList.Circuit_Wafer_Simple_SoC.get(1))
                     .duration(15 * SECONDS)
                     .eut(64)
                     .addTo(sLaserEngraverRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(ItemList.Circuit_Silicon_Wafer2.get(1), GT_Utility.copyAmount(0L, aStack))
+                    .itemInputs(ItemList.Circuit_Silicon_Wafer2.get(1), GT_Utility.copyAmount(0, aStack))
                     .itemOutputs(ItemList.Circuit_Wafer_Simple_SoC.get(4))
                     .duration(15 * SECONDS)
                     .eut(256)
                     .addTo(sLaserEngraverRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(ItemList.Circuit_Silicon_Wafer3.get(1), GT_Utility.copyAmount(0L, aStack))
+                    .itemInputs(ItemList.Circuit_Silicon_Wafer3.get(1), GT_Utility.copyAmount(0, aStack))
                     .itemOutputs(ItemList.Circuit_Wafer_Simple_SoC.get(16))
                     .duration(15 * SECONDS)
                     .eut(1024)
                     .addTo(sLaserEngraverRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(ItemList.Circuit_Silicon_Wafer4.get(1), GT_Utility.copyAmount(0L, aStack))
+                    .itemInputs(ItemList.Circuit_Silicon_Wafer4.get(1), GT_Utility.copyAmount(0, aStack))
                     .itemOutputs(ItemList.Circuit_Wafer_Simple_SoC.get(64))
                     .duration(15 * SECONDS)
                     .eut(4096)
@@ -197,7 +197,7 @@ public class ProcessingCrafting implements gregtech.api.interfaces.IOreRecipeReg
                 GT_Values.RA.stdBuilder()
                     .itemInputs(
                         GT_OreDictUnificator.get(OrePrefixes.block, Materials.Iron, 1L),
-                        GT_Utility.copyAmount(0L, aStack))
+                        GT_Utility.copyAmount(0, aStack))
                     .itemOutputs(GT_ModHandler.getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1L, 15))
                     .duration(1 * MINUTES + 40 * SECONDS)
                     .eut(TierEU.RECIPE_EV)
@@ -206,21 +206,21 @@ public class ProcessingCrafting implements gregtech.api.interfaces.IOreRecipeReg
                 GT_Values.RA.stdBuilder()
                     .itemInputs(
                         GT_OreDictUnificator.get(OrePrefixes.block, Materials.WroughtIron, 1L),
-                        GT_Utility.copyAmount(0L, aStack))
+                        GT_Utility.copyAmount(0, aStack))
                     .itemOutputs(GT_ModHandler.getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1L, 15))
                     .duration(1 * MINUTES + 40 * SECONDS)
                     .eut(TierEU.RECIPE_EV)
                     .addTo(sLaserEngraverRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(ItemList.Circuit_Silicon_Wafer.get(1), GT_Utility.copyAmount(0L, aStack))
+                    .itemInputs(ItemList.Circuit_Silicon_Wafer.get(1), GT_Utility.copyAmount(0, aStack))
                     .itemOutputs(ItemList.Circuit_Wafer_Ram.get(1))
                     .duration(60 * SECONDS)
                     .eut(TierEU.RECIPE_MV)
                     .addTo(sLaserEngraverRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(ItemList.Circuit_Silicon_Wafer2.get(1), GT_Utility.copyAmount(0L, aStack))
+                    .itemInputs(ItemList.Circuit_Silicon_Wafer2.get(1), GT_Utility.copyAmount(0, aStack))
                     .itemOutputs(ItemList.Circuit_Wafer_Ram.get(4))
                     .requiresCleanRoom()
                     .duration(45 * SECONDS)
@@ -228,7 +228,7 @@ public class ProcessingCrafting implements gregtech.api.interfaces.IOreRecipeReg
                     .addTo(sLaserEngraverRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(ItemList.Circuit_Silicon_Wafer3.get(1), GT_Utility.copyAmount(0L, aStack))
+                    .itemInputs(ItemList.Circuit_Silicon_Wafer3.get(1), GT_Utility.copyAmount(0, aStack))
                     .itemOutputs(ItemList.Circuit_Wafer_Ram.get(8))
                     .requiresCleanRoom()
                     .duration(30 * SECONDS)
@@ -236,7 +236,7 @@ public class ProcessingCrafting implements gregtech.api.interfaces.IOreRecipeReg
                     .addTo(sLaserEngraverRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(ItemList.Circuit_Silicon_Wafer4.get(1), GT_Utility.copyAmount(0L, aStack))
+                    .itemInputs(ItemList.Circuit_Silicon_Wafer4.get(1), GT_Utility.copyAmount(0, aStack))
                     .itemOutputs(ItemList.Circuit_Wafer_Ram.get(16))
                     .requiresCleanRoom()
                     .duration(15 * SECONDS)
@@ -244,7 +244,7 @@ public class ProcessingCrafting implements gregtech.api.interfaces.IOreRecipeReg
                     .addTo(sLaserEngraverRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(ItemList.Circuit_Silicon_Wafer5.get(1), GT_Utility.copyAmount(0L, aStack))
+                    .itemInputs(ItemList.Circuit_Silicon_Wafer5.get(1), GT_Utility.copyAmount(0, aStack))
                     .itemOutputs(ItemList.Circuit_Wafer_Ram.get(32))
                     .requiresCleanRoom()
                     .duration(7 * SECONDS + 10 * TICKS)
@@ -257,7 +257,7 @@ public class ProcessingCrafting implements gregtech.api.interfaces.IOreRecipeReg
                 GT_Values.RA.stdBuilder()
                     .itemInputs(
                         GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Redstone, 1L),
-                        GT_Utility.copyAmount(0L, aStack))
+                        GT_Utility.copyAmount(0, aStack))
                     .itemOutputs(GT_ModHandler.getModItem(BuildCraftSilicon.ID, "redstoneChipset", 1L, 0))
                     .duration(2 * SECONDS + 10 * TICKS)
                     .eut(TierEU.RECIPE_MV)
@@ -266,21 +266,21 @@ public class ProcessingCrafting implements gregtech.api.interfaces.IOreRecipeReg
                 GT_Values.RA.stdBuilder()
                     .itemInputs(
                         GT_OreDictUnificator.get(OrePrefixes.foil, Materials.RedAlloy, 1L),
-                        GT_Utility.copyAmount(0L, aStack))
+                        GT_Utility.copyAmount(0, aStack))
                     .itemOutputs(GT_ModHandler.getModItem(NewHorizonsCoreMod.ID, "item.EtchedLowVoltageWiring", 1L, 0))
                     .duration(10 * SECONDS)
                     .eut(16)
                     .addTo(sLaserEngraverRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(ItemList.Circuit_Silicon_Wafer.get(1), GT_Utility.copyAmount(0L, aStack))
+                    .itemInputs(ItemList.Circuit_Silicon_Wafer.get(1), GT_Utility.copyAmount(0, aStack))
                     .itemOutputs(ItemList.Circuit_Wafer_ILC.get(1))
                     .duration(60 * SECONDS)
                     .eut(TierEU.RECIPE_MV)
                     .addTo(sLaserEngraverRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(ItemList.Circuit_Silicon_Wafer2.get(1), GT_Utility.copyAmount(0L, aStack))
+                    .itemInputs(ItemList.Circuit_Silicon_Wafer2.get(1), GT_Utility.copyAmount(0, aStack))
                     .itemOutputs(ItemList.Circuit_Wafer_ILC.get(4))
                     .requiresCleanRoom()
                     .duration(45 * SECONDS)
@@ -288,7 +288,7 @@ public class ProcessingCrafting implements gregtech.api.interfaces.IOreRecipeReg
                     .addTo(sLaserEngraverRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(ItemList.Circuit_Silicon_Wafer3.get(1), GT_Utility.copyAmount(0L, aStack))
+                    .itemInputs(ItemList.Circuit_Silicon_Wafer3.get(1), GT_Utility.copyAmount(0, aStack))
                     .itemOutputs(ItemList.Circuit_Wafer_ILC.get(8))
                     .requiresCleanRoom()
                     .duration(30 * SECONDS)
@@ -296,7 +296,7 @@ public class ProcessingCrafting implements gregtech.api.interfaces.IOreRecipeReg
                     .addTo(sLaserEngraverRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(ItemList.Circuit_Silicon_Wafer4.get(1), GT_Utility.copyAmount(0L, aStack))
+                    .itemInputs(ItemList.Circuit_Silicon_Wafer4.get(1), GT_Utility.copyAmount(0, aStack))
                     .itemOutputs(ItemList.Circuit_Wafer_NPIC.get(1))
                     .requiresCleanRoom()
                     .duration(1 * MINUTES + 30 * SECONDS)
@@ -304,7 +304,7 @@ public class ProcessingCrafting implements gregtech.api.interfaces.IOreRecipeReg
                     .addTo(sLaserEngraverRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(ItemList.Circuit_Silicon_Wafer5.get(1), GT_Utility.copyAmount(0L, aStack))
+                    .itemInputs(ItemList.Circuit_Silicon_Wafer5.get(1), GT_Utility.copyAmount(0, aStack))
                     .itemOutputs(ItemList.Circuit_Wafer_NPIC.get(4))
                     .requiresCleanRoom()
                     .duration(1 * MINUTES + 15 * SECONDS)
@@ -315,7 +315,7 @@ public class ProcessingCrafting implements gregtech.api.interfaces.IOreRecipeReg
             case "craftingLensGreen" -> {
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(ItemList.Circuit_Parts_Crystal_Chip_Elite.get(1L), GT_Utility.copyAmount(0L, aStack))
+                    .itemInputs(ItemList.Circuit_Parts_Crystal_Chip_Elite.get(1L), GT_Utility.copyAmount(0, aStack))
                     .itemOutputs(ItemList.Circuit_Chip_CrystalCPU.get(1))
                     .requiresCleanRoom()
                     .duration(30 * SECONDS)
@@ -323,7 +323,7 @@ public class ProcessingCrafting implements gregtech.api.interfaces.IOreRecipeReg
                     .addTo(sLaserEngraverRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(ItemList.Circuit_Chip_CrystalSoC.get(1L), GT_Utility.copyAmount(0L, aStack))
+                    .itemInputs(ItemList.Circuit_Chip_CrystalSoC.get(1L), GT_Utility.copyAmount(0, aStack))
                     .itemOutputs(ItemList.Circuit_Chip_CrystalSoC2.get(1))
                     .requiresCleanRoom()
                     .duration(60 * SECONDS)
@@ -331,21 +331,21 @@ public class ProcessingCrafting implements gregtech.api.interfaces.IOreRecipeReg
                     .addTo(sLaserEngraverRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(ItemList.Circuit_Silicon_Wafer.get(1), GT_Utility.copyAmount(0L, aStack))
+                    .itemInputs(ItemList.Circuit_Silicon_Wafer.get(1), GT_Utility.copyAmount(0, aStack))
                     .itemOutputs(ItemList.Circuit_Wafer_ULPIC.get(2))
                     .duration(30 * SECONDS)
                     .eut(30)
                     .addTo(sLaserEngraverRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(ItemList.Circuit_Silicon_Wafer2.get(1), GT_Utility.copyAmount(0L, aStack))
+                    .itemInputs(ItemList.Circuit_Silicon_Wafer2.get(1), GT_Utility.copyAmount(0, aStack))
                     .itemOutputs(ItemList.Circuit_Wafer_ULPIC.get(8))
                     .duration(30 * SECONDS)
                     .eut(TierEU.RECIPE_MV)
                     .addTo(sLaserEngraverRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(ItemList.Circuit_Silicon_Wafer3.get(1), GT_Utility.copyAmount(0L, aStack))
+                    .itemInputs(ItemList.Circuit_Silicon_Wafer3.get(1), GT_Utility.copyAmount(0, aStack))
                     .itemOutputs(ItemList.Circuit_Wafer_SoC2.get(1))
                     .requiresCleanRoom()
                     .duration(1 * MINUTES + 30 * SECONDS)
@@ -353,7 +353,7 @@ public class ProcessingCrafting implements gregtech.api.interfaces.IOreRecipeReg
                     .addTo(sLaserEngraverRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(ItemList.Circuit_Silicon_Wafer4.get(1), GT_Utility.copyAmount(0L, aStack))
+                    .itemInputs(ItemList.Circuit_Silicon_Wafer4.get(1), GT_Utility.copyAmount(0, aStack))
                     .itemOutputs(ItemList.Circuit_Wafer_SoC2.get(2))
                     .requiresCleanRoom()
                     .duration(1 * MINUTES + 15 * SECONDS)
@@ -361,7 +361,7 @@ public class ProcessingCrafting implements gregtech.api.interfaces.IOreRecipeReg
                     .addTo(sLaserEngraverRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(ItemList.Circuit_Silicon_Wafer5.get(1), GT_Utility.copyAmount(0L, aStack))
+                    .itemInputs(ItemList.Circuit_Silicon_Wafer5.get(1), GT_Utility.copyAmount(0, aStack))
                     .itemOutputs(ItemList.Circuit_Wafer_SoC2.get(4))
                     .requiresCleanRoom()
                     .duration(60 * SECONDS)
@@ -373,7 +373,7 @@ public class ProcessingCrafting implements gregtech.api.interfaces.IOreRecipeReg
                 GT_Values.RA.stdBuilder()
                     .itemInputs(
                         GT_OreDictUnificator.get(OrePrefixes.block, Materials.Iron, 1L),
-                        GT_Utility.copyAmount(0L, aStack))
+                        GT_Utility.copyAmount(0, aStack))
                     .itemOutputs(GT_ModHandler.getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1L, 19))
                     .duration(1 * MINUTES + 40 * SECONDS)
                     .eut(TierEU.RECIPE_EV)
@@ -382,28 +382,28 @@ public class ProcessingCrafting implements gregtech.api.interfaces.IOreRecipeReg
                 GT_Values.RA.stdBuilder()
                     .itemInputs(
                         GT_OreDictUnificator.get(OrePrefixes.block, Materials.WroughtIron, 1L),
-                        GT_Utility.copyAmount(0L, aStack))
+                        GT_Utility.copyAmount(0, aStack))
                     .itemOutputs(GT_ModHandler.getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1L, 19))
                     .duration(1 * MINUTES + 40 * SECONDS)
                     .eut(TierEU.RECIPE_EV)
                     .addTo(sLaserEngraverRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(new ItemStack(Blocks.sandstone, 1, 2), GT_Utility.copyAmount(0L, aStack))
+                    .itemInputs(new ItemStack(Blocks.sandstone, 1, 2), GT_Utility.copyAmount(0, aStack))
                     .itemOutputs(new ItemStack(Blocks.sandstone, 1, 1))
                     .duration(2 * SECONDS + 10 * TICKS)
                     .eut(16)
                     .addTo(sLaserEngraverRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(new ItemStack(Blocks.stone, 1, 0), GT_Utility.copyAmount(0L, aStack))
+                    .itemInputs(new ItemStack(Blocks.stone, 1, 0), GT_Utility.copyAmount(0, aStack))
                     .itemOutputs(new ItemStack(Blocks.stonebrick, 1, 3))
                     .duration(2 * SECONDS + 10 * TICKS)
                     .eut(16)
                     .addTo(sLaserEngraverRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(new ItemStack(Blocks.quartz_block, 1, 0), GT_Utility.copyAmount(0L, aStack))
+                    .itemInputs(new ItemStack(Blocks.quartz_block, 1, 0), GT_Utility.copyAmount(0, aStack))
                     .itemOutputs(new ItemStack(Blocks.quartz_block, 1, 1))
                     .duration(2 * SECONDS + 10 * TICKS)
                     .eut(16)
@@ -412,14 +412,14 @@ public class ProcessingCrafting implements gregtech.api.interfaces.IOreRecipeReg
                 GT_Values.RA.stdBuilder()
                     .itemInputs(
                         GT_ModHandler.getModItem(AppliedEnergistics2.ID, "tile.BlockQuartz", 1L),
-                        GT_Utility.copyAmount(0L, aStack))
+                        GT_Utility.copyAmount(0, aStack))
                     .itemOutputs(GT_ModHandler.getModItem(AppliedEnergistics2.ID, "tile.BlockQuartzChiseled", 1L))
                     .duration(2 * SECONDS + 10 * TICKS)
                     .eut(16)
                     .addTo(sLaserEngraverRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(ItemList.Circuit_Silicon_Wafer.get(1), GT_Utility.copyAmount(0L, aStack))
+                    .itemInputs(ItemList.Circuit_Silicon_Wafer.get(1), GT_Utility.copyAmount(0, aStack))
                     .itemOutputs(ItemList.Circuit_Wafer_CPU.get(1))
                     .requiresCleanRoom()
                     .duration(60 * SECONDS)
@@ -427,7 +427,7 @@ public class ProcessingCrafting implements gregtech.api.interfaces.IOreRecipeReg
                     .addTo(sLaserEngraverRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(ItemList.Circuit_Silicon_Wafer2.get(1), GT_Utility.copyAmount(0L, aStack))
+                    .itemInputs(ItemList.Circuit_Silicon_Wafer2.get(1), GT_Utility.copyAmount(0, aStack))
                     .itemOutputs(ItemList.Circuit_Wafer_CPU.get(4))
                     .requiresCleanRoom()
                     .duration(45 * SECONDS)
@@ -435,7 +435,7 @@ public class ProcessingCrafting implements gregtech.api.interfaces.IOreRecipeReg
                     .addTo(sLaserEngraverRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(ItemList.Circuit_Silicon_Wafer3.get(1), GT_Utility.copyAmount(0L, aStack))
+                    .itemInputs(ItemList.Circuit_Silicon_Wafer3.get(1), GT_Utility.copyAmount(0, aStack))
                     .itemOutputs(ItemList.Circuit_Wafer_CPU.get(8))
                     .requiresCleanRoom()
                     .duration(30 * SECONDS)
@@ -443,7 +443,7 @@ public class ProcessingCrafting implements gregtech.api.interfaces.IOreRecipeReg
                     .addTo(sLaserEngraverRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(ItemList.Circuit_Silicon_Wafer4.get(1), GT_Utility.copyAmount(0L, aStack))
+                    .itemInputs(ItemList.Circuit_Silicon_Wafer4.get(1), GT_Utility.copyAmount(0, aStack))
                     .itemOutputs(ItemList.Circuit_Wafer_CPU.get(16))
                     .requiresCleanRoom()
                     .duration(15 * SECONDS)
@@ -451,7 +451,7 @@ public class ProcessingCrafting implements gregtech.api.interfaces.IOreRecipeReg
                     .addTo(sLaserEngraverRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(ItemList.Circuit_Silicon_Wafer5.get(1), GT_Utility.copyAmount(0L, aStack))
+                    .itemInputs(ItemList.Circuit_Silicon_Wafer5.get(1), GT_Utility.copyAmount(0, aStack))
                     .itemOutputs(ItemList.Circuit_Wafer_CPU.get(32))
                     .requiresCleanRoom()
                     .duration(7 * SECONDS + 10 * TICKS)

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingCrop.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingCrop.java
@@ -30,7 +30,7 @@ public class ProcessingCrop implements gregtech.api.interfaces.IOreRecipeRegistr
         net.minecraft.item.ItemStack aStack) {
         // Compressor recipes
         GT_Values.RA.stdBuilder()
-            .itemInputs(gregtech.api.util.GT_Utility.copyAmount(8L, aStack))
+            .itemInputs(gregtech.api.util.GT_Utility.copyAmount(8, aStack))
             .itemOutputs(ItemList.IC2_PlantballCompressed.get(1L))
             .duration(15 * SECONDS)
             .eut(2)

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingCrushedOre.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingCrushedOre.java
@@ -28,14 +28,14 @@ public class ProcessingCrushedOre implements gregtech.api.interfaces.IOreRecipeR
         switch (aPrefix) {
             case crushedCentrifuged -> {
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                    .itemInputs(GT_Utility.copyAmount(1, aStack))
                     .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial.mMacerateInto, 1L))
                     .duration(10 * TICKS)
                     .eut(16)
                     .addTo(sHammerRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                    .itemInputs(GT_Utility.copyAmount(1, aStack))
                     .itemOutputs(
                         GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial.mMacerateInto, 1L),
                         GT_OreDictUnificator.get(
@@ -49,7 +49,7 @@ public class ProcessingCrushedOre implements gregtech.api.interfaces.IOreRecipeR
             }
             case crushedPurified -> {
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                    .itemInputs(GT_Utility.copyAmount(1, aStack))
                     .itemOutputs(
                         GT_OreDictUnificator.get(
                             OrePrefixes.crushedCentrifuged,
@@ -73,7 +73,7 @@ public class ProcessingCrushedOre implements gregtech.api.interfaces.IOreRecipeR
                 switch (aMaterial.mName) {
                     case "Tanzanite", "Sapphire", "Olivine", "GreenSapphire", "Opal", "Amethyst", "Emerald", "Ruby", "Amber", "Diamond", "FoolsRuby", "BlueTopaz", "GarnetRed", "Topaz", "Jasper", "GarnetYellow" -> GT_Values.RA
                         .stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                        .itemInputs(GT_Utility.copyAmount(1, aStack))
                         .itemOutputs(
                             GT_OreDictUnificator.get(OrePrefixes.gemExquisite, aMaterial, tGem, 1L),
                             GT_OreDictUnificator.get(OrePrefixes.gemFlawless, aMaterial, tGem, 1L),
@@ -86,7 +86,7 @@ public class ProcessingCrushedOre implements gregtech.api.interfaces.IOreRecipeR
                         .eut(16)
                         .addTo(sSifterRecipes);
                     default -> GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                        .itemInputs(GT_Utility.copyAmount(1, aStack))
                         .itemOutputs(
                             GT_OreDictUnificator.get(OrePrefixes.gemExquisite, aMaterial, tGem, 1L),
                             GT_OreDictUnificator.get(OrePrefixes.gemFlawless, aMaterial, tGem, 1L),

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingCrystallized.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingCrystallized.java
@@ -32,14 +32,14 @@ public class ProcessingCrystallized implements gregtech.api.interfaces.IOreRecip
         }
 
         GT_Values.RA.stdBuilder()
-            .itemInputs(GT_Utility.copyAmount(1L, aStack))
+            .itemInputs(GT_Utility.copyAmount(1, aStack))
             .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial.mMacerateInto, 1L))
             .duration(10 * TICKS)
             .eut(16)
             .addTo(sHammerRecipes);
 
         GT_Values.RA.stdBuilder()
-            .itemInputs(GT_Utility.copyAmount(1L, aStack))
+            .itemInputs(GT_Utility.copyAmount(1, aStack))
             .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial.mMacerateInto, 1L))
             .duration(20 * SECONDS)
             .eut(2)

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingDirty.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingDirty.java
@@ -29,14 +29,14 @@ public class ProcessingDirty implements gregtech.api.interfaces.IOreRecipeRegist
     public void registerOre(OrePrefixes aPrefix, Materials aMaterial, String aOreDictName, String aModName,
         net.minecraft.item.ItemStack aStack) {
         GT_Values.RA.stdBuilder()
-            .itemInputs(GT_Utility.copyAmount(1L, aStack))
+            .itemInputs(GT_Utility.copyAmount(1, aStack))
             .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.dustImpure, aMaterial.mMacerateInto, 1L))
             .duration(10)
             .eut(16)
             .addTo(sHammerRecipes);
 
         GT_Values.RA.stdBuilder()
-            .itemInputs(GT_Utility.copyAmount(1L, aStack))
+            .itemInputs(GT_Utility.copyAmount(1, aStack))
             .itemOutputs(
                 GT_OreDictUnificator.get(
                     OrePrefixes.dustImpure,
@@ -53,7 +53,7 @@ public class ProcessingDirty implements gregtech.api.interfaces.IOreRecipeRegist
             .addTo(sMaceratorRecipes);
 
         GT_ModHandler.addOreWasherRecipe(
-            GT_Utility.copyAmount(1L, aStack),
+            GT_Utility.copyAmount(1, aStack),
             new int[] { 10000, 1111, 10000 },
             1000,
             GT_OreDictUnificator.get(
@@ -69,7 +69,7 @@ public class ProcessingDirty implements gregtech.api.interfaces.IOreRecipeRegist
         OrePrefixes prefix = aPrefix == OrePrefixes.crushed ? OrePrefixes.crushedCentrifuged : OrePrefixes.dust;
 
         GT_Values.RA.stdBuilder()
-            .itemInputs(GT_Utility.copyAmount(1L, aStack))
+            .itemInputs(GT_Utility.copyAmount(1, aStack))
             .itemOutputs(
                 GT_OreDictUnificator.get(prefix, aMaterial, 1L),
                 GT_OreDictUnificator.get(
@@ -95,7 +95,7 @@ public class ProcessingDirty implements gregtech.api.interfaces.IOreRecipeRegist
 
         if (byproduct.contains(SubTag.WASHING_MERCURY)) {
             GT_Values.RA.stdBuilder()
-                .itemInputs(GT_Utility.copyAmount(1L, stack))
+                .itemInputs(GT_Utility.copyAmount(1, stack))
                 .itemOutputs(
                     GT_OreDictUnificator.get(chemicalBathPrefix, material, 1L),
                     GT_OreDictUnificator.get(OrePrefixes.dust, byproduct.mMacerateInto, 1L),
@@ -108,7 +108,7 @@ public class ProcessingDirty implements gregtech.api.interfaces.IOreRecipeRegist
         }
         if (byproduct.contains(SubTag.WASHING_MERCURY_99_PERCENT)) {
             GT_Values.RA.stdBuilder()
-                .itemInputs(GT_Utility.copyAmount(1L, stack))
+                .itemInputs(GT_Utility.copyAmount(1, stack))
                 .itemOutputs(
                     GT_OreDictUnificator.get(chemicalBathPrefix, material, 1L),
                     GT_OreDictUnificator.get(OrePrefixes.dust, byproduct.mMacerateInto, 1L),
@@ -121,7 +121,7 @@ public class ProcessingDirty implements gregtech.api.interfaces.IOreRecipeRegist
         }
         if (byproduct.contains(SubTag.WASHING_SODIUMPERSULFATE)) {
             GT_Values.RA.stdBuilder()
-                .itemInputs(GT_Utility.copyAmount(1L, stack))
+                .itemInputs(GT_Utility.copyAmount(1, stack))
                 .itemOutputs(
                     GT_OreDictUnificator.get(chemicalBathPrefix, material, 1L),
                     GT_OreDictUnificator.get(OrePrefixes.dust, byproduct.mMacerateInto, 1L),

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingDust.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingDust.java
@@ -55,7 +55,7 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
             case dust -> {
                 if (aMaterial.mFuelPower > 0) {
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                        .itemInputs(GT_Utility.copyAmount(1, aStack))
                         .metadata(FUEL_VALUE, aMaterial.mFuelPower)
                         .metadata(FUEL_TYPE, aMaterial.mFuelType)
                         .duration(0)
@@ -75,7 +75,7 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                     GT_RecipeRegistrator.registerReverseFluidSmelting(aStack, aMaterial, aPrefix.mMaterialAmount, null);
                     if (aMaterial.mSmeltInto.mArcSmeltInto != aMaterial) {
                         GT_RecipeRegistrator.registerReverseArcSmelting(
-                            GT_Utility.copyAmount(1L, aStack),
+                            GT_Utility.copyAmount(1, aStack),
                             aMaterial,
                             aPrefix.mMaterialAmount,
                             null,
@@ -91,13 +91,13 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                         if (aMaterial.mAutoGenerateBlastFurnaceRecipes) {
                             GT_RecipeBuilder recipeBuilder = GT_Values.RA.stdBuilder();
                             recipeBuilder
-                                .itemInputs(GT_Utility.copyAmount(1L, aStack), GT_Utility.getIntegratedCircuit(1));
+                                .itemInputs(GT_Utility.copyAmount(1, aStack), GT_Utility.getIntegratedCircuit(1));
                             if (aMaterial.mBlastFurnaceTemp > 1750) {
                                 recipeBuilder.itemOutputs(
                                     GT_OreDictUnificator
                                         .get(OrePrefixes.ingotHot, aMaterial.mSmeltInto, tDustStack, 1L));
                             } else {
-                                recipeBuilder.itemOutputs(GT_Utility.copyAmount(1L, tDustStack));
+                                recipeBuilder.itemOutputs(GT_Utility.copyAmount(1, tDustStack));
                             }
                             recipeBuilder
                                 .duration(
@@ -115,7 +115,7 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                         && GT_OreDictUnificator.get(OrePrefixes.block, aMaterial, 1L) != null) {
 
                         GT_Values.RA.stdBuilder()
-                            .itemInputs(GT_Utility.copyAmount(9L, aStack))
+                            .itemInputs(GT_Utility.copyAmount(9, aStack))
                             .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.block, aMaterial, 1L))
                             .duration(15 * SECONDS)
                             .eut(2)
@@ -138,7 +138,7 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                         {
                             if (GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L) != null) {
                                 GT_Values.RA.stdBuilder()
-                                    .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                                    .itemInputs(GT_Utility.copyAmount(1, aStack))
                                     .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L))
                                     .duration(15 * SECONDS)
                                     .eut(2)
@@ -170,7 +170,7 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                                     && (tCapsuleCount + GT_ModHandler.getCapsuleCellContainerCount(tDustStack) * 64L
                                         <= 64L)) {
                                     tCapsuleCount += GT_ModHandler.getCapsuleCellContainerCount(tDustStack) * 64L;
-                                    tList.add(GT_Utility.copyAmount(64L, tDustStack));
+                                    tList.add(GT_Utility.copyAmount(64, tDustStack));
                                     tDustStack.stackSize -= 64;
                                 }
                                 if ((tDustStack.stackSize > 0) && (tList.size() < 6)
@@ -249,7 +249,7 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                 if (aMaterial.contains(SubTag.CRYSTALLISABLE)
                     && GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 1L) != null) {
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(1L, aStack), GT_Utility.getIntegratedCircuit(1))
+                        .itemInputs(GT_Utility.copyAmount(1, aStack), GT_Utility.getIntegratedCircuit(1))
                         .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 1L))
                         .outputChances(7000)
                         .fluidInputs(Materials.Water.getFluid(200L))
@@ -257,7 +257,7 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                         .eut(24)
                         .addTo(sAutoclaveRecipes);
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(1L, aStack), GT_Utility.getIntegratedCircuit(2))
+                        .itemInputs(GT_Utility.copyAmount(1, aStack), GT_Utility.getIntegratedCircuit(2))
                         .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 1L))
                         .outputChances(9000)
                         .fluidInputs(GT_ModHandler.getDistilledWater(100L))
@@ -265,7 +265,7 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                         .eut(24)
                         .addTo(sAutoclaveRecipes);
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(1L, aStack), GT_Utility.getIntegratedCircuit(3))
+                        .itemInputs(GT_Utility.copyAmount(1, aStack), GT_Utility.getIntegratedCircuit(3))
                         .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 1L))
                         .outputChances(10000)
                         .fluidInputs(Materials.Void.getMolten(36L))
@@ -278,7 +278,7 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                         break;
                     case "Glass":
                         GT_ModHandler.addSmeltingRecipe(
-                            GT_Utility.copyAmount(1L, aStack),
+                            GT_Utility.copyAmount(1, aStack),
                             new ItemStack(net.minecraft.init.Blocks.glass));
                         break;
                     case "NetherQuartz":
@@ -291,13 +291,13 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                         break;
                     case "MeatRaw":
                         GT_ModHandler.addSmeltingRecipe(
-                            GT_Utility.copyAmount(1L, aStack),
+                            GT_Utility.copyAmount(1, aStack),
                             GT_OreDictUnificator.get(OrePrefixes.dust, Materials.MeatCooked, 1L));
                         break;
                     case "Oilsands":
                         sCentrifugeRecipes.addRecipe(
                             true,
-                            new ItemStack[] { GT_Utility.copyAmount(1L, aStack) },
+                            new ItemStack[] { GT_Utility.copyAmount(1, aStack) },
                             null,
                             null,
                             null,
@@ -308,12 +308,12 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                         break;
                     case "HydratedCoal":
                         GT_ModHandler.addSmeltingRecipe(
-                            GT_Utility.copyAmount(1L, aStack),
+                            GT_Utility.copyAmount(1, aStack),
                             GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Coal, 1L));
                         break;
                     case "Diamond": {
                         GT_Values.RA.stdBuilder()
-                            .itemInputs(GT_Utility.copyAmount(4L, aStack), ItemList.Block_Powderbarrel.get(64))
+                            .itemInputs(GT_Utility.copyAmount(4, aStack), ItemList.Block_Powderbarrel.get(64))
                             .itemOutputs(
                                 ItemList.IC2_Industrial_Diamond.get(3L),
                                 GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 16L))
@@ -322,7 +322,7 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                             .addTo(sImplosionRecipes);
                         GT_Values.RA.stdBuilder()
                             .itemInputs(
-                                GT_Utility.copyAmount(4L, aStack),
+                                GT_Utility.copyAmount(4, aStack),
                                 GT_ModHandler.getIC2Item("dynamite", 16, null))
                             .itemOutputs(
                                 ItemList.IC2_Industrial_Diamond.get(3L),
@@ -331,7 +331,7 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                             .eut(TierEU.RECIPE_LV)
                             .addTo(sImplosionRecipes);
                         GT_Values.RA.stdBuilder()
-                            .itemInputs(GT_Utility.copyAmount(4L, aStack), new ItemStack(Blocks.tnt, 32))
+                            .itemInputs(GT_Utility.copyAmount(4, aStack), new ItemStack(Blocks.tnt, 32))
                             .itemOutputs(
                                 ItemList.IC2_Industrial_Diamond.get(3L),
                                 GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 16L))
@@ -339,7 +339,7 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                             .eut(TierEU.RECIPE_LV)
                             .addTo(sImplosionRecipes);
                         GT_Values.RA.stdBuilder()
-                            .itemInputs(GT_Utility.copyAmount(4L, aStack), GT_ModHandler.getIC2Item("industrialTnt", 8))
+                            .itemInputs(GT_Utility.copyAmount(4, aStack), GT_ModHandler.getIC2Item("industrialTnt", 8))
                             .itemOutputs(
                                 ItemList.IC2_Industrial_Diamond.get(3L),
                                 GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 16L))
@@ -359,7 +359,7 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                     case "Tanzanite":
                     case "Amethyst": {
                         GT_Values.RA.stdBuilder()
-                            .itemInputs(GT_Utility.copyAmount(4L, aStack), ItemList.Block_Powderbarrel.get(48))
+                            .itemInputs(GT_Utility.copyAmount(4, aStack), ItemList.Block_Powderbarrel.get(48))
                             .itemOutputs(
                                 GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 3L),
                                 GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 12L))
@@ -368,7 +368,7 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                             .addTo(sImplosionRecipes);
                         GT_Values.RA.stdBuilder()
                             .itemInputs(
-                                GT_Utility.copyAmount(4L, aStack),
+                                GT_Utility.copyAmount(4, aStack),
                                 GT_ModHandler.getIC2Item("dynamite", 12, null))
                             .itemOutputs(
                                 GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 3L),
@@ -377,7 +377,7 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                             .eut(TierEU.RECIPE_LV)
                             .addTo(sImplosionRecipes);
                         GT_Values.RA.stdBuilder()
-                            .itemInputs(GT_Utility.copyAmount(4L, aStack), new ItemStack(Blocks.tnt, 24))
+                            .itemInputs(GT_Utility.copyAmount(4, aStack), new ItemStack(Blocks.tnt, 24))
                             .itemOutputs(
                                 GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 3L),
                                 GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 12L))
@@ -385,7 +385,7 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                             .eut(TierEU.RECIPE_LV)
                             .addTo(sImplosionRecipes);
                         GT_Values.RA.stdBuilder()
-                            .itemInputs(GT_Utility.copyAmount(4L, aStack), GT_ModHandler.getIC2Item("industrialTnt", 6))
+                            .itemInputs(GT_Utility.copyAmount(4, aStack), GT_ModHandler.getIC2Item("industrialTnt", 6))
                             .itemOutputs(
                                 GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 3L),
                                 GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 12L))
@@ -404,7 +404,7 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                     case "Forcillium":
                     case "Force": {
                         GT_Values.RA.stdBuilder()
-                            .itemInputs(GT_Utility.copyAmount(4L, aStack), ItemList.Block_Powderbarrel.get(32))
+                            .itemInputs(GT_Utility.copyAmount(4, aStack), ItemList.Block_Powderbarrel.get(32))
                             .itemOutputs(
                                 GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 3L),
                                 GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 8L))
@@ -412,9 +412,7 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                             .eut(TierEU.RECIPE_LV)
                             .addTo(sImplosionRecipes);
                         GT_Values.RA.stdBuilder()
-                            .itemInputs(
-                                GT_Utility.copyAmount(4L, aStack),
-                                GT_ModHandler.getIC2Item("dynamite", 8, null))
+                            .itemInputs(GT_Utility.copyAmount(4, aStack), GT_ModHandler.getIC2Item("dynamite", 8, null))
                             .itemOutputs(
                                 GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 3L),
                                 GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 8L))
@@ -422,7 +420,7 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                             .eut(TierEU.RECIPE_LV)
                             .addTo(sImplosionRecipes);
                         GT_Values.RA.stdBuilder()
-                            .itemInputs(GT_Utility.copyAmount(4L, aStack), new ItemStack(Blocks.tnt, 16))
+                            .itemInputs(GT_Utility.copyAmount(4, aStack), new ItemStack(Blocks.tnt, 16))
                             .itemOutputs(
                                 GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 3L),
                                 GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 8L))
@@ -430,7 +428,7 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                             .eut(TierEU.RECIPE_LV)
                             .addTo(sImplosionRecipes);
                         GT_Values.RA.stdBuilder()
-                            .itemInputs(GT_Utility.copyAmount(4L, aStack), GT_ModHandler.getIC2Item("industrialTnt", 4))
+                            .itemInputs(GT_Utility.copyAmount(4, aStack), GT_ModHandler.getIC2Item("industrialTnt", 4))
                             .itemOutputs(
                                 GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 3L),
                                 GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 8L))
@@ -448,7 +446,7 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                 if (aPrefix == OrePrefixes.dustPure) {
                     if (aMaterial.contains(SubTag.ELECTROMAGNETIC_SEPERATION_GOLD)) {
                         GT_Values.RA.stdBuilder()
-                            .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                            .itemInputs(GT_Utility.copyAmount(1, aStack))
                             .itemOutputs(
                                 GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial, 1L),
                                 GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.Gold, 1L),
@@ -460,7 +458,7 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                     }
                     if (aMaterial.contains(SubTag.ELECTROMAGNETIC_SEPERATION_IRON)) {
                         GT_Values.RA.stdBuilder()
-                            .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                            .itemInputs(GT_Utility.copyAmount(1, aStack))
                             .itemOutputs(
                                 GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial, 1L),
                                 GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.Iron, 1L),
@@ -472,7 +470,7 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                     }
                     if (aMaterial.contains(SubTag.ELECTROMAGNETIC_SEPERATION_NEODYMIUM)) {
                         GT_Values.RA.stdBuilder()
-                            .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                            .itemInputs(GT_Utility.copyAmount(1, aStack))
                             .itemOutputs(
                                 GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial, 1L),
                                 GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.Neodymium, 1L),
@@ -486,7 +484,7 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                 if (aMaterial.contains(SubTag.CRYSTALLISABLE)
                     && GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 1L) != null) {
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(1L, aStack), GT_Utility.getIntegratedCircuit(1))
+                        .itemInputs(GT_Utility.copyAmount(1, aStack), GT_Utility.getIntegratedCircuit(1))
                         .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 1L))
                         .outputChances(9000)
                         .fluidInputs(Materials.Water.getFluid(200L))
@@ -494,7 +492,7 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                         .eut(24)
                         .addTo(sAutoclaveRecipes);
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(1L, aStack), GT_Utility.getIntegratedCircuit(2))
+                        .itemInputs(GT_Utility.copyAmount(1, aStack), GT_Utility.getIntegratedCircuit(2))
                         .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 1L))
                         .outputChances(9500)
                         .fluidInputs(GT_ModHandler.getDistilledWater(100L))
@@ -502,7 +500,7 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                         .eut(24)
                         .addTo(sAutoclaveRecipes);
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(1L, aStack), GT_Utility.getIntegratedCircuit(3))
+                        .itemInputs(GT_Utility.copyAmount(1, aStack), GT_Utility.getIntegratedCircuit(3))
                         .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 1L))
                         .outputChances(10000)
                         .fluidInputs(Materials.Void.getMolten(36L))
@@ -527,7 +525,7 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                             tImpureStack = GT_OreDictUnificator.get(OrePrefixes.cell, tByProduct, 1L);
                             if (tImpureStack == null) {
                                 GT_Values.RA.stdBuilder()
-                                    .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                                    .itemInputs(GT_Utility.copyAmount(1, aStack))
                                     .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial, 1L))
                                     .duration(Math.max(1L, aMaterial.getMass()))
                                     .eut(5)
@@ -536,7 +534,7 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                                 FluidStack tFluid = GT_Utility.getFluidForFilledItem(tImpureStack, true);
                                 if (tFluid == null) {
                                     GT_Values.RA.stdBuilder()
-                                        .itemInputs(GT_Utility.copyAmount(9L, aStack), ItemList.Cell_Empty.get(1))
+                                        .itemInputs(GT_Utility.copyAmount(9, aStack), ItemList.Cell_Empty.get(1))
                                         .itemOutputs(
                                             GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial, 9L),
                                             tImpureStack)
@@ -546,7 +544,7 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                                 } else {
                                     tFluid.amount /= 10;
                                     GT_Values.RA.stdBuilder()
-                                        .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                                        .itemInputs(GT_Utility.copyAmount(1, aStack))
                                         .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial, 1L))
                                         .fluidOutputs(tFluid)
                                         .duration(Math.max(1L, aMaterial.getMass() * 8L))
@@ -556,7 +554,7 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                             }
                         } else {
                             GT_Values.RA.stdBuilder()
-                                .itemInputs(GT_Utility.copyAmount(9L, aStack))
+                                .itemInputs(GT_Utility.copyAmount(9, aStack))
                                 .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial, 9L), tImpureStack)
                                 .duration(Math.max(1L, aMaterial.getMass() * 72L))
                                 .eut(5)
@@ -564,7 +562,7 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                         }
                     } else {
                         GT_Values.RA.stdBuilder()
-                            .itemInputs(GT_Utility.copyAmount(2L, aStack))
+                            .itemInputs(GT_Utility.copyAmount(2, aStack))
                             .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial, 2L), tImpureStack)
                             .duration(Math.max(1L, aMaterial.getMass() * 16L))
                             .eut(5)
@@ -572,7 +570,7 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                     }
                 } else {
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                        .itemInputs(GT_Utility.copyAmount(1, aStack))
                         .itemOutputs(
                             GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial, 1L),
                             GT_OreDictUnificator.get(
@@ -588,7 +586,7 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
             }
             case dustSmall -> {
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(4L, aStack), ItemList.Schematic_Dust.get(0L))
+                    .itemInputs(GT_Utility.copyAmount(4, aStack), ItemList.Schematic_Dust.get(0L))
                     .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial, 1L))
                     .duration(1 * SECONDS)
                     .eut(4)
@@ -597,7 +595,7 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                     GT_RecipeRegistrator.registerReverseFluidSmelting(aStack, aMaterial, aPrefix.mMaterialAmount, null);
                     if (aMaterial.mSmeltInto.mArcSmeltInto != aMaterial) {
                         GT_RecipeRegistrator.registerReverseArcSmelting(
-                            GT_Utility.copyAmount(1L, aStack),
+                            GT_Utility.copyAmount(1, aStack),
                             aMaterial,
                             aPrefix.mMaterialAmount,
                             null,
@@ -608,7 +606,7 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
             }
             case dustTiny -> {
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(9L, aStack), ItemList.Schematic_Dust.get(0L))
+                    .itemInputs(GT_Utility.copyAmount(9, aStack), ItemList.Schematic_Dust.get(0L))
                     .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial, 1L))
                     .duration(1 * SECONDS)
                     .eut(4)
@@ -617,7 +615,7 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                     GT_RecipeRegistrator.registerReverseFluidSmelting(aStack, aMaterial, aPrefix.mMaterialAmount, null);
                     if (aMaterial.mSmeltInto.mArcSmeltInto != aMaterial) {
                         GT_RecipeRegistrator.registerReverseArcSmelting(
-                            GT_Utility.copyAmount(1L, aStack),
+                            GT_Utility.copyAmount(1, aStack),
                             aMaterial,
                             aPrefix.mMaterialAmount,
                             null,

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingDye.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingDye.java
@@ -42,7 +42,7 @@ public class ProcessingDye implements IOreRecipeRegistrator {
             .toLowerCase(Locale.ENGLISH);
 
         GT_Values.RA.stdBuilder()
-            .itemInputs(GT_Utility.copyAmount(1L, stack), GT_Utility.getIntegratedCircuit(1))
+            .itemInputs(GT_Utility.copyAmount(1, stack), GT_Utility.getIntegratedCircuit(1))
             .fluidInputs(Materials.Water.getFluid(216L))
             .fluidOutputs(FluidRegistry.getFluidStack(fluidName, 192))
             .duration(16 * TICKS)
@@ -50,7 +50,7 @@ public class ProcessingDye implements IOreRecipeRegistrator {
             .addTo(sMixerRecipes);
 
         GT_Values.RA.stdBuilder()
-            .itemInputs(GT_Utility.copyAmount(1L, stack), GT_Utility.getIntegratedCircuit(1))
+            .itemInputs(GT_Utility.copyAmount(1, stack), GT_Utility.getIntegratedCircuit(1))
             .fluidInputs(GT_ModHandler.getDistilledWater(288L))
             .fluidOutputs(FluidRegistry.getFluidStack(fluidName, 216))
             .duration(16 * TICKS)
@@ -61,7 +61,7 @@ public class ProcessingDye implements IOreRecipeRegistrator {
     public void registerAlloySmelter(ItemStack stack, Dyes dye) {
         GT_ModHandler.addAlloySmelterRecipe(
             GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Glass, 8L),
-            GT_Utility.copyAmount(1L, stack),
+            GT_Utility.copyAmount(1, stack),
             new ItemStack(Blocks.stained_glass, 8, 15 - dye.mIndex),
             200,
             8,
@@ -69,7 +69,7 @@ public class ProcessingDye implements IOreRecipeRegistrator {
 
         GT_ModHandler.addAlloySmelterRecipe(
             new ItemStack(Blocks.glass, 8, 32767),
-            GT_Utility.copyAmount(1L, stack),
+            GT_Utility.copyAmount(1, stack),
             new ItemStack(Blocks.stained_glass, 8, 15 - dye.mIndex),
             200,
             8,
@@ -81,7 +81,7 @@ public class ProcessingDye implements IOreRecipeRegistrator {
             .toLowerCase(Locale.ENGLISH);
 
         GT_Values.RA.stdBuilder()
-            .itemInputs(GT_Utility.copyAmount(1L, stack), GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Salt, 2))
+            .itemInputs(GT_Utility.copyAmount(1, stack), GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Salt, 2))
             .fluidInputs(Materials.SulfuricAcid.getFluid(432))
             .fluidOutputs(FluidRegistry.getFluidStack(fluidName, 288))
             .duration(30 * SECONDS)

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingFineWire.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingFineWire.java
@@ -25,7 +25,7 @@ public class ProcessingFineWire implements gregtech.api.interfaces.IOreRecipeReg
         if ((aMaterial.mUnificatable) && (aMaterial.mMaterialInto == aMaterial)
             && !aMaterial.contains(SubTag.NO_WORKING)) {
             GT_ModHandler.addCraftingRecipe(
-                GT_Utility.copyAmount(1L, aStack),
+                GT_Utility.copyAmount(1, aStack),
                 GT_Proxy.tBits,
                 new Object[] { "Xx", 'X', OrePrefixes.foil.get(aMaterial) });
         }

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingFoil.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingFoil.java
@@ -30,7 +30,7 @@ public class ProcessingFoil implements IOreRecipeRegistrator {
     private void registerBenderRecipe(Materials material) {
         GT_Values.RA.stdBuilder()
             .itemInputs(
-                GT_Utility.copyAmount(1L, GT_OreDictUnificator.get(OrePrefixes.plate, material, 4L)),
+                GT_Utility.copyAmount(1, GT_OreDictUnificator.get(OrePrefixes.plate, material, 4L)),
                 GT_Utility.getIntegratedCircuit(1))
             .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.foil, material, 4L))
             .duration((int) Math.max(material.getMass(), 1L))

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingFood.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingFood.java
@@ -51,7 +51,7 @@ public class ProcessingFood implements gregtech.api.interfaces.IOreRecipeRegistr
 
     private void registerBenderRecipes(ItemStack stack) {
         GT_Values.RA.stdBuilder()
-            .itemInputs(GT_Utility.copyAmount(1L, stack), GT_Utility.getIntegratedCircuit(1))
+            .itemInputs(GT_Utility.copyAmount(1, stack), GT_Utility.getIntegratedCircuit(1))
             .itemOutputs(ItemList.Food_Flat_Dough.get(1L))
             .duration(16 * TICKS)
             .eut(4)
@@ -84,21 +84,21 @@ public class ProcessingFood implements gregtech.api.interfaces.IOreRecipeRegistr
     private void registerFormingPressRecipes(ItemStack stack) {
 
         GT_Values.RA.stdBuilder()
-            .itemInputs(GT_Utility.copyAmount(1L, stack), ItemList.Shape_Mold_Bun.get(0L))
+            .itemInputs(GT_Utility.copyAmount(1, stack), ItemList.Shape_Mold_Bun.get(0L))
             .itemOutputs(ItemList.Food_Raw_Bun.get(1L))
             .duration(6 * SECONDS + 8 * TICKS)
             .eut(4)
             .addTo(sPressRecipes);
 
         GT_Values.RA.stdBuilder()
-            .itemInputs(GT_Utility.copyAmount(2L, stack), ItemList.Shape_Mold_Bread.get(0L))
+            .itemInputs(GT_Utility.copyAmount(2, stack), ItemList.Shape_Mold_Bread.get(0L))
             .itemOutputs(ItemList.Food_Raw_Bread.get(1L))
             .duration(12 * SECONDS + 16 * TICKS)
             .eut(4)
             .addTo(sPressRecipes);
 
         GT_Values.RA.stdBuilder()
-            .itemInputs(GT_Utility.copyAmount(3L, stack), ItemList.Shape_Mold_Baguette.get(0L))
+            .itemInputs(GT_Utility.copyAmount(3, stack), ItemList.Shape_Mold_Baguette.get(0L))
             .itemOutputs(ItemList.Food_Raw_Baguette.get(1L))
             .duration(19 * SECONDS + 4 * TICKS)
             .eut(4)

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingGear.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingGear.java
@@ -73,7 +73,7 @@ public class ProcessingGear implements gregtech.api.interfaces.IOreRecipeRegistr
                     if (!(aMaterial == Materials.AnnealedCopper || aMaterial == Materials.WroughtIron)) {
                         GT_Values.RA.stdBuilder()
                             .itemInputs(ItemList.Shape_Mold_Gear_Small.get(0L))
-                            .itemOutputs(GT_Utility.copyAmount(1L, aStack))
+                            .itemOutputs(GT_Utility.copyAmount(1, aStack))
                             .fluidInputs(aMaterial.getMolten(144L))
                             .duration(16 * TICKS)
                             .eut(calculateRecipeEU(aMaterial, 8))

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingGem.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingGem.java
@@ -60,7 +60,7 @@ public class ProcessingGem implements gregtech.api.interfaces.IOreRecipeRegistra
                 // fuel recipes
                 if (aFuelPower) {
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                        .itemInputs(GT_Utility.copyAmount(1, aStack))
                         .metadata(FUEL_VALUE, aMaterial.mFuelPower * 2)
                         .metadata(FUEL_TYPE, aMaterial.mFuelType)
                         .duration(0)
@@ -74,7 +74,7 @@ public class ProcessingGem implements gregtech.api.interfaces.IOreRecipeRegistra
                     // need to avoid iridium exploit
                     if (aMaterial != Materials.Iridium) {
                         GT_Values.RA.stdBuilder()
-                            .itemInputs(GT_Utility.copyAmount(9L, aStack))
+                            .itemInputs(GT_Utility.copyAmount(9, aStack))
                             .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.block, aMaterial, 1L))
                             .duration(15 * SECONDS)
                             .eut(2)
@@ -85,7 +85,7 @@ public class ProcessingGem implements gregtech.api.interfaces.IOreRecipeRegistra
                 // Smelting recipe
                 if (!aNoSmelting) {
                     GT_ModHandler.addSmeltingRecipe(
-                        GT_Utility.copyAmount(1L, aStack),
+                        GT_Utility.copyAmount(1, aStack),
                         GT_OreDictUnificator.get(OrePrefixes.ingot, aMaterial.mSmeltInto, 1L));
                 }
 
@@ -108,7 +108,7 @@ public class ProcessingGem implements gregtech.api.interfaces.IOreRecipeRegistra
                         if (GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L) != null
                             && aMaterial != Materials.Iridium) {
                             GT_Values.RA.stdBuilder()
-                                .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                                .itemInputs(GT_Utility.copyAmount(1, aStack))
                                 .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L))
                                 .duration(Math.max(aMaterialMass, 1L))
                                 .eut(calculateRecipeEU(aMaterial, 16))
@@ -121,7 +121,7 @@ public class ProcessingGem implements gregtech.api.interfaces.IOreRecipeRegistra
                         if (GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L) != null) {
                             // Plate
                             GT_Values.RA.stdBuilder()
-                                .itemInputs(GT_Utility.copyAmount(1L, aStack), GT_Utility.getIntegratedCircuit(1))
+                                .itemInputs(GT_Utility.copyAmount(1, aStack), GT_Utility.getIntegratedCircuit(1))
                                 .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L))
                                 .duration((int) Math.max(aMaterialMass * 2L, 1L))
                                 .eut(calculateRecipeEU(aMaterial, 24))
@@ -131,7 +131,7 @@ public class ProcessingGem implements gregtech.api.interfaces.IOreRecipeRegistra
                         if (GT_OreDictUnificator.get(OrePrefixes.plateDouble, aMaterial, 1L) != null) {
                             // Double plates
                             GT_Values.RA.stdBuilder()
-                                .itemInputs(GT_Utility.copyAmount(2L, aStack), GT_Utility.getIntegratedCircuit(2))
+                                .itemInputs(GT_Utility.copyAmount(2, aStack), GT_Utility.getIntegratedCircuit(2))
                                 .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plateDouble, aMaterial, 1L))
                                 .duration(Math.max(aMaterialMass * 2L, 1L))
                                 .eut(calculateRecipeEU(aMaterial, 96))
@@ -141,7 +141,7 @@ public class ProcessingGem implements gregtech.api.interfaces.IOreRecipeRegistra
                         if (GT_OreDictUnificator.get(OrePrefixes.plateTriple, aMaterial, 1L) != null) {
                             // Triple plate
                             GT_Values.RA.stdBuilder()
-                                .itemInputs(GT_Utility.copyAmount(3L, aStack), GT_Utility.getIntegratedCircuit(3))
+                                .itemInputs(GT_Utility.copyAmount(3, aStack), GT_Utility.getIntegratedCircuit(3))
                                 .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plateTriple, aMaterial, 1L))
                                 .duration(Math.max(aMaterialMass * 3L, 1L))
                                 .eut(calculateRecipeEU(aMaterial, 96))
@@ -151,7 +151,7 @@ public class ProcessingGem implements gregtech.api.interfaces.IOreRecipeRegistra
                         if (GT_OreDictUnificator.get(OrePrefixes.plateQuadruple, aMaterial, 1L) != null) {
                             // Quadruple plate
                             GT_Values.RA.stdBuilder()
-                                .itemInputs(GT_Utility.copyAmount(4L, aStack), GT_Utility.getIntegratedCircuit(4))
+                                .itemInputs(GT_Utility.copyAmount(4, aStack), GT_Utility.getIntegratedCircuit(4))
                                 .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plateQuadruple, aMaterial, 1L))
                                 .duration(Math.max(aMaterialMass * 4L, 1L))
                                 .eut(calculateRecipeEU(aMaterial, 96))
@@ -161,7 +161,7 @@ public class ProcessingGem implements gregtech.api.interfaces.IOreRecipeRegistra
                         if (GT_OreDictUnificator.get(OrePrefixes.plateQuintuple, aMaterial, 1L) != null) {
                             // Quintuple plate
                             GT_Values.RA.stdBuilder()
-                                .itemInputs(GT_Utility.copyAmount(5L, aStack), GT_Utility.getIntegratedCircuit(5))
+                                .itemInputs(GT_Utility.copyAmount(5, aStack), GT_Utility.getIntegratedCircuit(5))
                                 .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plateQuintuple, aMaterial, 1L))
                                 .duration(Math.max(aMaterialMass * 5L, 1L))
                                 .eut(calculateRecipeEU(aMaterial, 96))
@@ -171,7 +171,7 @@ public class ProcessingGem implements gregtech.api.interfaces.IOreRecipeRegistra
                         if (GT_OreDictUnificator.get(OrePrefixes.plateDense, aMaterial, 1L) != null) {
                             // dense plate
                             GT_Values.RA.stdBuilder()
-                                .itemInputs(GT_Utility.copyAmount(9L, aStack), GT_Utility.getIntegratedCircuit(9))
+                                .itemInputs(GT_Utility.copyAmount(9, aStack), GT_Utility.getIntegratedCircuit(9))
                                 .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plateDense, aMaterial, 1L))
                                 .duration(Math.max(aMaterialMass * 9L, 1L))
                                 .eut(calculateRecipeEU(aMaterial, 96))
@@ -185,7 +185,7 @@ public class ProcessingGem implements gregtech.api.interfaces.IOreRecipeRegistra
                         if (GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial, 1L) != null
                             && GT_OreDictUnificator.get(OrePrefixes.dustSmall, aMaterial, 1L) != null) {
                             GT_Values.RA.stdBuilder()
-                                .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                                .itemInputs(GT_Utility.copyAmount(1, aStack))
                                 .itemOutputs(
                                     GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial, 1L),
                                     GT_OreDictUnificator.get(OrePrefixes.dustSmall, aMaterial, 2L))
@@ -200,7 +200,7 @@ public class ProcessingGem implements gregtech.api.interfaces.IOreRecipeRegistra
                         {
                             if (GT_OreDictUnificator.get(OrePrefixes.gemFlawless, aMaterial, 1) != null) {
                                 GT_Values.RA.stdBuilder()
-                                    .itemInputs(GT_Utility.copyAmount(3L, aStack), ItemList.Block_Powderbarrel.get(16))
+                                    .itemInputs(GT_Utility.copyAmount(3, aStack), ItemList.Block_Powderbarrel.get(16))
                                     .itemOutputs(
                                         GT_OreDictUnificator.get(OrePrefixes.gemFlawless, aMaterial, 1),
                                         GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 2))
@@ -209,7 +209,7 @@ public class ProcessingGem implements gregtech.api.interfaces.IOreRecipeRegistra
                                     .addTo(sImplosionRecipes);
                                 GT_Values.RA.stdBuilder()
                                     .itemInputs(
-                                        GT_Utility.copyAmount(3L, aStack),
+                                        GT_Utility.copyAmount(3, aStack),
                                         GT_ModHandler.getIC2Item("dynamite", 4, null))
                                     .itemOutputs(
                                         GT_OreDictUnificator.get(OrePrefixes.gemFlawless, aMaterial, 1),
@@ -218,7 +218,7 @@ public class ProcessingGem implements gregtech.api.interfaces.IOreRecipeRegistra
                                     .eut(TierEU.RECIPE_LV)
                                     .addTo(sImplosionRecipes);
                                 GT_Values.RA.stdBuilder()
-                                    .itemInputs(GT_Utility.copyAmount(3L, aStack), new ItemStack(Blocks.tnt, 8))
+                                    .itemInputs(GT_Utility.copyAmount(3, aStack), new ItemStack(Blocks.tnt, 8))
                                     .itemOutputs(
                                         GT_OreDictUnificator.get(OrePrefixes.gemFlawless, aMaterial, 1),
                                         GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 2))
@@ -227,7 +227,7 @@ public class ProcessingGem implements gregtech.api.interfaces.IOreRecipeRegistra
                                     .addTo(sImplosionRecipes);
                                 GT_Values.RA.stdBuilder()
                                     .itemInputs(
-                                        GT_Utility.copyAmount(3L, aStack),
+                                        GT_Utility.copyAmount(3, aStack),
                                         GT_ModHandler.getIC2Item("industrialTnt", 2))
                                     .itemOutputs(
                                         GT_OreDictUnificator.get(OrePrefixes.gemFlawless, aMaterial, 1),
@@ -247,7 +247,7 @@ public class ProcessingGem implements gregtech.api.interfaces.IOreRecipeRegistra
 
                             if (aMaterial.contains(SubTag.SMELTING_TO_GEM)) {
                                 GT_ModHandler.addCraftingRecipe(
-                                    GT_Utility.copyAmount(1L, aStack),
+                                    GT_Utility.copyAmount(1, aStack),
                                     GT_Proxy.tBits,
                                     new Object[] { "XXX", "XXX", "XXX", 'X', OrePrefixes.nugget.get(aMaterial) });
                             }
@@ -269,7 +269,7 @@ public class ProcessingGem implements gregtech.api.interfaces.IOreRecipeRegistra
                         if (GregTech_API.sRecipeFile
                             .get(ConfigCategories.Recipes.disabledrecipes, "torchesFromCoal", false)) {
                             GT_ModHandler.removeRecipeDelayed(
-                                GT_Utility.copyAmount(1L, aStack),
+                                GT_Utility.copyAmount(1, aStack),
                                 null,
                                 null,
                                 new ItemStack(net.minecraft.init.Items.stick, 1, 0));
@@ -296,7 +296,7 @@ public class ProcessingGem implements gregtech.api.interfaces.IOreRecipeRegistra
                             is.stackSize = 0;
 
                             GT_Values.RA.stdBuilder()
-                                .itemInputs(GT_Utility.copyAmount(3L, aStack), is)
+                                .itemInputs(GT_Utility.copyAmount(3, aStack), is)
                                 .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.gemFlawless, aMaterial, 1L))
                                 .duration(60 * SECONDS)
                                 .eut(TierEU.RECIPE_HV)
@@ -310,7 +310,7 @@ public class ProcessingGem implements gregtech.api.interfaces.IOreRecipeRegistra
                 // Fuel recipes
                 if (aFuelPower) {
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                        .itemInputs(GT_Utility.copyAmount(1, aStack))
                         .metadata(FUEL_VALUE, aMaterial.mFuelPower / 2)
                         .metadata(FUEL_TYPE, aMaterial.mFuelType)
                         .duration(0)
@@ -323,7 +323,7 @@ public class ProcessingGem implements gregtech.api.interfaces.IOreRecipeRegistra
                     if (GT_OreDictUnificator.get(OrePrefixes.bolt, aMaterial, 1L) != null
                         && GT_OreDictUnificator.get(OrePrefixes.dustTiny, aMaterial, 1L) != null) {
                         GT_Values.RA.stdBuilder()
-                            .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                            .itemInputs(GT_Utility.copyAmount(1, aStack))
                             .itemOutputs(
                                 GT_OreDictUnificator.get(OrePrefixes.bolt, aMaterial, 1L),
                                 GT_OreDictUnificator.get(OrePrefixes.dustTiny, aMaterial, 1L))
@@ -337,7 +337,7 @@ public class ProcessingGem implements gregtech.api.interfaces.IOreRecipeRegistra
                         {
                             if (GT_OreDictUnificator.get(OrePrefixes.gemFlawed, aMaterial, 1) != null) {
                                 GT_Values.RA.stdBuilder()
-                                    .itemInputs(GT_Utility.copyAmount(3L, aStack), ItemList.Block_Powderbarrel.get(16))
+                                    .itemInputs(GT_Utility.copyAmount(3, aStack), ItemList.Block_Powderbarrel.get(16))
                                     .itemOutputs(
                                         GT_OreDictUnificator.get(OrePrefixes.gemFlawed, aMaterial, 1),
                                         GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 2))
@@ -346,7 +346,7 @@ public class ProcessingGem implements gregtech.api.interfaces.IOreRecipeRegistra
                                     .addTo(sImplosionRecipes);
                                 GT_Values.RA.stdBuilder()
                                     .itemInputs(
-                                        GT_Utility.copyAmount(3L, aStack),
+                                        GT_Utility.copyAmount(3, aStack),
                                         GT_ModHandler.getIC2Item("dynamite", 4, null))
                                     .itemOutputs(
                                         GT_OreDictUnificator.get(OrePrefixes.gemFlawed, aMaterial, 1),
@@ -355,7 +355,7 @@ public class ProcessingGem implements gregtech.api.interfaces.IOreRecipeRegistra
                                     .eut(TierEU.RECIPE_LV)
                                     .addTo(sImplosionRecipes);
                                 GT_Values.RA.stdBuilder()
-                                    .itemInputs(GT_Utility.copyAmount(3L, aStack), new ItemStack(Blocks.tnt, 8))
+                                    .itemInputs(GT_Utility.copyAmount(3, aStack), new ItemStack(Blocks.tnt, 8))
                                     .itemOutputs(
                                         GT_OreDictUnificator.get(OrePrefixes.gemFlawed, aMaterial, 1),
                                         GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 2))
@@ -364,7 +364,7 @@ public class ProcessingGem implements gregtech.api.interfaces.IOreRecipeRegistra
                                     .addTo(sImplosionRecipes);
                                 GT_Values.RA.stdBuilder()
                                     .itemInputs(
-                                        GT_Utility.copyAmount(3L, aStack),
+                                        GT_Utility.copyAmount(3, aStack),
                                         GT_ModHandler.getIC2Item("industrialTnt", 2))
                                     .itemOutputs(
                                         GT_OreDictUnificator.get(OrePrefixes.gemFlawed, aMaterial, 1),
@@ -394,7 +394,7 @@ public class ProcessingGem implements gregtech.api.interfaces.IOreRecipeRegistra
                     is.stackSize = 0;
 
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(3L, aStack), is)
+                        .itemInputs(GT_Utility.copyAmount(3, aStack), is)
                         .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.gemFlawed, aMaterial, 1L))
                         .duration(30 * SECONDS)
                         .eut(30)
@@ -406,7 +406,7 @@ public class ProcessingGem implements gregtech.api.interfaces.IOreRecipeRegistra
                 // Fuel recipes
                 if (aFuelPower) {
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                        .itemInputs(GT_Utility.copyAmount(1, aStack))
                         .metadata(FUEL_VALUE, aMaterial.mFuelPower * 8)
                         .metadata(FUEL_TYPE, aMaterial.mFuelType)
                         .duration(0)
@@ -442,7 +442,7 @@ public class ProcessingGem implements gregtech.api.interfaces.IOreRecipeRegistra
                 // fuel recipes
                 if (aFuelPower) {
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                        .itemInputs(GT_Utility.copyAmount(1, aStack))
                         .metadata(FUEL_VALUE, aMaterial.mFuelPower)
                         .metadata(FUEL_TYPE, aMaterial.mFuelType)
                         .duration(0)
@@ -455,7 +455,7 @@ public class ProcessingGem implements gregtech.api.interfaces.IOreRecipeRegistra
                     if (GT_OreDictUnificator.get(OrePrefixes.bolt, aMaterial, 1L) != null
                         && GT_OreDictUnificator.get(OrePrefixes.dustSmall, aMaterial, 1L) != null) {
                         GT_Values.RA.stdBuilder()
-                            .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                            .itemInputs(GT_Utility.copyAmount(1, aStack))
                             .itemOutputs(
                                 GT_OreDictUnificator.get(OrePrefixes.bolt, aMaterial, 2L),
                                 GT_OreDictUnificator.get(OrePrefixes.dustSmall, aMaterial, 1L))
@@ -469,7 +469,7 @@ public class ProcessingGem implements gregtech.api.interfaces.IOreRecipeRegistra
                         {
                             if (GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 1) != null) {
                                 GT_Values.RA.stdBuilder()
-                                    .itemInputs(GT_Utility.copyAmount(3L, aStack), ItemList.Block_Powderbarrel.get(16))
+                                    .itemInputs(GT_Utility.copyAmount(3, aStack), ItemList.Block_Powderbarrel.get(16))
                                     .itemOutputs(
                                         GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 1),
                                         GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 2))
@@ -478,7 +478,7 @@ public class ProcessingGem implements gregtech.api.interfaces.IOreRecipeRegistra
                                     .addTo(sImplosionRecipes);
                                 GT_Values.RA.stdBuilder()
                                     .itemInputs(
-                                        GT_Utility.copyAmount(3L, aStack),
+                                        GT_Utility.copyAmount(3, aStack),
                                         GT_ModHandler.getIC2Item("dynamite", 4, null))
                                     .itemOutputs(
                                         GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 1),
@@ -487,7 +487,7 @@ public class ProcessingGem implements gregtech.api.interfaces.IOreRecipeRegistra
                                     .eut(TierEU.RECIPE_LV)
                                     .addTo(sImplosionRecipes);
                                 GT_Values.RA.stdBuilder()
-                                    .itemInputs(GT_Utility.copyAmount(3L, aStack), new ItemStack(Blocks.tnt, 8))
+                                    .itemInputs(GT_Utility.copyAmount(3, aStack), new ItemStack(Blocks.tnt, 8))
                                     .itemOutputs(
                                         GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 1),
                                         GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 2))
@@ -496,7 +496,7 @@ public class ProcessingGem implements gregtech.api.interfaces.IOreRecipeRegistra
                                     .addTo(sImplosionRecipes);
                                 GT_Values.RA.stdBuilder()
                                     .itemInputs(
-                                        GT_Utility.copyAmount(3L, aStack),
+                                        GT_Utility.copyAmount(3, aStack),
                                         GT_ModHandler.getIC2Item("industrialTnt", 2))
                                     .itemOutputs(
                                         GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 1),
@@ -534,7 +534,7 @@ public class ProcessingGem implements gregtech.api.interfaces.IOreRecipeRegistra
                     is.stackSize = 0;
 
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(3L, aStack), is)
+                        .itemInputs(GT_Utility.copyAmount(3, aStack), is)
                         .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, 1L))
                         .duration(30 * SECONDS)
                         .eut(TierEU.RECIPE_MV)
@@ -547,7 +547,7 @@ public class ProcessingGem implements gregtech.api.interfaces.IOreRecipeRegistra
                 // Fuel recipes
                 if (aFuelPower) {
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                        .itemInputs(GT_Utility.copyAmount(1, aStack))
                         .metadata(FUEL_VALUE, aMaterial.mFuelPower * 4)
                         .metadata(FUEL_TYPE, aMaterial.mFuelType)
                         .duration(0)
@@ -560,7 +560,7 @@ public class ProcessingGem implements gregtech.api.interfaces.IOreRecipeRegistra
                     if (GT_OreDictUnificator.get(OrePrefixes.stickLong, aMaterial, 1L) != null
                         && GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial, 1L) != null) {
                         GT_Values.RA.stdBuilder()
-                            .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                            .itemInputs(GT_Utility.copyAmount(1, aStack))
                             .itemOutputs(
                                 GT_OreDictUnificator.get(OrePrefixes.stickLong, aMaterial, 1L),
                                 GT_OreDictUnificator.getDust(
@@ -576,7 +576,7 @@ public class ProcessingGem implements gregtech.api.interfaces.IOreRecipeRegistra
                         {
                             if (GT_OreDictUnificator.get(OrePrefixes.gemExquisite, aMaterial, 1) != null) {
                                 GT_Values.RA.stdBuilder()
-                                    .itemInputs(GT_Utility.copyAmount(3L, aStack), ItemList.Block_Powderbarrel.get(16))
+                                    .itemInputs(GT_Utility.copyAmount(3, aStack), ItemList.Block_Powderbarrel.get(16))
                                     .itemOutputs(
                                         GT_OreDictUnificator.get(OrePrefixes.gemExquisite, aMaterial, 1),
                                         GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 2))
@@ -585,7 +585,7 @@ public class ProcessingGem implements gregtech.api.interfaces.IOreRecipeRegistra
                                     .addTo(sImplosionRecipes);
                                 GT_Values.RA.stdBuilder()
                                     .itemInputs(
-                                        GT_Utility.copyAmount(3L, aStack),
+                                        GT_Utility.copyAmount(3, aStack),
                                         GT_ModHandler.getIC2Item("dynamite", 4, null))
                                     .itemOutputs(
                                         GT_OreDictUnificator.get(OrePrefixes.gemExquisite, aMaterial, 1),
@@ -594,7 +594,7 @@ public class ProcessingGem implements gregtech.api.interfaces.IOreRecipeRegistra
                                     .eut(TierEU.RECIPE_LV)
                                     .addTo(sImplosionRecipes);
                                 GT_Values.RA.stdBuilder()
-                                    .itemInputs(GT_Utility.copyAmount(3L, aStack), new ItemStack(Blocks.tnt, 8))
+                                    .itemInputs(GT_Utility.copyAmount(3, aStack), new ItemStack(Blocks.tnt, 8))
                                     .itemOutputs(
                                         GT_OreDictUnificator.get(OrePrefixes.gemExquisite, aMaterial, 1),
                                         GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 2))
@@ -603,7 +603,7 @@ public class ProcessingGem implements gregtech.api.interfaces.IOreRecipeRegistra
                                     .addTo(sImplosionRecipes);
                                 GT_Values.RA.stdBuilder()
                                     .itemInputs(
-                                        GT_Utility.copyAmount(3L, aStack),
+                                        GT_Utility.copyAmount(3, aStack),
                                         GT_ModHandler.getIC2Item("industrialTnt", 2))
                                     .itemOutputs(
                                         GT_OreDictUnificator.get(OrePrefixes.gemExquisite, aMaterial, 1),
@@ -640,7 +640,7 @@ public class ProcessingGem implements gregtech.api.interfaces.IOreRecipeRegistra
 
                     is.stackSize = 0;
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(3L, aStack), is)
+                        .itemInputs(GT_Utility.copyAmount(3, aStack), is)
                         .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.gemExquisite, aMaterial, 1L))
                         .duration(2 * MINUTES)
                         .eut(2000)

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingIngot.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingIngot.java
@@ -54,7 +54,7 @@ public class ProcessingIngot implements gregtech.api.interfaces.IOreRecipeRegist
                 // Fuel recipe
                 if (aMaterial.mFuelPower > 0) {
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                        .itemInputs(GT_Utility.copyAmount(1, aStack))
                         .metadata(FUEL_VALUE, aMaterial.mFuelPower)
                         .metadata(FUEL_TYPE, aMaterial.mFuelType)
                         .duration(0)
@@ -80,7 +80,7 @@ public class ProcessingIngot implements gregtech.api.interfaces.IOreRecipeRegist
                         .registerReverseMacerating(aStack, aMaterial, aPrefix.mMaterialAmount, null, null, null, false);
                     if (aMaterial.mSmeltInto.mArcSmeltInto != aMaterial) {
                         GT_RecipeRegistrator.registerReverseArcSmelting(
-                            GT_Utility.copyAmount(1L, aStack),
+                            GT_Utility.copyAmount(1, aStack),
                             aMaterial,
                             aPrefix.mMaterialAmount,
                             null,
@@ -107,7 +107,7 @@ public class ProcessingIngot implements gregtech.api.interfaces.IOreRecipeRegist
                     if (aMaterial.getProcessingMaterialTierEU() < TierEU.IV
                         && GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L) != null) {
                         GT_Values.RA.stdBuilder()
-                            .itemInputs(GT_Utility.copyAmount(3L, aStack))
+                            .itemInputs(GT_Utility.copyAmount(3, aStack))
                             .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 2L))
                             .duration(Math.max(aMaterialMass, 1L))
                             .eut(calculateRecipeEU(aMaterial, 16))
@@ -118,7 +118,7 @@ public class ProcessingIngot implements gregtech.api.interfaces.IOreRecipeRegist
                     {
                         if (GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L) != null) {
                             GT_Values.RA.stdBuilder()
-                                .itemInputs(GT_Utility.copyAmount(1L, aStack), GT_Utility.getIntegratedCircuit(1))
+                                .itemInputs(GT_Utility.copyAmount(1, aStack), GT_Utility.getIntegratedCircuit(1))
                                 .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L))
                                 .duration(Math.max(aMaterialMass, 1L))
                                 .eut(calculateRecipeEU(aMaterial, 24))
@@ -127,7 +127,7 @@ public class ProcessingIngot implements gregtech.api.interfaces.IOreRecipeRegist
 
                         if (GT_OreDictUnificator.get(OrePrefixes.plateDouble, aMaterial, 1L) != null) {
                             GT_Values.RA.stdBuilder()
-                                .itemInputs(GT_Utility.copyAmount(2L, aStack), GT_Utility.getIntegratedCircuit(2))
+                                .itemInputs(GT_Utility.copyAmount(2, aStack), GT_Utility.getIntegratedCircuit(2))
                                 .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plateDouble, aMaterial, 1L))
                                 .duration(Math.max(aMaterialMass * 2L, 1L))
                                 .eut(calculateRecipeEU(aMaterial, 96))
@@ -136,7 +136,7 @@ public class ProcessingIngot implements gregtech.api.interfaces.IOreRecipeRegist
 
                         if (GT_OreDictUnificator.get(OrePrefixes.plateTriple, aMaterial, 1L) != null) {
                             GT_Values.RA.stdBuilder()
-                                .itemInputs(GT_Utility.copyAmount(3L, aStack), GT_Utility.getIntegratedCircuit(3))
+                                .itemInputs(GT_Utility.copyAmount(3, aStack), GT_Utility.getIntegratedCircuit(3))
                                 .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plateTriple, aMaterial, 1L))
                                 .duration(Math.max(aMaterialMass * 3L, 1L))
                                 .eut(calculateRecipeEU(aMaterial, 96))
@@ -145,7 +145,7 @@ public class ProcessingIngot implements gregtech.api.interfaces.IOreRecipeRegist
 
                         if (GT_OreDictUnificator.get(OrePrefixes.plateQuadruple, aMaterial, 1L) != null) {
                             GT_Values.RA.stdBuilder()
-                                .itemInputs(GT_Utility.copyAmount(4L, aStack), GT_Utility.getIntegratedCircuit(4))
+                                .itemInputs(GT_Utility.copyAmount(4, aStack), GT_Utility.getIntegratedCircuit(4))
                                 .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plateQuadruple, aMaterial, 1L))
                                 .duration(Math.max(aMaterialMass * 4L, 1L))
                                 .eut(calculateRecipeEU(aMaterial, 96))
@@ -154,7 +154,7 @@ public class ProcessingIngot implements gregtech.api.interfaces.IOreRecipeRegist
 
                         if (GT_OreDictUnificator.get(OrePrefixes.plateQuintuple, aMaterial, 1L) != null) {
                             GT_Values.RA.stdBuilder()
-                                .itemInputs(GT_Utility.copyAmount(5L, aStack), GT_Utility.getIntegratedCircuit(5))
+                                .itemInputs(GT_Utility.copyAmount(5, aStack), GT_Utility.getIntegratedCircuit(5))
                                 .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plateQuintuple, aMaterial, 1L))
                                 .duration(Math.max(aMaterialMass * 5L, 1L))
                                 .eut(calculateRecipeEU(aMaterial, 96))
@@ -163,7 +163,7 @@ public class ProcessingIngot implements gregtech.api.interfaces.IOreRecipeRegist
 
                         if (GT_OreDictUnificator.get(OrePrefixes.plateDense, aMaterial, 1L) != null) {
                             GT_Values.RA.stdBuilder()
-                                .itemInputs(GT_Utility.copyAmount(9L, aStack), GT_Utility.getIntegratedCircuit(9))
+                                .itemInputs(GT_Utility.copyAmount(9, aStack), GT_Utility.getIntegratedCircuit(9))
                                 .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plateDense, aMaterial, 1L))
                                 .duration(Math.max(aMaterialMass * 9L, 1L))
                                 .eut(calculateRecipeEU(aMaterial, 96))
@@ -172,7 +172,7 @@ public class ProcessingIngot implements gregtech.api.interfaces.IOreRecipeRegist
 
                         if (GT_OreDictUnificator.get(OrePrefixes.foil, aMaterial, 1L) != null) {
                             GT_Values.RA.stdBuilder()
-                                .itemInputs(GT_Utility.copyAmount(1L, aStack), GT_Utility.getIntegratedCircuit(10))
+                                .itemInputs(GT_Utility.copyAmount(1, aStack), GT_Utility.getIntegratedCircuit(10))
                                 .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.foil, aMaterial, 4L))
                                 .duration(Math.max(aMaterialMass * 2L, 1L))
                                 .eut(calculateRecipeEU(aMaterial, 24))
@@ -186,14 +186,14 @@ public class ProcessingIngot implements gregtech.api.interfaces.IOreRecipeRegist
                     // bender recipes
                     {
                         GT_Values.RA.stdBuilder()
-                            .itemInputs(GT_Utility.copyAmount(1L, aStack), GT_Utility.getIntegratedCircuit(1))
+                            .itemInputs(GT_Utility.copyAmount(1, aStack), GT_Utility.getIntegratedCircuit(1))
                             .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plateDouble, aMaterial, 1L))
                             .duration(Math.max(aMaterialMass, 1L))
                             .eut(calculateRecipeEU(aMaterial, 96))
                             .addTo(sBenderRecipes);
 
                         GT_Values.RA.stdBuilder()
-                            .itemInputs(GT_Utility.copyAmount(2L, aStack), GT_Utility.getIntegratedCircuit(2))
+                            .itemInputs(GT_Utility.copyAmount(2, aStack), GT_Utility.getIntegratedCircuit(2))
                             .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plateQuadruple, aMaterial, 1L))
                             .duration(Math.max(aMaterialMass * 2L, 1L))
                             .eut(calculateRecipeEU(aMaterial, 96))
@@ -216,14 +216,14 @@ public class ProcessingIngot implements gregtech.api.interfaces.IOreRecipeRegist
                     // Bender recipes
                     {
                         GT_Values.RA.stdBuilder()
-                            .itemInputs(GT_Utility.copyAmount(1L, aStack), GT_Utility.getIntegratedCircuit(1))
+                            .itemInputs(GT_Utility.copyAmount(1, aStack), GT_Utility.getIntegratedCircuit(1))
                             .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plateTriple, aMaterial, 1L))
                             .duration(Math.max(aMaterialMass, 1L))
                             .eut(calculateRecipeEU(aMaterial, 96))
                             .addTo(sBenderRecipes);
 
                         GT_Values.RA.stdBuilder()
-                            .itemInputs(GT_Utility.copyAmount(3L, aStack), GT_Utility.getIntegratedCircuit(3))
+                            .itemInputs(GT_Utility.copyAmount(3, aStack), GT_Utility.getIntegratedCircuit(3))
                             .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plateDense, aMaterial, 1L))
                             .duration(Math.max(aMaterialMass * 3L, 1L))
                             .eut(calculateRecipeEU(aMaterial, 96))
@@ -246,7 +246,7 @@ public class ProcessingIngot implements gregtech.api.interfaces.IOreRecipeRegist
                     // Bender recipes
                     {
                         GT_Values.RA.stdBuilder()
-                            .itemInputs(GT_Utility.copyAmount(1L, aStack), GT_Utility.getIntegratedCircuit(1))
+                            .itemInputs(GT_Utility.copyAmount(1, aStack), GT_Utility.getIntegratedCircuit(1))
                             .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plateQuadruple, aMaterial, 1L))
                             .duration(Math.max(aMaterialMass, 1L))
                             .eut(calculateRecipeEU(aMaterial, 96))
@@ -270,7 +270,7 @@ public class ProcessingIngot implements gregtech.api.interfaces.IOreRecipeRegist
                     // Bender recipes
                     {
                         GT_Values.RA.stdBuilder()
-                            .itemInputs(GT_Utility.copyAmount(1L, aStack), GT_Utility.getIntegratedCircuit(1))
+                            .itemInputs(GT_Utility.copyAmount(1, aStack), GT_Utility.getIntegratedCircuit(1))
                             .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plateQuintuple, aMaterial, 1L))
                             .duration(Math.max(aMaterialMass, 1L))
                             .eut(calculateRecipeEU(aMaterial, 96))
@@ -294,7 +294,7 @@ public class ProcessingIngot implements gregtech.api.interfaces.IOreRecipeRegist
                     && GT_OreDictUnificator.get(OrePrefixes.ingot, aMaterial, 1L) != null) {
                     // Vacuum freezer recipes
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                        .itemInputs(GT_Utility.copyAmount(1, aStack))
                         .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.ingot, aMaterial, 1L))
                         .duration(((int) Math.max(aMaterialMass * 3L, 1L)) * TICKS)
                         .eut(TierEU.RECIPE_MV)

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingLog.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingLog.java
@@ -38,7 +38,7 @@ public class ProcessingLog implements gregtech.api.interfaces.IOreRecipeRegistra
         ItemStack aStack) {
         if (aOreDictName.equals("logRubber")) {
             GT_Values.RA.stdBuilder()
-                .itemInputs(GT_Utility.copyAmount(1L, aStack), GT_Utility.getIntegratedCircuit(2))
+                .itemInputs(GT_Utility.copyAmount(1, aStack), GT_Utility.getIntegratedCircuit(2))
                 .itemOutputs(
                     ItemList.IC2_Resin.get(1L),
                     GT_ModHandler.getIC2Item("plantBall", 1L),
@@ -51,14 +51,14 @@ public class ProcessingLog implements gregtech.api.interfaces.IOreRecipeRegistra
                 .addTo(sCentrifugeRecipes);
 
             GT_Values.RA.stdBuilder()
-                .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                .itemInputs(GT_Utility.copyAmount(1, aStack))
                 .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.dust, Materials.RawRubber, 1L))
                 .duration(15 * SECONDS)
                 .eut(2)
                 .addTo(sExtractorRecipes);
 
             GT_Values.RA.stdBuilder()
-                .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                .itemInputs(GT_Utility.copyAmount(1, aStack))
                 .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 6L), ItemList.IC2_Resin.get(1L))
                 .outputChances(10000, 3300)
                 .duration(20 * SECONDS)
@@ -66,14 +66,14 @@ public class ProcessingLog implements gregtech.api.interfaces.IOreRecipeRegistra
                 .addTo(sMaceratorRecipes);
         } else {
             GT_Values.RA.stdBuilder()
-                .itemInputs(GT_Utility.copyAmount(1L, aStack), GT_Utility.getIntegratedCircuit(1))
+                .itemInputs(GT_Utility.copyAmount(1, aStack), GT_Utility.getIntegratedCircuit(1))
                 .fluidOutputs(Materials.Methane.getGas(60L))
                 .duration(10 * SECONDS)
                 .eut(20)
                 .addTo(sCentrifugeRecipes);
 
             GT_Values.RA.stdBuilder()
-                .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                .itemInputs(GT_Utility.copyAmount(1, aStack))
                 .itemOutputs(
                     GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 6L),
                     GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 1L))
@@ -87,10 +87,10 @@ public class ProcessingLog implements gregtech.api.interfaces.IOreRecipeRegistra
             GT_OreDictUnificator.get(OrePrefixes.stickLong, Materials.Wood, 2L),
             gregtech.api.util.GT_ModHandler.RecipeBits.DO_NOT_CHECK_FOR_COLLISIONS
                 | gregtech.api.util.GT_ModHandler.RecipeBits.BUFFERED,
-            new Object[] { "sLf", 'L', GT_Utility.copyAmount(1L, aStack) });
+            new Object[] { "sLf", 'L', GT_Utility.copyAmount(1, aStack) });
 
         GT_Values.RA.stdBuilder()
-            .itemInputs(GT_Utility.copyAmount(1L, aStack))
+            .itemInputs(GT_Utility.copyAmount(1, aStack))
             .itemOutputs(
                 GT_OreDictUnificator.get(OrePrefixes.stickLong, Materials.Wood, 4L),
                 GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 2L))
@@ -99,7 +99,7 @@ public class ProcessingLog implements gregtech.api.interfaces.IOreRecipeRegistra
             .addTo(sLatheRecipes);
 
         GT_Values.RA.stdBuilder()
-            .itemInputs(GT_Utility.copyAmount(1L, aStack), GT_Utility.getIntegratedCircuit(2))
+            .itemInputs(GT_Utility.copyAmount(1, aStack), GT_Utility.getIntegratedCircuit(2))
             .itemOutputs(ItemList.FR_Stick.get(1L))
             .fluidInputs(Materials.SeedOil.getFluid(50L))
             .duration(16 * TICKS)
@@ -107,7 +107,7 @@ public class ProcessingLog implements gregtech.api.interfaces.IOreRecipeRegistra
             .addTo(sAssemblerRecipes);
 
         GT_Values.RA.stdBuilder()
-            .itemInputs(GT_Utility.copyAmount(8L, aStack), GT_Utility.getIntegratedCircuit(8))
+            .itemInputs(GT_Utility.copyAmount(8, aStack), GT_Utility.getIntegratedCircuit(8))
             .itemOutputs(ItemList.FR_Casing_Impregnated.get(1L))
             .fluidInputs(Materials.SeedOil.getFluid(250L))
             .duration(3 * SECONDS + 4 * TICKS)
@@ -115,7 +115,7 @@ public class ProcessingLog implements gregtech.api.interfaces.IOreRecipeRegistra
             .addTo(sAssemblerRecipes);
 
         GT_Values.RA.stdBuilder()
-            .itemInputs(GT_Utility.copyAmount(1L, aStack))
+            .itemInputs(GT_Utility.copyAmount(1, aStack))
             .itemOutputs(GT_ModHandler.getModItem(Railcraft.ID, "cube", 1L, 8))
             .fluidInputs(Materials.Creosote.getFluid(750L))
             .duration(16 * TICKS)
@@ -126,12 +126,12 @@ public class ProcessingLog implements gregtech.api.interfaces.IOreRecipeRegistra
 
         if (aMeta == Short.MAX_VALUE) {
             if ((GT_Utility.areStacksEqual(
-                GT_ModHandler.getSmeltingOutput(GT_Utility.copyAmount(1L, aStack), false, null),
+                GT_ModHandler.getSmeltingOutput(GT_Utility.copyAmount(1, aStack), false, null),
                 new ItemStack(Items.coal, 1, 1)))) {
                 addPyrolyeOvenRecipes(aStack);
                 if (GregTech_API.sRecipeFile
                     .get(ConfigCategories.Recipes.disabledrecipes, "wood2charcoalsmelting", true)) {
-                    GT_ModHandler.removeFurnaceSmelting(GT_Utility.copyAmount(1L, aStack));
+                    GT_ModHandler.removeFurnaceSmelting(GT_Utility.copyAmount(1, aStack));
                 }
             }
             for (int i = 0; i < 32767; i++) {
@@ -166,8 +166,7 @@ public class ProcessingLog implements gregtech.api.interfaces.IOreRecipeRegistra
                             .itemInputs(new ItemStack(aStack.getItem(), 1, i))
                             .itemOutputs(
                                 GT_Utility.copyAmount(
-                                    GT_Mod.gregtechproxy.mNerfedWoodPlank ? tStack.stackSize
-                                        : tStack.stackSize * 5L / 4,
+                                    GT_Mod.gregtechproxy.mNerfedWoodPlank ? tStack.stackSize : tStack.stackSize * 5 / 4,
                                     tStack),
                                 GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 2L))
                             .fluidInputs(Materials.Water.getFluid(Math.min(1000, 200 * 8 / 320)))
@@ -178,8 +177,7 @@ public class ProcessingLog implements gregtech.api.interfaces.IOreRecipeRegistra
                             .itemInputs(new ItemStack(aStack.getItem(), 1, i))
                             .itemOutputs(
                                 GT_Utility.copyAmount(
-                                    GT_Mod.gregtechproxy.mNerfedWoodPlank ? tStack.stackSize
-                                        : tStack.stackSize * 5L / 4,
+                                    GT_Mod.gregtechproxy.mNerfedWoodPlank ? tStack.stackSize : tStack.stackSize * 5 / 4,
                                     tStack),
                                 GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 2L))
                             .fluidInputs(GT_ModHandler.getDistilledWater(3))
@@ -190,8 +188,7 @@ public class ProcessingLog implements gregtech.api.interfaces.IOreRecipeRegistra
                             .itemInputs(new ItemStack(aStack.getItem(), 1, i))
                             .itemOutputs(
                                 GT_Utility.copyAmount(
-                                    GT_Mod.gregtechproxy.mNerfedWoodPlank ? tStack.stackSize
-                                        : tStack.stackSize * 5L / 4,
+                                    GT_Mod.gregtechproxy.mNerfedWoodPlank ? tStack.stackSize : tStack.stackSize * 5 / 4,
                                     tStack),
                                 GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 2L))
                             .fluidInputs(Materials.Lubricant.getFluid(1))
@@ -203,14 +200,12 @@ public class ProcessingLog implements gregtech.api.interfaces.IOreRecipeRegistra
                             tPlanks,
                             GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 1L));
                         GT_ModHandler.removeRecipeDelayed(new ItemStack(aStack.getItem(), 1, i));
-                        GT_ModHandler
-                            .addCraftingRecipe(
-                                GT_Utility.copyAmount(
-                                    GT_Mod.gregtechproxy.mNerfedWoodPlank ? tStack.stackSize
-                                        : tStack.stackSize * 5L / 4,
-                                    tStack),
-                                GT_ModHandler.RecipeBits.BUFFERED,
-                                new Object[] { "s", "L", 'L', new ItemStack(aStack.getItem(), 1, i) });
+                        GT_ModHandler.addCraftingRecipe(
+                            GT_Utility.copyAmount(
+                                GT_Mod.gregtechproxy.mNerfedWoodPlank ? tStack.stackSize : tStack.stackSize * 5 / 4,
+                                tStack),
+                            GT_ModHandler.RecipeBits.BUFFERED,
+                            new Object[] { "s", "L", 'L', new ItemStack(aStack.getItem(), 1, i) });
                         GT_ModHandler.addShapelessCraftingRecipe(
                             GT_Utility
                                 .copyAmount(tStack.stackSize / (GT_Mod.gregtechproxy.mNerfedWoodPlank ? 2 : 1), tStack),
@@ -221,21 +216,21 @@ public class ProcessingLog implements gregtech.api.interfaces.IOreRecipeRegistra
             }
         } else {
             if ((GT_Utility.areStacksEqual(
-                GT_ModHandler.getSmeltingOutput(GT_Utility.copyAmount(1L, aStack), false, null),
+                GT_ModHandler.getSmeltingOutput(GT_Utility.copyAmount(1, aStack), false, null),
                 new ItemStack(Items.coal, 1, 1)))) {
                 addPyrolyeOvenRecipes(aStack);
                 if (GregTech_API.sRecipeFile
                     .get(ConfigCategories.Recipes.disabledrecipes, "wood2charcoalsmelting", true)) {
-                    GT_ModHandler.removeFurnaceSmelting(GT_Utility.copyAmount(1L, aStack));
+                    GT_ModHandler.removeFurnaceSmelting(GT_Utility.copyAmount(1, aStack));
                 }
             }
-            ItemStack tStack = GT_ModHandler.getRecipeOutput(GT_Utility.copyAmount(1L, aStack));
+            ItemStack tStack = GT_ModHandler.getRecipeOutput(GT_Utility.copyAmount(1, aStack));
             if (tStack != null) {
                 ItemStack tPlanks = GT_Utility.copyOrNull(tStack);
                 if (tPlanks != null) {
                     tPlanks.stackSize = (tPlanks.stackSize * 3 / 2);
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                        .itemInputs(GT_Utility.copyAmount(1, aStack))
                         .itemOutputs(
                             GT_Utility.copyOrNull(tPlanks),
                             GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 1L))
@@ -244,10 +239,10 @@ public class ProcessingLog implements gregtech.api.interfaces.IOreRecipeRegistra
                         .eut(8)
                         .addTo(sCutterRecipes);
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                        .itemInputs(GT_Utility.copyAmount(1, aStack))
                         .itemOutputs(
                             GT_Utility.copyAmount(
-                                GT_Mod.gregtechproxy.mNerfedWoodPlank ? tStack.stackSize : tStack.stackSize * 5L / 4,
+                                GT_Mod.gregtechproxy.mNerfedWoodPlank ? tStack.stackSize : tStack.stackSize * 5 / 4,
                                 tStack),
                             GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 2L))
                         .fluidInputs(Materials.Water.getFluid(Math.min(1000, 200 * 8 / 320)))
@@ -255,10 +250,10 @@ public class ProcessingLog implements gregtech.api.interfaces.IOreRecipeRegistra
                         .eut(8)
                         .addTo(sCutterRecipes);
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                        .itemInputs(GT_Utility.copyAmount(1, aStack))
                         .itemOutputs(
                             GT_Utility.copyAmount(
-                                GT_Mod.gregtechproxy.mNerfedWoodPlank ? tStack.stackSize : tStack.stackSize * 5L / 4,
+                                GT_Mod.gregtechproxy.mNerfedWoodPlank ? tStack.stackSize : tStack.stackSize * 5 / 4,
                                 tStack),
                             GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 2L))
                         .fluidInputs(GT_ModHandler.getDistilledWater(3))
@@ -266,10 +261,10 @@ public class ProcessingLog implements gregtech.api.interfaces.IOreRecipeRegistra
                         .eut(8)
                         .addTo(sCutterRecipes);
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                        .itemInputs(GT_Utility.copyAmount(1, aStack))
                         .itemOutputs(
                             GT_Utility.copyAmount(
-                                GT_Mod.gregtechproxy.mNerfedWoodPlank ? tStack.stackSize : tStack.stackSize * 5L / 4,
+                                GT_Mod.gregtechproxy.mNerfedWoodPlank ? tStack.stackSize : tStack.stackSize * 5 / 4,
                                 tStack),
                             GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 2L))
                         .fluidInputs(Materials.Lubricant.getFluid(1))
@@ -277,35 +272,35 @@ public class ProcessingLog implements gregtech.api.interfaces.IOreRecipeRegistra
                         .eut(8)
                         .addTo(sCutterRecipes);
                     GT_ModHandler.addSawmillRecipe(
-                        GT_Utility.copyAmount(1L, aStack),
+                        GT_Utility.copyAmount(1, aStack),
                         tPlanks,
                         GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 1L));
-                    GT_ModHandler.removeRecipeDelayed(GT_Utility.copyAmount(1L, aStack));
+                    GT_ModHandler.removeRecipeDelayed(GT_Utility.copyAmount(1, aStack));
                     GT_ModHandler.addCraftingRecipe(
                         GT_Utility.copyAmount(
-                            GT_Mod.gregtechproxy.mNerfedWoodPlank ? tStack.stackSize : tStack.stackSize * 5L / 4,
+                            GT_Mod.gregtechproxy.mNerfedWoodPlank ? tStack.stackSize : tStack.stackSize * 5 / 4,
                             tStack),
-                        new Object[] { "s", "L", 'L', GT_Utility.copyAmount(1L, aStack) });
+                        new Object[] { "s", "L", 'L', GT_Utility.copyAmount(1, aStack) });
                     GT_ModHandler.addShapelessCraftingRecipe(
                         GT_Utility
                             .copyAmount(tStack.stackSize / (GT_Mod.gregtechproxy.mNerfedWoodPlank ? 2 : 1), tStack),
-                        new Object[] { GT_Utility.copyAmount(1L, aStack) });
+                        new Object[] { GT_Utility.copyAmount(1, aStack) });
                 }
             }
         }
 
         if ((GT_Utility.areStacksEqual(
-            GT_ModHandler.getSmeltingOutput(GT_Utility.copyAmount(1L, aStack), false, null),
+            GT_ModHandler.getSmeltingOutput(GT_Utility.copyAmount(1, aStack), false, null),
             new ItemStack(Items.coal, 1, 1)))) {
             addPyrolyeOvenRecipes(aStack);
             if (GregTech_API.sRecipeFile.get(ConfigCategories.Recipes.disabledrecipes, "wood2charcoalsmelting", true))
-                GT_ModHandler.removeFurnaceSmelting(GT_Utility.copyAmount(1L, aStack));
+                GT_ModHandler.removeFurnaceSmelting(GT_Utility.copyAmount(1, aStack));
         }
     }
 
     public static void addPyrolyeOvenRecipes(ItemStack logStack) {
         GT_Values.RA.stdBuilder()
-            .itemInputs(GT_Utility.copyAmount(16L, logStack), GT_Utility.getIntegratedCircuit(1))
+            .itemInputs(GT_Utility.copyAmount(16, logStack), GT_Utility.getIntegratedCircuit(1))
             .itemOutputs(Materials.Charcoal.getGems(20))
             .fluidOutputs(Materials.Creosote.getFluid(4000))
             .duration(32 * SECONDS)
@@ -313,7 +308,7 @@ public class ProcessingLog implements gregtech.api.interfaces.IOreRecipeRegistra
             .noOptimize()
             .addTo(sPyrolyseRecipes);
         GT_Values.RA.stdBuilder()
-            .itemInputs(GT_Utility.copyAmount(16L, logStack), GT_Utility.getIntegratedCircuit(2))
+            .itemInputs(GT_Utility.copyAmount(16, logStack), GT_Utility.getIntegratedCircuit(2))
             .itemOutputs(Materials.Charcoal.getGems(20))
             .fluidInputs(Materials.Nitrogen.getGas(1000))
             .fluidOutputs(Materials.Creosote.getFluid(4000))
@@ -322,7 +317,7 @@ public class ProcessingLog implements gregtech.api.interfaces.IOreRecipeRegistra
             .noOptimize()
             .addTo(sPyrolyseRecipes);
         GT_Values.RA.stdBuilder()
-            .itemInputs(GT_Utility.copyAmount(16L, logStack), GT_Utility.getIntegratedCircuit(3))
+            .itemInputs(GT_Utility.copyAmount(16, logStack), GT_Utility.getIntegratedCircuit(3))
             .itemOutputs(Materials.Charcoal.getGems(20))
             .fluidOutputs(Materials.CharcoalByproducts.getGas(4000))
             .duration(32 * SECONDS)
@@ -330,7 +325,7 @@ public class ProcessingLog implements gregtech.api.interfaces.IOreRecipeRegistra
             .noOptimize()
             .addTo(sPyrolyseRecipes);
         GT_Values.RA.stdBuilder()
-            .itemInputs(GT_Utility.copyAmount(16L, logStack), GT_Utility.getIntegratedCircuit(4))
+            .itemInputs(GT_Utility.copyAmount(16, logStack), GT_Utility.getIntegratedCircuit(4))
             .itemOutputs(Materials.Charcoal.getGems(20))
             .fluidInputs(Materials.Nitrogen.getGas(1000))
             .fluidOutputs(Materials.CharcoalByproducts.getGas(4000))
@@ -339,7 +334,7 @@ public class ProcessingLog implements gregtech.api.interfaces.IOreRecipeRegistra
             .noOptimize()
             .addTo(sPyrolyseRecipes);
         GT_Values.RA.stdBuilder()
-            .itemInputs(GT_Utility.copyAmount(16L, logStack), GT_Utility.getIntegratedCircuit(5))
+            .itemInputs(GT_Utility.copyAmount(16, logStack), GT_Utility.getIntegratedCircuit(5))
             .itemOutputs(Materials.Charcoal.getGems(20))
             .fluidOutputs(Materials.WoodGas.getGas(1500))
             .duration(32 * SECONDS)
@@ -347,7 +342,7 @@ public class ProcessingLog implements gregtech.api.interfaces.IOreRecipeRegistra
             .noOptimize()
             .addTo(sPyrolyseRecipes);
         GT_Values.RA.stdBuilder()
-            .itemInputs(GT_Utility.copyAmount(16L, logStack), GT_Utility.getIntegratedCircuit(6))
+            .itemInputs(GT_Utility.copyAmount(16, logStack), GT_Utility.getIntegratedCircuit(6))
             .itemOutputs(Materials.Charcoal.getGems(20))
             .fluidInputs(Materials.Nitrogen.getGas(1000))
             .fluidOutputs(Materials.WoodGas.getGas(1500))
@@ -356,7 +351,7 @@ public class ProcessingLog implements gregtech.api.interfaces.IOreRecipeRegistra
             .noOptimize()
             .addTo(sPyrolyseRecipes);
         GT_Values.RA.stdBuilder()
-            .itemInputs(GT_Utility.copyAmount(16L, logStack), GT_Utility.getIntegratedCircuit(7))
+            .itemInputs(GT_Utility.copyAmount(16, logStack), GT_Utility.getIntegratedCircuit(7))
             .itemOutputs(Materials.Charcoal.getGems(20))
             .fluidOutputs(Materials.WoodVinegar.getFluid(3000))
             .duration(32 * SECONDS)
@@ -364,7 +359,7 @@ public class ProcessingLog implements gregtech.api.interfaces.IOreRecipeRegistra
             .noOptimize()
             .addTo(sPyrolyseRecipes);
         GT_Values.RA.stdBuilder()
-            .itemInputs(GT_Utility.copyAmount(16L, logStack), GT_Utility.getIntegratedCircuit(8))
+            .itemInputs(GT_Utility.copyAmount(16, logStack), GT_Utility.getIntegratedCircuit(8))
             .itemOutputs(Materials.Charcoal.getGems(20))
             .fluidInputs(Materials.Nitrogen.getGas(1000))
             .fluidOutputs(Materials.WoodVinegar.getFluid(3000))
@@ -373,7 +368,7 @@ public class ProcessingLog implements gregtech.api.interfaces.IOreRecipeRegistra
             .noOptimize()
             .addTo(sPyrolyseRecipes);
         GT_Values.RA.stdBuilder()
-            .itemInputs(GT_Utility.copyAmount(16L, logStack), GT_Utility.getIntegratedCircuit(9))
+            .itemInputs(GT_Utility.copyAmount(16, logStack), GT_Utility.getIntegratedCircuit(9))
             .itemOutputs(Materials.Charcoal.getGems(20))
             .fluidOutputs(Materials.WoodTar.getFluid(1500))
             .duration(32 * SECONDS)
@@ -381,7 +376,7 @@ public class ProcessingLog implements gregtech.api.interfaces.IOreRecipeRegistra
             .noOptimize()
             .addTo(sPyrolyseRecipes);
         GT_Values.RA.stdBuilder()
-            .itemInputs(GT_Utility.copyAmount(16L, logStack), GT_Utility.getIntegratedCircuit(10))
+            .itemInputs(GT_Utility.copyAmount(16, logStack), GT_Utility.getIntegratedCircuit(10))
             .itemOutputs(Materials.Charcoal.getGems(20))
             .fluidInputs(Materials.Nitrogen.getGas(1000))
             .fluidOutputs(Materials.WoodTar.getFluid(1500))
@@ -390,7 +385,7 @@ public class ProcessingLog implements gregtech.api.interfaces.IOreRecipeRegistra
             .noOptimize()
             .addTo(sPyrolyseRecipes);
         GT_Values.RA.stdBuilder()
-            .itemInputs(GT_Utility.copyAmount(16L, logStack), GT_Utility.getIntegratedCircuit(11))
+            .itemInputs(GT_Utility.copyAmount(16, logStack), GT_Utility.getIntegratedCircuit(11))
             .itemOutputs(Materials.Ash.getDust(4))
             .fluidOutputs(Materials.OilHeavy.getFluid(200))
             .duration(16 * SECONDS)

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingNugget.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingNugget.java
@@ -32,7 +32,7 @@ public class ProcessingNugget implements gregtech.api.interfaces.IOreRecipeRegis
         if (aMaterial.contains(SubTag.SMELTING_TO_GEM)
             && GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial.mSmeltInto, 1L) != null) {
             GT_Values.RA.stdBuilder()
-                .itemInputs(GT_Utility.copyAmount(9L, aStack), ItemList.Shape_Mold_Ball.get(0L))
+                .itemInputs(GT_Utility.copyAmount(9, aStack), ItemList.Shape_Mold_Ball.get(0L))
                 .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial.mSmeltInto, 1L))
                 .duration(10 * SECONDS)
                 .eut(calculateRecipeEU(aMaterial, 2))
@@ -42,7 +42,7 @@ public class ProcessingNugget implements gregtech.api.interfaces.IOreRecipeRegis
         if ((!aMaterial.contains(SubTag.SMELTING_TO_GEM))
             && GT_OreDictUnificator.get(OrePrefixes.ingot, aMaterial.mSmeltInto, 1L) != null) {
             GT_Values.RA.stdBuilder()
-                .itemInputs(GT_Utility.copyAmount(9L, aStack), ItemList.Shape_Mold_Ingot.get(0L))
+                .itemInputs(GT_Utility.copyAmount(9, aStack), ItemList.Shape_Mold_Ingot.get(0L))
                 .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.ingot, aMaterial.mSmeltInto, 1L))
                 .duration(10 * SECONDS)
                 .eut(calculateRecipeEU(aMaterial, 2))
@@ -70,7 +70,7 @@ public class ProcessingNugget implements gregtech.api.interfaces.IOreRecipeRegis
                 .itemInputs(
                     GT_OreDictUnificator.get(OrePrefixes.ingot, aMaterial, 1L),
                     ItemList.Shape_Mold_Nugget.get(0L))
-                .itemOutputs(GT_Utility.copyAmount(9L, aStack))
+                .itemOutputs(GT_Utility.copyAmount(9, aStack))
                 .duration(5 * SECONDS)
                 .eut(calculateRecipeEU(aMaterial, 1))
                 .addTo(sAlloySmelterRecipes);

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingOre.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingOre.java
@@ -43,7 +43,7 @@ public class ProcessingOre implements gregtech.api.interfaces.IOreRecipeRegistra
 
         if (aMaterial == Materials.Oilsands) {
             GT_Values.RA.stdBuilder()
-                .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                .itemInputs(GT_Utility.copyAmount(1, aStack))
                 .itemOutputs(new ItemStack(net.minecraft.init.Blocks.sand, 1, 0))
                 .outputChances(tIsRich ? 2000 : 4000)
                 .fluidOutputs(Materials.OilHeavy.getFluid(tIsRich ? 4000L : 2000L))
@@ -54,7 +54,7 @@ public class ProcessingOre implements gregtech.api.interfaces.IOreRecipeRegistra
             registerStandardOreRecipes(
                 aPrefix,
                 aMaterial,
-                GT_Utility.copyAmount(1L, aStack),
+                GT_Utility.copyAmount(1, aStack),
                 Math.max(
                     1,
                     gregtech.api.GregTech_API.sOPStuff.get(
@@ -73,7 +73,7 @@ public class ProcessingOre implements gregtech.api.interfaces.IOreRecipeRegistra
         Materials tMaterial = aMaterial.mOreReplacement;
         Materials tPrimaryByMaterial = null;
         aMultiplier = Math.max(1, aMultiplier);
-        aOreStack = GT_Utility.copyAmount(1L, aOreStack);
+        aOreStack = GT_Utility.copyAmount(1, aOreStack);
         aOreStack.stackSize = 1;
 
         ItemStack tIngot = GT_OreDictUnificator.get(OrePrefixes.ingot, aMaterial.mDirectSmelting, 1L);
@@ -107,7 +107,7 @@ public class ProcessingOre implements gregtech.api.interfaces.IOreRecipeRegistra
             tCrushed = GT_OreDictUnificator.get(
                 OrePrefixes.dustImpure,
                 tMaterial,
-                GT_Utility.copyAmount((long) aMaterial.mOreMultiplier * aMultiplier, tCleaned, tDust, tGem),
+                GT_Utility.copyAmount(aMaterial.mOreMultiplier * aMultiplier, tCleaned, tDust, tGem),
                 (long) aMaterial.mOreMultiplier * aMultiplier);
         }
 
@@ -134,7 +134,7 @@ public class ProcessingOre implements gregtech.api.interfaces.IOreRecipeRegistra
             } else {
                 tHasSmelting = GT_ModHandler.addSmeltingRecipe(
                     aOreStack,
-                    GT_Utility.copyAmount((long) aMultiplier * aMaterial.mSmeltingMultiplier, tSmeltInto));
+                    GT_Utility.copyAmount(aMultiplier * aMaterial.mSmeltingMultiplier, tSmeltInto));
             }
 
             if (aMaterial.contains(SubTag.BLASTFURNACE_CALCITE_TRIPLE)) {
@@ -144,7 +144,7 @@ public class ProcessingOre implements gregtech.api.interfaces.IOreRecipeRegistra
                             aOreStack,
                             GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Calcite, aMultiplier))
                         .itemOutputs(
-                            GT_Utility.mul((long) aMultiplier * 3 * aMaterial.mSmeltingMultiplier, tSmeltInto),
+                            GT_Utility.mul(aMultiplier * 3 * aMaterial.mSmeltingMultiplier, tSmeltInto),
                             GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.DarkAsh, 1L))
                         .duration(tSmeltInto.stackSize * 25 * SECONDS)
                         .eut(TierEU.RECIPE_MV)
@@ -155,7 +155,7 @@ public class ProcessingOre implements gregtech.api.interfaces.IOreRecipeRegistra
                             aOreStack,
                             GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Quicklime, aMultiplier))
                         .itemOutputs(
-                            GT_Utility.mul((long) aMultiplier * 3 * aMaterial.mSmeltingMultiplier, tSmeltInto),
+                            GT_Utility.mul(aMultiplier * 3 * aMaterial.mSmeltingMultiplier, tSmeltInto),
                             GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.DarkAsh, 1L))
                         .duration(tSmeltInto.stackSize * 25 * SECONDS)
                         .eut(TierEU.RECIPE_MV)
@@ -169,7 +169,7 @@ public class ProcessingOre implements gregtech.api.interfaces.IOreRecipeRegistra
                             aOreStack,
                             GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Calcite, aMultiplier))
                         .itemOutputs(
-                            GT_Utility.mul((long) aMultiplier * 2 * aMaterial.mSmeltingMultiplier, tSmeltInto),
+                            GT_Utility.mul(aMultiplier * 2 * aMaterial.mSmeltingMultiplier, tSmeltInto),
                             GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.DarkAsh, 1L))
                         .duration(tSmeltInto.stackSize * 25 * SECONDS)
                         .eut(TierEU.RECIPE_MV)
@@ -180,7 +180,7 @@ public class ProcessingOre implements gregtech.api.interfaces.IOreRecipeRegistra
                             aOreStack,
                             GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Quicklime, aMultiplier))
                         .itemOutputs(
-                            GT_Utility.mul((long) aMultiplier * 2 * aMaterial.mSmeltingMultiplier, tSmeltInto),
+                            GT_Utility.mul(aMultiplier * 2 * aMaterial.mSmeltingMultiplier, tSmeltInto),
                             GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.DarkAsh, 1L))
                         .duration(tSmeltInto.stackSize * 25 * SECONDS)
                         .eut(TierEU.RECIPE_MV)
@@ -213,15 +213,15 @@ public class ProcessingOre implements gregtech.api.interfaces.IOreRecipeRegistra
             GT_Values.RA.stdBuilder()
                 .itemInputs(aOreStack)
                 .itemOutputs(
-                    GT_Utility.mul(2L, tCrushed),
+                    GT_Utility.mul(2, tCrushed),
                     tMaterial.contains(SubTag.PULVERIZING_CINNABAR) ? GT_OreDictUnificator.get(
                         OrePrefixes.crystal,
                         Materials.Cinnabar,
                         GT_OreDictUnificator
-                            .get(OrePrefixes.gem, tPrimaryByMaterial, GT_Utility.copyAmount(1L, tPrimaryByProduct), 1L),
+                            .get(OrePrefixes.gem, tPrimaryByMaterial, GT_Utility.copyAmount(1, tPrimaryByProduct), 1L),
                         1L)
                         : GT_OreDictUnificator
-                            .get(OrePrefixes.gem, tPrimaryByMaterial, GT_Utility.copyAmount(1L, tPrimaryByProduct), 1L),
+                            .get(OrePrefixes.gem, tPrimaryByMaterial, GT_Utility.copyAmount(1, tPrimaryByProduct), 1L),
                     GT_OreDictUnificator.getDust(aPrefix.mSecondaryMaterial))
                 .outputChances(10000, chanceOre2, 5000)
                 .duration(20 * SECONDS)

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingOrePoor.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingOrePoor.java
@@ -44,14 +44,14 @@ public class ProcessingOrePoor implements gregtech.api.interfaces.IOreRecipeRegi
         }
         if (aMaterial != null) {
             GT_Values.RA.stdBuilder()
-                .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                .itemInputs(GT_Utility.copyAmount(1, aStack))
                 .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.dustTiny, aMaterial, aMultiplier))
                 .duration(10)
                 .eut(16)
                 .addTo(sHammerRecipes);
 
             GT_Values.RA.stdBuilder()
-                .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                .itemInputs(GT_Utility.copyAmount(1, aStack))
                 .itemOutputs(
                     GT_OreDictUnificator.get(OrePrefixes.dustTiny, aMaterial, 2 * aMultiplier),
                     GT_OreDictUnificator.get(
@@ -65,7 +65,7 @@ public class ProcessingOrePoor implements gregtech.api.interfaces.IOreRecipeRegi
                 .addTo(sMaceratorRecipes);
 
             if (aMaterial.contains(SubTag.NO_SMELTING)) GT_ModHandler.addSmeltingRecipe(
-                GT_Utility.copyAmount(1L, aStack),
+                GT_Utility.copyAmount(1, aStack),
                 GT_OreDictUnificator.get(OrePrefixes.nugget, aMaterial.mDirectSmelting, aMultiplier));
         }
     }

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingOreSmelting.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingOreSmelting.java
@@ -42,7 +42,7 @@ public class ProcessingOreSmelting implements gregtech.api.interfaces.IOreRecipe
                         && GT_OreDictUnificator.get(OrePrefixes.ingot, aMaterial, 1L) != null) {
                             GT_RecipeBuilder recipeBuilder = GT_Values.RA.stdBuilder();
                             recipeBuilder
-                                .itemInputs(GT_Utility.copyAmount(1L, aStack), GT_Utility.getIntegratedCircuit(1));
+                                .itemInputs(GT_Utility.copyAmount(1, aStack), GT_Utility.getIntegratedCircuit(1));
                             if (aMaterial.mBlastFurnaceTemp > 1750) {
                                 recipeBuilder.itemOutputs(
                                     GT_OreDictUnificator.get(

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingPipe.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingPipe.java
@@ -93,7 +93,7 @@ public class ProcessingPipe implements gregtech.api.interfaces.IOreRecipeRegistr
                             Materials.Steel,
                             aPrefix.mSecondaryMaterial.mAmount / OrePrefixes.ring.mMaterialAmount),
                         GT_OreDictUnificator.get(aOreDictName.replaceFirst("Restrictive", ""), null, 1L, false, true))
-                    .itemOutputs(GT_Utility.copyAmount(1L, aStack))
+                    .itemOutputs(GT_Utility.copyAmount(1, aStack))
                     .duration(
                         ((int) (aPrefix.mSecondaryMaterial.mAmount * 400L / OrePrefixes.ring.mMaterialAmount)) * TICKS)
                     .eut(4)

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingPlank.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingPlank.java
@@ -29,14 +29,14 @@ public class ProcessingPlank implements gregtech.api.interfaces.IOreRecipeRegist
         ItemStack aStack) {
         if (aOreDictName.startsWith("plankWood")) {
             GT_Values.RA.stdBuilder()
-                .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                .itemInputs(GT_Utility.copyAmount(1, aStack))
                 .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 2L))
                 .duration(10 * TICKS)
                 .eut(8)
                 .addTo(sLatheRecipes);
             GT_Values.RA.stdBuilder()
                 .itemInputs(
-                    GT_Utility.copyAmount(1L, aStack),
+                    GT_Utility.copyAmount(1, aStack),
                     GT_OreDictUnificator.get(OrePrefixes.screw, Materials.Iron, 1L))
                 .itemOutputs(ItemList.Crate_Empty.get(1L))
                 .duration(10 * SECONDS)
@@ -44,7 +44,7 @@ public class ProcessingPlank implements gregtech.api.interfaces.IOreRecipeRegist
                 .addTo(sAssemblerRecipes);
             GT_Values.RA.stdBuilder()
                 .itemInputs(
-                    GT_Utility.copyAmount(1L, aStack),
+                    GT_Utility.copyAmount(1, aStack),
                     GT_OreDictUnificator.get(OrePrefixes.screw, Materials.WroughtIron, 1L))
                 .itemOutputs(ItemList.Crate_Empty.get(1L))
                 .duration(10 * SECONDS)
@@ -52,20 +52,20 @@ public class ProcessingPlank implements gregtech.api.interfaces.IOreRecipeRegist
                 .addTo(sAssemblerRecipes);
             GT_Values.RA.stdBuilder()
                 .itemInputs(
-                    GT_Utility.copyAmount(1L, aStack),
+                    GT_Utility.copyAmount(1, aStack),
                     GT_OreDictUnificator.get(OrePrefixes.screw, Materials.Steel, 1L))
                 .itemOutputs(ItemList.Crate_Empty.get(1L))
                 .duration(10 * SECONDS)
                 .eut(1)
                 .addTo(sAssemblerRecipes);
             GT_Values.RA.stdBuilder()
-                .itemInputs(GT_Utility.copyAmount(8L, aStack), GT_Utility.getIntegratedCircuit(8))
+                .itemInputs(GT_Utility.copyAmount(8, aStack), GT_Utility.getIntegratedCircuit(8))
                 .itemOutputs(new ItemStack(Blocks.chest, 1))
                 .duration(40 * SECONDS)
                 .eut(4)
                 .addTo(sAssemblerRecipes);
             GT_Values.RA.stdBuilder()
-                .itemInputs(GT_Utility.copyAmount(6L, aStack), new ItemStack(Items.book, 3))
+                .itemInputs(GT_Utility.copyAmount(6, aStack), new ItemStack(Items.book, 3))
                 .itemOutputs(new ItemStack(Blocks.bookshelf, 1))
                 .duration(20 * SECONDS)
                 .eut(4)
@@ -78,21 +78,21 @@ public class ProcessingPlank implements gregtech.api.interfaces.IOreRecipeRegist
                     ItemStack tOutput = GT_ModHandler.getRecipeOutput(tStack, tStack, tStack);
                     if ((tOutput != null) && (tOutput.stackSize >= 3)) {
                         GT_Values.RA.stdBuilder()
-                            .itemInputs(GT_Utility.copyAmount(1L, tStack))
+                            .itemInputs(GT_Utility.copyAmount(1, tStack))
                             .itemOutputs(GT_Utility.copyAmount(tOutput.stackSize / 3, tOutput))
                             .fluidInputs(Materials.Water.getFluid(4))
                             .duration(2 * 25 * TICKS)
                             .eut(4)
                             .addTo(sCutterRecipes);
                         GT_Values.RA.stdBuilder()
-                            .itemInputs(GT_Utility.copyAmount(1L, tStack))
+                            .itemInputs(GT_Utility.copyAmount(1, tStack))
                             .itemOutputs(GT_Utility.copyAmount(tOutput.stackSize / 3, tOutput))
                             .fluidInputs(GT_ModHandler.getDistilledWater(3))
                             .duration(2 * 25 * TICKS)
                             .eut(4)
                             .addTo(sCutterRecipes);
                         GT_Values.RA.stdBuilder()
-                            .itemInputs(GT_Utility.copyAmount(1L, tStack))
+                            .itemInputs(GT_Utility.copyAmount(1, tStack))
                             .itemOutputs(GT_Utility.copyAmount(tOutput.stackSize / 3, tOutput))
                             .fluidInputs(Materials.Lubricant.getFluid(1))
                             .duration(25 * TICKS)
@@ -112,21 +112,21 @@ public class ProcessingPlank implements gregtech.api.interfaces.IOreRecipeRegist
                     : GT_ModHandler.getRecipeOutputNoOreDict(aStack, aStack, aStack);
                 if ((tOutput != null) && (tOutput.stackSize >= 3)) {
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                        .itemInputs(GT_Utility.copyAmount(1, aStack))
                         .itemOutputs(GT_Utility.copyAmount(tOutput.stackSize / 3, tOutput))
                         .fluidInputs(Materials.Water.getFluid(4))
                         .duration(2 * 25)
                         .eut(4)
                         .addTo(sCutterRecipes);
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                        .itemInputs(GT_Utility.copyAmount(1, aStack))
                         .itemOutputs(GT_Utility.copyAmount(tOutput.stackSize / 3, tOutput))
                         .fluidInputs(GT_ModHandler.getDistilledWater(3))
                         .duration(2 * 25)
                         .eut(4)
                         .addTo(sCutterRecipes);
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                        .itemInputs(GT_Utility.copyAmount(1, aStack))
                         .itemOutputs(GT_Utility.copyAmount(tOutput.stackSize / 3, tOutput))
                         .fluidInputs(Materials.Lubricant.getFluid(1))
                         .duration(25)

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingPlate.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingPlate.java
@@ -95,13 +95,13 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
         GT_ModHandler.removeRecipeDelayed(aStack);
 
         GT_Utility.removeSimpleIC2MachineRecipe(
-            GT_Utility.copyAmount(9L, aStack),
+            GT_Utility.copyAmount(9, aStack),
             GT_ModHandler.getCompressorRecipeList(),
             GT_OreDictUnificator.get(OrePrefixes.plateDense, aMaterial, 1L));
 
         if (aMaterial.mFuelPower > 0) {
             GT_Values.RA.stdBuilder()
-                .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                .itemInputs(GT_Utility.copyAmount(1, aStack))
                 .metadata(FUEL_VALUE, aMaterial.mFuelPower)
                 .metadata(FUEL_TYPE, aMaterial.mFuelType)
                 .duration(0)
@@ -128,7 +128,7 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
         if (aMaterial == Materials.Paper) {
 
             GT_ModHandler.addCraftingRecipe(
-                GT_Utility.copyAmount(GregTech_API.sRecipeFile.get(harderrecipes, aStack, true) ? 2L : 3L, aStack),
+                GT_Utility.copyAmount(GregTech_API.sRecipeFile.get(harderrecipes, aStack, true) ? 2 : 3, aStack),
                 BUFFERED,
                 new Object[] { "XXX", 'X', new ItemStack(Items.reeds, 1, W) });
         }
@@ -191,7 +191,7 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
             // 2 double -> 1 quadruple plate
             if (GT_OreDictUnificator.get(OrePrefixes.plateQuadruple, aMaterial, 1L) != null) {
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(2L, aStack), GT_Utility.getIntegratedCircuit(2))
+                    .itemInputs(GT_Utility.copyAmount(2, aStack), GT_Utility.getIntegratedCircuit(2))
                     .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plateQuadruple, aMaterial, 1L))
                     .duration(Math.max(aMaterialMass * 2L, 1L))
                     .eut(calculateRecipeEU(aMaterial, 96))
@@ -202,7 +202,7 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
                 .itemInputs(
                     GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 2L),
                     GT_Utility.getIntegratedCircuit(2))
-                .itemOutputs(GT_Utility.copyAmount(1L, aStack))
+                .itemOutputs(GT_Utility.copyAmount(1, aStack))
                 .duration(Math.max(aMaterialMass * 2L, 1L))
                 .eut(calculateRecipeEU(aMaterial, 96))
                 .addTo(sBenderRecipes);
@@ -211,7 +211,7 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
                 .itemInputs(
                     GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 2L),
                     GT_Utility.getIntegratedCircuit(2))
-                .itemOutputs(GT_Utility.copyAmount(1L, aStack))
+                .itemOutputs(GT_Utility.copyAmount(1, aStack))
                 .fluidInputs(Materials.Glue.getFluid(10L))
                 .duration(3 * SECONDS + 4 * TICKS)
                 .eut(8)
@@ -229,7 +229,7 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
 
                 if (aMaterial.getProcessingMaterialTierEU() < TierEU.IV) {
                     GT_ModHandler.addCraftingRecipe(
-                        GT_Utility.copyAmount(1L, aStack),
+                        GT_Utility.copyAmount(1, aStack),
                         DO_NOT_CHECK_FOR_COLLISIONS | BUFFERED,
                         new Object[] { "I", "B", "h", // craftingToolHardHammer
                             'I', aPlateStack, 'B', aPlateStack });
@@ -249,7 +249,7 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
             if (GT_OreDictUnificator.get(OrePrefixes.plateDense, aMaterial, 1L) != null) {
                 // 3 triple plates -> 1 dense plate
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(3L, aStack), GT_Utility.getIntegratedCircuit(3))
+                    .itemInputs(GT_Utility.copyAmount(3, aStack), GT_Utility.getIntegratedCircuit(3))
                     .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plateDense, aMaterial, 1L))
                     .duration(Math.max(aMaterialMass * 3L, 1L))
                     .eut(calculateRecipeEU(aMaterial, 96))
@@ -260,7 +260,7 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
                 .itemInputs(
                     GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 3L),
                     GT_Utility.getIntegratedCircuit(3))
-                .itemOutputs(GT_Utility.copyAmount(1L, aStack))
+                .itemOutputs(GT_Utility.copyAmount(1, aStack))
                 .duration(Math.max(aMaterialMass * 3L, 1L))
                 .eut(calculateRecipeEU(aMaterial, 96))
                 .addTo(sBenderRecipes);
@@ -269,7 +269,7 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
                 .itemInputs(
                     GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 3L),
                     GT_Utility.getIntegratedCircuit(3))
-                .itemOutputs(GT_Utility.copyAmount(1L, aStack))
+                .itemOutputs(GT_Utility.copyAmount(1, aStack))
                 .fluidInputs(Materials.Glue.getFluid(20L))
                 .duration(4 * SECONDS + 16 * TICKS)
                 .eut(8)
@@ -288,13 +288,13 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
                     Object aPlateStack = OrePrefixes.plate.get(aMaterial);
 
                     GT_ModHandler.addCraftingRecipe(
-                        GT_Utility.copyAmount(1L, aStack),
+                        GT_Utility.copyAmount(1, aStack),
                         DO_NOT_CHECK_FOR_COLLISIONS | BUFFERED,
                         new Object[] { "I", "B", "h", // craftingToolHardHammer
                             'I', OrePrefixes.plateDouble.get(aMaterial), 'B', aPlateStack });
 
                     GT_ModHandler.addShapelessCraftingRecipe(
-                        GT_Utility.copyAmount(1L, aStack),
+                        GT_Utility.copyAmount(1, aStack),
                         DO_NOT_CHECK_FOR_COLLISIONS | BUFFERED,
                         new Object[] { gregtech.api.enums.ToolDictNames.craftingToolForgeHammer, aPlateStack,
                             aPlateStack, aPlateStack });
@@ -304,7 +304,7 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
 
         if (GT_OreDictUnificator.get(OrePrefixes.compressed, aMaterial, 1L) != null) {
             GT_Values.RA.stdBuilder()
-                .itemInputs(GT_Utility.copyAmount(1L, aStack), ItemList.Block_Powderbarrel.get(4))
+                .itemInputs(GT_Utility.copyAmount(1, aStack), ItemList.Block_Powderbarrel.get(4))
                 .itemOutputs(
                     GT_OreDictUnificator.get(OrePrefixes.compressed, aMaterial, 1L),
                     GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 1L))
@@ -312,7 +312,7 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
                 .eut(TierEU.RECIPE_LV)
                 .addTo(sImplosionRecipes);
             GT_Values.RA.stdBuilder()
-                .itemInputs(GT_Utility.copyAmount(1L, aStack), GT_ModHandler.getIC2Item("dynamite", 1, null))
+                .itemInputs(GT_Utility.copyAmount(1, aStack), GT_ModHandler.getIC2Item("dynamite", 1, null))
                 .itemOutputs(
                     GT_OreDictUnificator.get(OrePrefixes.compressed, aMaterial, 1L),
                     GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 1L))
@@ -320,7 +320,7 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
                 .eut(TierEU.RECIPE_LV)
                 .addTo(sImplosionRecipes);
             GT_Values.RA.stdBuilder()
-                .itemInputs(GT_Utility.copyAmount(1L, aStack), new ItemStack(Blocks.tnt, 2))
+                .itemInputs(GT_Utility.copyAmount(1, aStack), new ItemStack(Blocks.tnt, 2))
                 .itemOutputs(
                     GT_OreDictUnificator.get(OrePrefixes.compressed, aMaterial, 1L),
                     GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 1L))
@@ -328,7 +328,7 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
                 .eut(TierEU.RECIPE_LV)
                 .addTo(sImplosionRecipes);
             GT_Values.RA.stdBuilder()
-                .itemInputs(GT_Utility.copyAmount(1L, aStack), GT_ModHandler.getIC2Item("industrialTnt", 1))
+                .itemInputs(GT_Utility.copyAmount(1, aStack), GT_ModHandler.getIC2Item("industrialTnt", 1))
                 .itemOutputs(
                     GT_OreDictUnificator.get(OrePrefixes.compressed, aMaterial, 1L),
                     GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 1L))
@@ -351,7 +351,7 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
                 .itemInputs(
                     GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 4L),
                     GT_Utility.getIntegratedCircuit(4))
-                .itemOutputs(GT_Utility.copyAmount(1L, aStack))
+                .itemOutputs(GT_Utility.copyAmount(1, aStack))
                 .duration(Math.max(aMaterialMass * 4L, 1L))
                 .eut(calculateRecipeEU(aMaterial, 96))
                 .addTo(sBenderRecipes);
@@ -360,7 +360,7 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
                 .itemInputs(
                     GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 4L),
                     GT_Utility.getIntegratedCircuit(4))
-                .itemOutputs(GT_Utility.copyAmount(1L, aStack))
+                .itemOutputs(GT_Utility.copyAmount(1, aStack))
                 .fluidInputs(Materials.Glue.getFluid(30L))
                 .duration(6 * SECONDS + 8 * TICKS)
                 .eut(8)
@@ -377,13 +377,13 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
                     Object aPlateStack = OrePrefixes.plate.get(aMaterial);
 
                     GT_ModHandler.addCraftingRecipe(
-                        GT_Utility.copyAmount(1L, aStack),
+                        GT_Utility.copyAmount(1, aStack),
                         DO_NOT_CHECK_FOR_COLLISIONS | BUFFERED,
                         new Object[] { "I", "B", "h", // craftingToolHardHammer
                             'I', OrePrefixes.plateTriple.get(aMaterial), 'B', aPlateStack });
 
                     GT_ModHandler.addShapelessCraftingRecipe(
-                        GT_Utility.copyAmount(1L, aStack),
+                        GT_Utility.copyAmount(1, aStack),
                         DO_NOT_CHECK_FOR_COLLISIONS | BUFFERED,
                         new Object[] { gregtech.api.enums.ToolDictNames.craftingToolForgeHammer, aPlateStack,
                             aPlateStack, aPlateStack, aPlateStack });
@@ -405,7 +405,7 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
                 .itemInputs(
                     GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 5L),
                     GT_Utility.getIntegratedCircuit(5))
-                .itemOutputs(GT_Utility.copyAmount(1L, aStack))
+                .itemOutputs(GT_Utility.copyAmount(1, aStack))
                 .duration(Math.max(aMaterialMass * 5L, 1L))
                 .eut(calculateRecipeEU(aMaterial, 96))
                 .addTo(sBenderRecipes);
@@ -414,7 +414,7 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
                 .itemInputs(
                     GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 5L),
                     GT_Utility.getIntegratedCircuit(5))
-                .itemOutputs(GT_Utility.copyAmount(1L, aStack))
+                .itemOutputs(GT_Utility.copyAmount(1, aStack))
                 .fluidInputs(Materials.Glue.getFluid(40L))
                 .duration(8 * SECONDS)
                 .eut(8)
@@ -431,13 +431,13 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
                     Object aPlateStack = OrePrefixes.plate.get(aMaterial);
 
                     GT_ModHandler.addCraftingRecipe(
-                        GT_Utility.copyAmount(1L, aStack),
+                        GT_Utility.copyAmount(1, aStack),
                         DO_NOT_CHECK_FOR_COLLISIONS | BUFFERED,
                         new Object[] { "I", "B", "h", // craftingToolHardHammer
                             'I', OrePrefixes.plateQuadruple.get(aMaterial), 'B', aPlateStack });
 
                     GT_ModHandler.addShapelessCraftingRecipe(
-                        GT_Utility.copyAmount(1L, aStack),
+                        GT_Utility.copyAmount(1, aStack),
                         DO_NOT_CHECK_FOR_COLLISIONS | BUFFERED,
                         new Object[] { ToolDictNames.craftingToolForgeHammer, aPlateStack, aPlateStack, aPlateStack,
                             aPlateStack, aPlateStack });
@@ -459,7 +459,7 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
                 .itemInputs(
                     GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 9L),
                     GT_Utility.getIntegratedCircuit(9))
-                .itemOutputs(GT_Utility.copyAmount(1L, aStack))
+                .itemOutputs(GT_Utility.copyAmount(1, aStack))
                 .duration(Math.max(aMaterialMass * 9L, 1L))
                 .eut(calculateRecipeEU(aMaterial, 96))
                 .addTo(sBenderRecipes);
@@ -505,7 +505,7 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
                 .itemInputs(
                     GT_OreDictUnificator.get(OrePrefixes.ingot, aMaterial, 2L),
                     ItemList.Shape_Mold_Casing.get(0L))
-                .itemOutputs(GT_Utility.copyAmount(3L, aStack))
+                .itemOutputs(GT_Utility.copyAmount(3, aStack))
                 .duration(6 * SECONDS + 8 * TICKS)
                 .eut(calculateRecipeEU(aMaterial, 15))
                 .addTo(sAlloySmelterRecipes);
@@ -572,20 +572,20 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
         switch (aOreDictName) {
             case "plateAlloyCarbon" -> {
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_ModHandler.getIC2Item("generator", 1L), GT_Utility.copyAmount(4L, aStack))
+                    .itemInputs(GT_ModHandler.getIC2Item("generator", 1L), GT_Utility.copyAmount(4, aStack))
                     .itemOutputs(GT_ModHandler.getIC2Item("windMill", 1L))
                     .duration(5 * MINUTES + 20 * SECONDS)
                     .eut(8)
                     .addTo(sAssemblerRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack), new ItemStack(Blocks.glass, 3, W))
+                    .itemInputs(GT_Utility.copyAmount(1, aStack), new ItemStack(Blocks.glass, 3, W))
                     .itemOutputs(GT_ModHandler.getIC2Item("reinforcedGlass", 4L))
                     .duration(20 * SECONDS)
                     .eut(4)
                     .addTo(sAlloySmelterRecipes);
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack), Materials.Glass.getDust(3))
+                    .itemInputs(GT_Utility.copyAmount(1, aStack), Materials.Glass.getDust(3))
                     .itemOutputs(GT_ModHandler.getIC2Item("reinforcedGlass", 4L))
                     .duration(20 * SECONDS)
                     .eut(4)
@@ -593,14 +593,14 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
             }
             case "plateAlloyAdvanced" -> {
                 GT_ModHandler.addAlloySmelterRecipe(
-                    GT_Utility.copyAmount(1L, aStack),
+                    GT_Utility.copyAmount(1, aStack),
                     new ItemStack(Blocks.glass, 3, W),
                     GT_ModHandler.getIC2Item("reinforcedGlass", 4L),
                     400,
                     4,
                     false);
                 GT_ModHandler.addAlloySmelterRecipe(
-                    GT_Utility.copyAmount(1L, aStack),
+                    GT_Utility.copyAmount(1, aStack),
                     Materials.Glass.getDust(3),
                     GT_ModHandler.getIC2Item("reinforcedGlass", 4L),
                     400,

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingPure.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingPure.java
@@ -24,14 +24,14 @@ public class ProcessingPure implements gregtech.api.interfaces.IOreRecipeRegistr
     public void registerOre(OrePrefixes aPrefix, Materials aMaterial, String aOreDictName, String aModName,
         ItemStack aStack) {
         GT_Values.RA.stdBuilder()
-            .itemInputs(GT_Utility.copyAmount(1L, aStack))
+            .itemInputs(GT_Utility.copyAmount(1, aStack))
             .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.dustPure, aMaterial.mMacerateInto, 1L))
             .duration(10)
             .eut(16)
             .addTo(sHammerRecipes);
 
         GT_Values.RA.stdBuilder()
-            .itemInputs(GT_Utility.copyAmount(1L, aStack))
+            .itemInputs(GT_Utility.copyAmount(1, aStack))
             .itemOutputs(
                 GT_OreDictUnificator.get(
                     OrePrefixes.dustPure,

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingRound.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingRound.java
@@ -28,7 +28,7 @@ public class ProcessingRound implements gregtech.api.interfaces.IOreRecipeRegist
             if (GT_OreDictUnificator.get(OrePrefixes.nugget, aMaterial, 1L) != null) {
                 GT_Values.RA.stdBuilder()
                     .itemInputs(GT_OreDictUnificator.get(OrePrefixes.nugget, aMaterial, 1L))
-                    .itemOutputs(GT_Utility.copyAmount(1L, aStack))
+                    .itemOutputs(GT_Utility.copyAmount(1, aStack))
                     .duration(((int) Math.max(aMaterial.getMass() / 4L, 1L)) * TICKS)
                     .eut(8)
                     .addTo(sLatheRecipes);

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingSand.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingSand.java
@@ -24,7 +24,7 @@ public class ProcessingSand implements gregtech.api.interfaces.IOreRecipeRegistr
         ItemStack aStack) {
         if (aOreDictName.equals("sandOil")) {
             GT_Values.RA.stdBuilder()
-                .itemInputs(GT_Utility.copyAmount(2L, aStack), ItemList.Cell_Empty.get(1))
+                .itemInputs(GT_Utility.copyAmount(2, aStack), ItemList.Cell_Empty.get(1))
                 .itemOutputs(
                     GT_OreDictUnificator.get(OrePrefixes.cell, Materials.Oil, 1L),
                     new ItemStack(Blocks.sand, 1, 0))

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingSaplings.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingSaplings.java
@@ -25,21 +25,21 @@ public class ProcessingSaplings implements gregtech.api.interfaces.IOreRecipeReg
     public void registerOre(OrePrefixes aPrefix, Materials aMaterial, String aOreDictName, String aModName,
         ItemStack aStack) {
         GT_Values.RA.stdBuilder()
-            .itemInputs(GT_Utility.copyAmount(1L, aStack))
+            .itemInputs(GT_Utility.copyAmount(1, aStack))
             .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.Wood, 2L))
             .duration(20 * SECONDS)
             .eut(2)
             .addTo(sMaceratorRecipes);
 
         GT_Values.RA.stdBuilder()
-            .itemInputs(GT_Utility.copyAmount(8L, aStack))
+            .itemInputs(GT_Utility.copyAmount(8, aStack))
             .itemOutputs(ItemList.IC2_Plantball.get(1L))
             .duration(15 * SECONDS)
             .eut(2)
             .addTo(sCompressorRecipes);
 
         GT_Values.RA.stdBuilder()
-            .itemInputs(GT_Utility.copyAmount(1L, aStack))
+            .itemInputs(GT_Utility.copyAmount(1, aStack))
             .itemOutputs(
                 GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1L),
                 GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Wood, 1L))

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingScrew.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingScrew.java
@@ -29,7 +29,7 @@ public class ProcessingScrew implements gregtech.api.interfaces.IOreRecipeRegist
             if (GT_OreDictUnificator.get(OrePrefixes.bolt, aMaterial, 1L) != null) {
                 GT_Values.RA.stdBuilder()
                     .itemInputs(GT_OreDictUnificator.get(OrePrefixes.bolt, aMaterial, 1L))
-                    .itemOutputs(GT_Utility.copyAmount(1L, aStack))
+                    .itemOutputs(GT_Utility.copyAmount(1, aStack))
                     .duration(((int) Math.max(aMaterial.getMass() / 8L, 1L)) * TICKS)
                     .eut(calculateRecipeEU(aMaterial, 4))
                     .addTo(sLatheRecipes);

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingShaping.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingShaping.java
@@ -51,7 +51,7 @@ public class ProcessingShaping implements gregtech.api.interfaces.IOreRecipeRegi
                 if (!OrePrefixes.block.isIgnored(aMaterial.mSmeltInto)
                     && (GT_OreDictUnificator.get(OrePrefixes.block, aMaterial.mSmeltInto, 1L) != null)) {
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(9L, aStack), ItemList.Shape_Extruder_Block.get(0L))
+                        .itemInputs(GT_Utility.copyAmount(9, aStack), ItemList.Shape_Extruder_Block.get(0L))
                         .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.block, aMaterial.mSmeltInto, tAmount))
                         .duration((10 * tAmount) * TICKS)
                         .eut(calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier))
@@ -60,7 +60,7 @@ public class ProcessingShaping implements gregtech.api.interfaces.IOreRecipeRegi
                     // Allow creation of alloy smelter recipes for material recycling if < IV tier.
                     if (tTrueVoltage < TierEU.IV) {
                         GT_Values.RA.stdBuilder()
-                            .itemInputs(GT_Utility.copyAmount(9L, aStack), ItemList.Shape_Mold_Block.get(0L))
+                            .itemInputs(GT_Utility.copyAmount(9, aStack), ItemList.Shape_Mold_Block.get(0L))
                             .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.block, aMaterial.mSmeltInto, tAmount))
                             .duration((5 * tAmount) * TICKS)
                             .eut(calculateRecipeEU(aMaterial, 4 * tVoltageMultiplier))
@@ -70,7 +70,7 @@ public class ProcessingShaping implements gregtech.api.interfaces.IOreRecipeRegi
                 if ((aPrefix != OrePrefixes.ingot || aMaterial != aMaterial.mSmeltInto)
                     && GT_OreDictUnificator.get(OrePrefixes.ingot, aMaterial.mSmeltInto, 1L) != null) {
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(1L, aStack), ItemList.Shape_Extruder_Ingot.get(0L))
+                        .itemInputs(GT_Utility.copyAmount(1, aStack), ItemList.Shape_Extruder_Ingot.get(0L))
                         .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.ingot, aMaterial.mSmeltInto, tAmount))
                         .duration(10 * TICKS)
                         .eut(calculateRecipeEU(aMaterial, 4 * tVoltageMultiplier))
@@ -78,7 +78,7 @@ public class ProcessingShaping implements gregtech.api.interfaces.IOreRecipeRegi
                 }
                 if (GT_OreDictUnificator.get(OrePrefixes.pipeTiny, aMaterial.mSmeltInto, 1L) != null) {
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(1L, aStack), ItemList.Shape_Extruder_Pipe_Tiny.get(0L))
+                        .itemInputs(GT_Utility.copyAmount(1, aStack), ItemList.Shape_Extruder_Pipe_Tiny.get(0L))
                         .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.pipeTiny, aMaterial.mSmeltInto, tAmount * 2))
                         .duration((4 * tAmount) * TICKS)
                         .eut(calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier))
@@ -86,7 +86,7 @@ public class ProcessingShaping implements gregtech.api.interfaces.IOreRecipeRegi
                 }
                 if (GT_OreDictUnificator.get(OrePrefixes.pipeSmall, aMaterial.mSmeltInto, 1L) != null) {
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(1L, aStack), ItemList.Shape_Extruder_Pipe_Small.get(0L))
+                        .itemInputs(GT_Utility.copyAmount(1, aStack), ItemList.Shape_Extruder_Pipe_Small.get(0L))
                         .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.pipeSmall, aMaterial.mSmeltInto, tAmount))
                         .duration((8 * tAmount) * TICKS)
                         .eut(calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier))
@@ -94,7 +94,7 @@ public class ProcessingShaping implements gregtech.api.interfaces.IOreRecipeRegi
                 }
                 if (GT_OreDictUnificator.get(OrePrefixes.pipeMedium, aMaterial.mSmeltInto, 1L) != null) {
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(3L, aStack), ItemList.Shape_Extruder_Pipe_Medium.get(0L))
+                        .itemInputs(GT_Utility.copyAmount(3, aStack), ItemList.Shape_Extruder_Pipe_Medium.get(0L))
                         .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.pipeMedium, aMaterial.mSmeltInto, tAmount))
                         .duration((24 * tAmount) * TICKS)
                         .eut(calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier))
@@ -102,7 +102,7 @@ public class ProcessingShaping implements gregtech.api.interfaces.IOreRecipeRegi
                 }
                 if (GT_OreDictUnificator.get(OrePrefixes.pipeLarge, aMaterial.mSmeltInto, 1L) != null) {
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(6L, aStack), ItemList.Shape_Extruder_Pipe_Large.get(0L))
+                        .itemInputs(GT_Utility.copyAmount(6, aStack), ItemList.Shape_Extruder_Pipe_Large.get(0L))
                         .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.pipeLarge, aMaterial.mSmeltInto, tAmount))
                         .duration((48 * tAmount) * TICKS)
                         .eut(calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier))
@@ -110,7 +110,7 @@ public class ProcessingShaping implements gregtech.api.interfaces.IOreRecipeRegi
                 }
                 if (GT_OreDictUnificator.get(OrePrefixes.pipeHuge, aMaterial.mSmeltInto, 1L) != null) {
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(12L, aStack), ItemList.Shape_Extruder_Pipe_Huge.get(0L))
+                        .itemInputs(GT_Utility.copyAmount(12, aStack), ItemList.Shape_Extruder_Pipe_Huge.get(0L))
                         .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.pipeHuge, aMaterial.mSmeltInto, tAmount))
                         .duration((96 * tAmount) * TICKS)
                         .eut(calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier))
@@ -118,7 +118,7 @@ public class ProcessingShaping implements gregtech.api.interfaces.IOreRecipeRegi
                 }
                 if (GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial.mSmeltInto, 1L) != null) {
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(1L, aStack), ItemList.Shape_Extruder_Plate.get(0L))
+                        .itemInputs(GT_Utility.copyAmount(1, aStack), ItemList.Shape_Extruder_Plate.get(0L))
                         .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial.mSmeltInto, tAmount))
                         .duration(((int) Math.max(aMaterialMass * tAmount, tAmount)) * TICKS)
                         .eut(calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier))
@@ -126,7 +126,7 @@ public class ProcessingShaping implements gregtech.api.interfaces.IOreRecipeRegi
                 }
                 if (GT_OreDictUnificator.get(OrePrefixes.gearGtSmall, aMaterial.mSmeltInto, 1L) != null) {
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(1L, aStack), ItemList.Shape_Extruder_Small_Gear.get(0L))
+                        .itemInputs(GT_Utility.copyAmount(1, aStack), ItemList.Shape_Extruder_Small_Gear.get(0L))
                         .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.gearGtSmall, aMaterial.mSmeltInto, tAmount))
                         .duration(((int) Math.max(aMaterialMass * tAmount, tAmount)) * TICKS)
                         .eut(calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier))
@@ -134,7 +134,7 @@ public class ProcessingShaping implements gregtech.api.interfaces.IOreRecipeRegi
                 }
                 if (GT_OreDictUnificator.get(OrePrefixes.turbineBlade, aMaterial.mSmeltInto, 1L) != null) {
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(6L, aStack), ItemList.Shape_Extruder_Turbine_Blade.get(0L))
+                        .itemInputs(GT_Utility.copyAmount(6, aStack), ItemList.Shape_Extruder_Turbine_Blade.get(0L))
                         .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.turbineBlade, aMaterial.mSmeltInto, tAmount))
                         .duration(((int) Math.max(aMaterialMass * tAmount, tAmount)) * TICKS)
                         .eut(calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier))
@@ -257,7 +257,7 @@ public class ProcessingShaping implements gregtech.api.interfaces.IOreRecipeRegi
                     if (!(aMaterial == Materials.Aluminium)) {
                         if (GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial.mSmeltInto, 1L) != null) {
                             GT_Values.RA.stdBuilder()
-                                .itemInputs(GT_Utility.copyAmount(1L, aStack), ItemList.Shape_Extruder_Rod.get(0L))
+                                .itemInputs(GT_Utility.copyAmount(1, aStack), ItemList.Shape_Extruder_Rod.get(0L))
                                 .itemOutputs(
                                     GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial.mSmeltInto, tAmount * 2))
                                 .duration(((int) Math.max(aMaterialMass * 2L * tAmount, tAmount)) * TICKS)
@@ -267,7 +267,7 @@ public class ProcessingShaping implements gregtech.api.interfaces.IOreRecipeRegi
                     } else {
                         if (GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial.mSmeltInto, 1L) != null) {
                             GT_Values.RA.stdBuilder()
-                                .itemInputs(GT_Utility.copyAmount(1L, aStack), ItemList.Shape_Extruder_Rod.get(0L))
+                                .itemInputs(GT_Utility.copyAmount(1, aStack), ItemList.Shape_Extruder_Rod.get(0L))
                                 .itemOutputs(
                                     GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial.mSmeltInto, tAmount * 2))
                                 .duration(10 * SECONDS)
@@ -279,7 +279,7 @@ public class ProcessingShaping implements gregtech.api.interfaces.IOreRecipeRegi
                 if (tAmount * 2 <= 64) {
                     if (GT_OreDictUnificator.get(OrePrefixes.wireGt01, aMaterial.mSmeltInto, 1L) != null) {
                         GT_Values.RA.stdBuilder()
-                            .itemInputs(GT_Utility.copyAmount(1L, aStack), ItemList.Shape_Extruder_Wire.get(0L))
+                            .itemInputs(GT_Utility.copyAmount(1, aStack), ItemList.Shape_Extruder_Wire.get(0L))
                             .itemOutputs(
                                 GT_OreDictUnificator.get(OrePrefixes.wireGt01, aMaterial.mSmeltInto, tAmount * 2))
                             .duration(((int) Math.max(aMaterialMass * 2L * tAmount, tAmount)) * TICKS)
@@ -290,7 +290,7 @@ public class ProcessingShaping implements gregtech.api.interfaces.IOreRecipeRegi
                 if (tAmount * 8 <= 64) {
                     if (GT_OreDictUnificator.get(OrePrefixes.bolt, aMaterial.mSmeltInto, 1L) != null) {
                         GT_Values.RA.stdBuilder()
-                            .itemInputs(GT_Utility.copyAmount(1L, aStack), ItemList.Shape_Extruder_Bolt.get(0L))
+                            .itemInputs(GT_Utility.copyAmount(1, aStack), ItemList.Shape_Extruder_Bolt.get(0L))
                             .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.bolt, aMaterial.mSmeltInto, tAmount * 8))
                             .duration(((int) Math.max(aMaterialMass * 2L * tAmount, tAmount)) * TICKS)
                             .eut(calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier))
@@ -300,7 +300,7 @@ public class ProcessingShaping implements gregtech.api.interfaces.IOreRecipeRegi
                 if (tAmount * 4 <= 64) {
                     if (GT_OreDictUnificator.get(OrePrefixes.ring, aMaterial.mSmeltInto, 1L) != null) {
                         GT_Values.RA.stdBuilder()
-                            .itemInputs(GT_Utility.copyAmount(1L, aStack), ItemList.Shape_Extruder_Ring.get(0L))
+                            .itemInputs(GT_Utility.copyAmount(1, aStack), ItemList.Shape_Extruder_Ring.get(0L))
                             .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.ring, aMaterial.mSmeltInto, tAmount * 4))
                             .duration(((int) Math.max(aMaterialMass * 2L * tAmount, tAmount)) * TICKS)
                             .eut(calculateRecipeEU(aMaterial, 6 * tVoltageMultiplier))
@@ -321,7 +321,7 @@ public class ProcessingShaping implements gregtech.api.interfaces.IOreRecipeRegi
 
                 if (GT_OreDictUnificator.get(OrePrefixes.toolHeadSword, aMaterial.mSmeltInto, 1L) != null) {
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(2L, aStack), ItemList.Shape_Extruder_Sword.get(0L))
+                        .itemInputs(GT_Utility.copyAmount(2, aStack), ItemList.Shape_Extruder_Sword.get(0L))
                         .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.toolHeadSword, aMaterial.mSmeltInto, tAmount))
                         .duration(((int) Math.max(aMaterialMass * 2L * tAmount, tAmount)) * TICKS)
                         .eut(calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier))
@@ -329,7 +329,7 @@ public class ProcessingShaping implements gregtech.api.interfaces.IOreRecipeRegi
                 }
                 if (GT_OreDictUnificator.get(OrePrefixes.toolHeadPickaxe, aMaterial.mSmeltInto, 1L) != null) {
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(3L, aStack), ItemList.Shape_Extruder_Pickaxe.get(0L))
+                        .itemInputs(GT_Utility.copyAmount(3, aStack), ItemList.Shape_Extruder_Pickaxe.get(0L))
                         .itemOutputs(
                             GT_OreDictUnificator.get(OrePrefixes.toolHeadPickaxe, aMaterial.mSmeltInto, tAmount))
                         .duration(((int) Math.max(aMaterialMass * 3L * tAmount, tAmount)) * TICKS)
@@ -338,7 +338,7 @@ public class ProcessingShaping implements gregtech.api.interfaces.IOreRecipeRegi
                 }
                 if (GT_OreDictUnificator.get(OrePrefixes.toolHeadShovel, aMaterial.mSmeltInto, 1L) != null) {
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(1L, aStack), ItemList.Shape_Extruder_Shovel.get(0L))
+                        .itemInputs(GT_Utility.copyAmount(1, aStack), ItemList.Shape_Extruder_Shovel.get(0L))
                         .itemOutputs(
                             GT_OreDictUnificator.get(OrePrefixes.toolHeadShovel, aMaterial.mSmeltInto, tAmount))
                         .duration(((int) Math.max(aMaterialMass * 1L * tAmount, tAmount)) * TICKS)
@@ -347,7 +347,7 @@ public class ProcessingShaping implements gregtech.api.interfaces.IOreRecipeRegi
                 }
                 if (GT_OreDictUnificator.get(OrePrefixes.toolHeadAxe, aMaterial.mSmeltInto, 1L) != null) {
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(3L, aStack), ItemList.Shape_Extruder_Axe.get(0L))
+                        .itemInputs(GT_Utility.copyAmount(3, aStack), ItemList.Shape_Extruder_Axe.get(0L))
                         .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.toolHeadAxe, aMaterial.mSmeltInto, tAmount))
                         .duration(((int) Math.max(aMaterialMass * 3L * tAmount, tAmount)) * TICKS)
                         .eut(calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier))
@@ -355,7 +355,7 @@ public class ProcessingShaping implements gregtech.api.interfaces.IOreRecipeRegi
                 }
                 if (GT_OreDictUnificator.get(OrePrefixes.toolHeadHoe, aMaterial.mSmeltInto, 1L) != null) {
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(2L, aStack), ItemList.Shape_Extruder_Hoe.get(0L))
+                        .itemInputs(GT_Utility.copyAmount(2, aStack), ItemList.Shape_Extruder_Hoe.get(0L))
                         .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.toolHeadHoe, aMaterial.mSmeltInto, tAmount))
                         .duration(((int) Math.max(aMaterialMass * 2L * tAmount, tAmount)) * TICKS)
                         .eut(calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier))
@@ -363,7 +363,7 @@ public class ProcessingShaping implements gregtech.api.interfaces.IOreRecipeRegi
                 }
                 if (GT_OreDictUnificator.get(OrePrefixes.toolHeadHammer, aMaterial.mSmeltInto, 1L) != null) {
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(6L, aStack), ItemList.Shape_Extruder_Hammer.get(0L))
+                        .itemInputs(GT_Utility.copyAmount(6, aStack), ItemList.Shape_Extruder_Hammer.get(0L))
                         .itemOutputs(
                             GT_OreDictUnificator.get(OrePrefixes.toolHeadHammer, aMaterial.mSmeltInto, tAmount))
                         .duration(((int) Math.max(aMaterialMass * 6L * tAmount, tAmount)) * TICKS)
@@ -372,7 +372,7 @@ public class ProcessingShaping implements gregtech.api.interfaces.IOreRecipeRegi
                 }
                 if (GT_OreDictUnificator.get(OrePrefixes.toolHeadFile, aMaterial.mSmeltInto, 1L) != null) {
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(2L, aStack), ItemList.Shape_Extruder_File.get(0L))
+                        .itemInputs(GT_Utility.copyAmount(2, aStack), ItemList.Shape_Extruder_File.get(0L))
                         .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.toolHeadFile, aMaterial.mSmeltInto, tAmount))
                         .duration(((int) Math.max(aMaterialMass * 2L * tAmount, tAmount)) * TICKS)
                         .eut(calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier))
@@ -380,7 +380,7 @@ public class ProcessingShaping implements gregtech.api.interfaces.IOreRecipeRegi
                 }
                 if (GT_OreDictUnificator.get(OrePrefixes.toolHeadSaw, aMaterial.mSmeltInto, 1L) != null) {
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(2L, aStack), ItemList.Shape_Extruder_Saw.get(0L))
+                        .itemInputs(GT_Utility.copyAmount(2, aStack), ItemList.Shape_Extruder_Saw.get(0L))
                         .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.toolHeadSaw, aMaterial.mSmeltInto, tAmount))
                         .duration(((int) Math.max(aMaterialMass * 2L * tAmount, tAmount)) * TICKS)
                         .eut(calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier))
@@ -388,7 +388,7 @@ public class ProcessingShaping implements gregtech.api.interfaces.IOreRecipeRegi
                 }
                 if (GT_OreDictUnificator.get(OrePrefixes.gearGt, aMaterial.mSmeltInto, 1L) != null) {
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(4L, aStack), ItemList.Shape_Extruder_Gear.get(0L))
+                        .itemInputs(GT_Utility.copyAmount(4, aStack), ItemList.Shape_Extruder_Gear.get(0L))
                         .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.gearGt, aMaterial.mSmeltInto, tAmount))
                         .duration(((int) Math.max(aMaterialMass * 5L * tAmount, tAmount)) * TICKS)
                         .eut(calculateRecipeEU(aMaterial, 8 * tVoltageMultiplier))
@@ -399,7 +399,7 @@ public class ProcessingShaping implements gregtech.api.interfaces.IOreRecipeRegi
                     if (aMaterial.getProcessingMaterialTierEU() < TierEU.IV) {
                         if (GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial.mSmeltInto, 1L) != null) {
                             GT_Values.RA.stdBuilder()
-                                .itemInputs(GT_Utility.copyAmount(2L, aStack), ItemList.Shape_Mold_Plate.get(0L))
+                                .itemInputs(GT_Utility.copyAmount(2, aStack), ItemList.Shape_Mold_Plate.get(0L))
                                 .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial.mSmeltInto, tAmount))
                                 .duration(((int) Math.max(aMaterialMass * 2L * tAmount, tAmount)) * TICKS)
                                 .eut(calculateRecipeEU(aMaterial, 2 * tVoltageMultiplier))
@@ -411,7 +411,7 @@ public class ProcessingShaping implements gregtech.api.interfaces.IOreRecipeRegi
                     if (tTrueVoltage < TierEU.IV) {
                         if (GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial.mSmeltInto, 1L) != null) {
                             GT_Values.RA.stdBuilder()
-                                .itemInputs(GT_Utility.copyAmount(1L, aStack), ItemList.Shape_Mold_Plate.get(0L))
+                                .itemInputs(GT_Utility.copyAmount(1, aStack), ItemList.Shape_Mold_Plate.get(0L))
                                 .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial.mSmeltInto, tAmount))
                                 .duration(((int) Math.max(aMaterialMass * 2L * tAmount, tAmount)) * TICKS)
                                 .eut(calculateRecipeEU(aMaterial, 2 * tVoltageMultiplier))
@@ -424,7 +424,7 @@ public class ProcessingShaping implements gregtech.api.interfaces.IOreRecipeRegi
                 if (tTrueVoltage < TierEU.IV) {
                     if (GT_OreDictUnificator.get(OrePrefixes.gearGt, aMaterial.mSmeltInto, 1L) != null) {
                         GT_Values.RA.stdBuilder()
-                            .itemInputs(GT_Utility.copyAmount(8L, aStack), ItemList.Shape_Mold_Gear.get(0L))
+                            .itemInputs(GT_Utility.copyAmount(8, aStack), ItemList.Shape_Mold_Gear.get(0L))
                             .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.gearGt, aMaterial.mSmeltInto, tAmount))
                             .duration(((int) Math.max(aMaterialMass * 10L * tAmount, tAmount)) * TICKS)
                             .eut(calculateRecipeEU(aMaterial, 2 * tVoltageMultiplier))
@@ -435,13 +435,13 @@ public class ProcessingShaping implements gregtech.api.interfaces.IOreRecipeRegi
                 switch (aMaterial.mSmeltInto.mName) {
                     case "Glass" -> {
                         GT_Values.RA.stdBuilder()
-                            .itemInputs(GT_Utility.copyAmount(1L, aStack), ItemList.Shape_Extruder_Bottle.get(0L))
+                            .itemInputs(GT_Utility.copyAmount(1, aStack), ItemList.Shape_Extruder_Bottle.get(0L))
                             .itemOutputs(new ItemStack(Items.glass_bottle, 1))
                             .duration((tAmount * 32) * TICKS)
                             .eut(16)
                             .addTo(sExtruderRecipes);
                         GT_Values.RA.stdBuilder()
-                            .itemInputs(GT_Utility.copyAmount(1L, aStack), ItemList.Shape_Mold_Bottle.get(0L))
+                            .itemInputs(GT_Utility.copyAmount(1, aStack), ItemList.Shape_Mold_Bottle.get(0L))
                             .itemOutputs(new ItemStack(Items.glass_bottle, 1))
                             .duration((tAmount * 64) * TICKS)
                             .eut(4)
@@ -449,14 +449,14 @@ public class ProcessingShaping implements gregtech.api.interfaces.IOreRecipeRegi
                     }
                     case "Steel" -> {
                         GT_Values.RA.stdBuilder()
-                            .itemInputs(GT_Utility.copyAmount(1L, aStack), ItemList.Shape_Extruder_Cell.get(0L))
+                            .itemInputs(GT_Utility.copyAmount(1, aStack), ItemList.Shape_Extruder_Cell.get(0L))
                             .itemOutputs(ItemList.Cell_Empty.get(tAmount))
                             .duration((tAmount * 128) * TICKS)
                             .eut(TierEU.RECIPE_LV)
                             .addTo(sExtruderRecipes);
                         if (tAmount * 2 <= 64) {
                             GT_Values.RA.stdBuilder()
-                                .itemInputs(GT_Utility.copyAmount(1L, aStack), ItemList.Shape_Extruder_Casing.get(0L))
+                                .itemInputs(GT_Utility.copyAmount(1, aStack), ItemList.Shape_Extruder_Casing.get(0L))
                                 .itemOutputs(GT_ModHandler.getIC2Item("casingadviron", tAmount * 2))
                                 .duration((tAmount * 32) * TICKS)
                                 .eut(3 * tVoltageMultiplier)
@@ -464,7 +464,7 @@ public class ProcessingShaping implements gregtech.api.interfaces.IOreRecipeRegi
                         }
                         if (tAmount * 2 <= 64) {
                             GT_Values.RA.stdBuilder()
-                                .itemInputs(GT_Utility.copyAmount(2L, aStack), ItemList.Shape_Mold_Casing.get(0L))
+                                .itemInputs(GT_Utility.copyAmount(2, aStack), ItemList.Shape_Mold_Casing.get(0L))
                                 .itemOutputs(GT_ModHandler.getIC2Item("casingadviron", tAmount * 3))
                                 .duration((tAmount * 128) * TICKS)
                                 .eut(1 * tVoltageMultiplier)
@@ -473,14 +473,14 @@ public class ProcessingShaping implements gregtech.api.interfaces.IOreRecipeRegi
                     }
                     case "Iron", "WroughtIron" -> {
                         GT_Values.RA.stdBuilder()
-                            .itemInputs(GT_Utility.copyAmount(1L, aStack), ItemList.Shape_Extruder_Cell.get(0L))
+                            .itemInputs(GT_Utility.copyAmount(1, aStack), ItemList.Shape_Extruder_Cell.get(0L))
                             .itemOutputs(GT_ModHandler.getIC2Item("fuelRod", tAmount))
                             .duration((tAmount * 128) * TICKS)
                             .eut(TierEU.RECIPE_LV)
                             .addTo(sExtruderRecipes);
                         if (tAmount * 2 <= 64) {
                             GT_Values.RA.stdBuilder()
-                                .itemInputs(GT_Utility.copyAmount(1L, aStack), ItemList.Shape_Extruder_Casing.get(0L))
+                                .itemInputs(GT_Utility.copyAmount(1, aStack), ItemList.Shape_Extruder_Casing.get(0L))
                                 .itemOutputs(GT_ModHandler.getIC2Item("casingiron", tAmount * 2))
                                 .duration((tAmount * 32) * TICKS)
                                 .eut(3 * tVoltageMultiplier)
@@ -488,7 +488,7 @@ public class ProcessingShaping implements gregtech.api.interfaces.IOreRecipeRegi
                         }
                         if (tAmount * 2 <= 64) {
                             GT_Values.RA.stdBuilder()
-                                .itemInputs(GT_Utility.copyAmount(2L, aStack), ItemList.Shape_Mold_Casing.get(0L))
+                                .itemInputs(GT_Utility.copyAmount(2, aStack), ItemList.Shape_Mold_Casing.get(0L))
                                 .itemOutputs(GT_ModHandler.getIC2Item("casingiron", tAmount * 3))
                                 .duration((tAmount * 128) * TICKS)
                                 .eut(1 * tVoltageMultiplier)
@@ -496,7 +496,7 @@ public class ProcessingShaping implements gregtech.api.interfaces.IOreRecipeRegi
                         }
                         if (tAmount * 31 <= 64) {
                             GT_Values.RA.stdBuilder()
-                                .itemInputs(GT_Utility.copyAmount(31L, aStack), ItemList.Shape_Mold_Anvil.get(0L))
+                                .itemInputs(GT_Utility.copyAmount(31, aStack), ItemList.Shape_Mold_Anvil.get(0L))
                                 .itemOutputs(new ItemStack(Blocks.anvil, 1, 0))
                                 .duration((tAmount * 512) * TICKS)
                                 .eut(4 * tVoltageMultiplier)
@@ -505,14 +505,14 @@ public class ProcessingShaping implements gregtech.api.interfaces.IOreRecipeRegi
                     }
                     case "Tin" -> {
                         GT_Values.RA.stdBuilder()
-                            .itemInputs(GT_Utility.copyAmount(2L, aStack), ItemList.Shape_Extruder_Cell.get(0L))
+                            .itemInputs(GT_Utility.copyAmount(2, aStack), ItemList.Shape_Extruder_Cell.get(0L))
                             .itemOutputs(ItemList.Cell_Empty.get(tAmount))
                             .duration((tAmount * 128) * TICKS)
                             .eut(TierEU.RECIPE_LV)
                             .addTo(sExtruderRecipes);
                         if (tAmount * 2 <= 64) {
                             GT_Values.RA.stdBuilder()
-                                .itemInputs(GT_Utility.copyAmount(1L, aStack), ItemList.Shape_Extruder_Casing.get(0L))
+                                .itemInputs(GT_Utility.copyAmount(1, aStack), ItemList.Shape_Extruder_Casing.get(0L))
                                 .itemOutputs(GT_ModHandler.getIC2Item("casingtin", tAmount * 2))
                                 .duration((tAmount * 32) * TICKS)
                                 .eut(3 * tVoltageMultiplier)
@@ -520,7 +520,7 @@ public class ProcessingShaping implements gregtech.api.interfaces.IOreRecipeRegi
                         }
                         if (tAmount * 2 <= 64) {
                             GT_Values.RA.stdBuilder()
-                                .itemInputs(GT_Utility.copyAmount(2L, aStack), ItemList.Shape_Mold_Casing.get(0L))
+                                .itemInputs(GT_Utility.copyAmount(2, aStack), ItemList.Shape_Mold_Casing.get(0L))
                                 .itemOutputs(GT_ModHandler.getIC2Item("casingtin", tAmount * 3))
                                 .duration((tAmount * 128) * TICKS)
                                 .eut(1 * tVoltageMultiplier)
@@ -530,7 +530,7 @@ public class ProcessingShaping implements gregtech.api.interfaces.IOreRecipeRegi
                     case "Lead" -> {
                         if (tAmount * 2 <= 64) {
                             GT_Values.RA.stdBuilder()
-                                .itemInputs(GT_Utility.copyAmount(1L, aStack), ItemList.Shape_Extruder_Casing.get(0L))
+                                .itemInputs(GT_Utility.copyAmount(1, aStack), ItemList.Shape_Extruder_Casing.get(0L))
                                 .itemOutputs(GT_ModHandler.getIC2Item("casinglead", tAmount * 2))
                                 .duration((tAmount * 32) * TICKS)
                                 .eut(3 * tVoltageMultiplier)
@@ -538,7 +538,7 @@ public class ProcessingShaping implements gregtech.api.interfaces.IOreRecipeRegi
                         }
                         if (tAmount * 2 <= 64) {
                             GT_Values.RA.stdBuilder()
-                                .itemInputs(GT_Utility.copyAmount(2L, aStack), ItemList.Shape_Mold_Casing.get(0L))
+                                .itemInputs(GT_Utility.copyAmount(2, aStack), ItemList.Shape_Mold_Casing.get(0L))
                                 .itemOutputs(GT_ModHandler.getIC2Item("casinglead", tAmount * 3))
                                 .duration((tAmount * 128) * TICKS)
                                 .eut(1 * tVoltageMultiplier)
@@ -548,7 +548,7 @@ public class ProcessingShaping implements gregtech.api.interfaces.IOreRecipeRegi
                     case "Copper", "AnnealedCopper" -> {
                         if (tAmount * 2 <= 64) {
                             GT_Values.RA.stdBuilder()
-                                .itemInputs(GT_Utility.copyAmount(1L, aStack), ItemList.Shape_Extruder_Casing.get(0L))
+                                .itemInputs(GT_Utility.copyAmount(1, aStack), ItemList.Shape_Extruder_Casing.get(0L))
                                 .itemOutputs(GT_ModHandler.getIC2Item("casingcopper", tAmount * 2))
                                 .duration((tAmount * 32) * TICKS)
                                 .eut(3 * tVoltageMultiplier)
@@ -556,7 +556,7 @@ public class ProcessingShaping implements gregtech.api.interfaces.IOreRecipeRegi
                         }
                         if (tAmount * 2 <= 64) {
                             GT_Values.RA.stdBuilder()
-                                .itemInputs(GT_Utility.copyAmount(2L, aStack), ItemList.Shape_Mold_Casing.get(0L))
+                                .itemInputs(GT_Utility.copyAmount(2, aStack), ItemList.Shape_Mold_Casing.get(0L))
                                 .itemOutputs(GT_ModHandler.getIC2Item("casingcopper", tAmount * 3))
                                 .duration((tAmount * 128) * TICKS)
                                 .eut(1 * tVoltageMultiplier)
@@ -566,7 +566,7 @@ public class ProcessingShaping implements gregtech.api.interfaces.IOreRecipeRegi
                     case "Bronze" -> {
                         if (tAmount * 2 <= 64) {
                             GT_Values.RA.stdBuilder()
-                                .itemInputs(GT_Utility.copyAmount(1L, aStack), ItemList.Shape_Extruder_Casing.get(0L))
+                                .itemInputs(GT_Utility.copyAmount(1, aStack), ItemList.Shape_Extruder_Casing.get(0L))
                                 .itemOutputs(GT_ModHandler.getIC2Item("casingbronze", tAmount * 2))
                                 .duration((tAmount * 32) * TICKS)
                                 .eut(3 * tVoltageMultiplier)
@@ -574,7 +574,7 @@ public class ProcessingShaping implements gregtech.api.interfaces.IOreRecipeRegi
                         }
                         if (tAmount * 2 <= 64) {
                             GT_Values.RA.stdBuilder()
-                                .itemInputs(GT_Utility.copyAmount(2L, aStack), ItemList.Shape_Mold_Casing.get(0L))
+                                .itemInputs(GT_Utility.copyAmount(2, aStack), ItemList.Shape_Mold_Casing.get(0L))
                                 .itemOutputs(GT_ModHandler.getIC2Item("casingbronze", tAmount * 3))
                                 .duration((tAmount * 128) * TICKS)
                                 .eut(1 * tVoltageMultiplier)
@@ -584,7 +584,7 @@ public class ProcessingShaping implements gregtech.api.interfaces.IOreRecipeRegi
                     case "Gold" -> {
                         if (tAmount * 2 <= 64) {
                             GT_Values.RA.stdBuilder()
-                                .itemInputs(GT_Utility.copyAmount(1L, aStack), ItemList.Shape_Extruder_Casing.get(0L))
+                                .itemInputs(GT_Utility.copyAmount(1, aStack), ItemList.Shape_Extruder_Casing.get(0L))
                                 .itemOutputs(GT_ModHandler.getIC2Item("casinggold", tAmount * 2))
                                 .duration((tAmount * 32) * TICKS)
                                 .eut(3 * tVoltageMultiplier)
@@ -592,7 +592,7 @@ public class ProcessingShaping implements gregtech.api.interfaces.IOreRecipeRegi
                         }
                         if (tAmount * 2 <= 64) {
                             GT_Values.RA.stdBuilder()
-                                .itemInputs(GT_Utility.copyAmount(2L, aStack), ItemList.Shape_Mold_Casing.get(0L))
+                                .itemInputs(GT_Utility.copyAmount(2, aStack), ItemList.Shape_Mold_Casing.get(0L))
                                 .itemOutputs(GT_ModHandler.getIC2Item("casinggold", tAmount * 3))
                                 .duration((tAmount * 128) * TICKS)
                                 .eut(1 * tVoltageMultiplier)
@@ -601,7 +601,7 @@ public class ProcessingShaping implements gregtech.api.interfaces.IOreRecipeRegi
                     }
                     case "Polytetrafluoroethylene" -> {
                         GT_Values.RA.stdBuilder()
-                            .itemInputs(GT_Utility.copyAmount(1L, aStack), ItemList.Shape_Extruder_Cell.get(0L))
+                            .itemInputs(GT_Utility.copyAmount(1, aStack), ItemList.Shape_Extruder_Cell.get(0L))
                             .itemOutputs(ItemList.Cell_Empty.get(tAmount * 4))
                             .duration((tAmount * 128) * TICKS)
                             .eut(TierEU.RECIPE_LV)

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingSlab.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingSlab.java
@@ -24,7 +24,7 @@ public class ProcessingSlab implements gregtech.api.interfaces.IOreRecipeRegistr
         if (aOreDictName.startsWith("slabWood")) {
             if (Railcraft.isModLoaded()) {
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(3L, aStack))
+                    .itemInputs(GT_Utility.copyAmount(3, aStack))
                     .itemOutputs(ItemList.RC_Tie_Wood.get(3L))
                     .fluidInputs(Materials.Creosote.getFluid(300L))
                     .duration(10 * SECONDS)

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingStick.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingStick.java
@@ -55,7 +55,7 @@ public class ProcessingStick implements gregtech.api.interfaces.IOreRecipeRegist
             if (GT_OreDictUnificator.get(OrePrefixes.bolt, aMaterial, 1L) != null) {
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                    .itemInputs(GT_Utility.copyAmount(1, aStack))
                     .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.bolt, aMaterial, 4L))
                     .fluidInputs(
                         Materials.Water.getFluid(
@@ -71,7 +71,7 @@ public class ProcessingStick implements gregtech.api.interfaces.IOreRecipeRegist
                     .addTo(sCutterRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                    .itemInputs(GT_Utility.copyAmount(1, aStack))
                     .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.bolt, aMaterial, 4L))
                     .fluidInputs(
                         GT_ModHandler.getDistilledWater(
@@ -87,7 +87,7 @@ public class ProcessingStick implements gregtech.api.interfaces.IOreRecipeRegist
                     .addTo(sCutterRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                    .itemInputs(GT_Utility.copyAmount(1, aStack))
                     .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.bolt, aMaterial, 4L))
                     .fluidInputs(
                         Materials.Lubricant.getFluid(
@@ -120,7 +120,7 @@ public class ProcessingStick implements gregtech.api.interfaces.IOreRecipeRegist
             {
                 if (GT_OreDictUnificator.get(OrePrefixes.springSmall, aMaterial, 1L) != null) {
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(1L, aStack), GT_Utility.getIntegratedCircuit(1))
+                        .itemInputs(GT_Utility.copyAmount(1, aStack), GT_Utility.getIntegratedCircuit(1))
                         .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.springSmall, aMaterial, 2L))
                         .duration(5 * SECONDS)
                         .eut(calculateRecipeEU(aMaterial, 8))
@@ -130,7 +130,7 @@ public class ProcessingStick implements gregtech.api.interfaces.IOreRecipeRegist
 
             if (GT_OreDictUnificator.get(OrePrefixes.stickLong, aMaterial, 1L) != null) {
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(2L, aStack))
+                    .itemInputs(GT_Utility.copyAmount(2, aStack))
                     .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.stickLong, aMaterial, 1L))
                     .duration(Math.max(aMaterial.getMass(), 1L))
                     .eut(calculateRecipeEU(aMaterial, 16))

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingStickLong.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingStickLong.java
@@ -37,7 +37,7 @@ public class ProcessingStickLong implements gregtech.api.interfaces.IOreRecipeRe
 
             if (GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial, 1L) != null) {
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                    .itemInputs(GT_Utility.copyAmount(1, aStack))
                     .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial, 2L))
                     .fluidInputs(
                         Materials.Water.getFluid(
@@ -52,7 +52,7 @@ public class ProcessingStickLong implements gregtech.api.interfaces.IOreRecipeRe
                     .addTo(sCutterRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                    .itemInputs(GT_Utility.copyAmount(1, aStack))
                     .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial, 2L))
                     .fluidInputs(
                         GT_ModHandler.getDistilledWater(
@@ -67,7 +67,7 @@ public class ProcessingStickLong implements gregtech.api.interfaces.IOreRecipeRe
                     .addTo(sCutterRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                    .itemInputs(GT_Utility.copyAmount(1, aStack))
                     .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial, 2L))
                     .fluidInputs(
                         Materials.Lubricant.getFluid(
@@ -100,7 +100,7 @@ public class ProcessingStickLong implements gregtech.api.interfaces.IOreRecipeRe
             {
                 if (GT_OreDictUnificator.get(OrePrefixes.spring, aMaterial, 1L) != null) {
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(1L, aStack), GT_Utility.getIntegratedCircuit(1))
+                        .itemInputs(GT_Utility.copyAmount(1, aStack), GT_Utility.getIntegratedCircuit(1))
                         .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.spring, aMaterial, 1L))
                         .duration(10 * SECONDS)
                         .eut(calculateRecipeEU(aMaterial, 16))

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingStone.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingStone.java
@@ -34,7 +34,7 @@ public class ProcessingStone implements IOreRecipeRegistrator {
         switch (aMaterial.mName) {
             case "NULL":
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(3L, aStack), new ItemStack(Blocks.redstone_torch, 2))
+                    .itemInputs(GT_Utility.copyAmount(3, aStack), new ItemStack(Blocks.redstone_torch, 2))
                     .itemOutputs(new ItemStack(Items.repeater, 1))
                     .fluidInputs(Materials.Redstone.getMolten(144L))
                     .duration(5 * SECONDS)
@@ -43,7 +43,7 @@ public class ProcessingStone implements IOreRecipeRegistrator {
                 break;
             case "Sand":
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                    .itemInputs(GT_Utility.copyAmount(1, aStack))
                     .itemOutputs(new ItemStack(Blocks.sand, 1, 0))
                     .duration(20 * SECONDS)
                     .eut(2)
@@ -51,7 +51,7 @@ public class ProcessingStone implements IOreRecipeRegistrator {
                 break;
             case "Endstone":
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                    .itemInputs(GT_Utility.copyAmount(1, aStack))
                     .itemOutputs(
                         GT_OreDictUnificator.get(OrePrefixes.dustImpure, Materials.Endstone, 1L),
                         GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Tungstate, 1L))
@@ -62,7 +62,7 @@ public class ProcessingStone implements IOreRecipeRegistrator {
                 break;
             case "Netherrack":
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                    .itemInputs(GT_Utility.copyAmount(1, aStack))
                     .itemOutputs(
                         GT_OreDictUnificator.get(OrePrefixes.dustImpure, Materials.Netherrack, 1L),
                         GT_OreDictUnificator.get(OrePrefixes.nugget, Materials.Gold, 1L))
@@ -73,7 +73,7 @@ public class ProcessingStone implements IOreRecipeRegistrator {
                 break;
             case "NetherBrick":
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack), GT_Utility.getIntegratedCircuit(1))
+                    .itemInputs(GT_Utility.copyAmount(1, aStack), GT_Utility.getIntegratedCircuit(1))
                     .itemOutputs(new ItemStack(Blocks.nether_brick_fence, 1))
                     .duration(5 * SECONDS)
                     .eut(4)
@@ -83,14 +83,14 @@ public class ProcessingStone implements IOreRecipeRegistrator {
                 if (aBlock != Blocks.air) aBlock.setResistance(20.0F);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack), ItemList.IC2_Compressed_Coal_Ball.get(8L))
+                    .itemInputs(GT_Utility.copyAmount(1, aStack), ItemList.IC2_Compressed_Coal_Ball.get(8L))
                     .itemOutputs(ItemList.IC2_Compressed_Coal_Chunk.get(1L))
                     .duration(20 * SECONDS)
                     .eut(4)
                     .addTo(sAssemblerRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                    .itemInputs(GT_Utility.copyAmount(1, aStack))
                     .itemOutputs(
                         GT_ModHandler.getModItem(Railcraft.ID, "cube", 1L, 4),
                         GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial, 1L))
@@ -101,7 +101,7 @@ public class ProcessingStone implements IOreRecipeRegistrator {
                 break;
             case "Concrete":
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                    .itemInputs(GT_Utility.copyAmount(1, aStack))
                     .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L))
                     .fluidInputs(Materials.Water.getFluid(Math.max(4, Math.min(1000, 200 * 30 / 320))))
                     .duration(10 * SECONDS)
@@ -109,7 +109,7 @@ public class ProcessingStone implements IOreRecipeRegistrator {
                     .addTo(sCutterRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                    .itemInputs(GT_Utility.copyAmount(1, aStack))
                     .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L))
                     .fluidInputs(GT_ModHandler.getDistilledWater(Math.max(3, Math.min(750, 200 * 30 / 426))))
                     .duration(10 * SECONDS)
@@ -117,7 +117,7 @@ public class ProcessingStone implements IOreRecipeRegistrator {
                     .addTo(sCutterRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                    .itemInputs(GT_Utility.copyAmount(1, aStack))
                     .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L))
                     .fluidInputs(Materials.Lubricant.getFluid(Math.max(1, Math.min(250, 100 * 30 / 1280))))
                     .duration(5 * SECONDS)
@@ -125,7 +125,7 @@ public class ProcessingStone implements IOreRecipeRegistrator {
                     .addTo(sCutterRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                    .itemInputs(GT_Utility.copyAmount(1, aStack))
                     .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial, 1L))
                     .duration(20 * SECONDS)
                     .eut(2)
@@ -133,7 +133,7 @@ public class ProcessingStone implements IOreRecipeRegistrator {
                 break;
             case "Rhyolite":
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                    .itemInputs(GT_Utility.copyAmount(1, aStack))
                     .itemOutputs(
                         GT_OreDictUnificator.get(OrePrefixes.dust, Materials.PotassiumFeldspar, 1L),
                         GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Quartz, 1L))
@@ -144,7 +144,7 @@ public class ProcessingStone implements IOreRecipeRegistrator {
                 break;
             case "Komatiite":
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                    .itemInputs(GT_Utility.copyAmount(1, aStack))
                     .itemOutputs(
                         GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Biotite, 1L),
                         GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Uranium, 1L))
@@ -156,7 +156,7 @@ public class ProcessingStone implements IOreRecipeRegistrator {
             case "Dacite":
             case "Andesite":
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                    .itemInputs(GT_Utility.copyAmount(1, aStack))
                     .itemOutputs(
                         GT_OreDictUnificator.get(OrePrefixes.dust, Materials.SiliconDioxide, 1L),
                         GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Obsidian, 1L))
@@ -167,7 +167,7 @@ public class ProcessingStone implements IOreRecipeRegistrator {
                 break;
             case "Gabbro":
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                    .itemInputs(GT_Utility.copyAmount(1, aStack))
                     .itemOutputs(
                         GT_OreDictUnificator.get(OrePrefixes.dust, Materials.PotassiumFeldspar, 1L),
                         GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Pyrite, 1L))
@@ -178,7 +178,7 @@ public class ProcessingStone implements IOreRecipeRegistrator {
                 break;
             case "Eclogite":
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                    .itemInputs(GT_Utility.copyAmount(1, aStack))
                     .itemOutputs(
                         GT_OreDictUnificator.get(OrePrefixes.dust, Materials.SiliconDioxide, 1L),
                         GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Rutile, 1L))
@@ -189,7 +189,7 @@ public class ProcessingStone implements IOreRecipeRegistrator {
                 break;
             case "Soapstone":
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                    .itemInputs(GT_Utility.copyAmount(1, aStack))
                     .itemOutputs(
                         GT_OreDictUnificator.get(OrePrefixes.dustImpure, Materials.Talc, 1L),
                         GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Chromite, 1L))
@@ -201,7 +201,7 @@ public class ProcessingStone implements IOreRecipeRegistrator {
             case "Greenschist":
             case "Blueschist":
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                    .itemInputs(GT_Utility.copyAmount(1, aStack))
                     .itemOutputs(
                         GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.Glauconite, 2L),
                         GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.Basalt, 1L))
@@ -213,7 +213,7 @@ public class ProcessingStone implements IOreRecipeRegistrator {
             case "Gneiss":
             case "Migmatite":
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                    .itemInputs(GT_Utility.copyAmount(1, aStack))
                     .itemOutputs(
                         GT_OreDictUnificator.get(OrePrefixes.dust, Materials.SiliconDioxide, 1L),
                         GT_OreDictUnificator.get(OrePrefixes.dustImpure, Materials.GraniteBlack, 1L))
@@ -225,7 +225,7 @@ public class ProcessingStone implements IOreRecipeRegistrator {
             case "Redrock":
             case "Marble":
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                    .itemInputs(GT_Utility.copyAmount(1, aStack))
                     .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L))
                     .fluidInputs(Materials.Water.getFluid(Math.max(4, Math.min(1000, 400 * 30 / 320))))
                     .duration(20 * SECONDS)
@@ -233,7 +233,7 @@ public class ProcessingStone implements IOreRecipeRegistrator {
                     .addTo(sCutterRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                    .itemInputs(GT_Utility.copyAmount(1, aStack))
                     .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L))
                     .fluidInputs(GT_ModHandler.getDistilledWater(Math.max(3, Math.min(750, 400 * 30 / 426))))
                     .duration(20 * SECONDS)
@@ -241,7 +241,7 @@ public class ProcessingStone implements IOreRecipeRegistrator {
                     .addTo(sCutterRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                    .itemInputs(GT_Utility.copyAmount(1, aStack))
                     .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L))
                     .fluidInputs(Materials.Lubricant.getFluid(Math.max(1, Math.min(250, 200 * 30 / 1280))))
                     .duration(10 * SECONDS)
@@ -249,7 +249,7 @@ public class ProcessingStone implements IOreRecipeRegistrator {
                     .addTo(sCutterRecipes);
             case "Basalt":
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack), GT_Utility.getIntegratedCircuit(3))
+                    .itemInputs(GT_Utility.copyAmount(1, aStack), GT_Utility.getIntegratedCircuit(3))
                     .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L))
                     .fluidInputs(Materials.Water.getFluid(Math.max(4, Math.min(1000, 400 * 30 / 320))))
                     .duration(20 * SECONDS)
@@ -257,7 +257,7 @@ public class ProcessingStone implements IOreRecipeRegistrator {
                     .addTo(sCutterRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack), GT_Utility.getIntegratedCircuit(3))
+                    .itemInputs(GT_Utility.copyAmount(1, aStack), GT_Utility.getIntegratedCircuit(3))
                     .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L))
                     .fluidInputs(GT_ModHandler.getDistilledWater(Math.max(3, Math.min(750, 400 * 30 / 426))))
                     .duration(20 * SECONDS)
@@ -265,7 +265,7 @@ public class ProcessingStone implements IOreRecipeRegistrator {
                     .addTo(sCutterRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack), GT_Utility.getIntegratedCircuit(3))
+                    .itemInputs(GT_Utility.copyAmount(1, aStack), GT_Utility.getIntegratedCircuit(3))
                     .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L))
                     .fluidInputs(Materials.Lubricant.getFluid(Math.max(1, Math.min(250, 200 * 30 / 1280))))
                     .duration(10 * SECONDS)
@@ -273,7 +273,7 @@ public class ProcessingStone implements IOreRecipeRegistrator {
                     .addTo(sCutterRecipes);
             case "Quartzite":
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                    .itemInputs(GT_Utility.copyAmount(1, aStack))
                     .itemOutputs(
                         GT_OreDictUnificator.get(OrePrefixes.dustImpure, aMaterial, 1L),
                         GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial, 1L))
@@ -284,7 +284,7 @@ public class ProcessingStone implements IOreRecipeRegistrator {
                 break;
             case "Flint":
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                    .itemInputs(GT_Utility.copyAmount(1, aStack))
                     .itemOutputs(
                         GT_OreDictUnificator.get(OrePrefixes.dustImpure, aMaterial, 2L),
                         new ItemStack(Items.flint, 1))
@@ -295,7 +295,7 @@ public class ProcessingStone implements IOreRecipeRegistrator {
                 break;
             case "GraniteBlack":
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                    .itemInputs(GT_Utility.copyAmount(1, aStack))
                     .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L))
                     .fluidInputs(Materials.Water.getFluid(Math.max(4, Math.min(1000, 400 * 30 / 320))))
                     .duration(20 * SECONDS)
@@ -303,7 +303,7 @@ public class ProcessingStone implements IOreRecipeRegistrator {
                     .addTo(sCutterRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                    .itemInputs(GT_Utility.copyAmount(1, aStack))
                     .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L))
                     .fluidInputs(GT_ModHandler.getDistilledWater(Math.max(3, Math.min(750, 400 * 30 / 426))))
                     .duration(20 * SECONDS)
@@ -311,7 +311,7 @@ public class ProcessingStone implements IOreRecipeRegistrator {
                     .addTo(sCutterRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                    .itemInputs(GT_Utility.copyAmount(1, aStack))
                     .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L))
                     .fluidInputs(Materials.Lubricant.getFluid(Math.max(1, Math.min(250, 200 * 30 / 1280))))
                     .duration(10 * SECONDS)
@@ -319,7 +319,7 @@ public class ProcessingStone implements IOreRecipeRegistrator {
                     .addTo(sCutterRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                    .itemInputs(GT_Utility.copyAmount(1, aStack))
                     .itemOutputs(
                         GT_OreDictUnificator.get(OrePrefixes.dustImpure, aMaterial, 1L),
                         GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Thorium, 1L))
@@ -330,7 +330,7 @@ public class ProcessingStone implements IOreRecipeRegistrator {
                 break;
             case "GraniteRed":
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                    .itemInputs(GT_Utility.copyAmount(1, aStack))
                     .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L))
                     .fluidInputs(Materials.Water.getFluid(Math.max(4, Math.min(1000, 400 * 30 / 320))))
                     .duration(20 * SECONDS)
@@ -338,7 +338,7 @@ public class ProcessingStone implements IOreRecipeRegistrator {
                     .addTo(sCutterRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                    .itemInputs(GT_Utility.copyAmount(1, aStack))
                     .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L))
                     .fluidInputs(GT_ModHandler.getDistilledWater(Math.max(3, Math.min(750, 400 * 30 / 426))))
                     .duration(20 * SECONDS)
@@ -346,7 +346,7 @@ public class ProcessingStone implements IOreRecipeRegistrator {
                     .addTo(sCutterRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                    .itemInputs(GT_Utility.copyAmount(1, aStack))
                     .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L))
                     .fluidInputs(Materials.Lubricant.getFluid(Math.max(1, Math.min(250, 200 * 30 / 1280))))
                     .duration(10 * SECONDS)
@@ -354,7 +354,7 @@ public class ProcessingStone implements IOreRecipeRegistrator {
                     .addTo(sCutterRecipes);
 
                 GT_Values.RA.stdBuilder()
-                    .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                    .itemInputs(GT_Utility.copyAmount(1, aStack))
                     .itemOutputs(
                         GT_OreDictUnificator.get(OrePrefixes.dustImpure, aMaterial, 1L),
                         GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.Uranium, 1L))

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingStoneCobble.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingStoneCobble.java
@@ -21,7 +21,7 @@ public class ProcessingStoneCobble implements gregtech.api.interfaces.IOreRecipe
     public void registerOre(OrePrefixes aPrefix, Materials aMaterial, String aOreDictName, String aModName,
         ItemStack aStack) {
         GT_Values.RA.stdBuilder()
-            .itemInputs(GT_Utility.copyAmount(8L, aStack), GT_Utility.getIntegratedCircuit(8))
+            .itemInputs(GT_Utility.copyAmount(8, aStack), GT_Utility.getIntegratedCircuit(8))
             .itemOutputs(new ItemStack(Blocks.furnace, 1))
             .duration(20 * SECONDS)
             .eut(4)

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingToolHead.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingToolHead.java
@@ -63,7 +63,7 @@ public class ProcessingToolHead implements gregtech.api.interfaces.IOreRecipeReg
                     if (!(aMaterial == Materials.AnnealedCopper || aMaterial == Materials.WroughtIron)) {
                         GT_Values.RA.stdBuilder()
                             .itemInputs(ItemList.Shape_Mold_Arrow.get(0L))
-                            .itemOutputs(GT_Utility.copyAmount(1L, aStack))
+                            .itemOutputs(GT_Utility.copyAmount(1, aStack))
                             .fluidInputs(aMaterial.getMolten(36L))
                             .duration(16 * TICKS)
                             .eut(8)

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingTransforming.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingTransforming.java
@@ -37,7 +37,7 @@ public class ProcessingTransforming implements IOreRecipeRegistrator {
             {
                 if (GT_OreDictUnificator.get(aPrefix, Materials.WoodSealed, 1L) != null) {
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                        .itemInputs(GT_Utility.copyAmount(1, aStack))
                         .itemOutputs(GT_OreDictUnificator.get(aPrefix, Materials.WoodSealed, 1L))
                         .fluidInputs(
                             Materials.SeedOil
@@ -53,7 +53,7 @@ public class ProcessingTransforming implements IOreRecipeRegistrator {
                 {
                     if (GT_OreDictUnificator.get(aPrefix, Materials.FierySteel, 1L) != null) {
                         GT_Values.RA.stdBuilder()
-                            .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                            .itemInputs(GT_Utility.copyAmount(1, aStack))
                             .itemOutputs(GT_OreDictUnificator.get(aPrefix, Materials.FierySteel, 1L))
                             .fluidInputs(
                                 Materials.FierySteel.getFluid(
@@ -68,7 +68,7 @@ public class ProcessingTransforming implements IOreRecipeRegistrator {
                 {
                     if (GT_OreDictUnificator.get(aPrefix, Materials.IronMagnetic, 1L) != null) {
                         GT_Values.RA.stdBuilder()
-                            .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                            .itemInputs(GT_Utility.copyAmount(1, aStack))
                             .itemOutputs(GT_OreDictUnificator.get(aPrefix, Materials.IronMagnetic, 1L))
                             .duration(((int) Math.max(16L, aPrefix.mMaterialAmount * 128L / GT_Values.M)) * TICKS)
                             .eut((int) TierEU.LV / 2)
@@ -81,7 +81,7 @@ public class ProcessingTransforming implements IOreRecipeRegistrator {
                 {
                     if (GT_OreDictUnificator.get(aPrefix, Materials.FierySteel, 1L) != null) {
                         GT_Values.RA.stdBuilder()
-                            .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                            .itemInputs(GT_Utility.copyAmount(1, aStack))
                             .itemOutputs(GT_OreDictUnificator.get(aPrefix, Materials.FierySteel, 1L))
                             .fluidInputs(
                                 Materials.FierySteel.getFluid(
@@ -96,7 +96,7 @@ public class ProcessingTransforming implements IOreRecipeRegistrator {
                 {
                     if (GT_OreDictUnificator.get(aPrefix, Materials.IronMagnetic, 1L) != null) {
                         GT_Values.RA.stdBuilder()
-                            .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                            .itemInputs(GT_Utility.copyAmount(1, aStack))
                             .itemOutputs(GT_OreDictUnificator.get(aPrefix, Materials.IronMagnetic, 1L))
                             .duration(((int) Math.max(16L, aPrefix.mMaterialAmount * 128L / GT_Values.M)) * TICKS)
                             .eut((int) TierEU.LV / 2)
@@ -109,7 +109,7 @@ public class ProcessingTransforming implements IOreRecipeRegistrator {
                 {
                     if (GT_OreDictUnificator.get(aPrefix, Materials.FierySteel, 1L) != null) {
                         GT_Values.RA.stdBuilder()
-                            .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                            .itemInputs(GT_Utility.copyAmount(1, aStack))
                             .itemOutputs(GT_OreDictUnificator.get(aPrefix, Materials.FierySteel, 1L))
                             .fluidInputs(
                                 Materials.FierySteel.getFluid(
@@ -124,7 +124,7 @@ public class ProcessingTransforming implements IOreRecipeRegistrator {
                 {
                     if (GT_OreDictUnificator.get(aPrefix, Materials.SteelMagnetic, 1L) != null) {
                         GT_Values.RA.stdBuilder()
-                            .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                            .itemInputs(GT_Utility.copyAmount(1, aStack))
                             .itemOutputs(GT_OreDictUnificator.get(aPrefix, Materials.SteelMagnetic, 1L))
                             .duration(((int) Math.max(16L, aPrefix.mMaterialAmount * 128L / GT_Values.M)) * TICKS)
                             .eut((int) TierEU.LV / 2)
@@ -137,7 +137,7 @@ public class ProcessingTransforming implements IOreRecipeRegistrator {
             {
                 if (GT_OreDictUnificator.get(aPrefix, Materials.NeodymiumMagnetic, 1L) != null) {
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                        .itemInputs(GT_Utility.copyAmount(1, aStack))
                         .itemOutputs(GT_OreDictUnificator.get(aPrefix, Materials.NeodymiumMagnetic, 1L))
                         .duration(((int) Math.max(16L, aPrefix.mMaterialAmount * 128L / GT_Values.M)) * TICKS)
                         .eut((int) TierEU.HV / 2)
@@ -149,7 +149,7 @@ public class ProcessingTransforming implements IOreRecipeRegistrator {
             {
                 if (GT_OreDictUnificator.get(aPrefix, Materials.SamariumMagnetic, 1L) != null) {
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                        .itemInputs(GT_Utility.copyAmount(1, aStack))
                         .itemOutputs(GT_OreDictUnificator.get(aPrefix, Materials.SamariumMagnetic, 1L))
                         .duration(((int) Math.max(16L, aPrefix.mMaterialAmount * 128L / GT_Values.M)) * TICKS)
                         .eut((int) TierEU.IV / 2)
@@ -162,7 +162,7 @@ public class ProcessingTransforming implements IOreRecipeRegistrator {
             {
                 if (GT_OreDictUnificator.get(aPrefix, Materials.TengamAttuned, 1L) != null) {
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                        .itemInputs(GT_Utility.copyAmount(1, aStack))
                         .itemOutputs(GT_OreDictUnificator.get(aPrefix, Materials.TengamAttuned, 1L))
                         .duration(((int) Math.max(16L, aPrefix.mMaterialAmount * 128L / GT_Values.M)) * TICKS)
                         .eut((int) TierEU.RECIPE_UHV)

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingWax.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingWax.java
@@ -22,7 +22,7 @@ public class ProcessingWax implements gregtech.api.interfaces.IOreRecipeRegistra
         ItemStack aStack) {
         if (aOreDictName.equals("waxMagical")) {
             GT_Values.RA.stdBuilder()
-                .itemInputs(GT_Utility.copyAmount(1L, aStack))
+                .itemInputs(GT_Utility.copyAmount(1, aStack))
                 .metadata(FUEL_VALUE, 6)
                 .metadata(FUEL_TYPE, 5)
                 .duration(0)

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingWire.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingWire.java
@@ -66,7 +66,7 @@ public class ProcessingWire implements gregtech.api.interfaces.IOreRecipeRegistr
                     {
                         if (GT_OreDictUnificator.get(OrePrefixes.springSmall, aMaterial, 1L) != null) {
                             GT_Values.RA.stdBuilder()
-                                .itemInputs(GT_Utility.copyAmount(1L, aStack), GT_Utility.getIntegratedCircuit(1))
+                                .itemInputs(GT_Utility.copyAmount(1, aStack), GT_Utility.getIntegratedCircuit(1))
                                 .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.springSmall, aMaterial, 2L))
                                 .duration(5 * SECONDS)
                                 .eut(calculateRecipeEU(aMaterial, 8))
@@ -78,7 +78,7 @@ public class ProcessingWire implements gregtech.api.interfaces.IOreRecipeRegistr
                     {
                         if (GT_OreDictUnificator.get(OrePrefixes.wireFine, aMaterial, 1L) != null) {
                             GT_Values.RA.stdBuilder()
-                                .itemInputs(GT_Utility.copyAmount(1L, aStack), GT_Utility.getIntegratedCircuit(1))
+                                .itemInputs(GT_Utility.copyAmount(1, aStack), GT_Utility.getIntegratedCircuit(1))
                                 .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.wireFine, aMaterial, 4L))
                                 .duration(10 * SECONDS)
                                 .eut(calculateRecipeEU(aMaterial, 8))
@@ -101,31 +101,31 @@ public class ProcessingWire implements gregtech.api.interfaces.IOreRecipeRegistr
                 // Assembler recipes
                 {
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(2L, aStack), GT_Utility.getIntegratedCircuit(2))
+                        .itemInputs(GT_Utility.copyAmount(2, aStack), GT_Utility.getIntegratedCircuit(2))
                         .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.wireGt02, aMaterial, 1L))
                         .duration(7 * SECONDS + 10 * TICKS)
                         .eut(calculateRecipeEU(aMaterial, 8))
                         .addTo(sAssemblerRecipes);
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(4L, aStack), GT_Utility.getIntegratedCircuit(4))
+                        .itemInputs(GT_Utility.copyAmount(4, aStack), GT_Utility.getIntegratedCircuit(4))
                         .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.wireGt04, aMaterial, 1L))
                         .duration(10 * SECONDS)
                         .eut(calculateRecipeEU(aMaterial, 8))
                         .addTo(sAssemblerRecipes);
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(8L, aStack), GT_Utility.getIntegratedCircuit(8))
+                        .itemInputs(GT_Utility.copyAmount(8, aStack), GT_Utility.getIntegratedCircuit(8))
                         .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.wireGt08, aMaterial, 1L))
                         .duration(15 * SECONDS)
                         .eut(calculateRecipeEU(aMaterial, 8))
                         .addTo(sAssemblerRecipes);
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(12L, aStack), GT_Utility.getIntegratedCircuit(12))
+                        .itemInputs(GT_Utility.copyAmount(12, aStack), GT_Utility.getIntegratedCircuit(12))
                         .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.wireGt12, aMaterial, 1L))
                         .duration(20 * SECONDS)
                         .eut(calculateRecipeEU(aMaterial, 8))
                         .addTo(sAssemblerRecipes);
                     GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_Utility.copyAmount(16L, aStack), GT_Utility.getIntegratedCircuit(16))
+                        .itemInputs(GT_Utility.copyAmount(16, aStack), GT_Utility.getIntegratedCircuit(16))
                         .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.wireGt16, aMaterial, 1L))
                         .duration(25 * SECONDS)
                         .eut(calculateRecipeEU(aMaterial, 8))
@@ -143,7 +143,7 @@ public class ProcessingWire implements gregtech.api.interfaces.IOreRecipeRegistr
                             new Object[] { aOreDictName });
 
                         GT_ModHandler.addShapelessCraftingRecipe(
-                            GT_Utility.copyAmount(1L, aStack),
+                            GT_Utility.copyAmount(1, aStack),
                             new Object[] { OrePrefixes.wireGt01.get(aMaterial), OrePrefixes.wireGt01.get(aMaterial) });
                     }
                 }
@@ -158,11 +158,11 @@ public class ProcessingWire implements gregtech.api.interfaces.IOreRecipeRegistr
                             GT_OreDictUnificator.get(OrePrefixes.wireGt01, aMaterial, 4L),
                             new Object[] { aOreDictName });
                         GT_ModHandler.addShapelessCraftingRecipe(
-                            GT_Utility.copyAmount(1L, aStack),
+                            GT_Utility.copyAmount(1, aStack),
                             new Object[] { OrePrefixes.wireGt01.get(aMaterial), OrePrefixes.wireGt01.get(aMaterial),
                                 OrePrefixes.wireGt01.get(aMaterial), OrePrefixes.wireGt01.get(aMaterial) });
                         GT_ModHandler.addShapelessCraftingRecipe(
-                            GT_Utility.copyAmount(1L, aStack),
+                            GT_Utility.copyAmount(1, aStack),
                             new Object[] { OrePrefixes.wireGt02.get(aMaterial), OrePrefixes.wireGt02.get(aMaterial) });
                     }
                 }
@@ -177,13 +177,13 @@ public class ProcessingWire implements gregtech.api.interfaces.IOreRecipeRegistr
                             GT_OreDictUnificator.get(OrePrefixes.wireGt01, aMaterial, 8L),
                             new Object[] { aOreDictName });
                         GT_ModHandler.addShapelessCraftingRecipe(
-                            GT_Utility.copyAmount(1L, aStack),
+                            GT_Utility.copyAmount(1, aStack),
                             new Object[] { OrePrefixes.wireGt01.get(aMaterial), OrePrefixes.wireGt01.get(aMaterial),
                                 OrePrefixes.wireGt01.get(aMaterial), OrePrefixes.wireGt01.get(aMaterial),
                                 OrePrefixes.wireGt01.get(aMaterial), OrePrefixes.wireGt01.get(aMaterial),
                                 OrePrefixes.wireGt01.get(aMaterial), OrePrefixes.wireGt01.get(aMaterial) });
                         GT_ModHandler.addShapelessCraftingRecipe(
-                            GT_Utility.copyAmount(1L, aStack),
+                            GT_Utility.copyAmount(1, aStack),
                             new Object[] { OrePrefixes.wireGt04.get(aMaterial), OrePrefixes.wireGt04.get(aMaterial) });
                     }
                 }
@@ -198,7 +198,7 @@ public class ProcessingWire implements gregtech.api.interfaces.IOreRecipeRegistr
                             GT_OreDictUnificator.get(OrePrefixes.wireGt01, aMaterial, 12L),
                             new Object[] { aOreDictName });
                         GT_ModHandler.addShapelessCraftingRecipe(
-                            GT_Utility.copyAmount(1L, aStack),
+                            GT_Utility.copyAmount(1, aStack),
                             new Object[] { OrePrefixes.wireGt08.get(aMaterial), OrePrefixes.wireGt04.get(aMaterial) });
                     }
                 }
@@ -213,10 +213,10 @@ public class ProcessingWire implements gregtech.api.interfaces.IOreRecipeRegistr
                             GT_OreDictUnificator.get(OrePrefixes.wireGt01, aMaterial, 16L),
                             new Object[] { aOreDictName });
                         GT_ModHandler.addShapelessCraftingRecipe(
-                            GT_Utility.copyAmount(1L, aStack),
+                            GT_Utility.copyAmount(1, aStack),
                             new Object[] { OrePrefixes.wireGt08.get(aMaterial), OrePrefixes.wireGt08.get(aMaterial) });
                         GT_ModHandler.addShapelessCraftingRecipe(
-                            GT_Utility.copyAmount(1L, aStack),
+                            GT_Utility.copyAmount(1, aStack),
                             new Object[] { OrePrefixes.wireGt12.get(aMaterial), OrePrefixes.wireGt04.get(aMaterial) });
                     }
 
@@ -251,7 +251,7 @@ public class ProcessingWire implements gregtech.api.interfaces.IOreRecipeRegistr
                 if (GT_OreDictUnificator.get(correspondingCable, aMaterial, 1L) != null) {
                     GT_Values.RA.stdBuilder()
                         .itemInputs(
-                            GT_Utility.copyAmount(1L, aStack),
+                            GT_Utility.copyAmount(1, aStack),
                             GT_OreDictUnificator.get(OrePrefixes.plate.get(Materials.Rubber), costMultiplier))
                         .itemOutputs(GT_OreDictUnificator.get(correspondingCable, aMaterial, 1L))
                         .duration(5 * SECONDS)
@@ -468,7 +468,7 @@ public class ProcessingWire implements gregtech.api.interfaces.IOreRecipeRegistr
         if (GT_OreDictUnificator.get(correspondingCable, aMaterial, 1L) != null) {
             GT_Values.RA.stdBuilder()
                 .itemInputs(GT_OreDictUnificator.get(correspondingCable, aMaterial, 1L))
-                .itemOutputs(GT_Utility.copyAmount(1L, aStack))
+                .itemOutputs(GT_Utility.copyAmount(1, aStack))
                 .duration(5 * SECONDS)
                 .eut(calculateRecipeEU(aMaterial, 8))
                 .addTo(sUnboxinatorRecipes);

--- a/src/main/java/gregtech/loaders/postload/GT_CraftingRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/postload/GT_CraftingRecipeLoader.java
@@ -160,7 +160,7 @@ public class GT_CraftingRecipeLoader implements Runnable {
         if (tStack != null) {
             GT_ModHandler.addCraftingRecipe(
                 GT_Utility.copyAmount(
-                    GT_Mod.gregtechproxy.mNerfedWoodPlank ? tStack.stackSize : tStack.stackSize * 5L / 4,
+                    GT_Mod.gregtechproxy.mNerfedWoodPlank ? tStack.stackSize : tStack.stackSize * 5 / 4,
                     tStack),
                 bits_no_remove_buffered,
                 new Object[] { "s", "P", "P", 'P', OrePrefixes.plank.get(Materials.Wood) });

--- a/src/main/java/gregtech/loaders/preload/GT_Loader_ItemData.java
+++ b/src/main/java/gregtech/loaders/preload/GT_Loader_ItemData.java
@@ -369,7 +369,7 @@ public class GT_Loader_ItemData implements Runnable {
             new ItemStack(Items.beef), new ItemStack(Items.chicken), new ItemStack(Items.fish) }) {
             if (tItem != null) {
                 GT_OreDictUnificator.addItemData(
-                    GT_Utility.copyMetaData(32767L, tItem),
+                    GT_Utility.copyMetaData(32767, tItem),
                     new ItemData(Materials.MeatRaw, 3628800L, new MaterialStack(Materials.Bone, 403200L)));
             }
         }
@@ -379,7 +379,7 @@ public class GT_Loader_ItemData implements Runnable {
             new ItemStack(Items.cooked_fished) }) {
             if (tItem != null) {
                 GT_OreDictUnificator.addItemData(
-                    GT_Utility.copyMetaData(32767L, tItem),
+                    GT_Utility.copyMetaData(32767, tItem),
                     new ItemData(Materials.MeatCooked, 3628800L, new MaterialStack(Materials.Bone, 403200L)));
             }
         }


### PR DESCRIPTION
A few calls restricted by other methods and interfaces are left untouched.