### PR TITLE
Make DTPF lose fuel efficiency over time instead of instantly

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
@@ -155,8 +155,6 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
 
     private long mLastWorkingTick = 0;
 
-    private long mIdleTime = 0;
-
     protected static final byte INTERRUPT_SOUND_INDEX = 8;
     protected static final byte PROCESS_START_SOUND_INDEX = 1;
 
@@ -252,7 +250,6 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
         aNBT.setInteger("mEfficiency", mEfficiency);
         aNBT.setInteger("mPollution", mPollution);
         aNBT.setInteger("mRuntime", mRuntime);
-        aNBT.setLong("mIdleTime", mIdleTime);
         if (supportsSingleRecipeLocking()) {
             aNBT.setBoolean("mLockedToSingleRecipe", mLockedToSingleRecipe);
             if (mLockedToSingleRecipe && mSingleRecipeCheck != null)
@@ -294,7 +291,6 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
         mEfficiency = aNBT.getInteger("mEfficiency");
         mPollution = aNBT.getInteger("mPollution");
         mRuntime = aNBT.getInteger("mRuntime");
-        mIdleTime = aNBT.getLong("mIdleTime");
         if (supportsSingleRecipeLocking()) {
             mLockedToSingleRecipe = aNBT.getBoolean("mLockedToSingleRecipe");
             if (mLockedToSingleRecipe && aNBT.hasKey("mSingleRecipeCheck", Constants.NBT.TAG_COMPOUND)) {
@@ -429,7 +425,6 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
                     | (mSolderingTool ? 0 : 16)
                     | (mCrowbar ? 0 : 32)
                     | (mMachine ? 0 : 64));
-            mIdleTime = (mMaxProgresstime > 0) ? 0 : mIdleTime + 1;
             aBaseMetaTileEntity.setActive(mMaxProgresstime > 0);
             boolean active = aBaseMetaTileEntity.isActive() && mPollution > 0;
             setMufflers(active);
@@ -2300,10 +2295,6 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
 
     public boolean shouldDisplayShutDownReason() {
         return true;
-    }
-
-    public long idleTime() {
-        return mIdleTime;
     }
 
     protected final NumberFormatMUI numberFormat = new NumberFormatMUI();

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
@@ -252,6 +252,7 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
         aNBT.setInteger("mEfficiency", mEfficiency);
         aNBT.setInteger("mPollution", mPollution);
         aNBT.setInteger("mRuntime", mRuntime);
+        aNBT.setLong("mIdleTime", mIdleTime);
         if (supportsSingleRecipeLocking()) {
             aNBT.setBoolean("mLockedToSingleRecipe", mLockedToSingleRecipe);
             if (mLockedToSingleRecipe && mSingleRecipeCheck != null)
@@ -293,6 +294,7 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
         mEfficiency = aNBT.getInteger("mEfficiency");
         mPollution = aNBT.getInteger("mPollution");
         mRuntime = aNBT.getInteger("mRuntime");
+        mIdleTime = aNBT.getLong("mIdleTime");
         if (supportsSingleRecipeLocking()) {
             mLockedToSingleRecipe = aNBT.getBoolean("mLockedToSingleRecipe");
             if (mLockedToSingleRecipe && aNBT.hasKey("mSingleRecipeCheck", Constants.NBT.TAG_COMPOUND)) {

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
@@ -155,6 +155,8 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
 
     private long mLastWorkingTick = 0;
 
+    private long mIdleTime = 0;
+
     protected static final byte INTERRUPT_SOUND_INDEX = 8;
     protected static final byte PROCESS_START_SOUND_INDEX = 1;
 
@@ -404,6 +406,7 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
             if (--mUpdate == 0 || --mStartUpCheck == 0) {
                 checkStructure(true, aBaseMetaTileEntity);
             }
+
             if (mStartUpCheck < 0) {
                 if (mMachine) {
                     checkMaintenance();
@@ -424,6 +427,7 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
                     | (mSolderingTool ? 0 : 16)
                     | (mCrowbar ? 0 : 32)
                     | (mMachine ? 0 : 64));
+            mIdleTime = (mMaxProgresstime > 0) ? 0 : mIdleTime + 1;
             aBaseMetaTileEntity.setActive(mMaxProgresstime > 0);
             boolean active = aBaseMetaTileEntity.isActive() && mPollution > 0;
             setMufflers(active);
@@ -2294,6 +2298,10 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
 
     public boolean shouldDisplayShutDownReason() {
         return true;
+    }
+
+    public long idleTime() {
+        return mIdleTime;
     }
 
     protected final NumberFormatMUI numberFormat = new NumberFormatMUI();

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_PlasmaForge.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_PlasmaForge.java
@@ -914,8 +914,7 @@ public class GT_MetaTileEntity_PlasmaForge extends
                 // Otherwise simply accept the proposed discount value
                 discount = proposedDiscount;
             }
-        }
-        else {
+        } else {
             // If we had any idle time before this, use that time to set the discount instead
             double idle_time_percentage = idleTime() / efficiency_decay_time_in_ticks;
             idle_time_percentage = Math.min(idle_time_percentage, 1.0d);

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_PlasmaForge.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_PlasmaForge.java
@@ -67,6 +67,8 @@ public class GT_MetaTileEntity_PlasmaForge extends
 
     // 3600 seconds in an hour, 8 hours, 20 ticks in a second.
     private static final double max_efficiency_time_in_ticks = 3600d * 8d * 20d;
+    // Time it takes for efficiency to decay to zero. Set to 5 minutes.
+    private static final double efficiency_decay_time_in_ticks = 60d * 5d * 20d;
     private static final double maximum_discount = 0.5d;
 
     // Valid fuels which the discount will get applied to.
@@ -538,6 +540,15 @@ public class GT_MetaTileEntity_PlasmaForge extends
                     + "%"
                     + EnumChatFormatting.GRAY
                     + ". Supports overclocking beyond MAX voltage.")
+            .addInfo(
+                "When no recipe is running, fuel discount gradually decreases to " + EnumChatFormatting.RED
+                    + "0%"
+                    + EnumChatFormatting.GRAY
+                    + " in "
+                    + EnumChatFormatting.RED
+                    + GT_Utility.formatNumbers(efficiency_decay_time_in_ticks / (20 * 60))
+                    + EnumChatFormatting.GRAY
+                    + " minutes.")
             .addInfo(AuthorColen)
             .addSeparator()
             .beginStructureBlock(33, 24, 33, false)
@@ -877,6 +888,9 @@ public class GT_MetaTileEntity_PlasmaForge extends
                 + GT_Utility.formatNumbers(100 * (1 - discount))
                 + EnumChatFormatting.RESET
                 + "%",
+            "Ticks idle (Debug): " + EnumChatFormatting.GREEN
+                + GT_Utility.formatNumbers(idleTime())
+                + EnumChatFormatting.RESET,
             "-----------------------------------------" };
     }
 

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_PlasmaForge.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_PlasmaForge.java
@@ -677,9 +677,7 @@ public class GT_MetaTileEntity_PlasmaForge extends
     @NotNull
     public CheckRecipeResult checkProcessing() {
         CheckRecipeResult recipe_process = super.checkProcessing();
-        if (!recipe_process.wasSuccessful()) {
-            resetDiscount();
-        } else {
+        if (recipe_process.wasSuccessful()) {
             running_time = Math.min(running_time + mMaxProgresstime, (long) max_efficiency_time_in_ticks);
         }
         return recipe_process;
@@ -805,11 +803,7 @@ public class GT_MetaTileEntity_PlasmaForge extends
 
     @Override
     public boolean onRunningTick(ItemStack aStack) {
-        boolean result = super.onRunningTick(aStack);
-        if (!result) {
-            resetDiscount();
-        }
-        return result;
+        return super.onRunningTick(aStack);
     }
 
     @Override
@@ -892,16 +886,9 @@ public class GT_MetaTileEntity_PlasmaForge extends
         discount = Math.max(maximum_discount, discount);
     }
 
-    // Reset running time and discount.
-    public void resetDiscount() {
-        recalculateDiscount();
-    }
-
     @Override
     public void onPostTick(IGregTechTileEntity aBaseMetaTileEntity, long aTick) {
         if (aBaseMetaTileEntity.isServerSide() && !aBaseMetaTileEntity.isAllowedToWork()) {
-            // Reset running time and discount.
-            resetDiscount();
             // If machine has stopped, stop chunkloading.
             GT_ChunkManager.releaseTicket((TileEntity) aBaseMetaTileEntity);
             isMultiChunkloaded = false;

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_PlasmaForge.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_PlasmaForge.java
@@ -802,11 +802,6 @@ public class GT_MetaTileEntity_PlasmaForge extends
     }
 
     @Override
-    public boolean onRunningTick(ItemStack aStack) {
-        return super.onRunningTick(aStack);
-    }
-
-    @Override
     public String[] getInfoData() {
 
         long storedEnergy = 0;


### PR DESCRIPTION
Implements GTNewHorizons/GT-New-Horizons-Modpack#15977. This PR makes it so the DTPF slowly loses its efficiency bonus over 5 minutes instead of instantly when it fails to run a recipe for whatever reason.

- ~~To implement this, I added a `mIdleTime` tracker in `GT_MetaTileEntity_MultiBlockBase` that is simply incremented every tick. Whenever the DTPF needs to calculate its fuel efficiency, this value is checked and the proper decayed efficiency can be obtained.~~ I moved this logic to the DTPF in `onPostTick` instead.

- One issue with this was that when the DTPF resumes when it hasn't decayed to zero yet, the `running_time` field is 0 ticks, so I added code to recalculate this value based on the current fuel discount, which may lead to some confusion (DTPF was just turned on, but shows it has been running for some time in scanner output).

- Another issue is that no matter the initial fuel bonus, it will always take 5 minutes to decay. This also means that if you only had a bonus of 10% you will not lose it at all for the first 4 minutes of runtime. If this is something that needs to be fixed, let me know and I will try to think of a fix.