### PR TITLE
Revert forge hammer recipe for plastic/rubber

### DIFF
--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingIngot.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingIngot.java
@@ -100,7 +100,7 @@ public class ProcessingIngot implements gregtech.api.interfaces.IOreRecipeRegist
                         GT_Proxy.tBits,
                         new Object[] { ToolDictNames.craftingToolMortar, OrePrefixes.ingot.get(aMaterial) });
                 }
-                if (!aNoSmashing || aStretchy) {
+                if (!aNoSmashing) {
                     // Forge hammer recipes
                     if (aMaterial.getProcessingMaterialTierEU() < TierEU.IV
                         && GT_OreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L) != null) {
@@ -111,6 +111,8 @@ public class ProcessingIngot implements gregtech.api.interfaces.IOreRecipeRegist
                             .eut(calculateRecipeEU(aMaterial, 16))
                             .addTo(hammerRecipes);
                     }
+                }
+                if (!aNoSmashing || aStretchy) {
 
                     // Bender recipes
                     {


### PR DESCRIPTION
A forge hammer recipe slipped in between the bending adjustments here https://github.com/GTNewHorizons/GT5-Unofficial/pull/2097. This was not discussed or the intention. It matters as that changes things in steam age a bit, specifically forge hammering rubber. This PR reverts that part, back to no forge hammer plating recipe for plastic/rubber but keeps all the bending changes.

Fixes https://discord.com/channels/181078474394566657/939305179524792340/1191775162031411280