### PR TITLE
Add NO_ORE_PROCESSING subtag

### DIFF
--- a/src/main/java/gregtech/api/enums/SubTag.java
+++ b/src/main/java/gregtech/api/enums/SubTag.java
@@ -104,6 +104,10 @@ public final class SubTag implements ICondition<ISubTagContainer> {
      */
     public static final SubTag NO_SMELTING = getNewSubTag("NO_SMELTING");
     /**
+     * This Material cannot have its Ore and associated prefixes processed, and must be handled manually.
+     */
+    public static final SubTag NO_ORE_PROCESSING = getNewSubTag("NO_ORE_PROCESSING");
+    /**
      * This Material can be molten into a Fluid
      */
     public static final SubTag SMELTING_TO_FLUID = getNewSubTag("SMELTING_TO_FLUID");

--- a/src/main/java/gregtech/common/GTProxy.java
+++ b/src/main/java/gregtech/common/GTProxy.java
@@ -1257,46 +1257,48 @@ public abstract class GTProxy implements IGTMod, IFuelHandler {
         GTLog.out.println("GTMod: Adding Tool Usage Crafting Recipes for OreDict Items.");
         for (Materials aMaterial : Materials.values()) {
             if ((aMaterial.mUnificatable) && (aMaterial.mMaterialInto == aMaterial)) {
-                GTModHandler.addCraftingRecipe(
-                    GTOreDictUnificator.get(OrePrefixes.dust, aMaterial.mMacerateInto, 1L),
-                    tBits,
-                    new Object[] { "h", "X", 'X', OrePrefixes.crushedCentrifuged.get(aMaterial) });
-                GTModHandler.addCraftingRecipe(
-                    GTOreDictUnificator.get(OrePrefixes.dust, aMaterial.mMacerateInto, 1L),
-                    tBits,
-                    new Object[] { "h", "X", 'X', OrePrefixes.crystalline.get(aMaterial) });
-                GTModHandler.addCraftingRecipe(
-                    GTOreDictUnificator.get(OrePrefixes.dust, aMaterial.mMacerateInto, 1L),
-                    tBits,
-                    new Object[] { "h", "X", 'X', OrePrefixes.crystal.get(aMaterial) });
-                GTModHandler.addCraftingRecipe(
-                    GTOreDictUnificator.get(OrePrefixes.dustPure, aMaterial.mMacerateInto, 1L),
-                    tBits,
-                    new Object[] { "h", "X", 'X', OrePrefixes.crushedPurified.get(aMaterial) });
-                GTModHandler.addCraftingRecipe(
-                    GTOreDictUnificator.get(OrePrefixes.dustPure, aMaterial.mMacerateInto, 1L),
-                    tBits,
-                    new Object[] { "h", "X", 'X', OrePrefixes.cleanGravel.get(aMaterial) });
-                GTModHandler.addCraftingRecipe(
-                    GTOreDictUnificator.get(OrePrefixes.dustPure, aMaterial.mMacerateInto, 1L),
-                    tBits,
-                    new Object[] { "h", "X", 'X', OrePrefixes.reduced.get(aMaterial) });
-                GTModHandler.addCraftingRecipe(
-                    GTOreDictUnificator.get(OrePrefixes.dustImpure, aMaterial.mMacerateInto, 1L),
-                    tBits,
-                    new Object[] { "h", "X", 'X', OrePrefixes.clump.get(aMaterial) });
-                GTModHandler.addCraftingRecipe(
-                    GTOreDictUnificator.get(OrePrefixes.dustImpure, aMaterial.mMacerateInto, 1L),
-                    tBits,
-                    new Object[] { "h", "X", 'X', OrePrefixes.shard.get(aMaterial) });
-                GTModHandler.addCraftingRecipe(
-                    GTOreDictUnificator.get(OrePrefixes.dustImpure, aMaterial.mMacerateInto, 1L),
-                    tBits,
-                    new Object[] { "h", "X", 'X', OrePrefixes.crushed.get(aMaterial) });
-                GTModHandler.addCraftingRecipe(
-                    GTOreDictUnificator.get(OrePrefixes.dustImpure, aMaterial.mMacerateInto, 1L),
-                    tBits,
-                    new Object[] { "h", "X", 'X', OrePrefixes.dirtyGravel.get(aMaterial) });
+                if (!aMaterial.contains(SubTag.NO_ORE_PROCESSING)) {
+                    GTModHandler.addCraftingRecipe(
+                        GTOreDictUnificator.get(OrePrefixes.dust, aMaterial.mMacerateInto, 1L),
+                        tBits,
+                        new Object[] { "h", "X", 'X', OrePrefixes.crushedCentrifuged.get(aMaterial) });
+                    GTModHandler.addCraftingRecipe(
+                        GTOreDictUnificator.get(OrePrefixes.dust, aMaterial.mMacerateInto, 1L),
+                        tBits,
+                        new Object[] { "h", "X", 'X', OrePrefixes.crystalline.get(aMaterial) });
+                    GTModHandler.addCraftingRecipe(
+                        GTOreDictUnificator.get(OrePrefixes.dust, aMaterial.mMacerateInto, 1L),
+                        tBits,
+                        new Object[] { "h", "X", 'X', OrePrefixes.crystal.get(aMaterial) });
+                    GTModHandler.addCraftingRecipe(
+                        GTOreDictUnificator.get(OrePrefixes.dustPure, aMaterial.mMacerateInto, 1L),
+                        tBits,
+                        new Object[] { "h", "X", 'X', OrePrefixes.crushedPurified.get(aMaterial) });
+                    GTModHandler.addCraftingRecipe(
+                        GTOreDictUnificator.get(OrePrefixes.dustPure, aMaterial.mMacerateInto, 1L),
+                        tBits,
+                        new Object[] { "h", "X", 'X', OrePrefixes.cleanGravel.get(aMaterial) });
+                    GTModHandler.addCraftingRecipe(
+                        GTOreDictUnificator.get(OrePrefixes.dustPure, aMaterial.mMacerateInto, 1L),
+                        tBits,
+                        new Object[] { "h", "X", 'X', OrePrefixes.reduced.get(aMaterial) });
+                    GTModHandler.addCraftingRecipe(
+                        GTOreDictUnificator.get(OrePrefixes.dustImpure, aMaterial.mMacerateInto, 1L),
+                        tBits,
+                        new Object[] { "h", "X", 'X', OrePrefixes.clump.get(aMaterial) });
+                    GTModHandler.addCraftingRecipe(
+                        GTOreDictUnificator.get(OrePrefixes.dustImpure, aMaterial.mMacerateInto, 1L),
+                        tBits,
+                        new Object[] { "h", "X", 'X', OrePrefixes.shard.get(aMaterial) });
+                    GTModHandler.addCraftingRecipe(
+                        GTOreDictUnificator.get(OrePrefixes.dustImpure, aMaterial.mMacerateInto, 1L),
+                        tBits,
+                        new Object[] { "h", "X", 'X', OrePrefixes.crushed.get(aMaterial) });
+                    GTModHandler.addCraftingRecipe(
+                        GTOreDictUnificator.get(OrePrefixes.dustImpure, aMaterial.mMacerateInto, 1L),
+                        tBits,
+                        new Object[] { "h", "X", 'X', OrePrefixes.dirtyGravel.get(aMaterial) });
+                }
                 GTModHandler.addCraftingRecipe(
                     GTOreDictUnificator.get(OrePrefixes.dustSmall, aMaterial, 4L),
                     tBits,

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingCrushedOre.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingCrushedOre.java
@@ -12,6 +12,7 @@ import net.minecraft.item.ItemStack;
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
+import gregtech.api.enums.SubTag;
 import gregtech.api.util.GTOreDictUnificator;
 import gregtech.api.util.GTUtility;
 
@@ -25,6 +26,10 @@ public class ProcessingCrushedOre implements gregtech.api.interfaces.IOreRecipeR
     @Override
     public void registerOre(OrePrefixes aPrefix, Materials aMaterial, String aOreDictName, String aModName,
         ItemStack aStack) {
+        if (aMaterial.contains(SubTag.NO_ORE_PROCESSING)) {
+            return;
+        }
+
         switch (aPrefix) {
             case crushedCentrifuged -> {
                 GTValues.RA.stdBuilder()

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingCrystallized.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingCrystallized.java
@@ -10,6 +10,7 @@ import net.minecraft.item.ItemStack;
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
+import gregtech.api.enums.SubTag;
 import gregtech.api.util.GTOreDictUnificator;
 import gregtech.api.util.GTUtility;
 
@@ -23,6 +24,10 @@ public class ProcessingCrystallized implements gregtech.api.interfaces.IOreRecip
     @Override
     public void registerOre(OrePrefixes aPrefix, Materials aMaterial, String aOreDictName, String aModName,
         ItemStack aStack) {
+        if (aMaterial.contains(SubTag.NO_ORE_PROCESSING)) {
+            return;
+        }
+
         if (aMaterial.mMacerateInto == null) {
             return;
         }

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingDirty.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingDirty.java
@@ -30,6 +30,10 @@ public class ProcessingDirty implements gregtech.api.interfaces.IOreRecipeRegist
     @Override
     public void registerOre(OrePrefixes aPrefix, Materials aMaterial, String aOreDictName, String aModName,
         net.minecraft.item.ItemStack aStack) {
+        if (aMaterial.contains(SubTag.NO_ORE_PROCESSING)) {
+            return;
+        }
+
         GTValues.RA.stdBuilder()
             .itemInputs(GTUtility.copyAmount(1, aStack))
             .itemOutputs(GTOreDictUnificator.get(OrePrefixes.dustImpure, aMaterial.mMacerateInto, 1L))

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingDust.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingDust.java
@@ -358,6 +358,10 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                 }
             }
             case dustPure, dustImpure, dustRefined -> {
+                if (aMaterial.contains(SubTag.NO_ORE_PROCESSING)) {
+                    return;
+                }
+
                 Materials tByProduct = GTUtility.selectItemInList(
                     aPrefix == OrePrefixes.dustRefined ? 2 : aPrefix == OrePrefixes.dustPure ? 1 : 0,
                     aMaterial,

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingOre.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingOre.java
@@ -36,6 +36,10 @@ public class ProcessingOre implements gregtech.api.interfaces.IOreRecipeRegistra
     @Override
     public void registerOre(OrePrefixes aPrefix, Materials aMaterial, String aOreDictName, String aModName,
         ItemStack aStack) {
+        if (aMaterial.contains(SubTag.NO_ORE_PROCESSING)) {
+            return;
+        }
+
         boolean tIsRich = false;
 
         // For Sake of god of balance!

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingOrePoor.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingOrePoor.java
@@ -43,6 +43,10 @@ public class ProcessingOrePoor implements gregtech.api.interfaces.IOreRecipeRegi
                 break;
         }
         if (aMaterial != null) {
+            if (aMaterial.contains(SubTag.NO_ORE_PROCESSING)) {
+                return;
+            }
+
             GTValues.RA.stdBuilder()
                 .itemInputs(GTUtility.copyAmount(1, aStack))
                 .itemOutputs(GTOreDictUnificator.get(OrePrefixes.dustTiny, aMaterial, aMultiplier))

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingOreSmelting.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingOreSmelting.java
@@ -34,6 +34,10 @@ public class ProcessingOreSmelting implements gregtech.api.interfaces.IOreRecipe
     @Override
     public void registerOre(OrePrefixes aPrefix, Materials aMaterial, String aOreDictName, String aModName,
         ItemStack aStack) {
+        if (aMaterial.contains(SubTag.NO_ORE_PROCESSING)) {
+            return;
+        }
+
         GTModHandler.removeFurnaceSmelting(aStack);
         if (!aMaterial.contains(SubTag.NO_SMELTING)) {
             if ((aMaterial.mBlastFurnaceRequired) || (aMaterial.mDirectSmelting.mBlastFurnaceRequired)) {

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingPure.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingPure.java
@@ -9,6 +9,7 @@ import net.minecraft.item.ItemStack;
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
+import gregtech.api.enums.SubTag;
 import gregtech.api.util.GTOreDictUnificator;
 import gregtech.api.util.GTUtility;
 
@@ -23,6 +24,10 @@ public class ProcessingPure implements gregtech.api.interfaces.IOreRecipeRegistr
     @Override
     public void registerOre(OrePrefixes aPrefix, Materials aMaterial, String aOreDictName, String aModName,
         ItemStack aStack) {
+        if (aMaterial.contains(SubTag.NO_ORE_PROCESSING)) {
+            return;
+        }
+
         GTValues.RA.stdBuilder()
             .itemInputs(GTUtility.copyAmount(1, aStack))
             .itemOutputs(GTOreDictUnificator.get(OrePrefixes.dustPure, aMaterial.mMacerateInto, 1L))

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingRawOre.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingRawOre.java
@@ -30,6 +30,10 @@ public class ProcessingRawOre implements gregtech.api.interfaces.IOreRecipeRegis
     @Override
     public void registerOre(OrePrefixes aPrefix, Materials aMaterial, String aOreDictName, String aModName,
         ItemStack aStack) {
+        if (aMaterial.contains(SubTag.NO_ORE_PROCESSING)) {
+            return;
+        }
+
         if (aMaterial == Materials.Oilsands) {
             GTValues.RA.stdBuilder()
                 .itemInputs(GTUtility.copyAmount(1, aStack))

--- a/src/main/java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechSimpleWasher.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechSimpleWasher.java
@@ -23,6 +23,7 @@ import gregtech.api.enums.GTValues;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.enums.SoundResource;
+import gregtech.api.enums.SubTag;
 import gregtech.api.metatileentity.implementations.MTEBasicMachineWithRecipe;
 import gregtech.api.metatileentity.implementations.MTEBasicMachineWithRecipe.SpecialEffects;
 import gregtech.api.util.GTOreDictUnificator;
@@ -133,6 +134,9 @@ public class GregtechSimpleWasher {
         ItemStack dustDirty;
         ItemStack dustPure;
         for (Materials v : Materials.values()) {
+            if (v.contains(SubTag.NO_ORE_PROCESSING)) {
+                continue;
+            }
             if (v == Materials.Platinum || v == Materials.Osmium
                 || v == Materials.Iridium
                 || v == Materials.Palladium) {
@@ -165,6 +169,9 @@ public class GregtechSimpleWasher {
         ItemStack crushedClean;
         ItemStack crushedDirty;
         for (Materials v : Materials.values()) {
+            if (v.contains(SubTag.NO_ORE_PROCESSING)) {
+                continue;
+            }
             crushedClean = GTOreDictUnificator.get(OrePrefixes.crushedPurified, v, 1L);
             crushedDirty = GTOreDictUnificator.get(OrePrefixes.crushed, v, 1L);
             addSimpleWashRecipe(crushedDirty, crushedClean);


### PR DESCRIPTION
Adds a new subtag to allow for a material to generate no recipes related to ore processing. This will be used in future PRs to process things like the platinum metallic powder, naquadah oxide, cerium-rich mixture, etc recipe replacements in a much more efficient way