### PR TITLE
Change Item filter name to Filtered conveyor

### DIFF
--- a/src/main/java/gregtech/common/items/GT_MetaGenerated_Item_01.java
+++ b/src/main/java/gregtech/common/items/GT_MetaGenerated_Item_01.java
@@ -2018,7 +2018,7 @@ public class GT_MetaGenerated_Item_01 extends GT_MetaGenerated_Item_X32 {
         ItemList.ItemFilter_Import.set(
             addItem(
                 ItemFilter_Import.ID,
-                "Filtered Cover (Import)",
+                "Filtered Conveyor Cover (Import)",
                 "Right click with an item to set filter (Only supports Import Mode)"));
 
         ItemList.Cover_FluidLimiter

--- a/src/main/java/gregtech/common/items/GT_MetaGenerated_Item_01.java
+++ b/src/main/java/gregtech/common/items/GT_MetaGenerated_Item_01.java
@@ -2012,13 +2012,13 @@ public class GT_MetaGenerated_Item_01 extends GT_MetaGenerated_Item_X32 {
         ItemList.ItemFilter_Export.set(
             addItem(
                 ItemFilter_Export.ID,
-                "Item Filter Cover (Export)",
+                "Filtered Conveyor Cover (Export)",
                 "Right click with an item to set filter (Only supports Export Mode)"));
 
         ItemList.ItemFilter_Import.set(
             addItem(
                 ItemFilter_Import.ID,
-                "Item Filter Cover (Import)",
+                "Filtered Cover (Import)",
                 "Right click with an item to set filter (Only supports Import Mode)"));
 
         ItemList.Cover_FluidLimiter


### PR DESCRIPTION
The name of Item filter cover item tends to confuse players about what the item really does, so we (w @FourIsTheNumber and @NotAPenguin0 ) have decided that it would be better to rename said item to "Filtered Conveyor".