### PR TITLE
Fixes fluid extractor recipes that come from the squeezer

### DIFF
--- a/src/main/java/gregtech/api/util/GT_Forestry_Compat.java
+++ b/src/main/java/gregtech/api/util/GT_Forestry_Compat.java
@@ -171,13 +171,14 @@ public class GT_Forestry_Compat {
         try {
             for (ISqueezerRecipe tRecipe : RecipeManagers.squeezerManager.recipes()) {
                 if ((tRecipe.getResources().length == 1) && (tRecipe.getFluidOutput() != null)
-                    && (tRecipe.getResources()[0] != null)
-                    && (tRecipe.getRemnants() != null)) {
-                    GT_Values.RA.stdBuilder()
-                        .itemInputs(tRecipe.getResources()[0])
-                        .itemOutputs(tRecipe.getRemnants())
-                        .outputChances((int) (tRecipe.getRemnantsChance() * 10000))
-                        .fluidOutputs(tRecipe.getFluidOutput())
+                    && (tRecipe.getResources()[0] != null)) {
+                    GT_RecipeBuilder recipeBuilder = GT_Values.RA.stdBuilder();
+                    recipeBuilder.itemInputs(tRecipe.getResources()[0]);
+                    if (tRecipe.getRemnants() != null) {
+                        recipeBuilder.itemOutputs(tRecipe.getRemnants())
+                            .outputChances((int) (tRecipe.getRemnantsChance() * 10000));
+                    }
+                    recipeBuilder.fluidOutputs(tRecipe.getFluidOutput())
                         .duration(1 * SECONDS + 12 * TICKS)
                         .eut(8)
                         .addTo(RecipeMaps.fluidExtractionRecipes);


### PR DESCRIPTION
Some squeezer recipes don't actually have remnants (notably peanuts with seed oil) which means they were getting skipped by the conditional.

Tested against the nightly 566 to confirm it works.