### PR TITLE
remove duplicate wheat maceration

### DIFF
--- a/src/main/java/gregtech/common/items/GT_MetaGenerated_Item_02.java
+++ b/src/main/java/gregtech/common/items/GT_MetaGenerated_Item_02.java
@@ -2692,13 +2692,6 @@ public class GT_MetaGenerated_Item_02 extends GT_MetaGenerated_Item_X32 {
             .addTo(maceratorRecipes);
 
         GT_Values.RA.stdBuilder()
-            .itemInputs(new ItemStack(Items.wheat, 1, 0))
-            .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wheat, 1L))
-            .duration(20 * SECONDS)
-            .eut(2)
-            .addTo(maceratorRecipes);
-
-        GT_Values.RA.stdBuilder()
             .itemInputs(GT_ModHandler.getIC2Item("crop", 1L))
             .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 1L))
             .duration(20 * SECONDS)


### PR DESCRIPTION
This removes the custom recipe and keeps the autogenerated one. They are very similar anyway.

fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16043