### PR TITLE
Replace all instances of Master/Slave dynamic within Optical and Data Bank/Assline Connector hatches

### DIFF
--- a/src/main/java/com/github/technus/tectech/loader/thing/MachineLoader.java
+++ b/src/main/java/com/github/technus/tectech/loader/thing/MachineLoader.java
@@ -2533,25 +2533,25 @@ public class MachineLoader implements Runnable {
             new GT_MetaTileEntity_Hatch_InputData(
                 OpticalSlaveConnector.ID,
                 "hatch.datain.tier.07",
-                "Optical Slave Connector",
+                "Optical Data Reception Connector",
                 7).getStackForm(1L));
         dataOut_Hatch.set(
             new GT_MetaTileEntity_Hatch_OutputData(
                 OpticalMasterConnector.ID,
                 "hatch.dataout.tier.07",
-                "Optical Master Connector",
+                "Optical Data Transmission Connector",
                 7).getStackForm(1L));
         dataInAss_Hatch.set(
             new GT_MetaTileEntity_Hatch_InputDataItems(
                 AssemblylineSlaveConnector.ID,
                 "hatch.datainass.tier.07",
-                "Assembly line Slave Connector",
+                "Assembly line Reception Connector",
                 7).getStackForm(1L));
         dataOutAss_Hatch.set(
             new GT_MetaTileEntity_Hatch_OutputDataItems(
                 DataBankMasterConnector.ID,
                 "hatch.dataoutass.tier.07",
-                "Data Bank Master Connector",
+                "Data Bank Transmission Connector",
                 7).getStackForm(1L));
         dataOut_Wireless_Hatch.set(
             new GT_MetaTileEntity_Hatch_WirelessComputation_Output(
@@ -2569,13 +2569,13 @@ public class MachineLoader implements Runnable {
             new GT_MetaTileEntity_Hatch_WirelessInputDataItems(
                 WirelessAssemblylineSlaveConnector.ID,
                 "hatch.datainass.wireless.tier.12",
-                "Wireless Assembly line Slave Connector",
+                "Wireless Assembly line Reception Connector",
                 12).getStackForm(1L));
         dataOutAss_Wireless_Hatch.set(
             new GT_MetaTileEntity_Hatch_WirelessOutputDataItems(
                 WirelessDataBankMasterConnector.ID,
                 "hatch.dataoutass.wireless.tier.12",
-                "Wireless Data Bank Master Connector",
+                "Wireless Data Bank Transmission Connector",
                 12).getStackForm(1L));
         rack_Hatch.set(
             new GT_MetaTileEntity_Hatch_Rack(ComputerRack.ID, "hatch.rack.tier.08", "Computer Rack", 8)

--- a/src/main/java/com/github/technus/tectech/loader/thing/MachineLoader.java
+++ b/src/main/java/com/github/technus/tectech/loader/thing/MachineLoader.java
@@ -2533,13 +2533,13 @@ public class MachineLoader implements Runnable {
             new GT_MetaTileEntity_Hatch_InputData(
                 OpticalSlaveConnector.ID,
                 "hatch.datain.tier.07",
-                "Optical Data Reception Connector",
+                "Optical Reception Connector",
                 7).getStackForm(1L));
         dataOut_Hatch.set(
             new GT_MetaTileEntity_Hatch_OutputData(
                 OpticalMasterConnector.ID,
                 "hatch.dataout.tier.07",
-                "Optical Data Transmission Connector",
+                "Optical Transmission Connector",
                 7).getStackForm(1L));
         dataInAss_Hatch.set(
             new GT_MetaTileEntity_Hatch_InputDataItems(

--- a/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_Slave.java
+++ b/src/main/java/gregtech/common/tileentities/machines/GT_MetaTileEntity_Hatch_CraftingInput_Slave.java
@@ -42,7 +42,7 @@ public class GT_MetaTileEntity_Hatch_CraftingInput_Slave extends GT_MetaTileEnti
             aNameRegional,
             6,
             0,
-            new String[] { "Slave for Crafting Input Buffer/Bus",
+            new String[] { "Proxy for Crafting Input Buffer/Bus",
                 "Link with Crafting Input Buffer/Bus using Data Stick to share inventory",
                 "Left click on the Crafting Input Buffer/Bus, then right click on this block to link them", });
         disableSort = true;

--- a/src/main/java/gregtech/loaders/preload/GT_Loader_MetaTileEntities.java
+++ b/src/main/java/gregtech/loaders/preload/GT_Loader_MetaTileEntities.java
@@ -10248,8 +10248,8 @@ public class GT_Loader_MetaTileEntities implements Runnable { // TODO CHECK CIRC
         ItemList.Hatch_CraftingInput_Bus_Slave.set(
             new GT_MetaTileEntity_Hatch_CraftingInput_Slave(
                 CRAFTING_INPUT_SLAVE.ID,
-                "hatch.crafting_input.slave",
-                "Crafting Input Slave").getStackForm(1L));
+                "hatch.crafting_input.proxy",
+                "Crafting Input Proxy").getStackForm(1L));
     }
 
     private static void registerMagHatch() {

--- a/src/main/resources/assets/tectech/lang/en_US.lang
+++ b/src/main/resources/assets/tectech/lang/en_US.lang
@@ -507,17 +507,17 @@ gt.blockmachines.hatch.certain.tier.10.name=Uncertainty Resolver X
 gt.blockmachines.hatch.certain.desc.0=Feeling certain, or not?
 gt.blockmachines.hatch.certain.desc.1=Schrödinger equation in a box
 
-gt.blockmachines.hatch.datain.tier.07.name=Optical Slave Connector
+gt.blockmachines.hatch.datain.tier.07.name=Optical Data Reception Connector
 gt.blockmachines.hatch.datain.desc.0=Quantum Data Input for Multiblocks
 gt.blockmachines.hatch.datain.desc.1=High speed fibre optics connector.
 gt.blockmachines.hatch.datain.desc.2=Must be painted to work
 
-gt.blockmachines.hatch.dataout.tier.07.name=Optical Master Connector
+gt.blockmachines.hatch.dataout.tier.07.name=Optical Data Transmission Connector
 gt.blockmachines.hatch.dataout.desc.0=Quantum Data Output for Multiblocks
 gt.blockmachines.hatch.dataout.desc.1=High speed fibre optics connector.
 gt.blockmachines.hatch.dataout.desc.2=Must be painted to work
 
-gt.blockmachines.hatch.datainass.tier.07.name=Assembly line Slave Connector
+gt.blockmachines.hatch.datainass.tier.07.name=Assembly line Reception Connector
 gt.blockmachines.hatch.datainass.desc.0=ItemStack Data Input for Multiblocks
 gt.blockmachines.hatch.datainass.desc.1=High speed fibre optics connector.
 gt.blockmachines.hatch.datainass.desc.2=Must be painted to work
@@ -525,7 +525,7 @@ gt.blockmachines.hatch.datainass.desc.2=Must be painted to work
 gt.blockmachines.hatch.datainasswireless.desc.0=Wireless ItemStack Data Input for Multiblocks
 gt.blockmachines.hatch.datainasswireless.desc.1=High speed internet connection
 
-gt.blockmachines.hatch.dataoutass.tier.07.name=Data Bank Master Connector
+gt.blockmachines.hatch.dataoutass.tier.07.name=Data Bank Transmission Connector
 gt.blockmachines.hatch.dataoutass.desc.0=ItemStack Data Output for Multiblocks
 gt.blockmachines.hatch.dataoutass.desc.1=High speed fibre optics connector.
 gt.blockmachines.hatch.dataoutass.desc.2=Must be painted to work

--- a/src/main/resources/assets/tectech/lang/en_US.lang
+++ b/src/main/resources/assets/tectech/lang/en_US.lang
@@ -507,12 +507,12 @@ gt.blockmachines.hatch.certain.tier.10.name=Uncertainty Resolver X
 gt.blockmachines.hatch.certain.desc.0=Feeling certain, or not?
 gt.blockmachines.hatch.certain.desc.1=Schrödinger equation in a box
 
-gt.blockmachines.hatch.datain.tier.07.name=Optical Data Reception Connector
+gt.blockmachines.hatch.datain.tier.07.name=Optical Reception Connector
 gt.blockmachines.hatch.datain.desc.0=Quantum Data Input for Multiblocks
 gt.blockmachines.hatch.datain.desc.1=High speed fibre optics connector.
 gt.blockmachines.hatch.datain.desc.2=Must be painted to work
 
-gt.blockmachines.hatch.dataout.tier.07.name=Optical Data Transmission Connector
+gt.blockmachines.hatch.dataout.tier.07.name=Optical Transmission Connector
 gt.blockmachines.hatch.dataout.desc.0=Quantum Data Output for Multiblocks
 gt.blockmachines.hatch.dataout.desc.1=High speed fibre optics connector.
 gt.blockmachines.hatch.dataout.desc.2=Must be painted to work


### PR DESCRIPTION
This PR distances these hatches from their previous names in an attempt to make some users feel more comfortable

- Replaced "Master" with "Transmission"
- Replaced "Slave"\* with "Reception"
- Replace the \*"Slave" in "Crafting Input Slave" with "Proxy"