### PR TITLE
Allow a recipe's displayed NEI item outputs to be changed

### DIFF
--- a/src/main/java/gregtech/api/util/GT_Recipe.java
+++ b/src/main/java/gregtech/api/util/GT_Recipe.java
@@ -579,6 +579,19 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
         if (aIndex < 0 || aIndex >= mOutputs.length) return null;
         return GT_Utility.copyOrNull(mOutputs[aIndex]);
     }
+    
+    /***
+     * Dictates the ItemStacks displayed in the output slots of any NEI page handled by the default GT NEI handler.
+     * Override to make shown items differ from a GT_Recipe's item output array
+     * @see gregtech.nei.GT_NEI_DefaultHandler
+     * @param i	Slot index
+     * @return ItemStack to be displayed in the slot
+     * 
+     */
+    // 
+	public ItemStack getRepresentativeOutput(int i) {
+		return getOutput(i);
+	}
 
     public int getOutputChance(int aIndex) {
         if (mChances == null) return 10000;
@@ -6523,9 +6536,5 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
     }
 
     
-    // Returns the stack to be displayed in the output slot of index i on the recipe's NEI page
-    // Override for more control over what items are displayed
-	public ItemStack getRepresentativeOutput(int i) {
-		return getOutput(i);
-	}
+    
 }

--- a/src/main/java/gregtech/api/util/GT_Recipe.java
+++ b/src/main/java/gregtech/api/util/GT_Recipe.java
@@ -579,19 +579,20 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
         if (aIndex < 0 || aIndex >= mOutputs.length) return null;
         return GT_Utility.copyOrNull(mOutputs[aIndex]);
     }
-    
+
     /***
      * Dictates the ItemStacks displayed in the output slots of any NEI page handled by the default GT NEI handler.
      * Override to make shown items differ from a GT_Recipe's item output array
+     * 
      * @see gregtech.nei.GT_NEI_DefaultHandler
-     * @param i	Slot index
+     * @param i Slot index
      * @return ItemStack to be displayed in the slot
      * 
      */
-    // 
-	public ItemStack getRepresentativeOutput(int i) {
-		return getOutput(i);
-	}
+    //
+    public ItemStack getRepresentativeOutput(int i) {
+        return getOutput(i);
+    }
 
     public int getOutputChance(int aIndex) {
         if (mChances == null) return 10000;

--- a/src/main/java/gregtech/api/util/GT_Recipe.java
+++ b/src/main/java/gregtech/api/util/GT_Recipe.java
@@ -6521,4 +6521,11 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
                     .setSize(10, 18));
         }
     }
+
+    
+    // Returns the stack to be displayed in the output slot of index i on the recipe's NEI page
+    // Override for more control over what items are displayed
+	public ItemStack getRepresentativeOutput(int i) {
+		return getOutput(i);
+	}
 }

--- a/src/main/java/gregtech/api/util/GT_Recipe.java
+++ b/src/main/java/gregtech/api/util/GT_Recipe.java
@@ -6534,15 +6534,4 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
                     .setSize(10, 18));
         }
     }
-
-<<<<<<< HEAD
-    
-    
-=======
-    // Returns the stack to be displayed in the output slot of index i on the recipe's NEI page
-    // Override for more control over what items are displayed
-    public ItemStack getRepresentativeOutput(int i) {
-        return getOutput(i);
-    }
->>>>>>> d7c5acea2137d463e5f8126a0835ea5b1498e772
 }

--- a/src/main/java/gregtech/nei/GT_NEI_DefaultHandler.java
+++ b/src/main/java/gregtech/nei/GT_NEI_DefaultHandler.java
@@ -20,12 +20,6 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.FontRenderer;
-import net.minecraft.client.gui.inventory.GuiContainer;
-import net.minecraft.item.ItemStack;
-import net.minecraftforge.fluids.FluidStack;
-
 import org.apache.commons.lang3.Range;
 import org.lwjgl.opengl.GL11;
 
@@ -67,15 +61,11 @@ import gregtech.api.util.GT_Utility;
 import gregtech.common.blocks.GT_Item_Machines;
 import gregtech.common.gui.modularui.UIHelper;
 import gregtech.common.power.Power;
