### PR TITLE
Rework item renderers

### DIFF
--- a/src/main/java/gregtech/common/render/GT_MetaGenerated_Tool_Renderer.java
+++ b/src/main/java/gregtech/common/render/GT_MetaGenerated_Tool_Renderer.java
@@ -1,9 +1,6 @@
 package gregtech.common.render;
 
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.ItemRenderer;
-import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.entity.RenderItem;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
 import net.minecraftforge.client.IItemRenderer;
@@ -13,10 +10,10 @@ import org.lwjgl.opengl.GL11;
 
 import gregtech.GT_Mod;
 import gregtech.api.enums.Materials;
+import gregtech.api.enums.Textures;
 import gregtech.api.interfaces.IIconContainer;
 import gregtech.api.interfaces.IToolStats;
 import gregtech.api.items.GT_MetaGenerated_Tool;
-import gregtech.api.util.GT_Utility;
 
 public class GT_MetaGenerated_Tool_Renderer implements IItemRenderer {
 
@@ -29,190 +26,105 @@ public class GT_MetaGenerated_Tool_Renderer implements IItemRenderer {
     }
 
     @Override
-    public boolean handleRenderType(ItemStack aStack, IItemRenderer.ItemRenderType aType) {
-        if ((GT_Utility.isStackInvalid(aStack)) || (aStack.getItemDamage() < 0)) {
-            return false;
-        }
-        return (aType == IItemRenderer.ItemRenderType.EQUIPPED_FIRST_PERSON)
-            || (aType == IItemRenderer.ItemRenderType.INVENTORY)
-            || (aType == IItemRenderer.ItemRenderType.EQUIPPED)
-            || (aType == IItemRenderer.ItemRenderType.ENTITY);
+    public boolean handleRenderType(ItemStack stack, ItemRenderType type) {
+        return (type == ItemRenderType.EQUIPPED_FIRST_PERSON) || (type == ItemRenderType.INVENTORY)
+            || (type == ItemRenderType.EQUIPPED)
+            || (type == ItemRenderType.ENTITY);
     }
 
     @Override
-    public boolean shouldUseRenderHelper(IItemRenderer.ItemRenderType aType, ItemStack aStack,
-        IItemRenderer.ItemRendererHelper aHelper) {
-        if (GT_Utility.isStackInvalid(aStack)) {
-            return false;
-        }
-        return aType == IItemRenderer.ItemRenderType.ENTITY;
+    public boolean shouldUseRenderHelper(ItemRenderType type, ItemStack stack, ItemRendererHelper helper) {
+        return type == ItemRenderType.ENTITY && helper == ItemRendererHelper.ENTITY_BOBBING
+            || (helper == ItemRendererHelper.ENTITY_ROTATION && Minecraft.getMinecraft().gameSettings.fancyGraphics);
     }
 
     @Override
-    public void renderItem(IItemRenderer.ItemRenderType aType, ItemStack aStack, Object... data) {
-        if (GT_Utility.isStackInvalid(aStack)) {
-            return;
-        }
-        GT_MetaGenerated_Tool aItem = (GT_MetaGenerated_Tool) aStack.getItem();
+    public void renderItem(ItemRenderType type, ItemStack stack, Object... data) {
+        GT_MetaGenerated_Tool item = (GT_MetaGenerated_Tool) stack.getItem();
         GL11.glEnable(GL11.GL_BLEND);
-        if (aType == IItemRenderer.ItemRenderType.ENTITY) {
-            if (RenderItem.renderInFrame) {
-                GL11.glScalef(0.85F, 0.85F, 0.85F);
-                GL11.glRotatef(-90.0F, 0.0F, 1.0F, 0.0F);
-                GL11.glTranslated(-0.5D, -0.42D, 0.0D);
-            } else {
-                GL11.glTranslated(-0.5D, -0.42D, 0.0D);
-            }
-        }
+        GT_RenderUtil.applyStandardItemTransform(type);
         GL11.glColor3f(1.0F, 1.0F, 1.0F);
 
-        IToolStats tToolStats = aItem.getToolStats(aStack);
-        if (tToolStats != null) {
-            IIconContainer aIcon = tToolStats.getIcon(false, aStack);
-            if (aIcon != null) {
-                IIcon tIcon = aIcon.getIcon();
-                IIcon tOverlay = aIcon.getOverlayIcon();
-                if (tIcon != null) {
-                    Minecraft.getMinecraft().renderEngine.bindTexture(aIcon.getTextureFile());
-                    GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
-                    short[] tModulation = tToolStats.getRGBa(false, aStack);
-                    GL11.glColor3f(tModulation[0] / 255.0F, tModulation[1] / 255.0F, tModulation[2] / 255.0F);
-                    if (aType.equals(IItemRenderer.ItemRenderType.INVENTORY)) {
-                        GT_RenderUtil.renderItemIcon(tIcon, 16.0D, 0.001D, 0.0F, 0.0F, -1.0F);
-                    } else {
-                        ItemRenderer.renderItemIn2D(
-                            Tessellator.instance,
-                            tIcon.getMaxU(),
-                            tIcon.getMinV(),
-                            tIcon.getMinU(),
-                            tIcon.getMaxV(),
-                            tIcon.getIconWidth(),
-                            tIcon.getIconHeight(),
-                            0.0625F);
-                    }
-                    GL11.glColor3f(1.0F, 1.0F, 1.0F);
-                }
-                if (tOverlay != null) {
-                    Minecraft.getMinecraft().renderEngine.bindTexture(aIcon.getTextureFile());
-                    GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
-                    if (aType.equals(IItemRenderer.ItemRenderType.INVENTORY)) {
-                        GT_RenderUtil.renderItemIcon(tOverlay, 16.0D, 0.001D, 0.0F, 0.0F, -1.0F);
-                    } else {
-                        ItemRenderer.renderItemIn2D(
-                            Tessellator.instance,
-                            tOverlay.getMaxU(),
-                            tOverlay.getMinV(),
-                            tOverlay.getMinU(),
-                            tOverlay.getMaxV(),
-                            tOverlay.getIconWidth(),
-                            tOverlay.getIconHeight(),
-                            0.0625F);
-                    }
-                }
-            }
-            aIcon = tToolStats.getIcon(true, aStack);
-            if (aIcon != null) {
-                IIcon tIcon = aIcon.getIcon();
-                IIcon tOverlay = aIcon.getOverlayIcon();
-                if (tIcon != null) {
-                    Minecraft.getMinecraft().renderEngine.bindTexture(aIcon.getTextureFile());
-                    GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
-                    short[] tModulation = tToolStats.getRGBa(true, aStack);
-                    GL11.glColor3f(tModulation[0] / 255.0F, tModulation[1] / 255.0F, tModulation[2] / 255.0F);
-                    if (aType.equals(IItemRenderer.ItemRenderType.INVENTORY)) {
-                        GT_RenderUtil.renderItemIcon(tIcon, 16.0D, 0.001D, 0.0F, 0.0F, -1.0F);
-                    } else {
-                        ItemRenderer.renderItemIn2D(
-                            Tessellator.instance,
-                            tIcon.getMaxU(),
-                            tIcon.getMinV(),
-                            tIcon.getMinU(),
-                            tIcon.getMaxV(),
-                            tIcon.getIconWidth(),
-                            tIcon.getIconHeight(),
-                            0.0625F);
-                    }
-                    GL11.glColor3f(1.0F, 1.0F, 1.0F);
-                }
-                if (tOverlay != null) {
-                    Minecraft.getMinecraft().renderEngine.bindTexture(aIcon.getTextureFile());
-                    GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
-                    if (aType.equals(IItemRenderer.ItemRenderType.INVENTORY)) {
-                        GT_RenderUtil.renderItemIcon(tOverlay, 16.0D, 0.001D, 0.0F, 0.0F, -1.0F);
-                    } else {
-                        ItemRenderer.renderItemIn2D(
-                            Tessellator.instance,
-                            tOverlay.getMaxU(),
-                            tOverlay.getMinV(),
-                            tOverlay.getMinU(),
-                            tOverlay.getMaxV(),
-                            tOverlay.getIconWidth(),
-                            tOverlay.getIconHeight(),
-                            0.0625F);
-                    }
-                }
-            }
-            if ((aType == IItemRenderer.ItemRenderType.INVENTORY)
-                && (GT_MetaGenerated_Tool.getPrimaryMaterial(aStack) != Materials._NULL)) {
+        IToolStats toolStats = item != null ? item.getToolStats(stack) : null;
+        if (toolStats != null) {
+            renderToolPart(type, stack, toolStats, false);
+            renderToolPart(type, stack, toolStats, true);
+
+            if ((type == ItemRenderType.INVENTORY)
+                && (GT_MetaGenerated_Tool.getPrimaryMaterial(stack) != Materials._NULL)) {
                 if (GT_Mod.gregtechproxy.mRenderItemDurabilityBar) {
-                    long tDamage = GT_MetaGenerated_Tool.getToolDamage(aStack);
-                    long tMaxDamage = GT_MetaGenerated_Tool.getToolMaxDamage(aStack);
-                    if (tDamage <= 0L) {
-                        aIcon = gregtech.api.enums.Textures.ItemIcons.DURABILITY_BAR[8];
-                    } else if (tDamage >= tMaxDamage) {
-                        aIcon = gregtech.api.enums.Textures.ItemIcons.DURABILITY_BAR[0];
+                    IIconContainer iconContainer;
+                    long damage = GT_MetaGenerated_Tool.getToolDamage(stack);
+                    long maxDamage = GT_MetaGenerated_Tool.getToolMaxDamage(stack);
+                    if (damage <= 0L) {
+                        iconContainer = Textures.ItemIcons.DURABILITY_BAR[8];
+                    } else if (damage >= maxDamage) {
+                        iconContainer = Textures.ItemIcons.DURABILITY_BAR[0];
                     } else {
-                        aIcon = gregtech.api.enums.Textures.ItemIcons.DURABILITY_BAR[((int) java.lang.Math
-                            .max(0L, java.lang.Math.min(7L, (tMaxDamage - tDamage) * 8L / tMaxDamage)))];
+                        iconContainer = Textures.ItemIcons.DURABILITY_BAR[((int) Math
+                            .max(0L, Math.min(7L, (maxDamage - damage) * 8L / maxDamage)))];
                     }
-                    if (aIcon != null) {
-                        IIcon tIcon = aIcon.getIcon();
-                        IIcon tOverlay = aIcon.getOverlayIcon();
-                        if (tIcon != null) {
-                            Minecraft.getMinecraft().renderEngine.bindTexture(aIcon.getTextureFile());
-                            GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
-                            GT_RenderUtil.renderItemIcon(tIcon, 16.0D, 0.001D, 0.0F, 0.0F, -1.0F);
-                        }
-                        if (tOverlay != null) {
-                            Minecraft.getMinecraft().renderEngine.bindTexture(aIcon.getTextureFile());
-                            GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
-                            GT_RenderUtil.renderItemIcon(tOverlay, 16.0D, 0.001D, 0.0F, 0.0F, -1.0F);
-                        }
-                    }
+                    renderIcon(iconContainer);
                 }
 
                 if (GT_Mod.gregtechproxy.mRenderItemChargeBar) {
-                    Long[] tStats = aItem.getElectricStats(aStack);
-                    if ((tStats != null) && (tStats[3] < 0L)) {
-                        long tCharge = aItem.getRealCharge(aStack);
+                    IIconContainer iconContainer;
+                    Long[] stats = item.getElectricStats(stack);
+                    if ((stats != null) && (stats[3] < 0L)) {
+                        long tCharge = item.getRealCharge(stack);
                         if (tCharge <= 0L) {
-                            aIcon = gregtech.api.enums.Textures.ItemIcons.ENERGY_BAR[0];
-                        } else if (tCharge >= tStats[0]) {
-                            aIcon = gregtech.api.enums.Textures.ItemIcons.ENERGY_BAR[8];
+                            iconContainer = Textures.ItemIcons.ENERGY_BAR[0];
+                        } else if (tCharge >= stats[0]) {
+                            iconContainer = Textures.ItemIcons.ENERGY_BAR[8];
                         } else {
-                            aIcon = gregtech.api.enums.Textures.ItemIcons.ENERGY_BAR[(7 - (int) java.lang.Math
-                                .max(0L, java.lang.Math.min(6L, (tStats[0] - tCharge) * 7L / tStats[0])))];
+                            iconContainer = Textures.ItemIcons.ENERGY_BAR[(7
+                                - (int) Math.max(0L, Math.min(6L, (stats[0] - tCharge) * 7L / stats[0])))];
                         }
                     } else {
-                        aIcon = null;
+                        iconContainer = null;
                     }
-                    if (aIcon != null) {
-                        IIcon tIcon = aIcon.getIcon();
-                        IIcon tOverlay = aIcon.getOverlayIcon();
-                        if (tIcon != null) {
-                            Minecraft.getMinecraft().renderEngine.bindTexture(aIcon.getTextureFile());
-                            GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
-                            GT_RenderUtil.renderItemIcon(tIcon, 16.0D, 0.001D, 0.0F, 0.0F, -1.0F);
-                        }
-                        if (tOverlay != null) {
-                            Minecraft.getMinecraft().renderEngine.bindTexture(aIcon.getTextureFile());
-                            GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
-                            GT_RenderUtil.renderItemIcon(tOverlay, 16.0D, 0.001D, 0.0F, 0.0F, -1.0F);
-                        }
-                    }
+                    renderIcon(iconContainer);
                 }
             }
         }
         GL11.glDisable(GL11.GL_BLEND);
+    }
+
+    private void renderIcon(IIconContainer iconContainer) {
+        if (iconContainer != null) {
+            IIcon icon = iconContainer.getIcon();
+            IIcon overlay = iconContainer.getOverlayIcon();
+            if (icon != null) {
+                Minecraft.getMinecraft().renderEngine.bindTexture(iconContainer.getTextureFile());
+                GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
+                GT_RenderUtil.renderItemIcon(icon, 16.0D, 0.001D, 0.0F, 0.0F, -1.0F);
+            }
+            if (overlay != null) {
+                Minecraft.getMinecraft().renderEngine.bindTexture(iconContainer.getTextureFile());
+                GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
+                GT_RenderUtil.renderItemIcon(overlay, 16.0D, 0.001D, 0.0F, 0.0F, -1.0F);
+            }
+        }
+    }
+
+    private static void renderToolPart(ItemRenderType type, ItemStack stack, IToolStats toolStats, boolean isToolHead) {
+        IIconContainer iconContainer = toolStats.getIcon(isToolHead, stack);
+        if (iconContainer != null) {
+            IIcon icon = iconContainer.getIcon();
+            IIcon overlay = iconContainer.getOverlayIcon();
+            if (icon != null) {
+                Minecraft.getMinecraft().renderEngine.bindTexture(iconContainer.getTextureFile());
+                GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
+                short[] modulation = toolStats.getRGBa(isToolHead, stack);
+                GL11.glColor3f(modulation[0] / 255.0F, modulation[1] / 255.0F, modulation[2] / 255.0F);
+                GT_RenderUtil.renderItem(type, icon);
+                GL11.glColor3f(1.0F, 1.0F, 1.0F);
+            }
+            if (overlay != null) {
+                Minecraft.getMinecraft().renderEngine.bindTexture(iconContainer.getTextureFile());
+                GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
+                GT_RenderUtil.renderItem(type, overlay);
+            }
+        }
     }
 }

--- a/src/main/java/gregtech/common/render/GT_RenderUtil.java
+++ b/src/main/java/gregtech/common/render/GT_RenderUtil.java
@@ -1,10 +1,15 @@
 package gregtech.common.render;
 
 import net.minecraft.block.Block;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.ItemRenderer;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.client.renderer.entity.RenderItem;
+import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
+import net.minecraftforge.client.IItemRenderer;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import org.lwjgl.opengl.GL11;
@@ -58,5 +63,79 @@ public class GT_RenderUtil {
             Tessellator.instance.addVertexWithUV(xStart, yStart, z, icon.getMinU(), icon.getMinV());
         }
         Tessellator.instance.draw();
+    }
+
+    @SuppressWarnings("RedundantLabeledSwitchRuleCodeBlock")
+    public static void renderItem(IItemRenderer.ItemRenderType type, IIcon icon) {
+        Tessellator tessellator = Tessellator.instance;
+        float maxU = icon.getMaxU();
+        float minV = icon.getMinV();
+        float minU = icon.getMinU();
+        float maxV = icon.getMaxV();
+
+        switch (type) {
+            case ENTITY -> {
+                if (Minecraft.getMinecraft().gameSettings.fancyGraphics) {
+                    ItemRenderer.renderItemIn2D(
+                        tessellator,
+                        maxU,
+                        minV,
+                        minU,
+                        maxV,
+                        icon.getIconWidth(),
+                        icon.getIconHeight(),
+                        0.0625F);
+                } else {
+                    GL11.glPushMatrix();
+
+                    if (!RenderItem.renderInFrame) {
+                        GL11.glRotatef(180.0F - RenderManager.instance.playerViewY, 0.0F, 1.0F, 0.0F);
+                    }
+
+                    tessellator.startDrawingQuads();
+                    tessellator.setNormal(0.0F, 1.0F, 0.0F);
+                    tessellator.addVertexWithUV(0.0F - 0.5F, 0.0F - 0.25F, 0.0D, minU, maxV);
+                    tessellator.addVertexWithUV(1.0F - 0.5F, 0.0F - 0.25F, 0.0D, maxU, maxV);
+                    tessellator.addVertexWithUV(1.0F - 0.5F, 1.0F - 0.25F, 0.0D, maxU, minV);
+                    tessellator.addVertexWithUV(0.0F - 0.5F, 1.0F - 0.25F, 0.0D, minU, minV);
+                    tessellator.draw();
+
+                    GL11.glPopMatrix();
+                }
+            }
+            case EQUIPPED, EQUIPPED_FIRST_PERSON -> {
+                ItemRenderer.renderItemIn2D(
+                    tessellator,
+                    maxU,
+                    minV,
+                    minU,
+                    maxV,
+                    icon.getIconWidth(),
+                    icon.getIconHeight(),
+                    0.0625F);
+            }
+            case INVENTORY -> {
+                renderItemIcon(icon, 16.0D, 0.001, 0.0F, 0.0F, -1.0F);
+            }
+            default -> {}
+        }
+    }
+
+    public static void applyStandardItemTransform(IItemRenderer.ItemRenderType type) {
+        if (type == IItemRenderer.ItemRenderType.ENTITY) {
+            if (RenderItem.renderInFrame) {
+                // Magic numbers calculated from vanilla code
+                GL11.glScalef(1.025641F, 1.025641F, 1.025641F);
+                GL11.glTranslatef(0.0F, -0.05F, 0.0F);
+            }
+
+            if (Minecraft.getMinecraft().gameSettings.fancyGraphics) {
+                if (RenderItem.renderInFrame) {
+                    GL11.glRotatef(180.0F, 0.0F, 1.0F, 0.0F);
+                }
+                // Magic numbers calculated from vanilla code
+                GL11.glTranslatef(-0.5F, -0.25F, 0.0421875F);
+            }
+        }
     }
 }

--- a/src/main/java/gregtech/common/render/items/CosmicNeutroniumRenderer.java
+++ b/src/main/java/gregtech/common/render/items/CosmicNeutroniumRenderer.java
@@ -2,7 +2,6 @@ package gregtech.common.render.items;
 
 import static gregtech.common.render.GT_RenderUtil.colorGTItem;
 
-import net.minecraft.client.renderer.ItemRenderer;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.entity.RenderItem;
 import net.minecraft.item.ItemStack;
@@ -26,6 +25,7 @@ public class CosmicNeutroniumRenderer extends GT_GeneratedMaterial_Renderer {
     private static final Pos2d point3 = new Pos2d(0  - 10, 17 + 10);
     // spotless:on
 
+    // TODO: Render halo outside of inventory.
     private void drawHalo(ItemRenderType type) {
         // Because when this class is instantiated, making this a static field will cause it to set to null.
         final IIcon haloFuzzy = Textures.ItemIcons.HALO_FUZZY.getIcon();
@@ -93,15 +93,7 @@ public class CosmicNeutroniumRenderer extends GT_GeneratedMaterial_Renderer {
                 GT_RenderUtil.renderItemIcon(icon, 16.0D, 0.001D, 0.0F, 0.0F, -1.0F);
             } else {
                 GL11.glEnable(GL11.GL_DEPTH_TEST);
-                ItemRenderer.renderItemIn2D(
-                    Tessellator.instance,
-                    icon.getMaxU(),
-                    icon.getMinV(),
-                    icon.getMinU(),
-                    icon.getMaxV(),
-                    icon.getIconWidth(),
-                    icon.getIconHeight(),
-                    0.0625F);
+                GT_RenderUtil.renderItem(type, icon);
             }
             GL11.glPopMatrix();
         }

--- a/src/main/java/gregtech/common/render/items/GT_GeneratedItem_Renderer.java
+++ b/src/main/java/gregtech/common/render/items/GT_GeneratedItem_Renderer.java
@@ -14,8 +14,6 @@ import static gregtech.api.enums.Mods.HodgePodge;
 import javax.annotation.Nullable;
 
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.ItemRenderer;
-import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.texture.TextureMap;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
@@ -44,7 +42,8 @@ public class GT_GeneratedItem_Renderer implements IItemRenderer {
 
     @Override
     public boolean shouldUseRenderHelper(ItemRenderType type, ItemStack item, ItemRendererHelper helper) {
-        return type == ItemRenderType.ENTITY;
+        return type == ItemRenderType.ENTITY && helper == ItemRendererHelper.ENTITY_BOBBING
+            || (helper == ItemRendererHelper.ENTITY_ROTATION && Minecraft.getMinecraft().gameSettings.fancyGraphics);
     }
 
     @Override
@@ -90,19 +89,7 @@ public class GT_GeneratedItem_Renderer implements IItemRenderer {
 
         Minecraft.getMinecraft().renderEngine.bindTexture(TextureMap.locationItemsTexture);
         GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
-        if (type.equals(IItemRenderer.ItemRenderType.INVENTORY)) {
-            GT_RenderUtil.renderItemIcon(tIcon, 16.0D, 0.001D, 0.0F, 0.0F, -1.0F);
-        } else {
-            ItemRenderer.renderItemIn2D(
-                Tessellator.instance,
-                tIcon.getMaxU(),
-                tIcon.getMinV(),
-                tIcon.getMinU(),
-                tIcon.getMaxV(),
-                tIcon.getIconWidth(),
-                tIcon.getIconHeight(),
-                0.0625F);
-        }
+        GT_RenderUtil.renderItem(type, tIcon);
         GL11.glDisable(GL11.GL_BLEND);
     }
 
@@ -137,18 +124,10 @@ public class GT_GeneratedItem_Renderer implements IItemRenderer {
         // Empty inner side
         Minecraft.getMinecraft().renderEngine.bindTexture(TextureMap.locationItemsTexture);
         markNeedsAnimationUpdate(inner);
-        if (type.equals(ItemRenderType.INVENTORY)) {
+        if (type == ItemRenderType.INVENTORY) {
             GT_RenderUtil.renderItemIcon(inner, 16.0D, -0.001D, 0.0F, 0.0F, -1.0F);
         } else {
-            ItemRenderer.renderItemIn2D(
-                Tessellator.instance,
-                inner.getMaxU(),
-                inner.getMinV(),
-                inner.getMinU(),
-                inner.getMaxV(),
-                inner.getIconWidth(),
-                inner.getIconHeight(),
-                0.0625F);
+            GT_RenderUtil.renderItem(type, inner);
         }
 
         FluidStack fluidStack = GT_Utility.getFluidForFilledItem(stack, true);
@@ -167,18 +146,10 @@ public class GT_GeneratedItem_Renderer implements IItemRenderer {
             GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
             GL11.glDepthFunc(GL11.GL_EQUAL);
             GL11.glColor3ub((byte) (fluidColor >> 16), (byte) (fluidColor >> 8), (byte) fluidColor);
-            if (type.equals(ItemRenderType.INVENTORY)) {
-                GT_RenderUtil.renderItemIcon(fluidIcon, 16.0D, -0.001D, 0.0F, 0.0F, -1.0F);
+            if (type == ItemRenderType.INVENTORY) {
+                GT_RenderUtil.renderItemIcon(inner, 16.0D, -0.001D, 0.0F, 0.0F, -1.0F);
             } else {
-                ItemRenderer.renderItemIn2D(
-                    Tessellator.instance,
-                    fluidIcon.getMaxU(),
-                    fluidIcon.getMinV(),
-                    fluidIcon.getMinU(),
-                    fluidIcon.getMaxV(),
-                    fluidIcon.getIconWidth(),
-                    fluidIcon.getIconHeight(),
-                    0.0625F);
+                GT_RenderUtil.renderItem(type, inner);
             }
 
             GL11.glColor3ub((byte) -1, (byte) -1, (byte) -1);

--- a/src/main/java/gregtech/common/render/items/GT_GeneratedMaterial_Renderer.java
+++ b/src/main/java/gregtech/common/render/items/GT_GeneratedMaterial_Renderer.java
@@ -2,8 +2,7 @@ package gregtech.common.render.items;
 
 import static gregtech.api.enums.Mods.HodgePodge;
 
-import net.minecraft.client.renderer.ItemRenderer;
-import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.client.Minecraft;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
 import net.minecraftforge.client.IItemRenderer;
@@ -30,7 +29,8 @@ public class GT_GeneratedMaterial_Renderer implements IItemRenderer {
 
     @Override
     public boolean shouldUseRenderHelper(ItemRenderType type, ItemStack item, ItemRendererHelper helper) {
-        return type == ItemRenderType.ENTITY;
+        return type == ItemRenderType.ENTITY && helper == ItemRendererHelper.ENTITY_BOBBING
+            || (helper == ItemRendererHelper.ENTITY_ROTATION && Minecraft.getMinecraft().gameSettings.fancyGraphics);
     }
 
     /**
@@ -104,19 +104,7 @@ public class GT_GeneratedMaterial_Renderer implements IItemRenderer {
             GL11.glColor3f(tModulation[0] / 255.0F, tModulation[1] / 255.0F, tModulation[2] / 255.0F);
         }
 
-        if (type.equals(IItemRenderer.ItemRenderType.INVENTORY)) {
-            GT_RenderUtil.renderItemIcon(icon, 16.0D, 0.001D, 0.0F, 0.0F, -1.0F);
-        } else {
-            ItemRenderer.renderItemIn2D(
-                Tessellator.instance,
-                icon.getMaxU(),
-                icon.getMinV(),
-                icon.getMinU(),
-                icon.getMaxV(),
-                icon.getIconWidth(),
-                icon.getIconHeight(),
-                0.0625F);
-        }
+        GT_RenderUtil.renderItem(type, icon);
     }
 
     protected void renderContainedFluid(ItemRenderType type, FluidStack aFluidStack, IIcon fluidIcon) {
@@ -126,36 +114,12 @@ public class GT_GeneratedMaterial_Renderer implements IItemRenderer {
         TextureUtils.bindAtlas(aFluid.getSpriteNumber());
 
         GL11.glDepthFunc(GL11.GL_EQUAL);
-        if (type.equals(IItemRenderer.ItemRenderType.INVENTORY)) {
-            GT_RenderUtil.renderItemIcon(fluidIcon, 16.0D, 0.001D, 0.0F, 0.0F, -1.0F);
-        } else {
-            ItemRenderer.renderItemIn2D(
-                Tessellator.instance,
-                fluidIcon.getMaxU(),
-                fluidIcon.getMinV(),
-                fluidIcon.getMinU(),
-                fluidIcon.getMaxV(),
-                fluidIcon.getIconWidth(),
-                fluidIcon.getIconHeight(),
-                0.0625F);
-        }
+        GT_RenderUtil.renderItem(type, fluidIcon);
         GL11.glDepthFunc(GL11.GL_LEQUAL);
     }
 
     protected void renderItemOverlay(ItemRenderType type, IIcon overlay) {
-        if (type.equals(IItemRenderer.ItemRenderType.INVENTORY)) {
-            GT_RenderUtil.renderItemIcon(overlay, 16.0D, 0.001D, 0.0F, 0.0F, -1.0F);
-        } else {
-            ItemRenderer.renderItemIn2D(
-                Tessellator.instance,
-                overlay.getMaxU(),
-                overlay.getMinV(),
-                overlay.getMinU(),
-                overlay.getMaxV(),
-                overlay.getIconWidth(),
-                overlay.getIconHeight(),
-                0.0625F);
-        }
+        GT_RenderUtil.renderItem(type, overlay);
     }
 
     protected void markNeedsAnimationUpdate(IIcon icon) {

--- a/src/main/java/gregtech/common/render/items/GT_MetaGenerated_Item_Renderer.java
+++ b/src/main/java/gregtech/common/render/items/GT_MetaGenerated_Item_Renderer.java
@@ -1,12 +1,9 @@
 package gregtech.common.render.items;
 
-import net.minecraft.client.renderer.entity.RenderItem;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.client.IItemRenderer;
 import net.minecraftforge.client.MinecraftForgeClient;
-
-import org.lwjgl.opengl.GL11;
 
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
@@ -14,6 +11,7 @@ import gregtech.api.interfaces.IGT_ItemWithMaterialRenderer;
 import gregtech.api.objects.ItemData;
 import gregtech.api.util.GT_OreDictUnificator;
 import gregtech.api.util.GT_Utility;
+import gregtech.common.render.GT_RenderUtil;
 
 public class GT_MetaGenerated_Item_Renderer implements IItemRenderer {
 
@@ -48,15 +46,7 @@ public class GT_MetaGenerated_Item_Renderer implements IItemRenderer {
 
     @Override
     public void renderItem(ItemRenderType type, ItemStack aStack, Object... data) {
-        if (type == IItemRenderer.ItemRenderType.ENTITY) {
-            if (RenderItem.renderInFrame) {
-                GL11.glScalef(0.85F, 0.85F, 0.85F);
-                GL11.glRotatef(-90.0F, 0.0F, 1.0F, 0.0F);
-                GL11.glTranslated(-0.5D, -0.42D, 0.0D);
-            } else {
-                GL11.glTranslated(-0.5D, -0.42D, 0.0D);
-            }
-        }
+        GT_RenderUtil.applyStandardItemTransform(type);
 
         IItemRenderer itemRenderer = getRendererForItemStack(aStack);
         itemRenderer.renderItem(type, aStack, data);

--- a/src/main/java/gregtech/common/render/items/GaiaSpiritRenderer.java
+++ b/src/main/java/gregtech/common/render/items/GaiaSpiritRenderer.java
@@ -2,8 +2,6 @@ package gregtech.common.render.items;
 
 import java.awt.Color;
 
-import net.minecraft.client.renderer.ItemRenderer;
-import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
 
@@ -24,18 +22,6 @@ public class GaiaSpiritRenderer extends GT_GeneratedMaterial_Renderer {
             GL11.glColor3f(color.getRed() / 255.0F, color.getGreen() / 255.0F, color.getBlue() / 255.0F);
         }
 
-        if (type.equals(ItemRenderType.INVENTORY)) {
-            GT_RenderUtil.renderItemIcon(icon, 16.0D, 0.001D, 0.0F, 0.0F, -1.0F);
-        } else {
-            ItemRenderer.renderItemIn2D(
-                Tessellator.instance,
-                icon.getMaxU(),
-                icon.getMinV(),
-                icon.getMinU(),
-                icon.getMaxV(),
-                icon.getIconWidth(),
-                icon.getIconHeight(),
-                0.0625F);
-        }
+        GT_RenderUtil.renderItem(type, icon);
     }
 }

--- a/src/main/java/gregtech/common/render/items/InfinityRenderer.java
+++ b/src/main/java/gregtech/common/render/items/InfinityRenderer.java
@@ -14,6 +14,8 @@ import gregtech.api.enums.Textures;
 import gregtech.api.interfaces.IGT_ItemWithMaterialRenderer;
 import gregtech.api.util.GT_Utility;
 
+// TODO: Render effects outside inventory.
+
 public class InfinityRenderer extends GT_GeneratedMaterial_Renderer {
 
     public Random rand = new Random();

--- a/src/main/java/gregtech/common/render/items/TranscendentMetalRenderer.java
+++ b/src/main/java/gregtech/common/render/items/TranscendentMetalRenderer.java
@@ -1,7 +1,9 @@
 package gregtech.common.render.items;
 
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.ItemRenderer;
 import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.client.renderer.entity.RenderItem;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
 import net.minecraftforge.client.IItemRenderer;
@@ -16,6 +18,21 @@ import gregtech.api.interfaces.IGT_ItemWithMaterialRenderer;
 import gregtech.api.util.GT_Util;
 
 public class TranscendentMetalRenderer extends GT_GeneratedMaterial_Renderer {
+
+    @Override
+    public void renderItem(ItemRenderType type, ItemStack aStack, Object... data) {
+        if (type == ItemRenderType.ENTITY) {
+            // Pretend fancy graphics is enabled
+            if (!Minecraft.getMinecraft().gameSettings.fancyGraphics) {
+                if (RenderItem.renderInFrame) {
+                    GL11.glRotatef(180.0F, 0.0F, 1.0F, 0.0F);
+                }
+                // Magic numbers calculated from vanilla code
+                GL11.glTranslatef(-0.5F, -0.25F, 0.0421875F);
+            }
+        }
+        super.renderItem(type, aStack, data);
+    }
 
     @Override
     protected void renderRegularItem(ItemRenderType type, ItemStack itemStack, IIcon icon,
@@ -96,6 +113,10 @@ public class TranscendentMetalRenderer extends GT_GeneratedMaterial_Renderer {
     }
 
     private void applyEffect(ItemRenderType type, short[] modulation, boolean shouldModulateColor) {
+        if (RenderItem.renderInFrame) {
+            // Float in front of item frame
+            GL11.glTranslatef(0.0f, 0.0f, -0.5f);
+        }
 
         if (type.equals(IItemRenderer.ItemRenderType.INVENTORY)) {
             GL11.glTranslatef(8f, 8f, 0f);
@@ -111,6 +132,9 @@ public class TranscendentMetalRenderer extends GT_GeneratedMaterial_Renderer {
         } else {
             GL11.glTranslatef(-0.5f, -0.5f, 0.0f);
         }
+
+        // Center on point of rotation
+        GL11.glTranslatef(0.0f, 0.0f, 0.03125F);
 
         if (shouldModulateColor) {
             GL11.glColor4f(modulation[0] / 255.0F, modulation[1] / 255.0F, modulation[2] / 255.0F, 255);

--- a/src/main/java/gregtech/common/render/items/UniversiumRenderer.java
+++ b/src/main/java/gregtech/common/render/items/UniversiumRenderer.java
@@ -3,12 +3,12 @@ package gregtech.common.render.items;
 import static gregtech.api.enums.Mods.Avaritia;
 
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.ItemRenderer;
 import net.minecraft.client.renderer.RenderHelper;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.entity.RenderItem;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.item.EntityItem;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
 import net.minecraft.util.MathHelper;
@@ -21,6 +21,7 @@ import codechicken.lib.render.TextureUtils;
 import fox.spiteful.avaritia.render.CosmicRenderShenanigans;
 import gregtech.api.enums.ItemList;
 import gregtech.api.interfaces.IGT_ItemWithMaterialRenderer;
+import gregtech.common.render.GT_RenderUtil;
 
 @SuppressWarnings("RedundantLabeledSwitchRuleCodeBlock")
 public class UniversiumRenderer extends GT_GeneratedMaterial_Renderer {
@@ -28,17 +29,14 @@ public class UniversiumRenderer extends GT_GeneratedMaterial_Renderer {
     private static final float cosmicOpacity = 2.5f;
 
     @Override
-    public boolean shouldUseRenderHelper(ItemRenderType type, ItemStack item, ItemRendererHelper helper) {
-        return helper == ItemRendererHelper.ENTITY_ROTATION || helper == ItemRendererHelper.ENTITY_BOBBING;
-    }
-
-    @Override
     public boolean renderFluidDisplayItem(ItemRenderType type, ItemStack aStack, Object... data) {
+        Item item = aStack.getItem();
+        if (item == null) return false;
+
         magicRenderMethod(
             type,
             ItemList.Emitter_UEV.get(1), // hack to make it render correctly
-            aStack.getItem()
-                .getIconFromDamage(aStack.getItemDamage()),
+            item.getIconFromDamage(aStack.getItemDamage()),
             true,
             data);
         return true;
@@ -89,133 +87,81 @@ public class UniversiumRenderer extends GT_GeneratedMaterial_Renderer {
         RenderItem r = RenderItem.getInstance();
         Minecraft mc = Minecraft.getMinecraft();
         Tessellator t = Tessellator.instance;
+        float minU = tIcon.getMinU();
+        float maxU = tIcon.getMaxU();
+        float minV = tIcon.getMinV();
+        float maxV = tIcon.getMaxV();
 
         processLightLevel(type, data);
 
-        switch (type) {
-            case ENTITY -> {
-                GL11.glPushMatrix();
-                if (aStack.isOnItemFrame()) GL11.glTranslatef(0F, -0.3F, 0.01F);
-                render(tIcon);
-                GL11.glPopMatrix();
-
-            }
-            case EQUIPPED, EQUIPPED_FIRST_PERSON -> {
-                render(tIcon);
-            }
-            case INVENTORY -> {
-                GL11.glPushMatrix();
-                GL11.glEnable(GL11.GL_BLEND);
-                GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
-                RenderHelper.enableGUIStandardItemLighting();
-
-                GL11.glDisable(GL11.GL_ALPHA_TEST);
-                GL11.glDisable(GL11.GL_DEPTH_TEST);
-
-                if (fluidDisplay) {
-                    // this somehow makes shader render correctly
-                    ResourceLocation resourcelocation = mc.getTextureManager()
-                        .getResourceLocation(aStack.getItemSpriteNumber());
-                    mc.getTextureManager()
-                        .bindTexture(resourcelocation);
-                } else {
-                    r.renderItemIntoGUI(mc.fontRenderer, mc.getTextureManager(), aStack, 0, 0, true);
-                }
-
-                GL11.glEnable(GL11.GL_BLEND);
-                GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
-                RenderHelper.enableGUIStandardItemLighting();
-
-                GL11.glDisable(GL11.GL_ALPHA_TEST);
-                GL11.glDisable(GL11.GL_DEPTH_TEST);
-
-                if (fluidDisplay) {
-                    GL11.glDisable(GL11.GL_BLEND);
-                }
-
-                CosmicRenderShenanigans.cosmicOpacity = cosmicOpacity;
-                CosmicRenderShenanigans.inventoryRender = true;
-                CosmicRenderShenanigans.useShader();
-
-                GL11.glColor4d(1, 1, 1, 1);
-
-                float minu = tIcon.getMinU();
-                float maxu = tIcon.getMaxU();
-                float minv = tIcon.getMinV();
-                float maxv = tIcon.getMaxV();
-
-                // Draw cosmic overlay
-                t.startDrawingQuads();
-                t.addVertexWithUV(0, 0, 0, minu, minv);
-                t.addVertexWithUV(0, 16, 0, minu, maxv);
-                t.addVertexWithUV(16, 16, 0, maxu, maxv);
-                t.addVertexWithUV(16, 0, 0, maxu, minv);
-                t.draw();
-
-                CosmicRenderShenanigans.releaseShader();
-                CosmicRenderShenanigans.inventoryRender = false;
-
-                GL11.glEnable(GL11.GL_ALPHA_TEST);
-                GL11.glEnable(GL12.GL_RESCALE_NORMAL);
-                GL11.glEnable(GL11.GL_DEPTH_TEST);
-
-                r.renderWithColor = true;
-
-                GL11.glDisable(GL11.GL_BLEND);
-                GL11.glPopMatrix();
-            }
-            default -> {}
-        }
-    }
-
-    private void render(IIcon icon) {
         GL11.glPushMatrix();
         GL11.glEnable(GL11.GL_BLEND);
         GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
-        GL11.glColor4f(1F, 1F, 1F, 1F);
 
-        float f, f1, f2, f3;
-        float scale = 1F / 16F;
+        if (type == ItemRenderType.INVENTORY) {
+            RenderHelper.enableGUIStandardItemLighting();
 
-        f = icon.getMinU();
-        f1 = icon.getMaxU();
-        f2 = icon.getMinV();
-        f3 = icon.getMaxV();
+            GL11.glDisable(GL11.GL_ALPHA_TEST);
+            GL11.glDisable(GL11.GL_DEPTH_TEST);
 
-        GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+            if (fluidDisplay) {
+                // this somehow makes shader render correctly
+                ResourceLocation resourcelocation = mc.getTextureManager()
+                    .getResourceLocation(aStack.getItemSpriteNumber());
+                mc.getTextureManager()
+                    .bindTexture(resourcelocation);
+            } else {
+                r.renderItemIntoGUI(mc.fontRenderer, mc.getTextureManager(), aStack, 0, 0, true);
+            }
 
-        // RENDER ITEM IN HAND
-        ItemRenderer
-            .renderItemIn2D(Tessellator.instance, f1, f2, f, f3, icon.getIconWidth(), icon.getIconHeight(), scale);
+            GL11.glEnable(GL11.GL_BLEND);
+            GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
+            RenderHelper.enableGUIStandardItemLighting();
 
-        GL11.glDisable(GL11.GL_ALPHA_TEST);
-        GL11.glDepthFunc(GL11.GL_EQUAL);
-        CosmicRenderShenanigans.cosmicOpacity = cosmicOpacity;
-        CosmicRenderShenanigans.useShader();
+            GL11.glDisable(GL11.GL_ALPHA_TEST);
+            GL11.glDisable(GL11.GL_DEPTH_TEST);
 
-        float minu = icon.getMinU();
-        float maxu = icon.getMaxU();
-        float minv = icon.getMinV();
-        float maxv = icon.getMaxV();
+            if (fluidDisplay) {
+                GL11.glDisable(GL11.GL_BLEND);
+            }
 
-        // RENDER COSMIC OVERLAY IN HAND
-        ItemRenderer.renderItemIn2D(
-            Tessellator.instance,
-            maxu,
-            minv,
-            minu,
-            maxv,
-            icon.getIconWidth(),
-            icon.getIconHeight(),
-            scale);
-        CosmicRenderShenanigans.releaseShader();
-        GL11.glDepthFunc(GL11.GL_LEQUAL);
+            CosmicRenderShenanigans.cosmicOpacity = cosmicOpacity;
+            CosmicRenderShenanigans.inventoryRender = true;
+            CosmicRenderShenanigans.useShader();
+
+            GL11.glColor4d(1, 1, 1, 1);
+
+            // Draw cosmic overlay
+            t.startDrawingQuads();
+            t.addVertexWithUV(0, 0, 0, minU, minV);
+            t.addVertexWithUV(0, 16, 0, minU, maxV);
+            t.addVertexWithUV(16, 16, 0, maxU, maxV);
+            t.addVertexWithUV(16, 0, 0, maxU, minV);
+            t.draw();
+
+            CosmicRenderShenanigans.releaseShader();
+            CosmicRenderShenanigans.inventoryRender = false;
+
+            GL11.glEnable(GL12.GL_RESCALE_NORMAL);
+        } else {
+            // RENDER ITEM
+            GT_RenderUtil.renderItem(type, tIcon);
+
+            GL11.glDisable(GL11.GL_ALPHA_TEST);
+            GL11.glDepthFunc(GL11.GL_EQUAL);
+            CosmicRenderShenanigans.cosmicOpacity = cosmicOpacity;
+            CosmicRenderShenanigans.useShader();
+
+            // RENDER COSMIC OVERLAY
+            GT_RenderUtil.renderItem(type, tIcon);
+            CosmicRenderShenanigans.releaseShader();
+            GL11.glDepthFunc(GL11.GL_LEQUAL);
+        }
+
+        GL11.glEnable(GL11.GL_DEPTH_TEST);
         GL11.glEnable(GL11.GL_ALPHA_TEST);
-
         GL11.glDisable(GL11.GL_BLEND);
         GL11.glPopMatrix();
-
-        GL11.glColor4f(1F, 1F, 1F, 1F);
     }
 
     private void processLightLevel(ItemRenderType type, Object... data) {

--- a/src/main/java/gregtech/common/render/items/UniversiumRenderer.java
+++ b/src/main/java/gregtech/common/render/items/UniversiumRenderer.java
@@ -16,6 +16,7 @@ import net.minecraft.util.ResourceLocation;
 
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
+import org.lwjgl.opengl.GL20;
 
 import codechicken.lib.render.TextureUtils;
 import fox.spiteful.avaritia.render.CosmicRenderShenanigans;
@@ -111,7 +112,7 @@ public class UniversiumRenderer extends GT_GeneratedMaterial_Renderer {
                 mc.getTextureManager()
                     .bindTexture(resourcelocation);
             } else {
-                r.renderItemIntoGUI(mc.fontRenderer, mc.getTextureManager(), aStack, 0, 0, true);
+                GT_RenderUtil.renderItem(type, tIcon);
             }
 
             GL11.glEnable(GL11.GL_BLEND);
@@ -132,12 +133,7 @@ public class UniversiumRenderer extends GT_GeneratedMaterial_Renderer {
             GL11.glColor4d(1, 1, 1, 1);
 
             // Draw cosmic overlay
-            t.startDrawingQuads();
-            t.addVertexWithUV(0, 0, 0, minU, minV);
-            t.addVertexWithUV(0, 16, 0, minU, maxV);
-            t.addVertexWithUV(16, 16, 0, maxU, maxV);
-            t.addVertexWithUV(16, 0, 0, maxU, minV);
-            t.draw();
+            GT_RenderUtil.renderItem(type, tIcon);
 
             CosmicRenderShenanigans.releaseShader();
             CosmicRenderShenanigans.inventoryRender = false;
@@ -146,6 +142,8 @@ public class UniversiumRenderer extends GT_GeneratedMaterial_Renderer {
         } else {
             // RENDER ITEM
             GT_RenderUtil.renderItem(type, tIcon);
+
+            int program = GL11.glGetInteger(GL20.GL_CURRENT_PROGRAM);
 
             GL11.glDisable(GL11.GL_ALPHA_TEST);
             GL11.glDepthFunc(GL11.GL_EQUAL);
@@ -156,6 +154,8 @@ public class UniversiumRenderer extends GT_GeneratedMaterial_Renderer {
             GT_RenderUtil.renderItem(type, tIcon);
             CosmicRenderShenanigans.releaseShader();
             GL11.glDepthFunc(GL11.GL_LEQUAL);
+
+            GL20.glUseProgram(program);
         }
 
         GL11.glEnable(GL11.GL_DEPTH_TEST);


### PR DESCRIPTION
Fixes bugs with fast graphics.

### API breaking changes (minor):

- Subclasses of `GT_GeneratedItem_Renderer` may need updating
- Subclasses of `GT_GeneratedMaterial_Renderer` may need updating
- Subclasses of `GT_DataStick_Renderer` may need updating