### PR TITLE
fix used spray can behavior id

### DIFF
--- a/src/main/java/gregtech/common/items/GT_MetaGenerated_Item_01.java
+++ b/src/main/java/gregtech/common/items/GT_MetaGenerated_Item_01.java
@@ -5086,7 +5086,7 @@ public class GT_MetaGenerated_Item_01 extends GT_MetaGenerated_Item_X32 {
                 512L,
                 i);
             addItemBehavior(32000 + Spray_Colors[i], behaviourSprayColor);
-            addItemBehavior(32001 + Spray_Colors_Used[i], behaviourSprayColor);
+            addItemBehavior(32000 + Spray_Colors_Used[i], behaviourSprayColor);
         }
     }
 


### PR DESCRIPTION
IDs are now precalculated, previously this was <offset> + lastID