### PR TITLE
Fix: Show CRIB always in interface terminal

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
@@ -496,7 +496,7 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
 
     @Override
     public boolean shouldDisplay() {
-        return false;
+        return true;
     }
 
     @Override


### PR DESCRIPTION
Closes: GTNewHorizons/GT-New-Horizons-Modpack#15117