### PR TITLE
Fixes #17207

### DIFF
--- a/src/main/java/goodgenerator/blocks/tileEntity/MTEComponentAssemblyLine.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/MTEComponentAssemblyLine.java
@@ -50,7 +50,7 @@ public class MTEComponentAssemblyLine extends MTEExtendedPowerMultiBlockBase<MTE
     implements ISurvivalConstructable {
 
     private int casingTier;
-    private float speedBonus;
+    private double speedBonus;
     protected static final String STRUCTURE_PIECE_MAIN = "main";
     private static final IStructureDefinition<MTEComponentAssemblyLine> STRUCTURE_DEFINITION = StructureDefinition
         .<MTEComponentAssemblyLine>builder()
@@ -321,7 +321,7 @@ public class MTEComponentAssemblyLine extends MTEExtendedPowerMultiBlockBase<MTE
             @Nonnull
             @Override
             protected OverclockCalculator createOverclockCalculator(@Nonnull GTRecipe recipe) {
-                speedBonus = (float) (1 / Math.pow(2, casingTier + 1 - recipe.mSpecialValue));
+                speedBonus = 1 / Math.pow(2, casingTier + 1 - recipe.mSpecialValue);
                 return super.createOverclockCalculator(recipe).setSpeedBoost(speedBonus);
             }
         };

--- a/src/main/java/goodgenerator/blocks/tileEntity/MTEPreciseAssembler.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/MTEPreciseAssembler.java
@@ -258,7 +258,7 @@ public class MTEPreciseAssembler extends MTEExtendedPowerMultiBlockBase<MTEPreci
             @Nonnull
             @Override
             protected OverclockCalculator createOverclockCalculator(@Nonnull GTRecipe recipe) {
-                return super.createOverclockCalculator(recipe).setSpeedBoost(mode == 0 ? 1 : 0.5F);
+                return super.createOverclockCalculator(recipe).setSpeedBoost(mode == 0 ? 1 : 0.5);
             }
         }.setMaxParallelSupplier(() -> mode == 0 ? 1 : (int) Math.pow(2, 4 + (casingTier + 1)));
     }

--- a/src/main/java/gregtech/api/logic/AbstractProcessingLogic.java
+++ b/src/main/java/gregtech/api/logic/AbstractProcessingLogic.java
@@ -39,8 +39,8 @@ public abstract class AbstractProcessingLogic<P extends AbstractProcessingLogic<
     protected Supplier<Integer> maxParallelSupplier;
     protected int calculatedParallels = 0;
     protected int batchSize = 1;
-    protected float euModifier = 1.0f;
-    protected float speedBoost = 1.0f;
+    protected double euModifier = 1.0;
+    protected double speedBoost = 1.0;
     protected boolean amperageOC = true;
     protected boolean isCleanroom;
 
@@ -100,12 +100,12 @@ public abstract class AbstractProcessingLogic<P extends AbstractProcessingLogic<
         return getThis();
     }
 
