### PR TITLE
Add wireless computation and data stick hatches

### DIFF
--- a/src/main/java/com/github/technus/tectech/loader/thing/MachineLoader.java
+++ b/src/main/java/com/github/technus/tectech/loader/thing/MachineLoader.java
@@ -60,8 +60,10 @@ import static com.github.technus.tectech.thing.CustomItemList.UnusedStuff;
 import static com.github.technus.tectech.thing.CustomItemList.capacitor_Hatch;
 import static com.github.technus.tectech.thing.CustomItemList.dataInAss_Hatch;
 import static com.github.technus.tectech.thing.CustomItemList.dataIn_Hatch;
+import static com.github.technus.tectech.thing.CustomItemList.dataIn_Wireless_Hatch;
 import static com.github.technus.tectech.thing.CustomItemList.dataOutAss_Hatch;
 import static com.github.technus.tectech.thing.CustomItemList.dataOut_Hatch;
+import static com.github.technus.tectech.thing.CustomItemList.dataOut_Wireless_Hatch;
 import static com.github.technus.tectech.thing.CustomItemList.eM_dynamoMulti16_EV;
 import static com.github.technus.tectech.thing.CustomItemList.eM_dynamoMulti16_IV;
 import static com.github.technus.tectech.thing.CustomItemList.eM_dynamoMulti16_LuV;
@@ -318,6 +320,8 @@ import com.github.technus.tectech.thing.metaTileEntity.hatch.GT_MetaTileEntity_H
 import com.github.technus.tectech.thing.metaTileEntity.hatch.GT_MetaTileEntity_Hatch_ParamText;
 import com.github.technus.tectech.thing.metaTileEntity.hatch.GT_MetaTileEntity_Hatch_Rack;
 import com.github.technus.tectech.thing.metaTileEntity.hatch.GT_MetaTileEntity_Hatch_Uncertainty;
+import com.github.technus.tectech.thing.metaTileEntity.hatch.GT_MetaTileEntity_Hatch_WirelessComputation_Input;
+import com.github.technus.tectech.thing.metaTileEntity.hatch.GT_MetaTileEntity_Hatch_WirelessComputation_Output;
 import com.github.technus.tectech.thing.metaTileEntity.hatch.GT_MetaTileEntity_Hatch_WirelessMulti;
 import com.github.technus.tectech.thing.metaTileEntity.multi.GT_MetaTileEntity_EM_EyeOfHarmony;
 import com.github.technus.tectech.thing.metaTileEntity.multi.GT_MetaTileEntity_EM_ForgeOfGods;
@@ -1929,7 +1933,18 @@ public class MachineLoader implements Runnable {
                 "hatch.dataoutass.tier.07",
                 "Data Bank Master Connector",
                 7).getStackForm(1L));
