### PR TITLE
Fix BaseMetaPipeEntity pass wrong side argument to 'onPlayerAttach'

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
@@ -960,7 +960,7 @@ public class BaseMetaPipeEntity extends CommonMetaTileEntity
                             && mMetaTileEntity.allowCoverOnSide(coverSide, new GTItemStack(tCurrentItem))) {
 
                             setCoverItemAtSide(coverSide, tCurrentItem);
-                            coverBehavior.onPlayerAttach(aPlayer, tCurrentItem, this, side);
+                            coverBehavior.onPlayerAttach(aPlayer, tCurrentItem, this, coverSide);
 
                             mMetaTileEntity.markDirty();
                             if (!aPlayer.capabilities.isCreativeMode) tCurrentItem.stackSize--;


### PR DESCRIPTION
The argument passed to 'onPlayerAttach' is the clicked side('side'), not the wrenching side('coverSide'), 'onPlayerAttach' will receive wrong argument if attaching cover when sneaking.

<p>
<img src=https://github.com/user-attachments/assets/30b11f6a-aee5-4828-b4b2-e77747b9e0bb width=30% />
</p>

This bug has no bad effects for now, because most 'onPlayerAttach' is a no-op for most covers.
And the only one CoverBehavour that overrides 'onPlayerAttach' is metrics cover, which is not allowed to be attched to BaseMetaPipeEntity.
But I think this will help if some CoverBehavour overrides onPlayerAttach in the future.


compare to BaseMetaTileEntity which is implemented correctly:
https://github.com/GTNewHorizons/GT5-Unofficial/blob/e9fe2d86f47121b308f08eab6162c51fa3d6aa01/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java#L1680-L1683

https://github.com/GTNewHorizons/GT5-Unofficial/blob/e9fe2d86f47121b308f08eab6162c51fa3d6aa01/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java#L961-L964

