### PR TITLE
Fix tiering of cable recipes 

### DIFF
--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingWire.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingWire.java
@@ -335,7 +335,7 @@ public class ProcessingWire implements gregtech.api.interfaces.IOreRecipeRegistr
                     }
                 }
             }
-            case "Iron", "Nickel", "Cupronickel", "Copper", "AnnealedCopper", "Kanthal", "Gold", "Electrum", "Silver", "Nichrome", "Steel", "BlackSteel", "Titanium", "Aluminium", "BlueAlloy", "NetherStar", "RedstoneAlloy" -> {
+            case "RedstoneAlloy", "Iron", "Nickel", "Cupronickel", "Copper", "AnnealedCopper", "ElectricalSteel", "Kanthal", "Gold", "Electrum", "Silver", "BlueAlloy", "EnergeticAlloy", "Nichrome", "Steel", "BlackSteel", "Titanium", "Aluminium", "TPVAlloy", "VibrantAlloy" -> {
 
                 if (GTOreDictUnificator.get(correspondingCable, aMaterial, 1L) == null) {
                     break;

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingWire.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingWire.java
@@ -393,16 +393,18 @@ public class ProcessingWire implements gregtech.api.interfaces.IOreRecipeRegistr
                 }
 
                 // Assembler recipes
-                GTValues.RA.stdBuilder()
-                    .itemInputs(
-                        aStack,
-                        GTOreDictUnificator.get(OrePrefixes.foil, aMaterial, costMultiplier),
-                        GTUtility.getIntegratedCircuit(24))
-                    .itemOutputs(GTOreDictUnificator.get(correspondingCable, aMaterial, 1L))
-                    .fluidInputs(Materials.Silicone.getMolten(costMultiplier * 72))
-                    .duration(5 * SECONDS)
-                    .eut(calculateRecipeEU(aMaterial, 8))
-                    .addTo(assemblerRecipes);
+                if (GTOreDictUnificator.get(OrePrefixes.foil, aMaterial, 1L) != null) {
+                    GTValues.RA.stdBuilder()
+                        .itemInputs(
+                            aStack,
+                            GTOreDictUnificator.get(OrePrefixes.foil, aMaterial, costMultiplier),
+                            GTUtility.getIntegratedCircuit(24))
+                        .itemOutputs(GTOreDictUnificator.get(correspondingCable, aMaterial, 1L))
+                        .fluidInputs(Materials.Silicone.getMolten(costMultiplier * 72))
+                        .duration(5 * SECONDS)
+                        .eut(calculateRecipeEU(aMaterial, 8))
+                        .addTo(assemblerRecipes);
+                }
 
                 GTValues.RA.stdBuilder()
                     .itemInputs(
@@ -418,16 +420,28 @@ public class ProcessingWire implements gregtech.api.interfaces.IOreRecipeRegistr
                 for (Materials dielectric : dielectrics) {
                     for (Materials syntheticRubber : syntheticRubbers) {
 
-                        GTValues.RA.stdBuilder()
-                            .itemInputs(
-                                GTUtility.copyAmount(4, aStack),
-                                dielectric.getDust(costMultiplier),
-                                GTOreDictUnificator.get(OrePrefixes.foil, aMaterial, costMultiplier * 4L))
-                            .itemOutputs(GTOreDictUnificator.get(correspondingCable, aMaterial, 4L))
-                            .fluidInputs(syntheticRubber.getMolten(costMultiplier * 144L))
-                            .duration(20 * SECONDS)
-                            .eut(calculateRecipeEU(aMaterial, 8))
-                            .addTo(assemblerRecipes);
+                        if (GTOreDictUnificator.get(OrePrefixes.foil, aMaterial, 1L) != null) {
+                            GTValues.RA.stdBuilder()
+                                .itemInputs(
+                                    GTUtility.copyAmount(4, aStack),
+                                    dielectric.getDust(costMultiplier),
+                                    GTOreDictUnificator.get(OrePrefixes.foil, aMaterial, costMultiplier * 4L))
+                                .itemOutputs(GTOreDictUnificator.get(correspondingCable, aMaterial, 4L))
+                                .fluidInputs(syntheticRubber.getMolten(costMultiplier * 144L))
+                                .duration(20 * SECONDS)
+                                .eut(calculateRecipeEU(aMaterial, 8))
+                                .addTo(assemblerRecipes);
+                            GTValues.RA.stdBuilder()
+                                .itemInputs(
+                                    aStack,
+                                    dielectric.getDustSmall(costMultiplier),
+                                    GTOreDictUnificator.get(OrePrefixes.foil, aMaterial, costMultiplier))
+                                .itemOutputs(GTOreDictUnificator.get(correspondingCable, aMaterial, 1L))
+                                .fluidInputs(syntheticRubber.getMolten(costMultiplier * 36L))
+                                .duration(5 * SECONDS)
+                                .eut(calculateRecipeEU(aMaterial, 8))
+                                .addTo(assemblerRecipes);
+                        }
                         GTValues.RA.stdBuilder()
                             .itemInputs(
                                 GTUtility.copyAmount(4, aStack),
@@ -437,16 +451,6 @@ public class ProcessingWire implements gregtech.api.interfaces.IOreRecipeRegistr
                             .itemOutputs(GTOreDictUnificator.get(correspondingCable, aMaterial, 4L))
                             .fluidInputs(syntheticRubber.getMolten(costMultiplier * 144L))
                             .duration(20 * SECONDS)
-                            .eut(calculateRecipeEU(aMaterial, 8))
-                            .addTo(assemblerRecipes);
-                        GTValues.RA.stdBuilder()
-                            .itemInputs(
-                                aStack,
-                                dielectric.getDustSmall(costMultiplier),
-                                GTOreDictUnificator.get(OrePrefixes.foil, aMaterial, costMultiplier))
-                            .itemOutputs(GTOreDictUnificator.get(correspondingCable, aMaterial, 1L))
-                            .fluidInputs(syntheticRubber.getMolten(costMultiplier * 36L))
-                            .duration(5 * SECONDS)
                             .eut(calculateRecipeEU(aMaterial, 8))
                             .addTo(assemblerRecipes);
                         GTValues.RA.stdBuilder()


### PR DESCRIPTION
fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17138

This adds rubber recipes for electrical steel, energetic alloy, tpv alloy, and vibrant alloy (all MV-EV), while removing the one for netherstar (UIV).

Then it is all consistent again with the rule that all cables up to EV have (normal) rubber recipes and all above need the more advanced recipes.

e.g. vibrant alloy:
![image](https://github.com/user-attachments/assets/7379bc5d-9139-4edb-9f20-3f8bdefc578f)
