### PR TITLE
Fix NPE in log with laser mirror pipes

### DIFF
--- a/src/main/java/tectech/thing/metaTileEntity/pipe/MTEPipeEnergyMirror.java
+++ b/src/main/java/tectech/thing/metaTileEntity/pipe/MTEPipeEnergyMirror.java
@@ -141,6 +141,7 @@ public class MTEPipeEnergyMirror extends MTEPipeEnergy {
     }
 
     public ForgeDirection getBendDirection(ForgeDirection dir) {
+        if (dir == null) return null;
         for (ForgeDirection bendDir : connectedSides) {
             if (bendDir != dir) {
                 chainedFrontFacing = bendDir.getOpposite();

--- a/src/main/java/tectech/thing/metaTileEntity/pipe/MTEPipeEnergyMirror.java
+++ b/src/main/java/tectech/thing/metaTileEntity/pipe/MTEPipeEnergyMirror.java
@@ -143,7 +143,7 @@ public class MTEPipeEnergyMirror extends MTEPipeEnergy {
     public ForgeDirection getBendDirection(ForgeDirection dir) {
         if (dir == null) return null;
         for (ForgeDirection bendDir : connectedSides) {
-            if (bendDir != dir) {
+            if (bendDir != null && bendDir != dir) {
                 chainedFrontFacing = bendDir.getOpposite();
                 return bendDir;
             }


### PR DESCRIPTION
Fixes this being spammed in the log:
![image](https://github.com/user-attachments/assets/4e615f3c-dec2-4eea-a777-68db1ead6193)
Doesn't seem to "cause issues" since the NPE is caught, but it causes a fair amount of log spam and I'm sure has some effect on performance as a result.
