### PR TITLE
Update GT_Proxy.java to Remove Natura OreDict Restriction.

### DIFF
--- a/src/main/java/gregtech/common/GT_Proxy.java
+++ b/src/main/java/gregtech/common/GT_Proxy.java
@@ -1736,11 +1736,7 @@ public abstract class GT_Proxy implements IGT_Mod, IGuiHandler, IFuelHandler {
                 if ((aOriginalMod.toLowerCase(Locale.ENGLISH)
                     .contains("xycraft"))
                     || (aOriginalMod.toLowerCase(Locale.ENGLISH)
-                        .contains("tconstruct"))
-                    || ((aOriginalMod.toLowerCase(Locale.ENGLISH)
-                        .contains("natura"))
-                        && (!aOriginalMod.toLowerCase(Locale.ENGLISH)
-                            .contains("natural")))) {
+                        .contains("tconstruct"))) {
                     if (GT_Values.D1) {
                         GT_Log.ore.println(aMod + " -> " + aEvent.Name + " is getting ignored, because of racism. :P");
                     }


### PR DESCRIPTION
The Natura blocks and items were being restricted from entering the Gregtech OreDictionary, and this change removes that restriction. See: [Issue 7143](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/7143) for more details.