### PR TITLE
Numeric widget and localized number formatting.

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicTank.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicTank.java
@@ -7,6 +7,7 @@ import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTankInfo;
 
+import com.gtnewhorizons.modularui.api.NumberFormatMUI;
 import com.gtnewhorizons.modularui.api.screen.ModularWindow;
 import com.gtnewhorizons.modularui.api.screen.UIBuildContext;
 import com.gtnewhorizons.modularui.common.fluid.FluidStackTank;
@@ -309,6 +310,8 @@ public abstract class GT_MetaTileEntity_BasicTank extends GT_MetaTileEntity_Tier
         // Do nothing
     }
 
+    protected static final NumberFormatMUI numberFormat = new NumberFormatMUI();
+
     @Override
     public void addUIWidgets(ModularWindow.Builder builder, UIBuildContext buildContext) {
         builder.widget(
@@ -334,7 +337,7 @@ public abstract class GT_MetaTileEntity_BasicTank extends GT_MetaTileEntity_Tier
                 new TextWidget("Liquid Amount").setDefaultColor(COLOR_TEXT_WHITE.get())
                     .setPos(10, 20))
             .widget(
-                TextWidget.dynamicString(() -> GT_Utility.parseNumberToString(mFluid != null ? mFluid.amount : 0))
+                new TextWidget().setStringSupplier(() -> numberFormat.format(mFluid != null ? mFluid.amount : 0))
                     .setDefaultColor(COLOR_TEXT_WHITE.get())
                     .setPos(10, 30));
     }

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
@@ -2210,11 +2210,11 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
         return true;
     }
 
-    protected static final NumberFormatMUI numberFormat = new NumberFormatMUI();
-
     protected boolean shouldDisplayShutDownReason() {
         return true;
     }
+
+    protected final NumberFormatMUI numberFormat = new NumberFormatMUI();
 
     protected String generateCurrentRecipeInfoString() {
         StringBuffer ret = new StringBuffer(EnumChatFormatting.WHITE + "Progress: ");
@@ -2225,10 +2225,12 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
         ret.append("s / ");
         numberFormat.format((double) mMaxProgresstime / 20, ret);
         ret.append("s (");
-        numberFormat.setMinimumFractionDigits(0);
+        numberFormat.setMinimumFractionDigits(1);
         numberFormat.setMaximumFractionDigits(1);
         numberFormat.format((double) mProgresstime / mMaxProgresstime * 100, ret);
         ret.append("%)\n");
+        numberFormat.setMinimumFractionDigits(0);
+        numberFormat.setMaximumFractionDigits(2);
 
         IntConsumer appendRate = (amount) -> {
             double processPerTick = (double) amount / mMaxProgresstime * 20;

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
@@ -2211,7 +2211,7 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
     }
 
     protected static final NumberFormatMUI numberFormat = new NumberFormatMUI();
-        
+
     protected boolean shouldDisplayShutDownReason() {
         return true;
     }

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
@@ -16,7 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
-import java.util.function.Function;
+import java.util.function.IntConsumer;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -43,6 +43,7 @@ import org.lwjgl.input.Keyboard;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import com.gtnewhorizons.modularui.api.NumberFormatMUI;
 import com.gtnewhorizons.modularui.api.math.Alignment;
 import com.gtnewhorizons.modularui.api.math.Pos2d;
 import com.gtnewhorizons.modularui.api.screen.ModularWindow;
@@ -2184,27 +2185,33 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
         return true;
     }
 
-    protected String generateCurrentRecipeInfoString() {
-        StringBuilder ret = new StringBuilder(EnumChatFormatting.WHITE + "Progress: ")
-            .append(String.format("%,.2f", (double) mProgresstime / 20))
-            .append("s / ")
-            .append(String.format("%,.2f", (double) mMaxProgresstime / 20))
-            .append("s (")
-            .append(String.format("%,.1f", (double) mProgresstime / mMaxProgresstime * 100))
-            .append("%)\n");
+    protected static final NumberFormatMUI numberFormat = new NumberFormatMUI();
 
-        Function<Integer, Void> appendRate = (Integer amount) -> {
+    protected String generateCurrentRecipeInfoString() {
+        StringBuffer ret = new StringBuffer(EnumChatFormatting.WHITE + "Progress: ");
+
+        numberFormat.setMinimumFractionDigits(2);
+        numberFormat.setMaximumFractionDigits(2);
+        numberFormat.format((double) mProgresstime / 20, ret);
+        ret.append("s / ");
+        numberFormat.format((double) mMaxProgresstime / 20, ret);
+        ret.append("s (");
+        numberFormat.setMinimumFractionDigits(0);
+        numberFormat.setMaximumFractionDigits(1);
+        numberFormat.format((double) mProgresstime / mMaxProgresstime * 100, ret);
+        ret.append("%)\n");
+
+        IntConsumer appendRate = (amount) -> {
             double processPerTick = (double) amount / mMaxProgresstime * 20;
             if (processPerTick > 1) {
-                ret.append(" (")
-                    .append(formatNumbers(Math.round(processPerTick * 10) / 10.0))
-                    .append("/s)");
+                ret.append(" (");
+                numberFormat.format(Math.round(processPerTick * 10) / 10.0, ret);
+                ret.append("/s)");
             } else {
-                ret.append(" (")
-                    .append(formatNumbers(Math.round(1 / processPerTick * 10) / 10.0))
-                    .append("s/ea)");
+                ret.append(" (");
+                numberFormat.format(Math.round(1 / processPerTick * 10) / 10.0, ret);
+                ret.append("s/ea)");
             }
-            return null;
         };
 
         int lines = 0;
@@ -2222,10 +2229,10 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
                     .append(item.getDisplayName())
                     .append(EnumChatFormatting.WHITE)
                     .append(" x ")
-                    .append(EnumChatFormatting.GOLD)
-                    .append(formatNumbers(item.stackSize))
-                    .append(EnumChatFormatting.WHITE);
-                appendRate.apply(item.stackSize);
+                    .append(EnumChatFormatting.GOLD);
+                numberFormat.format(item.stackSize, ret);
+                ret.append(EnumChatFormatting.WHITE);
+                appendRate.accept(item.stackSize);
                 ret.append('\n');
             }
         }
@@ -2241,11 +2248,11 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
                     .append(fluid.getLocalizedName())
                     .append(EnumChatFormatting.WHITE)
                     .append(" x ")
-                    .append(EnumChatFormatting.GOLD)
-                    .append(formatNumbers(fluid.amount))
-                    .append("L")
+                    .append(EnumChatFormatting.GOLD);
+                numberFormat.format(fluid.amount, ret);
+                ret.append("L")
                     .append(EnumChatFormatting.WHITE);
-                appendRate.apply(fluid.amount);
+                appendRate.accept(fluid.amount);
                 ret.append('\n');
             }
         }

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
@@ -2211,6 +2211,7 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
     }
 
     protected static final NumberFormatMUI numberFormat = new NumberFormatMUI();
+        
     protected boolean shouldDisplayShutDownReason() {
         return true;
     }

--- a/src/main/java/gregtech/common/covers/GT_Cover_FluidLimiter.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_FluidLimiter.java
@@ -13,7 +13,6 @@ import net.minecraftforge.fluids.FluidTankInfo;
 import net.minecraftforge.fluids.IFluidHandler;
 
 import com.google.common.io.ByteArrayDataInput;
-import com.gtnewhorizons.modularui.api.math.MathExpression;
 import com.gtnewhorizons.modularui.api.screen.ModularWindow;
 import com.gtnewhorizons.modularui.common.widget.TextWidget;
 
@@ -24,7 +23,7 @@ import gregtech.api.util.GT_CoverBehaviorBase;
 import gregtech.api.util.GT_Utility;
 import gregtech.api.util.ISerializableObject;
 import gregtech.common.gui.modularui.widget.CoverDataControllerWidget;
