### PR TITLE
fix vacuum furnace recipes and fusion skip

### DIFF
--- a/src/main/java/gtPlusPlus/core/item/chemistry/MilledOreProcessing.java
+++ b/src/main/java/gtPlusPlus/core/item/chemistry/MilledOreProcessing.java
@@ -365,7 +365,7 @@ public class MilledOreProcessing extends ItemPackage {
             .fluidOutputs(FluidUtils.getFluidStack(AgriculturalChem.RedMud, 2000), FluidUtils.getWater(2000))
             .eut((int) TierEU.RECIPE_LuV)
             .metadata(COIL_HEAT, 5500)
-            .duration(120 * SECONDS)
+            .duration(2 * MINUTES)
             .addTo(vacuumFurnaceRecipes);
         GT_Values.RA.stdBuilder()
             .itemInputs(GT_Utility.getIntegratedCircuit(aCircuitID++))
@@ -374,7 +374,7 @@ public class MilledOreProcessing extends ItemPackage {
             .fluidOutputs(FluidUtils.getFluidStack(AgriculturalChem.RedMud, 2000), FluidUtils.getWater(2000))
             .eut((int) TierEU.RECIPE_IV)
             .metadata(COIL_HEAT, 4500)
-            .duration(120 * SECONDS)
+            .duration(2 * MINUTES)
             .addTo(vacuumFurnaceRecipes);
         GT_Values.RA.stdBuilder()
             .itemInputs(GT_Utility.getIntegratedCircuit(aCircuitID++))
@@ -383,7 +383,7 @@ public class MilledOreProcessing extends ItemPackage {
             .fluidOutputs(FluidUtils.getFluidStack(AgriculturalChem.RedMud, 2000), FluidUtils.getWater(2000))
             .eut((int) TierEU.RECIPE_IV)
             .metadata(COIL_HEAT, 4500)
-            .duration(120 * SECONDS)
+            .duration(2 * MINUTES)
             .addTo(vacuumFurnaceRecipes);
         GT_Values.RA.stdBuilder()
             .itemInputs(GT_Utility.getIntegratedCircuit(aCircuitID++))
@@ -392,7 +392,7 @@ public class MilledOreProcessing extends ItemPackage {
             .fluidOutputs(FluidUtils.getFluidStack(AgriculturalChem.RedMud, 2000), FluidUtils.getWater(2000))
             .eut((int) TierEU.RECIPE_LuV)
             .metadata(COIL_HEAT, 5500)
-            .duration(120 * SECONDS)
+            .duration(2 * MINUTES)
             .addTo(vacuumFurnaceRecipes);
         GT_Values.RA.stdBuilder()
             .itemInputs(GT_Utility.getIntegratedCircuit(aCircuitID++))
@@ -401,7 +401,7 @@ public class MilledOreProcessing extends ItemPackage {
             .fluidOutputs(FluidUtils.getFluidStack(AgriculturalChem.RedMud, 2000), FluidUtils.getWater(2000))
             .eut((int) TierEU.RECIPE_LuV)
             .metadata(COIL_HEAT, 5500)
-            .duration(120 * SECONDS)
+            .duration(2 * MINUTES)
             .addTo(vacuumFurnaceRecipes);
         GT_Values.RA.stdBuilder()
             .itemInputs(GT_Utility.getIntegratedCircuit(aCircuitID++))
@@ -410,7 +410,7 @@ public class MilledOreProcessing extends ItemPackage {
             .fluidOutputs(FluidUtils.getFluidStack(AgriculturalChem.RedMud, 2000), FluidUtils.getWater(2000))
             .eut((int) TierEU.RECIPE_IV)
             .metadata(COIL_HEAT, 4500)
-            .duration(120 * SECONDS)
+            .duration(2 * MINUTES)
             .addTo(vacuumFurnaceRecipes);
         GT_Values.RA.stdBuilder()
             .itemInputs(GT_Utility.getIntegratedCircuit(aCircuitID++))
@@ -419,7 +419,7 @@ public class MilledOreProcessing extends ItemPackage {
             .fluidOutputs(FluidUtils.getFluidStack(AgriculturalChem.RedMud, 2000), FluidUtils.getWater(2000))
             .eut((int) TierEU.RECIPE_LuV)
             .metadata(COIL_HEAT, 5500)
-            .duration(120 * SECONDS)
+            .duration(2 * MINUTES)
             .addTo(vacuumFurnaceRecipes);
         GT_Values.RA.stdBuilder()
             .itemInputs(GT_Utility.getIntegratedCircuit(aCircuitID++))
@@ -428,7 +428,7 @@ public class MilledOreProcessing extends ItemPackage {
             .fluidOutputs(FluidUtils.getFluidStack(AgriculturalChem.RedMud, 2000), FluidUtils.getWater(2000))
             .eut((int) TierEU.RECIPE_LuV)
             .metadata(COIL_HEAT, 5500)
-            .duration(120 * SECONDS)
+            .duration(2 * MINUTES)
             .addTo(vacuumFurnaceRecipes);
         GT_Values.RA.stdBuilder()
             .itemInputs(GT_Utility.getIntegratedCircuit(aCircuitID++))
@@ -437,7 +437,7 @@ public class MilledOreProcessing extends ItemPackage {
             .fluidOutputs(FluidUtils.getFluidStack(AgriculturalChem.RedMud, 2000), FluidUtils.getWater(2000))
             .eut((int) TierEU.RECIPE_LuV)
             .metadata(COIL_HEAT, 5500)
-            .duration(120 * SECONDS)
+            .duration(2 * MINUTES)
             .addTo(vacuumFurnaceRecipes);
         GT_Values.RA.stdBuilder()
             .itemInputs(GT_Utility.getIntegratedCircuit(aCircuitID++))
@@ -446,7 +446,7 @@ public class MilledOreProcessing extends ItemPackage {
             .fluidOutputs(FluidUtils.getFluidStack(AgriculturalChem.RedMud, 2000), FluidUtils.getWater(2000))
             .eut((int) TierEU.RECIPE_EV)
             .metadata(COIL_HEAT, 3500)
-            .duration(120 * SECONDS)
+            .duration(2 * MINUTES)
             .addTo(vacuumFurnaceRecipes);
         GT_Values.RA.stdBuilder()
             .itemInputs(GT_Utility.getIntegratedCircuit(aCircuitID++))
@@ -456,7 +456,7 @@ public class MilledOreProcessing extends ItemPackage {
             .eut((int) TierEU.RECIPE_UV)
             .metadata(COIL_HEAT, 7500)
             // 60s UV instead of 120s ZPM to avoid fusion skip
-            .duration(60 * SECONDS)
+            .duration(1 * MINUTES)
             .addTo(vacuumFurnaceRecipes);
 
     }

--- a/src/main/java/gtPlusPlus/core/item/chemistry/MilledOreProcessing.java
+++ b/src/main/java/gtPlusPlus/core/item/chemistry/MilledOreProcessing.java
@@ -2,12 +2,11 @@ package gtPlusPlus.core.item.chemistry;
 
 import static gregtech.api.enums.Mods.BiomesOPlenty;
 import static gregtech.api.enums.Mods.Forestry;
-import static gregtech.api.recipe.RecipeMaps.vacuumFreezerRecipes;
 import static gregtech.api.util.GT_RecipeBuilder.MINUTES;
 import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
 import static gregtech.api.util.GT_RecipeConstants.CHEMPLANT_CASING_TIER;
-import static gtPlusPlus.api.recipe.GTPPRecipeMaps.chemicalPlantRecipes;
-import static gtPlusPlus.api.recipe.GTPPRecipeMaps.flotationCellRecipes;
+import static gregtech.api.util.GT_RecipeConstants.COIL_HEAT;
+import static gtPlusPlus.api.recipe.GTPPRecipeMaps.*;
 
 import java.util.HashMap;
 
@@ -364,89 +363,101 @@ public class MilledOreProcessing extends ItemPackage {
             .itemOutputs(getOutputsFromMap(SphaleriteFlotationFroth))
             .fluidInputs(FluidUtils.getFluidStack(SphaleriteFlotationFroth, 4000))
             .fluidOutputs(FluidUtils.getFluidStack(AgriculturalChem.RedMud, 2000), FluidUtils.getWater(2000))
-            .duration((int) TierEU.RECIPE_LuV)
-            .eut(5500)
-            .addTo(vacuumFreezerRecipes);
+            .eut((int) TierEU.RECIPE_LuV)
+            .metadata(COIL_HEAT, 5500)
+            .duration(120 * SECONDS)
+            .addTo(vacuumFurnaceRecipes);
         GT_Values.RA.stdBuilder()
             .itemInputs(GT_Utility.getIntegratedCircuit(aCircuitID++))
             .itemOutputs(getOutputsFromMap(ChalcopyriteFlotationFroth))
             .fluidInputs(FluidUtils.getFluidStack(ChalcopyriteFlotationFroth, 4000))
             .fluidOutputs(FluidUtils.getFluidStack(AgriculturalChem.RedMud, 2000), FluidUtils.getWater(2000))
-            .duration((int) TierEU.RECIPE_IV)
-            .eut(4500)
-            .addTo(vacuumFreezerRecipes);
+            .eut((int) TierEU.RECIPE_IV)
+            .metadata(COIL_HEAT, 4500)
+            .duration(120 * SECONDS)
+            .addTo(vacuumFurnaceRecipes);
         GT_Values.RA.stdBuilder()
             .itemInputs(GT_Utility.getIntegratedCircuit(aCircuitID++))
             .itemOutputs(getOutputsFromMap(NickelFlotationFroth))
             .fluidInputs(FluidUtils.getFluidStack(NickelFlotationFroth, 4000))
             .fluidOutputs(FluidUtils.getFluidStack(AgriculturalChem.RedMud, 2000), FluidUtils.getWater(2000))
-            .duration((int) TierEU.RECIPE_IV)
-            .eut(4500)
-            .addTo(vacuumFreezerRecipes);
+            .eut((int) TierEU.RECIPE_IV)
+            .metadata(COIL_HEAT, 4500)
+            .duration(120 * SECONDS)
+            .addTo(vacuumFurnaceRecipes);
         GT_Values.RA.stdBuilder()
             .itemInputs(GT_Utility.getIntegratedCircuit(aCircuitID++))
             .itemOutputs(getOutputsFromMap(PlatinumFlotationFroth))
             .fluidInputs(FluidUtils.getFluidStack(PlatinumFlotationFroth, 4000))
             .fluidOutputs(FluidUtils.getFluidStack(AgriculturalChem.RedMud, 2000), FluidUtils.getWater(2000))
-            .duration((int) TierEU.RECIPE_LuV)
-            .eut(5500)
-            .addTo(vacuumFreezerRecipes);
+            .eut((int) TierEU.RECIPE_LuV)
+            .metadata(COIL_HEAT, 5500)
+            .duration(120 * SECONDS)
+            .addTo(vacuumFurnaceRecipes);
         GT_Values.RA.stdBuilder()
             .itemInputs(GT_Utility.getIntegratedCircuit(aCircuitID++))
             .itemOutputs(getOutputsFromMap(PentlanditeFlotationFroth))
             .fluidInputs(FluidUtils.getFluidStack(PentlanditeFlotationFroth, 4000))
             .fluidOutputs(FluidUtils.getFluidStack(AgriculturalChem.RedMud, 2000), FluidUtils.getWater(2000))
-            .duration((int) TierEU.RECIPE_LuV)
-            .eut(5500)
-            .addTo(vacuumFreezerRecipes);
+            .eut((int) TierEU.RECIPE_LuV)
+            .metadata(COIL_HEAT, 5500)
+            .duration(120 * SECONDS)
+            .addTo(vacuumFurnaceRecipes);
         GT_Values.RA.stdBuilder()
             .itemInputs(GT_Utility.getIntegratedCircuit(aCircuitID++))
             .itemOutputs(getOutputsFromMap(RedstoneFlotationFroth))
             .fluidInputs(FluidUtils.getFluidStack(RedstoneFlotationFroth, 4000))
             .fluidOutputs(FluidUtils.getFluidStack(AgriculturalChem.RedMud, 2000), FluidUtils.getWater(2000))
-            .duration((int) TierEU.RECIPE_IV)
-            .eut(4500)
-            .addTo(vacuumFreezerRecipes);
+            .eut((int) TierEU.RECIPE_IV)
+            .metadata(COIL_HEAT, 4500)
+            .duration(120 * SECONDS)
+            .addTo(vacuumFurnaceRecipes);
         GT_Values.RA.stdBuilder()
             .itemInputs(GT_Utility.getIntegratedCircuit(aCircuitID++))
             .itemOutputs(getOutputsFromMap(SpessartineFlotationFroth))
             .fluidInputs(FluidUtils.getFluidStack(SpessartineFlotationFroth, 4000))
             .fluidOutputs(FluidUtils.getFluidStack(AgriculturalChem.RedMud, 2000), FluidUtils.getWater(2000))
-            .duration((int) TierEU.RECIPE_LuV)
-            .eut(5500)
-            .addTo(vacuumFreezerRecipes);
+            .eut((int) TierEU.RECIPE_LuV)
+            .metadata(COIL_HEAT, 5500)
+            .duration(120 * SECONDS)
+            .addTo(vacuumFurnaceRecipes);
         GT_Values.RA.stdBuilder()
             .itemInputs(GT_Utility.getIntegratedCircuit(aCircuitID++))
             .itemOutputs(getOutputsFromMap(GrossularFlotationFroth))
             .fluidInputs(FluidUtils.getFluidStack(GrossularFlotationFroth, 4000))
             .fluidOutputs(FluidUtils.getFluidStack(AgriculturalChem.RedMud, 2000), FluidUtils.getWater(2000))
-            .duration((int) TierEU.RECIPE_LuV)
-            .eut(5500)
-            .addTo(vacuumFreezerRecipes);
+            .eut((int) TierEU.RECIPE_LuV)
+            .metadata(COIL_HEAT, 5500)
+            .duration(120 * SECONDS)
+            .addTo(vacuumFurnaceRecipes);
         GT_Values.RA.stdBuilder()
             .itemInputs(GT_Utility.getIntegratedCircuit(aCircuitID++))
             .itemOutputs(getOutputsFromMap(AlmandineFlotationFroth))
             .fluidInputs(FluidUtils.getFluidStack(AlmandineFlotationFroth, 4000))
             .fluidOutputs(FluidUtils.getFluidStack(AgriculturalChem.RedMud, 2000), FluidUtils.getWater(2000))
-            .duration((int) TierEU.RECIPE_LuV)
-            .eut(5500)
-            .addTo(vacuumFreezerRecipes);
+            .eut((int) TierEU.RECIPE_LuV)
+            .metadata(COIL_HEAT, 5500)
+            .duration(120 * SECONDS)
+            .addTo(vacuumFurnaceRecipes);
         GT_Values.RA.stdBuilder()
             .itemInputs(GT_Utility.getIntegratedCircuit(aCircuitID++))
             .itemOutputs(getOutputsFromMap(PyropeFlotationFroth))
             .fluidInputs(FluidUtils.getFluidStack(PyropeFlotationFroth, 4000))
             .fluidOutputs(FluidUtils.getFluidStack(AgriculturalChem.RedMud, 2000), FluidUtils.getWater(2000))
-            .duration((int) TierEU.RECIPE_EV)
-            .eut(3500)
-            .addTo(vacuumFreezerRecipes);
+            .eut((int) TierEU.RECIPE_EV)
+            .metadata(COIL_HEAT, 3500)
+            .duration(120 * SECONDS)
+            .addTo(vacuumFurnaceRecipes);
         GT_Values.RA.stdBuilder()
             .itemInputs(GT_Utility.getIntegratedCircuit(aCircuitID++))
             .itemOutputs(getOutputsFromMap(MonaziteFlotationFroth))
             .fluidInputs(FluidUtils.getFluidStack(MonaziteFlotationFroth, 4000))
             .fluidOutputs(FluidUtils.getFluidStack(AgriculturalChem.RedMud, 2000), FluidUtils.getWater(2000))
-            .duration((int) TierEU.RECIPE_ZPM)
-            .eut(7500)
-            .addTo(vacuumFreezerRecipes);
+            .eut((int) TierEU.RECIPE_UV)
+            .metadata(COIL_HEAT, 7500)
+            // 60s UV instead of 120s ZPM to avoid fusion skip
+            .duration(60 * SECONDS)
+            .addTo(vacuumFurnaceRecipes);
 
     }
 


### PR DESCRIPTION
RA2 migration accidentally broke all vacuum furnace recipes by adding invalid recipes to the vacuum freezer recipe map instead. This PR fixes the recipes and adds them to the correct recipe map.

https://github.com/GTNewHorizons/GTplusplus/pull/873 also downtiered the vacuum furnace to LuV, from ZPM. This accidentally allowed players to skip fusion for europium by using monazite milling:
![image](https://github.com/user-attachments/assets/cd33eb0c-181a-40c6-a896-b282760971e9)

This PR also modifies this recipe to be 60s long and UV voltage, to remove the skip but keep the overall speed the same.