### PR TITLE
Moved tectech block registration to pre-init

### DIFF
--- a/src/main/java/bartworks/API/GlassTier.java
+++ b/src/main/java/bartworks/API/GlassTier.java
@@ -33,6 +33,7 @@ public class GlassTier {
     }
 
     public static void addCustomGlass(@NotNull Block block, int meta, int tier) {
+        Objects.requireNonNull(block, "Glass block cannot be null");
         GlassTier.glasses.put(new BlockMetaPair(block, (byte) meta), tier);
     }
 

--- a/src/main/java/tectech/loader/MainLoader.java
+++ b/src/main/java/tectech/loader/MainLoader.java
@@ -35,14 +35,18 @@ public final class MainLoader {
         } catch (Throwable t) {
             LOGGER.error("Loading textures...", t);
         }
+
+        ProgressManager.ProgressBar progressBarPreload = ProgressManager.push("TecTech Preload", 1);
+
+        progressBarPreload.step("Regular Things");
+        new ThingsLoader().run();
+        LOGGER.info("Block/Item Init Done");
+
+        ProgressManager.pop(progressBarPreload);
     }
 
     public static void load() {
-        ProgressManager.ProgressBar progressBarLoad = ProgressManager.push("TecTech Loader", 6);
-
-        progressBarLoad.step("Regular Things");
-        new ThingsLoader().run();
-        LOGGER.info("Block/Item Init Done");
+        ProgressManager.ProgressBar progressBarLoad = ProgressManager.push("TecTech Loader", 5);
 
         progressBarLoad.step("Machine Things");
         new MachineLoader().run();


### PR DESCRIPTION
TecTech was registering its blocks on load instead of on preInit. The recent bartworks glass refactor registered quantum glass as a tier 8 glass, but since the bartworks glass registration happens at the end of preInit, quantum glass was never registered.
Since TecTech is at fault, its block & item registration was moved to preInit.