### PR TITLE
Fix breakBlock using wrong block metadata

### DIFF
--- a/src/main/java/com/elisis/gtnhlanth/common/block/ShieldedAccGlass.java
+++ b/src/main/java/com/elisis/gtnhlanth/common/block/ShieldedAccGlass.java
@@ -49,7 +49,7 @@ public class ShieldedAccGlass extends Block {
 
     @Override
     public void breakBlock(World aWorld, int aX, int aY, int aZ, Block aBlock, int aMetaData) {
-        if (GregTech_API.isMachineBlock(this, aWorld.getBlockMetadata(aX, aY, aZ))) {
+        if (GregTech_API.isMachineBlock(this, aMetaData)) {
             GregTech_API.causeMachineUpdate(aWorld, aX, aY, aZ);
         }
     }

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/blocks/BW_Blocks.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/blocks/BW_Blocks.java
@@ -108,7 +108,7 @@ public class BW_Blocks extends Block {
 
     @Override
     public void breakBlock(World aWorld, int aX, int aY, int aZ, Block aBlock, int aMetaData) {
-        if (GregTech_API.isMachineBlock(this, aWorld.getBlockMetadata(aX, aY, aZ))) {
+        if (GregTech_API.isMachineBlock(this, aMetaData)) {
             GregTech_API.causeMachineUpdate(aWorld, aX, aY, aZ);
         }
     }

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/blocks/BW_TileEntityContainer_MachineBlock.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/blocks/BW_TileEntityContainer_MachineBlock.java
@@ -37,7 +37,7 @@ public class BW_TileEntityContainer_MachineBlock extends BW_TileEntityContainer 
 
     @Override
     public void breakBlock(World aWorld, int aX, int aY, int aZ, Block aBlock, int aMetaData) {
-        if (GregTech_API.isMachineBlock(this, aWorld.getBlockMetadata(aX, aY, aZ))) {
+        if (GregTech_API.isMachineBlock(this, aMetaData)) {
             GregTech_API.causeMachineUpdate(aWorld, aX, aY, aZ);
         }
     }

--- a/src/main/java/com/github/technus/tectech/thing/block/GodforgeGlassBlock.java
+++ b/src/main/java/com/github/technus/tectech/thing/block/GodforgeGlassBlock.java
@@ -93,7 +93,7 @@ public class GodforgeGlassBlock extends BlockBase {
 
     @Override
     public void breakBlock(World aWorld, int aX, int aY, int aZ, Block aBlock, int aMeta) {
-        if (GregTech_API.isMachineBlock(this, aWorld.getBlockMetadata(aX, aY, aZ))) {
+        if (GregTech_API.isMachineBlock(this, aMeta)) {
             GregTech_API.causeMachineUpdate(aWorld, aX, aY, aZ);
         }
     }

--- a/src/main/java/com/github/technus/tectech/thing/block/QuantumGlassBlock.java
+++ b/src/main/java/com/github/technus/tectech/thing/block/QuantumGlassBlock.java
@@ -97,7 +97,7 @@ public final class QuantumGlassBlock extends BlockBase {
 
     @Override
     public void breakBlock(World aWorld, int aX, int aY, int aZ, Block aBlock, int aMeta) {
-        if (GregTech_API.isMachineBlock(this, aWorld.getBlockMetadata(aX, aY, aZ))) {
+        if (GregTech_API.isMachineBlock(this, aMeta)) {
             GregTech_API.causeMachineUpdate(aWorld, aX, aY, aZ);
         }
     }

--- a/src/main/java/common/blocks/BaseGTUpdateableBlock.java
+++ b/src/main/java/common/blocks/BaseGTUpdateableBlock.java
@@ -50,7 +50,7 @@ public abstract class BaseGTUpdateableBlock extends Block {
 
     @Override
     public void breakBlock(World aWorld, int aX, int aY, int aZ, Block aBlock, int aMetaData) {
-        if (GregTech_API.isMachineBlock(this, aWorld.getBlockMetadata(aX, aY, aZ))) {
+        if (GregTech_API.isMachineBlock(this, aMetaData)) {
             GregTech_API.causeMachineUpdate(aWorld, aX, aY, aZ);
         }
     }

--- a/src/main/java/goodgenerator/blocks/regularBlock/Casing.java
+++ b/src/main/java/goodgenerator/blocks/regularBlock/Casing.java
@@ -97,7 +97,7 @@ public class Casing extends Block {
 
     @Override
     public void breakBlock(World aWorld, int aX, int aY, int aZ, Block aBlock, int aMetaData) {
-        if (GregTech_API.isMachineBlock(this, aWorld.getBlockMetadata(aX, aY, aZ))) {
+        if (GregTech_API.isMachineBlock(this, aMetaData)) {
             GregTech_API.causeMachineUpdate(aWorld, aX, aY, aZ);
         }
     }

--- a/src/main/java/goodgenerator/blocks/regularBlock/TEBlock.java
+++ b/src/main/java/goodgenerator/blocks/regularBlock/TEBlock.java
@@ -114,7 +114,7 @@ public class TEBlock extends BlockContainer {
 
     @Override
     public void breakBlock(World aWorld, int aX, int aY, int aZ, Block aBlock, int aMetaData) {
-        if (GregTech_API.isMachineBlock(this, aWorld.getBlockMetadata(aX, aY, aZ))) {
+        if (GregTech_API.isMachineBlock(this, aMetaData)) {
             GregTech_API.causeMachineUpdate(aWorld, aX, aY, aZ);
         }
         aWorld.removeTileEntity(aX, aY, aZ);

--- a/src/main/java/gregtech/common/blocks/GT_Block_Casings_Abstract.java
+++ b/src/main/java/gregtech/common/blocks/GT_Block_Casings_Abstract.java
@@ -100,7 +100,7 @@ public abstract class GT_Block_Casings_Abstract extends GT_Generic_Block
 
     @Override
     public void breakBlock(World aWorld, int aX, int aY, int aZ, Block aBlock, int aMetaData) {
-        if (GregTech_API.isMachineBlock(this, aWorld.getBlockMetadata(aX, aY, aZ))) {
+        if (GregTech_API.isMachineBlock(this, aMetaData)) {
             GregTech_API.causeMachineUpdate(aWorld, aX, aY, aZ);
         }
     }

--- a/src/main/java/gregtech/common/blocks/GT_Block_Laser.java
+++ b/src/main/java/gregtech/common/blocks/GT_Block_Laser.java
@@ -41,7 +41,7 @@ public class GT_Block_Laser extends Block implements ITileEntityProvider {
 
     @Override
     public void breakBlock(World aWorld, int aX, int aY, int aZ, Block aBlock, int aMetaData) {
-        if (GregTech_API.isMachineBlock(this, aWorld.getBlockMetadata(aX, aY, aZ))) {
+        if (GregTech_API.isMachineBlock(this, aMetaData)) {
             GregTech_API.causeMachineUpdate(aWorld, aX, aY, aZ);
         }
     }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/blocks/GregtechMetaCasingBlocksAbstract.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/blocks/GregtechMetaCasingBlocksAbstract.java
@@ -106,7 +106,7 @@ public abstract class GregtechMetaCasingBlocksAbstract extends GT_Block_Casings_
     @Override
     public void breakBlock(final World aWorld, final int aX, final int aY, final int aZ, final Block aBlock,
         final int aMetaData) {
-        if (GregTech_API.isMachineBlock(this, aWorld.getBlockMetadata(aX, aY, aZ))) {
+        if (GregTech_API.isMachineBlock(this, aMetaData)) {
             GregTech_API.causeMachineUpdate(aWorld, aX, aY, aZ);
         }
     }


### PR DESCRIPTION
When placing a block with structurelib, `World.setBlock()` is called, which then calls some chunk update function `func_150807_a`. This function *first* sets the world meta data (`setExtBlockMetadata`), and then calls `breakBlock()` on the original block. All fine so far, but `breakBlock` in `GT_Block_Casings_Abstract`  ignores the metadata parameter passed in and instead just uses `world.getBlockMetadata`, which returns the *new* metadata
```java
@Override
public void breakBlock(World aWorld, int aX, int aY, int aZ, Block aBlock, int aMetaData) {
    if (GregTech_API.isMachineBlock(this, aWorld.getBlockMetadata(aX, aY, aZ))) {
        GregTech_API.causeMachineUpdate(aWorld, aX, aY, aZ);
    }
}
```

This causes an inconsistency where `isMachineBlock` is called with the block of the old block, but the meta of the block that is replaced by it. It seems this has gone unnoticed for years because it only happens with creative autoplace, and only causes issues if one of the replacing blocks has a meta value outside `0..31`, but the new frame boxes are exactly that.

This PR simply replaces all these occurences of `getBlockMetadata` with the passed in `aMetaData` parameter.