### PR TITLE
Fix oc calculator

### DIFF
--- a/src/main/java/gregtech/api/util/GT_OverclockCalculator.java
+++ b/src/main/java/gregtech/api/util/GT_OverclockCalculator.java
@@ -393,7 +393,7 @@ public class GT_OverclockCalculator {
         double machinePowerTier = calculateMachinePowerTier();
 
         overclockCount = calculateAmountOfNeededOverclocks(machinePowerTier, recipePowerTier);
-        if (recipeVoltage <= GT_Values.V[0]) {
+        if (!amperageOC) {
             overclockCount = Math.min(overclockCount, calculateRecipeToMachineVoltageDifference());
         }
         if (overclockCount < 0) {
@@ -463,19 +463,19 @@ public class GT_OverclockCalculator {
 
     /**
      * Calculates the amount of overclocks needed to reach 1 ticking
-     * 
+     *
      * Here we limit "the tier difference overclock" amount to a number
      * of overclocks needed to reach 1 tick duration, for example:
-     * 
+     *
      * recipe initial duration = 250 ticks (12,5 seconds LV(1))
      * we have LCR with IV(5) energy hatch, which overclocks at 4/4 rate
-     * 
+     *
      * log_4 (250) ~ 3,98 is the number of overclocks needed to reach 1 tick
-     * 
+     *
      * to calculate log_a(b) we can use the log property:
      * log_a(b) = log_c(b) / log_c(a)
      * in our case we use natural log base as 'c'
-     * 
+     *
      * as a final step we apply Math.ceil(),
      * otherwise for fractional nums like 3,98 we will never reach 1 tick
      */

--- a/src/test/java/gregtech/overclock/GT_OverclockCalculator_UnitTest.java
+++ b/src/test/java/gregtech/overclock/GT_OverclockCalculator_UnitTest.java
@@ -116,8 +116,8 @@ class GT_OverclockCalculator_UnitTest {
     @Test
     void doubleEnergyHatchOC_Test() {
         GT_OverclockCalculator calculator = new GT_OverclockCalculator().setRecipeEUt(VP[1])
-            .setEUt(V[6] + V[6])
-            .setAmperage(2)
+            .setEUt(V[6])
+            .setAmperage(4)
             .setDuration(1024)
             .setAmperageOC(true)
             .calculate();

--- a/src/test/java/gregtech/overclock/GT_OverclockCalculator_UnitTest.java
+++ b/src/test/java/gregtech/overclock/GT_OverclockCalculator_UnitTest.java
@@ -126,6 +126,18 @@ class GT_OverclockCalculator_UnitTest {
     }
 
     @Test
+    void doubleEnergyHatchOCForULV_Test() {
+        GT_OverclockCalculator calculator = new GT_OverclockCalculator().setRecipeEUt(VP[0])
+            .setEUt(V[6])
+            .setAmperage(4)
+            .setDuration(1024)
+            .setAmperageOC(true)
+            .calculate();
+        assertEquals(1024 >> 6, calculator.getDuration(), messageDuration);
+        assertEquals(VP[0] << 12, calculator.getConsumption(), messageEUt);
+    }
+
+    @Test
     void multiAmpHatchOC_Test() {
         GT_OverclockCalculator calculator = new GT_OverclockCalculator().setRecipeEUt(VP[1])
             .setEUt(V[6])


### PR DESCRIPTION
fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15397

No ulv check should ever be needed. This just checks for amperageoc now. That is the deciding thing to know if we need a voltage difference check or not.

Also added a relevant unit test.

Also slightly fixed another unit test (that was passing however and still is).