### PR TITLE
Add expedited recipe checks for autopulling Stocking Hatch and Bus

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
@@ -105,6 +105,7 @@ import gregtech.common.tileentities.machines.GT_MetaTileEntity_Hatch_Output_ME;
 import gregtech.common.tileentities.machines.IDualInputHatch;
 import gregtech.common.tileentities.machines.IDualInputInventory;
 import gregtech.common.tileentities.machines.IRecipeProcessingAwareHatch;
+import gregtech.common.tileentities.machines.ISmartInputHatch;
 import gregtech.common.tileentities.machines.multi.GT_MetaTileEntity_LargeTurbine;
 import it.unimi.dsi.fastutil.objects.Object2ReferenceOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Reference2ReferenceOpenHashMap;
@@ -148,6 +149,7 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
     public ArrayList<GT_MetaTileEntity_Hatch_InputBus> mInputBusses = new ArrayList<>();
     public ArrayList<GT_MetaTileEntity_Hatch_OutputBus> mOutputBusses = new ArrayList<>();
     public ArrayList<IDualInputHatch> mDualInputHatches = new ArrayList<>();
+    public ArrayList<ISmartInputHatch> mSmartInputHatches = new ArrayList<>();
     public ArrayList<GT_MetaTileEntity_Hatch_Dynamo> mDynamoHatches = new ArrayList<>();
     public ArrayList<GT_MetaTileEntity_Hatch_Muffler> mMufflerHatches = new ArrayList<>();
     public ArrayList<GT_MetaTileEntity_Hatch_Energy> mEnergyHatches = new ArrayList<>();
@@ -390,6 +392,7 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
         mMufflerHatches.clear();
         mMaintenanceHatches.clear();
         mDualInputHatches.clear();
+        mSmartInputHatches.clear();
     }
 
     public boolean checkStructure(boolean aForceReset) {
@@ -512,6 +515,11 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
             shouldCheck |= craftingInputMe.justUpdated();
         }
         if (shouldCheck) return true;
+        // Do the same for Smart Input Hatches
+        for (ISmartInputHatch smartInputHatch : mSmartInputHatches) {
+            shouldCheck |= smartInputHatch.justUpdated();
+        }
+        if (shouldCheck) return true;
 
         // Perform more frequent recipe change after the machine just shuts down.
         long timeElapsed = aTick - mLastWorkingTick;
