### PR TITLE
prioritize gt ores for unification

### DIFF
--- a/src/main/java/gregtech/common/blocks/BlockOresAbstract.java
+++ b/src/main/java/gregtech/common/blocks/BlockOresAbstract.java
@@ -82,11 +82,18 @@ public abstract class BlockOresAbstract extends GTGenericBlock implements ITileE
                         GregTechAPI.sGeneratedMaterials[i].getToolTip());
                     if ((GregTechAPI.sGeneratedMaterials[i].mTypes & 0x8) != 0
                         && !aBlockedOres.contains(GregTechAPI.sGeneratedMaterials[i])) {
-                        GTOreDictUnificator.registerOre(
-                            this.getProcessingPrefix()[j] != null
-                                ? this.getProcessingPrefix()[j].get(GregTechAPI.sGeneratedMaterials[i])
-                                : "",
-                            new ItemStack(this, 1, i + (j * 1000)));
+                        if (this.getProcessingPrefix()[j] != null && this.getProcessingPrefix()[j].mIsUnificatable) {
+                            GTOreDictUnificator.set(
+                                this.getProcessingPrefix()[j],
+                                GregTechAPI.sGeneratedMaterials[i],
+                                new ItemStack(this, 1, i + (j * 1000)));
+                        } else {
+                            GTOreDictUnificator.registerOre(
+                                this.getProcessingPrefix()[j] != null
+                                    ? this.getProcessingPrefix()[j].get(GregTechAPI.sGeneratedMaterials[i])
+                                    : "",
+                                new ItemStack(this, 1, i + (j * 1000)));
+                        }
                         if (tHideOres) {
                             if (!(j == 0 && !aHideFirstMeta)) {
                                 codechicken.nei.api.API.hideItem(new ItemStack(this, 1, i + (j * 1000)));


### PR DESCRIPTION
Give gt priority when it comes to oreblocks in the sName2StackMap. (same as https://github.com/GTNewHorizons/GT5-Unofficial/pull/3023 for blocks)
in particular fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17234.