### PR TITLE
Fix Machine Metal color

### DIFF
--- a/src/main/java/gregtech/api/enums/Dyes.java
+++ b/src/main/java/gregtech/api/enums/Dyes.java
@@ -53,7 +53,7 @@ public enum Dyes implements IColorModulationContainer {
     private final ArrayList<Fluid> mFluidDyes = new GT_ArrayList<>(false, 1);
 
     Dyes(int aIndex, int aR, int aG, int aB, String aName) {
-        this(aIndex, aR, aR, aB, aName, EnumChatFormatting.GRAY);
+        this(aIndex, aR, aG, aB, aName, EnumChatFormatting.GRAY);
     }
 
     Dyes(int aIndex, int aR, int aG, int aB, String aName, EnumChatFormatting formatting) {


### PR DESCRIPTION
After GTNH 2.3.5, GT machine color was a little purplish.
This PR fixes it.