-import gregtech.common.gui.modularui.widget.CoverDataFollower_TextFieldWidget;
+import gregtech.common.gui.modularui.widget.CoverDataFollower_NumericWidget;
 import io.netty.buffer.ByteBuf;
 
 /***
@@ -190,13 +189,13 @@ public class GT_Cover_FluidLimiter extends GT_CoverBehaviorBase<GT_Cover_FluidLi
             builder.widget(
                 new CoverDataControllerWidget<>(this::getCoverData, this::setCoverData, GT_Cover_FluidLimiter.this)
                     .addFollower(
-                        new CoverDataFollower_TextFieldWidget<>(),
-                        coverData -> String.valueOf(Math.round(coverData.threshold * 100)),
+                        new CoverDataFollower_NumericWidget<>(),
+                        coverData -> (double) Math.round(coverData.threshold * 100),
                         (coverData, val) -> {
-                            coverData.threshold = (float) (MathExpression.parseMathExpression(val) / 100);
+                            coverData.threshold = val.floatValue() / 100;
                             return coverData;
                         },
-                        widget -> widget.setNumbers(0, 100)
+                        widget -> widget.setBounds(0, 100)
                             .setFocusOnGuiOpen(true)
                             .setPos(startX, startY + spaceY * 2 - 24)
                             .setSize(spaceX * 4 - 3, 12)))

--- a/src/main/java/gregtech/common/covers/GT_Cover_FluidRegulator.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_FluidRegulator.java
@@ -15,11 +15,10 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.IFluidHandler;
 
 import com.google.common.io.ByteArrayDataInput;
+import com.gtnewhorizons.modularui.api.NumberFormatMUI;
 import com.gtnewhorizons.modularui.api.drawable.Text;
-import com.gtnewhorizons.modularui.api.math.MathExpression;
 import com.gtnewhorizons.modularui.api.screen.ModularWindow;
 import com.gtnewhorizons.modularui.common.widget.TextWidget;
-import com.gtnewhorizons.modularui.common.widget.textfield.BaseTextFieldWidget;
 
 import gregtech.api.gui.modularui.GT_CoverUIBuildContext;
 import gregtech.api.gui.modularui.GT_UITextures;
@@ -30,7 +29,7 @@ import gregtech.api.util.GT_CoverBehaviorBase;
 import gregtech.api.util.GT_Utility;
 import gregtech.api.util.ISerializableObject;
 import gregtech.common.gui.modularui.widget.CoverDataControllerWidget;
-import gregtech.common.gui.modularui.widget.CoverDataFollower_TextFieldWidget;
+import gregtech.common.gui.modularui.widget.CoverDataFollower_NumericWidget;
 import gregtech.common.gui.modularui.widget.CoverDataFollower_ToggleButtonWidget;
 import io.netty.buffer.ByteBuf;
 
@@ -252,6 +251,12 @@ public class GT_Cover_FluidRegulator extends GT_CoverBehaviorBase<GT_Cover_Fluid
         private static final int spaceX = 18;
         private static final int spaceY = 18;
 
+        private static final NumberFormatMUI numberFormat;
+        static {
+            numberFormat = new NumberFormatMUI();
+            numberFormat.setMaximumFractionDigits(2);
+        }
+
         public FluidRegulatorUIFactory(GT_CoverUIBuildContext buildContext) {
             super(buildContext);
         }
@@ -314,14 +319,14 @@ public class GT_Cover_FluidRegulator extends GT_CoverBehaviorBase<GT_Cover_Fluid
                             .addTooltip(GT_Utility.trans("343.1", "Use Inverted Machine Processing State"))
                             .setPos(spaceX * 2, spaceY * 1))
                     .addFollower(
-                        new CoverDataFollower_TextFieldWidget<>(),
-                        coverData -> String.valueOf(coverData.speed),
+                        new CoverDataFollower_NumericWidget<>(),
+                        coverData -> (double) coverData.speed,
                         (coverData, state) -> {
-                            coverData.speed = (int) MathExpression.parseMathExpression(state);
+                            coverData.speed = state.intValue();
                             return coverData;
                         },
-                        widget -> widget.setOnScrollNumbersLong(1, 5, 50)
-                            .setNumbersLong(val -> {
+                        widget -> widget.setBounds(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY)
+                            .setValidator(val -> {
                                 final int tickRate = getCoverData() != null ? getCoverData().tickRate : 0;
                                 final long maxFlow = (long) mTransferRate
                                     * GT_Utility.clamp(tickRate, TICK_RATE_MIN, TICK_RATE_MAX);
@@ -335,19 +340,19 @@ public class GT_Cover_FluidRegulator extends GT_CoverBehaviorBase<GT_Cover_Fluid
                                 }
                                 return val;
                             })
-                            .setPattern(BaseTextFieldWidget.WHOLE_NUMS)
+                            .setScrollValues(1, 144, 1000)
                             .setFocusOnGuiOpen(true)
                             .setPos(spaceX * 0, spaceY * 2 + 2)
                             .setSize(spaceX * 4 - 3, 12))
                     .addFollower(
-                        new CoverDataFollower_TextFieldWidget<>(),
-                        coverData -> String.valueOf(coverData.tickRate),
+                        new CoverDataFollower_NumericWidget<>(),
+                        coverData -> (double) coverData.tickRate,
                         (coverData, state) -> {
-                            coverData.tickRate = (int) MathExpression.parseMathExpression(state);
+                            coverData.tickRate = state.intValue();
                             return coverData;
                         },
-                        widget -> widget.setOnScrollNumbersLong(1, 5, 50)
-                            .setNumbersLong(val -> {
+                        widget -> widget.setBounds(0, TICK_RATE_MAX)
+                            .setValidator(val -> {
                                 final int speed = getCoverData() != null ? getCoverData().speed : 0;
                                 warn.set(false);
                                 if (val > TICK_RATE_MAX) {
@@ -362,7 +367,6 @@ public class GT_Cover_FluidRegulator extends GT_CoverBehaviorBase<GT_Cover_Fluid
                                 }
                                 return val;
                             })
-                            .setPattern(BaseTextFieldWidget.WHOLE_NUMS)
                             .setPos(spaceX * 5, spaceY * 2 + 2)
                             .setSize(spaceX * 2 - 3, 12))
                     .setPos(startX, startY))
@@ -378,16 +382,17 @@ public class GT_Cover_FluidRegulator extends GT_CoverBehaviorBase<GT_Cover_Fluid
                 .widget(
                     new TextWidget(GT_Utility.trans("209", " ticks")).setDefaultColor(COLOR_TEXT_GRAY.get())
                         .setPos(startX + spaceX * 7, 4 + startY + spaceY * 2))
-                .widget(TextWidget.dynamicText(() -> {
+                .widget(new TextWidget().setTextSupplier(() -> {
                     FluidRegulatorData coverVariable = getCoverData();
                     if (coverVariable == null) return new Text("");
                     return new Text(
-                        String.format(
-                            GT_Utility.trans("210", "Average: %.2f L/sec"),
-                            coverVariable.tickRate == 0 ? 0 : coverVariable.speed * 20d / coverVariable.tickRate))
+                        GT_Utility.trans("210.1", "Average:") + " "
+                            + numberFormat.format(
+                                coverVariable.tickRate == 0 ? 0 : coverVariable.speed * 20d / coverVariable.tickRate)
+                            + " "
+                            + GT_Utility.trans("210.2", "L/sec"))
                                 .color(warn.get() ? COLOR_TEXT_WARN.get() : COLOR_TEXT_GRAY.get());
                 })
-                    .setSynced(false)
                     .setPos(startX + spaceX * 0, 4 + startY + spaceY * 3));
         }
     }

--- a/src/main/java/gregtech/common/covers/GT_Cover_LiquidMeter.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_LiquidMeter.java
@@ -217,9 +217,9 @@ public class GT_Cover_LiquidMeter extends GT_CoverBehaviorBase<GT_Cover_LiquidMe
                             .setSize(spaceX * 4 + 5, 12))
                     .setPos(startX, startY))
                 .widget(
-                    TextWidget
-                        .dynamicString(() -> getCoverData() != null ? getCoverData().inverted ? INVERTED : NORMAL : "")
-                        .setSynced(false)
+                    new TextWidget()
+                        .setStringSupplier(
+                            () -> getCoverData() != null ? getCoverData().inverted ? INVERTED : NORMAL : "")
                         .setDefaultColor(COLOR_TEXT_GRAY.get())
                         .setPos(startX + spaceX * 1, 4 + startY + spaceY * 0))
                 .widget(

--- a/src/main/java/gregtech/common/covers/GT_Cover_LiquidMeter.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_LiquidMeter.java
@@ -15,7 +15,6 @@ import net.minecraftforge.fluids.FluidTankInfo;
 import net.minecraftforge.fluids.IFluidHandler;
 
 import com.google.common.io.ByteArrayDataInput;
-import com.gtnewhorizons.modularui.api.math.MathExpression;
 import com.gtnewhorizons.modularui.api.screen.ModularWindow;
 import com.gtnewhorizons.modularui.common.widget.TextWidget;
 
@@ -27,7 +26,7 @@ import gregtech.api.util.GT_CoverBehaviorBase;
 import gregtech.api.util.GT_Utility;
 import gregtech.api.util.ISerializableObject;
 import gregtech.common.gui.modularui.widget.CoverDataControllerWidget;
-import gregtech.common.gui.modularui.widget.CoverDataFollower_TextFieldWidget;
+import gregtech.common.gui.modularui.widget.CoverDataFollower_NumericWidget;
 import gregtech.common.gui.modularui.widget.CoverDataFollower_ToggleButtonWidget;
 import gregtech.common.tileentities.storage.GT_MetaTileEntity_DigitalTankBase;
 import io.netty.buffer.ByteBuf;
@@ -178,6 +177,7 @@ public class GT_Cover_LiquidMeter extends GT_CoverBehaviorBase<GT_Cover_LiquidMe
         private static final int startY = 25;
         private static final int spaceX = 18;
         private static final int spaceY = 18;
+        private int maxCapacity;
 
         public LiquidMeterUIFactory(GT_CoverUIBuildContext buildContext) {
             super(buildContext);
@@ -188,17 +188,8 @@ public class GT_Cover_LiquidMeter extends GT_CoverBehaviorBase<GT_Cover_LiquidMe
         protected void addUIWidgets(ModularWindow.Builder builder) {
             final String INVERTED = GT_Utility.trans("INVERTED", "Inverted");
             final String NORMAL = GT_Utility.trans("NORMAL", "Normal");
-            final int maxCapacity;
 
-            if (getUIBuildContext().getTile() instanceof IFluidHandler) {
-                FluidTankInfo[] tanks = ((IFluidHandler) getUIBuildContext().getTile())
-                    .getTankInfo(ForgeDirection.UNKNOWN);
-                maxCapacity = Arrays.stream(tanks)
-                    .mapToInt(tank -> tank.capacity)
-                    .sum();
-            } else {
-                maxCapacity = -1;
-            }
+            setMaxCapacity();
 
             builder.widget(
                 new CoverDataControllerWidget<>(this::getCoverData, this::setCoverData, GT_Cover_LiquidMeter.this)
@@ -213,14 +204,14 @@ public class GT_Cover_LiquidMeter extends GT_CoverBehaviorBase<GT_Cover_LiquidMe
                             .addTooltip(1, INVERTED)
                             .setPos(spaceX * 0, spaceY * 0))
                     .addFollower(
-                        new CoverDataFollower_TextFieldWidget<>(),
-                        coverData -> String.valueOf(coverData.threshold),
+                        new CoverDataFollower_NumericWidget<>(),
+                        coverData -> (double) coverData.threshold,
                         (coverData, state) -> {
-                            coverData.threshold = (int) MathExpression.parseMathExpression(state);
+                            coverData.threshold = state.intValue();
                             return coverData;
                         },
-                        widget -> widget.setOnScrollNumbers(1000, 100, 100000)
-                            .setNumbers(0, maxCapacity > 0 ? maxCapacity : Integer.MAX_VALUE)
+                        widget -> widget.setBounds(0, maxCapacity > 0 ? maxCapacity : Integer.MAX_VALUE)
+                            .setScrollValues(1000, 144, 100000)
                             .setFocusOnGuiOpen(true)
                             .setPos(spaceX * 0, spaceY * 1 + 2)
                             .setSize(spaceX * 4 + 5, 12))
@@ -234,6 +225,18 @@ public class GT_Cover_LiquidMeter extends GT_CoverBehaviorBase<GT_Cover_LiquidMe
                 .widget(
                     new TextWidget(GT_Utility.trans("222", "Fluid threshold")).setDefaultColor(COLOR_TEXT_GRAY.get())
                         .setPos(startX + spaceX * 5 - 10, startY + spaceY * 1 + 4));
+        }
+
+        private void setMaxCapacity() {
+            final ICoverable tile = getUIBuildContext().getTile();
+            if (!tile.isDead() && tile instanceof IFluidHandler) {
+                FluidTankInfo[] tanks = ((IFluidHandler) tile).getTankInfo(ForgeDirection.UNKNOWN);
+                maxCapacity = Arrays.stream(tanks)
+                    .mapToInt(tank -> tank.capacity)
+                    .sum();
+            } else {
+                maxCapacity = -1;
+            }
         }
     }
 

--- a/src/main/java/gregtech/common/covers/GT_Cover_RedstoneWirelessBase.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_RedstoneWirelessBase.java
@@ -4,7 +4,6 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.Fluid;
 
-import com.gtnewhorizons.modularui.api.math.MathExpression;
 import com.gtnewhorizons.modularui.api.screen.ModularWindow;
 import com.gtnewhorizons.modularui.common.widget.TextWidget;
 
@@ -16,7 +15,7 @@ import gregtech.api.util.GT_CoverBehavior;
 import gregtech.api.util.GT_Utility;
 import gregtech.api.util.ISerializableObject;
 import gregtech.common.gui.modularui.widget.CoverDataControllerWidget;
-import gregtech.common.gui.modularui.widget.CoverDataFollower_TextFieldWidget;
+import gregtech.common.gui.modularui.widget.CoverDataFollower_NumericWidget;
 import gregtech.common.gui.modularui.widget.CoverDataFollower_ToggleButtonWidget;
 
 public abstract class GT_Cover_RedstoneWirelessBase extends GT_CoverBehavior {
@@ -195,16 +194,18 @@ public abstract class GT_Cover_RedstoneWirelessBase extends GT_CoverBehavior {
                     new CoverDataControllerWidget<>(
                         this::getCoverData,
                         this::setCoverData,
-                        GT_Cover_RedstoneWirelessBase.this).addFollower(
-                            new CoverDataFollower_TextFieldWidget<>(),
-                            coverData -> String.valueOf(getFlagFrequency(convert(coverData))),
-                            (coverData, text) -> new ISerializableObject.LegacyCoverData(
-                                (int) MathExpression.parseMathExpression(text) | getFlagCheckbox(convert(coverData))),
-                            widget -> widget.setOnScrollNumbers()
-                                .setNumbers(0, MAX_CHANNEL)
-                                .setFocusOnGuiOpen(true)
-                                .setPos(spaceX * 0, spaceY * 0 + 2)
-                                .setSize(spaceX * 4 - 3, 12))
+                        GT_Cover_RedstoneWirelessBase.this)
+
+                            .addFollower(
+                                new CoverDataFollower_NumericWidget<>(),
+                                coverData -> (double) getFlagFrequency(convert(coverData)),
+                                (coverData, state) -> new ISerializableObject.LegacyCoverData(
+                                    state.intValue() | getFlagCheckbox(convert(coverData))),
+                                widget -> widget.setBounds(0, MAX_CHANNEL)
+                                    .setScrollValues(1, 1000, 10)
+                                    .setFocusOnGuiOpen(true)
+                                    .setPos(spaceX * 0, spaceY * 0 + 2)
+                                    .setSize(spaceX * 4 - 3, 12))
                             .addFollower(
                                 CoverDataFollower_ToggleButtonWidget.ofCheck(),
                                 coverData -> getFlagCheckbox(convert(coverData)) > 0,

--- a/src/main/java/gregtech/common/covers/redstone/GT_Cover_AdvancedWirelessRedstoneBase.java
+++ b/src/main/java/gregtech/common/covers/redstone/GT_Cover_AdvancedWirelessRedstoneBase.java
@@ -13,7 +13,6 @@ import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.Fluid;
 
 import com.google.common.io.ByteArrayDataInput;
-import com.gtnewhorizons.modularui.api.math.MathExpression;
 import com.gtnewhorizons.modularui.api.screen.ModularWindow;
 import com.gtnewhorizons.modularui.common.widget.TextWidget;
 
@@ -25,7 +24,7 @@ import gregtech.api.util.GT_CoverBehaviorBase;
 import gregtech.api.util.GT_Utility;
 import gregtech.api.util.ISerializableObject;
 import gregtech.common.gui.modularui.widget.CoverDataControllerWidget;
-import gregtech.common.gui.modularui.widget.CoverDataFollower_TextFieldWidget;
+import gregtech.common.gui.modularui.widget.CoverDataFollower_NumericWidget;
 import gregtech.common.gui.modularui.widget.CoverDataFollower_ToggleButtonWidget;
 import io.netty.buffer.ByteBuf;
 
@@ -270,15 +269,14 @@ public abstract class GT_Cover_AdvancedWirelessRedstoneBase<T extends GT_Cover_A
 
         protected void addUIForDataController(CoverDataControllerWidget<T> controller) {
             controller.addFollower(
-                new CoverDataFollower_TextFieldWidget<>(),
-                coverData -> String.valueOf(coverData.frequency),
+                new CoverDataFollower_NumericWidget<>(),
+                coverData -> (double) coverData.frequency,
                 (coverData, state) -> {
-                    coverData.frequency = (int) MathExpression.parseMathExpression(state);
+                    coverData.frequency = state.intValue();
                     return coverData;
                 },
-                widget -> widget.setOnScrollNumbers()
-                    .setNumbers(0, Integer.MAX_VALUE)
-                    .setFocusOnGuiOpen(true)
+                widget -> widget.setScrollValues(1, 1000, 10)
+                    .setBounds(0, Integer.MAX_VALUE)
                     .setPos(1, 2 + spaceY * getFrequencyRow())
                     .setSize(spaceX * 5 - 4, 12))
                 .addFollower(

--- a/src/main/java/gregtech/common/covers/redstone/GT_Cover_WirelessItemDetector.java
+++ b/src/main/java/gregtech/common/covers/redstone/GT_Cover_WirelessItemDetector.java
@@ -1,5 +1,6 @@
 package gregtech.common.covers.redstone;
 
+import java.text.FieldPosition;
 import java.util.UUID;
 
 import javax.annotation.Nonnull;
@@ -12,10 +13,9 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import com.google.common.io.ByteArrayDataInput;
-import com.gtnewhorizons.modularui.api.math.MathExpression;
+import com.gtnewhorizons.modularui.api.NumberFormatMUI;
 import com.gtnewhorizons.modularui.api.screen.ModularWindow;
 import com.gtnewhorizons.modularui.common.widget.TextWidget;
-import com.gtnewhorizons.modularui.common.widget.textfield.BaseTextFieldWidget;
 
 import gregtech.api.gui.modularui.GT_CoverUIBuildContext;
 import gregtech.api.interfaces.ITexture;
@@ -25,7 +25,7 @@ import gregtech.api.util.GT_Utility;
 import gregtech.api.util.ISerializableObject;
 import gregtech.common.covers.GT_Cover_ItemMeter;
 import gregtech.common.gui.modularui.widget.CoverDataControllerWidget;
-import gregtech.common.gui.modularui.widget.CoverDataFollower_TextFieldWidget;
+import gregtech.common.gui.modularui.widget.CoverDataFollower_NumericWidget;
 import gregtech.common.gui.modularui.widget.ItemWatcherSlotWidget;
 import gregtech.common.tileentities.storage.GT_MetaTileEntity_DigitalChestBase;
 import io.netty.buffer.ByteBuf;
@@ -149,10 +149,22 @@ public class GT_Cover_WirelessItemDetector
 
     private class WirelessItemDetectorUIFactory extends AdvancedRedstoneTransmitterBaseUIFactory {
 
-        private static final String ALL_TEXT = "All";
-
         private int maxSlot;
         private int maxThreshold;
+        /**
+         * Display the text "All" instead of a number when the slot is set to -1.
+         */
+        private static final NumberFormatMUI numberFormatAll = new NumberFormatMUI() {
+
+            @Override
+            public StringBuffer format(double number, StringBuffer toAppendTo, FieldPosition pos) {
+                if (number < 0) {
+                    return toAppendTo.append(GT_Utility.trans("ALL", "All"));
+                } else {
+                    return super.format(number, toAppendTo, pos);
+                }
+            }
+        };
 
         public WirelessItemDetectorUIFactory(GT_CoverUIBuildContext buildContext) {
             super(buildContext);
@@ -180,7 +192,7 @@ public class GT_Cover_WirelessItemDetector
                     new TextWidget(GT_Utility.trans("221", "Item threshold")).setDefaultColor(COLOR_TEXT_GRAY.get())
                         .setPos(startX + spaceX * 5, 4 + startY + spaceY * 2))
                 .widget(
-                    new TextWidget(GT_Utility.trans("254.0", "Detect Slot")).setDefaultColor(COLOR_TEXT_GRAY.get())
+                    new TextWidget(GT_Utility.trans("254", "Detect Slot #")).setDefaultColor(COLOR_TEXT_GRAY.get())
                         .setPos(startX + spaceX * 5, 4 + startY + spaceY * 3));
         }
 
