### PR TITLE
Adjust cleanroom assembler recipe cost

### DIFF
--- a/src/main/java/gregtech/loaders/postload/recipes/AssemblerRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/AssemblerRecipes.java
@@ -70,13 +70,13 @@ public class AssemblerRecipes implements Runnable {
             GT_Values.RA.stdBuilder()
                 .itemInputs(
                     ItemList.Hull_HV.get(1L),
-                    ItemList.Component_Filter.get(2L),
+                    ItemList.Component_Filter.get(3L),
                     GT_OreDictUnificator.get(OrePrefixes.rotor, Materials.StainlessSteel, 1L),
-                    ItemList.Electric_Motor_HV.get(1L),
+                    ItemList.Electric_Motor_HV.get(2L),
                     GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.HV, 1L),
                     GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(ItemList.Machine_Multi_Cleanroom.get(1L))
-                .fluidInputs(Materials.StainlessSteel.getMolten(864L))
+                .fluidInputs(Materials.StainlessSteel.getMolten(144L))
                 .duration(60 * SECONDS)
                 .eut(TierEU.RECIPE_MV)
                 .addTo(assemblerRecipes);


### PR DESCRIPTION
While assembler recipes should generally be cheaper, they definitely should not be making your first (and only) cleanroom controller at half the price. This PR adjusts the cost to still be slightly cheaper than the crafting table recipe, but not by as much as before.

![afbeelding](https://github.com/user-attachments/assets/fe990f0e-93ac-41e1-92f9-cfafba108bef)
![afbeelding](https://github.com/user-attachments/assets/07d83bb9-839b-447d-9a61-c62a48d860f9)
