### PR TITLE
merge similar code into new utility function moveFluid

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_Output.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_Output.java
@@ -131,17 +131,12 @@ public class GT_MetaTileEntity_Hatch_Output extends GT_MetaTileEntity_Hatch
             IFluidHandler tTileEntity = aBaseMetaTileEntity
                 .getITankContainerAtSide(aBaseMetaTileEntity.getFrontFacing());
             if (tTileEntity != null) {
-                FluidStack tDrained = aBaseMetaTileEntity
-                    .drain(aBaseMetaTileEntity.getFrontFacing(), Math.max(1, mFluid.amount), false);
-                if (tDrained != null) {
-                    int tFilledAmount = tTileEntity.fill(aBaseMetaTileEntity.getBackFacing(), tDrained, false);
-                    if (tFilledAmount > 0) {
-                        tTileEntity.fill(
-                            aBaseMetaTileEntity.getBackFacing(),
-                            aBaseMetaTileEntity.drain(aBaseMetaTileEntity.getFrontFacing(), tFilledAmount, true),
-                            true);
-                    }
-                }
+                GT_Utility.moveFluid(
+                    aBaseMetaTileEntity,
+                    tTileEntity,
+                    aBaseMetaTileEntity.getFrontFacing(),
+                    Math.max(1, mFluid.amount),
+                    null);
             }
         }
     }

--- a/src/main/java/gregtech/api/util/GT_Utility.java
+++ b/src/main/java/gregtech/api/util/GT_Utility.java
@@ -45,6 +45,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.function.IntFunction;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
@@ -1680,6 +1681,47 @@ public class GT_Utility {
             aMaxMoveAtOnce,
             aMinMoveAtOnce,
             true);
