### PR TITLE
Fix EBF tooltip

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_ElectricBlastFurnace.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_ElectricBlastFurnace.java
@@ -122,9 +122,8 @@ public class GT_MetaTileEntity_ElectricBlastFurnace extends
             .addInfo("Controller block for the Electric Blast Furnace")
             .addInfo("You can use some fluids to reduce recipe time. Place the circuit in the Input Bus")
             .addInfo("Each 900K over the min. Heat required reduces power consumption by 5% (multiplicatively)")
-            .addInfo("Each 1800K over the min. Heat required grants one perfect overclock")
-            .addInfo(
-                "For each perfect overclock the EBF will reduce recipe time 4 times (instead of 2) (100% efficiency)")
+            .addInfo("Each 1800K over the min. Heat allows for an overclock to be upgraded to a perfect overclock.")
+            .addInfo("That means the EBF will reduce recipe time by a factor 4 instead of 2 (giving 100% efficiency).")
             .addInfo("Additionally gives +100K for every tier past MV")
             .addPollutionAmount(getPollutionPerSecond(null))
             .addSeparator()


### PR DESCRIPTION
The tooltip used to be correct but is no longer since https://github.com/GTNewHorizons/GT5-Unofficial/pull/958 in turn caused by the incorrect suggestion in https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/7173.

In short, the +1800K for an EBF **does not** grant an OC. It only upgrades an existing oc from 4/2 to 4/4.