### PR TITLE
Small rework to black hole instability

### DIFF
--- a/src/main/java/gregtech/api/recipe/check/CheckRecipeResultRegistry.java
+++ b/src/main/java/gregtech/api/recipe/check/CheckRecipeResultRegistry.java
@@ -113,11 +113,6 @@ public final class CheckRecipeResultRegistry {
      * Black Hole Compressor does not have an active black hole
      */
     public static final CheckRecipeResult NO_BLACK_HOLE = SimpleCheckRecipeResult.ofFailure("no_black_hole");
-    /**
-     * Black Hole Compressor became unstable
-     */
-    public static final CheckRecipeResult UNSTABLE_BLACK_HOLE = SimpleCheckRecipeResult
-        .ofFailure("unstable_black_hole");
 
     public static final CheckRecipeResult NO_SEE_SKY = SimpleCheckRecipeResult.ofFailure("no_see_sky");
 

--- a/src/main/java/gregtech/common/tileentities/machines/multi/compressor/MTEBlackHoleCompressor.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/compressor/MTEBlackHoleCompressor.java
@@ -579,61 +579,62 @@ public class MTEBlackHoleCompressor extends MTEExtendedPowerMultiBlockBase<MTEBl
         super.onPostTick(aBaseMetaTileEntity, aTick);
         if (!aBaseMetaTileEntity.isServerSide()) {
             playBlackHoleSounds();
-        } else {
-            // Run stability checks once per second if a black hole is open
-            if (blackHoleStatus == 1 || aTick % 20 != 0) return;
-
-            // Base 1 loss
-            float stabilityDecrease = 1F;
-
-            boolean didDrain = false;
-
-            // Only do loss reductions if the black hole is stable - unstable black hole can't be frozen
-            if (blackHoleStability >= 0) {
-
-                // If the machine is running, reduce stability loss by 25%
-                if (this.maxProgresstime() != 0) {
-                    stabilityDecrease = 0.75F;
-                }
-
-                // Search all hatches for catalyst fluid
-                // If found enough, drain it and reduce stability loss to 0
-                // Every 30 drains, double the cost
-                FluidStack totalCost = new FluidStack(blackholeCatalyzingCost, catalyzingCostModifier);
-
-                for (MTEHatchInput hatch : spacetimeHatches) {
-                    if (drain(hatch, totalCost, false)) {
-                        drain(hatch, totalCost, true);
-                        catalyzingCounter += 1;
-                        stabilityDecrease = 0;
-                        if (catalyzingCounter >= 30) {
-                            // Hidden cap at 1B per tick so we don't integer overflow
-                            if (catalyzingCostModifier <= 1000000000) catalyzingCostModifier *= 2;
-                            catalyzingCounter = 0;
-                        }
-                        didDrain = true;
-                        break;
-                    }
-                }
-            } else blackHoleStatus = 3;
-
-            if (shouldRender) {
-                if (rendererTileEntity == null) createRenderBlock();
-                rendererTileEntity.toggleLaser(didDrain);
-                rendererTileEntity.setStability(blackHoleStability / 100F);
-            }
-
-            blackHoleStability -= stabilityDecrease;
-
-            // Close black hole and reset if it has been unstable for 15 minutes or more
-            if (blackHoleStability <= -900) {
-                blackHoleStatus = 1;
-                blackHoleStability = 100;
-                catalyzingCostModifier = 1;
-                rendererTileEntity = null;
-                destroyRenderBlock();
-            }
         }
+
+        // Run stability checks once per second if a black hole is open
+        if (blackHoleStatus == 1 || aTick % 20 != 0) return;
+
+        // Base 1 loss
+        float stabilityDecrease = 1F;
+
+        boolean didDrain = false;
+
+        // Only do loss reductions if the black hole is stable - unstable black hole can't be frozen
+        if (blackHoleStability >= 0) {
+
+            // If the machine is running, reduce stability loss by 25%
+            if (this.maxProgresstime() != 0) {
+                stabilityDecrease = 0.75F;
+            }
+
+            // Search all hatches for catalyst fluid
+            // If found enough, drain it and reduce stability loss to 0
+            // Every 30 drains, double the cost
+            FluidStack totalCost = new FluidStack(blackholeCatalyzingCost, catalyzingCostModifier);
+
+            for (MTEHatchInput hatch : spacetimeHatches) {
+                if (drain(hatch, totalCost, false)) {
+                    drain(hatch, totalCost, true);
+                    catalyzingCounter += 1;
+                    stabilityDecrease = 0;
+                    if (catalyzingCounter >= 30) {
+                        // Hidden cap at 1B per tick so we don't integer overflow
+                        if (catalyzingCostModifier <= 1000000000) catalyzingCostModifier *= 2;
+                        catalyzingCounter = 0;
+                    }
+                    didDrain = true;
+                    break;
+                }
+            }
+        } else blackHoleStatus = 3;
+
+        if (shouldRender) {
+            if (rendererTileEntity == null) createRenderBlock();
+            rendererTileEntity.toggleLaser(didDrain);
+            rendererTileEntity.setStability(blackHoleStability / 100F);
+        }
+
+        blackHoleStability -= stabilityDecrease;
+
+        // Close black hole and reset if it has been unstable for 15 minutes or more
+        if (blackHoleStability <= -900) {
+            blackHoleStatus = 1;
+            blackHoleStability = 100;
+            catalyzingCostModifier = 1;
+            rendererTileEntity = null;
+            destroyRenderBlock();
+        }
+
     }
 
     public int getMaxParallelRecipes() {

--- a/src/main/java/gregtech/common/tileentities/machines/multi/compressor/MTEBlackHoleCompressor.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/compressor/MTEBlackHoleCompressor.java
@@ -607,7 +607,7 @@ public class MTEBlackHoleCompressor extends MTEExtendedPowerMultiBlockBase<MTEBl
                         catalyzingCounter += 1;
                         stabilityDecrease = 0;
                         if (catalyzingCounter >= 30) {
-                            //Hidden cap at 1B per tick so we don't integer overflow
+                            // Hidden cap at 1B per tick so we don't integer overflow
                             if (catalyzingCostModifier <= 1000000000) catalyzingCostModifier *= 2;
                             catalyzingCounter = 0;
                         }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/compressor/MTEBlackHoleCompressor.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/compressor/MTEBlackHoleCompressor.java
@@ -579,59 +579,60 @@ public class MTEBlackHoleCompressor extends MTEExtendedPowerMultiBlockBase<MTEBl
         super.onPostTick(aBaseMetaTileEntity, aTick);
         if (!aBaseMetaTileEntity.isServerSide()) {
             playBlackHoleSounds();
-        }
+        } else {
+            // Run stability checks once per second if a black hole is open
+            if (blackHoleStatus == 1 || aTick % 20 != 0) return;
 
-        // Run stability checks once per second if a black hole is open
-        if (blackHoleStatus == 1 || aTick % 20 != 0) return;
+            // Base 1 loss
+            float stabilityDecrease = 1F;
 
-        // Base 1 loss
-        float stabilityDecrease = 1F;
+            boolean didDrain = false;
 
-        boolean didDrain = false;
+            // Only do loss reductions if the black hole is stable - unstable black hole can't be frozen
+            if (blackHoleStability >= 0) {
 
-        // Only do loss reductions if the black hole is stable - unstable black hole can't be frozen
-        if (blackHoleStability >= 0) {
-
-            // If the machine is running, reduce stability loss by 25%
-            if (this.maxProgresstime() != 0) {
-                stabilityDecrease = 0.75F;
-            }
-
-            // Search all hatches for catalyst fluid
-            // If found enough, drain it and reduce stability loss to 0
-            // Every 30 drains, double the cost
-            FluidStack totalCost = new FluidStack(blackholeCatalyzingCost, catalyzingCostModifier);
-
-            for (MTEHatchInput hatch : spacetimeHatches) {
-                if (drain(hatch, totalCost, false)) {
-                    drain(hatch, totalCost, true);
-                    catalyzingCounter += 1;
-                    stabilityDecrease = 0;
-                    if (catalyzingCounter >= 30) {
-                        catalyzingCostModifier *= 2;
-                        catalyzingCounter = 0;
-                    }
-                    didDrain = true;
-                    break;
+                // If the machine is running, reduce stability loss by 25%
+                if (this.maxProgresstime() != 0) {
+                    stabilityDecrease = 0.75F;
                 }
+
+                // Search all hatches for catalyst fluid
+                // If found enough, drain it and reduce stability loss to 0
+                // Every 30 drains, double the cost
+                FluidStack totalCost = new FluidStack(blackholeCatalyzingCost, catalyzingCostModifier);
+
+                for (MTEHatchInput hatch : spacetimeHatches) {
+                    if (drain(hatch, totalCost, false)) {
+                        drain(hatch, totalCost, true);
+                        catalyzingCounter += 1;
+                        stabilityDecrease = 0;
+                        if (catalyzingCounter >= 30) {
+                            //Hidden cap at 1B per tick so we don't integer overflow
+                            if (catalyzingCostModifier <= 1000000000) catalyzingCostModifier *= 2;
+                            catalyzingCounter = 0;
+                        }
+                        didDrain = true;
+                        break;
+                    }
+                }
+            } else blackHoleStatus = 3;
+
+            if (shouldRender) {
+                if (rendererTileEntity == null) createRenderBlock();
+                rendererTileEntity.toggleLaser(didDrain);
+                rendererTileEntity.setStability(blackHoleStability / 100F);
             }
-        } else blackHoleStatus = 3;
 
-        if (shouldRender) {
-            if (rendererTileEntity == null) createRenderBlock();
-            rendererTileEntity.toggleLaser(didDrain);
-            rendererTileEntity.setStability(blackHoleStability / 100F);
-        }
+            blackHoleStability -= stabilityDecrease;
 
-        blackHoleStability -= stabilityDecrease;
-
-        // Close black hole and reset if it has been unstable for 15 minutes or more
-        if (blackHoleStability <= -900) {
-            blackHoleStatus = 1;
-            blackHoleStability = 100;
-            catalyzingCostModifier = 1;
-            rendererTileEntity = null;
-            destroyRenderBlock();
+            // Close black hole and reset if it has been unstable for 15 minutes or more
+            if (blackHoleStability <= -900) {
+                blackHoleStatus = 1;
+                blackHoleStability = 100;
+                catalyzingCostModifier = 1;
+                rendererTileEntity = null;
+                destroyRenderBlock();
+            }
         }
     }
 

--- a/src/main/resources/assets/gregtech/lang/en_US.lang
+++ b/src/main/resources/assets/gregtech/lang/en_US.lang
@@ -535,7 +535,6 @@ GT5U.gui.text.drill_generic_finished=§7Mining pipes have been retracted
 GT5U.gui.text.drill_retract_pipes_finished=§7Operation aborted
 GT5U.gui.text.backfiller_no_concrete=§7No liquid concrete
 GT5U.gui.text.no_black_hole=§7Requires an active black hole
-GT5U.gui.text.unstable_black_hole=§7Black hole is unstable
 GT5U.gui.text.backfiller_finished=§aWork complete
 GT5U.gui.text.backfiller_working=§aPouring concrete
 GT5U.gui.text.backfiller_current_area=§7Filling at y-level: §a%s


### PR DESCRIPTION
Brings black hole punishment more in line, instead of voiding all inputs constantly when the black hole is unstable, deleting potentially infinite resources in a handful of ticks. This was very funny but too far, and probably more egregious backup fodder than just exploding the thing would have been.

Now, the black hole will continue to perform recipes while unstable, but the outputs will be removed. After 15 minutes of being unstable, the black hole will close itself and stop performing recipes. The primary difference is that it will need to complete a botched recipe before it can start (and void) the next one, so it will now void ~15 minutes worth of recipes instead of infinite. This is still a much larger punishment than basically anything other than a chain explosion. The black hole cannot be frozen at negative stability (internally used to represent the 15 minute timer). 

Also fixed a very unlikely-to-see integer overflow, the spacetime cost is now capped at ~1 billion spacetime per tick.