### PR TITLE
Created LHECoolantRegistry from LHE coolant logic

### DIFF
--- a/src/main/java/gregtech/GT_Mod.java
+++ b/src/main/java/gregtech/GT_Mod.java
@@ -62,6 +62,7 @@ import gregtech.api.metatileentity.BaseMetaPipeEntity;
 import gregtech.api.objects.ItemData;
 import gregtech.api.objects.XSTR;
 import gregtech.api.recipe.RecipeMaps;
+import gregtech.api.registries.LHECoolantRegistry;
 import gregtech.api.threads.GT_Runnable_MachineBlockUpdate;
 import gregtech.api.util.GT_Assemblyline_Server;
 import gregtech.api.util.GT_Forestry_Compat;
@@ -358,6 +359,9 @@ public class GT_Mod implements IGT_Mod {
         if (Mods.HoloInventory.isModLoaded()) {
             HoloInventory.init();
         }
+
+        LHECoolantRegistry.registerBaseCoolants();
+
         GregTech_API.sLoadFinished = true;
         GT_Log.out.println("GT_Mod: Load-Phase finished!");
         GT_Log.ore.println("GT_Mod: Load-Phase finished!");

--- a/src/main/java/gregtech/api/registries/LHECoolantRegistry.java
+++ b/src/main/java/gregtech/api/registries/LHECoolantRegistry.java
@@ -1,0 +1,108 @@
+package gregtech.api.registries;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidRegistry;
+import net.minecraftforge.fluids.FluidStack;
+
+public class LHECoolantRegistry {
+
+    private static final Map<String, LHECoolantInfo> lheCoolants = new HashMap<>();
+
+    /**
+     * Registers a coolant for use in Large Heat Exchangers and Whakawhiti Weras.
+     * See the constants in {@link #registerBaseCoolants()} as a reference for what the multipliers should be.
+     * The multipliers are used in
+     * {@link gregtech.common.tileentities.machines.multi.GT_MetaTileEntity_HeatExchanger#checkProcessing()}
+     * and {@link gregtech.common.tileentities.machines.multi.GT_MetaTileEntity_HeatExchanger#onRunningTick()}.
+     * 
+     * @param coldFluidName        The fluid name of the resulting cold coolant
+     * @param hotFluidName         The fluid name of the input hot coolant
+     * @param steamMultiplier      The steam multiplier
+     * @param superheatedThreshold The super heated threshold multiplier - see the constants in
+     *                             {@link #registerBaseCoolants()} for a reference
+     */
+    public static void registerCoolant(String coldFluidName, String hotFluidName, double steamMultiplier,
+        double superheatedThreshold) {
+        var coolant = new LHECoolantInfo(coldFluidName, hotFluidName, steamMultiplier, superheatedThreshold);
+
+        lheCoolants.put(coldFluidName, coolant);
+        lheCoolants.put(hotFluidName, coolant);
+    }
+
+    public static LHECoolantInfo getCoolant(String fluidName) {
+        return lheCoolants.get(fluidName);
+    }
+
+    public static LHECoolantInfo getCoolant(Fluid fluid) {
+        return lheCoolants.get(fluid.getName());
+    }
+
+    public static void registerBaseCoolants() {
+        // I have no idea where these constants originally came from, but I've preserved the comments from
+        // GT_MetaTileEntity_HeatExchanger
+
+        registerCoolant(
+            "ic2pahoehoelava",
+            "lava",
+            1.0 / 5.0, // lava is not boosted
+            1.0 / 4.0 // unchanged
+        );
+
+        registerCoolant(
+            "ic2coolant",
+            "ic2hotcoolant",
+            1.0 / 2.0, // was boosted x2 on top of x5 -> total x10 -> nerf with this code back to 5x
+            1.0 / 5.0 // 10x smaller since the Hot Things production in reactor is the same
+        );
+
+        registerCoolant(
+            "molten.solarsaltcold",
+            "molten.solarsalthot",
+            2.5, // Solar Salt to Steam ratio is 5x higher than Hot Coolant's ratio
+            1.0 / 25.0 // Given that, multiplier is 5x higher and threshold is 5x lower
+        );
+    }
+
+    public static class LHECoolantInfo {
+
+        public final String coldFluidName, hotFluidName;
+        public final double steamMultiplier, superheatedThreshold;
+
+        private Fluid coldFluid, hotFluid;
+
+        public LHECoolantInfo(String coldFluidName, String hotFluidName, double steamMultiplier,
+            double superheatedThreshold) {
+            this.coldFluidName = coldFluidName;
+            this.hotFluidName = hotFluidName;
+            this.steamMultiplier = steamMultiplier;
+            this.superheatedThreshold = superheatedThreshold;
+        }
+
+        public Fluid getColdFluid() {
+            if (coldFluid == null) {
+                coldFluid = FluidRegistry.getFluid(coldFluidName);
+            }
+
+            return coldFluid;
+        }
+
+        public Fluid getHotFluid() {
+            if (hotFluid == null) {
+                hotFluid = FluidRegistry.getFluid(hotFluidName);
+            }
+
+            return hotFluid;
+        }
+
+        public FluidStack getColdFluid(int amount) {
+            return new FluidStack(getColdFluid(), amount);
+        }
+
+        public FluidStack getHotFluid(int amount) {
+            return new FluidStack(getHotFluid(), amount);
+        }
+    }
+}


### PR DESCRIPTION
* Removed coolant logic from LHE & XL LHE
* Added LHECoolantRegistry, which replaces the coolant checking logic

I want to be able to add new coolants to the LHE from Nuclear Horizons, so I added a registry for this. A full recipe registry would include too much boilerplate, so I made a basic HashMap wrapper instead.

I also added the ability for the XL LHE to use hot solar salt. It would take several solar towers to saturate an XL LHE, but since there weren't any code comments about this I figured it would be fine to add this.