### PR TITLE
Add mention of required air to LGT structure tooltip

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeTurbine_Gas.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeTurbine_Gas.java
@@ -69,6 +69,7 @@ public class GT_MetaTileEntity_LargeTurbine_Gas extends GT_MetaTileEntity_LargeT
             .addMaintenanceHatch("Side centered", 2)
             .addMufflerHatch("Side centered", 2)
             .addInputHatch("Gas Fuel, Side centered", 2)
+            .addOtherStructurePart("Air", "3x3 area in front of controller")
             .toolTipFinisher("Gregtech");
         return tt;
     }


### PR DESCRIPTION
The LGT tooltip does not mention the 3x3 area in front of it must be air, the only way to find this information is using the projector and the questbook. This adds a single line to the tooltip with a short explanation.