### PR TITLE
Add oredict for LV and HV circuits (try no 2)

### DIFF
--- a/src/functionalTest/java/gregtech/test/GTRecipeTest.java
+++ b/src/functionalTest/java/gregtech/test/GTRecipeTest.java
@@ -1,8 +1,6 @@
 package gregtech.test;
 
 import static gregtech.api.enums.GT_Values.RA;
-import static gregtech.api.enums.ItemList.Circuit_Advanced;
-import static gregtech.api.enums.ItemList.Circuit_Nanoprocessor;
 import static gregtech.api.enums.ItemList.Circuit_Parts_Crystal_Chip_Master;
 import static gregtech.api.enums.ItemList.IC2_LapotronCrystal;
 import static gregtech.api.enums.Materials.Advanced;
@@ -12,7 +10,6 @@ import static gregtech.api.enums.OrePrefixes.circuit;
 import static gregtech.api.enums.OrePrefixes.lens;
 import static gregtech.api.util.GT_ModHandler.getModItem;
 import static gregtech.api.util.GT_OreDictUnificator.get;
-import static gregtech.api.util.GT_OreDictUnificator.isItemStackInstanceOf;
 import static gregtech.api.util.GT_Utility.copyAmount;
 import static net.minecraft.init.Blocks.chest;
 import static net.minecraft.init.Blocks.iron_ore;
@@ -27,7 +24,6 @@ import static net.minecraftforge.oredict.OreDictionary.WILDCARD_VALUE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -223,26 +219,6 @@ class GTRecipeTest {
             .items(ItemList.Tool_DataStick.get(0))
             .find();
         assertNull(checkNBTRecipe);
-    }
-
-    @Test
-    void findOredicted() {
-        // https://github.com/GTNewHorizons/GT5-Unofficial/pull/2373
-        assertTrue(
-            isItemStackInstanceOf(Circuit_Nanoprocessor.get(1), "circuitAdvanced"),
-            "Nanoprocessor is not registered as HV circuit");
-        GT_Recipe recipeByNanoProcessor = recipeMap.findRecipeQuery()
-            .items(new ItemStack(lapis_block, 1), Circuit_Nanoprocessor.get(1))
-            .find();
-        assertNotNull(recipeByNanoProcessor);
-
-        assertTrue(
-            isItemStackInstanceOf(Circuit_Advanced.get(1), "circuitAdvanced"),
-            "Processor Assembly is not registered as HV circuit");
-        GT_Recipe recipeByCircuitAssembly = recipeMap.findRecipeQuery()
-            .items(new ItemStack(lapis_block, 1), Circuit_Advanced.get(1))
-            .find();
-        assertNotNull(recipeByCircuitAssembly);
     }
 
     @Test

--- a/src/main/java/gregtech/common/items/GT_MetaGenerated_Item_01.java
+++ b/src/main/java/gregtech/common/items/GT_MetaGenerated_Item_01.java
@@ -4187,15 +4187,6 @@ public class GT_MetaGenerated_Item_01 extends GT_MetaGenerated_Item_X32 {
             .addTo(assemblerRecipes);
         GT_Values.RA.stdBuilder()
             .itemInputs(
-                ItemList.Cover_Shutter.get(1L),
-                GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Basic, 1),
-                GT_Utility.getIntegratedCircuit(1))
-            .itemOutputs(ItemList.FluidFilter.get(1L))
-            .duration(40 * SECONDS)
-            .eut(4)
-            .addTo(assemblerRecipes);
-        GT_Values.RA.stdBuilder()
-            .itemInputs(
                 ItemList.Cover_Screen.get(1L),
                 ItemList.Cover_FluidDetector.get(1L),
                 GT_Utility.getIntegratedCircuit(1))

