### PR TITLE
Small solidifier structure check fix

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEMultiSolidifier.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEMultiSolidifier.java
@@ -258,6 +258,7 @@ public class MTEMultiSolidifier extends MTEExtendedPowerMultiBlockBase<MTEMultiS
     public boolean checkMachine(IGregTechTileEntity aBaseMetaTileEntity, ItemStack aStack) {
         width = 0;
         casingAmount = 0;
+        glassTier = 0;
 
         if (checkPiece(STRUCTURE_PIECE_MAIN, 3, 4, 0)) {
             while (width < (6)) {


### PR DESCRIPTION
Reset the glass tier on machine check so it doesn't stop forming when you change glass.