### PR TITLE
Kill bartworks fluid canner registry

### DIFF
--- a/src/main/java/bartworks/system/material/gtenhancement/GTMetaItemEnhancer.java
+++ b/src/main/java/bartworks/system/material/gtenhancement/GTMetaItemEnhancer.java
@@ -14,8 +14,6 @@
 package bartworks.system.material.gtenhancement;
 
 import static gregtech.api.enums.Mods.Forestry;
-import static gregtech.api.recipe.RecipeMaps.fluidCannerRecipes;
-import static gregtech.api.util.GTRecipeBuilder.TICKS;
 import static gregtech.api.util.GTRecipeBuilder.WILDCARD;
 
 import java.util.List;
@@ -29,7 +27,6 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.oredict.OreDictionary;
 
 import codechicken.nei.api.API;
-import gregtech.api.enums.GTValues;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.util.GTModHandler;
@@ -65,22 +62,6 @@ public class GTMetaItemEnhancer {
                     GTModHandler.getModItem(Forestry.ID, "refractoryEmpty", 1));
                 FluidContainerRegistry.registerFluidContainer(emptyData);
                 GTUtility.addFluidContainerData(emptyData);
-
-                GTValues.RA.stdBuilder()
-                    .itemInputs(GTModHandler.getModItem(Forestry.ID, "refractoryEmpty", 1))
-                    .itemOutputs(new ItemStack(moltenCapsuls, 1, i))
-                    .fluidInputs(m.getMolten(144))
-                    .duration(2 * TICKS)
-                    .eut(2)
-                    .addTo(fluidCannerRecipes);
-
-                GTValues.RA.stdBuilder()
-                    .itemInputs(new ItemStack(moltenCapsuls, 1, i))
-                    .fluidOutputs(m.getMolten(144))
-                    .duration(2 * TICKS)
-                    .eut(2)
-                    .addTo(fluidCannerRecipes);
-
             }
             if (m.getFluid(1) == null && m.getGas(1) == null || OreDictionary.doesOreNameExist("capsule" + m.mName))
                 continue;
@@ -110,22 +91,6 @@ public class GTMetaItemEnhancer {
             container);
         FluidContainerRegistry.registerFluidContainer(emptyData);
         GTUtility.addFluidContainerData(emptyData);
