### PR TITLE
Readd advanced alloy recipe

### DIFF
--- a/src/main/java/gregtech/loaders/postload/recipes/CompressorRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/CompressorRecipes.java
@@ -25,6 +25,14 @@ public class CompressorRecipes implements Runnable {
 
     @Override
     public void run() {
+
+        GTValues.RA.stdBuilder()
+            .itemInputs(GTModHandler.getIC2Item("mixedMetalIngot", 1L))
+            .itemOutputs(GTModHandler.getIC2Item("advancedAlloy", 1L))
+            .duration(15 * SECONDS)
+            .eut(2)
+            .addTo(compressorRecipes);
+
         GTValues.RA.stdBuilder()
             .itemInputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.Lapis, 1L))
             .itemOutputs(GTOreDictUnificator.get(OrePrefixes.plate, Materials.Lapis, 1L))


### PR DESCRIPTION
it was among the removed ic2 recipes.

fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17183

![image](https://github.com/user-attachments/assets/0ebd7003-2c8b-4fac-a52b-e0ffebd4792d)
