### PR TITLE
Single-block Steam Boiler item handling improvements

### DIFF
--- a/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler.java
+++ b/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler.java
@@ -351,16 +351,21 @@ public abstract class GT_MetaTileEntity_Boiler extends GT_MetaTileEntity_BasicTa
         }
     }
 
+    protected boolean isAutomatable() {
+        return GT_Mod.gregtechproxy.mAllowSmallBoilerAutomation;
+    }
+
     @Override
     public boolean allowPullStack(IGregTechTileEntity aBaseMetaTileEntity, int aIndex, ForgeDirection side,
         ItemStack aStack) {
-        return GT_Mod.gregtechproxy.mAllowSmallBoilerAutomation;
+        return isAutomatable() && aIndex == 1 || aIndex == 3;
     }
 
     @Override
     public boolean allowPutStack(IGregTechTileEntity aBaseMetaTileEntity, int aIndex, ForgeDirection side,
         ItemStack aStack) {
-        return GT_Mod.gregtechproxy.mAllowSmallBoilerAutomation;
+        return isAutomatable() && (aIndex == 0 && isItemValidFluidFilledItem(aStack))
+            || (aIndex == 2 && isItemValidFuel(aStack));
     }
 
     @Override

--- a/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler.java
+++ b/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler.java
@@ -14,6 +14,7 @@ import com.gtnewhorizons.modularui.api.drawable.IDrawable;
 import com.gtnewhorizons.modularui.api.drawable.UITexture;
 import com.gtnewhorizons.modularui.api.screen.ModularWindow;
 import com.gtnewhorizons.modularui.api.screen.UIBuildContext;
+import com.gtnewhorizons.modularui.api.widget.Widget;
 import com.gtnewhorizons.modularui.common.widget.DrawableWidget;
 import com.gtnewhorizons.modularui.common.widget.ProgressBar;
 import com.gtnewhorizons.modularui.common.widget.SlotWidget;
@@ -471,8 +472,8 @@ public abstract class GT_MetaTileEntity_Boiler extends GT_MetaTileEntity_BasicTa
                     .setSize(18, 18));
     }
 
-    protected SlotWidget createFuelSlot() {
-        return (SlotWidget) new SlotWidget(inventoryHandler, 2).setPos(115, 61)
+    protected Widget createFuelSlot() {
+        return new SlotWidget(inventoryHandler, 2).setPos(115, 61)
             .setBackground(getFuelSlotBackground());
     }
 

--- a/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler.java
+++ b/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler.java
@@ -10,6 +10,8 @@ import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.IFluidHandler;
 
+import org.jetbrains.annotations.NotNull;
+
 import com.gtnewhorizons.modularui.api.drawable.IDrawable;
 import com.gtnewhorizons.modularui.api.drawable.UITexture;
 import com.gtnewhorizons.modularui.api.screen.ModularWindow;
@@ -433,10 +435,12 @@ public abstract class GT_MetaTileEntity_Boiler extends GT_MetaTileEntity_BasicTa
     @Override
     public void addUIWidgets(ModularWindow.Builder builder, UIBuildContext buildContext) {
         builder.widget(
-            new SlotWidget(inventoryHandler, 0).setPos(43, 25)
+            new SlotWidget(inventoryHandler, 0).setFilter(this::isItemValidFluidFilledItem)
+                .setPos(43, 25)
                 .setBackground(getGUITextureSet().getItemSlot(), getOverlaySlotIn()))
             .widget(
-                new SlotWidget(inventoryHandler, 1).setPos(43, 61)
+                new SlotWidget(inventoryHandler, 1).setAccess(true, false)
+                    .setPos(43, 61)
                     .setBackground(getGUITextureSet().getItemSlot(), getOverlaySlotOut()))
             .widget(createFuelSlot())
             .widget(createAshSlot())
@@ -472,9 +476,18 @@ public abstract class GT_MetaTileEntity_Boiler extends GT_MetaTileEntity_BasicTa
                     .setSize(18, 18));
     }
 
