### PR TITLE
Optimize recipe check forcing and add a button to enable/disable

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
@@ -1603,7 +1603,10 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity
             return mDualInputHatches.add(hatch);
         }
         if (aMetaTileEntity instanceof ISmartInputHatch hatch) {
-            mSmartInputHatches.add(hatch);
+            // Only add them to be iterated if enabled for performance reasons
+            if (hatch.doFastRecipeCheck()) {
+                mSmartInputHatches.add(hatch);
+            }
         }
         if (aMetaTileEntity instanceof GT_MetaTileEntity_Hatch_Input) {
             setHatchRecipeMap((GT_MetaTileEntity_Hatch_Input) aMetaTileEntity);

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_InputBus_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_InputBus_ME.java
@@ -58,7 +58,6 @@ import appeng.me.GridAccessException;
 import appeng.me.helpers.AENetworkProxy;
 import appeng.me.helpers.IGridProxyable;
 import appeng.util.item.AEItemStack;
-import goodgenerator.client.GUI.GG_UITextures;
 import gregtech.api.enums.ItemList;
 import gregtech.api.gui.modularui.GT_UITextures;
 import gregtech.api.interfaces.IConfigurationCircuitSupport;
@@ -237,6 +236,10 @@ public class GT_MetaTileEntity_Hatch_InputBus_ME extends GT_MetaTileEntity_Hatch
             refreshItemList();
         }
         updateAllInformationSlots();
+    }
+
+    public boolean doFastRecipeCheck() {
+        return expediteRecipeCheck;
     }
 
     @Override
@@ -490,8 +493,8 @@ public class GT_MetaTileEntity_Hatch_InputBus_ME extends GT_MetaTileEntity_Hatch
                     ItemStack itemstack = GT_Utility.copyAmount(1, currItem.getItemStack());
                     if (expediteRecipeCheck) {
                         ItemStack previous = this.mInventory[index];
-                        if (itemstack != null && previous != null) {
-                            justHadNewItems = !itemstack.isItemEqual(previous);
+                        if (itemstack != null) {
+                            justHadNewItems = !ItemStack.areItemStacksEqual(itemstack, previous);
                         }
                     }
                     this.mInventory[index] = itemstack;
@@ -575,8 +578,8 @@ public class GT_MetaTileEntity_Hatch_InputBus_ME extends GT_MetaTileEntity_Hatch
                     // check early
                     if (expediteRecipeCheck) {
                         ItemStack previous = getStackInSlot(aIndex + SLOT_COUNT);
-                        if (s != null && previous != null) {
-                            justHadNewItems = !s.isItemEqual(previous);
+                        if (s != null) {
+                            justHadNewItems = !ItemStack.areItemStacksEqual(s, previous);
                         }
                     }
                     setInventorySlotContents(aIndex + SLOT_COUNT, s);
@@ -791,13 +794,14 @@ public class GT_MetaTileEntity_Hatch_InputBus_ME extends GT_MetaTileEntity_Hatch
                 .setPos(3, 88)
                 .setSize(50, 14))
             .widget(
-            new CycleButtonWidget().setToggle(() -> expediteRecipeCheck, val -> setRecipeCheck(val))
-                .setTextureGetter(
-                    state -> expediteRecipeCheck ? GT_UITextures.OVERLAY_BUTTON_CHECKMARK
-                        : GT_UITextures.OVERLAY_BUTTON_CROSS)
-                .setBackground(GT_UITextures.BUTTON_STANDARD)
-                .setPos(53, 87)
-                .setSize(16, 16));
+                new CycleButtonWidget().setToggle(() -> expediteRecipeCheck, val -> setRecipeCheck(val))
+                    .setTextureGetter(
+                        state -> expediteRecipeCheck ? GT_UITextures.OVERLAY_BUTTON_CHECKMARK
+                            : GT_UITextures.OVERLAY_BUTTON_CROSS)
+                    .setBackground(GT_UITextures.BUTTON_STANDARD)
+                    .setPos(53, 87)
+                    .setSize(16, 16)
+                    .addTooltip(StatCollector.translateToLocal("GT5U.machines.stocking_bus.hatch_warning")));
         return builder.build();
     }
 
