### PR TITLE
Fix EV+ Powered Repeller Range

### DIFF
--- a/src/main/java/gregtech/api/util/GT_SpawnEventHandler.java
+++ b/src/main/java/gregtech/api/util/GT_SpawnEventHandler.java
@@ -40,9 +40,9 @@ public class GT_SpawnEventHandler {
     public void denyMobSpawn(CheckSpawn event) {
         if (event.getResult() == Event.Result.DENY) return;
 
-        if (event.entityLiving instanceof EntitySlime && !(((EntitySlime) event.entityLiving).getCustomNameTag()
-            .length() > 0)) {
-            if (event.getResult() == Event.Result.ALLOW) event.setResult(Event.Result.DEFAULT);
+        if (event.entityLiving instanceof EntitySlime slime && !slime.hasCustomNameTag()
+            && event.getResult() == Event.Result.ALLOW) {
+            event.setResult(Event.Result.DEFAULT);
         }
 
         if (event.getResult() == Event.Result.ALLOW) {
@@ -50,7 +50,7 @@ public class GT_SpawnEventHandler {
         }
 
         if (event.entityLiving.isCreatureType(EnumCreatureType.monster, false)) {
-            final double maxRangeCheck = Math.pow(getUnpoweredRepellentRange(GT_Values.V.length - 1), 2);
+            final double maxRangeCheck = Math.pow(getPoweredRepellentRange(GT_Values.V.length - 1), 2);
             for (int[] rep : mobReps) {
                 if (rep[3] == event.entity.worldObj.provider.dimensionId) {
                     // If the chunk isn't loaded, we ignore this Repellent
@@ -64,17 +64,15 @@ public class GT_SpawnEventHandler {
                     if (check > maxRangeCheck) continue;
 
                     final TileEntity tTile = event.entity.worldObj.getTileEntity(rep[0], rep[1], rep[2]);
-                    if (tTile instanceof BaseMetaTileEntity && ((BaseMetaTileEntity) tTile)
-                        .getMetaTileEntity() instanceof GT_MetaTileEntity_MonsterRepellent) {
-                        final int r = ((GT_MetaTileEntity_MonsterRepellent) ((BaseMetaTileEntity) tTile)
-                            .getMetaTileEntity()).mRange;
-                        if (check <= Math.pow(r, 2)) {
-                            if (event.entityLiving instanceof EntitySlime)
-                                ((EntitySlime) event.entityLiving).setCustomNameTag("DoNotSpawnSlimes");
-                            event.setResult(Event.Result.DENY);
-                            // We're already DENYing it. No reason to keep checking
-                            return;
+                    if (tTile instanceof BaseMetaTileEntity metaTile
+                        && metaTile.getMetaTileEntity() instanceof GT_MetaTileEntity_MonsterRepellent repellent
+                        && check <= Math.pow(repellent.mRange, 2)) {
+                        if (event.entityLiving instanceof EntitySlime slime) {
+                            slime.setCustomNameTag("DoNotSpawnSlimes");
                         }
+                        event.setResult(Event.Result.DENY);
+                        // We're already DENYing it. No reason to keep checking
+                        return;
                     }
                 }
             }


### PR DESCRIPTION
Powered Repellers have a range of up to 400 blocks. Due to the wrong range function being used for maxRange calculation they are however effectively limited to 184 blocks. As such Repellers EV and up dont have their advertised range when powered.