### PR TITLE
moved bartworks ic2 nuke fuel rod init

### DIFF
--- a/src/main/java/bartworks/common/loaders/ItemRegistry.java
+++ b/src/main/java/bartworks/common/loaders/ItemRegistry.java
@@ -215,6 +215,7 @@ import bartworks.common.tileentities.tiered.MTEEnergyDistributor;
 import bartworks.common.tileentities.tiered.MTEGiantOutputHatch;
 import bartworks.common.tileentities.tiered.MTEHumongousInputHatch;
 import bartworks.system.material.WerkstoffLoader;
+import bartworks.system.material.processingLoaders.LoadItemContainers;
 import bwcrossmod.galacticgreg.MTEVoidMiners;
 import bwcrossmod.tectech.tileentites.tiered.MTELowPowerLaserBox;
 import bwcrossmod.tectech.tileentites.tiered.MTELowPowerLaserDynamo;
@@ -648,5 +649,7 @@ public class ItemRegistry {
                     amps).getStackForm(1L);
             }
         }
+
+        LoadItemContainers.run();
     }
 }

--- a/src/main/java/bartworks/system/material/processingLoaders/AdditionalRecipes.java
+++ b/src/main/java/bartworks/system/material/processingLoaders/AdditionalRecipes.java
@@ -486,8 +486,6 @@ public class AdditionalRecipes {
             .metadata(FUEL_VALUE, 125_000)
             .addTo(ultraHugeNaquadahReactorFuels);
 
-        LoadItemContainers.run();
-
         GTValues.RA.stdBuilder()
             .itemInputs(ItemList.Large_Fluid_Cell_TungstenSteel.get(1L), WerkstoffLoader.Tiberium.get(dust, 3))
             .itemOutputs(BWNonMetaMaterialItems.TiberiumCell_1.get(1L))


### PR DESCRIPTION
This moves bartworks' ic2 nuke fuel rod item init to the init stage rather than the post init stage. I couldn't find another item that does something similar, so I'm guessing this was just forgotten/misplaced. From what I can see this doesn't break anything in the pack but I need to access these items in nuclear horizons.

![2024-09-28_17 26 58](https://github.com/user-attachments/assets/c485a832-9cc8-4b78-9046-d72268b099bd)
![2024-09-28_17 26 55](https://github.com/user-attachments/assets/3b5806ed-a85a-4b28-b6d4-a722cc383ab5)