@@ -855,10 +859,9 @@ public class GT_MetaTileEntity_Hatch_InputBus_ME extends GT_MetaTileEntity_Hatch
             strings.add(
                 "Auto-Pull from ME mode will automatically stock the first 16 items in the ME system, updated every 5 seconds.");
             strings.add("Toggle by right-clicking with screwdriver, or use the GUI.");
-            strings
-                .add("Use the GUI to limit the minimum stack size for Auto-Pulling, adjust the slot refresh timer and enable fast recipe checks.");
-            strings
-                .add("WARNING: Fast recipe checks can be laggy. Use with caution.");
+            strings.add(
+                "Use the GUI to limit the minimum stack size for Auto-Pulling, adjust the slot refresh timer and enable fast recipe checks.");
+            strings.add("WARNING: Fast recipe checks can be laggy. Use with caution.");
         }
 
         strings.add("Change ME connection behavior by right-clicking with wire cutter.");

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_InputBus_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_InputBus_ME.java
@@ -35,6 +35,7 @@ import com.gtnewhorizons.modularui.api.screen.ModularWindow;
 import com.gtnewhorizons.modularui.api.screen.UIBuildContext;
 import com.gtnewhorizons.modularui.common.internal.wrapper.BaseSlot;
 import com.gtnewhorizons.modularui.common.widget.ButtonWidget;
+import com.gtnewhorizons.modularui.common.widget.CycleButtonWidget;
 import com.gtnewhorizons.modularui.common.widget.DrawableWidget;
 import com.gtnewhorizons.modularui.common.widget.FakeSyncWidget;
 import com.gtnewhorizons.modularui.common.widget.SlotGroup;
@@ -57,6 +58,7 @@ import appeng.me.GridAccessException;
 import appeng.me.helpers.AENetworkProxy;
 import appeng.me.helpers.IGridProxyable;
 import appeng.util.item.AEItemStack;
+import goodgenerator.client.GUI.GG_UITextures;
 import gregtech.api.enums.ItemList;
 import gregtech.api.gui.modularui.GT_UITextures;
 import gregtech.api.interfaces.IConfigurationCircuitSupport;
@@ -94,6 +96,7 @@ public class GT_MetaTileEntity_Hatch_InputBus_ME extends GT_MetaTileEntity_Hatch
     private static final int CONFIG_WINDOW_ID = 10;
     private boolean additionalConnection = false;
     private boolean justHadNewItems = false;
