### PR TITLE
Microoptimizations for GT_MetaTileEntity_BasicTank.onPreTick

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicTank.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicTank.java
@@ -164,21 +164,27 @@ public abstract class GT_MetaTileEntity_BasicTank extends GT_MetaTileEntity_Tier
     @Override
     public void onPreTick(IGregTechTileEntity aBaseMetaTileEntity, long aTick) {
         if (aBaseMetaTileEntity.isServerSide()) {
-            if (isFluidChangingAllowed() && getFillableStack() != null && getFillableStack().amount <= 0)
+            if (isFluidChangingAllowed() && getFillableStack() != null && getFillableStack().amount <= 0) {
                 setFillableStack(null);
+            }
+
+            final int inputSlot = getInputSlot();
+            if (mInventory[inputSlot] == null) {
+                return;
+            }
 
             if (doesEmptyContainers()) {
-                FluidStack tFluid = GT_Utility.getFluidForFilledItem(mInventory[getInputSlot()], true);
+                FluidStack tFluid = GT_Utility.getFluidForFilledItem(mInventory[inputSlot], true);
                 if (tFluid != null && isFluidInputAllowed(tFluid)) {
                     if (getFillableStack() == null) {
                         if (isFluidInputAllowed(tFluid) && tFluid.amount <= getCapacity()) {
                             if (aBaseMetaTileEntity.addStackToSlot(
                                 getOutputSlot(),
-                                GT_Utility.getContainerForFilledItem(mInventory[getInputSlot()], true),
+                                GT_Utility.getContainerForFilledItem(mInventory[inputSlot], true),
                                 1)) {
                                 setFillableStack(tFluid.copy());
                                 this.onEmptyingContainerWhenEmpty();
-                                aBaseMetaTileEntity.decrStackSize(getInputSlot(), 1);
+                                aBaseMetaTileEntity.decrStackSize(inputSlot, 1);
                             }
                         }
                     } else {
@@ -186,10 +192,10 @@ public abstract class GT_MetaTileEntity_BasicTank extends GT_MetaTileEntity_Tier
                             && ((long) tFluid.amount + getFillableStack().amount) <= (long) getCapacity()) {
                             if (aBaseMetaTileEntity.addStackToSlot(
                                 getOutputSlot(),
-                                GT_Utility.getContainerForFilledItem(mInventory[getInputSlot()], true),
+                                GT_Utility.getContainerForFilledItem(mInventory[inputSlot], true),
                                 1)) {
                                 getFillableStack().amount += tFluid.amount;
-                                aBaseMetaTileEntity.decrStackSize(getInputSlot(), 1);
+                                aBaseMetaTileEntity.decrStackSize(inputSlot, 1);
                             }
                         }
                     }
@@ -198,10 +204,10 @@ public abstract class GT_MetaTileEntity_BasicTank extends GT_MetaTileEntity_Tier
 
             if (doesFillContainers()) {
                 ItemStack tOutput = GT_Utility
-                    .fillFluidContainer(getDrainableStack(), mInventory[getInputSlot()], false, true);
+                    .fillFluidContainer(getDrainableStack(), mInventory[inputSlot], false, true);
                 if (tOutput != null && aBaseMetaTileEntity.addStackToSlot(getOutputSlot(), tOutput, 1)) {
                     FluidStack tFluid = GT_Utility.getFluidForFilledItem(tOutput, true);
-                    aBaseMetaTileEntity.decrStackSize(getInputSlot(), 1);
+                    aBaseMetaTileEntity.decrStackSize(inputSlot, 1);
                     if (tFluid != null) getDrainableStack().amount -= tFluid.amount;
                     if (getDrainableStack().amount <= 0 && isFluidChangingAllowed()) setDrainableStack(null);
                 }


### PR DESCRIPTION
Cache the input slot number in the method and do an early exit if there is no item in that slot.
Based on a spark profile from discord.