### PR TITLE
Simplify GT Assembler recipes for Muffler Upgrades

### DIFF
--- a/src/main/java/gregtech/loaders/postload/recipes/AssemblerRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/AssemblerRecipes.java
@@ -245,22 +245,23 @@ public class AssemblerRecipes implements Runnable {
                 .eut(256)
                 .addTo(assemblerRecipes);
 
+            // Muffler Upgrades
             GTValues.RA.stdBuilder()
-                .itemInputs(
-                    GTOreDictUnificator.get(OrePrefixes.plate, Materials.Aluminium, 1L),
-                    GTOreDictUnificator.get(OrePrefixes.dust, Materials.Plastic, 2L),
-                    GTUtility.getIntegratedCircuit(1))
-                .itemOutputs(ItemList.Upgrade_Muffler.get(1L))
-                .duration(1 * MINUTES + 20 * SECONDS)
-                .eut(2)
-                .addTo(assemblerRecipes);
+            .itemInputs(
+                GTOreDictUnificator.get(OrePrefixes.plate, Materials.Aluminium, 1L),
+                GTOreDictUnificator.get(OrePrefixes.dust, Materials.Plastic, 2L),
+                GTUtility.getIntegratedCircuit(1))
+            .itemOutputs(ItemList.Upgrade_Muffler.get(4L))
+            .duration(1 * MINUTES + 20 * SECONDS)
+            .eut(2)
+            .addTo(assemblerRecipes);
             GTValues.RA.stdBuilder()
                 .itemInputs(
                     GTOreDictUnificator.get(OrePrefixes.plate, Materials.Aluminium, 1L),
                     GTOreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 2L),
                     GTUtility.getIntegratedCircuit(1))
-                .itemOutputs(ItemList.Upgrade_Muffler.get(1L))
-                .duration(1 * MINUTES + 20 * SECONDS)
+                .itemOutputs(ItemList.Upgrade_Muffler.get(2L))
+                .duration(1 * MINUTES)
                 .eut(2)
                 .addTo(assemblerRecipes);
             GTValues.RA.stdBuilder()
@@ -269,7 +270,7 @@ public class AssemblerRecipes implements Runnable {
                     GTOreDictUnificator.get(OrePrefixes.dust, Materials.Plastic, 2L),
                     GTUtility.getIntegratedCircuit(1))
                 .itemOutputs(ItemList.Upgrade_Muffler.get(1L))
-                .duration(1 * MINUTES + 20 * SECONDS)
+                .duration(1 * MINUTES)
                 .eut(2)
                 .addTo(assemblerRecipes);
             GTValues.RA.stdBuilder()
@@ -286,7 +287,7 @@ public class AssemblerRecipes implements Runnable {
                     GTOreDictUnificator.get(OrePrefixes.plate, Materials.WroughtIron, 1L),
                     GTOreDictUnificator.get(OrePrefixes.dust, Materials.Plastic, 2L),
                     GTUtility.getIntegratedCircuit(1))
-                .itemOutputs(ItemList.Upgrade_Muffler.get(1L))
+                .itemOutputs(ItemList.Upgrade_Muffler.get(2L))
                 .duration(1 * MINUTES + 20 * SECONDS)
                 .eut(2)
                 .addTo(assemblerRecipes);
@@ -296,9 +297,10 @@ public class AssemblerRecipes implements Runnable {
                     GTOreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 2L),
                     GTUtility.getIntegratedCircuit(1))
                 .itemOutputs(ItemList.Upgrade_Muffler.get(1L))
-                .duration(1 * MINUTES + 20 * SECONDS)
+                .duration(1 * MINUTES)
                 .eut(2)
                 .addTo(assemblerRecipes);
