### PR TITLE
Fix the cursed chembath again

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/MTEIndustrialWashPlant.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/MTEIndustrialWashPlant.java
@@ -298,8 +298,6 @@ public class MTEIndustrialWashPlant extends GTPPMultiBlockBase<MTEIndustrialWash
             mOffsetZ_Upper = 2;
         }
 
-        // if (aBaseMetaTileEntity.fac)
-
         final int xDir = aBaseMetaTileEntity.getBackFacing().offsetX * mCurrentDirectionX;
         final int zDir = aBaseMetaTileEntity.getBackFacing().offsetZ * mCurrentDirectionZ;
 
@@ -314,7 +312,6 @@ public class MTEIndustrialWashPlant extends GTPPMultiBlockBase<MTEIndustrialWash
                             for (FluidStack stored : this.getStoredFluids()) {
                                 if (stored.isFluidEqual(FluidUtils.getFluidStack("water", 1))) {
                                     if (stored.amount >= 1000) {
-                                        // Utils.LOG_WARNING("Going to try swap an air block for water from inut bus.");
                                         stored.amount -= 1000;
                                         Block fluidUsed = null;
                                         if (tBlock == Blocks.air || tBlock == Blocks.flowing_water) {
@@ -336,10 +333,8 @@ public class MTEIndustrialWashPlant extends GTPPMultiBlockBase<MTEIndustrialWash
                     }
                     if (tBlock == Blocks.water) {
                         ++tAmount;
-                        // Utils.LOG_WARNING("Found Water");
                     } else if (tBlock == BlocksItems.getFluidBlock(InternalName.fluidDistilledWater)) {
                         ++tAmount;
-                        // Utils.LOG_WARNING("Found Distilled Water");
                     } else if (Mods.COFHCore.isModLoaded()) {
                         if (tBlock instanceof BlockWater || tBlock instanceof BlockTickingWater) {
                             ++tAmount;
@@ -349,7 +344,7 @@ public class MTEIndustrialWashPlant extends GTPPMultiBlockBase<MTEIndustrialWash
             }
         }
 
-        boolean isValidWater = tAmount >= 45;
+        boolean isValidWater = tAmount >= 30;
         if (isValidWater) {
             Logger.WARNING("Filled structure.");
         } else {


### PR DESCRIPTION
Chembath expected 45 water blocks, while only 30 blocks are available. It did this by counting distilled water as two blocks and replacing regular water with distilled while checking. In a previous PR I made it count distilled water only as a single block because it confused me, so now I've just adjusted the check to only ask for 30 blocks of water.