### PR TITLE
Fix min casings on T2 MVF

### DIFF
--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaVacuumFreezer.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaVacuumFreezer.java
@@ -314,7 +314,7 @@ public class GT_TileEntity_MegaVacuumFreezer extends GT_TileEntity_MegaMultiBloc
             .addCasingInfoMinColored(
                 "Frost Proof Machine Casing",
                 EnumChatFormatting.GRAY,
-                800,
+                700,
                 EnumChatFormatting.GOLD,
                 false)
             .addCasingInfoExactlyColored(
@@ -469,7 +469,7 @@ public class GT_TileEntity_MegaVacuumFreezer extends GT_TileEntity_MegaMultiBloc
             // Structure is Tier 2
             this.mTier = 2;
         }
-        return this.mMaintenanceHatches.size() == 1 && this.mCasingFrostProof >= 800;
+        return this.mMaintenanceHatches.size() == 1 && this.mCasingFrostProof >= 700;
     }
 
     @Override


### PR DESCRIPTION
T2 MVF needed 800 frost proof machine casings but only has space for 787. I adjusted the number down to 700 so there is plenty of hatch space.