### PR TITLE
Add bonus for using higher tier CoAl casings

### DIFF
--- a/src/main/java/goodgenerator/blocks/tileEntity/ComponentAssemblyLine.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/ComponentAssemblyLine.java
@@ -8,6 +8,8 @@ import static gregtech.api.enums.Textures.BlockIcons.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import javax.annotation.Nonnull;
+
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -39,6 +41,7 @@ import gregtech.api.recipe.check.CheckRecipeResult;
 import gregtech.api.recipe.check.CheckRecipeResultRegistry;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GT_Multiblock_Tooltip_Builder;
+import gregtech.api.util.GT_OverclockCalculator;
 import gregtech.api.util.GT_Recipe;
 import gregtech.api.util.GT_StructureUtility;
 import gregtech.api.util.GT_Utility;
@@ -47,6 +50,7 @@ public class ComponentAssemblyLine extends GT_MetaTileEntity_ExtendedPowerMultiB
     implements ISurvivalConstructable {
 
     private int casingTier;
+    private float speedBonus;
     protected static final String STRUCTURE_PIECE_MAIN = "main";
     private static final IStructureDefinition<ComponentAssemblyLine> STRUCTURE_DEFINITION = StructureDefinition
         .<ComponentAssemblyLine>builder()
@@ -310,6 +314,13 @@ public class ComponentAssemblyLine extends GT_MetaTileEntity_ExtendedPowerMultiB
                     return CheckRecipeResultRegistry.insufficientMachineTier(recipe.mSpecialValue);
                 }
                 return CheckRecipeResultRegistry.SUCCESSFUL;
+            }
+
+            @Nonnull
+            @Override
+            protected GT_OverclockCalculator createOverclockCalculator(@Nonnull GT_Recipe recipe) {
+                speedBonus = (float) (1 / Math.pow(2, casingTier + 1 - recipe.mSpecialValue));
+                return super.createOverclockCalculator(recipe).setSpeedBoost(speedBonus);
             }
         };
     }

--- a/src/main/java/goodgenerator/blocks/tileEntity/ComponentAssemblyLine.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/ComponentAssemblyLine.java
@@ -223,6 +223,8 @@ public class ComponentAssemblyLine extends GT_MetaTileEntity_ExtendedPowerMultiB
                     + EnumChatFormatting.RESET
                     + EnumChatFormatting.GRAY
                     + "limits the recipes the machine can perform. See the NEI pages for details.")
+            .addInfo("Using casings above the required recipe tier provides a speed bonus:")
+            .addInfo(EnumChatFormatting.YELLOW + "Halves recipe time per tier above recipe")
             .addInfo(
                 "Supports " + EnumChatFormatting.BLUE
                     + "Tec"


### PR DESCRIPTION
This PR adds a speed bonus to the component assemblyline that encourages the use of higher tier casings while also helps alleviate the spam.
This bonus halves the recipe time for each tier of casing above the required recipe tier.
e.g. a uhv coal running a zpm component recipe would get a 4x speed bonus on that recipe 
(basically the same as converting 1 regular OC into a perfect OC per casing tier above required recipe tier)