### PR TITLE
Fix broken oredict cache if cached early during load time

### DIFF
--- a/src/main/java/gregtech/GT_Mod.java
+++ b/src/main/java/gregtech/GT_Mod.java
@@ -573,6 +573,7 @@ public class GT_Mod implements IGT_Mod {
             }
         }
         GregTech_API.sGTCompleteLoad = null;
+        GregTech_API.sFullLoadFinished = true;
     }
 
     @Mod.EventHandler

--- a/src/main/java/gregtech/api/GregTech_API.java
+++ b/src/main/java/gregtech/api/GregTech_API.java
@@ -278,7 +278,8 @@ public class GregTech_API {
      * Getting assigned by the Mod loading
      */
     public static boolean sUnificationEntriesRegistered = false, sPreloadStarted = false, sPreloadFinished = false,
-        sLoadStarted = false, sLoadFinished = false, sPostloadStarted = false, sPostloadFinished = false;
+        sLoadStarted = false, sLoadFinished = false, sPostloadStarted = false, sPostloadFinished = false,
+        sFullLoadFinished = false;
 
     private static Class<BaseMetaTileEntity> sBaseMetaTileEntityClass = null;
 

--- a/src/main/java/gregtech/api/util/GT_Recipe.java
+++ b/src/main/java/gregtech/api/util/GT_Recipe.java
@@ -510,8 +510,11 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
                     existingInput.inputAmount = Math.addExact(existingInput.inputAmount, itemStack.stackSize);
                 }
             }
-            mergedInputCache = newCache.toArray(new RecipeItemInput[0]);
-            return mergedInputCache;
+            final RecipeItemInput[] frozenCache = newCache.toArray(new RecipeItemInput[0]);
+            if (GregTech_API.sFullLoadFinished) {
+                mergedInputCache = frozenCache;
+            }
+            return frozenCache;
         }
     }
 


### PR DESCRIPTION
Fix invalid oredict caches in some recipes due to them checking for conflicts early during load time.