### PR TITLE
Skip recipe checks if input contains only programmed circuits.

### DIFF
--- a/src/main/java/gregtech/api/enums/OrePrefixes.java
+++ b/src/main/java/gregtech/api/enums/OrePrefixes.java
@@ -1322,7 +1322,7 @@ public enum OrePrefixes {
             return;
         }
 
-        if (aMaterial != Materials._NULL) {
+        if (!aOreDictName.startsWith("stone") && aMaterial != Materials._NULL) {
             if (!used.add(aMaterial)) {
                 if (DEBUG_MODE_COLLISION) {
                     GTLog.out

--- a/src/main/java/gregtech/api/recipe/RecipeMapBackend.java
+++ b/src/main/java/gregtech/api/recipe/RecipeMapBackend.java
@@ -398,6 +398,19 @@ public class RecipeMapBackend {
                     return Stream.empty();
                 }
             }
+            if (!properties.allowCircuitOnly && properties.minItemInputs == 0 && properties.minFluidInputs == 0) {
+                // Both items and fluids can be empty, but we still need at least one non-circuit input.
+                int count = 0;
+                for (FluidStack fluid : fluids) if (fluid != null) {
+                    count++;
+                    break;
+                }
+                if (count == 0) for (ItemStack item : rawItems) if (!isAnyIntegratedCircuit(item)) {
+                    count++;
+                    break;
+                }
+                if (count == 0) return Stream.empty();
+            }
         }
 
         ItemStack[] items;

--- a/src/main/java/gregtech/api/recipe/RecipeMapBackend.java
+++ b/src/main/java/gregtech/api/recipe/RecipeMapBackend.java
@@ -6,6 +6,7 @@ import static gregtech.api.util.GTRecipeBuilder.handleInvalidRecipeLowFluids;
 import static gregtech.api.util.GTRecipeBuilder.handleInvalidRecipeLowItems;
 import static gregtech.api.util.GTRecipeBuilder.handleRecipeCollision;
 import static gregtech.api.util.GTUtility.areStacksEqualOrNull;
+import static gregtech.api.util.GTUtility.isAnyIntegratedCircuit;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -392,7 +393,7 @@ public class RecipeMapBackend {
             }
             if (properties.minItemInputs > 0) {
                 int count = 0;
-                for (ItemStack item : rawItems) if (item != null) count++;
+                for (ItemStack item : rawItems) if (!isAnyIntegratedCircuit(item)) count++;
                 if (count < properties.minItemInputs) {
                     return Stream.empty();
                 }

--- a/src/main/java/gregtech/api/recipe/RecipeMapBackendProperties.java
+++ b/src/main/java/gregtech/api/recipe/RecipeMapBackendProperties.java
@@ -30,6 +30,11 @@ public final class RecipeMapBackendProperties {
      * Minimum amount of fluid inputs required for the recipes.
      */
     public final int minFluidInputs;
+    /**
+     * Whether to allow recipes which only use a programmed circuit, and no item/fluid inputs. If this is false, such
+     * recipes are optimized away.
+     */
+    public boolean allowCircuitOnly;
 
     /**
      * Whether this backend should check for equality of special slot when searching recipe.
@@ -52,8 +57,8 @@ public final class RecipeMapBackendProperties {
     @Nullable
     public final Function<? super GTRecipe, ? extends GTRecipe> recipeTransformer;
 
-    RecipeMapBackendProperties(int minItemInputs, int minFluidInputs, boolean specialSlotSensitive,
-        boolean disableOptimize,
+    RecipeMapBackendProperties(int minItemInputs, int minFluidInputs, boolean allowCircuitOnly,
+        boolean specialSlotSensitive, boolean disableOptimize,
         Function<? super GTRecipeBuilder, ? extends Iterable<? extends GTRecipe>> recipeEmitter,
         @Nullable Function<? super GTRecipe, ? extends GTRecipe> recipeTransformer) {
         if (minItemInputs < 0 || minFluidInputs < 0) {
@@ -61,6 +66,7 @@ public final class RecipeMapBackendProperties {
         }
         this.minItemInputs = minItemInputs;
         this.minFluidInputs = minFluidInputs;
+        this.allowCircuitOnly = allowCircuitOnly;
         this.specialSlotSensitive = specialSlotSensitive;
         this.disableOptimize = disableOptimize;
         this.recipeEmitter = recipeEmitter;

--- a/src/main/java/gregtech/api/recipe/RecipeMapBackendPropertiesBuilder.java
+++ b/src/main/java/gregtech/api/recipe/RecipeMapBackendPropertiesBuilder.java
@@ -23,6 +23,7 @@ public final class RecipeMapBackendPropertiesBuilder {
 
     private int minItemInputs;
     private int minFluidInputs;
+    private boolean allowCircuitOnly;
 
     private boolean specialSlotSensitive;
 
@@ -39,6 +40,7 @@ public final class RecipeMapBackendPropertiesBuilder {
         return new RecipeMapBackendProperties(
             minItemInputs,
             minFluidInputs,
+            allowCircuitOnly,
             specialSlotSensitive,
             disableOptimize,
             recipeEmitter,
@@ -52,6 +54,11 @@ public final class RecipeMapBackendPropertiesBuilder {
 
     public RecipeMapBackendPropertiesBuilder minFluidInputs(int minFluidInputs) {
         this.minFluidInputs = minFluidInputs;
+        return this;
+    }
+
+    public RecipeMapBackendPropertiesBuilder allowCircuitOnly(boolean allowCircuitOnly) {
+        this.allowCircuitOnly = allowCircuitOnly;
         return this;
     }
 

--- a/src/main/java/gregtech/api/recipe/RecipeMapBuilder.java
+++ b/src/main/java/gregtech/api/recipe/RecipeMapBuilder.java
@@ -92,6 +92,8 @@ public final class RecipeMapBuilder<B extends RecipeMapBackend> {
 
     /**
      * Sets minimum amount of inputs required for the recipes.
+     * This ignores programmed circuits; so if a machine requires one input item and a programmed circuit, set
+     * minItemInputs to 1.
      */
     public RecipeMapBuilder<B> minInputs(int minItemInputs, int minFluidInputs) {
         backendPropertiesBuilder.minItemInputs(minItemInputs)

--- a/src/main/java/gregtech/api/recipe/RecipeMapBuilder.java
+++ b/src/main/java/gregtech/api/recipe/RecipeMapBuilder.java
@@ -102,6 +102,15 @@ public final class RecipeMapBuilder<B extends RecipeMapBackend> {
     }
 
     /**
+     * Whether to allow recipes which only use a programmed circuit, and no item/fluid inputs. If this is false, such
+     * recipes are optimized away.
+     */
+    public RecipeMapBuilder<B> allowCircuitOnly(boolean allowCircuitOnly) {
+        backendPropertiesBuilder.allowCircuitOnly(allowCircuitOnly);
+        return this;
+    }
+
+    /**
      * Whether this recipemap should check for equality of special slot when searching recipe.
      */
     public RecipeMapBuilder<B> specialSlotSensitive() {

--- a/src/main/java/gregtech/api/recipe/RecipeMaps.java
+++ b/src/main/java/gregtech/api/recipe/RecipeMaps.java
@@ -845,7 +845,6 @@ public final class RecipeMaps {
         .build();
     public static final RecipeMap<RecipeMapBackend> pyrolyseRecipes = RecipeMapBuilder.of("gt.recipe.pyro")
         .maxIO(2, 1, 1, 1)
-        .minInputs(0, 0)
         .disableOptimize()
         .build();
     public static final RecipeMap<RecipeMapBackend> wiremillRecipes = RecipeMapBuilder.of("gt.recipe.wiremill")

--- a/src/main/java/gregtech/api/recipe/RecipeMaps.java
+++ b/src/main/java/gregtech/api/recipe/RecipeMaps.java
@@ -299,7 +299,7 @@ public final class RecipeMaps {
     public static final RecipeMap<FormingPressBackend> formingPressRecipes = RecipeMapBuilder
         .of("gt.recipe.press", FormingPressBackend::new)
         .maxIO(6, 1, 0, 0)
-        .minInputs(2, 0)
+        .minInputs(1, 0)
         .slotOverlays((index, isFluid, isOutput, isSpecial) -> {
             if (isOutput) {
                 return GTUITextures.OVERLAY_SLOT_PRESS_3;
@@ -407,7 +407,7 @@ public final class RecipeMaps {
         .build();
     public static final RecipeMap<RecipeMapBackend> distilleryRecipes = RecipeMapBuilder.of("gt.recipe.distillery")
         .maxIO(1, 1, 1, 1)
-        .minInputs(1, 1)
+        .minInputs(0, 1)
         .slotOverlays((index, isFluid, isOutput, isSpecial) -> {
             if (!isFluid) {
                 return null;
@@ -467,7 +467,7 @@ public final class RecipeMaps {
     public static final RecipeMap<RecipeMapBackend> fluidSolidifierRecipes = RecipeMapBuilder
         .of("gt.recipe.fluidsolidifier")
         .maxIO(1, 1, 1, 0)
-        .minInputs(1, 1)
+        .minInputs(0, 1)
         .slotOverlays(
             (index, isFluid, isOutput, isSpecial) -> !isFluid && !isOutput ? GTUITextures.OVERLAY_SLOT_MOLD : null)
         .recipeTransformer(r -> {
@@ -840,12 +840,12 @@ public final class RecipeMaps {
     public static final RecipeMap<OilCrackerBackend> crackingRecipes = RecipeMapBuilder
         .of("gt.recipe.craker", OilCrackerBackend::new)
         .maxIO(1, 1, 2, 1)
-        .minInputs(1, 2)
+        .minInputs(0, 2)
         .progressBar(GTUITextures.PROGRESSBAR_ARROW_MULTIPLE)
         .build();
     public static final RecipeMap<RecipeMapBackend> pyrolyseRecipes = RecipeMapBuilder.of("gt.recipe.pyro")
         .maxIO(2, 1, 1, 1)
-        .minInputs(1, 0)
+        .minInputs(0, 0)
         .disableOptimize()
         .build();
     public static final RecipeMap<RecipeMapBackend> wiremillRecipes = RecipeMapBuilder.of("gt.recipe.wiremill")
@@ -857,14 +857,14 @@ public final class RecipeMaps {
         .build();
     public static final RecipeMap<RecipeMapBackend> benderRecipes = RecipeMapBuilder.of("gt.recipe.metalbender")
         .maxIO(2, 1, 0, 0)
-        .minInputs(2, 0)
+        .minInputs(1, 0)
         .slotOverlays(
             (index, isFluid, isOutput, isSpecial) -> !isFluid && !isOutput ? GTUITextures.OVERLAY_SLOT_BENDER : null)
         .progressBar(GTUITextures.PROGRESSBAR_BENDING)
         .build();
     public static final RecipeMap<RecipeMapBackend> alloySmelterRecipes = RecipeMapBuilder.of("gt.recipe.alloysmelter")
         .maxIO(2, 1, 0, 0)
-        .minInputs(2, 0)
+        .minInputs(1, 0)
         .slotOverlays(
             (index, isFluid, isOutput, isSpecial) -> !isFluid && !isOutput ? GTUITextures.OVERLAY_SLOT_FURNACE : null)
         .slotOverlaysSteam((index, isFluid, isOutput, isSpecial) -> GTUITextures.OVERLAY_SLOT_FURNACE_STEAM)

--- a/src/main/java/gtPlusPlus/api/recipe/GTPPRecipeMaps.java
+++ b/src/main/java/gtPlusPlus/api/recipe/GTPPRecipeMaps.java
@@ -35,6 +35,7 @@ public class GTPPRecipeMaps {
     public static final RecipeMap<RecipeMapBackend> multiblockMassFabricatorRecipes = RecipeMapBuilder
         .of("gtpp.recipe.matterfab2")
         .maxIO(2, 0, 1, 1)
+        .allowCircuitOnly(true)
         .build();
     public static final RecipeMap<FuelBackend> rocketFuels = RecipeMapBuilder
         .of("gtpp.recipe.rocketenginefuel", FuelBackend::new)


### PR DESCRIPTION
### Background

Many machines use programmed circuits as a non-consumed input in their recipes. To automate such a process, the player typically leaves a circuit in the machine's input bus permanently, and inserts other inputs as needed. Moreover, certain "universal" setups rely on keeping several circuits in the input bus, and use recipe check order to pick the correct recipe when input items are inserted. As an example, one can run an electric blast furnace with circuits [1] and [11] in the bottom-right slots of an input bus; and when the EBF receives an input dust, it will use a circuit [11] recipe if available, otherwise a circuit [1] recipe, and finally a recipe without any circuits. This allows for automating many different recipes using only one machine.

The downside to this setup is that circuits in an input bus are still treated as items for the purpose of recipe checks (and this applies to phantom circuits set in the input bus's UI as well). This means that a machine with several circuits in its input bus iterates over its recipe map over and over with each recipe check, even though from the player's point of view the machine is effectively idle. When scaled up, and especially with machines with long recipe lists (EBF, LCR, ...), this starts having noticeable impact on tick times (see Evaluation section below). In fact I have noticed this in my survival world with Volcanuses and MCRs.

This PR modifies recipe checks in such a way that programmed circuits are no longer counted towards the number of items in the input bus. This means that if the input bus contains *only* circuits, it is treated as being empty, and thus recipe checks are completely skipped.

I note that this only specifically affects GT programmed circuits, and not the GT++ bio or breakthrough circuits, or other similar items (shapes, molds, lenses etc.) A more generic solution could be developed, but I wanted to keep the impact of this change minimal for now.

### Evaluation

I have tested the performance impact in a new test world, with 256 Electric Blast Furnaces, with input buses configured as in the table below. In all cases except for the last circuits are the only items in the EBF's input, and therefore it is impossible for it to run any recipes. Comparison is made between 2.5.7-beta-2, and the same pack with only this change added. I note that the table only shows the average time. Since recipe checks are not run every tick, the actual impact on maximal tick time (which contributes to TPS spikes) is even larger than the table shows. Spark profiler results are included.

The number in the table is specifically time spent in `MTEMultiBlockBase.checkProcessing()`.

| Bus Configuration | 2.5.0-beta-2 | | With this PR | |
| ------------- | ------------- | ------------- | ------------- | ------------- |
| Empty | 0.02ms | https://spark.lucko.me/MqHeYmdJzs | 0.03ms| https://spark.lucko.me/Lj1bNnKjxT |
| Phantom circuit | 0.17ms | https://spark.lucko.me/WofiQ5CHhh | 0.02ms | https://spark.lucko.me/drpBHnGPx0 |
| One phantom and one real circuit | 0.38ms | https://spark.lucko.me/P2DHmDpd2i | 0.02ms | https://spark.lucko.me/y85W2mejnn |
| 16 real circuits | 0.76ms | https://spark.lucko.me/Oge2FuBdR7 | 0.02ms | https://spark.lucko.me/xxC9cwEHRV |
| 16 non-circuit items | 0.14ms | https://spark.lucko.me/uJH4GNEJuv | 0.14ms | https://spark.lucko.me/ow2fc1ulUY |

### Caveats

Since every input item is now tested for being a circuit, this change could have a negligible performance effect in case there are many non-circuit items in the input bus. However, this is not the case in a typical setup; and in my testing I was unable to measure any difference; see last row of table above.


More importantly, this change modifies the semantics of `RecipeMapBuilder.minInputs()`. Previously the minimum number of item inputs included any programmed circuits which were a part of the recipe. After this change, since circuits are ignored when counting input items, the minimum number of inputs must be set to the number of "real" (non-circuit) items in any recipe.

For example, previously a Bending Machine required a minimum of 2 inputs: a metal ingot, and a programmed circuit. With this change, the minimum number of inputs is set to 1 (the ingot), since the circuit is no longer counted.

I did my best diligence to update the `minInputs()` calls everywhere this makes a difference, and I tested several machines in the beta version to ensure that all recipes still run correctly. However I would appreciate someone double-checking that I haven't missed anything.


Finally, if the *only* thing in a machine's inputs is a circuit (no other items and no fluids), recipe checks are skipped completely. This means that if a recipe takes no inputs other than a circuit, it will not be able to be processed correctly. This is currently the case for only one machine: the GT++ Matter Fabricator multiblock. The Rock Breaker and Zhuhai Fishing Port have similar recipes; however they implement their own processing logic and so they are not affected.

I have added a skip to this last check in form of `RecipeMapBuilder.allowCircuitOnly()` (see `GTPPRecipeMaps.java:38`) so that these recipes work correctly; this is used for the Matter Fabricator, but it can also be used for any future machines which might need such recipes.