### PR TITLE
cache the ItemList.values() call in the PlatinumSludgeOverHaul makes it run 8 times faster

### DIFF
--- a/src/main/java/bartworks/system/material/gtenhancement/PlatinumSludgeOverHaul.java
+++ b/src/main/java/bartworks/system/material/gtenhancement/PlatinumSludgeOverHaul.java
@@ -798,6 +798,15 @@ public class PlatinumSludgeOverHaul {
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public static void replacePureElements() {
+        // Cache the ItemList.values() call
+        final ItemList[] values = ItemList.values();
+        final ArrayList<ItemStack> ITEMLIST_VALUES = new ArrayList<>(values.length);
+        for (ItemList e : values) {
+            if (e.hasBeenSet()) {
+                ITEMLIST_VALUES.add(e.get(1));
+            }
+        }
+
         // furnace
         for (Object entry : FurnaceRecipes.smelting()
             .getSmeltingList()
@@ -823,7 +832,7 @@ public class PlatinumSludgeOverHaul {
 
             Werkstoff mat = (ass.mMaterial.mMaterial.equals(Materials.Platinum)) ? PTMetallicPowder : PDMetallicPowder;
 
-            if (PlatinumSludgeOverHaul.isInBlackList((ItemStack) realEntry.getKey())) continue;
+            if (PlatinumSludgeOverHaul.isInBlackList((ItemStack) realEntry.getKey(), ITEMLIST_VALUES)) continue;
             realEntry.setValue(mat.get(prefix, stack.stackSize * 2));
         }
         // vanilla crafting
@@ -877,7 +886,7 @@ public class PlatinumSludgeOverHaul {
                         || BWUtil.areStacksEqualOrNull(Ruthenium.get(dustPure), recipe.mOutputs[i]))
                         && !BWUtil.areStacksEqualOrNull(Ruthenium.get(ingot), recipe.mInputs[0])) {
                         for (ItemStack mInput : recipe.mInputs)
-                            if (PlatinumSludgeOverHaul.isInBlackList(mInput)) continue recipeloop;
+                            if (PlatinumSludgeOverHaul.isInBlackList(mInput, ITEMLIST_VALUES)) continue recipeloop;
                         int amount = recipe.mOutputs[i].stackSize * 2;
                         GTLog.err.println("Recipe edited: " + displayRecipe(recipe));
                         recipe.mOutputs[i] = LeachResidue.get(dust, amount);
@@ -888,7 +897,7 @@ public class PlatinumSludgeOverHaul {
                         || BWUtil.areStacksEqualOrNull(Rhodium.get(dustPure), recipe.mOutputs[i]))
                         && !BWUtil.areStacksEqualOrNull(Rhodium.get(ingot), recipe.mInputs[0])) {
                         for (ItemStack mInput : recipe.mInputs)
-                            if (PlatinumSludgeOverHaul.isInBlackList(mInput)) continue recipeloop;
+                            if (PlatinumSludgeOverHaul.isInBlackList(mInput, ITEMLIST_VALUES)) continue recipeloop;
                         int amount = recipe.mOutputs[i].stackSize * 2;
                         GTLog.err.println("Recipe edited: " + displayRecipe(recipe));
                         recipe.mOutputs[i] = CrudeRhMetall.get(dust, amount);
@@ -899,7 +908,7 @@ public class PlatinumSludgeOverHaul {
                     if (GTOreDictUnificator.getAssociation(recipe.mOutputs[i]).mMaterial.mMaterial
                         .equals(Materials.Platinum)) {
                         for (ItemStack mInput : recipe.mInputs) {
-                            if (PlatinumSludgeOverHaul.isInBlackList(mInput)) continue recipeloop;
+                            if (PlatinumSludgeOverHaul.isInBlackList(mInput, ITEMLIST_VALUES)) continue recipeloop;
                         }
                         if (dust.equals(GTOreDictUnificator.getAssociation(recipe.mOutputs[i]).mPrefix)
                             || dustImpure.equals(GTOreDictUnificator.getAssociation(recipe.mOutputs[i]).mPrefix)
@@ -922,7 +931,7 @@ public class PlatinumSludgeOverHaul {
                     } else if (GTOreDictUnificator.getAssociation(recipe.mOutputs[i]).mMaterial.mMaterial
                         .equals(Materials.Palladium)) {
                             for (ItemStack mInput : recipe.mInputs) {
-                                if (PlatinumSludgeOverHaul.isInBlackList(mInput)) continue recipeloop;
+                                if (PlatinumSludgeOverHaul.isInBlackList(mInput, ITEMLIST_VALUES)) continue recipeloop;
                             }
                             if (dust.equals(GTOreDictUnificator.getAssociation(recipe.mOutputs[i]).mPrefix)
                                 || dustImpure.equals(GTOreDictUnificator.getAssociation(recipe.mOutputs[i]).mPrefix)
@@ -949,7 +958,8 @@ public class PlatinumSludgeOverHaul {
                         } else if (GTOreDictUnificator.getAssociation(recipe.mOutputs[i]).mMaterial.mMaterial
                             .equals(Materials.Osmium)) {
                                 for (ItemStack mInput : recipe.mInputs) {
-                                    if (PlatinumSludgeOverHaul.isInBlackList(mInput)) continue recipeloop;
+                                    if (PlatinumSludgeOverHaul.isInBlackList(mInput, ITEMLIST_VALUES))
+                                        continue recipeloop;
                                 }
                                 if (dust.equals(GTOreDictUnificator.getAssociation(recipe.mOutputs[i]).mPrefix)
                                     || dustImpure.equals(GTOreDictUnificator.getAssociation(recipe.mOutputs[i]).mPrefix)
@@ -977,7 +987,8 @@ public class PlatinumSludgeOverHaul {
                             } else if (GTOreDictUnificator.getAssociation(recipe.mOutputs[i]).mMaterial.mMaterial
                                 .equals(Materials.Iridium)) {
                                     for (ItemStack mInput : recipe.mInputs) {
-                                        if (PlatinumSludgeOverHaul.isInBlackList(mInput)) continue recipeloop;
+                                        if (PlatinumSludgeOverHaul.isInBlackList(mInput, ITEMLIST_VALUES))
+                                            continue recipeloop;
                                     }
                                     if (dust.equals(GTOreDictUnificator.getAssociation(recipe.mOutputs[i]).mPrefix)
                                         || dustImpure
@@ -1106,7 +1117,7 @@ public class PlatinumSludgeOverHaul {
         return false;
     }
 
-    private static boolean isInBlackList(ItemStack stack) {
+    private static boolean isInBlackList(ItemStack stack, List<ItemStack> ITEMLIST_VALUES) {
         if (stack == null || stack.getItem() instanceof BWMetaGeneratedItems
             || MainMod.MOD_ID.equals(GameRegistry.findUniqueIdentifierFor(stack.getItem()).modId)
             || BartWorksCrossmod.MOD_ID.equals(GameRegistry.findUniqueIdentifierFor(stack.getItem()).modId))
@@ -1122,10 +1133,11 @@ public class PlatinumSludgeOverHaul {
         if (Block.getBlockFromItem(stack.getItem()) instanceof GTGenericBlock
             && !(Block.getBlockFromItem(stack.getItem()) instanceof BlockOresAbstract)) return true;
 
-        if (Arrays.stream(ItemList.values())
-            .filter(ItemList::hasBeenSet)
-            .anyMatch(e -> !BWUtil.checkStackAndPrefix(stack) && GTUtility.areStacksEqual(e.get(1), stack, true)))
-            return true;
+        for (ItemStack itemStack : ITEMLIST_VALUES) {
+            if (!BWUtil.checkStackAndPrefix(stack) && GTUtility.areStacksEqual(itemStack, stack, true)) {
+                return true;
+            }
+        }
 
         if (stack.getItem() instanceof GTGenericItem) {
             if (!BWUtil.checkStackAndPrefix(stack)) return false;


### PR DESCRIPTION
It's calling 1700 times Enum.values() on an enum of size 2366 which spams memory allocations