### PR TITLE
fixed ross128b & ross128ba oregen

### DIFF
--- a/src/main/java/bartworks/system/oregen/BWWorldGenRoss128b.java
+++ b/src/main/java/bartworks/system/oregen/BWWorldGenRoss128b.java
@@ -27,9 +27,11 @@ import static gregtech.api.enums.Materials.Uraninite;
 import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 import net.minecraft.util.StatCollector;
+import net.minecraft.world.World;
 
 import bartworks.common.configs.ConfigHandler;
 import bartworks.system.material.WerkstoffLoader;
+import bwcrossmod.galacticraft.planets.ross128b.WorldProviderRoss128b;
 import gregtech.api.interfaces.ISubTagContainer;
 
 public class BWWorldGenRoss128b extends BWOreLayer {
@@ -47,6 +49,18 @@ public class BWWorldGenRoss128b extends BWOreLayer {
     @Override
     public String getDimName() {
         return StatCollector.translateToLocal("planet.Ross128b");
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Override
+    public boolean isGenerationAllowed(World aWorld, Class... aAllowedDimensionTypes) {
+        for (Class<?> clazz : aAllowedDimensionTypes) {
+            if (clazz == WorldProviderRoss128b.class) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public BWWorldGenRoss128b(String aName, boolean aDefault, int aMinY, int aMaxY, int aWeight, int aDensity,

--- a/src/main/java/bartworks/system/oregen/BWWorldGenRoss128ba.java
+++ b/src/main/java/bartworks/system/oregen/BWWorldGenRoss128ba.java
@@ -24,9 +24,11 @@ import static gregtech.api.enums.Materials.Tetrahedrite;
 
 import net.minecraft.block.Block;
 import net.minecraft.util.StatCollector;
+import net.minecraft.world.World;
 
 import bartworks.common.configs.ConfigHandler;
 import bartworks.system.material.WerkstoffLoader;
+import bwcrossmod.galacticraft.planets.ross128ba.WorldProviderRoss128ba;
 import gregtech.api.interfaces.ISubTagContainer;
 
 public class BWWorldGenRoss128ba extends BWOreLayer {
@@ -54,6 +56,18 @@ public class BWWorldGenRoss128ba extends BWOreLayer {
     @Override
     public String getDimName() {
         return StatCollector.translateToLocal("moon.Ross128ba");
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Override
+    public boolean isGenerationAllowed(World aWorld, Class... aAllowedDimensionTypes) {
+        for (Class clazz : aAllowedDimensionTypes) {
+            if (clazz == WorldProviderRoss128ba.class) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public static void init_Ores() {


### PR DESCRIPTION
Ross oregen was disabled because the isGenerationAllowed (see [BWWordGenerator](https://github.com/GTNewHorizons/GT5-Unofficial/blob/fix-ross-ores/src/main/java/bartworks/system/oregen/BWWordGenerator.java#L106) and [GTWorldgen](https://github.com/GTNewHorizons/GT5-Unofficial/blob/fix-ross-ores/src/main/java/gregtech/api/world/GTWorldgen.java#L92)) method always returned false for ross128b and ross128ba. This commit adds an override for the ross gen layers to return true when they're generating for their respective planet.

Ross128b:
![2024-09-08_15 56 59](https://github.com/user-attachments/assets/ceae4965-df38-4ef6-bd83-33c68a2ce470)

Ross128ba:
![2024-09-08_15 56 00](https://github.com/user-attachments/assets/1e8da0fb-21e2-46ff-b6dc-d94900c5ab2e)
