### PR TITLE
Use correct dummy world for BlockRenderer6343

### DIFF
--- a/src/main/java/gregtech/api/GregTechAPI.java
+++ b/src/main/java/gregtech/api/GregTechAPI.java
@@ -297,17 +297,6 @@ public class GregTechAPI {
         }
     }
 
-    private static void tryAddDummyWorld(String className) {
-        ClassLoader cl = GregTechAPI.class.getClassLoader();
-        Class<?> clazz;
-        try {
-            clazz = Class.forName(className, false, cl);
-        } catch (ReflectiveOperationException ex) {
-            return;
-        }
-        dummyWorlds.add(clazz);
-    }
-
     public static void addDummyWorld(Class<?> clazz) {
         dummyWorlds.add(clazz);
     }

--- a/src/main/java/gregtech/api/GregTechAPI.java
+++ b/src/main/java/gregtech/api/GregTechAPI.java
@@ -35,10 +35,12 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import com.google.common.collect.SetMultimap;
 
+import blockrenderer6343.client.world.TrackedDummyWorld;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.Materials;
+import gregtech.api.enums.Mods;
 import gregtech.api.enums.SoundResource;
 import gregtech.api.enums.Textures;
 import gregtech.api.interfaces.IDamagableItem;
@@ -289,7 +291,10 @@ public class GregTechAPI {
         sItemStackMappings.add(sCoverBehaviors);
 
         dummyWorlds.add(GTDummyWorld.class);
-        tryAddDummyWorld("blockrenderer6343.client.world.DummyWorld");
+
+        if (Mods.BlockRenderer6343.isModLoaded()) {
+            dummyWorlds.add(TrackedDummyWorld.class);
+        }
     }
 
     private static void tryAddDummyWorld(String className) {


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16755

No idea how it gets to this crash, but the packet that's causing it is hidden behind a [!GregTechAPI.isDummyWorld()](https://github.com/GTNewHorizons/GT5-Unofficial/blob/b0364a9c8630d217daf1d9b8379253d4eeeb0b76/src/main/java/gregtech/api/metatileentity/implementations/MTEEnhancedMultiBlockBase.java#L64) check and this is currently checking for the wrong one.