### PR TITLE
Buff later naqfuels and misc changes

### DIFF
--- a/src/main/java/goodgenerator/api/recipe/GoodGeneratorRecipeMaps.java
+++ b/src/main/java/goodgenerator/api/recipe/GoodGeneratorRecipeMaps.java
@@ -28,7 +28,7 @@ public class GoodGeneratorRecipeMaps {
         .build();
     public static final RecipeMap<RecipeMapBackend> naquadahFuelRefineFactoryRecipes = RecipeMapBuilder
         .of("gg.recipe.naquadah_fuel_refine_factory")
-        .maxIO(6, 0, 2, 1)
+        .maxIO(6, 0, 4, 1)
         .minInputs(0, 1)
         .neiSpecialInfoFormatter(new SimpleSpecialValueFormatter("value.naquadah_fuel_refine_factory"))
         .build();

--- a/src/main/java/goodgenerator/blocks/tileEntity/FuelRefineFactory.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/FuelRefineFactory.java
@@ -191,10 +191,10 @@ public class FuelRefineFactory extends GT_MetaTileEntity_TooltipMultiBlockBase_E
             .addInfo(BLUE_PRINT_INFO)
             .addSeparator()
             .beginStructureBlock(3, 15, 15, false)
-            .addInputHatch("The casings adjoin the field restriction glass.")
-            .addInputBus("The casings adjoin the field restriction glass.", 1)
-            .addOutputHatch("The casings adjoin the field restriction glass.", 1)
-            .addEnergyHatch("The casings adjoin the field restriction glass.", 1)
+            .addInputHatch("The casings adjacent to field restriction glass.")
+            .addInputBus("The casings adjacent to field restriction glass.", 1)
+            .addOutputHatch("The casings adjacent to field restriction glass.", 1)
+            .addEnergyHatch("The casings adjacent to field restriction glass.", 1)
             .toolTipFinisher("Good Generator");
         return tt;
     }

--- a/src/main/java/goodgenerator/blocks/tileEntity/MultiNqGenerator.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/MultiNqGenerator.java
@@ -419,14 +419,11 @@ public class MultiNqGenerator extends GT_MetaTileEntity_TooltipMultiBlockBase_EM
                     + " ONE"
                     + EnumChatFormatting.GRAY
                     + " type of fuel in hatches!")
-            .addInfo("Can consume 1000L/s of coolant to increase efficiency:")
-            .addInfo(
-                String.format(
-                    "IC2 Coolant %d%%, Super Coolant %d%%, Cryotheum %d%%, Tachyon Rich Temporal Fluid %d%%",
-                    CoolantEfficiency[3],
-                    CoolantEfficiency[2],
-                    CoolantEfficiency[1],
-                    CoolantEfficiency[0]))
+            .addInfo("Can consume coolants to increase efficiency:")
+            .addInfo(String.format("IC2 Coolant | %d%% | 1000 L/s ", CoolantEfficiency[3]))
+            .addInfo(String.format("Super Coolant | %d%% | 1000 L/s", CoolantEfficiency[2]))
+            .addInfo(String.format("Cryotheum | %d%% | 1000 L/s", CoolantEfficiency[1]))
+            .addInfo(String.format("Tachyon Rich Temporal Fluid | %d%% | 20 L/s", CoolantEfficiency[0]))
             .addInfo("Can consume excited liquid to increase the output power and fuel usage:")
             .addInfo(String.format("Molten Caesium | %dx power | 180 L/s ", ExcitedLiquidCoe[4]))
             .addInfo(String.format("Molten Uranium-235 | %dx power | 180 L/s", ExcitedLiquidCoe[3]))

--- a/src/main/java/goodgenerator/loader/FuelRecipeLoader.java
+++ b/src/main/java/goodgenerator/loader/FuelRecipeLoader.java
@@ -6,6 +6,7 @@ import static goodgenerator.main.GG_Config_Loader.NaquadahFuelTime;
 import static goodgenerator.main.GG_Config_Loader.NaquadahFuelVoltage;
 import static gregtech.api.enums.Mods.GTPlusPlus;
 import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
+import static gregtech.api.util.GT_RecipeBuilder.TICKS;
 import static gregtech.api.util.GT_RecipeConstants.LNG_BASIC_OUTPUT;
 import static gregtech.api.util.GT_RecipeConstants.NFR_COIL_TIER;
 
@@ -111,7 +112,7 @@ public class FuelRecipeLoader {
                 MyMaterial.orundum.get(OrePrefixes.dust, 64))
             .fluidInputs(
                 MyMaterial.naquadahBasedFuelMkIII.getFluidOrGas(2000),
-                new FluidStack(FluidRegistry.getFluid("molten.hypogen"), 1440))
+                new FluidStack(FluidRegistry.getFluid("molten.hypogen"), 720))
             .fluidOutputs(MyMaterial.naquadahBasedFuelMkIV.getFluidOrGas(500))
             .duration(8 * SECONDS)
             .eut(75_000_000)
