### PR TITLE
Fix NEI preview for Implosion Compressor and Density^2

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEImplosionCompressor.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEImplosionCompressor.java
@@ -2,14 +2,22 @@ package gregtech.common.tileentities.machines.multi;
 
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofBlock;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofChain;
+import static gregtech.api.enums.HatchElement.Energy;
+import static gregtech.api.enums.HatchElement.InputBus;
+import static gregtech.api.enums.HatchElement.Maintenance;
+import static gregtech.api.enums.HatchElement.Muffler;
+import static gregtech.api.enums.HatchElement.OutputBus;
 import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_FRONT_IMPLOSION_COMPRESSOR;
 import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_FRONT_IMPLOSION_COMPRESSOR_ACTIVE;
 import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_FRONT_IMPLOSION_COMPRESSOR_ACTIVE_GLOW;
 import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_FRONT_IMPLOSION_COMPRESSOR_GLOW;
 
+import java.util.List;
+
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import com.google.common.collect.ImmutableList;
 import com.gtnewhorizon.structurelib.structure.IStructureElement;
 
 import gregtech.GTMod;
@@ -17,6 +25,7 @@ import gregtech.api.GregTechAPI;
 import gregtech.api.enums.SoundResource;
 import gregtech.api.enums.Textures;
 import gregtech.api.enums.Textures.BlockIcons;
+import gregtech.api.interfaces.IHatchElement;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
@@ -121,6 +130,11 @@ public class MTEImplosionCompressor extends MTECubicMultiBlockBase<MTEImplosionC
     @Override
     protected IStructureElement<MTECubicMultiBlockBase<?>> getCasingElement() {
         return ofChain(ofBlock(GregTechAPI.sBlockCasings2, 0), ofBlock(GregTechAPI.sBlockCasings3, 4));
+    }
+
+    @Override
+    protected List<IHatchElement<? super MTECubicMultiBlockBase<?>>> getAllowedHatches() {
+        return ImmutableList.of(InputBus, OutputBus, Maintenance, Energy, Muffler);
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/advanced/MTEAdvImplosionCompressor.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/advanced/MTEAdvImplosionCompressor.java
@@ -14,7 +14,9 @@ import static gregtech.api.util.GTStructureUtility.buildHatchAdder;
 
 import net.minecraft.item.ItemStack;
 
+import com.gtnewhorizon.structurelib.alignment.constructable.ISurvivalConstructable;
 import com.gtnewhorizon.structurelib.structure.IStructureDefinition;
+import com.gtnewhorizon.structurelib.structure.ISurvivalBuildEnvironment;
 import com.gtnewhorizon.structurelib.structure.StructureDefinition;
 
 import gregtech.api.enums.SoundResource;
@@ -30,7 +32,8 @@ import gregtech.common.pollution.PollutionConfig;
 import gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.base.GTPPMultiBlockBase;
 import gtPlusPlus.xmod.gregtech.common.blocks.textures.TexturesGtBlock;
 
-public class MTEAdvImplosionCompressor extends GTPPMultiBlockBase<MTEAdvImplosionCompressor> {
+public class MTEAdvImplosionCompressor extends GTPPMultiBlockBase<MTEAdvImplosionCompressor>
+    implements ISurvivalConstructable {
 
     private int mCasing;
     private static IStructureDefinition<MTEAdvImplosionCompressor> STRUCTURE_DEFINITION = null;
@@ -86,7 +89,7 @@ public class MTEAdvImplosionCompressor extends GTPPMultiBlockBase<MTEAdvImplosio
                     ofChain(
                         buildHatchAdder(MTEAdvImplosionCompressor.class)
                             .atLeast(InputBus, OutputBus, Maintenance, Energy, Muffler)
-                            .casingIndex(48)
+                            .casingIndex(getCasingTextureId())
                             .dot(1)
                             .build(),
                         onElementPass(x -> ++x.mCasing, ofBlock(sBlockCasings4, 0))))
@@ -98,6 +101,12 @@ public class MTEAdvImplosionCompressor extends GTPPMultiBlockBase<MTEAdvImplosio
     @Override
     public void construct(ItemStack stackSize, boolean hintsOnly) {
         buildPiece(mName, stackSize, hintsOnly, 1, 1, 0);
+    }
+
+    @Override
+    public int survivalConstruct(ItemStack stackSize, int elementBudget, ISurvivalBuildEnvironment env) {
+        if (mMachine) return -1;
+        return survivialBuildPiece(mName, stackSize, 1, 1, 0, elementBudget, env, false, true);
     }
 
     @Override


### PR DESCRIPTION
This PR contains:

* Remove input/output hatch from NEI preview for Implosion Compressor
* Show busses/hatches in the NEI preview for Density^2

![image](https://github.com/user-attachments/assets/a21dd628-355c-4fa6-a166-1a5ae35c0a1b)
![image](https://github.com/user-attachments/assets/a59f24a7-0393-4132-9fba-9bd819cced30)

Also tested constructing the Density^2 with the hologram projector in survival mode.