### PR TITLE
fixed crash in kubatech if witchery is not loaded

### DIFF
--- a/src/main/java/kubatech/loaders/DEFCRecipes.java
+++ b/src/main/java/kubatech/loaders/DEFCRecipes.java
@@ -317,17 +317,19 @@ public class DEFCRecipes {
             .noOptimize()
             .addTo(fusionCraftingRecipes);
 
-        GTValues.RA.stdBuilder()
-            .itemInputs(
-                GTModHandler.getModItem(Witchery.ID, "infinityegg", 0),
-                GTOreDictUnificator.get(OrePrefixes.dust, Materials.DraconiumAwakened, 64),
-                GTPPCombType.DRAGONBLOOD.getStackForType(1))
-            .fluidInputs(Materials.Radon.getPlasma(108))
-            .fluidOutputs(new FluidStack(FluidRegistry.getFluid("molten.dragonblood"), 648))
-            .eut(TierEU.RECIPE_UHV)
-            .duration(2400)
-            .metadata(DEFC_CASING_TIER, 3)
-            .noOptimize()
-            .addTo(fusionCraftingRecipes);
+        if (Witchery.isModLoaded()) {
+            GTValues.RA.stdBuilder()
+                .itemInputs(
+                    GTModHandler.getModItem(Witchery.ID, "infinityegg", 0),
+                    GTOreDictUnificator.get(OrePrefixes.dust, Materials.DraconiumAwakened, 64),
+                    GTPPCombType.DRAGONBLOOD.getStackForType(1))
+                .fluidInputs(Materials.Radon.getPlasma(108))
+                .fluidOutputs(new FluidStack(FluidRegistry.getFluid("molten.dragonblood"), 648))
+                .eut(TierEU.RECIPE_UHV)
+                .duration(2400)
+                .metadata(DEFC_CASING_TIER, 3)
+                .noOptimize()
+                .addTo(fusionCraftingRecipes);
+        }
     }
 }

--- a/src/main/java/kubatech/loaders/DEFCRecipes.java
+++ b/src/main/java/kubatech/loaders/DEFCRecipes.java
@@ -289,18 +289,20 @@ public class DEFCRecipes {
             .noOptimize()
             .addTo(fusionCraftingRecipes);
 
-        GTValues.RA.stdBuilder()
-            .itemInputs(
-                GTModHandler.getModItem(Witchery.ID, "infinityegg", 0),
-                GTOreDictUnificator.get(OrePrefixes.dust, Materials.DraconiumAwakened, 64),
-                GTUtility.getIntegratedCircuit(1))
-            .fluidInputs(Materials.Radon.getPlasma(72))
-            .fluidOutputs(new FluidStack(FluidRegistry.getFluid("molten.dragonblood"), 432))
-            .eut(TierEU.RECIPE_UHV)
-            .duration(3600)
-            .metadata(DEFC_CASING_TIER, 3)
-            .noOptimize()
-            .addTo(fusionCraftingRecipes);
+        if (Witchery.isModLoaded()) {
+            GTValues.RA.stdBuilder()
+                .itemInputs(
+                    GTModHandler.getModItem(Witchery.ID, "infinityegg", 0),
+                    GTOreDictUnificator.get(OrePrefixes.dust, Materials.DraconiumAwakened, 64),
+                    GTUtility.getIntegratedCircuit(1))
+                .fluidInputs(Materials.Radon.getPlasma(72))
+                .fluidOutputs(new FluidStack(FluidRegistry.getFluid("molten.dragonblood"), 432))
+                .eut(TierEU.RECIPE_UHV)
+                .duration(3600)
+                .metadata(DEFC_CASING_TIER, 3)
+                .noOptimize()
+                .addTo(fusionCraftingRecipes);
+        }
 
         GTValues.RA.stdBuilder()
             .itemInputs(


### PR DESCRIPTION
seemed these recipes would crash the game if witchery was not loaded since the item they used didn't exist