### PR TITLE
Change method GT_Multiblock_Tooltip_Builder#toolTipFinisher

### DIFF
--- a/src/main/java/gregtech/api/util/GT_Multiblock_Tooltip_Builder.java
+++ b/src/main/java/gregtech/api/util/GT_Multiblock_Tooltip_Builder.java
@@ -697,7 +697,7 @@ public class GT_Multiblock_Tooltip_Builder {
      *
      * @param mod Name of the mod that adds this multiblock machine
      */
-    public void toolTipFinisher(String mod) {
+    public GT_Multiblock_Tooltip_Builder toolTipFinisher(String mod) {
         iLines.add(
             TT_hold + " "
                 + EnumChatFormatting.BOLD
@@ -718,6 +718,7 @@ public class GT_Multiblock_Tooltip_Builder {
                 .stream()
                 .map(e -> TT_dots[e.getKey() - 1] + COLON + String.join(SEPARATOR, e.getValue())))
             .toArray(String[]::new);
+        return this;
     }
 
     public String[] getInformation() {


### PR DESCRIPTION
Changed the method to return the builder instead of being void.