### PR TITLE
Prevent duplicate material registry

### DIFF
--- a/src/main/java/gregtech/api/enums/OrePrefixes.java
+++ b/src/main/java/gregtech/api/enums/OrePrefixes.java
@@ -15,6 +15,7 @@ import net.minecraft.item.ItemStack;
 
 import com.google.common.collect.ImmutableList;
 
+import gregtech.api.GregTechAPI;
 import gregtech.api.enums.TCAspects.TC_AspectStack;
 import gregtech.api.interfaces.ICondition;
 import gregtech.api.interfaces.IOreRecipeRegistrator;
@@ -1179,6 +1180,8 @@ public enum OrePrefixes {
         } else if (name().startsWith("battery")) {
             new TC_AspectStack(TCAspects.ELECTRUM, 1).addToAspectList(mAspects);
         }
+
+        GregTechAPI.sGTCompleteLoad.add(this::onLoadComplete);
     }
 
     public static boolean isInstanceOf(String aName, OrePrefixes aPrefix) {
@@ -1298,7 +1301,7 @@ public enum OrePrefixes {
     }
 
     // Hack to prevent duplicate registry of oredicted materials
-    final HashSet<Materials> used = new HashSet<>();
+    HashSet<Materials> used = new HashSet<>();
 
     public void processOre(Materials aMaterial, String aOreDictName, String aModName, ItemStack aStack) {
 
@@ -1306,7 +1309,8 @@ public enum OrePrefixes {
             return;
         }
 
-        if (!used.add(aMaterial)) {
+        if (aMaterial != Materials._NULL && !used.add(aMaterial)) {
+            GTLog.out.println("Duplicate material registry attempted by " + aModName + " for " + aOreDictName);
             return;
         }
 
@@ -1330,6 +1334,10 @@ public enum OrePrefixes {
                     + GTUtility.getClassName(tRegistrator));
             tRegistrator.registerOre(this, aMaterial, aOreDictName, aModName, GTUtility.copyAmount(1, aStack));
         }
+    }
+
+    public void onLoadComplete() {
+        used = null;
     }
 
     public Object get(Object aMaterial) {

--- a/src/main/java/gregtech/api/enums/OrePrefixes.java
+++ b/src/main/java/gregtech/api/enums/OrePrefixes.java
@@ -1297,9 +1297,16 @@ public enum OrePrefixes {
         return mOreProcessing.add(aRegistrator);
     }
 
+    // Hack to prevent duplicate registry of oredicted materials
+    final HashSet<Materials> used = new HashSet<>();
+
     public void processOre(Materials aMaterial, String aOreDictName, String aModName, ItemStack aStack) {
 
         if (aMaterial == null) {
+            return;
+        }
+
+        if (!used.add(aMaterial)) {
             return;
         }
 

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingPlate.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingPlate.java
@@ -19,7 +19,6 @@ import static gregtech.api.util.GTRecipeBuilder.SECONDS;
 import static gregtech.api.util.GTRecipeBuilder.TICKS;
 import static gregtech.api.util.GTRecipeBuilder.WILDCARD;
 import static gregtech.api.util.GTRecipeConstants.ADDITIVE_AMOUNT;
-import static gregtech.api.util.GTRecipeConstants.COMPRESSION_TIER;
 import static gregtech.api.util.GTRecipeConstants.FUEL_TYPE;
 import static gregtech.api.util.GTRecipeConstants.FUEL_VALUE;
 import static gregtech.api.util.GTUtility.calculateRecipeEU;


### PR DESCRIPTION
Tracks materials which have been registered in a hashset and prevents registry if already in the hashset. This tiny change drops 3,500 collisions by itself.

![image](https://github.com/user-attachments/assets/e4a2476c-1828-4351-b980-06cd38844e1d)