-    public P setEuModifier(float modifier) {
+    public P setEuModifier(double modifier) {
         this.euModifier = modifier;
         return getThis();
     }
 
-    public P setSpeedBonus(float speedModifier) {
+    public P setSpeedBonus(double speedModifier) {
         this.speedBoost = speedModifier;
         return getThis();
     }

--- a/src/main/java/gregtech/api/util/OverclockCalculator.java
+++ b/src/main/java/gregtech/api/util/OverclockCalculator.java
@@ -251,7 +251,7 @@ public class OverclockCalculator {
      * Sets an EUtDiscount. 0.9 is 10% less energy. 1.1 is 10% more energy
      */
     @Nonnull
-    public OverclockCalculator setEUtDiscount(float aEUtDiscount) {
+    public OverclockCalculator setEUtDiscount(double aEUtDiscount) {
         this.eutDiscount = aEUtDiscount;
         return this;
     }
@@ -260,7 +260,7 @@ public class OverclockCalculator {
      * Sets a Speed Boost for the multiblock. 0.9 is 10% faster. 1.1 is 10% slower
      */
     @Nonnull
-    public OverclockCalculator setSpeedBoost(float aSpeedBoost) {
+    public OverclockCalculator setSpeedBoost(double aSpeedBoost) {
         this.speedBoost = aSpeedBoost;
         return this;
     }
@@ -279,7 +279,7 @@ public class OverclockCalculator {
      * Discount
      */
     @Nonnull
-    public OverclockCalculator setHeatDiscountMultiplier(float heatDiscountExponent) {
+    public OverclockCalculator setHeatDiscountMultiplier(double heatDiscountExponent) {
         this.heatDiscountExponent = heatDiscountExponent;
         return this;
     }

--- a/src/main/java/gregtech/api/util/ParallelHelper.java
+++ b/src/main/java/gregtech/api/util/ParallelHelper.java
@@ -121,7 +121,7 @@ public class ParallelHelper {
     /**
      * Modifier which is applied on the recipe eut. Useful for GT++ machines
      */
-    private float eutModifier = 1;
+    private double eutModifier = 1;
     /**
      * Multiplier that is applied on the output chances
      */
@@ -224,7 +224,7 @@ public class ParallelHelper {
      * Sets the modifier for recipe eut. 1 does nothing 0.9 is 10% less. 1.1 is 10% more
      */
     @Nonnull
-    public ParallelHelper setEUtModifier(float aEUtModifier) {
+    public ParallelHelper setEUtModifier(double aEUtModifier) {
         this.eutModifier = aEUtModifier;
         return this;
     }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEPCBFactory.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEPCBFactory.java
@@ -571,7 +571,7 @@ public class MTEPCBFactory extends MTEExtendedPowerMultiBlockBase<MTEPCBFactory>
             @Override
             protected OverclockCalculator createOverclockCalculator(@Nonnull GTRecipe recipe) {
                 return super.createOverclockCalculator(recipe).setNoOverclock(isNoOC())
-                    .setEUtDiscount((float) Math.sqrt(mUpgradesInstalled == 0 ? 1 : mUpgradesInstalled))
+                    .setEUtDiscount(Math.sqrt(mUpgradesInstalled == 0 ? 1 : mUpgradesInstalled))
                     .setSpeedBoost(getDurationMultiplierFromRoughness())
                     .setDurationDecreasePerOC(mOCTier2 ? 4.0 : 2.0);
             }
@@ -590,8 +590,8 @@ public class MTEPCBFactory extends MTEExtendedPowerMultiBlockBase<MTEPCBFactory>
         return !mOCTier1 && !mOCTier2;
     }
 
-    private float getDurationMultiplierFromRoughness() {
-        return (float) Math.pow(mRoughnessMultiplier, 2);
+    private double getDurationMultiplierFromRoughness() {
+        return Math.pow(mRoughnessMultiplier, 2);
     }
 
     private int ticker = 0;

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/MTEIndustrialAlloySmelter.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/MTEIndustrialAlloySmelter.java
@@ -195,7 +195,7 @@ public class MTEIndustrialAlloySmelter extends GTPPMultiBlockBase<MTEIndustrialA
             @NotNull
             @Override
             protected OverclockCalculator createOverclockCalculator(@NotNull GTRecipe recipe) {
-                return super.createOverclockCalculator(recipe).setSpeedBoost(100F / (100F + 5F * mLevel))
+                return super.createOverclockCalculator(recipe).setSpeedBoost(100.0 / (100 + 5 * mLevel))
                     .setHeatOC(true)
                     .setRecipeHeat(0)
                     // Need to multiply by 2 because heat OC is done only once every 1800 and this one does it once

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/MTESteamCentrifuge.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/MTESteamCentrifuge.java
@@ -312,8 +312,8 @@ public class MTESteamCentrifuge extends MTESteamMultiBase<MTESteamCentrifuge> im
             @Nonnull
             protected OverclockCalculator createOverclockCalculator(@NotNull GTRecipe recipe) {
                 return OverclockCalculator.ofNoOverclock(recipe)
-                    .setEUtDiscount(1.33F)
-                    .setSpeedBoost(1.5F);
+                    .setEUtDiscount(1.33)
+                    .setSpeedBoost(1.5);
             }
         }.setMaxParallelSupplier(this::getMaxParallelRecipes);
     }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/MTESteamCompressor.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/MTESteamCompressor.java
@@ -253,8 +253,8 @@ public class MTESteamCompressor extends MTESteamMultiBase<MTESteamCompressor> im
             @Nonnull
             protected OverclockCalculator createOverclockCalculator(@NotNull GTRecipe recipe) {
                 return OverclockCalculator.ofNoOverclock(recipe)
-                    .setEUtDiscount(1.33F)
-                    .setSpeedBoost(1.5F);
+                    .setEUtDiscount(1.33)
+                    .setSpeedBoost(1.5);
             }
         }.setMaxParallelSupplier(this::getMaxParallelRecipes);
     }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/MTESteamForgeHammer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/MTESteamForgeHammer.java
@@ -306,8 +306,8 @@ public class MTESteamForgeHammer extends MTESteamMultiBase<MTESteamForgeHammer> 
             @Nonnull
             protected OverclockCalculator createOverclockCalculator(@NotNull GTRecipe recipe) {
                 return OverclockCalculator.ofNoOverclock(recipe)
-                    .setEUtDiscount(1.33F)
-                    .setSpeedBoost(1.5F);
+                    .setEUtDiscount(1.33)
+                    .setSpeedBoost(1.5);
             }
         }.setMaxParallelSupplier(this::getMaxParallelRecipes);
     }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/MTESteamMacerator.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/MTESteamMacerator.java
@@ -255,8 +255,8 @@ public class MTESteamMacerator extends MTESteamMultiBase<MTESteamMacerator> impl
             @Nonnull
             protected OverclockCalculator createOverclockCalculator(@NotNull GTRecipe recipe) {
                 return OverclockCalculator.ofNoOverclock(recipe)
-                    .setEUtDiscount(1.33F)
-                    .setSpeedBoost(1.5F);
+                    .setEUtDiscount(1.33)
+                    .setSpeedBoost(1.5);
             }
         }.setMaxParallelSupplier(this::getMaxParallelRecipes);
     }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/MTESteamMixer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/MTESteamMixer.java
@@ -353,8 +353,8 @@ public class MTESteamMixer extends MTESteamMultiBase<MTESteamMixer> implements I
             @Nonnull
             protected OverclockCalculator createOverclockCalculator(@NotNull GTRecipe recipe) {
                 return OverclockCalculator.ofNoOverclock(recipe)
-                    .setEUtDiscount(1.33F)
-                    .setSpeedBoost(1.5F);
+                    .setEUtDiscount(1.33)
+                    .setSpeedBoost(1.5);
             }
         }.setMaxParallelSupplier(this::getMaxParallelRecipes);
     }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/MTESteamWasher.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/MTESteamWasher.java
@@ -331,8 +331,8 @@ public class MTESteamWasher extends MTESteamMultiBase<MTESteamWasher> implements
             @Nonnull
             protected OverclockCalculator createOverclockCalculator(@NotNull GTRecipe recipe) {
                 return OverclockCalculator.ofNoOverclock(recipe)
-                    .setEUtDiscount(1.33F)
-                    .setSpeedBoost(1.5F);
+                    .setEUtDiscount(1.33)
+                    .setSpeedBoost(1.5);
             }
         }.setMaxParallelSupplier(this::getMaxParallelRecipes);
     }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTEIndustrialRockBreaker.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTEIndustrialRockBreaker.java
@@ -316,8 +316,8 @@ public class MTEIndustrialRockBreaker extends GTPPMultiBlockBase<MTEIndustrialRo
         OverclockCalculator calculator = new OverclockCalculator().setRecipeEUt(tRecipe.mEUt)
             .setEUt(tEnergy)
             .setDuration(tRecipe.mDuration)
-            .setEUtDiscount(0.75F)
-            .setSpeedBoost(1F / 3F)
+            .setEUtDiscount(0.75)
+            .setSpeedBoost(1 / 3.0)
             .setParallel((int) Math.floor(helper.getCurrentParallel() / helper.getDurationMultiplierDouble()))
             .calculate();
         lEUt = -calculator.getConsumption();

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/mega/MTEMegaAlloyBlastSmelter.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/mega/MTEMegaAlloyBlastSmelter.java
@@ -62,8 +62,8 @@ public class MTEMegaAlloyBlastSmelter extends MTEExtendedPowerMultiBlockBase<MTE
     private static final int MAX_PARALLELS = 256;
     private HeatingCoilLevel coilLevel;
     private byte glassTier = -1;
-    private float speedBonus = 1;
-    private float energyDiscount = 1;
+    private double speedBonus = 1;
+    private double energyDiscount = 1;
     private boolean hasNormalCoils;
 
     private static final IStructureDefinition<MTEMegaAlloyBlastSmelter> STRUCTURE_DEFINITION = StructureDefinition
