### PR TITLE
Ceria chem balance

### DIFF
--- a/src/main/java/common/recipeLoaders/ChemicalReactor.java
+++ b/src/main/java/common/recipeLoaders/ChemicalReactor.java
@@ -19,9 +19,9 @@ public class ChemicalReactor implements Runnable {
 
         // Ceria Dust
         GT_Values.RA.stdBuilder()
-            .itemInputs(Materials.Cerium.getDust(2), GT_Utility.getIntegratedCircuit(6))
-            .itemOutputs(craftingItem.getStackOfAmountFromDamage(Items.CeriaDust.getMetaID(), 2))
-            .fluidInputs(Materials.Oxygen.getGas(3000))
+            .itemInputs(Materials.Cerium.getDust(1), GT_Utility.getIntegratedCircuit(6))
+            .itemOutputs(craftingItem.getStackOfAmountFromDamage(Items.CeriaDust.getMetaID(), 3))
+            .fluidInputs(Materials.Oxygen.getGas(2000))
             .duration(20 * SECONDS)
             .eut(TierEU.RECIPE_LV)
             .addTo(UniversalChemical);


### PR DESCRIPTION
fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16944

keep in mind that
- IRL Ceria=Cerium dioxide = Cerium(IV) oxide, thats all the same and has formula CeO2
- however the Cerium dioxide we already have is in the middle of samariumline and I dont want to interfere with that, so this doesnt get an oredict or any unification.

I think in light of those we can just interpret our 'ceria' as more impure than our 'ceriumdioxide', which would explain why we dont unify them. Though I am open to better solutions.