### PR TITLE
Fix recipe check once more

### DIFF
--- a/src/main/java/gregtech/api/util/GT_Recipe.java
+++ b/src/main/java/gregtech/api/util/GT_Recipe.java
@@ -583,11 +583,11 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
     /***
      * Dictates the ItemStacks displayed in the output slots of any NEI page handled by the default GT NEI handler.
      * Override to make shown items differ from a GT_Recipe's item output array
-     * 
+     *
      * @see gregtech.nei.GT_NEI_DefaultHandler
      * @param i Slot index
      * @return ItemStack to be displayed in the slot
-     * 
+     *
      */
     //
     public ItemStack getRepresentativeOutput(int i) {
@@ -802,14 +802,17 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
             }
             for (ItemStack itemStack : aInputs) {
                 if (itemStack == null) continue;
+                ItemStack unifiedStack = GT_OreDictUnificator.get_nocopy(false, itemStack);
+                if (unifiedStack == null) continue;
                 if (isNBTSensitive) {
-                    itemMap.merge(GT_Utility.ItemId.createNoCopy(itemStack), itemStack.stackSize, Integer::sum);
+                    itemMap.merge(GT_Utility.ItemId.createNoCopy(unifiedStack), unifiedStack.stackSize, Integer::sum);
                 } else {
-                    itemMap.merge(GT_Utility.ItemId.createWithoutNBT(itemStack), itemStack.stackSize, Integer::sum);
+                    itemMap
+                        .merge(GT_Utility.ItemId.createWithoutNBT(unifiedStack), unifiedStack.stackSize, Integer::sum);
                 }
                 if (foundWildcard) {
                     itemMapWildcard
-                        .merge(GT_Utility.ItemId.createAsWildcard(itemStack), itemStack.stackSize, Integer::sum);
+                        .merge(GT_Utility.ItemId.createAsWildcard(unifiedStack), unifiedStack.stackSize, Integer::sum);
                 }
             }
             // Check how many parallels can it perform for each item

--- a/src/main/java/gregtech/api/util/GT_Recipe.java
+++ b/src/main/java/gregtech/api/util/GT_Recipe.java
@@ -802,7 +802,7 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
             }
             for (ItemStack itemStack : aInputs) {
                 if (itemStack == null) continue;
-                ItemStack unifiedStack = GT_OreDictUnificator.get_nocopy(false, itemStack);
+                ItemStack unifiedStack = GT_OreDictUnificator.get(false, itemStack, true);
                 if (unifiedStack == null) continue;
                 if (isNBTSensitive) {
                     itemMap.merge(GT_Utility.ItemId.createNoCopy(unifiedStack), unifiedStack.stackSize, Integer::sum);


### PR DESCRIPTION
Follow-up to https://github.com/GTNewHorizons/GT5-Unofficial/pull/2358
Close https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14892

`isRecipeInputEqual` used to check `GT_OreDictUnificator#isInputStackEqual` so that supplied item inputs will be recognized as unificated items. https://github.com/GTNewHorizons/GT5-Unofficial/blob/581d16e61ddd8ed195fa5e6618fe0cea6fdde167/src/main/java/gregtech/api/util/GT_Recipe.java#L722
Now this behavior has been restored. `aUseBlackList` is set to false, as `#isInputStackEqual` eventually checks `ItemData#mUnificationTarget` even if it's blacklisted.