### PR TITLE
Fix molecular transformer recipes

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/HandlerGT.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/HandlerGT.java
@@ -1,7 +1,5 @@
 package gtPlusPlus.xmod.gregtech;
 
-import static gregtech.api.enums.Mods.AdvancedSolarPanel;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -89,8 +87,6 @@ public class HandlerGT {
         MetaGTProxy.fixIC2FluidNames();
         RecipeLoaderAlgaeFarm.generateRecipes();
         RecipeLoaderTreeFarm.generateRecipes();
-        if (AdvancedSolarPanel.isModLoaded()) {
-            RecipeLoaderMolecularTransformer.run();
-        }
+        RecipeLoaderMolecularTransformer.run();
     }
 }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoaderMolecularTransformer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoaderMolecularTransformer.java
@@ -2,46 +2,100 @@ package gtPlusPlus.xmod.gregtech.loaders.recipe;
 
 import static advsolar.utils.MTRecipeManager.transformerRecipes;
 import static gregtech.api.enums.Mods.AdvancedSolarPanel;
+import static gregtech.api.enums.Mods.GalacticraftCore;
 import static gregtech.api.enums.Mods.GalaxySpace;
+import static gregtech.api.enums.Mods.PamsHarvestCraft;
+import static gregtech.api.util.GTRecipeBuilder.MINUTES;
 import static gregtech.api.util.GTRecipeBuilder.SECONDS;
 import static gregtech.api.util.GTRecipeBuilder.TICKS;
 import static gtPlusPlus.api.recipe.GTPPRecipeMaps.molecularTransformerRecipes;
 
-import advsolar.utils.MTRecipeRecord;
 import gregtech.api.enums.GTValues;
+import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.enums.TierEU;
 import gregtech.api.util.GTModHandler;
 import gregtech.api.util.GTOreDictUnificator;
-import gtPlusPlus.api.objects.Logger;
-import gtPlusPlus.core.util.math.MathUtils;
 
 public class RecipeLoaderMolecularTransformer {
 
     public static void run() {
 
-        for (MTRecipeRecord aRecipe : transformerRecipes) {
-            int aEU = (int) TierEU.RECIPE_IV;
-            Logger.INFO("=======================");
-            Logger.INFO("Generating GT recipe for Molecular Transformer.");
-            Logger.INFO(
-                "Input: " + aRecipe.inputStack
-                    .getDisplayName() + ", Output: " + aRecipe.outputStack.getDisplayName() + ", EU/t: " + aEU);
-            float aTicks = (float) aRecipe.energyPerOperation / (float) aEU;
-            Logger.INFO("Ticks: " + aTicks);
-            int aTicksRoundedUp = MathUtils.roundToClosestInt(Math.ceil(aTicks));
-            Logger.INFO("Ticks: " + aTicksRoundedUp);
-            Logger.INFO("Total EU equal or greater? " + ((aTicksRoundedUp * aEU) >= aRecipe.energyPerOperation));
-            GTValues.RA.stdBuilder()
-                .itemInputs(aRecipe.inputStack)
-                .itemOutputs(aRecipe.outputStack)
-                .duration(aTicksRoundedUp)
-                .eut(aEU)
-                .addTo(molecularTransformerRecipes);
+        GTValues.RA.stdBuilder()
+            .itemInputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.NetherQuartz, 1L))
+            .itemOutputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.CertusQuartz, 1L))
+            .duration(1 * SECONDS + 13 * TICKS)
+            .eut(TierEU.RECIPE_IV)
+            .addTo(molecularTransformerRecipes);
+        GTValues.RA.stdBuilder()
+            .itemInputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.CertusQuartz, 1L))
+            .itemOutputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.NetherQuartz, 1L))
+            .duration(1 * SECONDS + 13 * TICKS)
+            .eut(TierEU.RECIPE_IV)
+            .addTo(molecularTransformerRecipes);
+        GTValues.RA.stdBuilder()
+            .itemInputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.Redstone, 1L))
+            .itemOutputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.Ruby, 1L))
+            .duration(16 * SECONDS + 6 * TICKS)
+            .eut(TierEU.RECIPE_IV)
+            .addTo(molecularTransformerRecipes);
+        // GT Cheese(and pams cheese) -> GalactiCraft Cheese
+        GTValues.RA.stdBuilder()
+            .itemInputs(ItemList.Food_Cheese.get(1L))
+            .itemOutputs(GTModHandler.getModItem(GalacticraftCore.ID, "item.cheeseCurd", 1L))
+            .duration(16 * SECONDS + 6 * TICKS)
+            .eut(TierEU.RECIPE_IV)
+            .addTo(molecularTransformerRecipes);
+        GTValues.RA.stdBuilder()
+            .itemInputs(GTModHandler.getModItem(PamsHarvestCraft.ID, "cheeseItem", 1L))
+            .itemOutputs(GTModHandler.getModItem(GalacticraftCore.ID, "item.cheeseCurd", 1L))
+            .duration(16 * SECONDS + 6 * TICKS)
+            .eut(TierEU.RECIPE_IV)
+            .addTo(molecularTransformerRecipes);
 
