### PR TITLE
Plasma Line buffs, EHE nerfs, Unstable Naquadah rebalance

### DIFF
--- a/src/main/java/goodgenerator/blocks/tileEntity/SupercriticalFluidTurbine.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/SupercriticalFluidTurbine.java
@@ -78,7 +78,7 @@ public class SupercriticalFluidTurbine extends GT_MetaTileEntity_LargeTurbineBas
         }
         if (totalFlow <= 0) return 0;
         tEU = totalFlow;
-        addOutput(GT_ModHandler.getSteam(totalFlow * 10));
+        addOutput(GT_ModHandler.getSteam(totalFlow * 100));
         if (totalFlow == aOptFlow) {
             tEU = GT_Utility.safeInt((long) tEU * (long) aBaseEff / 10000L);
         } else {
@@ -91,7 +91,7 @@ public class SupercriticalFluidTurbine extends GT_MetaTileEntity_LargeTurbineBas
             tEU = GT_Utility.safeInt(maxPower);
         }
 
-        return tEU * 10;
+        return tEU * 100;
     }
 
     @Override
@@ -151,8 +151,8 @@ public class SupercriticalFluidTurbine extends GT_MetaTileEntity_LargeTurbineBas
             .addInfo("Controller block for Supercritical Fluid Turbine")
             .addInfo("Needs a Turbine, place inside controller")
             .addInfo("Use Supercritical Steam to generate power.")
-            .addInfo("Outputs 10L of Steam per 1L of SC Steam as well as producing power")
-            .addInfo("1L Supercritical Steam = 10 EU")
+            .addInfo("Outputs 100L of Steam per 1L of SC Steam as well as producing power")
+            .addInfo("1L Supercritical Steam = 100 EU")
             .addInfo("Extreme Heated Steam will cause more damage to the turbine.")
             .addInfo("Power output depends on turbine and fitting")
             .addInfo("Use screwdriver to adjust fitting of turbine")

--- a/src/main/java/goodgenerator/blocks/tileEntity/SupercriticalFluidTurbine.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/SupercriticalFluidTurbine.java
@@ -78,20 +78,20 @@ public class SupercriticalFluidTurbine extends GT_MetaTileEntity_LargeTurbineBas
         }
         if (totalFlow <= 0) return 0;
         tEU = totalFlow;
-        addOutput(GT_ModHandler.getSteam(totalFlow));
+        addOutput(GT_ModHandler.getSteam(totalFlow * 10));
         if (totalFlow == aOptFlow) {
-            tEU = GT_Utility.safeInt((long) tEU * (long) aBaseEff / 100L);
+            tEU = GT_Utility.safeInt((long) tEU * (long) aBaseEff / 10000L);
         } else {
             float efficiency = 1.0f - Math.abs((totalFlow - aOptFlow) / (float) aOptFlow);
             tEU *= efficiency;
-            tEU = Math.max(1, GT_Utility.safeInt((long) tEU * (long) aBaseEff / 100L));
+            tEU = Math.max(1, GT_Utility.safeInt((long) tEU * (long) aBaseEff / 10000L));
         }
 
         if (tEU > maxPower) {
             tEU = GT_Utility.safeInt(maxPower);
         }
 
-        return tEU;
+        return tEU * 10;
     }
 
     @Override
@@ -151,8 +151,8 @@ public class SupercriticalFluidTurbine extends GT_MetaTileEntity_LargeTurbineBas
             .addInfo("Controller block for Supercritical Fluid Turbine")
             .addInfo("Needs a Turbine, place inside controller")
             .addInfo("Use Supercritical Steam to generate power.")
-            .addInfo("Outputs Steam as well as producing power")
-            .addInfo("1L Supercritical Steam = 100 EU")
+            .addInfo("Outputs 10L of Steam per 1L of SC Steam as well as producing power")
+            .addInfo("1L Supercritical Steam = 10 EU")
             .addInfo("Extreme Heated Steam will cause more damage to the turbine.")
             .addInfo("Power output depends on turbine and fitting")
             .addInfo("Use screwdriver to adjust fitting of turbine")

