### PR TITLE
Fix tooltips and other typos in steam multis

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/GregtechMetaTileEntity_SteamCentrifuge.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/GregtechMetaTileEntity_SteamCentrifuge.java
@@ -163,7 +163,7 @@ public class GregtechMetaTileEntity_SteamCentrifuge
         currenttip.add(
             StatCollector.translateToLocal("GT5U.multiblock.curparallelism") + ": "
                 + EnumChatFormatting.BLUE
-                + tag.getInteger("paralell")
+                + tag.getInteger("parallel")
                 + EnumChatFormatting.RESET);
     }
 
@@ -172,7 +172,7 @@ public class GregtechMetaTileEntity_SteamCentrifuge
         int z) {
         super.getWailaNBTData(player, tile, tag, world, x, y, z);
         tag.setInteger("tierMachine", tierMachine);
-        tag.setInteger("paralell", getMaxParallelRecipes());
+        tag.setInteger("parallel", getMaxParallelRecipes());
     }
 
     @Override
@@ -346,8 +346,11 @@ public class GregtechMetaTileEntity_SteamCentrifuge
         tt.addMachineType(getMachineType())
             .addInfo("Controller Block for the Steam Centrifuge")
             .addInfo("Runs recipes up to MV tier")
-            .addInfo("Centrifuges up to Tier 1 - 8 and Tier 2 - 16 things at a time")
-            .addInfo("Multi consumes x2 amount of steam on Tier 2")
+            .addInfo("33.3% faster than a single block steam machine would run.")
+            .addInfo(
+                "On Tier 1, it uses only 66.6% of the steam/s required compared to what a single block steam machine would use.")
+            .addInfo("The steam consumption doubles from Tier 1 to Tier 2.")
+            .addInfo("Centrifuges up to 8 x Tier things at a time.")
             .addSeparator()
             .beginStructureBlock(5, 5, 5, false)
             .addCasingInfoMin(tMachineCasing, 60, false)

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/GregtechMetaTileEntity_SteamCompressor.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/GregtechMetaTileEntity_SteamCompressor.java
@@ -1,7 +1,9 @@
 package gtPlusPlus.xmod.gregtech.common.tileentities.machines.multi.processing.steam;
 
-import static com.gtnewhorizon.structurelib.structure.StructureUtility.*;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofBlocksTiered;
+import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofChain;
+import static com.gtnewhorizon.structurelib.structure.StructureUtility.transpose;
+import static com.gtnewhorizon.structurelib.structure.StructureUtility.withChannel;
 import static gregtech.api.GregTech_API.sBlockCasings1;
 import static gregtech.api.GregTech_API.sBlockCasings2;
 import static gregtech.api.util.GT_StructureUtility.buildHatchAdder;
@@ -102,8 +104,8 @@ public class GregtechMetaTileEntity_SteamCompressor
             .addInfo("Controller Block for the Steam Compressor")
             .addInfo("33.3% faster than using a single block Steam Compressor.")
             .addInfo("Uses only 66.6% of the steam/s compared to a single block Steam Compressor.")
-            .addInfo("Compresses up to Tier 1 - 8 and Tier 2 - 16 things at a time")
-            .addInfo("Multi consumes x2 amount of steam on Tier 2")
+            .addInfo("The steam consumption doubles from Tier 1 to Tier 2.")
+            .addInfo("Compresses up to 8 x Tier things at a time.")
             .addSeparator()
             .beginStructureBlock(3, 3, 4, true)
             .addController("Front center")
@@ -247,7 +249,7 @@ public class GregtechMetaTileEntity_SteamCompressor
         currenttip.add(
             StatCollector.translateToLocal("GT5U.multiblock.curparallelism") + ": "
                 + EnumChatFormatting.BLUE
-                + tag.getInteger("paralell")
+                + tag.getInteger("parallel")
                 + EnumChatFormatting.RESET);
     }
 
@@ -256,7 +258,7 @@ public class GregtechMetaTileEntity_SteamCompressor
         int z) {
         super.getWailaNBTData(player, tile, tag, world, x, y, z);
         tag.setInteger("tierMachine", tierMachine);
-        tag.setInteger("paralell", getMaxParallelRecipes());
+        tag.setInteger("parallel", getMaxParallelRecipes());
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/GregtechMetaTileEntity_SteamMacerator.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/GregtechMetaTileEntity_SteamMacerator.java
@@ -1,7 +1,9 @@
 package gtPlusPlus.xmod.gregtech.common.tileentities.machines.multi.processing.steam;
 
-import static com.gtnewhorizon.structurelib.structure.StructureUtility.*;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofBlocksTiered;
+import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofChain;
+import static com.gtnewhorizon.structurelib.structure.StructureUtility.transpose;
+import static com.gtnewhorizon.structurelib.structure.StructureUtility.withChannel;
 import static gregtech.api.GregTech_API.sBlockCasings1;
 import static gregtech.api.GregTech_API.sBlockCasings2;
 import static gregtech.api.util.GT_StructureUtility.buildHatchAdder;
@@ -106,9 +108,9 @@ public class GregtechMetaTileEntity_SteamMacerator
         tt.addMachineType(getMachineType())
             .addInfo("Controller Block for the Steam Macerator")
             .addInfo("33.3% faster than using a single block Steam Macerator.")
-            .addInfo("Uses only 66.6% of the steam/s required compared to a single block Steam Macerator.")
-            .addInfo("Compresses up to Tier 1 - 8 and Tier 2 - 16 things at a time")
-            .addInfo("Multi consumes x2 amount of steam on Tier 2")
+            .addInfo("Uses only 66.6% of the steam/s required compared to a single block Steam Macerator on Tier 1.")
+            .addInfo("The steam consumption doubles from Tier 1 to Tier 2.")
+            .addInfo("Macerates up to 8 x Tier things at a time.")
             .addSeparator()
             .beginStructureBlock(3, 3, 3, true)
             .addController("Front center")
@@ -212,8 +214,6 @@ public class GregtechMetaTileEntity_SteamMacerator
         return RecipeMaps.maceratorRecipes;
     }
 
