### PR TITLE
Fix DC UI height

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/drone/GT_MetaTileEntity_DroneCentre.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/drone/GT_MetaTileEntity_DroneCentre.java
@@ -523,8 +523,9 @@ public class GT_MetaTileEntity_DroneCentre extends
     }
 
     protected ModularWindow createMachineListWindow(final EntityPlayer player) {
-        double heightCoff = getBaseMetaTileEntity().isServerSide() ? 0 : Minecraft.getMinecraft().displayHeight / 480.0;
-        ModularWindow.Builder builder = ModularWindow.builder(260, (int) (215 * heightCoff));
+        int heightCoff = getBaseMetaTileEntity().isServerSide() ? 0
+            : Minecraft.getMinecraft().currentScreen.height - 40;
+        ModularWindow.Builder builder = ModularWindow.builder(260, heightCoff);
         builder.setBackground(GT_UITextures.BACKGROUND_SINGLEBLOCK_DEFAULT);
         builder.setGuiTint(getGUIColorization());
         builder.widget(
@@ -703,7 +704,7 @@ public class GT_MetaTileEntity_DroneCentre extends
         }
         return builder.widget(
             MachineContainer.setPos(10, 50)
-                .setSize(240, (int) (215 * heightCoff) - 60))
+                .setSize(240, heightCoff - 60))
             .setDraggable(false)
             .build();
     }


### PR DESCRIPTION
Prevent UI height calculator oversize like this
![403}}JZ$@11QH@ R}$FQ(BI](https://github.com/GTNewHorizons/GT5-Unofficial/assets/31100241/1af8a56c-dcfe-43ee-a655-aebcb2e3a68a)
