### PR TITLE
Fix microwave crash when gunpowder is inside

### DIFF
--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/GT_MetaTileEntity_TM_microwave.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/GT_MetaTileEntity_TM_microwave.java
@@ -187,7 +187,7 @@ public class GT_MetaTileEntity_TM_microwave extends GT_MetaTileEntity_Multiblock
                                 null,
                                 null,
                                 new ItemStack[] { ((EntityItem) entity).getEntityItem() });
-                            if (tRecipe == null || tRecipe.mInputs[0].stackSize != 1) {
+                            if (tRecipe == null || tRecipe.mInputs.length == 0 || tRecipe.mInputs[0].stackSize != 1) {
                                 itemsToOutput.add(((EntityItem) entity).getEntityItem());
                             } else {
                                 ItemStack newStuff = tRecipe.getOutput(0)


### PR DESCRIPTION
## Environment

GTNH 2.5.1
GregTech 5.09.44.110
TecTech - Tec Technology! 5.3.23

### Reproduce

1) Build Microwave

2) Spawn Creeper (easy with cursed earth)

3) Cook creeper

4) Dropped gunpowder causes...

Explosion!
![image](https://github.com/GTNewHorizons/GT5-Unofficial/assets/4434752/5afdab0c-e374-4eb3-8d86-d6cb0ddd7b2d)

![image](https://github.com/GTNewHorizons/GT5-Unofficial/assets/4434752/58cc18a8-7582-4cc1-bb04-dfa86fb57c72)

### Fix

By checking following log
![image](https://github.com/GTNewHorizons/GT5-Unofficial/assets/4434752/f0112168-6793-4185-9dab-0dc554c7870e)

I simply added guard logic for array index out of bounds.
Maybe we need more investigation for the reason why `mInputs` is empty.

### Test

Tested on my server. It is fixed