### PR TITLE
Remove gangue dust

### DIFF
--- a/src/main/java/com/elisis/gtnhlanth/common/register/WerkstoffMaterialPool.java
+++ b/src/main/java/com/elisis/gtnhlanth/common/register/WerkstoffMaterialPool.java
@@ -680,16 +680,6 @@ public class WerkstoffMaterialPool implements Runnable {
         offsetID2 + 8,
         TextureSet.SET_DULL);
 
-    public static final Werkstoff Gangue = new Werkstoff(
-        new short[] { 0, 0, 0 },
-        "Gangue",
-        subscriptNumbers("Useless..."),
-        new Werkstoff.Stats(),
-        Werkstoff.Types.MIXTURE,
-        new Werkstoff.GenerationFeatures().disable()
-            .onlyDust(),
-        offsetID2 + 9,
-        TextureSet.SET_DULL);
     // TODO: Deal with colouring
     public static final Werkstoff RoastedRareEarthOxides = new Werkstoff(
         new short[] { 160, 82, 45 },

--- a/src/main/java/com/elisis/gtnhlanth/loader/RecipeLoader.java
+++ b/src/main/java/com/elisis/gtnhlanth/loader/RecipeLoader.java
@@ -807,7 +807,6 @@ public class RecipeLoader {
                 WerkstoffMaterialPool.ConditionedBastnasiteMud.getFluidOrGas(1000))
             .itemInputs(Materials.Saltpeter.getDust(1))
             .fluidOutputs(WerkstoffMaterialPool.DiltedRareEarthBastnasiteMud.getFluidOrGas(11000))
-            .itemOutputs(WerkstoffMaterialPool.Gangue.get(OrePrefixes.dust, 1))
             .eut(1920)
             .duration(1000)
             .specialValue(10)
@@ -1011,7 +1010,7 @@ public class RecipeLoader {
             null,
             Materials.Samarium.getDust(1),
             WerkstoffLoader.Thorianit.get(OrePrefixes.dust, 2),
-            WerkstoffMaterialPool.Gangue.get(OrePrefixes.dust, 4),
+            null,
             null,
             null,
             null,
@@ -2625,7 +2624,7 @@ public class RecipeLoader {
             114);
         GT_Values.RA.stdBuilder()
             .itemInputs(DephosphatedSamariumConcentrate.get(OrePrefixes.dust, 1))
-            .itemOutputs(SamariumOxide.get(OrePrefixes.dust, 1), Gangue.get(OrePrefixes.dust, 1))
+            .itemOutputs(SamariumOxide.get(OrePrefixes.dust, 1))
             .specialValue(1200)
             .eut(514)
             .duration(2 * SECONDS)
@@ -2636,7 +2635,7 @@ public class RecipeLoader {
         // null,
         // null,
         // SamariumOxide.get(OrePrefixes.dust, 1),
-        // Gangue.get(OrePrefixes.dust, 1),
+        // null,
         // 40,
         // 514,
         // 1200);


### PR DESCRIPTION
Gangue is an output from the bastline with actual zero uses. Even the tooltip admits it's worthless. 