### PR TITLE
Volumetric flask UI fixes.

### DIFF
--- a/src/main/java/gregtech/common/items/GT_VolumetricFlask.java
+++ b/src/main/java/gregtech/common/items/GT_VolumetricFlask.java
@@ -325,9 +325,9 @@ public class GT_VolumetricFlask extends GT_Generic_Item implements IFluidContain
             ModularWindow.Builder builder = ModularWindow.builder(150, 54);
             builder.setBackground(ModularUITextures.VANILLA_BACKGROUND);
 
-            NumericWidget capacityWidget;
+            NumericWidget capacityWidget = new NumericWidget();
             builder.widget(
-                capacityWidget = (NumericWidget) new NumericWidget().setGetter(() -> capacity)
+                capacityWidget.setGetter(() -> capacity)
                     .setSetter(value -> setCapacity(getCurrentItem(), capacity = (int) value))
                     .setBounds(1, maxCapacity)
                     .setScrollValues(1, 144, 1000)

--- a/src/main/java/gregtech/common/items/GT_VolumetricFlask.java
+++ b/src/main/java/gregtech/common/items/GT_VolumetricFlask.java
@@ -325,8 +325,9 @@ public class GT_VolumetricFlask extends GT_Generic_Item implements IFluidContain
             ModularWindow.Builder builder = ModularWindow.builder(150, 54);
             builder.setBackground(ModularUITextures.VANILLA_BACKGROUND);
 
+            NumericWidget capacityWidget;
             builder.widget(
-                new NumericWidget().setGetter(() -> capacity)
+                capacityWidget = (NumericWidget) new NumericWidget().setGetter(() -> capacity)
                     .setSetter(value -> setCapacity(getCurrentItem(), capacity = (int) value))
                     .setBounds(1, maxCapacity)
                     .setScrollValues(1, 144, 1000)
@@ -341,6 +342,7 @@ public class GT_VolumetricFlask extends GT_Generic_Item implements IFluidContain
                 .widget(
                     new VanillaButtonWidget().setDisplayString("Confirm")
                         .setOnClick((clickData, widget) -> {
+                            capacityWidget.onRemoveFocus();
                             if (!widget.isClient()) {
                                 widget.getWindow()
                                     .tryClose();


### PR DESCRIPTION
Fixes two related issues with editing the capacity of volumetric flasks:

* If the player changes the capacity of a flask using the right-click UI, and immediately opens another inventory (such as a fluid tank), the capacity gets reset to the previous value. This was reported by @hallucinogender on discord.
* If the player changes the capacity of a flask using the right-click UI, and immediately opens the same UI again by right-clicking the flask; the game crashes with a NPE in Minecraft networking code. (:concern:)

In the current build, both problems can be worked around by opening and closing the player's inventory after editing the flask capacity. This PR makes both cases work as expected.

Note: *I have no idea how this change actually fixes anything, especially the latter issue.* But it works with it, and doesn't work without. I tried tracking down what was causing the desync/NPE, but was unsuccessful. If anyone has any ideas, I'd love to know more.