### PR TITLE
Replace Bee description containing Diddy with his new socials for obvious reasons

### DIFF
--- a/src/main/resources/assets/gregtech/lang/en_US.lang
+++ b/src/main/resources/assets/gregtech/lang/en_US.lang
@@ -1460,9 +1460,9 @@ for.bees.species.nethershard=Nether Shard
 for.bees.species.endshard=Ender Shard
 for.bees.species.dragonblood=Dragonblood
 
-for.description.machinist=The Machinist Queen, born from the synergy of active machinery and roaring fire. It manufactures essential components needed to build and expand an apiarists empire.||Diddy & Noila
+for.description.machinist=The Machinist Queen, born from the synergy of active machinery and roaring fire. It manufactures essential components needed to build and expand an apiarists empire.||Aditya & Noila
 
-for.bees.authority.machinist=Diddy & Noila
+for.bees.authority.machinist=Aditya & Noila
 
 for.mutation.condition.biomeid=Required Biome
 for.mutation.condition.dim=Required Dimension


### PR DESCRIPTION
For obvious reasons Diddy decided to rebrand his socials and use Aditya. Since we also use Diddy in the game its probably better to disassociate ourselves with that name and use Aditya's new name.