### PR TITLE
Add Banded Iron EBF processing.

### DIFF
--- a/src/main/java/gregtech/loaders/postload/recipes/BlastFurnaceRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/BlastFurnaceRecipes.java
@@ -131,6 +131,15 @@ public class BlastFurnaceRecipes implements Runnable {
             .addTo(blastFurnaceRecipes);
 
         GT_Values.RA.stdBuilder()
+            .itemInputs(Materials.BandedIron.getDust(2), Materials.Carbon.getDust(1))
+            .itemOutputs(Materials.Iron.getIngots(outputIngotAmount), Materials.Ash.getDustTiny(2))
+            .fluidOutputs(Materials.CarbonDioxide.getGas(1000))
+            .duration(12 * SECONDS)
+            .eut((int) TierEU.RECIPE_MV)
+            .metadata(COIL_HEAT, 1200)
+            .addTo(blastFurnaceRecipes);
+
+        GT_Values.RA.stdBuilder()
             .itemInputs(Materials.Magnetite.getDust(2), Materials.Carbon.getDust(1))
             .itemOutputs(Materials.Iron.getIngots(outputIngotAmount), Materials.Ash.getDustTiny(2))
             .fluidOutputs(Materials.CarbonDioxide.getGas(1000))


### PR DESCRIPTION
![](https://i.imgur.com/OvOOGY9.png)

2 Banded Iron + 1 Carbon --> 3 Iron + 2/9 Ashes + 1000 CO2. Same as all the other 2:3 ore recipes.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14022.