### PR TITLE
Rework Indium comb Processing

### DIFF
--- a/src/main/java/goodgenerator/loader/NaquadahReworkRecipeLoader.java
+++ b/src/main/java/goodgenerator/loader/NaquadahReworkRecipeLoader.java
@@ -408,6 +408,7 @@ public class NaquadahReworkRecipeLoader {
         // 2InPO4 + 3Ca = 2In + Ca3(PO4)2
         GTValues.RA.stdBuilder()
             .itemInputs(
+                GTUtility.getIntegratedCircuit(1),
                 indiumPhosphate.get(OrePrefixes.dust, 12),
                 GTOreDictUnificator.get(OrePrefixes.dust, Materials.Calcium, 3))
             .itemOutputs(

--- a/src/main/java/goodgenerator/loader/NaquadahReworkRecipeLoader.java
+++ b/src/main/java/goodgenerator/loader/NaquadahReworkRecipeLoader.java
@@ -416,7 +416,7 @@ public class NaquadahReworkRecipeLoader {
                 GTOreDictUnificator.get(OrePrefixes.dust, Materials.TricalciumPhosphate, 5))
             .duration(1 * SECONDS)
             .eut(TierEU.RECIPE_LV)
-            .addTo(UniversalChemical);
+            .addTo(multiblockChemicalReactorRecipes);
 
         GTValues.RA.stdBuilder()
             .itemInputs(lowQualityNaquadriaPhosphate.get(OrePrefixes.dust, 10), Materials.SulfuricAcid.getCells(30))

--- a/src/main/java/gregtech/common/items/ItemComb.java
+++ b/src/main/java/gregtech/common/items/ItemComb.java
@@ -484,7 +484,6 @@ public class ItemComb extends Item implements IGT_ItemWithMaterialRenderer {
         addProcessGT(CombType.COPPER, new Materials[] { Materials.Copper }, Voltage.LV);
         addProcessGT(CombType.TIN, new Materials[] { Materials.Tin }, Voltage.LV);
         addProcessGT(CombType.LEAD, new Materials[] { Materials.Lead }, Voltage.LV);
-        addProcessGT(CombType.INDIUM, new Materials[] { Materials.Indium }, Voltage.ZPM);
         addProcessGT(CombType.NICKEL, new Materials[] { Materials.Nickel }, Voltage.LV);
         addProcessGT(CombType.ZINC, new Materials[] { Materials.Zinc }, Voltage.LV);
         addProcessGT(CombType.SILVER, new Materials[] { Materials.Silver }, Voltage.LV);


### PR DESCRIPTION
Related to https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/967

This adds circuit to Indium Phosphate to indium recipe and makes it LCR only.
Removes direct indium comb to purified indium recipe.