--- a/src/main/java/gregtech/loaders/load/GT_Loader_MetaTileEntities_Recipes.java
+++ b/src/main/java/gregtech/loaders/load/GT_Loader_MetaTileEntities_Recipes.java
@@ -6444,19 +6444,6 @@ public class GT_Loader_MetaTileEntities_Recipes implements Runnable {
                 new Object[] { "FFF", "RHR", "MCM", 'H', ItemList.Hull_HV, 'F', ItemList.Component_Filter, 'R',
                     OrePrefixes.rotor.get(Materials.StainlessSteel), 'M', ItemList.Electric_Motor_HV, 'C',
                     OrePrefixes.circuit.get(Materials.Advanced) });
-            GT_Values.RA.stdBuilder()
-                .itemInputs(
-                    ItemList.Hull_HV.get(1L),
-                    ItemList.Component_Filter.get(2L),
-                    GT_OreDictUnificator.get(OrePrefixes.rotor, Materials.StainlessSteel, 1L),
-                    ItemList.Electric_Motor_HV.get(1L),
-                    GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Advanced, 1L),
-                    GT_Utility.getIntegratedCircuit(1))
-                .itemOutputs(ItemList.Machine_Multi_Cleanroom.get(1L))
-                .fluidInputs(Materials.StainlessSteel.getMolten(864L))
-                .duration(60 * SECONDS)
-                .eut(TierEU.RECIPE_MV)
-                .addTo(assemblerRecipes);
         } else {
             if (NotEnoughItems.isModLoaded()) {
                 API.hideItem(ItemList.Machine_Multi_Cleanroom.get(1L));

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingCircuit.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingCircuit.java
@@ -4,7 +4,6 @@ import static gregtech.api.enums.Mods.GregTech;
 
 import net.minecraft.item.ItemStack;
 
-import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.util.GT_ModHandler;
@@ -25,20 +24,7 @@ public class ProcessingCircuit implements gregtech.api.interfaces.IOreRecipeRegi
                 if (!GT_OreDictUnificator.isBlacklisted(aStack) && !aModName.equals(GregTech.ID))
                     GT_ModHandler.removeRecipeByOutputDelayed(aStack);
             }
-            case "Primitive", "Advanced" -> GT_ModHandler.removeRecipeByOutputDelayed(aStack);
-            case "Basic" -> {
-                GT_ModHandler.removeRecipeByOutputDelayed(aStack);
-                GT_ModHandler.addCraftingRecipe(
-                    GT_ModHandler.getIC2Item("electronicCircuit", 1L),
-                    GT_ModHandler.RecipeBits.BUFFERED,
-                    new Object[] { "RIR", "VBV", "CCC", 'R', ItemList.Circuit_Parts_Resistor.get(1), 'C',
-                        GT_OreDictUnificator.get(OrePrefixes.cableGt01, Materials.RedAlloy, 1), 'V',
-                        ItemList.Circuit_Parts_Vacuum_Tube.get(1), 'B', ItemList.Circuit_Board_Coated_Basic.get(1), 'I',
-                        ItemList.IC2_Item_Casing_Steel.get(1) });
-                GT_ModHandler.addShapelessCraftingRecipe(
-                    GT_ModHandler.getIC2Item("electronicCircuit", 1L),
-                    new Object[] { ItemList.Circuit_Integrated.getWildcard(1L) });
-            }
+            case "Primitive", "Basic", "Advanced" -> GT_ModHandler.removeRecipeByOutputDelayed(aStack);
         }
     }
 }

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingCircuit.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingCircuit.java
@@ -29,7 +29,7 @@ public class ProcessingCircuit implements gregtech.api.interfaces.IOreRecipeRegi
             case "Basic" -> {
                 GT_ModHandler.removeRecipeByOutputDelayed(aStack);
                 GT_ModHandler.addCraftingRecipe(
-                    aStack,
+                    GT_ModHandler.getIC2Item("electronicCircuit", 1L),
                     GT_ModHandler.RecipeBits.BUFFERED,
                     new Object[] { "RIR", "VBV", "CCC", 'R', ItemList.Circuit_Parts_Resistor.get(1), 'C',
                         GT_OreDictUnificator.get(OrePrefixes.cableGt01, Materials.RedAlloy, 1), 'V',

--- a/src/main/java/gregtech/loaders/postload/GT_CraftingRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/postload/GT_CraftingRecipeLoader.java
@@ -2047,5 +2047,15 @@ public class GT_CraftingRecipeLoader implements Runnable {
                     new Object[] { "s ", " P", 'P', slabWoodFireproof });
             }
         }
+        GT_ModHandler.addCraftingRecipe(
+            GT_ModHandler.getIC2Item("electronicCircuit", 1L),
+            GT_ModHandler.RecipeBits.BUFFERED,
+            new Object[] { "RIR", "VBV", "CCC", 'R', ItemList.Circuit_Parts_Resistor.get(1), 'C',
+                GT_OreDictUnificator.get(OrePrefixes.cableGt01, Materials.RedAlloy, 1), 'V',
+                ItemList.Circuit_Parts_Vacuum_Tube.get(1), 'B', ItemList.Circuit_Board_Coated_Basic.get(1), 'I',
+                ItemList.IC2_Item_Casing_Steel.get(1) });
+        GT_ModHandler.addShapelessCraftingRecipe(
+            GT_ModHandler.getIC2Item("electronicCircuit", 1L),
+            new Object[] { ItemList.Circuit_Integrated.getWildcard(1L) });
     }
 }