@@ -119,17 +120,36 @@ public class FuelRecipeLoader {
             .noOptimize()
             .addTo(naquadahFuelRefineFactoryRecipes);
 
+        // One-step recipe to allow easier scaling for MK VI
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                MyMaterial.extremelyUnstableNaquadah.get(OrePrefixes.dust, 54),
+                MyMaterial.orundum.get(OrePrefixes.dust, 32),
+                ItemRefer.High_Density_Uranium.get(10),
+                ItemRefer.High_Density_Plutonium.get(5))
+            .fluidInputs(
+                MyMaterial.heavyNaquadahFuel.getFluidOrGas(4000),
+                MyMaterial.lightNaquadahFuel.getFluidOrGas(5000),
+                new FluidStack(FluidRegistry.getFluid("molten.hypogen"), 360),
+                new FluidStack(FluidRegistry.getFluid("molten.chromaticglass"), 6480))
+            .fluidOutputs(MyMaterial.naquadahBasedFuelMkIV.getFluidOrGas(250))
+            .duration(10 * TICKS)
+            .eut(350_000_000)
+            .metadata(NFR_COIL_TIER, 4)
+            .noOptimize()
+            .addTo(naquadahFuelRefineFactoryRecipes);
+
         // MK V Naquadah Fuel
         GT_Values.RA.stdBuilder()
             .itemInputs(
-                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Infinity, 16),
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Infinity, 8),
                 MyMaterial.atomicSeparationCatalyst.get(OrePrefixes.dust, 32))
             .fluidInputs(
                 MyMaterial.naquadahBasedFuelMkIV.getFluidOrGas(2000),
-                FluidRegistry.getFluidStack("heavyradox", 1000))
+                FluidRegistry.getFluidStack("heavyradox", 250))
             .fluidOutputs(MyMaterial.naquadahBasedFuelMkV.getFluidOrGas(500))
-            .duration(100_000_000)
-            .eut(10 * SECONDS)
+            .duration(10 * SECONDS)
+            .eut(100_000_000)
             .metadata(NFR_COIL_TIER, 2)
             .noOptimize()
             .addTo(naquadahFuelRefineFactoryRecipes);
@@ -137,12 +157,12 @@ public class FuelRecipeLoader {
         // Alternate higher tier recipe
         GT_Values.RA.stdBuilder()
             .itemInputs(
-                GT_OreDictUnificator.get(OrePrefixes.dust, MaterialsUEVplus.SpaceTime, 8),
+                GT_OreDictUnificator.get(OrePrefixes.dust, MaterialsUEVplus.SpaceTime, 4),
                 GT_OreDictUnificator.get(OrePrefixes.dust, MaterialsUEVplus.TranscendentMetal, 16),
                 MyMaterial.atomicSeparationCatalyst.get(OrePrefixes.dust, 48))
             .fluidInputs(
                 MyMaterial.naquadahBasedFuelMkIV.getFluidOrGas(2000),
-                FluidRegistry.getFluidStack("heavyradox", 1000))
+                FluidRegistry.getFluidStack("heavyradox", 250))
             .fluidOutputs(MyMaterial.naquadahBasedFuelMkV.getFluidOrGas(750))
             .duration(10 * SECONDS)
             .eut(300_000_000)
@@ -157,7 +177,7 @@ public class FuelRecipeLoader {
                 GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Tritanium, 32))
             .fluidInputs(
                 MyMaterial.naquadahBasedFuelMkV.getFluidOrGas(2000),
-                FluidRegistry.getFluidStack("molten.shirabon", 1440))
+                FluidRegistry.getFluidStack("molten.shirabon", 360))
             .fluidOutputs(MyMaterial.naquadahBasedFuelMkVI.getFluidOrGas(500))
             .duration(12 * SECONDS)
             .eut(320_000_000)
@@ -168,14 +188,14 @@ public class FuelRecipeLoader {
         // Alternate higher tier recipe
         GT_Values.RA.stdBuilder()
             .itemInputs(
-                GT_OreDictUnificator.get(OrePrefixes.dust, MaterialsUEVplus.WhiteDwarfMatter, 8),
+                GT_OreDictUnificator.get(OrePrefixes.dust, MaterialsUEVplus.WhiteDwarfMatter, 4),
                 ELEMENT.STANDALONE.CELESTIAL_TUNGSTEN.getDust(64),
                 GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Tritanium, 48))
             .fluidInputs(
                 MyMaterial.naquadahBasedFuelMkV.getFluidOrGas(2000),
                 FluidRegistry.getFluidStack("molten.shirabon", 1440))
             .fluidOutputs(MyMaterial.naquadahBasedFuelMkVI.getFluidOrGas(750))
-            .duration(12 * SECONDS)
+            .duration(4 * SECONDS)
             .eut(530_000_000)
             .metadata(NFR_COIL_TIER, 4)
             .noOptimize()

--- a/src/main/java/goodgenerator/loader/FuelRecipeLoader.java
+++ b/src/main/java/goodgenerator/loader/FuelRecipeLoader.java
@@ -164,7 +164,7 @@ public class FuelRecipeLoader {
                 MyMaterial.naquadahBasedFuelMkIV.getFluidOrGas(2000),
                 FluidRegistry.getFluidStack("heavyradox", 250))
             .fluidOutputs(MyMaterial.naquadahBasedFuelMkV.getFluidOrGas(750))
