### PR TITLE
Fix ph sensor not taking decimal numbers

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/purification/GT_MetaTileEntity_pHSensor.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/purification/GT_MetaTileEntity_pHSensor.java
@@ -177,8 +177,9 @@ public class GT_MetaTileEntity_pHSensor extends GT_MetaTileEntity_Hatch {
                     .setPos(28, 12))
             .widget(
                 new NumericWidget().setBounds(0, 14.0)
+                    .setIntegerOnly(false)
                     .setGetter(() -> (double) threshold)
-                    .setSetter((value) -> threshold = (float) value)
+                    .setSetter((value) -> threshold = (float) Math.round(value * 100.0) / 100.0f)
                     .setScrollValues(0.1, 0.01, 1.0)
                     .setMaximumFractionDigits(2)
                     .setTextColor(Color.WHITE.dark(1))


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ccafef88-d436-4c1b-8d49-95c0674d5e28)
The sensor was always supposed to be able to take in decimals, not just integer values, but this never worked properly.