### PR TITLE
Fix QFT recipes

### DIFF
--- a/src/main/java/goodgenerator/loader/NaquadahReworkRecipeLoader.java
+++ b/src/main/java/goodgenerator/loader/NaquadahReworkRecipeLoader.java
@@ -92,99 +92,94 @@ public class NaquadahReworkRecipeLoader {
 
         if (!EnableNaquadahRework) return;
 
-        try {
-            // Naquadah (UEV)
-            GT_Values.RA.stdBuilder()
-                .itemInputs(
-                    naquadahEarth.get(OrePrefixes.dust, 32),
-                    Materials.Sodium.getDust(64),
-                    Materials.Carbon.getDust(1),
-                    GT_Utility.copyAmount(0, GenericChem.mSimpleNaquadahCatalyst))
-                .itemOutputs(
-                    inertNaquadah.get(OrePrefixes.dust, 1),
-                    Materials.Titanium.getDust(64),
-                    Materials.Adamantium.getDust(64),
-                    Materials.Gallium.getDust(64))
-                .fluidInputs(
-                    Materials.Hydrogen.getGas(64000L),
-                    Materials.Fluorine.getGas(64000L),
-                    Materials.Oxygen.getGas(100L))
-                .duration(10 * SECONDS)
-                .eut(GT_Values.VP[10])
-                .metadata(QFT_FOCUS_TIER, 2)
-                .addTo(quantumForceTransformerRecipes);
-            // Enriched Naquadah (UIV)
-            GT_Values.RA.stdBuilder()
-                .itemInputs(
-                    enrichedNaquadahEarth.get(OrePrefixes.dust, 32),
-                    Materials.Zinc.getDust(64),
-                    Materials.Carbon.getDust(1),
-                    GT_Utility.copyAmount(0, GenericChem.mSimpleNaquadahCatalyst))
-                .itemOutputs(inertEnrichedNaquadah.get(OrePrefixes.dust, 1), Materials.Trinium.getDust(64))
-                .fluidInputs(Materials.SulfuricAcid.getFluid(16000), Materials.Oxygen.getGas(100L))
-                .fluidOutputs(wasteLiquid.getFluidOrGas(32000))
-                .duration(10 * SECONDS)
-                .eut(GT_Values.VP[11])
-                .metadata(QFT_FOCUS_TIER, 2)
-                .addTo(quantumForceTransformerRecipes);
-            // Naquadria (UMV)
-            GT_Values.RA.stdBuilder()
-                .itemInputs(
-                    naquadriaEarth.get(OrePrefixes.dust, 32),
-                    Materials.Magnesium.getDust(64),
-                    GT_Utility.copyAmount(0, GenericChem.mAdvancedNaquadahCatalyst))
-                .itemOutputs(
-                    inertNaquadria.get(OrePrefixes.dust, 1),
-                    Materials.Barium.getDust(64),
-                    Materials.Indium.getDust(64),
-                    ItemList.NaquadriaSupersolid.get(1))
-                .fluidInputs(
-                    Materials.PhosphoricAcid.getFluid(16000),
-                    Materials.SulfuricAcid.getFluid(16000),
-                    Materials.Oxygen.getGas(100L))
-                .duration(5 * SECONDS)
-                .eut(GT_Values.VP[12])
-                .metadata(QFT_FOCUS_TIER, 3)
-                .addTo(quantumForceTransformerRecipes);
+        // Naquadah (UEV)
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                naquadahEarth.get(OrePrefixes.dust, 32),
+                Materials.Sodium.getDust(64),
+                Materials.Carbon.getDust(1),
+                GT_Utility.copyAmount(0, GenericChem.mSimpleNaquadahCatalyst))
+            .itemOutputs(
+                inertNaquadah.get(OrePrefixes.dust, 1),
+                Materials.Titanium.getDust(64),
+                Materials.Adamantium.getDust(64),
+                Materials.Gallium.getDust(64))
+            .fluidInputs(
+                Materials.Hydrogen.getGas(64000L),
+                Materials.Fluorine.getGas(64000L),
+                Materials.Oxygen.getGas(100L))
+            .duration(10 * SECONDS)
+            .eut(GT_Values.VP[10])
+            .metadata(QFT_FOCUS_TIER, 2)
+            .addTo(quantumForceTransformerRecipes);
+        // Enriched Naquadah (UIV)
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                enrichedNaquadahEarth.get(OrePrefixes.dust, 32),
+                Materials.Zinc.getDust(64),
+                Materials.Carbon.getDust(1),
+                GT_Utility.copyAmount(0, GenericChem.mSimpleNaquadahCatalyst))
+            .itemOutputs(inertEnrichedNaquadah.get(OrePrefixes.dust, 1), Materials.Trinium.getDust(64))
+            .fluidInputs(Materials.SulfuricAcid.getFluid(16000), Materials.Oxygen.getGas(100L))
+            .fluidOutputs(wasteLiquid.getFluidOrGas(32000))
+            .duration(10 * SECONDS)
+            .eut(GT_Values.VP[11])
+            .metadata(QFT_FOCUS_TIER, 2)
+            .addTo(quantumForceTransformerRecipes);
+        // Naquadria (UMV)
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                naquadriaEarth.get(OrePrefixes.dust, 32),
+                Materials.Magnesium.getDust(64),
+                GT_Utility.copyAmount(0, GenericChem.mAdvancedNaquadahCatalyst))
+            .itemOutputs(
+                inertNaquadria.get(OrePrefixes.dust, 1),
+                Materials.Barium.getDust(64),
+                Materials.Indium.getDust(64),
+                ItemList.NaquadriaSupersolid.get(1))
+            .fluidInputs(
+                Materials.PhosphoricAcid.getFluid(16000),
+                Materials.SulfuricAcid.getFluid(16000),
+                Materials.Oxygen.getGas(100L))
+            .duration(5 * SECONDS)
+            .eut(GT_Values.VP[12])
+            .metadata(QFT_FOCUS_TIER, 3)
+            .addTo(quantumForceTransformerRecipes);
 
