### PR TITLE
Add valid covers bit mask to CoverableTileEntity

### DIFF
--- a/src/main/java/gregtech/common/covers/CoverInfo.java
+++ b/src/main/java/gregtech/common/covers/CoverInfo.java
@@ -33,8 +33,8 @@ public final class CoverInfo {
     public static final CoverInfo EMPTY_INFO = new CoverInfo(ForgeDirection.UNKNOWN, null);
     private final ForgeDirection coverSide;
     private int coverID = 0;
-    private GT_CoverBehaviorBase<?> coverBehavior = null;
-    private ISerializableObject coverData = null;
+    private GT_CoverBehaviorBase<?> coverBehavior;
+    private ISerializableObject coverData;
     private final WeakReference<ICoverable> coveredTile;
     private boolean needsUpdate = false;
 
@@ -43,6 +43,7 @@ public final class CoverInfo {
     public CoverInfo(ForgeDirection side, ICoverable aTile) {
         coverSide = side;
         coveredTile = new WeakReference<>(aTile);
+        coverBehavior = GregTech_API.sNoBehavior;
     }
 
     public CoverInfo(ForgeDirection side, int aID, ICoverable aTile, ISerializableObject aCoverData) {
@@ -89,8 +90,7 @@ public final class CoverInfo {
     }
 
     public GT_CoverBehaviorBase<?> getCoverBehavior() {
-        if (coverBehavior != null) return coverBehavior;
-        return GregTech_API.sNoBehavior;
+        return coverBehavior;
     }
 
     public ISerializableObject getCoverData() {


### PR DESCRIPTION
Adds a bitmask for valid covers which allows us to do as little work as possible in `doCoverThings`.

This is a performance comparison from before and after in our stargate tier base. We have around 100k `CoverableTileEntity` and because of having to check every side this runs about 600 thousand times per tick and checks if there for valid covers. After this change a bit mask is set when covers are added so we can return early which makes this way more efficient. This was tested and works as intended.

Before:
![image](https://github.com/GTNewHorizons/GT5-Unofficial/assets/36999320/e7f50220-d520-436c-a202-b95e1fc1e6ff)

After:
![image](https://github.com/GTNewHorizons/GT5-Unofficial/assets/36999320/2fb6e896-e68e-4a64-879c-acc96fd1652c)

