### PR TITLE
Large boiler overhaul for super fuel

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeBoiler_Titanium.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeBoiler_Titanium.java
@@ -76,7 +76,7 @@ public class GT_MetaTileEntity_LargeBoiler_Titanium extends GT_MetaTileEntity_La
 
     @Override
     public int getEUt() {
-        return 4000;
+        return 64000;
     }
 
     @Override

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeBoiler_TungstenSteel.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeBoiler_TungstenSteel.java
@@ -76,7 +76,7 @@ public class GT_MetaTileEntity_LargeBoiler_TungstenSteel extends GT_MetaTileEnti
 
     @Override
     public int getEUt() {
-        return 16000;
+        return 256000;
     }
 
     @Override

--- a/src/main/java/gregtech/loaders/load/GT_Loader_MetaTileEntities_Recipes.java
+++ b/src/main/java/gregtech/loaders/load/GT_Loader_MetaTileEntities_Recipes.java
@@ -6045,12 +6045,12 @@ public class GT_Loader_MetaTileEntities_Recipes implements Runnable {
             ItemList.Machine_Multi_LargeBoiler_Titanium.get(1L),
             bitsd,
             new Object[] { aTextWireCoil, aTextCableHull, aTextWireCoil, 'M', ItemList.Casing_Firebox_Titanium, 'C',
-                OrePrefixes.circuit.get(Materials.Data), 'W', OrePrefixes.cableGt01.get(Materials.Gold) });
+                OrePrefixes.circuit.get(Materials.Elite), 'W', OrePrefixes.cableGt01.get(Materials.Gold) });
         GT_ModHandler.addCraftingRecipe(
             ItemList.Machine_Multi_LargeBoiler_TungstenSteel.get(1L),
             bitsd,
             new Object[] { aTextWireCoil, aTextCableHull, aTextWireCoil, 'M', ItemList.Casing_Firebox_TungstenSteel,
-                'C', OrePrefixes.circuit.get(Materials.Elite), 'W', OrePrefixes.cableGt01.get(Materials.Aluminium) });
+                'C', OrePrefixes.circuit.get(Materials.Master), 'W', OrePrefixes.cableGt01.get(Materials.Aluminium) });
 
         GT_ModHandler.addCraftingRecipe(
             ItemList.Generator_Diesel_LV.get(1L),


### PR DESCRIPTION
This PR is for adjusting the way the large titanium and tungensteel superheated steam output amount.

It also pushes the boilers to the later portion of the tier.

The circuits the titanium boiler has gone from ev to luv 
Circuits for tungensteel boiler from iv to zpm

The reasoning for circuit change is that the circuits match the power output while also always are at the lastest for the tier which remains the same as the large bronze and large steel boilers.

The power output has been increased by 16 times since the casings are two tiers higher to match the same as the large bronze and large steel boilers.

Numbers below:

Large bronze

mv tier circuits, steam tier plating = 400 eu or 1.9 times mv

Large steel

hv tier circuits, lv tier plating = 1000 eu or 1.9 times hv

large titanium current

ev tier circuits, ev tier plating = 4000 eu or 1.9 times ev
53,333l/s
New : 64,000eu or 1.9 times luv
853,328l/s
large tungensteel current
iv tier circuits, iv tier plating = 16000 eu or 1.9 tier iv
53,333l/s Superheated steam
new: 256,000 eu or 1.9 times zpm
3,413,328 l/s superheated steam

This would remain in step with the logical power increment for large boilers and the fuel input would still be acceptable at 1 super magic fuel per 0.875 seconds. Players can also reduce boiler rates with circuits.

Source for more info
Effiency numbers: https://discord.com/channels/181078474394566657/1257220321979797514/1257220321979797514

Large boiler changes: https://discord.com/channels/181078474394566657/603348502637969419/1257909269794390106