+    private boolean isItemValidFluidFilledItem(@NotNull ItemStack stack) {
+        return isFluidInputAllowed(GT_Utility.getFluidForFilledItem(stack, true));
+    }
+
     protected Widget createFuelSlot() {
-        return new SlotWidget(inventoryHandler, 2).setPos(115, 61)
+        return new SlotWidget(inventoryHandler, 2).setFilter(this::isItemValidFuel)
+            .setPos(115, 61)
             .setBackground(getFuelSlotBackground());
+    }
+
+    protected boolean isItemValidFuel(@NotNull ItemStack stack) {
+        return true;
     }
 
     protected SlotWidget createAshSlot() {

--- a/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Bronze.java
+++ b/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Bronze.java
@@ -11,8 +11,11 @@ import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_PIPE;
 import static gregtech.api.objects.XSTR.XSTR_INSTANCE;
 
 import net.minecraft.block.Block;
+import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntityFurnace;
 import net.minecraftforge.common.util.ForgeDirection;
+
+import org.jetbrains.annotations.NotNull;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
@@ -28,6 +31,8 @@ import gregtech.api.objects.XSTR;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GT_OreDictUnificator;
 import gregtech.api.util.GT_Utility;
+import gregtech.api.util.ValidationResult;
+import gregtech.api.util.ValidationType;
 import gregtech.api.util.WorldSpawnedEventBuilder.ParticleEventBuilder;
 import gregtech.common.GT_Pollution;
 
@@ -179,129 +184,138 @@ public class GT_MetaTileEntity_Boiler_Bronze extends GT_MetaTileEntity_Boiler {
 
     @Override
     protected void updateFuel(IGregTechTileEntity aBaseMetaTileEntity, long aTick) {
-        if (this.mInventory[2] == null) return;
-        if ((GT_Utility.isPartOfMaterials(this.mInventory[2], Materials.Coal)
-            && !GT_Utility.isPartOfOrePrefix(this.mInventory[2], OrePrefixes.block))
-            || (GT_Utility.isPartOfMaterials(this.mInventory[2], Materials.Charcoal)
-                && !GT_Utility.isPartOfOrePrefix(this.mInventory[2], OrePrefixes.block))
-            || (GT_Utility.isPartOfMaterials(this.mInventory[2], Materials.Lignite)
-                && !GT_Utility.isPartOfOrePrefix(this.mInventory[2], OrePrefixes.block))
-            || (GT_Utility.isPartOfMaterials(this.mInventory[2], Materials.Diamond)
-                && !GT_Utility.isPartOfOrePrefix(this.mInventory[2], OrePrefixes.block))
-            || GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], "fuelCoke")
-            || GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], "fuelCactusCharcoal")
-            || GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], "fuelCactusCoke")
-            || GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], "fuelSugarCharcoal")
-            || GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], "fuelSugarCoke")) {
-            if ((TileEntityFurnace.getItemBurnTime(this.mInventory[2]) / 10) > 0) {
-                this.mProcessingEnergy += (TileEntityFurnace.getItemBurnTime(this.mInventory[2]) / 10);
-                if (XSTR.XSTR_INSTANCE.nextInt(
-                    GT_Utility.isPartOfMaterials(this.mInventory[2], Materials.Coal)
-                        || GT_Utility.isPartOfMaterials(this.mInventory[2], Materials.Charcoal) ? 3
-                            : GT_Utility.isPartOfMaterials(this.mInventory[2], Materials.Lignite) ? 8 : 2)
-                    == 0) {
-                    aBaseMetaTileEntity.addStackToSlot(
-                        3,
-                        GT_OreDictUnificator.get(
-                            OrePrefixes.dustTiny,
-                            (GT_Utility.isPartOfMaterials(this.mInventory[2], Materials.Lignite)
-                                || GT_Utility.isPartOfMaterials(this.mInventory[2], Materials.Coal)) ? Materials.DarkAsh
-                                    : Materials.Ash,
-                            1L));
-                }
-                aBaseMetaTileEntity.decrStackSize(2, 1);
-            }
-        } else if (
+        int fuelItemCombustionEnergy = TileEntityFurnace.getItemBurnTime(mInventory[2]) / 10;
+        if (fuelItemCombustionEnergy <= 0) return;
+        ValidationResult<ItemStack> combustionResult = tryCombustFuel(mInventory[2]);
+        if (combustionResult.getType() == ValidationType.VALID) {
+            this.mProcessingEnergy += fuelItemCombustionEnergy;
+            if (combustionResult.getResult() != null)
+                aBaseMetaTileEntity.addStackToSlot(3, combustionResult.getResult());
+            aBaseMetaTileEntity.decrStackSize(2, 1);
+        }
+    }
+
+    @NotNull
+    private static ValidationResult<ItemStack> tryCombustFuel(@NotNull ItemStack stack) {
+        ValidationType valid = ValidationType.VALID;
+        ItemStack ashes = null;
+        if (isItemSolidCarbonFuelItem(stack)) {
+            ashes = combustSolidCarbonFuelItem(stack);
+        } else if (isItemSolidCarbonFuelBlock(stack)) {
+            ashes = combustSolidCarbonFuelBlock(stack);
+        } else if (isDenseSolidFuel(stack)) {
+            ashes = combustDenseSolidFuel(stack);
+        } else {
+            valid = ValidationType.INVALID;
+        }
+        return ValidationResult.of(valid, ashes);
+    }
+
+    private static boolean isItemSolidCarbonFuelItem(@NotNull ItemStack fuelStack) {
+        return (GT_Utility.isPartOfMaterials(fuelStack, Materials.Coal)
+            && !GT_Utility.isPartOfOrePrefix(fuelStack, OrePrefixes.block))
+            || (GT_Utility.isPartOfMaterials(fuelStack, Materials.Charcoal)
+                && !GT_Utility.isPartOfOrePrefix(fuelStack, OrePrefixes.block))
+            || (GT_Utility.isPartOfMaterials(fuelStack, Materials.Lignite)
+                && !GT_Utility.isPartOfOrePrefix(fuelStack, OrePrefixes.block))
+            || (GT_Utility.isPartOfMaterials(fuelStack, Materials.Diamond)
+                && !GT_Utility.isPartOfOrePrefix(fuelStack, OrePrefixes.block))
+            || GT_OreDictUnificator.isItemStackInstanceOf(fuelStack, "fuelCoke")
+            || GT_OreDictUnificator.isItemStackInstanceOf(fuelStack, "fuelCactusCharcoal")
+            || GT_OreDictUnificator.isItemStackInstanceOf(fuelStack, "fuelCactusCoke")
+            || GT_OreDictUnificator.isItemStackInstanceOf(fuelStack, "fuelSugarCharcoal")
+            || GT_OreDictUnificator.isItemStackInstanceOf(fuelStack, "fuelSugarCoke");
+    }
+
+    private static ItemStack combustSolidCarbonFuelItem(@NotNull ItemStack stack) {
+        return XSTR.XSTR_INSTANCE.nextInt(
+            GT_Utility.isPartOfMaterials(stack, Materials.Coal)
+                || GT_Utility.isPartOfMaterials(stack, Materials.Charcoal) ? 3
+                    : GT_Utility.isPartOfMaterials(stack, Materials.Lignite) ? 8 : 2)
+            == 0 ? GT_OreDictUnificator.get(OrePrefixes.dustTiny, (GT_Utility.isPartOfMaterials(stack, Materials.Lignite) || GT_Utility.isPartOfMaterials(stack, Materials.Coal)) ? Materials.DarkAsh : Materials.Ash, 1L) : null;
+    }
+
+    private static boolean isItemSolidCarbonFuelBlock(@NotNull ItemStack fuelStack) {
         // If its a block of the following materials
-        GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.block.get(Materials.Coal))
-            || GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.block.get(Materials.Lignite))
-            || GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.block.get(Materials.Charcoal))
-            || GT_OreDictUnificator.isItemStackInstanceOf(this.mInventory[2], OrePrefixes.block.get(Materials.Diamond))
+        return GT_OreDictUnificator.isItemStackInstanceOf(fuelStack, OrePrefixes.block.get(Materials.Coal))
+            || GT_OreDictUnificator.isItemStackInstanceOf(fuelStack, OrePrefixes.block.get(Materials.Lignite))
+            || GT_OreDictUnificator.isItemStackInstanceOf(fuelStack, OrePrefixes.block.get(Materials.Charcoal))
+            || GT_OreDictUnificator.isItemStackInstanceOf(fuelStack, OrePrefixes.block.get(Materials.Diamond))
             ||
 
             // if its either a Railcraft Coke Block or a custom GTNH compressed Coal/charcoal/lignite/coke block
