### PR TITLE
fix gtpp recycling fluid extracting

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/RecipeGen_Recycling.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/RecipeGen_Recycling.java
@@ -140,11 +140,11 @@ public class RecipeGen_Recycling implements Runnable {
             if (ItemUtils.checkForInvalidItems(tempStack)) {
                 int aFluidAmount = (int) ((144 * validPrefix.getKey().mMaterialAmount) / (M * tempStack.stackSize));
                 int aDuration = (int) Math.max(1, (24 * validPrefix.getKey().mMaterialAmount) / M);
-                FluidStack fluidInput = material.getFluidStack(aFluidAmount);
-                if (fluidInput != null) {
+                FluidStack fluidOutput = material.getFluidStack(aFluidAmount);
+                if (fluidOutput != null) {
                     GT_Values.RA.stdBuilder()
                         .itemInputs(tempStack)
-                        .fluidOutputs()
+                        .fluidOutputs(fluidOutput)
                         .duration(aDuration)
                         .eut(material.vVoltageMultiplier)
                         .addTo(fluidExtractionRecipes);


### PR DESCRIPTION
actually put in the output and name it output as well.

fixes https://discord.com/channels/181078474394566657/939305179524792340/1267586911518855209

was broken in the last ra2 push

now:
![image](https://github.com/user-attachments/assets/826684ca-63cc-401d-9e8c-e5ecde8d28ed)