@@ -188,34 +200,28 @@ public class GT_Cover_WirelessItemDetector
         protected void addUIForDataController(CoverDataControllerWidget<ItemTransmitterData> controller) {
             super.addUIForDataController(controller);
             controller.addFollower(
-                new CoverDataFollower_TextFieldWidget<>(),
-                coverData -> String.valueOf(coverData.threshold),
+                new CoverDataFollower_NumericWidget<>(),
+                coverData -> (double) coverData.threshold,
                 (coverData, state) -> {
-                    coverData.threshold = (int) MathExpression.parseMathExpression(state);
+                    coverData.threshold = state.intValue();
                     return coverData;
                 },
-                widget -> widget.setOnScrollNumbers(1, 10, 64)
-                    .setNumbers(0, maxThreshold)
+                widget -> widget.setBounds(0, maxThreshold)
+                    .setScrollValues(1, 64, 1000)
+                    .setFocusOnGuiOpen(true)
                     .setPos(1, 2 + spaceY * 2)
                     .setSize(spaceX * 5 - 4, 12))
                 .addFollower(
-                    new CoverDataFollower_TextFieldWidget<>(),
-                    coverData -> getSlotTextFieldContent(coverData.slot),
+                    new CoverDataFollower_NumericWidget<>(),
+                    coverData -> (double) coverData.slot,
                     (coverData, state) -> {
-                        coverData.slot = getIntFromText(state);
+                        coverData.slot = state.intValue();
                         return coverData;
                     },
-                    widget -> widget.setOnScrollText()
-                        .setValidator(val -> {
-                            final int valSlot = getIntFromText(val);
-                            if (valSlot > -1) {
-                                return widget.getDecimalFormatter()
-                                    .format(Math.min(valSlot, maxSlot));
-                            } else {
-                                return ALL_TEXT;
-                            }
-                        })
-                        .setPattern(BaseTextFieldWidget.NATURAL_NUMS)
+                    widget -> widget.setBounds(-1, maxSlot)
+                        .setDefaultValue(-1)
+                        .setScrollValues(1, 100, 10)
+                        .setNumberFormat(numberFormatAll)
                         .setPos(1, 2 + spaceY * 3)
                         .setSize(spaceX * 4 - 8, 12));
         }
