### PR TITLE
Small waterline fixes

### DIFF
--- a/src/main/java/gregtech/common/items/GT_MetaGenerated_Item_03.java
+++ b/src/main/java/gregtech/common/items/GT_MetaGenerated_Item_03.java
@@ -1152,13 +1152,13 @@ public class GT_MetaGenerated_Item_03 extends GT_MetaGenerated_Item_X32 {
         ItemList.Quark_Creation_Catalyst_Bottom.set(
             addItem(
                 Quark_Creation_Catalyst_Bottom.ID,
-                "Top-Quark Releasing Catalyst",
+                "Bottom-Quark Releasing Catalyst",
                 "Can release top-quarks into environment to reshape matter",
                 SubTag.NO_UNIFICATION));
         ItemList.Quark_Creation_Catalyst_Top.set(
             addItem(
                 Quark_Creation_Catalyst_Top.ID,
-                "Bottom-Quark Releasing Catalyst",
+                "Top-Quark Releasing Catalyst",
                 "Can release bottom-quarks into environment to reshape matter",
                 SubTag.NO_UNIFICATION));
         ItemList.Quark_Creation_Catalyst_Unaligned.set(

--- a/src/main/java/gregtech/loaders/postload/chains/GT_PurifiedWaterRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/chains/GT_PurifiedWaterRecipes.java
@@ -52,7 +52,7 @@ public class GT_PurifiedWaterRecipes {
         // Grade 1 - Clarifier
         GT_Values.RA.stdBuilder()
             .itemInputs(ItemList.ActivatedCarbonFilterMesh.get(1))
-            .fluidInputs(GT_ModHandler.getDistilledWater(1000L))
+            .fluidInputs(GT_ModHandler.getWater(1000L))
             .fluidOutputs(Materials.Grade1PurifiedWater.getFluid(900L))
             .itemOutputs(new ItemStack(Items.stick, 1), Materials.Stone.getDust(1), Materials.Gold.getNuggets(1))
             .outputChances(1000, 500, 100)


### PR DESCRIPTION
- Fix name for bottom and top quark releasing catalysts
- Start the line on regular water instead of distilled water