### PR TITLE
Implement dim num agnostic isGenerationAllowed function

### DIFF
--- a/src/main/java/com/github/bartimaeusnek/bartworks/system/oregen/BW_WordGenerator.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/system/oregen/BW_WordGenerator.java
@@ -57,8 +57,8 @@ public class BW_WordGenerator implements IWorldGenerator {
         public int mX;
         public int mZ;
 
-        public WorldGenContainer(int aX, int aZ, WorldProvider aWorldProvider, World aWorld, IChunkProvider aChunkGenerator,
-            IChunkProvider aChunkProvider) {
+        public WorldGenContainer(int aX, int aZ, WorldProvider aWorldProvider, World aWorld,
+            IChunkProvider aChunkGenerator, IChunkProvider aChunkProvider) {
             this.mX = aX;
             this.mZ = aZ;
             this.mWorldProvider = aWorldProvider;
@@ -103,9 +103,7 @@ public class BW_WordGenerator implements IWorldGenerator {
                     for (int i = 0; i < 256 && temp; i++) {
                         tRandomWeight = random.nextInt(BW_OreLayer.sWeight);
                         for (BW_OreLayer tWorldGen : BW_OreLayer.sList) {
-                            if (!tWorldGen.isGenerationAllowed(
-                                this.mWorld,
-                                mWorldProvider.getClass())) continue;
+                            if (!tWorldGen.isGenerationAllowed(this.mWorld, mWorldProvider.getClass())) continue;
                             tRandomWeight -= tWorldGen.mWeight;
                             if (tRandomWeight <= 0) {
                                 try {

--- a/src/main/java/com/github/bartimaeusnek/bartworks/system/oregen/BW_WordGenerator.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/system/oregen/BW_WordGenerator.java
@@ -18,9 +18,9 @@ import java.util.Random;
 
 import net.minecraft.world.ChunkCoordIntPair;
 import net.minecraft.world.World;
+import net.minecraft.world.WorldProvider;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.IChunkProvider;
-import net.minecraftforge.common.DimensionManager;
 
 import cpw.mods.fml.common.IWorldGenerator;
 import gregtech.api.objects.XSTR;
@@ -41,7 +41,7 @@ public class BW_WordGenerator implements IWorldGenerator {
         new BW_WordGenerator.WorldGenContainer(
             aX * 16,
             aZ * 16,
-            aWorld.provider.dimensionId,
+            aWorld.provider,
             aWorld,
             aChunkGenerator,
             aChunkProvider).run();
@@ -50,18 +50,18 @@ public class BW_WordGenerator implements IWorldGenerator {
     public static class WorldGenContainer implements Runnable {
 
         public static HashSet<ChunkCoordIntPair> mGenerated = new HashSet<>(2000);
-        public final int mDimensionType;
+        public final WorldProvider mWorldProvider;
         public final World mWorld;
         public final IChunkProvider mChunkGenerator;
         public final IChunkProvider mChunkProvider;
         public int mX;
         public int mZ;
 
-        public WorldGenContainer(int aX, int aZ, int aDimensionType, World aWorld, IChunkProvider aChunkGenerator,
+        public WorldGenContainer(int aX, int aZ, WorldProvider aWorldProvider, World aWorld, IChunkProvider aChunkGenerator,
             IChunkProvider aChunkProvider) {
             this.mX = aX;
             this.mZ = aZ;
-            this.mDimensionType = aDimensionType;
+            this.mWorldProvider = aWorldProvider;
             this.mWorld = aWorld;
             this.mChunkGenerator = aChunkGenerator;
             this.mChunkProvider = aChunkProvider;
@@ -105,7 +105,7 @@ public class BW_WordGenerator implements IWorldGenerator {
                         for (BW_OreLayer tWorldGen : BW_OreLayer.sList) {
                             if (!tWorldGen.isGenerationAllowed(
                                 this.mWorld,
-                                DimensionManager.getWorld(mDimensionType).provider.getClass())) continue;
+                                mWorldProvider.getClass())) continue;
                             tRandomWeight -= tWorldGen.mWeight;
                             if (tRandomWeight <= 0) {
                                 try {
@@ -116,7 +116,7 @@ public class BW_WordGenerator implements IWorldGenerator {
                                             this.mWorld,
                                             random,
                                             "",
-                                            this.mDimensionType,
+                                            this.mWorldProvider.dimensionId,
                                             xCenter,
                                             zCenter,
                                             this.mChunkGenerator,

--- a/src/main/java/com/github/bartimaeusnek/bartworks/system/oregen/BW_WordGenerator.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/system/oregen/BW_WordGenerator.java
@@ -20,6 +20,7 @@ import net.minecraft.world.ChunkCoordIntPair;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.IChunkProvider;
+import net.minecraftforge.common.DimensionManager;
 
 import cpw.mods.fml.common.IWorldGenerator;
 import gregtech.api.objects.XSTR;
@@ -102,8 +103,9 @@ public class BW_WordGenerator implements IWorldGenerator {
                     for (int i = 0; i < 256 && temp; i++) {
                         tRandomWeight = random.nextInt(BW_OreLayer.sWeight);
                         for (BW_OreLayer tWorldGen : BW_OreLayer.sList) {
-                            if (!tWorldGen.isGenerationAllowed(this.mWorld, this.mDimensionType, this.mDimensionType))
-                                continue;
+                            if (!tWorldGen.isGenerationAllowed(
+                                this.mWorld,
+                                DimensionManager.getWorld(mDimensionType).provider.getClass())) continue;
                             tRandomWeight -= tWorldGen.mWeight;
                             if (tRandomWeight <= 0) {
                                 try {

--- a/src/main/java/gregtech/api/world/GT_Worldgen.java
+++ b/src/main/java/gregtech/api/world/GT_Worldgen.java
@@ -1,5 +1,6 @@
 package gregtech.api.world;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -86,6 +87,33 @@ public abstract class GT_Worldgen {
         if (tAllowed == null) {
             boolean tValue = GregTech_API.sWorldgenFile
                 .get("worldgen." + mWorldGenName, aDimName, aDimensionType == aAllowedDimensionType);
+            mDimensionMap.put(aDimName, tValue);
+            return tValue;
+        }
+        return tAllowed;
+    }
+
+    /**
+     *
+     * @param aWorld                 The World Object
+     * @param aAllowedDimensionTypes The Types of allowed Worldgeneration
+     * @return if generation for this world is allowed for MoronTech (tm) OreGen (ATM (2.0.3.1Dev) only End, Nether,
+     *         Overworld, Twilight Forest and Deep Dark)
+     */
+    public boolean isGenerationAllowed(World aWorld, Class... aAllowedDimensionTypes) {
+        String aDimName = aWorld.provider.getDimensionName();
+        if (!(aDimName.equalsIgnoreCase("Overworld") || aDimName.equalsIgnoreCase("Nether")
+            || aDimName.equalsIgnoreCase("The End")
+            || aDimName.equalsIgnoreCase("Twilight Forest")
+            || aDimName.equalsIgnoreCase("Underdark"))) return false;
+
+        Boolean tAllowed = mDimensionMap.get(aDimName);
+        if (tAllowed == null) {
+            boolean tValue = GregTech_API.sWorldgenFile.get(
+                "worldgen." + mWorldGenName,
+                aDimName,
+                Arrays.stream(aAllowedDimensionTypes)
+                    .anyMatch(worldProvider -> worldProvider.isInstance(aWorld.provider)));
             mDimensionMap.put(aDimName, tValue);
             return tValue;
         }

--- a/src/main/java/gregtech/api/world/GT_Worldgen.java
+++ b/src/main/java/gregtech/api/world/GT_Worldgen.java
@@ -8,6 +8,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.IChunkProvider;
+import net.minecraftforge.common.DimensionManager;
 
 import gregtech.api.GregTech_API;
 
@@ -93,6 +94,15 @@ public abstract class GT_Worldgen {
         return tAllowed;
     }
 
+    public boolean isGenerationAllowed(World aWorld, int aAllowedDimensionType) {
+        World allowedWorld = DimensionManager.getWorld(aAllowedDimensionType);
+        if (allowedWorld != null && allowedWorld.provider != null )
+        {
+            return isGenerationAllowed(aWorld, allowedWorld.provider.getClass());
+        } else {
+            return aWorld.provider.dimensionId == aAllowedDimensionType;
+        }
+    }
     /**
      *
      * @param aWorld                 The World Object

--- a/src/main/java/gregtech/api/world/GT_Worldgen.java
+++ b/src/main/java/gregtech/api/world/GT_Worldgen.java
@@ -96,13 +96,13 @@ public abstract class GT_Worldgen {
 
     public boolean isGenerationAllowed(World aWorld, int aAllowedDimensionType) {
         World allowedWorld = DimensionManager.getWorld(aAllowedDimensionType);
-        if (allowedWorld != null && allowedWorld.provider != null )
-        {
+        if (allowedWorld != null && allowedWorld.provider != null) {
             return isGenerationAllowed(aWorld, allowedWorld.provider.getClass());
         } else {
             return aWorld.provider.dimensionId == aAllowedDimensionType;
         }
     }
+
     /**
      *
      * @param aWorld                 The World Object

--- a/src/main/java/gregtech/api/world/GT_Worldgen_Ore_SingleBlock.java
+++ b/src/main/java/gregtech/api/world/GT_Worldgen_Ore_SingleBlock.java
@@ -7,7 +7,6 @@ import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.IChunkProvider;
-import net.minecraftforge.common.DimensionManager;
 
 public class GT_Worldgen_Ore_SingleBlock extends GT_Worldgen_Ore {
 
@@ -32,8 +31,7 @@ public class GT_Worldgen_Ore_SingleBlock extends GT_Worldgen_Ore {
     @Override
     public boolean executeWorldgen(World aWorld, Random aRandom, String aBiome, int aDimensionType, int aChunkX,
         int aChunkZ, IChunkProvider aChunkGenerator, IChunkProvider aChunkProvider) {
-        if (isGenerationAllowed(aWorld, mDimensionType)
-            && (mBiomeList.isEmpty() || mBiomeList.contains(aBiome))
+        if (isGenerationAllowed(aWorld, mDimensionType) && (mBiomeList.isEmpty() || mBiomeList.contains(aBiome))
             && (mProbability <= 1 || aRandom.nextInt(mProbability) == 0)) {
             for (int i = 0; i < mAmount; i++) {
                 int tX = aChunkX + aRandom.nextInt(16), tY = mMinY + aRandom.nextInt(mMaxY - mMinY),

--- a/src/main/java/gregtech/api/world/GT_Worldgen_Ore_SingleBlock.java
+++ b/src/main/java/gregtech/api/world/GT_Worldgen_Ore_SingleBlock.java
@@ -32,7 +32,7 @@ public class GT_Worldgen_Ore_SingleBlock extends GT_Worldgen_Ore {
     @Override
     public boolean executeWorldgen(World aWorld, Random aRandom, String aBiome, int aDimensionType, int aChunkX,
         int aChunkZ, IChunkProvider aChunkGenerator, IChunkProvider aChunkProvider) {
-        if (isGenerationAllowed(aWorld, DimensionManager.getWorld(mDimensionType).provider.getClass())
+        if (isGenerationAllowed(aWorld, mDimensionType)
             && (mBiomeList.isEmpty() || mBiomeList.contains(aBiome))
             && (mProbability <= 1 || aRandom.nextInt(mProbability) == 0)) {
             for (int i = 0; i < mAmount; i++) {

--- a/src/main/java/gregtech/api/world/GT_Worldgen_Ore_SingleBlock.java
+++ b/src/main/java/gregtech/api/world/GT_Worldgen_Ore_SingleBlock.java
@@ -7,6 +7,7 @@ import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.IChunkProvider;
+import net.minecraftforge.common.DimensionManager;
 
 public class GT_Worldgen_Ore_SingleBlock extends GT_Worldgen_Ore {
 
@@ -31,7 +32,7 @@ public class GT_Worldgen_Ore_SingleBlock extends GT_Worldgen_Ore {
     @Override
     public boolean executeWorldgen(World aWorld, Random aRandom, String aBiome, int aDimensionType, int aChunkX,
         int aChunkZ, IChunkProvider aChunkGenerator, IChunkProvider aChunkProvider) {
-        if (isGenerationAllowed(aWorld, aDimensionType, mDimensionType)
+        if (isGenerationAllowed(aWorld, DimensionManager.getWorld(mDimensionType).provider.getClass())
             && (mBiomeList.isEmpty() || mBiomeList.contains(aBiome))
             && (mProbability <= 1 || aRandom.nextInt(mProbability) == 0)) {
             for (int i = 0; i < mAmount; i++) {

--- a/src/main/java/gregtech/api/world/GT_Worldgen_Ore_SingleBlock_UnderLava.java
+++ b/src/main/java/gregtech/api/world/GT_Worldgen_Ore_SingleBlock_UnderLava.java
@@ -32,7 +32,7 @@ public class GT_Worldgen_Ore_SingleBlock_UnderLava extends GT_Worldgen_Ore {
     @Override
     public boolean executeCavegen(World aWorld, Random aRandom, String aBiome, int aDimensionType, int aChunkX,
         int aChunkZ, IChunkProvider aChunkGenerator, IChunkProvider aChunkProvider) {
-        if (isGenerationAllowed(aWorld, DimensionManager.getWorld(mDimensionType).provider.getClass())
+        if (isGenerationAllowed(aWorld, mDimensionType)
             && (mBiomeList.isEmpty() || mBiomeList.contains(aBiome))
             && (mProbability <= 1 || aRandom.nextInt(mProbability) == 0)) {
             for (int i = 0; i < mAmount; i++) {

--- a/src/main/java/gregtech/api/world/GT_Worldgen_Ore_SingleBlock_UnderLava.java
+++ b/src/main/java/gregtech/api/world/GT_Worldgen_Ore_SingleBlock_UnderLava.java
@@ -7,6 +7,7 @@ import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.IChunkProvider;
+import net.minecraftforge.common.DimensionManager;
 
 public class GT_Worldgen_Ore_SingleBlock_UnderLava extends GT_Worldgen_Ore {
 
@@ -31,7 +32,7 @@ public class GT_Worldgen_Ore_SingleBlock_UnderLava extends GT_Worldgen_Ore {
     @Override
     public boolean executeCavegen(World aWorld, Random aRandom, String aBiome, int aDimensionType, int aChunkX,
         int aChunkZ, IChunkProvider aChunkGenerator, IChunkProvider aChunkProvider) {
-        if (isGenerationAllowed(aWorld, aDimensionType, mDimensionType)
+        if (isGenerationAllowed(aWorld, DimensionManager.getWorld(mDimensionType).provider.getClass())
             && (mBiomeList.isEmpty() || mBiomeList.contains(aBiome))
             && (mProbability <= 1 || aRandom.nextInt(mProbability) == 0)) {
             for (int i = 0; i < mAmount; i++) {

--- a/src/main/java/gregtech/api/world/GT_Worldgen_Ore_SingleBlock_UnderLava.java
+++ b/src/main/java/gregtech/api/world/GT_Worldgen_Ore_SingleBlock_UnderLava.java
@@ -7,7 +7,6 @@ import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.IChunkProvider;
-import net.minecraftforge.common.DimensionManager;
 
 public class GT_Worldgen_Ore_SingleBlock_UnderLava extends GT_Worldgen_Ore {
 
@@ -32,8 +31,7 @@ public class GT_Worldgen_Ore_SingleBlock_UnderLava extends GT_Worldgen_Ore {
     @Override
     public boolean executeCavegen(World aWorld, Random aRandom, String aBiome, int aDimensionType, int aChunkX,
         int aChunkZ, IChunkProvider aChunkGenerator, IChunkProvider aChunkProvider) {
-        if (isGenerationAllowed(aWorld, mDimensionType)
-            && (mBiomeList.isEmpty() || mBiomeList.contains(aBiome))
+        if (isGenerationAllowed(aWorld, mDimensionType) && (mBiomeList.isEmpty() || mBiomeList.contains(aBiome))
             && (mProbability <= 1 || aRandom.nextInt(mProbability) == 0)) {
             for (int i = 0; i < mAmount; i++) {
                 int tX = aChunkX + aRandom.nextInt(16), tY = mMinY + aRandom.nextInt(mMaxY - mMinY),

--- a/src/main/java/gregtech/common/GT_Worldgen_GT_Ore_Layer.java
+++ b/src/main/java/gregtech/common/GT_Worldgen_GT_Ore_Layer.java
@@ -5,12 +5,16 @@ import static gregtech.api.enums.GT_Values.oreveinPlacerOres;
 import static gregtech.api.enums.GT_Values.oreveinPlacerOresMultiplier;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Random;
 
 import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
+import net.minecraft.world.WorldProviderEnd;
+import net.minecraft.world.WorldProviderHell;
+import net.minecraft.world.WorldProviderSurface;
 import net.minecraft.world.chunk.IChunkProvider;
 
 import gregtech.api.GregTech_API;
@@ -47,6 +51,8 @@ public class GT_Worldgen_GT_Ore_Layer extends GT_Worldgen {
 
     public final boolean mMoon = false, mMars = false, mAsteroid = false;
     public final String aTextWorldgen = "worldgen.";
+
+    public Class[] mAllowedProviders;
 
     @Deprecated
     public GT_Worldgen_GT_Ore_Layer(String aName, boolean aDefault, int aMinY, int aMaxY, int aWeight, int aDensity,
@@ -104,6 +110,20 @@ public class GT_Worldgen_GT_Ore_Layer extends GT_Worldgen {
         if (this.mEnabled) {
             sWeight += this.mWeight;
         }
+
+        List<Class> allowedProviders = new ArrayList<>();
+        if (this.mNether) {
+            allowedProviders.add(WorldProviderHell.class);
+        }
+
+        if (this.mOverworld) {
+            allowedProviders.add(WorldProviderSurface.class);
+        }
+
+        if (this.mEnd) {
+            allowedProviders.add(WorldProviderEnd.class);
+        }
+        mAllowedProviders = allowedProviders.toArray(new Class[allowedProviders.size()]);
     }
 
     @Override
@@ -114,11 +134,8 @@ public class GT_Worldgen_GT_Ore_Layer extends GT_Worldgen {
             // Return a special empty orevein
             return ORE_PLACED;
         }
-        if (!isGenerationAllowed(
-            aWorld,
-            aDimensionType,
-            ((aDimensionType == -1) && (this.mNether)) || ((aDimensionType == 0) && (this.mOverworld))
-                || ((aDimensionType == 1) && (this.mEnd)) ? aDimensionType : ~aDimensionType)) {
+
+        if (!isGenerationAllowed(aWorld, mAllowedProviders)) {
             // The following code can be used for debugging, but it spams in logs
             // if (debugOrevein) { GT_Log.out.println( "Wrong dimension" ); }
             return WRONG_DIMENSION;

--- a/src/main/java/gregtech/common/GT_Worldgen_GT_Ore_SmallPieces.java
+++ b/src/main/java/gregtech/common/GT_Worldgen_GT_Ore_SmallPieces.java
@@ -3,9 +3,13 @@ package gregtech.common;
 import static gregtech.api.enums.GT_Values.debugSmallOres;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Random;
 
 import net.minecraft.world.World;
+import net.minecraft.world.WorldProviderEnd;
+import net.minecraft.world.WorldProviderHell;
+import net.minecraft.world.WorldProviderSurface;
 import net.minecraft.world.chunk.IChunkProvider;
 
 import gregtech.api.GregTech_API;
@@ -28,6 +32,8 @@ public class GT_Worldgen_GT_Ore_SmallPieces extends GT_Worldgen {
     public final String aTextWorldgen = "worldgen.";
     public static ArrayList<GT_Worldgen_GT_Ore_SmallPieces> sList = new ArrayList<>();
 
+    public Class[] mAllowedProviders;
+
     // TODO CHECK IF INSTANTIATION IS CORRECT
     public GT_Worldgen_GT_Ore_SmallPieces(String aName, boolean aDefault, int aMinY, int aMaxY, int aAmount,
         boolean aOverworld, boolean aNether, boolean aEnd, Materials aPrimary) {
@@ -45,6 +51,20 @@ public class GT_Worldgen_GT_Ore_SmallPieces extends GT_Worldgen {
             .get(aTextWorldgen + this.mWorldGenName, "Ore", aPrimary.mMetaItemSubID));
         this.mBiome = GregTech_API.sWorldgenFile.get(aTextWorldgen + this.mWorldGenName, "BiomeName", "None");
         sList.add(this);
+
+        List<Class> allowedProviders = new ArrayList<>();
+        if (this.mNether) {
+            allowedProviders.add(WorldProviderHell.class);
+        }
+
+        if (this.mOverworld) {
+            allowedProviders.add(WorldProviderSurface.class);
+        }
+
+        if (this.mEnd) {
+            allowedProviders.add(WorldProviderEnd.class);
+        }
+        mAllowedProviders = allowedProviders.toArray(new Class[allowedProviders.size()]);
     }
 
     public GT_Worldgen_GT_Ore_SmallPieces(String aName, boolean aDefault, int aMinY, int aMaxY, int aAmount,
@@ -64,6 +84,20 @@ public class GT_Worldgen_GT_Ore_SmallPieces extends GT_Worldgen {
             .get(aTextWorldgen + this.mWorldGenName, "Ore", aPrimary.mMetaItemSubID));
         this.mBiome = GregTech_API.sWorldgenFile.get(aTextWorldgen + this.mWorldGenName, "BiomeName", "None");
         sList.add(this);
+
+        List<Class> allowedProviders = new ArrayList<>();
+        if (this.mNether) {
+            allowedProviders.add(WorldProviderHell.class);
+        }
+
+        if (this.mOverworld) {
+            allowedProviders.add(WorldProviderSurface.class);
+        }
+
+        if (this.mEnd) {
+            allowedProviders.add(WorldProviderEnd.class);
+        }
+        mAllowedProviders = allowedProviders.toArray(new Class[allowedProviders.size()]);
     }
 
     @Override
@@ -72,11 +106,7 @@ public class GT_Worldgen_GT_Ore_SmallPieces extends GT_Worldgen {
         if (!this.mBiome.equals("None") && !(this.mBiome.equals(aBiome))) {
             return false; // Not the correct biome for ore mix
         }
-        if (!isGenerationAllowed(
-            aWorld,
-            aDimensionType,
-            ((aDimensionType == -1) && (this.mNether)) || ((aDimensionType == 0) && (this.mOverworld))
-                || ((aDimensionType == 1) && (this.mEnd)) ? aDimensionType : ~aDimensionType)) {
+        if (!isGenerationAllowed(aWorld, mAllowedProviders)) {
             return false;
         }
         int count = 0;

--- a/src/main/java/gregtech/common/GT_Worldgen_Stone.java
+++ b/src/main/java/gregtech/common/GT_Worldgen_Stone.java
@@ -12,7 +12,6 @@ import net.minecraft.init.Blocks;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.IChunkProvider;
-import net.minecraftforge.common.DimensionManager;
 
 import gregtech.api.GregTech_API;
 import gregtech.api.objects.XSTR;

--- a/src/main/java/gregtech/common/GT_Worldgen_Stone.java
+++ b/src/main/java/gregtech/common/GT_Worldgen_Stone.java
@@ -83,7 +83,7 @@ public class GT_Worldgen_Stone extends GT_Worldgen_Ore {
         XSTR stoneRNG = new XSTR();
         ArrayList<ValidSeeds> stones = new ArrayList<>();
 
-        if (!isGenerationAllowed(aWorld, DimensionManager.getWorld(mDimensionType).provider.getClass())) {
+        if (!isGenerationAllowed(aWorld, mDimensionType)) {
             return false;
         }
         if (!(this.mBiomeList.isEmpty() || this.mBiomeList.contains(aBiome))) {

--- a/src/main/java/gregtech/common/GT_Worldgen_Stone.java
+++ b/src/main/java/gregtech/common/GT_Worldgen_Stone.java
@@ -12,6 +12,7 @@ import net.minecraft.init.Blocks;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.IChunkProvider;
+import net.minecraftforge.common.DimensionManager;
 
 import gregtech.api.GregTech_API;
 import gregtech.api.objects.XSTR;
@@ -82,7 +83,7 @@ public class GT_Worldgen_Stone extends GT_Worldgen_Ore {
         XSTR stoneRNG = new XSTR();
         ArrayList<ValidSeeds> stones = new ArrayList<>();
 
-        if (!isGenerationAllowed(aWorld, aDimensionType, this.mDimensionType)) {
+        if (!isGenerationAllowed(aWorld, DimensionManager.getWorld(mDimensionType).provider.getClass())) {
             return false;
         }
         if (!(this.mBiomeList.isEmpty() || this.mBiomeList.contains(aBiome))) {


### PR DESCRIPTION
Replaces references to old function in as many places as possible Only reference that can't be changed right now is `E:\MinecraftProjects\GT5-Unofficial\src\main\java\com\github\bartimaeusnek\crossmod\galacticgreg\VoidMinerUtility.java:189`

I think this is fine since this is isolated to the void miner itself

The main goal is to provide compatibility with Multiworld mods / plugins such as Forge Essentials Multiworld.

Also, it won't effect mods like Personal Space since that has it's own provider that does not extend the vanilla providers.