### PR TITLE
Downgrade Diamond Chipset Forming Press Tier

### DIFF
--- a/src/main/java/gregtech/loaders/postload/recipes/FormingPressRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/FormingPressRecipes.java
@@ -55,7 +55,7 @@ public class FormingPressRecipes implements Runnable {
                     getModItem(BuildCraftSilicon.ID, "redstoneChipset", 1L, 0))
                 .itemOutputs(getModItem(BuildCraftSilicon.ID, "redstoneChipset", 1L, 3))
                 .duration(5 * SECONDS)
-                .eut(TierEU.RECIPE_HV)
+                .eut(TierEU.RECIPE_MV)
                 .addTo(formingPressRecipes);
 
             GT_Values.RA.stdBuilder()


### PR DESCRIPTION
HV -> MV

Since Logistics Pipes should be available in early LV, the diamond chipset, which is used for complex modules, should be gated by MV. HV tier is too high for them and too complex recipes should be carefully patched on an individual basis in future