-            (Block.getBlockFromItem(this.mInventory[2].getItem()) != null && // check if the block exists
-                (Block.getBlockFromItem(this.mInventory[2].getItem())
+            (Block.getBlockFromItem(fuelStack.getItem()) != null && // check if the block exists
+                (Block.getBlockFromItem(fuelStack.getItem())
                     .getUnlocalizedName()
                     .toLowerCase()
                     .contains("tile") && // check if the block is a tile -> block
                     (
                     // If the name of the block contains these names
-                    Block.getBlockFromItem(this.mInventory[2].getItem())
+                    Block.getBlockFromItem(fuelStack.getItem())
                         .getUnlocalizedName()
                         .toLowerCase()
                         .contains("charcoal")
-                        || Block.getBlockFromItem(this.mInventory[2].getItem())
+                        || Block.getBlockFromItem(fuelStack.getItem())
                             .getUnlocalizedName()
                             .toLowerCase()
                             .contains("coal")
-                        || Block.getBlockFromItem(this.mInventory[2].getItem())
+                        || Block.getBlockFromItem(fuelStack.getItem())
                             .getUnlocalizedName()
                             .toLowerCase()
                             .contains("diamond")
-                        || Block.getBlockFromItem(this.mInventory[2].getItem())
+                        || Block.getBlockFromItem(fuelStack.getItem())
                             .getUnlocalizedName()
                             .toLowerCase()
                             .contains("coke")
-                        || Block.getBlockFromItem(this.mInventory[2].getItem())
+                        || Block.getBlockFromItem(fuelStack.getItem())
                             .getUnlocalizedName()
                             .toLowerCase()
                             .contains("railcraft.cube")
-                        || Block.getBlockFromItem(this.mInventory[2].getItem())
+                        || Block.getBlockFromItem(fuelStack.getItem())
                             .getUnlocalizedName()
                             .toLowerCase()
-                            .contains("lignite"))))) {
-                                // try to add 10% of the burnvalue as Processing energy, no boost
-                                // for coal coke here
-                                if ((TileEntityFurnace.getItemBurnTime(this.mInventory[2]) / 10) > 0) {
-                                    this.mProcessingEnergy += (TileEntityFurnace.getItemBurnTime(this.mInventory[2])
-                                        / 10);
-                                    aBaseMetaTileEntity.addStackToSlot(
-                                        3,
-                                        GT_OreDictUnificator.get(
-                                            OrePrefixes.dust,
-                                            (GT_Utility.isPartOfMaterials(this.mInventory[2], Materials.Lignite)
-                                                || GT_Utility.isPartOfMaterials(this.mInventory[2], Materials.Coal)
-                                                || Block.getBlockFromItem(this.mInventory[2].getItem())
-                                                    .getUnlocalizedName()
-                                                    .toLowerCase()
-                                                    .contains("coal")
-                                                || Block.getBlockFromItem(this.mInventory[2].getItem())
-                                                    .getUnlocalizedName()
-                                                    .toLowerCase()
-                                                    .contains("lignite")) ? Materials.DarkAsh : Materials.Ash,
-                                            1L));
-                                    aBaseMetaTileEntity.decrStackSize(2, 1);
-                                }
-                                // enables every other fuel with at least 2000 burntime as a fuel,
-                                // i.e. peat, Magic/Solid Super Fuel, Coal
-                                // Singularities, Nitor, while bucket of creosite should be blocked
-                                // same goes for lava
-                            } else
-            if ((TileEntityFurnace.getItemBurnTime(this.mInventory[2])) >= 2000
-                && !(this.mInventory[2].getUnlocalizedName()
+                            .contains("lignite"))));
+    }
+
+    private static ItemStack combustSolidCarbonFuelBlock(@NotNull ItemStack stack) {
+        return GT_OreDictUnificator.get(
+            OrePrefixes.dust,
+            (GT_Utility.isPartOfMaterials(stack, Materials.Lignite)
+                || GT_Utility.isPartOfMaterials(stack, Materials.Coal)
+                || Block.getBlockFromItem(stack.getItem())
+                    .getUnlocalizedName()
                     .toLowerCase()
-                    .contains("bucket")
-                    || this.mInventory[2].getUnlocalizedName()
-                        .toLowerCase()
-                        .contains("cell"))) {
-                            this.mProcessingEnergy += (TileEntityFurnace.getItemBurnTime(this.mInventory[2]) / 10);
-                            // adds tiny pile of ash for burntime under 10k, small pile for
-                            // under 100k and pile for
-                            // bigger values
-                            if (XSTR.XSTR_INSTANCE.nextInt(2) == 0)
-                                aBaseMetaTileEntity.addStackToSlot(
-                                    3,
-                                    GT_OreDictUnificator.get(
-                                        (TileEntityFurnace.getItemBurnTime(this.mInventory[2]) >= 10000
-                                            ? TileEntityFurnace.getItemBurnTime(this.mInventory[2]) >= 100000
-                                                ? OrePrefixes.dust
-                                                : OrePrefixes.dustSmall
-                                            : OrePrefixes.dustTiny),
-                                        Materials.Ash,
-                                        1L));
-                            aBaseMetaTileEntity.decrStackSize(2, 1);
-                        }
+                    .contains("coal")
+                || Block.getBlockFromItem(stack.getItem())
+                    .getUnlocalizedName()
+                    .toLowerCase()
+                    .contains("lignite")) ? Materials.DarkAsh : Materials.Ash,
+            1L);
+    }
+
+    private static boolean isDenseSolidFuel(@NotNull ItemStack fuelStack) {
+        // enables every other fuel with at least 2000 burntime as a fuel,
+        // i.e. peat, Magic/Solid Super Fuel, Coal
+        // Singularities, Nitor, while bucket of creosite should be blocked
+        // same goes for lava
+        return (TileEntityFurnace.getItemBurnTime(fuelStack)) >= 2000 && !(fuelStack.getUnlocalizedName()
+            .toLowerCase()
+            .contains("bucket")
+            || fuelStack.getUnlocalizedName()
+                .toLowerCase()
+                .contains("cell"));
+    }
+
+    private static ItemStack combustDenseSolidFuel(@NotNull ItemStack stack) {
+        // adds tiny pile of ash for burntime under 10k, small pile for
+        // under 100k and pile for
+        // bigger values
+        return (XSTR.XSTR_INSTANCE.nextInt(2) == 0) ? GT_OreDictUnificator.get(
+            (TileEntityFurnace.getItemBurnTime(stack) >= 10000
+                ? TileEntityFurnace.getItemBurnTime(stack) >= 100000 ? OrePrefixes.dust : OrePrefixes.dustSmall
+                : OrePrefixes.dustTiny),
+            Materials.Ash,
+            1L) : null;
     }
 
     @Override

