### PR TITLE
make crop tooltip appropriate

### DIFF
--- a/src/main/java/gregtech/common/items/GT_MetaGenerated_Item_02.java
+++ b/src/main/java/gregtech/common/items/GT_MetaGenerated_Item_02.java
@@ -2172,7 +2172,7 @@ public class GT_MetaGenerated_Item_02 extends GT_MetaGenerated_Item_X32 {
             addItem(
                 Crop_Drop_Rape.ID,
                 "Rape",
-                "Time to oil up!",
+                "Also known as Canola.",
                 new TC_Aspects.TC_AspectStack(TC_Aspects.MESSIS, 1L),
                 new TC_Aspects.TC_AspectStack(TC_Aspects.HERBA, 1L),
                 new TC_Aspects.TC_AspectStack(TC_Aspects.POTENTIA, 1L)));


### PR DESCRIPTION
Maybe it is not easily possible to rename the crop, but at least this messed up 'joke' should not be a thing in GTNH.