@@ -580,10 +588,11 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
                 }
             }
         } else {
-            if (shouldCheckRecipeThisTick(aTick) || aBaseMetaTileEntity.hasWorkJustBeenEnabled()
-                || aBaseMetaTileEntity.hasInventoryBeenModified()) {
+            // Check if the machine is enabled in the first place!
+            if (aBaseMetaTileEntity.isAllowedToWork()) {
 
-                if (aBaseMetaTileEntity.isAllowedToWork()) {
+                if (shouldCheckRecipeThisTick(aTick) || aBaseMetaTileEntity.hasWorkJustBeenEnabled()
+                    || aBaseMetaTileEntity.hasInventoryBeenModified()) {
                     if (checkRecipe()) {
                         markDirty();
                     }
@@ -1591,6 +1600,9 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
             hatch.updateCraftingIcon(this.getMachineCraftingIcon());
             return mDualInputHatches.add(hatch);
         }
+        if (aMetaTileEntity instanceof ISmartInputHatch hatch) {
+            mSmartInputHatches.add(hatch);
+        }
         if (aMetaTileEntity instanceof GT_MetaTileEntity_Hatch_Input) {
             setHatchRecipeMap((GT_MetaTileEntity_Hatch_Input) aMetaTileEntity);
             return mInputHatches.add((GT_MetaTileEntity_Hatch_Input) aMetaTileEntity);
@@ -1697,7 +1709,9 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
             hatch.updateCraftingIcon(this.getMachineCraftingIcon());
             return mDualInputHatches.add(hatch);
         }
-
+        if (aMetaTileEntity instanceof ISmartInputHatch hatch) {
+            mSmartInputHatches.add(hatch);
+        }
         if (aMetaTileEntity instanceof GT_MetaTileEntity_Hatch_InputBus hatch) {
             hatch.updateTexture(aBaseCasingIndex);
             hatch.updateCraftingIcon(this.getMachineCraftingIcon());
@@ -1723,6 +1737,9 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
         if (aTileEntity == null) return false;
         IMetaTileEntity aMetaTileEntity = aTileEntity.getMetaTileEntity();
         if (aMetaTileEntity == null) return false;
+        if (aMetaTileEntity instanceof ISmartInputHatch hatch) {
+            mSmartInputHatches.add(hatch);
+        }
         if (aMetaTileEntity instanceof GT_MetaTileEntity_Hatch_Input hatch) {
             hatch.updateTexture(aBaseCasingIndex);
             hatch.updateCraftingIcon(this.getMachineCraftingIcon());

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_InputBus_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_InputBus_ME.java
@@ -77,8 +77,9 @@ import gregtech.common.gui.modularui.widget.AESlotWidget;
 import mcp.mobius.waila.api.IWailaConfigHandler;
 import mcp.mobius.waila.api.IWailaDataAccessor;
 
-public class GT_MetaTileEntity_Hatch_InputBus_ME extends GT_MetaTileEntity_Hatch_InputBus implements
-    IConfigurationCircuitSupport, IRecipeProcessingAwareHatch, IAddGregtechLogo, IAddUIWidgets, IPowerChannelState {
+public class GT_MetaTileEntity_Hatch_InputBus_ME extends GT_MetaTileEntity_Hatch_InputBus
+    implements IConfigurationCircuitSupport, IRecipeProcessingAwareHatch, IAddGregtechLogo, IAddUIWidgets,
+    IPowerChannelState, ISmartInputHatch {
 
     private static final int SLOT_COUNT = 16;
     private BaseActionSource requestSource = null;
@@ -92,6 +93,7 @@ public class GT_MetaTileEntity_Hatch_InputBus_ME extends GT_MetaTileEntity_Hatch
     private int autoPullRefreshTime = 100;
     private static final int CONFIG_WINDOW_ID = 10;
     private boolean additionalConnection = false;
+    private boolean justHadNewItems = false;
 
     public GT_MetaTileEntity_Hatch_InputBus_ME(int aID, boolean autoPullAvailable, String aName, String aNameRegional) {
         super(
@@ -392,6 +394,24 @@ public class GT_MetaTileEntity_Hatch_InputBus_ME extends GT_MetaTileEntity_Hatch
     }
 
     @Override
+    public boolean justUpdated() {
+        if (autoPullItemList) {
+            boolean ret = justHadNewItems;
+            justHadNewItems = false;
+            return ret;
+        }
+        return false;
+    }
+
+    @Override
+    public void setInventorySlotContents(int aIndex, ItemStack aStack) {
+        if (aStack != null) {
+            justHadNewItems = true;
+        }
+        super.setInventorySlotContents(aIndex, aStack);
+    }
+
+    @Override
     public ItemStack getStackInSlot(int aIndex) {
         if (!processingRecipe) return super.getStackInSlot(aIndex);
         if (aIndex < 0 || aIndex > mInventory.length) return null;
@@ -459,7 +479,11 @@ public class GT_MetaTileEntity_Hatch_InputBus_ME extends GT_MetaTileEntity_Hatch
                 IAEItemStack currItem = iterator.next();
                 if (currItem.getStackSize() >= minAutoPullStackSize) {
                     ItemStack itemstack = GT_Utility.copyAmount(1, currItem.getItemStack());
+                    ItemStack previous = this.mInventory[index];
                     this.mInventory[index] = itemstack;
+                    if (previous != itemstack) {
+                        justHadNewItems = true;
+                    }
                     index++;
                 }
             }
@@ -516,6 +540,9 @@ public class GT_MetaTileEntity_Hatch_InputBus_ME extends GT_MetaTileEntity_Hatch
         return checkRecipeResult;
     }
 
+    /**
+     * Update the right side of the GUI, which shows the amounts of items set on the left side
+     */
     public ItemStack updateInformationSlot(int aIndex, ItemStack aStack) {
         if (aIndex >= 0 && aIndex < SLOT_COUNT) {
             if (aStack == null) {
@@ -533,7 +560,13 @@ public class GT_MetaTileEntity_Hatch_InputBus_ME extends GT_MetaTileEntity_Hatch
                     request.setStackSize(Integer.MAX_VALUE);
                     IAEItemStack result = sg.extractItems(request, Actionable.SIMULATE, getRequestSource());
                     ItemStack s = (result != null) ? result.getItemStack() : null;
+                    // We want to track changes in any ItemStack to notify any connected controllers to make a recipe
+                    // check early
+                    ItemStack previous = getStackInSlot(aIndex + SLOT_COUNT);
                     setInventorySlotContents(aIndex + SLOT_COUNT, s);
+                    if (s != null) {
+                        justHadNewItems = previous != s;
+                    }
                     return s;
                 } catch (final GridAccessException ignored) {}
             }

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_InputBus_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_InputBus_ME.java
@@ -565,7 +565,7 @@ public class GT_MetaTileEntity_Hatch_InputBus_ME extends GT_MetaTileEntity_Hatch
                     ItemStack previous = getStackInSlot(aIndex + SLOT_COUNT);
                     setInventorySlotContents(aIndex + SLOT_COUNT, s);
                     if (s != null) {
-                        justHadNewItems = previous != s;
+                        justHadNewItems = s.isItemEqual(previous);
                     }
                     return s;
                 } catch (final GridAccessException ignored) {}

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_InputBus_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_InputBus_ME.java
@@ -481,9 +481,9 @@ public class GT_MetaTileEntity_Hatch_InputBus_ME extends GT_MetaTileEntity_Hatch
                     ItemStack itemstack = GT_Utility.copyAmount(1, currItem.getItemStack());
                     ItemStack previous = this.mInventory[index];
                     this.mInventory[index] = itemstack;
-                    if (previous != itemstack) {
-                        justHadNewItems = true;
-                    }
+                    if (itemstack != null) {
+                        justHadNewItems = !itemstack.isItemEqual(previous);
+                    }   
                     index++;
                 }
             }

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_InputBus_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_InputBus_ME.java
@@ -483,7 +483,7 @@ public class GT_MetaTileEntity_Hatch_InputBus_ME extends GT_MetaTileEntity_Hatch
                     this.mInventory[index] = itemstack;
                     if (itemstack != null) {
                         justHadNewItems = !itemstack.isItemEqual(previous);
-                    }   
+                    }
                     index++;
                 }
             }
@@ -565,7 +565,7 @@ public class GT_MetaTileEntity_Hatch_InputBus_ME extends GT_MetaTileEntity_Hatch
                     ItemStack previous = getStackInSlot(aIndex + SLOT_COUNT);
                     setInventorySlotContents(aIndex + SLOT_COUNT, s);
                     if (s != null) {
-                        justHadNewItems = s.isItemEqual(previous);
+                        justHadNewItems = !s.isItemEqual(previous);
                     }
                     return s;
                 } catch (final GridAccessException ignored) {}

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_Input_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_Input_ME.java
@@ -170,8 +170,8 @@ public class GT_MetaTileEntity_Hatch_Input_ME extends GT_MetaTileEntity_Hatch_In
                     FluidStack fluidStack = GT_Utility.copyAmount(1, currItem.getFluidStack());
                     FluidStack previous = storedFluids[index];
                     storedFluids[index] = fluidStack;
-                    if (fluidStack != previous) {
-                        justHadNewItems = true;
+                    if (fluidStack != null) {
+                        justHadNewItems = !fluidStack.isFluidEqual(previous);
                     }
                     index++;
                 }
@@ -401,7 +401,7 @@ public class GT_MetaTileEntity_Hatch_Input_ME extends GT_MetaTileEntity_Hatch_In
             FluidStack previous = storedInformationFluids[index];
             storedInformationFluids[index] = resultFluid;
             if (resultFluid != null) {
-                justHadNewItems = previous != resultFluid;
+                justHadNewItems = !resultFluid.isFluidEqual(previous);
             }
         } catch (final GridAccessException ignored) {}
     }

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_Input_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_Input_ME.java
@@ -81,7 +81,7 @@ import mcp.mobius.waila.api.IWailaConfigHandler;
 import mcp.mobius.waila.api.IWailaDataAccessor;
 
 public class GT_MetaTileEntity_Hatch_Input_ME extends GT_MetaTileEntity_Hatch_Input
