### PR TITLE
Fix and Buff Solidifier Min Casing Check and Improve Tooltip

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEMultiSolidifier.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEMultiSolidifier.java
@@ -192,10 +192,11 @@ public class MTEMultiSolidifier extends MTEExtendedPowerMultiBlockBase<MTEMultiS
             .addInfo(EnumChatFormatting.BLUE + "Pretty Ⱄⱁⰾⰻⰴ, isn't it")
             .beginVariableStructureBlock(17, 33, 5, 5, 5, 5, true)
             .addController("Front Center bottom")
-            .addCasingInfoMin("Solidifier Casing", 146, false)
-            .addCasingInfoMin("Radiator Casing", 18, false)
-            .addCasingInfoMin("Heat Proof Casing", 4, false)
-            .addCasingInfoMin("Solid Steel Casing", 4, false)
+            .addCasingInfoRange("Solidifier Casing", 91, 211, false)
+            .addCasingInfoRange("Solidifier Radiator", 13, 73, false)
+            .addCasingInfoRange("Heat Proof Machine Casing", 4, 16, false)
+            .addCasingInfoRange("Clean Stainless Steel Machine Casing", 4, 16, false)
+            .addCasingInfoRange("Glass", 21, 117, true)
             .addInputBus("Any Casing", 1)
             .addOutputBus("Any Casing", 1)
             .addInputHatch("Any Casing", 1)
@@ -260,14 +261,15 @@ public class MTEMultiSolidifier extends MTEExtendedPowerMultiBlockBase<MTEMultiS
         if (!checkPiece(MS_END, -4 - 2 * width, 4, 0) || !checkPiece(MS_END, 4 + 2 * width, 4, 0)) {
             return false;
         }
-        if (glassTier >= VoltageIndex.UMV) return true;
+
         for (MTEHatchEnergy mEnergyHatch : this.mEnergyHatches) {
-            if (mEnergyHatch.mTier > glassTier) {
+            if (glassTier < VoltageIndex.UMV & mEnergyHatch.mTier > glassTier) {
                 return false;
             }
         }
 
-        return casingAmount >= (100 + width * 23);
+        return casingAmount >= (91 + width * 20)
+            && mMaintenanceHatches.size() == 1;
     }
 
     @Override

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEMultiSolidifier.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEMultiSolidifier.java
@@ -268,8 +268,7 @@ public class MTEMultiSolidifier extends MTEExtendedPowerMultiBlockBase<MTEMultiS
             }
         }
 
-        return casingAmount >= (91 + width * 20)
-            && mMaintenanceHatches.size() == 1;
+        return casingAmount >= (91 + width * 20) && mMaintenanceHatches.size() == 1;
     }
 
     @Override


### PR DESCRIPTION
When built with UMV glass, the structure check early returned before the minimum casing check - this has been corrected so that it just applies to the energy hatch tier checking. I also added a check for a maintenance hatch.

However, this bug existing was probably hiding just how oppressive the minimum casing count was. A full-length multi has 257 casings. With the old math, the minimum casing count was 100 + 6*23 = 238, leaving room for just 19 hatches on a multi which has dedicated mold hatches and is _33_ tiles long. Most of this is from the min-size, which is 113 total casings, so a min-size solidifier gets 13 spots and each width increment (3 tiles on each side) added _1_.

I have buffed this to instead be 91 + w*20. This means a min-size solidifier has room for 22 hatches, and a max size one has room for 46. To represent this visually:

Before:
![before, 19 hatches](https://github.com/user-attachments/assets/47e162a1-fc50-4f43-9a1e-a8ad23344c8e)

After:
![after, 46 hatches](https://github.com/user-attachments/assets/c3f2af36-6a57-42c4-9def-a05f56e5fe00)

Finally, I improved the tooltip to not have entirely random casing counts and to instead show the actual min count ranges.  I also glass to the tooltip (it is not borosilicate limited, as tested with Alfglass) and the correct block names (it does not use steel casings).

Before:
![before](https://cdn.discordapp.com/attachments/663567514856325150/1296336837450797096/image.png?ex=6711eb42&is=671099c2&hm=d8332e0f32d3e0a0ca56ccb0fbac4b5a01f830d63b11e61c38e0c9bcbd4ed1f4&)

After:
![after with correct numbers and names](https://cdn.discordapp.com/attachments/663567514856325150/1296337311553945610/image.png?ex=6711ebb3&is=67109a33&hm=0f2528ce88e7d4cbc71645dedc7b785d75cc4ca6a2bff4430cf2c01a2ffa3bca&)