### PR TITLE
Fix Large HP Turbine reverting to tight mode when scanned

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTELargeTurbineHPSteam.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTELargeTurbineHPSteam.java
@@ -199,12 +199,6 @@ public class MTELargeTurbineHPSteam extends MTELargeTurbine {
     }
 
     @Override
-    public String[] getInfoData() {
-        super.looseFit = looseFit;
-        return super.getInfoData();
-    }
-
-    @Override
     public void saveNBTData(NBTTagCompound aNBT) {
         super.saveNBTData(aNBT);
         aNBT.setBoolean("turbineFitting", looseFit);


### PR DESCRIPTION
I wish I could `git blame` this...

Fixes https://discord.com/channels/181078474394566657/603348502637969419/1283705024270303273