### PR TITLE
Update GT_MetaTileEntity_IndustrialApiary.java

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_IndustrialApiary.java
+++ b/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_IndustrialApiary.java
@@ -69,8 +69,6 @@ import com.gtnewhorizons.modularui.common.widget.SlotWidget;
 import com.gtnewhorizons.modularui.common.widget.TextWidget;
 import com.mojang.authlib.GameProfile;
 
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 import forestry.api.apiculture.BeeManager;
 import forestry.api.apiculture.EnumBeeChromosome;
 import forestry.api.apiculture.EnumBeeType;
@@ -743,7 +741,6 @@ public class GT_MetaTileEntity_IndustrialApiary extends GT_MetaTileEntity_BasicM
         if (aIndex > drone && aIndex < getOutputSlot()) updateModifiers();
     }
 
-    @SideOnly(Side.CLIENT)
     public ItemStack getUsedQueen() {
         return usedQueen;
     }


### PR DESCRIPTION
The Apimancer's Drainer uses GT_MetaTileEntity_IndustrialApiary.getUsedQueen to retrieve the queen currently being processed by the Industrial Apiary.

getUsedQueen is annotated with @SideOnly(Side.CLIENT) which only allows this function to be called from singleplayer. This function is not available when called from server-side and leads to the crash detailed in this issue.

As far as I can tell, this function has no reason to be singleplayer / client-side only. This seems to be an artifact from when this function was imported over 2 years ago.

Testing this change in our world prevents the crash and allows the Apimancer's Drainer to work as expected with the Industrial Apiary.

Resolves GTNewHorizons/GT-New-Horizons-Modpack#16222