### PR TITLE
Fix Fusion overclock

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_FusionComputer.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_FusionComputer.java
@@ -339,7 +339,7 @@ public abstract class GT_MetaTileEntity_FusionComputer
                 }
                 return result;
             }
-        }.setOverclock(1, 1);
+        };
     }
 
     @Override


### PR DESCRIPTION
With this, fusion recipes will get OCs that match the description in NEI : Fusion Computer tier - recipe tier.