### PR TITLE
Implement cache limits on ME Output Hatch & Bus

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
@@ -2125,9 +2125,11 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
     public List<ItemStack> getItemOutputSlots(ItemStack[] toOutput) {
         List<ItemStack> ret = new ArrayList<>();
         for (final GT_MetaTileEntity_Hatch tBus : filterValidMTEs(mOutputBusses)) {
-            final IInventory tBusInv = tBus.getBaseMetaTileEntity();
-            for (int i = 0; i < tBusInv.getSizeInventory(); i++) {
-                ret.add(tBus.getStackInSlot(i));
+            if (!(tBus instanceof GT_MetaTileEntity_Hatch_OutputBus_ME)) {
+                final IInventory tBusInv = tBus.getBaseMetaTileEntity();
+                for (int i = 0; i < tBusInv.getSizeInventory(); i++) {
+                    ret.add(tBus.getStackInSlot(i));
+                }
             }
         }
         return ret;
@@ -2165,7 +2167,9 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
     public boolean canDumpItemToME() {
         for (GT_MetaTileEntity_Hatch tHatch : filterValidMTEs(mOutputBusses)) {
             if (tHatch instanceof GT_MetaTileEntity_Hatch_OutputBus_ME) {
-                return true;
+                if ((((GT_MetaTileEntity_Hatch_OutputBus_ME) tHatch).canAcceptItem())) {
+                    return true;
+                }
             }
         }
         return false;
@@ -2175,7 +2179,9 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
     public boolean canDumpFluidToME() {
         for (IFluidStore tHatch : getFluidOutputSlots(new FluidStack[0])) {
             if (tHatch instanceof GT_MetaTileEntity_Hatch_Output_ME) {
-                return true;
+                if ((((GT_MetaTileEntity_Hatch_Output_ME) tHatch).canAcceptFluid())) {
+                    return true;
+                }
             }
         }
         return false;

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_OutputBus_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_OutputBus_ME.java
@@ -72,8 +72,7 @@ public class GT_MetaTileEntity_Hatch_OutputBus_ME extends GT_MetaTileEntity_Hatc
             3,
             new String[] { "Item Output for Multiblocks", "Stores directly into ME", "Can cache 1600 items by default",
                 "Change cache size by inserting a storage cell",
-                "Change ME connection behavior by right-clicking with wire cutter",
-                "Current base cache capacity: " + ReadableNumberConverter.INSTANCE.toWideReadableForm(1_600) },
+                "Change ME connection behavior by right-clicking with wire cutter"},
             1);
     }
 
@@ -272,6 +271,23 @@ public class GT_MetaTileEntity_Hatch_OutputBus_ME extends GT_MetaTileEntity_Hatc
             if (tickCounter % 20 == 0) getBaseMetaTileEntity().setActive(isActive());
         }
         super.onPostTick(aBaseMetaTileEntity, aTick);
+    }
+
+    @Override
+    public void addAdditionalTooltipInformation(ItemStack stack, List<String> tooltip) {
+
+        if (stack.hasTagCompound() && stack.stackTagCompound.hasKey("baseCapacity")) {
+            tooltip.add(
+                "Current cache capacity: "
+                    + EnumChatFormatting.YELLOW
+                    + ReadableNumberConverter.INSTANCE.toWideReadableForm(baseCapacity));
+        }
+    }
+
+    @Override
+    public void setItemNBT(NBTTagCompound aNBT) {
+        super.setItemNBT(aNBT);
+        aNBT.setLong("baseCapacity", baseCapacity);
     }
 
     @Override

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_OutputBus_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_OutputBus_ME.java
@@ -72,7 +72,7 @@ public class GT_MetaTileEntity_Hatch_OutputBus_ME extends GT_MetaTileEntity_Hatc
             3,
             new String[] { "Item Output for Multiblocks", "Stores directly into ME", "Can cache 1600 items by default",
                 "Change cache size by inserting a storage cell",
-                "Change ME connection behavior by right-clicking with wire cutter"},
+                "Change ME connection behavior by right-clicking with wire cutter" },
             1);
     }
 
