### PR TITLE
[ci skip] add NEI Ore Plugin to the excluded GMI

### DIFF
--- a/.github/workflows/test-forbidden-getmoditems.yml
+++ b/.github/workflows/test-forbidden-getmoditems.yml
@@ -15,4 +15,4 @@ jobs:
       - name: Detect forbidden getModItem calls
         shell: bash
         run: |
-          ! grep -E -r 'getModItem\(("(bartworks|galacticgreg|ggfab|GoodGenerator|gregtech|gtnhlanth|miscutils|kekztech|kubatech|tectech)"|(BartWorks|GalactiGreg|GGFab|GoodGenerator|GTNHLanthanides|GTPlusPlus|KekzTech|KubaTech|TecTech)\.ID)' src/main/java
+          ! grep -E -r 'getModItem\(("(bartworks|galacticgreg|ggfab|GoodGenerator|gregtech|gtnhlanth|miscutils|kekztech|kubatech|tectech|gtneioreplugin)"|(BartWorks|GalactiGreg|GGFab|GoodGenerator|GTNHLanthanides|GTPlusPlus|KekzTech|KubaTech|TecTech|NEIOrePlugin)\.ID)' src/main/java


### PR DESCRIPTION
since this mod has planet blocks, they should be accessed properly within GT5U now that it is merged.