### PR TITLE
Revert material hashing

### DIFF
--- a/src/main/java/gregtech/api/enums/OrePrefixes.java
+++ b/src/main/java/gregtech/api/enums/OrePrefixes.java
@@ -1308,26 +1308,9 @@ public enum OrePrefixes {
             return;
         }
 
-        if (aMaterial == Materials._NULL && !mIsSelfReferencing && mIsMaterialBased) {
+        if (!((aMaterial != Materials._NULL || mIsSelfReferencing || !mIsMaterialBased)
+            && GTUtility.isStackValid(aStack))) {
             return;
-        }
-
-        if (!GTUtility.isStackValid(aStack)) {
-            return;
-        }
-
-        if (aMaterial != Materials._NULL) {
-            if (!used.add(aMaterial)) {
-                if (DEBUG_MODE_COLLISION) {
-                    GTLog.out
-                        .println("Attempted duplicate recipe registration by " + aModName + " for " + aOreDictName);
-                }
-                return;
-            } else {
-                if (DEBUG_MODE_COLLISION) {
-                    GTLog.out.println("New recipe registration by " + aModName + " for " + aOreDictName);
-                }
-            }
         }
 
         for (IOreRecipeRegistrator tRegistrator : mOreProcessing) {

--- a/src/main/java/gregtech/api/enums/OrePrefixes.java
+++ b/src/main/java/gregtech/api/enums/OrePrefixes.java
@@ -16,7 +16,6 @@ import net.minecraft.item.ItemStack;
 
 import com.google.common.collect.ImmutableList;
 
-import gregtech.api.GregTechAPI;
 import gregtech.api.enums.TCAspects.TC_AspectStack;
 import gregtech.api.interfaces.ICondition;
 import gregtech.api.interfaces.IOreRecipeRegistrator;
@@ -1181,8 +1180,6 @@ public enum OrePrefixes {
         } else if (name().startsWith("battery")) {
             new TC_AspectStack(TCAspects.ELECTRUM, 1).addToAspectList(mAspects);
         }
-
-        GregTechAPI.sGTCompleteLoad.add(this::onLoadComplete);
     }
 
     public static boolean isInstanceOf(String aName, OrePrefixes aPrefix) {
@@ -1301,9 +1298,6 @@ public enum OrePrefixes {
         return mOreProcessing.add(aRegistrator);
     }
 
-    // Hack to prevent duplicate registry of oredicted materials
-    HashSet<Materials> used = new HashSet<>();
-
     public void processOre(Materials aMaterial, String aOreDictName, String aModName, ItemStack aStack) {
 
         if (aMaterial == null) {
@@ -1347,10 +1341,6 @@ public enum OrePrefixes {
                     + GTUtility.getClassName(tRegistrator));
             tRegistrator.registerOre(this, aMaterial, aOreDictName, aModName, GTUtility.copyAmount(1, aStack));
         }
-    }
-
-    public void onLoadComplete() {
-        used = null;
     }
 
     public Object get(Object aMaterial) {

--- a/src/main/java/gregtech/api/enums/OrePrefixes.java
+++ b/src/main/java/gregtech/api/enums/OrePrefixes.java
@@ -1322,7 +1322,7 @@ public enum OrePrefixes {
             return;
         }
 
-        if (!aOreDictName.startsWith("stone") && aMaterial != Materials._NULL) {
+        if (aMaterial != Materials._NULL) {
             if (!used.add(aMaterial)) {
                 if (DEBUG_MODE_COLLISION) {
                     GTLog.out

--- a/src/main/java/gregtech/api/enums/OrePrefixes.java
+++ b/src/main/java/gregtech/api/enums/OrePrefixes.java
@@ -3,7 +3,6 @@ package gregtech.api.enums;
 import static gregtech.api.enums.GTValues.B;
 import static gregtech.api.enums.GTValues.D2;
 import static gregtech.api.enums.GTValues.M;
-import static gregtech.api.util.GTRecipeBuilder.DEBUG_MODE_COLLISION;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingBlock.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingBlock.java
@@ -81,7 +81,7 @@ public class ProcessingBlock implements gregtech.api.interfaces.IOreRecipeRegist
             else if (aMaterial != Materials.Clay && aMaterial != Materials.Basalt) {
 
                 GTValues.RA.stdBuilder()
-                    .itemInputs(GTOreDictUnificator.get(OrePrefixes.block, aMaterial, 1))
+                    .itemInputs(GTUtility.copyAmount(1, aStack))
                     .itemOutputs(GTOreDictUnificator.get(OrePrefixes.plate, aMaterial, 9L))
                     .fluidInputs(
                         Materials.Water.getFluid(
@@ -93,7 +93,7 @@ public class ProcessingBlock implements gregtech.api.interfaces.IOreRecipeRegist
                     .addTo(cutterRecipes);
 
                 GTValues.RA.stdBuilder()
-                    .itemInputs(GTOreDictUnificator.get(OrePrefixes.block, aMaterial, 1))
+                    .itemInputs(GTUtility.copyAmount(1, aStack))
                     .itemOutputs(GTOreDictUnificator.get(OrePrefixes.plate, aMaterial, 9L))
                     .fluidInputs(
                         GTModHandler.getDistilledWater(
@@ -105,7 +105,7 @@ public class ProcessingBlock implements gregtech.api.interfaces.IOreRecipeRegist
                     .addTo(cutterRecipes);
 
                 GTValues.RA.stdBuilder()
-                    .itemInputs(GTOreDictUnificator.get(OrePrefixes.block, aMaterial, 1))
+                    .itemInputs(GTUtility.copyAmount(1, aStack))
                     .itemOutputs(GTOreDictUnificator.get(OrePrefixes.plate, aMaterial, 9L))
                     .fluidInputs(
                         Materials.Lubricant.getFluid(
@@ -154,7 +154,7 @@ public class ProcessingBlock implements gregtech.api.interfaces.IOreRecipeRegist
 
         if (tStack2 != null) {
             GTValues.RA.stdBuilder()
-                .itemInputs(GTOreDictUnificator.get(OrePrefixes.block, aMaterial, 1))
+                .itemInputs(aStack)
                 .itemOutputs(tStack2)
                 .duration(5 * SECONDS)
                 .eut(24)

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingDust.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingDust.java
@@ -114,7 +114,7 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                         && (aMaterial != Materials.Clay)) {
 
                         GTValues.RA.stdBuilder()
-                            .itemInputs(GTOreDictUnificator.get(OrePrefixes.dust, aMaterial, 9))
+                            .itemInputs(GTUtility.copyAmount(9, aStack))
                             .itemOutputs(GTOreDictUnificator.get(OrePrefixes.block, aMaterial, 1L))
                             .duration(15 * SECONDS)
                             .eut(2)
@@ -140,7 +140,7 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                         {
                             if (GTOreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L) != null) {
                                 GTValues.RA.stdBuilder()
-                                    .itemInputs(GTOreDictUnificator.get(OrePrefixes.dust, aMaterial, 1))
+                                    .itemInputs(GTUtility.copyAmount(1, aStack))
                                     .itemOutputs(GTOreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L))
                                     .duration(15 * SECONDS)
                                     .eut(2)

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingGem.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingGem.java
@@ -69,7 +69,7 @@ public class ProcessingGem implements gregtech.api.interfaces.IOreRecipeRegistra
                     // need to avoid iridium exploit
                     if (aMaterial != Materials.Iridium) {
                         GTValues.RA.stdBuilder()
-                            .itemInputs(GTOreDictUnificator.get(OrePrefixes.gem, aMaterial, 9))
+                            .itemInputs(GTUtility.copyAmount(9, aStack))
                             .itemOutputs(GTOreDictUnificator.get(OrePrefixes.block, aMaterial, 1L))
                             .duration(15 * SECONDS)
                             .eut(2)

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingOre.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingOre.java
@@ -79,7 +79,8 @@ public class ProcessingOre implements gregtech.api.interfaces.IOreRecipeRegistra
         Materials tMaterial = aMaterial.mOreReplacement;
         Materials tPrimaryByMaterial = null;
         aMultiplier = Math.max(1, aMultiplier);
-        aOreStack = GTOreDictUnificator.get(aPrefix, aMaterial, 1L);
+        aOreStack = GTUtility.copyAmount(1, aOreStack);
+        aOreStack.stackSize = 1;
 
         ItemStack tIngot = GTOreDictUnificator.get(OrePrefixes.ingot, aMaterial.mDirectSmelting, 1L);
         ItemStack tGem = GTOreDictUnificator.get(OrePrefixes.gem, tMaterial, 1L);

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingOreSmelting.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingOreSmelting.java
@@ -183,7 +183,7 @@ public class ProcessingOreSmelting implements gregtech.api.interfaces.IOreRecipe
                     1L);
                 if ((tStack == null) && (!aMaterial.contains(SubTag.SMELTING_TO_GEM)))
                     tStack = GTOreDictUnificator.get(OrePrefixes.ingot, aMaterial.mDirectSmelting, 1L);
-                GTModHandler.addSmeltingRecipe(GTOreDictUnificator.get(aPrefix, aMaterial, 1L), tStack);
+                GTModHandler.addSmeltingRecipe(aStack, tStack);
             }
         }
     }

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingPlate.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingPlate.java
@@ -19,6 +19,7 @@ import static gregtech.api.util.GTRecipeBuilder.SECONDS;
 import static gregtech.api.util.GTRecipeBuilder.TICKS;
 import static gregtech.api.util.GTRecipeBuilder.WILDCARD;
 import static gregtech.api.util.GTRecipeConstants.ADDITIVE_AMOUNT;
+import static gregtech.api.util.GTRecipeConstants.COMPRESSION_TIER;
 import static gregtech.api.util.GTRecipeConstants.FUEL_TYPE;
 import static gregtech.api.util.GTRecipeConstants.FUEL_VALUE;
 import static gregtech.api.util.GTUtility.calculateRecipeEU;

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingStick.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingStick.java
@@ -61,7 +61,7 @@ public class ProcessingStick implements gregtech.api.interfaces.IOreRecipeRegist
             if (GTOreDictUnificator.get(OrePrefixes.bolt, aMaterial, 1L) != null) {
 
                 GTValues.RA.stdBuilder()
-                    .itemInputs(GTOreDictUnificator.get(OrePrefixes.stick, aMaterial, 1L))
+                    .itemInputs(GTUtility.copyAmount(1, aStack))
                     .itemOutputs(GTOreDictUnificator.get(OrePrefixes.bolt, aMaterial, 4L))
                     .fluidInputs(
                         Materials.Water.getFluid(
@@ -77,7 +77,7 @@ public class ProcessingStick implements gregtech.api.interfaces.IOreRecipeRegist
                     .addTo(cutterRecipes);
 
                 GTValues.RA.stdBuilder()
-                    .itemInputs(GTOreDictUnificator.get(OrePrefixes.stick, aMaterial, 1L))
+                    .itemInputs(GTUtility.copyAmount(1, aStack))
                     .itemOutputs(GTOreDictUnificator.get(OrePrefixes.bolt, aMaterial, 4L))
                     .fluidInputs(
                         GTModHandler.getDistilledWater(
@@ -93,7 +93,7 @@ public class ProcessingStick implements gregtech.api.interfaces.IOreRecipeRegist
                     .addTo(cutterRecipes);
 
                 GTValues.RA.stdBuilder()
-                    .itemInputs(GTOreDictUnificator.get(OrePrefixes.stick, aMaterial, 1L))
+                    .itemInputs(GTUtility.copyAmount(1, aStack))
                     .itemOutputs(GTOreDictUnificator.get(OrePrefixes.bolt, aMaterial, 4L))
                     .fluidInputs(
                         Materials.Lubricant.getFluid(

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingTransforming.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingTransforming.java
@@ -37,7 +37,7 @@ public class ProcessingTransforming implements IOreRecipeRegistrator {
             {
                 if (GTOreDictUnificator.get(aPrefix, Materials.WoodSealed, 1L) != null) {
                     GTValues.RA.stdBuilder()
-                        .itemInputs(GTOreDictUnificator.get(aPrefix, Materials.Wood, 1L))
+                        .itemInputs(GTUtility.copyAmount(1, aStack))
                         .itemOutputs(GTOreDictUnificator.get(aPrefix, Materials.WoodSealed, 1L))
                         .fluidInputs(
                             Materials.SeedOil
@@ -53,7 +53,7 @@ public class ProcessingTransforming implements IOreRecipeRegistrator {
                 {
                     if (GTOreDictUnificator.get(aPrefix, Materials.FierySteel, 1L) != null) {
                         GTValues.RA.stdBuilder()
-                            .itemInputs(GTOreDictUnificator.get(aPrefix, Materials.Iron, 1L))
+                            .itemInputs(GTUtility.copyAmount(1, aStack))
                             .itemOutputs(GTOreDictUnificator.get(aPrefix, Materials.FierySteel, 1L))
                             .fluidInputs(
                                 Materials.FierySteel
@@ -68,7 +68,7 @@ public class ProcessingTransforming implements IOreRecipeRegistrator {
                 {
                     if (GTOreDictUnificator.get(aPrefix, Materials.IronMagnetic, 1L) != null) {
                         GTValues.RA.stdBuilder()
-                            .itemInputs(GTOreDictUnificator.get(aPrefix, Materials.Iron, 1L))
+                            .itemInputs(GTUtility.copyAmount(1, aStack))
                             .itemOutputs(GTOreDictUnificator.get(aPrefix, Materials.IronMagnetic, 1L))
                             .duration(((int) Math.max(16L, aPrefix.mMaterialAmount * 128L / GTValues.M)) * TICKS)
                             .eut((int) TierEU.LV / 2)
@@ -81,7 +81,7 @@ public class ProcessingTransforming implements IOreRecipeRegistrator {
                 {
                     if (GTOreDictUnificator.get(aPrefix, Materials.FierySteel, 1L) != null) {
                         GTValues.RA.stdBuilder()
-                            .itemInputs(GTOreDictUnificator.get(aPrefix, Materials.WroughtIron, 1L))
+                            .itemInputs(GTUtility.copyAmount(1, aStack))
                             .itemOutputs(GTOreDictUnificator.get(aPrefix, Materials.FierySteel, 1L))
                             .fluidInputs(
                                 Materials.FierySteel
@@ -96,7 +96,7 @@ public class ProcessingTransforming implements IOreRecipeRegistrator {
                 {
                     if (GTOreDictUnificator.get(aPrefix, Materials.IronMagnetic, 1L) != null) {
                         GTValues.RA.stdBuilder()
-                            .itemInputs(GTOreDictUnificator.get(aPrefix, Materials.WroughtIron, 1L))
+                            .itemInputs(GTUtility.copyAmount(1, aStack))
                             .itemOutputs(GTOreDictUnificator.get(aPrefix, Materials.IronMagnetic, 1L))
                             .duration(((int) Math.max(16L, aPrefix.mMaterialAmount * 128L / GTValues.M)) * TICKS)
                             .eut((int) TierEU.LV / 2)
@@ -109,7 +109,7 @@ public class ProcessingTransforming implements IOreRecipeRegistrator {
                 {
                     if (GTOreDictUnificator.get(aPrefix, Materials.FierySteel, 1L) != null) {
                         GTValues.RA.stdBuilder()
-                            .itemInputs(GTOreDictUnificator.get(aPrefix, Materials.Steel, 1L))
+                            .itemInputs(GTUtility.copyAmount(1, aStack))
                             .itemOutputs(GTOreDictUnificator.get(aPrefix, Materials.FierySteel, 1L))
                             .fluidInputs(
                                 Materials.FierySteel
@@ -124,7 +124,7 @@ public class ProcessingTransforming implements IOreRecipeRegistrator {
                 {
                     if (GTOreDictUnificator.get(aPrefix, Materials.SteelMagnetic, 1L) != null) {
                         GTValues.RA.stdBuilder()
-                            .itemInputs(GTOreDictUnificator.get(aPrefix, Materials.Steel, 1L))
+                            .itemInputs(GTUtility.copyAmount(1, aStack))
                             .itemOutputs(GTOreDictUnificator.get(aPrefix, Materials.SteelMagnetic, 1L))
                             .duration(((int) Math.max(16L, aPrefix.mMaterialAmount * 128L / GTValues.M)) * TICKS)
                             .eut((int) TierEU.LV / 2)
@@ -137,7 +137,7 @@ public class ProcessingTransforming implements IOreRecipeRegistrator {
             {
                 if (GTOreDictUnificator.get(aPrefix, Materials.NeodymiumMagnetic, 1L) != null) {
                     GTValues.RA.stdBuilder()
-                        .itemInputs(GTOreDictUnificator.get(aPrefix, Materials.Neodymium, 1L))
+                        .itemInputs(GTUtility.copyAmount(1, aStack))
                         .itemOutputs(GTOreDictUnificator.get(aPrefix, Materials.NeodymiumMagnetic, 1L))
                         .duration(((int) Math.max(16L, aPrefix.mMaterialAmount * 128L / GTValues.M)) * TICKS)
                         .eut((int) TierEU.HV / 2)
@@ -149,7 +149,7 @@ public class ProcessingTransforming implements IOreRecipeRegistrator {
             {
                 if (GTOreDictUnificator.get(aPrefix, Materials.SamariumMagnetic, 1L) != null) {
                     GTValues.RA.stdBuilder()
-                        .itemInputs(GTOreDictUnificator.get(aPrefix, Materials.Samarium, 1L))
+                        .itemInputs(GTUtility.copyAmount(1, aStack))
                         .itemOutputs(GTOreDictUnificator.get(aPrefix, Materials.SamariumMagnetic, 1L))
                         .duration(((int) Math.max(16L, aPrefix.mMaterialAmount * 128L / GTValues.M)) * TICKS)
                         .eut((int) TierEU.IV / 2)
@@ -162,7 +162,7 @@ public class ProcessingTransforming implements IOreRecipeRegistrator {
             {
                 if (GTOreDictUnificator.get(aPrefix, Materials.TengamAttuned, 1L) != null) {
                     GTValues.RA.stdBuilder()
-                        .itemInputs(GTOreDictUnificator.get(aPrefix, Materials.TengamPurified, 1L))
+                        .itemInputs(GTUtility.copyAmount(1, aStack))
                         .itemOutputs(GTOreDictUnificator.get(aPrefix, Materials.TengamAttuned, 1L))
                         .duration(((int) Math.max(16L, aPrefix.mMaterialAmount * 128L / GTValues.M)) * TICKS)
                         .eut((int) TierEU.RECIPE_UHV)


### PR DESCRIPTION
This was a fun experiment and did indeed remove a lot of collisions. However, it is fundamentally incompatible with gt5 and recipe lookups, as seen in the myriad of new issues that have cropped up.

Reverts the duplicate material hashing and all the changes associated with it. 🫡 

- Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17530
- Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17527
- Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17510
- Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17434
- Unticketed bug where shadow ore can't be macerated
- Countless bugs yet to be found

This is also my throwing in the towel for collision removal. These issues are far too deeply embedded and would require full refactors of critical systems. The huge amount of work I and others have put into collision removal is still there - we have made a huge dent in the numbers, most of which were real issues unrelated to duplicate materials. If these refactors happen, there will be very few left to clean up and we can finalize it. But it will need time and a new release cycle, critical refactors cannot happen during a beta feature freeze cycle.