### PR TITLE
Fix silver nanite recipe time

### DIFF
--- a/src/main/java/gregtech/loaders/postload/chains/GT_NaniteChain.java
+++ b/src/main/java/gregtech/loaders/postload/chains/GT_NaniteChain.java
@@ -106,7 +106,7 @@ public class GT_NaniteChain {
             .itemOutputs(Materials.Silver.getNanite(1))
             .fluidInputs(Materials.UUMatter.getFluid(200_000))
             .metadata(NANO_FORGE_TIER, 2)
-            .duration(37 * MINUTES + 30 * SECONDS)
+            .duration(12 * MINUTES + 30 * SECONDS)
             .eut(10_000_000)
             .addTo(nanoForgeRecipes);
 


### PR DESCRIPTION
RA2 port accidentally changed silver nanite time from the intended 750 seconds to 2250 seconds. This reverts the time back to the original