### PR TITLE
[Draft] Allow tools to break stuff with a lower harvest level

### DIFF
--- a/src/main/java/gregtech/api/items/GT_MetaGenerated_Tool.java
+++ b/src/main/java/gregtech/api/items/GT_MetaGenerated_Tool.java
@@ -685,7 +685,7 @@ public abstract class GT_MetaGenerated_Tool extends GT_MetaBase_Item
         if (tStats == null || Math.max(0, getHarvestLevel(aStack, "")) < aBlock.getHarvestLevel(aMetaData)) return 0.0F;
         return tStats.isMinableBlock(aBlock, (byte) aMetaData)
             ? Math.max(Float.MIN_NORMAL, tStats.getSpeedMultiplier() * getPrimaryMaterial(aStack).mToolSpeed)
-            : 0.0F;
+            : 1.0F;
     }
 
     @Override


### PR DESCRIPTION
Tested with a flint pickaxe and the following:

Tall grass - works
Cobblestone - works
Diamond Ore (minecraft) - does not (higher harvest level)
Diamond Ore (gregtech) - does not (higher harvest level)
Obsidian - does not (higher harvest level)

Current issues: Allows breaking blocks with the incorrect tool, i.e breaking a pipe with a pickaxe, while slow, will drop the item.