### PR TITLE
Clarify Antimatter Forge tooltip

### DIFF
--- a/src/main/java/goodgenerator/blocks/tileEntity/AntimatterForge.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/AntimatterForge.java
@@ -229,8 +229,13 @@ public class AntimatterForge extends MTEExtendedPowerMultiBlockBase<AntimatterFo
                     + EnumChatFormatting.AQUA
                     + String.valueOf(this.baseSkew)
                     + EnumChatFormatting.GRAY
-                    + ", 1) of antimatter per cycle, consuming equal amounts of Protomatter")
-            .addInfo("The change can be negative! (N = Normal Distribution with mean of 0.2)")
+                    + ", 0.25) of antimatter per cycle, consuming equal amounts of Protomatter")
+            .addInfo(
+                "The change is split between the 16 Antimatter Hatches, sampled from N(" + EnumChatFormatting.AQUA
+                    + String.valueOf(this.baseSkew)
+                    + EnumChatFormatting.GRAY
+                    + ", 1) (Gaussian distribution with mean of 0.2)")
+            .addInfo("The total change be negative!")
             .addSeparator()
             .addInfo("Can be supplied with stabilization fluids to improve antimatter generation")
             .addInfo(
@@ -299,6 +304,7 @@ public class AntimatterForge extends MTEExtendedPowerMultiBlockBase<AntimatterFo
                 "2. Depleted Naquadah Fuel Mk VI - Distribution skew " + EnumChatFormatting.AQUA
                     + "+0.10"
                     + EnumChatFormatting.GRAY)
+            .addInfo("Each stabilization can only use one of the fluids at a time")
             .addSeparator()
             .addCasingInfoMin("Antimatter Containment Casing", 512, false)
             .addCasingInfoMin("Magnetic Flux Casing", 2274, false)

--- a/src/main/java/goodgenerator/blocks/tileEntity/AntimatterForge.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/AntimatterForge.java
@@ -234,7 +234,9 @@ public class AntimatterForge extends MTEExtendedPowerMultiBlockBase<AntimatterFo
                 "The change is split between the 16 Antimatter Hatches, sampled from N(" + EnumChatFormatting.AQUA
                     + String.valueOf(this.baseSkew)
                     + EnumChatFormatting.GRAY
-                    + ", 1) (Gaussian distribution with mean of 0.2)")
+                    + ", 1) (Gaussian distribution with mean of "
+                    + String.valueOf(this.baseSkew)
+                    + ")")
             .addInfo("The total change be negative!")
             .addSeparator()
             .addInfo("Can be supplied with stabilization fluids to improve antimatter generation")

--- a/src/main/java/goodgenerator/blocks/tileEntity/AntimatterForge.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/AntimatterForge.java
@@ -237,7 +237,7 @@ public class AntimatterForge extends MTEExtendedPowerMultiBlockBase<AntimatterFo
                     + ", 1) (Gaussian distribution with mean of "
                     + String.valueOf(this.baseSkew)
                     + ")")
-            .addInfo("The total change be negative!")
+            .addInfo("The total change can be negative!")
             .addSeparator()
             .addInfo("Can be supplied with stabilization fluids to improve antimatter generation")
             .addInfo(


### PR DESCRIPTION
- Make the total production mathematically correct (Use STD of population instead of distribution)
- Add a line about how the antimatter is distributed between the 16 hatches
- Add a line saying you can only use a single upgrade fluid per category at a time

![image](https://github.com/user-attachments/assets/003934e6-2898-4633-868e-081f44c5a1b0)
