### PR TITLE
Fix GT lang not accepting en_US string updates

### DIFF
--- a/src/main/java/gregtech/api/util/GT_LanguageManager.java
+++ b/src/main/java/gregtech/api/util/GT_LanguageManager.java
@@ -37,6 +37,11 @@ public class GT_LanguageManager {
      */
     public static Configuration sEnglishFile;
     /**
+     * If the game is running with en_US language. This does not get updated when user changes language in game;
+     * GT lang system cannot handle that anyway.
+     */
+    public static boolean isEN_US;
+    /**
      * If placeholder like %material should be used for writing lang entries to file.
      */
     public static boolean i18nPlaceholder = true;
@@ -125,14 +130,25 @@ public class GT_LanguageManager {
             sEnglishFile.save();
             hasUnsavedEntry = false;
         }
-        if (!tProperty.wasRead()) {
-            if (GregTech_API.sPostloadFinished) {
-                sEnglishFile.save();
-            } else {
-                hasUnsavedEntry = true;
+        String translation = tProperty.getString();
+        if (tProperty.wasRead()) {
+            if (isEN_US && !aEnglish.equals(translation)) {
+                tProperty.set(aEnglish);
+                markFileDirty();
+                return aEnglish;
             }
+        } else {
+            markFileDirty();
         }
-        return tProperty.getString();
+        return translation;
+    }
+
+    private static synchronized void markFileDirty() {
+        if (GregTech_API.sPostloadFinished) {
+            sEnglishFile.save();
+        } else {
+            hasUnsavedEntry = true;
+        }
     }
 
     public static String getTranslation(String aKey) {

--- a/src/main/java/gregtech/loaders/preload/GT_PreLoad.java
+++ b/src/main/java/gregtech/loaders/preload/GT_PreLoad.java
@@ -104,6 +104,7 @@ public class GT_PreLoad {
             GT_FML_LOGGER.info("User lang is " + userLang);
             if (userLang.equals("en_US")) {
                 GT_FML_LOGGER.info("Loading GregTech.lang");
+                GT_LanguageManager.isEN_US = true;
                 GT_LanguageManager.sEnglishFile = new Configuration(new File(languageDir, "GregTech.lang"));
             } else {
                 String l10nFileName = "GregTech_" + userLang + ".lang";
@@ -113,10 +114,12 @@ public class GT_PreLoad {
                     GT_LanguageManager.sEnglishFile = new Configuration(l10nFile);
                 } else {
                     GT_FML_LOGGER.info("Cannot find l10n file " + l10nFileName + ", fallback to GregTech.lang");
+                    GT_LanguageManager.isEN_US = true;
                     GT_LanguageManager.sEnglishFile = new Configuration(new File(languageDir, "GregTech.lang"));
                 }
             }
         } else {
+            GT_LanguageManager.isEN_US = true;
             GT_LanguageManager.sEnglishFile = new Configuration(new File(languageDir, "GregTech.lang"));
         }
         GT_LanguageManager.sEnglishFile.load();


### PR DESCRIPTION
Oversight in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2511
So `sUseEnglishFile` was actually used. If lang file was not marked to behave as translation file, newer English string was always used to inject into MC lang system. This behavior is now restored and even improved to inject into lang file as well. Behaviors when using `GregTech_xx_XX.lang` should not have been changed with this PR.