### PR TITLE
Hot salt ehe support

### DIFF
--- a/src/main/java/goodgenerator/loader/RecipeLoader_02.java
+++ b/src/main/java/goodgenerator/loader/RecipeLoader_02.java
@@ -1077,7 +1077,7 @@ public class RecipeLoader_02 {
             FluidRegistry.getFluidStack("ic2superheatedsteam", 3200000),
             FluidRegistry.getFluidStack("supercriticalsteam", 32000),
             8000);
-            
+
         MyRecipeAdder.instance.addExtremeHeatExchangerRecipe(
             FluidRegistry.getFluidStack("molten.solarsalthot", 3200),
             FluidRegistry.getFluidStack("molten.solarsaltcold", 3200),
@@ -1085,7 +1085,7 @@ public class RecipeLoader_02 {
             FluidRegistry.getFluidStack("ic2superheatedsteam", 3200000),
             FluidRegistry.getFluidStack("supercriticalsteam", 32000),
             1600);
-    
+
         GT_Values.RA.stdBuilder()
             .itemInputs(GT_OreDictUnificator.get(OrePrefixes.crushedPurified, Materials.Lepidolite, 1))
             .fluidInputs(Materials.HydrochloricAcid.getFluid(1000))

--- a/src/main/java/goodgenerator/loader/RecipeLoader_02.java
+++ b/src/main/java/goodgenerator/loader/RecipeLoader_02.java
@@ -1077,7 +1077,15 @@ public class RecipeLoader_02 {
             FluidRegistry.getFluidStack("ic2superheatedsteam", 3200000),
             FluidRegistry.getFluidStack("supercriticalsteam", 32000),
             8000);
-
+            
+        MyRecipeAdder.instance.addExtremeHeatExchangerRecipe(
+            FluidRegistry.getFluidStack("molten.solarsalthot", 3200),
+            FluidRegistry.getFluidStack("molten.solarsaltcold", 3200),
+            FluidRegistry.getFluidStack("ic2distilledwater", 20000),
+            FluidRegistry.getFluidStack("ic2superheatedsteam", 3200000),
+            FluidRegistry.getFluidStack("supercriticalsteam", 32000),
+            1600);
+    
         GT_Values.RA.stdBuilder()
             .itemInputs(GT_OreDictUnificator.get(OrePrefixes.crushedPurified, Materials.Lepidolite, 1))
             .fluidInputs(Materials.HydrochloricAcid.getFluid(1000))


### PR DESCRIPTION
This provides support for the hot salt from the solar tower in the EHE. The numbers are based off of the heat exchanger which is that hot salt is five times as dense as hot coolant.

The reason being is that this provides a way for the player to gain some bonus to the power output of the solar tower when coming into the late iv age and early luv age. The EHE provides a boost of double the output which is the same as what the hot coolant does for the EHE with the added complexity of needing to use all three steam based turbines to make the most of it.