### PR TITLE
Add locale code support for lang manager

### DIFF
--- a/src/main/java/gregtech/api/GregTech_API.java
+++ b/src/main/java/gregtech/api/GregTech_API.java
@@ -481,8 +481,7 @@ public class GregTech_API {
         return new gregtech.api.items.GT_Generic_Item(
             aUnlocalized,
             aEnglish,
-            "Doesn't work as intended, this is a Bug",
-            false);
+            "Doesn't work as intended, this is a Bug");
     }
 
     /**
@@ -528,8 +527,7 @@ public class GregTech_API {
         return new gregtech.api.items.GT_Generic_Item(
             aUnlocalized,
             aEnglish,
-            "Doesn't work as intended, this is a Bug",
-            false);
+            "Doesn't work as intended, this is a Bug");
     }
 
     /**
@@ -552,8 +550,7 @@ public class GregTech_API {
         return new gregtech.api.items.GT_Generic_Item(
             aUnlocalized,
             aEnglish,
-            "Doesn't work as intended, this is a Bug",
-            false);
+            "Doesn't work as intended, this is a Bug");
     }
 
     /**

--- a/src/main/java/gregtech/api/items/GT_Generic_Item.java
+++ b/src/main/java/gregtech/api/items/GT_Generic_Item.java
@@ -40,16 +40,11 @@ public class GT_Generic_Item extends Item implements IProjectileItem {
     protected IIcon mIcon;
 
     public GT_Generic_Item(String aUnlocalized, String aEnglish, String aEnglishTooltip) {
-        this(aUnlocalized, aEnglish, aEnglishTooltip, true);
-    }
-
-    public GT_Generic_Item(String aUnlocalized, String aEnglish, String aEnglishTooltip,
-        boolean aWriteToolTipIntoLangFile) {
         super();
         mName = "gt." + aUnlocalized;
         GT_LanguageManager.addStringLocalization(mName + ".name", aEnglish);
-        if (GT_Utility.isStringValid(aEnglishTooltip)) GT_LanguageManager
-            .addStringLocalization(mTooltip = mName + ".tooltip_main", aEnglishTooltip, aWriteToolTipIntoLangFile);
+        if (GT_Utility.isStringValid(aEnglishTooltip))
+            GT_LanguageManager.addStringLocalization(mTooltip = mName + ".tooltip_main", aEnglishTooltip);
         else mTooltip = null;
         setCreativeTab(GregTech_API.TAB_GREGTECH);
         GameRegistry.registerItem(this, mName, GregTech.ID);
@@ -154,7 +149,7 @@ public class GT_Generic_Item extends Item implements IProjectileItem {
     }
 
     public String transItem(String aKey, String aEnglish) {
-        return GT_LanguageManager.addStringLocalization("Item_DESCRIPTION_Index_" + aKey, aEnglish, false);
+        return GT_LanguageManager.addStringLocalization("Item_DESCRIPTION_Index_" + aKey, aEnglish);
     }
 
     public static class GT_Item_Dispense extends BehaviorProjectileDispense {

--- a/src/main/java/gregtech/api/items/GT_MetaBase_Item.java
+++ b/src/main/java/gregtech/api/items/GT_MetaBase_Item.java
@@ -46,7 +46,7 @@ public abstract class GT_MetaBase_Item extends GT_Generic_Item
      * @param aUnlocalized The Unlocalized Name of this Item.
      */
     public GT_MetaBase_Item(String aUnlocalized) {
-        super(aUnlocalized, "Generated Item", null, false);
+        super(aUnlocalized, "Generated Item", null);
         setHasSubtypes(true);
         setMaxDamage(0);
     }

