### PR TITLE
Remove method in multiblock tooltip

### DIFF
--- a/src/main/java/gregtech/api/util/MultiblockTooltipBuilder.java
+++ b/src/main/java/gregtech/api/util/MultiblockTooltipBuilder.java
@@ -131,7 +131,6 @@ public class MultiblockTooltipBuilder {
      * Add a separator line
      *
      * @return Instance this method was called on.
-     * @see #addStructureSeparator()
      */
     public MultiblockTooltipBuilder addSeparator() {
         return addSeparator(EnumChatFormatting.GRAY, 41);
@@ -718,18 +717,6 @@ public class MultiblockTooltipBuilder {
      */
     public MultiblockTooltipBuilder addSubChannelUsage(String channel, String purpose) {
         sLines.add(TAB + StatCollector.translateToLocalFormatted("GT5U.MBTT.subchannel", channel, purpose));
-        return this;
-    }
-
-    /**
-     * Add a separator line like this, to the structural hint:<br>
-     * -----------------------------------------
-     *
-     * @return Instance this method was called on.
-     * @see #addSeparator()
-     */
-    public MultiblockTooltipBuilder addStructureSeparator() {
-        sLines.add(TAB + "-----------------------------------------");
         return this;
     }
 


### PR DESCRIPTION
Remove unused method from MultiblockTooltipBuilder that was mistakenly added by https://github.com/GTNewHorizons/GT5-Unofficial/commit/37c33c050e5c6039f410c6b7360fb146b9aae7a2