--- a/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Bronze.java
+++ b/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Bronze.java
@@ -319,6 +319,12 @@ public class GT_MetaTileEntity_Boiler_Bronze extends GT_MetaTileEntity_Boiler {
     }
 
     @Override
+    protected boolean isItemValidFuel(@NotNull ItemStack stack) {
+        return (TileEntityFurnace.getItemBurnTime(stack) / 10) > 0
+            && (isItemSolidCarbonFuelItem(stack) || isItemSolidCarbonFuelBlock(stack) || isDenseSolidFuel(stack));
+    }
+
+    @Override
     public SteamVariant getSteamVariant() {
         return SteamVariant.BRONZE;
     }

--- a/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Bronze.java
+++ b/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Bronze.java
@@ -23,7 +23,6 @@ import gregtech.GT_Mod;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.enums.ParticleFX;
-import gregtech.api.enums.SteamVariant;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
@@ -83,11 +82,6 @@ public class GT_MetaTileEntity_Boiler_Bronze extends GT_MetaTileEntity_Boiler {
             rTextures[4][i] = texFrontActive;
         }
         return rTextures;
-    }
-
-    @Override
-    public int maxProgresstime() {
-        return 500;
     }
 
     @Override
@@ -324,8 +318,4 @@ public class GT_MetaTileEntity_Boiler_Bronze extends GT_MetaTileEntity_Boiler {
             && (isItemSolidCarbonFuelItem(stack) || isItemSolidCarbonFuelBlock(stack) || isDenseSolidFuel(stack));
     }
 
