### PR TITLE
Improve circuit selection on the large boilers by adding the ability to grab a ghost circuit from a input hatch and adds logic for other circuit tiers

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
@@ -1462,6 +1462,19 @@ public abstract class MTEMultiBlockBase extends MetaTileEntity
         return false;
     }
 
+    public ItemStack getConfigurationCircuit() {
+        for (MTEHatchInputBus tHatch : filterValidMTEs(mInputBusses)) {
+            if (tHatch.allowSelectCircuit()) {
+                // Grabs the first ghost circuit we can find and returns it
+                ItemStack stack = tHatch.getStackInSlot(tHatch.getCircuitSlot());
+                if (stack != null) {
+                    return stack;
+                }
+            }
+        }
+        return null;
+    }
+
     public ArrayList<ItemStack> getStoredInputs() {
         ArrayList<ItemStack> rList = new ArrayList<>();
         Map<GTUtility.ItemId, ItemStack> inputsFromME = new HashMap<>();


### PR DESCRIPTION
Can grab a ghost circuit from the first input hatch with a item in the ghost slot and also supports bio and breakthrough circuits, providing a 0.5x and 2x modifier to the base circuit value respectively.