+    private boolean expediteRecipeCheck = false;
 
     public GT_MetaTileEntity_Hatch_InputBus_ME(int aID, boolean autoPullAvailable, String aName, String aNameRegional) {
         super(
@@ -215,6 +218,7 @@ public class GT_MetaTileEntity_Hatch_InputBus_ME extends GT_MetaTileEntity_Hatch
         aNBT.setBoolean("autoStock", autoPullItemList);
         aNBT.setInteger("minAutoPullStackSize", minAutoPullStackSize);
         aNBT.setBoolean("additionalConnection", additionalConnection);
+        aNBT.setBoolean("expediteRecipeCheck", expediteRecipeCheck);
         aNBT.setInteger("refreshTime", autoPullRefreshTime);
         getProxy().writeToNBT(aNBT);
     }
@@ -253,6 +257,7 @@ public class GT_MetaTileEntity_Hatch_InputBus_ME extends GT_MetaTileEntity_Hatch
         autoPullItemList = aNBT.getBoolean("autoStock");
         minAutoPullStackSize = aNBT.getInteger("minAutoPullStackSize");
         additionalConnection = aNBT.getBoolean("additionalConnection");
+        expediteRecipeCheck = aNBT.getBoolean("expediteRecipeCheck");
         if (aNBT.hasKey("refreshTime")) {
             autoPullRefreshTime = aNBT.getInteger("refreshTime");
         }
@@ -395,7 +400,7 @@ public class GT_MetaTileEntity_Hatch_InputBus_ME extends GT_MetaTileEntity_Hatch
 
     @Override
     public boolean justUpdated() {
-        if (autoPullItemList) {
+        if (expediteRecipeCheck) {
             boolean ret = justHadNewItems;
             justHadNewItems = false;
             return ret;
@@ -403,9 +408,13 @@ public class GT_MetaTileEntity_Hatch_InputBus_ME extends GT_MetaTileEntity_Hatch
         return false;
     }
 
+    public void setRecipeCheck(boolean value) {
+        expediteRecipeCheck = value;
+    }
+
     @Override
     public void setInventorySlotContents(int aIndex, ItemStack aStack) {
-        if (aStack != null) {
+        if (expediteRecipeCheck && aStack != null) {
             justHadNewItems = true;
         }
         super.setInventorySlotContents(aIndex, aStack);
@@ -479,11 +488,13 @@ public class GT_MetaTileEntity_Hatch_InputBus_ME extends GT_MetaTileEntity_Hatch
                 IAEItemStack currItem = iterator.next();
                 if (currItem.getStackSize() >= minAutoPullStackSize) {
                     ItemStack itemstack = GT_Utility.copyAmount(1, currItem.getItemStack());
-                    ItemStack previous = this.mInventory[index];
-                    this.mInventory[index] = itemstack;
-                    if (itemstack != null && previous != null) {
-                        justHadNewItems = !itemstack.isItemEqual(previous);
+                    if (expediteRecipeCheck) {
+                        ItemStack previous = this.mInventory[index];
+                        if (itemstack != null && previous != null) {
+                            justHadNewItems = !itemstack.isItemEqual(previous);
+                        }
                     }
+                    this.mInventory[index] = itemstack;
                     index++;
                 }
             }
@@ -562,11 +573,13 @@ public class GT_MetaTileEntity_Hatch_InputBus_ME extends GT_MetaTileEntity_Hatch
                     ItemStack s = (result != null) ? result.getItemStack() : null;
                     // We want to track changes in any ItemStack to notify any connected controllers to make a recipe
                     // check early
-                    ItemStack previous = getStackInSlot(aIndex + SLOT_COUNT);
-                    setInventorySlotContents(aIndex + SLOT_COUNT, s);
-                    if (s != null && previous != null) {
-                        justHadNewItems = !s.isItemEqual(previous);
+                    if (expediteRecipeCheck) {
+                        ItemStack previous = getStackInSlot(aIndex + SLOT_COUNT);
+                        if (s != null && previous != null) {
+                            justHadNewItems = !s.isItemEqual(previous);
+                        }
                     }
+                    setInventorySlotContents(aIndex + SLOT_COUNT, s);
                     return s;
                 } catch (final GridAccessException ignored) {}
             }
@@ -733,7 +746,7 @@ public class GT_MetaTileEntity_Hatch_InputBus_ME extends GT_MetaTileEntity_Hatch
 
     protected ModularWindow createStackSizeConfigurationWindow(final EntityPlayer player) {
         final int WIDTH = 78;
-        final int HEIGHT = 80;
+        final int HEIGHT = 115;
         final int PARENT_WIDTH = getGUIWidth();
         final int PARENT_HEIGHT = getGUIHeight();
         ModularWindow.Builder builder = ModularWindow.builder(WIDTH, HEIGHT);
@@ -773,6 +786,18 @@ public class GT_MetaTileEntity_Hatch_InputBus_ME extends GT_MetaTileEntity_Hatch
                     .setSize(70, 18)
                     .setPos(3, 58)
                     .setBackground(GT_UITextures.BACKGROUND_TEXT_FIELD));
+        builder.widget(
+            TextWidget.localised("GT5U.machines.stocking_bus.force_check")
+                .setPos(3, 88)
+                .setSize(50, 14))
+            .widget(
+            new CycleButtonWidget().setToggle(() -> expediteRecipeCheck, val -> setRecipeCheck(val))
+                .setTextureGetter(
+                    state -> expediteRecipeCheck ? GT_UITextures.OVERLAY_BUTTON_CHECKMARK
+                        : GT_UITextures.OVERLAY_BUTTON_CROSS)
+                .setBackground(GT_UITextures.BUTTON_STANDARD)
+                .setPos(53, 87)
+                .setSize(16, 16));
         return builder.build();
     }
 
@@ -831,7 +856,9 @@ public class GT_MetaTileEntity_Hatch_InputBus_ME extends GT_MetaTileEntity_Hatch
                 "Auto-Pull from ME mode will automatically stock the first 16 items in the ME system, updated every 5 seconds.");
             strings.add("Toggle by right-clicking with screwdriver, or use the GUI.");
             strings
-                .add("Use the GUI to limit the minimum stack size for Auto-Pulling and adjust the slot refresh timer.");
+                .add("Use the GUI to limit the minimum stack size for Auto-Pulling, adjust the slot refresh timer and enable fast recipe checks.");
+            strings
+                .add("WARNING: Fast recipe checks can be laggy. Use with caution.");
         }
 
         strings.add("Change ME connection behavior by right-clicking with wire cutter.");

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_Input_ME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_Input_ME.java
@@ -7,7 +7,6 @@ import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_ME_INPUT_FLUID_HATC
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.List;
@@ -64,7 +63,6 @@ import appeng.me.GridAccessException;
 import appeng.me.helpers.AENetworkProxy;
 import appeng.me.helpers.IGridProxyable;
 import appeng.util.item.AEFluidStack;
-import goodgenerator.client.GUI.GG_UITextures;
 import gregtech.api.enums.ItemList;
 import gregtech.api.gui.modularui.GT_UITextures;
 import gregtech.api.interfaces.ITexture;
@@ -376,6 +374,10 @@ public class GT_MetaTileEntity_Hatch_Input_ME extends GT_MetaTileEntity_Hatch_In
         updateAllInformationSlots();
     }
 
