### PR TITLE
Fix string references to classes in callConstructor calls

### DIFF
--- a/src/main/java/gregtech/common/GTProxy.java
+++ b/src/main/java/gregtech/common/GTProxy.java
@@ -802,7 +802,7 @@ public abstract class GTProxy implements IGTMod, IFuelHandler {
             .bus()
             .register(this);
         GregTechAPI.sThaumcraftCompat = (IThaumcraftCompat) GTUtility
-            .callConstructor("gregtech.common.GT_ThaumcraftCompat", 0, null, GTValues.D1, new Object[0]);
+            .callConstructor("gregtech.common.GTThaumcraftCompat", 0, null, GTValues.D1, new Object[0]);
         for (FluidContainerRegistry.FluidContainerData tData : FluidContainerRegistry
             .getRegisteredFluidContainerData()) {
             onFluidContainerRegistration(new FluidContainerRegistry.FluidContainerRegisterEvent(tData));

--- a/src/main/java/gregtech/common/tools/ToolPlunger.java
+++ b/src/main/java/gregtech/common/tools/ToolPlunger.java
@@ -68,7 +68,7 @@ public class ToolPlunger extends GTTool {
         aItem.addItemBehavior(aID, new BehaviourPlungerFluid(getToolDamagePerDropConversion()));
         try {
             Object tObject = GTUtility.callConstructor(
-                "gregtech.common.items.behaviors.Behaviour_Plunger_Essentia",
+                "gregtech.common.items.behaviors.BehaviourPlungerEssentia",
                 0,
                 null,
                 false,

--- a/src/main/java/gregtech/loaders/preload/LoaderGTBlockFluid.java
+++ b/src/main/java/gregtech/loaders/preload/LoaderGTBlockFluid.java
@@ -175,7 +175,7 @@ public class LoaderGTBlockFluid implements Runnable {
         ItemList.VOLUMETRIC_FLASK.set(new ItemVolumetricFlask("Volumetric_Flask", "Volumetric flask", 1000));
 
         Item tItem = (Item) GTUtility.callConstructor(
-            "gregtech.common.items.GT_SensorCard_Item",
+            "gregtech.common.items.ItemSensorCard",
             0,
             null,
             false,
@@ -185,7 +185,7 @@ public class LoaderGTBlockFluid implements Runnable {
                 : tItem);
 
         Item advSensorCard = (Item) GTUtility
-            .callConstructor("gregtech.common.items.GT_AdvancedSensorCard_Item", 0, null, false);
+            .callConstructor("gregtech.common.items.ItemAdvancedSensorCard", 0, null, false);
         ItemList.NC_AdvancedSensorCard.set(
             advSensorCard == null
                 ? new GTGenericItem(


### PR DESCRIPTION
These classes were never loaded because they were renamed. This should fix coremod and AE2 erroring on server run.