### PR TITLE
Fix wireless EU voiding in multiplayer for non-network owners

### DIFF
--- a/src/main/java/gregtech/common/misc/WirelessNetworkManager.java
+++ b/src/main/java/gregtech/common/misc/WirelessNetworkManager.java
@@ -14,8 +14,9 @@ public class WirelessNetworkManager {
 
     public static void strongCheckOrAddUser(UUID user_uuid) {
         SpaceProjectManager.checkOrCreateTeam(user_uuid);
+        user_uuid = SpaceProjectManager.getLeader(user_uuid);
         if (!GlobalEnergy.containsKey(user_uuid)) {
-            GlobalEnergy.put(SpaceProjectManager.getLeader(user_uuid), BigInteger.ZERO);
+            GlobalEnergy.put(user_uuid, BigInteger.ZERO);
         }
     }
 


### PR DESCRIPTION
Fixes an unknown amount of issues with the wireless energy net voiding for machines placed by players other than the network owner in a multiplayer server. Confirmed to happen with EOHs as seen in the issue below, but I suspect this could happen in other places as well. This code is convoluted and not very well done imo, relying on two systems currently, and this is something I hope to improve with a refactor after 2.7 stable. But hopefully this fixes some more of the current issues affecting players.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17485
Related to https://github.com/GTNewHorizons/GT5-Unofficial/pull/3078