### PR TITLE
Disable optimize on 8 gtpp recipe maps

### DIFF
--- a/src/main/java/gtPlusPlus/api/recipe/GTPPRecipeMaps.java
+++ b/src/main/java/gtPlusPlus/api/recipe/GTPPRecipeMaps.java
@@ -52,17 +52,20 @@ public class GTPPRecipeMaps {
         .progressBar(GT_UITextures.PROGRESSBAR_ARROW_MULTIPLE)
         .neiSpecialInfoFormatter(new SimpleSpecialValueFormatter("GT5U.nei.tier"))
         .frontend(LargeNEIFrontend::new)
+        .disableOptimize()
         .build();
     public static final RecipeMap<RecipeMapBackend> chemicalDehydratorRecipes = RecipeMapBuilder
         .of("gtpp.recipe.chemicaldehydrator")
         .maxIO(2, 9, 1, 1)
         .progressBar(GT_UITextures.PROGRESSBAR_SIFT, ProgressBar.Direction.DOWN)
+        .disableOptimize()
         .build();
     public static final RecipeMap<RecipeMapBackend> vacuumFurnaceRecipes = RecipeMapBuilder.of("gtpp.recipe.vacfurnace")
         .maxIO(9, 9, 3, 3)
         .minInputs(1, 0)
         .neiSpecialInfoFormatter(HeatingCoilSpecialValueFormatter.INSTANCE)
         .frontend(LargeNEIFrontend::new)
+        .disableOptimize()
         .build();
     public static final RecipeMap<RecipeMapBackend> alloyBlastSmelterRecipes = RecipeMapBuilder
         .of("gtpp.recipe.alloyblastsmelter")
@@ -85,6 +88,7 @@ public class GTPPRecipeMaps {
                 StatCollector
                     .translateToLocalFormatted("gtpp.nei.lftr.total", MathUtils.formatNumbers(duration * eut * 4)));
         })
+        .disableOptimize()
         .build();
     public static final RecipeMap<RecipeMapBackend> nuclearSaltProcessingPlantRecipes = RecipeMapBuilder
         .of("gtpp.recipe.nuclearsaltprocessingplant")
@@ -95,11 +99,13 @@ public class GTPPRecipeMaps {
         .maxIO(3, 1, 0, 0)
         .minInputs(1, 0)
         .frontend(MillingFrontend::new)
+        .disableOptimize()
         .build();
     public static final RecipeMap<RecipeMapBackend> fissionFuelProcessingRecipes = RecipeMapBuilder
         .of("gtpp.recipe.fissionfuel")
         .maxIO(0, 0, 6, 1)
         .frontend(FluidOnlyFrontend::new)
+        .disableOptimize()
         .build();
     public static final RecipeMap<RecipeMapBackend> coldTrapRecipes = RecipeMapBuilder.of("gtpp.recipe.coldtrap")
         .maxIO(2, 9, 1, 1)
@@ -151,6 +157,7 @@ public class GTPPRecipeMaps {
                 .singletonList(StatCollector.translateToLocalFormatted("GT5U.nei.tier", tier + " - " + materialName));
         })
         .frontend(ChemicalPlantFrontend::new)
+        .disableOptimize()
         .build();
     public static final RecipeMap<FuelBackend> rtgFuels = RecipeMapBuilder
         .of("gtpp.recipe.RTGgenerators", FuelBackend::new)
