### PR TITLE
Assign force fuel value in GT

### DIFF
--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingCell.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingCell.java
@@ -193,6 +193,10 @@ public class ProcessingCell implements IOreRecipeRegistrator {
                             recipeBuilder.metadata(FUEL_VALUE, 150_000)
                                 .metadata(FUEL_TYPE, 4)
                                 .addTo(GT_RecipeConstants.Fuel);
+                        case "Force":
+                            recipeBuilder.metadata(FUEL_VALUE, 150_000)
+                                .metadata(FUEL_TYPE, 4)
+                                .addTo(GT_RecipeConstants.Fuel);
                         default:
                             recipeBuilder.metadata(FUEL_VALUE, (int) Math.max(1024L, 1024L * aMaterial.getMass()))
                                 .metadata(FUEL_TYPE, 4)


### PR DESCRIPTION
Its a gt material, so it has to be here, not in gt++.

fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15533

goes together with https://github.com/GTNewHorizons/GTplusplus/pull/836.