--- a/src/main/java/gregtech/api/items/GT_Tool_Item.java
+++ b/src/main/java/gregtech/api/items/GT_Tool_Item.java
@@ -31,11 +31,7 @@ public class GT_Tool_Item extends GT_Generic_Item {
 
     public GT_Tool_Item(String aUnlocalized, String aEnglish, String aTooltip, int aMaxDamage, int aEntityDamage,
         boolean aSwingIfUsed, int aChargedGTID, int aDisChargedGTID, int aToolQuality, float aToolStrength) {
-        super(
-            aUnlocalized,
-            aEnglish,
-            aTooltip,
-            aTooltip != null && !aTooltip.equals("Doesn't work as intended, this is a Bug"));
+        super(aUnlocalized, aEnglish, aTooltip);
         setMaxDamage(aMaxDamage);
         setMaxStackSize(1);
         setNoRepair();

--- a/src/main/java/gregtech/api/multitileentity/MultiTileEntityRegistry.java
+++ b/src/main/java/gregtech/api/multitileentity/MultiTileEntityRegistry.java
@@ -147,8 +147,7 @@ public class MultiTileEntityRegistry {
             return null;
         }
 
-        GT_LanguageManager
-            .addStringLocalization(mNameInternal + "." + aClassContainer.mID + ".name", aLocalised, false);
+        GT_LanguageManager.addStringLocalization(mNameInternal + "." + aClassContainer.mID + ".name", aLocalised);
         mRegistry.put(aClassContainer.mID, aClassContainer);
         mLastRegisteredID = aClassContainer.mID;
         mRegistrations.add(aClassContainer);

--- a/src/main/java/gregtech/api/util/GT_Assemblyline_Server.java
+++ b/src/main/java/gregtech/api/util/GT_Assemblyline_Server.java
@@ -1,6 +1,5 @@
 package gregtech.api.util;
 
-import java.io.File;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -22,24 +21,13 @@ public class GT_Assemblyline_Server {
     private static HashMap<String, Property> internal = new HashMap<>();
 
     public static void fillMap(FMLPreInitializationEvent aEvent) {
-
-        String s = aEvent.getModConfigurationDirectory()
-            .getAbsolutePath();
-        s = s.substring(
-            0,
-            aEvent.getModConfigurationDirectory()
-                .getAbsolutePath()
-                .length() - 6);
-        s = s + "GregTech.lang";
-        File f = new File(s);
-        s = "";
-        Configuration conf = new Configuration(f);
+        Configuration conf = GT_LanguageManager.sEnglishFile;
 
         ConfigCategory cat = conf.getCategory("languagefile");
         internal.putAll(cat.getValues());
         for (Map.Entry<String, Property> entry : internal.entrySet()) {
             try {
-                s = entry.getValue()
+                String s = entry.getValue()
                     .getString()
                     .replaceAll("%", "");
 

--- a/src/main/java/gregtech/api/util/GT_LanguageManager.java
+++ b/src/main/java/gregtech/api/util/GT_LanguageManager.java
@@ -71,11 +71,19 @@ public class GT_LanguageManager {
         }
     }
 
-    public static String addStringLocalization(String aKey, String aEnglish) {
-        return addStringLocalization(aKey, aEnglish, true);
+    /**
+     * @deprecated Parameter aWriteIntoLangFile is no longer used,
+     *             use {@link #addStringLocalization(String, String)} or consider migrating to MC lang system instead.
+     */
+    @Deprecated
+    public static synchronized String addStringLocalization(String aKey, String aEnglish, boolean aWriteIntoLangFile) {
+        return addStringLocalization(aKey, aEnglish);
     }
 
-    public static synchronized String addStringLocalization(String aKey, String aEnglish, boolean aWriteIntoLangFile) {
+    /**
+     * If you newly use this method, please consider using MC lang system instead.
+     */
+    public static synchronized String addStringLocalization(String aKey, String aEnglish) {
         String trimmedKey = aKey != null ? aKey.trim() : "";
         if (trimmedKey.isEmpty()) return E; // RIP cascading class loading, don't use GT_Utility here
         if (sEnglishFile == null) {

--- a/src/main/java/gregtech/api/util/GT_Utility.java
+++ b/src/main/java/gregtech/api/util/GT_Utility.java
@@ -3866,7 +3866,7 @@ public class GT_Utility {
     }
 
     public static String trans(String aKey, String aEnglish) {
-        return GT_LanguageManager.addStringLocalization("Interaction_DESCRIPTION_Index_" + aKey, aEnglish, false);
+        return GT_LanguageManager.addStringLocalization("Interaction_DESCRIPTION_Index_" + aKey, aEnglish);
     }
 
     public static String getTrans(String aKey) {

--- a/src/main/java/gregtech/common/GT_Proxy.java
+++ b/src/main/java/gregtech/common/GT_Proxy.java
@@ -2368,8 +2368,7 @@ public abstract class GT_Proxy implements IGT_Mod, IGuiHandler, IFuelHandler {
                         aEvent.player,
                         GT_LanguageManager.addStringLocalization(
                             "Interaction_DESCRIPTION_Index_097",
-                            "It's dangerous to go alone! Take this.",
-                            false));
+                            "It's dangerous to go alone! Take this."));
                     aEvent.player.worldObj.spawnEntityInWorld(
                         new EntityItem(
                             aEvent.player.worldObj,

--- a/src/main/java/gregtech/common/blocks/GT_Item_Machines.java
+++ b/src/main/java/gregtech/common/blocks/GT_Item_Machines.java
@@ -75,29 +75,22 @@ public class GT_Item_Machines extends ItemBlock implements IFluidContainerItem {
                     && tTileEntity.getMetaTileEntity() instanceof ISecondaryDescribable) {
                     final String[] tSecondaryDescription = ((ISecondaryDescribable) tTileEntity.getMetaTileEntity())
                         .getSecondaryDescription();
-                    addDescription(null, tSecondaryDescription, tDamage, "_Secondary", true);
+                    addDescription(null, tSecondaryDescription, tDamage, "_Secondary");
                 }
                 {
                     final IMetaTileEntity tMetaTileEntity = tTileEntity.getMetaTileEntity();
                     final String tSuffix = (tMetaTileEntity instanceof ISecondaryDescribable
                         && ((ISecondaryDescribable) tMetaTileEntity).isDisplaySecondaryDescription()) ? "_Secondary"
                             : "";
-                    addDescription(
-                        aList,
-                        tTileEntity.getDescription(),
-                        tDamage,
-                        tSuffix,
-                        !GregTech_API.sPostloadFinished);
+                    addDescription(aList, tTileEntity.getDescription(), tDamage, tSuffix);
                     tMetaTileEntity.addAdditionalTooltipInformation(aStack, aList);
                 }
                 if (tTileEntity.getEUCapacity() > 0L) {
                     if (tTileEntity.getInputVoltage() > 0L) {
                         final byte inputTier = GT_Utility.getTier(tTileEntity.getInputVoltage());
                         aList.add(
-                            GT_LanguageManager.addStringLocalization(
-                                "TileEntity_EUp_IN",
-                                "Voltage IN: ",
-                                !GregTech_API.sPostloadFinished) + EnumChatFormatting.GREEN
+                            GT_LanguageManager.addStringLocalization("TileEntity_EUp_IN", "Voltage IN: ")
+                                + EnumChatFormatting.GREEN
                                 + GT_Utility.formatNumbers(tTileEntity.getInputVoltage())
                                 + " ("
                                 + GT_Utility.getColoredTierNameFromTier(inputTier)
@@ -108,10 +101,8 @@ public class GT_Item_Machines extends ItemBlock implements IFluidContainerItem {
                     if (tTileEntity.getOutputVoltage() > 0L) {
                         final byte outputTier = GT_Utility.getTier(tTileEntity.getOutputVoltage());
                         aList.add(
-                            GT_LanguageManager.addStringLocalization(
-                                "TileEntity_EUp_OUT",
-                                "Voltage OUT: ",
-                                !GregTech_API.sPostloadFinished) + EnumChatFormatting.GREEN
+                            GT_LanguageManager.addStringLocalization("TileEntity_EUp_OUT", "Voltage OUT: ")
+                                + EnumChatFormatting.GREEN
                                 + GT_Utility.formatNumbers(tTileEntity.getOutputVoltage())
                                 + " ("
                                 + GT_Utility.getColoredTierNameFromTier(outputTier)
@@ -121,18 +112,14 @@ public class GT_Item_Machines extends ItemBlock implements IFluidContainerItem {
                     }
                     if (tTileEntity.getOutputAmperage() > 1L) {
                         aList.add(
-                            GT_LanguageManager.addStringLocalization(
-                                "TileEntity_EUp_AMOUNT",
-                                "Amperage: ",
-                                !GregTech_API.sPostloadFinished) + EnumChatFormatting.YELLOW
+                            GT_LanguageManager.addStringLocalization("TileEntity_EUp_AMOUNT", "Amperage: ")
+                                + EnumChatFormatting.YELLOW
                                 + GT_Utility.formatNumbers(tTileEntity.getOutputAmperage())
                                 + EnumChatFormatting.GRAY);
                     }
                     aList.add(
-                        GT_LanguageManager.addStringLocalization(
-                            "TileEntity_EUp_STORE",
-                            "Capacity: ",
-                            !GregTech_API.sPostloadFinished) + EnumChatFormatting.BLUE
+                        GT_LanguageManager.addStringLocalization("TileEntity_EUp_STORE", "Capacity: ")
+                            + EnumChatFormatting.BLUE
                             + GT_Utility.formatNumbers(tTileEntity.getEUCapacity())
                             + EnumChatFormatting.GRAY
                             + " EU");
@@ -141,35 +128,24 @@ public class GT_Item_Machines extends ItemBlock implements IFluidContainerItem {
             final NBTTagCompound aNBT = aStack.getTagCompound();
             if (aNBT != null) {
                 if (aNBT.getBoolean("mMuffler")) {
-                    aList.add(
-                        GT_LanguageManager.addStringLocalization(
-                            "GT_TileEntity_MUFFLER",
-                            "has Muffler Upgrade",
-                            !GregTech_API.sPostloadFinished));
+                    aList.add(GT_LanguageManager.addStringLocalization("GT_TileEntity_MUFFLER", "has Muffler Upgrade"));
                 }
                 if (aNBT.getBoolean("mSteamConverter")) {
                     aList.add(
-                        GT_LanguageManager.addStringLocalization(
-                            "GT_TileEntity_STEAMCONVERTER",
-                            "has Steam Upgrade",
-                            !GregTech_API.sPostloadFinished));
+                        GT_LanguageManager.addStringLocalization("GT_TileEntity_STEAMCONVERTER", "has Steam Upgrade"));
                 }
                 int tAmount = 0;
                 if ((tAmount = aNBT.getByte("mSteamTanks")) > 0) {
                     aList.add(
                         tAmount + " "
-                            + GT_LanguageManager.addStringLocalization(
-                                "GT_TileEntity_STEAMTANKS",
-                                "Steam Tank Upgrades",
-                                !GregTech_API.sPostloadFinished));
+                            + GT_LanguageManager
+                                .addStringLocalization("GT_TileEntity_STEAMTANKS", "Steam Tank Upgrades"));
                 }
 
                 CoverableTileEntity.addInstalledCoversInformation(aNBT, aList);
                 if (aNBT.hasKey("mColor") && aNBT.getByte("mColor") != -1) {
                     aList.add(
-                        GT_LanguageManager
-                            .addStringLocalization("GT_TileEntity_COLORED", "Colored", !GregTech_API.sPostloadFinished)
-                            + " ("
+                        GT_LanguageManager.addStringLocalization("GT_TileEntity_COLORED", "Colored") + " ("
                             + Dyes.get(aNBT.getByte("mColor") - 1).formatting
                             + Dyes.get(aNBT.getByte("mColor") - 1).mName
                             + EnumChatFormatting.GRAY
@@ -182,7 +158,7 @@ public class GT_Item_Machines extends ItemBlock implements IFluidContainerItem {
     }
 
     private void addDescription(@Nullable List<String> aList, @Nullable String[] aDescription, int aDamage,
-        String aSuffix, boolean aWriteIntoLangFile) {
+        String aSuffix) {
         if (aDescription == null) return;
         for (int i = 0, tLength = aDescription.length; i < tLength; i++) {
             String tDescLine = aDescription[i];
@@ -198,12 +174,11 @@ public class GT_Item_Machines extends ItemBlock implements IFluidContainerItem {
                     tBuffer.append("%s");
                     tRep[j / 2] = tSplitStrings[j];
                 }
-                final String tTranslated = String.format(
-                    GT_LanguageManager.addStringLocalization(tKey, tBuffer.toString(), aWriteIntoLangFile),
-                    (Object[]) tRep);
+                final String tTranslated = String
+                    .format(GT_LanguageManager.addStringLocalization(tKey, tBuffer.toString()), (Object[]) tRep);
                 if (aList != null) aList.add(tTranslated);
             } else {
-                String tTranslated = GT_LanguageManager.addStringLocalization(tKey, tDescLine, aWriteIntoLangFile);
+                String tTranslated = GT_LanguageManager.addStringLocalization(tKey, tDescLine);
                 if (aList != null) aList.add(tTranslated.equals("") ? tDescLine : tTranslated);
             }
         }
@@ -218,9 +193,9 @@ public class GT_Item_Machines extends ItemBlock implements IFluidContainerItem {
             if (tMetaTileEntity instanceof ISecondaryDescribable) {
                 final String[] tSecondaryDescription = ((ISecondaryDescribable) tMetaTileEntity)
                     .getSecondaryDescription();
-                addDescription(null, tSecondaryDescription, aDamage, "_Secondary", true);
+                addDescription(null, tSecondaryDescription, aDamage, "_Secondary");
             }
-            addDescription(null, tMetaTileEntity.getDescription(), aDamage, "", true);
+            addDescription(null, tMetaTileEntity.getDescription(), aDamage, "");
         }
     }
 

--- a/src/main/java/gregtech/common/tileentities/storage/GT_MetaTileEntity_DigitalChestBase.java
+++ b/src/main/java/gregtech/common/tileentities/storage/GT_MetaTileEntity_DigitalChestBase.java
@@ -32,7 +32,6 @@ import appeng.api.storage.data.IAEItemStack;
 import appeng.api.storage.data.IItemList;
 import appeng.util.item.AEItemStack;
 import appeng.util.item.ItemList;
-import gregtech.api.GregTech_API;
 import gregtech.api.enums.GT_Values;
 import gregtech.api.gui.modularui.GT_UIInfos;
 import gregtech.api.gui.modularui.GT_UITextures;
@@ -98,17 +97,13 @@ public abstract class GT_MetaTileEntity_DigitalChestBase extends GT_MetaTileEnti
             final int tSize = stack.stackTagCompound.getInteger("mItemCount");
             if (tContents != null && tSize > 0) {
                 tooltip.add(
-                    GT_LanguageManager.addStringLocalization(
-                        "TileEntity_CHEST_INFO",
-                        "Contains Item: ",
-                        !GregTech_API.sPostloadFinished) + EnumChatFormatting.YELLOW
+                    GT_LanguageManager.addStringLocalization("TileEntity_CHEST_INFO", "Contains Item: ")
+                        + EnumChatFormatting.YELLOW
                         + tContents.getDisplayName()
                         + EnumChatFormatting.GRAY);
                 tooltip.add(
-                    GT_LanguageManager.addStringLocalization(
-                        "TileEntity_CHEST_AMOUNT",
-                        "Item Amount: ",
-                        !GregTech_API.sPostloadFinished) + EnumChatFormatting.GREEN
+                    GT_LanguageManager.addStringLocalization("TileEntity_CHEST_AMOUNT", "Item Amount: ")
+                        + EnumChatFormatting.GREEN
                         + GT_Utility.formatNumbers(tSize)
                         + EnumChatFormatting.GRAY);
             }

--- a/src/main/java/gregtech/common/tileentities/storage/GT_MetaTileEntity_DigitalTankBase.java
+++ b/src/main/java/gregtech/common/tileentities/storage/GT_MetaTileEntity_DigitalTankBase.java
@@ -35,7 +35,6 @@ import com.gtnewhorizons.modularui.common.widget.FluidSlotWidget;
 import com.gtnewhorizons.modularui.common.widget.SlotWidget;
 import com.gtnewhorizons.modularui.common.widget.TextWidget;
 
-import gregtech.api.GregTech_API;
 import gregtech.api.gui.modularui.GT_UIInfos;
 import gregtech.api.gui.modularui.GT_UITextures;
 import gregtech.api.interfaces.ITexture;
@@ -125,17 +124,13 @@ public abstract class GT_MetaTileEntity_DigitalTankBase extends GT_MetaTileEntit
                 .loadFluidStackFromNBT(stack.stackTagCompound.getCompoundTag("mFluid"));
             if (tContents != null && tContents.amount > 0) {
                 tooltip.add(
-                    GT_LanguageManager.addStringLocalization(
-                        "TileEntity_TANK_INFO",
-                        "Contains Fluid: ",
-                        !GregTech_API.sPostloadFinished) + EnumChatFormatting.YELLOW
+                    GT_LanguageManager.addStringLocalization("TileEntity_TANK_INFO", "Contains Fluid: ")
+                        + EnumChatFormatting.YELLOW
                         + tContents.getLocalizedName()
                         + EnumChatFormatting.GRAY);
                 tooltip.add(
-                    GT_LanguageManager.addStringLocalization(
-                        "TileEntity_TANK_AMOUNT",
-                        "Fluid Amount: ",
-                        !GregTech_API.sPostloadFinished) + EnumChatFormatting.GREEN
+                    GT_LanguageManager.addStringLocalization("TileEntity_TANK_AMOUNT", "Fluid Amount: ")
+                        + EnumChatFormatting.GREEN
                         + formatNumbers(tContents.amount)
                         + " L"
                         + EnumChatFormatting.GRAY);

--- a/src/main/java/gregtech/loaders/misc/GT_BeeDefinition.java
+++ b/src/main/java/gregtech/loaders/misc/GT_BeeDefinition.java
@@ -2617,7 +2617,7 @@ public enum GT_BeeDefinition implements IBeeDefinition {
         String uid = "gregtech.bee.species" + species;
         String description = "for.description." + species;
         String name = "for.bees.species." + lowercaseName;
-        GT_LanguageManager.addStringLocalization("for.bees.species." + lowercaseName, species, true);
+        GT_LanguageManager.addStringLocalization("for.bees.species." + lowercaseName, species);
 
         this.branch = branch;
         this.species = new GT_AlleleBeeSpecies(

--- a/src/main/java/gregtech/loaders/preload/GT_Loader_Item_Block_And_Fluid.java
+++ b/src/main/java/gregtech/loaders/preload/GT_Loader_Item_Block_And_Fluid.java
@@ -170,8 +170,7 @@ public class GT_Loader_Item_Block_And_Fluid implements Runnable {
             false,
             new Object[] { "sensorcard", "GregTech Sensor Card" });
         ItemList.NC_SensorCard.set(
-            tItem == null
-                ? new GT_Generic_Item("sensorcard", "GregTech Sensor Card", "Nuclear Control not installed", false)
+            tItem == null ? new GT_Generic_Item("sensorcard", "GregTech Sensor Card", "Nuclear Control not installed")
                 : tItem);
 
         Item advSensorCard = (Item) GT_Utility
@@ -181,8 +180,7 @@ public class GT_Loader_Item_Block_And_Fluid implements Runnable {
                 ? new GT_Generic_Item(
                     "advancedsensorcard",
                     "GregTech Advanced Sensor Card",
-                    "Nuclear Control not installed",
-                    false)
+                    "Nuclear Control not installed")
                 : advSensorCard);
 
         ItemList.Neutron_Reflector

--- a/src/main/java/gregtech/loaders/preload/GT_PreLoad.java
+++ b/src/main/java/gregtech/loaders/preload/GT_PreLoad.java
@@ -26,12 +26,14 @@ import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import net.minecraft.client.Minecraft;
 import net.minecraft.init.Blocks;
 import net.minecraft.launchwrapper.Launch;
 import net.minecraftforge.common.config.Configuration;
 
 import org.apache.commons.lang3.StringUtils;
 
+import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.LoadController;
 import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.ModContainer;
@@ -91,13 +93,33 @@ public class GT_PreLoad {
 
     public static void initLocalization(File languageDir) {
         GT_FML_LOGGER.info("GT_Mod: Generating Lang-File");
-        GT_LanguageManager.sEnglishFile = new Configuration(new File(languageDir, "GregTech.lang"));
-        GT_LanguageManager.sEnglishFile.load();
-        if (GT_LanguageManager.sEnglishFile.get("EnableLangFile", "UseThisFileAsLanguageFile", false)
-            .getBoolean(false)) {
-            GT_LanguageManager.sLanguage = GT_LanguageManager.sEnglishFile.get("EnableLangFile", "Language", "en_US")
-                .getString();
+
+        if (FMLCommonHandler.instance()
+            .getEffectiveSide()
+            .isClient()) {
+            String userLang = Minecraft.getMinecraft()
+                .getLanguageManager()
+                .getCurrentLanguage()
+                .getLanguageCode();
+            GT_FML_LOGGER.info("User lang is " + userLang);
+            if (userLang.equals("en_US")) {
+                GT_FML_LOGGER.info("Loading GregTech.lang");
+                GT_LanguageManager.sEnglishFile = new Configuration(new File(languageDir, "GregTech.lang"));
+            } else {
+                String l10nFileName = "GregTech_" + userLang + ".lang";
+                File l10nFile = new File(languageDir, l10nFileName);
+                if (l10nFile.isFile()) {
+                    GT_FML_LOGGER.info("Loading l10n file: " + l10nFileName);
+                    GT_LanguageManager.sEnglishFile = new Configuration(l10nFile);
+                } else {
+                    GT_FML_LOGGER.info("Cannot find l10n file " + l10nFileName + ", fallback to GregTech.lang");
+                    GT_LanguageManager.sEnglishFile = new Configuration(new File(languageDir, "GregTech.lang"));
+                }
+            }
+        } else {
+            GT_LanguageManager.sEnglishFile = new Configuration(new File(languageDir, "GregTech.lang"));
         }
+        GT_LanguageManager.sEnglishFile.load();
 
         Materials.getMaterialsMap()
             .values()


### PR DESCRIPTION
In order to combine all the translation projects into one place, we need a way to have translation files for multiple languages at the same time. Now we can have `GregTech_zh_CN.lang` and `GregTech_ja_JP.lang` at the same time just fine. Also, old `GregTech.lang` with translations still works as a fallback as it used to.
However, we still can't _load_ multiple lang entries at once. We need to yeet lang manager in the future, but until then this PR would be enough as a workaround.

I tried to write as many documents as possible during rewriting intricate logic, but if there's something you're not sure, feel free to ask.