@@ -278,8 +278,7 @@ public class GT_MetaTileEntity_Hatch_OutputBus_ME extends GT_MetaTileEntity_Hatc
 
         if (stack.hasTagCompound() && stack.stackTagCompound.hasKey("baseCapacity")) {
             tooltip.add(
-                "Current cache capacity: "
-                    + EnumChatFormatting.YELLOW
+                "Current cache capacity: " + EnumChatFormatting.YELLOW
                     + ReadableNumberConverter.INSTANCE.toWideReadableForm(baseCapacity));
         }
     }

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_OutputBus_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_OutputBus_ME.java
@@ -9,10 +9,6 @@ import java.util.List;
 
 import javax.annotation.Nullable;
 
-import com.glodblock.github.common.item.FCBaseItemCell;
-import com.gtnewhorizons.modularui.api.screen.ModularWindow;
-import com.gtnewhorizons.modularui.api.screen.UIBuildContext;
-
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTBase;
@@ -22,6 +18,9 @@ import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import com.gtnewhorizons.modularui.api.screen.ModularWindow;
+import com.gtnewhorizons.modularui.api.screen.UIBuildContext;
+
 import appeng.api.AEApi;
 import appeng.api.implementations.IPowerChannelState;
 import appeng.api.networking.GridFlags;
@@ -29,7 +28,6 @@ import appeng.api.networking.security.BaseActionSource;
 import appeng.api.networking.security.IActionHost;
 import appeng.api.networking.security.MachineSource;
 import appeng.api.storage.IMEMonitor;
-import appeng.api.storage.data.IAEFluidStack;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.api.storage.data.IItemList;
 import appeng.api.util.AECableType;
@@ -72,8 +70,8 @@ public class GT_MetaTileEntity_Hatch_OutputBus_ME extends GT_MetaTileEntity_Hatc
             aName,
             aNameRegional,
             3,
-            new String[] { "Item Output for Multiblocks", "Stores directly into ME",
-                "Can cache 1600 items by default", "Change cache size by inserting a storage cell",
+            new String[] { "Item Output for Multiblocks", "Stores directly into ME", "Can cache 1600 items by default",
+                "Change cache size by inserting a storage cell",
                 "Change ME connection behavior by right-clicking with wire cutter" },
             1);
     }
@@ -144,7 +142,7 @@ public class GT_MetaTileEntity_Hatch_OutputBus_ME extends GT_MetaTileEntity_Hatc
      */
     public int store(final ItemStack stack) {
         if (lastOutputFailed) return stack.stackSize;
-        //Always allow insertion on the same tick so we can output the entire recipe
+        // Always allow insertion on the same tick so we can output the entire recipe
         if (canAcceptItem() || (lastInputTick == tickCounter)) {
             itemCache.add(
                 AEApi.instance()
@@ -337,9 +335,7 @@ public class GT_MetaTileEntity_Hatch_OutputBus_ME extends GT_MetaTileEntity_Hatc
             "The bus is " + ((getProxy() != null && getProxy().isActive()) ? EnumChatFormatting.GREEN + "online"
                 : EnumChatFormatting.RED + "offline" + getAEDiagnostics()) + EnumChatFormatting.RESET);
         IWideReadableNumberConverter nc = ReadableNumberConverter.INSTANCE;
-        ss.add(
-            "Item cache capacity: " +
-            nc.toWideReadableForm(getCacheCapacity()));
+        ss.add("Item cache capacity: " + nc.toWideReadableForm(getCacheCapacity()));
         if (itemCache.isEmpty()) {
             ss.add("The bus has no cached items");
         } else {

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_OutputBus_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_OutputBus_ME.java
@@ -72,7 +72,8 @@ public class GT_MetaTileEntity_Hatch_OutputBus_ME extends GT_MetaTileEntity_Hatc
             3,
             new String[] { "Item Output for Multiblocks", "Stores directly into ME", "Can cache 1600 items by default",
                 "Change cache size by inserting a storage cell",
-                "Change ME connection behavior by right-clicking with wire cutter" },
+                "Change ME connection behavior by right-clicking with wire cutter",
+                "Current base cache capacity: " + ReadableNumberConverter.INSTANCE.toWideReadableForm(1_600) },
             1);
     }
 
