### PR TITLE
remove crowbar playing breaking sounds when not breaking

### DIFF
--- a/src/main/java/gregtech/common/tools/GT_Tool_Crowbar.java
+++ b/src/main/java/gregtech/common/tools/GT_Tool_Crowbar.java
@@ -10,7 +10,6 @@ import net.minecraft.util.IChatComponent;
 
 import com.google.common.base.Strings;
 
-import gregtech.api.enums.SoundResource;
 import gregtech.api.enums.Textures;
 import gregtech.api.interfaces.IIconContainer;
 import gregtech.api.interfaces.IToolStats;
@@ -62,17 +61,17 @@ public class GT_Tool_Crowbar extends GT_Tool {
 
     @Override
     public String getCraftingSound() {
-        return SoundResource.RANDOM_BREAK.toString();
+        return null;
     }
 
     @Override
     public String getEntityHitSound() {
-        return SoundResource.RANDOM_BREAK.toString();
+        return null;
     }
 
     @Override
     public String getMiningSound() {
-        return SoundResource.RANDOM_BREAK.toString();
+        return null;
     }
 
     @Override


### PR DESCRIPTION
I think this has been trolling players and devs for years.

Fixes https://discord.com/channels/181078474394566657/603348502637969419/1276976918016561225 and probably fixes https://discord.com/channels/181078474394566657/603348502637969419/1276983491669659700 as well.

Better no sound than the wrong one, some other tools dont have a crafting sound either.