### PR TITLE
Fix ABS recipe times for Potin and Tumbaga

### DIFF
--- a/src/main/java/gtPlusPlus/core/material/ALLOY.java
+++ b/src/main/java/gtPlusPlus/core/material/ALLOY.java
@@ -90,7 +90,7 @@ public final class ALLOY {
         "Tumbaga", // Material Name
         MaterialState.SOLID, // State
         new short[] { 255, 178, 15, 0 }, // Material Colour
-        -1,
+        1300,
         -1,
         -1,
         -1,
@@ -103,7 +103,7 @@ public final class ALLOY {
         "Potin", // Material Name
         MaterialState.SOLID, // State
         new short[] { 201, 151, 129, 0 }, // Material Colour
-        -1,
+        1300,
         -1,
         -1,
         -1,


### PR DESCRIPTION
This is to address this ticket: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15932

The way the ABS generates recipes was based off of melting points, since these were set to -1 it would then do the calcualtion for the duration as 14 * 20 * (3 or 2) * 8. I've adjusted the melting points to be that of 20 * 1 * 10 and to still use LV power.

![image](https://github.com/user-attachments/assets/3eceace7-0741-4871-ac8b-d82911f48835)

![image](https://github.com/user-attachments/assets/2b8b28de-7ff3-4cf0-abcd-e5df76cb7dd6)
