### PR TITLE
fix another ra2 issue

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/RecipeGen_DustGeneration.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/RecipeGen_DustGeneration.java
@@ -28,7 +28,6 @@ import gtPlusPlus.core.material.Material;
 import gtPlusPlus.core.material.MaterialGenerator;
 import gtPlusPlus.core.material.MaterialStack;
 import gtPlusPlus.core.material.state.MaterialState;
-import gtPlusPlus.core.util.math.MathUtils;
 import gtPlusPlus.core.util.minecraft.ItemUtils;
 import gtPlusPlus.core.util.minecraft.RecipeUtils;
 
@@ -404,13 +403,9 @@ public class RecipeGen_DustGeneration extends RecipeGen_Base {
     private void addMacerationRecipe(Material aMatInfo) {
         try {
             Logger.MATERIALS("Adding Maceration recipe for " + aMatInfo.getLocalizedName() + " Ingot -> Dusts");
-            int chance = (aMatInfo.vTier * 10) / MathUtils.randInt(10, 20);
-            chance = chance <= 0 ? 1000 : 100 * chance; // comes from RA1 -> RA2 conversion
-
             RA.stdBuilder()
                 .itemInputs(aMatInfo.getIngot(1))
                 .itemOutputs(aMatInfo.getDust(1))
-                .outputChances(chance)
                 .eut(2)
                 .duration(20 * SECONDS)
                 .addTo(maceratorRecipes);


### PR DESCRIPTION
Just a bug from the RA2 conversion I found in the nightly.
Apparently there were some weird random chances for non-existing secondaries in the code which the ra2 conversion falsely put on the primary instead. This is just ingot to dust maceration, so no secondaries and no chances.

now correct:
![image](https://github.com/user-attachments/assets/24af71cc-7132-4383-9bca-015c15f52fe5)