@@ -139,6 +140,8 @@ public class GT_MetaTileEntity_Hatch_OutputBus_ME extends GT_MetaTileEntity_Hatc
      */
     public void setBaseCapacity(long capacity) {
         baseCapacity = capacity;
+        mDescriptionArray[5] = "Current base cache capacity: "
+            + ReadableNumberConverter.INSTANCE.toWideReadableForm(baseCapacity);
     }
 
     /**
@@ -325,6 +328,12 @@ public class GT_MetaTileEntity_Hatch_OutputBus_ME extends GT_MetaTileEntity_Hatc
         }
         additionalConnection = aNBT.getBoolean("additionalConnection");
         baseCapacity = aNBT.getLong("baseCapacity");
+        // Set the base capacity of existing hatches to be infinite
+        if (baseCapacity == 0) {
+            baseCapacity = Long.MAX_VALUE;
+        }
+        mDescriptionArray[5] = "Current base cache capacity: "
+            + ReadableNumberConverter.INSTANCE.toWideReadableForm(baseCapacity);
         getProxy().readFromNBT(aNBT);
     }
 

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_OutputBus_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_OutputBus_ME.java
@@ -135,15 +135,6 @@ public class GT_MetaTileEntity_Hatch_OutputBus_ME extends GT_MetaTileEntity_Hatc
     }
 
     /**
-     * Set the base capacity of the bus
-     */
-    public void setBaseCapacity(long capacity) {
-        baseCapacity = capacity;
-        mDescriptionArray[5] = "Current base cache capacity: "
-            + ReadableNumberConverter.INSTANCE.toWideReadableForm(baseCapacity);
-    }
-
-    /**
      * Attempt to store items in connected ME network. Returns how many items did not fit (if the network was down e.g.)
      *
      * @param stack input stack
@@ -279,7 +270,8 @@ public class GT_MetaTileEntity_Hatch_OutputBus_ME extends GT_MetaTileEntity_Hatc
         if (stack.hasTagCompound() && stack.stackTagCompound.hasKey("baseCapacity")) {
             tooltip.add(
                 "Current cache capacity: " + EnumChatFormatting.YELLOW
-                    + ReadableNumberConverter.INSTANCE.toWideReadableForm(baseCapacity));
+                    + ReadableNumberConverter.INSTANCE
+                        .toWideReadableForm(stack.stackTagCompound.getLong("baseCapacity")));
         }
     }
 
@@ -347,8 +339,6 @@ public class GT_MetaTileEntity_Hatch_OutputBus_ME extends GT_MetaTileEntity_Hatc
         if (baseCapacity == 0) {
             baseCapacity = Long.MAX_VALUE;
         }
-        mDescriptionArray[5] = "Current base cache capacity: "
-            + ReadableNumberConverter.INSTANCE.toWideReadableForm(baseCapacity);
         getProxy().readFromNBT(aNBT);
     }
 

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_OutputBus_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_OutputBus_ME.java
@@ -51,7 +51,7 @@ import gregtech.api.util.GT_Utility;
 public class GT_MetaTileEntity_Hatch_OutputBus_ME extends GT_MetaTileEntity_Hatch_OutputBus
     implements IPowerChannelState {
 
-    private final long baseCapacity = 1_600;
+    private long baseCapacity = 1_600;
 
     private BaseActionSource requestSource = null;
     private @Nullable AENetworkProxy gridProxy = null;
@@ -132,6 +132,13 @@ public class GT_MetaTileEntity_Hatch_OutputBus_ME extends GT_MetaTileEntity_Hatc
             return true;
         }
         return false;
+    }
+
+    /**
+     * Set the base capacity of the bus
+     */
+    public void setBaseCapacity(long capacity) {
+        baseCapacity = capacity;
     }
 
     /**
@@ -278,6 +285,7 @@ public class GT_MetaTileEntity_Hatch_OutputBus_ME extends GT_MetaTileEntity_Hatc
         }
         aNBT.setBoolean("additionalConnection", additionalConnection);
         aNBT.setTag("cachedItems", items);
+        aNBT.setLong("baseCapacity", baseCapacity);
         getProxy().writeToNBT(aNBT);
     }
 
@@ -316,6 +324,7 @@ public class GT_MetaTileEntity_Hatch_OutputBus_ME extends GT_MetaTileEntity_Hatc
             }
         }
         additionalConnection = aNBT.getBoolean("additionalConnection");
+        baseCapacity = aNBT.getLong("baseCapacity");
         getProxy().readFromNBT(aNBT);
     }
 

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_Output_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_Output_ME.java
@@ -9,10 +9,6 @@ import java.util.List;
 
 import javax.annotation.Nullable;
 
-import com.glodblock.github.common.item.FCBaseItemCell;
-import com.gtnewhorizons.modularui.api.screen.ModularWindow;
-import com.gtnewhorizons.modularui.api.screen.UIBuildContext;
-
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTBase;
@@ -22,6 +18,10 @@ import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.FluidStack;
+
+import com.glodblock.github.common.item.FCBaseItemCell;
+import com.gtnewhorizons.modularui.api.screen.ModularWindow;
+import com.gtnewhorizons.modularui.api.screen.UIBuildContext;
 
 import appeng.api.AEApi;
 import appeng.api.config.Actionable;
@@ -44,7 +44,6 @@ import appeng.me.helpers.AENetworkProxy;
 import appeng.me.helpers.IGridProxyable;
 import appeng.util.IWideReadableNumberConverter;
 import appeng.util.ReadableNumberConverter;
-import appeng.items.AEBaseItem;
 import gregtech.GT_Mod;
 import gregtech.api.enums.GT_Values;
 import gregtech.api.enums.ItemList;
@@ -162,7 +161,7 @@ public class GT_MetaTileEntity_Hatch_Output_ME extends GT_MetaTileEntity_Hatch_O
      */
     public int tryFillAE(final FluidStack aFluid) {
         if (lastOutputFailed || aFluid == null) return 0;
-        //Always allow insertion on the same tick so we can output the entire recipe
+        // Always allow insertion on the same tick so we can output the entire recipe
         if (canAcceptFluid() || (lastInputTick == tickCounter)) {
             fluidCache.add(
                 AEApi.instance()
@@ -356,10 +355,7 @@ public class GT_MetaTileEntity_Hatch_Output_ME extends GT_MetaTileEntity_Hatch_O
             "The hatch is " + ((getProxy() != null && getProxy().isActive()) ? EnumChatFormatting.GREEN + "online"
                 : EnumChatFormatting.RED + "offline" + getAEDiagnostics()) + EnumChatFormatting.RESET);
         IWideReadableNumberConverter nc = ReadableNumberConverter.INSTANCE;
-        ss.add(
-            "Fluid cache capacity: " +
-            nc.toWideReadableForm(getCacheCapacity()) +
-            " mB");
+        ss.add("Fluid cache capacity: " + nc.toWideReadableForm(getCacheCapacity()) + " mB");
         if (fluidCache.isEmpty()) {
             ss.add("The bus has no cached fluids");
         } else {

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_Output_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_Output_ME.java
@@ -16,7 +16,6 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.util.EnumChatFormatting;
-import net.minecraft.util.StatCollector;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.FluidStack;
 
@@ -54,7 +53,6 @@ import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_Output;
 import gregtech.api.render.TextureFactory;
-import gregtech.api.util.GT_LanguageManager;
 import gregtech.api.util.GT_Utility;
 
 public class GT_MetaTileEntity_Hatch_Output_ME extends GT_MetaTileEntity_Hatch_Output implements IPowerChannelState {
@@ -80,7 +78,7 @@ public class GT_MetaTileEntity_Hatch_Output_ME extends GT_MetaTileEntity_Hatch_O
             3,
             new String[] { "Fluid Output for Multiblocks", "Stores directly into ME",
                 "Can cache up to 128kL of fluids by default", "Change cache size by inserting a fluid storage cell",
-                "Change ME connection behavior by right-clicking with wire cutter"},
+                "Change ME connection behavior by right-clicking with wire cutter" },
             1);
     }
 
@@ -313,9 +311,9 @@ public class GT_MetaTileEntity_Hatch_Output_ME extends GT_MetaTileEntity_Hatch_O
 
         if (stack.hasTagCompound() && stack.stackTagCompound.hasKey("baseCapacity")) {
             tooltip.add(
-                "Current cache capacity: "
-                    + EnumChatFormatting.YELLOW
-                    + ReadableNumberConverter.INSTANCE.toWideReadableForm(baseCapacity) + " mB");
+                "Current cache capacity: " + EnumChatFormatting.YELLOW
+                    + ReadableNumberConverter.INSTANCE.toWideReadableForm(baseCapacity)
+                    + " mB");
         }
     }
 

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_Output_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_Output_ME.java
@@ -57,7 +57,7 @@ import gregtech.api.util.GT_Utility;
 
 public class GT_MetaTileEntity_Hatch_Output_ME extends GT_MetaTileEntity_Hatch_Output implements IPowerChannelState {
 
-    private final long baseCapacity = 128_000;
+    private long baseCapacity = 128_000;
 
     private BaseActionSource requestSource = null;
     private @Nullable AENetworkProxy gridProxy = null;
@@ -151,6 +151,10 @@ public class GT_MetaTileEntity_Hatch_Output_ME extends GT_MetaTileEntity_Hatch_O
             return true;
         }
         return false;
