### PR TITLE
Fix water bottle fluid exploit

### DIFF
--- a/src/main/java/gregtech/api/util/GT_Utility.java
+++ b/src/main/java/gregtech/api/util/GT_Utility.java
@@ -1891,6 +1891,12 @@ public class GT_Utility {
     public static ItemStack fillFluidContainer(FluidStack aFluid, ItemStack aStack, boolean aRemoveFluidDirectly,
         boolean aCheckIFluidContainerItems) {
         if (isStackInvalid(aStack) || aFluid == null) return null;
+        if (GT_ModHandler.isWater(aFluid) && ItemList.Bottle_Empty.isStackEqual(aStack)) {
+            if (aFluid.amount >= 1000) {
+                return new ItemStack(Items.potionitem, 1, 0);
+            }
+            return null;
+        }
         if (aCheckIFluidContainerItems && aStack.getItem() instanceof IFluidContainerItem
             && ((IFluidContainerItem) aStack.getItem()).getFluid(aStack) == null
             && ((IFluidContainerItem) aStack.getItem()).getCapacity(aStack) <= aFluid.amount) {

--- a/src/main/java/gregtech/common/GT_Proxy.java
+++ b/src/main/java/gregtech/common/GT_Proxy.java
@@ -850,7 +850,7 @@ public abstract class GT_Proxy implements IGT_Mod, IGuiHandler, IFuelHandler {
         for (FluidContainerRegistry.FluidContainerData tData : FluidContainerRegistry
             .getRegisteredFluidContainerData()) {
             if ((tData.filledContainer.getItem() == Items.potionitem) && (tData.filledContainer.getItemDamage() == 0)) {
-                tData.fluid.amount = 250;
+                tData.fluid.amount = 0;
                 break;
             }
         }
@@ -1252,7 +1252,7 @@ public abstract class GT_Proxy implements IGT_Mod, IGuiHandler, IFuelHandler {
         for (FluidContainerRegistry.FluidContainerData tData : FluidContainerRegistry
             .getRegisteredFluidContainerData()) {
             if ((tData.filledContainer.getItem() == Items.potionitem) && (tData.filledContainer.getItemDamage() == 0)) {
-                tData.fluid.amount = 250;
+                tData.fluid.amount = 0;
                 break;
             }
         }
@@ -1284,7 +1284,7 @@ public abstract class GT_Proxy implements IGT_Mod, IGuiHandler, IFuelHandler {
         for (FluidContainerRegistry.FluidContainerData tData : FluidContainerRegistry
             .getRegisteredFluidContainerData()) {
             if ((tData.filledContainer.getItem() == Items.potionitem) && (tData.filledContainer.getItemDamage() == 0)) {
-                tData.fluid.amount = 250;
+                tData.fluid.amount = 0;
                 break;
             }
         }
@@ -1379,7 +1379,7 @@ public abstract class GT_Proxy implements IGT_Mod, IGuiHandler, IFuelHandler {
         for (FluidContainerRegistry.FluidContainerData tData : FluidContainerRegistry
             .getRegisteredFluidContainerData()) {
             if ((tData.filledContainer.getItem() == Items.potionitem) && (tData.filledContainer.getItemDamage() == 0)) {
-                tData.fluid.amount = 250;
+                tData.fluid.amount = 0;
                 break;
             }
         }
@@ -2210,7 +2210,7 @@ public abstract class GT_Proxy implements IGT_Mod, IGuiHandler, IFuelHandler {
     public void onFluidContainerRegistration(FluidContainerRegistry.FluidContainerRegisterEvent aFluidEvent) {
         if ((aFluidEvent.data.filledContainer.getItem() == Items.potionitem)
             && (aFluidEvent.data.filledContainer.getItemDamage() == 0)) {
-            aFluidEvent.data.fluid.amount = 250;
+            aFluidEvent.data.fluid.amount = 0;
         }
         GT_OreDictUnificator.addToBlacklist(aFluidEvent.data.emptyContainer);
         GT_OreDictUnificator.addToBlacklist(aFluidEvent.data.filledContainer);


### PR DESCRIPTION
This is a follow-up/partial revert to https://github.com/GTNewHorizons/GT5-Unofficial/pull/2337. The main fix from there is kept.

I was mislead back then by claims that infinite water from bottles would be possible anyway with tank instead of fluid canner. That was the only reason I approved it back then. However that is not the case, it is just these specific set fluid numbers that make it possible for both tanks and canners.

We specifically dont water infinite water without the railcraft water collection tank, cactus farm, stirling pump, or thirsty tank in early game. As one can fill water bottles from a water source block, gt always had their amount set to 0, so that you cant turn them into infinite water in gt machines.

As people are now advertising fluid bottles as a great infinite early game water source on discord, its time we quickly fix this.

I have tested that this change works for: low voltage tank, super tank, quantum tank, fluid canner.

edit: one adjustment. one now needs at least 1000L water available to fill water bottles.