### PR TITLE
Add messages about the reasons for machine shutdown during processing

### DIFF
--- a/src/main/java/gregtech/api/interfaces/tileentity/IGregTechTileEntity.java
+++ b/src/main/java/gregtech/api/interfaces/tileentity/IGregTechTileEntity.java
@@ -4,6 +4,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+import javax.annotation.Nonnull;
+
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
@@ -19,6 +21,7 @@ import gregtech.api.interfaces.IDescribable;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.modularui.IAddInventorySlots;
 import gregtech.api.interfaces.modularui.IGetGUITextureSet;
+import gregtech.api.util.shutdown.ShutDownReason;
 import gregtech.common.blocks.GT_Block_Machines;
 
 /**
@@ -178,6 +181,8 @@ public interface IGregTechTileEntity extends ITexturedTileEntity, IGearEnergyTil
     }
 
     default void setShutdownStatus(boolean newStatus) {}
+
+    default void setShutDownReason(@Nonnull ShutDownReason reason) {}
 
     /**
      * A randomly called display update to be able to add particles or other items for display The event is proxied by

--- a/src/main/java/gregtech/api/interfaces/tileentity/IMachineProgress.java
+++ b/src/main/java/gregtech/api/interfaces/tileentity/IMachineProgress.java
@@ -1,5 +1,10 @@
 package gregtech.api.interfaces.tileentity;
 
+import javax.annotation.Nonnull;
+
+import gregtech.api.util.shutdown.ShutDownReason;
+import gregtech.api.util.shutdown.ShutDownReasonRegistry;
+
 /**
  * For Machines which have Progress
  */
@@ -82,5 +87,10 @@ public interface IMachineProgress extends IHasWorldObjectAndCoords {
      */
     default boolean wasShutdown() {
         return false;
+    }
+
+    @Nonnull
+    default ShutDownReason getLastShutDownReason() {
+        return ShutDownReasonRegistry.NONE;
     }
 }

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
@@ -115,7 +115,7 @@ public class BaseMetaTileEntity extends CommonMetaTileEntity
     protected final long[] mAverageEUOutput = new long[] { 0, 0, 0, 0, 0 };
     private boolean mHasEnoughEnergy = true, mRunningThroughTick = false, mInputDisabled = false,
         mOutputDisabled = false, mMuffler = false, mLockUpgrade = false;
-    private boolean mActive = false, mWorkUpdate = false, mSteamConverter = false, mWorks = false;
+    private boolean mActive = false, mWorkUpdate = false, mSteamConverter = false, mWorks = true;
     private boolean oRedstone = false;
     private byte mColor = 0, oColor = 0, oStrongRedstone = 0, oRedstoneData = 63, oTextureData = 0, oUpdateData = 0,
         oTexturePage = 0;

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
@@ -12,6 +12,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import net.minecraft.block.Block;
@@ -35,6 +36,8 @@ import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTankInfo;
+
+import org.jetbrains.annotations.NotNull;
 
 import com.gtnewhorizon.structurelib.alignment.IAlignment;
 import com.gtnewhorizon.structurelib.alignment.IAlignmentProvider;
@@ -78,6 +81,8 @@ import gregtech.api.util.GT_Log;
 import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_OreDictUnificator;
 import gregtech.api.util.GT_Utility;
+import gregtech.api.util.shutdown.ShutDownReason;
+import gregtech.api.util.shutdown.ShutDownReasonRegistry;
 import gregtech.common.GT_Pollution;
 import gregtech.common.covers.CoverInfo;
 import ic2.api.Direction;
@@ -101,6 +106,7 @@ public class BaseMetaTileEntity extends CommonMetaTileEntity
     private boolean hasTimeStatisticsStarted;
     public long mLastSoundTick = 0;
     public boolean mWasShutdown = false;
+    public @Nonnull ShutDownReason lastShutDownReason = ShutDownReasonRegistry.NONE;
     protected MetaTileEntity mMetaTileEntity;
     protected long mStoredEnergy = 0, mStoredSteam = 0;
     protected int mAverageEUInputIndex = 0, mAverageEUOutputIndex = 0;
@@ -109,7 +115,7 @@ public class BaseMetaTileEntity extends CommonMetaTileEntity
     protected final long[] mAverageEUOutput = new long[] { 0, 0, 0, 0, 0 };
     private boolean mHasEnoughEnergy = true, mRunningThroughTick = false, mInputDisabled = false,
         mOutputDisabled = false, mMuffler = false, mLockUpgrade = false;
-    private boolean mActive = false, mWorkUpdate = false, mSteamConverter = false, mWorks = true;
+    private boolean mActive = false, mWorkUpdate = false, mSteamConverter = false, mWorks = false;
     private boolean oRedstone = false;
     private byte mColor = 0, oColor = 0, oStrongRedstone = 0, oRedstoneData = 63, oTextureData = 0, oUpdateData = 0,
         oTexturePage = 0;
@@ -2466,6 +2472,16 @@ public class BaseMetaTileEntity extends CommonMetaTileEntity
     @Override
     public void setShutdownStatus(boolean newStatus) {
         mWasShutdown = newStatus;
+    }
+
+    @Override
+    public void setShutDownReason(@NotNull ShutDownReason reason) {
+        lastShutDownReason = reason;
+    }
+
+    @Override
+    public @NotNull ShutDownReason getLastShutDownReason() {
+        return lastShutDownReason;
     }
 
     @Override

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_EnhancedMultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_EnhancedMultiBlockBase.java
@@ -22,6 +22,7 @@ import cpw.mods.fml.common.network.NetworkRegistry;
 import gregtech.api.GregTech_API;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.util.GT_Multiblock_Tooltip_Builder;
