### PR TITLE
Add super fuel mixture documentation to prevent future removals

### DIFF
--- a/src/main/java/gregtech/loaders/postload/recipes/MixerRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/MixerRecipes.java
@@ -711,6 +711,8 @@ public class MixerRecipes implements Runnable {
             .eut(16)
             .addTo(mixerRecipes);
 
+        // McGuffium239 is non-renewable and only obtainable though world gen.
+        // It's a meme, don't think too deep about it.
         GT_Values.RA.stdBuilder()
             .itemInputs(
                 GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Sulfur, 1),


### PR DESCRIPTION
Since those recipes have been nuked a couple of times over, and some people seem to believe McGuffium239 is craftable and/or renewable, It would be a good idea to leave a note that it's just a joke material/recipe and that it shouldn't be removed, or thought of too deeply about.

proof it's only obtained though worldgen (village blacksmith and stronghold crossing chest loot pools) https://github.com/GTNewHorizons/GT5-Unofficial/pull/2704#issuecomment-2208035737