### PR TITLE
Revert solar reflector and reinforced steam turbine recipe

### DIFF
--- a/src/main/java/gtPlusPlus/core/recipe/RecipesMachines.java
+++ b/src/main/java/gtPlusPlus/core/recipe/RecipesMachines.java
@@ -8,6 +8,7 @@ import static gregtech.api.recipe.RecipeMaps.assemblerRecipes;
 import static gregtech.api.recipe.RecipeMaps.cutterRecipes;
 import static gregtech.api.recipe.RecipeMaps.distilleryRecipes;
 import static gregtech.api.util.GTRecipeBuilder.HOURS;
+import static gregtech.api.util.GTRecipeBuilder.INGOTS;
 import static gregtech.api.util.GTRecipeBuilder.MINUTES;
 import static gregtech.api.util.GTRecipeBuilder.SECONDS;
 import static gregtech.api.util.GTRecipeBuilder.TICKS;
@@ -625,12 +626,12 @@ public class RecipesMachines {
             .itemInputs(
                 CI.getNumberedAdvancedCircuit(17),
                 CI.getTieredGTPPMachineCasing(2, 1),
-                CI.getPlate(3, 2),
-                CI.getGear(3, 4),
+                MaterialsAlloy.INCONEL_625.getPlate(2),
+                MaterialsAlloy.INCONEL_625.getGear(4),
                 CI.getElectricMotor(3, 2),
                 CI.getCircuit(3, 4))
             .itemOutputs(GregtechItemList.Solar_Tower_Reflector.get(1))
-            .fluidInputs(CI.getTertiaryTieredFluid(3, 144 * 4))
+            .fluidInputs(Materials.Titanium.getMolten(4 * INGOTS))
             .duration(60 * SECONDS)
             .eut(TierEU.RECIPE_HV)
             .addTo(assemblerRecipes);

--- a/src/main/java/gtPlusPlus/core/recipe/RecipesMachines.java
+++ b/src/main/java/gtPlusPlus/core/recipe/RecipesMachines.java
@@ -451,10 +451,10 @@ public class RecipesMachines {
             .itemInputs(
                 CI.getNumberedAdvancedCircuit(18),
                 ItemList.Casing_Turbine.get(1),
-                CI.getPlate(3, 4),
-                CI.getScrew(3, 8))
+                MaterialsAlloy.INCONEL_625.getPlate(4),
+                MaterialsAlloy.INCONEL_625.getScrew(8))
             .itemOutputs(GregtechItemList.Casing_Turbine_LP.get(1))
-            .fluidInputs(CI.tieredMaterials[2].getMolten(144 * 2))
+            .fluidInputs(Materials.Aluminium.getMolten(2 * INGOTS))
             .duration(5 * SECONDS)
             .eut(TierEU.RECIPE_HV)
             .addTo(assemblerRecipes);


### PR DESCRIPTION
these two recipes were caught up in some unrelated changes due to the awkward way they are defined. This was not intentional and so this PR reverts that.

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17545

New recipes same as 2.6.1:
![image](https://github.com/user-attachments/assets/c21c90ed-bf86-4c1a-b7e6-81ed2052106b)
![image](https://github.com/user-attachments/assets/faefb4da-a904-4fba-875f-dfbe6ca64498)