-            // Activate Them
+        // Activate Them
 
-            GT_Values.RA.stdBuilder()
-                .itemInputs(inertNaquadah.get(OrePrefixes.dust, 64), inertNaquadah.get(OrePrefixes.dust, 32))
-                .itemOutputs(Materials.Nickel.getDust(16))
-                .fluidInputs(Materials.Nickel.getPlasma(144 * 16))
-                .fluidOutputs(Materials.Naquadah.getMolten(144 * 9216))
-                .duration(1 * MINUTES + 40 * SECONDS)
-                .eut(0)
-                .metadata(NKE_RANGE, computeRangeNKE(600, 500))
-                .noOptimize()
-                .addTo(neutronActivatorRecipes);
-            GT_Values.RA.stdBuilder()
-                .itemInputs(
-                    inertEnrichedNaquadah.get(OrePrefixes.dust, 64),
-                    inertEnrichedNaquadah.get(OrePrefixes.dust, 32))
-                .itemOutputs(Materials.Titanium.getDust(16))
-                .fluidInputs(Materials.Titanium.getPlasma(16 * 144))
-                .fluidOutputs(Materials.NaquadahEnriched.getMolten(144 * 9216))
-                .duration(1 * MINUTES + 40 * SECONDS)
-                .eut(0)
-                .metadata(NKE_RANGE, computeRangeNKE(900, 850))
-                .noOptimize()
-                .addTo(neutronActivatorRecipes);
-            GT_Values.RA.stdBuilder()
-                .itemInputs(inertNaquadria.get(OrePrefixes.dust, 64), inertNaquadria.get(OrePrefixes.dust, 32))
-                .itemOutputs(Materials.Americium.getDust(16))
-                .fluidInputs(Materials.Americium.getPlasma(144 * 16))
-                .fluidOutputs(Materials.Naquadria.getMolten(144 * 9216))
-                .duration(1 * MINUTES + 40 * SECONDS)
-                .eut(0)
-                .metadata(NKE_RANGE, computeRangeNKE(1100, 1080))
-                .noOptimize()
-                .addTo(neutronActivatorRecipes);
-
-        } catch (Throwable t) {
-            // Cry about it
-        }
+        GT_Values.RA.stdBuilder()
+            .itemInputs(inertNaquadah.get(OrePrefixes.dust, 64), inertNaquadah.get(OrePrefixes.dust, 32))
+            .itemOutputs(Materials.Nickel.getDust(16))
+            .fluidInputs(Materials.Nickel.getPlasma(144 * 16))
+            .fluidOutputs(Materials.Naquadah.getMolten(144 * 9216))
+            .duration(1 * MINUTES + 40 * SECONDS)
+            .eut(0)
+            .metadata(NKE_RANGE, computeRangeNKE(600, 500))
+            .noOptimize()
+            .addTo(neutronActivatorRecipes);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(
+                inertEnrichedNaquadah.get(OrePrefixes.dust, 64),
+                inertEnrichedNaquadah.get(OrePrefixes.dust, 32))
+            .itemOutputs(Materials.Titanium.getDust(16))
+            .fluidInputs(Materials.Titanium.getPlasma(16 * 144))
+            .fluidOutputs(Materials.NaquadahEnriched.getMolten(144 * 9216))
+            .duration(1 * MINUTES + 40 * SECONDS)
+            .eut(0)
+            .metadata(NKE_RANGE, computeRangeNKE(900, 850))
+            .noOptimize()
+            .addTo(neutronActivatorRecipes);
+        GT_Values.RA.stdBuilder()
+            .itemInputs(inertNaquadria.get(OrePrefixes.dust, 64), inertNaquadria.get(OrePrefixes.dust, 32))
+            .itemOutputs(Materials.Americium.getDust(16))
+            .fluidInputs(Materials.Americium.getPlasma(144 * 16))
+            .fluidOutputs(Materials.Naquadria.getMolten(144 * 9216))
+            .duration(1 * MINUTES + 40 * SECONDS)
+            .eut(0)
+            .metadata(NKE_RANGE, computeRangeNKE(1100, 1080))
+            .noOptimize()
+            .addTo(neutronActivatorRecipes);
 
         // Fix shit
         GT_Values.RA.stdBuilder()

