### PR TITLE
Halkonite/Superdense Plate fixes

### DIFF
--- a/src/main/java/gregtech/api/enums/Materials.java
+++ b/src/main/java/gregtech/api/enums/Materials.java
@@ -2548,6 +2548,10 @@ public class Materials implements IColorModulationContainer, ISubTagContainer {
         OrePrefixes.ingotHot.disableComponent(Materials.EnergeticAlloy);
         OrePrefixes.ingotHot.disableComponent(Materials.PulsatingIron);
         OrePrefixes.ingotHot.disableComponent(Materials.CrudeSteel);
+        OrePrefixes.ingotHot.disableComponent(MaterialsUEVplus.HotProtoHalkonite);
+        OrePrefixes.ingotHot.disableComponent(MaterialsUEVplus.ProtoHalkonite);
+        OrePrefixes.ingotHot.disableComponent(MaterialsUEVplus.HotExoHalkonite);
+        OrePrefixes.ingotHot.disableComponent(MaterialsUEVplus.ExoHalkonite);
     }
 
     /**

--- a/src/main/java/gregtech/api/enums/Materials.java
+++ b/src/main/java/gregtech/api/enums/Materials.java
@@ -2276,6 +2276,8 @@ public class Materials implements IColorModulationContainer, ISubTagContainer {
             TengamAttuned,
             MaterialsUEVplus.Eternity,
             MaterialsUEVplus.MagMatter,
+            MaterialsUEVplus.Creon,
+            MaterialsUEVplus.Mellion,
             MaterialsUEVplus.HotProtoHalkonite,
             MaterialsUEVplus.ProtoHalkonite,
             MaterialsUEVplus.HotExoHalkonite,

--- a/src/main/java/gregtech/common/items/MetaGeneratedItem01.java
+++ b/src/main/java/gregtech/common/items/MetaGeneratedItem01.java
@@ -584,7 +584,6 @@ public class MetaGeneratedItem01 extends MetaGeneratedItemX32 {
             OrePrefixes.plateQuadruple,
             OrePrefixes.plateQuintuple,
             OrePrefixes.plateDense,
-            OrePrefixes.plateSuperdense,
             OrePrefixes.stick,
             OrePrefixes.lens,
             OrePrefixes.round,

--- a/src/main/java/gregtech/loaders/postload/recipes/ChemicalBathRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/ChemicalBathRecipes.java
@@ -421,6 +421,7 @@ public class ChemicalBathRecipes implements Runnable {
         this.addProtoHalkonitePartRecipe(OrePrefixes.frameGt, 1);
         this.addProtoHalkonitePartRecipe(OrePrefixes.ingot, 1);
         this.addProtoHalkonitePartRecipe(OrePrefixes.plate, 1);
+        this.addProtoHalkonitePartRecipe(OrePrefixes.plateDouble, 1);
         this.addProtoHalkonitePartRecipe(OrePrefixes.plateDense, 1);
         this.addProtoHalkonitePartRecipe(OrePrefixes.stick, 2);
         this.addProtoHalkonitePartRecipe(OrePrefixes.round, 8);

--- a/src/main/java/gregtech/loaders/postload/recipes/CompressorRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/CompressorRecipes.java
@@ -277,6 +277,26 @@ public class CompressorRecipes implements Runnable {
             .addTo(compressorRecipes);
 
         GTValues.RA.stdBuilder()
+            .itemInputs(GTOreDictUnificator.get(OrePrefixes.plateSuperdense, MaterialsUEVplus.Creon, 1))
+            .fluidInputs(MaterialsUEVplus.MoltenProtoHalkoniteBase.getFluid(32 * 144))
+            .itemOutputs(GTOreDictUnificator.get(OrePrefixes.plateSuperdense, MaterialsUEVplus.HotProtoHalkonite, 1))
+            // Require stabilized black hole
+            .metadata(CompressionTierKey.INSTANCE, 2)
+            .duration(45 * SECONDS / 4)
+            .eut(TierEU.RECIPE_UIV)
+            .addTo(compressorRecipes);
+
+        GTValues.RA.stdBuilder()
+            .itemInputs(GTOreDictUnificator.get(OrePrefixes.plateSuperdense, MaterialsUEVplus.Mellion, 1))
+            .fluidInputs(MaterialsUEVplus.MoltenProtoHalkoniteBase.getFluid(32 * 144))
+            .itemOutputs(GTOreDictUnificator.get(OrePrefixes.plateSuperdense, MaterialsUEVplus.HotProtoHalkonite, 1))
+            // Require stabilized black hole
+            .metadata(CompressionTierKey.INSTANCE, 2)
+            .duration(45 * SECONDS / 4)
+            .eut(TierEU.RECIPE_UIV)
+            .addTo(compressorRecipes);
+
+        GTValues.RA.stdBuilder()
             .itemInputs(WerkstoffLoader.MagnetoResonaticDust.get(OrePrefixes.gem, 9))
             .itemOutputs(WerkstoffLoader.MagnetoResonaticDust.get(OrePrefixes.block, 1))
             .duration(15 * SECONDS)

--- a/src/main/java/gregtech/loaders/postload/recipes/VacuumFreezerRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/VacuumFreezerRecipes.java
@@ -415,6 +415,7 @@ public class VacuumFreezerRecipes implements Runnable {
         this.addProtoHalkonitePartRecipe(OrePrefixes.frameGt, 1);
         this.addProtoHalkonitePartRecipe(OrePrefixes.ingot, 1);
         this.addProtoHalkonitePartRecipe(OrePrefixes.plate, 1);
+        this.addProtoHalkonitePartRecipe(OrePrefixes.plateDouble, 1);
         this.addProtoHalkonitePartRecipe(OrePrefixes.plateDense, 1);
         this.addProtoHalkonitePartRecipe(OrePrefixes.stick, 2);
         this.addProtoHalkonitePartRecipe(OrePrefixes.round, 8);

--- a/src/main/resources/assets/gregtech/textures/items/materialicons/CUSTOM/spacetime/plateSuperdense.png.mcmeta
+++ b/src/main/resources/assets/gregtech/textures/items/materialicons/CUSTOM/spacetime/plateSuperdense.png.mcmeta
@@ -1,1 +1,1 @@
-{ "animation": { "interpolate": false, "frametime": 1 } }
+{"animation": {"frametime": 3}}


### PR DESCRIPTION
- Fix Creon+Mellion missing fine wires, causing recipe crashes on nightly 629
- Fix Double Proto-Halkonite Plate having no recipes
- Fix Hot Superdense Proto-Halkonite Plate only having a recipe with Infinity
- Fix every material having 2 Superdense Plates (artifact of #3068)
- Fix Superdense Spacetime Plate having a faster animation than other Spacetime items
- Remove `ingotHot` generated items from all 4 halkonites