+import gregtech.api.util.shutdown.ShutDownReasonRegistry;
 
 /**
  * Enhanced multiblock base class, featuring following improvement over {@link GT_MetaTileEntity_MultiBlockBase}
@@ -53,7 +54,7 @@ public abstract class GT_MetaTileEntity_EnhancedMultiBlockBase<T extends GT_Meta
     @Override
     public void setExtendedFacing(ExtendedFacing newExtendedFacing) {
         if (mExtendedFacing != newExtendedFacing) {
-            if (mMachine) stopMachine();
+            if (mMachine) stopMachine(ShutDownReasonRegistry.STRUCTURE_INCOMPLETE);
             mExtendedFacing = newExtendedFacing;
             final IGregTechTileEntity base = getBaseMetaTileEntity();
             mMachine = false;

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_ExtendedPowerMultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_ExtendedPowerMultiBlockBase.java
@@ -16,12 +16,16 @@ import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 
+import org.jetbrains.annotations.NotNull;
+
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.logic.ProcessingLogic;
 import gregtech.api.recipe.check.CheckRecipeResult;
 import gregtech.api.util.GT_ExoticEnergyInputHelper;
 import gregtech.api.util.GT_OverclockCalculator;
 import gregtech.api.util.GT_Utility;
+import gregtech.api.util.shutdown.ShutDownReason;
+import gregtech.api.util.shutdown.ShutDownReasonRegistry;
 
 /**
  * Multiblock base class that allows machine to use power over int.
@@ -72,7 +76,7 @@ public abstract class GT_MetaTileEntity_ExtendedPowerMultiBlockBase<T extends GT
         }
         if (this.lEUt < 0) {
             if (!drainEnergyInput(getActualEnergyUsage())) {
-                criticalStopMachine();
+                stopMachine(ShutDownReasonRegistry.POWER_LOSS);
                 return false;
             }
         }
@@ -80,9 +84,9 @@ public abstract class GT_MetaTileEntity_ExtendedPowerMultiBlockBase<T extends GT
     }
 
     @Override
-    public void stopMachine() {
+    public void stopMachine(@NotNull ShutDownReason reason) {
         this.lEUt = 0;
-        super.stopMachine();
+        super.stopMachine(reason);
     }
 
     @Override

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
@@ -88,9 +88,12 @@ import gregtech.api.util.GT_Utility;
 import gregtech.api.util.GT_Waila;
 import gregtech.api.util.OutputHatchWrapper;
 import gregtech.api.util.VoidProtectionHelper;
+import gregtech.api.util.shutdown.ShutDownReason;
+import gregtech.api.util.shutdown.ShutDownReasonRegistry;
 import gregtech.client.GT_SoundLoop;
 import gregtech.common.GT_Pollution;
 import gregtech.common.gui.modularui.widget.CheckRecipeResultSyncer;
+import gregtech.common.gui.modularui.widget.ShutDownReasonSyncer;
 import gregtech.common.items.GT_MetaGenerated_Tool_01;
 import gregtech.common.tileentities.machines.GT_MetaTileEntity_Hatch_InputBus_ME;
 import gregtech.common.tileentities.machines.GT_MetaTileEntity_Hatch_Input_ME;
@@ -896,7 +899,26 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
      */
     public abstract boolean explodesOnComponentBreak(ItemStack aStack);
 
