### PR TITLE
Fix advanced mufflers in the XLGT and other multiblocks with >1 muffler hatch

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
@@ -635,7 +635,11 @@ public abstract class MTEMultiBlockBase extends MetaTileEntity
         // Early exit if pollution is disabled
         if (!GTMod.gregtechproxy.mPollution) return true;
         mPollution += aPollutionLevel;
-        for (MTEHatchMuffler tHatch : validMTEList(mMufflerHatches)) {
+        if (mPollution < 10000) return true;
+        var validMufflers = new ArrayList<MTEHatchMuffler>(mMufflerHatches.size());
+        validMTEList(mMufflerHatches).forEach(validMufflers::add);
+        Collections.shuffle(validMufflers);
+        for (MTEHatchMuffler tHatch : validMufflers) {
             if (mPollution >= 10000) {
                 if (tHatch.polluteEnvironment(this)) {
                     mPollution -= 10000;
@@ -1823,8 +1827,13 @@ public abstract class MTEMultiBlockBase extends MetaTileEntity
     @Override
     public String[] getInfoData() {
         int mPollutionReduction = 0;
-        for (MTEHatchMuffler tHatch : validMTEList(mMufflerHatches)) {
-            mPollutionReduction = Math.max(tHatch.calculatePollutionReduction(100), mPollutionReduction);
+        var validMufflers = new ArrayList<MTEHatchMuffler>(mMufflerHatches.size());
+        validMTEList(mMufflerHatches).forEach(validMufflers::add);
+        if (validMufflers.size() > 0) {
+            for (MTEHatchMuffler tHatch : validMufflers) {
+                mPollutionReduction += tHatch.calculatePollutionReduction(100);
+            }
+            mPollutionReduction /= validMufflers.size();
         }
 
         long storedEnergy = 0;

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/MTELargerTurbineBase.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/MTELargerTurbineBase.java
@@ -49,7 +49,6 @@ import gregtech.api.util.MultiblockTooltipBuilder;
 import gregtech.api.util.TurbineStatCalculator;
 import gregtech.api.util.shutdown.ShutDownReason;
 import gregtech.api.util.shutdown.ShutDownReasonRegistry;
-import gregtech.common.pollution.Pollution;
 import gtPlusPlus.api.objects.Logger;
 import gtPlusPlus.api.objects.minecraft.BlockPos;
 import gtPlusPlus.core.block.ModBlocks;
@@ -651,25 +650,6 @@ public abstract class MTELargerTurbineBase extends GTPPMultiBlockBase<MTELargerT
     }
 
     @Override
-    public boolean polluteEnvironment(int aPollutionLevel) {
-        if (this.requiresMufflers()) {
-            mPollution += aPollutionLevel * getPollutionMultiplier() * mufflerReduction;
-            for (MTEHatchMuffler tHatch : validMTEList(mMufflerHatches)) {
-                if (mPollution >= 10000) {
-                    if (GTMod.gregtechproxy.mPollution) {
-                        Pollution.addPollution(this.getBaseMetaTileEntity(), 10000);
-                        mPollution -= 10000;
-                    }
-                } else {
-                    break;
-                }
-            }
-            return mPollution < 10000;
-        }
-        return true;
-    }
-
-    @Override
     public long maxAmperesOut() {
         return 16;
     }
@@ -838,10 +818,6 @@ public abstract class MTELargerTurbineBase extends GTPPMultiBlockBase<MTELargerT
     }
 
     public int getMaintenanceThreshold() {
-        return 1;
-    }
-
-    public int getPollutionMultiplier() {
         return 1;
     }
 


### PR DESCRIPTION
See https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17953.

With this change, multiblocks with >1 muffler hatch vent pollution evenly through all of them, selecting a different one at random each time. Also, the XLGT now correctly pulls air filters from input buses if you used advanced muffler hatches with it.