### PR TITLE
Fix CAL weirdness

### DIFF
--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_CircuitAssemblyLine.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_CircuitAssemblyLine.java
@@ -255,7 +255,9 @@ public class GT_TileEntity_CircuitAssemblyLine extends
         this.imprintedItemName = this.type == null ? ""
             : GT_LanguageManager.getTranslateableItemStackName(ItemStack.loadItemStackFromNBT(this.type));
         mode = aNBT.getInteger(RUNNING_MODE_KEY);
-        length = aNBT.getInteger(LENGTH_KEY);
+        if (aNBT.hasKey(LENGTH_KEY)) {
+            length = aNBT.getInteger(LENGTH_KEY);
+        }
         super.loadNBTData(aNBT);
     }
 
@@ -263,7 +265,6 @@ public class GT_TileEntity_CircuitAssemblyLine extends
     public void setItemNBT(NBTTagCompound aNBT) {
         if (!this.type.equals(new NBTTagCompound())) aNBT.setTag(IMPRINT_KEY, this.type);
         aNBT.setInteger(RUNNING_MODE_KEY, mode);
-        aNBT.setInteger(LENGTH_KEY, length);
         super.saveNBTData(aNBT);
     }
 

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_CircuitAssemblyLine.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_CircuitAssemblyLine.java
@@ -606,13 +606,13 @@ public class GT_TileEntity_CircuitAssemblyLine extends
     }
 
     @Override
-    public boolean isInputSeparationEnabled() {
-        return mode == 1 && super.isInputSeparationEnabled();
+    public boolean supportsSingleRecipeLocking() {
+        return true;
     }
 
     @Override
-    public boolean isRecipeLockingEnabled() {
-        return this.mode == 0 && this.imprintedItemName != null && !"".equals(this.imprintedItemName);
+    public boolean isInputSeparationEnabled() {
+        return mode == 1 && super.isInputSeparationEnabled();
     }
 
     @Override


### PR DESCRIPTION
- Removes implicit recipe locking in CAL mode. You can still enable it with the lock recipe button, but this way users won't be confused when trying to switch from a regular recipe to a SoC recipe and finding they need to replace the controller for the CAL to switch the recipe.
- No longer save length in item NBT. It's still saved in world NBT of course, but this should make CALs properly stack when broken if they have the same imprint and mode.