+    public boolean doFastRecipeCheck() {
+        return expediteRecipeCheck;
+    }
+
     private void updateAllInformationSlots() {
         for (int index = 0; index < SLOT_COUNT; index++) {
             updateInformationSlot(index);
@@ -410,7 +412,7 @@ public class GT_MetaTileEntity_Hatch_Input_ME extends GT_MetaTileEntity_Hatch_In
             // early
             if (expediteRecipeCheck) {
                 FluidStack previous = storedInformationFluids[index];
-                if (resultFluid != null && previous != null) {
+                if (resultFluid != null) {
                     justHadNewFluids = !resultFluid.isFluidEqual(previous);
                 }
             }
@@ -854,13 +856,14 @@ public class GT_MetaTileEntity_Hatch_Input_ME extends GT_MetaTileEntity_Hatch_In
                 .setPos(3, 88)
                 .setSize(50, 14))
             .widget(
-            new CycleButtonWidget().setToggle(() -> expediteRecipeCheck, val -> setRecipeCheck(val))
-                .setTextureGetter(
-                    state -> expediteRecipeCheck ? GT_UITextures.OVERLAY_BUTTON_CHECKMARK
-                        : GT_UITextures.OVERLAY_BUTTON_CROSS)
-                .setBackground(GT_UITextures.BUTTON_STANDARD)
-                .setPos(53, 87)
-                .setSize(16, 16));
+                new CycleButtonWidget().setToggle(() -> expediteRecipeCheck, val -> setRecipeCheck(val))
+                    .setTextureGetter(
+                        state -> expediteRecipeCheck ? GT_UITextures.OVERLAY_BUTTON_CHECKMARK
+                            : GT_UITextures.OVERLAY_BUTTON_CROSS)
+                    .setBackground(GT_UITextures.BUTTON_STANDARD)
+                    .setPos(53, 87)
+                    .setSize(16, 16)
+                    .addTooltip(StatCollector.translateToLocal("GT5U.machines.stocking_bus.hatch_warning")));
         return builder.build();
     }
 