-    implements IPowerChannelState, IAddGregtechLogo, IAddUIWidgets, IRecipeProcessingAwareHatch {
+    implements IPowerChannelState, IAddGregtechLogo, IAddUIWidgets, IRecipeProcessingAwareHatch, ISmartInputHatch {
 
     private static final int SLOT_COUNT = 16;
 
@@ -106,6 +106,7 @@ public class GT_MetaTileEntity_Hatch_Input_ME extends GT_MetaTileEntity_Hatch_In
     protected int minAutoPullAmount = 1;
     private int autoPullRefreshTime = 100;
     protected boolean processingRecipe = false;
+    private boolean justHadNewItems = false;
 
     protected static final int CONFIG_WINDOW_ID = 10;
 
@@ -167,7 +168,11 @@ public class GT_MetaTileEntity_Hatch_Input_ME extends GT_MetaTileEntity_Hatch_In
                 IAEFluidStack currItem = iterator.next();
                 if (currItem.getStackSize() >= minAutoPullAmount) {
                     FluidStack fluidStack = GT_Utility.copyAmount(1, currItem.getFluidStack());
+                    FluidStack previous = storedFluids[index];
                     storedFluids[index] = fluidStack;
+                    if (fluidStack != previous) {
+                        justHadNewItems = true;
+                    }
                     index++;
                 }
             }
@@ -212,6 +217,16 @@ public class GT_MetaTileEntity_Hatch_Input_ME extends GT_MetaTileEntity_Hatch_In
         }
 
         return shadowStoredFluids;
