### PR TITLE
Fix CAL tierskip

### DIFF
--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_CircuitAssemblyLine.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_CircuitAssemblyLine.java
@@ -308,6 +308,12 @@ public class GT_TileEntity_CircuitAssemblyLine extends
                 if (GT_TileEntity_CircuitAssemblyLine.this.mode == 1
                     && recipe.mEUt > GT_TileEntity_CircuitAssemblyLine.this.getMaxInputVoltage() / 4) {
                     return CheckRecipeResultRegistry.NO_RECIPE;
+                } else if (GT_TileEntity_CircuitAssemblyLine.this.mode == 0) {
+                    // Limit CAL mode recipes to hatch tier, otherwise it will run low EU recipes
+                    // with a tier-1 hatch and pull 2A to supply the power
+                    if (recipe.mEUt > GT_TileEntity_CircuitAssemblyLine.this.getMaxInputVoltage()) {
+                        return CheckRecipeResultRegistry.insufficientPower(recipe.mEUt);
+                    }
                 }
                 return CheckRecipeResultRegistry.SUCCESSFUL;
             }


### PR DESCRIPTION
CAL could run UV recipes with a ZPM energy hatch (and similar) because a lot of its recipes take less than 2A of the previous voltage, even if they are listed at a higher voltage tier. This would allow players to run recipes that are intended to require a UV energy hatch a tier earlier.

![image](https://github.com/user-attachments/assets/f763bf2d-6cfe-490f-9874-6d0a55f47893)
The fix correctly identifies the input voltage, not the total amount of EU/t in.