### PR TITLE
Dont show ulv tier for recipes

### DIFF
--- a/src/main/java/gregtech/api/util/GT_Utility.java
+++ b/src/main/java/gregtech/api/util/GT_Utility.java
@@ -534,6 +534,8 @@ public class GT_Utility {
         byte tier = getTier(voltage);
         if (tier < 0) {
             return "";
+        } else if (tier == 0) {
+            return " (" + GT_Values.VN[1] + ")";
         } else if (tier >= GT_Values.VN.length - 1) {
             return " (MAX+)";
         }


### PR DESCRIPTION
This is a constant cause for confusion and should probably have been fixed years ago. ULV never existed for overclocks. But now it is deprecated more fully, so this is overdue.

![image](https://github.com/user-attachments/assets/1c0e5a01-ef48-49f8-9cb6-9315e0463ad3)
