### PR TITLE
Add the Research Completer to ItemList

### DIFF
--- a/src/main/java/gregtech/api/enums/ItemList.java
+++ b/src/main/java/gregtech/api/enums/ItemList.java
@@ -2553,6 +2553,7 @@ public enum ItemList implements IItemContainer {
     BetterJukebox_EV,
     BetterJukebox_IV,
     WirelessHeadphones,
+    ResearchCompleter, // Populated in EMT
     // semicolon after the comment to reduce merge conflicts
     ;
 

--- a/src/main/java/gregtech/api/enums/MetaTileEntityIDs.java
+++ b/src/main/java/gregtech/api/enums/MetaTileEntityIDs.java
@@ -1446,6 +1446,7 @@ public enum MetaTileEntityIDs {
     AcidGeneratorLV(12793),
     HumongousInputHatch(12799),
     CreativeScanner(12800),
+    ResearchCompleter(13001), // In EMT
     sofc1(13101),
     sofc2(13102),
     tfft(13104),


### PR DESCRIPTION
NHCore needs the research completer from EMT, but i don't want to edit EMT to extract all the machinery into GT5U. Therefore, i'm adding a new entry in the ItemList that will be populated by EMT if present.