### PR TITLE
Slight change to ampoc logic

### DIFF
--- a/src/main/java/gregtech/api/util/GT_OverclockCalculator.java
+++ b/src/main/java/gregtech/api/util/GT_OverclockCalculator.java
@@ -428,11 +428,11 @@ public class GT_OverclockCalculator {
         if (!amperageOC) {
             overclockCount = Math.min(overclockCount, calculateRecipeToMachineVoltageDifference());
         }
-        if (overclockCount < 0) {
-            recipeVoltage = Long.MAX_VALUE;
-            duration = Integer.MAX_VALUE;
-            return;
-        }
+
+        // Not just a safeguard. This also means that you can run a 1.2A recipe on a single hatch for a regular gt
+        // multi.
+        // This is intended, including the fact that you don't get an OC with a one tier upgrade in that case.
+        overclockCount = Math.max(overclockCount, 0);
 
         overclockCount = limitOverclocks ? Math.min(maxOverclocks, overclockCount) : overclockCount;
         heatOverclockCount = Math.min(heatOverclockCount, overclockCount);

--- a/src/test/java/gregtech/overclock/GT_OverclockCalculator_UnitTest.java
+++ b/src/test/java/gregtech/overclock/GT_OverclockCalculator_UnitTest.java
@@ -583,4 +583,16 @@ class GT_OverclockCalculator_UnitTest {
         assertEquals(expectedDuration, calculator.getDuration(), messageDuration);
         assertEquals(VP[6], calculator.getConsumption(), messageEUt);
     }
+
+    @Test
+    void slightlyOverOneAmpRecipeWorksWithSingleEnergyHatch() {
+        GT_OverclockCalculator calculator = new GT_OverclockCalculator().setRecipeEUt(614400)
+            .setEUt(TierEU.UV)
+            .setDuration(600)
+            .setAmperage(2)
+            .setAmperageOC(false)
+            .calculate();
+        assertEquals(600, calculator.getDuration(), messageDuration);
+        assertEquals(614400, calculator.getConsumption(), messageEUt);
+    }
 }


### PR DESCRIPTION
This fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16135 and replaces https://github.com/GTNewHorizons/GT5-Unofficial/pull/2589

On the surface this is just a better safeguard against a negative oc count, as inputs have already been consumed and a general power check already happened at the start.

However this comes with a slight change in functionality: even with ampoc off multis can now use amperage to upvolt to the initial recipe. (they still dont get an oc when you go one tier higher)

This is intentional and requested by boubou.

Some more background: I am not fully sure but I do think that some GT multis did indeed allow this as well pre-GPL. (CAL did not, nor did any gt++ multi) But we rather have this one rule for all of them.

The good news is that not many recipes are affected anyway, only the ones with 1A<recipeusage<=2A of a tier. Or 0.25A<recipeusage<=0.5A judging by the next tier. Mostly 0.5A recipes exist in a bunch of places. There are also a few CAL recipes. And we might need to have a look at SoC quest tiers.

I am not sure how best to communicated this (mostly new) behaviour to the players, but there is a comment in the code and a unit test to communicate it to future devs.