### PR TITLE
Blackhole fixes

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/compressor/MTEBlackHoleCompressor.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/compressor/MTEBlackHoleCompressor.java
@@ -574,15 +574,18 @@ public class MTEBlackHoleCompressor extends MTEExtendedPowerMultiBlockBase<MTEBl
     @Override
     public void onPostTick(IGregTechTileEntity aBaseMetaTileEntity, long aTick) {
         super.onPostTick(aBaseMetaTileEntity, aTick);
-        if (!aBaseMetaTileEntity.isServerSide()) {
-            playBlackHoleSounds();
-        }
 
         if (collapseTimer != -1) {
             if (collapseTimer == 0) {
                 destroyRenderBlock();
             }
             collapseTimer--;
+        }
+
+        // Skip all the drain logic for clientside, just play sounds
+        if (!aBaseMetaTileEntity.isServerSide()) {
+            playBlackHoleSounds();
+            return;
         }
 
         // Run stability checks once per second if a black hole is open

--- a/src/main/java/gregtech/common/tileentities/machines/multi/compressor/MTEBlackHoleCompressor.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/compressor/MTEBlackHoleCompressor.java
@@ -19,6 +19,7 @@ import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_MULTI_BLACKHOLE_UNS
 import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_MULTI_BLACKHOLE_UNSTABLE_GLOW;
 import static gregtech.api.util.GTStructureUtility.buildHatchAdder;
 import static gregtech.api.util.GTStructureUtility.ofFrame;
+import static gregtech.api.util.GTUtility.filterValidMTEs;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -474,33 +475,24 @@ public class MTEBlackHoleCompressor extends MTEExtendedPowerMultiBlockBase<MTEBl
         // Loop through all items and look for the Activation and Deactivation Catalysts
         // Deactivation resets stability to 100 and catalyzing cost to 1
 
-        // Has to do this "start/endRecipeProcessing" nonsense, or it doesn't work with stocking bus.
-        for (MTEHatchInputBus bus : mInputBusses) {
-            ItemStack[] inv = bus.getRealInventory();
-            if (inv != null) {
-                for (int i = 0; i < inv.length; i++) {
-                    ItemStack inputItem = inv[i];
-                    if (inputItem != null) {
-                        if (inputItem.getItem() instanceof MetaGeneratedItem01) {
-                            if (inputItem.getItemDamage() == 32418 && (blackHoleStatus == 1)) {
-                                startRecipeProcessing();
-                                bus.decrStackSize(i, 1);
-                                endRecipeProcessing();
-                                blackHoleStatus = 2;
-                                createRenderBlock();
-                                return;
-                            } else if (inputItem.getItemDamage() == 32419 && !(blackHoleStatus == 1)) {
-                                startRecipeProcessing();
-                                bus.decrStackSize(i, 1);
-                                endRecipeProcessing();
-                                inputItem.stackSize -= 1;
-                                blackHoleStatus = 1;
-                                blackHoleStability = 100;
-                                catalyzingCostModifier = 1;
-                                if (rendererTileEntity != null) rendererTileEntity.startScaleChange(false);
-                                collapseTimer = 40;
-                                return;
-                            }
+        for (MTEHatchInputBus bus : filterValidMTEs(mInputBusses)) {
+            for (int i = 0; i < bus.getSizeInventory(); i++) {
+                ItemStack inputItem = bus.getStackInSlot(i);
+                if (inputItem != null) {
+                    if (inputItem.getItem() instanceof MetaGeneratedItem01) {
+                        if (inputItem.getItemDamage() == 32418 && (blackHoleStatus == 1)) {
+                            bus.decrStackSize(i, 1);
+                            blackHoleStatus = 2;
+                            createRenderBlock();
+                            return;
+                        } else if (inputItem.getItemDamage() == 32419 && !(blackHoleStatus == 1)) {
+                            bus.decrStackSize(i, 1);
+                            blackHoleStatus = 1;
+                            blackHoleStability = 100;
+                            catalyzingCostModifier = 1;
+                            if (rendererTileEntity != null) rendererTileEntity.startScaleChange(false);
+                            collapseTimer = 40;
+                            return;
                         }
                     }
                 }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/compressor/MTEBlackHoleCompressor.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/compressor/MTEBlackHoleCompressor.java
@@ -78,6 +78,7 @@ import gregtech.api.util.MultiblockTooltipBuilder;
 import gregtech.api.util.OverclockCalculator;
 import gregtech.common.blocks.BlockCasings10;
 import gregtech.common.items.MetaGeneratedItem01;
+import gregtech.common.tileentities.machines.IRecipeProcessingAwareHatch;
 import gregtech.common.tileentities.render.TileEntityBlackhole;
 import gtPlusPlus.core.util.minecraft.PlayerUtils;
 import mcp.mobius.waila.api.IWailaConfigHandler;
@@ -482,15 +483,19 @@ public class MTEBlackHoleCompressor extends MTEExtendedPowerMultiBlockBase<MTEBl
                     if (inputItem.getItem() instanceof MetaGeneratedItem01) {
                         if (inputItem.getItemDamage() == 32418 && (blackHoleStatus == 1)) {
                             bus.decrStackSize(i, 1);
-                            endRecipeProcessing();
-                            startRecipeProcessing();
+                            if (bus instanceof IRecipeProcessingAwareHatch aware) {
+                                setResultIfFailure(aware.endRecipeProcessing(this));
+                                aware.startRecipeProcessing();
+                            }
                             blackHoleStatus = 2;
                             createRenderBlock();
                             return;
                         } else if (inputItem.getItemDamage() == 32419 && !(blackHoleStatus == 1)) {
                             bus.decrStackSize(i, 1);
-                            endRecipeProcessing();
-                            startRecipeProcessing();
+                            if (bus instanceof IRecipeProcessingAwareHatch aware) {
+                                setResultIfFailure(aware.endRecipeProcessing(this));
+                                aware.startRecipeProcessing();
+                            }
                             blackHoleStatus = 1;
                             blackHoleStability = 100;
                             catalyzingCostModifier = 1;

--- a/src/main/java/gregtech/common/tileentities/machines/multi/compressor/MTEBlackHoleCompressor.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/compressor/MTEBlackHoleCompressor.java
@@ -482,11 +482,15 @@ public class MTEBlackHoleCompressor extends MTEExtendedPowerMultiBlockBase<MTEBl
                     if (inputItem.getItem() instanceof MetaGeneratedItem01) {
                         if (inputItem.getItemDamage() == 32418 && (blackHoleStatus == 1)) {
                             bus.decrStackSize(i, 1);
+                            endRecipeProcessing();
+                            startRecipeProcessing();
                             blackHoleStatus = 2;
                             createRenderBlock();
                             return;
                         } else if (inputItem.getItemDamage() == 32419 && !(blackHoleStatus == 1)) {
                             bus.decrStackSize(i, 1);
+                            endRecipeProcessing();
+                            startRecipeProcessing();
                             blackHoleStatus = 1;
                             blackHoleStability = 100;
                             catalyzingCostModifier = 1;
@@ -501,14 +505,18 @@ public class MTEBlackHoleCompressor extends MTEExtendedPowerMultiBlockBase<MTEBl
     }
 
     @Override
+    protected void setupProcessingLogic(ProcessingLogic logic) {
+        super.setupProcessingLogic(logic);
+        searchAndDecrementCatalysts();
+    }
+
+    @Override
     protected ProcessingLogic createProcessingLogic() {
         return new ProcessingLogic() {
 
             @NotNull
             @Override
             protected Stream<GTRecipe> findRecipeMatches(@Nullable RecipeMap<?> map) {
-                searchAndDecrementCatalysts();
-
                 switch (getModeFromCircuit(inputItems)) {
                     case MACHINEMODE_COMPRESSOR -> {
                         return super.findRecipeMatches(RecipeMaps.compressorRecipes);


### PR DESCRIPTION
- Refactor the code for using seeds/collapsers so that it does not do shenanigans with stocking input buses
- Prevent unnecessary code from running on client thread to fix syncing issues
- Move catalyst check to setupProcessingLogic so that it doesn't pointlessly run multiple times per recipe check

Fixes: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17912
Fixes: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17910
Hopefully also fixes an undiagnosed bug that caused black hole to (rarely) perform recipes without consuming inputs from stocking buses.