### PR TITLE
Battery tier fixes

### DIFF
--- a/src/main/java/gregtech/common/items/GT_MetaGenerated_Item_01.java
+++ b/src/main/java/gregtech/common/items/GT_MetaGenerated_Item_01.java
@@ -1439,11 +1439,10 @@ public class GT_MetaGenerated_Item_01 extends GT_MetaGenerated_Item_X32 {
                 Energy_Lapotronic_Orb.ID,
                 "Lapotronic Energy Orb",
                 "Reusable battery",
-                "batteryIV",
                 new TC_Aspects.TC_AspectStack(TC_Aspects.ELECTRUM, 16L),
                 new TC_Aspects.TC_AspectStack(TC_Aspects.VITREUS, 16L),
                 new TC_Aspects.TC_AspectStack(TC_Aspects.POTENTIA, 16L),
-                OrePrefixes.battery.get(Materials.ZPM)));
+                OrePrefixes.battery.get(Materials.IV)));
 
         // ZPM Module
         ItemList.ZPM.set(
@@ -1462,11 +1461,10 @@ public class GT_MetaGenerated_Item_01 extends GT_MetaGenerated_Item_X32 {
                 Energy_Lapotronic_orb_2.ID,
                 "Lapotronic Energy Orb Cluster",
                 "Reusable battery",
-                "batteryLuV",
                 new TC_Aspects.TC_AspectStack(TC_Aspects.ELECTRUM, 16L),
                 new TC_Aspects.TC_AspectStack(TC_Aspects.VITREUS, 16L),
                 new TC_Aspects.TC_AspectStack(TC_Aspects.POTENTIA, 16L),
-                OrePrefixes.battery.get(Materials.ZPM)));
+                OrePrefixes.battery.get(Materials.LuV)));
 
         // UV Battery
         ItemList.ZPM2.set(
@@ -1529,7 +1527,6 @@ public class GT_MetaGenerated_Item_01 extends GT_MetaGenerated_Item_X32 {
                 Energy_Module.ID,
                 "Energy Module",
                 "Reusable battery",
-                "batteryZPM",
                 new TC_Aspects.TC_AspectStack(TC_Aspects.ELECTRUM, 16L),
                 new TC_Aspects.TC_AspectStack(TC_Aspects.VITREUS, 16L),
                 new TC_Aspects.TC_AspectStack(TC_Aspects.POTENTIA, 16L),
@@ -1541,10 +1538,10 @@ public class GT_MetaGenerated_Item_01 extends GT_MetaGenerated_Item_X32 {
                 Energy_Cluster.ID,
                 "Energy Cluster",
                 "Reusable battery",
-                "batteryUV",
                 new TC_Aspects.TC_AspectStack(TC_Aspects.ELECTRUM, 64L),
                 new TC_Aspects.TC_AspectStack(TC_Aspects.VITREUS, 16L),
-                new TC_Aspects.TC_AspectStack(TC_Aspects.POTENTIA, 64L)));
+                new TC_Aspects.TC_AspectStack(TC_Aspects.POTENTIA, 64L),
+                OrePrefixes.battery.get(Materials.UV)));
 
         // UIV, UMV, UXV and MAX component textures backported from gregicality.
         ItemList.Electric_Motor_LV.set(

--- a/src/main/java/gregtech/loaders/load/GT_Loader_MetaTileEntities_Recipes.java
+++ b/src/main/java/gregtech/loaders/load/GT_Loader_MetaTileEntities_Recipes.java
@@ -5726,25 +5726,25 @@ public class GT_Loader_MetaTileEntities_Recipes implements Runnable {
             bitsd,
             new Object[] { aTextWireChest, aTextWireHull, "BCB", 'M', ItemList.Hull_EV, 'W',
                 OrePrefixes.wireGt16.get(Materials.Aluminium), 'T', OreDictNames.craftingChest, 'B',
-                OrePrefixes.battery.get(Materials.LuV), 'C', OrePrefixes.circuit.get(Materials.EV) });
+                OrePrefixes.battery.get(Materials.EV), 'C', OrePrefixes.circuit.get(Materials.EV) });
         GT_ModHandler.addCraftingRecipe(
             ItemList.Battery_Charger_4by4_IV.get(1L),
             bitsd,
             new Object[] { aTextWireChest, aTextWireHull, "BCB", 'M', ItemList.Hull_IV, 'W',
                 OrePrefixes.wireGt16.get(Materials.Tungsten), 'T', OreDictNames.craftingChest, 'B',
-                ItemList.Energy_LapotronicOrb, 'C', OrePrefixes.circuit.get(Materials.IV) });
+                OrePrefixes.battery.get(Materials.IV), 'C', OrePrefixes.circuit.get(Materials.IV) });
         GT_ModHandler.addCraftingRecipe(
             ItemList.Battery_Charger_4by4_LuV.get(1L),
             bitsd,
             new Object[] { aTextWireChest, aTextWireHull, "BCB", 'M', ItemList.Hull_LuV, 'W',
                 OrePrefixes.wireGt16.get(Materials.VanadiumGallium), 'T', OreDictNames.craftingChest, 'B',
-                ItemList.Energy_LapotronicOrb2, 'C', OrePrefixes.circuit.get(Materials.LuV) });
+                OrePrefixes.battery.get(Materials.LuV), 'C', OrePrefixes.circuit.get(Materials.LuV) });
         GT_ModHandler.addCraftingRecipe(
             ItemList.Battery_Charger_4by4_ZPM.get(1L),
             bitsd,
             new Object[] { aTextWireChest, aTextWireHull, "BCB", 'M', ItemList.Hull_ZPM, 'W',
                 OrePrefixes.wireGt16.get(Materials.Naquadah), 'T', OreDictNames.craftingChest, 'B',
-                ItemList.Energy_LapotronicOrb2, 'C', OrePrefixes.circuit.get(Materials.ZPM) });
+                OrePrefixes.battery.get(Materials.ZPM), 'C', OrePrefixes.circuit.get(Materials.ZPM) });
         GT_ModHandler.addCraftingRecipe(
             ItemList.Battery_Charger_4by4_UV.get(1L),
             bitsd,

--- a/src/main/java/gregtech/loaders/postload/GT_CraftingRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/postload/GT_CraftingRecipeLoader.java
@@ -1953,7 +1953,7 @@ public class GT_CraftingRecipeLoader implements Runnable {
         GT_ModHandler.addCraftingRecipe(
             GT_ModHandler.getIC2Item("nanoSaber", 1L),
             bits_no_remove_buffered,
-            new Object[] { "PI ", "PI ", "CLC", 'L', OrePrefixes.battery.get(Materials.LuV), 'I',
+            new Object[] { "PI ", "PI ", "CLC", 'L', OrePrefixes.battery.get(Materials.EV), 'I',
                 OrePrefixes.plateAlloy.get("Iridium"), 'P', OrePrefixes.plate.get(Materials.Platinum), 'C',
                 OrePrefixes.circuit.get(Materials.IV) });
 

--- a/src/main/java/gregtech/loaders/preload/GT_Loader_OreDictionary.java
+++ b/src/main/java/gregtech/loaders/preload/GT_Loader_OreDictionary.java
@@ -172,11 +172,11 @@ public class GT_Loader_OreDictionary implements Runnable {
         GT_OreDictUnificator
             .registerOre(OrePrefixes.battery, Materials.LV, GT_ModHandler.getIC2Item("chargedReBattery", 1L, 32767));
         GT_OreDictUnificator
-            .registerOre(OrePrefixes.battery, Materials.HV, GT_ModHandler.getIC2Item("advBattery", 1L, 32767));
+            .registerOre(OrePrefixes.battery, Materials.MV, GT_ModHandler.getIC2Item("advBattery", 1L, 32767));
         GT_OreDictUnificator
-            .registerOre(OrePrefixes.battery, Materials.EV, GT_ModHandler.getIC2Item("energyCrystal", 1L, 32767));
+            .registerOre(OrePrefixes.battery, Materials.HV, GT_ModHandler.getIC2Item("energyCrystal", 1L, 32767));
         GT_OreDictUnificator
-            .registerOre(OrePrefixes.battery, Materials.IV, GT_ModHandler.getIC2Item("lapotronCrystal", 1L, 32767));
+            .registerOre(OrePrefixes.battery, Materials.EV, GT_ModHandler.getIC2Item("lapotronCrystal", 1L, 32767));
 
         GT_OreDictUnificator
             .registerOre(OreDictNames.craftingWireCopper, GT_ModHandler.getIC2Item("insulatedCopperCableItem", 1L));


### PR DESCRIPTION
Fixes the tiers of various batteries and some recipes. Some recipes in NHcoremod are fixed in a related PR https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/919.

Fixes a crash in nightly where the luv tier battery was missing. and makes the new tier materials usable for the lapo-based battery progression.