### PR TITLE
Move Forestry to api dep

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -45,13 +45,13 @@ dependencies {
     api('com.github.GTNewHorizons:Yamcl:0.6.0:dev')
     api('com.github.GTNewHorizons:ThaumicTinkerer:2.10.0:dev')
     api("com.github.GTNewHorizons:Mobs-Info:0.2.6-GTNH:dev")
+    api("com.github.GTNewHorizons:ForestryMC:4.9.3:dev")
 
     devOnlyNonPublishable("com.github.GTNewHorizons:Infernal-Mobs:1.8.1-GTNH:dev")
     runtimeOnly("com.github.GTNewHorizons:Draconic-Evolution:1.3.5-GTNH:dev") // needed?
 
     implementation('com.github.GTNewHorizons:GTNEIOrePlugin:1.3.0:dev') { transitive = false }
     implementation("com.github.GTNewHorizons:Avaritia:1.49:dev")
-    implementation("com.github.GTNewHorizons:ForestryMC:4.9.3:dev") { transitive = false }
 
     compileOnlyApi('com.github.GTNewHorizons:Angelica:1.0.0-alpha52:api') { transitive = false }
     compileOnlyApi("com.github.GTNewHorizons:AppleCore:3.3.0:dev") { transitive = false }


### PR DESCRIPTION
Currently, Forestry is depped as `implementation` - it's available at compile time and runtime for GT5u, but only available at runtime for mods depending on GT5u. However, a Forestry class is used in `gregtech.api.items.GT_MetaGenerated_Tool` - it implements `forestry.api.arboriculture.IToolGrafter` as an optional interface. This gets stripped at runtime so Forestry shouldn't be needed, but at compile time it breaks anything depending on GT5u and attempting to implement `GT_MetaGenerated_Tool`, but not depping Forestry. Moving it to an `api` dep would fix this.

If Forestry is not intended to be required at runtime, it could also be moved to `compileOnlyApi` and `runtimeOnlyNonPublishable`. I did not do this as `implementation` implies that it's intended to be a hard dep. If that is desired, uses of Forestry should also be simplified to hard deps, there's no need for the optional interfaces and such.