### PR TITLE
Fix RecipeMapBackend not indexing Alternate ItemStacks

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -48,17 +48,17 @@ dependencies {
     compileOnlyApi("com.github.GTNewHorizons:AppleCore:3.2.12:dev") { transitive = false }
     compileOnlyApi("com.github.GTNewHorizons:BuildCraft:7.1.38:dev") { transitive = false }
     compileOnlyApi("com.github.GTNewHorizons:EnderIO:2.6.1:dev") { transitive = false }
-    compileOnlyApi("com.github.GTNewHorizons:ForestryMC:4.7.1:dev") { transitive = false }
-    compileOnlyApi("com.github.GTNewHorizons:ProjectRed:4.8.1-GTNH:dev") { transitive = false }
+    compileOnlyApi("com.github.GTNewHorizons:ForestryMC:4.8.0:dev") { transitive = false }
+    compileOnlyApi("com.github.GTNewHorizons:ProjectRed:4.9.0-GTNH:dev") { transitive = false }
     compileOnlyApi("com.github.GTNewHorizons:Railcraft:9.15.3:dev") { transitive = false }
 
-    compileOnly("com.github.GTNewHorizons:EnderCore:0.2.19:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:Galacticraft:3.0.75-GTNH:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:TinkersConstruct:1.10.13-GTNH:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:EnderCore:0.3.0:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:Galacticraft:3.1.1-GTNH:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:TinkersConstruct:1.11.1-GTNH:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:Chisel:2.12.3-GTNH:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:Translocators:1.1.2.21:dev") { transitive = false }
     compileOnly("curse.maven:cofh-core-69162:2388751") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:Nuclear-Control:2.5.1:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:Nuclear-Control:2.6.0:dev") { transitive = false }
     compileOnly("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:Hodgepodge:2.4.3:dev") { transitive = false }
     compileOnly('com.github.GTNewHorizons:Botania:1.10.3-GTNH:dev') { transitive = false }
@@ -69,7 +69,7 @@ dependencies {
     annotationProcessor("com.google.auto.value:auto-value:1.10.1")
 
     // For testing iApiary
-    //runtimeOnlyNonPublishable("com.github.GTNewHorizons:ForestryMC:4.7.1:dev")
+    //runtimeOnlyNonPublishable("com.github.GTNewHorizons:ForestryMC:4.8.0:dev")
 
     testImplementation(platform('org.junit:junit-bom:5.9.2'))
     testImplementation('org.junit.jupiter:junit-jupiter')

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -40,27 +40,27 @@ dependencies {
     api("com.github.GTNewHorizons:GTNHLib:0.0.13:dev")
     api("com.github.GTNewHorizons:ModularUI:1.1.24:dev")
     api("com.github.GTNewHorizons:waila:1.6.5:dev")
-    api("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-304-GTNH:dev")
-    api("com.github.GTNewHorizons:AE2FluidCraft-Rework:1.2.4-gtnh:dev")
+    api("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-305-GTNH:dev")
+    api("com.github.GTNewHorizons:AE2FluidCraft-Rework:1.2.5-gtnh:dev")
 
     implementation("com.github.GTNewHorizons:Avaritia:1.46:dev")
 
     compileOnlyApi("com.github.GTNewHorizons:AppleCore:3.2.12:dev") { transitive = false }
     compileOnlyApi("com.github.GTNewHorizons:BuildCraft:7.1.38:dev") { transitive = false }
-    compileOnlyApi("com.github.GTNewHorizons:EnderIO:2.6.0:dev") { transitive = false }
-    compileOnlyApi("com.github.GTNewHorizons:ForestryMC:4.8.0:dev") { transitive = false }
-    compileOnlyApi("com.github.GTNewHorizons:ProjectRed:4.9.0-GTNH:dev") { transitive = false }
+    compileOnlyApi("com.github.GTNewHorizons:EnderIO:2.6.1:dev") { transitive = false }
+    compileOnlyApi("com.github.GTNewHorizons:ForestryMC:4.7.1:dev") { transitive = false }
+    compileOnlyApi("com.github.GTNewHorizons:ProjectRed:4.8.1-GTNH:dev") { transitive = false }
     compileOnlyApi("com.github.GTNewHorizons:Railcraft:9.15.3:dev") { transitive = false }
 
-    compileOnly("com.github.GTNewHorizons:EnderCore:0.3.0:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:Galacticraft:3.1.1-GTNH:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:TinkersConstruct:1.11.1-GTNH:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:EnderCore:0.2.19:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:Galacticraft:3.0.75-GTNH:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:TinkersConstruct:1.10.13-GTNH:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:Chisel:2.12.3-GTNH:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:Translocators:1.1.2.21:dev") { transitive = false }
     compileOnly("curse.maven:cofh-core-69162:2388751") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:Nuclear-Control:2.6.0:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:Nuclear-Control:2.5.1:dev") { transitive = false }
     compileOnly("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:Hodgepodge:2.4.2:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:Hodgepodge:2.4.3:dev") { transitive = false }
     compileOnly('com.github.GTNewHorizons:Botania:1.10.3-GTNH:dev') { transitive = false }
     compileOnly('com.github.GTNewHorizons:HoloInventory:2.3.2-GTNH:dev') { transitive = false }
     compileOnly('curse.maven:minefactory-reloaded-66672:2366150') { transitive = false }
@@ -69,7 +69,7 @@ dependencies {
     annotationProcessor("com.google.auto.value:auto-value:1.10.1")
 
     // For testing iApiary
-    //runtimeOnlyNonPublishable("com.github.GTNewHorizons:ForestryMC:4.8.0:dev")
+    //runtimeOnlyNonPublishable("com.github.GTNewHorizons:ForestryMC:4.7.1:dev")
 
     testImplementation(platform('org.junit:junit-bom:5.9.2'))
     testImplementation('org.junit.jupiter:junit-jupiter')

--- a/src/main/java/gregtech/api/recipe/RecipeMapBackend.java
+++ b/src/main/java/gregtech/api/recipe/RecipeMapBackend.java
@@ -152,6 +152,15 @@ public class RecipeMapBackend {
             if (item == null) continue;
             itemIndex.put(new GT_ItemStack(item), recipe);
         }
+        if (recipe instanceof GT_Recipe.GT_Recipe_WithAlt recipeWithAlt) {
+            for (ItemStack[] itemStacks : recipeWithAlt.mOreDictAlt) {
+                if (itemStacks == null) continue;
+                for (ItemStack item : itemStacks) {
+                    if (item == null) continue;
+                    itemIndex.put(new GT_ItemStack(item), recipe);
+                }
+            }
+        }
         return recipe;
     }
 

--- a/src/main/java/gregtech/api/util/GT_Recipe.java
+++ b/src/main/java/gregtech/api/util/GT_Recipe.java
@@ -912,7 +912,7 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
 
     public static class GT_Recipe_WithAlt extends GT_Recipe {
 
-        ItemStack[][] mOreDictAlt;
+        public ItemStack[][] mOreDictAlt;
 
         /**
          * Only for {@link GT_RecipeBuilder}.


### PR DESCRIPTION
In 2.5.1 it is not possible to insert some circuits (and other items) into the input bus of an AssemblyLine if the input bus has filter mode enabled. This is due to the circuits not being an alternate instead of a primary crafting ingredient.

This PR adds alternate ItemStacks into the index, which fixes the issue.

This should fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15113