### PR TITLE
Fix solenoid page assignment

### DIFF
--- a/src/main/java/gregtech/api/enums/Textures.java
+++ b/src/main/java/gregtech/api/enums/Textures.java
@@ -1762,6 +1762,7 @@ public class Textures {
             casingTexturePages[0] = new ITexture[128];
             // adds some known pages, modders also can do it...
             GT_Utility.addTexturePage((byte) 1);
+            GT_Utility.addTexturePage((byte) 2);
             GT_Utility.addTexturePage((byte) 8);
             GT_Utility.addTexturePage((byte) 16);
             setCasingTextureForId(ERROR_TEXTURE_INDEX, ERROR_RENDERING[0]);

--- a/src/main/java/gregtech/api/enums/Textures.java
+++ b/src/main/java/gregtech/api/enums/Textures.java
@@ -1739,6 +1739,7 @@ public class Textures {
          * by Default pages are null
          * page 0: 0-63 GT casing 1-4, 64-127 GT++
          * page 1: 0-15 GT casing 5, 22-26 GS dyson swarm, 48-57 GT casing 8, 63 EMT, 80-95 GT reinforced blocks, 96 casing 2 meta 6, 97 error casing
+         * page 2: 0-15 solenoid coils
          * page 8: 0-111 TecTech, 112-127 GT casing 6
          * page 12: 0-127 GlodBlock
          * page 16: 0-15 GT glass 1, 16-31 GT casing 9, 32-47 GT glass 2, 48-63 GT casing 10, 64-79 GT casing 11

--- a/src/main/java/gregtech/common/blocks/GT_Cyclotron_Coils.java
+++ b/src/main/java/gregtech/common/blocks/GT_Cyclotron_Coils.java
@@ -38,9 +38,8 @@ public class GT_Cyclotron_Coils extends GT_Block_Casings_Abstract {
         ItemList.Superconducting_Magnet_Solenoid_UMV.set(new ItemStack(this, 1, 10));
     }
 
-    @Override // Magic numbers...
     public int getTextureIndex(int aMeta) {
-        return (2 << 7) | aMeta;
+        return (2 << 7) | (aMeta);
     }
 
     @Override

--- a/src/main/java/gregtech/common/blocks/GT_Cyclotron_Coils.java
+++ b/src/main/java/gregtech/common/blocks/GT_Cyclotron_Coils.java
@@ -38,6 +38,7 @@ public class GT_Cyclotron_Coils extends GT_Block_Casings_Abstract {
         ItemList.Superconducting_Magnet_Solenoid_UMV.set(new ItemStack(this, 1, 10));
     }
 
+    @Override
     public int getTextureIndex(int aMeta) {
         return (2 << 7) | (aMeta);
     }

--- a/src/main/java/gregtech/common/blocks/GT_Cyclotron_Coils.java
+++ b/src/main/java/gregtech/common/blocks/GT_Cyclotron_Coils.java
@@ -40,7 +40,7 @@ public class GT_Cyclotron_Coils extends GT_Block_Casings_Abstract {
 
     @Override // Magic numbers...
     public int getTextureIndex(int aMeta) {
-        return 208 + aMeta;
+        return (2 << 7) | aMeta;
     }
 
     @Override


### PR DESCRIPTION
Solenoid coil texture page was assigned to a random magic number that used to conflict with blockcasings9 (which was mostly unused). Someone recently moved them to a different random magic number... which just made them conflict with other casings like cleanroom, causing issues like this:
![image](https://github.com/user-attachments/assets/ec248db3-194c-42c9-8093-51b9d55ba8dc)

This just puts solenoid coils on a properly assigned page and adds them to the directory in Textures.java.
Behold, normal cleanroom texture:
![2024-08-07_23 00 55](https://github.com/user-attachments/assets/f7add4ba-acea-40f0-9d9b-c2de28b78128)
