### PR TITLE
Add oredict for IC2 LV and HV circuits

### DIFF
--- a/src/main/java/gregtech/loaders/preload/GT_Loader_OreDictionary.java
+++ b/src/main/java/gregtech/loaders/preload/GT_Loader_OreDictionary.java
@@ -346,8 +346,16 @@ public class GT_Loader_OreDictionary implements Runnable {
             GT_ModHandler.getModItem(NewHorizonsCoreMod.ID, "item.CircuitULV", 1L));
         GT_OreDictUnificator.registerOre(
             OrePrefixes.circuit,
+            Materials.Basic,
+            GT_ModHandler.getModItem(NewHorizonsCoreMod.ID, "item.CircuitLV", 1L));
+        GT_OreDictUnificator.registerOre(
+            OrePrefixes.circuit,
             Materials.Good,
             GT_ModHandler.getModItem(NewHorizonsCoreMod.ID, "item.CircuitMV", 1L));
+        GT_OreDictUnificator.registerOre(
+            OrePrefixes.circuit,
+            Materials.Advanced,
+            GT_ModHandler.getModItem(NewHorizonsCoreMod.ID, "item.CircuitHV", 1L));
         GT_OreDictUnificator.registerOre(
             OrePrefixes.circuit,
             Materials.Data,


### PR DESCRIPTION
Allows using the Any LV Circuit and Any HV Circuit as circuits of their respective tier. Required for https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/875 to work with these circuits.

Interestingly, IC2 intercepts the Any circuits, which causes the IC2 variants of LV and HV circuits to essentially become the Any circuit for these tiers. This is fully cosmetic with no gameplay considerations, except allowing HV players to craft Good Electronic Circuits with Microprocessors, a recipe they should not be using at that point anyways.