### PR TITLE
Fix research collision

### DIFF
--- a/src/main/java/com/github/technus/tectech/loader/recipe/ResearchStationAssemblyLine.java
+++ b/src/main/java/com/github/technus/tectech/loader/recipe/ResearchStationAssemblyLine.java
@@ -3257,7 +3257,7 @@ public class ResearchStationAssemblyLine implements Runnable {
 
         // 4M UXV Target
         TT_recipeAdder.addResearchableAssemblylineRecipe(
-            CustomItemList.eM_energyTunnel7_UXV.get(1),
+            CustomItemList.eM_energyTunnel8_UMV.get(1),
             totalComputation * 64,
             compPerSecond * 64,
             researchEuPerTick * 4,

--- a/src/main/java/com/github/technus/tectech/loader/recipe/ResearchStationAssemblyLine.java
+++ b/src/main/java/com/github/technus/tectech/loader/recipe/ResearchStationAssemblyLine.java
@@ -577,12 +577,12 @@ public class ResearchStationAssemblyLine implements Runnable {
 
         // Transcendent Plasma Mixer - TPM.
         TT_recipeAdder.addResearchableAssemblylineRecipe(
-            CustomItemList.eM_energyTunnel7_UV.get(1),
+            CustomItemList.eM_energyTunnel6_UEV.get(1),
             32_000_000,
             4096,
             (int) TierEU.RECIPE_UIV,
             1,
-            new Object[] { CustomItemList.eM_energyTunnel7_UV.get(32),
+            new Object[] { CustomItemList.eM_energyTunnel6_UEV.get(4),
                 new Object[] { OrePrefixes.circuit.get(Materials.UMV), 32L }, ItemList.Electric_Pump_UIV.get(16),
                 GT_OreDictUnificator.get(OrePrefixes.plate, MaterialsUEVplus.TranscendentMetal, 64),
 


### PR DESCRIPTION
UXV 1M Laser Target Hatch was used for both 1M Wireless and 4M Target hatch

Change 4M Target to use 4M UMV Target instead