### PR TITLE
Fix full amp voltage requirements on some gt++ recipes

### DIFF
--- a/src/main/java/gtPlusPlus/core/recipe/RECIPES_GREGTECH.java
+++ b/src/main/java/gtPlusPlus/core/recipe/RECIPES_GREGTECH.java
@@ -407,7 +407,7 @@ public class RECIPES_GREGTECH {
                     CI.getTertiaryTieredFluid(j - 2, 144 * 16),
                     CI.getAlternativeTieredFluid(j, 144 * 16))
                 .itemOutputs(aGemCasings[aCasingSlot++])
-                .eut(GT_Values.V[j])
+                .eut(GT_Values.VP[j])
                 .duration(2 * MINUTES)
                 .addTo(AssemblyLine);
         }
@@ -442,7 +442,7 @@ public class RECIPES_GREGTECH {
                     CI.getAlternativeTieredFluid(j, 144 * 16),
                     CI.getTertiaryTieredFluid(j - 1, 144 * 16))
                 .itemOutputs(aGemBatteries[aCasingSlot++])
-                .eut(GT_Values.V[j])
+                .eut(GT_Values.VP[j])
                 .duration(2 * MINUTES)
                 .addTo(AssemblyLine);
         }
@@ -506,7 +506,7 @@ public class RECIPES_GREGTECH {
                         CI.getAlternativeTieredFluid(h - 1, 144 * 4 * 8),
                         CI.getAlternativeTieredFluid(h - 2, 144 * 4 * 8))
                     .itemOutputs(aChargeOutputs[aCurrSlot])
-                    .eut(GT_Values.V[h])
+                    .eut(GT_Values.VP[h])
                     .duration((aCurrSlot + 1) * HOURS)
                     .addTo(AssemblyLine);
                 aCurrSlot++;
@@ -1196,7 +1196,7 @@ public class RECIPES_GREGTECH {
                 .itemOutputs(aPackOutput[aAS])
                 .fluidInputs(CI.getTieredFluid(i, (144 * 4)))
                 .duration(30 * i * SECONDS)
-                .eut(GT_Values.V[i])
+                .eut(GT_Values.VP[i])
                 .addTo(assemblerRecipes);
         }
 


### PR DESCRIPTION
Fixes:
- Energy Core
- Containment Unit
- Charge Pack
- "Gem" batteries (proton cell, electron cell, etc)
recipes to use the normal adjusted EU/t rather than a full amp. I'm sure there are others that this PR doesn't catch, but I found one of these while playing, and then went ahead and fixed others in this same file.