+    /**
+     * @deprecated Use {@link #stopMachine(ShutDownReason)}
+     */
+    @Deprecated
     public void stopMachine() {
+        stopMachine(ShutDownReasonRegistry.NONE);
+    }
+
+    /**
+     * @deprecated Use {@link #stopMachine(ShutDownReason)}
+     */
+    @Deprecated
+    public void criticalStopMachine() {
+        stopMachine(ShutDownReasonRegistry.CRITICAL_NONE);
+    }
+
+    public void stopMachine(@Nonnull ShutDownReason reason) {
+        if (!ShutDownReasonRegistry.isRegistered(reason.getID())) {
+            throw new RuntimeException(String.format("Reason %s is not registered for registry", reason.getID()));
+        }
         mOutputItems = null;
         mOutputFluids = null;
         mEUt = 0;
@@ -905,12 +927,11 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
         mMaxProgresstime = 0;
         mEfficiencyIncrease = 0;
         getBaseMetaTileEntity().disableWorking();
-    }
-
-    public void criticalStopMachine() {
-        stopMachine();
-        sendSound(INTERRUPT_SOUND_INDEX);
+        getBaseMetaTileEntity().setShutDownReason(reason);
         getBaseMetaTileEntity().setShutdownStatus(true);
+        if (reason.wasCritical()) {
+            sendSound(INTERRUPT_SOUND_INDEX);
+        }
     }
 
     public int getRepairStatus() {
@@ -931,8 +952,9 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
     }
 
     public boolean doRandomMaintenanceDamage() {
-        if (!isCorrectMachinePart(mInventory[1]) || getRepairStatus() == 0) {
-            stopMachine();
+        if (!isCorrectMachinePart(mInventory[1])) {
+            stopMachine(ShutDownReasonRegistry.NO_MACHINE_PART);
+            return false;
             return false;
         }
         if (mRuntime++ > 1000) {
@@ -2184,6 +2206,10 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
         return true;
     }
 
+    protected boolean shouldDisplayShutDownReason() {
+        return true;
+    }
+
     protected String generateCurrentRecipeInfoString() {
         StringBuilder ret = new StringBuilder(EnumChatFormatting.WHITE + "Progress: ")
             .append(String.format("%,.2f", (double) mProgresstime / 20))
@@ -2324,6 +2350,28 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
             new TextWidget(GT_Utility.trans("142", "Running perfectly.")).setDefaultColor(COLOR_TEXT_WHITE.get())
                 .setEnabled(
                     widget -> getBaseMetaTileEntity().getErrorDisplayID() == 0 && getBaseMetaTileEntity().isActive()));
+
+        screenElements.widget(
+            TextWidget.dynamicString(
+                () -> getBaseMetaTileEntity().getLastShutDownReason()
+                    .getDisplayString())
+                .setSynced(false)
+                .setTextAlignment(Alignment.CenterLeft)
+                .setEnabled(
+                    widget -> shouldDisplayShutDownReason() && !getBaseMetaTileEntity().isActive()
+                        && GT_Utility.isStringValid(
+                            getBaseMetaTileEntity().getLastShutDownReason()
+                                .getDisplayString())
+                        && getBaseMetaTileEntity().wasShutdown()))
+            .widget(
+                new ShutDownReasonSyncer(
+                    () -> getBaseMetaTileEntity().getLastShutDownReason(),
+                    reason -> getBaseMetaTileEntity().setShutDownReason(reason)))
+            .widget(
+                new FakeSyncWidget.BooleanSyncer(
+                    () -> getBaseMetaTileEntity().wasShutdown(),
+                    wasShutDown -> getBaseMetaTileEntity().setShutdownStatus(wasShutDown)));
+
         screenElements.widget(
             TextWidget.dynamicString(() -> checkRecipeResult.getDisplayString())
                 .setSynced(false)

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
@@ -405,11 +405,11 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
                     checkMaintenance();
                     if (getRepairStatus() > 0) {
                         runMachine(aBaseMetaTileEntity, aTick);
-                    } else {
-                        stopMachine();
+                    } else if (aBaseMetaTileEntity.isAllowedToWork()) {
+                        stopMachine(ShutDownReasonRegistry.NO_REPAIR);
                     }
-                } else {
-                    stopMachine();
+                } else if (aBaseMetaTileEntity.isAllowedToWork()) {
+                    stopMachine(ShutDownReasonRegistry.STRUCTURE_INCOMPLETE);
                 }
             }
             aBaseMetaTileEntity.setErrorDisplayID(
@@ -523,7 +523,7 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
             if (onRunningTick(mInventory[1])) {
                 markDirty();
                 if (!polluteEnvironment(getPollutionPerTick(mInventory[1]))) {
-                    stopMachine();
+                    stopMachine(ShutDownReasonRegistry.POLLUTION_FAIL);
                 }
                 if (mMaxProgresstime > 0 && ++mProgresstime >= mMaxProgresstime) {
                     if (mOutputItems != null) {
@@ -671,7 +671,7 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
         }
         if (mEUt < 0) {
             if (!drainEnergyInput(getActualEnergyUsage())) {
-                criticalStopMachine();
+                stopMachine(ShutDownReasonRegistry.POWER_LOSS);
                 return false;
             }
         }
@@ -955,6 +955,9 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
         if (!isCorrectMachinePart(mInventory[1])) {
             stopMachine(ShutDownReasonRegistry.NO_MACHINE_PART);
             return false;
+        }
+        if (getRepairStatus() == 0) {
+            stopMachine(ShutDownReasonRegistry.NO_REPAIR);
             return false;
         }
         if (mRuntime++ > 1000) {

--- a/src/main/java/gregtech/api/util/GT_Utility.java
+++ b/src/main/java/gregtech/api/util/GT_Utility.java
@@ -3720,11 +3720,15 @@ public class GT_Utility {
         int rEUAmount = 0;
         try {
             if (tTileEntity instanceof IMachineProgress progress) {
-                if (progress.isAllowedToWork()) {
+                if (progress.isAllowedToWork() && !progress.hasThingsToDo()) {
                     tList.add(EnumChatFormatting.RED + "Disabled." + EnumChatFormatting.RESET);
                 }
-                if (progress.wasShutdown()) {
-                    tList.add(EnumChatFormatting.RED + "Shut down due to power loss." + EnumChatFormatting.RESET);
+                if (progress.wasShutdown() && isStringValid(
+                    progress.getLastShutDownReason()
+                        .getDisplayString())) {
+                    tList.add(
+                        progress.getLastShutDownReason()
+                            .getDisplayString());
                 }
                 rEUAmount += 400;
                 int tValue = 0;

--- a/src/main/java/gregtech/api/util/shutdown/ReasonOutOfFluid.java
+++ b/src/main/java/gregtech/api/util/shutdown/ReasonOutOfFluid.java
@@ -1,0 +1,63 @@
+package gregtech.api.util.shutdown;
+
+import static gregtech.api.util.GT_ModHandler.getWater;
+import static gregtech.api.util.GT_Utility.formatNumbers;
+
+import java.util.Objects;
+
+import net.minecraft.network.PacketBuffer;
+import net.minecraft.util.StatCollector;
+import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidRegistry;
+import net.minecraftforge.fluids.FluidStack;
+
+import org.jetbrains.annotations.NotNull;
+
+public class ReasonOutOfFluid implements ShutDownReason {
+
+    private FluidStack requiredFluid;
+
+    ReasonOutOfFluid(@NotNull FluidStack requiredFluid) {
+        this.requiredFluid = requiredFluid;
+    }
+
+    @NotNull
+    @Override
+    public String getID() {
+        return "out_of_fluid";
+    }
+
+    @NotNull
+    @Override
+    public String getDisplayString() {
+        return Objects.requireNonNull(
+            StatCollector.translateToLocalFormatted(
+                "GT5U.gui.text.out_of_fluid",
+                requiredFluid.getLocalizedName(),
+                formatNumbers(requiredFluid.amount)));
+    }
+
+    @NotNull
+    @Override
+    public ShutDownReason newInstance() {
+        return new ReasonOutOfFluid(getWater(0));
+    }
+
+    @Override
+    public void encode(@NotNull PacketBuffer buffer) {
+        buffer.writeInt(requiredFluid.getFluidID());
+        buffer.writeInt(requiredFluid.amount);
+    }
+
+    @Override
+    public void decode(PacketBuffer buffer) {
+        int fluidID = buffer.readInt();
+        Fluid fluid = FluidRegistry.getFluid(fluidID);
+        requiredFluid = new FluidStack(fluid, buffer.readInt());
+    }
+
+    @Override
+    public boolean wasCritical() {
+        return true;
+    }
+}

--- a/src/main/java/gregtech/api/util/shutdown/ReasonOutOfItem.java
+++ b/src/main/java/gregtech/api/util/shutdown/ReasonOutOfItem.java
@@ -1,0 +1,62 @@
+package gregtech.api.util.shutdown;
+
+import static gregtech.api.util.GT_Utility.formatNumbers;
+
+import java.util.Objects;
+
+import net.minecraft.init.Items;
+import net.minecraft.item.ItemStack;
+import net.minecraft.network.PacketBuffer;
+import net.minecraft.util.StatCollector;
+
+import org.jetbrains.annotations.NotNull;
+
+public class ReasonOutOfItem implements ShutDownReason {
+
+    private ItemStack requiredItem;
+
+    ReasonOutOfItem(@NotNull ItemStack requiredItem) {
+        this.requiredItem = requiredItem;
+    }
+
+    @NotNull
+    @Override
+    public String getID() {
+        return "out_of_item";
+    }
+
+    @NotNull
+    @Override
+    public String getDisplayString() {
+        return Objects.requireNonNull(
+            StatCollector.translateToLocalFormatted(
+                "GT5U.gui.text.out_of_item",
+                requiredItem.getDisplayName(),
+                formatNumbers(requiredItem.stackSize)));
+    }
+
+    @NotNull
+    @Override
+    public ShutDownReason newInstance() {
+        return new ReasonOutOfItem(new ItemStack(Items.feather, 0));
+    }
+
+    @Override
+    public void encode(@NotNull PacketBuffer buffer) {
+        try {
+            buffer.writeItemStackToBuffer(requiredItem);
+        } catch (Exception ignored) {}
+    }
+
+    @Override
+    public void decode(PacketBuffer buffer) {
+        try {
+            requiredItem = buffer.readItemStackFromBuffer();
+        } catch (Exception ignored) {}
+    }
+
+    @Override
+    public boolean wasCritical() {
+        return true;
+    }
+}

--- a/src/main/java/gregtech/api/util/shutdown/ReasonOutOfStuff.java
+++ b/src/main/java/gregtech/api/util/shutdown/ReasonOutOfStuff.java
@@ -1,0 +1,61 @@
+package gregtech.api.util.shutdown;
+
+import static gregtech.api.util.GT_Utility.formatNumbers;
+
+import java.util.Objects;
+
+import net.minecraft.network.PacketBuffer;
+import net.minecraft.util.StatCollector;
+
+import org.jetbrains.annotations.NotNull;
+
+public class ReasonOutOfStuff implements ShutDownReason {
+
+    private String required;
+    private int amount;
+
+    ReasonOutOfStuff(@NotNull String required, int amount) {
+        this.required = required;
+        this.amount = amount;
+    }
+
+    @NotNull
+    @Override
+    public String getID() {
+        return "out_of_stuff";
+    }
+
+    @NotNull
+    @Override
+    public String getDisplayString() {
+        return Objects.requireNonNull(
+            StatCollector.translateToLocalFormatted("GT5U.gui.text.out_of_stuff", required, formatNumbers(amount)));
+    }
+
+    @NotNull
+    @Override
+    public ShutDownReason newInstance() {
+        return new ReasonOutOfStuff("stuff", 1);
+    }
+
+    @Override
+    public void encode(@NotNull PacketBuffer buffer) {
+        buffer.writeInt(amount);
+        try {
+            buffer.writeStringToBuffer(required);
+        } catch (Exception ignored) {}
+    }
+
+    @Override
+    public void decode(PacketBuffer buffer) {
+        amount = buffer.readInt();
+        try {
+            required = buffer.readStringFromBuffer(32768);
+        } catch (Exception ignored) {}
+    }
+
+    @Override
+    public boolean wasCritical() {
+        return true;
+    }
+}

--- a/src/main/java/gregtech/api/util/shutdown/ShutDownReason.java
+++ b/src/main/java/gregtech/api/util/shutdown/ShutDownReason.java
@@ -1,0 +1,41 @@
+package gregtech.api.util.shutdown;
+
+import javax.annotation.Nonnull;
+
+import net.minecraft.network.PacketBuffer;
+
+public interface ShutDownReason {
+
+    /**
+     * @return Unique registry ID
+     */
+    @Nonnull
+    String getID();
+
+    /**
+     * @return Actual text to show on client GUI
+     */
+    @Nonnull
+    String getDisplayString();
+
+    /**
+     * Create new instance to receive packet.
+     */
+    @Nonnull
+    ShutDownReason newInstance();
+
+    /**
+     * Encode value to sync.
+     */
+    void encode(@Nonnull PacketBuffer buffer);
+
+    /**
+     * Decode synced value.
+     */
+    void decode(PacketBuffer buffer);
+
+    /**
+     * @return Whether the reason is critical.
+     */
+    boolean wasCritical();
+}

--- a/src/main/java/gregtech/api/util/shutdown/ShutDownReasonRegistry.java
+++ b/src/main/java/gregtech/api/util/shutdown/ShutDownReasonRegistry.java
@@ -58,12 +58,12 @@ public class ShutDownReasonRegistry {
      * Shut down due to incomplete structure.
      */
     @Nonnull
-    public static final ShutDownReason STRUCTURE_INCOMPLETE = SimpleShutDownReason.ofCritical("structure_incomplete");
+    public static final ShutDownReason STRUCTURE_INCOMPLETE = SimpleShutDownReason.ofNormal("structure_incomplete");
     /**
      * Shut down due to machine damage.
      */
     @Nonnull
-    public static final ShutDownReason NO_REPAIR = SimpleShutDownReason.ofCritical("no_repair");
+    public static final ShutDownReason NO_REPAIR = SimpleShutDownReason.ofNormal("no_repair");
     /**
      * No valid turbine found.
      */

--- a/src/main/java/gregtech/api/util/shutdown/ShutDownReasonRegistry.java
+++ b/src/main/java/gregtech/api/util/shutdown/ShutDownReasonRegistry.java
@@ -1,0 +1,118 @@
+package gregtech.api.util.shutdown;
+
+import static gregtech.api.util.GT_ModHandler.getWater;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.annotation.Nonnull;
+
+import net.minecraft.init.Items;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
+
+public class ShutDownReasonRegistry {
+
+    private static final Map<String, ShutDownReason> registry = new HashMap<>();
+
+    /**
+     * Registers ShutDownReason. No duplicated IDs are allowed.
+     *
+     * @param sample Sample object to register
+     */
+    public static void register(ShutDownReason sample) {
+        if (isRegistered(sample.getID())) {
+            throw new IllegalStateException(
+                String.format(
+                    "ID %s is already registered for %s",
+                    sample.getID(),
+                    registry.get(sample.getID())
+                        .getClass()
+                        .getCanonicalName()));
+        }
+        registry.put(sample.getID(), sample);
+    }
+
+    public static ShutDownReason getSampleFromRegistry(String id) {
+        if (!isRegistered(id)) {
+            throw new RuntimeException("Unknown id: " + id);
+        }
+        return registry.get(id);
+    }
+
+    public static boolean isRegistered(String id) {
+        return registry.containsKey(id);
+    }
+
+    /**
+     * Shut down due to power loss.
+     */
+    @Nonnull
+    public static final ShutDownReason POWER_LOSS = SimpleShutDownReason.ofCritical("power_loss");
+    /**
+     * Failed to output the pollution.
+     */
+    @Nonnull
+    public static final ShutDownReason POLLUTION_FAIL = SimpleShutDownReason.ofCritical("pollution_fail");
+    /**
+     * Shut down due to incomplete structure.
+     */
+    @Nonnull
+    public static final ShutDownReason STRUCTURE_INCOMPLETE = SimpleShutDownReason.ofCritical("structure_incomplete");
+    /**
+     * Shut down due to machine damage.
+     */
+    @Nonnull
+    public static final ShutDownReason NO_REPAIR = SimpleShutDownReason.ofCritical("no_repair");
+    /**
+     * No valid turbine found.
+     */
+    @Nonnull
+    public static final ShutDownReason NO_TURBINE = SimpleShutDownReason.ofNormal("no_turbine");
+    /**
+     * No correct machine part in controller slot.
+     */
+    @Nonnull
+    public static final ShutDownReason NO_MACHINE_PART = SimpleShutDownReason.ofNormal("no_machine_part");
+    /**
+     * Default unknown state.
+     */
+    @Nonnull
+    public static final ShutDownReason NONE = SimpleShutDownReason.ofNormal("none");
+    /**
+     * Critical unknown state.
+     */
+    @Nonnull
+    public static final ShutDownReason CRITICAL_NONE = SimpleShutDownReason.ofCritical("none");
+
+    /**
+     * Fluid that needs to be constantly supplied are out. E.g. PCB coolant with cooling upgrades enabled.
+     */
+    @Nonnull
+    public static ShutDownReason outOfFluid(@Nonnull FluidStack required) {
+        return new ReasonOutOfFluid(required);
+    }
+
+    /**
+     * Item that needs to be constantly supplied are out.
+     */
+    @Nonnull
+    public static ShutDownReason outOfItem(@Nonnull ItemStack required) {
+        return new ReasonOutOfItem(required);
+    }
+
+    /**
+     * Stuff that needs to be constantly supplied are out.
+     */
+    @Nonnull
+    public static ShutDownReason outOfStuff(@Nonnull String required, int amount) {
+        return new ReasonOutOfStuff(required, amount);
+    }
+
+    static {
+        register(new SimpleShutDownReason("", false));
+        register(new ReasonOutOfFluid(getWater(0)));
+        register(new ReasonOutOfItem(new ItemStack(Items.feather, 1)));
+        register(new ReasonOutOfStuff("stuff", 1));
+    }
+}

--- a/src/main/java/gregtech/api/util/shutdown/SimpleShutDownReason.java
+++ b/src/main/java/gregtech/api/util/shutdown/SimpleShutDownReason.java
@@ -1,0 +1,79 @@
+package gregtech.api.util.shutdown;
+
+import java.util.Objects;
+
+import javax.annotation.Nonnull;
+
+import net.minecraft.network.PacketBuffer;
+import net.minecraft.util.StatCollector;
+
+import org.jetbrains.annotations.NotNull;
+
+import com.gtnewhorizons.modularui.common.internal.network.NetworkUtils;
+
+/**
+ * Simple implementation of {@link ShutDownReason}. You can create new object without registering it.
+ */
+public class SimpleShutDownReason implements ShutDownReason {
+
+    private String key;
+    private boolean wasCritical;
+
+    public SimpleShutDownReason(String key, boolean isCritical) {
+        this.key = key;
+        this.wasCritical = isCritical;
+    }
+
+    @NotNull
+    @Override
+    public String getID() {
+        return "simple_result";
+    }
+
+    @NotNull
+    @Override
+    public String getDisplayString() {
+        return Objects.requireNonNull(StatCollector.translateToLocal("GT5U.gui.text." + key));
+    }
+
+    @NotNull
+    @Override
+    public ShutDownReason newInstance() {
+        return new SimpleShutDownReason("", false);
+    }
+
+    @Override
+    public void encode(@NotNull PacketBuffer buffer) {
+        buffer.writeBoolean(wasCritical);
+        NetworkUtils.writeStringSafe(buffer, key);
+    }
+
+    @Override
+    public void decode(PacketBuffer buffer) {
+        wasCritical = buffer.readBoolean();
+        key = NetworkUtils.readStringSafe(buffer);
+    }
+
+    @Override
+    public boolean wasCritical() {
+        return wasCritical;
+    }
+
+    /**
+     * Creates new reason with critical state. Add your localized description with `GT5U.gui.text.{key}`.
+     * This is already registered to registry.
+     */
+    @Nonnull
+    public static ShutDownReason ofCritical(String key) {
+        return new SimpleShutDownReason(key, true);
+    }
+
+    /**
+     * Creates new reason with normal state. Add your localized description with `GT5U.gui.text.{key}`.
+     * This is already registered to registry.
+     */
+    @Nonnull
+    public static ShutDownReason ofNormal(String key) {
+        return new SimpleShutDownReason(key, false);
+    }
+}

--- a/src/main/java/gregtech/common/gui/modularui/widget/ShutDownReasonSyncer.java
+++ b/src/main/java/gregtech/common/gui/modularui/widget/ShutDownReasonSyncer.java
@@ -1,0 +1,26 @@
+package gregtech.common.gui.modularui.widget;
+
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import com.gtnewhorizons.modularui.common.internal.network.NetworkUtils;
+import com.gtnewhorizons.modularui.common.widget.FakeSyncWidget;
+
+import gregtech.api.util.shutdown.ShutDownReason;
+import gregtech.api.util.shutdown.ShutDownReasonRegistry;
+
+public class ShutDownReasonSyncer extends FakeSyncWidget<ShutDownReason> {
+
+    public ShutDownReasonSyncer(Supplier<ShutDownReason> getter, Consumer<ShutDownReason> setter) {
+        super(getter, setter, (buffer, result) -> {
+            NetworkUtils.writeStringSafe(buffer, result.getID());
+            result.encode(buffer);
+        }, buffer -> {
+            String id = NetworkUtils.readStringSafe(buffer);
+            ShutDownReason result = ShutDownReasonRegistry.getSampleFromRegistry(id)
+                .newInstance();
+            result.decode(buffer);
+            return result;
+        });
+    }
+}

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_InputBus_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_InputBus_ME.java
@@ -72,6 +72,7 @@ import gregtech.api.recipe.check.CheckRecipeResultRegistry;
 import gregtech.api.recipe.check.SimpleCheckRecipeResult;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GT_Utility;
+import gregtech.api.util.shutdown.ShutDownReasonRegistry;
 import gregtech.common.gui.modularui.widget.AESlotWidget;
 import mcp.mobius.waila.api.IWailaConfigHandler;
 import mcp.mobius.waila.api.IWailaDataAccessor;
@@ -489,7 +490,7 @@ public class GT_MetaTileEntity_Hatch_InputBus_ME extends GT_MetaTileEntity_Hatch
                             .extractAEPower(request.getStackSize(), Actionable.MODULATE, PowerMultiplier.CONFIG);
                         setInventorySlotContents(i + SLOT_COUNT, oldStack);
                         if (result == null || result.getStackSize() != toExtract) {
-                            controller.criticalStopMachine();
+                            controller.stopMachine(ShutDownReasonRegistry.CRITICAL_NONE);
                             checkRecipeResult = SimpleCheckRecipeResult
                                 .ofFailurePersistOnShutdown("stocking_bus_fail_extraction");
                         }

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_Input_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_Input_ME.java
@@ -76,6 +76,7 @@ import gregtech.api.recipe.check.CheckRecipeResultRegistry;
 import gregtech.api.recipe.check.SimpleCheckRecipeResult;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GT_Utility;
+import gregtech.api.util.shutdown.ShutDownReasonRegistry;
 import mcp.mobius.waila.api.IWailaConfigHandler;
 import mcp.mobius.waila.api.IWailaDataAccessor;
 
@@ -248,7 +249,7 @@ public class GT_MetaTileEntity_Hatch_Input_ME extends GT_MetaTileEntity_Hatch_In
                     .extractAEPower(toExtract, Actionable.MODULATE, PowerMultiplier.CONFIG);
 
                 if (extractionResult == null || extractionResult.getStackSize() != toExtract) {
-                    controller.criticalStopMachine();
+                    controller.stopMachine(ShutDownReasonRegistry.CRITICAL_NONE);
                     checkRecipeResult = SimpleCheckRecipeResult
                         .ofFailurePersistOnShutdown("stocking_hatch_fail_extraction");
                 }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_ConcreteBackfillerBase.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_ConcreteBackfillerBase.java
@@ -25,6 +25,7 @@ import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.recipe.check.CheckRecipeResultRegistry;
 import gregtech.api.util.GT_Multiblock_Tooltip_Builder;
 import gregtech.api.util.GT_Utility;
+import gregtech.api.util.shutdown.ShutDownReasonRegistry;
 
 public abstract class GT_MetaTileEntity_ConcreteBackfillerBase extends GT_MetaTileEntity_DrillerBase {
 
@@ -122,7 +123,7 @@ public abstract class GT_MetaTileEntity_ConcreteBackfillerBase extends GT_MetaTi
             return true;
         } else {
             workState = STATE_DOWNWARD;
-            stopMachine();
+            stopMachine(ShutDownReasonRegistry.NONE);
             setShutdownReason(StatCollector.translateToLocal("GT5U.gui.text.backfiller_finished"));
             return false;
         }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_DrillerBase.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_DrillerBase.java
@@ -81,6 +81,7 @@ import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_Utility;
 import gregtech.api.util.IGT_HatchAdder;
+import gregtech.api.util.shutdown.ShutDownReasonRegistry;
 
 public abstract class GT_MetaTileEntity_DrillerBase
     extends GT_MetaTileEntity_EnhancedMultiBlockBase<GT_MetaTileEntity_DrillerBase>
@@ -460,7 +461,7 @@ public abstract class GT_MetaTileEntity_DrillerBase
             return true;
         } else {
             workState = STATE_DOWNWARD;
-            stopMachine();
+            stopMachine(ShutDownReasonRegistry.NONE);
             return false;
         }
     }
@@ -488,7 +489,7 @@ public abstract class GT_MetaTileEntity_DrillerBase
             return true;
         } else {
             workState = STATE_DOWNWARD;
-            stopMachine();
+            stopMachine(ShutDownReasonRegistry.NONE);
             return false;
         }
     }
@@ -516,10 +517,10 @@ public abstract class GT_MetaTileEntity_DrillerBase
         setElectricityStats();
         int oldYHead = yHead;
         if (!checkPipesAndSetYHead()) {
-            stopMachine();
+            stopMachine(ShutDownReasonRegistry.NONE);
             return SimpleCheckRecipeResult.ofFailure("no_mining_pipe");
         } else if (!isEnergyEnough()) {
-            stopMachine();
+            stopMachine(ShutDownReasonRegistry.NONE);
             return SimpleCheckRecipeResult.ofFailure("not_enough_energy");
         }
         putMiningPipesFromInputsInController();

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_FusionComputer.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_FusionComputer.java
@@ -72,6 +72,8 @@ import gregtech.api.util.GT_OverclockCalculator;
 import gregtech.api.util.GT_ParallelHelper;
 import gregtech.api.util.GT_Recipe;
 import gregtech.api.util.GT_Utility;
+import gregtech.api.util.shutdown.ShutDownReason;
+import gregtech.api.util.shutdown.ShutDownReasonRegistry;
 
 public abstract class GT_MetaTileEntity_FusionComputer
     extends GT_MetaTileEntity_EnhancedMultiBlockBase<GT_MetaTileEntity_FusionComputer>
@@ -397,7 +399,7 @@ public abstract class GT_MetaTileEntity_FusionComputer
                         }
                     }
                     if (this.mEUStore <= 0 && mMaxProgresstime > 0) {
-                        criticalStopMachine();
+                        stopMachine(ShutDownReasonRegistry.POWER_LOSS);
                     }
                     if (mMaxProgresstime > 0) {
                         this.getBaseMetaTileEntity()
@@ -432,7 +434,7 @@ public abstract class GT_MetaTileEntity_FusionComputer
                                 this.mEUStore = aBaseMetaTileEntity.getStoredEU();
                                 if (checkRecipe()) {
                                     if (this.mEUStore < this.mLastRecipe.mSpecialValue + this.mEUt) {
-                                        criticalStopMachine();
+                                        stopMachine(ShutDownReasonRegistry.POWER_LOSS);
                                     }
                                     aBaseMetaTileEntity
                                         .decreaseStoredEnergyUnits(this.mLastRecipe.mSpecialValue + this.mEUt, true);
@@ -441,9 +443,9 @@ public abstract class GT_MetaTileEntity_FusionComputer
                             if (mMaxProgresstime <= 0) mEfficiency = Math.max(0, mEfficiency - 1000);
                         }
                     }
-                } else {
+                } else if (aBaseMetaTileEntity.isAllowedToWork()) {
                     this.mLastRecipe = null;
-                    stopMachine();
+                    stopMachine(ShutDownReasonRegistry.STRUCTURE_INCOMPLETE);
                 }
             }
             aBaseMetaTileEntity
@@ -473,8 +475,8 @@ public abstract class GT_MetaTileEntity_FusionComputer
     }
 
     @Override
-    public void stopMachine() {
-        super.stopMachine();
+    public void stopMachine(@NotNull ShutDownReason reason) {
+        super.stopMachine(reason);
         turnCasingActive(false);
     }
 

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeTurbine.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeTurbine.java
@@ -51,6 +51,7 @@ import gregtech.api.recipe.check.CheckRecipeResult;
 import gregtech.api.recipe.check.CheckRecipeResultRegistry;
 import gregtech.api.util.GT_Utility;
 import gregtech.api.util.LightingHelper;
+import gregtech.api.util.shutdown.ShutDownReasonRegistry;
 import gregtech.common.items.GT_MetaGenerated_Tool_01;
 import gregtech.common.render.GT_RenderUtil;
 
@@ -262,7 +263,7 @@ public abstract class GT_MetaTileEntity_LargeTurbine
             && (controllerSlot == null || !(controllerSlot.getItem() instanceof GT_MetaGenerated_Tool)
                 || controllerSlot.getItemDamage() < 170
                 || controllerSlot.getItemDamage() > 179)) {
-            stopMachine();
+            stopMachine(ShutDownReasonRegistry.NO_TURBINE);
             return CheckRecipeResultRegistry.NO_TURBINE_FOUND;
         }
         ArrayList<FluidStack> tFluids = getStoredFluids();
@@ -293,7 +294,7 @@ public abstract class GT_MetaTileEntity_LargeTurbine
                 flowMultipliers[2] = GT_MetaGenerated_Tool.getPrimaryMaterial(controllerSlot).mPlasmaMultiplier;
 
                 if (optFlow <= 0 || baseEff <= 0) {
-                    stopMachine(); // in case the turbine got removed
+                    stopMachine(ShutDownReasonRegistry.NONE); // in case the turbine got removed
                     return CheckRecipeResultRegistry.NO_FUEL_FOUND;
                 }
             } else {

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeTurbine_Plasma.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeTurbine_Plasma.java
@@ -34,6 +34,7 @@ import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GT_Multiblock_Tooltip_Builder;
 import gregtech.api.util.GT_Recipe;
 import gregtech.api.util.GT_Utility;
+import gregtech.api.util.shutdown.ShutDownReasonRegistry;
 import gregtech.common.items.GT_MetaGenerated_Tool_01;
 
 public class GT_MetaTileEntity_LargeTurbine_Plasma extends GT_MetaTileEntity_LargeTurbine {
@@ -231,7 +232,7 @@ public class GT_MetaTileEntity_LargeTurbine_Plasma extends GT_MetaTileEntity_Lar
             && (controllerSlot == null || !(controllerSlot.getItem() instanceof GT_MetaGenerated_Tool)
                 || controllerSlot.getItemDamage() < 170
                 || controllerSlot.getItemDamage() > 179)) {
-            stopMachine();
+            stopMachine(ShutDownReasonRegistry.NO_TURBINE);
             return CheckRecipeResultRegistry.NO_TURBINE_FOUND;
         }
         ArrayList<FluidStack> tFluids = getStoredFluids();
@@ -258,14 +259,14 @@ public class GT_MetaTileEntity_LargeTurbine_Plasma extends GT_MetaTileEntity_Lar
                 flowMultipliers[0] = GT_MetaGenerated_Tool.getPrimaryMaterial(controllerSlot).mSteamMultiplier;
                 flowMultipliers[1] = GT_MetaGenerated_Tool.getPrimaryMaterial(controllerSlot).mGasMultiplier;
                 flowMultipliers[2] = GT_MetaGenerated_Tool.getPrimaryMaterial(controllerSlot).mPlasmaMultiplier;
+
+                if (optFlow <= 0 || baseEff <= 0) {
+                    stopMachine(ShutDownReasonRegistry.NONE); // in case the turbine got removed
+                    return CheckRecipeResultRegistry.NO_FUEL_FOUND;
+                }
             } else {
                 counter++;
             }
-        }
-
-        if (optFlow <= 0 || baseEff <= 0) {
-            stopMachine(); // in case the turbine got removed
-            return CheckRecipeResultRegistry.NO_FUEL_FOUND;
         }
 
         int newPower = fluidIntoPower(tFluids, optFlow, baseEff, overflowMultiplier, flowMultipliers); // How much the

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_PCBFactory.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_PCBFactory.java
@@ -29,8 +29,6 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.StatCollector;
 import net.minecraftforge.common.util.ForgeDirection;
