### PR TITLE
Rewrite Helioflux Module, add NEI support

### DIFF
--- a/src/main/java/bartworks/MainMod.java
+++ b/src/main/java/bartworks/MainMod.java
@@ -74,6 +74,7 @@ import gregtech.api.GregTechAPI;
 import gregtech.api.enums.Mods;
 import gregtech.api.recipe.RecipeMap;
 import gregtech.api.recipe.check.CheckRecipeResultRegistry;
+import tectech.loader.recipe.Godforge;
 
 @Mod(modid = MainMod.MOD_ID, name = MainMod.NAME, version = GT_Version.VERSION, dependencies = """
     required-after:IC2;\
@@ -210,5 +211,8 @@ public final class MainMod {
             .forEach(
                 map -> map.getBackend()
                     .reInit());
+
+        // because the above code runs so late that I couldn't find anywhere else to call this
+        Godforge.initMoltenModuleRecipes();
     }
 }

--- a/src/main/java/tectech/loader/recipe/Godforge.java
+++ b/src/main/java/tectech/loader/recipe/Godforge.java
@@ -3,6 +3,8 @@ package tectech.loader.recipe;
 import static gregtech.api.enums.Mods.EternalSingularity;
 import static gregtech.api.enums.Mods.GalaxySpace;
 import static gregtech.api.util.GTModHandler.getModItem;
+import static gregtech.api.util.GTRecipeBuilder.BUCKETS;
+import static gregtech.api.util.GTRecipeBuilder.INGOTS;
 import static gregtech.api.util.GTRecipeBuilder.SECONDS;
 import static gregtech.api.util.GTRecipeBuilder.TICKS;
 import static gregtech.api.util.GTRecipeConstants.FOG_EXOTIC_TIER;
@@ -30,11 +32,18 @@ import gregtech.api.enums.Materials;
 import gregtech.api.enums.MaterialsUEVplus;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.enums.TierEU;
+import gregtech.api.objects.ItemData;
+import gregtech.api.recipe.RecipeMaps;
 import gregtech.api.util.GTOreDictUnificator;
+import gregtech.api.util.GTRecipe;
+import gregtech.api.util.GTRecipeBuilder;
 import gregtech.api.util.GTUtility;
 import gtPlusPlus.core.material.MaterialsAlloy;
 import gtPlusPlus.core.material.MaterialsElements;
 import gtPlusPlus.xmod.gregtech.api.enums.GregtechItemList;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
+import tectech.recipe.TecTechRecipeMaps;
 import tectech.thing.CustomItemList;
 
 public class Godforge implements Runnable {
@@ -735,5 +744,79 @@ public class Godforge implements Runnable {
                     ItemList.Robot_Arm_UMV.get(64), ItemList.Conveyor_Module_UMV.get(64) });
         }
 
+    }
+
+    public static void initMoltenModuleRecipes() {
+        for (GTRecipe recipe : RecipeMaps.blastFurnaceRecipes.getAllRecipes()) {
+            List<ItemStack> itemOutputs = new ArrayList<>(1);
+            List<FluidStack> fluidOutputs = new ArrayList<>(2);
+
+            int[] originalChances = recipe.mChances;
+            IntList newChances = new IntArrayList();
+            for (int i = 0; i < recipe.mOutputs.length; i++) {
+                ItemStack stack = recipe.getOutput(i);
+                if (stack == null) continue;
+                FluidStack potentialFluid = convertToMolten(stack);
+                if (potentialFluid != null) {
+                    potentialFluid.amount *= stack.stackSize;
+                    fluidOutputs.add(potentialFluid);
+                } else {
+                    itemOutputs.add(stack);
+                    if (originalChances != null) {
+                        int chance = 10000;
+                        if (originalChances.length > i) {
+                            chance = originalChances[i];
+                        }
+                        newChances.add(chance);
+                    }
+                }
+            }
+
+            fluidOutputs.addAll(Arrays.asList(recipe.mFluidOutputs));
+
+            GTRecipeBuilder builder = GTValues.RA.stdBuilder()
+                .noOptimize()
+                .itemOutputs(itemOutputs.toArray(new ItemStack[0]))
+                .fluidOutputs(fluidOutputs.toArray(new FluidStack[0]))
+                .duration(recipe.mDuration)
+                .eut(recipe.mEUt)
+                .specialValue(recipe.mSpecialValue);
+
+            if (recipe.mInputs != null) builder.itemInputs(recipe.mInputs);
+            if (recipe.mFluidInputs != null) builder.fluidInputs(recipe.mFluidInputs);
+            if (!newChances.isEmpty()) builder.outputChances(newChances.toIntArray());
+
+            builder.addTo(TecTechRecipeMaps.godforgeMoltenRecipes);
+        }
+    }
+
+    private static FluidStack convertToMolten(ItemStack stack) {
+        // if this is null it has to be a gt++ material
+        ItemData data = GTOreDictUnificator.getAssociation(stack);
+        Materials mat = data == null ? null : data.mMaterial.mMaterial;
+        if (mat != null) {
+            if (mat.mStandardMoltenFluid != null) {
+                return mat.getMolten(INGOTS * data.mMaterial.mAmount / GTValues.M);
+            } else if (mat.mFluid != null) {
+                return mat.getFluid(BUCKETS);
+            }
+        }
+        int[] oreIDs = OreDictionary.getOreIDs(stack);
+        if (oreIDs.length == 0) {
+            return null;
+        }
+        String dict = OreDictionary.getOreName(oreIDs[0]);
+
+        // Check various oredicts
+        String strippedOreDict = null;
+        if (dict.startsWith("ingotHot")) {
+            strippedOreDict = dict.substring(8);
+        } else if (dict.startsWith("dustRoasted") && !dict.contains("Cobalt")) {
+            strippedOreDict = dict.substring(11);
+        }
+        if (strippedOreDict != null) {
+            return FluidRegistry.getFluidStack("molten." + strippedOreDict.toLowerCase(), INGOTS);
+        }
+        return null;
     }
 }

--- a/src/main/java/tectech/recipe/TecTechRecipeMaps.java
+++ b/src/main/java/tectech/recipe/TecTechRecipeMaps.java
@@ -10,6 +10,7 @@ import gregtech.api.recipe.RecipeMap;
 import gregtech.api.recipe.RecipeMapBackend;
 import gregtech.api.recipe.RecipeMapBuilder;
 import gregtech.api.util.GTRecipe;
+import gregtech.nei.formatter.HeatingCoilSpecialValueFormatter;
 import tectech.thing.CustomItemList;
 import tectech.thing.gui.TecTechUITextures;
 
@@ -73,6 +74,15 @@ public class TecTechRecipeMaps {
         .progressBarPos(78, 33)
         .neiTransferRect(78, 33, 20, 20)
         .frontend(GodforgeExoticFrontend::new)
+        .build();
+    public static final RecipeMap<RecipeMapBackend> godforgeMoltenRecipes = RecipeMapBuilder.of("gt.recipe.fog_molten")
+        .maxIO(6, 6, 1, 2)
+        .minInputs(1, 0)
+        .progressBar(TecTechUITextures.PROGRESSBAR_GODFORGE_PLASMA, ProgressBar.Direction.RIGHT)
+        .neiSpecialInfoFormatter(HeatingCoilSpecialValueFormatter.INSTANCE)
+        .logo(TecTechUITextures.PICTURE_GODFORGE_LOGO)
+        .logoSize(18, 18)
+        .logoPos(151, 63)
         .build();
 
 }

--- a/src/main/java/tectech/thing/metaTileEntity/multi/godforge_modules/MTEMoltenModule.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/godforge_modules/MTEMoltenModule.java
@@ -1,11 +1,6 @@
 package tectech.thing.metaTileEntity.multi.godforge_modules;
 
-import static gregtech.api.util.GTOreDictUnificator.getAssociation;
-import static gregtech.api.util.GTRecipeBuilder.BUCKETS;
-import static gregtech.api.util.GTRecipeBuilder.INGOTS;
 import static gregtech.api.util.GTUtility.formatNumbers;
-import static gregtech.api.util.ParallelHelper.addFluidsLong;
-import static gregtech.api.util.ParallelHelper.addItemsLong;
 import static gregtech.common.misc.WirelessNetworkManager.addEUToGlobalEnergyMap;
 import static gregtech.common.misc.WirelessNetworkManager.getUserEU;
 import static net.minecraft.util.EnumChatFormatting.GREEN;
@@ -18,25 +13,20 @@ import java.util.ArrayList;
 
 import javax.annotation.Nonnull;
 
-import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumChatFormatting;
-import net.minecraftforge.fluids.FluidRegistry;
-import net.minecraftforge.fluids.FluidStack;
-import net.minecraftforge.oredict.OreDictionary;
 
 import org.jetbrains.annotations.NotNull;
 
-import gregtech.api.enums.Materials;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.logic.ProcessingLogic;
-import gregtech.api.objects.ItemData;
+import gregtech.api.recipe.RecipeMap;
 import gregtech.api.recipe.check.CheckRecipeResult;
 import gregtech.api.recipe.check.CheckRecipeResultRegistry;
 import gregtech.api.util.GTRecipe;
 import gregtech.api.util.MultiblockTooltipBuilder;
 import gregtech.api.util.OverclockCalculator;
-import gregtech.api.util.ParallelHelper;
+import tectech.recipe.TecTechRecipeMaps;
 import tectech.util.CommonValues;
 
 public class MTEMoltenModule extends MTEBaseModule {
@@ -63,12 +53,9 @@ public class MTEMoltenModule extends MTEBaseModule {
     protected ProcessingLogic createProcessingLogic() {
         return new ProcessingLogic() {
 
-            private FluidStack[] meltableItems;
-
             @NotNull
             @Override
             protected CheckRecipeResult validateRecipe(@Nonnull GTRecipe recipe) {
-
                 if (recipe.mSpecialValue > getHeat()) {
                     return CheckRecipeResultRegistry.insufficientHeat(recipe.mSpecialValue);
                 }
@@ -76,31 +63,6 @@ public class MTEMoltenModule extends MTEBaseModule {
                 if (getUserEU(userUUID).compareTo(BigInteger.valueOf(wirelessEUt * recipe.mDuration)) < 0) {
                     return CheckRecipeResultRegistry.insufficientPower(wirelessEUt * recipe.mDuration);
                 }
-
-                meltableItems = new FluidStack[recipe.mOutputs.length];
-                for (int i = 0; i < recipe.mOutputs.length; i++) {
-                    ItemStack item = recipe.getOutput(i);
-                    if (item == null) {
-                        continue;
-                    }
-                    // if this is null it has to be a gt++ material
-                    ItemData data = getAssociation(item);
-                    Materials mat = data == null ? null : data.mMaterial.mMaterial;
-                    if (mat != null) {
-                        if (mat.mStandardMoltenFluid != null) {
-                            meltableItems[i] = mat.getMolten(INGOTS);
-                        } else if (mat.mFluid != null) {
-                            meltableItems[i] = mat.getFluid(BUCKETS);
-                        }
-                    } else {
-                        String dict = OreDictionary.getOreName(OreDictionary.getOreIDs(item)[0]);
-                        // substring 8 because ingotHot is 8 characters long
-                        String strippedOreDict = dict.substring(8);
-                        meltableItems[i] = FluidRegistry
-                            .getFluidStack("molten." + strippedOreDict.toLowerCase(), INGOTS);
-                    }
-                }
-
                 return CheckRecipeResultRegistry.SUCCESSFUL;
             }
 
@@ -132,47 +94,6 @@ public class MTEMoltenModule extends MTEBaseModule {
                 setCalculatedEut(0);
                 return CheckRecipeResultRegistry.SUCCESSFUL;
             }
-
-            @Nonnull
-            @Override
-            protected ParallelHelper createParallelHelper(@Nonnull GTRecipe recipe) {
-                return super.createParallelHelper(recipe).setCustomItemOutputCalculation(currentParallel -> {
-                    ArrayList<ItemStack> outputItems = new ArrayList<>();
-                    for (int i = 0; i < recipe.mOutputs.length; i++) {
-                        ItemStack item = recipe.getOutput(i);
-                        if (item == null || meltableItems[i] != null) {
-                            continue;
-                        }
-                        ItemStack itemToAdd = item.copy();
-                        addItemsLong(outputItems, itemToAdd, (long) item.stackSize * currentParallel);
-                    }
-                    return outputItems.toArray(new ItemStack[0]);
-                })
-                    .setCustomFluidOutputCalculation(currentParallel -> {
-                        ArrayList<FluidStack> fluids = new ArrayList<>();
-
-                        for (int i = 0; i < recipe.mOutputs.length; i++) {
-                            FluidStack fluid = meltableItems[i];
-                            if (fluid == null) {
-                                continue;
-                            }
-                            FluidStack fluidToAdd = fluid.copy();
-                            long fluidAmount = (long) fluidToAdd.amount * recipe.mOutputs[i].stackSize
-                                * currentParallel;
-                            addFluidsLong(fluids, fluidToAdd, fluidAmount);
-                        }
-
-                        for (int i = 0; i < recipe.mFluidOutputs.length; i++) {
-                            FluidStack fluid = recipe.getFluidOutput(i);
-                            if (fluid == null) {
-                                continue;
-                            }
-                            FluidStack fluidToAdd = fluid.copy();
-                            addFluidsLong(fluids, fluidToAdd, (long) fluidToAdd.amount * currentParallel);
-                        }
-                        return fluids.toArray(new FluidStack[0]);
-                    });
-            }
         };
     }
 
@@ -184,6 +105,11 @@ public class MTEMoltenModule extends MTEBaseModule {
         logic.setMaxParallel(getMaxParallel());
         logic.setSpeedBonus(getSpeedBonus());
         logic.setEuModifier(getEnergyDiscount());
+    }
+
+    @Override
+    public RecipeMap<?> getRecipeMap() {
+        return TecTechRecipeMaps.godforgeMoltenRecipes;
     }
 
     @Override

--- a/src/main/resources/assets/tectech/lang/en_US.lang
+++ b/src/main/resources/assets/tectech/lang/en_US.lang
@@ -1254,6 +1254,7 @@ gt.recipe.eyeofharmony=Eye of Harmony
 gt.recipe.researchStation=Research Station
 gt.recipe.fog_plasma=Heliothermal Plasma Fabricator
 gt.recipe.fog_exotic=Heliofusion Exoticizer
+gt.recipe.fog_molten=Helioflux Melting Core
 
 
 # NEI


### PR DESCRIPTION
PR targeting the godforge-finale PR branch

Rewrites the Helioflux module primarily to give NEI support and more future flexibility with recipes as needed. Additionally, this fixes a variety of bugs in the code, such as:
- Various NPEs and array out of bounds exceptions causing recipes to not give molten form properly
- Some extra special cases such as roasted metals (where applicable) not being given directly as molten
- Recipes outputting non-full ingot/dust amounts duping material (things like PMP ebf, naq oxide ebf, Silicon Carbide ebf recipes)