### PR TITLE
Fix massfab

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_Massfabricator.java
+++ b/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_Massfabricator.java
@@ -116,7 +116,7 @@ public class GT_MetaTileEntity_Massfabricator extends GT_MetaTileEntity_BasicMac
     }
 
     public GT_MetaTileEntity_Massfabricator(String aName, int aTier, String[] aDescription, ITexture[][][] aTextures) {
-        super(aName, aTier, 1, aDescription, aTextures, 1, 1);
+        super(aName, aTier, 8, aDescription, aTextures, 1, 1);
     }
 
     @Override


### PR DESCRIPTION
Fix massfab OCs. Only the other constructor had amperage set to 8, this one was missing and apparently its the relevant one. :P
thanks to Rami on discord for helping to find this!

fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15209
was caused by https://github.com/GTNewHorizons/GT5-Unofficial/pull/2345


working now. here is LV:
![image](https://github.com/GTNewHorizons/GT5-Unofficial/assets/40274384/659cafee-226a-40b4-9956-c33fa18dd5ad)
