### PR TITLE
Require screwdriver to adjust laser hatches

### DIFF
--- a/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchDynamoTunnel.java
+++ b/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchDynamoTunnel.java
@@ -46,6 +46,7 @@ public class MTEHatchDynamoTunnel extends MTEHatchDynamoMulti implements IConnec
             0,
             new String[] { CommonValues.TEC_MARK_GENERAL,
                 translateToLocal("gt.blockmachines.hatch.dynamotunnel.desc.0"),
+                translateToLocal("gt.blockmachines.hatch.screwdrivertooltip"),
                 translateToLocal("gt.blockmachines.hatch.dynamotunnel.desc.1") + ": "
                     + EnumChatFormatting.YELLOW
                     + GTUtility.formatNumbers(amps * V[tier])
@@ -252,9 +253,10 @@ public class MTEHatchDynamoTunnel extends MTEHatchDynamoMulti implements IConnec
     }
 
     @Override
-    public boolean onRightclick(IGregTechTileEntity aBaseMetaTileEntity, EntityPlayer aPlayer) {
-        GTUIInfos.openGTTileEntityUI(aBaseMetaTileEntity, aPlayer);
-        return true;
+    public void onScrewdriverRightClick(ForgeDirection side, EntityPlayer aPlayer, float aX, float aY, float aZ,
+        ItemStack aTool) {
+        GTUIInfos.openGTTileEntityUI(this.getBaseMetaTileEntity(), aPlayer);
+        super.onScrewdriverRightClick(side, aPlayer, aX, aY, aZ, aTool);
     }
 
     @Override

--- a/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchEnergyTunnel.java
+++ b/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchEnergyTunnel.java
@@ -41,11 +41,12 @@ public class MTEHatchEnergyTunnel extends MTEHatchEnergyMulti implements IConnec
             0,
             new String[] { CommonValues.TEC_MARK_GENERAL,
                 translateToLocal("gt.blockmachines.hatch.energytunnel.desc.0"),
+                translateToLocal("gt.blockmachines.hatch.screwdrivertooltip"),
                 translateToLocal("gt.blockmachines.hatch.energytunnel.desc.1") + ": "
                     + EnumChatFormatting.YELLOW
                     + GTUtility.formatNumbers(aAmp * V[aTier])
                     + EnumChatFormatting.RESET
-                    + " EU/t" },
+                    + " EU/t", },
             aAmp); // Energy injecting terminal for Multiblocks
         TTUtility.setTier(aTier, this);
     }
@@ -154,9 +155,10 @@ public class MTEHatchEnergyTunnel extends MTEHatchEnergyMulti implements IConnec
     }
 
     @Override
-    public boolean onRightclick(IGregTechTileEntity aBaseMetaTileEntity, EntityPlayer aPlayer) {
-        GTUIInfos.openGTTileEntityUI(aBaseMetaTileEntity, aPlayer);
-        return true;
+    public void onScrewdriverRightClick(ForgeDirection side, EntityPlayer aPlayer, float aX, float aY, float aZ,
+        ItemStack aTool) {
+        GTUIInfos.openGTTileEntityUI(this.getBaseMetaTileEntity(), aPlayer);
+        super.onScrewdriverRightClick(side, aPlayer, aX, aY, aZ, aTool);
     }
 
     @Override

--- a/src/main/resources/assets/tectech/lang/en_US.lang
+++ b/src/main/resources/assets/tectech/lang/en_US.lang
@@ -478,6 +478,7 @@ gt.blockmachines.hatch.dynamotunnel7.tier.13.name=UXV 1,048,576A/t Laser Source 
 gt.blockmachines.hatch.dynamotunnel.tier.14.name=Legendary Laser Source Hatch
 gt.blockmachines.hatch.dynamotunnel.desc.0=Energy extracting terminal for Multiblocks
 gt.blockmachines.hatch.dynamotunnel.desc.1=Throughput
+gt.blockmachines.hatch.screwdrivertooltip=Use screwdriver to adjust amperage
 
 gt.blockmachines.emin.tier.08.name=UV Elemental Input Hatch
 gt.blockmachines.emin.tier.09.name=UHV Elemental Input Hatch


### PR DESCRIPTION
Require screwdriver right click instead of normal right click to make it less common and irritating to accidentally open the amperage adjustment window. Adds line to tooltip of laser hatches explaining this.