### PR TITLE
Allow interacting with machines instantly upon placing

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
@@ -517,7 +517,7 @@ public class BaseMetaPipeEntity extends CommonMetaTileEntity
 
     @Override
     public boolean isUseableByPlayer(EntityPlayer aPlayer) {
-        return hasValidMetaTileEntity() && mTickTimer > 40
+        return hasValidMetaTileEntity() && mTickTimer > 1
             && getTileEntityOffset(0, 0, 0) == this
             && aPlayer.getDistanceSq(xCoord + 0.5, yCoord + 0.5, zCoord + 0.5) < 64
             && mMetaTileEntity.isAccessAllowed(aPlayer);

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
@@ -943,7 +943,7 @@ public class BaseMetaTileEntity extends CommonMetaTileEntity
     @Override
     public boolean isUseableByPlayer(EntityPlayer aPlayer) {
         return canAccessData() && playerOwnsThis(aPlayer, false)
-            && mTickTimer > 40
+            && mTickTimer > 1
             && getTileEntityOffset(0, 0, 0) == this
             && aPlayer.getDistanceSq(xCoord + 0.5, yCoord + 0.5, zCoord + 0.5) < 64
             && mMetaTileEntity.isAccessAllowed(aPlayer);

--- a/src/main/java/gregtech/common/blocks/GT_Block_Machines.java
+++ b/src/main/java/gregtech/common/blocks/GT_Block_Machines.java
@@ -367,7 +367,7 @@ public class GT_Block_Machines extends GT_Generic_Block implements IDebugableBlo
                 && !GT_Utility.isStackInList(tCurrentItem, GregTech_API.sJackhammerList)) return false;
         }
         if (tTileEntity instanceof IGregTechTileEntity gtTE) {
-            if (gtTE.getTimer() < 50L) {
+            if (gtTE.getTimer() < 1L) {
                 return false;
             }
             if ((!aWorld.isRemote) && !gtTE.isUseableByPlayer(aPlayer)) {


### PR DESCRIPTION
I've tested this with a lot of different singleblocks, multiblocks, hatches, etc. in dev and it doesn't seem to break anything in at least gt5u, and has always really annoyed me when playing. Now the 50 tick delay(!) becomes 1 tick because some important state is only set up on the first tick of a TE's life.