### PR TITLE
Added a tooltip line for strong redstone output

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/CoverableTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/CoverableTileEntity.java
@@ -609,6 +609,7 @@ public abstract class CoverableTileEntity extends BaseTileEntity implements ICov
     public static void addInstalledCoversInformation(NBTTagCompound aNBT, List<String> aList) {
         if (aNBT == null || aList == null) return;
         final NBTTagList tList = aNBT.getTagList(GT_Values.NBT.COVERS, 10);
+
         for (byte i = 0; i < tList.tagCount(); i++) {
             final NBTTagCompound tNBT = tList.getCompoundTagAt(i);
             final CoverInfo coverInfo = new CoverInfo(null, tNBT);
@@ -645,6 +646,22 @@ public abstract class CoverableTileEntity extends BaseTileEntity implements ICov
                                 .format("Cover on %s side: %s", getTranslation(FACES[i]), coverStack.getDisplayName()));
                     }
                 }
+            }
+        }
+
+        byte strongRedstone = aNBT.getByte("mStrongRedstone");
+
+        for (ForgeDirection dir : ForgeDirection.VALID_DIRECTIONS) {
+            if ((strongRedstone & dir.flag) != 0) {
+                aList.add(String.format("Emits a strong redstone signal on the %s side", switch (dir) {
+                    case DOWN -> "bottom";
+                    case UP -> "top";
+                    case NORTH -> "north";
+                    case SOUTH -> "south";
+                    case WEST -> "west";
+                    case EAST -> "east";
+                    default -> "<unknown>";
+                }));
             }
         }
     }


### PR DESCRIPTION
Machines keep their 'strong redstone output' setting when broken. While machines with the same strong output settings will stack, machines won't combine with each other if they have conflicting settings, leading to several stacks with no obvious reason. There isn't a way to see what sides will output a strong signal without placing the machine down and using a soldering iron on all six sides.

This commit will add a variable number of lines to all machine's tooltips, one per strong output side.

![2024-08-26_15 06 08](https://github.com/user-attachments/assets/2b626109-2012-46d4-8774-06eeb79dcae1)
![2024-08-26_15 06 05](https://github.com/user-attachments/assets/87ee02a4-a772-42b6-9c47-1e366983d9f3)
![2024-08-26_15 06 28](https://github.com/user-attachments/assets/49cb5356-8183-4ce7-bc3d-60ee838a231d)
