### PR TITLE
Fix MetaBaseItem tooltips crash when holding shift

### DIFF
--- a/src/main/java/gregtech/api/interfaces/IItemBehaviour.java
+++ b/src/main/java/gregtech/api/interfaces/IItemBehaviour.java
@@ -13,8 +13,6 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import com.google.common.collect.ImmutableList;
-
 import gregtech.api.enums.SubTag;
 import gregtech.api.items.MetaBaseItem;
 
@@ -64,7 +62,7 @@ public interface IItemBehaviour<E extends Item> {
     List<String> getAdditionalToolTips(E aItem, List<String> aList, ItemStack aStack);
 
     default List<String> getAdditionalToolTipsWhileSneaking(E aItem, List<String> aList, ItemStack aStack) {
-        return ImmutableList.of();
+        return aList;
     }
 
     void onUpdate(E aItem, ItemStack aStack, World aWorld, Entity aPlayer, int aTimer, boolean aIsInHand);


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17401
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17405