### PR TITLE
Xenoxene and Radox Cells

### DIFF
--- a/src/main/java/gregtech/common/items/GT_MetaGenerated_Item_98.java
+++ b/src/main/java/gregtech/common/items/GT_MetaGenerated_Item_98.java
@@ -48,7 +48,7 @@ public class GT_MetaGenerated_Item_98 extends GT_MetaGenerated_Item {
      * leave a comment mentioning the old ID, so that we don't re-use it for a new fluid.
      */
     public enum FluidCell {
-        // Next unused ID: 27
+        // Next unused ID: 32
 
         // GregTech
         DRILLING_FLUID(5, "liquid_drillingfluid", CellType.REGULAR),
@@ -62,11 +62,16 @@ public class GT_MetaGenerated_Item_98 extends GT_MetaGenerated_Item {
         // New Horizons Core Mod
         UNKNOWN_NUTRIENT_AGAR(7, "unknownnutrientagar", CellType.REGULAR),
         SEAWEED_BROTH(8, "seaweedbroth", CellType.REGULAR),
+        SUPER_HEAVY_RADOX(28, "superheavyradox", CellType.REGULAR),
+        HEAVY_RADOX(29, "heavyradox", CellType.REGULAR),
+        CRACKED_RADOX(30, "crackedradox", CellType.REGULAR),
+        LIGHT_RADOX(31, "lightradox", CellType.REGULAR),
         SUPER_LIGHT_RADOX(9, "superlightradox", CellType.REGULAR),
         SODIUM_POTASSIUM(18, "sodiumpotassium", CellType.REGULAR),
         ENRICHED_BACTERIAL_SLUDGE(19, "enrichedbacterialsludge", CellType.REGULAR),
         FERMENTED_BACTERIAL_SLUDGE(20, "fermentedbacterialsludge", CellType.REGULAR),
         POLLUTION(21, "pollution", CellType.REGULAR),
+        XENOXENE(27, "xenoxene", CellType.REGULAR),
 
         // BartWorks
         ENZYME_SOLUTION(10, "enzymessollution", CellType.REGULAR),


### PR DESCRIPTION
Added Fluid Cells for Xenoxene + Super Heavy, Heavy, Cracked and Light Radox.
Fixes: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14858
Now one can search for it in NEI and use it more easily in e.g. ME stocking input hatches and to format fluid cells in the cell workbench.
Correct me if I am missing something.