### PR TITLE
Removes voltage and amperage information in NEI for Research Station

### DIFF
--- a/src/main/java/tectech/recipe/ResearchStationFrontend.java
+++ b/src/main/java/tectech/recipe/ResearchStationFrontend.java
@@ -57,8 +57,6 @@ public class ResearchStationFrontend extends RecipeMapFrontend {
                 GTUtility.formatNumbers(
                     (1 + (computation - minComputationPerSec) / minComputationPerSec) * eut * ampere * 20)));
         recipeInfo.drawText(trans("153", "Usage: ") + GTUtility.formatNumbers(eut * ampere) + " EU/t");
-        recipeInfo.drawText(trans("154", "Voltage: ") + GTUtility.formatNumbers(eut) + " EU/t");
-        recipeInfo.drawText(trans("155", "Amperage: ") + GTUtility.formatNumbers(ampere));
         recipeInfo
             .drawText(translateToLocalFormatted("tt.nei.research.computation", GTUtility.formatNumbers(computation)));
         recipeInfo.drawText(


### PR DESCRIPTION
Removes two unnecessary lines for Research Station NEI page to reduce confusion because you only need to provide the EU/t via TecTech hatches/laser since it ignores the min voltage limit.
There has been a couple instances of people not researching certain items because they thought researching them was gated further than they were.
![image](https://github.com/user-attachments/assets/61739f8a-eeb1-4bef-bcc0-4214269e1168)
