### PR TITLE
save debug mode to NBT to prevent it turning it off on game reload

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/purification/MTEPurificationPlant.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/purification/MTEPurificationPlant.java
@@ -770,4 +770,17 @@ public class MTEPurificationPlant extends MTEExtendedPowerMultiBlockBase<MTEPuri
             return null;
         }));
     }
+
+    @Override
+    public void loadNBTData(NBTTagCompound aNBT) {
+        super.loadNBTData(aNBT);
+        debugMode = aNBT.getBoolean("debugMode");
+    }
+
+    @Override
+    public void saveNBTData(NBTTagCompound aNBT) {
+        super.saveNBTData(aNBT);
+        aNBT.setBoolean("debugMode", debugMode);
+
+    }
 }


### PR DESCRIPTION
bugfix

does as the title suggests

Related to
https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17725

reloading the game could replicate the same issue with toggling the button manually