### PR TITLE
remove unnecessary reflection to add IC2 scrapbox drop

### DIFF
--- a/src/main/java/gregtech/api/util/GTModHandler.java
+++ b/src/main/java/gregtech/api/util/GTModHandler.java
@@ -477,22 +477,7 @@ public class GTModHandler {
         aOutput.stackSize = 1;
         if (GTConfig.troll && !GTUtility.areStacksEqual(aOutput, new ItemStack(Items.wooden_hoe, 1, 0))) return false;
         try {
-            GTUtility.callMethod(
-                GTUtility.getFieldContent("ic2.api.recipe.Recipes", "scrapboxDrops", true, true),
-                "addDrop",
-                true,
-                false,
-                true,
-                GTUtility.copyOrNull(aOutput),
-                aChance);
-            GTUtility.callMethod(
-                GTUtility.getFieldContent("ic2.api.recipe.Recipes", "scrapboxDrops", true, true),
-                "addRecipe",
-                true,
-                true,
-                false,
-                GTUtility.copyOrNull(aOutput),
-                aChance);
+            ic2.api.recipe.Recipes.scrapboxDrops.addDrop(GTUtility.copyOrNull(aOutput), aChance);
         } catch (Throwable e) {
             /* Do nothing */
         }


### PR DESCRIPTION
This was using reflection to call a public static method as well as adding each recipe twice