@@ -918,10 +921,9 @@ public class GT_MetaTileEntity_Hatch_Input_ME extends GT_MetaTileEntity_Hatch_In
             strings.add(
                 "Auto-Pull from ME mode will automatically stock the first 16 fluid in the ME system, updated every 5 seconds.");
             strings.add("Toggle by right-clicking with screwdriver, or use the GUI.");
-            strings
-                .add("Use the GUI to limit the minimum stack size for Auto-Pulling, adjust the slot refresh timer and enable fast recipe checks.");
-            strings
-                .add("WARNING: Fast recipe checks can be laggy. Use with caution.");
+            strings.add(
+                "Use the GUI to limit the minimum stack size for Auto-Pulling, adjust the slot refresh timer and enable fast recipe checks.");
+            strings.add("WARNING: Fast recipe checks can be laggy. Use with caution.");
         }
 
         strings.add("Change ME connection behavior by right-clicking with wire cutter.");

--- a/src/main/java/gregtech/common/tileentities/machines/ISmartInputHatch.java
+++ b/src/main/java/gregtech/common/tileentities/machines/ISmartInputHatch.java
@@ -10,4 +10,6 @@ public interface ISmartInputHatch {
     // Have the contents of the hatch changed since the last check?
     boolean justUpdated();
 
+    public boolean doFastRecipeCheck();
+
 }

--- a/src/main/resources/assets/gregtech/lang/en_US.lang
+++ b/src/main/resources/assets/gregtech/lang/en_US.lang
@@ -418,6 +418,7 @@ GT5U.machines.stocking_bus.auto_pull.tooltip.2=Right-Click to edit additional pa
 GT5U.machines.stocking_bus.min_stack_size=Min Stack Size
 GT5U.machines.stocking_bus.refresh_time=Slot Refresh Time (Ticks)
 GT5U.machines.stocking_bus.force_check=Recipe Check on change
+GT5U.machines.stocking_bus.hatch_warning=Requires a fresh structure check to apply (Reboot/Replace controller)
 GT5U.machines.stocking_bus.auto_pull_toggle.enabled=Automatic Item Pull Enabled
 GT5U.machines.stocking_bus.auto_pull_toggle.disabled=Automatic Item Pull Disabled
 GT5U.machines.stocking_hatch.auto_pull.tooltip.1=Click to toggle automatic fluid pulling from ME.

--- a/src/main/resources/assets/gregtech/lang/en_US.lang
+++ b/src/main/resources/assets/gregtech/lang/en_US.lang
@@ -417,6 +417,7 @@ GT5U.machines.stocking_bus.auto_pull.tooltip.1=Click to toggle automatic item pu
 GT5U.machines.stocking_bus.auto_pull.tooltip.2=Right-Click to edit additional parameters.
 GT5U.machines.stocking_bus.min_stack_size=Min Stack Size
 GT5U.machines.stocking_bus.refresh_time=Slot Refresh Time (Ticks)
+GT5U.machines.stocking_bus.force_check=Recipe Check on change
 GT5U.machines.stocking_bus.auto_pull_toggle.enabled=Automatic Item Pull Enabled
 GT5U.machines.stocking_bus.auto_pull_toggle.disabled=Automatic Item Pull Disabled
 GT5U.machines.stocking_hatch.auto_pull.tooltip.1=Click to toggle automatic fluid pulling from ME.


### PR DESCRIPTION
Players can have a large amount of stocking hatches, so this feature should be opt-in instead of forced on for TPS reasons.
Also does some small optimizations and fixes.

![image](https://github.com/user-attachments/assets/89acdbca-eebc-4cb5-973a-a93dbc66e71c)

![image](https://github.com/user-attachments/assets/9ab5385b-116d-49c5-9cd9-ddf5b8b3badf)

Hatches that have never pressed the button will never be iterated over, which should make the TPS impact very minimal.