### PR TITLE
Fix ruby/sapphire juice mistake

### DIFF
--- a/src/main/java/gregtech/loaders/postload/chains/BauxiteRefineChain.java
+++ b/src/main/java/gregtech/loaders/postload/chains/BauxiteRefineChain.java
@@ -157,7 +157,7 @@ public class BauxiteRefineChain {
         GTValues.RA.stdBuilder()
             .itemInputs(GTUtility.getIntegratedCircuit(1))
             .itemOutputs(
-                Materials.Aluminiumhydroxide.getDust(1),
+                Materials.Aluminiumhydroxide.getDust(2),
                 Materials.Iron.getDust(1),
                 Materials.Vanadium.getDust(1),
                 Materials.Magnesium.getDust(1))
@@ -171,7 +171,7 @@ public class BauxiteRefineChain {
         GTValues.RA.stdBuilder()
             .itemInputs(GTUtility.getIntegratedCircuit(1))
             .itemOutputs(
-                Materials.Aluminiumhydroxide.getDust(1),
+                Materials.Aluminiumhydroxide.getDust(2),
                 Materials.Iron.getDust(1),
                 Materials.Vanadium.getDust(1),
                 Materials.Manganese.getDust(1),
@@ -186,7 +186,7 @@ public class BauxiteRefineChain {
         GTValues.RA.stdBuilder()
             .itemInputs(GTUtility.getIntegratedCircuit(1))
             .itemOutputs(
-                Materials.Aluminiumhydroxide.getDust(1),
+                Materials.Aluminiumhydroxide.getDust(2),
                 Materials.Chrome.getDust(1),
                 Materials.Iron.getDust(1),
                 Materials.Vanadium.getDust(1),


### PR DESCRIPTION
I made a miscalculation about the aluminium output change in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1017.

It only changed aluminium output by 1.75x, it decreased aluminium output by 3x.

This fixes it to only decrease it by 1.5x from the old recipes.