### PR TITLE
Fix memory leak in gt++ PlayerUtils

### DIFF
--- a/src/main/java/gtPlusPlus/core/handler/events/EntityDeathHandler.java
+++ b/src/main/java/gtPlusPlus/core/handler/events/EntityDeathHandler.java
@@ -2,7 +2,6 @@ package gtPlusPlus.core.handler.events;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
@@ -27,8 +26,8 @@ import gtPlusPlus.core.util.minecraft.PlayerUtils;
 @Optional.Interface(iface = "com.kuba6000.mobsinfo.api.IMobExtraInfoProvider", modid = "mobsinfo")
 public class EntityDeathHandler implements IMobExtraInfoProvider {
 
-    private static final HashMap<Class, ArrayList<Triplet<ItemStack, Integer, Integer>>> mMobDropMap = new HashMap<>();
-    private static final HashSet<Class> mInternalClassKeyCache = new HashSet<>();
+    private static final HashMap<Class<?>, ArrayList<Triplet<ItemStack, Integer, Integer>>> mMobDropMap = new HashMap<>();
+    private static final ArrayList<Class<?>> mInternalClassKeyCache = new ArrayList<>();
 
     /**
      * Provides the ability to provide custom drops upon the death of EntityLivingBase objects.

--- a/src/main/java/gtPlusPlus/core/util/minecraft/PlayerUtils.java
+++ b/src/main/java/gtPlusPlus/core/util/minecraft/PlayerUtils.java
@@ -1,9 +1,7 @@
 package gtPlusPlus.core.util.minecraft;
 
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
-import java.util.WeakHashMap;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.entity.EntityLivingBase;
@@ -11,22 +9,15 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.util.ChunkCoordinates;
 import net.minecraft.util.IChatComponent;
 import net.minecraft.world.World;
-import net.minecraftforge.common.util.FakePlayer;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import gregtech.api.util.GTUtility;
-import gregtech.api.util.ReflectionUtil;
 import gtPlusPlus.core.util.Utils;
 
 public class PlayerUtils {
-
-    public static final Map<String, EntityPlayer> mCachedFakePlayers = new WeakHashMap<>();
-    private static final Class<?> mThaumcraftFakePlayer = ReflectionUtil
-        .getClass("thaumcraft.common.lib.FakeThaumcraftPlayer");
 
     public static List<EntityPlayerMP> getOnlinePlayers() {
         return MinecraftServer.getServer()
@@ -105,55 +96,9 @@ public class PlayerUtils {
         return !aPlayer.capabilities.disableDamage;
     }
 
-    public static void cacheFakePlayer(EntityPlayer aPlayer) {
-        ChunkCoordinates aChunkLocation = aPlayer.getPlayerCoordinates();
-        // Cache Fake Player
-        if (aPlayer instanceof FakePlayer
-            || (mThaumcraftFakePlayer != null && mThaumcraftFakePlayer.isInstance(aPlayer))
-            || (aPlayer.getCommandSenderName() == null || aPlayer.getCommandSenderName()
-                .isEmpty())
-            || (aPlayer.isEntityInvulnerable() && !aPlayer.canCommandSenderUseCommand(0, "") && (aChunkLocation == null)
-                || (aChunkLocation.posX == 0 && aChunkLocation.posY == 0 && aChunkLocation.posZ == 0))) {
-            mCachedFakePlayers.put(
-                aPlayer.getUniqueID()
-                    .toString(),
-                aPlayer);
-        }
-    }
-
-    public static boolean isCachedFakePlayer(String aUUID) {
-        return mCachedFakePlayers.containsKey(aUUID);
-    }
-
-    public static boolean isRealPlayer(EntityLivingBase aEntity) {
-        if (aEntity instanceof EntityPlayer p) {
-            ChunkCoordinates aChunkLocation = p.getPlayerCoordinates();
-            if (p instanceof FakePlayer) {
-                cacheFakePlayer(p);
-                return false;
-            }
-            if (mThaumcraftFakePlayer != null && mThaumcraftFakePlayer.isInstance(p)) {
-                cacheFakePlayer(p);
-                return false;
-            }
-            if (p.getCommandSenderName() == null) {
-                cacheFakePlayer(p);
-                return false;
-            }
-            if (p.getCommandSenderName()
-                .isEmpty()) {
-                cacheFakePlayer(p);
-                return false;
-            }
-            if (p.isEntityInvulnerable() && !p.canCommandSenderUseCommand(0, "")
-                && (aChunkLocation.posX == 0 && aChunkLocation.posY == 0 && aChunkLocation.posZ == 0)) {
-                cacheFakePlayer(p);
-                return false;
-            }
-            return !isCachedFakePlayer(
-                p.getUniqueID()
-                    .toString());
-        }
-        return false;
+    public static boolean isRealPlayer(EntityLivingBase entity) {
+        return entity instanceof EntityPlayer p && !p.getClass()
+            .getName()
+            .contains("Fake");
     }
 }


### PR DESCRIPTION
It was using a `WeakHashMap<String, EntityPlayer>` thinking it wouldn't cause any memory leak, turns out the weak hashmap is only weak with the keys and not the values.

So I just removed that map that actsas a cache since it's unnecessary and things work the same.