### PR TITLE
Bind all tooltip separators to the config

### DIFF
--- a/src/main/java/gregtech/api/util/MultiblockTooltipBuilder.java
+++ b/src/main/java/gregtech/api/util/MultiblockTooltipBuilder.java
@@ -133,14 +133,7 @@ public class MultiblockTooltipBuilder {
      * @return Instance this method was called on.
      */
     public MultiblockTooltipBuilder addSeparator() {
-        switch (GTMod.gregtechproxy.separatorStyle) {
-            case 0 -> iLines.add(" ");
-            case 1 -> iLines.add(EnumChatFormatting.GRAY + StringUtils.getRepetitionOf('-', 41));
-            default -> iLines.add(
-                EnumChatFormatting.GRAY.toString() + EnumChatFormatting.STRIKETHROUGH
-                    + StringUtils.getRepetitionOf('-', 41));
-        }
-        return this;
+        return addSeparator(EnumChatFormatting.GRAY, 41);
     }
 
     /**
@@ -148,11 +141,12 @@ public class MultiblockTooltipBuilder {
      *
      * @return Instance this method was called on.
      */
-    public MultiblockTooltipBuilder addLineSeparator(EnumChatFormatting color, int length) {
-        if (GTMod.gregtechproxy.separatorStyle == 1) {
-            iLines.add(color + StringUtils.getRepetitionOf('-', length));
-        } else {
-            iLines.add(color.toString() + EnumChatFormatting.STRIKETHROUGH + StringUtils.getRepetitionOf('-', length));
+    public MultiblockTooltipBuilder addSeparator(EnumChatFormatting color, int length) {
+        switch (GTMod.gregtechproxy.separatorStyle) {
+            case 0 -> iLines.add(" ");
+            case 1 -> iLines.add(color + StringUtils.getRepetitionOf('-', length));
+            default -> iLines
+                .add(color.toString() + EnumChatFormatting.STRIKETHROUGH + StringUtils.getRepetitionOf('-', length));
         }
         return this;
     }
@@ -681,11 +675,12 @@ public class MultiblockTooltipBuilder {
      *
      * @return Instance this method was called on.
      */
-    public MultiblockTooltipBuilder addStructureInfoLineSeparator(EnumChatFormatting color, int length) {
-        if (GTMod.gregtechproxy.separatorStyle == 1) {
-            sLines.add(color + StringUtils.getRepetitionOf('-', length));
-        } else {
-            sLines.add(color.toString() + EnumChatFormatting.STRIKETHROUGH + StringUtils.getRepetitionOf('-', length));
+    public MultiblockTooltipBuilder addStructureInfoSeparator(EnumChatFormatting color, int length) {
+        switch (GTMod.gregtechproxy.separatorStyle) {
+            case 0 -> sLines.add(TAB + " ");
+            case 1 -> sLines.add(TAB + color + StringUtils.getRepetitionOf('-', length));
+            default -> sLines
+                .add(TAB + color + EnumChatFormatting.STRIKETHROUGH + StringUtils.getRepetitionOf('-', length));
         }
         return this;
     }
@@ -696,14 +691,7 @@ public class MultiblockTooltipBuilder {
      * @return Instance this method was called on.
      */
     public MultiblockTooltipBuilder addStructureInfoSeparator() {
-        switch (GTMod.gregtechproxy.separatorStyle) {
-            case 0 -> sLines.add(" ");
-            case 1 -> sLines.add(EnumChatFormatting.GRAY + StringUtils.getRepetitionOf('-', 30));
-            default -> sLines.add(
-                EnumChatFormatting.GRAY.toString() + EnumChatFormatting.STRIKETHROUGH
-                    + StringUtils.getRepetitionOf('-', 30));
-        }
-        return this;
+        return addStructureInfoSeparator(EnumChatFormatting.GRAY, 30);
     }
 
     /**
@@ -754,8 +742,7 @@ public class MultiblockTooltipBuilder {
      * @param authors Formatted names of the creators of this multiblock machine - if any
      */
     public MultiblockTooltipBuilder toolTipFinisher(@Nullable String... authors) {
-        iLines.add(" ");
-        return toolTipFinisher0(authors);
+        return toolTipFinisher(EnumChatFormatting.GRAY, 41, authors);
     }
 
     /**
@@ -768,13 +755,10 @@ public class MultiblockTooltipBuilder {
      *
      * @param authors Formatted names of the creators of this multiblock machine - if any
      */
+
     public MultiblockTooltipBuilder toolTipFinisher(EnumChatFormatting separatorColor, int separatorLength,
         @Nullable String... authors) {
-        this.addLineSeparator(separatorColor, separatorLength);
-        return toolTipFinisher0(authors);
-    }
-
-    private MultiblockTooltipBuilder toolTipFinisher0(@Nullable String... authors) {
+        this.addSeparator(separatorColor, separatorLength);
         iLines.add(
             TT_hold + " "
                 + EnumChatFormatting.BOLD
@@ -807,7 +791,7 @@ public class MultiblockTooltipBuilder {
             iLines.add(sb.toString());
         }
         hLines.add(TT_structurehint);
-        sLines.add(" ");
+        this.addStructureInfoSeparator();
         sLines.add(EnumChatFormatting.WHITE + TT_StructureComplex);
         sLines.add(
             EnumChatFormatting.WHITE + TT_SeeStructure1

--- a/src/main/java/tectech/thing/metaTileEntity/multi/MTEEyeOfHarmony.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/MTEEyeOfHarmony.java
@@ -976,7 +976,7 @@ public class MTEEyeOfHarmony extends TTMultiblockBase implements IConstructable,
             .addInfo("engineering. Certified Time Lord regulation compliant. This multi uses too much EU")
             .addInfo("to be handled with conventional means. All EU requirements are handled directly by")
             .addInfo("your wireless EU network.")
-            .addLineSeparator(EnumChatFormatting.GOLD, 87)
+            .addSeparator(EnumChatFormatting.GOLD, 87)
             .addInfo("This multiblock will constantly consume hydrogen and helium when it is not running a")
             .addInfo("recipe once per second. It will store this internally, you can see the totals by")
             .addInfo("using a scanner. This multi also has three tiered blocks with " + RED + 9 + GRAY + " tiers")
@@ -1030,24 +1030,24 @@ public class MTEEyeOfHarmony extends TTMultiblockBase implements IConstructable,
                     + "%"
                     + GRAY
                     + " per tier (additive).")
-            .addLineSeparator(EnumChatFormatting.GOLD, 87)
+            .addSeparator(EnumChatFormatting.GOLD, 87)
             .addInfo("Going over a recipe requirement on hydrogen or helium has a penalty on yield and recipe chance.")
             .addInfo("All stored hydrogen and helium is consumed during a craft. The associated formulas are:")
             .addInfo(GREEN + "Overflow ratio = (Stored fluid / Recipe requirement) - 1")
             .addInfo(GREEN + "Adjustment value = 1 - exp(-(30 * Overflow ratio)^2)")
             .addInfo("The Adjustment value is then subtracted from the total yield and recipe chance.")
-            .addLineSeparator(EnumChatFormatting.GOLD, 87)
+            .addSeparator(EnumChatFormatting.GOLD, 87)
             .addInfo("It should be noted that base recipe chance is determined per recipe and yield always starts")
             .addInfo("at 1 and subtracts depending on penalties. All fluid/item outputs are multiplied by the")
             .addInfo("yield. Failure fluid is exempt.")
-            .addLineSeparator(EnumChatFormatting.GOLD, 87)
+            .addSeparator(EnumChatFormatting.GOLD, 87)
             .addInfo("This multiblock can only output to ME output buses/hatches.")
-            .addLineSeparator(EnumChatFormatting.GOLD, 87)
+            .addSeparator(EnumChatFormatting.GOLD, 87)
             .addInfo("This multiblock can be overclocked by placing a programmed circuit into the input bus.")
             .addInfo(
                 "E.g. A circuit of 2 will provide 2 OCs, 16x EU input and 0.25x the time. EU output is unaffected.")
             .addInfo("All outputs are equal. All item and fluid output chances & amounts per recipe are unaffected.")
-            .addLineSeparator(EnumChatFormatting.GOLD, 87)
+            .addSeparator(EnumChatFormatting.GOLD, 87)
             .addInfo(
                 "If a recipe fails the EOH will output " + GREEN
                     + "Success chance * "
@@ -1060,14 +1060,14 @@ public class MTEEyeOfHarmony extends TTMultiblockBase implements IConstructable,
             .addInfo(
                 MaterialsUEVplus.SpaceTime.getLocalizedNameForItem("%material")
                     + " instead of fluid/item outputs and output as much EU as a successful recipe.")
-            .addLineSeparator(EnumChatFormatting.GOLD, 87)
+            .addSeparator(EnumChatFormatting.GOLD, 87)
             .addInfo(
                 "This multiblock can perform parallel processing by placing Astral Array Fabricators into the input bus.")
             .addInfo(
                 "They are stored internally and can be retrieved via right-clicking the controller with a wire cutter.")
             .addInfo(
                 "The maximum amount of stored Astral Arrays is " + formatNumbers(ASTRAL_ARRAY_LIMIT)
-                    + ". The amount of parallel is calculated via these formulas:")
+                    + ". Parallel amount is calculated via these formulas:")
             .addInfo(
                 GREEN + "Parallel exponent = floor(log("
                     + formatNumbers(PARALLEL_FOR_FIRST_ASTRAL_ARRAY)
@@ -1095,7 +1095,7 @@ public class MTEEyeOfHarmony extends TTMultiblockBase implements IConstructable,
                     + GRAY
                     + ".")
             .addInfo("The success or failure of each parallel is determined independently.")
-            .addLineSeparator(EnumChatFormatting.GOLD, 87)
+            .addSeparator(EnumChatFormatting.GOLD, 87)
             .addInfo("Animations can be disabled by using a screwdriver on the multiblock.")
             .addInfo("Planet block can be inserted directly by right-clicking the controller with planet block.")
             .beginStructureBlock(33, 33, 33, false)
@@ -1113,7 +1113,7 @@ public class MTEEyeOfHarmony extends TTMultiblockBase implements IConstructable,
                 EnumChatFormatting.GOLD + "48" + EnumChatFormatting.GRAY + " Stabilisation Field Generator.")
             .addStructureInfo(
                 EnumChatFormatting.GOLD + "138" + EnumChatFormatting.GRAY + " Spacetime Compression Field Generator.")
-            .addStructureInfo("")
+            .addStructureInfoSeparator()
             .addStructureInfo("Requires " + EnumChatFormatting.GOLD + 2 + EnumChatFormatting.GRAY + " input hatches.")
             .addStructureInfo("Requires " + EnumChatFormatting.GOLD + 1 + EnumChatFormatting.GRAY + " ME output hatch.")
             .addStructureInfo("Requires " + EnumChatFormatting.GOLD + 1 + EnumChatFormatting.GRAY + " input bus.")

--- a/src/main/java/tectech/thing/metaTileEntity/multi/MTEForgeOfGods.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/MTEForgeOfGods.java
@@ -3065,7 +3065,7 @@ public class MTEForgeOfGods extends TTMultiblockBase implements IConstructable, 
         final MultiblockTooltipBuilder tt = new MultiblockTooltipBuilder();
         tt.addMachineType("Stellar Forge")
             .addInfo(EnumChatFormatting.ITALIC + "Also known as Godforge or Gorge for short.")
-            .addLineSeparator(EnumChatFormatting.AQUA, 74)
+            .addSeparator(EnumChatFormatting.AQUA, 73)
             .addInfo("A massive structure harnessing the thermal, gravitational and")
             .addInfo("kinetic energy of a stabilised neutron star for material processing.")
             .addInfo(
@@ -3075,7 +3075,7 @@ public class MTEForgeOfGods extends TTMultiblockBase implements IConstructable, 
                     + "which utilize the star to energize materials")
             .addInfo("to varying degrees, ranging from regular smelting to matter degeneration.")
             .addInfo("EU requirements for all modules are handled via wireless energy directly.")
-            .addLineSeparator(EnumChatFormatting.AQUA, 74)
+            .addSeparator(EnumChatFormatting.AQUA, 73)
             .addInfo(
                 "This multiblock has an " + EnumChatFormatting.GOLD
                     + "extensive upgrade tree "
@@ -3093,7 +3093,7 @@ public class MTEForgeOfGods extends TTMultiblockBase implements IConstructable, 
                     + EnumChatFormatting.GRAY
                     + "These upgrades can be unlocked by reaching")
             .addInfo("certain milestones and/or spending materials.")
-            .addLineSeparator(EnumChatFormatting.AQUA, 74)
+            .addSeparator(EnumChatFormatting.AQUA, 73)
             .addInfo(
                 EnumChatFormatting.GREEN
                     + "Clicking on the logo in the controller gui opens an extensive information window,")
@@ -3196,11 +3196,11 @@ public class MTEForgeOfGods extends TTMultiblockBase implements IConstructable, 
                     + " Graviton Flow Modulator")
             .addStructureInfo(
                 EnumChatFormatting.GOLD + "36" + EnumChatFormatting.GRAY + " Stellar Energy Siphon Casing")
-            .addStructureInfo("")
+            .addStructureInfoSeparator()
             .addStructureInfo("Requires " + EnumChatFormatting.GOLD + 1 + EnumChatFormatting.GRAY + " Input Hatch")
             .addStructureInfo("Requires " + EnumChatFormatting.GOLD + 1 + EnumChatFormatting.GRAY + " Output Bus (ME)")
             .addStructureInfo("Requires " + EnumChatFormatting.GOLD + 1 + EnumChatFormatting.GRAY + " Input Bus")
-            .toolTipFinisher(EnumChatFormatting.AQUA, 74);
+            .toolTipFinisher(EnumChatFormatting.AQUA, 73);
         return tt;
     }
 

--- a/src/main/java/tectech/thing/metaTileEntity/multi/godforge_modules/MTEExoticModule.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/godforge_modules/MTEExoticModule.java
@@ -646,7 +646,7 @@ public class MTEExoticModule extends MTEBaseModule {
             .addInfo("This is a module of the Godforge.")
             .addInfo("Must be part of a Godforge to function.")
             .addInfo("Used for ultra high temperature matter degeneration.")
-            .addLineSeparator(EnumChatFormatting.AQUA, 74)
+            .addSeparator(EnumChatFormatting.AQUA, 75)
             .addInfo("The fourth and final module of the Godforge, this module breaks apart the very")
             .addInfo("building blocks of matter, producing exotic mixtures in the process. Quark-Gluon Plasma")
             .addInfo("can be manufactured right away, but production of Magnetic Monopole Matter (Magmatter)")
@@ -668,7 +668,7 @@ public class MTEExoticModule extends MTEBaseModule {
             .addStructureInfo(EnumChatFormatting.GOLD + "1" + EnumChatFormatting.GRAY + " Stellar Energy Siphon Casing")
             .addStructureInfo("Requires " + EnumChatFormatting.GOLD + 1 + EnumChatFormatting.GRAY + " Output Hatch")
             .addStructureInfo("Requires " + EnumChatFormatting.GOLD + 1 + EnumChatFormatting.GRAY + " Output Bus")
-            .toolTipFinisher(EnumChatFormatting.AQUA, 74);
+            .toolTipFinisher(EnumChatFormatting.AQUA, 75);
         return tt;
     }
 

--- a/src/main/java/tectech/thing/metaTileEntity/multi/godforge_modules/MTEMoltenModule.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/godforge_modules/MTEMoltenModule.java
@@ -153,7 +153,7 @@ public class MTEMoltenModule extends MTEBaseModule {
             .addInfo("This is a module of the Godforge.")
             .addInfo("Must be part of a Godforge to function.")
             .addInfo("Used for high temperature material liquefaction.")
-            .addLineSeparator(EnumChatFormatting.AQUA, 74)
+            .addSeparator(EnumChatFormatting.AQUA, 74)
             .addInfo("The second module of the Godforge, this module melts materials directly into")
             .addInfo("their liquid form. If an output material does not have a liquid form, it will be output")
             .addInfo("as a regular solid instead.")

--- a/src/main/java/tectech/thing/metaTileEntity/multi/godforge_modules/MTEPlasmaModule.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/godforge_modules/MTEPlasmaModule.java
@@ -224,7 +224,7 @@ public class MTEPlasmaModule extends MTEBaseModule {
             .addInfo("This is a module of the Godforge.")
             .addInfo("Must be part of a Godforge to function.")
             .addInfo("Used for extreme temperature matter ionization.")
-            .addLineSeparator(EnumChatFormatting.AQUA, 74)
+            .addSeparator(EnumChatFormatting.AQUA, 74)
             .addInfo("The third module of the Godforge, this module infuses materials with extreme amounts")
             .addInfo("of heat, ionizing and turning them into plasma directly. Not all plasmas can be produced")
             .addInfo("right away, some of them require certain upgrades to be unlocked.")

--- a/src/main/java/tectech/thing/metaTileEntity/multi/godforge_modules/MTESmeltingModule.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/godforge_modules/MTESmeltingModule.java
@@ -233,7 +233,7 @@ public class MTESmeltingModule extends MTEBaseModule {
             .addInfo("This is a module of the Godforge.")
             .addInfo("Must be part of a Godforge to function.")
             .addInfo("Used for basic smelting operations at various temperatures.")
-            .addLineSeparator(EnumChatFormatting.AQUA, 74)
+            .addSeparator(EnumChatFormatting.AQUA, 74)
             .addInfo("As the first of the Godforge modules, this module performs the most basic")
             .addInfo("thermal processing, namely smelting materials identically to a furnace or blast furnace.")
             .addInfo("The desired method of processing can be selected in the gui.")


### PR DESCRIPTION
This PR binds all tooltip separator lines to the style config so nobody is forced to look at separators they dont want to see.
Also fixes some very minor things in a couple multi tooltips