### PR TITLE
Reduce Bounding Box allocations

### DIFF
--- a/src/main/java/goodgenerator/blocks/tileEntity/render/TileAntimatter.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/render/TileAntimatter.java
@@ -17,6 +17,7 @@ import com.gtnewhorizon.structurelib.alignment.enumerable.Rotation;
 public class TileAntimatter extends TileEntity {
 
     public boolean shouldRender = true;
+    private AxisAlignedBB boundingBox;
 
     // Antimatter Core settings
     public static final float spikeR = 0.153f, spikeG = 0.435f, spikeB = 1f;
@@ -85,13 +86,16 @@ public class TileAntimatter extends TileEntity {
 
     @Override
     public AxisAlignedBB getRenderBoundingBox() {
-        return AxisAlignedBB.getBoundingBox(
-            xCoord - maximalRadius - 1,
-            yCoord - maximalRadius - 1,
-            zCoord - maximalRadius - 1,
-            xCoord + maximalRadius + 1,
-            yCoord + maximalRadius + 1,
-            zCoord + maximalRadius + 1);
+        if (boundingBox == null){
+            boundingBox = AxisAlignedBB.getBoundingBox(
+                xCoord - maximalRadius - 1,
+                yCoord - maximalRadius - 1,
+                zCoord - maximalRadius - 1,
+                xCoord + maximalRadius + 1,
+                yCoord + maximalRadius + 1,
+                zCoord + maximalRadius + 1);
+        }
+        return boundingBox;
     }
 
     @Override

--- a/src/main/java/goodgenerator/blocks/tileEntity/render/TileAntimatter.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/render/TileAntimatter.java
@@ -86,7 +86,7 @@ public class TileAntimatter extends TileEntity {
 
     @Override
     public AxisAlignedBB getRenderBoundingBox() {
-        if (boundingBox == null){
+        if (boundingBox == null) {
             boundingBox = AxisAlignedBB.getBoundingBox(
                 xCoord - maximalRadius - 1,
                 yCoord - maximalRadius - 1,

--- a/src/main/java/gregtech/common/tileentities/render/TileEntityBlackhole.java
+++ b/src/main/java/gregtech/common/tileentities/render/TileEntityBlackhole.java
@@ -71,8 +71,9 @@ public class TileEntityBlackhole extends TileEntity {
 
     @Override
     public AxisAlignedBB getRenderBoundingBox() {
-        if (boundingBox == null){
-            boundingBox = AxisAlignedBB.getBoundingBox(xCoord - 10, yCoord - 10, zCoord - 10, xCoord + 10, yCoord + 10, zCoord + 10);
+        if (boundingBox == null) {
+            boundingBox = AxisAlignedBB
+                .getBoundingBox(xCoord - 10, yCoord - 10, zCoord - 10, xCoord + 10, yCoord + 10, zCoord + 10);
         }
         return boundingBox;
     }

--- a/src/main/java/gregtech/common/tileentities/render/TileEntityBlackhole.java
+++ b/src/main/java/gregtech/common/tileentities/render/TileEntityBlackhole.java
@@ -9,6 +9,8 @@ import net.minecraft.util.AxisAlignedBB;
 
 public class TileEntityBlackhole extends TileEntity {
 
+    private AxisAlignedBB boundingBox;
+
     // Should run from 0 to 1, >.5 starts showing changes
     private float stability = 1;
     // true = growing, false = shrinking
@@ -69,8 +71,10 @@ public class TileEntityBlackhole extends TileEntity {
 
     @Override
     public AxisAlignedBB getRenderBoundingBox() {
-        return AxisAlignedBB
-            .getBoundingBox(xCoord - 10, yCoord - 10, zCoord - 10, xCoord + 10, yCoord + 10, zCoord + 10);
+        if (boundingBox == null){
+            boundingBox = AxisAlignedBB.getBoundingBox(xCoord - 10, yCoord - 10, zCoord - 10, xCoord + 10, yCoord + 10, zCoord + 10);
+        }
+        return boundingBox;
     }
 
     public long getStartTime() {

--- a/src/main/java/tectech/thing/block/TileEntityEyeOfHarmony.java
+++ b/src/main/java/tectech/thing/block/TileEntityEyeOfHarmony.java
@@ -29,7 +29,7 @@ public class TileEntityEyeOfHarmony extends TileEntity {
     // Prevent culling when block is out of frame so model can remain active.
     @Override
     public AxisAlignedBB getRenderBoundingBox() {
-        if (boundingBox == null){
+        if (boundingBox == null) {
             // Assuming your block is at (x, y, z)
             double x = this.xCoord;
             double y = this.yCoord;

--- a/src/main/java/tectech/thing/block/TileEntityEyeOfHarmony.java
+++ b/src/main/java/tectech/thing/block/TileEntityEyeOfHarmony.java
@@ -36,7 +36,7 @@ public class TileEntityEyeOfHarmony extends TileEntity {
             double z = this.zCoord;
 
             // Create a bounding box that extends 'size' blocks in all directions from the block.
-            return AxisAlignedBB.getBoundingBox(
+            boundingBox = AxisAlignedBB.getBoundingBox(
                 x - EOH_STAR_FIELD_RADIUS,
                 y - EOH_STAR_FIELD_RADIUS,
                 z - EOH_STAR_FIELD_RADIUS,

--- a/src/main/java/tectech/thing/block/TileEntityEyeOfHarmony.java
+++ b/src/main/java/tectech/thing/block/TileEntityEyeOfHarmony.java
@@ -24,24 +24,27 @@ import gtneioreplugin.plugin.block.ModBlocks;
 public class TileEntityEyeOfHarmony extends TileEntity {
 
     private static final double EOH_STAR_FIELD_RADIUS = 13;
+    private AxisAlignedBB boundingBox;
 
     // Prevent culling when block is out of frame so model can remain active.
     @Override
     public AxisAlignedBB getRenderBoundingBox() {
+        if (boundingBox == null){
+            // Assuming your block is at (x, y, z)
+            double x = this.xCoord;
+            double y = this.yCoord;
+            double z = this.zCoord;
 
-        // Assuming your block is at (x, y, z)
-        double x = this.xCoord;
-        double y = this.yCoord;
-        double z = this.zCoord;
-
-        // Create a bounding box that extends 'size' blocks in all directions from the block.
-        return AxisAlignedBB.getBoundingBox(
-            x - EOH_STAR_FIELD_RADIUS,
-            y - EOH_STAR_FIELD_RADIUS,
-            z - EOH_STAR_FIELD_RADIUS,
-            x + EOH_STAR_FIELD_RADIUS + 1,
-            y + EOH_STAR_FIELD_RADIUS + 1,
-            z + EOH_STAR_FIELD_RADIUS + 1);
+            // Create a bounding box that extends 'size' blocks in all directions from the block.
+            return AxisAlignedBB.getBoundingBox(
+                x - EOH_STAR_FIELD_RADIUS,
+                y - EOH_STAR_FIELD_RADIUS,
+                z - EOH_STAR_FIELD_RADIUS,
+                x + EOH_STAR_FIELD_RADIUS + 1,
+                y + EOH_STAR_FIELD_RADIUS + 1,
+                z + EOH_STAR_FIELD_RADIUS + 1);
+        }
+        return boundingBox;
     }
 
     public void setSize(float size) {


### PR DESCRIPTION
Lazily instantiate the rendering bounding box for TileEntities, then reuse it since bounding boxes are unchanging to reduce allocations.
Affects the following multies.
- Antimatter Forge
- Blackhole Compressor
- Eye of Harmony