### PR TITLE
Fix luag macerating

### DIFF
--- a/src/main/java/gregtech/loaders/postload/recipes/Pulverizer.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/Pulverizer.java
@@ -21,6 +21,7 @@ import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.enums.TierEU;
 import gregtech.api.util.GTOreDictUnificator;
+import gtnhlanth.common.register.WerkstoffMaterialPool;
 
 public class Pulverizer implements Runnable {
 
@@ -599,5 +600,41 @@ public class Pulverizer implements Runnable {
                 .eut(2)
                 .addTo(maceratorRecipes);
         }
+
+        // LUAG gems
+        GTValues.RA.stdBuilder()
+            .itemInputs(WerkstoffMaterialPool.CeriumDopedLutetiumAluminiumGarnet.get(OrePrefixes.gemChipped, 1))
+            .itemOutputs(WerkstoffMaterialPool.CeriumDopedLutetiumAluminiumGarnet.get(OrePrefixes.dustSmall, 1))
+            .duration(25 * TICKS)
+            .eut(4)
+            .addTo(maceratorRecipes);
+
+        GTValues.RA.stdBuilder()
+            .itemInputs(WerkstoffMaterialPool.CeriumDopedLutetiumAluminiumGarnet.get(OrePrefixes.gemFlawed, 1))
+            .itemOutputs(WerkstoffMaterialPool.CeriumDopedLutetiumAluminiumGarnet.get(OrePrefixes.dustSmall, 2))
+            .duration(50 * TICKS)
+            .eut(4)
+            .addTo(maceratorRecipes);
+
+        GTValues.RA.stdBuilder()
+            .itemInputs(WerkstoffMaterialPool.CeriumDopedLutetiumAluminiumGarnet.get(OrePrefixes.gem, 1))
+            .itemOutputs(WerkstoffMaterialPool.CeriumDopedLutetiumAluminiumGarnet.get(OrePrefixes.dust, 1))
+            .duration(5 * SECONDS)
+            .eut(4)
+            .addTo(maceratorRecipes);
+
+        GTValues.RA.stdBuilder()
+            .itemInputs(WerkstoffMaterialPool.CeriumDopedLutetiumAluminiumGarnet.get(OrePrefixes.gemFlawless, 1))
+            .itemOutputs(WerkstoffMaterialPool.CeriumDopedLutetiumAluminiumGarnet.get(OrePrefixes.dust, 2))
+            .duration(10 * SECONDS)
+            .eut(4)
+            .addTo(maceratorRecipes);
+
+        GTValues.RA.stdBuilder()
+            .itemInputs(WerkstoffMaterialPool.CeriumDopedLutetiumAluminiumGarnet.get(OrePrefixes.gemExquisite, 1))
+            .itemOutputs(WerkstoffMaterialPool.CeriumDopedLutetiumAluminiumGarnet.get(OrePrefixes.dust, 4))
+            .duration(20 * SECONDS)
+            .eut(4)
+            .addTo(maceratorRecipes);
     }
 }

--- a/src/main/java/gtnhlanth/common/register/WerkstoffMaterialPool.java
+++ b/src/main/java/gtnhlanth/common/register/WerkstoffMaterialPool.java
@@ -1859,7 +1859,8 @@ public class WerkstoffMaterialPool implements Runnable {
         subscriptNumbers("(Ce)Lu3Al5O12"),
         new Werkstoff.Stats(),
         Werkstoff.Types.MATERIAL,
-        new Werkstoff.GenerationFeatures().addGems(),
+        new Werkstoff.GenerationFeatures().disable()
+            .addGems(),
         offsetID5 + 39,
         TextureSet.SET_GEM_VERTICAL);
 

--- a/src/main/java/gtnhlanth/common/register/WerkstoffMaterialPool.java
+++ b/src/main/java/gtnhlanth/common/register/WerkstoffMaterialPool.java
@@ -1859,8 +1859,7 @@ public class WerkstoffMaterialPool implements Runnable {
         subscriptNumbers("(Ce)Lu3Al5O12"),
         new Werkstoff.Stats(),
         Werkstoff.Types.MATERIAL,
-        new Werkstoff.GenerationFeatures().disable()
-            .addGems(),
+        new Werkstoff.GenerationFeatures().addGems(),
         offsetID5 + 39,
         TextureSet.SET_GEM_VERTICAL);
 


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17564

Due to some of the intricacies of Werkstoff and collision changes, the luag gem macerating recipes were lost. This just manually adds them as macerator recipes since they seem to be the only ones like this (specific consequence of being an artificial gem).