### PR TITLE
Fix Infinite Spraycan client desync issue

### DIFF
--- a/src/main/java/gregtech/api/net/GTPacketInfiniteSpraycan.java
+++ b/src/main/java/gregtech/api/net/GTPacketInfiniteSpraycan.java
@@ -71,15 +71,10 @@ public class GTPacketInfiniteSpraycan extends GTPacket {
     public void process(final IBlockAccess aWorld) {
         ItemStack currentItemStack = player.inventory.getCurrentItem();
         if (currentItemStack != null && currentItemStack.getItem() instanceof MetaBaseItem item) {
-            item.forEachBehavior(currentItemStack, behavior -> {
-                if (behavior instanceof BehaviourSprayColorInfinite spraycanBehavior
-                    && action.execute(spraycanBehavior, currentItemStack, player, newColor)) {
-                    player.sendSlotContents(player.inventoryContainer, player.inventory.currentItem, currentItemStack);
-                    return true;
-                }
-
-                return false;
-            });
+            item.forEachBehavior(
+                currentItemStack,
+                behavior -> behavior instanceof BehaviourSprayColorInfinite spraycanBehavior
+                    && action.execute(spraycanBehavior, currentItemStack, player, newColor));
         }
     }
 


### PR DESCRIPTION
The infinite spraycan was making an unnecessary call to `player.sendSlotContents`, which was causing client-side weirdness. Sometimes, it would try to put the spraycan in your boots slot, but taking it out brought the boots back. Other times, it was populating the top-left square in the 2x2 crafting window. Removing this call stopped the weird ghost spraycans showing up.

Tested on both SSP and SMP versions of the dev pack; spray can worked fine.