### PR TITLE
Fix NPE on IC2 recycler blacklist

### DIFF
--- a/src/main/java/gregtech/api/util/GTModHandler.java
+++ b/src/main/java/gregtech/api/util/GTModHandler.java
@@ -482,12 +482,26 @@ public class GTModHandler {
         return true;
     }
 
+    // temporary buffer list to fix NPE if you try to access the recyclerBlacklist too early
+    private static List<RecipeInputItemStack> tempRecyclerBlackList = new ArrayList<>();
+
     /**
      * Adds an Item to the Recycler Blacklist
      */
     public static boolean addToRecyclerBlackList(ItemStack aRecycledStack) {
         if (aRecycledStack == null) return false;
-        Recipes.recyclerBlacklist.add(new RecipeInputItemStack(aRecycledStack));
+        final RecipeInputItemStack iRecipeInput = new RecipeInputItemStack(aRecycledStack);
+        if (Recipes.recyclerBlacklist == null) {
+            tempRecyclerBlackList.add(iRecipeInput);
+            return true;
+        }
+        if (tempRecyclerBlackList != null) {
+            for (RecipeInputItemStack recipe : tempRecyclerBlackList) {
+                Recipes.recyclerBlacklist.add(recipe);
+            }
+            tempRecyclerBlackList = null;
+        }
+        Recipes.recyclerBlacklist.add(iRecipeInput);
         return true;
     }
 

--- a/src/main/java/gregtech/common/GTProxy.java
+++ b/src/main/java/gregtech/common/GTProxy.java
@@ -814,22 +814,15 @@ public abstract class GTProxy implements IGTMod, IFuelHandler {
             .getRegisteredFluidContainerData()) {
             onFluidContainerRegistration(new FluidContainerRegistry.FluidContainerRegisterEvent(tData));
         }
-        try {
-            for (String tOreName : OreDictionary.getOreNames()) {
-                ItemStack tOreStack;
-                for (Iterator<ItemStack> i$ = OreDictionary.getOres(tOreName)
-                    .iterator(); i$.hasNext(); registerOre(new OreDictionary.OreRegisterEvent(tOreName, tOreStack))) {
-                    tOreStack = i$.next();
-                }
+        for (String tOreName : OreDictionary.getOreNames()) {
+            for (ItemStack itemStack : OreDictionary.getOres(tOreName)) {
+                registerOre(new OreDictionary.OreRegisterEvent(tOreName, itemStack));
             }
-        } catch (Throwable e) {
-            e.printStackTrace(GTLog.err);
         }
     }
 
     public void onPreLoad() {
         GTLog.out.println("GTMod: Preload-Phase started!");
-        GTLog.ore.println("GTMod: Preload-Phase started!");
 
         GregTechAPI.sPreloadStarted = true;
         this.mIgnoreTcon = OPStuff.ignoreTinkerConstruct;


### PR DESCRIPTION
This error was previously hidden by a try catch (ignore) that is now removed.

I resolved it by adding a temporary list to buffer the items to add to the recycler blacklist while it is null.

```
java.lang.NullPointerException: Cannot invoke "ic2.api.recipe.IListRecipeManager.add(ic2.api.recipe.IRecipeInput)" because "ic2.api.recipe.Recipes.recyclerBlacklist" is null
	at Launch//gregtech.api.util.GTModHandler.addToRecyclerBlackList(GTModHandler.java:490)
	at Launch//gregtech.api.util.GTOreDictUnificator.setItemData(GTOreDictUnificator.java:374)
	at Launch//gregtech.api.util.GTOreDictUnificator.addItemData(GTOreDictUnificator.java:336)
	at Launch//gregtech.common.GTProxy.registerOre(GTProxy.java:2076)
	at Launch//gregtech.common.GTProxy.<init>(GTProxy.java:821)
	at Launch//gregtech.common.GTClient.<init>(GTClient.java:205)
	at java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)
	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:502)
	at java.base/java.lang.reflect.ReflectAccess.newInstance(ReflectAccess.java:132)
	at java.base/jdk.internal.reflect.ReflectionFactory.newInstance(ReflectionFactory.java:259)
	at java.base/java.lang.Class.newInstance(Class.java:755)
	at Launch//cpw.mods.fml.common.ProxyInjector.inject(ProxyInjector.java:59)
	at Launch//cpw.mods.fml.common.FMLModContainer.constructMod(FMLModContainer.java:512)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at System//com.google.common.eventbus.EventSubscriber.handleEvent(EventSubscriber.java:74)
	at System//com.google.common.eventbus.SynchronizedEventSubscriber.handleEvent(SynchronizedEventSubscriber.java:47)
	at System//com.google.common.eventbus.EventBus.dispatch(EventBus.java:322)
	at System//com.google.common.eventbus.EventBus.dispatchQueuedEvents(EventBus.java:304)
	at System//com.google.common.eventbus.EventBus.post(EventBus.java:275)
	at Launch//cpw.mods.fml.common.LoadController.sendEventToModContainer(LoadController.java:212)
	at Launch//cpw.mods.fml.common.LoadController.propogateStateMessage(LoadController.java:190)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at System//com.google.common.eventbus.EventSubscriber.handleEvent(EventSubscriber.java:74)
	at System//com.google.common.eventbus.SynchronizedEventSubscriber.handleEvent(SynchronizedEventSubscriber.java:47)
	at System//com.google.common.eventbus.EventBus.dispatch(EventBus.java:322)
	at System//com.google.common.eventbus.EventBus.dispatchQueuedEvents(EventBus.java:304)
	at System//com.google.common.eventbus.EventBus.post(EventBus.java:275)
	at Launch//cpw.mods.fml.common.LoadController.distributeStateMessage(LoadController.java:119)
	at Launch//cpw.mods.fml.common.Loader.loadMods(Loader.java:513)
	at Launch//cpw.mods.fml.client.FMLClientHandler.beginMinecraftLoading(FMLClientHandler.java:208)
	at Launch//net.minecraft.client.Minecraft.func_71384_a(Minecraft.java:480)
	at Launch//net.minecraft.client.Minecraft.func_99999_d(Minecraft.java:878)
	at Launch//net.minecraft.client.main.Main.main(SourceFile:148)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at System//net.minecraft.launchwrapper.Launch.rfb$realLaunch(Launch.java:250)
	at System//net.minecraft.launchwrapper.Launch.launch(Launch.java:35)
	at System//net.minecraft.launchwrapper.Launch.main(Launch.java:60)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at com.gtnewhorizons.retrofuturabootstrap.Main.main(Main.java:207)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at System//org.multimc.onesix.OneSixLauncher.launchWithMainClass(OneSixLauncher.java:243)
	at System//org.multimc.onesix.OneSixLauncher.launch(OneSixLauncher.java:278)
	at System//org.multimc.EntryPoint.listen(EntryPoint.java:143)
	at System//org.multimc.EntryPoint.main(EntryPoint.java:34)```