### PR TITLE
Second batch of fixes for new multis

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_IndustrialElectromagneticSeparator.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_IndustrialElectromagneticSeparator.java
@@ -9,6 +9,7 @@ import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_FRONT_EMS_ACTIVE_GL
 import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_FRONT_EMS_GLOW;
 import static gregtech.api.util.GT_StructureUtility.buildHatchAdder;
 import static gregtech.api.util.GT_StructureUtility.ofFrame;
+import static gregtech.api.util.GT_StructureUtility.ofHatchAdder;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -16,6 +17,8 @@ import java.util.List;
 
 import javax.annotation.Nonnull;
 
+import gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_Turbine;
+import gtPlusPlus.xmod.gregtech.common.tileentities.machines.multi.production.turbines.GregtechMetaTileEntity_LargerTurbineBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
@@ -126,7 +129,7 @@ public class GT_MetaTileEntity_IndustrialElectromagneticSeparator
                         "     D     ", "     C     ", "           " },
                     { "           ", "    AAA    ", "   A   A   ", " CDA D ADC ", "   A   A   ", "    AAA    ",
                         "     D     ", "     C     ", "           " },
-                    { "           ", "    BBB    ", "   BBBBB   ", " CDBBBBBDC ", "   BBBBB   ", "    BBB    ",
+                    { "           ", "    BEB    ", "   BBBBB   ", " CDBBBBBDC ", "   BBBBB   ", "    BBB    ",
                         "     D     ", "     C     ", "           " },
                     { "    B~B    ", "   BBBBB   ", "  BBBBBBB  ", "CDBBBBBBBDC", "  BBBBBBB  ", "   BBBBB   ",
                         "    BBB    ", "     D     ", "     C     " } })))
@@ -134,13 +137,6 @@ public class GT_MetaTileEntity_IndustrialElectromagneticSeparator
         .addElement(
             'B',
             ofChain(
-                buildHatchAdder(GT_MetaTileEntity_IndustrialElectromagneticSeparator.class)
-                    .adder(GT_MetaTileEntity_IndustrialElectromagneticSeparator::addMagHatch)
-                    .hatchClass(GT_MetaTileEntity_MagHatch.class)
-                    .shouldReject(t -> !(t.mMagHatch == null))
-                    .casingIndex(((GT_Block_Casings10) GregTech_API.sBlockCasings10).getTextureIndex(0))
-                    .dot(1)
-                    .build(),
                 buildHatchAdder(GT_MetaTileEntity_IndustrialElectromagneticSeparator.class)
                     .atLeast(InputBus, OutputBus, Maintenance, Energy.or(ExoticEnergy))
                     .casingIndex(((GT_Block_Casings10) GregTech_API.sBlockCasings10).getTextureIndex(0))
@@ -151,6 +147,13 @@ public class GT_MetaTileEntity_IndustrialElectromagneticSeparator
                             ofBlock(GregTech_API.sBlockCasings10, 0)))))
         .addElement('C', ofFrame(Materials.NeodymiumMagnetic))
         .addElement('D', ofFrame(Materials.SamariumMagnetic))
