### PR TITLE
Let gt ignore more oredicts

### DIFF
--- a/src/main/java/gregtech/common/GT_Proxy.java
+++ b/src/main/java/gregtech/common/GT_Proxy.java
@@ -420,7 +420,15 @@ public abstract class GT_Proxy implements IGT_Mod, IGuiHandler, IFuelHandler, IG
             "shardEarth",
             "ingotRefinedIron",
             "blockMarble",
-            "ingotUnstable"));
+            "ingotUnstable",
+            "obsidian",
+            "dirt",
+            "gravel",
+            "grass",
+            "soulsand",
+            "paper",
+            "brick",
+            "chest"));
     private final Collection<String> mInvalidNames = new HashSet<>(
         Arrays.asList(
             "diamondShard",


### PR DESCRIPTION
Let GT ignore 'obsidian' and multiple other oredicts as they are not valid for the GT prefix+material system. This is in line with oredicts like "clay" and "glowstone" already being ignored.

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14584