### PR TITLE
Fix free energy generation from LFTR (Thorium Reactor) during warm-up

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMTE_NuclearReactor.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMTE_NuclearReactor.java
@@ -414,6 +414,7 @@ public class GregtechMTE_NuclearReactor extends GregtechMeta_MultiBlockBase<Greg
         if (mEfficiency < this.getMaxEfficiency(null)) {
             this.mMaxProgresstime = 1;
             this.mEfficiencyIncrease = 2;
+            this.lEUt = 0;
             return SimpleCheckRecipeResult.ofSuccess("warm_up");
         }
         CheckRecipeResult result = super.checkProcessing();


### PR DESCRIPTION
### Related Issue

Fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16584

### Changes Suggested

`lEUt` detemines energy output or usage of the machine. `lEUt` is basically set to 0 by `stopMachine`
https://github.com/GTNewHorizons/GT5-Unofficial/blob/933650dd0a1267e8a33b686f8262300111d94acd/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_ExtendedPowerMultiBlockBase.java#L86-L90

However this `stopMachine` is only called when the recipe was unsuccessful.
https://github.com/GTNewHorizons/GT5-Unofficial/blob/933650dd0a1267e8a33b686f8262300111d94acd/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMTE_NuclearReactor.java#L361-L369

Therefore intentionally turning off the machine never reset the `lEUt` value. 

To fix this problem, we can reset `lEUt` after all reciple processing. But I think changing `GT_MetaTileEntity_MultiBlockBase` will result unexpected side-effects.

https://github.com/GTNewHorizons/GT5-Unofficial/blob/933650dd0a1267e8a33b686f8262300111d94acd/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java#L561-L564


So I decided to modify here.

https://github.com/GTNewHorizons/GT5-Unofficial/blob/933650dd0a1267e8a33b686f8262300111d94acd/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMTE_NuclearReactor.java#L414-L418


### Test

I have tested on my server. But my server is running on 2.5.1 and I actually built it from GtPlusPlus repository, not here(GT5-Unofficial).