+        .addElement('E',
+            buildHatchAdder(GT_MetaTileEntity_IndustrialElectromagneticSeparator.class)
+                .adder(GT_MetaTileEntity_IndustrialElectromagneticSeparator::addMagHatch)
+                .hatchClass(GT_MetaTileEntity_MagHatch.class)
+                .casingIndex(((GT_Block_Casings10) GregTech_API.sBlockCasings10).getTextureIndex(0))
+                .dot(2)
+                .build())
         .build();
 
     public GT_MetaTileEntity_IndustrialElectromagneticSeparator(final int aID, final String aName,

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_IndustrialElectromagneticSeparator.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_IndustrialElectromagneticSeparator.java
@@ -240,7 +240,7 @@ public class GT_MetaTileEntity_IndustrialElectromagneticSeparator
             .addOtherStructurePart("Any glass", "x12")
             .addOtherStructurePart("Magnetic Neodymium Frame Box", "x40")
             .addOtherStructurePart("Magnetic Samarium Frame Box", "x45")
-            .addOtherStructurePart("Electromagnet Housing", "x1 Only, Any Casing")
+            .addOtherStructurePart("Electromagnet Housing", "1 Block Above/Behind Controller", 2)
             .addInputBus("Any Casing", 1)
             .addOutputBus("Any Casing", 1)
             .addEnergyHatch("Any Casing", 1)

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_IndustrialElectromagneticSeparator.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_IndustrialElectromagneticSeparator.java
@@ -9,7 +9,6 @@ import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_FRONT_EMS_ACTIVE_GL
 import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_FRONT_EMS_GLOW;
 import static gregtech.api.util.GT_StructureUtility.buildHatchAdder;
 import static gregtech.api.util.GT_StructureUtility.ofFrame;
-import static gregtech.api.util.GT_StructureUtility.ofHatchAdder;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -17,8 +16,6 @@ import java.util.List;
 
 import javax.annotation.Nonnull;
 
-import gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_Turbine;
-import gtPlusPlus.xmod.gregtech.common.tileentities.machines.multi.production.turbines.GregtechMetaTileEntity_LargerTurbineBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
@@ -147,7 +144,8 @@ public class GT_MetaTileEntity_IndustrialElectromagneticSeparator
                             ofBlock(GregTech_API.sBlockCasings10, 0)))))
         .addElement('C', ofFrame(Materials.NeodymiumMagnetic))
         .addElement('D', ofFrame(Materials.SamariumMagnetic))
-        .addElement('E',
+        .addElement(
+            'E',
             buildHatchAdder(GT_MetaTileEntity_IndustrialElectromagneticSeparator.class)
                 .adder(GT_MetaTileEntity_IndustrialElectromagneticSeparator::addMagHatch)
                 .hatchClass(GT_MetaTileEntity_MagHatch.class)

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_IndustrialElectromagneticSeparator.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_IndustrialElectromagneticSeparator.java
@@ -142,7 +142,7 @@ public class GT_MetaTileEntity_IndustrialElectromagneticSeparator
                     .dot(1)
                     .build(),
                 buildHatchAdder(GT_MetaTileEntity_IndustrialElectromagneticSeparator.class)
-                    .atLeast(InputBus, OutputBus, Maintenance, Energy, ExoticEnergy)
+                    .atLeast(InputBus, OutputBus, Maintenance, Energy.or(ExoticEnergy))
                     .casingIndex(((GT_Block_Casings10) GregTech_API.sBlockCasings10).getTextureIndex(0))
                     .dot(1)
                     .buildAndChain(
@@ -323,6 +323,11 @@ public class GT_MetaTileEntity_IndustrialElectromagneticSeparator
     @Override
     public Collection<RecipeMap<?>> getAvailableRecipeMaps() {
         return Arrays.asList(RecipeMaps.polarizerRecipes, RecipeMaps.electroMagneticSeparatorRecipes);
+    }
+
+    @Override
+    public int getRecipeCatalystPriority() {
+        return -10;
     }
 
     @Override

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_MultiCanner.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_MultiCanner.java
@@ -216,6 +216,11 @@ public class GT_MetaTileEntity_MultiCanner
     }
 
     @Override
+    public int getRecipeCatalystPriority() {
+        return -10;
+    }
+
+    @Override
     public void loadNBTData(NBTTagCompound aNBT) {
         if (aNBT.hasKey("fluidMode")) {
             machineMode = aNBT.getBoolean("fluidMode") ? MACHINEMODE_FLUIDCANNER : MACHINEMODE_CANNER;


### PR DESCRIPTION
-MFE/TurboCan no longer appear as the header for their respective NEI categories
-MFE structure preview no longer shows a laser hatch
-Electromagnet Housing is now locked to a specific position on the MFE so that you cannot wallshare it and get extra use out of your magnets