### PR TITLE
Use distilled wafer for engraving naq wafers instead of no water + circuit

### DIFF
--- a/src/main/java/gregtech/api/util/GT_RecipeConstants.java
+++ b/src/main/java/gregtech/api/util/GT_RecipeConstants.java
@@ -289,24 +289,22 @@ public class GT_RecipeConstants {
         switch (wafer) {
             case Naquadah -> {
                 ArrayList<ItemStack> items = new ArrayList<>(Arrays.asList(builder.getItemInputsBasic()));
-                items.add(GT_Utility.getIntegratedCircuit(1));
-                ItemStack[] inputItemsWithC1 = items.toArray(new ItemStack[] {});
-
-                ArrayList<ItemStack> items2 = new ArrayList<>(Arrays.asList(builder.getItemInputsBasic()));
-                items2.add(GT_Utility.getIntegratedCircuit(2));
-                ItemStack[] itemsWithC2 = items2.toArray(new ItemStack[] {});
-                // Naquadah wafers can use grade 1-2 purified water for a bonus
+                ItemStack[] itemInputs = items.toArray(new ItemStack[] {});
+                // Naquadah wafers can use grade 1-2 purified water for a bonus, otherwise use distilled so we don't
+                // have to
+                // deal with circuits
                 return GT_Utility.concat(
                     builder.copy()
-                        .itemInputs(inputItemsWithC1)
+                        .itemInputs(itemInputs)
+                        .fluidInputs(GT_ModHandler.getDistilledWater(100L))
                         .addTo(RecipeMaps.laserEngraverRecipes),
                     builder.copy()
-                        .itemInputs(itemsWithC2)
+                        .itemInputs(itemInputs)
                         .fluidInputs(Materials.Grade1PurifiedWater.getFluid(100L))
                         .duration(halfBoostedRecipeTime)
                         .addTo(RecipeMaps.laserEngraverRecipes),
                     builder.copy()
-                        .itemInputs(itemsWithC2)
+                        .itemInputs(itemInputs)
                         .fluidInputs(Materials.Grade2PurifiedWater.getFluid(100L))
                         .duration(boostedRecipeTime)
                         .addTo(RecipeMaps.laserEngraverRecipes));


### PR DESCRIPTION
The programmed circuits for naq wafer engraving used in waterline were a bit messy but necessary to avoid conflicts. Using distilled water as a fluid input instead of no fluid input fixes this in a much more clean way.

closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16938