### PR TITLE
Add alternative recipe for Rhenium.

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoaderNuclear.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoaderNuclear.java
@@ -626,6 +626,14 @@ public class RecipeLoaderNuclear {
             .eut(TierEU.RECIPE_UV)
             .metadata(FUSION_THRESHOLD, 500_000_000)
             .addTo(fusionRecipes);
+
+        GTValues.RA.stdBuilder()
+            .fluidInputs(MaterialsElements.getInstance().MOLYBDENUM.getFluidStack(144), Materials.Helium.getGas(1000))
+            .fluidOutputs(new FluidStack(MaterialsElements.getInstance().RHENIUM.getFluid(), 144))
+            .duration(2 * SECONDS + 4 * TICKS)
+            .eut(TierEU.RECIPE_ZPM / 2)
+            .metadata(FUSION_THRESHOLD, 500_000_000)
+            .addTo(fusionRecipes);
     }
 
     private static void macerator() {


### PR DESCRIPTION
Currently rhenium can be obtainet only from proccesiong some purified ores in ABS. Which kinda annoying in late game.

Molybdenium + Helium

![image](https://github.com/user-attachments/assets/a3895174-445c-41ab-8750-0b2da08a6a5a)


![image](https://github.com/user-attachments/assets/b5e21634-f916-42f1-b373-ad52c75329b5)
