### PR TITLE
Fix opencomputers cheese of T8 waterline

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/purification/GT_MetaTileEntity_PurificationUnitParticleExtractor.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/purification/GT_MetaTileEntity_PurificationUnitParticleExtractor.java
@@ -479,9 +479,6 @@ public class GT_MetaTileEntity_PurificationUnitParticleExtractor
 
     @Override
     public void saveNBTData(NBTTagCompound aNBT) {
-        if (this.currentCombination != null) {
-            aNBT.setTag("currentCombination", this.currentCombination.saveToNBT());
-        }
         NBTTagCompound insertedNBT = new NBTTagCompound();
         for (int i = 0; i < insertedCatalysts.size(); ++i) {
             ItemStack inserted = insertedCatalysts.get(i);
@@ -496,9 +493,8 @@ public class GT_MetaTileEntity_PurificationUnitParticleExtractor
 
     @Override
     public void loadNBTData(NBTTagCompound aNBT) {
-        if (aNBT.hasKey("currentCombination")) {
-            currentCombination = CatalystCombination.readFromNBT(aNBT.getCompoundTag("currentCombination"));
-        }
+        // Generate a random combination on load
+        currentCombination = generateNewCombination();
         if (aNBT.hasKey("insertedItems")) {
             NBTTagCompound insertedList = aNBT.getCompoundTag("insertedItems");
             // Initialize empty list with correct size


### PR DESCRIPTION
By saving the correct combination in NBT you can read out the combination using opencomputers and cheese the entire puzzle.

This fix will cause the multi to regenerate a random combination if it's running on world load, which might cause one cycle to fail, but I think this is a fine tradeoff