### PR TITLE
Fix radiobarite name

### DIFF
--- a/src/main/java/gtPlusPlus/core/material/ORES.java
+++ b/src/main/java/gtPlusPlus/core/material/ORES.java
@@ -488,7 +488,7 @@ public final class ORES {
     // Radiobarite
     // Radium, Barium, Barite?
     public static final Material RADIOBARITE = new Material(
-        "Barite (Rd)", // Material Name
+        "Barite (Ra)", // Material Name
         MaterialState.ORE, // State
         TextureSet.SET_FLINT, // Texture Set
         new short[] { 205, 205, 205, 0 }, // Material Colour


### PR DESCRIPTION
fixes https://discord.com/channels/181078474394566657/181078474394566657/1271770639925248050

The symbol for radium is Ra, not Rd.