### PR TITLE
fix coal chunk recipe weirdness

### DIFF
--- a/src/main/java/gregtech/loaders/postload/recipes/AssemblerRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/AssemblerRecipes.java
@@ -2435,13 +2435,6 @@ public class AssemblerRecipes implements Runnable {
             .eut(20)
             .addTo(assemblerRecipes);
 
-        GT_Values.RA.stdBuilder()
-            .itemInputs(GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Coal, 8), new ItemStack(Items.flint, 1))
-            .itemOutputs(ItemList.IC2_Compressed_Coal_Ball.get(1))
-            .duration(20 * SECONDS)
-            .eut(4)
-            .addTo(assemblerRecipes);
-
         if (!GT_Mod.gregtechproxy.mDisableIC2Cables) {
             GT_Values.RA.stdBuilder()
                 .itemInputs(


### PR DESCRIPTION
Removes the assembler recipe for ic2 coal ball. Now there is only one path for the compressed coal ball, the NHcoremod one: mix&compress.

There is no point in having two *almost* identical paths, and mixing+compressing makes more sense here.

supersedes https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/763
fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/11445