### PR TITLE
Only trigger Machine Controller Cover Safe Mode when a shutdown was critical.

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -36,7 +36,7 @@
 dependencies {
     api("com.github.GTNewHorizons:StructureLib:1.3.1:dev")
     api("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev")
-    api("com.github.GTNewHorizons:NotEnoughItems:2.5.26-GTNH:dev")
+    api("com.github.GTNewHorizons:NotEnoughItems:2.5.27-GTNH:dev")
     api("com.github.GTNewHorizons:GTNHLib:0.2.11:dev")
     api("com.github.GTNewHorizons:ModularUI:1.1.42:dev")
     api("com.github.GTNewHorizons:waila:1.7.3:dev")
@@ -45,10 +45,10 @@ dependencies {
 
     implementation("com.github.GTNewHorizons:Avaritia:1.49:dev")
 
-    compileOnlyApi('com.github.GTNewHorizons:Angelica:1.0.0-alpha38:api') { transitive = false }
+    compileOnlyApi('com.github.GTNewHorizons:Angelica:1.0.0-alpha39:api') { transitive = false }
     compileOnlyApi("com.github.GTNewHorizons:AppleCore:3.3.0:dev") { transitive = false }
     compileOnlyApi("com.github.GTNewHorizons:BuildCraft:7.1.39:dev") { transitive = false }
-    compileOnlyApi("com.github.GTNewHorizons:EnderIO:2.7.3:dev") { transitive = false }
+    compileOnlyApi("com.github.GTNewHorizons:EnderIO:2.7.4:dev") { transitive = false }
     compileOnlyApi("com.github.GTNewHorizons:ProjectRed:4.9.5-GTNH:dev") { transitive = false }
     compileOnlyApi("com.github.GTNewHorizons:ForestryMC:4.8.9:dev") { transitive = false }
     compileOnlyApi("com.github.GTNewHorizons:Railcraft:9.15.8:dev") { transitive = false }

--- a/src/main/java/gregtech/common/covers/GT_Cover_ControlsWork.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_ControlsWork.java
@@ -39,7 +39,8 @@ public class GT_Cover_ControlsWork extends GT_CoverBehavior implements IControls
             } else if (aCoverVariable == 2) {
                 machine.disableWorking();
             } else {
-                if (machine.wasShutdown() && machine.getLastShutDownReason().wasCritical()) {
+                if (machine.wasShutdown() && machine.getLastShutDownReason()
+                    .wasCritical()) {
                     machine.disableWorking();
                     if (!mPlayerNotified) {
                         EntityPlayer player = lastPlayer == null ? null : lastPlayer.get();

--- a/src/main/java/gregtech/common/covers/GT_Cover_ControlsWork.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_ControlsWork.java
@@ -39,7 +39,7 @@ public class GT_Cover_ControlsWork extends GT_CoverBehavior implements IControls
             } else if (aCoverVariable == 2) {
                 machine.disableWorking();
             } else {
-                if (machine.wasShutdown()) {
+                if (machine.wasShutdown() && machine.getLastShutDownReason().wasCritical()) {
                     machine.disableWorking();
                     if (!mPlayerNotified) {
                         EntityPlayer player = lastPlayer == null ? null : lastPlayer.get();


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16002.

Some background for why I think this is a bug fix, and the change in cover behavior was not intentional:

The issue was caused by https://github.com/GTNewHorizons/GT5-Unofficial/pull/2522, specifically in method `GT_MetaTileEntity_MultiBlockBase::stopMachine()`. Before this PR, only the method `criticalStopMachine()` would call `getBaseMetaTileEntity().setShutdownStatus(true)`, the method `stopMachine()` would not. After this PR, the shutdown status is set whether the shutdown was critical or not. The shutdown status is what the machine controller cover checks to trigger its safe mode, and to completely disable the machine until it is manually reset.

I believe setting the shutdown status regardless of the reason is the correct behavior; and regardless, this is what allows the machine GUI to display a message about the shutdown reason, whether it was critical or not. However, this change inadvertently affected the controller cover behavior, as it now triggers safe mode for non-critical shutdown reasons too (such as incomplete structure).

This PR fixes the cover to check whether a shutdown was critical (for example, power loss), and only trigger safe mode and disable the machine if so. This restores the cover's intended behavior to before #2522, while not affecting the shutdown reason display.