+
             GTValues.RA.stdBuilder()
                 .itemInputs(
                     GTOreDictUnificator.get(OrePrefixes.plate, Materials.Aluminium, 1L),

--- a/src/main/java/gregtech/loaders/postload/recipes/AssemblerRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/AssemblerRecipes.java
@@ -247,14 +247,14 @@ public class AssemblerRecipes implements Runnable {
 
             // Muffler Upgrades
             GTValues.RA.stdBuilder()
-            .itemInputs(
-                GTOreDictUnificator.get(OrePrefixes.plate, Materials.Aluminium, 1L),
-                GTOreDictUnificator.get(OrePrefixes.dust, Materials.Plastic, 2L),
-                GTUtility.getIntegratedCircuit(1))
-            .itemOutputs(ItemList.Upgrade_Muffler.get(4L))
-            .duration(1 * MINUTES + 20 * SECONDS)
-            .eut(2)
-            .addTo(assemblerRecipes);
+                .itemInputs(
+                    GTOreDictUnificator.get(OrePrefixes.plate, Materials.Aluminium, 1L),
+                    GTOreDictUnificator.get(OrePrefixes.dust, Materials.Plastic, 2L),
+                    GTUtility.getIntegratedCircuit(1))
+                .itemOutputs(ItemList.Upgrade_Muffler.get(4L))
+                .duration(1 * MINUTES + 20 * SECONDS)
+                .eut(2)
+                .addTo(assemblerRecipes);
             GTValues.RA.stdBuilder()
                 .itemInputs(
                     GTOreDictUnificator.get(OrePrefixes.plate, Materials.Aluminium, 1L),

--- a/src/main/java/gregtech/loaders/postload/recipes/AssemblerRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/AssemblerRecipes.java
@@ -248,57 +248,12 @@ public class AssemblerRecipes implements Runnable {
             // Muffler Upgrades
             GTValues.RA.stdBuilder()
                 .itemInputs(
-                    GTOreDictUnificator.get(OrePrefixes.plate, Materials.Aluminium, 1L),
-                    GTOreDictUnificator.get(OrePrefixes.dust, Materials.Plastic, 2L),
-                    GTUtility.getIntegratedCircuit(1))
-                .itemOutputs(ItemList.Upgrade_Muffler.get(4L))
-                .duration(1 * MINUTES + 20 * SECONDS)
-                .eut(2)
-                .addTo(assemblerRecipes);
-            GTValues.RA.stdBuilder()
-                .itemInputs(
-                    GTOreDictUnificator.get(OrePrefixes.plate, Materials.Aluminium, 1L),
-                    GTOreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 2L),
-                    GTUtility.getIntegratedCircuit(1))
-                .itemOutputs(ItemList.Upgrade_Muffler.get(2L))
-                .duration(1 * MINUTES)
-                .eut(2)
-                .addTo(assemblerRecipes);
-            GTValues.RA.stdBuilder()
-                .itemInputs(
-                    GTOreDictUnificator.get(OrePrefixes.plate, Materials.Iron, 1L),
-                    GTOreDictUnificator.get(OrePrefixes.dust, Materials.Plastic, 2L),
-                    GTUtility.getIntegratedCircuit(1))
-                .itemOutputs(ItemList.Upgrade_Muffler.get(1L))
-                .duration(1 * MINUTES)
-                .eut(2)
-                .addTo(assemblerRecipes);
-            GTValues.RA.stdBuilder()
-                .itemInputs(
                     GTOreDictUnificator.get(OrePrefixes.plate, Materials.Iron, 1L),
                     GTOreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 2L),
                     GTUtility.getIntegratedCircuit(1))
                 .itemOutputs(ItemList.Upgrade_Muffler.get(1L))
-                .duration(1 * MINUTES + 20 * SECONDS)
-                .eut(2)
-                .addTo(assemblerRecipes);
-            GTValues.RA.stdBuilder()
-                .itemInputs(
-                    GTOreDictUnificator.get(OrePrefixes.plate, Materials.WroughtIron, 1L),
-                    GTOreDictUnificator.get(OrePrefixes.dust, Materials.Plastic, 2L),
-                    GTUtility.getIntegratedCircuit(1))
-                .itemOutputs(ItemList.Upgrade_Muffler.get(2L))
-                .duration(1 * MINUTES + 20 * SECONDS)
-                .eut(2)
-                .addTo(assemblerRecipes);
-            GTValues.RA.stdBuilder()
-                .itemInputs(
-                    GTOreDictUnificator.get(OrePrefixes.plate, Materials.WroughtIron, 1L),
-                    GTOreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 2L),
-                    GTUtility.getIntegratedCircuit(1))
-                .itemOutputs(ItemList.Upgrade_Muffler.get(1L))
-                .duration(1 * MINUTES)
-                .eut(2)
+                .duration(5 * SECONDS)
+                .eut(30)
                 .addTo(assemblerRecipes);
 
             GTValues.RA.stdBuilder()


### PR DESCRIPTION
~~Currently, Muffler Upgrades have 6 recipe variants which are a combination of one of 3 plates and one of 2 dusts, but they all give the same result despite some variants being more expensive. The table below shows the previous recipes and the changes made, the balancing has been done based on how hard to get each material is.~~

| Plate Material | Dust Material | Original Output | Original Duration    | New Output | New  Duration        |
| -------------- | ------------- | --------------- | -------------------- | ---------- | -------------------- |
| Aluminium      | Plastic       | 1               | 1 minute, 20 seconds | 4          | 1 minute, 20 seconds |
| Aluminium      | Wood          | 1               | 1 minute, 20 seconds | 2          | 1 minute             |
| Wrought Iron   | Plastic       | 1               | 1 minute, 20 seconds | 2          | 1 minute, 20 seconds |
| Wrought Iron   | Wood          | 1               | 1 minute, 20 seconds | 1          | 1 minute             |
| Iron           | Plastic       | 1               | 1 minute, 20 seconds | 1          | 1 minute             |
| Iron           | Wood          | 1               | 1 minute, 20 seconds | 1          | 1 minute, 20 seconds |

Edit:
Just remove all the recipes and leave the cheapest one with an updated recipe time to be faster. After all the muffler upgrade is a quality of life upgrade and the item isn't used in crafting anywhere else there is no point to have multiple recipe variants that give increasingly more.