### PR TITLE
Improve EoH tier numbering in portable scanner info

### DIFF
--- a/src/main/java/tectech/thing/metaTileEntity/multi/MTEEyeOfHarmony.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/MTEEyeOfHarmony.java
@@ -1560,7 +1560,7 @@ public class MTEEyeOfHarmony extends TTMultiblockBase implements IConstructable,
                     + RESET
                     + " ("
                     + YELLOW
-                    + spacetimeCompressionFieldMetadata
+                    + (spacetimeCompressionFieldMetadata + 1)
                     + RESET
                     + ")");
         }
@@ -1572,7 +1572,7 @@ public class MTEEyeOfHarmony extends TTMultiblockBase implements IConstructable,
                     + RESET
                     + " ("
                     + YELLOW
-                    + timeAccelerationFieldMetadata
+                    + (timeAccelerationFieldMetadata + 1)
                     + RESET
                     + ")");
         }
@@ -1584,7 +1584,7 @@ public class MTEEyeOfHarmony extends TTMultiblockBase implements IConstructable,
                     + RESET
                     + " ("
                     + YELLOW
-                    + stabilisationFieldMetadata
+                    + (stabilisationFieldMetadata + 1)
                     + RESET
                     + ")");
         }


### PR DESCRIPTION
In most cases, EoH tier numbering is 1-9, but the tier displayed by the portable scanner is 0-8.
This PR changes it to 1-9 and removes the confusion.

before
![image](https://github.com/user-attachments/assets/d88c046f-786c-4cd9-b120-943f34d4b204)

after
![image](https://github.com/user-attachments/assets/479fdfde-9d8d-47fe-91fc-b9d6b11b401d)