--- a/src/main/java/gregtech/loaders/postload/recipes/AssemblerRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/AssemblerRecipes.java
@@ -84,6 +84,16 @@ public class AssemblerRecipes implements Runnable {
 
         GT_Values.RA.stdBuilder()
             .itemInputs(
+                ItemList.Cover_Shutter.get(1L),
+                GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Basic, 1),
+                GT_Utility.getIntegratedCircuit(1))
+            .itemOutputs(ItemList.FluidFilter.get(1L))
+            .duration(40 * SECONDS)
+            .eut(4)
+            .addTo(assemblerRecipes);
+
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
                 GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1),
                 GT_Utility.getIntegratedCircuit(2))
             .itemOutputs(ItemList.FR_Stick.get(1L))

--- a/src/main/java/gregtech/loaders/postload/recipes/AssemblerRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/AssemblerRecipes.java
@@ -65,6 +65,23 @@ public class AssemblerRecipes implements Runnable {
         this.loadOutputHatchesRecipes();
         this.withIC2NuclearControl();
 
+        // If Cleanroom is enabled, add an assembler recipe
+        if (GT_Mod.gregtechproxy.mEnableCleanroom) {
+            GT_Values.RA.stdBuilder()
+                .itemInputs(
+                    ItemList.Hull_HV.get(1L),
+                    ItemList.Component_Filter.get(2L),
+                    GT_OreDictUnificator.get(OrePrefixes.rotor, Materials.StainlessSteel, 1L),
+                    ItemList.Electric_Motor_HV.get(1L),
+                    GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Advanced, 1L),
+                    GT_Utility.getIntegratedCircuit(1))
+                .itemOutputs(ItemList.Machine_Multi_Cleanroom.get(1L))
+                .fluidInputs(Materials.StainlessSteel.getMolten(864L))
+                .duration(60 * SECONDS)
+                .eut(TierEU.RECIPE_MV)
+                .addTo(assemblerRecipes);
+        }
+
         GT_Values.RA.stdBuilder()
             .itemInputs(
                 GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1),