+    }
+
+    /**
+     * Move up to maxAmount amount of fluid from source to dest, with optional filtering via allowMove. note that this
+     * filter cannot bypass filtering done by IFluidHandlers themselves.
+     *
+     * this overload will assume the fill side is the opposite of drainSide
+     *
+     * @param source tank to drain from. method become noop if this is null
+     * @param dest tank to fill to. method become noop if this is null
+     * @param drainSide side used during draining operation
+     * @param maxAmount max amount of fluid to transfer. method become noop if this is not a positive integer
+     * @param allowMove filter. can be null to signal all fluids are accepted
+     */
+    public static void moveFluid(IFluidHandler source, IFluidHandler dest, ForgeDirection drainSide, int maxAmount,
+                                 @Nullable Predicate<FluidStack> allowMove) {
+        moveFluid(source, dest, drainSide, drainSide.getOpposite(), maxAmount, allowMove);
+    }
+
+
+    /**
+     * Move up to maxAmount amount of fluid from source to dest, with optional filtering via allowMove. note that this
+     * filter cannot bypass filtering done by IFluidHandlers themselves.
+     *
+     * @param source tank to drain from. method become noop if this is null
+     * @param dest tank to fill to. method become noop if this is null
+     * @param drainSide side used during draining operation
+     * @param fillSide  side used during filling operation
+     * @param maxAmount max amount of fluid to transfer. method become noop if this is not a positive integer
+     * @param allowMove filter. can be null to signal all fluids are accepted
+     */
+    public static void moveFluid(IFluidHandler source, IFluidHandler dest, ForgeDirection drainSide,
+                                 ForgeDirection fillSide, int maxAmount, @Nullable Predicate<FluidStack> allowMove) {
+        if (source == null || dest == null || maxAmount <= 0) return;
+        FluidStack liquid = source.drain(drainSide, maxAmount, false);
+        if (liquid == null) return;
+        liquid = liquid.copy();
+        liquid.amount = dest.fill(drainSide.getOpposite(), liquid, false);
+        if (liquid.amount > 0 && allowMove != null && allowMove.test(liquid)) {
+            dest.fill(fillSide, dest.drain(drainSide.getOpposite(), liquid.amount, true), true);
+        }
     }
 
     public static boolean listContainsItem(Collection<ItemStack> aList, ItemStack aStack, boolean aTIfListEmpty,

--- a/src/main/java/gregtech/api/util/GT_Utility.java
+++ b/src/main/java/gregtech/api/util/GT_Utility.java
@@ -1689,31 +1689,30 @@ public class GT_Utility {
      *
      * this overload will assume the fill side is the opposite of drainSide
      *
-     * @param source tank to drain from. method become noop if this is null
-     * @param dest tank to fill to. method become noop if this is null
+     * @param source    tank to drain from. method become noop if this is null
+     * @param dest      tank to fill to. method become noop if this is null
      * @param drainSide side used during draining operation
      * @param maxAmount max amount of fluid to transfer. method become noop if this is not a positive integer
      * @param allowMove filter. can be null to signal all fluids are accepted
      */
     public static void moveFluid(IFluidHandler source, IFluidHandler dest, ForgeDirection drainSide, int maxAmount,
-                                 @Nullable Predicate<FluidStack> allowMove) {
+        @Nullable Predicate<FluidStack> allowMove) {
         moveFluid(source, dest, drainSide, drainSide.getOpposite(), maxAmount, allowMove);
     }
-
 
     /**
      * Move up to maxAmount amount of fluid from source to dest, with optional filtering via allowMove. note that this
      * filter cannot bypass filtering done by IFluidHandlers themselves.
      *
-     * @param source tank to drain from. method become noop if this is null
-     * @param dest tank to fill to. method become noop if this is null
+     * @param source    tank to drain from. method become noop if this is null
+     * @param dest      tank to fill to. method become noop if this is null
      * @param drainSide side used during draining operation
      * @param fillSide  side used during filling operation
      * @param maxAmount max amount of fluid to transfer. method become noop if this is not a positive integer
      * @param allowMove filter. can be null to signal all fluids are accepted
      */
     public static void moveFluid(IFluidHandler source, IFluidHandler dest, ForgeDirection drainSide,
-                                 ForgeDirection fillSide, int maxAmount, @Nullable Predicate<FluidStack> allowMove) {
+        ForgeDirection fillSide, int maxAmount, @Nullable Predicate<FluidStack> allowMove) {
         if (source == null || dest == null || maxAmount <= 0) return;
         FluidStack liquid = source.drain(drainSide, maxAmount, false);
         if (liquid == null) return;

--- a/src/main/java/gregtech/api/util/GT_Utility.java
+++ b/src/main/java/gregtech/api/util/GT_Utility.java
@@ -1718,7 +1718,7 @@ public class GT_Utility {
         if (liquid == null) return;
         liquid = liquid.copy();
         liquid.amount = dest.fill(drainSide.getOpposite(), liquid, false);
-        if (liquid.amount > 0 && allowMove != null && allowMove.test(liquid)) {
+        if (liquid.amount > 0 && (allowMove == null ||  allowMove.test(liquid))) {
             dest.fill(fillSide, dest.drain(drainSide.getOpposite(), liquid.amount, true), true);
         }
     }

--- a/src/main/java/gregtech/common/covers/GT_Cover_FluidRegulator.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_FluidRegulator.java
@@ -108,14 +108,8 @@ public class GT_Cover_FluidRegulator extends GT_CoverBehaviorBase<GT_Cover_Fluid
             }
             if (tTank1 != null && tTank2 != null) {
                 allowFluid = true;
-                FluidStack tLiquid = tTank1.drain(directionFrom, Math.abs(aCoverVariable.speed), false);
-                if (tLiquid != null && this.canTransferFluid(tLiquid)) {
-                    tLiquid = tLiquid.copy();
-                    tLiquid.amount = tTank2.fill(directionTo, tLiquid, false);
-                    if (tLiquid.amount > 0) {
-                        tTank2.fill(directionTo, tTank1.drain(directionFrom, tLiquid.amount, true), true);
-                    }
-                }
+                GT_Utility
+                    .moveFluid(tTank1, tTank2, directionFrom, Math.abs(aCoverVariable.speed), this::canTransferFluid);
                 allowFluid = false;
             }
         }

--- a/src/main/java/gregtech/common/covers/GT_Cover_Pump.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_Pump.java
@@ -50,32 +50,16 @@ public class GT_Cover_Pump extends GT_CoverBehavior {
             final IFluidHandler toAccess = aTileEntity.getITankContainerAtSide(side);
             if (toAccess == null) return aCoverVariable;
 
-            transferFluid(current, toAccess, side, aCoverVariable % 2);
+            transferFluid(current, toAccess, side, aCoverVariable % 2 == 0);
         }
         return aCoverVariable;
     }
 
-    protected void transferFluid(IFluidHandler current, IFluidHandler toAccess, ForgeDirection side,
-        int exportOrImport) {
-        if (exportOrImport == 0) {
-            FluidStack liquid = current.drain(side, this.mTransferRate, false);
-            if (liquid != null) {
-                liquid = liquid.copy();
-                liquid.amount = toAccess.fill(side.getOpposite(), liquid, false);
-                if (liquid.amount > 0 && canTransferFluid(liquid)) {
-                    toAccess.fill(side.getOpposite(), current.drain(side, liquid.amount, true), true);
-                }
-            }
-            return;
-        }
-        FluidStack liquid = toAccess.drain(side.getOpposite(), this.mTransferRate, false);
-        if (liquid != null) {
-            liquid = liquid.copy();
-            liquid.amount = current.fill(side, liquid, false);
-            if (liquid.amount > 0 && canTransferFluid(liquid)) {
-                current.fill(side, toAccess.drain(side.getOpposite(), liquid.amount, true), true);
-            }
-        }
+    protected void transferFluid(IFluidHandler current, IFluidHandler toAccess, ForgeDirection side, boolean export) {
+        IFluidHandler source = export ? current : toAccess;
+        IFluidHandler dest = export ? toAccess : current;
+        ForgeDirection drainSide = export ? side : side.getOpposite();
+        GT_Utility.moveFluid(source, dest, drainSide, mTransferRate, this::canTransferFluid);
     }
 
     protected boolean canTransferFluid(FluidStack fluid) {

--- a/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler.java
+++ b/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler.java
@@ -320,11 +320,7 @@ public abstract class GT_MetaTileEntity_Boiler extends GT_MetaTileEntity_BasicTa
         if (mSteam == null || mSteam.amount == 0) return;
         final IFluidHandler tTileEntity = aBaseMetaTileEntity.getITankContainerAtSide(side);
         if (tTileEntity == null) return;
-        final FluidStack tDrained = aBaseMetaTileEntity.drain(side, Math.max(1, this.mSteam.amount / 2), false);
-        if (tDrained == null) return;
-        final int tFilledAmount = tTileEntity.fill(side.getOpposite(), tDrained, false);
-        if (tFilledAmount <= 0) return;
-        tTileEntity.fill(side.getOpposite(), aBaseMetaTileEntity.drain(side, tFilledAmount, true), true);
+        GT_Utility.moveFluid(aBaseMetaTileEntity, tTileEntity, side, Math.max(1, this.mSteam.amount / 2), null);
     }
 
     /**


### PR DESCRIPTION
my follow up on #2452. I was trying to do the same but got distracted by the mess in transferFluid. Now with #2452 merged, the moveFluid should still be helpful

Honestly, why is this not in forge itself?