### PR TITLE
Make GT++ weights consistent with the other weights

### DIFF
--- a/src/main/java/gtPlusPlus/everglades/GTplusplus_Everglades.java
+++ b/src/main/java/gtPlusPlus/everglades/GTplusplus_Everglades.java
@@ -159,8 +159,8 @@ public class GTplusplus_Everglades implements ActionListener {
         for (WorldGen_GT_Ore_Layer t : WorldGen_Ores.validOreveins.values()) {
             addVMDrop(t.mPrimaryMeta, 0, t.mWeight);
             addVMDrop(t.mSecondaryMeta, 0, t.mWeight);
-            addVMDrop(t.mBetweenMeta, 0, t.mWeight);
-            addVMDrop(t.mSporadicMeta, 0, t.mWeight);
+            addVMDrop(t.mBetweenMeta, 0, t.mWeight / 8f);
+            addVMDrop(t.mSporadicMeta, 0, t.mWeight / 8f);
         }
     }
 


### PR DESCRIPTION
sporadict and in between ores weights are / 8 for GT and BW, this PR does the same for the GT++ ores.