### PR TITLE
Remove IC2 iridium exploit

### DIFF
--- a/src/main/java/gregtech/api/util/GT_RecipeRegistrator.java
+++ b/src/main/java/gregtech/api/util/GT_RecipeRegistrator.java
@@ -188,11 +188,13 @@ public class GT_RecipeRegistrator {
             aData.mMaterial.mMaterial,
             aData.mMaterial.mAmount,
             true);
-        registerReverseFluidSmelting(
-            GT_Utility.copyAmount(1, aStack),
-            aData.mMaterial.mMaterial,
-            aData.mMaterial.mAmount,
-            aData.getByProduct(0));
+        if (!GT_Utility.areStacksEqual(GT_ModHandler.getIC2Item("iridiumOre", 1L), aStack)) {
+            registerReverseFluidSmelting(
+                GT_Utility.copyAmount(1, aStack),
+                aData.mMaterial.mMaterial,
+                aData.mMaterial.mAmount,
+                aData.getByProduct(0));
+        }
         registerReverseArcSmelting(GT_Utility.copyAmount(1, aStack), aData);
     }
 


### PR DESCRIPTION
fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15104

only the dust recycling remains as we want that one:

![image](https://github.com/GTNewHorizons/GT5-Unofficial/assets/40274384/a439c1e6-bcfd-4171-b1a7-8fa7be85dfd8)
