### PR TITLE
Fix -  Collision of TPV and Indium Gallium Phosphide recipes in Mixer

### DIFF
--- a/src/main/java/gregtech/loaders/postload/recipes/MixerRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/MixerRecipes.java
@@ -374,7 +374,7 @@ public class MixerRecipes implements Runnable {
                 GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Titanium, 3),
                 GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Platinum, 3),
                 GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Vanadium, 1),
-                GT_Utility.getIntegratedCircuit(1))
+                GT_Utility.getIntegratedCircuit(4))
             .itemOutputs(GT_OreDictUnificator.getDust(Materials.TPV, 7L * OrePrefixes.dust.mMaterialAmount))
             .duration(8 * SECONDS + 15 * TICKS)
             .eut(TierEU.RECIPE_EV)


### PR DESCRIPTION
Fix this pr - https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16384