-import net.minecraftforge.fluids.Fluid;
-import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 
 import org.jetbrains.annotations.NotNull;
@@ -91,6 +89,7 @@ import gregtech.api.util.GT_OverclockCalculator;
 import gregtech.api.util.GT_ParallelHelper;
 import gregtech.api.util.GT_Recipe;
 import gregtech.api.util.GT_Utility;
+import gregtech.api.util.shutdown.ShutDownReasonRegistry;
 import gregtech.common.blocks.GT_Block_Casings8;
 
 @SuppressWarnings("SpellCheckingInspection")
@@ -588,32 +587,15 @@ public class GT_MetaTileEntity_PCBFactory extends
     @Override
     public boolean onRunningTick(ItemStack aStack) {
         if (!super.onRunningTick(aStack)) {
-            criticalStopMachine();
             return false;
         }
 
         if (ticker % 20 == 0) {
-            if (mOCTier1) {
-                if (mCoolantInputHatch == null) {
-                    criticalStopMachine();
-                    return false;
-                }
-                FluidStack tFluid = GT_ModHandler.getDistilledWater(COOLANT_CONSUMED_PER_SEC);
+            if (!isNoOC()) {
+                FluidStack tFluid = mOCTier1 ? GT_ModHandler.getDistilledWater(COOLANT_CONSUMED_PER_SEC)
+                    : Materials.SuperCoolant.getFluid(COOLANT_CONSUMED_PER_SEC);
                 if (!drain(mCoolantInputHatch, tFluid, true)) {
-                    criticalStopMachine();
-                    return false;
-                }
-            }
-
-            if (mOCTier2) {
-                if (mCoolantInputHatch == null) {
-                    criticalStopMachine();
-                    return false;
-                }
-                Fluid superCoolant = FluidRegistry.getFluid("supercoolant");
-                FluidStack tFluid = new FluidStack(superCoolant, COOLANT_CONSUMED_PER_SEC);
-                if (!drain(mCoolantInputHatch, tFluid, true)) {
-                    criticalStopMachine();
+                    stopMachine(ShutDownReasonRegistry.outOfFluid(tFluid));
                     return false;
                 }
             }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_PlasmaForge.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_PlasmaForge.java
@@ -804,18 +804,11 @@ public class GT_MetaTileEntity_PlasmaForge extends
 
     @Override
     public boolean onRunningTick(ItemStack aStack) {
-        if (this.lEUt > 0) {
-            addEnergyOutput((this.lEUt * mEfficiency) / 10000);
-            return true;
+        boolean result = super.onRunningTick(aStack);
+        if (!result) {
+            resetDiscount();
         }
-        if (this.lEUt < 0) {
-            if (!drainEnergyInput(getActualEnergyUsage())) {
-                resetDiscount();
-                criticalStopMachine();
-                return false;
-            }
-        }
-        return true;
+        return result;
     }
 
     @Override

--- a/src/main/java/gregtech/common/tileentities/machines/multi/drone/GT_MetaTileEntity_DroneCentre.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/drone/GT_MetaTileEntity_DroneCentre.java
@@ -71,6 +71,8 @@ import gregtech.api.recipe.check.SimpleCheckRecipeResult;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GT_Log;
 import gregtech.api.util.GT_Multiblock_Tooltip_Builder;
+import gregtech.api.util.shutdown.ShutDownReason;
+import gregtech.api.util.shutdown.ShutDownReasonRegistry;
 import gregtech.common.items.GT_TierDrone;
 import mcp.mobius.waila.api.IWailaConfigHandler;
 import mcp.mobius.waila.api.IWailaDataAccessor;
@@ -226,9 +228,9 @@ public class GT_MetaTileEntity_DroneCentre extends
     }
 
     @Override
-    public void stopMachine() {
+    public void stopMachine(@NotNull ShutDownReason reason) {
         destroyRenderBlock();
-        super.stopMachine();
+        super.stopMachine(reason);
     }
 
     @Override
@@ -242,7 +244,7 @@ public class GT_MetaTileEntity_DroneCentre extends
                     default -> 1;
                 } == 0) {
                     droneLevel = 0;
-                    if (!tryConsumeDrone()) criticalStopMachine();
+                    if (!tryConsumeDrone()) stopMachine(ShutDownReasonRegistry.outOfStuff("Any Drone", 1));
                 }
             }
             // Clean invalid connections every 4 seconds

--- a/src/main/resources/assets/gregtech/lang/en_US.lang
+++ b/src/main/resources/assets/gregtech/lang/en_US.lang
@@ -485,6 +485,14 @@ GT5U.gui.text.drone_operating=§aDrone operating normally!
 GT5U.gui.text.drone_title=Drone Control Centre
 GT5U.gui.text.drone_custom_name=Custom Machine Name
 GT5U.gui.text.drone_search=Search machine name
+GT5U.gui.text.out_of_fluid=§4No following fluids supplied: §b%s§f x §6%s L
+GT5U.gui.text.out_of_item=§4No following items supplied: §b%s§f x §6%s
+GT5U.gui.text.out_of_stuff=§4No following stuffs supplied: §b%s§f x §6%s
+GT5U.gui.text.power_loss=§4Shut down due to power loss.
+GT5U.gui.text.pollution_fail=§4Failed to output the pollution.
+GT5U.gui.text.structure_incomplete=§4Shut down due to incomplete structure.
+GT5U.gui.text.no_repair=§4Shut down due to machine damage.
+GT5U.gui.text.no_machine_part=No correct machine part in controller slot.
 
 GT5U.item.programmed_circuit.select.header=Reprogram Circuit
 


### PR DESCRIPTION
Technically it's a runtime version of CheckRecipeResult. 
The messages will be displayed in the controller GUI and the scanner result.
Should fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15457.

# Images

![1](https://github.com/GTNewHorizons/GT5-Unofficial/assets/48403212/edd0f83e-0860-48a1-adc0-9bf9bb8bd1bf)
![2](https://github.com/GTNewHorizons/GT5-Unofficial/assets/48403212/da35aafa-b966-41f6-89e3-11daddcd9b6f)
![3](https://github.com/GTNewHorizons/GT5-Unofficial/assets/48403212/3d85e463-1a1a-47a4-8d7f-bbc70b1ff45a)