-            Logger.INFO("=======================");
-        }
+        GTValues.RA.stdBuilder()
+            .itemInputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.Copper, 1L))
+            .itemOutputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.Nickel, 1L))
+            .duration(16 * SECONDS + 6 * TICKS)
+            .eut(TierEU.RECIPE_IV)
+            .addTo(molecularTransformerRecipes);
+        GTValues.RA.stdBuilder()
+            .itemInputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.Tin, 1L))
+            .itemOutputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.Silver, 1L))
+            .duration(16 * SECONDS + 6 * TICKS)
+            .eut(TierEU.RECIPE_IV)
+            .addTo(molecularTransformerRecipes);
+        GTValues.RA.stdBuilder()
+            .itemInputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.GarnetRed, 1L))
+            .itemOutputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.GarnetYellow, 1L))
+            .duration(16 * SECONDS + 6 * TICKS)
+            .eut(TierEU.RECIPE_IV)
+            .addTo(molecularTransformerRecipes);
+        GTValues.RA.stdBuilder()
+            .itemInputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.GarnetYellow, 1L))
+            .itemOutputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.GarnetRed, 1L))
+            .duration(16 * SECONDS + 6 * TICKS)
+            .eut(TierEU.RECIPE_IV)
+            .addTo(molecularTransformerRecipes);
+        GTValues.RA.stdBuilder()
+            .itemInputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.Silver, 1L))
+            .itemOutputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.Gold, 1L))
+            .duration(32 * SECONDS + 12 * TICKS)
+            .eut(TierEU.RECIPE_IV)
+            .addTo(molecularTransformerRecipes);
+        GTValues.RA.stdBuilder()
+            .itemInputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.Carbon, 1L))
+            .itemOutputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.Graphene, 1L))
+            .duration(32 * SECONDS + 12 * TICKS)
+            .eut(TierEU.RECIPE_IV)
+            .addTo(molecularTransformerRecipes);
+        GTValues.RA.stdBuilder()
+            .itemInputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.Gold, 1L))
+            .itemOutputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.Platinum, 1L))
+            .duration(4 * MINUTES + 20 * SECONDS + 9 * TICKS)
+            .eut(TierEU.RECIPE_IV)
+            .addTo(molecularTransformerRecipes);
 
         transformerRecipes.clear();
         if (AdvancedSolarPanel.isModLoaded() && GalaxySpace.isModLoaded()) {

--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoaderMolecularTransformer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoaderMolecularTransformer.java
@@ -9,6 +9,7 @@ import static gregtech.api.util.GTRecipeBuilder.SECONDS;
 import static gregtech.api.util.GTRecipeBuilder.TICKS;
 import static gtPlusPlus.api.recipe.GTPPRecipeMaps.molecularTransformerRecipes;
 
+import advsolar.utils.MTRecipeManager;
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
@@ -100,45 +101,48 @@ public class RecipeLoaderMolecularTransformer {
             .eut(TierEU.RECIPE_IV)
             .addTo(molecularTransformerRecipes);
 
-        if (AdvancedSolarPanel.isModLoaded() && GalaxySpace.isModLoaded()) {
+        if (AdvancedSolarPanel.isModLoaded()) {
+            MTRecipeManager.transformerRecipes.clear();
+            if (GalaxySpace.isModLoaded()) {
 
-            GTValues.RA.stdBuilder()
-                .itemInputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.Glowstone, 1L))
-                .itemOutputs(GTModHandler.getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 1L, 9))
-                .duration(30 * SECONDS)
-                .eut(TierEU.RECIPE_EV)
-                .addTo(molecularTransformerRecipes);
-            GTValues.RA.stdBuilder()
-                .itemInputs(GTModHandler.getModItem(GalaxySpace.ID, "item.GlowstoneDusts", 1L, 0))
-                .itemOutputs(GTModHandler.getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 1L, 9))
-                .duration(7 * SECONDS + 10 * TICKS)
-                .eut(TierEU.RECIPE_IV)
-                .addTo(molecularTransformerRecipes);
-            GTValues.RA.stdBuilder()
-                .itemInputs(GTModHandler.getModItem(GalaxySpace.ID, "item.GlowstoneDusts", 1L, 1))
-                .itemOutputs(GTModHandler.getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 1L, 9))
-                .duration(1 * SECONDS + 18 * TICKS)
-                .eut(TierEU.RECIPE_LuV)
-                .addTo(molecularTransformerRecipes);
-            GTValues.RA.stdBuilder()
-                .itemInputs(GTModHandler.getModItem(GalaxySpace.ID, "item.GlowstoneDusts", 1L, 2))
-                .itemOutputs(GTModHandler.getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 1L, 9))
-                .duration(10 * TICKS)
-                .eut(TierEU.RECIPE_ZPM)
-                .addTo(molecularTransformerRecipes);
-            GTValues.RA.stdBuilder()
-                .itemInputs(GTModHandler.getModItem(GalaxySpace.ID, "item.GlowstoneDusts", 1L, 3))
-                .itemOutputs(GTModHandler.getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 1L, 9))
-                .duration(3 * TICKS)
-                .eut(TierEU.RECIPE_UV)
-                .addTo(molecularTransformerRecipes);
-            GTValues.RA.stdBuilder()
-                .itemInputs(GTModHandler.getModItem(GalaxySpace.ID, "item.GlowstoneDusts", 1L, 4))
-                .itemOutputs(GTModHandler.getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 1L, 9))
-                .duration(1 * TICKS)
-                .eut(TierEU.RECIPE_UHV)
-                .addTo(molecularTransformerRecipes);
+                GTValues.RA.stdBuilder()
+                    .itemInputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.Glowstone, 1L))
+                    .itemOutputs(GTModHandler.getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 1L, 9))
+                    .duration(30 * SECONDS)
+                    .eut(TierEU.RECIPE_EV)
+                    .addTo(molecularTransformerRecipes);
+                GTValues.RA.stdBuilder()
+                    .itemInputs(GTModHandler.getModItem(GalaxySpace.ID, "item.GlowstoneDusts", 1L, 0))
+                    .itemOutputs(GTModHandler.getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 1L, 9))
+                    .duration(7 * SECONDS + 10 * TICKS)
+                    .eut(TierEU.RECIPE_IV)
+                    .addTo(molecularTransformerRecipes);
+                GTValues.RA.stdBuilder()
+                    .itemInputs(GTModHandler.getModItem(GalaxySpace.ID, "item.GlowstoneDusts", 1L, 1))
+                    .itemOutputs(GTModHandler.getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 1L, 9))
+                    .duration(1 * SECONDS + 18 * TICKS)
+                    .eut(TierEU.RECIPE_LuV)
+                    .addTo(molecularTransformerRecipes);
+                GTValues.RA.stdBuilder()
+                    .itemInputs(GTModHandler.getModItem(GalaxySpace.ID, "item.GlowstoneDusts", 1L, 2))
+                    .itemOutputs(GTModHandler.getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 1L, 9))
+                    .duration(10 * TICKS)
+                    .eut(TierEU.RECIPE_ZPM)
+                    .addTo(molecularTransformerRecipes);
+                GTValues.RA.stdBuilder()
+                    .itemInputs(GTModHandler.getModItem(GalaxySpace.ID, "item.GlowstoneDusts", 1L, 3))
+                    .itemOutputs(GTModHandler.getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 1L, 9))
+                    .duration(3 * TICKS)
+                    .eut(TierEU.RECIPE_UV)
+                    .addTo(molecularTransformerRecipes);
+                GTValues.RA.stdBuilder()
+                    .itemInputs(GTModHandler.getModItem(GalaxySpace.ID, "item.GlowstoneDusts", 1L, 4))
+                    .itemOutputs(GTModHandler.getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 1L, 9))
+                    .duration(1 * TICKS)
+                    .eut(TierEU.RECIPE_UHV)
+                    .addTo(molecularTransformerRecipes);
 
