### PR TITLE
Allow Oil Cracker to use an Input Bus for programmed circuit automation.

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_OilCracker.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_OilCracker.java
@@ -89,6 +89,7 @@ public class GT_MetaTileEntity_OilCracker extends GT_MetaTileEntity_EnhancedMult
                 .atLeast(
                     GT_HatchElement.InputHatch.withAdder(GT_MetaTileEntity_OilCracker::addMiddleInputToMachineList)
                         .withCount(t -> t.mMiddleInputHatches.size()),
+                    GT_HatchElement.InputBus,
                     GT_HatchElement.Energy,
                     GT_HatchElement.Maintenance)
                 .dot(1)
@@ -137,6 +138,7 @@ public class GT_MetaTileEntity_OilCracker extends GT_MetaTileEntity_EnhancedMult
             .addInputHatch("Any left/right side casing", 2, 3)
             .addOutputHatch("Any right/left side casing", 2, 3)
             .addStructureInfo("Input/Output Hatches must be on opposite sides!")
+            .addInputBus("Any middle ring casing, optional for programmed circuit automation")
             .addStructureHint("GT5U.cracker.io_side")
             .toolTipFinisher("Gregtech");
         return tt;

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_OilCracker.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_OilCracker.java
@@ -125,7 +125,7 @@ public class GT_MetaTileEntity_OilCracker extends GT_MetaTileEntity_EnhancedMult
             .addInfo("Hydro - Consumes 20% less Hydrogen and outputs 25% more cracked fluid")
             .addInfo("Steam - Outputs 50% more cracked fluid")
             .addInfo("(Values compared to cracking in the Chemical Reactor)")
-            .addInfo("Place the appropriate circuit in the controller")
+            .addInfo("Place the appropriate circuit in the controller or an input bus")
             .addSeparator()
             .beginStructureBlock(5, 3, 3, true)
             .addController("Front center")


### PR DESCRIPTION
This allows the Oil Cracker to use an input bus in the structure. The bus must replace one of the casings in the middle ring.

While no Oil Cracker recipes currently take any input items, this allows the player to place multiple different programmed circuits into the bus, and run different recipes with the same cracker without manually changing the circuit in the controller. While this does not make sense for regular oil byproduct cracking, several ore processing lines use oil cracker recipes with different circuits that can be run in the same machine without conflicts.

This also opens the door for future automation setups, for example using a Stocking Bus to change the circuit used automatically.

See https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14795 for a discussion, which this PR resolves.

An associated PR implementing the same change for the Mega Oil Cracker is here: https://github.com/GTNewHorizons/bartworks/pull/382