### PR TITLE
Adjust number formatting in WAILA machine progress line

### DIFF
--- a/src/main/java/gregtech/api/util/GTWaila.java
+++ b/src/main/java/gregtech/api/util/GTWaila.java
@@ -10,11 +10,11 @@ public abstract class GTWaila {
 
         if (!isActive) return "Idle";
 
-        return "In progress: " + String.format("%,.2f", (double) progresstime / 20)
+        return "In progress: " + String.format("%,.1f", (double) progresstime / 20)
             + "s / "
-            + String.format("%,.2f", (double) maxProgresstime / 20)
+            + String.format("%,.1f", (double) maxProgresstime / 20)
             + "s ("
-            + GTUtility.formatNumbers((Math.round((double) progresstime / maxProgresstime * 1000) / 10.0))
+            + String.format("%,.1f", (Math.round((double) progresstime / maxProgresstime * 1000) / 10.0))
             + "%)";
     }
 }


### PR DESCRIPTION
Very small cosmetic changes:

1. The progress percentage in WAILA on a GT machine is shown with one decimal place except when that digit is 0, where it is not shown. In cases where the progress line is the longest line in the WAILA status, that will cause resizing of the WAILA overlay which I find mildly distracting. This fixes this by showing 0 as well, keeping the string at a constant width from 10% on.
2. The progress time is shown with needless precision (two decimal places) as the WAILA status doesn't update quickly enough for that information to be useful. This drops the time formatting to one decimal place.

Before:

https://github.com/user-attachments/assets/b3c16ccd-e6d1-434b-8353-e5f646e6ad2f

After:

https://github.com/user-attachments/assets/d06a8761-adb8-4de1-826b-8a5d87a59ad3

