### PR TITLE
Fix Heat Exchanger interaction with Stocking Input Hatch(ME)

### DIFF
--- a/src/main/java/goodgenerator/blocks/tileEntity/MTEExtremeHeatExchanger.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/MTEExtremeHeatExchanger.java
@@ -265,7 +265,8 @@ public class MTEExtremeHeatExchanger extends MTETooltipMultiBlockBaseEM
 
         this.mMaxProgresstime = 20;
         this.mEUt = (int) (tRecipe.getEUt() * efficiency * ((double) tRealConsume / (double) tMaxConsume));
-        mHotFluidHatch.drain(ForgeDirection.UNKNOWN, new FluidStack(hotFluid.getFluid(), tRealConsume), true);
+        // the 3-arg drain will work on both normal hatch and ME hatch
+		mHotFluidHatch.drain(ForgeDirection.UNKNOWN, new FluidStack(hotFluid.getFluid(), tRealConsume), true);
         mCooledFluidHatch.fill(new FluidStack(tRecipe.getCooledFluid(), tRealConsume), true);
         this.mEfficiencyIncrease = 160;
 

--- a/src/main/java/goodgenerator/blocks/tileEntity/MTEExtremeHeatExchanger.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/MTEExtremeHeatExchanger.java
@@ -51,6 +51,8 @@ import gregtech.api.util.GTModHandler;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.IGTHatchAdder;
 import gregtech.api.util.MultiblockTooltipBuilder;
