### PR TITLE
Fix Purification Unit not consuming fluid in Stocking Input Hatch(ME).

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/purification/MTEPurificationUnitBase.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/purification/MTEPurificationUnitBase.java
@@ -357,6 +357,7 @@ public abstract class MTEPurificationUnitBase<T extends MTEExtendedPowerMultiBlo
      * @param progressTime Current progress time
      */
     public void startCycle(int cycleTime, int progressTime) {
+        startRecipeProcessing();
         // Important to calculate this before depleting inputs, otherwise we may get issues with boost items
         // disappearing.
         this.currentRecipeChance = this.calculateBoostedSuccessChance();
@@ -390,6 +391,7 @@ public abstract class MTEPurificationUnitBase<T extends MTEExtendedPowerMultiBlo
         // specifically overridden so setting this value does not actually drain power.
         // Instead, power is drained by the main purification plant controller.
         this.lEUt = -this.getActualPowerUsage();
+        endRecipeProcessing();
     }
 
     public void addRecipeOutputs() {


### PR DESCRIPTION
Purification Unit consumes fluid in startCycle()
call method startRecipeProcessing() and endRecipeProcessing() to make Input Hatches that implements IRecipeProcessingAwareHatch work fine.

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17418