### PR TITLE
Clean up goodgen reflecting nhcoremod

### DIFF
--- a/src/main/java/goodgenerator/loader/ComponentAssemblyLineMiscRecipes.java
+++ b/src/main/java/goodgenerator/loader/ComponentAssemblyLineMiscRecipes.java
@@ -14,7 +14,6 @@ import static goodgenerator.util.ItemRefer.Compassline_Casing_UV;
 import static goodgenerator.util.ItemRefer.Compassline_Casing_UXV;
 import static goodgenerator.util.ItemRefer.Compassline_Casing_ZPM;
 import static goodgenerator.util.ItemRefer.Component_Assembly_Line;
-import static goodgenerator.util.Log.LOGGER;
 import static gregtech.api.recipe.RecipeMaps.assemblerRecipes;
 import static gregtech.api.util.GT_RecipeBuilder.HOURS;
 import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
@@ -31,8 +30,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
-
-import org.apache.logging.log4j.Level;
 
 import com.github.bartimaeusnek.bartworks.system.material.WerkstoffLoader;
 import com.github.technus.tectech.recipe.TT_recipeAdder;
@@ -64,20 +61,6 @@ public class ComponentAssemblyLineMiscRecipes {
 
         generateCasingRecipes();
         generateWrapRecipes();
-        // Try and find the ZPM Fluid solidifier
-        ItemStack solidifier;
-        try {
-            Class<?> c = Class.forName("com.dreammaster.gthandler.CustomItemList");
-            Object maybeSolidifier = c.getMethod("valueOf", String.class)
-                .invoke(null, "FluidSolidifierZPM");
-            solidifier = (ItemStack) (c.getMethod("get", long.class, Object[].class)
-                .invoke(maybeSolidifier, 16L, null));
-            if (GT_Utility.isStackValid(solidifier)) LOGGER.log(Level.INFO, "ZPM Fluid Solidifier found.");
-            else throw new NullPointerException();
-        } catch (Exception e) {
-            LOGGER.log(Level.ERROR, "ZPM Fluid Solidifier not found, falling back to IV.", e);
-            solidifier = ItemList.Machine_IV_FluidSolidifier.get(16);
-        }
 
         // The controller itself
         GT_Values.RA.stdBuilder()
@@ -95,7 +78,7 @@ public class ComponentAssemblyLineMiscRecipes {
                     .get(32),
                 GT_OreDictUnificator.get(OrePrefixes.pipeMedium, Materials.Polybenzimidazole, 16),
                 GT_OreDictUnificator.get(OrePrefixes.plateDense, Materials.Iridium, 32),
-                solidifier,
+                ItemList.FluidSolidifierZPM.get(16L),
                 getALCircuit(8, 16),
                 getALCircuit(7, 20),
                 getALCircuit(6, 24))


### PR DESCRIPTION
removes goodgen reflecting nhcoremod which fixes the CoAL recipe after some MTEs were moved from nhcoremod to gt.

![image](https://github.com/user-attachments/assets/443b5e25-d689-4849-a005-b79f8af41c35)
