### PR TITLE
Fix laser engraver recipemap comparator

### DIFF
--- a/src/main/java/gregtech/api/recipe/RecipeMaps.java
+++ b/src/main/java/gregtech/api/recipe/RecipeMaps.java
@@ -290,21 +290,10 @@ public final class RecipeMaps {
             (index, isFluid, isOutput,
                 isSpecial) -> !isFluid && !isOutput && index != 0 ? GT_UITextures.OVERLAY_SLOT_LENS : null)
         // Add a simple ordering so lower tier purified water is displayed first, otherwise it gets really confusing
-        .neiRecipeComparator((a, b) -> {
-            // Find lens, if no lens was present we can use the default comparator
-            if (a.mInputs.length > 1 && b.mInputs.length > 1) {
-                ItemStack firstLens = a.mInputs[1];
-                ItemStack secondLens = b.mInputs[1];
-                // Find purified water/any fluid, if none was present simply use the lens to compare
-                if (ItemStack.areItemStacksEqual(firstLens, secondLens) && a.mFluidInputs.length > 0
-                    && b.mFluidInputs.length > 0) {
-                    return Comparator
-                        .<GT_Recipe, Integer>comparing(r -> PurifiedWaterHelpers.getWaterTier(r.mFluidInputs[0]))
-                        .compare(a, b);
-                }
-            }
-            return a.compareTo(b);
-        })
+        .neiRecipeComparator(
+            (a, b) -> Comparator.comparing(PurifiedWaterHelpers::getWaterTierFromRecipe)
+                .thenComparing(GT_Recipe::compareTo)
+                .compare(a, b))
         .build();
     public static final RecipeMap<RecipeMapBackend> mixerRecipes = RecipeMapBuilder.of("gt.recipe.mixer")
         .maxIO(9, 4, 1, 1)

--- a/src/main/java/gregtech/common/tileentities/machines/multi/purification/PurifiedWaterHelpers.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/purification/PurifiedWaterHelpers.java
@@ -3,6 +3,7 @@ package gregtech.common.tileentities.machines.multi.purification;
 import net.minecraftforge.fluids.FluidStack;
 
 import gregtech.api.enums.Materials;
+import gregtech.api.util.GT_Recipe;
 
 public class PurifiedWaterHelpers {
 
@@ -31,5 +32,11 @@ public class PurifiedWaterHelpers {
         else if (fluid.isFluidEqual(Materials.Grade7PurifiedWater.getFluid(1000L))) return 7;
         else if (fluid.isFluidEqual(Materials.Grade8PurifiedWater.getFluid(1000L))) return 8;
         else return 0;
+    }
+
+    // Used to construct NEI comparator for water tier. Returns 0 if no water is used in this recipe
+    public static int getWaterTierFromRecipe(GT_Recipe recipe) {
+        if (recipe.mFluidInputs.length == 0) return 0;
+        else return getWaterTier(recipe.mFluidInputs[0]);
     }
 }


### PR DESCRIPTION
Should fix the recipe map not generating properly, this comparator should be properly transitive (and as a bonus it's a lot simpler)