### PR TITLE
Fix Drone Centre Memory Leak

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/drone/GT_MetaTileEntity_DroneCentre.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/drone/GT_MetaTileEntity_DroneCentre.java
@@ -281,6 +281,7 @@ public class GT_MetaTileEntity_DroneCentre extends
     public void loadNBTData(NBTTagCompound aNBT) {
         super.loadNBTData(aNBT);
         droneLevel = aNBT.getInteger("drone");
+        useRender = aNBT.getBoolean("useRender");
         NBTTagCompound nameList = aNBT.getCompoundTag("conList");
         for (String s : nameList.func_150296_c()) {
             tempNameList.put(s, nameList.getString(s));
@@ -291,6 +292,7 @@ public class GT_MetaTileEntity_DroneCentre extends
     public void saveNBTData(NBTTagCompound aNBT) {
         super.saveNBTData(aNBT);
         aNBT.setInteger("drone", droneLevel);
+        aNBT.setBoolean("useRender", useRender);
         NBTTagCompound conList = new NBTTagCompound();
         for (DroneConnection con : connectionList) {
             if (!Objects.equals(con.customName, con.machine.getLocalName()))

--- a/src/main/java/gregtech/common/tileentities/machines/multi/drone/GT_MetaTileEntity_Hatch_DroneDownLink.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/drone/GT_MetaTileEntity_Hatch_DroneDownLink.java
@@ -193,6 +193,7 @@ public class GT_MetaTileEntity_Hatch_DroneDownLink extends GT_MetaTileEntity_Hat
                         connection = new DroneConnection(machine, centre);
                         connection.centre.getConnectionList()
                             .add(connection);
+                        return;
                     }
                 }
             }

--- a/src/main/resources/assets/gregtech/lang/en_US.lang
+++ b/src/main/resources/assets/gregtech/lang/en_US.lang
@@ -395,6 +395,8 @@ GT5U.machines.dronecentre.shutdown=You cannot control machine when drone centre 
 GT5U.machines.dronecentre.turnon=Successfully turn on all machines!
 GT5U.machines.dronecentre.turnoff=Successfully turn off all machines!
 GT5U.machines.dronecentre.noconnection=No valid connection
+GT5U.machines.dronecentre.enableRender=Enable Drone Render
+GT5U.machines.dronecentre.disableRender=Disable Drone Render
 
 GT5U.recipe_filter.empty_representation_slot.tooltip=§7Click with a machine to set filter
 GT5U.recipe_filter.representation_slot.tooltip=§7Click to clear


### PR DESCRIPTION
- Prevent drone downlink from connecting to multiple centres.
- Probably fix memory leak.
- Spawn a drone item if the centre is destroyed.
- Use a screwdriver to disable the render.

Fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16005
Close https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16006
