### PR TITLE
Fix of [Nightly] Steam Tier Furnace has an incorrect tooltip type

### DIFF
--- a/src/main/java/gregtech/api/recipe/RecipeMaps.java
+++ b/src/main/java/gregtech/api/recipe/RecipeMaps.java
@@ -180,7 +180,7 @@ public final class RecipeMaps {
         .disableRegisterNEI()
         .build();
     public static final RecipeMap<FurnaceBackend> furnaceRecipes = RecipeMapBuilder
-        .of("mc.recipe.furnace", FurnaceBackend::new)
+        .of("gt.recipe.furnace", FurnaceBackend::new)
         .maxIO(1, 1, 0, 0)
         .minInputs(1, 9)
         .slotOverlays(


### PR DESCRIPTION
It's used `mc.recipe.furnace` instead of  `gt.recipe.furnace` .

![image](https://github.com/user-attachments/assets/4c986f6f-754c-4198-94ca-94bcc376be81)
![image](https://github.com/user-attachments/assets/ca18762b-3be4-4723-a6d7-019775526569)

- https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17329