### PR TITLE
Fix NEI not showing any recipes for GT machines

### DIFF
--- a/src/main/java/gregtech/common/GTClient.java
+++ b/src/main/java/gregtech/common/GTClient.java
@@ -106,7 +106,7 @@ import gregtech.common.tileentities.debug.MTEAdvDebugStructureWriter;
 import gregtech.loaders.ExtraIcons;
 import gregtech.loaders.misc.GTBees;
 import gregtech.loaders.preload.GTPreLoad;
-import gregtech.nei.GTNEIConfig;
+import gregtech.nei.NEIGTConfig;
 import ic2.api.tile.IWrenchable;
 import paulscode.sound.SoundSystemConfig;
 import paulscode.sound.SoundSystemException;
@@ -642,7 +642,7 @@ public class GTClient extends GTProxy implements Runnable {
         new MetaGeneratedToolRenderer();
         new FlaskRenderer();
         new FluidDisplayStackRenderer();
-        MinecraftForge.EVENT_BUS.register(new GTNEIConfig());
+        MinecraftForge.EVENT_BUS.register(new NEIGTConfig());
     }
 
     @Override

--- a/src/main/java/gregtech/nei/NEIGTConfig.java
+++ b/src/main/java/gregtech/nei/NEIGTConfig.java
@@ -37,7 +37,7 @@ import gregtech.nei.dumper.MetaTileEntityDumper;
 import gregtech.nei.dumper.RecipeLockingSupportDumper;
 import gregtech.nei.dumper.VoidProtectionSupportDumper;
 
-public class GTNEIConfig implements IConfigureNEI {
+public class NEIGTConfig implements IConfigureNEI {
 
     /**
      * This map determines the order in which NEI handlers will be registered and displayed in tabs.
@@ -87,7 +87,7 @@ public class GTNEIConfig implements IConfigureNEI {
                     .getNEIProperties().registerNEI)
             .map(GTNEIDefaultHandler::new)
             .sorted(RECIPE_MAP_HANDLER_COMPARATOR)
-            .forEach(GTNEIConfig::addHandler);
+            .forEach(NEIGTConfig::addHandler);
     }
 
     private void registerCatalysts() {


### PR DESCRIPTION
NEI discovers config classes automatically by looking for classes that start in `NEI` and end in `Config` (because of course it does, who doesn't love implicit behaviour!). The great renaming broke this, so here is a new name that should be discovered fine.