### PR TITLE
Remove maintenance hatch requirement for late multis

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_PlasmaForge.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_PlasmaForge.java
@@ -647,8 +647,6 @@ public class GT_MetaTileEntity_PlasmaForge extends
                     + EnumChatFormatting.GRAY
                     + " TT energy hatch.")
             .addStructureInfo(
-                "Requires " + EnumChatFormatting.GOLD + "1" + EnumChatFormatting.GRAY + " maintenance hatch.")
-            .addStructureInfo(
                 "Requires " + EnumChatFormatting.GOLD
                     + min_input_hatch
                     + EnumChatFormatting.GRAY
@@ -864,8 +862,9 @@ public class GT_MetaTileEntity_PlasmaForge extends
         // If there are no energy hatches or TT energy hatches, structure will fail to form.
         if ((mEnergyHatches.size() == 0) && (mExoticEnergyHatches.size() == 0)) return false;
 
-        // One maintenance hatch only. Mandatory.
-        if (mMaintenanceHatches.size() != 1) return false;
+        // Maintenance hatch not required but left for compatibility.
+        // Don't allow more than 1, no free casing spam!
+        if (mMaintenanceHatches.size() > 1) return false;
 
         // Heat capacity of coils used on multi. No free heat from extra EU!
         mHeatingCapacity = (int) getCoilLevel().getHeat();
@@ -1219,5 +1218,10 @@ public class GT_MetaTileEntity_PlasmaForge extends
     @Override
     public boolean supportsBatchMode() {
         return true;
+    }
+
+    @Override
+    public boolean getDefaultHasMaintenanceChecks() {
+        return false;
     }
 }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_TranscendentPlasmaMixer.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_TranscendentPlasmaMixer.java
@@ -123,7 +123,6 @@ public class GT_MetaTileEntity_TranscendentPlasmaMixer
             .addStructureInfo(GOLD + "1+ " + GRAY + "Input Hatch")
             .addStructureInfo(GOLD + "1+ " + GRAY + "Output Hatch")
             .addStructureInfo(GOLD + "1+ " + GRAY + "Input Bus")
-            .addStructureInfo(GOLD + "1 " + GRAY + "Maintenance Hatch")
             .toolTipFinisher("Gregtech");
         return tt;
     }
@@ -254,7 +253,9 @@ public class GT_MetaTileEntity_TranscendentPlasmaMixer
             return false;
         }
 
-        return (mMaintenanceHatches.size() == 1);
+        // Maintenance hatch not required but left for compatibility.
+        // Don't allow more than 1, no free casing spam!
+        return (mMaintenanceHatches.size() <= 1);
     }
 
     @Override
@@ -359,5 +360,10 @@ public class GT_MetaTileEntity_TranscendentPlasmaMixer
     @Override
     public boolean supportsVoidProtection() {
         return true;
+    }
+
+    @Override
+    public boolean getDefaultHasMaintenanceChecks() {
+        return false;
     }
 }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_QuantumForceTransformer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_QuantumForceTransformer.java
@@ -279,16 +279,6 @@ public class GregtechMetaTileEntity_QuantumForceTransformer
             .addOutputHatch(EnumChatFormatting.AQUA + "Top" + EnumChatFormatting.GRAY + " Layer", 5)
             .addOutputBus(EnumChatFormatting.AQUA + "Top" + EnumChatFormatting.GRAY + " Layer", 5)
             .addEnergyHatch(EnumChatFormatting.BLUE + "Bottom" + EnumChatFormatting.GRAY + " Layer", 4)
-            .addMaintenanceHatch(
-                EnumChatFormatting.BLUE + "Bottom"
-                    + EnumChatFormatting.GRAY
-                    + " or "
-                    + EnumChatFormatting.AQUA
-                    + "Top"
-                    + EnumChatFormatting.GRAY
-                    + " Layer",
-                4,
-                5)
             .addStructureInfo(
                 EnumChatFormatting.WHITE + "Neptunium Plasma Hatch: "
                     + EnumChatFormatting.GREEN
@@ -324,7 +314,13 @@ public class GregtechMetaTileEntity_QuantumForceTransformer
             return false;
         }
 
-        if (mMaintenanceHatches.size() != 1 || mOutputBusses.isEmpty() || mOutputHatches.isEmpty()) {
+        if (mOutputBusses.isEmpty() || mOutputHatches.isEmpty()) {
+            return false;
+        }
+
+        // Maintenance hatch not required but left for compatibility.
+        // Don't allow more than 1, no free casing spam!
+        if (mMaintenanceHatches.size() > 1) {
             return false;
         }
 
@@ -935,5 +931,10 @@ public class GregtechMetaTileEntity_QuantumForceTransformer
     @Override
     public boolean supportsBatchMode() {
         return true;
+    }
+
+    @Override
+    public boolean getDefaultHasMaintenanceChecks() {
+        return false;
     }
 }


### PR DESCRIPTION
Removes maintenance hatch requirement for DTPF, QFT, Transcendent Plasma Mixer. Similar late multis such as Space Elevator, EOH, and upcoming multis like gorge and antimatter do not require maintenance hatches. It had been discussed in the past that Space Elevator is a good cutoff point for this, since at this point, maintenance really has no impact any longer on gameplay. I plan to change this for Dyson as well in a PR to that repo.

The multiblocks I changed still allow the maintenance hatch for compatibility, so nothing needs to be updated. Maintenance checks just will no longer occur, and the hatch is optional (and I still left the checks for no more than 1 maintenance hatch).