@@ -238,18 +244,6 @@ public class GT_Cover_WirelessItemDetector
             } else {
                 maxThreshold = maxSlot > 0 ? maxSlot * 64 : Integer.MAX_VALUE;
             }
-        }
-
-        private int getIntFromText(String text) {
-            try {
-                return (int) MathExpression.parseMathExpression(text, -1);
-            } catch (Exception e) {
-                return -1;
-            }
-        }
-
-        private String getSlotTextFieldContent(int val) {
-            return val < 0 ? ALL_TEXT : String.valueOf(val);
         }
 
         private ItemStack getTargetItem() {

--- a/src/main/java/gregtech/common/gui/MachineGUIProvider.java
+++ b/src/main/java/gregtech/common/gui/MachineGUIProvider.java
@@ -13,6 +13,7 @@ import javax.annotation.Nonnull;
 import net.minecraft.util.StatCollector;
 
 import com.gtnewhorizons.modularui.api.ModularUITextures;
+import com.gtnewhorizons.modularui.api.NumberFormatMUI;
 import com.gtnewhorizons.modularui.api.drawable.IDrawable;
 import com.gtnewhorizons.modularui.api.drawable.ItemDrawable;
 import com.gtnewhorizons.modularui.api.drawable.UITexture;
@@ -58,6 +59,8 @@ public class MachineGUIProvider<T extends GUIHost & ProcessingLogicHost<? extend
     protected static final Pos2d BATCH_MODE_BUTTON_DEFAULT_POS = new Pos2d(18, 0);
     @Nonnull
     protected static final Pos2d RECIPE_LOCKING_BUTTON_DEFAULT_POS = new Pos2d(0, 0);
+
+    protected static final NumberFormatMUI numberFormat = new NumberFormatMUI();
 
     public MachineGUIProvider(@Nonnull T host) {
         super(host);
@@ -252,10 +255,19 @@ public class MachineGUIProvider<T extends GUIHost & ProcessingLogicHost<? extend
         @Nonnull UIBuildContext uiBuildContext) {
         PowerLogic power = host.getPowerLogic();
         tab.addChild(
-            TextWidget.dynamicString(() -> power.getStoredEnergy() + "/" + power.getCapacity() + " EU")
+            new TextWidget()
+                .setStringSupplier(
+                    () -> numberFormat.format(power.getStoredEnergy()) + "/"
+                        + numberFormat.format(power.getCapacity())
+                        + " EU")
                 .setPos(10, 30))
             .addChild(
-                TextWidget.dynamicString(() -> power.getVoltage() + " EU/t" + "(" + power.getMaxAmperage() + " A)")
+                new TextWidget()
+                    .setStringSupplier(
+                        () -> numberFormat.format(power.getVoltage()) + " EU/t"
+                            + "("
+                            + numberFormat.format(power.getMaxAmperage())
+                            + " A)")
                     .setPos(10, 60));
     }
 

--- a/src/main/java/gregtech/common/gui/modularui/widget/CoverDataFollower_NumericWidget.java
+++ b/src/main/java/gregtech/common/gui/modularui/widget/CoverDataFollower_NumericWidget.java
@@ -1,0 +1,60 @@
+package gregtech.common.gui.modularui.widget;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import com.gtnewhorizons.modularui.api.math.Alignment;
+import com.gtnewhorizons.modularui.api.math.Color;
+import com.gtnewhorizons.modularui.common.widget.textfield.NumericWidget;
+
+import gregtech.api.gui.modularui.GT_UITextures;
+import gregtech.api.gui.modularui.IDataFollowerWidget;
+import gregtech.api.util.ISerializableObject;
+
+public class CoverDataFollower_NumericWidget<T extends ISerializableObject> extends NumericWidget
+    implements IDataFollowerWidget<T, Double> {
+
+    private Function<T, Double> dataToStateGetter;
+
+    public CoverDataFollower_NumericWidget() {
+        super();
+        setGetter(() -> 0); // fake getter; used only for init
+        setSynced(false, false);
+        setTextColor(Color.WHITE.dark(1));
+        setTextAlignment(Alignment.CenterLeft);
+        setBackground(GT_UITextures.BACKGROUND_TEXT_FIELD.withOffset(-1, -1, 2, 2));
+    }
+
+    @Override
+    public void onPostInit() {
+        // Widget#onPostInit is called earlier than IDataFollowerWidget#onPostInit,
+        // so we make sure cursor is set after text is set
+        super.onPostInit();
+
+        // On first call #handler does not contain text.
+        // On second call, it contains correct text to update #lastText,
+        // but #shouldGetFocus call is skipped by Cursor#updateFocused,
+        // so we need to manually call this.
+        if (focusOnGuiOpen) {
+            shouldGetFocus();
+        }
+    }
+
+    @Override
+    public CoverDataFollower_NumericWidget<T> setDataToStateGetter(Function<T, Double> dataToStateGetter) {
+        this.dataToStateGetter = dataToStateGetter;
+        return this;
+    }
+
+    @Override
+    public CoverDataFollower_NumericWidget<T> setStateSetter(Consumer<Double> setter) {
+        super.setSetter(setter::accept);
+        return this;
+    }
+
+    @Override
+    public void updateState(T data) {
+        setValue(dataToStateGetter.apply(data));
+    }
+
+}

--- a/src/main/java/gregtech/common/gui/modularui/widget/CoverDataFollower_TextFieldWidget.java
+++ b/src/main/java/gregtech/common/gui/modularui/widget/CoverDataFollower_TextFieldWidget.java
@@ -3,6 +3,7 @@ package gregtech.common.gui.modularui.widget;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import com.gtnewhorizon.gtnhlib.util.parsing.MathExpressionParser;
 import net.minecraft.client.gui.GuiScreen;
 
 import com.gtnewhorizons.modularui.api.math.Alignment;
@@ -60,6 +61,10 @@ public class CoverDataFollower_TextFieldWidget<T extends ISerializableObject> ex
         setText(dataToStateGetter.apply(data));
     }
 