+import gregtech.common.tileentities.machines.IRecipeProcessingAwareHatch;
+import gregtech.common.tileentities.machines.MTEHatchInputME;
 
 public class MTEExtremeHeatExchanger extends MTETooltipMultiBlockBaseEM
     implements IConstructable, ISurvivalConstructable {
@@ -223,18 +225,26 @@ public class MTEExtremeHeatExchanger extends MTETooltipMultiBlockBaseEM
     @Override
     public @NotNull CheckRecipeResult checkProcessing_EM() {
         tRunningRecipe = null;
-        if (mHotFluidHatch.getFluid() == null) return CheckRecipeResultRegistry.SUCCESSFUL;
+        FluidStack hotFluid = null;
+        if (mHotFluidHatch instanceof MTEHatchInputME inputME) {
+            FluidStack[] fluids = inputME.getStoredFluids();
+            if (fluids.length > 0) {
+                hotFluid = fluids[0];
+            }
+        } else {
+            hotFluid = mHotFluidHatch.getFluid();
+        }
+        if (hotFluid == null) return CheckRecipeResultRegistry.SUCCESSFUL;
         ExtremeHeatExchangerRecipe tRecipe = (ExtremeHeatExchangerRecipe) GoodGeneratorRecipeMaps.extremeHeatExchangerFuels
             .getBackend()
-            .findFuel(mHotFluidHatch.getFluid());
+            .findFuel(hotFluid);
         if (tRecipe == null) return CheckRecipeResultRegistry.NO_RECIPE;
         tRunningRecipe = tRecipe;
-        this.hotName = mHotFluidHatch.getFluid()
-            .getFluid()
+        this.hotName = hotFluid.getFluid()
             .getName();
         int tMaxConsume = tRecipe.getMaxHotFluidConsume();
         int transformed_threshold = tRecipe.mSpecialValue;
-        int tRealConsume = Math.min(tMaxConsume, mHotFluidHatch.getFluid().amount);
+        int tRealConsume = Math.min(tMaxConsume, hotFluid.amount);
         double penalty = 0.0d;
         double efficiency = 1d;
         int shs_reduction_per_config = 150;
@@ -255,7 +265,7 @@ public class MTEExtremeHeatExchanger extends MTETooltipMultiBlockBaseEM
 
         this.mMaxProgresstime = 20;
         this.mEUt = (int) (tRecipe.getEUt() * efficiency * ((double) tRealConsume / (double) tMaxConsume));
-        mHotFluidHatch.drain(tRealConsume, true);
+        mHotFluidHatch.drain(ForgeDirection.UNKNOWN, new FluidStack(hotFluid.getFluid(), tRealConsume), true);
         mCooledFluidHatch.fill(new FluidStack(tRecipe.getCooledFluid(), tRealConsume), true);
         this.mEfficiencyIncrease = 160;
 
@@ -269,7 +279,10 @@ public class MTEExtremeHeatExchanger extends MTETooltipMultiBlockBaseEM
             int waterAmount = (int) (this.mEUt / getUnitSteamPower(tReadySteam.getName())) / 160;
             if (waterAmount < 0) return false;
             int steamToOutput;
-            if (depleteInput(GTModHandler.getDistilledWater(waterAmount))) {
+            startRecipeProcessing();
+            boolean isDepleteSuccess = depleteInput(GTModHandler.getDistilledWater(waterAmount));
+            endRecipeProcessing();
+            if (isDepleteSuccess) {
                 if (tRunningRecipe.mFluidInputs[0].getUnlocalizedName()
                     .contains("plasma")) {
                     steamToOutput = waterAmount * 160 / 1000;
@@ -419,6 +432,22 @@ public class MTEExtremeHeatExchanger extends MTETooltipMultiBlockBaseEM
 
         public IGTHatchAdder<? super MTEExtremeHeatExchanger> adder() {
             return adder;
+        }
+    }
+
+    @Override
+    public void startRecipeProcessing() {
+        super.startRecipeProcessing();
+        if (mHotFluidHatch instanceof IRecipeProcessingAwareHatch aware && mHotFluidHatch.isValid()) {
+            aware.startRecipeProcessing();
+        }
+    }
+
+    @Override
+    public void endRecipeProcessing() {
+        super.endRecipeProcessing();
+        if (mHotFluidHatch instanceof IRecipeProcessingAwareHatch aware && mHotFluidHatch.isValid()) {
+            aware.endRecipeProcessing(this);
         }
     }
 }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEHeatExchanger.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEHeatExchanger.java
@@ -230,7 +230,7 @@ public class MTEHeatExchanger extends MTEEnhancedMultiBlockBase<MTEHeatExchanger
 
         // Don't consume too much hot fluid per second
         fluidAmountToConsume = Math.min(fluidAmountToConsume, superheated_threshold * 2);
-
+		// the 3-arg drain will work on both normal hatch and ME hatch
         mInputHotFluidHatch
             .drain(ForgeDirection.UNKNOWN, new FluidStack(hotFluid.getFluid(), fluidAmountToConsume), true);
         mOutputColdFluidHatch.fill(coolant.getColdFluid(fluidAmountToConsume), true);

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEHeatExchanger.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEHeatExchanger.java
@@ -48,6 +48,8 @@ import gregtech.api.util.GTLog;
 import gregtech.api.util.GTModHandler;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.MultiblockTooltipBuilder;
+import gregtech.common.tileentities.machines.IRecipeProcessingAwareHatch;
+import gregtech.common.tileentities.machines.MTEHatchInputME;
 
 public class MTEHeatExchanger extends MTEEnhancedMultiBlockBase<MTEHeatExchanger> implements ISurvivalConstructable {
 
@@ -179,9 +181,19 @@ public class MTEHeatExchanger extends MTEEnhancedMultiBlockBase<MTEHeatExchanger
     @Override
     @Nonnull
     public CheckRecipeResult checkProcessing() {
-        if (mInputHotFluidHatch.getFluid() == null) return CheckRecipeResultRegistry.NO_RECIPE;
+        FluidStack hotFluid = null;
+        if (mInputHotFluidHatch instanceof MTEHatchInputME inputME) {
+            FluidStack[] fluids = inputME.getStoredFluids();
+            if (fluids.length > 0) {
+                hotFluid = fluids[0];
+            }
+        } else {
+            hotFluid = mInputHotFluidHatch.getFluid();
+        }
 
-        int fluidAmountToConsume = mInputHotFluidHatch.getFluidAmount(); // how much fluid is in hatch
+        if (hotFluid == null) return CheckRecipeResultRegistry.NO_RECIPE;
+
+        int fluidAmountToConsume = hotFluid.amount; // how much fluid is in hatch
 
         superheated_threshold = 4000; // default: must have 4000L per second to generate superheated steam
         float efficiency = 1f; // default: operate at 100% efficiency with no integrated circuitry
@@ -202,9 +214,7 @@ public class MTEHeatExchanger extends MTEEnhancedMultiBlockBase<MTEHeatExchanger
 
         efficiency -= penalty;
 
-        var coolant = LHECoolantRegistry.getCoolant(
-            mInputHotFluidHatch.getFluid()
-                .getFluid());
+        var coolant = LHECoolantRegistry.getCoolant(hotFluid.getFluid());
 
         if (coolant == null) {
             superheated_threshold = 0;
@@ -221,7 +231,8 @@ public class MTEHeatExchanger extends MTEEnhancedMultiBlockBase<MTEHeatExchanger
         // Don't consume too much hot fluid per second
         fluidAmountToConsume = Math.min(fluidAmountToConsume, superheated_threshold * 2);
 
-        mInputHotFluidHatch.drain(fluidAmountToConsume, true);
+        mInputHotFluidHatch
+            .drain(ForgeDirection.UNKNOWN, new FluidStack(hotFluid.getFluid(), fluidAmountToConsume), true);
         mOutputColdFluidHatch.fill(coolant.getColdFluid(fluidAmountToConsume), true);
 
         this.mMaxProgresstime = 20;
@@ -392,5 +403,21 @@ public class MTEHeatExchanger extends MTEEnhancedMultiBlockBase<MTEHeatExchanger
     public int survivalConstruct(ItemStack stackSize, int elementBudget, ISurvivalBuildEnvironment env) {
         if (mMachine) return -1;
         return survivialBuildPiece(STRUCTURE_PIECE_MAIN, stackSize, 1, 3, 0, elementBudget, env, false, true);
+    }
+
+    @Override
+    public void startRecipeProcessing() {
+        super.startRecipeProcessing();
+        if (mInputHotFluidHatch instanceof IRecipeProcessingAwareHatch aware && mInputHotFluidHatch.isValid()) {
+            aware.startRecipeProcessing();
+        }
+    }
+
+    @Override
+    public void endRecipeProcessing() {
+        super.endRecipeProcessing();
+        if (mInputHotFluidHatch instanceof IRecipeProcessingAwareHatch aware && mInputHotFluidHatch.isValid()) {
+            aware.endRecipeProcessing(this);
+        }
     }
 }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/advanced/MTEAdvHeatExchanger.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/advanced/MTEAdvHeatExchanger.java
@@ -220,7 +220,7 @@ public class MTEAdvHeatExchanger extends GTPPMultiBlockBase<MTEAdvHeatExchanger>
 
         // Don't consume too much hot fluid per second, maximum is 2x SH threshold.
         fluidAmountToConsume = Math.min(fluidAmountToConsume, superheated_threshold * 2);
-
+		// the 3-arg drain will work on both normal hatch and ME hatch
         mInputHotFluidHatch
             .drain(ForgeDirection.UNKNOWN, new FluidStack(hotFluid.getFluid(), fluidAmountToConsume), true);
         mOutputColdFluidHatch.fill(coolant.getColdFluid(fluidAmountToConsume), true);

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/advanced/MTEAdvHeatExchanger.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/advanced/MTEAdvHeatExchanger.java
@@ -11,6 +11,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.StatCollector;
+import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 
@@ -35,6 +36,8 @@ import gregtech.api.util.GTLog;
 import gregtech.api.util.GTModHandler;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.MultiblockTooltipBuilder;
+import gregtech.common.tileentities.machines.IRecipeProcessingAwareHatch;
+import gregtech.common.tileentities.machines.MTEHatchInputME;
 import gtPlusPlus.core.block.ModBlocks;
 import gtPlusPlus.core.block.base.BasicBlock.BlockTypes;
 import gtPlusPlus.core.block.base.BlockBaseModular;
@@ -168,9 +171,18 @@ public class MTEAdvHeatExchanger extends GTPPMultiBlockBase<MTEAdvHeatExchanger>
 
     @Override
     public @NotNull CheckRecipeResult checkProcessing() {
-        if (mInputHotFluidHatch.getFluid() == null) return CheckRecipeResultRegistry.SUCCESSFUL;
+        FluidStack hotFluid = null;
+        if (mInputHotFluidHatch instanceof MTEHatchInputME inputME) {
+            FluidStack[] fluids = inputME.getStoredFluids();
+            if (fluids.length > 0) {
+                hotFluid = fluids[0];
+            }
+        } else {
+            hotFluid = mInputHotFluidHatch.getFluid();
+        }
+        if (hotFluid == null) return CheckRecipeResultRegistry.SUCCESSFUL;
 
-        int fluidAmountToConsume = mInputHotFluidHatch.getFluidAmount(); // how much fluid is in hatch
+        int fluidAmountToConsume = hotFluid.amount; // how much fluid is in hatch
 
         // The XL LHE works as fast as 32 regular LHEs. These are the comments from the original LHE,
         // with changes where the values needed to change for the 32x speed multiplier
@@ -193,9 +205,7 @@ public class MTEAdvHeatExchanger extends GTPPMultiBlockBase<MTEAdvHeatExchanger>
 
         efficiency -= penalty;
 
-        var coolant = LHECoolantRegistry.getCoolant(
-            mInputHotFluidHatch.getFluid()
-                .getFluid());
+        var coolant = LHECoolantRegistry.getCoolant(hotFluid.getFluid());
 
         if (coolant == null) {
             superheated_threshold = 0;
@@ -211,7 +221,8 @@ public class MTEAdvHeatExchanger extends GTPPMultiBlockBase<MTEAdvHeatExchanger>
         // Don't consume too much hot fluid per second, maximum is 2x SH threshold.
         fluidAmountToConsume = Math.min(fluidAmountToConsume, superheated_threshold * 2);
 
-        mInputHotFluidHatch.drain(fluidAmountToConsume, true);
+        mInputHotFluidHatch
+            .drain(ForgeDirection.UNKNOWN, new FluidStack(hotFluid.getFluid(), fluidAmountToConsume), true);
         mOutputColdFluidHatch.fill(coolant.getColdFluid(fluidAmountToConsume), true);
 
         this.mMaxProgresstime = 20;
@@ -242,6 +253,7 @@ public class MTEAdvHeatExchanger extends GTPPMultiBlockBase<MTEAdvHeatExchanger>
                 // 1:160 ratio with distilled water consumption
 
                 FluidStack distilledStack = GTModHandler.getDistilledWater(distilledConsumed);
+                startRecipeProcessing();
                 if (depleteInput(distilledStack)) // Consume the distilled water
                 {
                     if (superheated) {
@@ -255,6 +267,7 @@ public class MTEAdvHeatExchanger extends GTPPMultiBlockBase<MTEAdvHeatExchanger>
                     GTLog.exp.println(this.mName + " had no more Distilled water!");
                     explodeMultiblock(); // Generate crater
                 }
+                endRecipeProcessing();
             }
             return true;
         }
@@ -392,5 +405,21 @@ public class MTEAdvHeatExchanger extends GTPPMultiBlockBase<MTEAdvHeatExchanger>
             sFrame = BlockBaseModular.getMaterialBlock(MaterialsAlloy.TALONITE, BlockTypes.FRAME);
         }
         return sFrame;
+    }
+
+    @Override
+    public void startRecipeProcessing() {
+        super.startRecipeProcessing();
+        if (mInputHotFluidHatch instanceof IRecipeProcessingAwareHatch aware && mInputHotFluidHatch.isValid()) {
+            aware.startRecipeProcessing();
+        }
+    }
+
+    @Override
+    public void endRecipeProcessing() {
+        super.endRecipeProcessing();
+        if (mInputHotFluidHatch instanceof IRecipeProcessingAwareHatch aware && mInputHotFluidHatch.isValid()) {
+            aware.endRecipeProcessing(this);
+        }
     }
 }


### PR DESCRIPTION
This PR tries to fix two problems.
1. Heat Exchanger(all 3 varients) hotfluid Input Hatch position does not support Stocking Input Hatch(ME)
https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17419
2. Heat Exchanger(only Adv and Extreme ver.) distilledwater Input Hatch position works with Stocking Input Hatch(ME), but with wired behaviour(x20 times the output stream)
https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16954

This PR add missing 'startRecipeProcessing' & 'endRecipeProcessing' method calls back
and make Stocking Input Hatch(ME) work properly with Heat Exchanger.

figure : Heat Exchangers running with Stocking Input Hatch(ME)
![2024-09-24_22 21 49](https://github.com/user-attachments/assets/f5cbcceb-945e-4e6e-bd1a-ef4087ff5c26)
![2024-09-24_22 25 20](https://github.com/user-attachments/assets/4a1c3f62-0350-4f4e-aecc-2443b0b958af)
![2024-09-24_22 10 38](https://github.com/user-attachments/assets/65f2f01a-2c62-4c10-a0c0-a8399ef34801)
