### PR TITLE
Remove Cell Chemistry in LFTR and Fix Recipe Tooltip

### DIFF
--- a/src/main/java/gtPlusPlus/api/recipe/GTPPRecipeMaps.java
+++ b/src/main/java/gtPlusPlus/api/recipe/GTPPRecipeMaps.java
@@ -23,6 +23,8 @@ import gtPlusPlus.core.util.minecraft.ItemUtils;
 import gtPlusPlus.xmod.gregtech.api.gui.GTPP_UITextures;
 import gtPlusPlus.xmod.gregtech.common.tileentities.machines.multi.production.GregtechMetaTileEntityTreeFarm;
 
+import static gregtech.api.util.GT_RecipeConstants.LFTR_OUTPUT_POWER;
+
 public class GTPPRecipeMaps {
 
     public static final RecipeMap<RecipeMapBackend> cokeOvenRecipes = RecipeMapBuilder.of("gtpp.recipe.cokeoven")
@@ -74,7 +76,7 @@ public class GTPPRecipeMaps {
         .minInputs(0, 2)
         .frontend(FluidOnlyFrontend::new)
         .neiSpecialInfoFormatter(recipeInfo -> {
-            final long eut = recipeInfo.recipe.mSpecialValue;
+            final long eut = recipeInfo.recipe.getMetadataOrDefault(LFTR_OUTPUT_POWER, 0);
             final int duration = recipeInfo.recipe.mDuration;
             return Arrays.asList(
                 StatCollector.translateToLocalFormatted("gtpp.nei.lftr.power", GT_Utility.formatNumbers(eut)),

--- a/src/main/java/gtPlusPlus/api/recipe/GTPPRecipeMaps.java
+++ b/src/main/java/gtPlusPlus/api/recipe/GTPPRecipeMaps.java
@@ -1,5 +1,7 @@
 package gtPlusPlus.api.recipe;
 
+import static gregtech.api.util.GT_RecipeConstants.LFTR_OUTPUT_POWER;
+
 import java.util.Arrays;
 import java.util.Collections;
 
@@ -22,8 +24,6 @@ import gtPlusPlus.core.util.math.MathUtils;
 import gtPlusPlus.core.util.minecraft.ItemUtils;
 import gtPlusPlus.xmod.gregtech.api.gui.GTPP_UITextures;
 import gtPlusPlus.xmod.gregtech.common.tileentities.machines.multi.production.GregtechMetaTileEntityTreeFarm;
-
-import static gregtech.api.util.GT_RecipeConstants.LFTR_OUTPUT_POWER;
 
 public class GTPPRecipeMaps {
 

--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_LFTR.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_LFTR.java
@@ -74,6 +74,7 @@ public class RecipeLoader_LFTR {
             .duration(1 * MINUTES + 40 * SECONDS)
             .eut(0)
             .metadata(LFTR_OUTPUT_POWER, 32768 * 4)
+            .noOptimize()
             .addTo(liquidFluorineThoriumReactorRecipes);
 
         // LiFBeF2ZrF4UF4 - T2

--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_Nuclear.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_Nuclear.java
@@ -420,10 +420,7 @@ public class RecipeLoader_Nuclear {
         GT_Values.RA.stdBuilder()
             .itemInputs(FLUORIDES.BERYLLIUM_HYDROXIDE.getDust(3), CI.getNumberedAdvancedCircuit(17))
             .fluidInputs(FLUORIDES.AMMONIUM_BIFLUORIDE.getFluidStack(1152))
-            .fluidOutputs(
-                Materials.Water.getFluid(2000L),
-                FLUORIDES.AMMONIUM_TETRAFLUOROBERYLLATE.getFluidStack(1000)
-            )
+            .fluidOutputs(Materials.Water.getFluid(2000L), FLUORIDES.AMMONIUM_TETRAFLUOROBERYLLATE.getFluidStack(1000))
             .eut(TierEU.RECIPE_MV)
             .duration(5 * MINUTES)
             .addTo(multiblockChemicalReactorRecipes);
@@ -446,13 +443,11 @@ public class RecipeLoader_Nuclear {
 
         GT_Values.RA.stdBuilder()
             .itemInputs(CI.getNumberedAdvancedCircuit(17))
-            .itemOutputs(
-                FLUORIDES.BERYLLIUM_FLUORIDE.getDust(3))
+            .itemOutputs(FLUORIDES.BERYLLIUM_FLUORIDE.getDust(3))
             .fluidInputs(FLUORIDES.AMMONIUM_TETRAFLUOROBERYLLATE.getFluidStack(1000))
             .fluidOutputs(
                 MISC_MATERIALS.AMMONIA.getFluidStack(2000),
-                FluidUtils.getFluidStack("hydrofluoricacid", 1000)
-            )
+                FluidUtils.getFluidStack("hydrofluoricacid", 1000))
             .eut(TierEU.RECIPE_MV)
             .duration(5 * MINUTES)
             .addTo(multiblockChemicalReactorRecipes);

--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_Nuclear.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_Nuclear.java
@@ -11,6 +11,7 @@ import static gregtech.api.recipe.RecipeMaps.fluidHeaterRecipes;
 import static gregtech.api.recipe.RecipeMaps.fusionRecipes;
 import static gregtech.api.recipe.RecipeMaps.maceratorRecipes;
 import static gregtech.api.recipe.RecipeMaps.mixerRecipes;
+import static gregtech.api.recipe.RecipeMaps.multiblockChemicalReactorRecipes;
 import static gregtech.api.recipe.RecipeMaps.sifterRecipes;
 import static gregtech.api.util.GT_RecipeBuilder.MINUTES;
 import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
@@ -385,7 +386,7 @@ public class RecipeLoader_Nuclear {
             .itemInputs(
                 CI.getNumberedAdvancedCircuit(11),
                 ItemUtils.getItemStackOfAmountFromOreDict("dustCookedZrCl4", 1))
-            .itemOutputs()
+            .itemOutputs(FLUORIDES.ZIRCONIUM_TETRAFLUORIDE.getDust(1))
             .fluidInputs(FluidUtils.getFluidStack("hydrofluoricacid", 400))
             .fluidOutputs(aHydrogenChloride)
             .eut(500)
@@ -416,6 +417,17 @@ public class RecipeLoader_Nuclear {
             .duration(6 * SECONDS)
             .addTo(chemicalDehydratorRecipes);
 
+        GT_Values.RA.stdBuilder()
+            .itemInputs(FLUORIDES.BERYLLIUM_HYDROXIDE.getDust(3), CI.getNumberedAdvancedCircuit(17))
+            .fluidInputs(FLUORIDES.AMMONIUM_BIFLUORIDE.getFluidStack(1152))
+            .fluidOutputs(
+                Materials.Water.getFluid(2000L),
+                FLUORIDES.AMMONIUM_TETRAFLUOROBERYLLATE.getFluidStack(1000)
+            )
+            .eut(TierEU.RECIPE_MV)
+            .duration(5 * MINUTES)
+            .addTo(multiblockChemicalReactorRecipes);
+
         // (NH4)2BeF4 → 2 NH3 + 2 HF + BeF2
         // Ammonium tetrafluoroberyllate uses fluid rule because it is not a molten form of a solid
         // Beryllium fluoride uses solid rule
@@ -431,6 +443,19 @@ public class RecipeLoader_Nuclear {
             .eut(TierEU.RECIPE_MV)
             .duration(5 * MINUTES)
             .addTo(chemicalDehydratorRecipes);
+
+        GT_Values.RA.stdBuilder()
+            .itemInputs(CI.getNumberedAdvancedCircuit(17))
+            .itemOutputs(
+                FLUORIDES.BERYLLIUM_FLUORIDE.getDust(3))
+            .fluidInputs(FLUORIDES.AMMONIUM_TETRAFLUOROBERYLLATE.getFluidStack(1000))
+            .fluidOutputs(
+                MISC_MATERIALS.AMMONIA.getFluidStack(2000),
+                FluidUtils.getFluidStack("hydrofluoricacid", 1000)
+            )
+            .eut(TierEU.RECIPE_MV)
+            .duration(5 * MINUTES)
+            .addTo(multiblockChemicalReactorRecipes);
     }
 
     private static void electroMagneticSeperator() {


### PR DESCRIPTION
This PR gives the LCR two recipes from the Dehydrator that force cell chemistry in the LFTR chain until the Dehydrator multi can be built in late-LuV. It also fixes the missing output of a recipe in the chain, and fixes the NEI recipe tooltip that currently displays all EU values produced as 0.