### PR TITLE
added recipe using rutile, scheelite and ilmenite for qft Tita-Tungsten-Catalyst

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoaderChemicalSkips.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoaderChemicalSkips.java
@@ -212,6 +212,22 @@ public class RecipeLoaderChemicalSkips {
             .eut(TierEU.RECIPE_UV)
             .metadata(QFT_FOCUS_TIER, 1)
             .addTo(quantumForceTransformerRecipes);
+        GTValues.RA.stdBuilder()
+            .itemInputs(
+                Materials.Rutile.getDust(32),
+                Materials.Scheelite.getDust(16),
+                Materials.Ilmenite.getDust(16),
+                ItemUtils.getSimpleStack(GenericChem.mTitaTungstenIndiumCatalyst, 0))
+            .itemOutputs(
+                Materials.Titanium.getDust(64),
+                Materials.TungstenSteel.getDust(64),
+                Materials.Tantalum.getDust(64),
+                Materials.Indium.getDust(64),
+                Materials.Niobium.getDust(64))
+            .duration(20 * SECONDS)
+            .eut(TierEU.RECIPE_UV)
+            .metadata(QFT_FOCUS_TIER, 1)
+            .addTo(quantumForceTransformerRecipes);
         // Thorium, Uranium, Plutonium
         GTValues.RA.stdBuilder()
             .itemInputs(


### PR DESCRIPTION
Closes [#17924](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17924)

![image](https://github.com/user-attachments/assets/3f0b4f18-a992-4706-8fb0-faad9685d983)
Recipe is similar to the other with the same catalyst, makes niobium and tantalum instead of tungsten carbide, since those are common byproducts from ilmenite.