### PR TITLE
Add cable info to WAILA

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
@@ -46,6 +46,8 @@ import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_OreDictUnificator;
 import gregtech.api.util.GT_Utility;
 import gregtech.common.covers.CoverInfo;
+import mcp.mobius.waila.api.IWailaConfigHandler;
+import mcp.mobius.waila.api.IWailaDataAccessor;
 
 /**
  * NEVER INCLUDE THIS FILE IN YOUR MOD!!!
@@ -1403,5 +1405,12 @@ public class BaseMetaPipeEntity extends CommonMetaTileEntity
     @Override
     public void startTimeStatistics() {
         hasTimeStatisticsStarted = true;
+    }
+
+    @Override
+    public void getWailaBody(ItemStack itemStack, List<String> currentTip, IWailaDataAccessor accessor,
+        IWailaConfigHandler config) {
+        super.getWailaBody(itemStack, currentTip, accessor, config);
+        mMetaTileEntity.getWailaBody(itemStack, currentTip, accessor, config);
     }
 }

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Cable.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Cable.java
@@ -64,6 +64,8 @@ import ic2.api.energy.tile.IEnergySink;
 import ic2.api.energy.tile.IEnergySource;
 import ic2.api.energy.tile.IEnergyTile;
 import ic2.api.reactor.IReactorChamber;
+import mcp.mobius.waila.api.IWailaConfigHandler;
+import mcp.mobius.waila.api.IWailaDataAccessor;
 
 public class GT_MetaPipeEntity_Cable extends MetaPipeEntity implements IMetaTileEntityCable {
 
@@ -648,5 +650,30 @@ public class GT_MetaPipeEntity_Cable extends MetaPipeEntity implements IMetaTile
                 pipe.removeFromLock(pipe, DOWN);
             }
         }
+    }
+
+    @Override
+    public void getWailaBody(ItemStack itemStack, List<String> currenttip, IWailaDataAccessor accessor,
+        IWailaConfigHandler config) {
+
+        currenttip.add(
+            StatCollector.translateToLocal("GT5U.item.cable.max_voltage") + ": "
+                + EnumChatFormatting.GREEN
+                + GT_Utility.formatNumbers(mVoltage)
+                + " ("
+                + GT_Utility.getColoredTierNameFromVoltage(mVoltage)
+                + EnumChatFormatting.GREEN
+                + ")");
+        currenttip.add(
+            StatCollector.translateToLocal("GT5U.item.cable.max_amperage") + ": "
+                + EnumChatFormatting.YELLOW
+                + GT_Utility.formatNumbers(mAmperage));
+        currenttip.add(
+            StatCollector.translateToLocal("GT5U.item.cable.loss") + ": "
+                + EnumChatFormatting.RED
+                + GT_Utility.formatNumbers(mCableLossPerMeter)
+                + EnumChatFormatting.RESET
+                + " "
+                + StatCollector.translateToLocal("GT5U.item.cable.eu_volt"));
     }
 }


### PR DESCRIPTION
Preview:

![image](https://github.com/GTNewHorizons/GT5-Unofficial/assets/18713839/4bde2899-8f91-4315-8b1b-bbc8e5f29bf5)

w/cover:
![image](https://github.com/GTNewHorizons/GT5-Unofficial/assets/18713839/aa1cc874-bb05-4f65-ac8f-81cbefc2ab07)


Should this be behind the extended/shift info?
Should this be behind a config option (default true)?  
Should the text be cached per cable/size?