--- a/src/main/java/goodgenerator/items/MyMaterial.java
+++ b/src/main/java/goodgenerator/items/MyMaterial.java
@@ -302,7 +302,10 @@ public class MyMaterial implements Runnable {
             .setBlastFurnace(true)
             .setProtons(200)
             .setMass(450)
-            .setRadioactive(true),
+            .setRadioactive(true)
+            .setDurOverride(180224)
+            .setSpeedOverride(100f)
+            .setQualityOverride((byte) 11),
         Werkstoff.Types.ELEMENT,
         new Werkstoff.GenerationFeatures().disable()
             .onlyDust()

--- a/src/main/java/goodgenerator/loader/RecipeLoader_02.java
+++ b/src/main/java/goodgenerator/loader/RecipeLoader_02.java
@@ -1835,6 +1835,8 @@ public class RecipeLoader_02 {
             .addTo(plasmaForgeRecipes);
     }
 
+    public static float EHEEfficiencyMultiplier = 1.5f;
+
     public static void FinishLoadRecipe() {
         for (GT_Recipe plasmaFuel : RecipeMaps.plasmaFuels.getAllRecipes()) {
             FluidStack tPlasma = GT_Utility.getFluidForFilledItem(plasmaFuel.mInputs[0], true);
@@ -1843,15 +1845,15 @@ public class RecipeLoader_02 {
             }
             int tUnit = plasmaFuel.mSpecialValue;
             if (tUnit > 200_000) {
-                tPlasma.amount = 1500;
+                tPlasma.amount = 15000;
             } else if (tUnit > 100_000) {
-                tPlasma.amount = 1000;
+                tPlasma.amount = 10000;
             } else if (tUnit > 50_000) {
-                tPlasma.amount = 800;
+                tPlasma.amount = 8000;
             } else if (tUnit > 10_000) {
-                tPlasma.amount = 500;
+                tPlasma.amount = 5000;
             } else {
-                tPlasma.amount = 100;
+                tPlasma.amount = 1000;
             }
 
             String tPlasmaName = FluidRegistry.getFluidName(tPlasma);
@@ -1861,8 +1863,8 @@ public class RecipeLoader_02 {
                 FluidStack output = FluidRegistry.getFluidStack(tOutName, tPlasma.amount);
                 if (output == null) output = FluidRegistry.getFluidStack("molten." + tOutName, tPlasma.amount);
                 if (output != null) {
-                    long waterAmount = (long) tUnit * 3 * tPlasma.amount / 160;
-                    long criticalSteamAmount = (long) tUnit * 3 * tPlasma.amount / 100;
+                    long waterAmount = (long) (tUnit * EHEEfficiencyMultiplier * tPlasma.amount / 16);
+                    long criticalSteamAmount = (long) (tUnit * EHEEfficiencyMultiplier * tPlasma.amount / 10);
                     MyRecipeAdder.instance.addExtremeHeatExchangerRecipe(
                         tPlasma,
                         output,

--- a/src/main/java/goodgenerator/loader/RecipeLoader_02.java
+++ b/src/main/java/goodgenerator/loader/RecipeLoader_02.java
@@ -1835,7 +1835,7 @@ public class RecipeLoader_02 {
             .addTo(plasmaForgeRecipes);
     }
 
-    public static float EHEEfficiencyMultiplier = 1.0f;
+    public static float EHEEfficiencyMultiplier = 1.2f;
 
     public static void FinishLoadRecipe() {
         for (GT_Recipe plasmaFuel : RecipeMaps.plasmaFuels.getAllRecipes()) {
@@ -1844,16 +1844,16 @@ public class RecipeLoader_02 {
                 continue;
             }
             int tUnit = plasmaFuel.mSpecialValue;
-            if (tUnit > 200_000) {
-                tPlasma.amount = 15000;
-            } else if (tUnit > 100_000) {
+            if (tUnit > 500_000) {
+                tPlasma.amount = 25000;
+            } else if (tUnit > 300_000) {
                 tPlasma.amount = 10000;
-            } else if (tUnit > 50_000) {
-                tPlasma.amount = 8000;
+            } else if (tUnit > 100_000) {
+                tPlasma.amount = 2500;
             } else if (tUnit > 10_000) {
-                tPlasma.amount = 5000;
+                tPlasma.amount = 500;
             } else {
-                tPlasma.amount = 1000;
+                tPlasma.amount = 100;
             }
 
             String tPlasmaName = FluidRegistry.getFluidName(tPlasma);
@@ -1864,7 +1864,7 @@ public class RecipeLoader_02 {
                 if (output == null) output = FluidRegistry.getFluidStack("molten." + tOutName, tPlasma.amount);
                 if (output != null) {
                     long waterAmount = (long) (tUnit * EHEEfficiencyMultiplier * tPlasma.amount / 160);
-                    long criticalSteamAmount = (long) (tUnit * EHEEfficiencyMultiplier * tPlasma.amount / 10);
+                    long criticalSteamAmount = (long) (tUnit * EHEEfficiencyMultiplier * tPlasma.amount / 100);
                     MyRecipeAdder.instance.addExtremeHeatExchangerRecipe(
                         tPlasma,
                         output,

--- a/src/main/java/goodgenerator/loader/RecipeLoader_02.java
+++ b/src/main/java/goodgenerator/loader/RecipeLoader_02.java
@@ -1863,7 +1863,7 @@ public class RecipeLoader_02 {
                 FluidStack output = FluidRegistry.getFluidStack(tOutName, tPlasma.amount);
                 if (output == null) output = FluidRegistry.getFluidStack("molten." + tOutName, tPlasma.amount);
                 if (output != null) {
-                    long waterAmount = (long) (tUnit * EHEEfficiencyMultiplier * tPlasma.amount / 16);
+                    long waterAmount = (long) (tUnit * EHEEfficiencyMultiplier * tPlasma.amount / 160);
                     long criticalSteamAmount = (long) (tUnit * EHEEfficiencyMultiplier * tPlasma.amount / 10);
                     MyRecipeAdder.instance.addExtremeHeatExchangerRecipe(
                         tPlasma,

--- a/src/main/java/goodgenerator/loader/RecipeLoader_02.java
+++ b/src/main/java/goodgenerator/loader/RecipeLoader_02.java
@@ -1835,7 +1835,7 @@ public class RecipeLoader_02 {
             .addTo(plasmaForgeRecipes);
     }
 
-    public static float EHEEfficiencyMultiplier = 1.5f;
+    public static float EHEEfficiencyMultiplier = 1.0f;
 
     public static void FinishLoadRecipe() {
         for (GT_Recipe plasmaFuel : RecipeMaps.plasmaFuels.getAllRecipes()) {

--- a/src/main/java/gregtech/api/items/GT_MetaGenerated_Tool.java
+++ b/src/main/java/gregtech/api/items/GT_MetaGenerated_Tool.java
@@ -524,7 +524,7 @@ public abstract class GT_MetaGenerated_Tool extends GT_MetaBase_Item
                                     (long) (Math.max(
                                         Float.MIN_NORMAL,
                                         tStats.getSpeedMultiplier() * getPrimaryMaterial(aStack).mToolSpeed
-                                            * (10000f / 20f)))))
+                                            * (1000f / 20f)))))
                             + EnumChatFormatting.GRAY));
                 aList.add(
                     tOffset + 10,

--- a/src/main/java/gregtech/api/items/GT_MetaGenerated_Tool.java
+++ b/src/main/java/gregtech/api/items/GT_MetaGenerated_Tool.java
@@ -524,7 +524,7 @@ public abstract class GT_MetaGenerated_Tool extends GT_MetaBase_Item
                                     (long) (Math.max(
                                         Float.MIN_NORMAL,
                                         tStats.getSpeedMultiplier() * getPrimaryMaterial(aStack).mToolSpeed
-                                            * (1000f / 20f)))))
+                                            * (10000f / 20f)))))
                             + EnumChatFormatting.GRAY));
                 aList.add(
                     tOffset + 10,

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingCell.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingCell.java
@@ -259,7 +259,7 @@ public class ProcessingCell implements IOreRecipeRegistrator {
                         case "Fluorine" -> recipeBuilder.metadata(FUEL_VALUE, 147_456)
                             .metadata(FUEL_TYPE, 4)
                             .addTo(GT_RecipeConstants.Fuel);
-                        case "Force" -> recipeBuilder.metadata(FUEL_VALUE, 150_000)
+                        case "Force" -> recipeBuilder.metadata(FUEL_VALUE, 180_000)
                             .metadata(FUEL_TYPE, 4)
                             .addTo(GT_RecipeConstants.Fuel);
                         case "Gadolinium" -> recipeBuilder.metadata(FUEL_VALUE, 366_551)

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GT_MTE_LargeTurbine_SCSteam.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GT_MTE_LargeTurbine_SCSteam.java
@@ -81,7 +81,7 @@ public class GT_MTE_LargeTurbine_SCSteam extends GregtechMetaTileEntity_LargerTu
         }
         if (totalFlow <= 0) return 0;
         tEU = totalFlow;
-        addOutput(GT_ModHandler.getSteam(totalFlow));
+        addOutput(GT_ModHandler.getSteam(totalFlow * 10));
         if (totalFlow != realOptFlow) {
             float efficiency = 1.0f - Math.abs((totalFlow - (float) realOptFlow) / (float) realOptFlow);
             // if(totalFlow>aOptFlow){efficiency = 1.0f;}
@@ -91,7 +91,7 @@ public class GT_MTE_LargeTurbine_SCSteam extends GregtechMetaTileEntity_LargerTu
             tEU = MathUtils.safeInt((long) tEU * (long) aBaseEff / 10000L);
         }
 
-        return tEU * 100L;
+        return tEU * 10L;
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GT_MTE_LargeTurbine_SCSteam.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/GT_MTE_LargeTurbine_SCSteam.java
@@ -81,7 +81,7 @@ public class GT_MTE_LargeTurbine_SCSteam extends GregtechMetaTileEntity_LargerTu
         }
         if (totalFlow <= 0) return 0;
         tEU = totalFlow;
-        addOutput(GT_ModHandler.getSteam(totalFlow * 10));
+        addOutput(GT_ModHandler.getSteam(totalFlow * 100));
         if (totalFlow != realOptFlow) {
             float efficiency = 1.0f - Math.abs((totalFlow - (float) realOptFlow) / (float) realOptFlow);
             // if(totalFlow>aOptFlow){efficiency = 1.0f;}
@@ -91,7 +91,7 @@ public class GT_MTE_LargeTurbine_SCSteam extends GregtechMetaTileEntity_LargerTu
             tEU = MathUtils.safeInt((long) tEU * (long) aBaseEff / 10000L);
         }
 
-        return tEU * 10L;
+        return tEU * 100L;
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_Nuclear.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_Nuclear.java
@@ -554,7 +554,7 @@ public class RecipeLoader_Nuclear {
                 new FluidStack(ELEMENT.getInstance().NEON.getPlasma(), 144),
                 Materials.Bedrockium.getMolten(144))
             .fluidOutputs(new FluidStack(ELEMENT.STANDALONE.FORCE.getPlasma(), 1000))
-            .duration(3 * SECONDS + 4 * TICKS)
+            .duration(1 * SECONDS + 12 * TICKS)
             .eut(TierEU.RECIPE_LuV)
             .metadata(FUSION_THRESHOLD, 100_000_000)
             .addTo(fusionRecipes);
@@ -609,10 +609,10 @@ public class RecipeLoader_Nuclear {
 
         GT_Values.RA.stdBuilder()
             .fluidInputs(
-                new FluidStack(ELEMENT.STANDALONE.ADVANCED_NITINOL.getPlasma(), 144),
+                new FluidStack(ELEMENT.STANDALONE.ADVANCED_NITINOL.getPlasma(), 72),
                 Materials.Tartarite.getMolten(2))
             .fluidOutputs(new FluidStack(ELEMENT.STANDALONE.CELESTIAL_TUNGSTEN.getPlasma(), 1000))
-            .duration(16 * TICKS)
+            .duration(8 * TICKS)
             .eut(TierEU.RECIPE_UV)
             .metadata(FUSION_THRESHOLD, 500_000_000)
             .addTo(fusionRecipes);


### PR DESCRIPTION
The Extreme Heat Exchanger completely bypasses the earlier Plasma Turbine nerf, while additionally increasing the EU per unit of Plasma by !200%! for essentially free. Even more, the intended loop of Distilled Water -> SC Steam -> Steam -> Distilled Water is generally ignored, as 99% of the EU from the plasma is contained within the SC steam, and the distilled water can be bruteforced with a mega distillation tower.

This PR nerfs the EHE by ~40%, heavily incentivizes the usage of a Steam turbine after the SC step, and buffs the Power Plasma line to make it a more attractive option over using simple plasmas such as Helium and Silver with the EHE.

**Material changes**
Extremely Unstable Naquadah has been rebalanced to be similar to SpNt:
375% -> 235% Efficiency 
12M -> 70M Durability
4500 -> 2000 SC Flow

This makes it similar to SpNt, a good Turbine material available 2 tiers later. With its current values, the turbine is only  beaten in efficiency by Shirabon and Eternity (UMV and UXV materials respectively), which is utterly stupid for a material you can acquire in IV.

**Plasma Line changes**
- Change Force Plasma fuel value from 150M to 180M
- Change Force Plasma recipe time from 64 ticks to 32 ticks
(~40% buff per reactor)

- Change Runite Plasma recipe time from 32 to 16 ticks
(~17% buff per reactor)

- Change Celestial Tungsten recipe time from 16 ticks to 8 ticks
- Change Advanced Nitinol Plasma input from 144 to 72
(~50% buff per reactor)


**Extreme Heat Exchanger loop change + nerf**

- Make the EHE be able to consume more Plasma depending on the fuel value (Reduce spam and incentivize higher tiers of plasma)
- Change EHE efficiency from 300% to 120%
- Make SC Turbines produce 100L of Steam per 1L of SC Steam
- This changes the ratio of EU within the turbines from 99:11 (SC:SH) to 66:33, incentivizing the use of normal steam turbines to 1. Recover the distilled water and 2. get one third of the energy from plasma.
- The EHE has a 180% Fuel value efficiency over Plasma turbines by utilizing the extra steam, but requires two sets of turbines instead of one. With just the SC turbine, the efficiency is 120% over using Plasma turbines.