### PR TITLE
Fix broken imprecise casing recipe

### DIFF
--- a/src/main/java/bartworks/system/material/WerkstoffLoader.java
+++ b/src/main/java/bartworks/system/material/WerkstoffLoader.java
@@ -1049,6 +1049,7 @@ public class WerkstoffLoader {
         new Werkstoff.GenerationFeatures().onlyDust()
             .addMolten()
             .addMetalItems()
+            .addCraftingMetalWorkingItems()
             .enforceUnification(),
         64,
         TextureSet.SET_METALLIC
@@ -1236,6 +1237,7 @@ public class WerkstoffLoader {
             .onlyDust()
             .addMetalItems()
             .addMolten()
+            .addCraftingMetalWorkingItems()
             .enforceUnification(),
         78,
         TextureSet.SET_METALLIC);


### PR DESCRIPTION
Lost a recipe when removing gt++ duplicate materials since it was using ruthenium bolts and the bartworks ruthenium did not generate bolts. 

Made ruthenium (and rhodium for good measure) generate the standard set of metalwork materials, unification works as expected and recipe is no longer broken.

![image](https://github.com/user-attachments/assets/4e398320-abd0-44f0-b771-4481e558e19c)
