### PR TITLE
Fix muffler hatch numbers

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_ElectricBlastFurnace.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_ElectricBlastFurnace.java
@@ -285,7 +285,7 @@ public class GT_MetaTileEntity_ElectricBlastFurnace extends
     }
 
     protected void multiplyPollutionFluidAmount(@Nonnull FluidStack fluid) {
-        fluid.amount = fluid.amount * Math.min(100 - getPollutionReduction() + 5, 100) / 100;
+        fluid.amount = fluid.amount * Math.min(100 - getPollutionReduction(), 100) / 100;
     }
 
     @Override


### PR DESCRIPTION
Fix the fluid output percentages in the EBF for muffler hatches. They now correctly line up with their tooltip and with the pollution reduction as intended. That means they range from 0% at LV to 100% at UHV.

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15223. The intended numbers can be found here: https://github.com/GTNewHorizons/GT5-Unofficial/pull/391

Potential future work: ideally we should adjust void protection to not trigger in the case of the LV muffler hatch where the fluid amount is 0. For now it still does.