-    // note that a basic steam machine has .setEUtDiscount(2F).setSpeedBoost(2F). So these are bonuses.
-
     @Override
     public int getItemOutputLimit() {
         return 1;
@@ -223,6 +223,7 @@ public class GregtechMetaTileEntity_SteamMacerator
     protected ProcessingLogic createProcessingLogic() {
         return new ProcessingLogic() {
 
+            // note that a basic steam machine has .setEUtDiscount(2F).setSpeedBoost(2F). So these here are bonuses.
             @Override
             @Nonnull
             protected GT_OverclockCalculator createOverclockCalculator(@NotNull GT_Recipe recipe) {
@@ -257,7 +258,7 @@ public class GregtechMetaTileEntity_SteamMacerator
         currenttip.add(
             StatCollector.translateToLocal("GT5U.multiblock.curparallelism") + ": "
                 + EnumChatFormatting.BLUE
-                + tag.getInteger("paralell")
+                + tag.getInteger("parallel")
                 + EnumChatFormatting.RESET);
     }
 
@@ -266,7 +267,7 @@ public class GregtechMetaTileEntity_SteamMacerator
         int z) {
         super.getWailaNBTData(player, tile, tag, world, x, y, z);
         tag.setInteger("tierMachine", tierMachine);
-        tag.setInteger("paralell", getMaxParallelRecipes());
+        tag.setInteger("parallel", getMaxParallelRecipes());
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/GregtechMetaTileEntity_SteamWasher.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/GregtechMetaTileEntity_SteamWasher.java
@@ -167,7 +167,7 @@ public class GregtechMetaTileEntity_SteamWasher extends GregtechMeta_SteamMultiB
         currenttip.add(
             StatCollector.translateToLocal("GT5U.multiblock.curparallelism") + ": "
                 + EnumChatFormatting.BLUE
-                + tag.getInteger("paralell")
+                + tag.getInteger("parallel")
                 + EnumChatFormatting.RESET);
     }
 
@@ -176,7 +176,7 @@ public class GregtechMetaTileEntity_SteamWasher extends GregtechMeta_SteamMultiB
         int z) {
         super.getWailaNBTData(player, tile, tag, world, x, y, z);
         tag.setInteger("tierMachine", tierMachine);
-        tag.setInteger("paralell", getMaxParallelRecipes());
+        tag.setInteger("parallel", getMaxParallelRecipes());
     }
 
     public boolean checkMachine(IGregTechTileEntity aBaseMetaTileEntity, ItemStack aStack) {
@@ -347,8 +347,11 @@ public class GregtechMetaTileEntity_SteamWasher extends GregtechMeta_SteamMultiB
         tt.addMachineType(getMachineType())
             .addInfo("Controller Block for the Steam Washer")
             .addInfo("Runs recipes up to LV tier")
-            .addInfo("Washing up to Tier 1 - 8 and Tier 2 - 16 things at a time")
-            .addInfo("Multi consumes x2 amount of steam on Tier 2")
+            .addInfo("33.3% faster than a single block steam machine would run.")
+            .addInfo(
+                "On Tier 1, it uses only 66.6% of the steam/s required compared to what a single block steam machine would use.")
+            .addInfo("The steam consumption doubles from Tier 1 to Tier 2.")
+            .addInfo("Washes up to 8 x Tier things at a time.")
             .addSeparator()
             .beginStructureBlock(5, 5, 9, false)
             .addCasingInfoMin(tMachineCasing, 55, false)


### PR DESCRIPTION
The existing steam multis were sneak-changed to a new 2 tier system when the steam centrifuge and washer were added. Some minor mistakes were introduced in the process.

This PR fixes these minor mistakes (contradictory tooltip on steam usage, typo for parallel, the macerator now compressing).

Additionally this adds the discount information to the new multis were it was just missing and fixes the same issues there.


Remark: The new steel tier seems terrible. Nobody is going to make that. Making it 2x less efficient was a really bad idea and should probably be changed. But not in the PR, this is just a fix without balance aspects.
