### PR TITLE
Change Heat Value of Mar-Ce-M200 EBF Recipe from TPV to HSS-G Coils

### DIFF
--- a/src/main/java/goodgenerator/loader/RecipeLoader_02.java
+++ b/src/main/java/goodgenerator/loader/RecipeLoader_02.java
@@ -1108,7 +1108,7 @@ public class RecipeLoader_02 {
             .itemOutputs(MyMaterial.marCeM200.get(OrePrefixes.ingotHot, 19))
             .duration(4 * MINUTES + 45 * SECONDS)
             .eut(TierEU.RECIPE_ZPM)
-            .metadata(COIL_HEAT, 4500)
+            .metadata(COIL_HEAT, 5400)
             .addTo(blastFurnaceRecipes);
 
         GT_ModHandler.addCraftingRecipe(


### PR DESCRIPTION
This PR changes the heat value of Mar-Ce-M200's EBF recipe to one that, instead of needing TPV coils, needs HSS-G coils. This is because, while the material is LuV, it can be crafted in IV by avoiding the ZPM energy requirement through the mega EBF. Preferably, an LuV coil like Naquadah would be set to avoid this altogether, but Naquadah does need the Precise Assembler, which needs this metal, so it can't be done.