### PR TITLE
Implement itemInputsUnsafe

### DIFF
--- a/src/main/java/gregtech/api/recipe/RecipeMapBackend.java
+++ b/src/main/java/gregtech/api/recipe/RecipeMapBackend.java
@@ -277,8 +277,8 @@ public class RecipeMapBackend {
     public void reInit() {
         itemIndex.clear();
         for (GTRecipe recipe : allRecipes()) {
-            GTOreDictUnificator.setStackArray(true, recipe.mInputs);
-            GTOreDictUnificator.setStackArray(true, recipe.mOutputs);
+            GTOreDictUnificator.setStackArray(true, true, recipe.mInputs);
+            GTOreDictUnificator.setStackArray(true, true, recipe.mOutputs);
             addToItemMap(recipe);
         }
     }

--- a/src/main/java/gregtech/api/util/GTOreDictUnificator.java
+++ b/src/main/java/gregtech/api/util/GTOreDictUnificator.java
@@ -140,8 +140,16 @@ public class GTOreDictUnificator {
         return GTUtility.copyAmount(aAmount, aReplacement);
     }
 
+    /**
+     * Wrapper for setStackArray that assumes safe copying
+     */
     public static ItemStack[] setStackArray(boolean aUseBlackList, ItemStack... aStacks) {
-        for (int i = 0; i < aStacks.length; i++) aStacks[i] = get(aUseBlackList, GTUtility.copyOrNull(aStacks[i]));
+        return setStackArray(aUseBlackList, false, aStacks);
+    }
+
+    public static ItemStack[] setStackArray(boolean aUseBlackList, boolean aUnsafe, ItemStack... aStacks) {
+        for (int i = 0; i < aStacks.length; i++)
+            aStacks[i] = get(aUseBlackList, GTUtility.copyOrNull(aStacks[i]), aUnsafe);
         return aStacks;
     }
 

--- a/src/main/java/gregtech/api/util/GTRecipe.java
+++ b/src/main/java/gregtech/api/util/GTRecipe.java
@@ -252,8 +252,8 @@ public class GTRecipe implements Comparable<GTRecipe> {
         aFluidInputs = ArrayExt.withoutNulls(aFluidInputs, FluidStack[]::new);
         aFluidOutputs = ArrayExt.withoutNulls(aFluidOutputs, FluidStack[]::new);
 
-        GTOreDictUnificator.setStackArray(true, aInputs);
-        GTOreDictUnificator.setStackArray(true, aOutputs);
+        GTOreDictUnificator.setStackArray(true, true, aInputs);
+        GTOreDictUnificator.setStackArray(true, true, aOutputs);
 
         for (ItemStack tStack : aOutputs) GTUtility.updateItemStack(tStack);
 

--- a/src/main/java/gregtech/api/util/GTRecipeBuilder.java
+++ b/src/main/java/gregtech/api/util/GTRecipeBuilder.java
@@ -163,8 +163,9 @@ public class GTRecipeBuilder {
             .toArray(FluidStack[]::new);
     }
 
-    private static ItemStack[] fix(ItemStack[] inputs) {
-        return GTOreDictUnificator.setStackArray(true, ArrayExt.withoutTrailingNulls(inputs, ItemStack[]::new));
+    private static ItemStack[] fix(ItemStack[] inputs, boolean aUnsafe) {
+        return GTOreDictUnificator
+            .setStackArray(true, aUnsafe, ArrayExt.withoutTrailingNulls(inputs, ItemStack[]::new));
     }
 
     public static GTRecipeBuilder builder() {
@@ -250,7 +251,19 @@ public class GTRecipeBuilder {
     public GTRecipeBuilder itemInputs(ItemStack... inputs) {
         if (skip) return this;
         if (debugNull() && containsNull(inputs)) handleNullRecipeComponents("itemInputs");
-        inputsBasic = fix(inputs);
+        inputsBasic = fix(inputs, false);
+        inputsOreDict = null;
+        alts = null;
+        return this;
+    }
+
+    /**
+     * Non-OreDicted item inputs, allowing stack sizes greater than 64. Assumes input is not unified
+     */
+    public GTRecipeBuilder itemInputsUnsafe(ItemStack... inputs) {
+        if (skip) return this;
+        if (debugNull() && containsNull(inputs)) handleNullRecipeComponents("itemInputs");
+        inputsBasic = fix(inputs, true);
         inputsOreDict = null;
         alts = null;
         return this;


### PR DESCRIPTION
Adds an unsafe input builder for recipes. This allows the creation of recipes with stack sizes larger than 64. I have also changed later stages of the recipe transform pipeline to not do safety checks for stacksize. This is because these checks are already performed when building the recipe by .itemInputs().

This is required for the Neutronium Compressor recipemap to function properly.