### PR TITLE
Generate solidifier recipes for nuclear gt++ materials

### DIFF
--- a/src/main/java/gtPlusPlus/core/material/MaterialGenerator.java
+++ b/src/main/java/gtPlusPlus/core/material/MaterialGenerator.java
@@ -294,11 +294,11 @@ public class MaterialGenerator {
 
             if (!disableOptionalRecipes) {
                 new RecipeGenShapedCrafting(matInfo);
-                new RecipeGenFluids(matInfo);
                 new RecipeGenMaterialProcessing(matInfo);
                 new RecipeGenRecycling(matInfo);
             }
 
+            new RecipeGenFluids(matInfo);
             new RecipeGenMetalRecipe(matInfo);
             new RecipeGenDustGeneration(matInfo, disableOptionalRecipes);
             new RecipeGenPlasma(matInfo);


### PR DESCRIPTION
Generate solidifier recipes for gt++ materials under the 'nuclear' category, as some of them (like neptunium and fermium) have craftable molten variants but cant be solidified.