### PR TITLE
Destroy non-GT tools when they are completely broken

### DIFF
--- a/src/main/java/gregtech/api/util/GT_ModHandler.java
+++ b/src/main/java/gregtech/api/util/GT_ModHandler.java
@@ -2249,6 +2249,8 @@ public class GT_ModHandler {
                         aStack.setItemDamage(tStack.getItemDamage());
                         aStack.stackSize = tStack.stackSize;
                         aStack.setTagCompound(tStack.getTagCompound());
+                    } else if (aStack.stackSize > 0) {
+                        aStack.stackSize--;
                     }
                 }
                 return true;


### PR DESCRIPTION
Fixes TGS tool exploit (grafters and shears were never destroyed).