### PR TITLE
Reduce packets sent for shutdown duration UI

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
@@ -2604,6 +2604,7 @@ public abstract class MTEMultiBlockBase extends MetaTileEntity
                 time.toMinutes() % 60,
                 time.getSeconds() % 60);
         })
+            .setSynced(false)
             .setEnabled(
                 widget -> shouldDisplayShutDownReason() && !getBaseMetaTileEntity().isActive()
                     && getBaseMetaTileEntity().wasShutdown()))


### PR DESCRIPTION
Reduces packets sent for the shutdown duration UI in multiblocks since this was double-synced.