### PR TITLE
Hopefully fix obliterating people's gpu memory

### DIFF
--- a/src/main/java/tectech/thing/block/RenderForgeOfGods.java
+++ b/src/main/java/tectech/thing/block/RenderForgeOfGods.java
@@ -40,6 +40,7 @@ public class RenderForgeOfGods extends TileEntitySpecialRenderer {
     private static float modelNormalize = .0067f * 2;
 
     private static boolean initialized = false;
+    private static boolean failedInit = false;
     private static int u_Color = -1, u_ModelMatrix = -1, u_Gamma = -1;
     private Matrix4fStack starModelMatrix = new Matrix4fStack(3);
 
@@ -402,13 +403,24 @@ public class RenderForgeOfGods extends TileEntitySpecialRenderer {
 
     @Override
     public void renderTileEntityAt(TileEntity tile, double x, double y, double z, float timeSinceLastTick) {
+        if (failedInit) return;
         if (!(tile instanceof TileEntityForgeOfGods forgeTile)) return;
         if (forgeTile.getRingCount() < 1) return;
 
+        // If something ever fails, just early return and never try again this session
         if (!initialized) {
             init();
-            initRings();
-            if (!initialized) return;
+            if (!initialized) {
+                failedInit = true;
+                return;
+            }
+            try {
+                initRings();
+            } catch (Exception e) {
+                System.out.println(e.getMessage());
+                failedInit = true;
+                return;
+            }
         }
 
         // Based on system time to prevent tps issues from causing stutters

--- a/src/main/resources/assets/tectech/shaders/star.frag.glsl
+++ b/src/main/resources/assets/tectech/shaders/star.frag.glsl
@@ -24,7 +24,7 @@ void main() {
         vec3 originalYIQ = toYIQ(texture);
         vec3 yiqColor = vec3(original.x,targetYIQ.yz);
         vec3 finalrgb = toRGB(yiqColor);
-        finalrgb = pow(finalrgb,vec3(1/u_Gamma));
+        finalrgb = pow(finalrgb,vec3(1.0/u_Gamma));
         gl_FragColor = vec4(finalrgb,u_Color.a);
     }
 }


### PR DESCRIPTION
Adds a graceful fail to the gorge render so if it fails to intialize it will never try to again.  Previously when it failed it would try again next frame, and since memory isnt handled by garbage collection, this would consume all the ram available. 
Should at least mask issues like:
https://discord.com/channels/181078474394566657/401118216228831252/1289593334482079744

Until all driver differences are found

Also should fix the driver difference issue this time