+    }
+
+    public void setBaseCapacity(long capacity) {
+        baseCapacity = capacity;
     }
 
     /**
@@ -311,6 +315,7 @@ public class GT_MetaTileEntity_Hatch_Output_ME extends GT_MetaTileEntity_Hatch_O
         }
         aNBT.setTag("cachedFluids", fluids);
         aNBT.setBoolean("additionalConnection", additionalConnection);
+        aNBT.setLong("baseCapacity", baseCapacity);
         getProxy().writeToNBT(aNBT);
     }
 
@@ -336,6 +341,7 @@ public class GT_MetaTileEntity_Hatch_Output_ME extends GT_MetaTileEntity_Hatch_O
             }
         }
         additionalConnection = aNBT.getBoolean("additionalConnection");
+        baseCapacity = aNBT.getLong("baseCapacity");
         getProxy().readFromNBT(aNBT);
     }
 

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_Output_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_Output_ME.java
@@ -16,6 +16,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.util.EnumChatFormatting;
+import net.minecraft.util.StatCollector;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.FluidStack;
 
@@ -53,6 +54,7 @@ import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_Output;
 import gregtech.api.render.TextureFactory;
+import gregtech.api.util.GT_LanguageManager;
 import gregtech.api.util.GT_Utility;
 
 public class GT_MetaTileEntity_Hatch_Output_ME extends GT_MetaTileEntity_Hatch_Output implements IPowerChannelState {
@@ -78,9 +80,7 @@ public class GT_MetaTileEntity_Hatch_Output_ME extends GT_MetaTileEntity_Hatch_O
             3,
             new String[] { "Fluid Output for Multiblocks", "Stores directly into ME",
                 "Can cache up to 128kL of fluids by default", "Change cache size by inserting a fluid storage cell",
-                "Change ME connection behavior by right-clicking with wire cutter",
-                "Current base cache capacity: " + ReadableNumberConverter.INSTANCE.toWideReadableForm(128_000)
-                    + " mB" },
+                "Change ME connection behavior by right-clicking with wire cutter"},
             1);
     }
 
@@ -158,11 +158,12 @@ public class GT_MetaTileEntity_Hatch_Output_ME extends GT_MetaTileEntity_Hatch_O
     /**
      * Set the base capacity of the hatch
      */
