### PR TITLE
Remove all usages of GT_ItemStack2 as Set/Map keys by using fastutil

### DIFF
--- a/src/main/java/gregtech/GT_Mod.java
+++ b/src/main/java/gregtech/GT_Mod.java
@@ -128,7 +128,7 @@ import ic2.api.recipe.RecipeOutput;
     version = "MC1710",
     guiFactory = "gregtech.client.GT_GuiFactory",
     dependencies = " required-after:IC2;" + " required-after:structurelib;"
-        + " required-after:gtnhlib@[0.0.8,);"
+        + " required-after:gtnhlib@[0.2.1,);"
         + " required-after:modularui@[1.1.12,);"
         + " required-after:appliedenergistics2@[rv3-beta-258,);"
         + " after:dreamcraft;"

--- a/src/main/java/gregtech/GT_Mod.java
+++ b/src/main/java/gregtech/GT_Mod.java
@@ -796,7 +796,7 @@ public class GT_Mod implements IGT_Mod {
         GT_Utility.reInit();
         GT_Recipe.reInit();
         try {
-            for (Map<? extends ItemHolder, ?> gt_itemStackMap : GregTech_API.sItemStackMappings) {
+            for (Map<?, ?> gt_itemStackMap : GregTech_API.sItemStackMappings) {
                 GT_Utility.reMap(gt_itemStackMap);
             }
             for (SetMultimap<? extends ItemHolder, ?> gt_itemStackMap : GregTech_API.itemStackMultiMaps) {

--- a/src/main/java/gregtech/api/GregTech_API.java
+++ b/src/main/java/gregtech/api/GregTech_API.java
@@ -107,8 +107,12 @@ public class GregTech_API {
     public static final long FLUID_MATERIAL_UNIT = L;
     /**
      * Fixes the HashMap Mappings for ItemStacks once the Server started
+     * <br>
+     * <br>
+     * NOTE: We use wildcards generics for the key because it could be for example {@link ItemStack} or
+     * {@link GT_ItemStack}
      */
-    public static final Collection<Map<? extends ItemHolder, ?>> sItemStackMappings = new ArrayList<>();
+    public static final Collection<Map<?, ?>> sItemStackMappings = new ArrayList<>();
     public static final Collection<SetMultimap<? extends ItemHolder, ?>> itemStackMultiMaps = new ArrayList<>();
 
     /**

--- a/src/main/java/gregtech/api/enums/OrePrefixes.java
+++ b/src/main/java/gregtech/api/enums/OrePrefixes.java
@@ -20,13 +20,14 @@ import gregtech.api.interfaces.ICondition;
 import gregtech.api.interfaces.IOreRecipeRegistrator;
 import gregtech.api.interfaces.ISubTagContainer;
 import gregtech.api.objects.GT_ArrayList;
-import gregtech.api.objects.GT_HashSet;
-import gregtech.api.objects.GT_ItemStack2;
+import gregtech.api.objects.GT_ItemStack;
 import gregtech.api.objects.ItemData;
 import gregtech.api.objects.MaterialStack;
 import gregtech.api.util.GT_Log;
 import gregtech.api.util.GT_Utility;
 import gregtech.loaders.materialprocessing.ProcessingModSupport;
+import it.unimi.dsi.fastutil.objects.ObjectOpenCustomHashSet;
+import it.unimi.dsi.fastutil.objects.ObjectSet;
 
 public enum OrePrefixes {
 
@@ -1015,7 +1016,10 @@ public enum OrePrefixes {
     public MaterialStack mSecondaryMaterial = null;
     public OrePrefixes mPrefixInto = this;
     public float mHeatDamage = 0.0F; // Negative for Frost Damage
-    private final GT_HashSet<GT_ItemStack2> mContainsTestCache = new GT_HashSet<>(512, 0.5f);
+    private final ObjectSet<ItemStack> mContainsTestCache = new ObjectOpenCustomHashSet<>(
+        512,
+        0.5f,
+        GT_ItemStack.ITEMSTACK_HASH_STRATEGY2);
     public static final List<OrePrefixes> mPreventableComponents = new LinkedList<>(
         Arrays.asList(
             OrePrefixes.gem,
@@ -1205,13 +1209,13 @@ public enum OrePrefixes {
         if (!contains(aStack)) {
             mPrefixedItems.add(aStack);
             // It's now in there... so update the cache
-            mContainsTestCache.add(new GT_ItemStack2(aStack));
+            mContainsTestCache.add(aStack);
         }
         return true;
     }
 
     public boolean contains(ItemStack aStack) {
-        return !GT_Utility.isStackInvalid(aStack) && mContainsTestCache.contains(new GT_ItemStack2(aStack));
+        return !GT_Utility.isStackInvalid(aStack) && mContainsTestCache.contains(aStack);
     }
 
     public boolean containsUnCached(ItemStack aStack) {

--- a/src/main/java/gregtech/api/objects/GT_ItemStack.java
+++ b/src/main/java/gregtech/api/objects/GT_ItemStack.java
@@ -7,12 +7,32 @@ import net.minecraft.item.ItemStack;
 import gregtech.api.enums.GT_Values;
 import gregtech.api.util.GT_Utility;
 import gregtech.api.util.item.ItemHolder;
+import it.unimi.dsi.fastutil.Hash;
 
 /**
  * An optimization of {@link ItemStack} to have a better {@code hashcode} and {@code equals} in order to improve
  * {@code HashMap} and {@code Set} performance
  */
 public class GT_ItemStack extends ItemHolder {
+
+    /**
+     * A better {@link Hash.Strategy} for {@link ItemStack}. Implementation originally from {@code GT_ItemStack2}.
+     */
+    public static final Hash.Strategy<ItemStack> ITEMSTACK_HASH_STRATEGY2 = new Hash.Strategy<>() {
+
+        @Override
+        public int hashCode(ItemStack o) {
+            return o.getItem()
+                .hashCode() * 38197 + Items.feather.getDamage(o);
+        }
+
+        @Override
+        public boolean equals(ItemStack a, ItemStack b) {
+            if (a == b) return true;
+            if (a == null || b == null) return false;
+            return a.getItem() == b.getItem() && Items.feather.getDamage(a) == Items.feather.getDamage(b);
+        }
+    };
 
     public final Item mItem;
     public final byte mStackSize;
@@ -65,5 +85,23 @@ public class GT_ItemStack extends ItemHolder {
     @Override
     public int hashCode() {
         return GT_Utility.stackToInt(toStack());
+    }
+
+    /**
+     * @see #internalCopyStack(ItemStack, boolean)
+     */
+    public static ItemStack internalCopyStack(ItemStack aStack) {
+        return internalCopyStack(aStack, false);
+    }
+
+    /**
+     * Replicates the copy behavior of {@link #toStack()} but for normal {@link ItemStack}s.
+     *
+     * @param aStack   the stack to copy
+     * @param wildcard whether to use wildcard damage value
+     * @return a copy of the stack with stack size 1 and no NBT
+     */
+    public static ItemStack internalCopyStack(ItemStack aStack, boolean wildcard) {
+        return new ItemStack(aStack.getItem(), 1, wildcard ? GT_Values.W : Items.feather.getDamage(aStack));
     }
 }

--- a/src/main/java/gregtech/api/objects/GT_ItemStack2.java
+++ b/src/main/java/gregtech/api/objects/GT_ItemStack2.java
@@ -7,7 +7,10 @@ import net.minecraft.item.ItemStack;
  * GT_ItemStack, but with a better hashCode(). Due to this change, it should not be placed in the same hash based data
  * structure with GT_ItemStack. It also shouldn't be used to construct search query into a hash based data structure
  * that contains GT_ItemStack.
+ *
+ * @deprecated See {@link GT_ItemStack#ITEMSTACK_HASH_STRATEGY2}
  */
+@Deprecated
 public class GT_ItemStack2 extends GT_ItemStack {
 
     public GT_ItemStack2(Item aItem, long aStackSize, long aMetaData) {

--- a/src/main/java/gregtech/api/util/GT_OreDictUnificator.java
+++ b/src/main/java/gregtech/api/util/GT_OreDictUnificator.java
@@ -396,11 +396,7 @@ public class GT_OreDictUnificator {
         if (GT_Utility.isStackInvalid(aStack)) return null;
         ItemData rData = sItemStack2DataMap.get(aStack);
         if (rData == null) { // Try the lookup again but with wildcard damage value
-            // Modifying the parameter avoids allocating a new ItemStack
-            int oldDamage = aStack.getItemDamage();
-            Items.feather.setDamage(aStack, W);
-            rData = sItemStack2DataMap.get(aStack);
-            Items.feather.setDamage(aStack, oldDamage);
+            rData = sItemStack2DataMap.get(GT_ItemStack.internalCopyStack(aStack, true));
         }
         return rData;
     }

--- a/src/main/java/gregtech/api/util/GT_OreDictUnificator.java
+++ b/src/main/java/gregtech/api/util/GT_OreDictUnificator.java
@@ -7,7 +7,6 @@ import static gregtech.api.enums.GT_Values.W;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -25,9 +24,10 @@ import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.enums.SubTag;
 import gregtech.api.objects.GT_ItemStack;
-import gregtech.api.objects.GT_ItemStack2;
 import gregtech.api.objects.ItemData;
 import gregtech.api.objects.MaterialStack;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenCustomHashMap;
+import it.unimi.dsi.fastutil.objects.ObjectOpenCustomHashSet;
 
 /**
  * NEVER INCLUDE THIS FILE IN YOUR MOD!!!
@@ -41,9 +41,12 @@ import gregtech.api.objects.MaterialStack;
 public class GT_OreDictUnificator {
 
     private static final Map<String, ItemStack> sName2StackMap = new HashMap<>();
-    private static final Map<GT_ItemStack2, ItemData> sItemStack2DataMap = new HashMap<>();
-    private static final Map<GT_ItemStack2, List<ItemStack>> sUnificationTable = new HashMap<>();
-    private static final Set<GT_ItemStack2> sNoUnificationList = new HashSet<>();
+    private static final Map<ItemStack, ItemData> sItemStack2DataMap = new Object2ObjectOpenCustomHashMap<>(
+        GT_ItemStack.ITEMSTACK_HASH_STRATEGY2);
+    private static final Map<ItemStack, List<ItemStack>> sUnificationTable = new Object2ObjectOpenCustomHashMap<>(
+        GT_ItemStack.ITEMSTACK_HASH_STRATEGY2);
+    private static final Set<ItemStack> sNoUnificationList = new ObjectOpenCustomHashSet<>(
+        GT_ItemStack.ITEMSTACK_HASH_STRATEGY2);
     private static int isRegisteringOre = 0, isAddingOre = 0;
     private static boolean mRunThroughTheList = true;
 
@@ -57,12 +60,12 @@ public class GT_OreDictUnificator {
      * the Industrial Diamond, which is better than regular Diamond, but also usable in absolutely all Diamond Recipes.
      */
     public static void addToBlacklist(ItemStack aStack) {
-        if (GT_Utility.isStackValid(aStack) && !GT_Utility.isStackInList(aStack, sNoUnificationList))
-            sNoUnificationList.add(new GT_ItemStack2(aStack));
+        if (GT_Utility.isStackValid(aStack) && !GT_Utility.isStackInStackSet(aStack, sNoUnificationList))
+            sNoUnificationList.add(aStack);
     }
 
     public static boolean isBlacklisted(ItemStack aStack) {
-        return GT_Utility.isStackInList(aStack, sNoUnificationList);
+        return GT_Utility.isStackInStackSet(aStack, sNoUnificationList);
     }
 
     public static void add(OrePrefixes aPrefix, Materials aMaterial, ItemStack aStack) {
@@ -281,12 +284,11 @@ public class GT_OreDictUnificator {
             // 5900x tries to do NEI lookup
             synchronized (sUnificationTable) {
                 if (sUnificationTable.isEmpty() && !sItemStack2DataMap.isEmpty()) {
-                    for (GT_ItemStack tGTStack0 : sItemStack2DataMap.keySet()) {
-                        ItemStack tStack0 = tGTStack0.toStack();
+                    for (ItemStack tGTStack0 : sItemStack2DataMap.keySet()) {
+                        ItemStack tStack0 = GT_ItemStack.internalCopyStack(tGTStack0);
                         ItemStack tStack1 = get_nocopy(false, tStack0);
                         if (!GT_Utility.areStacksEqual(tStack0, tStack1)) {
-                            GT_ItemStack2 tGTStack1 = new GT_ItemStack2(tStack1);
-                            List<ItemStack> list = sUnificationTable.computeIfAbsent(tGTStack1, k -> new ArrayList<>());
+                            List<ItemStack> list = sUnificationTable.computeIfAbsent(tStack1, k -> new ArrayList<>());
                             // greg's original code tries to dedupe the list using List#contains, which won't work
                             // on vanilla ItemStack. I removed it since it never worked and can be slow.
                             list.add(tStack0);
@@ -303,7 +305,7 @@ public class GT_OreDictUnificator {
         for (ItemStack aStack : aStacks) {
             if (aStack == null) continue;
             rList.add(aStack);
-            List<ItemStack> tList = sUnificationTable.get(new GT_ItemStack2(aStack));
+            List<ItemStack> tList = sUnificationTable.get(aStack);
             if (tList != null) {
                 for (ItemStack tStack : tList) {
                     ItemStack tStack1 = GT_Utility.copyAmount(aStack.stackSize, tStack);
@@ -346,7 +348,7 @@ public class GT_OreDictUnificator {
                 for (MaterialStack tMaterial : aData.mByProducts) tMaterial.mAmount /= aStack.stackSize;
                 aStack = GT_Utility.copyAmount(1, aStack);
             }
-            sItemStack2DataMap.put(new GT_ItemStack2(aStack), aData);
+            sItemStack2DataMap.put(aStack, aData);
             if (aData.hasValidMaterialData()) {
                 long tValidMaterialAmount = aData.mMaterial.mMaterial.contains(SubTag.NO_RECYCLING) ? 0
                     : aData.mMaterial.mAmount >= 0 ? aData.mMaterial.mAmount : M;
@@ -358,11 +360,10 @@ public class GT_OreDictUnificator {
             if (mRunThroughTheList) {
                 if (GregTech_API.sLoadStarted) {
                     mRunThroughTheList = false;
-                    for (Entry<GT_ItemStack2, ItemData> tEntry : sItemStack2DataMap.entrySet()) if (!tEntry.getValue()
+                    for (Entry<ItemStack, ItemData> tEntry : sItemStack2DataMap.entrySet()) if (!tEntry.getValue()
                         .hasValidPrefixData() || tEntry.getValue().mPrefix.mAllowNormalRecycling)
                         GT_RecipeRegistrator.registerMaterialRecycling(
-                            tEntry.getKey()
-                                .toStack(),
+                            GT_ItemStack.internalCopyStack(tEntry.getKey()),
                             tEntry.getValue());
                 }
             } else {
@@ -379,7 +380,7 @@ public class GT_OreDictUnificator {
         if (GT_Utility.isStackInvalid(aStack)) {
             return;
         }
-        sItemStack2DataMap.remove(new GT_ItemStack2(aStack));
+        sItemStack2DataMap.remove(aStack);
     }
 
     public static void addAssociation(OrePrefixes aPrefix, Materials aMaterial, ItemStack aStack,
@@ -393,8 +394,14 @@ public class GT_OreDictUnificator {
     @Nullable
     public static ItemData getItemData(ItemStack aStack) {
         if (GT_Utility.isStackInvalid(aStack)) return null;
-        ItemData rData = sItemStack2DataMap.get(new GT_ItemStack2(aStack));
-        if (rData == null) rData = sItemStack2DataMap.get(new GT_ItemStack2(aStack, true));
+        ItemData rData = sItemStack2DataMap.get(aStack);
+        if (rData == null) { // Try the lookup again but with wildcard damage value
+            // Modifying the parameter avoids allocating a new ItemStack
+            int oldDamage = aStack.getItemDamage();
+            Items.feather.setDamage(aStack, W);
+            rData = sItemStack2DataMap.get(aStack);
+            Items.feather.setDamage(aStack, oldDamage);
+        }
         return rData;
     }
 

--- a/src/main/java/gregtech/api/util/GT_Utility.java
+++ b/src/main/java/gregtech/api/util/GT_Utility.java
@@ -3141,12 +3141,7 @@ public class GT_Utility {
         if (aStack == null) return false;
         if (aSet.contains(aStack)) return true;
 
-        // Modifying the parameter avoids allocating a new ItemStack
-        int oldDamage = aStack.getItemDamage();
-        Items.feather.setDamage(aStack, W);
-        boolean contains = aSet.contains(aStack);
-        Items.feather.setDamage(aStack, oldDamage);
-        return contains;
+        return aSet.contains(GT_ItemStack.internalCopyStack(aStack, true));
     }
 
     public static boolean isStackInList(ItemStack aStack, Collection<GT_ItemStack> aList) {


### PR DESCRIPTION
This should be properly tested and reviewed in-case I broke something.

Memory allocations when starting GT5 dev environment:

_Before_
![image](https://github.com/GTNewHorizons/GT5-Unofficial/assets/36999320/2bb17508-0fd3-4af0-b4ca-07acf57dcca5)

_After_
![image](https://github.com/GTNewHorizons/GT5-Unofficial/assets/36999320/f0a0618d-9d3a-4ae2-8104-979a8fd54555)