+    /**
+     * @deprecated Use {@link CoverDataFollower_NumericWidget}
+     */
+    @Deprecated
     public CoverDataFollower_TextFieldWidget<T> setOnScrollNumbers(int baseStep, int ctrlStep, int shiftStep) {
         setOnScrollNumbers((val, direction) -> {
             int step = (GuiScreen.isShiftKeyDown() ? shiftStep : GuiScreen.isCtrlKeyDown() ? ctrlStep : baseStep)
@@ -74,13 +79,21 @@ public class CoverDataFollower_TextFieldWidget<T extends ISerializableObject> ex
         return this;
     }
 
+    /**
+     * @deprecated Use {@link CoverDataFollower_NumericWidget}
+     */
+    @Deprecated
     public CoverDataFollower_TextFieldWidget<T> setOnScrollNumbers() {
         return setOnScrollNumbers(1, 50, 1000);
     }
 
+    /**
+     * @deprecated Use {@link CoverDataFollower_NumericWidget}
+     */
+    @Deprecated
     public CoverDataFollower_TextFieldWidget<T> setOnScrollText(int baseStep, int ctrlStep, int shiftStep) {
         setOnScroll((text, direction) -> {
-            int val = (int) MathExpression.parseMathExpression(text, -1);
+            int val = (int) MathExpressionParser.parse(text);
             int step = (GuiScreen.isShiftKeyDown() ? shiftStep : GuiScreen.isCtrlKeyDown() ? ctrlStep : baseStep)
                 * direction;
             try {
@@ -94,10 +107,18 @@ public class CoverDataFollower_TextFieldWidget<T extends ISerializableObject> ex
         return this;
     }
 
+    /**
+     * @deprecated Use {@link CoverDataFollower_NumericWidget}
+     */
+    @Deprecated
     public CoverDataFollower_TextFieldWidget<T> setOnScrollText() {
         return setOnScrollText(1, 5, 50);
     }
 
+    /**
+     * @deprecated Use {@link CoverDataFollower_NumericWidget}
+     */
+    @Deprecated
     public CoverDataFollower_TextFieldWidget<T> setOnScrollNumbersLong(long baseStep, long ctrlStep, long shiftStep) {
         setOnScrollNumbersLong((val, direction) -> {
             long step = (GuiScreen.isShiftKeyDown() ? shiftStep : GuiScreen.isCtrlKeyDown() ? ctrlStep : baseStep)

--- a/src/main/java/gregtech/common/gui/modularui/widget/CoverDataFollower_TextFieldWidget.java
+++ b/src/main/java/gregtech/common/gui/modularui/widget/CoverDataFollower_TextFieldWidget.java
@@ -3,12 +3,11 @@ package gregtech.common.gui.modularui.widget;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import com.gtnewhorizon.gtnhlib.util.parsing.MathExpressionParser;
 import net.minecraft.client.gui.GuiScreen;
 
+import com.gtnewhorizon.gtnhlib.util.parsing.MathExpressionParser;
 import com.gtnewhorizons.modularui.api.math.Alignment;
 import com.gtnewhorizons.modularui.api.math.Color;
-import com.gtnewhorizons.modularui.api.math.MathExpression;
 import com.gtnewhorizons.modularui.common.widget.textfield.TextFieldWidget;
 
 import gregtech.api.gui.modularui.GT_UITextures;

--- a/src/main/java/gregtech/common/items/GT_VolumetricFlask.java
+++ b/src/main/java/gregtech/common/items/GT_VolumetricFlask.java
@@ -7,7 +7,6 @@ import static ic2.core.util.LiquidUtil.fillContainerStack;
 import static ic2.core.util.LiquidUtil.placeFluid;
 
 import java.util.List;
-import java.util.function.Function;
 
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.texture.IIconRegister;
@@ -34,15 +33,12 @@ import net.minecraftforge.fluids.IFluidHandler;
 import com.gtnewhorizons.modularui.api.ModularUITextures;
 import com.gtnewhorizons.modularui.api.math.Alignment;
 import com.gtnewhorizons.modularui.api.math.Color;
-import com.gtnewhorizons.modularui.api.math.MathExpression;
-import com.gtnewhorizons.modularui.api.math.Pos2d;
-import com.gtnewhorizons.modularui.api.math.Size;
 import com.gtnewhorizons.modularui.api.screen.IItemWithModularUI;
 import com.gtnewhorizons.modularui.api.screen.ModularWindow;
 import com.gtnewhorizons.modularui.api.screen.UIBuildContext;
+import com.gtnewhorizons.modularui.common.widget.TextWidget;
 import com.gtnewhorizons.modularui.common.widget.VanillaButtonWidget;
-import com.gtnewhorizons.modularui.common.widget.textfield.BaseTextFieldWidget;
-import com.gtnewhorizons.modularui.common.widget.textfield.TextFieldWidget;
+import com.gtnewhorizons.modularui.common.widget.textfield.NumericWidget;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
@@ -315,76 +311,45 @@ public class GT_VolumetricFlask extends GT_Generic_Item implements IFluidContain
     private class VolumetricFlaskUIFactory {
 
         private final UIBuildContext buildContext;
+        private int capacity;
         private final int maxCapacity;
-        private TextFieldWidget textField;
 
         public VolumetricFlaskUIFactory(UIBuildContext buildContext, ItemStack flask) {
             this.buildContext = buildContext;
-            this.maxCapacity = ((GT_VolumetricFlask) flask.getItem()).getMaxCapacity();
+            GT_VolumetricFlask flaskItem = (GT_VolumetricFlask) flask.getItem();
+            this.capacity = flaskItem.getCapacity(flask);
+            this.maxCapacity = flaskItem.getMaxCapacity();
         }
 
         public ModularWindow createWindow() {
-            ModularWindow.Builder builder = ModularWindow.builder(176, 107);
+            ModularWindow.Builder builder = ModularWindow.builder(150, 54);
             builder.setBackground(ModularUITextures.VANILLA_BACKGROUND);
 
-            textField = new TextFieldWidget() {
-
-                @Override
-                public void onDestroy() {
-                    if (isClient()) return;
-                    setCapacity(getCurrentItem(), (int) MathExpression.parseMathExpression(getText(), 1));
-                    getContext().onWidgetUpdate();
-                }
-            };
-            textField.setText(
-                String.valueOf(((GT_VolumetricFlask) getCurrentItem().getItem()).getCapacity(getCurrentItem())));
             builder.widget(
-                textField.setNumbers(() -> 1, () -> maxCapacity)
-                    .setPattern(BaseTextFieldWidget.NATURAL_NUMS)
-                    .setTextAlignment(Alignment.CenterLeft)
+                new NumericWidget().setGetter(() -> capacity)
+                    .setSetter(value -> setCapacity(getCurrentItem(), capacity = (int) value))
+                    .setBounds(1, maxCapacity)
+                    .setScrollValues(1, 144, 1000)
+                    .setDefaultValue(capacity)
                     .setTextColor(Color.WHITE.dark(1))
+                    .setTextAlignment(Alignment.CenterLeft)
                     .setFocusOnGuiOpen(true)
-                    .setBackground(GT_UITextures.BACKGROUND_TEXT_FIELD_LIGHT_GRAY.withOffset(-1, -1, 2, 2))
-                    .setPos(60, 55)
-                    .setSize(59, 12));
-
-            addChangeAmountButton(builder, "+1", new Pos2d(20, 26), new Size(22, 20), val -> val + 1);
-            addChangeAmountButton(builder, "+10", new Pos2d(48, 26), new Size(28, 20), val -> val + 10);
-            addChangeAmountButton(builder, "+100", new Pos2d(82, 26), new Size(32, 20), val -> val + 100);
-            addChangeAmountButton(builder, "+1000", new Pos2d(120, 26), new Size(38, 20), val -> val + 1000);
-            addChangeAmountButton(builder, "-1", new Pos2d(20, 75), new Size(22, 20), val -> val - 1);
-            addChangeAmountButton(builder, "-10", new Pos2d(48, 75), new Size(28, 20), val -> val - 10);
-            addChangeAmountButton(builder, "-100", new Pos2d(82, 75), new Size(32, 20), val -> val - 100);
-            addChangeAmountButton(builder, "-1000", new Pos2d(120, 75), new Size(38, 20), val -> val - 1000);
-            builder.widget(
-                new VanillaButtonWidget().setDisplayString("Accept")
-                    .setClickableGetter(() -> MathExpression.parseMathExpression(textField.getText()) > 0)
-                    .setOnClick((clickData, widget) -> {
-                        if (widget.isClient()) {
-                            textField.onRemoveFocus();
-                        } else {
-                            widget.getWindow()
-                                .tryClose();
-                        }
-                    })
-                    .setPos(128, 51)
-                    .setSize(38, 20));
+                    .setBackground(GT_UITextures.BACKGROUND_TEXT_FIELD.withOffset(-1, -1, 2, 2))
+                    .setPos(8, 8)
+                    .setSize(77, 12))
+                .widget(new TextWidget("Capacity").setPos(88, 10))
+                .widget(
+                    new VanillaButtonWidget().setDisplayString("Confirm")
+                        .setOnClick((clickData, widget) -> {
+                            if (!widget.isClient()) {
+                                widget.getWindow()
+                                    .tryClose();
+                            }
+                        })
+                        .setPos(8, 26)
+                        .setSize(48, 20));
 
             return builder.build();
-        }
-
-        private void addChangeAmountButton(ModularWindow.Builder builder, String text, Pos2d pos, Size size,
-            Function<Integer, Integer> function) {
-            builder.widget(
-                new VanillaButtonWidget().setDisplayString(text)
-                    .setOnClick((clickData, widget) -> {
-                        String currentText = textField.getText();
-                        int amount = (int) MathExpression.parseMathExpression(currentText, 1);
-                        amount = Math.min(maxCapacity, Math.max(1, function.apply(amount)));
-                        textField.setText(String.valueOf(amount));
-                    })
-                    .setPos(pos)
-                    .setSize(size));
         }
 
         private ItemStack getCurrentItem() {

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_InputBus_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_InputBus_ME.java
@@ -40,7 +40,7 @@ import com.gtnewhorizons.modularui.common.widget.FakeSyncWidget;
 import com.gtnewhorizons.modularui.common.widget.SlotGroup;
 import com.gtnewhorizons.modularui.common.widget.SlotWidget;
 import com.gtnewhorizons.modularui.common.widget.TextWidget;
-import com.gtnewhorizons.modularui.common.widget.textfield.TextFieldWidget;
+import com.gtnewhorizons.modularui.common.widget.textfield.NumericWidget;
 
 import appeng.api.config.Actionable;
 import appeng.api.config.PowerMultiplier;
@@ -697,10 +697,10 @@ public class GT_MetaTileEntity_Hatch_InputBus_ME extends GT_MetaTileEntity_Hatch
                 .setPos(3, 2)
                 .setSize(74, 14))
             .widget(
-                new TextFieldWidget().setSetterInt(val -> minAutoPullStackSize = val)
-                    .setGetterInt(() -> minAutoPullStackSize)
-                    .setNumbers(1, Integer.MAX_VALUE)
-                    .setOnScrollNumbers(1, 4, 64)
+                new NumericWidget().setSetter(val -> minAutoPullStackSize = (int) val)
+                    .setGetter(() -> minAutoPullStackSize)
+                    .setBounds(1, Integer.MAX_VALUE)
+                    .setScrollValues(1, 4, 64)
                     .setTextAlignment(Alignment.Center)
                     .setTextColor(Color.WHITE.normal)
                     .setSize(70, 18)
@@ -711,10 +711,10 @@ public class GT_MetaTileEntity_Hatch_InputBus_ME extends GT_MetaTileEntity_Hatch
                 .setPos(3, 42)
                 .setSize(74, 14))
             .widget(
-                new TextFieldWidget().setSetterInt(val -> autoPullRefreshTime = val)
-                    .setGetterInt(() -> autoPullRefreshTime)
-                    .setNumbers(1, Integer.MAX_VALUE)
-                    .setOnScrollNumbers(1, 4, 64)
+                new NumericWidget().setSetter(val -> autoPullRefreshTime = (int) val)
+                    .setGetter(() -> autoPullRefreshTime)
+                    .setBounds(1, Integer.MAX_VALUE)
+                    .setScrollValues(1, 4, 64)
                     .setTextAlignment(Alignment.Center)
                     .setTextColor(Color.WHITE.normal)
                     .setSize(70, 18)

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_Input_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_Input_ME.java
@@ -45,7 +45,7 @@ import com.gtnewhorizons.modularui.common.widget.FakeSyncWidget;
 import com.gtnewhorizons.modularui.common.widget.FluidSlotWidget;
 import com.gtnewhorizons.modularui.common.widget.SlotGroup;
 import com.gtnewhorizons.modularui.common.widget.TextWidget;
-import com.gtnewhorizons.modularui.common.widget.textfield.TextFieldWidget;
+import com.gtnewhorizons.modularui.common.widget.textfield.NumericWidget;
 
 import appeng.api.config.Actionable;
 import appeng.api.config.PowerMultiplier;
@@ -776,10 +776,10 @@ public class GT_MetaTileEntity_Hatch_Input_ME extends GT_MetaTileEntity_Hatch_In
                 .setPos(3, 2)
                 .setSize(74, 14))
             .widget(
-                new TextFieldWidget().setSetterInt(val -> minAutoPullAmount = val)
-                    .setGetterInt(() -> minAutoPullAmount)
-                    .setNumbers(1, Integer.MAX_VALUE)
-                    .setOnScrollNumbers(1, 4, 64)
+                new NumericWidget().setSetter(val -> minAutoPullAmount = (int) val)
+                    .setGetter(() -> minAutoPullAmount)
+                    .setBounds(1, Integer.MAX_VALUE)
+                    .setScrollValues(1, 4, 64)
                     .setTextAlignment(Alignment.Center)
                     .setTextColor(Color.WHITE.normal)
                     .setSize(70, 18)
@@ -790,10 +790,10 @@ public class GT_MetaTileEntity_Hatch_Input_ME extends GT_MetaTileEntity_Hatch_In
                 .setPos(3, 42)
                 .setSize(74, 14))
             .widget(
-                new TextFieldWidget().setSetterInt(val -> autoPullRefreshTime = val)
-                    .setGetterInt(() -> autoPullRefreshTime)
-                    .setNumbers(1, Integer.MAX_VALUE)
-                    .setOnScrollNumbers(1, 4, 64)
+                new NumericWidget().setSetter(val -> autoPullRefreshTime = (int) val)
+                    .setGetter(() -> autoPullRefreshTime)
+                    .setBounds(1, Integer.MAX_VALUE)
+                    .setScrollValues(1, 4, 64)
                     .setTextAlignment(Alignment.Center)
                     .setTextColor(Color.WHITE.normal)
                     .setSize(70, 18)

--- a/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_MicrowaveEnergyTransmitter.java
+++ b/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_MicrowaveEnergyTransmitter.java
@@ -18,6 +18,7 @@ import net.minecraftforge.common.DimensionManager;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.FluidStack;
 
+import com.gtnewhorizons.modularui.api.NumberFormatMUI;
 import com.gtnewhorizons.modularui.api.drawable.IDrawable;
 import com.gtnewhorizons.modularui.api.screen.ModularWindow;
 import com.gtnewhorizons.modularui.api.screen.UIBuildContext;
@@ -412,6 +413,8 @@ public class GT_MetaTileEntity_MicrowaveEnergyTransmitter extends GT_MetaTileEnt
         return true;
     }
 
+    protected static final NumberFormatMUI numberFormat = new NumberFormatMUI();
+
     @Override
     public void addUIWidgets(ModularWindow.Builder builder, UIBuildContext buildContext) {
         builder.widget(
@@ -419,19 +422,19 @@ public class GT_MetaTileEntity_MicrowaveEnergyTransmitter extends GT_MetaTileEnt
                 .setSize(90, 72)
                 .setPos(43, 4))
             .widget(
-                TextWidget.dynamicString(() -> "X: " + GT_Utility.parseNumberToString(mTargetX))
+                new TextWidget().setStringSupplier(() -> "X: " + numberFormat.format(mTargetX))
                     .setDefaultColor(COLOR_TEXT_WHITE.get())
                     .setPos(46, 8))
             .widget(
-                TextWidget.dynamicString(() -> "Y: " + GT_Utility.parseNumberToString(mTargetY))
+                new TextWidget().setStringSupplier(() -> "Y: " + numberFormat.format(mTargetY))
                     .setDefaultColor(COLOR_TEXT_WHITE.get())
                     .setPos(46, 16))
             .widget(
-                TextWidget.dynamicString(() -> "Z: " + GT_Utility.parseNumberToString(mTargetZ))
+                new TextWidget().setStringSupplier(() -> "Z: " + numberFormat.format(mTargetZ))
                     .setDefaultColor(COLOR_TEXT_WHITE.get())
                     .setPos(46, 24))
             .widget(
-                TextWidget.dynamicString(() -> "Dim: " + GT_Utility.parseNumberToString(mTargetD))
+                new TextWidget().setStringSupplier(() -> "Dim: " + numberFormat.format(mTargetD))
                     .setDefaultColor(COLOR_TEXT_WHITE.get())
                     .setPos(46, 32))
             .widget(

--- a/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_Teleporter.java
+++ b/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_Teleporter.java
@@ -41,6 +41,7 @@ import net.minecraftforge.common.DimensionManager;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.FluidStack;
 
+import com.gtnewhorizons.modularui.api.NumberFormatMUI;
 import com.gtnewhorizons.modularui.api.drawable.IDrawable;
 import com.gtnewhorizons.modularui.api.screen.ModularWindow;
 import com.gtnewhorizons.modularui.api.screen.UIBuildContext;
@@ -520,6 +521,8 @@ public class GT_MetaTileEntity_Teleporter extends GT_MetaTileEntity_BasicTank
         return true;
     }
 
+    protected static final NumberFormatMUI numberFormat = new NumberFormatMUI();
+
     @Override
     public void addUIWidgets(ModularWindow.Builder builder, UIBuildContext buildContext) {
         builder.widget(
@@ -527,19 +530,19 @@ public class GT_MetaTileEntity_Teleporter extends GT_MetaTileEntity_BasicTank
                 .setSize(90, 72)
                 .setPos(43, 4))
             .widget(
-                TextWidget.dynamicString(() -> "X: " + GT_Utility.parseNumberToString(mTargetX))
+                new TextWidget().setStringSupplier(() -> "X: " + numberFormat.format(mTargetX))
                     .setDefaultColor(COLOR_TEXT_WHITE.get())
                     .setPos(46, 8))
             .widget(
-                TextWidget.dynamicString(() -> "Y: " + GT_Utility.parseNumberToString(mTargetY))
+                new TextWidget().setStringSupplier(() -> "Y: " + numberFormat.format(mTargetY))
                     .setDefaultColor(COLOR_TEXT_WHITE.get())
                     .setPos(46, 16))
             .widget(
-                TextWidget.dynamicString(() -> "Z: " + GT_Utility.parseNumberToString(mTargetZ))
+                new TextWidget().setStringSupplier(() -> "Z: " + numberFormat.format(mTargetZ))
                     .setDefaultColor(COLOR_TEXT_WHITE.get())
                     .setPos(46, 24))
             .widget(
-                TextWidget.dynamicString(() -> "Dim: " + GT_Utility.parseNumberToString(mTargetD))
+                new TextWidget().setStringSupplier(() -> "Dim: " + numberFormat.format(mTargetD))
                     .setDefaultColor(COLOR_TEXT_WHITE.get())
                     .setPos(46, 32))
             .widget(

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_ConcreteBackfillerBase.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_ConcreteBackfillerBase.java
@@ -12,6 +12,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.StatCollector;
 
 import com.google.common.collect.ImmutableList;
+import com.gtnewhorizons.modularui.api.NumberFormatMUI;
 import com.gtnewhorizons.modularui.api.math.Alignment;
 import com.gtnewhorizons.modularui.common.widget.DynamicPositionedColumn;
 import com.gtnewhorizons.modularui.common.widget.FakeSyncWidget;
@@ -157,6 +158,8 @@ public abstract class GT_MetaTileEntity_ConcreteBackfillerBase extends GT_MetaTi
         return true;
     }
 
+    protected static final NumberFormatMUI numberFormat = new NumberFormatMUI();
+
     @Override
     protected void drawTexts(DynamicPositionedColumn screenElements, SlotWidget inventorySlot) {
         super.drawTexts(screenElements, inventorySlot);
@@ -166,7 +169,7 @@ public abstract class GT_MetaTileEntity_ConcreteBackfillerBase extends GT_MetaTi
                     .dynamicString(
                         () -> StatCollector.translateToLocalFormatted(
                             "GT5U.gui.text.backfiller_current_area",
-                            GT_Utility.formatNumbers(clientYHead)))
+                            numberFormat.format(clientYHead)))
                     .setSynced(false)
                     .setTextAlignment(Alignment.CenterLeft)
                     .setEnabled(widget -> getBaseMetaTileEntity().isActive() && workState == STATE_UPWARD))

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_FusionComputer.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_FusionComputer.java
@@ -32,6 +32,7 @@ import com.gtnewhorizon.structurelib.alignment.constructable.ISurvivalConstructa
 import com.gtnewhorizon.structurelib.structure.IStructureDefinition;
 import com.gtnewhorizon.structurelib.structure.ISurvivalBuildEnvironment;
 import com.gtnewhorizon.structurelib.structure.StructureDefinition;
+import com.gtnewhorizons.modularui.api.NumberFormatMUI;
 import com.gtnewhorizons.modularui.api.math.Alignment;
 import com.gtnewhorizons.modularui.api.screen.ModularWindow;
 import com.gtnewhorizons.modularui.api.screen.UIBuildContext;
@@ -563,6 +564,8 @@ public abstract class GT_MetaTileEntity_FusionComputer
         return 166;
     }
 
+    protected static final NumberFormatMUI numberFormat = new NumberFormatMUI();
+
     @Override
     public void addUIWidgets(ModularWindow.Builder builder, UIBuildContext buildContext) {
         builder
@@ -608,7 +611,7 @@ public abstract class GT_MetaTileEntity_FusionComputer
                     .setTexture(GT_UITextures.PROGRESSBAR_STORED_EU, 147)
                     .setPos(5, 156)
                     .setSize(147, 5))
-            .widget(TextWidget.dynamicString(() -> {
+            .widget(new TextWidget().setStringSupplier(() -> {
                 long energy = getBaseMetaTileEntity().getStoredEU();
                 if (energy > 160_000_000L && energy < 160_010_000L) {
                     energy = 160_000_000L;
@@ -622,7 +625,7 @@ public abstract class GT_MetaTileEntity_FusionComputer
                 if (energy > 5_120_000_000L && energy < 5_120_080_000L) {
                     energy = 5_120_000_000L;
                 }
-                return GT_Utility.formatNumbers(energy) + " EU";
+                return numberFormat.format(energy) + " EU";
             })
                 .setDefaultColor(COLOR_TEXT_RED.get())
                 .setPos(50, 155))

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_OilDrillBase.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_OilDrillBase.java
@@ -36,6 +36,7 @@ import net.minecraftforge.fluids.FluidStack;
 import org.jetbrains.annotations.NotNull;
 
 import com.google.common.collect.ImmutableList;
+import com.gtnewhorizons.modularui.api.NumberFormatMUI;
 import com.gtnewhorizons.modularui.api.math.Alignment;
 import com.gtnewhorizons.modularui.common.widget.DynamicPositionedColumn;
 import com.gtnewhorizons.modularui.common.widget.FakeSyncWidget;
@@ -401,7 +402,7 @@ public abstract class GT_MetaTileEntity_OilDrillBase extends GT_MetaTileEntity_D
                 builder.add(
                     StatCollector.translateToLocalFormatted(
                         "GT5U.gui.text.pump_rate.1",
-                        EnumChatFormatting.AQUA + getFlowRatePerTick())
+                        EnumChatFormatting.AQUA + numberFormat.format(getFlowRatePerTick()))
                         + StatCollector.translateToLocal("GT5U.gui.text.pump_rate.2"),
                     getReservoirContents() + StatCollector.translateToLocal("GT5U.gui.text.pump_recovery.2"));
             } else {
@@ -423,9 +424,8 @@ public abstract class GT_MetaTileEntity_OilDrillBase extends GT_MetaTileEntity_D
         return ImmutableList.of(failureReason);
     }
 
-    @NotNull
-    protected String getFlowRatePerTick() {
-        return GT_Utility.formatNumbers(this.mMaxProgresstime > 0 ? (mOilFlow / this.mMaxProgresstime) : 0);
+    protected int getFlowRatePerTick() {
+        return this.mMaxProgresstime > 0 ? (mOilFlow / this.mMaxProgresstime) : 0;
     }
 
     @NotNull
@@ -438,7 +438,7 @@ public abstract class GT_MetaTileEntity_OilDrillBase extends GT_MetaTileEntity_D
     }
 
     private @NotNull String clientFluidType = "";
-    private @NotNull String clientPumpRate = "";
+    private int clientPumpRate = 0;
     private @NotNull String clientReservoirContents = "";
 
     @NotNull
@@ -455,42 +455,41 @@ public abstract class GT_MetaTileEntity_OilDrillBase extends GT_MetaTileEntity_D
             .translateToLocalFormatted("GT5U.gui.text.pump_recovery.1", GT_Utility.formatNumbers(amount));
     }
 
+    protected static final NumberFormatMUI numberFormat = new NumberFormatMUI();
+
     @Override
     protected void drawTexts(DynamicPositionedColumn screenElements, SlotWidget inventorySlot) {
         super.drawTexts(screenElements, inventorySlot);
         screenElements
             .widget(
-                TextWidget
-                    .dynamicString(
+                new TextWidget()
+                    .setStringSupplier(
                         () -> EnumChatFormatting.GRAY
                             + StatCollector.translateToLocalFormatted("GT5U.gui.text.pump_fluid_type", clientFluidType))
-                    .setSynced(false)
                     .setTextAlignment(Alignment.CenterLeft)
                     .setEnabled(widget -> getBaseMetaTileEntity().isActive() && workState == STATE_AT_BOTTOM))
             .widget(
-                TextWidget
-                    .dynamicString(
+                new TextWidget()
+                    .setStringSupplier(
                         () -> EnumChatFormatting.GRAY
                             + StatCollector.translateToLocalFormatted(
                                 "GT5U.gui.text.pump_rate.1",
-                                EnumChatFormatting.AQUA + clientPumpRate)
+                                EnumChatFormatting.AQUA + numberFormat.format(clientPumpRate))
                             + EnumChatFormatting.GRAY
                             + StatCollector.translateToLocal("GT5U.gui.text.pump_rate.2"))
-                    .setSynced(false)
                     .setTextAlignment(Alignment.CenterLeft)
                     .setEnabled(widget -> getBaseMetaTileEntity().isActive() && workState == STATE_AT_BOTTOM))
             .widget(
-                TextWidget
-                    .dynamicString(
+                new TextWidget()
+                    .setStringSupplier(
                         () -> EnumChatFormatting.GRAY + clientReservoirContents
                             + EnumChatFormatting.GRAY
                             + StatCollector.translateToLocal("GT5U.gui.text.pump_recovery.2"))
-                    .setSynced(false)
                     .setTextAlignment(Alignment.CenterLeft)
                     .setEnabled(widget -> getBaseMetaTileEntity().isActive() && workState == STATE_AT_BOTTOM))
             .widget(new FakeSyncWidget.IntegerSyncer(() -> workState, newInt -> workState = newInt))
             .widget(new FakeSyncWidget.StringSyncer(this::getFluidName, newString -> clientFluidType = newString))
-            .widget(new FakeSyncWidget.StringSyncer(this::getFlowRatePerTick, newString -> clientPumpRate = newString))
+            .widget(new FakeSyncWidget.IntegerSyncer(this::getFlowRatePerTick, newInt -> clientPumpRate = newInt))
             .widget(
                 new FakeSyncWidget.StringSyncer(
                     this::getReservoirContents,

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_OreDrillingPlantBase.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_OreDrillingPlantBase.java
@@ -30,6 +30,7 @@ import net.minecraftforge.fluids.FluidStack;
 import org.jetbrains.annotations.NotNull;
 
 import com.google.common.collect.ImmutableList;
+import com.gtnewhorizons.modularui.api.NumberFormatMUI;
 import com.gtnewhorizons.modularui.api.drawable.IDrawable;
 import com.gtnewhorizons.modularui.api.math.Alignment;
 import com.gtnewhorizons.modularui.api.screen.ModularWindow;
@@ -588,40 +589,39 @@ public abstract class GT_MetaTileEntity_OreDrillingPlantBase extends GT_MetaTile
         return tt;
     }
 
+    protected static final NumberFormatMUI numberFormat = new NumberFormatMUI();
+
     @Override
     protected void drawTexts(DynamicPositionedColumn screenElements, SlotWidget inventorySlot) {
         super.drawTexts(screenElements, inventorySlot);
         screenElements
             .widget(
-                TextWidget
-                    .dynamicString(
+                new TextWidget()
+                    .setStringSupplier(
                         () -> EnumChatFormatting.GRAY + StatCollector.translateToLocalFormatted(
                             "GT5U.gui.text.drill_ores_left_chunk",
-                            GT_Utility.formatNumbers(clientOreListSize)))
-                    .setSynced(false)
+                            numberFormat.format(clientOreListSize)))
                     .setTextAlignment(Alignment.CenterLeft)
                     .setEnabled(
                         widget -> getBaseMetaTileEntity().isActive() && clientOreListSize > 0
                             && workState == STATE_AT_BOTTOM))
             .widget(
-                TextWidget
-                    .dynamicString(
+                new TextWidget()
+                    .setStringSupplier(
                         () -> EnumChatFormatting.GRAY + StatCollector.translateToLocalFormatted(
                             "GT5U.gui.text.drill_ores_left_layer",
-                            GT_Utility.formatNumbers(clientYHead),
-                            GT_Utility.formatNumbers(clientOreListSize)))
-                    .setSynced(false)
+                            numberFormat.format(clientYHead),
+                            numberFormat.format(clientOreListSize)))
                     .setTextAlignment(Alignment.CenterLeft)
                     .setEnabled(
                         widget -> getBaseMetaTileEntity().isActive() && clientYHead > 0 && workState == STATE_DOWNWARD))
             .widget(
-                TextWidget
-                    .dynamicString(
+                new TextWidget()
+                    .setStringSupplier(
                         () -> EnumChatFormatting.GRAY + StatCollector.translateToLocalFormatted(
                             "GT5U.gui.text.drill_chunks_left",
-                            GT_Utility.formatNumbers(clientCurrentChunk),
-                            GT_Utility.formatNumbers(clientTotalChunks)))
-                    .setSynced(false)
+                            numberFormat.format(clientCurrentChunk),
+                            numberFormat.format(clientTotalChunks)))
                     .setTextAlignment(Alignment.CenterLeft)
                     .setEnabled(
                         widget -> getBaseMetaTileEntity().isActive() && clientCurrentChunk > 0

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_PCBFactory.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_PCBFactory.java
@@ -56,7 +56,7 @@ import com.gtnewhorizons.modularui.common.widget.DynamicPositionedColumn;
 import com.gtnewhorizons.modularui.common.widget.DynamicPositionedRow;
 import com.gtnewhorizons.modularui.common.widget.MultiChildWidget;
 import com.gtnewhorizons.modularui.common.widget.TextWidget;
-import com.gtnewhorizons.modularui.common.widget.textfield.TextFieldWidget;
+import com.gtnewhorizons.modularui.common.widget.textfield.NumericWidget;
 
 import gregtech.api.GregTech_API;
 import gregtech.api.enums.Materials;
@@ -1068,9 +1068,9 @@ public class GT_MetaTileEntity_PCBFactory extends
                     .setSize(20, 16)
                     .setPos(173, 98))
             .widget(
-                new TextFieldWidget().setGetterInt(() -> mSetTier)
-                    .setSetterInt(val -> mSetTier = val)
-                    .setNumbers(1, 3)
+                new NumericWidget().setGetter(() -> mSetTier)
+                    .setSetter(val -> mSetTier = (int) val)
+                    .setBounds(1, 3)
                     .setTextColor(Color.WHITE.normal)
                     .setTextAlignment(Alignment.Center)
                     .addTooltip("PCB Factory Tier")
@@ -1179,9 +1179,9 @@ public class GT_MetaTileEntity_PCBFactory extends
                             .setEnabled(widget -> !getBaseMetaTileEntity().isActive())
                             .setPos(0, 4))
                     .widget(
-                        new TextFieldWidget().setGetterInt(() -> (int) ((1f / mRoughnessMultiplier) * 100f))
-                            .setSetterInt(val -> mRoughnessMultiplier = 100f / val)
-                            .setNumbers(50, 200)
+                        new NumericWidget().setGetter(() -> (int) ((1f / mRoughnessMultiplier) * 100f))
+                            .setSetter(val -> mRoughnessMultiplier = 100f / (int) val)
+                            .setBounds(50, 200)
                             .setTextColor(Color.WHITE.normal)
                             .setTextAlignment(Alignment.Center)
                             .addTooltip(
@@ -1202,18 +1202,18 @@ public class GT_MetaTileEntity_PCBFactory extends
                     .widget(
                         new DynamicPositionedRow().setSynced(false)
                             .widget(
-                                new TextFieldWidget().setGetterInt(() -> mBioOffsets[0])
-                                    .setSetterInt(val -> mBioOffsets[0] = val)
-                                    .setNumbers(-16, 16)
+                                new NumericWidget().setGetter(() -> mBioOffsets[0])
+                                    .setSetter(val -> mBioOffsets[0] = (int) val)
+                                    .setBounds(-16, 16)
                                     .setTextColor(Color.WHITE.normal)
                                     .setTextAlignment(Alignment.Center)
                                     .addTooltip("X Offset")
                                     .setBackground(GT_UITextures.BACKGROUND_TEXT_FIELD)
                                     .setSize(36, 18))
                             .widget(
-                                new TextFieldWidget().setGetterInt(() -> mBioOffsets[1])
-                                    .setSetterInt(val -> mBioOffsets[1] = val)
-                                    .setNumbers(-16, 16)
+                                new NumericWidget().setGetter(() -> mBioOffsets[1])
+                                    .setSetter(val -> mBioOffsets[1] = (int) val)
+                                    .setBounds(-16, 16)
                                     .setTextColor(Color.WHITE.normal)
                                     .setTextAlignment(Alignment.Center)
                                     .addTooltip("Z Offset")
@@ -1226,18 +1226,18 @@ public class GT_MetaTileEntity_PCBFactory extends
                     .widget(
                         new DynamicPositionedRow().setSynced(false)
                             .widget(
-                                new TextFieldWidget().setGetterInt(() -> mOCTier1Offsets[0])
-                                    .setSetterInt(val -> mOCTier1Offsets[0] = val)
-                                    .setNumbers(-16, 16)
+                                new NumericWidget().setGetter(() -> mOCTier1Offsets[0])
+                                    .setSetter(val -> mOCTier1Offsets[0] = (int) val)
+                                    .setBounds(-16, 16)
                                     .setTextColor(Color.WHITE.normal)
                                     .setTextAlignment(Alignment.Center)
                                     .addTooltip("X Offset")
                                     .setBackground(GT_UITextures.BACKGROUND_TEXT_FIELD)
                                     .setSize(36, 18))
                             .widget(
-                                new TextFieldWidget().setGetterInt(() -> mOCTier1Offsets[1])
-                                    .setSetterInt(val -> mOCTier1Offsets[1] = val)
-                                    .setNumbers(-16, 16)
+                                new NumericWidget().setGetter(() -> mOCTier1Offsets[1])
+                                    .setSetter(val -> mOCTier1Offsets[1] = (int) val)
+                                    .setBounds(-16, 16)
                                     .setTextColor(Color.WHITE.normal)
                                     .setTextAlignment(Alignment.Center)
                                     .addTooltip("Z Offset")
@@ -1250,18 +1250,18 @@ public class GT_MetaTileEntity_PCBFactory extends
                     .widget(
                         new DynamicPositionedRow().setSynced(false)
                             .widget(
-                                new TextFieldWidget().setGetterInt(() -> mOCTier2Offsets[0])
-                                    .setSetterInt(val -> mOCTier2Offsets[0] = val)
-                                    .setNumbers(-16, 16)
+                                new NumericWidget().setGetter(() -> mOCTier2Offsets[0])
+                                    .setSetter(val -> mOCTier2Offsets[0] = (int) val)
+                                    .setBounds(-16, 16)
                                     .setTextColor(Color.WHITE.normal)
                                     .setTextAlignment(Alignment.Center)
                                     .addTooltip("X Offset")
                                     .setBackground(GT_UITextures.BACKGROUND_TEXT_FIELD)
                                     .setSize(36, 18))
                             .widget(
-                                new TextFieldWidget().setGetterInt(() -> mOCTier2Offsets[1])
-                                    .setSetterInt(val -> mOCTier2Offsets[1] = val)
-                                    .setNumbers(-16, 16)
+                                new NumericWidget().setGetter(() -> mOCTier2Offsets[1])
+                                    .setSetter(val -> mOCTier2Offsets[1] = (int) val)
+                                    .setBounds(-16, 16)
                                     .setTextColor(Color.WHITE.normal)
                                     .setTextAlignment(Alignment.Center)
                                     .addTooltip("Z Offset")

--- a/src/main/java/gregtech/common/tileentities/machines/multiblock/AdvChemicalProcessor.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multiblock/AdvChemicalProcessor.java
@@ -38,7 +38,7 @@ import com.gtnewhorizons.modularui.common.widget.ButtonWidget;
 import com.gtnewhorizons.modularui.common.widget.MultiChildWidget;
 import com.gtnewhorizons.modularui.common.widget.SlotGroup;
 import com.gtnewhorizons.modularui.common.widget.TextWidget;
-import com.gtnewhorizons.modularui.common.widget.textfield.TextFieldWidget;
+import com.gtnewhorizons.modularui.common.widget.textfield.NumericWidget;
 
 import gregtech.api.GregTech_API;
 import gregtech.api.enums.GT_Values;
@@ -390,9 +390,9 @@ public class AdvChemicalProcessor
                     .setPos(20 * (i % 4) + 18, 18 + (i / 4) * 20));
         }
         child.addChild(
-            new TextFieldWidget().setGetterInt(() -> maxComplexParallels)
-                .setSetterInt(parallel -> setMaxComplexParallels(parallel, true))
-                .setNumbers(1, MAX_PROCESSES)
+            new NumericWidget().setGetter(() -> maxComplexParallels)
+                .setSetter(parallel -> setMaxComplexParallels((int) parallel, true))
+                .setBounds(1, MAX_PROCESSES)
                 .setTextColor(Color.WHITE.normal)
                 .setTextAlignment(Alignment.Center)
                 .addTooltip("Tier")

--- a/src/main/java/gregtech/common/tileentities/machines/multiblock/LaserEngraver.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multiblock/LaserEngraver.java
@@ -23,7 +23,7 @@ import com.gtnewhorizons.modularui.api.math.Color;
 import com.gtnewhorizons.modularui.api.widget.IWidgetBuilder;
 import com.gtnewhorizons.modularui.common.widget.ButtonWidget;
 import com.gtnewhorizons.modularui.common.widget.MultiChildWidget;
-import com.gtnewhorizons.modularui.common.widget.textfield.TextFieldWidget;
+import com.gtnewhorizons.modularui.common.widget.textfield.NumericWidget;
 
 import gregtech.api.GregTech_API;
 import gregtech.api.enums.GT_Values;
@@ -250,9 +250,9 @@ public class LaserEngraver extends ComplexParallelController<LaserEngraver, Lase
                     .setPos(20 * (i % 4) + 18, 18 + (i / 4) * 20));
         }
         child.addChild(
-            new TextFieldWidget().setGetterInt(() -> maxComplexParallels)
-                .setSetterInt(parallel -> setMaxComplexParallels(parallel, true))
-                .setNumbers(1, MAX_PROCESSES)
+            new NumericWidget().setGetter(() -> maxComplexParallels)
+                .setSetter(parallel -> setMaxComplexParallels((int) parallel, true))
+                .setBounds(1, MAX_PROCESSES)
                 .setTextColor(Color.WHITE.normal)
                 .setTextAlignment(Alignment.Center)
                 .addTooltip("Tier")

--- a/src/main/java/gregtech/common/tileentities/storage/GT_MetaTileEntity_DigitalChestBase.java
+++ b/src/main/java/gregtech/common/tileentities/storage/GT_MetaTileEntity_DigitalChestBase.java
@@ -19,6 +19,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.util.Constants;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import com.gtnewhorizons.modularui.api.NumberFormatMUI;
 import com.gtnewhorizons.modularui.api.screen.ModularWindow;
 import com.gtnewhorizons.modularui.api.screen.UIBuildContext;
 import com.gtnewhorizons.modularui.common.widget.DrawableWidget;
@@ -522,6 +523,8 @@ public abstract class GT_MetaTileEntity_DigitalChestBase extends GT_MetaTileEnti
         return true;
     }
 
+    protected static final NumberFormatMUI numberFormat = new NumberFormatMUI();
+
     @Override
     public void addUIWidgets(ModularWindow.Builder builder, UIBuildContext buildContext) {
         builder.widget(
@@ -545,9 +548,9 @@ public abstract class GT_MetaTileEntity_DigitalChestBase extends GT_MetaTileEnti
                 new TextWidget("Item Amount").setDefaultColor(COLOR_TEXT_WHITE.get())
                     .setPos(10, 20))
             .widget(
-                TextWidget
-                    .dynamicString(
-                        () -> GT_Utility.parseNumberToString(
+                new TextWidget()
+                    .setStringSupplier(
+                        () -> numberFormat.format(
                             this instanceof GT_MetaTileEntity_QuantumChest
                                 ? ((GT_MetaTileEntity_QuantumChest) this).mItemCount
                                 : 0))

--- a/src/main/java/gregtech/common/tileentities/storage/GT_MetaTileEntity_DigitalTankBase.java
+++ b/src/main/java/gregtech/common/tileentities/storage/GT_MetaTileEntity_DigitalTankBase.java
@@ -26,6 +26,7 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTankInfo;
 import net.minecraftforge.fluids.IFluidHandler;
 
+import com.gtnewhorizons.modularui.api.NumberFormatMUI;
 import com.gtnewhorizons.modularui.api.math.Alignment;
 import com.gtnewhorizons.modularui.api.screen.ModularWindow;
 import com.gtnewhorizons.modularui.api.screen.UIBuildContext;
@@ -543,6 +544,8 @@ public abstract class GT_MetaTileEntity_DigitalTankBase extends GT_MetaTileEntit
         return true;
     }
 
+    protected static final NumberFormatMUI numberFormat = new NumberFormatMUI();
+
     @Override
     public void addUIWidgets(ModularWindow.Builder builder, UIBuildContext buildContext) {
         fluidTank.setAllowOverflow(allowOverflow());
@@ -570,7 +573,7 @@ public abstract class GT_MetaTileEntity_DigitalTankBase extends GT_MetaTileEntit
                     .setDefaultColor(COLOR_TEXT_WHITE.get())
                     .setPos(10, 20))
             .widget(
-                TextWidget.dynamicString(() -> GT_Utility.parseNumberToString(mFluid != null ? mFluid.amount : 0))
+                new TextWidget().setStringSupplier(() -> numberFormat.format(mFluid != null ? mFluid.amount : 0))
                     .setDefaultColor(COLOR_TEXT_WHITE.get())
                     .setPos(10, 30))
             .widget(


### PR DESCRIPTION
This is the penultimate (still need to do GT++, coming later today) and by far the largest set of changes to support localized number formatting in ModularUI.

* Replaces text fields where the user is expected to input a number with NumericWidget, supporting extended syntax and formatting. (See https://github.com/GTNewHorizons/ModularUI/pull/62.)
* Replaces instances where a dynamic text field is being communicated between server and client with a purely client-side method. In some cases this allows the client to do localization on these texts correctly. (See https://github.com/GTNewHorizons/ModularUI/pull/69.)
* Modifies other instances where the UI displays a number to use a locale-aware formatter. (See https://github.com/GTNewHorizons/ModularUI/pull/67.)

&nbsp;

Notes:
* Most covers correctly understand the maximum possible amount of whatever they are measuring (items, fluids, EU, ...), so expressions like `50%` or `100% - 1000` will correctly evaluate to the desired value.
* The positions of some fields in the Item Detector and Advanced Item Detector cover UIs have been moved around to be consistent with each other and other wireless covers. (Wireless frequency on top, cover data below.)
* The UI of Volumetric Flasks was completely redone, as it was godawful.
* Known bug: Robot Arm cover occasionally resets the adjacent slot value to 0 (instead of any slot). This is not caused by this PR, it was also an issue beforehand (https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15687). If the player interacts with the UI widget at any point and sets the slot to anything (including "Any" again), this is fixed and never happens again with the same cover.
* In a few places I have modified the amounts by which a value changes when the player ctrl- or shift-scrolls on a numeric field. For example, fluid-related fields will now change by 144 when ctrl-scrolled.
* I have specifically *only* changed places where numbers appear in a ModularUI window. This means that item tooltips, WAILA, scanner text, etc. will show the same number formats as before (almost always either #.# or #,###.#, regardless of regional settings). This could be looked at further if the feature is popular, but not before feature freeze.
* As a reminder, if a player finds the locally-formatted numbers annoying, the current locale can be forced in ModularUI config. This defaults to the system's locale as detected by JDK, but can be changed to any locale (for example, `en-US`).
* Tracking down every single instance where a mod writes a number is nearly impossible. I use a few heuristics and code searches, but it is very likely that I miss some places. If an UI displays an unformatted or wrongly formatted number somewhere, please report it to be fixed.

<details>
<summary>Some examples (click to expand):</summary>

Energy detector cover using the percent function of `NumericWidget`:
![](https://i.imgur.com/5OlmkhE.gif)

Some other functions in action:
![](https://i.imgur.com/BRmf3cy.gif)

Machine process (`fr-FR` locale):
![](https://i.imgur.com/hvhlHUs.png)

New volumetric flask UI:
![](https://i.imgur.com/lV3ez1Q.png)</details>