### PR TITLE
Fix callisto ice bee products

### DIFF
--- a/src/main/java/gregtech/loaders/misc/GTBeeDefinition.java
+++ b/src/main/java/gregtech/loaders/misc/GTBeeDefinition.java
@@ -1937,7 +1937,7 @@ public enum GTBeeDefinition implements IBeeDefinition {
     JUPITER(GTBranchDefinition.PLANET, "Jupiter", false, new Color(0x734B2E), new Color(0xD0CBC4), beeSpecies -> {
         beeSpecies.addProduct(GTBees.combs.getStackForType(CombType.JUPITER), 0.35f);
         beeSpecies.addSpecialty(GTModHandler.getModItem(NewHorizonsCoreMod.ID, "item.CallistoStoneDust", 1, 0), 0.05f);
-        beeSpecies.addSpecialty(GTModHandler.getModItem(NewHorizonsCoreMod.ID, "item.CallistoIceDust", 1, 0), 0.05f);
+        beeSpecies.addSpecialty(Materials.CallistoIce.getDust(1), 0.05f);
         beeSpecies.addSpecialty(GTModHandler.getModItem(NewHorizonsCoreMod.ID, "item.IoStoneDust", 1, 0), 0.05f);
         beeSpecies.addSpecialty(GTModHandler.getModItem(NewHorizonsCoreMod.ID, "item.EuropaStoneDust", 1, 0), 0.05f);
         beeSpecies.addSpecialty(GTModHandler.getModItem(NewHorizonsCoreMod.ID, "item.EuropaIceDust", 1, 0), 0.05f);
@@ -1991,7 +1991,7 @@ public enum GTBeeDefinition implements IBeeDefinition {
     CALLISTO(GTBranchDefinition.PLANET, "Callisto", true, new Color(0x0f333d), new Color(0x0d84a5), beeSpecies -> {
         beeSpecies.addProduct(GTBees.combs.getStackForType(CombType.JUPITER), 0.25f);
         beeSpecies.addSpecialty(GTModHandler.getModItem(NewHorizonsCoreMod.ID, "item.CallistoStoneDust", 1, 0), 0.10f);
-        beeSpecies.addSpecialty(GTModHandler.getModItem(NewHorizonsCoreMod.ID, "item.CallistoIceDust", 1, 0), 0.10f);
+        beeSpecies.addSpecialty(Materials.CallistoIce.getDust(1), 0.10f);
         beeSpecies.setHumidity(DAMP);
         beeSpecies.setTemperature(ICY);
         beeSpecies.setNocturnal();


### PR DESCRIPTION
Changes the Jupiter and Callisto bees to produce Gregtech Callisto Ice Dust instead of the coremod variant. This is especially needed after [this pr](https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1013) which removes the coremod variant - if you merge that without merging this, these bees will now produce vanilla minecraft boats :)

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17327