### PR TITLE
Require at least 1 fluid input in assline recipes

### DIFF
--- a/src/main/java/gregtech/api/util/GT_RecipeConstants.java
+++ b/src/main/java/gregtech/api/util/GT_RecipeConstants.java
@@ -393,7 +393,7 @@ public class GT_RecipeConstants {
             .validateInputCount(4, 16)
             .validateOutputCount(1, 1)
             .validateOutputFluidCount(-1, 0)
-            .validateInputFluidCount(0, 4)
+            .validateInputFluidCount(1, 4)
             .buildWithAlt();
         // noinspection SimplifyOptionalCallChains
         if (!rr.isPresent()) return Collections.emptyList();


### PR DESCRIPTION
Changes the assembly line recipemap to require at least 1 input fluid. Currently all assembly line recipes satisfy this as far as I'm aware. 

The reason for this is that batch mode on the AAL assumes each recipe has a fluid to determine parallel. This check will make sure nothing breaks with this in the future.