### PR TITLE
Fix random stocking hatch extraction fail

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_Input_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_Input_ME.java
@@ -207,8 +207,6 @@ public class GT_MetaTileEntity_Hatch_Input_ME extends GT_MetaTileEntity_Hatch_In
             }
 
             FluidStack fluidStackWithAmount = storedInformationFluids[i];
-            // Nothing in stock, no need to save anything
-            if (fluidStackWithAmount == null) continue;
 
             setSavedFluid(i, fluidStackWithAmount);
         }


### PR DESCRIPTION
Probably fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16267

Tested on simple DTPF catalyst mixer automation (before the commit 1-3 mixers always crashes on the craft request)
![image](https://github.com/GTNewHorizons/GT5-Unofficial/assets/53441451/e6ba1d6d-c308-4bf7-b696-427bf3d83ca7)