-
+        dataOut_Wireless_Hatch.set(
+            new GT_MetaTileEntity_Hatch_WirelessComputation_Output(
+                15444,
+                "hatch.dataout.wireless.tier.12",
+                "Wireless Optical Master Connector",
+                12).getStackForm(1L));
+        dataIn_Wireless_Hatch.set(
+            new GT_MetaTileEntity_Hatch_WirelessComputation_Input(
+                15445,
+                "hatch.datain.wireless.tier.12",
+                "Wireless Optical Slave Connector",
+                12).getStackForm(1L));
         rack_Hatch
             .set(new GT_MetaTileEntity_Hatch_Rack(15450, "hatch.rack.tier.08", "Computer Rack", 8).getStackForm(1L));
         holder_Hatch.set(

--- a/src/main/java/com/github/technus/tectech/loader/thing/MachineLoader.java
+++ b/src/main/java/com/github/technus/tectech/loader/thing/MachineLoader.java
@@ -1941,13 +1941,13 @@ public class MachineLoader implements Runnable {
             new GT_MetaTileEntity_Hatch_WirelessComputation_Output(
                 15444,
                 "hatch.dataout.wireless.tier.12",
-                "Cloud Computation Upload Hatch",
+                "Cloud Computation Server Hatch",
                 12).getStackForm(1L));
         dataIn_Wireless_Hatch.set(
             new GT_MetaTileEntity_Hatch_WirelessComputation_Input(
                 15445,
                 "hatch.datain.wireless.tier.12",
-                "Cloud Computation Download Hatch",
+                "Cloud Computation Client Hatch",
                 12).getStackForm(1L));
         dataInAss_Wireless_Hatch.set(
             new GT_MetaTileEntity_Hatch_WirelessInputDataItems(

--- a/src/main/java/com/github/technus/tectech/loader/thing/MachineLoader.java
+++ b/src/main/java/com/github/technus/tectech/loader/thing/MachineLoader.java
@@ -1941,13 +1941,13 @@ public class MachineLoader implements Runnable {
             new GT_MetaTileEntity_Hatch_WirelessComputation_Output(
                 15444,
                 "hatch.dataout.wireless.tier.12",
-                "Wireless Optical Master Connector",
+                "Cloud Computation Upload Hatch",
                 12).getStackForm(1L));
         dataIn_Wireless_Hatch.set(
             new GT_MetaTileEntity_Hatch_WirelessComputation_Input(
                 15445,
                 "hatch.datain.wireless.tier.12",
-                "Wireless Optical Slave Connector",
+                "Cloud Computation Download Hatch",
                 12).getStackForm(1L));
         dataInAss_Wireless_Hatch.set(
             new GT_MetaTileEntity_Hatch_WirelessInputDataItems(

--- a/src/main/java/com/github/technus/tectech/loader/thing/MachineLoader.java
+++ b/src/main/java/com/github/technus/tectech/loader/thing/MachineLoader.java
@@ -59,9 +59,11 @@ import static com.github.technus.tectech.thing.CustomItemList.Uncertainty_Hatch;
 import static com.github.technus.tectech.thing.CustomItemList.UnusedStuff;
 import static com.github.technus.tectech.thing.CustomItemList.capacitor_Hatch;
 import static com.github.technus.tectech.thing.CustomItemList.dataInAss_Hatch;
+import static com.github.technus.tectech.thing.CustomItemList.dataInAss_Wireless_Hatch;
 import static com.github.technus.tectech.thing.CustomItemList.dataIn_Hatch;
 import static com.github.technus.tectech.thing.CustomItemList.dataIn_Wireless_Hatch;
 import static com.github.technus.tectech.thing.CustomItemList.dataOutAss_Hatch;
+import static com.github.technus.tectech.thing.CustomItemList.dataOutAss_Wireless_Hatch;
 import static com.github.technus.tectech.thing.CustomItemList.dataOut_Hatch;
 import static com.github.technus.tectech.thing.CustomItemList.dataOut_Wireless_Hatch;
 import static com.github.technus.tectech.thing.CustomItemList.eM_dynamoMulti16_EV;
@@ -322,7 +324,9 @@ import com.github.technus.tectech.thing.metaTileEntity.hatch.GT_MetaTileEntity_H
 import com.github.technus.tectech.thing.metaTileEntity.hatch.GT_MetaTileEntity_Hatch_Uncertainty;
 import com.github.technus.tectech.thing.metaTileEntity.hatch.GT_MetaTileEntity_Hatch_WirelessComputation_Input;
 import com.github.technus.tectech.thing.metaTileEntity.hatch.GT_MetaTileEntity_Hatch_WirelessComputation_Output;
+import com.github.technus.tectech.thing.metaTileEntity.hatch.GT_MetaTileEntity_Hatch_WirelessInputDataItems;
 import com.github.technus.tectech.thing.metaTileEntity.hatch.GT_MetaTileEntity_Hatch_WirelessMulti;
+import com.github.technus.tectech.thing.metaTileEntity.hatch.GT_MetaTileEntity_Hatch_WirelessOutputDataItems;
 import com.github.technus.tectech.thing.metaTileEntity.multi.GT_MetaTileEntity_EM_EyeOfHarmony;
 import com.github.technus.tectech.thing.metaTileEntity.multi.GT_MetaTileEntity_EM_ForgeOfGods;
 import com.github.technus.tectech.thing.metaTileEntity.multi.GT_MetaTileEntity_EM_computer;
@@ -1944,6 +1948,18 @@ public class MachineLoader implements Runnable {
                 15445,
                 "hatch.datain.wireless.tier.12",
                 "Wireless Optical Slave Connector",
+                12).getStackForm(1L));
+        dataInAss_Wireless_Hatch.set(
+            new GT_MetaTileEntity_Hatch_WirelessInputDataItems(
+                15446,
+                "hatch.datainass.wireless.tier.12",
+                "Wireless Assembly line Slave Connector",
+                12).getStackForm(1L));
+        dataOutAss_Wireless_Hatch.set(
+            new GT_MetaTileEntity_Hatch_WirelessOutputDataItems(
+                15447,
+                "hatch.dataoutass.wireless.tier.12",
+                "Wireless Data Bank Master Connector",
                 12).getStackForm(1L));
         rack_Hatch
             .set(new GT_MetaTileEntity_Hatch_Rack(15450, "hatch.rack.tier.08", "Computer Rack", 8).getStackForm(1L));

--- a/src/main/java/com/github/technus/tectech/thing/CustomItemList.java
+++ b/src/main/java/com/github/technus/tectech/thing/CustomItemList.java
@@ -309,6 +309,8 @@ public enum CustomItemList implements IItemContainer {
     UncertaintyX_Hatch,
     dataIn_Hatch,
     dataOut_Hatch,
+    dataOut_Wireless_Hatch,
+    dataIn_Wireless_Hatch,
     dataInAss_Hatch,
     dataOutAss_Hatch,
     eM_Containment,

--- a/src/main/java/com/github/technus/tectech/thing/CustomItemList.java
+++ b/src/main/java/com/github/technus/tectech/thing/CustomItemList.java
@@ -311,6 +311,8 @@ public enum CustomItemList implements IItemContainer {
     dataOut_Hatch,
     dataOut_Wireless_Hatch,
     dataIn_Wireless_Hatch,
+    dataInAss_Wireless_Hatch,
+    dataOutAss_Wireless_Hatch,
     dataInAss_Hatch,
     dataOutAss_Hatch,
     eM_Containment,

--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/hatch/GT_MetaTileEntity_Hatch_InputDataItems.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/hatch/GT_MetaTileEntity_Hatch_InputDataItems.java
@@ -10,6 +10,10 @@ import static net.minecraft.util.StatCollector.translateToLocal;
 import static net.minecraft.util.StatCollector.translateToLocalFormatted;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -197,6 +201,13 @@ public class GT_MetaTileEntity_Hatch_InputDataItems extends GT_MetaTileEntity_Ha
     @Override
     public ItemStack getStackInSlot(int aIndex) {
         return stacks != null && aIndex < stacks.length ? stacks[aIndex] : null;
+    }
+
+    @Override
+    public List<ItemStack> getInventoryItems(Predicate<ItemStack> filter) {
+        return Arrays.stream(stacks)
+            .filter(stack -> stack != null && filter.test(stack))
+            .collect(Collectors.toList());
     }
 
     @Override

--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/hatch/GT_MetaTileEntity_Hatch_WirelessComputation_Input.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/hatch/GT_MetaTileEntity_Hatch_WirelessComputation_Input.java
@@ -74,7 +74,7 @@ public class GT_MetaTileEntity_Hatch_WirelessComputation_Input extends GT_MetaTi
     public void onPreTick(IGregTechTileEntity aBaseMetaTileEntity, long aTick) {
         super.onPreTick(aBaseMetaTileEntity, aTick);
         if (aBaseMetaTileEntity.isServerSide() && q == null) {
-            q = WirelessComputationPacket.downloadData(aBaseMetaTileEntity.getOwnerUuid(), requiredComputation);
+            q = WirelessComputationPacket.downloadData(aBaseMetaTileEntity.getOwnerUuid(), requiredComputation, aTick);
         }
 
     }
@@ -113,8 +113,8 @@ public class GT_MetaTileEntity_Hatch_WirelessComputation_Input extends GT_MetaTi
     public void addUIWidgets(ModularWindow.Builder builder, UIBuildContext buildContext) {
         builder.widget(
             TextWidget.localised("tt.wirelessInputData.config.text")
-                .setPos(49, 18)
-                .setSize(81, 14))
+                .setPos(20, 12)
+                .setSize(140, 14))
             .widget(
                 new TextFieldWidget().setSetterInt(val -> requiredComputation = val)
                     .setGetterLong(() -> requiredComputation)

--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/hatch/GT_MetaTileEntity_Hatch_WirelessComputation_Input.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/hatch/GT_MetaTileEntity_Hatch_WirelessComputation_Input.java
@@ -1,0 +1,139 @@
+package com.github.technus.tectech.thing.metaTileEntity.hatch;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraftforge.common.util.ForgeDirection;
+
+import org.apache.commons.lang3.reflect.FieldUtils;
+
+import com.github.technus.tectech.thing.gui.TecTechUITextures;
+import com.gtnewhorizons.modularui.api.math.Alignment;
+import com.gtnewhorizons.modularui.api.math.Color;
+import com.gtnewhorizons.modularui.api.screen.ModularWindow;
+import com.gtnewhorizons.modularui.api.screen.UIBuildContext;
+import com.gtnewhorizons.modularui.common.widget.DrawableWidget;
+import com.gtnewhorizons.modularui.common.widget.TextWidget;
+import com.gtnewhorizons.modularui.common.widget.textfield.TextFieldWidget;
+
+import gregtech.api.gui.modularui.GT_UIInfos;
+import gregtech.api.gui.modularui.GT_UITextures;
+import gregtech.api.interfaces.ITexture;
+import gregtech.api.interfaces.modularui.IAddGregtechLogo;
+import gregtech.api.interfaces.modularui.IAddUIWidgets;
+import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
+import gregtech.api.metatileentity.MetaTileEntity;
+import gregtech.common.WirelessComputationPacket;
+
+public class GT_MetaTileEntity_Hatch_WirelessComputation_Input extends GT_MetaTileEntity_Hatch_InputData
+    implements IAddGregtechLogo, IAddUIWidgets {
+
+    public long requiredComputation = 10000;
+
+    private String clientLocale = "en_US";
+
+    public GT_MetaTileEntity_Hatch_WirelessComputation_Input(int aID, String aName, String aNameRegional, int aTier) {
+        super(aID, aName, aNameRegional, aTier);
+    }
+
+    public GT_MetaTileEntity_Hatch_WirelessComputation_Input(String aName, int aTier, String[] aDescription,
+        ITexture[][][] aTextures) {
+        super(aName, aTier, aDescription, aTextures);
+    }
+
+    @Override
+    public MetaTileEntity newMetaEntity(IGregTechTileEntity aTileEntity) {
+        return new GT_MetaTileEntity_Hatch_WirelessComputation_Input(mName, mTier, mDescriptionArray, mTextures);
+    }
+
+    @Override
+    public boolean onRightclick(IGregTechTileEntity aBaseMetaTileEntity, EntityPlayer aPlayer) {
+        try {
+            EntityPlayerMP player = (EntityPlayerMP) aPlayer;
+            clientLocale = (String) FieldUtils.readField(player, "translator", true);
+        } catch (Exception e) {
+            clientLocale = "en_US";
+        }
+        if (!aPlayer.isUsingItem()) {
+            GT_UIInfos.openGTTileEntityUI(aBaseMetaTileEntity, aPlayer);
+        }
+        return super.onRightclick(aBaseMetaTileEntity, aPlayer);
+    }
+
+    @Override
+    public boolean isDataInputFacing(ForgeDirection side) {
+        return false;
+    }
+
+    @Override
+    public boolean canConnectData(ForgeDirection side) {
+        return false;
+    }
+
+    @Override
+    public void onPreTick(IGregTechTileEntity aBaseMetaTileEntity, long aTick) {
+        super.onPreTick(aBaseMetaTileEntity, aTick);
+        if (aBaseMetaTileEntity.isServerSide() && q == null) {
+            q = WirelessComputationPacket.downloadData(aBaseMetaTileEntity.getOwnerUuid(), requiredComputation);
+        }
+
+    }
+
+    @Override
+    public void onFirstTick(IGregTechTileEntity aBaseMetaTileEntity) {
+        super.onFirstTick(aBaseMetaTileEntity);
+    }
+
+    @Override
+    public boolean useModularUI() {
+        return true;
+    }
+
+    @Override
+    public void addGregTechLogo(ModularWindow.Builder builder) {
+        builder.widget(
+            new DrawableWidget().setDrawable(TecTechUITextures.PICTURE_TECTECH_LOGO)
+                .setSize(18, 18)
+                .setPos(151, 63));
+    }
+
+    @Override
+    public void loadNBTData(NBTTagCompound aNBT) {
+        super.loadNBTData(aNBT);
+        requiredComputation = aNBT.getLong("requiredComputation");
+    }
+
+    @Override
+    public void saveNBTData(NBTTagCompound aNBT) {
+        super.saveNBTData(aNBT);
+        aNBT.setLong("requiredComputation", requiredComputation);
+    }
+
+    @Override
+    public void addUIWidgets(ModularWindow.Builder builder, UIBuildContext buildContext) {
+        builder.widget(
+            TextWidget.localised("tt.wirelessInputData.config.text")
+                .setPos(49, 18)
+                .setSize(81, 14))
+            .widget(
+                new TextFieldWidget().setSetterInt(val -> requiredComputation = val)
+                    .setGetterLong(() -> requiredComputation)
+                    .setNumbers(1, Integer.MAX_VALUE)
+                    .setOnScrollNumbers(1, 4, 64)
+                    .setTextAlignment(Alignment.Center)
+                    .setTextColor(Color.WHITE.normal)
+                    .setSize(70, 18)
+                    .setPos(54, 36)
+                    .setBackground(GT_UITextures.BACKGROUND_TEXT_FIELD));
+    }
+
+    private static String[] tooltips;
+
+    @Override
+    public String[] getDescription() {
+        if (tooltips == null) {
+            tooltips = new String[] { "Wireless Computation Data Input for Multiblocks" };
+        }
+        return tooltips;
+    }
+}

--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/hatch/GT_MetaTileEntity_Hatch_WirelessComputation_Output.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/hatch/GT_MetaTileEntity_Hatch_WirelessComputation_Output.java
@@ -1,0 +1,61 @@
+package com.github.technus.tectech.thing.metaTileEntity.hatch;
+
+import net.minecraftforge.common.util.ForgeDirection;
+
+import gregtech.api.interfaces.ITexture;
+import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
+import gregtech.api.metatileentity.MetaTileEntity;
+import gregtech.common.WirelessComputationPacket;
+
+public class GT_MetaTileEntity_Hatch_WirelessComputation_Output extends GT_MetaTileEntity_Hatch_OutputData {
+
+    public GT_MetaTileEntity_Hatch_WirelessComputation_Output(int aID, String aName, String aNameRegional, int aTier) {
+        super(aID, aName, aNameRegional, aTier);
+
+    }
+
+    public GT_MetaTileEntity_Hatch_WirelessComputation_Output(String aName, int aTier, String[] aDescription,
+        ITexture[][][] aTextures) {
+        super(aName, aTier, aDescription, aTextures);
+
+    }
+
+    @Override
+    public MetaTileEntity newMetaEntity(IGregTechTileEntity aTileEntity) {
+        return new GT_MetaTileEntity_Hatch_WirelessComputation_Output(mName, mTier, mDescriptionArray, mTextures);
+    }
+
+    @Override
+    public boolean isOutputFacing(ForgeDirection side) {
+        return false;
+    }
+
+    @Override
+    public boolean isDataInputFacing(ForgeDirection side) {
+        return false;
+    }
+
+    @Override
+    public boolean canConnectData(ForgeDirection side) {
+        return false;
+    }
+
+    @Override
+    public void onPreTick(IGregTechTileEntity aBaseMetaTileEntity, long aTick) {
+        super.onPreTick(aBaseMetaTileEntity, aTick);
+        if (aBaseMetaTileEntity.isServerSide() && q != null) {
+            WirelessComputationPacket.uploadData(aBaseMetaTileEntity.getOwnerUuid(), q.getContent());
+            q = null;
+        }
+    }
+
+    private static String[] tooltips;
+
+    @Override
+    public String[] getDescription() {
+        if (tooltips == null) {
+            tooltips = new String[] { "Wireless Computation Output for Multiblocks" };
+        }
+        return tooltips;
+    }
+}

--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/hatch/GT_MetaTileEntity_Hatch_WirelessComputation_Output.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/hatch/GT_MetaTileEntity_Hatch_WirelessComputation_Output.java
@@ -44,7 +44,7 @@ public class GT_MetaTileEntity_Hatch_WirelessComputation_Output extends GT_MetaT
     public void onPreTick(IGregTechTileEntity aBaseMetaTileEntity, long aTick) {
         super.onPreTick(aBaseMetaTileEntity, aTick);
         if (aBaseMetaTileEntity.isServerSide() && q != null) {
-            WirelessComputationPacket.uploadData(aBaseMetaTileEntity.getOwnerUuid(), q.getContent());
+            WirelessComputationPacket.uploadData(aBaseMetaTileEntity.getOwnerUuid(), q.getContent(), aTick);
             q = null;
         }
     }

--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/hatch/GT_MetaTileEntity_Hatch_WirelessInputDataItems.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/hatch/GT_MetaTileEntity_Hatch_WirelessInputDataItems.java
@@ -1,0 +1,146 @@
+package com.github.technus.tectech.thing.metaTileEntity.hatch;
+
+import static com.github.technus.tectech.thing.metaTileEntity.hatch.GT_MetaTileEntity_Hatch_DataConnector.EM_D_ACTIVE;
+import static com.github.technus.tectech.thing.metaTileEntity.hatch.GT_MetaTileEntity_Hatch_DataConnector.EM_D_CONN;
+import static com.github.technus.tectech.thing.metaTileEntity.hatch.GT_MetaTileEntity_Hatch_DataConnector.EM_D_SIDES;
+import static gregtech.api.enums.Dyes.MACHINE_METAL;
+import static net.minecraft.util.StatCollector.translateToLocal;
+import static net.minecraft.util.StatCollector.translateToLocalFormatted;
+
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.common.util.ForgeDirection;
+
+import org.apache.commons.lang3.reflect.FieldUtils;
+
+import com.github.technus.tectech.util.CommonValues;
+import com.github.technus.tectech.util.TT_Utility;
+
+import gregtech.api.enums.Dyes;
+import gregtech.api.interfaces.ITexture;
+import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
+import gregtech.api.metatileentity.MetaTileEntity;
+import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_DataAccess;
+import gregtech.api.objects.GT_RenderedTexture;
+import gregtech.common.WirelessDataStore;
+
+public class GT_MetaTileEntity_Hatch_WirelessInputDataItems extends GT_MetaTileEntity_Hatch_DataAccess {
+
+    private String clientLocale = "en_US";
+
+    public GT_MetaTileEntity_Hatch_WirelessInputDataItems(int aID, String aName, String aNameRegional, int aTier) {
+        super(aID, aName, aNameRegional, aTier);
+        TT_Utility.setTier(aTier, this);
+    }
+
+    public GT_MetaTileEntity_Hatch_WirelessInputDataItems(String aName, int aTier, String aDescription,
+        ITexture[][][] aTextures) {
+        super(aName, aTier, aDescription, aTextures);
+    }
+
+    public GT_MetaTileEntity_Hatch_WirelessInputDataItems(String aName, int aTier, String[] aDescription,
+        ITexture[][][] aTextures) {
+        super(aName, aTier, aDescription, aTextures);
+    }
+
+    @Override
+    public MetaTileEntity newMetaEntity(IGregTechTileEntity aTileEntity) {
+        return new GT_MetaTileEntity_Hatch_WirelessInputDataItems(
+            this.mName,
+            this.mTier,
+            mDescriptionArray,
+            this.mTextures);
+    }
+
+    @Override
+    public ITexture[] getTexturesActive(ITexture aBaseTexture) {
+        return new ITexture[] { aBaseTexture,
+            new GT_RenderedTexture(
+                EM_D_ACTIVE,
+                Dyes.getModulation(getBaseMetaTileEntity().getColorization(), MACHINE_METAL.getRGBA())),
+            new GT_RenderedTexture(EM_D_CONN) };
+    }
+
+    @Override
+    public ITexture[] getTexturesInactive(ITexture aBaseTexture) {
+        return new ITexture[] { aBaseTexture,
+            new GT_RenderedTexture(
+                EM_D_SIDES,
+                Dyes.getModulation(getBaseMetaTileEntity().getColorization(), MACHINE_METAL.getRGBA())),
+            new GT_RenderedTexture(EM_D_CONN) };
+    }
+
+    @Override
+    public boolean allowPullStack(IGregTechTileEntity aBaseMetaTileEntity, int aIndex, ForgeDirection side,
+        ItemStack aStack) {
+        return false;
+    }
+
+    @Override
+    public boolean allowPutStack(IGregTechTileEntity aBaseMetaTileEntity, int aIndex, ForgeDirection side,
+        ItemStack aStack) {
+        return false;
+    }
+
+    @Override
+    public boolean onRightclick(IGregTechTileEntity aBaseMetaTileEntity, EntityPlayer aPlayer) {
+        if (aBaseMetaTileEntity.isClientSide()) {
+            return true;
+        }
+        try {
+            EntityPlayerMP player = (EntityPlayerMP) aPlayer;
+            clientLocale = (String) FieldUtils.readField(player, "translator", true);
+        } catch (Exception e) {
+            clientLocale = "en_US";
+        }
+        return true;
+    }
+
+    @Override
+    public int getInventoryStackLimit() {
+        return 1;
+    }
+
+    @Override
+    public boolean isOutputFacing(ForgeDirection side) {
+        return false;
+    }
+
+    @Override
+    public boolean isInputFacing(ForgeDirection side) {
+        return side == getBaseMetaTileEntity().getFrontFacing();
+    }
+
+    @Override
+    public String[] getDescription() {
+        return new String[] { CommonValues.TEC_MARK_EM,
+            translateToLocal("gt.blockmachines.hatch.datainasswireless.desc.0"),
+            translateToLocal("gt.blockmachines.hatch.datainasswireless.desc.1"), };
+    }
+
+    @Override
+    public List<ItemStack> getInventoryItems(Predicate<ItemStack> filter) {
+        WirelessDataStore wirelessData = WirelessDataStore
+            .getWirelessDataSticks(getBaseMetaTileEntity().getOwnerUuid());
+        return wirelessData.downloadData()
+            .stream()
+            .filter(stack -> stack != null && filter.test(stack))
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    public boolean isGivingInformation() {
+        return true;
+    }
+
+    @Override
+    public String[] getInfoData() {
+        return new String[] { translateToLocalFormatted("tt.keyphrase.Content_Stack_Count", clientLocale) + ": "
+            + getInventoryItems(_stack -> true).size() };
+    }
+}

--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/hatch/GT_MetaTileEntity_Hatch_WirelessOutputDataItems.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/hatch/GT_MetaTileEntity_Hatch_WirelessOutputDataItems.java
@@ -1,0 +1,148 @@
+package com.github.technus.tectech.thing.metaTileEntity.hatch;
+
+import static com.github.technus.tectech.thing.metaTileEntity.hatch.GT_MetaTileEntity_Hatch_DataConnector.EM_D_ACTIVE;
+import static com.github.technus.tectech.thing.metaTileEntity.hatch.GT_MetaTileEntity_Hatch_DataConnector.EM_D_CONN;
+import static com.github.technus.tectech.thing.metaTileEntity.hatch.GT_MetaTileEntity_Hatch_DataConnector.EM_D_SIDES;
+import static gregtech.api.enums.Dyes.MACHINE_METAL;
+import static net.minecraft.util.StatCollector.translateToLocal;
+
+import java.util.Arrays;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraftforge.common.util.ForgeDirection;
+
+import com.github.technus.tectech.mechanics.dataTransport.InventoryDataPacket;
+import com.github.technus.tectech.util.CommonValues;
+import com.github.technus.tectech.util.TT_Utility;
+
+import gregtech.api.enums.Dyes;
+import gregtech.api.interfaces.ITexture;
+import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
+import gregtech.api.metatileentity.MetaTileEntity;
+import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch;
+import gregtech.api.objects.GT_RenderedTexture;
+import gregtech.common.WirelessDataStore;
+
+public class GT_MetaTileEntity_Hatch_WirelessOutputDataItems extends GT_MetaTileEntity_Hatch {
+
+    public InventoryDataPacket dataPacket = null;
+
+    public boolean uploadedSinceReset = false;
+
+    public GT_MetaTileEntity_Hatch_WirelessOutputDataItems(int aID, String aName, String aNameRegional, int aTier) {
+        super(
+            aID,
+            aName,
+            aNameRegional,
+            aTier,
+            0,
+            new String[] { CommonValues.TEC_MARK_EM,
+                translateToLocal("gt.blockmachines.hatch.wirelessdataoutass.desc.0"),
+                translateToLocal("gt.blockmachines.hatch.wirelessdataoutass.desc.1"), });
+        TT_Utility.setTier(aTier, this);
+    }
+
+    public GT_MetaTileEntity_Hatch_WirelessOutputDataItems(String aName, int aTier, String[] aDescription,
+        ITexture[][][] aTextures) {
+        super(aName, aTier, 0, aDescription, aTextures);
+    }
+
+    @Override
+    public boolean isSimpleMachine() {
+        return true;
+    }
+
+    @Override
+    public boolean isFacingValid(ForgeDirection facing) {
+        return true;
+    }
+
+    @Override
+    public MetaTileEntity newMetaEntity(IGregTechTileEntity aTileEntity) {
+        return new GT_MetaTileEntity_Hatch_WirelessOutputDataItems(
+            this.mName,
+            this.mTier,
+            this.mDescriptionArray,
+            this.mTextures);
+    }
+
+    @Override
+    public boolean allowPullStack(IGregTechTileEntity aBaseMetaTileEntity, int aIndex, ForgeDirection side,
+        ItemStack aStack) {
+        return false;
+    }
+
+    @Override
+    public boolean allowPutStack(IGregTechTileEntity aBaseMetaTileEntity, int aIndex, ForgeDirection side,
+        ItemStack aStack) {
+        return false;
+    }
+
+    @Override
+    public int getInventoryStackLimit() {
+        return 1;
+    }
+
+    @Override
+    public boolean isOutputFacing(ForgeDirection side) {
+        return side == getBaseMetaTileEntity().getFrontFacing();
+    }
+
+    @Override
+    public boolean isInputFacing(ForgeDirection side) {
+        return false;
+    }
+
+    @Override
+    public void saveNBTData(NBTTagCompound aNBT) {
+        super.saveNBTData(aNBT);
+        if (dataPacket != null) {
+            aNBT.setTag("eDATA", dataPacket.toNbt());
+        }
+        aNBT.setBoolean("uploadedSinceReset", uploadedSinceReset);
+    }
+
+    @Override
+    public void loadNBTData(NBTTagCompound aNBT) {
+        super.loadNBTData(aNBT);
+        if (aNBT.hasKey("eDATA")) {
+            dataPacket = new InventoryDataPacket(aNBT.getCompoundTag("eDATA"));
+        }
+        if (aNBT.hasKey("uploadedSinceReset")) {
+            uploadedSinceReset = aNBT.getBoolean("uploadedSinceReset");
+        }
+    }
+
+    @Override
+    public void onPostTick(IGregTechTileEntity aBaseMetaTileEntity, long aTick) {
+        if (aBaseMetaTileEntity.isServerSide()) {
+            // Upload data packet and mark it as uploaded, so it will not be uploaded again
+            // until the data bank resets the wireless network
+            if (dataPacket != null && !uploadedSinceReset) {
+                WirelessDataStore wirelessDataStore = WirelessDataStore
+                    .getWirelessDataSticks(getBaseMetaTileEntity().getOwnerUuid());
+                wirelessDataStore.uploadData(Arrays.asList(dataPacket.getContent()));
+                uploadedSinceReset = true;
+            }
+        }
+    }
+
+    @Override
+    public ITexture[] getTexturesActive(ITexture aBaseTexture) {
+        return new ITexture[] { aBaseTexture,
+            new GT_RenderedTexture(
+                EM_D_ACTIVE,
+                Dyes.getModulation(getBaseMetaTileEntity().getColorization(), MACHINE_METAL.getRGBA())),
+            new GT_RenderedTexture(EM_D_CONN) };
+    }
+
+    @Override
+    public ITexture[] getTexturesInactive(ITexture aBaseTexture) {
+        return new ITexture[] { aBaseTexture,
+            new GT_RenderedTexture(
+                EM_D_SIDES,
+                Dyes.getModulation(getBaseMetaTileEntity().getColorization(), MACHINE_METAL.getRGBA())),
+            new GT_RenderedTexture(EM_D_CONN) };
+    }
+}

--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/GT_MetaTileEntity_EM_computer.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/GT_MetaTileEntity_EM_computer.java
@@ -568,7 +568,12 @@ public class GT_MetaTileEntity_EM_computer extends GT_MetaTileEntity_MultiblockB
     public String[] getInfoData() {
         ArrayList<String> data = new ArrayList<>(Arrays.asList(super.getInfoData()));
         if (wirelessModeEnabled) {
+            WirelessComputationPacket wirelessComputationPacket = WirelessComputationPacket
+                .getPacketByUserId(getBaseMetaTileEntity().getOwnerUuid());
             data.add("Wireless mode: " + EnumChatFormatting.GREEN + "enabled");
+            data.add(
+                "Total wireless computation available: " + EnumChatFormatting.YELLOW
+                    + wirelessComputationPacket.getTotalComputationStored());
         } else {
             data.add("Wireless mode: " + EnumChatFormatting.RED + "disabled");
         }

--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/GT_MetaTileEntity_EM_computer.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/GT_MetaTileEntity_EM_computer.java
@@ -18,6 +18,7 @@ import static gregtech.api.util.GT_Utility.filterValidMTEs;
 import static net.minecraft.util.StatCollector.translateToLocal;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -229,6 +230,9 @@ public class GT_MetaTileEntity_EM_computer extends GT_MetaTileEntity_MultiblockB
         }
         if (aNBT.hasKey("wirelessModeEnabled")) {
             wirelessModeEnabled = aNBT.getBoolean("wirelessModeEnabled");
+            if (wirelessModeEnabled) {
+                WirelessComputationPacket.enableWirelessNetWork(getBaseMetaTileEntity());
+            }
         } else {
             wirelessModeEnabled = false;
         }
@@ -237,7 +241,7 @@ public class GT_MetaTileEntity_EM_computer extends GT_MetaTileEntity_MultiblockB
     @Override
     public void onPreTick(IGregTechTileEntity aBaseMetaTileEntity, long aTick) {
         super.onPreTick(aBaseMetaTileEntity, aTick);
-        if (aBaseMetaTileEntity.isServerSide() && wirelessModeEnabled) {
+        if (aBaseMetaTileEntity.isServerSide() && wirelessModeEnabled && aTick % 20 == 0) {
             WirelessComputationPacket.updatePacket(aBaseMetaTileEntity, aTick);
         }
     }
@@ -558,6 +562,17 @@ public class GT_MetaTileEntity_EM_computer extends GT_MetaTileEntity_MultiblockB
     @Override
     public String[] getStructureDescription(ItemStack stackSize) {
         return description;
+    }
+
+    @Override
+    public String[] getInfoData() {
+        ArrayList<String> data = new ArrayList<>(Arrays.asList(super.getInfoData()));
+        if (wirelessModeEnabled) {
+            data.add("Wireless mode: " + EnumChatFormatting.GREEN + "enabled");
+        } else {
+            data.add("Wireless mode: " + EnumChatFormatting.RED + "disabled");
+        }
+        return data.toArray(new String[] {});
     }
 
     private enum RackHatchElement implements IHatchElement<GT_MetaTileEntity_EM_computer> {

--- a/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/GT_MetaTileEntity_EM_dataBank.java
+++ b/src/main/java/com/github/technus/tectech/thing/metaTileEntity/multi/GT_MetaTileEntity_EM_dataBank.java
@@ -15,9 +15,11 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.util.ForgeDirection;
@@ -28,6 +30,7 @@ import com.github.technus.tectech.Reference;
 import com.github.technus.tectech.mechanics.dataTransport.InventoryDataPacket;
 import com.github.technus.tectech.thing.metaTileEntity.hatch.GT_MetaTileEntity_Hatch_InputDataItems;
 import com.github.technus.tectech.thing.metaTileEntity.hatch.GT_MetaTileEntity_Hatch_OutputDataItems;
+import com.github.technus.tectech.thing.metaTileEntity.hatch.GT_MetaTileEntity_Hatch_WirelessOutputDataItems;
 import com.github.technus.tectech.thing.metaTileEntity.multi.base.GT_MetaTileEntity_MultiblockBase_EM;
 import com.github.technus.tectech.thing.metaTileEntity.multi.base.render.TT_RenderedExtendedFacingTexture;
 import com.github.technus.tectech.util.CommonValues;
@@ -47,15 +50,20 @@ import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_DataA
 import gregtech.api.recipe.check.CheckRecipeResult;
 import gregtech.api.recipe.check.SimpleCheckRecipeResult;
 import gregtech.api.util.GT_Multiblock_Tooltip_Builder;
+import gregtech.api.util.GT_Utility;
 import gregtech.api.util.IGT_HatchAdder;
+import gregtech.common.WirelessComputationPacket;
+import gregtech.common.WirelessDataStore;
 
 public class GT_MetaTileEntity_EM_dataBank extends GT_MetaTileEntity_MultiblockBase_EM
     implements ISurvivalConstructable {
 
     // region variables
     private final ArrayList<GT_MetaTileEntity_Hatch_OutputDataItems> eStacksDataOutputs = new ArrayList<>();
+    private final ArrayList<GT_MetaTileEntity_Hatch_WirelessOutputDataItems> eWirelessStacksDataOutputs = new ArrayList<>();
     private final ArrayList<IInventory> eDataAccessHatches = new ArrayList<>();
     private boolean slave = false;
+    private boolean wirelessModeEnabled = false;
     // endregion
 
     // region structure
@@ -81,7 +89,10 @@ public class GT_MetaTileEntity_EM_dataBank extends GT_MetaTileEntity_MultiblockB
         .addElement(
             'D',
             buildHatchAdder(GT_MetaTileEntity_EM_dataBank.class)
-                .atLeast(DataBankHatches.OutboundConnector, DataBankHatches.InboundConnector)
+                .atLeast(
+                    DataBankHatches.OutboundConnector,
+                    DataBankHatches.InboundConnector,
+                    DataBankHatches.WirelessOutboundConnector)
                 .casingIndex(textureOffset + 1)
                 .dot(2)
                 .buildAndChain(DataBankHatches.DataStick.newAny(textureOffset + 1, 2), ofBlock(sBlockCasingsTT, 1)))
@@ -111,8 +122,11 @@ public class GT_MetaTileEntity_EM_dataBank extends GT_MetaTileEntity_MultiblockB
                                                                                            // Assembling Lines
             // with more Data Sticks
             .addInfo(translateToLocal("gt.blockmachines.multimachine.em.databank.desc.2")) // and give multiple
-                                                                                           // Assembling
-            // Lines access to the same Data
+                                                                                           // Assembling Lines access to
+                                                                                           // the same Data
+            .addInfo(translateToLocal("gt.blockmachines.multimachine.em.databank.desc.3")) // Use screwdriver to toggle
+                                                                                           // wireless mode
+
             // Stick
             .addInfo(translateToLocal("tt.keyword.Structure.StructureTooComplex")) // The structure is too complex!
             .addSeparator()
@@ -138,6 +152,7 @@ public class GT_MetaTileEntity_EM_dataBank extends GT_MetaTileEntity_MultiblockB
     public boolean checkMachine_EM(IGregTechTileEntity iGregTechTileEntity, ItemStack itemStack) {
         eDataAccessHatches.clear();
         eStacksDataOutputs.clear();
+        eWirelessStacksDataOutputs.clear();
         slave = false;
         return structureCheck_EM("main", 2, 1, 0);
     }
@@ -145,9 +160,10 @@ public class GT_MetaTileEntity_EM_dataBank extends GT_MetaTileEntity_MultiblockB
     @Override
     @NotNull
     protected CheckRecipeResult checkProcessing_EM() {
-        if (eDataAccessHatches.size() > 0 && eStacksDataOutputs.size() > 0) {
+        if (eDataAccessHatches.size() > 0 && (eStacksDataOutputs.size() > 0 || eWirelessStacksDataOutputs.size() > 0)) {
             mEUt = -(int) V[slave ? 6 : 4];
-            eAmpereFlow = 1 + (long) eStacksDataOutputs.size() * eDataAccessHatches.size();
+            eAmpereFlow = 1
+                + (long) (eStacksDataOutputs.size() + eWirelessStacksDataOutputs.size()) * eDataAccessHatches.size();
             mMaxProgresstime = 20;
             mEfficiencyIncrease = 10000;
             return SimpleCheckRecipeResult.ofSuccess("providing_data");
@@ -172,9 +188,17 @@ public class GT_MetaTileEntity_EM_dataBank extends GT_MetaTileEntity_MultiblockB
             for (GT_MetaTileEntity_Hatch_OutputDataItems hatch : eStacksDataOutputs) {
                 hatch.q = new InventoryDataPacket(arr);
             }
+            if (wirelessModeEnabled) {
+                for (GT_MetaTileEntity_Hatch_WirelessOutputDataItems hatch : eWirelessStacksDataOutputs) {
+                    hatch.dataPacket = new InventoryDataPacket(arr);
+                }
+            }
         } else {
             for (GT_MetaTileEntity_Hatch_OutputDataItems hatch : eStacksDataOutputs) {
                 hatch.q = null;
+            }
+            for (GT_MetaTileEntity_Hatch_WirelessOutputDataItems hatch : eWirelessStacksDataOutputs) {
+                hatch.dataPacket = null;
             }
         }
     }
@@ -207,6 +231,10 @@ public class GT_MetaTileEntity_EM_dataBank extends GT_MetaTileEntity_MultiblockB
         if (aMetaTileEntity == null) {
             return false;
         }
+        if (aMetaTileEntity instanceof GT_MetaTileEntity_Hatch_WirelessOutputDataItems) {
+            ((GT_MetaTileEntity_Hatch_WirelessOutputDataItems) aMetaTileEntity).updateTexture(aBaseCasingIndex);
+            return eWirelessStacksDataOutputs.add((GT_MetaTileEntity_Hatch_WirelessOutputDataItems) aMetaTileEntity);
+        }
         if (aMetaTileEntity instanceof GT_MetaTileEntity_Hatch_OutputDataItems) {
             ((GT_MetaTileEntity_Hatch) aMetaTileEntity).updateTexture(aBaseCasingIndex);
             return eStacksDataOutputs.add((GT_MetaTileEntity_Hatch_OutputDataItems) aMetaTileEntity);
@@ -220,6 +248,53 @@ public class GT_MetaTileEntity_EM_dataBank extends GT_MetaTileEntity_MultiblockB
                 return eDataAccessHatches.add(aMetaTileEntity);
             }
         return false;
+    }
+
+    @Override
+    public void onPreTick(IGregTechTileEntity aBaseMetaTileEntity, long aTick) {
+        super.onPreTick(aBaseMetaTileEntity, aTick);
+        // Every 200 ticks, clear wireless data store so hatches need to provide their data again in
+        // their onPostTick() call. This also happens every 200 ticks
+        if (mMachine && aBaseMetaTileEntity.isActive() && wirelessModeEnabled && aTick % 200 == 0) {
+            WirelessDataStore wirelessStore = WirelessDataStore
+                .getWirelessDataSticks(aBaseMetaTileEntity.getOwnerUuid());
+            wirelessStore.clearData();
+
+            // After reset, clear uploadedSinceReset of all connected hatches
+            for (GT_MetaTileEntity_Hatch_WirelessOutputDataItems hatch : eWirelessStacksDataOutputs) {
+                hatch.uploadedSinceReset = false;
+            }
+        }
+    }
+
+    @Override
+    public void onScrewdriverRightClick(ForgeDirection side, EntityPlayer aPlayer, float aX, float aY, float aZ) {
+        if (getBaseMetaTileEntity().isServerSide()) {
+            wirelessModeEnabled = !wirelessModeEnabled;
+            if (wirelessModeEnabled) {
+                GT_Utility.sendChatToPlayer(aPlayer, "Wireless mode enabled");
+                WirelessComputationPacket.enableWirelessNetWork(getBaseMetaTileEntity());
+            } else {
+                GT_Utility.sendChatToPlayer(aPlayer, "Wireless mode disabled");
+                WirelessComputationPacket.disableWirelessNetWork(getBaseMetaTileEntity());
+            }
+        }
+    }
+
+    @Override
+    public void saveNBTData(NBTTagCompound aNBT) {
+        super.saveNBTData(aNBT);
+        aNBT.setBoolean("wirelessModeEnabled", wirelessModeEnabled);
+    }
+
+    @Override
+    public void loadNBTData(NBTTagCompound aNBT) {
+        super.loadNBTData(aNBT);
+        if (aNBT.hasKey("wirelessModeEnabled")) {
+            wirelessModeEnabled = aNBT.getBoolean("wirelessModeEnabled");
+        } else {
+            wirelessModeEnabled = false;
+        }
     }
 
     @Override
@@ -264,6 +339,13 @@ public class GT_MetaTileEntity_EM_dataBank extends GT_MetaTileEntity_MultiblockB
             @Override
             public long count(GT_MetaTileEntity_EM_dataBank t) {
                 return t.eDataAccessHatches.size();
+            }
+        },
+        WirelessOutboundConnector(GT_MetaTileEntity_Hatch_WirelessOutputDataItems.class) {
+
+            @Override
+            public long count(GT_MetaTileEntity_EM_dataBank t) {
+                return t.eWirelessStacksDataOutputs.size();
             }
         };
 

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_DataAccess.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_DataAccess.java
@@ -2,6 +2,10 @@ package gregtech.api.metatileentity.implementations;
 
 import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_DATA_ACCESS;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
+
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -137,6 +141,20 @@ public class GT_MetaTileEntity_Hatch_DataAccess extends GT_MetaTileEntity_Hatch 
     public void setInventorySlotContents(int aIndex, ItemStack aStack) {
         super.setInventorySlotContents(aIndex, aStack);
         GT_AssemblyLineUtils.processDataStick(aStack);
+    }
+
+    public List<ItemStack> getInventoryItems(Predicate<ItemStack> filter) {
+        ArrayList<ItemStack> items = new ArrayList<>();
+        IGregTechTileEntity te = getBaseMetaTileEntity();
+        for (int i = 0; i < te.getSizeInventory(); ++i) {
+            ItemStack slot = te.getStackInSlot(i);
+            if (slot != null) {
+                if (filter != null && filter.test(slot)) {
+                    items.add(slot);
+                }
+            }
+        }
+        return items;
     }
 
     @Override

--- a/src/main/java/gregtech/common/WirelessComputationPacket.java
+++ b/src/main/java/gregtech/common/WirelessComputationPacket.java
@@ -23,7 +23,7 @@ public class WirelessComputationPacket {
 
     public Vec3Impl controllerPosition = null;
 
-    private long getTotalComputationStored() {
+    public long getTotalComputationStored() {
         return computationStored[0] + computationStored[1];
     }
 

--- a/src/main/java/gregtech/common/WirelessComputationPacket.java
+++ b/src/main/java/gregtech/common/WirelessComputationPacket.java
@@ -1,6 +1,6 @@
 package gregtech.common;
 
-import static gregtech.common.misc.GlobalVariableStorage.GlobalWirelessData;
+import static gregtech.common.misc.GlobalVariableStorage.GlobalWirelessComputation;
 
 import java.util.UUID;
 
@@ -10,7 +10,7 @@ import com.gtnewhorizon.structurelib.util.Vec3Impl;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.common.misc.spaceprojects.SpaceProjectManager;
 
-public class WirelessDataPacket {
+public class WirelessComputationPacket {
 
     public boolean wirelessEnabled = false;
 
@@ -89,11 +89,11 @@ public class WirelessDataPacket {
         getPacketByUserId(entity.getOwnerUuid()).setWirelessEnabled(false);
     }
 
-    public static WirelessDataPacket getPacketByUserId(UUID userId) {
+    public static WirelessComputationPacket getPacketByUserId(UUID userId) {
         UUID team = SpaceProjectManager.getLeader(userId);
-        if (GlobalWirelessData.get(team) == null) {
-            GlobalWirelessData.put(team, new WirelessDataPacket());
+        if (GlobalWirelessComputation.get(team) == null) {
+            GlobalWirelessComputation.put(team, new WirelessComputationPacket());
         }
-        return GlobalWirelessData.get(team);
+        return GlobalWirelessComputation.get(team);
     }
 }

--- a/src/main/java/gregtech/common/WirelessComputationPacket.java
+++ b/src/main/java/gregtech/common/WirelessComputationPacket.java
@@ -14,10 +14,6 @@ public class WirelessComputationPacket {
 
     public boolean wirelessEnabled = false;
 
-    public long latestPacketUpdate = -1000000;
-    public long[] latestUpload = new long[20];
-    public long[] latestDownload = new long[20];
-
     // The main idea: 'Clearing' the computation net advances the index and sets the computation stored
     // for this index to zero. Uploading is always done to the current index, but data can be downloaded from
     // both indices
@@ -25,12 +21,7 @@ public class WirelessComputationPacket {
     private long computationDownloaded = 0;
     private int currentIndex = 0;
 
-    public final long[] previewUploaded = new long[20];
-
-    public final long[] previewDownloaded = new long[20];
-
     public Vec3Impl controllerPosition = null;
-    public int loopTags = 0;
 
     private long getTotalComputationStored() {
         return computationStored[0] + computationStored[1];
@@ -52,17 +43,6 @@ public class WirelessComputationPacket {
             computationDownloaded += dataIn;
             return new QuantumDataPacket(dataIn);
         } else return new QuantumDataPacket(0L);
-
-        /*
-         * latestDownload[loopTags] += dataIn;
-         * double totalRequired = 1, totalUploaded = 1;
-         * for (int i = 0; i < 20; i++) {
-         * totalRequired += latestDownload[i];
-         * totalUploaded += latestUpload[i];
-         * }
-         * long result = (long) (Math.min(1.0, totalUploaded / totalRequired) * dataIn);
-         * return new QuantumDataPacket(result).unifyTraceWith(controllerPosition);
-         */
     }
 
     private void update(IGregTechTileEntity entity, long aTick) {
@@ -88,14 +68,6 @@ public class WirelessComputationPacket {
         computationDownloaded = 0;
         // Now advance the current index to the next index
         currentIndex = nextIndex;
-        /*
-         * latestPacketUpdate = System.currentTimeMillis();
-         * loopTags = (loopTags + 1) % 20;
-         * latestUpload[loopTags] -= previewUploaded[loopTags];
-         * latestDownload[loopTags] -= previewDownloaded[loopTags];
-         * previewUploaded[loopTags] = latestUpload[loopTags];
-         * previewDownloaded[loopTags] = latestDownload[loopTags];
-         */
     }
 
     private void setWirelessEnabled(boolean wirelessEnabled) {
@@ -105,9 +77,6 @@ public class WirelessComputationPacket {
     private void upload(long dataOut, long aTick) {
         // Store computation that is uploaded internally
         computationStored[currentIndex] += dataOut;
-        long time = System.currentTimeMillis();
-        if (!wirelessEnabled || Math.abs(time - latestPacketUpdate) > 10000) return;
-        latestUpload[loopTags] += dataOut;
     }
 
     public static QuantumDataPacket downloadData(UUID userId, long dataIn, long aTick) {

--- a/src/main/java/gregtech/common/WirelessDataPacket.java
+++ b/src/main/java/gregtech/common/WirelessDataPacket.java
@@ -1,0 +1,99 @@
+package gregtech.common;
+
+import static gregtech.common.misc.GlobalVariableStorage.GlobalWirelessData;
+
+import java.util.UUID;
+
+import com.github.technus.tectech.mechanics.dataTransport.QuantumDataPacket;
+import com.gtnewhorizon.structurelib.util.Vec3Impl;
+
+import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
+import gregtech.common.misc.spaceprojects.SpaceProjectManager;
+
+public class WirelessDataPacket {
+
+    public boolean wirelessEnabled = false;
+
+    public long latestPacketUpdate = -1000000;
+    public long[] latestUpload = new long[20];
+    public long[] latestDownload = new long[20];
+
+    public final long[] previewUploaded = new long[20];
+
+    public final long[] previewDownloaded = new long[20];
+
+    public Vec3Impl controllerPosition = null;
+    public int loopTags = 0;
+
+    private QuantumDataPacket download(long dataIn) {
+        long time = System.currentTimeMillis();
+        if (!wirelessEnabled || Math.abs(time - latestPacketUpdate) > 10000 || controllerPosition == null)
+            return new QuantumDataPacket(0L);
+        latestDownload[loopTags] += dataIn;
+        double totalRequired = 1, totalUploaded = 1;
+        for (int i = 0; i < 20; i++) {
+            totalRequired += latestDownload[i];
+            totalUploaded += latestUpload[i];
+        }
+        long result = (long) (Math.min(1.0, totalUploaded / totalRequired) * dataIn);
+        return new QuantumDataPacket(result).unifyTraceWith(controllerPosition);
+    }
+
+    private void update(IGregTechTileEntity entity, long aTick) {
+        latestPacketUpdate = System.currentTimeMillis();
+        loopTags = (loopTags + 1) % 20;
+        latestUpload[loopTags] -= previewUploaded[loopTags];
+        latestDownload[loopTags] -= previewDownloaded[loopTags];
+        previewUploaded[loopTags] = latestUpload[loopTags];
+        previewDownloaded[loopTags] = latestDownload[loopTags];
+    }
+
+    private void setWirelessEnabled(boolean wirelessEnabled) {
+        this.wirelessEnabled = wirelessEnabled;
+    }
+
+    private void upload(long dataOut) {
+        long time = System.currentTimeMillis();
+        if (!wirelessEnabled || Math.abs(time - latestPacketUpdate) > 10000) return;
+        latestUpload[loopTags] += dataOut;
+    }
+
+    public static QuantumDataPacket downloadData(UUID userId, long dataIn) {
+        return getPacketByUserId(userId).download(dataIn);
+    }
+
+    public static void uploadData(UUID userId, long dataOut) {
+        getPacketByUserId(userId).upload(dataOut);
+    }
+
+    public static void updatePacket(IGregTechTileEntity entity, long aTick) {
+        getPacketByUserId(entity.getOwnerUuid()).update(entity, aTick);
+    }
+
+    public static boolean enableWirelessNetWork(IGregTechTileEntity entity) {
+        var packet = getPacketByUserId(entity.getOwnerUuid());
+        Vec3Impl pos = new Vec3Impl(entity.getXCoord(), entity.getYCoord(), entity.getZCoord());
+        if (packet.wirelessEnabled && packet.controllerPosition != null
+            && pos.compareTo(packet.controllerPosition) != 0) return false;
+        getPacketByUserId(entity.getOwnerUuid()).setWirelessEnabled(true);
+        if (packet.controllerPosition == null) {
+            packet.controllerPosition = new Vec3Impl(entity.getXCoord(), entity.getYCoord(), entity.getZCoord());
+        }
+        return true;
+    }
+
+    public static void disableWirelessNetWork(IGregTechTileEntity entity) {
+        var packet = getPacketByUserId(entity.getOwnerUuid());
+        Vec3Impl pos = new Vec3Impl(entity.getXCoord(), entity.getYCoord(), entity.getZCoord());
+        if (packet.controllerPosition != null && packet.controllerPosition.compareTo(pos) != 0) return;
+        getPacketByUserId(entity.getOwnerUuid()).setWirelessEnabled(false);
+    }
+
+    public static WirelessDataPacket getPacketByUserId(UUID userId) {
+        UUID team = SpaceProjectManager.getLeader(userId);
+        if (GlobalWirelessData.get(team) == null) {
+            GlobalWirelessData.put(team, new WirelessDataPacket());
+        }
+        return GlobalWirelessData.get(team);
+    }
+}

--- a/src/main/java/gregtech/common/WirelessDataStore.java
+++ b/src/main/java/gregtech/common/WirelessDataStore.java
@@ -1,0 +1,36 @@
+package gregtech.common;
+
+import static gregtech.common.misc.GlobalVariableStorage.GlobalWirelessDataSticks;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import net.minecraft.item.ItemStack;
+
+import gregtech.common.misc.spaceprojects.SpaceProjectManager;
+
+public class WirelessDataStore {
+
+    private final ArrayList<ItemStack> dataSticks = new ArrayList<>();
+
+    public void clearData() {
+        dataSticks.clear();
+    }
+
+    public void uploadData(List<ItemStack> sticks) {
+        dataSticks.addAll(sticks);
+    }
+
+    public List<ItemStack> downloadData() {
+        return dataSticks;
+    }
+
+    public static WirelessDataStore getWirelessDataSticks(UUID uuid) {
+        UUID team = SpaceProjectManager.getLeader(uuid);
+        if (GlobalWirelessDataSticks.get(team) == null) {
+            GlobalWirelessDataSticks.put(team, new WirelessDataStore());
+        }
+        return GlobalWirelessDataSticks.get(team);
+    }
+}

--- a/src/main/java/gregtech/common/misc/GlobalVariableStorage.java
+++ b/src/main/java/gregtech/common/misc/GlobalVariableStorage.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.UUID;
 
 import gregtech.common.WirelessComputationPacket;
+import gregtech.common.WirelessDataStore;
 
 public abstract class GlobalVariableStorage {
     // --------------------- NEVER access these maps! Use the methods provided! ---------------------
@@ -14,6 +15,9 @@ public abstract class GlobalVariableStorage {
 
     // Global Wireless Data map
     public static HashMap<UUID, WirelessComputationPacket> GlobalWirelessComputation = new HashMap<>(100, 0.9f);
+
+    // Global Wireless Data Stick map
+    public static HashMap<UUID, WirelessDataStore> GlobalWirelessDataSticks = new HashMap<>(100, 0.9f);
 
     // ----------------------------------------------------------------------------------------------
 }

--- a/src/main/java/gregtech/common/misc/GlobalVariableStorage.java
+++ b/src/main/java/gregtech/common/misc/GlobalVariableStorage.java
@@ -4,12 +4,16 @@ import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.UUID;
 
+import gregtech.common.WirelessDataPacket;
+
 public abstract class GlobalVariableStorage {
     // --------------------- NEVER access these maps! Use the methods provided! ---------------------
 
     // Global EU map.
     public static HashMap<UUID, BigInteger> GlobalEnergy = new HashMap<>(100, 0.9f);
 
-    // ----------------------------------------------------------------------------------------------
+    // Global Wireless Data map
+    public static HashMap<UUID, WirelessDataPacket> GlobalWirelessData = new HashMap<>(100, 0.9f);
 
+    // ----------------------------------------------------------------------------------------------
 }

--- a/src/main/java/gregtech/common/misc/GlobalVariableStorage.java
+++ b/src/main/java/gregtech/common/misc/GlobalVariableStorage.java
@@ -4,7 +4,7 @@ import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.UUID;
 
-import gregtech.common.WirelessDataPacket;
+import gregtech.common.WirelessComputationPacket;
 
 public abstract class GlobalVariableStorage {
     // --------------------- NEVER access these maps! Use the methods provided! ---------------------
@@ -13,7 +13,7 @@ public abstract class GlobalVariableStorage {
     public static HashMap<UUID, BigInteger> GlobalEnergy = new HashMap<>(100, 0.9f);
 
     // Global Wireless Data map
-    public static HashMap<UUID, WirelessDataPacket> GlobalWirelessData = new HashMap<>(100, 0.9f);
+    public static HashMap<UUID, WirelessComputationPacket> GlobalWirelessComputation = new HashMap<>(100, 0.9f);
 
     // ----------------------------------------------------------------------------------------------
 }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_AssemblyLine.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_AssemblyLine.java
@@ -395,7 +395,7 @@ public class GT_MetaTileEntity_AssemblyLine extends
     /**
      * @param state using bitmask, 1 for IntegratedCircuit, 2 for DataStick, 4 for DataOrb
      */
-    private boolean isCorrectDataItem(ItemStack aStack, int state) {
+    private static boolean isCorrectDataItem(ItemStack aStack, int state) {
         if ((state & 1) != 0 && ItemList.Circuit_Integrated.isStackEqual(aStack, true, true)) return true;
         if ((state & 2) != 0 && ItemList.Tool_DataStick.isStackEqual(aStack, false, true)) return true;
         return (state & 4) != 0 && ItemList.Tool_DataOrb.isStackEqual(aStack, false, true);
@@ -410,17 +410,7 @@ public class GT_MetaTileEntity_AssemblyLine extends
             rList.add(mInventory[1]);
         }
         for (GT_MetaTileEntity_Hatch_DataAccess tHatch : filterValidMTEs(mDataAccessHatches)) {
-            for (int i = 0; i < tHatch.getBaseMetaTileEntity()
-                .getSizeInventory(); i++) {
-                if (tHatch.getBaseMetaTileEntity()
-                    .getStackInSlot(i) != null && isCorrectDataItem(
-                        tHatch.getBaseMetaTileEntity()
-                            .getStackInSlot(i),
-                        state))
-                    rList.add(
-                        tHatch.getBaseMetaTileEntity()
-                            .getStackInSlot(i));
-            }
+            rList.addAll(tHatch.getInventoryItems(stack -> isCorrectDataItem(stack, state)));
         }
         return rList;
     }

--- a/src/main/resources/assets/tectech/lang/en_US.lang
+++ b/src/main/resources/assets/tectech/lang/en_US.lang
@@ -703,6 +703,7 @@ gt.blockmachines.multimachine.em.computer.cfgo.0=Current max. heat
 gt.blockmachines.multimachine.em.computer.cfgo.1=Produced computation
 gt.blockmachines.multimachine.em.computer.desc.0=Controller block of the Quantum Computer
 gt.blockmachines.multimachine.em.computer.desc.1=Used to generate computation (and heat)
+gt.blockmachines.multimachine.em.computer.desc.2=Use screwdriver to toggle wireless mode
 
 gt.blockmachines.multimachine.em.databank.name=Data Bank
 gt.blockmachines.multimachine.em.databank.hint.0=1 - Classic Hatches or high power casing
@@ -1226,6 +1227,7 @@ tt.keyword.Structure.EssentiaStorage=Essentia Storage
 tt.keyword.Structure.DataConnector=Data Connector
 tt.keyword.Structure.SuperconductingCoilBlock=Superconducting Coil Block
 tt.keyword.Structure.StainlessSteelCasing=Stainless Steel Casing
+tt.wirelessInputData.config.text=Configure how much computation to pull from wireless network
 
 
 tt.keyphrase.Hint_Details=Hint Details

--- a/src/main/resources/assets/tectech/lang/en_US.lang
+++ b/src/main/resources/assets/tectech/lang/en_US.lang
@@ -522,10 +522,16 @@ gt.blockmachines.hatch.datainass.desc.0=ItemStack Data Input for Multiblocks
 gt.blockmachines.hatch.datainass.desc.1=High speed fibre optics connector.
 gt.blockmachines.hatch.datainass.desc.2=Must be painted to work
 
+gt.blockmachines.hatch.datainasswireless.desc.0=Wireless ItemStack Data Input for Multiblocks
+gt.blockmachines.hatch.datainasswireless.desc.1=High speed internet connection
+
 gt.blockmachines.hatch.dataoutass.tier.07.name=Data Bank Master Connector
 gt.blockmachines.hatch.dataoutass.desc.0=ItemStack Data Output for Multiblocks
 gt.blockmachines.hatch.dataoutass.desc.1=High speed fibre optics connector.
 gt.blockmachines.hatch.dataoutass.desc.2=Must be painted to work
+
+gt.blockmachines.hatch.wirelessdataoutass.desc.0=Wireless ItemStack Data Output for Multiblocks
+gt.blockmachines.hatch.wirelessdataoutass.desc.1=High speed internet connection
 
 gt.blockmachines.hatch.rack.tier.08.name=Computer Rack
 gt.blockmachines.hatch.rack.desc.0=4 Slot Rack
@@ -711,6 +717,7 @@ gt.blockmachines.multimachine.em.databank.hint.1=2 - Data Access/Data Bank Maste
 gt.blockmachines.multimachine.em.databank.desc.0=Controller block of the Data Bank
 gt.blockmachines.multimachine.em.databank.desc.1=Used to supply Assembling Lines with more Data Sticks
 gt.blockmachines.multimachine.em.databank.desc.2=and give multiple Assembling Lines access to the same Data Stick
+gt.blockmachines.multimachine.em.databank.desc.3=Use screwdriver to toggle wireless mode
 
 gt.blockmachines.multimachine.em.junction.name=Matter Junction
 gt.blockmachines.multimachine.em.junction.hint.0=1 - Classic Hatches or High Power Casing


### PR DESCRIPTION
This PR adds special hatches for wireless computation and data sticks. These are managed through space teams. The idea will be  to gate the hatches to UMV+, but this will be done in a separate PR to coremod once this PR is merged. For the computation hatches, a large part of the implementation was (with permission) adapted from Twist Space Technology.

- The wireless computation output hatch uploads its computation to your team's wireless network
- The wireless computation input hatch has a GUI that allows you to specify how much computation from your wireless network you want the hatch to pull
- To use wireless computation, enable wireless mode with a screwdriver on the quantum computer and place a Wireless Optical Master Hatch, which will upload its contents to the wireless network.

- To use wireless data sticks, enable wireless mode with a screwdriver on a data bank. 
- For wireless mode to do anything, you need at least one Wireless Data Bank Master Connector on the data bank. Adding more has no functional effect. Placing a Wireless Data Bank Master Connector will expose all data sticks inside the data bank to the wireless data stick network.
- Place a Wireless Assembly Line Slave Connector anywhere to make the data sticks in the wireless network available for the machine using them.

Demo videos on streamable:
https://streamable.com/12bmoe
https://streamable.com/lezfia