### PR TITLE
Allow single-block pump to ignore replaceable blocks, and water

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_Pump.java
+++ b/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_Pump.java
@@ -530,11 +530,14 @@ public class GT_MetaTileEntity_Pump extends GT_MetaTileEntity_BasicMachine {
 
         int x = getBaseMetaTileEntity().getXCoord(), z = getBaseMetaTileEntity().getZCoord();
 
-        if ((!consumeFluid(x, yHead - 1, z)) && (!getBaseMetaTileEntity().getBlock(x, yHead - 1, z)
-            .isAir(getBaseMetaTileEntity().getWorld(), x, yHead - 1, z))) {
-            // Either we didn't consume a fluid, or it's a non Air block
+        Block aBlock = getBaseMetaTileEntity().getBlock(x, yHead - 1, z);
+        boolean canReplaceBlock = aBlock.isAir(getBaseMetaTileEntity().getWorld(), x, yHead - 1, z)
+            || aBlock == Blocks.fire;
+
+        if (!canReplaceBlock && !consumeFluid(x, yHead - 1, z)) {
+            // Either we didn't consume a fluid, or it's a non-replaceable block
             if (debugBlockPump) {
-                GT_Log.out.println("PUMP: Did not consume fluid, or non-airblock found");
+                GT_Log.out.println("PUMP: Did not consume fluid, or non-replaceable block found");
             }
             return false;
         }
@@ -730,7 +733,7 @@ public class GT_MetaTileEntity_Pump extends GT_MetaTileEntity_BasicMachine {
             || aBlock == Blocks.lava
             || aBlock == Blocks.flowing_lava
             || aBlock instanceof IFluidBlock
-            || aBlock.isAir(getBaseMetaTileEntity().getWorld(), aX, aY, aZ));
+            || aBlock.isAir(getBaseMetaTileEntity().getWorld(), aX, aY, aZ)) || aBlock == Blocks.fire;
     }
 
     private boolean consumeFluid(int aX, int aY, int aZ) {

--- a/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_Pump.java
+++ b/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_Pump.java
@@ -533,8 +533,10 @@ public class GT_MetaTileEntity_Pump extends GT_MetaTileEntity_BasicMachine {
         Block aBlock = getBaseMetaTileEntity().getBlock(x, yHead - 1, z);
         boolean canReplaceBlock = aBlock.isReplaceable(getBaseMetaTileEntity().getWorld(), x, yHead - 1, z);
 
+        // We specifically allow replacing water even if we can't consume it
+        // (e.g. pump holds a different fluid) to help avoid getting stuck on random water pockets.
         if (!canReplaceBlock || (isFluid(aBlock) && !consumeFluid(x, yHead - 1, z) && !isWater(aBlock))) {
-            // Either we didn't consume a fluid, or it's a non-replaceable block
+            // Either we didn't consume a fluid, or it's a non-replaceable block, or it's water.
             if (debugBlockPump) {
                 GT_Log.out.println("PUMP: Did not consume fluid, or non-replaceable block found");
             }

--- a/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_Pump.java
+++ b/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_Pump.java
@@ -531,10 +531,9 @@ public class GT_MetaTileEntity_Pump extends GT_MetaTileEntity_BasicMachine {
         int x = getBaseMetaTileEntity().getXCoord(), z = getBaseMetaTileEntity().getZCoord();
 
         Block aBlock = getBaseMetaTileEntity().getBlock(x, yHead - 1, z);
-        boolean canReplaceBlock = aBlock.isAir(getBaseMetaTileEntity().getWorld(), x, yHead - 1, z)
-            || aBlock == Blocks.fire;
+        boolean canReplaceBlock = aBlock.isReplaceable(getBaseMetaTileEntity().getWorld(), x, yHead - 1, z);
 
-        if (!canReplaceBlock && !consumeFluid(x, yHead - 1, z)) {
+        if (!canReplaceBlock || (isFluid(aBlock) && !consumeFluid(x, yHead - 1, z) && !isWater(aBlock))) {
             // Either we didn't consume a fluid, or it's a non-replaceable block
             if (debugBlockPump) {
                 GT_Log.out.println("PUMP: Did not consume fluid, or non-replaceable block found");
@@ -703,12 +702,12 @@ public class GT_MetaTileEntity_Pump extends GT_MetaTileEntity_BasicMachine {
 
         Block aBlock = getBaseMetaTileEntity().getBlock(aX, aY, aZ);
         if (aBlock != null) {
-            if ((aBlock == Blocks.water) || (aBlock == Blocks.flowing_water)) {
+            if (isWater(aBlock)) {
                 this.mPrimaryPumpedBlock = Blocks.water;
                 this.mSecondaryPumpedBlock = Blocks.flowing_water;
                 return;
             }
-            if ((aBlock == Blocks.lava) || (aBlock == Blocks.flowing_lava)) {
+            if (isLava(aBlock)) {
                 this.mPrimaryPumpedBlock = Blocks.lava;
                 this.mSecondaryPumpedBlock = Blocks.flowing_lava;
                 return;
@@ -729,11 +728,7 @@ public class GT_MetaTileEntity_Pump extends GT_MetaTileEntity_BasicMachine {
 
         Block aBlock = getBaseMetaTileEntity().getBlock(aX, aY, aZ);
 
-        return aBlock != null && (aBlock == Blocks.water || aBlock == Blocks.flowing_water
-            || aBlock == Blocks.lava
-            || aBlock == Blocks.flowing_lava
-            || aBlock instanceof IFluidBlock
-            || aBlock.isAir(getBaseMetaTileEntity().getWorld(), aX, aY, aZ)) || aBlock == Blocks.fire;
+        return aBlock != null && aBlock.isReplaceable(getBaseMetaTileEntity().getWorld(), aX, aY, aZ);
     }
 
     private boolean consumeFluid(int aX, int aY, int aZ) {
@@ -742,6 +737,9 @@ public class GT_MetaTileEntity_Pump extends GT_MetaTileEntity_BasicMachine {
         if (!GT_Utility.eraseBlockByFakePlayer(getFakePlayer(getBaseMetaTileEntity()), aX, aY, aZ, true)) return false;
 
         Block aBlock = getBaseMetaTileEntity().getBlock(aX, aY, aZ);
+        if (!isFluid(aBlock)) {
+            return false;
+        }
 
         if (aBlock != null && ((this.mPrimaryPumpedBlock == aBlock) || (this.mSecondaryPumpedBlock == aBlock))) {
             boolean isWaterOrLava = ((this.mPrimaryPumpedBlock == Blocks.water
@@ -789,6 +787,18 @@ public class GT_MetaTileEntity_Pump extends GT_MetaTileEntity_BasicMachine {
             return true;
         }
         return false;
+    }
+
+    private static boolean isWater(Block aBlock) {
+        return aBlock == Blocks.water || aBlock == Blocks.flowing_water;
+    }
+
+    private static boolean isLava(Block aBlock) {
+        return aBlock == Blocks.lava || aBlock == Blocks.flowing_lava;
+    }
+
+    private static boolean isFluid(Block aBlock) {
+        return isWater(aBlock) || isLava(aBlock) || aBlock instanceof IFluidBlock;
     }
 
     @Override


### PR DESCRIPTION
Allow the single-block pump to ignore replaceable blocks (fire, grass, vines, etc.) when lowering the pipe. Also allow voiding water when the pump contains a different fluid.

This should make it much less annoying to pump out an oil well that is on fire, or has pockets of water interspersed.