### PR TITLE
Allow the controller slots of multiblocks to be automated

### DIFF
--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_CircuitAssemblyLine.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_CircuitAssemblyLine.java
@@ -574,6 +574,11 @@ public class GT_TileEntity_CircuitAssemblyLine extends
     }
 
     @Override
+    protected boolean supportsSlotAutomation(int aSlot) {
+        return aSlot == getControllerSlotIndex();
+    }
+
+    @Override
     public boolean onWireCutterRightClick(ForgeDirection side, ForgeDirection wrenchingSide, EntityPlayer aPlayer,
         float aX, float aY, float aZ) {
         if (!aPlayer.isSneaking()) {

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
@@ -1822,13 +1822,13 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
     @Override
     public boolean allowPullStack(IGregTechTileEntity aBaseMetaTileEntity, int aIndex, ForgeDirection side,
         ItemStack aStack) {
-        return false;
+        return supportsSlotAutomation(aIndex);
     }
 
     @Override
     public boolean allowPutStack(IGregTechTileEntity aBaseMetaTileEntity, int aIndex, ForgeDirection side,
         ItemStack aStack) {
-        return false;
+        return supportsSlotAutomation(aIndex);
     }
 
     protected ItemStack[] getCompactedInputs() {
@@ -2088,7 +2088,16 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
     }
 
     public ItemStack getControllerSlot() {
-        return mInventory[1];
+        return mInventory[getControllerSlotIndex()];
+    }
+
+    public final int getControllerSlotIndex() {
+        return 1;
+    }
+
+    // True if the slot with index aSlot may be interacted with through automation
+    protected boolean supportsSlotAutomation(int aSlot) {
+        return false;
     }
 
     @Override

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_ProcessingArray.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_ProcessingArray.java
@@ -498,6 +498,11 @@ public class GT_MetaTileEntity_ProcessingArray extends
     }
 
     @Override
+    protected boolean supportsSlotAutomation(int aSlot) {
+        return aSlot == getControllerSlotIndex();
+    }
+
+    @Override
     public void addUIWidgets(ModularWindow.Builder builder, UIBuildContext buildContext) {
         super.addUIWidgets(builder, buildContext);
 

--- a/src/main/java/net/glease/ggfab/mte/MTE_AdvAssLine.java
+++ b/src/main/java/net/glease/ggfab/mte/MTE_AdvAssLine.java
@@ -932,6 +932,11 @@ public class MTE_AdvAssLine extends GT_MetaTileEntity_ExtendedPowerMultiBlockBas
     }
 
     @Override
+    protected boolean supportsSlotAutomation(int aSlot) {
+        return aSlot == getControllerSlotIndex();
+    }
+
+    @Override
     public void getWailaBody(ItemStack itemStack, List<String> currentTip, IWailaDataAccessor accessor,
         IWailaConfigHandler config) {
         super.getWailaBody(itemStack, currentTip, accessor, config);


### PR DESCRIPTION
This PR adds a method to the `MultiBlockBase` class that can be overridden to control which slots can be interacted with through automation (AE2, conduits, hoppers, etc). This feature is enabled for the controller slots of the PA, CAL and AAL. 

- Filling hundreds of PAs by hand is awfully tedious
- Imprinting hundreds of CALs with circuit imprints is just as bad
- People using dedicated AALs without data banks can use this to more easily insert data sticks in their AALs, though this can also be done with the automatable data hatch.