-
-        GTValues.RA.stdBuilder()
-            .itemInputs(container)
-            .itemOutputs(new ItemStack(filled, 1, it))
-            .fluidInputs(new FluidStack(f, amount))
-            .duration(amount / 62)
-            .eut(2)
-            .addTo(fluidCannerRecipes);
-
-        GTValues.RA.stdBuilder()
-            .itemInputs(new ItemStack(filled, 1, it))
-            .fluidOutputs(new FluidStack(f, amount))
-            .duration(amount / 62)
-            .eut(2)
-            .addTo(fluidCannerRecipes);
-
     }
 
     public static void addAdditionalOreDictToForestry() {

--- a/src/main/java/bartworks/system/material/werkstoff_loaders/recipe/CellLoader.java
+++ b/src/main/java/bartworks/system/material/werkstoff_loaders/recipe/CellLoader.java
@@ -17,11 +17,9 @@ import static gregtech.api.enums.Mods.Forestry;
 import static gregtech.api.enums.OrePrefixes.capsule;
 import static gregtech.api.enums.OrePrefixes.cell;
 import static gregtech.api.enums.OrePrefixes.dust;
-import static gregtech.api.recipe.RecipeMaps.fluidCannerRecipes;
 import static gregtech.api.recipe.RecipeMaps.fluidExtractionRecipes;
 import static gregtech.api.recipe.RecipeMaps.fluidSolidifierRecipes;
 import static gregtech.api.recipe.RecipeMaps.scannerFakeRecipes;
-import static gregtech.api.util.GTRecipeBuilder.TICKS;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -224,22 +222,6 @@ public class CellLoader implements IWerkstoffRunnable {
             werkstoff.get(cell),
             Materials.Empty.getCells(1));
 
-        GTValues.RA.stdBuilder()
-            .itemInputs(Materials.Empty.getCells(1))
-            .itemOutputs(werkstoff.get(cell))
-            .fluidInputs(new FluidStack(Objects.requireNonNull(WerkstoffLoader.fluids.get(werkstoff)), 1000))
-            .duration(16 * TICKS)
-            .eut(2)
-            .addTo(fluidCannerRecipes);
-
-        GTValues.RA.stdBuilder()
-            .itemInputs(werkstoff.get(cell))
-            .itemOutputs(Materials.Empty.getCells(1))
-            .fluidOutputs(new FluidStack(Objects.requireNonNull(WerkstoffLoader.fluids.get(werkstoff)), 1000))
-            .duration(16 * TICKS)
-            .eut(2)
-            .addTo(fluidCannerRecipes);
-
         if (Forestry.isModLoaded()) {
             FluidContainerRegistry.FluidContainerData emptyData = new FluidContainerRegistry.FluidContainerData(
                 new FluidStack(Objects.requireNonNull(WerkstoffLoader.fluids.get(werkstoff)), 1000),
@@ -249,12 +231,6 @@ public class CellLoader implements IWerkstoffRunnable {
             GTUtility.addFluidContainerData(emptyData);
             FluidContainerRegistry.registerFluidContainer(emptyData);
 
-            GTValues.RA.stdBuilder()
-                .itemInputs(werkstoff.get(capsule))
-                .fluidOutputs(new FluidStack(Objects.requireNonNull(WerkstoffLoader.fluids.get(werkstoff)), 1000))
-                .duration(16 * TICKS)
-                .eut(2)
-                .addTo(fluidCannerRecipes);
         }
 
         if (werkstoff.hasItemType(dust)) {

--- a/src/main/java/bartworks/system/material/werkstoff_loaders/recipe/MoltenCellLoader.java
+++ b/src/main/java/bartworks/system/material/werkstoff_loaders/recipe/MoltenCellLoader.java
@@ -32,11 +32,9 @@ import static gregtech.api.enums.OrePrefixes.rotor;
 import static gregtech.api.enums.OrePrefixes.screw;
 import static gregtech.api.enums.OrePrefixes.stick;
 import static gregtech.api.enums.OrePrefixes.stickLong;
-import static gregtech.api.recipe.RecipeMaps.fluidCannerRecipes;
 import static gregtech.api.recipe.RecipeMaps.fluidExtractionRecipes;
 import static gregtech.api.recipe.RecipeMaps.fluidSolidifierRecipes;
 import static gregtech.api.util.GTRecipeBuilder.SECONDS;
-import static gregtech.api.util.GTRecipeBuilder.TICKS;
 
 import java.util.Objects;
 
@@ -331,22 +329,6 @@ public class MoltenCellLoader implements IWerkstoffRunnable {
             .registerFluidContainer(werkstoff.getMolten(144), werkstoff.get(cellMolten), Materials.Empty.getCells(1));
         GTUtility.addFluidContainerData(data);
 
-        GTValues.RA.stdBuilder()
-            .itemInputs(Materials.Empty.getCells(1))
-            .itemOutputs(werkstoff.get(cellMolten))
-            .fluidInputs(new FluidStack(Objects.requireNonNull(WerkstoffLoader.molten.get(werkstoff)), 144))
-            .duration(2 * TICKS)
-            .eut(2)
-            .addTo(fluidCannerRecipes);
-
-        GTValues.RA.stdBuilder()
-            .itemInputs(werkstoff.get(cellMolten))
-            .itemOutputs(Materials.Empty.getCells(1))
-            .fluidOutputs(new FluidStack(Objects.requireNonNull(WerkstoffLoader.molten.get(werkstoff)), 144))
-            .duration(2 * TICKS)
-            .eut(2)
-            .addTo(fluidCannerRecipes);
-
         if (!Forestry.isModLoaded()) return;
 
         final FluidContainerRegistry.FluidContainerData emptyData = new FluidContainerRegistry.FluidContainerData(
@@ -358,13 +340,6 @@ public class MoltenCellLoader implements IWerkstoffRunnable {
             werkstoff.get(capsuleMolten),
             GTModHandler.getModItem(Forestry.ID, "refractoryEmpty", 1));
         GTUtility.addFluidContainerData(emptyData);
-
-        GTValues.RA.stdBuilder()
-            .itemInputs(werkstoff.get(capsuleMolten))
-            .fluidOutputs(new FluidStack(Objects.requireNonNull(WerkstoffLoader.molten.get(werkstoff)), 144))
-            .duration(2 * TICKS)
-            .eut(2)
-            .addTo(fluidCannerRecipes);
 
     }
 }


### PR DESCRIPTION
Stop bartworks from doing any registry of fluid canner recipes. Has no impact on real recipes whatsoever since these recipes are all loaded by gt anyways.

Before: ![image](https://github.com/user-attachments/assets/8b9f4323-8131-4e25-b492-7ae462a50664)
After: ![image](https://github.com/user-attachments/assets/b869aeab-65d3-46bc-8cf8-ad50e32c604c)
