### PR TITLE
Add an alias to SP_Command

### DIFF
--- a/src/main/java/gregtech/GT_Mod.java
+++ b/src/main/java/gregtech/GT_Mod.java
@@ -85,6 +85,7 @@ import gregtech.common.entities.GT_Entity_Arrow_Potion;
 import gregtech.common.misc.GT_Command;
 import gregtech.common.misc.spaceprojects.commands.SPM_Command;
 import gregtech.common.misc.spaceprojects.commands.SP_Command;
+import gregtech.common.misc.spaceprojects.commands.SpaceProject_Command;
 import gregtech.common.tileentities.machines.GT_MetaTileEntity_Hatch_CraftingInput_ME;
 import gregtech.common.tileentities.storage.GT_MetaTileEntity_DigitalChestBase;
 import gregtech.crossmod.holoinventory.HoloInventory;
@@ -756,6 +757,7 @@ public class GT_Mod implements IGT_Mod {
         aEvent.registerServerCommand(new GT_Command());
         aEvent.registerServerCommand(new SP_Command());
         aEvent.registerServerCommand(new SPM_Command());
+        aEvent.registerServerCommand(new SpaceProject_Command());
         // Sets a new Machine Block Update Thread everytime a world is loaded
         GT_Runnable_MachineBlockUpdate.initExecutorService();
     }

--- a/src/main/java/gregtech/common/misc/spaceprojects/commands/SpaceProject_Command.java
+++ b/src/main/java/gregtech/common/misc/spaceprojects/commands/SpaceProject_Command.java
@@ -1,0 +1,9 @@
+package gregtech.common.misc.spaceprojects.commands;
+
+public class SpaceProject_Command extends SP_Command {
+
+    @Override
+    public String getCommandName() {
+        return "spaceproject";
+    }
+}


### PR DESCRIPTION
fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16275

Allows the played to use `/spaceproject` as a substitute for `/sp`