### PR TITLE
Fix silently multiblock failure from attempted amperage based up-volting

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
@@ -758,7 +758,7 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
      */
     protected void setProcessingLogicPower(ProcessingLogic logic) {
         logic.setAvailableVoltage(getAverageInputVoltage());
-        logic.setAvailableAmperage(getMaxInputAmps());
+        logic.setAvailableAmperage(mEnergyHatches.size() == 1 ? 1 : getMaxInputAmps());
         logic.setAmperageOC(mEnergyHatches.size() != 1);
     }
 


### PR DESCRIPTION
Moves up the amp check to not silently fail later after inputs are already consumed.

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16135

With a single UV hatch:
![image](https://github.com/GTNewHorizons/GT5-Unofficial/assets/40274384/e0622b05-a55a-4ad0-99bc-37986b88f912)
