### PR TITLE
Fix Production of SC Steam on the EHE

### DIFF
--- a/src/main/java/goodgenerator/blocks/tileEntity/MTEExtremeHeatExchanger.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/MTEExtremeHeatExchanger.java
@@ -300,9 +300,7 @@ public class MTEExtremeHeatExchanger extends MTETooltipMultiBlockBaseEM
     public double getUnitSteamPower(String steam) {
         return switch (steam) {
             case "steam" -> 0.5;
-            case "ic2superheatedsteam" -> 1;
-            case "supercriticalsteam" -> 100;
-            case "densesupercriticalsteam" -> 1;
+            case "ic2superheatedsteam", "supercriticalsteam", "densesupercriticalsteam" -> 1;
             default -> -1;
         };
     }

--- a/src/main/java/goodgenerator/loader/RecipeLoader2.java
+++ b/src/main/java/goodgenerator/loader/RecipeLoader2.java
@@ -1076,7 +1076,7 @@ public class RecipeLoader2 {
             FluidRegistry.getFluidStack("ic2coolant", 16000),
             FluidRegistry.getFluidStack("ic2distilledwater", 20000),
             FluidRegistry.getFluidStack("ic2superheatedsteam", 3200000),
-            FluidRegistry.getFluidStack("supercriticalsteam", 32000),
+            FluidRegistry.getFluidStack("supercriticalsteam", 3200000),
             8000);
 
         MyRecipeAdder.instance.addExtremeHeatExchangerRecipe(
@@ -1084,7 +1084,7 @@ public class RecipeLoader2 {
             FluidRegistry.getFluidStack("molten.solarsaltcold", 3200),
             FluidRegistry.getFluidStack("ic2distilledwater", 20000),
             FluidRegistry.getFluidStack("ic2superheatedsteam", 3200000),
-            FluidRegistry.getFluidStack("supercriticalsteam", 32000),
+            FluidRegistry.getFluidStack("supercriticalsteam", 3200000),
             1600);
 
         GTValues.RA.stdBuilder()


### PR DESCRIPTION
After #3075, Supercritical Steam was changed to have the same EU density as Superheated Steam, when previously it was 100x denser. The plasma processing had been changed to take this into account, but the other recipes that can output SC Steam but weren't plasma were still unaffected, which meant a lot less EU from the steam than intended. This PR fixes that.

I built a simple EHE to Large SC Steam Turbine setup, and it seemed to work just fine.

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17569.