### PR TITLE
Adjust T4 waterline logic to avoid automation cheese

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/purification/GT_MetaTileEntity_PurificationUnitPhAdjustment.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/purification/GT_MetaTileEntity_PurificationUnitPhAdjustment.java
@@ -513,7 +513,7 @@ public class GT_MetaTileEntity_PurificationUnitPhAdjustment
 
             // If pH is 0 or 14, stop the machine
             if (Math.abs(this.currentpHValue) < 0.001 || Math.abs(this.currentpHValue - 14.0f) < 0.001) {
-                stopMachine(new SimpleShutDownReason("critical_ph_value", false));
+                stopMachine(SimpleShutDownReason.ofNormal("critical_ph_value"));
             }
         }
     }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/purification/GT_MetaTileEntity_PurificationUnitPhAdjustment.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/purification/GT_MetaTileEntity_PurificationUnitPhAdjustment.java
@@ -55,6 +55,7 @@ import gregtech.api.util.GT_Multiblock_Tooltip_Builder;
 import gregtech.api.util.GT_StructureUtility;
 import gregtech.api.util.GT_Utility;
 import gregtech.api.util.IGT_HatchAdder;
+import gregtech.api.util.shutdown.SimpleShutDownReason;
 
 public class GT_MetaTileEntity_PurificationUnitPhAdjustment
     extends GT_MetaTileEntity_PurificationUnitBase<GT_MetaTileEntity_PurificationUnitPhAdjustment>
@@ -349,6 +350,7 @@ public class GT_MetaTileEntity_PurificationUnitPhAdjustment
                     + "of 7.0 pH at the end of the cycle, the recipe always succeeds.")
             .addInfo("Otherwise, the recipe always fails.")
             .addInfo("Use a pH Sensor Hatch to read the current pH value.")
+            .addInfo("For safety, the machine will shut down if the pH goes below 0 or exceeds 14.")
             .addSeparator()
             .addInfo(
                 "Every " + EnumChatFormatting.RED
@@ -508,6 +510,11 @@ public class GT_MetaTileEntity_PurificationUnitPhAdjustment
 
             // Round to 2 decimals
             this.currentpHValue = Math.round(this.currentpHValue * 100.0f) / 100.0f;
+
+            // If pH is 0 or 14, stop the machine
+            if (Math.abs(this.currentpHValue) < 0.001 || Math.abs(this.currentpHValue - 14.0f) < 0.001) {
+                stopMachine(new SimpleShutDownReason("critical_ph_value", false));
+            }
         }
     }
 

--- a/src/main/resources/assets/gregtech/lang/en_US.lang
+++ b/src/main/resources/assets/gregtech/lang/en_US.lang
@@ -557,6 +557,7 @@ GT5U.gui.text.no_repair=§4Shut down due to machine damage.
 GT5U.gui.text.no_machine_part=No correct machine part in controller slot.
 GT5U.gui.text.missing_item=§7Missing required item: §b%s§f
 GT5U.gui.text.ph_sensor=pH threshold
+GT5U.gui.text.critical_ph_value=pH exceeded critical value.
 
 GT5U.item.programmed_circuit.select.header=Reprogram Circuit
 


### PR DESCRIPTION
Automation for T4 could be cheesed by first inserting a bunch of HCl, lowering pH to zero, and then inserting exactly 700 NaOH to get it to exactly 7. This is a simple fix that will shut down the machine if a critical value is reached, preventing any sort of cheese using this method.