--- a/src/main/java/gregtech/loaders/preload/GT_Loader_OreDictionary.java
+++ b/src/main/java/gregtech/loaders/preload/GT_Loader_OreDictionary.java
@@ -268,6 +268,8 @@ public class GT_Loader_OreDictionary implements Runnable {
         GT_OreDictUnificator.registerOre(OreDictNames.craftingBook, new ItemStack(Items.written_book, 1, 32767));
         GT_OreDictUnificator.registerOre(OreDictNames.craftingBook, new ItemStack(Items.enchanted_book, 1, 32767));
 
+        GT_OreDictUnificator.addToBlacklist(GT_ModHandler.getIC2Item("electronicCircuit", 1L));
+        GT_OreDictUnificator.addToBlacklist(GT_ModHandler.getIC2Item("advancedCircuit", 1L));
         GT_OreDictUnificator
             .registerOre(OrePrefixes.circuit, Materials.Basic, GT_ModHandler.getIC2Item("electronicCircuit", 1L));
         GT_OreDictUnificator
@@ -346,8 +348,16 @@ public class GT_Loader_OreDictionary implements Runnable {
             GT_ModHandler.getModItem(NewHorizonsCoreMod.ID, "item.CircuitULV", 1L));
         GT_OreDictUnificator.registerOre(
             OrePrefixes.circuit,
+            Materials.Basic,
+            GT_ModHandler.getModItem(NewHorizonsCoreMod.ID, "item.CircuitLV", 1L));
+        GT_OreDictUnificator.registerOre(
+            OrePrefixes.circuit,
             Materials.Good,
             GT_ModHandler.getModItem(NewHorizonsCoreMod.ID, "item.CircuitMV", 1L));
+        GT_OreDictUnificator.registerOre(
+            OrePrefixes.circuit,
+            Materials.Advanced,
+            GT_ModHandler.getModItem(NewHorizonsCoreMod.ID, "item.CircuitHV", 1L));
         GT_OreDictUnificator.registerOre(
             OrePrefixes.circuit,
             Materials.Data,

--- a/src/main/java/gtPlusPlus/core/recipe/RECIPES_Machines.java
+++ b/src/main/java/gtPlusPlus/core/recipe/RECIPES_Machines.java
@@ -759,8 +759,8 @@ public class RECIPES_Machines {
         CORE.RA.addSixSlotAssemblingRecipe(
             new ItemStack[] { ItemUtils.getSimpleStack(CI.robotArm_LV, 4 * (1)),
                 ItemList.Cover_Controller.get(1, CI.electricMotor_MV), CI.machineHull_MV,
-                ItemUtils.getItemStackOfAmountFromOreDict(CI.getTieredCircuitOreDictName(1), 2),
-                ItemUtils.getItemStackOfAmountFromOreDict(CI.getTieredCircuitOreDictName(2), 2) },
+                GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Basic, 2),
+                GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Good, 2) },
             ELEMENT.getInstance().IRON.getFluidStack(144 * 4),
             ItemUtils.getSimpleStack(ModBlocks.blockCircuitProgrammer),
             60 * 10 * 1,
@@ -790,7 +790,7 @@ public class RECIPES_Machines {
 
         // Super Jukebox
         CORE.RA.addSixSlotAssemblingRecipe(
-            new ItemStack[] { CI.machineHull_LV, ItemUtils.getItemStackOfAmountFromOreDict("circuitBasic", 4),
+            new ItemStack[] { CI.machineHull_LV, GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Basic, 4),
                 ItemUtils.getItemStackOfAmountFromOreDict("plateTumbaga", 8),
                 ItemUtils.getSimpleStack(Blocks.jukebox) },
             ELEMENT.getInstance().COPPER.getFluidStack(144 * 2),


### PR DESCRIPTION
second try of https://github.com/GTNewHorizons/GT5-Unofficial/pull/2675

note that:
- ~~this will need a bunch of fixes of not properly oredicted recipe inputs (just taking ic2 lv or hv circuit and not all of the variants like we want most of the time). most of these are in the nhcoremod scripts.~~ Done. a few here, including moving recipes to overcome load order problems. The rest is in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/877.
- this fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/11488 as it resolves the recipe conflict!
- ~~the unit test only fails because its stupid. It would fail before already for any tier but HV or LV. that is because the any circuits are in coremod and not available.~~ resolved. the unit test is gone now.

now ready for review.