@@ -254,7 +254,7 @@ public class MTEMegaAlloyBlastSmelter extends MTEExtendedPowerMultiBlockBase<MTE
             energyDiscount = 1;
             return;
         }
-        energyDiscount = (float) Math.pow(0.95, tierDifference);
+        energyDiscount = Math.pow(0.95, tierDifference);
     }
 
     @Override

--- a/src/main/java/kubatech/tileentity/gregtech/multiblock/MTEDEFusionCrafter.java
+++ b/src/main/java/kubatech/tileentity/gregtech/multiblock/MTEDEFusionCrafter.java
@@ -232,7 +232,7 @@ public class MTEDEFusionCrafter extends KubaTechGTMultiBlockBase<MTEDEFusionCraf
             @Override
             protected OverclockCalculator createOverclockCalculator(@NotNull GTRecipe recipe) {
                 return super.createOverclockCalculator(recipe)
-                    .setSpeedBoost(1f / (mTierCasing - recipe.mSpecialValue + 1));
+                    .setSpeedBoost(1.0 / (mTierCasing - recipe.mSpecialValue + 1));
             }
         };
     }

--- a/src/main/java/tectech/thing/metaTileEntity/multi/godforge_modules/MTEBaseModule.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/godforge_modules/MTEBaseModule.java
@@ -70,8 +70,8 @@ public class MTEBaseModule extends TTMultiblockBase {
     protected int overclockHeat = 0;
     protected int maximumParallel = 0;
     protected int plasmaTier = 0;
-    protected float processingSpeedBonus = 0;
-    protected float energyDiscount = 0;
+    protected double processingSpeedBonus = 0;
+    protected double energyDiscount = 0;
     protected long processingVoltage = 2_000_000_000;
     protected BigInteger powerTally = BigInteger.ZERO;
     protected long recipeTally = 0;
@@ -155,19 +155,19 @@ public class MTEBaseModule extends TTMultiblockBase {
         return maximumParallel;
     }
 
-    public void setSpeedBonus(float bonus) {
+    public void setSpeedBonus(double bonus) {
         processingSpeedBonus = bonus;
     }
 
-    public float getSpeedBonus() {
+    public double getSpeedBonus() {
         return processingSpeedBonus;
     }
 
-    public void setEnergyDiscount(float discount) {
+    public void setEnergyDiscount(double discount) {
         energyDiscount = discount;
     }
 
-    public float getEnergyDiscount() {
+    public double getEnergyDiscount() {
         return energyDiscount;
     }
 
@@ -199,8 +199,8 @@ public class MTEBaseModule extends TTMultiblockBase {
         isMagmatterCapable = isCapable;
     }
 
-    public float getHeatEnergyDiscount() {
-        return isUpgrade83Unlocked ? 0.92f : 0.95f;
+    public double getHeatEnergyDiscount() {
+        return isUpgrade83Unlocked ? 0.92 : 0.95;
     }
 
     public void setPlasmaTier(int tier) {

--- a/src/main/java/tectech/util/GodforgeMath.java
+++ b/src/main/java/tectech/util/GodforgeMath.java
@@ -117,7 +117,7 @@ public class GodforgeMath {
             }
         }
 
-        module.setSpeedBonus((float) speedBonus);
+        module.setSpeedBonus(speedBonus);
     }
 
     public static void calculateMaxParallelForModules(MTEBaseModule module, MTEForgeOfGods godforge) {


### PR DESCRIPTION
Fixes [#17207](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17207)

Changed methods in `OverclockCalculator`:
- `setEUtDiscount`
- `setSpeedBoost`
- `setHeatDiscountMultiplier`

Most of other changes are directly related to them. 
Adds a unit test.