@@ -219,6 +226,7 @@ public class GTPPRecipeMaps {
     public static final RecipeMap<RecipeMapBackend> flotationCellRecipes = RecipeMapBuilder
         .of("gtpp.recipe.flotationcell")
         .maxIO(6, 0, 1, 1)
+        .disableOptimize()
         .build();
     public static final RecipeMap<RecipeMapBackend> treeGrowthSimulatorFakeRecipes = RecipeMapBuilder
         .of("gtpp.recipe.treefarm")

--- a/src/main/java/gtPlusPlus/core/item/base/ore/BaseItemMilledOre.java
+++ b/src/main/java/gtPlusPlus/core/item/base/ore/BaseItemMilledOre.java
@@ -35,28 +35,24 @@ public class BaseItemMilledOre extends BaseOreComponent {
             .itemOutputs(milledStackOres1)
             .duration(2 * MINUTES)
             .eut(materialEU)
-            .noOptimize()
             .addTo(millingRecipes);
         GT_Values.RA.stdBuilder()
             .itemInputs(GT_Utility.getIntegratedCircuit(11), oreStack, millingBall_Soapstone)
             .itemOutputs(milledStackOres2)
             .duration(2 * MINUTES + 30 * SECONDS)
             .eut(materialEU)
-            .noOptimize()
             .addTo(millingRecipes);
         GT_Values.RA.stdBuilder()
             .itemInputs(GT_Utility.getIntegratedCircuit(10), crushedStack, millingBall_Alumina)
             .itemOutputs(milledStackCrushed1)
             .duration(1 * MINUTES)
             .eut(materialEU)
-            .noOptimize()
             .addTo(millingRecipes);
         GT_Values.RA.stdBuilder()
             .itemInputs(GT_Utility.getIntegratedCircuit(11), crushedStack, millingBall_Soapstone)
             .itemOutputs(milledStackCrushed2)
             .duration(1 * MINUTES + 15 * SECONDS)
             .eut(materialEU)
-            .noOptimize()
             .addTo(millingRecipes);
     }
 

--- a/src/main/java/gtPlusPlus/core/item/chemistry/MilledOreProcessing.java
+++ b/src/main/java/gtPlusPlus/core/item/chemistry/MilledOreProcessing.java
@@ -477,7 +477,6 @@ public class MilledOreProcessing extends ItemPackage {
             .fluidOutputs(FluidUtils.getFluidStack(SphaleriteFlotationFroth, 1000))
             .duration(8 * MINUTES)
             .eut(TierEU.RECIPE_LuV)
-            .noOptimize()
             .addTo(flotationCellRecipes);
 
         // Chalcopyrite
@@ -494,7 +493,6 @@ public class MilledOreProcessing extends ItemPackage {
             .fluidOutputs(FluidUtils.getFluidStack(ChalcopyriteFlotationFroth, 1000))
             .duration(8 * MINUTES)
             .eut(TierEU.RECIPE_IV)
-            .noOptimize()
             .addTo(flotationCellRecipes);
 
         // Nickel
@@ -511,7 +509,6 @@ public class MilledOreProcessing extends ItemPackage {
             .fluidOutputs(FluidUtils.getFluidStack(NickelFlotationFroth, 1000))
             .duration(8 * MINUTES)
             .eut(TierEU.RECIPE_IV)
-            .noOptimize()
             .addTo(flotationCellRecipes);
 
         // Platinum
@@ -528,7 +525,6 @@ public class MilledOreProcessing extends ItemPackage {
             .fluidOutputs(FluidUtils.getFluidStack(PlatinumFlotationFroth, 1000))
             .duration(8 * MINUTES)
             .eut(TierEU.RECIPE_LuV)
-            .noOptimize()
             .addTo(flotationCellRecipes);
 
         // Pentlandite
@@ -545,7 +541,6 @@ public class MilledOreProcessing extends ItemPackage {
             .fluidOutputs(FluidUtils.getFluidStack(PentlanditeFlotationFroth, 1000))
             .duration(8 * MINUTES)
             .eut(TierEU.RECIPE_LuV)
-            .noOptimize()
             .addTo(flotationCellRecipes);
 
         // Redstone
@@ -562,7 +557,6 @@ public class MilledOreProcessing extends ItemPackage {
             .fluidOutputs(FluidUtils.getFluidStack(RedstoneFlotationFroth, 1000))
             .duration(8 * MINUTES)
             .eut(TierEU.RECIPE_IV)
-            .noOptimize()
             .addTo(flotationCellRecipes);
 
         // Spessartine
@@ -579,7 +573,6 @@ public class MilledOreProcessing extends ItemPackage {
             .fluidOutputs(FluidUtils.getFluidStack(SpessartineFlotationFroth, 1000))
             .duration(8 * MINUTES)
             .eut(TierEU.RECIPE_LuV)
-            .noOptimize()
             .addTo(flotationCellRecipes);
 
         // Grossular
@@ -596,7 +589,6 @@ public class MilledOreProcessing extends ItemPackage {
             .fluidOutputs(FluidUtils.getFluidStack(GrossularFlotationFroth, 1000))
             .duration(8 * MINUTES)
             .eut(TierEU.RECIPE_LuV)
-            .noOptimize()
             .addTo(flotationCellRecipes);
 
         // Almandine
@@ -613,7 +605,6 @@ public class MilledOreProcessing extends ItemPackage {
             .fluidOutputs(FluidUtils.getFluidStack(AlmandineFlotationFroth, 1000))
             .duration(8 * MINUTES)
             .eut(TierEU.RECIPE_IV)
-            .noOptimize()
             .addTo(flotationCellRecipes);
 
         // Pyrope
@@ -630,7 +621,6 @@ public class MilledOreProcessing extends ItemPackage {
             .fluidOutputs(FluidUtils.getFluidStack(PyropeFlotationFroth, 1000))
             .duration(8 * MINUTES)
             .eut(TierEU.RECIPE_EV)
-            .noOptimize()
             .addTo(flotationCellRecipes);
 
         // Monazite
@@ -647,7 +637,6 @@ public class MilledOreProcessing extends ItemPackage {
             .fluidOutputs(FluidUtils.getFluidStack(MonaziteFlotationFroth, 1000))
             .duration(8 * MINUTES)
             .eut(TierEU.RECIPE_LuV)
-            .noOptimize()
             .addTo(flotationCellRecipes);
     }
 

--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_LFTR.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_LFTR.java
@@ -74,7 +74,6 @@ public class RecipeLoader_LFTR {
             .duration(1 * MINUTES + 40 * SECONDS)
             .eut(0)
             .metadata(LFTR_OUTPUT_POWER, 32768 * 4)
-            .noOptimize()
             .addTo(liquidFluorineThoriumReactorRecipes);
 
         // LiFBeF2ZrF4UF4 - T2
@@ -88,7 +87,6 @@ public class RecipeLoader_LFTR {
             .duration(1 * MINUTES + 40 * SECONDS)
             .eut(0)
             .metadata(LFTR_OUTPUT_POWER, 8192 * 4)
-            .noOptimize()
             .addTo(liquidFluorineThoriumReactorRecipes);
 
         // LiFBeF2ZrF4U235 - T1
@@ -102,7 +100,6 @@ public class RecipeLoader_LFTR {
             .duration(1 * MINUTES + 40 * SECONDS)
             .eut(0)
             .metadata(LFTR_OUTPUT_POWER, 8192)
-            .noOptimize()
             .addTo(liquidFluorineThoriumReactorRecipes);
 
         // Sparging NEI Recipes


### PR DESCRIPTION
this 'optimization' (divide amounts to smaller numbers where possible) was not happening for these machines before RA2 and there is no reason they should now. Better to keep all the recipes as they were before the conversion a few weeks ago.