### PR TITLE
Reintroduce CRIB name to WAILA

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_ME.java
@@ -476,7 +476,7 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
         if (getCrafterIcon() != null) {
             name.append(getCrafterIcon().getDisplayName());
         } else {
-            name.append(getInventoryName());
+            name.append(getLocalName());
         }
 
         if (mInventory[SLOT_CIRCUIT] != null) {
@@ -776,6 +776,8 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
     public void getWailaBody(ItemStack itemStack, List<String> currenttip, IWailaDataAccessor accessor,
         IWailaConfigHandler config) {
         NBTTagCompound tag = accessor.getNBTData();
+        if (tag.hasKey("name"))
+            currenttip.add(EnumChatFormatting.AQUA + tag.getString("name") + EnumChatFormatting.RESET);
         if (tag.hasKey("inventory")) {
             var inventory = tag.getTagList("inventory", Constants.NBT.TAG_COMPOUND);
             for (int i = 0; i < inventory.tagCount(); ++i) {
@@ -823,7 +825,9 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_ME extends GT_MetaTileEntity_
         }
 
         tag.setTag("inventory", inventory);
-        tag.setString("name", getName());
+        if (!Objects.equals(getName(), getLocalName())) {
+            tag.setString("name", getName());
+        }
         super.getWailaNBTData(player, tile, tag, world, x, y, z);
     }
 


### PR DESCRIPTION
Addresses https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14424 and part of https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15321.

Reverts https://github.com/GTNewHorizons/GT5-Unofficial/pull/2272

* Changes default CRIB from unlocalized to localized item name.
* Reintroduces CRIB name in WAILA except if it is the default name (to prevent the name from appearing exactly the same twice).

Custom name: ![image](https://github.com/GTNewHorizons/GT5-Unofficial/assets/109012629/3455403e-20f9-4cec-bfb7-d6e53ceee8b0)
Non-default name: 
![image](https://github.com/GTNewHorizons/GT5-Unofficial/assets/109012629/cbd90ab3-6c5d-47e7-bdab-3dd06ad0e672)
Default name: ![image](https://github.com/GTNewHorizons/GT5-Unofficial/assets/109012629/5b193896-e83d-4e3b-a7e2-952a895f6832)
