### PR TITLE
Remove steam blender hatches

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/MTESteamMixer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/MTESteamMixer.java
@@ -82,7 +82,7 @@ public class MTESteamMixer extends MTESteamMultiBase<MTESteamMixer> implements I
         return "Mixer";
     }
 
-    private static final String STRUCTUR_PIECE_MAIN = "main";
+    private static final String STRUCTURE_PIECE_MAIN = "main";
 
     private IStructureDefinition<MTESteamMixer> STRUCTURE_DEFINITION = null;
     // spotless:off
@@ -181,7 +181,7 @@ public class MTESteamMixer extends MTESteamMultiBase<MTESteamMixer> implements I
 
             STRUCTURE_DEFINITION = StructureDefinition.<MTESteamMixer>builder()
 
-                .addShape(STRUCTUR_PIECE_MAIN, transpose(shape))
+                .addShape(STRUCTURE_PIECE_MAIN, transpose(shape))
                 .addElement(
                     'B',
                     ofBlocksTiered(
@@ -207,7 +207,7 @@ public class MTESteamMixer extends MTESteamMultiBase<MTESteamMixer> implements I
                             .allowOnly(ForgeDirection.NORTH)
                             .build(),
                         buildHatchAdder(MTESteamMixer.class)
-                            .atLeast(
+                            .anyOf(
                                 SteamHatchElement.InputBus_Steam,
                                 SteamHatchElement.OutputBus_Steam,
                                 OutputHatch,
@@ -230,14 +230,14 @@ public class MTESteamMixer extends MTESteamMultiBase<MTESteamMixer> implements I
 
     @Override
     public void construct(ItemStack stackSize, boolean hintsOnly) {
-        this.buildPiece(STRUCTUR_PIECE_MAIN, stackSize, hintsOnly, HORIZONTAL_OFF_SET, VERTICAL_OFF_SET, DEPTH_OFF_SET);
+        this.buildPiece(STRUCTURE_PIECE_MAIN, stackSize, hintsOnly, HORIZONTAL_OFF_SET, VERTICAL_OFF_SET, DEPTH_OFF_SET);
     }
 
     @Override
     public int survivalConstruct(ItemStack stackSize, int elementBudget, ISurvivalBuildEnvironment env) {
         if (this.mMachine) return -1;
         return this.survivialBuildPiece(
-            STRUCTUR_PIECE_MAIN,
+            STRUCTURE_PIECE_MAIN,
             stackSize,
             HORIZONTAL_OFF_SET,
             VERTICAL_OFF_SET,
@@ -254,16 +254,12 @@ public class MTESteamMixer extends MTESteamMultiBase<MTESteamMixer> implements I
         tierPipeCasing = -1;
         tierMachineCasing = -1;
         tCountCasing = 0;
-        if (!checkPiece(STRUCTUR_PIECE_MAIN, HORIZONTAL_OFF_SET, VERTICAL_OFF_SET, DEPTH_OFF_SET)) return false;
+        if (!checkPiece(STRUCTURE_PIECE_MAIN, HORIZONTAL_OFF_SET, VERTICAL_OFF_SET, DEPTH_OFF_SET)) return false;
         if (tierGearBoxCasing < 0 && tierPipeCasing < 0 && tierMachineCasing < 0) return false;
         if (tierGearBoxCasing == 1 && tierPipeCasing == 1
             && tierMachineCasing == 1
             && tCountCasing >= 90
-            && !mSteamInputFluids.isEmpty()
-            && !mSteamInputs.isEmpty()
-            && !mSteamOutputs.isEmpty()
-            && !mInputHatches.isEmpty()
-            && !mOutputHatches.isEmpty()) {
+            && !mSteamInputFluids.isEmpty()) {
             updateHatchTexture();
             tierMachine = 1;
             return true;
@@ -271,11 +267,7 @@ public class MTESteamMixer extends MTESteamMultiBase<MTESteamMixer> implements I
         if (tierGearBoxCasing == 2 && tierPipeCasing == 2
             && tierMachineCasing == 2
             && tCountCasing >= 90
-            && !mSteamInputFluids.isEmpty()
-            && !mSteamInputs.isEmpty()
-            && !mSteamOutputs.isEmpty()
-            && !mInputHatches.isEmpty()
-            && !mOutputHatches.isEmpty()) {
+            && !mSteamInputFluids.isEmpty()) {
             updateHatchTexture();
             tierMachine = 2;
             return true;

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/MTESteamMixer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/MTESteamMixer.java
@@ -207,7 +207,7 @@ public class MTESteamMixer extends MTESteamMultiBase<MTESteamMixer> implements I
                             .allowOnly(ForgeDirection.NORTH)
                             .build(),
                         buildHatchAdder(MTESteamMixer.class)
-                            .anyOf(
+                            .atLeast(
                                 SteamHatchElement.InputBus_Steam,
                                 SteamHatchElement.OutputBus_Steam,
                                 OutputHatch,

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/MTESteamMixer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/MTESteamMixer.java
@@ -230,7 +230,13 @@ public class MTESteamMixer extends MTESteamMultiBase<MTESteamMixer> implements I
 
     @Override
     public void construct(ItemStack stackSize, boolean hintsOnly) {
-        this.buildPiece(STRUCTURE_PIECE_MAIN, stackSize, hintsOnly, HORIZONTAL_OFF_SET, VERTICAL_OFF_SET, DEPTH_OFF_SET);
+        this.buildPiece(
+            STRUCTURE_PIECE_MAIN,
+            stackSize,
+            hintsOnly,
+            HORIZONTAL_OFF_SET,
+            VERTICAL_OFF_SET,
+            DEPTH_OFF_SET);
     }
 
     @Override


### PR DESCRIPTION
This removes the hatch/bus requirements for steam blenders, since they seem to be confusing a lot of people. Many mixer recipes also don't require all 4 hatches, so it doesn't make much sense to require them. The steam input hatches (power) are still required.

I'll ask @evgengoldwar to review this since it's his multi and I'm not sure if this is what he intends.

closes: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17378
closes: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17287

![2024-09-27_18 55 41](https://github.com/user-attachments/assets/999881a8-515e-4e25-9b7f-d3f1b6c365ba)
![2024-09-27_18 55 36](https://github.com/user-attachments/assets/d91ea81e-5df2-442d-973b-9299a2e96ebe)
