### PR TITLE
Packet cleanup: avoid duplicating IDs across multiple files using an enum

### DIFF
--- a/src/main/java/gregtech/api/GregTech_API.java
+++ b/src/main/java/gregtech/api/GregTech_API.java
@@ -152,7 +152,8 @@ public class GregTech_API {
      * 14001 - 14100 are reserved for glowredman.
      * 14101 - 14200 are reserved for MuXiu1997.
      * 14201 - 14300 are reserved for kuba6000.
-     * 14301 - 14999 are currently free.
+     * 14301 - 14400 are reserved for eigenraven.
+     * 14401 - 14999 are currently free.
      * 15000 - 16999 are reserved for TecTech.
      * 17000 - 29999 are currently free.
      * 30000 - 31999 are reserved for Alkalus.

--- a/src/main/java/gregtech/api/net/GT_PacketTypes.java
+++ b/src/main/java/gregtech/api/net/GT_PacketTypes.java
@@ -1,0 +1,71 @@
+package gregtech.api.net;
+
+import java.util.Arrays;
+
+import gregtech.common.blocks.GT_Packet_Ores;
+import gregtech.common.net.MessageSetFlaskCapacity;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+
+/**
+ * Centralized place to keep all the GT packet ID constants
+ */
+public enum GT_PacketTypes {
+
+    TILE_ENTITY(0, new GT_Packet_TileEntity()),
+    SOUND(1, new GT_Packet_Sound()),
+    BLOCK_EVENT(2, new GT_Packet_Block_Event()),
+    ORES(3, new GT_Packet_Ores()),
+    POLLUTION(4, new GT_Packet_Pollution()),
+    @SuppressWarnings("deprecation")
+    SET_FLASK_CAPACITY(5, new MessageSetFlaskCapacity()),
+    COVER(6, new GT_Packet_TileEntityCover()),
+    COVER_GUI(7, new GT_Packet_TileEntityCoverGUI()),
+    CLIENT_PREFERENCE(9, new GT_Packet_ClientPreference()),
+    WIRELESS_REDSTONE_COVER(10, new GT_Packet_WirelessRedstoneCover()),
+    COVER_NEW(11, new GT_Packet_TileEntityCoverNew()),
+    SET_CONFIGURATION_CIRCUIT(12, new GT_Packet_SetConfigurationCircuit()),
+    UPDATE_ITEM(13, new GT_Packet_UpdateItem()),
+    TILE_ENTITY_GUI_REQUEST(15, new GT_Packet_GtTileEntityGuiRequest()),
+    SEND_COVER_DATA(16, new GT_Packet_SendCoverData()),
+    REQUEST_COVER_DATA(17, new GT_Packet_RequestCoverData()),
+    MULTI_TILE_ENTITY(18, new GT_Packet_MultiTileEntity(true)),
+    SEND_OREGEN_PATTERN(19, new GT_Packet_SendOregenPattern()),
+    TOOL_SWITCH_MODE(20, new GT_Packet_ToolSwitchMode()),
+    // merge conflict prevention comment, keep a trailing comma above
+    ;
+
+    static {
+        // Validate no duplicate IDs
+        final GT_PacketTypes[] types = values();
+        final Int2ObjectOpenHashMap<GT_Packet_New> foundIds = new Int2ObjectOpenHashMap<>(types.length);
+        for (GT_PacketTypes type : types) {
+            final GT_Packet_New previous = foundIds.get(type.id);
+            if (previous != null) {
+                throw new IllegalStateException(
+                    "Duplicate packet IDs defined: " + type.id
+                        + " for "
+                        + type.getClass()
+                        + " and "
+                        + previous.getClass());
+            }
+            foundIds.put(type.id, type.referencePacket);
+        }
+    }
+
+    public final byte id;
+    public final GT_Packet_New referencePacket;
+
+    GT_PacketTypes(int id, GT_Packet_New referencePacket) {
+        if (((int) (byte) id) != id) {
+            throw new IllegalArgumentException("Value outside of byte normal range: " + id);
+        }
+        this.id = (byte) id;
+        this.referencePacket = referencePacket;
+    }
+
+    public static GT_Packet_New[] referencePackets() {
+        return Arrays.stream(values())
+            .map(p -> p.referencePacket)
+            .toArray(GT_Packet_New[]::new);
+    }
+}

--- a/src/main/java/gregtech/api/net/GT_Packet_Block_Event.java
+++ b/src/main/java/gregtech/api/net/GT_Packet_Block_Event.java
@@ -58,6 +58,6 @@ public class GT_Packet_Block_Event extends GT_Packet_New {
 
     @Override
     public byte getPacketID() {
-        return 2;
+        return GT_PacketTypes.BLOCK_EVENT.id;
     }
 }

--- a/src/main/java/gregtech/api/net/GT_Packet_ClientPreference.java
+++ b/src/main/java/gregtech/api/net/GT_Packet_ClientPreference.java
@@ -27,7 +27,7 @@ public class GT_Packet_ClientPreference extends GT_Packet_New {
 
     @Override
     public byte getPacketID() {
-        return 9;
+        return GT_PacketTypes.CLIENT_PREFERENCE.id;
     }
 
     @Override

--- a/src/main/java/gregtech/api/net/GT_Packet_GtTileEntityGuiRequest.java
+++ b/src/main/java/gregtech/api/net/GT_Packet_GtTileEntityGuiRequest.java
@@ -81,7 +81,7 @@ public class GT_Packet_GtTileEntityGuiRequest extends GT_Packet_New {
 
     @Override
     public byte getPacketID() {
-        return 15;
+        return GT_PacketTypes.TILE_ENTITY_GUI_REQUEST.id;
     }
 
     @Override

--- a/src/main/java/gregtech/api/net/GT_Packet_MultiTileEntity.java
+++ b/src/main/java/gregtech/api/net/GT_Packet_MultiTileEntity.java
@@ -237,7 +237,7 @@ public class GT_Packet_MultiTileEntity extends GT_Packet_New {
 
     @Override
     public byte getPacketID() {
-        return 18;
+        return GT_PacketTypes.MULTI_TILE_ENTITY.id;
     }
 
     public void clearData() {

--- a/src/main/java/gregtech/api/net/GT_Packet_Pollution.java
+++ b/src/main/java/gregtech/api/net/GT_Packet_Pollution.java
@@ -42,6 +42,6 @@ public class GT_Packet_Pollution extends GT_Packet_New {
 
     @Override
     public byte getPacketID() {
-        return 4;
+        return GT_PacketTypes.POLLUTION.id;
     }
 }

--- a/src/main/java/gregtech/api/net/GT_Packet_RequestCoverData.java
+++ b/src/main/java/gregtech/api/net/GT_Packet_RequestCoverData.java
@@ -66,7 +66,7 @@ public class GT_Packet_RequestCoverData extends GT_Packet_New {
 
     @Override
     public byte getPacketID() {
-        return 17;
+        return GT_PacketTypes.REQUEST_COVER_DATA.id;
     }
 
     @Override

--- a/src/main/java/gregtech/api/net/GT_Packet_SendCoverData.java
+++ b/src/main/java/gregtech/api/net/GT_Packet_SendCoverData.java
@@ -67,7 +67,7 @@ public class GT_Packet_SendCoverData extends GT_Packet_New {
 
     @Override
     public byte getPacketID() {
-        return 16;
+        return GT_PacketTypes.SEND_COVER_DATA.id;
     }
 
     @Override

--- a/src/main/java/gregtech/api/net/GT_Packet_SendOregenPattern.java
+++ b/src/main/java/gregtech/api/net/GT_Packet_SendOregenPattern.java
@@ -45,7 +45,7 @@ public class GT_Packet_SendOregenPattern extends GT_Packet_New {
 
     @Override
     public byte getPacketID() {
-        return 19;
+        return GT_PacketTypes.SEND_OREGEN_PATTERN.id;
     }
 
     @Override

--- a/src/main/java/gregtech/api/net/GT_Packet_SetConfigurationCircuit.java
+++ b/src/main/java/gregtech/api/net/GT_Packet_SetConfigurationCircuit.java
@@ -55,7 +55,7 @@ public class GT_Packet_SetConfigurationCircuit extends GT_Packet_New {
 
     @Override
     public byte getPacketID() {
-        return 12;
+        return GT_PacketTypes.SET_CONFIGURATION_CIRCUIT.id;
     }
 
     @Override

--- a/src/main/java/gregtech/api/net/GT_Packet_Sound.java
+++ b/src/main/java/gregtech/api/net/GT_Packet_Sound.java
@@ -65,6 +65,6 @@ public class GT_Packet_Sound extends GT_Packet_New {
 
     @Override
     public byte getPacketID() {
-        return 1;
+        return GT_PacketTypes.SOUND.id;
     }
 }

--- a/src/main/java/gregtech/api/net/GT_Packet_TileEntity.java
+++ b/src/main/java/gregtech/api/net/GT_Packet_TileEntity.java
@@ -152,6 +152,6 @@ public class GT_Packet_TileEntity extends GT_Packet_New {
 
     @Override
     public byte getPacketID() {
-        return 0;
+        return GT_PacketTypes.TILE_ENTITY.id;
     }
 }

--- a/src/main/java/gregtech/api/net/GT_Packet_TileEntityCover.java
+++ b/src/main/java/gregtech/api/net/GT_Packet_TileEntityCover.java
@@ -57,7 +57,7 @@ public class GT_Packet_TileEntityCover extends GT_Packet_New {
 
     @Override
     public byte getPacketID() {
-        return 6;
+        return GT_PacketTypes.COVER.id;
     }
 
     @Override

--- a/src/main/java/gregtech/api/net/GT_Packet_TileEntityCoverGUI.java
+++ b/src/main/java/gregtech/api/net/GT_Packet_TileEntityCoverGUI.java
@@ -151,7 +151,7 @@ public class GT_Packet_TileEntityCoverGUI extends GT_Packet_New {
 
     @Override
     public byte getPacketID() {
-        return 7;
+        return GT_PacketTypes.COVER_GUI.id;
     }
 
     @Override

--- a/src/main/java/gregtech/api/net/GT_Packet_TileEntityCoverNew.java
+++ b/src/main/java/gregtech/api/net/GT_Packet_TileEntityCoverNew.java
@@ -66,7 +66,7 @@ public class GT_Packet_TileEntityCoverNew extends GT_Packet_New {
 
     @Override
     public byte getPacketID() {
-        return 11;
+        return GT_PacketTypes.COVER_NEW.id;
     }
 
     @Override

--- a/src/main/java/gregtech/api/net/GT_Packet_ToolSwitchMode.java
+++ b/src/main/java/gregtech/api/net/GT_Packet_ToolSwitchMode.java
@@ -21,7 +21,7 @@ public class GT_Packet_ToolSwitchMode extends GT_Packet_New {
 
     @Override
     public byte getPacketID() {
-        return 20;
+        return GT_PacketTypes.TOOL_SWITCH_MODE.id;
     }
 
     @Override

--- a/src/main/java/gregtech/api/net/GT_Packet_UpdateItem.java
+++ b/src/main/java/gregtech/api/net/GT_Packet_UpdateItem.java
@@ -33,7 +33,7 @@ public class GT_Packet_UpdateItem extends GT_Packet_New {
 
     @Override
     public byte getPacketID() {
-        return 13;
+        return GT_PacketTypes.UPDATE_ITEM.id;
     }
 
     @Override

--- a/src/main/java/gregtech/api/net/GT_Packet_WirelessRedstoneCover.java
+++ b/src/main/java/gregtech/api/net/GT_Packet_WirelessRedstoneCover.java
@@ -45,7 +45,7 @@ public class GT_Packet_WirelessRedstoneCover extends GT_Packet_TileEntityCover {
 
     @Override
     public byte getPacketID() {
-        return 10;
+        return GT_PacketTypes.WIRELESS_REDSTONE_COVER.id;
     }
 
     @Override

--- a/src/main/java/gregtech/common/GT_Network.java
+++ b/src/main/java/gregtech/common/GT_Network.java
@@ -20,26 +20,9 @@ import cpw.mods.fml.common.network.internal.FMLProxyPacket;
 import cpw.mods.fml.relauncher.Side;
 import gregtech.api.enums.GT_Values;
 import gregtech.api.net.GT_Packet;
-import gregtech.api.net.GT_Packet_Block_Event;
-import gregtech.api.net.GT_Packet_ClientPreference;
-import gregtech.api.net.GT_Packet_GtTileEntityGuiRequest;
-import gregtech.api.net.GT_Packet_MultiTileEntity;
-import gregtech.api.net.GT_Packet_Pollution;
-import gregtech.api.net.GT_Packet_RequestCoverData;
-import gregtech.api.net.GT_Packet_SendCoverData;
-import gregtech.api.net.GT_Packet_SendOregenPattern;
-import gregtech.api.net.GT_Packet_SetConfigurationCircuit;
-import gregtech.api.net.GT_Packet_Sound;
-import gregtech.api.net.GT_Packet_TileEntity;
-import gregtech.api.net.GT_Packet_TileEntityCover;
-import gregtech.api.net.GT_Packet_TileEntityCoverGUI;
-import gregtech.api.net.GT_Packet_TileEntityCoverNew;
-import gregtech.api.net.GT_Packet_ToolSwitchMode;
-import gregtech.api.net.GT_Packet_UpdateItem;
-import gregtech.api.net.GT_Packet_WirelessRedstoneCover;
+import gregtech.api.net.GT_PacketTypes;
+import gregtech.api.net.GT_Packet_New;
 import gregtech.api.net.IGT_NetworkHandler;
-import gregtech.common.blocks.GT_Packet_Ores;
-import gregtech.common.net.MessageSetFlaskCapacity;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandler;
@@ -55,33 +38,10 @@ public class GT_Network extends MessageToMessageCodec<FMLProxyPacket, GT_Packet>
     private final GT_Packet[] mSubChannels;
 
     public GT_Network() {
-        this(
-            "GregTech",
-            new GT_Packet_TileEntity(), // 0
-            new GT_Packet_Sound(), // 1
-            new GT_Packet_Block_Event(), // 2
-            new GT_Packet_Ores(), // 3
-            new GT_Packet_Pollution(), // 4
-            new MessageSetFlaskCapacity(), // 5
-            new GT_Packet_TileEntityCover(), // 6
-            new GT_Packet_TileEntityCoverGUI(), // 7
-            // 8
-            new GT_Packet_ClientPreference(), // 9
-            new GT_Packet_WirelessRedstoneCover(), // 10
-            new GT_Packet_TileEntityCoverNew(), // 11
-            new GT_Packet_SetConfigurationCircuit(), // 12
-            new GT_Packet_UpdateItem(), // 13
-            // 14
-            new GT_Packet_GtTileEntityGuiRequest(), // 15
-            new GT_Packet_SendCoverData(), // 16
-            new GT_Packet_RequestCoverData(), // 17
-            new GT_Packet_MultiTileEntity(true), // 18
-            new GT_Packet_SendOregenPattern(), // 19
-            new GT_Packet_ToolSwitchMode() // 20
-        );
+        this("GregTech", GT_PacketTypes.referencePackets());
     }
 
-    public GT_Network(String channelName, GT_Packet... packetTypes) {
+    public GT_Network(String channelName, GT_Packet_New... packetTypes) {
         this.mChannel = NetworkRegistry.INSTANCE.newChannel(channelName, this, new HandlerShared());
         final int lastPId = packetTypes[packetTypes.length - 1].getPacketID();
         this.mSubChannels = new GT_Packet[lastPId + 1];

--- a/src/main/java/gregtech/common/blocks/GT_Packet_Ores.java
+++ b/src/main/java/gregtech/common/blocks/GT_Packet_Ores.java
@@ -6,6 +6,7 @@ import net.minecraft.world.World;
 
 import com.google.common.io.ByteArrayDataInput;
 
+import gregtech.api.net.GT_PacketTypes;
 import gregtech.api.net.GT_Packet_New;
 import io.netty.buffer.ByteBuf;
 
@@ -56,6 +57,6 @@ public class GT_Packet_Ores extends GT_Packet_New {
 
     @Override
     public byte getPacketID() {
-        return 3;
+        return GT_PacketTypes.ORES.id;
     }
 }

--- a/src/main/java/gregtech/common/net/MessageSetFlaskCapacity.java
+++ b/src/main/java/gregtech/common/net/MessageSetFlaskCapacity.java
@@ -9,6 +9,7 @@ import net.minecraftforge.common.DimensionManager;
 
 import com.google.common.io.ByteArrayDataInput;
 
+import gregtech.api.net.GT_PacketTypes;
 import gregtech.api.net.GT_Packet_New;
 import gregtech.common.items.GT_VolumetricFlask;
 import io.netty.buffer.ByteBuf;
@@ -38,7 +39,7 @@ public final class MessageSetFlaskCapacity extends GT_Packet_New {
 
     @Override
     public byte getPacketID() {
-        return 5;
+        return GT_PacketTypes.SET_FLASK_CAPACITY.id;
     }
 
     @Override


### PR DESCRIPTION
I moved the packet list with IDs into an enum instead of split between GT_Network and the individual packet files, also added some validation to make sure there are no duplicate IDs if anyone adds one by accident.

Also reserved a MTE ID range for myself for future PRs.