### PR TITLE
Cake CAL only eat a single imprint instead of the entire stack

### DIFF
--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_CircuitAssemblyLine.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_CircuitAssemblyLine.java
@@ -229,6 +229,7 @@ public class GT_TileEntity_CircuitAssemblyLine extends
             && this.type.equals(new NBTTagCompound())) {
             this.type = itemStack.getTagCompound();
             this.mInventory[1].stackSize -= 1;
+            if (this.mInventory[1].stackSize <= 0) this.mInventory[1] = null;
             this.getBaseMetaTileEntity()
                 .issueBlockUpdate();
             return true;

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_CircuitAssemblyLine.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_CircuitAssemblyLine.java
@@ -228,7 +228,7 @@ public class GT_TileEntity_CircuitAssemblyLine extends
             && itemStack.getTagCompound() != null
             && this.type.equals(new NBTTagCompound())) {
             this.type = itemStack.getTagCompound();
-            this.mInventory[1] = null;
+            this.mInventory[1].stackSize -= 1;
             this.getBaseMetaTileEntity()
                 .issueBlockUpdate();
             return true;


### PR DESCRIPTION
When imprinting a CAL, if you insert a stack of imprints it will happily eat the entire stack even if it only eats one. This PR simply changes the behaviour to instead only consume a single item.