### PR TITLE
large luv tier boiler

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeBoiler_RhodiumPalladium.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeBoiler_RhodiumPalladium.java
@@ -1,0 +1,96 @@
+package gregtech.common.tileentities.machines.multi;
+
+import net.minecraft.block.Block;
+
+import gregtech.GT_Mod;
+import gregtech.api.GregTech_API;
+import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
+import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
+
+public class GT_MetaTileEntity_LargeBoiler_RhodiumPalladium extends GT_MetaTileEntity_LargeBoiler {
+
+    public GT_MetaTileEntity_LargeBoiler_RhodiumPalladium(int aID, String aName, String aNameRegional) {
+        super(aID, aName, aNameRegional);
+        pollutionPerSecond = GT_Mod.gregtechproxy.mPollutionLargeRhodiumPalladiumBoilerPerSecond;
+    }
+
+    public GT_MetaTileEntity_LargeBoiler_RhodiumPalladium(String aName) {
+        super(aName);
+        pollutionPerSecond = GT_Mod.gregtechproxy.mPollutionLargeRhodiumPalladiumBoilerPerSecond;
+    }
+
+    @Override
+    public IMetaTileEntity newMetaEntity(IGregTechTileEntity aTileEntity) {
+        return new GT_MetaTileEntity_LargeBoiler_RhodiumPalladium(this.mName);
+    }
+
+    @Override
+    public String getCasingMaterial() {
+        return "RhodiumPalladium";
+    }
+
+    @Override
+    public String getCasingBlockType() {
+        return "Machine Casings";
+    }
+
+    @Override
+    public Block getCasingBlock() {
+        return GregTech_API.sBlockCasings4;
+    }
+
+    @Override
+    public byte getCasingMeta() {
+        return 0;
+    }
+
+    @Override
+    public byte getCasingTextureIndex() {
+        return 48;
+    }
+
+    @Override
+    public Block getPipeBlock() {
+        return GregTech_API.sBlockCasings2;
+    }
+
+    @Override
+    public byte getPipeMeta() {
+        return 15;
+    }
+
+    @Override
+    public Block getFireboxBlock() {
+        return GregTech_API.sBlockCasings3;
+    }
+
+    @Override
+    public byte getFireboxMeta() {
+        return 15;
+    }
+
+    @Override
+    public byte getFireboxTextureIndex() {
+        return 47;
+    }
+
+    @Override
+    public int getEUt() {
+        return 64000;
+    }
+
+    @Override
+    public int getEfficiencyIncrease() {
+        return 2;
+    }
+
+    @Override
+    int runtimeBoost(int mTime) {
+        return mTime * 120 / 750;
+    }
+
+    @Override
+    boolean isSuperheated() {
+        return true;
+    }
+}

--- a/src/main/java/gregtech/loaders/load/GT_Loader_MetaTileEntities_Recipes.java
+++ b/src/main/java/gregtech/loaders/load/GT_Loader_MetaTileEntities_Recipes.java
@@ -6051,6 +6051,11 @@ public class GT_Loader_MetaTileEntities_Recipes implements Runnable {
             bitsd,
             new Object[] { aTextWireCoil, aTextCableHull, aTextWireCoil, 'M', ItemList.Casing_Firebox_TungstenSteel,
                 'C', OrePrefixes.circuit.get(Materials.Elite), 'W', OrePrefixes.cableGt01.get(Materials.Aluminium) });
+        GT_ModHandler.addCraftingRecipe(
+            ItemList.Machine_Multi_LargeBoiler_RhodiumPalladium.get(1L),
+            bitsd,
+            new Object[] { aTextWireCoil, aTextCableHull, aTextWireCoil, 'M', ItemList.Casing_Firebox_RhodiumPalladium,
+                'C', OrePrefixes.circuit.get(Materials.Master), 'W', OrePrefixes.cableGt01.get(Materials.Tungsten) });
 
         GT_ModHandler.addCraftingRecipe(
             ItemList.Generator_Diesel_LV.get(1L),


### PR DESCRIPTION
This is in reference to https://github.com/GTNewHorizons/GT5-Unofficial/pull/2706 that was in order to provide the player with a means of extracting more throughput from the super fuel line considering the vast efficacy of the fuel and the fact that it is not appealing to spam boilers for players.

So far this pr is WIP and i will be adding to it as i learn how to make a mutliblock.