### PR TITLE
Replace neutronium compressor with neutronium compressor

### DIFF
--- a/src/main/java/bartworks/common/loaders/ElectricImplosionCompressorRecipes.java
+++ b/src/main/java/bartworks/common/loaders/ElectricImplosionCompressorRecipes.java
@@ -14,9 +14,7 @@ import static gregtech.api.enums.Mods.OpenComputers;
 import static gregtech.api.enums.Mods.SuperSolarPanels;
 import static gregtech.api.enums.Mods.UniversalSingularities;
 import static gregtech.api.util.GTModHandler.getModItem;
-import static gregtech.api.util.GTRecipeBuilder.MINUTES;
 import static gregtech.api.util.GTRecipeBuilder.SECONDS;
-import static gregtech.api.util.GTRecipeBuilder.TICKS;
 
 import net.minecraft.item.ItemStack;
 
@@ -27,7 +25,6 @@ import gregtech.api.enums.MaterialsUEVplus;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.enums.TierEU;
 import gregtech.api.util.GTOreDictUnificator;
-import gregtech.api.util.GTUtility;
 
 public class ElectricImplosionCompressorRecipes implements Runnable {
 
@@ -36,14 +33,6 @@ public class ElectricImplosionCompressorRecipes implements Runnable {
         // Custom electric implosion compressor recipes. Cannot be overclocked.
 
         if (EternalSingularity.isModLoaded()) {
-
-            GTValues.RA.stdBuilder()
-                .itemOutputs(getModItem(EternalSingularity.ID, "eternal_singularity", 1L))
-                .fluidInputs(MaterialsUEVplus.SpaceTime.getMolten(72L))
-                .duration(1 * MINUTES + 40 * SECONDS)
-                .eut(TierEU.RECIPE_UMV)
-                .noOptimize()
-                .addTo(electricImplosionCompressorRecipes);
 
             if (UniversalSingularities.isModLoaded()) {
                 // Raw Exposed Optical Chip
@@ -56,28 +45,6 @@ public class ElectricImplosionCompressorRecipes implements Runnable {
                     .duration(5 * SECONDS)
                     .eut(TierEU.RECIPE_UMV)
                     .noOptimize()
-                    .addTo(electricImplosionCompressorRecipes);
-
-                GTValues.RA.stdBuilder()
-                    .itemInputs(
-                        // fluxed electrum singularity
-                        getModItem(UniversalSingularities.ID, "universal.general.singularity", 1L, 20))
-                    .fluidInputs(MaterialsUEVplus.Mellion.getMolten(4 * 144L))
-                    // spaghettic singularity
-                    .itemOutputs(getModItem(EternalSingularity.ID, "combined_singularity", 1L, 2))
-                    .duration(1 * SECONDS)
-                    .eut(TierEU.RECIPE_UMV)
-                    .addTo(electricImplosionCompressorRecipes);
-
-                GTValues.RA.stdBuilder()
-                    .itemInputs(
-                        // iron singularity
-                        getModItem(Avaritia.ID, "Singularity", 1L, 0))
-                    .fluidInputs(MaterialsUEVplus.Creon.getMolten(4 * 144L))
-                    // cryptic singularity
-                    .itemOutputs(getModItem(EternalSingularity.ID, "combined_singularity", 1L, 4))
-                    .duration(1 * SECONDS)
-                    .eut(TierEU.RECIPE_UMV)
                     .addTo(electricImplosionCompressorRecipes);
             }
         }
@@ -131,43 +98,6 @@ public class ElectricImplosionCompressorRecipes implements Runnable {
             .noOptimize()
             .addTo(electricImplosionCompressorRecipes);
 
-        if (UniversalSingularities.isModLoaded()) {
-            // Fluxed Singularity
-            GTValues.RA.stdBuilder()
-                .itemInputs(GTOreDictUnificator.get(OrePrefixes.block, Materials.ElectrumFlux, 16L))
-                .itemOutputs(getModItem(UniversalSingularities.ID, "universal.general.singularity", 1L, 20))
-                .duration(1)
-                .eut(TierEU.RECIPE_UIV)
-                .noOptimize()
-                .addTo(electricImplosionCompressorRecipes);
-
-            // Iron Singularity
-            GTValues.RA.stdBuilder()
-                .itemOutputs(getModItem(Avaritia.ID, "Singularity", 1L, 0))
-                .fluidInputs(Materials.Iron.getMolten(7296 * 9 * 144L))
-                .duration(1)
-                .eut(TierEU.RECIPE_UIV)
-                .noOptimize()
-                .addTo(electricImplosionCompressorRecipes);
-
-            // Copper Singularity
-            GTValues.RA.stdBuilder()
-                .fluidInputs(Materials.Copper.getMolten(3648 * 9 * 144L))
-                .itemOutputs(getModItem(Avaritia.ID, "Singularity", 1L, 5))
-                .duration(1 * TICKS)
-                .eut(TierEU.RECIPE_UIV)
-                .addTo(electricImplosionCompressorRecipes);
-
-            ItemStack diamondBlocks = GTUtility
-                .copyAmountUnsafe(729, GTOreDictUnificator.get(OrePrefixes.block, Materials.Diamond, 1L));
-            // Diamond Singularity
-            GTValues.RA.stdBuilder()
-                .itemInputs(diamondBlocks)
-                .itemOutputs(getModItem(UniversalSingularities.ID, "universal.vanilla.singularity", 1L, 2))
-                .duration(1 * TICKS)
-                .eut(TierEU.RECIPE_UIV)
-                .addTo(electricImplosionCompressorRecipes);
-        }
         // MHDCSM V2
         GTValues.RA.stdBuilder()
             .itemInputs(MaterialsUEVplus.Eternity.getNanite(1), MaterialsUEVplus.Universium.getNanite(1))

--- a/src/main/java/goodgenerator/loader/RecipeLoader2.java
+++ b/src/main/java/goodgenerator/loader/RecipeLoader2.java
@@ -4,7 +4,6 @@ import static goodgenerator.api.recipe.GoodGeneratorRecipeMaps.neutronActivatorR
 import static goodgenerator.api.recipe.GoodGeneratorRecipeMaps.preciseAssemblerRecipes;
 import static goodgenerator.util.MyRecipeAdder.computeRangeNKE;
 import static gregtech.api.enums.Mods.AppliedEnergistics2;
-import static gregtech.api.enums.Mods.Avaritia;
 import static gregtech.api.enums.Mods.GalacticraftMars;
 import static gregtech.api.enums.Mods.NewHorizonsCoreMod;
 import static gregtech.api.recipe.RecipeMaps.assemblerRecipes;
@@ -416,7 +415,7 @@ public class RecipeLoader2 {
             .itemInputs(
                 GTModHandler.getModItem(GalacticraftMars.ID, "item.null", 64L, 6),
                 ItemList.Electric_Pump_ZPM.get(8),
-                GTModHandler.getModItem(Avaritia.ID, "Neutronium_Compressor", 1L, 0),
+                ItemList.Machine_Multi_NeutroniumCompressor.get(1),
                 ItemList.Quantum_Tank_EV.get(32),
                 GTOreDictUnificator.get(OrePrefixes.pipeNonuple, Materials.Infinity, 8),
                 GTOreDictUnificator.get(OrePrefixes.plateQuintuple, Materials.InfinityCatalyst, 8),
@@ -436,7 +435,7 @@ public class RecipeLoader2 {
             .itemInputs(
                 GTModHandler.getModItem(GalacticraftMars.ID, "item.null", 64L, 6),
                 ItemList.Electric_Pump_UV.get(8),
-                GTModHandler.getModItem(Avaritia.ID, "Neutronium_Compressor", 2L, 0),
+                ItemList.Machine_Multi_NeutroniumCompressor.get(2),
                 ItemList.Quantum_Tank_EV.get(64),
                 GTOreDictUnificator.get(OrePrefixes.pipeNonuple, Materials.Infinity, 16),
                 GTOreDictUnificator.get(OrePrefixes.plateQuintuple, Materials.Infinity, 24),
@@ -456,7 +455,7 @@ public class RecipeLoader2 {
             .itemInputs(
                 GTModHandler.getModItem(GalacticraftMars.ID, "item.null", 64L, 6),
                 ItemList.Electric_Pump_UHV.get(8),
-                GTModHandler.getModItem(Avaritia.ID, "Neutronium_Compressor", 2L, 0),
+                ItemList.Machine_Multi_NeutroniumCompressor.get(2),
                 ItemList.Quantum_Tank_IV.get(8),
                 GTOreDictUnificator.get(OrePrefixes.pipeNonuple, Materials.Infinity, 32),
                 GTOreDictUnificator.get(OrePrefixes.plateQuintuple, Materials.Infinity, 36),
@@ -477,7 +476,7 @@ public class RecipeLoader2 {
             .itemInputs(
                 GTModHandler.getModItem(GalacticraftMars.ID, "item.null", 64L, 6),
                 ItemList.Electric_Pump_UEV.get(8),
-                GTModHandler.getModItem(Avaritia.ID, "Neutronium_Compressor", 4L, 0),
+                ItemList.Machine_Multi_NeutroniumCompressor.get(4),
                 ItemList.Quantum_Tank_IV.get(16),
                 GTOreDictUnificator.get(OrePrefixes.pipeNonuple, Materials.Infinity, 32),
                 GTOreDictUnificator.get(OrePrefixes.plateQuintuple, Materials.CosmicNeutronium, 24),

--- a/src/main/java/kekztech/common/recipeLoaders/AssemblyLine.java
+++ b/src/main/java/kekztech/common/recipeLoaders/AssemblyLine.java
@@ -1,7 +1,6 @@
 package kekztech.common.recipeLoaders;
 
 import static goodgenerator.loader.Loaders.huiCircuit;
-import static gregtech.api.enums.Mods.Avaritia;
 import static gregtech.api.enums.Mods.EnderIO;
 import static gregtech.api.enums.Mods.EternalSingularity;
 import static gregtech.api.enums.Mods.NewHorizonsCoreMod;
@@ -86,7 +85,7 @@ public class AssemblyLine implements Runnable {
             .metadata(RESEARCH_TIME, 2 * HOURS + 40 * MINUTES)
             .itemInputs(
                 ItemList.Quantum_Tank_IV.get(1),
-                GTModHandler.getModItem(Avaritia.ID, "Neutronium_Compressor", 1),
+                ItemList.Machine_Multi_NeutroniumCompressor.get(1),
                 GTOreDictUnificator.get(OrePrefixes.plateDense, Materials.StellarAlloy, 6),
                 GTOreDictUnificator.get(OrePrefixes.plateDense, Materials.StellarAlloy, 6),
                 GTOreDictUnificator.get(OrePrefixes.pipeNonuple, Materials.DraconiumAwakened, 3),
@@ -107,7 +106,7 @@ public class AssemblyLine implements Runnable {
             .metadata(RESEARCH_TIME, 2 * HOURS + 13 * MINUTES + 20 * SECONDS)
             .itemInputs(
                 ItemList.Quantum_Tank_IV.get(4),
-                GTModHandler.getModItem(Avaritia.ID, "Neutronium_Compressor", 2),
+                ItemList.Machine_Multi_NeutroniumCompressor.get(2),
                 GTOreDictUnificator.get(OrePrefixes.plateDense, MaterialsUEVplus.TranscendentMetal, 6),
                 GTOreDictUnificator.get(OrePrefixes.plateDense, MaterialsUEVplus.ProtoHalkonite, 6),
                 GTOreDictUnificator.get(OrePrefixes.pipeNonuple, Materials.Infinity, 3),
@@ -129,7 +128,7 @@ public class AssemblyLine implements Runnable {
             .metadata(RESEARCH_TIME, 2 * HOURS + 46 * MINUTES + 40 * SECONDS)
             .itemInputs(
                 ItemList.Quantum_Tank_IV.get(16),
-                GTModHandler.getModItem(Avaritia.ID, "Neutronium_Compressor", 4),
+                ItemList.Machine_Multi_NeutroniumCompressor.get(4),
                 GTOreDictUnificator.get(OrePrefixes.plateDense, MaterialsUEVplus.SpaceTime, 6),
                 GTOreDictUnificator.get(OrePrefixes.plateDense, MaterialsUEVplus.SpaceTime, 6),
                 GTOreDictUnificator.get(OrePrefixes.pipeNonuple, MaterialsUEVplus.SpaceTime, 3),

--- a/src/main/java/kubatech/loaders/RecipeLoader.java
+++ b/src/main/java/kubatech/loaders/RecipeLoader.java
@@ -338,7 +338,7 @@ public class RecipeLoader {
                 .metadata(RESEARCH_TIME, 8 * MINUTES + 20 * SECONDS)
                 .itemInputs(
                     LegendaryUltimateTea.get(0),
-                    GameRegistry.findItemStack("Avaritia", "Neutronium_Compressor", 1),
+                    gregtech.api.enums.ItemList.Machine_Multi_NeutroniumCompressor.get(1),
                     gregtech.api.enums.ItemList.Quantum_Tank_EV.get(1),
                     FluidExtractorUHV.get(10),
                     new Object[] { OrePrefixes.circuit.get(Materials.UV), 4L },


### PR DESCRIPTION
Companion to https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/974

Replaces all uses of the Avaritia singleblock Neutronium Compressor with the controller for the new GT multiblock. The recipe for the new block is extremely similar, so this should have little impact: 
![image](https://github.com/user-attachments/assets/668d7c36-7767-40f5-9650-a55ca2a366ae)

Removes all singularity recipes from the EIC. These are now made in the Black Hole Compressor and belong to that recipemap