-    public void setBaseCapacity(long capacity) {
+    public GT_MetaTileEntity_Hatch_Output_ME setBaseCapacity(long capacity) {
         baseCapacity = capacity;
         mDescriptionArray[5] = "Current base cache capacity: "
             + ReadableNumberConverter.INSTANCE.toWideReadableForm(baseCapacity)
             + " mB";
+        return this;
     }
 
     /**
@@ -305,6 +306,23 @@ public class GT_MetaTileEntity_Hatch_Output_ME extends GT_MetaTileEntity_Hatch_O
             if (tickCounter % 20 == 0) getBaseMetaTileEntity().setActive(isActive());
         }
         super.onPostTick(aBaseMetaTileEntity, aTick);
+    }
+
+    @Override
+    public void addAdditionalTooltipInformation(ItemStack stack, List<String> tooltip) {
+
+        if (stack.hasTagCompound() && stack.stackTagCompound.hasKey("baseCapacity")) {
+            tooltip.add(
+                "Current cache capacity: "
+                    + EnumChatFormatting.YELLOW
+                    + ReadableNumberConverter.INSTANCE.toWideReadableForm(baseCapacity) + " mB");
+        }
+    }
+
+    @Override
+    public void setItemNBT(NBTTagCompound aNBT) {
+        super.setItemNBT(aNBT);
+        aNBT.setLong("baseCapacity", baseCapacity);
     }
 
     @Override

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_Output_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_Output_ME.java
@@ -9,7 +9,12 @@ import java.util.List;
 
 import javax.annotation.Nullable;
 
+import com.glodblock.github.common.item.FCBaseItemCell;
+import com.gtnewhorizons.modularui.api.screen.ModularWindow;
+import com.gtnewhorizons.modularui.api.screen.UIBuildContext;
+
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTBase;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
@@ -39,9 +44,11 @@ import appeng.me.helpers.AENetworkProxy;
 import appeng.me.helpers.IGridProxyable;
 import appeng.util.IWideReadableNumberConverter;
 import appeng.util.ReadableNumberConverter;
+import appeng.items.AEBaseItem;
 import gregtech.GT_Mod;
 import gregtech.api.enums.GT_Values;
 import gregtech.api.enums.ItemList;
+import gregtech.api.gui.modularui.GT_UIInfos;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
@@ -51,6 +58,8 @@ import gregtech.api.util.GT_Utility;
 
 public class GT_MetaTileEntity_Hatch_Output_ME extends GT_MetaTileEntity_Hatch_Output implements IPowerChannelState {
 
+    private final long baseCapacity = 128_000;
+
     private BaseActionSource requestSource = null;
     private @Nullable AENetworkProxy gridProxy = null;
     final IItemList<IAEFluidStack> fluidCache = AEApi.instance()
@@ -59,7 +68,6 @@ public class GT_MetaTileEntity_Hatch_Output_ME extends GT_MetaTileEntity_Hatch_O
     long lastOutputTick = 0;
     long tickCounter = 0;
     boolean lastOutputFailed = false;
-    boolean infiniteCache = true;
     boolean additionalConnection = false;
 
     public GT_MetaTileEntity_Hatch_Output_ME(int aID, String aName, String aNameRegional) {
@@ -69,13 +77,13 @@ public class GT_MetaTileEntity_Hatch_Output_ME extends GT_MetaTileEntity_Hatch_O
             aNameRegional,
             3,
             new String[] { "Fluid Output for Multiblocks", "Stores directly into ME",
-                "Can cache infinite amount of fluids.", "Change cache behavior by right-clicking with screwdriver.",
+                "Can cache up to 128kL of fluids by default", "Change cache size by inserting a fluid storage cell",
                 "Change ME connection behavior by right-clicking with wire cutter" },
-            0);
+            1);
     }
 
     public GT_MetaTileEntity_Hatch_Output_ME(String aName, int aTier, String[] aDescription, ITexture[][][] aTextures) {
-        super(aName, aTier, 0, aDescription, aTextures);
+        super(aName, aTier, 1, aDescription, aTextures);
     }
 
     @Override
@@ -109,9 +117,40 @@ public class GT_MetaTileEntity_Hatch_Output_ME extends GT_MetaTileEntity_Hatch_O
         if (doFill) {
             return tryFillAE(aFluid);
         } else {
-            if ((!infiniteCache && lastOutputFailed) || aFluid == null) return 0;
+            if (lastOutputFailed || aFluid == null) return 0;
             return aFluid.amount;
         }
+    }
+
+    @Override
+    public int getCapacity() {
+        return 0;
+    }
+
+
+    private long getCacheCapacity() {
+        ItemStack upgradeItemStack = mInventory[0];
+        if (upgradeItemStack == null) {
+            return baseCapacity;
+        }
+        if (upgradeItemStack.getItem() instanceof FCBaseItemCell) {
+            return ((FCBaseItemCell) upgradeItemStack.getItem()).getBytes(upgradeItemStack) * 8;
+        }
+        return baseCapacity;
+    }
+
+    /**
+     * Check if the internal cache can still fit more fluids in it
+     */
+    public boolean canAcceptFluid() {
+        long fluidAmount = 0;
+        for (IAEFluidStack fluid : fluidCache) {
+            fluidAmount += fluid.getStackSize();
+        }
+        if (fluidAmount < getCacheCapacity()) {
+            return true;
+        }
+        return false;
     }
 
     /**
@@ -121,7 +160,7 @@ public class GT_MetaTileEntity_Hatch_Output_ME extends GT_MetaTileEntity_Hatch_O
      * @return amount of fluid filled
      */
     public int tryFillAE(final FluidStack aFluid) {
-        if ((!infiniteCache && lastOutputFailed) || aFluid == null) return 0;
+        if (lastOutputFailed || aFluid == null) return 0;
         fluidCache.add(
             AEApi.instance()
                 .storage()
@@ -154,7 +193,8 @@ public class GT_MetaTileEntity_Hatch_Output_ME extends GT_MetaTileEntity_Hatch_O
 
     @Override
     public boolean onRightclick(IGregTechTileEntity aBaseMetaTileEntity, EntityPlayer aPlayer) {
-        return false;
+        GT_UIInfos.openGTTileEntityUI(aBaseMetaTileEntity, aPlayer);
+        return true;
     }
 
     @Override
@@ -172,8 +212,6 @@ public class GT_MetaTileEntity_Hatch_Output_ME extends GT_MetaTileEntity_Hatch_O
         // Don't allow to lock fluid in me fluid hatch
         if (!getBaseMetaTileEntity().getCoverInfoAtSide(side)
             .isGUIClickable()) return;
-        infiniteCache = !infiniteCache;
-        aPlayer.addChatComponentMessage(new ChatComponentTranslation("GT5U.hatch.infiniteCacheFluid." + infiniteCache));
     }
 
     @Override
@@ -267,7 +305,6 @@ public class GT_MetaTileEntity_Hatch_Output_ME extends GT_MetaTileEntity_Hatch_O
             fluids.appendTag(tag);
         }
         aNBT.setTag("cachedFluids", fluids);
-        aNBT.setBoolean("infiniteCache", infiniteCache);
         aNBT.setBoolean("additionalConnection", additionalConnection);
         getProxy().writeToNBT(aNBT);
     }
