### PR TITLE
Change Antimatter Forge cycle time from 100 ticks to 20 ticks

### DIFF
--- a/src/main/java/goodgenerator/blocks/tileEntity/AntimatterForge.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/AntimatterForge.java
@@ -95,7 +95,7 @@ public class AntimatterForge extends MTEExtendedPowerMultiBlockBase<AntimatterFo
     private final int[] fluidConsumptions = { 0, 0, 0, 0 };
 
     public static final String MAIN_NAME = "antimatterForge";
-    private final int speed = 100;
+    private final int speed = 20;
     private long rollingCost = 0L;
     private boolean isLoadedChunk;
     public GTRecipe mLastRecipe;


### PR DESCRIPTION
All of the balancing was done around the cycle time being 20 ticks, with the forge having a variable cycle speed. Forge does not have variable cycle speed. Therefore it is 5 times worse than it should be.