### PR TITLE
Fix MuTE Casings Not Forming Correctly

### DIFF
--- a/src/main/java/gregtech/api/multitileentity/base/MultiTileEntity.java
+++ b/src/main/java/gregtech/api/multitileentity/base/MultiTileEntity.java
@@ -1343,18 +1343,19 @@ public abstract class MultiTileEntity extends CoverableTileEntity
     public void getFullPacketData(GT_Packet_MultiTileEntity packet) {
         packet.addData(new CoordinateData(getCoords()));
         packet.addData(new CommonData(mStrongRedstone, color, (byte) 0));
-        packet.addData(new MultiTileEntityData(mteRegistry, blockMetadata));
+        packet.addData(new MultiTileEntityData(mteRegistry, mteID));
     }
 
     @Override
     public void getGraphicPacketData(GT_Packet_MultiTileEntity packet) {
         packet.addData(new CoordinateData(getCoords()));
+        packet.addData(new MultiTileEntityData(mteRegistry, mteID));
     }
 
     @Override
     public void getTimedPacketData(GT_Packet_MultiTileEntity packet) {
         packet.addData(new CoordinateData(getCoords()));
-        packet.addData(new MultiTileEntityData(mteRegistry, blockMetadata));
+        packet.addData(new MultiTileEntityData(mteRegistry, mteID));
     }
 
     @Override

--- a/src/main/java/gregtech/api/multitileentity/base/NonTickableMultiTileEntity.java
+++ b/src/main/java/gregtech/api/multitileentity/base/NonTickableMultiTileEntity.java
@@ -20,7 +20,10 @@ public abstract class NonTickableMultiTileEntity extends MultiTileEntity {
 
     @Override
     public void issueClientUpdate() {
-        if (worldObj != null && !worldObj.isRemote) sendClientData(null);
+        if (worldObj != null && !worldObj.isRemote) {
+            sendClientData(null);
+            sendGraphicPacket();
+        }
     }
 
     @Override

--- a/src/main/java/gregtech/api/multitileentity/base/TickableMultiTileEntity.java
+++ b/src/main/java/gregtech/api/multitileentity/base/TickableMultiTileEntity.java
@@ -163,6 +163,7 @@ public abstract class TickableMultiTileEntity extends MultiTileEntity implements
     @Override
     public void issueClientUpdate() {
         sendClientData = true;
+        sendGraphicPacket();
     }
 
     @Override

--- a/src/main/java/gregtech/api/net/data/MultiTileEntityData.java
+++ b/src/main/java/gregtech/api/net/data/MultiTileEntityData.java
@@ -26,10 +26,16 @@ public class MultiTileEntityData extends PacketData<MultiTileEntityProcess> {
     }
 
     @Override
-    public void encode(@Nonnull ByteBuf out) {}
+    public void encode(@Nonnull ByteBuf out) {
+        out.writeInt(registryId);
+        out.writeInt(metaId);
+    }
 
     @Override
-    public void decode(@Nonnull ByteArrayDataInput in) {}
+    public void decode(@Nonnull ByteArrayDataInput in) {
+        registryId = in.readInt();
+        metaId = in.readInt();
+    }
 
     @Override
     public void process(MultiTileEntityProcess processData) {


### PR DESCRIPTION
This PR fixes the errors that happen when a MuTE is build in creative with the Hologram Projector, and also for working casings when the world is loaded once again. They turn into "corrupted" blocks due to IDs not being encoded and decoded. @BlueWeabo suggested code additions to fix this and the casings appear correctly now.

- Changed blockMetadata to mteID on methods in MultiTileEntity.hava that are not being used yet (Blue said this is how they're supposed to be);
- Send graphic packets for tickable and non-tickable MuTEs;
- Encode and decode relevant IDs to ensure MuTE casings form correctly on world load and auto-building.