### PR TITLE
Disable unused hot black steel

### DIFF
--- a/src/main/java/gregtech/api/enums/Materials.java
+++ b/src/main/java/gregtech/api/enums/Materials.java
@@ -2436,6 +2436,7 @@ public class Materials implements IColorModulationContainer, ISubTagContainer {
         OrePrefixes.ingotHot.disableComponent(Materials.RedstoneAlloy);
         OrePrefixes.ingotHot.disableComponent(Materials.Ardite);
         OrePrefixes.ingotHot.disableComponent(Materials.DarkSteel);
+        OrePrefixes.ingotHot.disableComponent(Materials.BlackSteel);
         OrePrefixes.ingotHot.disableComponent(Materials.EnergeticAlloy);
         OrePrefixes.ingotHot.disableComponent(Materials.PulsatingIron);
         OrePrefixes.ingotHot.disableComponent(Materials.CrudeSteel);


### PR DESCRIPTION
Just an oversight that it isnt disabled. Black steel has a custom EBF recipe which directly gives the (cold) ingot.

fixes https://discord.com/channels/181078474394566657/401118216228831252/1223140104521121872