@@ -293,9 +330,6 @@ public class GT_MetaTileEntity_Hatch_Output_ME extends GT_MetaTileEntity_Hatch_O
                 }
             }
         }
-        if (aNBT.hasKey("infiniteCache")) {
-            infiniteCache = aNBT.getBoolean("infiniteCache");
-        }
         additionalConnection = aNBT.getBoolean("additionalConnection");
         getProxy().readFromNBT(aNBT);
     }
@@ -315,10 +349,14 @@ public class GT_MetaTileEntity_Hatch_Output_ME extends GT_MetaTileEntity_Hatch_O
         ss.add(
             "The hatch is " + ((getProxy() != null && getProxy().isActive()) ? EnumChatFormatting.GREEN + "online"
                 : EnumChatFormatting.RED + "offline" + getAEDiagnostics()) + EnumChatFormatting.RESET);
+        IWideReadableNumberConverter nc = ReadableNumberConverter.INSTANCE;
+        ss.add(
+            "Fluid cache capacity: " +
+            nc.toWideReadableForm(getCacheCapacity()) +
+            " mB");
         if (fluidCache.isEmpty()) {
             ss.add("The bus has no cached fluids");
         } else {
-            IWideReadableNumberConverter nc = ReadableNumberConverter.INSTANCE;
             ss.add(String.format("The hatch contains %d cached fluids: ", fluidCache.size()));
             int counter = 0;
             for (IAEFluidStack s : fluidCache) {
@@ -379,5 +417,15 @@ public class GT_MetaTileEntity_Hatch_Output_ME extends GT_MetaTileEntity_Hatch_O
         }
 
         return input;
+    }
+
+    @Override
+    public boolean useModularUI() {
+        return true;
+    }
+
+    @Override
+    public void addUIWidgets(ModularWindow.Builder builder, UIBuildContext buildContext) {
+        getBaseMetaTileEntity().add1by1Slot(builder);
     }
 }

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_Output_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_Output_ME.java
@@ -78,7 +78,9 @@ public class GT_MetaTileEntity_Hatch_Output_ME extends GT_MetaTileEntity_Hatch_O
             3,
             new String[] { "Fluid Output for Multiblocks", "Stores directly into ME",
                 "Can cache up to 128kL of fluids by default", "Change cache size by inserting a fluid storage cell",
-                "Change ME connection behavior by right-clicking with wire cutter" },
+                "Change ME connection behavior by right-clicking with wire cutter",
+                "Current base cache capacity: " + ReadableNumberConverter.INSTANCE.toWideReadableForm(128_000)
+                    + " mB" },
             1);
     }
 
