### PR TITLE
Fix issues with catalyst damage + empty catalyst output

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/chemplant/MTEChemicalPlant.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/chemplant/MTEChemicalPlant.java
@@ -545,21 +545,25 @@ public class MTEChemicalPlant extends GTPPMultiBlockBase<MTEChemicalPlant> imple
         }
     }
 
-    private void damageCatalyst(@Nonnull ItemStack aStack, int minParallel) {
+    /**
+     * @return if the catalyst item is fully destroyed as a result of the damage applied.
+     */
+    private boolean damageCatalyst(@Nonnull ItemStack aStack, int minParallel) {
         // Awakened Draconium Coils with Tungstensteel Pipe Casings (or above) no longer consume catalysts.
-        if (!isCatalystDamageable()) return;
+        if (!isCatalystDamageable()) return false;
         for (int i = 0; i < minParallel; i++) {
             if (MathUtils.randFloat(0, 10000000) / 10000000f < (1.2f - (0.2 * this.mPipeCasingTier))) {
                 int damage = getDamage(aStack) + 1;
                 if (damage >= getMaxCatalystDurability()) {
                     addOutput(CI.getEmptyCatalyst(1));
                     aStack.stackSize -= 1;
-                    return;
+                    return aStack.stackSize == 0;
                 } else {
                     setDamage(aStack, damage);
                 }
             }
         }
+        return false;
     }
 
     private boolean isCatalystDamageable() {
@@ -592,6 +596,9 @@ public class MTEChemicalPlant extends GTPPMultiBlockBase<MTEChemicalPlant> imple
                     if (catalyst == null) {
                         return SimpleCheckRecipeResult.ofFailure("no_catalyst");
                     }
+                } else {
+                    // remove reference to the old catalyst if our new recipe doesn't use it
+                    catalyst = null;
                 }
                 return CheckRecipeResultRegistry.SUCCESSFUL;
             }
@@ -608,8 +615,9 @@ public class MTEChemicalPlant extends GTPPMultiBlockBase<MTEChemicalPlant> imple
             @NotNull
             @Override
             protected CheckRecipeResult onRecipeStart(@NotNull GTRecipe recipe) {
-                if (catalyst != null) {
-                    damageCatalyst(catalyst, getCurrentParallels());
+                if (!GTUtility.isStackValid(catalyst) || damageCatalyst(catalyst, getCurrentParallels())) {
+                    // remove reference to the catalyst if it is invalid, or if the damage destroys it
+                    catalyst = null;
                 }
                 return super.onRecipeStart(recipe);
             }


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17516

Fixes issues where the catalyst stack is held reference to for too long, causing an invalid stack to be checked for catalyst damage (whether due to an old recipe no longer using a catalyst, or an invalid stack for an already destroyed catalyst being checked again and again for damage).