### PR TITLE
Delete NBT data about crafting components on MetaTileEntity

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
@@ -126,7 +126,6 @@ public class BaseMetaTileEntity extends CommonMetaTileEntity
     private long mLastCheckTick = 0;
     private String mOwnerName = "";
     private UUID mOwnerUuid = GTUtility.defaultUuid;
-    private NBTTagCompound mRecipeStuff = new NBTTagCompound();
     private int cableUpdateDelay = 30;
 
     public BaseMetaTileEntity() {}
@@ -158,7 +157,6 @@ public class BaseMetaTileEntity extends CommonMetaTileEntity
             nbt.setBoolean("mWorks", !mWorks);
             nbt.setBoolean("mInputDisabled", mInputDisabled);
             nbt.setBoolean("mOutputDisabled", mOutputDisabled);
-            nbt.setTag("GT.CraftingComponents", mRecipeStuff);
             nbt.setString("shutDownReasonID", getLastShutDownReason().getID());
             nbt.setTag("shutDownReason", getLastShutDownReason().writeToNBT(new NBTTagCompound()));
         } catch (Throwable e) {
@@ -215,7 +213,6 @@ public class BaseMetaTileEntity extends CommonMetaTileEntity
             mOtherUpgrades = (byte) (aNBT.getByte("mOtherUpgrades") + aNBT.getByte("mBatteries")
                 + aNBT.getByte("mLiBatteries"));
 
-            mRecipeStuff = aNBT.getCompoundTag("GT.CraftingComponents");
             final int nbtVersion = aNBT.getInteger("nbtVersion");
             readCoverNBT(aNBT);
             loadMetaTileNBT(aNBT);
@@ -1412,14 +1409,6 @@ public class BaseMetaTileEntity extends CommonMetaTileEntity
                     }
                 }
             }
-            if (mRecipeStuff != null) {
-                for (int i = 0; i < 9; i++) {
-                    if (this.getRandomNumber(100) < 50) {
-                        dropItems(GTUtility.loadItem(mRecipeStuff, "Ingredient." + i));
-                    }
-                }
-            }
-
             Pollution.addPollution((TileEntity) this, GTMod.gregtechproxy.mPollutionOnExplosion);
             mMetaTileEntity.doExplosion(aAmount);
         }
@@ -1455,7 +1444,6 @@ public class BaseMetaTileEntity extends CommonMetaTileEntity
     public ArrayList<ItemStack> getDrops() {
         final ItemStack rStack = new ItemStack(GregTechAPI.sBlockMachines, 1, mID);
         final NBTTagCompound tNBT = new NBTTagCompound();
-        if (mRecipeStuff != null && !mRecipeStuff.hasNoTags()) tNBT.setTag("GT.CraftingComponents", mRecipeStuff);
         if (mMuffler) tNBT.setBoolean("mMuffler", true);
         if (mLockUpgrade) tNBT.setBoolean("mLockUpgrade", true);
         if (mSteamConverter) tNBT.setBoolean("mSteamConverter", true);

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
@@ -1456,9 +1456,9 @@ public class BaseMetaTileEntity extends CommonMetaTileEntity
         final ItemStack rStack = new ItemStack(GregTechAPI.sBlockMachines, 1, mID);
         final NBTTagCompound tNBT = new NBTTagCompound();
         if (mRecipeStuff != null && !mRecipeStuff.hasNoTags()) tNBT.setTag("GT.CraftingComponents", mRecipeStuff);
-        if (mMuffler) tNBT.setBoolean("mMuffler", mMuffler);
-        if (mLockUpgrade) tNBT.setBoolean("mLockUpgrade", mLockUpgrade);
-        if (mSteamConverter) tNBT.setBoolean("mSteamConverter", mSteamConverter);
+        if (mMuffler) tNBT.setBoolean("mMuffler", true);
+        if (mLockUpgrade) tNBT.setBoolean("mLockUpgrade", true);
+        if (mSteamConverter) tNBT.setBoolean("mSteamConverter", true);
         if (mColor > 0) tNBT.setByte("mColor", mColor);
         if (mOtherUpgrades > 0) tNBT.setByte("mOtherUpgrades", mOtherUpgrades);
 

--- a/src/main/java/gregtech/api/metatileentity/CoverableTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/CoverableTileEntity.java
@@ -91,7 +91,6 @@ public abstract class CoverableTileEntity extends BaseTileEntity implements ICov
 
     protected void writeCoverNBT(NBTTagCompound aNBT, boolean isDrop) {
         final NBTTagList tList = new NBTTagList();
-        final int[] coverSides = new int[] { 0, 0, 0, 0, 0, 0 };
 
         for (final ForgeDirection side : ForgeDirection.VALID_DIRECTIONS) {
             final CoverInfo coverInfo = getCoverInfoAtSide(side);
@@ -107,6 +106,7 @@ public abstract class CoverableTileEntity extends BaseTileEntity implements ICov
         if (tList.tagCount() > 0) {
             aNBT.setTag(GTValues.NBT.COVERS, tList);
             // Backwards compat, in case of a revert... for now
+            final int[] coverSides = new int[] { 0, 0, 0, 0, 0, 0 };
             aNBT.setIntArray("mCoverSides", coverSides);
         }
 


### PR DESCRIPTION
This data is only used for the dissassembler that now doesn't not exist anymore