### PR TITLE
Convert tiny Ash dusts for various EBF recipes to chances

### DIFF
--- a/src/main/java/gregtech/loaders/postload/recipes/BlastFurnaceRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/BlastFurnaceRecipes.java
@@ -51,7 +51,8 @@ public class BlastFurnaceRecipes implements Runnable {
 
         GT_Values.RA.stdBuilder()
             .itemInputs(Materials.RoastedCopper.getDust(2), Materials.Carbon.getDust(1))
-            .itemOutputs(Materials.Copper.getIngots(outputIngotAmount), Materials.Ash.getDustTiny(2))
+            .itemOutputs(Materials.Copper.getIngots(outputIngotAmount), Materials.Ash.getDust(1))
+            .outputChances(10000, 2222)
             .fluidOutputs(Materials.CarbonDioxide.getGas(1000))
             .duration(12 * SECONDS)
             .eut((int) TierEU.RECIPE_MV)
@@ -60,7 +61,8 @@ public class BlastFurnaceRecipes implements Runnable {
 
         GT_Values.RA.stdBuilder()
             .itemInputs(Materials.RoastedAntimony.getDust(2), Materials.Carbon.getDust(1))
-            .itemOutputs(Materials.Antimony.getIngots(outputIngotAmount), Materials.Ash.getDustTiny(2))
+            .itemOutputs(Materials.Antimony.getIngots(outputIngotAmount), Materials.Ash.getDust(1))
+            .outputChances(10000, 2222)
             .fluidOutputs(Materials.CarbonDioxide.getGas(1000))
             .duration(12 * SECONDS)
             .eut((int) TierEU.RECIPE_MV)
@@ -69,7 +71,8 @@ public class BlastFurnaceRecipes implements Runnable {
 
         GT_Values.RA.stdBuilder()
             .itemInputs(Materials.RoastedIron.getDust(2), Materials.Carbon.getDust(1))
-            .itemOutputs(Materials.Iron.getIngots(outputIngotAmount), Materials.Ash.getDustTiny(2))
+            .itemOutputs(Materials.Iron.getIngots(outputIngotAmount), Materials.Ash.getDust(1))
+            .outputChances(10000, 2222)
             .fluidOutputs(Materials.CarbonDioxide.getGas(1000))
             .duration(12 * SECONDS)
             .eut((int) TierEU.RECIPE_MV)
@@ -78,7 +81,8 @@ public class BlastFurnaceRecipes implements Runnable {
 
         GT_Values.RA.stdBuilder()
             .itemInputs(Materials.RoastedNickel.getDust(2), Materials.Carbon.getDust(1))
-            .itemOutputs(Materials.Nickel.getIngots(outputIngotAmount), Materials.Ash.getDustTiny(2))
+            .itemOutputs(Materials.Nickel.getIngots(outputIngotAmount), Materials.Ash.getDust(1))
+            .outputChances(10000, 2222)
             .fluidOutputs(Materials.CarbonDioxide.getGas(1000))
             .duration(12 * SECONDS)
             .eut((int) TierEU.RECIPE_MV)
@@ -87,7 +91,8 @@ public class BlastFurnaceRecipes implements Runnable {
 
         GT_Values.RA.stdBuilder()
             .itemInputs(Materials.RoastedZinc.getDust(2), Materials.Carbon.getDust(1))
-            .itemOutputs(Materials.Zinc.getIngots(outputIngotAmount), Materials.Ash.getDustTiny(2))
+            .itemOutputs(Materials.Zinc.getIngots(outputIngotAmount), Materials.Ash.getDust(1))
+            .outputChances(10000, 2222)
             .fluidOutputs(Materials.CarbonDioxide.getGas(1000))
             .duration(12 * SECONDS)
             .eut((int) TierEU.RECIPE_MV)
@@ -96,7 +101,8 @@ public class BlastFurnaceRecipes implements Runnable {
 
         GT_Values.RA.stdBuilder()
             .itemInputs(Materials.RoastedCobalt.getDust(2), Materials.Carbon.getDust(1))
-            .itemOutputs(Materials.Cobalt.getIngots(outputIngotAmount), Materials.Ash.getDustTiny(2))
+            .itemOutputs(Materials.Cobalt.getIngots(outputIngotAmount), Materials.Ash.getDust(1))
+            .outputChances(10000, 2222)
             .fluidOutputs(Materials.CarbonDioxide.getGas(1000))
             .duration(12 * SECONDS)
             .eut((int) TierEU.RECIPE_MV)
@@ -105,7 +111,8 @@ public class BlastFurnaceRecipes implements Runnable {
 
         GT_Values.RA.stdBuilder()
             .itemInputs(Materials.RoastedArsenic.getDust(2), Materials.Carbon.getDust(1))
-            .itemOutputs(Materials.Arsenic.getIngots(outputIngotAmount), Materials.Ash.getDustTiny(2))
+            .itemOutputs(Materials.Arsenic.getIngots(outputIngotAmount), Materials.Ash.getDust(1))
+            .outputChances(10000, 2222)
             .fluidOutputs(Materials.CarbonDioxide.getGas(1000))
             .duration(12 * SECONDS)
             .eut((int) TierEU.RECIPE_MV)
@@ -114,7 +121,8 @@ public class BlastFurnaceRecipes implements Runnable {
 
         GT_Values.RA.stdBuilder()
             .itemInputs(Materials.RoastedLead.getDust(2), Materials.Carbon.getDust(1))
-            .itemOutputs(Materials.Lead.getIngots(outputIngotAmount), Materials.Ash.getDustTiny(2))
+            .itemOutputs(Materials.Lead.getIngots(outputIngotAmount), Materials.Ash.getDust(1))
+            .outputChances(10000, 2222)
             .fluidOutputs(Materials.CarbonDioxide.getGas(1000))
             .duration(12 * SECONDS)
             .eut((int) TierEU.RECIPE_MV)
@@ -123,7 +131,8 @@ public class BlastFurnaceRecipes implements Runnable {
 
         GT_Values.RA.stdBuilder()
             .itemInputs(Materials.Malachite.getDust(2), Materials.Carbon.getDust(1))
-            .itemOutputs(Materials.Copper.getIngots(outputIngotAmount), Materials.Ash.getDustTiny(2))
+            .itemOutputs(Materials.Copper.getIngots(outputIngotAmount), Materials.Ash.getDust(1))
+            .outputChances(10000, 2222)
             .fluidOutputs(Materials.CarbonDioxide.getGas(3000))
             .duration(12 * SECONDS)
             .eut((int) TierEU.RECIPE_MV)
@@ -132,7 +141,8 @@ public class BlastFurnaceRecipes implements Runnable {
 
         GT_Values.RA.stdBuilder()
             .itemInputs(Materials.Magnetite.getDust(2), Materials.Carbon.getDust(1))
-            .itemOutputs(Materials.Iron.getIngots(outputIngotAmount), Materials.Ash.getDustTiny(2))
+            .itemOutputs(Materials.Iron.getIngots(outputIngotAmount), Materials.Ash.getDust(1))
+            .outputChances(10000, 2222)
             .fluidOutputs(Materials.CarbonDioxide.getGas(1000))
             .duration(12 * SECONDS)
             .eut((int) TierEU.RECIPE_MV)
@@ -141,7 +151,8 @@ public class BlastFurnaceRecipes implements Runnable {
 
         GT_Values.RA.stdBuilder()
             .itemInputs(Materials.YellowLimonite.getDust(2), Materials.Carbon.getDust(1))
-            .itemOutputs(Materials.Iron.getIngots(outputIngotAmount), Materials.Ash.getDustTiny(2))
+            .itemOutputs(Materials.Iron.getIngots(outputIngotAmount), Materials.Ash.getDust(1))
+            .outputChances(10000, 2222)
             .fluidOutputs(Materials.CarbonDioxide.getGas(1000))
             .duration(12 * SECONDS)
             .eut((int) TierEU.RECIPE_MV)
@@ -150,7 +161,8 @@ public class BlastFurnaceRecipes implements Runnable {
 
         GT_Values.RA.stdBuilder()
             .itemInputs(Materials.BrownLimonite.getDust(2), Materials.Carbon.getDust(1))
-            .itemOutputs(Materials.Iron.getIngots(outputIngotAmount), Materials.Ash.getDustTiny(2))
+            .itemOutputs(Materials.Iron.getIngots(outputIngotAmount), Materials.Ash.getDust(1))
+            .outputChances(10000, 2222)
             .fluidOutputs(Materials.CarbonDioxide.getGas(1000))
             .duration(12 * SECONDS)
             .eut((int) TierEU.RECIPE_MV)
@@ -159,7 +171,8 @@ public class BlastFurnaceRecipes implements Runnable {
 
         GT_Values.RA.stdBuilder()
             .itemInputs(Materials.BasalticMineralSand.getDust(2), Materials.Carbon.getDust(1))
-            .itemOutputs(Materials.Iron.getIngots(outputIngotAmount), Materials.Ash.getDustTiny(2))
+            .itemOutputs(Materials.Iron.getIngots(outputIngotAmount), Materials.Ash.getDust(1))
+            .outputChances(10000, 2222)
             .fluidOutputs(Materials.CarbonDioxide.getGas(1000))
             .duration(12 * SECONDS)
             .eut((int) TierEU.RECIPE_MV)
@@ -168,7 +181,8 @@ public class BlastFurnaceRecipes implements Runnable {
 
         GT_Values.RA.stdBuilder()
             .itemInputs(Materials.GraniticMineralSand.getDust(2), Materials.Carbon.getDust(1))
-            .itemOutputs(Materials.Iron.getIngots(outputIngotAmount), Materials.Ash.getDustTiny(2))
+            .itemOutputs(Materials.Iron.getIngots(outputIngotAmount), Materials.Ash.getDust(1))
+            .outputChances(10000, 2222)
             .fluidOutputs(Materials.CarbonDioxide.getGas(1000))
             .duration(12 * SECONDS)
             .eut((int) TierEU.RECIPE_MV)
@@ -177,7 +191,8 @@ public class BlastFurnaceRecipes implements Runnable {
 
         GT_Values.RA.stdBuilder()
             .itemInputs(Materials.Cassiterite.getDust(2), Materials.Carbon.getDust(1))
-            .itemOutputs(Materials.Tin.getIngots(outputIngotAmount), Materials.Ash.getDustTiny(2))
+            .itemOutputs(Materials.Tin.getIngots(outputIngotAmount), Materials.Ash.getDust(1))
+            .outputChances(10000, 2222)
             .fluidOutputs(Materials.CarbonDioxide.getGas(1000))
             .duration(12 * SECONDS)
             .eut((int) TierEU.RECIPE_MV)
@@ -186,7 +201,8 @@ public class BlastFurnaceRecipes implements Runnable {
 
         GT_Values.RA.stdBuilder()
             .itemInputs(Materials.CassiteriteSand.getDust(2), Materials.Carbon.getDust(1))
-            .itemOutputs(Materials.Tin.getIngots(outputIngotAmount), Materials.Ash.getDustTiny(2))
+            .itemOutputs(Materials.Tin.getIngots(outputIngotAmount), Materials.Ash.getDust(1))
+            .outputChances(10000, 2222)
             .fluidOutputs(Materials.CarbonDioxide.getGas(1000))
             .duration(12 * SECONDS)
             .eut((int) TierEU.RECIPE_MV)
@@ -195,7 +211,8 @@ public class BlastFurnaceRecipes implements Runnable {
 
         GT_Values.RA.stdBuilder()
             .itemInputs(Materials.SiliconDioxide.getDust(3), Materials.Carbon.getDust(2))
-            .itemOutputs(Materials.Silicon.getIngots(1), Materials.Ash.getDustTiny(1))
+            .itemOutputs(Materials.Silicon.getIngots(1), Materials.Ash.getDust(1))
+            .outputChances(10000, 1111)
             .fluidOutputs(Materials.CarbonMonoxide.getGas(2000))
             .duration(4 * SECONDS)
             .eut((int) TierEU.RECIPE_MV)
@@ -205,7 +222,8 @@ public class BlastFurnaceRecipes implements Runnable {
         if (GT_Mod.gregtechproxy.mMixedOreOnlyYieldsTwoThirdsOfPureOre) {
             GT_Values.RA.stdBuilder()
                 .itemInputs(Materials.CupricOxide.getDust(2), Materials.Carbon.getDustSmall(4))
-                .itemOutputs(Materials.Copper.getIngots(1), Materials.Ash.getDustTiny(2))
+                .itemOutputs(Materials.Copper.getIngots(1), Materials.Ash.getDust(1))
+                .outputChances(10000, 2222)
                 .fluidOutputs(Materials.CarbonDioxide.getGas(1000))
                 .duration(12 * SECONDS)
                 .eut((int) TierEU.RECIPE_MV)
@@ -214,7 +232,8 @@ public class BlastFurnaceRecipes implements Runnable {
 
             GT_Values.RA.stdBuilder()
                 .itemInputs(Materials.Malachite.getDust(2), Materials.Carbon.getDustSmall(4))
-                .itemOutputs(Materials.Copper.getIngots(outputIngotAmount), Materials.Ash.getDustTiny(2))
+                .itemOutputs(Materials.Copper.getIngots(outputIngotAmount), Materials.Ash.getDust(1))
+                .outputChances(10000, 2222)
                 .fluidOutputs(Materials.CarbonDioxide.getGas(3000))
                 .duration(12 * SECONDS)
                 .eut((int) TierEU.RECIPE_MV)
@@ -223,7 +242,8 @@ public class BlastFurnaceRecipes implements Runnable {
 
             GT_Values.RA.stdBuilder()
                 .itemInputs(Materials.AntimonyTrioxide.getDust(5), Materials.Carbon.getDustSmall(4))
-                .itemOutputs(Materials.Antimony.getIngots(2), Materials.Ash.getDustTiny(2))
+                .itemOutputs(Materials.Antimony.getIngots(2), Materials.Ash.getDust(1))
+                .outputChances(10000, 2222)
                 .fluidOutputs(Materials.CarbonDioxide.getGas(3000))
                 .duration(12 * SECONDS)
                 .eut((int) TierEU.RECIPE_MV)
@@ -232,7 +252,8 @@ public class BlastFurnaceRecipes implements Runnable {
 
             GT_Values.RA.stdBuilder()
                 .itemInputs(Materials.BandedIron.getDust(5), Materials.Carbon.getDustSmall(4))
-                .itemOutputs(Materials.Iron.getIngots(2), Materials.Ash.getDustTiny(2))
+                .itemOutputs(Materials.Iron.getIngots(2), Materials.Ash.getDust(1))
+                .outputChances(10000, 2222)
                 .fluidOutputs(Materials.CarbonDioxide.getGas(1000))
                 .duration(12 * SECONDS)
                 .eut((int) TierEU.RECIPE_MV)
@@ -241,7 +262,8 @@ public class BlastFurnaceRecipes implements Runnable {
 
             GT_Values.RA.stdBuilder()
                 .itemInputs(Materials.Magnetite.getDust(2), Materials.Carbon.getDustSmall(4))
-                .itemOutputs(Materials.Iron.getIngots(outputIngotAmount), Materials.Ash.getDustTiny(2))
+                .itemOutputs(Materials.Iron.getIngots(outputIngotAmount), Materials.Ash.getDust(1))
+                .outputChances(10000, 2222)
                 .fluidOutputs(Materials.CarbonDioxide.getGas(1000))
                 .duration(12 * SECONDS)
                 .eut((int) TierEU.RECIPE_MV)
@@ -250,7 +272,8 @@ public class BlastFurnaceRecipes implements Runnable {
 
             GT_Values.RA.stdBuilder()
                 .itemInputs(Materials.YellowLimonite.getDust(2), Materials.Carbon.getDustSmall(4))
-                .itemOutputs(Materials.Iron.getIngots(outputIngotAmount), Materials.Ash.getDustTiny(2))
+                .itemOutputs(Materials.Iron.getIngots(outputIngotAmount), Materials.Ash.getDust(1))
+                .outputChances(10000, 2222)
                 .fluidOutputs(Materials.CarbonDioxide.getGas(1000))
                 .duration(12 * SECONDS)
                 .eut((int) TierEU.RECIPE_MV)
@@ -259,7 +282,8 @@ public class BlastFurnaceRecipes implements Runnable {
 
             GT_Values.RA.stdBuilder()
                 .itemInputs(Materials.BrownLimonite.getDust(2), Materials.Carbon.getDustSmall(4))
-                .itemOutputs(Materials.Iron.getIngots(outputIngotAmount), Materials.Ash.getDustTiny(2))
+                .itemOutputs(Materials.Iron.getIngots(outputIngotAmount), Materials.Ash.getDust(1))
+                .outputChances(10000, 2222)
                 .fluidOutputs(Materials.CarbonDioxide.getGas(1000))
                 .duration(12 * SECONDS)
                 .eut((int) TierEU.RECIPE_MV)
@@ -268,7 +292,8 @@ public class BlastFurnaceRecipes implements Runnable {
 
             GT_Values.RA.stdBuilder()
                 .itemInputs(Materials.BasalticMineralSand.getDust(2), Materials.Carbon.getDustSmall(4))
-                .itemOutputs(Materials.Iron.getIngots(outputIngotAmount), Materials.Ash.getDustTiny(2))
+                .itemOutputs(Materials.Iron.getIngots(outputIngotAmount), Materials.Ash.getDust(1))
+                .outputChances(10000, 2222)
                 .fluidOutputs(Materials.CarbonDioxide.getGas(1000))
                 .duration(12 * SECONDS)
                 .eut((int) TierEU.RECIPE_MV)
@@ -277,7 +302,8 @@ public class BlastFurnaceRecipes implements Runnable {
 
             GT_Values.RA.stdBuilder()
                 .itemInputs(Materials.GraniticMineralSand.getDust(2), Materials.Carbon.getDustSmall(4))
-                .itemOutputs(Materials.Iron.getIngots(outputIngotAmount), Materials.Ash.getDustTiny(2))
+                .itemOutputs(Materials.Iron.getIngots(outputIngotAmount), Materials.Ash.getDust(1))
+                .outputChances(10000, 2222)
                 .fluidOutputs(Materials.CarbonDioxide.getGas(1000))
                 .duration(12 * SECONDS)
                 .eut((int) TierEU.RECIPE_MV)
@@ -286,7 +312,8 @@ public class BlastFurnaceRecipes implements Runnable {
 
             GT_Values.RA.stdBuilder()
                 .itemInputs(Materials.Cassiterite.getDust(2), Materials.Carbon.getDustSmall(4))
-                .itemOutputs(Materials.Tin.getIngots(outputIngotAmount), Materials.Ash.getDustTiny(2))
+                .itemOutputs(Materials.Tin.getIngots(outputIngotAmount), Materials.Ash.getDust(1))
+                .outputChances(10000, 2222)
                 .fluidOutputs(Materials.CarbonDioxide.getGas(1000))
                 .duration(12 * SECONDS)
                 .eut((int) TierEU.RECIPE_MV)
@@ -295,7 +322,8 @@ public class BlastFurnaceRecipes implements Runnable {
 
             GT_Values.RA.stdBuilder()
                 .itemInputs(Materials.CassiteriteSand.getDust(2), Materials.Carbon.getDustSmall(4))
-                .itemOutputs(Materials.Tin.getIngots(outputIngotAmount), Materials.Ash.getDustTiny(2))
+                .itemOutputs(Materials.Tin.getIngots(outputIngotAmount), Materials.Ash.getDust(1))
+                .outputChances(10000, 2222)
                 .fluidOutputs(Materials.CarbonDioxide.getGas(1000))
                 .duration(12 * SECONDS)
                 .eut((int) TierEU.RECIPE_MV)
@@ -304,7 +332,8 @@ public class BlastFurnaceRecipes implements Runnable {
 
             GT_Values.RA.stdBuilder()
                 .itemInputs(Materials.Garnierite.getDust(2), Materials.Carbon.getDustSmall(4))
-                .itemOutputs(Materials.Nickel.getIngots(1), Materials.Ash.getDustTiny(2))
+                .itemOutputs(Materials.Nickel.getIngots(1), Materials.Ash.getDust(1))
+                .outputChances(10000, 2222)
                 .fluidOutputs(Materials.CarbonDioxide.getGas(1000))
                 .duration(12 * SECONDS)
                 .eut((int) TierEU.RECIPE_MV)
@@ -313,7 +342,8 @@ public class BlastFurnaceRecipes implements Runnable {
 
             GT_Values.RA.stdBuilder()
                 .itemInputs(Materials.CobaltOxide.getDust(2), Materials.Carbon.getDustSmall(4))
-                .itemOutputs(Materials.Cobalt.getIngots(1), Materials.Ash.getDustTiny(2))
+                .itemOutputs(Materials.Cobalt.getIngots(1), Materials.Ash.getDust(1))
+                .outputChances(10000, 2222)
                 .fluidOutputs(Materials.CarbonDioxide.getGas(1000))
                 .duration(12 * SECONDS)
                 .eut((int) TierEU.RECIPE_MV)
@@ -322,7 +352,8 @@ public class BlastFurnaceRecipes implements Runnable {
 
             GT_Values.RA.stdBuilder()
                 .itemInputs(Materials.ArsenicTrioxide.getDust(5), Materials.Carbon.getDustSmall(4))
-                .itemOutputs(Materials.Arsenic.getIngots(2), Materials.Ash.getDustTiny(2))
+                .itemOutputs(Materials.Arsenic.getIngots(2), Materials.Ash.getDust(1))
+                .outputChances(10000, 2222)
                 .fluidOutputs(Materials.CarbonDioxide.getGas(1000))
                 .duration(12 * SECONDS)
                 .eut((int) TierEU.RECIPE_MV)
@@ -331,7 +362,8 @@ public class BlastFurnaceRecipes implements Runnable {
 
             GT_Values.RA.stdBuilder()
                 .itemInputs(Materials.Massicot.getDust(2), Materials.Carbon.getDustSmall(4))
-                .itemOutputs(Materials.Lead.getIngots(1), Materials.Ash.getDustTiny(2))
+                .itemOutputs(Materials.Lead.getIngots(1), Materials.Ash.getDust(1))
+                .outputChances(10000, 2222)
                 .fluidOutputs(Materials.CarbonDioxide.getGas(1000))
                 .duration(12 * SECONDS)
                 .eut((int) TierEU.RECIPE_MV)
@@ -532,7 +564,8 @@ public class BlastFurnaceRecipes implements Runnable {
             .addTo(blastFurnaceRecipes);
         GT_Values.RA.stdBuilder()
             .itemInputs(Materials.Pyrite.getDust(1))
-            .itemOutputs(Materials.RoastedIron.getDust(1), Materials.Ash.getDustTiny(1))
+            .itemOutputs(Materials.RoastedIron.getDust(1), Materials.Ash.getDust(1))
+            .outputChances(10000, 1111)
             .fluidInputs(Materials.Oxygen.getGas(3000))
             .fluidOutputs(Materials.SulfurDioxide.getGas(2000))
             .duration(6 * SECONDS)
@@ -541,7 +574,8 @@ public class BlastFurnaceRecipes implements Runnable {
             .addTo(blastFurnaceRecipes);
         GT_Values.RA.stdBuilder()
             .itemInputs(Materials.Pentlandite.getDust(1))
-            .itemOutputs(Materials.RoastedNickel.getDust(1), Materials.Ash.getDustTiny(1))
+            .itemOutputs(Materials.RoastedNickel.getDust(1), Materials.Ash.getDust(1))
+            .outputChances(10000, 1111)
             .fluidInputs(Materials.Oxygen.getGas(3000))
             .fluidOutputs(Materials.SulfurDioxide.getGas(2000))
             .duration(6 * SECONDS)
@@ -550,7 +584,8 @@ public class BlastFurnaceRecipes implements Runnable {
             .addTo(blastFurnaceRecipes);
         GT_Values.RA.stdBuilder()
             .itemInputs(Materials.Sphalerite.getDust(1))
-            .itemOutputs(Materials.RoastedZinc.getDust(1), Materials.Ash.getDustTiny(1))
+            .itemOutputs(Materials.RoastedZinc.getDust(1), Materials.Ash.getDust(1))
+            .outputChances(10000, 1111)
             .fluidInputs(Materials.Oxygen.getGas(3000))
             .fluidOutputs(Materials.SulfurDioxide.getGas(1000))
             .duration(6 * SECONDS)
@@ -568,7 +603,8 @@ public class BlastFurnaceRecipes implements Runnable {
             .addTo(blastFurnaceRecipes);
         GT_Values.RA.stdBuilder()
             .itemInputs(Materials.Stibnite.getDust(1))
-            .itemOutputs(Materials.RoastedAntimony.getDust(1), Materials.Ash.getDustTiny(1))
+            .itemOutputs(Materials.RoastedAntimony.getDust(1), Materials.Ash.getDust(1))
+            .outputChances(10000, 1111)
             .fluidInputs(Materials.Oxygen.getGas(3000))
             .fluidOutputs(Materials.SulfurDioxide.getGas(1500))
             .duration(6 * SECONDS)
@@ -577,7 +613,8 @@ public class BlastFurnaceRecipes implements Runnable {
             .addTo(blastFurnaceRecipes);
         GT_Values.RA.stdBuilder()
             .itemInputs(Materials.Galena.getDust(1))
-            .itemOutputs(Materials.RoastedLead.getDust(1), Materials.Ash.getDustTiny(1))
+            .itemOutputs(Materials.RoastedLead.getDust(1), Materials.Ash.getDust(1))
+            .outputChances(10000, 1111)
             .fluidInputs(Materials.Oxygen.getGas(3000))
             .fluidOutputs(Materials.SulfurDioxide.getGas(1000))
             .duration(6 * SECONDS)


### PR DESCRIPTION
This is a replacement for https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/743 which was reverted here https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/791 due to various issues.
This PR also includes a few more recipes.

For conversion math, this PR only uses averages. The more advanced boubou-algorithm (TM) is not needed as this is just a bulk byproduct and there is nothing special about getting the first few.

For example: roasted arsenic in dev-env (couldnt test in full pack as nightlies are too broken):
![image](https://github.com/GTNewHorizons/GT5-Unofficial/assets/40274384/59869af3-e199-41ef-b0da-0ddd00fa16cc)
