### PR TITLE
Autogen recipe fixes

### DIFF
--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingOre.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingOre.java
@@ -79,8 +79,7 @@ public class ProcessingOre implements gregtech.api.interfaces.IOreRecipeRegistra
         Materials tMaterial = aMaterial.mOreReplacement;
         Materials tPrimaryByMaterial = null;
         aMultiplier = Math.max(1, aMultiplier);
-        aOreStack = GTUtility.copyAmount(1, aOreStack);
-        aOreStack.stackSize = 1;
+        aOreStack = GTOreDictUnificator.get(aPrefix, aMaterial, 1L);
 
         ItemStack tIngot = GTOreDictUnificator.get(OrePrefixes.ingot, aMaterial.mDirectSmelting, 1L);
         ItemStack tGem = GTOreDictUnificator.get(OrePrefixes.gem, tMaterial, 1L);

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingOreSmelting.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingOreSmelting.java
@@ -191,7 +191,7 @@ public class ProcessingOreSmelting implements gregtech.api.interfaces.IOreRecipe
                     1L);
                 if ((tStack == null) && (!aMaterial.contains(SubTag.SMELTING_TO_GEM)))
                     tStack = GTOreDictUnificator.get(OrePrefixes.ingot, aMaterial.mDirectSmelting, 1L);
-                GTModHandler.addSmeltingRecipe(aStack, tStack);
+                GTModHandler.addSmeltingRecipe(GTOreDictUnificator.get(aPrefix, aMaterial, 1L), tStack);
             }
         }
     }


### PR DESCRIPTION
fixes missing ore macerating and crushed ore smelting recipes.

also fixes the custom nei pages for ore processing.

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17417

Caveats:
- ~~I dont understand why this is needed~~ I do understand now. Things that extend itemblock are blacklisted from unification.
- there might be more similar issues