### PR TITLE
Remove nanoforge hatch requirement & more frequent structure check

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_NanoForge.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_NanoForge.java
@@ -260,6 +260,16 @@ public class GT_MetaTileEntity_NanoForge extends
     }
 
     @Override
+    public void onPostTick(IGregTechTileEntity aBaseMetaTileEntity, long aTick) {
+        super.onPostTick(aBaseMetaTileEntity, aTick);
+        if (aBaseMetaTileEntity.isServerSide()) {
+            // TODO: Look for proper fix
+            // Updates every 10 sec
+            if (mUpdate <= -150) mUpdate = 50;
+        }
+    }
+
+    @Override
     public boolean checkMachine(IGregTechTileEntity aBaseMetaTileEntity, ItemStack aStack) {
         mSpecialTier = 0;
         if (checkPiece(STRUCTURE_PIECE_MAIN, 4, 37, 1) && aStack != null) {
@@ -278,9 +288,7 @@ public class GT_MetaTileEntity_NanoForge extends
             }
         }
 
-        if (mMaintenanceHatches.size() != 1 || mInputBusses.isEmpty()
-            || mOutputBusses.isEmpty()
-            || mInputHatches.isEmpty()) {
+        if (mMaintenanceHatches.size() != 1) {
             return false;
         }
 

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_PCBFactory.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_PCBFactory.java
@@ -612,8 +612,8 @@ public class GT_MetaTileEntity_PCBFactory extends
         super.onPostTick(aBaseMetaTileEntity, aTick);
         if (aBaseMetaTileEntity.isServerSide()) {
             // TODO: Look for proper fix
-            // Updates every 30 sec
-            if (mUpdate <= -550) mUpdate = 50;
+            // Updates every 10 sec
+            if (mUpdate <= -150) mUpdate = 50;
         }
     }
 


### PR DESCRIPTION
Remove nanoforge hatch requirement so it will not have crib trouble.
Add forced structure check to nanoforge, and now nanoforge and pcb check structure every 10s instead of 30s. 