### PR TITLE
hackfix for TF oregen problems

### DIFF
--- a/src/main/java/gregtech/api/world/GTWorldgen.java
+++ b/src/main/java/gregtech/api/world/GTWorldgen.java
@@ -97,7 +97,7 @@ public abstract class GTWorldgen {
         if (tAllowed == null) {
             boolean value = false;
             for (Class aAllowedDimensionType : aAllowedDimensionTypes) {
-                if (aAllowedDimensionType.isInstance(aWorld.provider)) {
+                if (aAllowedDimensionType.isInstance(aWorld.provider) && !(aWorld.provider.dimensionId == 7)) {
                     value = true;
                     break;
                 }


### PR DESCRIPTION
draft for now because apparently the idea was to get rid of ids and now they are back everywhere. So feel free to do better.

the problem was that tf worldgen provider extends the overworld one.