-<<<<<<< HEAD
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
-=======
-import gregtech.nei.GT_NEI_DefaultHandler.FixedPositionedStack;
->>>>>>> d7c5acea2137d463e5f8126a0835ea5b1498e772
 
 public class GT_NEI_DefaultHandler extends RecipeMapHandler {
 
@@ -763,13 +753,8 @@ public class GT_NEI_DefaultHandler extends RecipeMapHandler {
                             .getItemHandler() == itemOutputsInventory) {
                                 int i = widget.getMcSlot()
                                     .getSlotIndex();
-<<<<<<< HEAD
-                                ItemStack output = aRecipe.getRepresentativeOutput(i);
                                 
-=======
-                                Object output = aRecipe.getRepresentativeOutput(i);
-
->>>>>>> d7c5acea2137d463e5f8126a0835ea5b1498e772
+                                ItemStack output = aRecipe.getRepresentativeOutput(i);     
                                 if (output != null) {
                                     mOutputs.add(
                                         new FixedPositionedStack(

--- a/src/main/java/gregtech/nei/GT_NEI_DefaultHandler.java
+++ b/src/main/java/gregtech/nei/GT_NEI_DefaultHandler.java
@@ -20,6 +20,12 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.FontRenderer;
+import net.minecraft.client.gui.inventory.GuiContainer;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
+
 import org.apache.commons.lang3.Range;
 import org.lwjgl.opengl.GL11;
 
@@ -61,11 +67,6 @@ import gregtech.api.util.GT_Utility;
 import gregtech.common.blocks.GT_Item_Machines;
 import gregtech.common.gui.modularui.UIHelper;
 import gregtech.common.power.Power;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.FontRenderer;
-import net.minecraft.client.gui.inventory.GuiContainer;
-import net.minecraft.item.ItemStack;
-import net.minecraftforge.fluids.FluidStack;
 
 public class GT_NEI_DefaultHandler extends RecipeMapHandler {
 
@@ -83,7 +84,7 @@ public class GT_NEI_DefaultHandler extends RecipeMapHandler {
      * Static version of {@link TemplateRecipeHandler#cycleticks}. Can be referenced from cached recipes.
      */
     public static int cycleTicksStatic = Math.abs((int) System.currentTimeMillis());
-    /**	
+    /**
      * Basically {@link #cycleTicksStatic} but always updated even while holding shift
      */
     private static int drawTicks;
@@ -753,8 +754,8 @@ public class GT_NEI_DefaultHandler extends RecipeMapHandler {
                             .getItemHandler() == itemOutputsInventory) {
                                 int i = widget.getMcSlot()
                                     .getSlotIndex();
-                                
-                                ItemStack output = aRecipe.getRepresentativeOutput(i);     
+
+                                ItemStack output = aRecipe.getRepresentativeOutput(i);
                                 if (output != null) {
                                     mOutputs.add(
                                         new FixedPositionedStack(

--- a/src/main/java/gregtech/nei/GT_NEI_DefaultHandler.java
+++ b/src/main/java/gregtech/nei/GT_NEI_DefaultHandler.java
@@ -20,12 +20,6 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.FontRenderer;
-import net.minecraft.client.gui.inventory.GuiContainer;
-import net.minecraft.item.ItemStack;
-import net.minecraftforge.fluids.FluidStack;
-
 import org.apache.commons.lang3.Range;
 import org.lwjgl.opengl.GL11;
 
@@ -67,6 +61,12 @@ import gregtech.api.util.GT_Utility;
 import gregtech.common.blocks.GT_Item_Machines;
 import gregtech.common.gui.modularui.UIHelper;
 import gregtech.common.power.Power;
+import gregtech.nei.GT_NEI_DefaultHandler.FixedPositionedStack;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.FontRenderer;
+import net.minecraft.client.gui.inventory.GuiContainer;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
 
 public class GT_NEI_DefaultHandler extends RecipeMapHandler {
 
@@ -754,16 +754,22 @@ public class GT_NEI_DefaultHandler extends RecipeMapHandler {
                             .getItemHandler() == itemOutputsInventory) {
                                 int i = widget.getMcSlot()
                                     .getSlotIndex();
-                                if (aRecipe.mOutputs.length > i && aRecipe.mOutputs[i] != null) {
-                                    mOutputs.add(
+                                Object output = aRecipe.getRepresentativeOutput(i);
+                                
+                                if (output != null) {
+                                	mOutputs.add(
                                         new FixedPositionedStack(
-                                            aRecipe.mOutputs[i],
+                                        	output,
                                             GT_NEI_DefaultHandler.this.mRecipeMap.renderRealStackSizes,
                                             widget.getPos().x + 1,
                                             widget.getPos().y + 1,
                                             aRecipe.getOutputChance(i),
                                             GT_NEI_DefaultHandler.this.mRecipeMap.mNEIUnificateOutput));
-                                }
+                            }
+                                
+                                
+                                    
+                                
                             } else if (widget.getMcSlot()
                                 .getItemHandler() == specialSlotInventory) {
                                     if (aRecipe.mSpecialItems != null) {

--- a/src/main/java/gregtech/nei/GT_NEI_DefaultHandler.java
+++ b/src/main/java/gregtech/nei/GT_NEI_DefaultHandler.java
@@ -61,7 +61,6 @@ import gregtech.api.util.GT_Utility;
 import gregtech.common.blocks.GT_Item_Machines;
 import gregtech.common.gui.modularui.UIHelper;
 import gregtech.common.power.Power;
-import gregtech.nei.GT_NEI_DefaultHandler.FixedPositionedStack;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.inventory.GuiContainer;
@@ -84,7 +83,7 @@ public class GT_NEI_DefaultHandler extends RecipeMapHandler {
      * Static version of {@link TemplateRecipeHandler#cycleticks}. Can be referenced from cached recipes.
      */
     public static int cycleTicksStatic = Math.abs((int) System.currentTimeMillis());
-    /**
+    /**	
      * Basically {@link #cycleTicksStatic} but always updated even while holding shift
      */
     private static int drawTicks;
@@ -754,7 +753,7 @@ public class GT_NEI_DefaultHandler extends RecipeMapHandler {
                             .getItemHandler() == itemOutputsInventory) {
                                 int i = widget.getMcSlot()
                                     .getSlotIndex();
-                                Object output = aRecipe.getRepresentativeOutput(i);
+                                ItemStack output = aRecipe.getRepresentativeOutput(i);
                                 
                                 if (output != null) {
                                 	mOutputs.add(


### PR DESCRIPTION
- Adds a new method, `GT_Recipe#getRepresentativeOutput(int)`, which can be overridden for a greater level of control in displaying items in the output slots of a recipe's NEI page, on a slot-by-slot basis. This is similar in behaviour to the `GT_Recipe#getRepresentativeInput(int)` method. By default, returns only the items in the recipe's output array, as expected.

- Updates the default GT recipe handler to use this new method in finding items to display instead of relying only on the aforementioned output array's contents.