### PR TITLE
use log to calculate tier instead of using up to 14 cycles

### DIFF
--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -209,6 +209,8 @@ public class GTUtility {
     private static int sBookCount = 0;
     public static UUID defaultUuid = null; // maybe default non-null?
     // UUID.fromString("00000000-0000-0000-0000-000000000000");
+    private static double LOG4 = Math.log(4);
+
 
     static {
         GregTechAPI.sItemStackMappings.add(sFilledContainerToData);
@@ -500,9 +502,10 @@ public class GTUtility {
     }
 
     public static byte getTier(long l) {
-        byte i = -1;
-        while (++i < V.length) if (l <= V[i]) return i;
-        return (byte) (V.length - 1);
+        if(l > V[14]) {
+            return 15;
+        }
+        return (byte)Math.ceil(Math.log(Math.max(l,8) / 8.0) / LOG4);
     }
 
     public static long getAmperageForTier(long voltage, byte tier) {

--- a/src/test/java/gregtech/api/metatileentity/implementations/GTUtilityTest.java
+++ b/src/test/java/gregtech/api/metatileentity/implementations/GTUtilityTest.java
@@ -1,0 +1,18 @@
+package gregtech.api.metatileentity.implementations;
+
+import gregtech.api.enums.GTValues;
+import gregtech.api.util.GTUtility;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class GTUtilityTest {
+    @Test
+    public void testGetTier() {
+        Assertions.assertEquals(0, GTUtility.getTier(1));
+        Assertions.assertEquals(0, GTUtility.getTier(GTValues.V[0]));
+        for(int i = 1; i < 16; i++) {
+            Assertions.assertEquals(i, GTUtility.getTier(GTValues.V[i - 1] + 1));
+            Assertions.assertEquals(i, GTUtility.getTier(GTValues.V[i]));
+        }
+    }
+}


### PR DESCRIPTION
This is to avoid up to 14 cycles in getTier(long/double).