### PR TITLE
Fix log 1:6 in cutting machine

### DIFF
--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingLog.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingLog.java
@@ -145,6 +145,15 @@ public class ProcessingLog implements gregtech.api.interfaces.IOreRecipeRegistra
                         GTValues.RA.stdBuilder()
                             .itemInputs(new ItemStack(aStack.getItem(), 1, i))
                             .itemOutputs(
+                                GTUtility.copyOrNull(tPlanks),
+                                GTOreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 1L))
+                            .fluidInputs(Materials.Lubricant.getFluid(1L))
+                            .duration(10 * SECONDS)
+                            .eut(8)
+                            .addTo(cutterRecipes);
+                        GTValues.RA.stdBuilder()
+                            .itemInputs(new ItemStack(aStack.getItem(), 1, i))
+                            .itemOutputs(
                                 GTUtility.copyAmount(
                                     GTMod.gregtechproxy.mNerfedWoodPlank ? tStack.stackSize : tStack.stackSize * 5 / 4,
                                     tStack),
@@ -162,17 +171,6 @@ public class ProcessingLog implements gregtech.api.interfaces.IOreRecipeRegistra
                                 GTOreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 2L))
                             .fluidInputs(GTModHandler.getDistilledWater(3))
                             .duration(20 * SECONDS)
-                            .eut(8)
-                            .addTo(cutterRecipes);
-                        GTValues.RA.stdBuilder()
-                            .itemInputs(new ItemStack(aStack.getItem(), 1, i))
-                            .itemOutputs(
-                                GTUtility.copyAmount(
-                                    GTMod.gregtechproxy.mNerfedWoodPlank ? tStack.stackSize : tStack.stackSize * 5 / 4,
-                                    tStack),
-                                GTOreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 2L))
-                            .fluidInputs(Materials.Lubricant.getFluid(1))
-                            .duration(10 * SECONDS)
                             .eut(8)
                             .addTo(cutterRecipes);
                         GTModHandler.removeRecipeDelayed(new ItemStack(aStack.getItem(), 1, i));


### PR DESCRIPTION
Logs should be 1:6 planks in cutting machine with lubricant - this used to have a collision with a 1:4 (with lubricant). Deleted the wrong one of the two during collision removal.

The git changelog for this looks really strange since it's struggling to interpret the recipe added on previous line as recipe removed while all 4 recipes have similar builders. The recipes are working though:

![image](https://github.com/user-attachments/assets/5320c865-5794-4757-b160-156169c15dd7)
![image](https://github.com/user-attachments/assets/5ecdf85f-3833-4205-b6f9-1bf298089cbf)
![image](https://github.com/user-attachments/assets/889d2395-f64f-4a0f-98df-368021aa52b6)
