### PR TITLE
Removes "right-click to adjust amount" function of regulator covers

### DIFF
--- a/src/main/java/gregtech/common/covers/GT_Cover_FluidRegulator.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_FluidRegulator.java
@@ -152,17 +152,6 @@ public class GT_Cover_FluidRegulator extends GT_CoverBehaviorBase<GT_Cover_Fluid
         return aCoverVariable;
     }
 
-    @Override
-    protected boolean onCoverRightClickImpl(ForgeDirection side, int aCoverID, FluidRegulatorData aCoverVariable,
-        ICoverable aTileEntity, EntityPlayer aPlayer, float aX, float aY, float aZ) {
-        if (GT_Utility.getClickedFacingCoords(side, aX, aY, aZ)[0] >= 0.5F) {
-            adjustSpeed(aPlayer, aCoverVariable, 1);
-        } else {
-            adjustSpeed(aPlayer, aCoverVariable, -1);
-        }
-        return true;
-    }
-
     protected boolean canTransferFluid(FluidStack fluid) {
         return true;
     }


### PR DESCRIPTION
With the cover changes that allow the player to right click on a cover without sneaking to open the housing blocks' GUI, the old right click functionality for adjusting the amount on regulator covers is more of a hindrance than a feature. This PR removes the old right click functionality and allows the cover to pass the right click to the base block like other covers.

Of note is that this functionality doesn't work anyways; chat will report a change in the regulator amount, but the GUI reports it as unchanged.

Functionality with a screwdriver is unchanged.