### PR TITLE
Revert zirconium removal

### DIFF
--- a/src/main/java/gtnhlanth/common/register/WerkstoffMaterialPool.java
+++ b/src/main/java/gtnhlanth/common/register/WerkstoffMaterialPool.java
@@ -113,6 +113,19 @@ public class WerkstoffMaterialPool implements Runnable {
         offsetID + 6,
         TextureSet.SET_DULL);
 
+    public static final Werkstoff Zirconium = new Werkstoff(
+        new short[] { 225, 230, 225 },
+        "Zirconium",
+        subscriptNumbers("Zr"),
+        new Werkstoff.Stats().setBlastFurnace(true),
+        Werkstoff.Types.ELEMENT,
+        new Werkstoff.GenerationFeatures().disable()
+            .onlyDust()
+            .addMetalItems(),
+        // .enforceUnification(),
+        offsetID + 7,
+        TextureSet.SET_METALLIC);
+
     public static final Werkstoff Zirconia = new Werkstoff(
         new short[] { 177, 152, 101 },
         "Zirconia",


### PR DESCRIPTION
I removed the GTNH Lanth version of zirconium, mistakenly believing it was unused. This probably brings back some collisions but it needs to be restored for now, nulled a lot of items.