+    }
+
+    @Override
+    public boolean justUpdated() {
+        if (autoPullFluidList) {
+            boolean ret = justHadNewItems;
+            justHadNewItems = false;
+            return ret;
+        }
+        return false;
     }
 
     @Override
@@ -381,7 +396,13 @@ public class GT_MetaTileEntity_Hatch_Input_ME extends GT_MetaTileEntity_Hatch_In
             request.setStackSize(Integer.MAX_VALUE);
             IAEFluidStack result = sg.extractItems(request, Actionable.SIMULATE, getRequestSource());
             FluidStack resultFluid = (result != null) ? result.getFluidStack() : null;
+            // We want to track if any FluidStack is modified to notify any connected controllers to make a recipe check
+            // early
+            FluidStack previous = storedInformationFluids[index];
             storedInformationFluids[index] = resultFluid;
+            if (resultFluid != null) {
+                justHadNewItems = previous != resultFluid;
+            }
         } catch (final GridAccessException ignored) {}
     }
 

--- a/src/main/java/gregtech/common/tileentities/machines/ISmartInputHatch.java
+++ b/src/main/java/gregtech/common/tileentities/machines/ISmartInputHatch.java
@@ -1,0 +1,13 @@
+package gregtech.common.tileentities.machines;
+
+public interface ISmartInputHatch {
+
+    /*
+     * An interface to allow advanced interaction between hatches and a multiblock controller
+     * Adapted from the Crafting Input Buffer functionality
+     */
+
+    // Have the contents of the hatch changed since the last check?
+    boolean justUpdated();
+
+}


### PR DESCRIPTION
Matches the mechanic of CRIBs, where any change in the network will tell any connected controllers to do their recipe check. Should make autocrafting setups using stocking buses and hatches feel a lot more snappier, as the worst-case scenario can have 199 ticks between items entering and the machine doing a recipe check.

Also changes multiblocks checking if they should do a recipe check on a tick, even if they are disabled (and will never do a recipe check anyways).


https://github.com/user-attachments/assets/d3ae88d9-b19f-4b11-97c2-84d169e63973

