### PR TITLE
Fix LFTR Running, Stocking and Maintenance Hatches

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMTE_NuclearReactor.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMTE_NuclearReactor.java
@@ -354,7 +354,8 @@ public class GregtechMTE_NuclearReactor extends GregtechMeta_MultiBlockBase<Greg
             @NotNull
             @Override
             protected GT_OverclockCalculator createOverclockCalculator(@NotNull GT_Recipe recipe) {
-                return GT_OverclockCalculator.ofNoOverclock(recipe.getMetadataOrDefault(LFTR_OUTPUT_POWER, 0) * 4L, recipe.mDuration);
+                return GT_OverclockCalculator
+                    .ofNoOverclock(recipe.getMetadataOrDefault(LFTR_OUTPUT_POWER, 0) * 4L, recipe.mDuration);
             }
 
             @NotNull

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMTE_NuclearReactor.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMTE_NuclearReactor.java
@@ -106,7 +106,6 @@ public class GregtechMTE_NuclearReactor extends GregtechMeta_MultiBlockBase<Greg
             .addInputHatch("Top or bottom layer edges", 1)
             .addOutputHatch("Top or bottom layer edges", 1)
             .addDynamoHatch("Top or bottom layer edges", 1)
-            .addMaintenanceHatch("Top or bottom layer edges", 1)
             .addMufflerHatch("Top 3x3", 2)
             .addStructureInfo("All dynamos must be between EV and LuV tier.")
             .addStructureInfo("All other hatches must be IV+ tier.")

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMTE_NuclearReactor.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMTE_NuclearReactor.java
@@ -9,6 +9,7 @@ import static gregtech.api.enums.GT_HatchElement.InputHatch;
 import static gregtech.api.enums.GT_HatchElement.Maintenance;
 import static gregtech.api.enums.GT_HatchElement.Muffler;
 import static gregtech.api.enums.GT_HatchElement.OutputHatch;
+import static gregtech.api.util.GT_RecipeConstants.LFTR_OUTPUT_POWER;
 import static gregtech.api.util.GT_StructureUtility.buildHatchAdder;
 import static gregtech.api.util.GT_StructureUtility.filterByMTETier;
 
@@ -355,7 +356,7 @@ public class GregtechMTE_NuclearReactor extends GregtechMeta_MultiBlockBase<Greg
             @NotNull
             @Override
             protected GT_OverclockCalculator createOverclockCalculator(@NotNull GT_Recipe recipe) {
-                return GT_OverclockCalculator.ofNoOverclock(recipe.mSpecialValue * 4L, recipe.mDuration);
+                return GT_OverclockCalculator.ofNoOverclock(recipe.getMetadataOrDefault(LFTR_OUTPUT_POWER, 0) * 4L, recipe.mDuration);
             }
 
             @NotNull
@@ -382,7 +383,7 @@ public class GregtechMTE_NuclearReactor extends GregtechMeta_MultiBlockBase<Greg
                     }
                 }
                 if (aFuelFluid != null) {
-                    for (FluidStack fluidStack : getStoredFluids()) {
+                    for (FluidStack fluidStack : inputFluids) {
                         if (fluidStack.isFluidEqual(aFuelFluid)) {
                             mFuelRemaining += fluidStack.amount;
                         } else if (fluidStack.getFluid()

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMTE_NuclearReactor.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMTE_NuclearReactor.java
@@ -110,8 +110,8 @@ public class GregtechMTE_NuclearReactor extends GregtechMeta_MultiBlockBase<Greg
             .addMufflerHatch("Top 3x3", 2)
             .addStructureInfo("All dynamos must be between EV and LuV tier.")
             .addStructureInfo("All other hatches must be IV+ tier.")
-            .addStructureInfo("4x Output Hatches or 1x Output Hatch (ME), 1+ Input Hatches, 4x Dynamo Hatches")
-            .addStructureInfo("2x Maintenance Hatches, 4x Mufflers")
+            .addStructureInfo("4x Output Hatches or 1x Output Hatch (ME), 1+ Input Hatches")
+            .addStructureInfo("4x Dynamo Hatches, 4x Mufflers")
             .toolTipFinisher(CORE.GT_Tooltip_Builder.get());
         return tt;
     }
@@ -268,8 +268,7 @@ public class GregtechMTE_NuclearReactor extends GregtechMeta_MultiBlockBase<Greg
         if (checkPiece(mName, 3, 3, 0) && mCasing >= 27) {
             if ((mOutputHatches.size() >= 3 || canDumpFluidToME()) && mInputHatches.size() >= 1
                 && mDynamoHatches.size() == 4
-                && mMufflerHatches.size() == 4
-                && mMaintenanceHatches.size() == 2) {
+                && mMufflerHatches.size() == 4) {
                 this.turnCasingActive(false);
                 return true;
             }


### PR DESCRIPTION
This PR fixes the bug of the LFTR not outputting EU because its EU output value was set to 0 from the old specialValue that is no longer used. Additionally, stocking hatches can keep the LFTR running without consuming fuel, but this fixes that. Finally, the requirement for maintenance hatches was removed, since the multi doesn't have maintenance problems.