### PR TITLE
Fix free oxygen loop caused by chem balance violation

### DIFF
--- a/src/main/java/gregtech/loaders/postload/recipes/ArcFurnaceRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/ArcFurnaceRecipes.java
@@ -1,6 +1,7 @@
 package gregtech.loaders.postload.recipes;
 
 import static gregtech.api.enums.Mods.Railcraft;
+import static gregtech.api.recipe.RecipeMaps.arcFurnaceRecipes;
 import static gregtech.api.util.GT_ModHandler.getModItem;
 import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
 import static gregtech.api.util.GT_RecipeBuilder.TICKS;
@@ -470,7 +471,7 @@ public class ArcFurnaceRecipes implements Runnable {
             .fluidInputs(Materials.Oxygen.getGas(2000L))
             .duration(60 * SECONDS)
             .eut((int) TierEU.RECIPE_LV)
-            .addTo(UniversalArcFurnace);
+            .addTo(arcFurnaceRecipes);
 
     }
 }


### PR DESCRIPTION
Fixes https://discord.com/channels/181078474394566657/241133365489696768/1221250847728734289 - was broken by https://github.com/GTNewHorizons/GT5-Unofficial/pull/1770.

The amounts are actually correct in code. We just have to use the correct recipe map so that the oxygen amount isnt overwritten.

Now all good:
![image](https://github.com/GTNewHorizons/GT5-Unofficial/assets/40274384/1f377ce3-ed0d-40ff-ab11-1c9d9c9fd88e)
