### PR TITLE
Prevent supertank use as a cell when stackSize > 1

### DIFF
--- a/src/main/java/gregtech/common/blocks/ItemMachines.java
+++ b/src/main/java/gregtech/common/blocks/ItemMachines.java
@@ -373,6 +373,9 @@ public class ItemMachines extends ItemBlock implements IFluidContainerItem {
             if (!(tMetaTile instanceof MTEDigitalTankBase)) {
                 return 0;
             }
+            if (container.stackSize > 1) {
+                return 0;
+            }
             if (container.stackTagCompound == null) container.stackTagCompound = new NBTTagCompound();
             final FluidStack tStoredFluid = getFluid(container);
             final int tCapacity = getCapacity(container);


### PR DESCRIPTION
This prevents super tanks from being used as a cell when the stackSize > 1. This has no effect on FluidSlotWidgets because modular UI sets the stackSize to 1 before filling a IFluidContainerItem, then emulates filling the rest of the stack. The changed code only affects super tanks, so fluid cells still work the same.

Close https://github.com/GTNewHorizons/Dupes-Exploits-GTNH/issues/146