+            }
         }
     }
 }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoaderMolecularTransformer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoaderMolecularTransformer.java
@@ -41,18 +41,22 @@ public class RecipeLoaderMolecularTransformer {
             .eut(TierEU.RECIPE_IV)
             .addTo(molecularTransformerRecipes);
         // GT Cheese(and pams cheese) -> GalactiCraft Cheese
-        GTValues.RA.stdBuilder()
-            .itemInputs(ItemList.Food_Cheese.get(1L))
-            .itemOutputs(GTModHandler.getModItem(GalacticraftCore.ID, "item.cheeseCurd", 1L))
-            .duration(16 * SECONDS + 6 * TICKS)
-            .eut(TierEU.RECIPE_IV)
-            .addTo(molecularTransformerRecipes);
-        GTValues.RA.stdBuilder()
-            .itemInputs(GTModHandler.getModItem(PamsHarvestCraft.ID, "cheeseItem", 1L))
-            .itemOutputs(GTModHandler.getModItem(GalacticraftCore.ID, "item.cheeseCurd", 1L))
-            .duration(16 * SECONDS + 6 * TICKS)
-            .eut(TierEU.RECIPE_IV)
-            .addTo(molecularTransformerRecipes);
+        if (GalacticraftCore.isModLoaded()) {
+            GTValues.RA.stdBuilder()
+                .itemInputs(ItemList.Food_Cheese.get(1L))
+                .itemOutputs(GTModHandler.getModItem(GalacticraftCore.ID, "item.cheeseCurd", 1L))
+                .duration(16 * SECONDS + 6 * TICKS)
+                .eut(TierEU.RECIPE_IV)
+                .addTo(molecularTransformerRecipes);
+            if (PamsHarvestCraft.isModLoaded()) {
+                GTValues.RA.stdBuilder()
+                    .itemInputs(GTModHandler.getModItem(PamsHarvestCraft.ID, "cheeseItem", 1L))
+                    .itemOutputs(GTModHandler.getModItem(GalacticraftCore.ID, "item.cheeseCurd", 1L))
+                    .duration(16 * SECONDS + 6 * TICKS)
+                    .eut(TierEU.RECIPE_IV)
+                    .addTo(molecularTransformerRecipes);
+            }
+        }
 
         GTValues.RA.stdBuilder()
             .itemInputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.Copper, 1L))

--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoaderMolecularTransformer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoaderMolecularTransformer.java
@@ -1,6 +1,5 @@
 package gtPlusPlus.xmod.gregtech.loaders.recipe;
 
-import static advsolar.utils.MTRecipeManager.transformerRecipes;
 import static gregtech.api.enums.Mods.AdvancedSolarPanel;
 import static gregtech.api.enums.Mods.GalacticraftCore;
 import static gregtech.api.enums.Mods.GalaxySpace;
@@ -101,7 +100,6 @@ public class RecipeLoaderMolecularTransformer {
             .eut(TierEU.RECIPE_IV)
             .addTo(molecularTransformerRecipes);
 
-        transformerRecipes.clear();
         if (AdvancedSolarPanel.isModLoaded() && GalaxySpace.isModLoaded()) {
 
             GTValues.RA.stdBuilder()


### PR DESCRIPTION
fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17531

the recipes in adv solar panels were nuked.

this is fixed specifically by adding the recipes manually direct. I tested in full game and all 18 recipes look the same. that also means the config can go.

it might not be to hard to remove the advsolar compile dep in GT from here if someone wants to do that.