### PR TITLE
Set new default for tooltip finisher separator line

### DIFF
--- a/src/main/java/gregtech/common/config/Client.java
+++ b/src/main/java/gregtech/common/config/Client.java
@@ -109,7 +109,7 @@ public class Client {
         public int separatorStyle;
 
         @Config.Comment("Which style should tooltip finisher separator lines have? 0: no line, 1: empty line, 2: dashed line, 3+: continuous line.")
-        @Config.DefaultInt(1)
+        @Config.DefaultInt(3)
         public int tooltipFinisherStyle;
     }
 


### PR DESCRIPTION
This PR changes the default for the separator line from blank line to smooth line, as discussed in meta dev.