### PR TITLE
Fix hatches voiding if they fail an output check

### DIFF
--- a/src/main/java/gregtech/common/covers/GT_Cover_ItemMeter.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_ItemMeter.java
@@ -78,9 +78,9 @@ public class GT_Cover_ItemMeter extends GT_CoverBehaviorBase<GT_Cover_ItemMeter.
             max = dc.getMaxItemCount();
             used = dc.getProgresstime();
         } else if (mte instanceof GT_MetaTileEntity_Hatch_OutputBus_ME) {
-            if (((GT_MetaTileEntity_Hatch_OutputBus_ME) mte).isLastOutputFailed()) {
+            if (((GT_MetaTileEntity_Hatch_OutputBus_ME) mte).canAcceptItem()) {
                 max = 64;
-                used = 64;
+                used = 0;
             }
         } else {
             final int[] slots = slot >= 0 ? new int[] { slot } : tileEntity.getAccessibleSlotsFromSide(ordinalSide);

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_OutputBus_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_OutputBus_ME.java
@@ -61,7 +61,6 @@ public class GT_MetaTileEntity_Hatch_OutputBus_ME extends GT_MetaTileEntity_Hatc
     long lastOutputTick = 0;
     long lastInputTick = 0;
     long tickCounter = 0;
-    boolean lastOutputFailed = false;
     boolean additionalConnection = false;
 
     public GT_MetaTileEntity_Hatch_OutputBus_ME(int aID, String aName, String aNameRegional) {
@@ -141,7 +140,6 @@ public class GT_MetaTileEntity_Hatch_OutputBus_ME extends GT_MetaTileEntity_Hatc
      * @return amount of items left over
      */
     public int store(final ItemStack stack) {
-        if (lastOutputFailed) return stack.stackSize;
         // Always allow insertion on the same tick so we can output the entire recipe
         if (canAcceptItem() || (lastInputTick == tickCounter)) {
             itemCache.add(
@@ -219,10 +217,8 @@ public class GT_MetaTileEntity_Hatch_OutputBus_ME extends GT_MetaTileEntity_Hatc
     }
 
     private void flushCachedStack() {
-        lastOutputFailed = false;
         AENetworkProxy proxy = getProxy();
         if (proxy == null) {
-            lastOutputFailed = true;
             return;
         }
         try {
@@ -232,14 +228,13 @@ public class GT_MetaTileEntity_Hatch_OutputBus_ME extends GT_MetaTileEntity_Hatc
                 if (s.getStackSize() == 0) continue;
                 IAEItemStack rest = Platform.poweredInsert(proxy.getEnergy(), sg, s, getRequest());
                 if (rest != null && rest.getStackSize() > 0) {
-                    lastOutputFailed = true;
                     s.setStackSize(rest.getStackSize());
                     break;
                 }
                 s.setStackSize(0);
             }
         } catch (final GridAccessException ignored) {
-            lastOutputFailed = true;
+
         }
         lastOutputTick = tickCounter;
     }
@@ -340,10 +335,6 @@ public class GT_MetaTileEntity_Hatch_OutputBus_ME extends GT_MetaTileEntity_Hatc
             baseCapacity = Long.MAX_VALUE;
         }
         getProxy().readFromNBT(aNBT);
-    }
-
-    public boolean isLastOutputFailed() {
-        return lastOutputFailed;
     }
 
     @Override

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_Output_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_Output_ME.java
@@ -67,7 +67,6 @@ public class GT_MetaTileEntity_Hatch_Output_ME extends GT_MetaTileEntity_Hatch_O
     long lastOutputTick = 0;
     long lastInputTick = 0;
     long tickCounter = 0;
-    boolean lastOutputFailed = false;
     boolean additionalConnection = false;
 
     public GT_MetaTileEntity_Hatch_Output_ME(int aID, String aName, String aNameRegional) {
@@ -117,7 +116,7 @@ public class GT_MetaTileEntity_Hatch_Output_ME extends GT_MetaTileEntity_Hatch_O
         if (doFill) {
             return tryFillAE(aFluid);
         } else {
-            if (lastOutputFailed || aFluid == null) return 0;
+            if (aFluid == null) return 0;
             return aFluid.amount;
         }
     }
@@ -160,7 +159,7 @@ public class GT_MetaTileEntity_Hatch_Output_ME extends GT_MetaTileEntity_Hatch_O
      * @return amount of fluid filled
      */
     public int tryFillAE(final FluidStack aFluid) {
-        if (lastOutputFailed || aFluid == null) return 0;
+        if (aFluid == null) return 0;
         // Always allow insertion on the same tick so we can output the entire recipe
         if (canAcceptFluid() || (lastInputTick == tickCounter)) {
             fluidCache.add(
@@ -250,10 +249,8 @@ public class GT_MetaTileEntity_Hatch_Output_ME extends GT_MetaTileEntity_Hatch_O
 
     private void flushCachedStack() {
         if (fluidCache.isEmpty()) return;
-        lastOutputFailed = true;
         AENetworkProxy proxy = getProxy();
         if (proxy == null) {
-            lastOutputFailed = true;
             return;
         }
         try {
@@ -266,12 +263,9 @@ public class GT_MetaTileEntity_Hatch_Output_ME extends GT_MetaTileEntity_Hatch_O
                     s.setStackSize(rest.getStackSize());
                     continue;
                 }
-                lastOutputFailed = false;
                 s.setStackSize(0);
             }
-        } catch (final GridAccessException ignored) {
-            lastOutputFailed = true;
-        }
+        } catch (final GridAccessException ignored) {}
         lastOutputTick = tickCounter;
     }
 
@@ -361,10 +355,6 @@ public class GT_MetaTileEntity_Hatch_Output_ME extends GT_MetaTileEntity_Hatch_O
             baseCapacity = Long.MAX_VALUE;
         }
         getProxy().readFromNBT(aNBT);
-    }
-
-    public boolean isLastOutputFailed() {
-        return lastOutputFailed;
     }
 
     @Override


### PR DESCRIPTION
The ME output hatches had a check to prevent item caching if infinite caching was disabled and the last output failed, which would never evaluate to true because nobody disabled the infinite cache. However, with the removal of the cache, this line of code caused the hatch to void any inputs if it failed the check to insert items into AE.