### PR TITLE
Allow a soldering iron to use soldering material from an IC2 Tool Box.

### DIFF
--- a/src/main/java/gregtech/api/util/GT_LanguageManager.java
+++ b/src/main/java/gregtech/api/util/GT_LanguageManager.java
@@ -249,6 +249,7 @@ public class GT_LanguageManager {
         addStringLocalization("Interaction_DESCRIPTION_Index_092", " set to: ");
         addStringLocalization("Interaction_DESCRIPTION_Index_093", "Strong");
         addStringLocalization("Interaction_DESCRIPTION_Index_094", "Weak");
+        addStringLocalization("Interaction_DESCRIPTION_Index_094.1", "Not enough soldering material!");
         addStringLocalization("Interaction_DESCRIPTION_Index_095", "Input from Output Side allowed");
         addStringLocalization("Interaction_DESCRIPTION_Index_096", "Input from Output Side forbidden");
         addStringLocalization("Interaction_DESCRIPTION_Index_098", "Do not regulate Item Stack Size");

--- a/src/main/java/gregtech/api/util/GT_ModHandler.java
+++ b/src/main/java/gregtech/api/util/GT_ModHandler.java
@@ -81,6 +81,7 @@ import ic2.api.reactor.IReactorComponent;
 import ic2.api.recipe.IRecipeInput;
 import ic2.api.recipe.RecipeInputItemStack;
 import ic2.api.recipe.RecipeOutput;
+import ic2.core.item.ItemToolbox;
 
 /**
  * NEVER INCLUDE THIS FILE IN YOUR MOD!!!
@@ -2290,11 +2291,25 @@ public class GT_ModHandler {
 
     public static boolean consumeSolderingMaterial(EntityPlayer aPlayer) {
         if (aPlayer.capabilities.isCreativeMode) return true;
-        if (consumeSolderingMaterial(aPlayer.inventory)) {
+        IInventory tInventory = aPlayer.inventory;
+        if (consumeSolderingMaterial(tInventory)) {
             if (aPlayer.inventoryContainer != null) {
                 aPlayer.inventoryContainer.detectAndSendChanges();
             }
             return true;
+        }
+        for (int i = 0; i < tInventory.getSizeInventory(); i++) {
+            ItemStack tStack = tInventory.getStackInSlot(i);
+            if (tStack != null && tStack.getItem() instanceof ItemToolbox) {
+                IInventory tToolboxInventory = ((ItemToolbox) tStack.getItem()).getInventory(aPlayer, tStack);
+                if (consumeSolderingMaterial(tToolboxInventory)) {
+                    tInventory.markDirty();
+                    if (aPlayer.inventoryContainer != null) {
+                        aPlayer.inventoryContainer.detectAndSendChanges();
+                    }
+                    return true;
+                }
+            }
         }
         return false;
     }

--- a/src/main/java/gregtech/api/util/GT_ModHandler.java
+++ b/src/main/java/gregtech/api/util/GT_ModHandler.java
@@ -2311,6 +2311,7 @@ public class GT_ModHandler {
                 }
             }
         }
+        GT_Utility.sendChatToPlayer(aPlayer, GT_Utility.trans("094.1", "Not enough soldering material!"));
         return false;
     }
 


### PR DESCRIPTION
When using a soldering iron to configure machines or maintain multiblocks, the soldering wire can now be used directly from a Tool Box, without the player having to manually move the wire to their inventory.

Currently only the IC2 Tool Box is supported; I could add other backpack-like inventories, but I think restricting it only to the tool box fits the theme.

This also adds an error message in chat if no soldering wire is found.