-            .duration(10 * SECONDS)
+            .duration(5 * SECONDS)
             .eut(300_000_000)
             .metadata(NFR_COIL_TIER, 3)
             .noOptimize()

--- a/src/main/java/gregtech/common/gui/modularui/UIHelper.java
+++ b/src/main/java/gregtech/common/gui/modularui/UIHelper.java
@@ -121,10 +121,11 @@ public class UIHelper {
      */
     public static List<Pos2d> getFluidInputPositions(int fluidInputCount) {
         List<Pos2d> results = new ArrayList<>();
-        int x = 52;
+        int base = Math.max(70 - (fluidInputCount * 18), 16);
+        int x = 0;
         for (int i = 0; i < fluidInputCount; i++) {
-            results.add(new Pos2d(x, 62));
-            x -= 18;
+            results.add(new Pos2d(base + x, 62));
+            x += 18;
         }
         return results;
     }

--- a/src/main/resources/assets/goodgenerator/lang/en_US.lang
+++ b/src/main/resources/assets/goodgenerator/lang/en_US.lang
@@ -318,7 +318,7 @@ gt.blockmachines.YottaFluidTank.cfgi.0=Tick rate (Update I/O every x ticks)
 
 # RecipeMaps
 gg.recipe.naquadah_reactor=Large Naquadah Reactor
-gg.recipe.naquadah_fuel_refine_factory=Naquadah Fuel Refine Factory
+gg.recipe.naquadah_fuel_refine_factory=Naquadah Fuel Refinery
 gg.recipe.neutron_activator=Neutron Activator
 gg.recipe.extreme_heat_exchanger=Extreme Heat Exchanger
 gg.recipe.precise_assembler=Precise Assembler
@@ -474,9 +474,9 @@ essentiaoutputhatch.chat.0=Cleared.
 #Achievement
 achievement.gt.blockmachines.nag=Large Naquadah Reactor
 achievement.gt.blockmachines.nag.desc=Pickup this item to see the recipe in NEI
-achievement.gt.blockmachines.frf=Naquadah Fuel Refine Factory
+achievement.gt.blockmachines.frf=Naquadah Fuel Refinery
 achievement.gt.blockmachines.frf.desc=Pickup this item to see the recipe in NEI
-achievement.FRF_Casing.0=Naquadah Fuel Refine Factory Casing
+achievement.FRF_Casing.0=Naquadah Fuel Refinery Casing
 achievement.FRF_Casing.0.desc=Pickup this item to see the recipe in NEI
 achievement.FRF_Coil_1.0=Field Restriction Coil
 achievement.FRF_Coil_1.0.desc=Pickup this item to see the recipe in NEI


### PR DESCRIPTION
**Naquadah Reactor tooltip:**
- Add info that Tachyon Rich Temporal Fluid only consumes 20L/s instead of 1000L/s

![image](https://github.com/user-attachments/assets/d1dcb5ed-2e4a-4a5d-920d-4008b93fea0f)


**Refinery tooltip:**
- Change "adjoin" -> "adjacent to" in structure tooltip

**Mk4 Naquadah Fuel:**
Alternate recipe:
- Change Hypogen consumption from 1440L to 720L

Added new recipe to one-step Mk4 fuel, reducing Mk3+Mk4 Refinery spam with T4 coils
Recipe:
- 54 Extremely Unstable Naquadah Dust
- 32 Orundum Dust
- 10 High Density Uranium
- 5 High Density Plutonium
- 4000L Heavy Naquadah Fuel
- 5000L Light Naquadah Fuel
- 360L Molten Hypogen
- 6480L (45 dust ) Molten Chromatic Glass

![image](https://github.com/user-attachments/assets/c464f086-c3fd-40b0-b463-b3d56c2d27da)


Produces 250L at 10 ticks per recipe.
The recipe combines the Tier 3 and Tier 4 recipes, while being around 4 times faster. This should reduce the refinery spam for scaling up in UMV.
It uses 4 fluids because the refinery does not accept more than 4 item inputs in the recipes (??? Couldn't figure out why)

**Mk5 Naquadah Fuel:**
Primary Recipe
- Infinity Dust 16 -> 8
- Heavy Radox 1000L -> 250L
- Time from 5 000 000s to 10s (RA2 Fix)
- Usage from 200 EU/t to 100 000 000 EU/t (RA2 Fix)

Alternate Recipe:
- Spacetime Dust 8 -> 4
- Heavy Radox from 1000L to 250L
- Time from 10s to 5s


**Mk6 Naquadah Fuel:**
Primary Recipe
- Molten Shirabon 1440L -> 360L

Alternate Recipe:
- Molten Shirabon 1440L -> 360L
- Time from 12s to 8s
- White Dwarf Matter 8 -> 4

**Additional changes:**
- Changes the default NEI recipe display widget to support 4 fluids in the default view better.
- Change references from "Naquadah Fuel Refine Factory" -> "Naquadah Fuel Refinery"

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16425