### PR TITLE
Fix waterline bugs

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/purification/MTEPurificationUnitBase.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/purification/MTEPurificationUnitBase.java
@@ -318,7 +318,7 @@ public abstract class MTEPurificationUnitBase<T extends MTEExtendedPowerMultiBlo
     public FluidStack getWaterBoostAmount(GTRecipe recipe) {
         // Recipes should always be constructed so that output water is always the first fluid output
         FluidStack outputWater = recipe.mFluidOutputs[0];
-        int amount = Math.round(outputWater.amount * WATER_BOOST_NEEDED_FLUID);
+        int amount = Math.round(outputWater.amount * WATER_BOOST_NEEDED_FLUID * this.effectiveParallel);
         return new FluidStack(outputWater.getFluid(), amount);
     }
 
@@ -337,11 +337,15 @@ public abstract class MTEPurificationUnitBase<T extends MTEExtendedPowerMultiBlo
 
     /**
      * Consumes all <b>fluid</b> inputs of the current recipe.
+     * Should only scale the first fluid input with water
      */
     public void depleteRecipeInputs() {
-        for (FluidStack input : this.currentRecipe.mFluidInputs) {
+        for (int i = 0; i < this.currentRecipe.mFluidInputs.length; ++i) {
+            FluidStack input = this.currentRecipe.mFluidInputs[i];
             FluidStack copyWithParallel = input.copy();
-            copyWithParallel.amount = input.amount * effectiveParallel;
+            if (i == 0) {
+                copyWithParallel.amount = input.amount * effectiveParallel;
+            }
             this.depleteInput(copyWithParallel);
         }
     }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/purification/MTEPurificationUnitOzonation.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/purification/MTEPurificationUnitOzonation.java
@@ -261,8 +261,7 @@ public class MTEPurificationUnitOzonation extends MTEPurificationUnitBase<MTEPur
         for (FluidStack fluid : this.storedFluids) {
             if (fluid.isFluidEqual(Materials.Ozone.getGas(1L))) {
                 if (fluid.amount > MAX_OZONE_GAS_FOR_EXPLOSION) {
-                    // TODO: Fix crash in hatch
-                    // this.explodeMultiblock();
+                    this.explodeMultiblock();
                 }
             }
         }


### PR DESCRIPTION
- Fix ozonation plant producing ozone instead of consuming it when parallel is set very high. At the same time, fix fluid inputs other than water scaling.
- Fix water boost amount not scaling with parallel.
- Fix ozonation plant not exploding like the tooltip says