### PR TITLE
Fix waterline multiblocks not resuming their first recipe on server start

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/purification/MTEPurificationPlant.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/purification/MTEPurificationPlant.java
@@ -495,7 +495,11 @@ public class MTEPurificationPlant extends MTEExtendedPowerMultiBlockBase<MTEPuri
     }
 
     public void registerLinkedUnit(MTEPurificationUnitBase<?> unit) {
-        this.mLinkedUnits.add(new LinkedPurificationUnit(unit));
+        LinkedPurificationUnit link = new LinkedPurificationUnit(unit);
+        // Make sure to mark it as active if it is running a recipe. This happens on server restart and fixes
+        // waterline multiblocks not resuming their progress until the next cycle.
+        link.setActive(unit.mMaxProgresstime > 0);
+        this.mLinkedUnits.add(link);
     }
 
     public void unregisterLinkedUnit(MTEPurificationUnitBase<?> unit) {


### PR DESCRIPTION
All waterline multiblocks got stuck in their current cycle every time the world reloads, because the code to link them to the main plant did not take into account marking the multis as active based on their current recipe progress. This causes some issues for automation and also causes T8 to void catalysts. This should now all be fixed.