### PR TITLE
Plasma Mixer: only consume power when recipe starts. Fixes #14895.

### DIFF
--- a/src/main/java/gregtech/api/logic/ProcessingLogic.java
+++ b/src/main/java/gregtech/api/logic/ProcessingLogic.java
@@ -378,6 +378,11 @@ public class ProcessingLogic {
         }
         duration = (int) finalDuration;
 
+        CheckRecipeResult hookResult = onRecipeStart(recipe);
+        if (!hookResult.wasSuccessful()) {
+            return hookResult;
+        }
+
         outputItems = helper.getItemOutputs();
         outputFluids = helper.getFluidOutputs();
 
@@ -469,6 +474,19 @@ public class ProcessingLogic {
             .setAmperageOC(amperageOC)
             .setDurationDecreasePerOC(overClockTimeReduction)
             .setEUtIncreasePerOC(overClockPowerIncrease);
+    }
+
+    /**
+     * Override to perform additional logic when recipe starts.
+     *
+     * This is called when the recipe processing logic has finished all
+     * checks, consumed all inputs, but has not yet set the outputs to
+     * be produced. Returning a result other than SUCCESSFUL will void
+     * all inputs!
+     */
+    @Nonnull
+    protected CheckRecipeResult onRecipeStart(@Nonnull GT_Recipe recipe) {
+        return CheckRecipeResultRegistry.SUCCESSFUL;
     }
 
     // endregion


### PR DESCRIPTION
Note this is just a draft, I've not actually tested it yet. I'd like feedback as to whether adding an onRecipeStart hook is the appropriate way to solve this problem or if you'd prefer a different approach.