### PR TITLE
Adjust mk5 plasmas to account for 1 lost OC

### DIFF
--- a/src/main/java/gregtech/loaders/postload/recipes/FusionReactorRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/FusionReactorRecipes.java
@@ -270,25 +270,25 @@ public class FusionReactorRecipes implements Runnable {
             .addTo(fusionRecipes); // FT3
 
         GT_Values.RA.stdBuilder()
-            .fluidInputs(Materials.Lutetium.getMolten(144), Materials.Vanadium.getMolten(144))
-            .fluidOutputs(Materials.Plutonium241.getPlasma(144))
-            .duration(8 * TICKS)
+            .fluidInputs(Materials.Lutetium.getMolten(288), Materials.Vanadium.getMolten(288))
+            .fluidOutputs(Materials.Plutonium241.getPlasma(288))
+            .duration(4 * TICKS)
             .eut(TierEU.RECIPE_UEV / 2)
             .metadata(FUSION_THRESHOLD, 1_000_000_000)
             .addTo(fusionRecipes); // FT5 because of UEV voltage
 
         GT_Values.RA.stdBuilder()
-            .fluidInputs(Materials.Tellurium.getMolten(144), Materials.Zinc.getMolten(144))
-            .fluidOutputs(Materials.Lead.getPlasma(144))
-            .duration(8 * TICKS)
+            .fluidInputs(Materials.Tellurium.getMolten(288), Materials.Zinc.getMolten(288))
+            .fluidOutputs(Materials.Lead.getPlasma(288))
+            .duration(4 * TICKS)
             .eut(TierEU.RECIPE_UEV / 2)
             .metadata(FUSION_THRESHOLD, 1_000_000_000)
             .addTo(fusionRecipes); // FT5 because of UEV voltage
 
         GT_Values.RA.stdBuilder()
-            .fluidInputs(Materials.Osmium.getMolten(144), Materials.Silicon.getMolten(144))
-            .fluidOutputs(Materials.Thorium.getPlasma(144))
-            .duration(8 * TICKS)
+            .fluidInputs(Materials.Osmium.getMolten(288), Materials.Silicon.getMolten(288))
+            .fluidOutputs(Materials.Thorium.getPlasma(288))
+            .duration(4 * TICKS)
             .eut(TierEU.RECIPE_UEV / 2)
             .metadata(FUSION_THRESHOLD, 1_000_000_000)
             .addTo(fusionRecipes); // FT5 because of UEV voltage


### PR DESCRIPTION
Adjusts the recipes for mk5 plasmas to account for the 1 less OC that compact mk5s will get <https://github.com/GTNewHorizons/GoodGenerator/pull/238>
Speed will be exactly the same as before the compact tierskip & OC fix 
(double materials and half time to account for loss of 1 perfect OC)