### PR TITLE
Disable godforge debug

### DIFF
--- a/src/main/java/tectech/thing/metaTileEntity/multi/MTEForgeOfGods.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/MTEForgeOfGods.java
@@ -178,7 +178,7 @@ public class MTEForgeOfGods extends TTMultiblockBase implements IConstructable, 
     private static final ItemStack STELLAR_FUEL = Avaritia.isModLoaded() ? getModItem(Avaritia.ID, "Resource", 1, 8)
         : GTOreDictUnificator.get(OrePrefixes.block, Materials.CosmicNeutronium, 1);
 
-    private final boolean debugMode = true;
+    private final boolean debugMode = false;
 
     public int survivalConstruct(ItemStack stackSize, int elementBudget, ISurvivalBuildEnvironment env) {
         if (mMachine) return -1;

--- a/src/main/java/tectech/thing/metaTileEntity/multi/godforge_modules/MTEPlasmaModule.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/godforge_modules/MTEPlasmaModule.java
@@ -49,7 +49,7 @@ public class MTEPlasmaModule extends MTEBaseModule {
 
     private long EUt = 0;
     private int currentParallel = 0;
-    private boolean debug = true;
+    private boolean debug = false;
     private int inputMaxParallel = 0;
 
     public MTEPlasmaModule(int aID, String aName, String aNameRegional) {


### PR DESCRIPTION
Disables debug mode on the godforge so nightly testers can actually test the multi's functionality