### PR TITLE
Improve a new debug log

### DIFF
--- a/src/main/java/gregtech/api/enums/OrePrefixes.java
+++ b/src/main/java/gregtech/api/enums/OrePrefixes.java
@@ -1325,7 +1325,8 @@ public enum OrePrefixes {
         if (aMaterial != Materials._NULL) {
             if (!used.add(aMaterial)) {
                 if (DEBUG_MODE_COLLISION) {
-                    GTLog.out.println("Attempted duplicate recipe registration by " + aModName + " for " + aOreDictName);
+                    GTLog.out
+                        .println("Attempted duplicate recipe registration by " + aModName + " for " + aOreDictName);
                 }
                 return;
             } else {

--- a/src/main/java/gregtech/api/enums/OrePrefixes.java
+++ b/src/main/java/gregtech/api/enums/OrePrefixes.java
@@ -3,6 +3,7 @@ package gregtech.api.enums;
 import static gregtech.api.enums.GTValues.B;
 import static gregtech.api.enums.GTValues.D2;
 import static gregtech.api.enums.GTValues.M;
+import static gregtech.api.util.GTRecipeBuilder.DEBUG_MODE_COLLISION;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -1309,18 +1310,29 @@ public enum OrePrefixes {
             return;
         }
 
-        if (aMaterial != Materials._NULL && !used.add(aMaterial)) {
-            GTLog.out.println("Duplicate material registry attempted by " + aModName + " for " + aOreDictName);
-            return;
-        }
-
         if (aMaterial.contains(SubTag.NO_RECIPES)) {
             return;
         }
 
-        if (!((aMaterial != Materials._NULL || mIsSelfReferencing || !mIsMaterialBased)
-            && GTUtility.isStackValid(aStack))) {
+        if (aMaterial == Materials._NULL && !mIsSelfReferencing && mIsMaterialBased) {
             return;
+        }
+
+        if (!GTUtility.isStackValid(aStack)) {
+            return;
+        }
+
+        if (aMaterial != Materials._NULL) {
+            if (!used.add(aMaterial)) {
+                if (DEBUG_MODE_COLLISION) {
+                    GTLog.out.println("Attempted duplicate recipe registration by " + aModName + " for " + aOreDictName);
+                }
+                return;
+            } else {
+                if (DEBUG_MODE_COLLISION) {
+                    GTLog.out.println("New recipe registration by " + aModName + " for " + aOreDictName);
+                }
+            }
         }
 
         for (IOreRecipeRegistrator tRegistrator : mOreProcessing) {

--- a/src/main/java/gregtech/api/util/GTRecipeBuilder.java
+++ b/src/main/java/gregtech/api/util/GTRecipeBuilder.java
@@ -43,7 +43,7 @@ public class GTRecipeBuilder {
     private static final boolean DEBUG_MODE_FULL_ENERGY;
     // Any stable release should be tested at least once with this: -Dgt.recipebuilder.panic.invalid=true
     private static final boolean PANIC_MODE_INVALID;
-    private static final boolean DEBUG_MODE_COLLISION;
+    public static final boolean DEBUG_MODE_COLLISION;
 
     // Any stable release should be tested at least once with this: -Dgt.recipebuilder.panic.collision=true
     private static final boolean PANIC_MODE_COLLISION;


### PR DESCRIPTION
specifically the one added in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3240.

This hides the log behind the relevant debug flag, adds the positive entry to the negative (has been very helpful to me), and untangles some of the convoluted logic around the early exits.