### PR TITLE
Rename Dragon Blood bee and items

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/forestry/bees/handler/GTPP_CombType.java
+++ b/src/main/java/gtPlusPlus/xmod/forestry/bees/handler/GTPP_CombType.java
@@ -9,7 +9,7 @@ import gtPlusPlus.xmod.forestry.bees.registry.GTPP_Bees;
 
 public enum GTPP_CombType {
 
-    DRAGONBLOOD(0, "Dragon Blood", true, 30, Utils.rgbtoHexValue(220, 20, 20), Utils.rgbtoHexValue(20, 20, 20)),
+    DRAGONBLOOD(0, "Dragonblood", true, 30, Utils.rgbtoHexValue(220, 20, 20), Utils.rgbtoHexValue(20, 20, 20)),
     FORCE(1, "Force", true, 30, Utils.rgbtoHexValue(250, 250, 20), Utils.rgbtoHexValue(200, 200, 5));
 
     public boolean mShowInList;

--- a/src/main/java/gtPlusPlus/xmod/forestry/bees/handler/GTPP_DropType.java
+++ b/src/main/java/gtPlusPlus/xmod/forestry/bees/handler/GTPP_DropType.java
@@ -9,7 +9,7 @@ import gtPlusPlus.xmod.forestry.bees.registry.GTPP_Bees;
 
 public enum GTPP_DropType {
 
-    DRAGONBLOOD(0, "Dragon Blood", true, Utils.rgbtoHexValue(220, 20, 20), Utils.rgbtoHexValue(20, 20, 20)),
+    DRAGONBLOOD(0, "Dragonblood", true, Utils.rgbtoHexValue(220, 20, 20), Utils.rgbtoHexValue(20, 20, 20)),
     FORCE(1, "Force", true, Utils.rgbtoHexValue(250, 250, 20), Utils.rgbtoHexValue(200, 200, 5));
 
     public boolean mShowInList;

--- a/src/main/java/gtPlusPlus/xmod/forestry/bees/handler/GTPP_PollenType.java
+++ b/src/main/java/gtPlusPlus/xmod/forestry/bees/handler/GTPP_PollenType.java
@@ -9,7 +9,7 @@ import gtPlusPlus.xmod.forestry.bees.registry.GTPP_Bees;
 
 public enum GTPP_PollenType {
 
-    DRAGONBLOOD(0, "Dragon Blood", true, Utils.rgbtoHexValue(220, 20, 20), Utils.rgbtoHexValue(20, 20, 20));
+    DRAGONBLOOD(0, "Dragonblood", true, Utils.rgbtoHexValue(220, 20, 20), Utils.rgbtoHexValue(20, 20, 20));
 
     public boolean mShowInList;
     public final Material mMaterial;

--- a/src/main/java/gtPlusPlus/xmod/forestry/bees/handler/GTPP_PropolisType.java
+++ b/src/main/java/gtPlusPlus/xmod/forestry/bees/handler/GTPP_PropolisType.java
@@ -9,7 +9,7 @@ import gtPlusPlus.xmod.forestry.bees.registry.GTPP_Bees;
 
 public enum GTPP_PropolisType {
 
-    DRAGONBLOOD(0, "Dragon Blood", true, Utils.rgbtoHexValue(220, 20, 20)),
+    DRAGONBLOOD(0, "Dragonblood", true, Utils.rgbtoHexValue(220, 20, 20)),
     FORCE(1, "Force", true, Utils.rgbtoHexValue(250, 250, 20));
 
     public boolean mShowInList;

--- a/src/main/java/gtPlusPlus/xmod/forestry/bees/registry/GTPP_BeeDefinition.java
+++ b/src/main/java/gtPlusPlus/xmod/forestry/bees/registry/GTPP_BeeDefinition.java
@@ -51,7 +51,7 @@ import gtPlusPlus.xmod.forestry.bees.handler.GTPP_CombType;
 
 public enum GTPP_BeeDefinition implements IBeeDefinition {
 
-    DRAGONBLOOD(GTPP_BranchDefinition.LEGENDARY, "Dragon Blood", STANDALONE.DRAGON_METAL, true,
+    DRAGONBLOOD(GTPP_BranchDefinition.LEGENDARY, "Dragonblood", STANDALONE.DRAGON_METAL, true,
         Utils.rgbtoHexValue(220, 20, 20), Utils.rgbtoHexValue(20, 20, 20), beeSpecies -> {
             beeSpecies.addProduct(GT_ModHandler.getModItem(Forestry.ID, "beeCombs", 1, 8), 0.30f);
             beeSpecies.addSpecialty(GTPP_Bees.combs.getStackForType(GTPP_CombType.DRAGONBLOOD), 0.10f);

--- a/src/main/java/gtPlusPlus/xmod/forestry/bees/registry/GTPP_BeeDefinition.java
+++ b/src/main/java/gtPlusPlus/xmod/forestry/bees/registry/GTPP_BeeDefinition.java
@@ -51,7 +51,7 @@ import gtPlusPlus.xmod.forestry.bees.handler.GTPP_CombType;
 
 public enum GTPP_BeeDefinition implements IBeeDefinition {
 
-    DRAGONBLOOD(GTPP_BranchDefinition.LEGENDARY, "Dragonblood", STANDALONE.DRAGON_METAL, true,
+    DRAGONBLOOD(GTPP_BranchDefinition.LEGENDARY, "Dragon Blood", STANDALONE.DRAGON_METAL, true,
         Utils.rgbtoHexValue(220, 20, 20), Utils.rgbtoHexValue(20, 20, 20), beeSpecies -> {
             beeSpecies.addProduct(GT_ModHandler.getModItem(Forestry.ID, "beeCombs", 1, 8), 0.30f);
             beeSpecies.addSpecialty(GTPP_Bees.combs.getStackForType(GTPP_CombType.DRAGONBLOOD), 0.10f);

--- a/src/main/resources/assets/gregtech/lang/en_US.lang
+++ b/src/main/resources/assets/gregtech/lang/en_US.lang
@@ -1399,6 +1399,7 @@ for.bees.species.fireessence=Fire Essence
 for.bees.species.unknownwater=Unknown Liquid
 for.bees.species.nethershard=Nether Shard
 for.bees.species.endshard=Ender Shard
+for.bees.species.dragonblood=Dragonblood
 
 for.mutation.condition.biomeid=Required Biome
 for.mutation.condition.dim=Required Dimension


### PR DESCRIPTION
Just to further reflect bees so that they're named similarly to what they produce, someone in discord testing the beta pointed out this was still called "Dragon Blood" when it produced "Dragonblood"