### PR TITLE
Remove malus for steel variant of steam multiblocks

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/GregtechMetaTileEntity_SteamCentrifuge.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/GregtechMetaTileEntity_SteamCentrifuge.java
@@ -334,7 +334,7 @@ public class GregtechMetaTileEntity_SteamCentrifuge
             @Nonnull
             protected GT_OverclockCalculator createOverclockCalculator(@NotNull GT_Recipe recipe) {
                 return GT_OverclockCalculator.ofNoOverclock(recipe)
-                    .setEUtDiscount(1.33F * tierMachine)
+                    .setEUtDiscount(1.33F)
                     .setSpeedBoost(1.5F);
             }
         }.setMaxParallelSupplier(this::getMaxParallelRecipes);
@@ -349,7 +349,6 @@ public class GregtechMetaTileEntity_SteamCentrifuge
             .addInfo("33.3% faster than a single block steam machine would run.")
             .addInfo(
                 "On Tier 1, it uses only 66.6% of the steam/s required compared to what a single block steam machine would use.")
-            .addInfo("The steam consumption doubles from Tier 1 to Tier 2.")
             .addInfo("Centrifuges up to 8 x Tier things at a time.")
             .addSeparator()
             .beginStructureBlock(5, 5, 5, false)

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/GregtechMetaTileEntity_SteamCompressor.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/GregtechMetaTileEntity_SteamCompressor.java
@@ -104,7 +104,6 @@ public class GregtechMetaTileEntity_SteamCompressor
             .addInfo("Controller Block for the Steam Compressor")
             .addInfo("33.3% faster than using a single block Steam Compressor.")
             .addInfo("Uses only 66.6% of the steam/s compared to a single block Steam Compressor.")
-            .addInfo("The steam consumption doubles from Tier 1 to Tier 2.")
             .addInfo("Compresses up to 8 x Tier things at a time.")
             .addSeparator()
             .beginStructureBlock(3, 3, 4, true)
@@ -219,7 +218,7 @@ public class GregtechMetaTileEntity_SteamCompressor
             @Nonnull
             protected GT_OverclockCalculator createOverclockCalculator(@NotNull GT_Recipe recipe) {
                 return GT_OverclockCalculator.ofNoOverclock(recipe)
-                    .setEUtDiscount(1.33F * tierMachine)
+                    .setEUtDiscount(1.33F)
                     .setSpeedBoost(1.5F);
             }
         }.setMaxParallelSupplier(this::getMaxParallelRecipes);

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/GregtechMetaTileEntity_SteamMacerator.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/GregtechMetaTileEntity_SteamMacerator.java
@@ -109,7 +109,6 @@ public class GregtechMetaTileEntity_SteamMacerator
             .addInfo("Controller Block for the Steam Macerator")
             .addInfo("33.3% faster than using a single block Steam Macerator.")
             .addInfo("Uses only 66.6% of the steam/s required compared to a single block Steam Macerator on Tier 1.")
-            .addInfo("The steam consumption doubles from Tier 1 to Tier 2.")
             .addInfo("Macerates up to 8 x Tier things at a time.")
             .addSeparator()
             .beginStructureBlock(3, 3, 3, true)
@@ -228,7 +227,7 @@ public class GregtechMetaTileEntity_SteamMacerator
             @Nonnull
             protected GT_OverclockCalculator createOverclockCalculator(@NotNull GT_Recipe recipe) {
                 return GT_OverclockCalculator.ofNoOverclock(recipe)
-                    .setEUtDiscount(1.33F * tierMachine)
+                    .setEUtDiscount(1.33F)
                     .setSpeedBoost(1.5F);
             }
         }.setMaxParallelSupplier(this::getMaxParallelRecipes);

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/GregtechMetaTileEntity_SteamWasher.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/GregtechMetaTileEntity_SteamWasher.java
@@ -335,7 +335,7 @@ public class GregtechMetaTileEntity_SteamWasher extends GregtechMeta_SteamMultiB
             @Nonnull
             protected GT_OverclockCalculator createOverclockCalculator(@NotNull GT_Recipe recipe) {
                 return GT_OverclockCalculator.ofNoOverclock(recipe)
-                    .setEUtDiscount(1.33F * tierMachine)
+                    .setEUtDiscount(1.33F)
                     .setSpeedBoost(1.5F);
             }
         }.setMaxParallelSupplier(this::getMaxParallelRecipes);
@@ -350,7 +350,6 @@ public class GregtechMetaTileEntity_SteamWasher extends GregtechMeta_SteamMultiB
             .addInfo("33.3% faster than a single block steam machine would run.")
             .addInfo(
                 "On Tier 1, it uses only 66.6% of the steam/s required compared to what a single block steam machine would use.")
-            .addInfo("The steam consumption doubles from Tier 1 to Tier 2.")
             .addInfo("Washes up to 8 x Tier things at a time.")
             .addSeparator()
             .beginStructureBlock(5, 5, 9, false)


### PR DESCRIPTION
This is regarding the new steel variants of the old and new steam multiblocks.

They are quite expensive pre-MV and absolutely not worth it with such an extra malus that made them 2x less efficient than their bronze counterparts.

So this just remove that malus. As discussed in the beta-testing channel.