@@ -153,8 +155,14 @@ public class GT_MetaTileEntity_Hatch_Output_ME extends GT_MetaTileEntity_Hatch_O
         return false;
     }
 
+    /**
+     * Set the base capacity of the hatch
+     */
     public void setBaseCapacity(long capacity) {
         baseCapacity = capacity;
+        mDescriptionArray[5] = "Current base cache capacity: "
+            + ReadableNumberConverter.INSTANCE.toWideReadableForm(baseCapacity)
+            + " mB";
     }
 
     /**
@@ -342,6 +350,13 @@ public class GT_MetaTileEntity_Hatch_Output_ME extends GT_MetaTileEntity_Hatch_O
         }
         additionalConnection = aNBT.getBoolean("additionalConnection");
         baseCapacity = aNBT.getLong("baseCapacity");
+        // Set the base capacity of existing hatches to be infinite
+        if (baseCapacity == 0) {
+            baseCapacity = Long.MAX_VALUE;
+        }
+        mDescriptionArray[5] = "Current base cache capacity: "
+            + ReadableNumberConverter.INSTANCE.toWideReadableForm(baseCapacity)
+            + " mB";
         getProxy().readFromNBT(aNBT);
     }
 

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_Output_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_Output_ME.java
@@ -154,17 +154,6 @@ public class GT_MetaTileEntity_Hatch_Output_ME extends GT_MetaTileEntity_Hatch_O
     }
 
     /**
-     * Set the base capacity of the hatch
-     */
-    public GT_MetaTileEntity_Hatch_Output_ME setBaseCapacity(long capacity) {
-        baseCapacity = capacity;
-        mDescriptionArray[5] = "Current base cache capacity: "
-            + ReadableNumberConverter.INSTANCE.toWideReadableForm(baseCapacity)
-            + " mB";
-        return this;
-    }
-
-    /**
      * Attempt to store fluid in connected ME network. Returns how much fluid is accepted (if the network was down e.g.)
      *
      * @param aFluid input fluid
@@ -312,8 +301,9 @@ public class GT_MetaTileEntity_Hatch_Output_ME extends GT_MetaTileEntity_Hatch_O
         if (stack.hasTagCompound() && stack.stackTagCompound.hasKey("baseCapacity")) {
             tooltip.add(
                 "Current cache capacity: " + EnumChatFormatting.YELLOW
-                    + ReadableNumberConverter.INSTANCE.toWideReadableForm(baseCapacity)
-                    + " mB");
+                    + ReadableNumberConverter.INSTANCE
+                        .toWideReadableForm(stack.stackTagCompound.getLong("baseCapacity"))
+                    + "L");
         }
     }
 
@@ -370,9 +360,6 @@ public class GT_MetaTileEntity_Hatch_Output_ME extends GT_MetaTileEntity_Hatch_O
         if (baseCapacity == 0) {
             baseCapacity = Long.MAX_VALUE;
         }
-        mDescriptionArray[5] = "Current base cache capacity: "
-            + ReadableNumberConverter.INSTANCE.toWideReadableForm(baseCapacity)
-            + " mB";
         getProxy().readFromNBT(aNBT);
     }
 


### PR DESCRIPTION
Currently, the hatch and bus can infinitely cache items and fluids inside them, leading to players using them as infinite fluid and item storage as early as EV. Additionally, they cannot be used with void protection as pseudo-redstone control for passive machinery.

This PR implements a limit of 128000L / 1600 items to these blocks, and allows the insertion of fluid and item storage cells to modify the cache capacity. This will match the cache capacity with the byte capacity of the drive, disregarding any type limits.

The caches are still "infinite" and allow the machine to operate as long as there is space for 1L/1 item, storing the entire recipe output. After that, they will block the machine from operating if void protection is enabled, or void any items that try to enter the hatch/bus if void protection is disabled until the cache is cleared.

https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/891 adds recipes to allow pre-applying storage components to the hatches, so you don't have to add a storage cell to every hatch.

![image](https://github.com/GTNewHorizons/GT5-Unofficial/assets/69092953/809b6d6d-679d-47f9-910f-2bbdabd1611b)

![image](https://github.com/GTNewHorizons/GT5-Unofficial/assets/69092953/3554abed-643e-4a6b-a414-d7c3408400fb)

![image](https://github.com/GTNewHorizons/GT5-Unofficial/assets/69092953/c75f9224-fdb4-4246-8f23-617df4ec2659)

![image](https://github.com/GTNewHorizons/GT5-Unofficial/assets/69092953/beeb69be-9ab7-4049-bb25-95ef1f0085c5)

![image](https://github.com/GTNewHorizons/GT5-Unofficial/assets/69092953/085c25da-92a7-4999-8779-7a440b6a629a)
