### PR TITLE
Fix Overflows with Burn Times and adjust burn-time when the super efficiency increase logic reaches max efficiency 

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTELargeBoiler.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTELargeBoiler.java
@@ -366,19 +366,13 @@ public abstract class MTELargeBoiler extends MTEEnhancedMultiBlockBase<MTELargeB
     public boolean onRunningTick(ItemStack aStack) {
         if (this.mEUt > 0) {
             int maxEff = getMaxEfficiency(mInventory[1]) - ((getIdealStatus() - getRepairStatus()) * 1000);
-            if (this.mSuperEfficencyIncrease > 0 && mEfficiency < maxEff)
-            {
-                mEfficiency = Math.max(
-                    0,
-                    Math.min(
-                        mEfficiency + mSuperEfficencyIncrease,
-                        maxEff));
-                if (mEfficiency == maxEff)
-                {
-                    //Adjust the burntime dynamically to account for circuit program
-                    //This is to account for the dramatic issue where the machine outputs the throttled
-                    //amount but the burntime is not throttled.
-                    //This is very apparent when burning blocks with super high burntimes
+            if (this.mSuperEfficencyIncrease > 0 && mEfficiency < maxEff) {
+                mEfficiency = Math.max(0, Math.min(mEfficiency + mSuperEfficencyIncrease, maxEff));
+                if (mEfficiency == maxEff) {
+                    // Adjust the burntime dynamically to account for circuit program
+                    // This is to account for the dramatic issue where the machine outputs the throttled
+                    // amount but the burntime is not throttled.
+                    // This is very apparent when burning blocks with super high burntimes
                     int oldProgressTime = mProgresstime;
                     int oldMaxProgressTime = mMaxProgresstime;
                     int maxProgressTime = adjustBurnTimeForConfig(oldMaxProgressTime);

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTELargeBoiler.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTELargeBoiler.java
@@ -366,7 +366,7 @@ public abstract class MTELargeBoiler extends MTEEnhancedMultiBlockBase<MTELargeB
     public boolean onRunningTick(ItemStack aStack) {
         if (this.mEUt > 0) {
             int maxEff = getMaxEfficiency(mInventory[1]) - ((getIdealStatus() - getRepairStatus()) * 1000);
-            if (this.mSuperEfficencyIncrease > 0 && mEfficiency < maxEff) {
+            if (this.mSuperEfficencyIncrease > 0 && mEfficiency <= maxEff) {
                 mEfficiency = Math.max(0, Math.min(mEfficiency + mSuperEfficencyIncrease, maxEff));
                 if (mEfficiency == maxEff) {
                     // Adjust the burntime dynamically to account for circuit program


### PR DESCRIPTION
Also, removes the arbitrary limit that was applied in this PR https://github.com/GTNewHorizons/GT5-Unofficial/pull/866 that was added to fix the overflow in the past.

By removing this limit, this may effect balance, though it is clear from the commit that it was added in that it was not for balance but to fix a bug with overflow.

This PR fixes that bug for good and thus a limit is no longer needed for the purpose of checking overflow.

(Personally, I don't think the old logic of disallowing large burn times (basically any kind of compressed charcoal / coal block) was a good thing balance wise since you can still use these blocks in the small boilers (bronze, steel, LV, MV, HV) and it was very much an inconstancy, especially since you also couldn't use stuff like compressed charcoal in the superheated steam boilers.)