### PR TITLE
Fix flocculation plant deforming when it has a cover emitting a strong redstone signal

### DIFF
--- a/src/main/java/gregtech/api/util/GTStructureUtility.java
+++ b/src/main/java/gregtech/api/util/GTStructureUtility.java
@@ -19,6 +19,7 @@ import javax.annotation.Nonnull;
 
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
@@ -36,6 +37,8 @@ import com.gtnewhorizon.structurelib.structure.IStructureElement;
 import com.gtnewhorizon.structurelib.structure.IStructureElementNoPlacement;
 import com.gtnewhorizon.structurelib.util.ItemStackPredicate;
 
+import cofh.asmhooks.block.BlockTickingWater;
+import cofh.asmhooks.block.BlockWater;
 import gregtech.api.GregTechAPI;
 import gregtech.api.enums.HeatingCoilLevel;
 import gregtech.api.enums.Materials;
@@ -63,6 +66,35 @@ public class GTStructureUtility {
     public static <T> IStructureElementNoPlacement<T> ofHatchAdder(IGTHatchAdder<T> aHatchAdder, int aTextureIndex,
         int aDots) {
         return ofHatchAdder(aHatchAdder, aTextureIndex, StructureLibAPI.getBlockHint(), aDots - 1);
+    }
+
+    public static <T> IStructureElement<T> ofAnyWater() {
+        return new IStructureElement<>() {
+
+            @Override
+            public boolean check(T t, World world, int x, int y, int z) {
+                Block block = world.getBlock(x, y, z);
+                return block == Blocks.water || block instanceof BlockWater || block instanceof BlockTickingWater;
+            }
+
+            @Override
+            public boolean placeBlock(T t, World world, int x, int y, int z, ItemStack trigger) {
+                world.setBlock(x, y, z, Blocks.water, 0, 2);
+                return true;
+            }
+
+            @Override
+            public boolean spawnHint(T t, World world, int x, int y, int z, ItemStack trigger) {
+                StructureLibAPI.hintParticle(world, x, y, z, Blocks.water, 0);
+                return true;
+            }
+
+            @Override
+            public IStructureElement.BlocksToPlace getBlocksToPlace(T t, World world, int x, int y, int z,
+                ItemStack trigger, AutoPlaceEnvironment env) {
+                return IStructureElement.BlocksToPlace.create(Blocks.water, 0);
+            }
+        };
     }
 
     public static <T> IStructureElement<T> ofFrame(Materials aFrameMaterial) {

--- a/src/main/java/gregtech/api/util/GTStructureUtility.java
+++ b/src/main/java/gregtech/api/util/GTStructureUtility.java
@@ -42,6 +42,7 @@ import cofh.asmhooks.block.BlockWater;
 import gregtech.api.GregTechAPI;
 import gregtech.api.enums.HeatingCoilLevel;
 import gregtech.api.enums.Materials;
+import gregtech.api.enums.Mods;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.interfaces.IHeatingCoil;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
@@ -51,6 +52,8 @@ import gregtech.common.blocks.BlockCasings5;
 import gregtech.common.blocks.BlockCyclotronCoils;
 import gregtech.common.blocks.BlockFrameBox;
 import gregtech.common.blocks.ItemMachines;
+import ic2.core.init.BlocksItems;
+import ic2.core.init.InternalName;
 
 public class GTStructureUtility {
 
@@ -71,10 +74,16 @@ public class GTStructureUtility {
     public static <T> IStructureElement<T> ofAnyWater() {
         return new IStructureElement<>() {
 
+            final Block distilledWater = BlocksItems.getFluidBlock(InternalName.fluidDistilledWater);
+
             @Override
             public boolean check(T t, World world, int x, int y, int z) {
                 Block block = world.getBlock(x, y, z);
-                return block == Blocks.water || block instanceof BlockWater || block instanceof BlockTickingWater;
+                if (block == Blocks.water || block == distilledWater) return true;
+                if (Mods.COFHCore.isModLoaded()) {
+                    return block instanceof BlockWater || block instanceof BlockTickingWater;
+                }
+                return false;
             }
 
             @Override

--- a/src/main/java/gregtech/api/util/GTStructureUtility.java
+++ b/src/main/java/gregtech/api/util/GTStructureUtility.java
@@ -71,7 +71,7 @@ public class GTStructureUtility {
         return ofHatchAdder(aHatchAdder, aTextureIndex, StructureLibAPI.getBlockHint(), aDots - 1);
     }
 
-    public static <T> IStructureElement<T> ofAnyWater() {
+    public static <T> IStructureElement<T> ofAnyWater(boolean allowFlowing) {
         return new IStructureElement<>() {
 
             final Block distilledWater = BlocksItems.getFluidBlock(InternalName.fluidDistilledWater);
@@ -80,6 +80,7 @@ public class GTStructureUtility {
             public boolean check(T t, World world, int x, int y, int z) {
                 Block block = world.getBlock(x, y, z);
                 if (block == Blocks.water || block == distilledWater) return true;
+                if (allowFlowing && block == Blocks.flowing_water) return true;
                 if (Mods.COFHCore.isModLoaded()) {
                     return block instanceof BlockWater || block instanceof BlockTickingWater;
                 }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/purification/MTEPurificationUnitFlocculation.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/purification/MTEPurificationUnitFlocculation.java
@@ -143,7 +143,7 @@ public class MTEPurificationUnitFlocculation extends MTEPurificationUnitBase<MTE
         // Sterile Water Plant Casing
         .addElement('D', ofBlock(GregTechAPI.sBlockCasings9, 4))
         .addElement('E', ofFrame(Materials.Adamantium))
-        .addElement('W', ofAnyWater())
+        .addElement('W', ofAnyWater(false))
         // Tinted industrial glass
         .addElement('G', ofBlockAnyMeta(GregTechAPI.sBlockTintedGlass))
         .build();

--- a/src/main/java/gregtech/common/tileentities/machines/multi/purification/MTEPurificationUnitFlocculation.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/purification/MTEPurificationUnitFlocculation.java
@@ -15,13 +15,13 @@ import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_FRONT_LARGE_CHEMICA
 import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_FRONT_LARGE_CHEMICAL_REACTOR_ACTIVE_GLOW;
 import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_FRONT_LARGE_CHEMICAL_REACTOR_GLOW;
 import static gregtech.api.util.GTRecipeBuilder.SECONDS;
+import static gregtech.api.util.GTStructureUtility.ofAnyWater;
 import static gregtech.api.util.GTStructureUtility.ofFrame;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumChatFormatting;
@@ -143,7 +143,7 @@ public class MTEPurificationUnitFlocculation extends MTEPurificationUnitBase<MTE
         // Sterile Water Plant Casing
         .addElement('D', ofBlock(GregTechAPI.sBlockCasings9, 4))
         .addElement('E', ofFrame(Materials.Adamantium))
-        .addElement('W', ofBlock(Blocks.water, 0))
+        .addElement('W', ofAnyWater())
         // Tinted industrial glass
         .addElement('G', ofBlockAnyMeta(GregTechAPI.sBlockTintedGlass))
         .build();

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/MTEIndustrialWashPlant.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/MTEIndustrialWashPlant.java
@@ -149,7 +149,7 @@ public class MTEIndustrialWashPlant extends GTPPMultiBlockBase<MTEIndustrialWash
                         .casingIndex(getCasingTextureIndex())
                         .dot(1)
                         .buildAndChain(onElementPass(x -> ++x.mCasing, ofBlock(getCasingBlock(), getCasingMeta()))))
-                .addElement('w', ofChain(isAir(), ofAnyWater()))
+                .addElement('w', ofChain(isAir(), ofAnyWater(true)))
                 .build();
         }
         return STRUCTURE_DEFINITION;

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/MTEIndustrialWashPlant.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/MTEIndustrialWashPlant.java
@@ -2,7 +2,6 @@ package gtPlusPlus.xmod.gregtech.common.tileentities.machines.multi.processing;
 
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.isAir;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofBlock;
-import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofBlockAnyMeta;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofChain;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.onElementPass;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.transpose;
@@ -14,6 +13,7 @@ import static gregtech.api.enums.HatchElement.Muffler;
 import static gregtech.api.enums.HatchElement.OutputBus;
 import static gregtech.api.enums.HatchElement.OutputHatch;
 import static gregtech.api.util.GTStructureUtility.buildHatchAdder;
+import static gregtech.api.util.GTStructureUtility.ofAnyWater;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -42,8 +42,11 @@ import com.gtnewhorizon.structurelib.structure.IStructureDefinition;
 import com.gtnewhorizon.structurelib.structure.ISurvivalBuildEnvironment;
 import com.gtnewhorizon.structurelib.structure.StructureDefinition;
 
+import cofh.asmhooks.block.BlockTickingWater;
+import cofh.asmhooks.block.BlockWater;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import gregtech.api.enums.Mods;
 import gregtech.api.enums.SoundResource;
 import gregtech.api.enums.TAE;
 import gregtech.api.gui.modularui.GTUITextures;
@@ -146,13 +149,7 @@ public class MTEIndustrialWashPlant extends GTPPMultiBlockBase<MTEIndustrialWash
                         .casingIndex(getCasingTextureIndex())
                         .dot(1)
                         .buildAndChain(onElementPass(x -> ++x.mCasing, ofBlock(getCasingBlock(), getCasingMeta()))))
-                .addElement(
-                    'w',
-                    ofChain(
-                        isAir(),
-                        ofBlockAnyMeta(Blocks.water),
-                        ofBlockAnyMeta(Blocks.flowing_water),
-                        ofBlockAnyMeta(BlocksItems.getFluidBlock(InternalName.fluidDistilledWater))))
+                .addElement('w', ofChain(isAir(), ofAnyWater()))
                 .build();
         }
         return STRUCTURE_DEFINITION;
@@ -342,8 +339,11 @@ public class MTEIndustrialWashPlant extends GTPPMultiBlockBase<MTEIndustrialWash
                         // Utils.LOG_WARNING("Found Water");
                     } else if (tBlock == BlocksItems.getFluidBlock(InternalName.fluidDistilledWater)) {
                         ++tAmount;
-                        ++tAmount;
                         // Utils.LOG_WARNING("Found Distilled Water");
+                    } else if (Mods.COFHCore.isModLoaded()) {
+                        if (tBlock instanceof BlockWater || tBlock instanceof BlockTickingWater) {
+                            ++tAmount;
+                        }
                     }
                 }
             }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTEIndustrialFishingPond.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTEIndustrialFishingPond.java
@@ -28,6 +28,9 @@ import com.gtnewhorizon.structurelib.structure.IStructureDefinition;
 import com.gtnewhorizon.structurelib.structure.ISurvivalBuildEnvironment;
 import com.gtnewhorizon.structurelib.structure.StructureDefinition;
 
+import cofh.asmhooks.block.BlockTickingWater;
+import cofh.asmhooks.block.BlockWater;
+import gregtech.api.enums.Mods;
 import gregtech.api.enums.TAE;
 import gregtech.api.enums.Textures;
 import gregtech.api.interfaces.IIconContainer;
@@ -334,6 +337,10 @@ public class MTEIndustrialFishingPond extends GTPPMultiBlockBase<MTEIndustrialFi
                     tBlock = aBaseMetaTileEntity.getBlockOffset(xDir + i, h, zDir + j);
                     if (tBlock == Blocks.water || tBlock == Blocks.flowing_water) {
                         ++tAmount;
+                    } else if (Mods.COFHCore.isModLoaded()) {
+                        if (tBlock instanceof BlockWater || tBlock instanceof BlockTickingWater) {
+                            ++tAmount;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
As it turns out, cofhcore turns any redstone-powered water into a  `BlockTickingWater`, making it fail the structure check against regular water blocks. This PR fixes it by adding a new `ofAnyWater` structure element that also tests this class. 