--- a/src/main/java/goodgenerator/loader/NaquadahReworkRecipeLoader.java
+++ b/src/main/java/goodgenerator/loader/NaquadahReworkRecipeLoader.java
@@ -105,7 +105,6 @@ public class NaquadahReworkRecipeLoader {
                     Materials.Titanium.getDust(64),
                     Materials.Adamantium.getDust(64),
                     Materials.Gallium.getDust(64))
-                .outputChances(2500, 2500, 2500, 2500)
                 .fluidInputs(
                     Materials.Hydrogen.getGas(64000L),
                     Materials.Fluorine.getGas(64000L),
@@ -122,7 +121,6 @@ public class NaquadahReworkRecipeLoader {
                     Materials.Carbon.getDust(1),
                     GT_Utility.copyAmount(0, GenericChem.mSimpleNaquadahCatalyst))
                 .itemOutputs(inertEnrichedNaquadah.get(OrePrefixes.dust, 1), Materials.Trinium.getDust(64))
-                .outputChances(3300, 3300, 3300)
                 .fluidInputs(Materials.SulfuricAcid.getFluid(16000), Materials.Oxygen.getGas(100L))
                 .fluidOutputs(wasteLiquid.getFluidOrGas(32000))
                 .duration(10 * SECONDS)
@@ -140,7 +138,6 @@ public class NaquadahReworkRecipeLoader {
                     Materials.Barium.getDust(64),
                     Materials.Indium.getDust(64),
                     ItemList.NaquadriaSupersolid.get(1))
-                .outputChances(2500, 2500, 2500, 2500)
                 .fluidInputs(
                     Materials.PhosphoricAcid.getFluid(16000),
                     Materials.SulfuricAcid.getFluid(16000),

--- a/src/main/java/gtPlusPlus/api/recipe/GTPPRecipeMaps.java
+++ b/src/main/java/gtPlusPlus/api/recipe/GTPPRecipeMaps.java
@@ -51,7 +51,7 @@ public class GTPPRecipeMaps {
         .minInputs(1, 0)
         .progressBar(GT_UITextures.PROGRESSBAR_ARROW_MULTIPLE)
         .neiSpecialInfoFormatter(new SimpleSpecialValueFormatter("GT5U.nei.tier"))
-        .frontend(LargeNEIFrontend::new)
+        .frontend(QuantumForceTransformerFrontend::new)
         .disableOptimize()
         .build();
     public static final RecipeMap<RecipeMapBackend> chemicalDehydratorRecipes = RecipeMapBuilder

--- a/src/main/java/gtPlusPlus/api/recipe/QuantumForceTransformerFrontend.java
+++ b/src/main/java/gtPlusPlus/api/recipe/QuantumForceTransformerFrontend.java
@@ -1,0 +1,39 @@
+package gtPlusPlus.api.recipe;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+
+import codechicken.nei.PositionedStack;
+import gregtech.api.recipe.BasicUIPropertiesBuilder;
+import gregtech.api.recipe.NEIRecipePropertiesBuilder;
+import gregtech.api.recipe.maps.LargeNEIFrontend;
+import gregtech.api.util.MethodsReturnNonnullByDefault;
+import gregtech.nei.GT_NEI_DefaultHandler;
+import gtPlusPlus.xmod.gregtech.common.tileentities.machines.multi.production.GregtechMetaTileEntity_QuantumForceTransformer;
+
+@ParametersAreNonnullByDefault
+@MethodsReturnNonnullByDefault
+public class QuantumForceTransformerFrontend extends LargeNEIFrontend {
+
+    public QuantumForceTransformerFrontend(BasicUIPropertiesBuilder uiPropertiesBuilder,
+        NEIRecipePropertiesBuilder neiPropertiesBuilder) {
+        super(uiPropertiesBuilder, neiPropertiesBuilder);
+    }
+
+    public String getChanceFormat(int chance) {
+        return GT_NEI_DefaultHandler.FixedPositionedStack.chanceFormat.format((float) chance / 10000);
+    }
+
+    @Override
+    public void drawNEIOverlays(GT_NEI_DefaultHandler.CachedDefaultRecipe neiCachedRecipe) {
+        // Replicates the default behaviour, but since we cannot actually modify the mChance variable we need to
+        // essentially re-implement it.
+        int chance = GregtechMetaTileEntity_QuantumForceTransformer.getBaseOutputChance(neiCachedRecipe.mRecipe);
+        String chanceFormat = getChanceFormat(chance);
+        for (PositionedStack stack : neiCachedRecipe.mOutputs) {
+            if (stack instanceof GT_NEI_DefaultHandler.FixedPositionedStack) {
+                super.drawNEIOverlayText(chanceFormat, stack);
+            }
+        }
+        super.drawNEIOverlays(neiCachedRecipe);
+    }
+}

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_QuantumForceTransformer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_QuantumForceTransformer.java
@@ -654,6 +654,11 @@ public class GregtechMetaTileEntity_QuantumForceTransformer
         return false;
     }
 
+    public static int getBaseOutputChange(GT_Recipe tRecipe) {
+        int aOutputsAmount = tRecipe.mOutputs.length + tRecipe.mFluidOutputs.length;
+        return 10000 / aOutputsAmount;
+    }
+
     private int[] getOutputChances(GT_Recipe tRecipe, int aChanceIncreased) {
         int difference = getFocusingTier() - tRecipe.mSpecialValue;
         int aOutputsAmount = tRecipe.mOutputs.length + tRecipe.mFluidOutputs.length;

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_QuantumForceTransformer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/GregtechMetaTileEntity_QuantumForceTransformer.java
@@ -654,7 +654,7 @@ public class GregtechMetaTileEntity_QuantumForceTransformer
         return false;
     }
 
-    public static int getBaseOutputChange(GT_Recipe tRecipe) {
+    public static int getBaseOutputChance(GT_Recipe tRecipe) {
         int aOutputsAmount = tRecipe.mOutputs.length + tRecipe.mFluidOutputs.length;
         return 10000 / aOutputsAmount;
     }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_ChemicalSkips.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoader_ChemicalSkips.java
@@ -81,7 +81,6 @@ public class RecipeLoader_ChemicalSkips {
                 Materials.Osmium.getDust(64),
                 WerkstoffLoader.Rhodium.get(OrePrefixes.dust, 64),
                 WerkstoffLoader.Ruthenium.get(OrePrefixes.dust, 64))
-            .outputChances(1667, 1667, 1667, 1667, 1667, 1667)
             .duration(20 * SECONDS)
             .eut(TierEU.RECIPE_UV)
             .metadata(QFT_FOCUS_TIER, 1)
@@ -95,7 +94,6 @@ public class RecipeLoader_ChemicalSkips {
                 Materials.Palladium.getDust(64),
                 Materials.Platinum.getDust(64),
                 WerkstoffLoader.LuVTierMaterial.get(OrePrefixes.dust, 64))
-            .outputChances(3333, 3333, 3333)
             .duration(20 * SECONDS)
             .eut(TierEU.RECIPE_UV)
             .metadata(QFT_FOCUS_TIER, 1)
@@ -108,7 +106,6 @@ public class RecipeLoader_ChemicalSkips {
                 Materials.Iridium.getDust(64),
                 Materials.Platinum.getDust(64),
                 Materials.Osmiridium.getDust(64))
-            .outputChances(3333, 3333, 3333)
             .duration(20 * SECONDS)
             .eut(TierEU.RECIPE_UV)
             .metadata(QFT_FOCUS_TIER, 1)
@@ -118,7 +115,6 @@ public class RecipeLoader_ChemicalSkips {
                 WerkstoffLoader.IrOsLeachResidue.get(OrePrefixes.dust, 32),
                 ItemUtils.getSimpleStack(GenericChem.mPlatinumGroupCatalyst, 0))
             .itemOutputs(Materials.Osmium.getDust(64), Materials.Iridium.getDust(64), Materials.Osmiridium.getDust(64))
-            .outputChances(3333, 3333, 3333)
             .duration(20 * SECONDS)
             .eut(TierEU.RECIPE_UV)
             .metadata(QFT_FOCUS_TIER, 1)
@@ -132,7 +128,6 @@ public class RecipeLoader_ChemicalSkips {
                 Materials.Palladium.getDust(64),
                 Materials.Platinum.getDust(64),
                 WerkstoffLoader.LuVTierMaterial.get(OrePrefixes.dust, 64))
-            .outputChances(2500, 2500, 2500, 2500)
             .duration(20 * SECONDS)
             .eut(TierEU.RECIPE_UV)
             .metadata(QFT_FOCUS_TIER, 1)
@@ -146,7 +141,6 @@ public class RecipeLoader_ChemicalSkips {
                 Materials.Osmium.getDust(64),
                 WerkstoffLoader.Rhodium.get(OrePrefixes.dust, 64),
                 WerkstoffLoader.Ruthenium.get(OrePrefixes.dust, 64))
-            .outputChances(2500, 2500, 2500, 2500)
             .duration(20 * SECONDS)
             .eut(TierEU.RECIPE_UV)
             .metadata(QFT_FOCUS_TIER, 1)
@@ -193,7 +187,6 @@ public class RecipeLoader_ChemicalSkips {
                 Materials.Bismuth.getDust(32),
                 ItemUtils.getSimpleStack(GenericChem.mAdhesionPromoterCatalyst, 0))
             .itemOutputs(ItemList.StableAdhesive.get(1))
-            .outputChances(2000)
             .fluidInputs(Materials.Oxygen.getGas(10000), Materials.Hydrogen.getGas(10000))
             .fluidOutputs(
                 MISC_MATERIALS.ETHYL_CYANOACRYLATE.getFluidStack(1000 * 32),
@@ -216,7 +209,6 @@ public class RecipeLoader_ChemicalSkips {
                 Materials.TungstenSteel.getDust(64),
                 Materials.TungstenCarbide.getDust(64),
                 Materials.Indium.getDust(64))
-            .outputChances(2500, 2500, 2500, 2500)
             .duration(20 * SECONDS)
             .eut(TierEU.RECIPE_UV)
             .metadata(QFT_FOCUS_TIER, 1)
@@ -234,7 +226,6 @@ public class RecipeLoader_ChemicalSkips {
                 ELEMENT.getInstance().PLUTONIUM238.getDust(64),
                 Materials.Plutonium.getDust(64),
                 Materials.Plutonium241.getDust(64))
-            .outputChances(1667, 1667, 1667, 1667, 1667, 1667)
             .duration(20 * SECONDS)
             .eut(TierEU.RECIPE_UV)
             .metadata(QFT_FOCUS_TIER, 1)
@@ -251,7 +242,6 @@ public class RecipeLoader_ChemicalSkips {
                 getModItem(BartWorks.ID, "gt.bwMetaGenerateddust", 64L, 11002),
                 getModItem(BartWorks.ID, "gt.bwMetaGenerateddust", 64L, 11007),
                 ItemList.SuperconductorComposite.get(1))
-            .outputChances(1667, 1667, 1667, 1667, 1667, 1667)
             .duration(20 * SECONDS)
             .eut(TierEU.RECIPE_UHV)
             .metadata(QFT_FOCUS_TIER, 2)
@@ -267,7 +257,6 @@ public class RecipeLoader_ChemicalSkips {
                 Materials.Samarium.getDust(64),
                 Materials.Gadolinium.getDust(64),
                 Materials.Lanthanum.getDust(64))
-            .outputChances(2000, 2000, 2000, 2000, 2000)
             .duration(20 * SECONDS)
             .eut(TierEU.RECIPE_UHV)
             .metadata(QFT_FOCUS_TIER, 2)
@@ -283,7 +272,6 @@ public class RecipeLoader_ChemicalSkips {
                 Materials.Samarium.getDust(64),
                 Materials.Gadolinium.getDust(64),
                 Materials.Lanthanum.getDust(64))
-            .outputChances(2000, 2000, 2000, 2000, 2000)
             .duration(20 * SECONDS)
             .eut(TierEU.RECIPE_UHV)
             .metadata(QFT_FOCUS_TIER, 2)
@@ -309,7 +297,6 @@ public class RecipeLoader_ChemicalSkips {
                 getModItem(NewHorizonsCoreMod.ID, "GTNHBioItems", 32, 2),
                 ItemUtils.getSimpleStack(GenericChem.mRawIntelligenceCatalyst, 0))
             .itemOutputs(stemcells)
-            .outputChances(3333)
             .fluidOutputs(
                 Materials.GrowthMediumRaw.getFluid(1000 * 1024),
                 Materials.GrowthMediumSterilized.getFluid(1000 * 512))
@@ -325,7 +312,6 @@ public class RecipeLoader_ChemicalSkips {
                 Particle.getBaseParticle(Particle.GRAVITON),
                 Particle.getBaseParticle(Particle.PROTON),
                 Particle.getBaseParticle(Particle.ELECTRON))
-            .outputChances(2000, 2000, 2000, 2000)
             .fluidInputs(Materials.Hydrogen.getGas(10000L), Materials.Deuterium.getGas(1000L))
             .fluidOutputs(FluidUtils.getFluidStack("plasma.hydrogen", 1000))
             .duration(5 * SECONDS)
@@ -387,7 +373,6 @@ public class RecipeLoader_ChemicalSkips {
                 Materials.InfinityCatalyst.getDust(4),
                 ItemUtils.getSimpleStack(GenericChem.mBiologicalIntelligenceCatalyst, 0))
             .itemOutputs(biocells)
-            .outputChances(2500)
             .fluidOutputs(
                 MISC_MATERIALS.MUTATED_LIVING_SOLDER.getFluidStack(144 * 128),
                 Materials.BioMediumSterilized.getFluid(1000 * 256),
@@ -420,7 +405,6 @@ public class RecipeLoader_ChemicalSkips {
                 Particle.getBaseParticle(Particle.LAMBDA),
                 Particle.getBaseParticle(Particle.OMEGA),
                 Particle.getBaseParticle(Particle.HIGGS_BOSON))
-            .outputChances(2000, 2000, 2000, 2000, 2000)
             .fluidInputs(
                 FluidUtils.getFluidStack("plasma.hydrogen", 30000),
                 Materials.Helium.getPlasma(30000L),
@@ -441,7 +425,6 @@ public class RecipeLoader_ChemicalSkips {
                     Materials.Mytryl.getDust(16),
                     ItemUtils.getSimpleStack(GenericChem.mAlgagenicGrowthPromoterCatalyst, 0))
                 .itemOutputs(seaweed, getModItem(NewHorizonsCoreMod.ID, "item.TCetiESeaweedExtract", 16))
-                .outputChances(25_00, 25_00)
                 .fluidInputs(FluidUtils.getFluidStack("unknowwater", 25_000))
                 .fluidOutputs(
                     FluidUtils.getFluidStack("seaweedbroth", 50_000),


### PR DESCRIPTION
Fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16958. All chances are removed from the recipe data, since the QFT calculates them implicitly anyway.

Also draws NEI overlays for all outputs, including fluids (only for QFT). This was always somewhat confusing before.

![image](https://github.com/user-attachments/assets/beb575fc-bb34-40df-a32f-5e8cd05c68db)
