### PR TITLE
Fix nano forge nei preview

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_NanoForge.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_NanoForge.java
@@ -262,21 +262,20 @@ public class GT_MetaTileEntity_NanoForge extends
     @Override
     public boolean checkMachine(IGregTechTileEntity aBaseMetaTileEntity, ItemStack aStack) {
         mSpecialTier = 0;
-        if (aStack == null) return false;
-        if (aStack.isItemEqual(Materials.Carbon.getNanite(1)) && checkPiece(STRUCTURE_PIECE_MAIN, 4, 37, 1)) {
-            mSpecialTier = 1;
-        }
+        if (checkPiece(STRUCTURE_PIECE_MAIN, 4, 37, 1) && aStack != null) {
+            if (aStack.isItemEqual(Materials.Carbon.getNanite(1))) {
+                mSpecialTier = 1;
+            }
 
-        if (aStack.isItemEqual(Materials.Neutronium.getNanite(1)) && checkPiece(STRUCTURE_PIECE_MAIN, 4, 37, 1)
-            && checkPiece(STRUCTURE_PIECE_TIER2, -7, 14, 4)) {
-            mSpecialTier = 2;
-        }
+            if (aStack.isItemEqual(Materials.Neutronium.getNanite(1)) && checkPiece(STRUCTURE_PIECE_TIER2, -7, 14, 4)) {
+                mSpecialTier = 2;
+            }
 
-        if (aStack.isItemEqual(MaterialsUEVplus.TranscendentMetal.getNanite(1))
-            && checkPiece(STRUCTURE_PIECE_MAIN, 4, 37, 1)
-            && checkPiece(STRUCTURE_PIECE_TIER2, -7, 14, 4)
-            && checkPiece(STRUCTURE_PIECE_TIER3, 14, 26, 4)) {
-            mSpecialTier = 3;
+            if (aStack.isItemEqual(MaterialsUEVplus.TranscendentMetal.getNanite(1))
+                && checkPiece(STRUCTURE_PIECE_TIER2, -7, 14, 4)
+                && checkPiece(STRUCTURE_PIECE_TIER3, 14, 26, 4)) {
+                mSpecialTier = 3;
+            }
         }
 
         if (mMaintenanceHatches.size() != 1 || mInputBusses.isEmpty()
@@ -310,8 +309,8 @@ public class GT_MetaTileEntity_NanoForge extends
     @Override
     public int survivalConstruct(ItemStack stackSize, int elementBudget, ISurvivalBuildEnvironment env) {
         if (mMachine) return -1;
-        int built = 0;
-        built += survivialBuildPiece(STRUCTURE_PIECE_MAIN, stackSize, 4, 37, 1, elementBudget, env, false, true);
+        int built = survivialBuildPiece(STRUCTURE_PIECE_MAIN, stackSize, 4, 37, 1, elementBudget, env, false, true);
+        if (built >= 0) return built;
         if (stackSize.stackSize > 1) {
             built += survivialBuildPiece(STRUCTURE_PIECE_TIER2, stackSize, -7, 14, 4, elementBudget, env, false, true);
         }


### PR DESCRIPTION
Turns it from this:
![nano_pre](https://github.com/GTNewHorizons/GT5-Unofficial/assets/127234178/b81a0146-e13e-46a1-90e3-7766254d4044)
To this:
![nano_complete](https://github.com/GTNewHorizons/GT5-Unofficial/assets/127234178/b4a0002b-b13a-41c6-a2c1-59f138732b35)

Minor changes were made to survivalConstruct to ensure that the main structure is done before beginning the tier structures.

Some changes also had to be made to checkMachine to ensure that `checkPiece(STRUCTURE_PIECE_MAIN, 4, 37, 1)` is checked before failing the structure check. The tier logic remains the same though.

If that is not done we end up with too many hatches in the preview:
![nano-check](https://github.com/GTNewHorizons/GT5-Unofficial/assets/127234178/153085e3-1b4d-4a87-89c1-af6f0e8efcbd)
