### PR TITLE
Fixed LFE OCs and clarified tooltip

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTELargeFluidExtractor.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTELargeFluidExtractor.java
@@ -200,8 +200,10 @@ public class MTELargeFluidExtractor extends MTEExtendedPowerMultiBlockBase<MTELa
 
     @Override
     protected void setProcessingLogicPower(ProcessingLogic logic) {
-        super.setProcessingLogicPower(logic);
-        logic.setAvailableAmperage(mEnergyHatches.size());
+        logic.setAmperageOC(true);
+        logic.setAvailableVoltage(this.getMaxInputEu());
+        logic.setAvailableAmperage(1);
+
         logic.setEuModifier((float) (getEUMultiplier()));
         logic.setMaxParallel(getParallels());
         logic.setSpeedBonus(1.0f / (float) (getSpeedBonus()));
@@ -285,8 +287,10 @@ public class MTELargeFluidExtractor extends MTEExtendedPowerMultiBlockBase<MTELa
                 (int) Math.round((1 - HEATING_COIL_EU_MULTIPLIER) * 100)
             ))
             .addInfo(String.format(
-                "Every solenoid tier gives +%d parallels",
-                (int) PARALLELS_PER_SOLENOID
+                "Every solenoid tier gives %s%d * tier%s parallels (MV is tier 2)",
+                EnumChatFormatting.ITALIC,
+                PARALLELS_PER_SOLENOID,
+                EnumChatFormatting.GRAY
             ))
             .addInfo(String.format(
                 "The EU multiplier is %s%.2f * (%.2f ^ Heating Coil Tier)%s, prior to overclocks",


### PR DESCRIPTION
I got some feedback that the solenoid tooltip wasn't clear on the number of parallels given by MV coils (since they're the first coil, but MV)
![2024-09-20_13 43 13](https://github.com/user-attachments/assets/50aeed94-d0c1-4f62-90dd-8cb08ea598d7)

With one hatch:
![2024-09-20_13 43 36](https://github.com/user-attachments/assets/2f42906e-52a8-41ec-91bf-88d44a4aaa57)

With two hatches:
![2024-09-20_13 43 47](https://github.com/user-attachments/assets/0128bc0f-9d8b-4163-ac27-8ca30c379870)