-    @Override
-    public SteamVariant getSteamVariant() {
-        return SteamVariant.BRONZE;
-    }
 }

--- a/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Lava.java
+++ b/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Lava.java
@@ -388,14 +388,7 @@ public class GT_MetaTileEntity_Boiler_Lava extends GT_MetaTileEntity_Boiler {
     }
 
     @Override
-    public boolean allowPullStack(IGregTechTileEntity aBaseMetaTileEntity, int aIndex, ForgeDirection side,
-        ItemStack aStack) {
-        return true;
-    }
-
-    @Override
-    public boolean allowPutStack(IGregTechTileEntity aBaseMetaTileEntity, int aIndex, ForgeDirection side,
-        ItemStack aStack) {
+    protected boolean isAutomatable() {
         return true;
     }
 

--- a/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Lava.java
+++ b/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Lava.java
@@ -31,12 +31,8 @@ import net.minecraftforge.fluids.IFluidHandler;
 import net.minecraftforge.fluids.IFluidTank;
 
 import com.gtnewhorizons.modularui.api.drawable.IDrawable;
-import com.gtnewhorizons.modularui.api.screen.ModularWindow;
-import com.gtnewhorizons.modularui.api.screen.UIBuildContext;
-import com.gtnewhorizons.modularui.common.widget.DrawableWidget;
+import com.gtnewhorizons.modularui.api.widget.Widget;
 import com.gtnewhorizons.modularui.common.widget.FluidSlotWidget;
-import com.gtnewhorizons.modularui.common.widget.ProgressBar;
-import com.gtnewhorizons.modularui.common.widget.SlotWidget;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
@@ -466,48 +462,9 @@ public class GT_MetaTileEntity_Boiler_Lava extends GT_MetaTileEntity_Boiler {
     }
 
     @Override
-    public void addUIWidgets(ModularWindow.Builder builder, UIBuildContext buildContext) {
-        builder.widget(
-            new SlotWidget(inventoryHandler, 0).setPos(43, 25)
-                .setBackground(getGUITextureSet().getItemSlot(), getOverlaySlotIn()))
-            .widget(
-                new SlotWidget(inventoryHandler, 1).setAccess(true, false)
-                    .setPos(43, 61)
-                    .setBackground(getGUITextureSet().getItemSlot(), getOverlaySlotOut()))
-            .widget(
-                new FluidSlotWidget(lavaTank).setBackground(getGUITextureSet().getFluidSlot(), getOverlaySlotIn())
-                    .setPos(115, 61))
-            .widget(createAshSlot())
-            .widget(
-                new ProgressBar().setProgress(() -> mSteam == null ? 0 : (float) mSteam.amount / getSteamCapacity())
-                    .setTexture(getProgressbarEmpty(), GT_UITextures.PROGRESSBAR_BOILER_STEAM, 10)
-                    .setDirection(ProgressBar.Direction.UP)
-                    .setPos(70, 25)
-                    .setSize(10, 54))
-            .widget(
-                new ProgressBar().setProgress(() -> mFluid == null ? 0 : (float) mFluid.amount / getCapacity())
-                    .setTexture(getProgressbarEmpty(), GT_UITextures.PROGRESSBAR_BOILER_WATER, 10)
-                    .setDirection(ProgressBar.Direction.UP)
-                    .setPos(83, 25)
-                    .setSize(10, 54))
-            .widget(
-                new ProgressBar().setProgress(() -> (float) mTemperature / maxProgresstime())
-                    .setTexture(getProgressbarEmpty(), GT_UITextures.PROGRESSBAR_BOILER_HEAT, 10)
-                    .setDirection(ProgressBar.Direction.UP)
-                    .setPos(96, 25)
-                    .setSize(10, 54))
-            .widget(
-                new ProgressBar()
-                    // cap minimum so that one can easily see there's fuel remaining
-                    .setProgress(() -> mProcessingEnergy > 0 ? Math.max((float) mProcessingEnergy / 1000, 1f / 5) : 0)
-                    .setTexture(getProgressbarFuel(), 14)
-                    .setDirection(ProgressBar.Direction.UP)
-                    .setPos(116, 45)
-                    .setSize(14, 14))
-            .widget(
-                new DrawableWidget().setDrawable(getOverlaySlotCanister())
-                    .setPos(43, 43)
-                    .setSize(18, 18));
+    protected Widget createFuelSlot() {
+        return new FluidSlotWidget(lavaTank).setBackground(getGUITextureSet().getFluidSlot(), getOverlaySlotIn())
+            .setPos(115, 61);
     }
 
     static class LavaTank extends FluidTank {

--- a/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Solar.java
+++ b/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Solar.java
@@ -16,6 +16,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import com.gtnewhorizons.modularui.api.drawable.IDrawable;
+import com.gtnewhorizons.modularui.api.widget.Widget;
 import com.gtnewhorizons.modularui.common.widget.SlotWidget;
 
 import gregtech.api.enums.Dyes;
@@ -287,9 +288,9 @@ public class GT_MetaTileEntity_Boiler_Solar extends GT_MetaTileEntity_Boiler {
     }
 
     @Override
-    protected SlotWidget createFuelSlot() {
+    protected Widget createFuelSlot() {
         // todo: remove this slot after some time
-        return super.createFuelSlot().setAccess(true, false);
+        return ((SlotWidget) super.createFuelSlot()).setAccess(true, false);
     }
 
     @Override

--- a/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Solar.java
+++ b/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Solar.java
@@ -15,14 +15,12 @@ import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import com.gtnewhorizons.modularui.api.drawable.IDrawable;
 import com.gtnewhorizons.modularui.api.widget.Widget;
 import com.gtnewhorizons.modularui.common.widget.SlotWidget;
 
 import gregtech.api.enums.Dyes;
 import gregtech.api.enums.SteamVariant;
 import gregtech.api.enums.Textures.BlockIcons;
-import gregtech.api.gui.modularui.GT_UITextures;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
@@ -278,25 +276,13 @@ public class GT_MetaTileEntity_Boiler_Solar extends GT_MetaTileEntity_Boiler {
     }
 
     @Override
-    protected IDrawable[] getFuelSlotBackground() {
-        return new IDrawable[] { GT_UITextures.TRANSPARENT };
-    }
-
-    @Override
-    protected IDrawable[] getAshSlotBackground() {
-        return new IDrawable[] { GT_UITextures.TRANSPARENT };
-    }
-
-    @Override
     protected Widget createFuelSlot() {
-        // todo: remove this slot after some time
-        return ((SlotWidget) super.createFuelSlot()).setAccess(true, false);
+        return null;
     }
 
     @Override
     protected SlotWidget createAshSlot() {
-        // todo: remove this slot after some time
-        return super.createAshSlot().setAccess(true, false);
+        return null;
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/generators/GT_MetaTileEntity_Boiler_Base.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/generators/GT_MetaTileEntity_Boiler_Base.java
@@ -6,6 +6,7 @@ import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.FluidTankInfo;
 
 import org.apache.commons.lang3.ArrayUtils;
+import org.jetbrains.annotations.NotNull;
 
 import com.gtnewhorizons.modularui.api.drawable.IDrawable;
 import com.gtnewhorizons.modularui.api.drawable.UITexture;
@@ -208,6 +209,11 @@ public class GT_MetaTileEntity_Boiler_Base extends GT_MetaTileEntity_Boiler {
         if (burnTime > 0 && this.mTemperature <= 101) {
             consumeFuel(tile, fuelStack, burnTime);
         }
+    }
+
+    @Override
+    protected boolean isItemValidFuel(@NotNull ItemStack stack) {
+        return getBurnTime(stack) > 0;
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/generators/GT_MetaTileEntity_Boiler_Base.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/generators/GT_MetaTileEntity_Boiler_Base.java
@@ -225,15 +225,8 @@ public class GT_MetaTileEntity_Boiler_Base extends GT_MetaTileEntity_Boiler {
     }
 
     @Override
-    public boolean allowPullStack(IGregTechTileEntity aBaseMetaTileEntity, int aIndex, ForgeDirection side,
-        ItemStack aStack) {
-        return aIndex == 1 || aIndex == 3;
-    }
-
-    @Override
-    public boolean allowPutStack(IGregTechTileEntity aBaseMetaTileEntity, int aIndex, ForgeDirection side,
-        ItemStack aStack) {
-        return aIndex == 2;
+    protected boolean isAutomatable() {
+        return true;
     }
 
     @Override


### PR DESCRIPTION
### Reason for change
Shift-clicking item stacks into boilers annoyingly always places them in the fluid container slot, which is almost never the intended behavior, as the only input you cannot automate early on is fuel items. This PR makes sure shift clicking item stacks into a boiler always a sensible outcome.

### Affected machines
- Small Coal Boiler
- High Pressure Coal Boiler
- High Pressure Lava Boiler
- Simple Solar Boiler
- High pressure Solar Boiler
- Advanced Boiler[LV]
- Advanced Boiler[MV]
- Advanced Boiler[HV]

### General changes
- Clicking slots, shift-clicking item stacks and item pipes can no longer place items in stacks where they do not belong.
  - Specifically: fuel slots only accept items the boiler will consume for fuel and fluid container input slots will only accept containers which the boiler will drain. (Water for all, and also lava for **High Pressure Lava Boiler**)
  - As a result, you can no longer place any items in output slots.
- Item pipes can no longer pull items from input slots.

### Machine specific changes
 - Solar Boilers still had 2 unusable slots which were made unusable 2 years ago with intent to remove them at a later time. Now should be safe to remove them entirely, so this was done.

### Balance considerations
- None, as long as you don't consider annoying UI and item pipe interactions part of a hidden automation challenge.

### Backwards incompatible API changes
- `GT_MetaTileEntity_Boiler::createFuelSlot`'s return type was changed from `SlotWidget` to `Widget` which could in theory break overrides of that method which depend on `SlotWidget` specific functionality in the return value of `super()`, but a code search makes me confident that there is no such instance of this in the codebase that wasn't corrected as part of this PR.

## Media
![before](https://github.com/user-attachments/assets/3bdbbc68-e619-4230-b470-af9440f80132)
*Before*

![shift-click-works](https://github.com/user-attachments/assets/ab8d1f7e-33e2-458b-952f-9adc37ddc385)
*After*

![solar-boiler-old-slots](https://github.com/user-attachments/assets/a2ccebcb-23a9-4db6-ba03-0d97e4921958)
*These unusable slots are gone*

![image](https://github.com/user-attachments/assets/9bdf57b5-0df5-4cb5-90c7-883955929468)
*Pipes can't create this mess anymore*