### PR TITLE
Fix stocking bus division by zero

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_InputBus_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_InputBus_ME.java
@@ -319,7 +319,11 @@ public class GT_MetaTileEntity_Hatch_InputBus_ME extends GT_MetaTileEntity_Hatch
         if (autoPullAvailable) {
             setAutoPullItemList(nbt.getBoolean("autoPull"));
             minAutoPullStackSize = nbt.getInteger("minStackSize");
-            autoPullRefreshTime = nbt.getInteger("refreshTime");
+            // Data sticks created before refreshTime was implemented should not cause stocking buses to
+            // spam divide by zero errors
+            if (nbt.hasKey("refreshTime")) {
+                autoPullRefreshTime = nbt.getInteger("refreshTime");
+            }
         }
 
         additionalConnection = nbt.getBoolean("additionalConnection");


### PR DESCRIPTION
When using a data stick to load stocking bus settings that was created before the refresh timer was configurable, the stocking bus will currently happily set `autoPullRefreshTime` to 0, causing it to generate division by zero exceptions on each tick. This fix simply adds a check to see if the tag is present before setting it, meaning it will fall back to the default value of 100 ticks for these evil data sticks.

Yes this happened in game 🙃 