### PR TITLE
Add name of glass tiers to Bacterial Vat NEI page

### DIFF
--- a/src/main/java/bartworks/API/recipe/BacterialVatFrontend.java
+++ b/src/main/java/bartworks/API/recipe/BacterialVatFrontend.java
@@ -81,11 +81,13 @@ public class BacterialVatFrontend extends RecipeMapFrontend {
         public List<String> format(RecipeDisplayInfo recipeInfo) {
             int[] tSpecialA = MTEBioVat.specialValueUnpack(recipeInfo.recipe.mSpecialValue);
             String glassTier = StatCollector.translateToLocalFormatted("nei.biovat.0.name", GTValues.VN[tSpecialA[0]]);
-            String sievert;
-            if (tSpecialA[2] == 1) {
-                sievert = StatCollector.translateToLocalFormatted("nei.biovat.1.name", tSpecialA[3]);
-            } else {
-                sievert = StatCollector.translateToLocalFormatted("nei.biovat.2.name", tSpecialA[3]);
+            String sievert = "";
+            if (!(tSpecialA[3] == 0)) {
+                if (tSpecialA[2] == 1) {
+                    sievert = StatCollector.translateToLocalFormatted("nei.biovat.1.name", tSpecialA[3]);
+                } else {
+                    sievert = StatCollector.translateToLocalFormatted("nei.biovat.2.name", tSpecialA[3]);
+                }
             }
             return Arrays.asList(glassTier, sievert);
         }

--- a/src/main/java/bartworks/API/recipe/BacterialVatFrontend.java
+++ b/src/main/java/bartworks/API/recipe/BacterialVatFrontend.java
@@ -11,6 +11,7 @@ import net.minecraft.util.StatCollector;
 import com.gtnewhorizons.modularui.api.math.Alignment;
 
 import bartworks.common.tileentities.multis.MTEBioVat;
+import gregtech.api.enums.GTValues;
 import gregtech.api.recipe.BasicUIPropertiesBuilder;
 import gregtech.api.recipe.NEIRecipePropertiesBuilder;
 import gregtech.api.recipe.RecipeMapFrontend;
@@ -79,7 +80,7 @@ public class BacterialVatFrontend extends RecipeMapFrontend {
         @Override
         public List<String> format(RecipeDisplayInfo recipeInfo) {
             int[] tSpecialA = MTEBioVat.specialValueUnpack(recipeInfo.recipe.mSpecialValue);
-            String glassTier = StatCollector.translateToLocalFormatted("nei.biovat.0.name", tSpecialA[0]);
+            String glassTier = StatCollector.translateToLocalFormatted("nei.biovat.0.name", GTValues.VN[tSpecialA[0]]);
             String sievert;
             if (tSpecialA[2] == 1) {
                 sievert = StatCollector.translateToLocalFormatted("nei.biovat.1.name", tSpecialA[3]);

--- a/src/main/java/bartworks/common/loaders/BioRecipeLoader.java
+++ b/src/main/java/bartworks/common/loaders/BioRecipeLoader.java
@@ -15,10 +15,12 @@ package bartworks.common.loaders;
 
 import static bartworks.API.recipe.BartWorksRecipeMaps.bacterialVatRecipes;
 import static bartworks.API.recipe.BartWorksRecipeMaps.bioLabRecipes;
+import static bartworks.util.BWRecipes.computeSieverts;
 import static gregtech.api.enums.Mods.CropsPlusPlus;
 import static gregtech.api.util.GTRecipeBuilder.MINUTES;
 import static gregtech.api.util.GTRecipeBuilder.SECONDS;
 import static gregtech.api.util.GTRecipeBuilder.TICKS;
+import static gregtech.api.util.GTRecipeConstants.SIEVERTS;
 
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
@@ -130,6 +132,7 @@ public class BioRecipeLoader {
                     .special(BioItemList.getPetriDish(BioCultureLoader.CommonYeast))
                     .fluidInputs(new FluidStack(fluidStack, 100))
                     .fluidOutputs(FluidRegistry.getFluidStack("potion.ghp", 1))
+                    .metadata(SIEVERTS, computeSieverts(0, 3, false, false, false))
                     .duration(17 * SECONDS + 10 * TICKS)
                     .eut(TierEU.RECIPE_EV)
                     .noOptimize()
@@ -141,6 +144,7 @@ public class BioRecipeLoader {
                 .special(BioItemList.getPetriDish(BioCultureLoader.WhineYeast))
                 .fluidInputs(new FluidStack(fluidStack, 100))
                 .fluidOutputs(FluidRegistry.getFluidStack("potion.wine", 12))
+                .metadata(SIEVERTS, computeSieverts(0, 3, false, false, false))
                 .duration(10 * SECONDS)
                 .eut(TierEU.RECIPE_MV)
                 .noOptimize()
@@ -154,6 +158,7 @@ public class BioRecipeLoader {
                 .special(BioItemList.getPetriDish(BioCultureLoader.BeerYeast))
                 .fluidInputs(new FluidStack(fluidStack, 100))
                 .fluidOutputs(FluidRegistry.getFluidStack("potion.beer", 5))
+                .metadata(SIEVERTS, computeSieverts(0, 3, false, false, false))
                 .duration(30 * SECONDS)
                 .eut(TierEU.RECIPE_LV)
                 .noOptimize()
@@ -164,6 +169,7 @@ public class BioRecipeLoader {
                 .special(BioItemList.getPetriDish(BioCultureLoader.BeerYeast))
                 .fluidInputs(new FluidStack(fluidStack, 100))
                 .fluidOutputs(FluidRegistry.getFluidStack("potion.darkbeer", 10))
+                .metadata(SIEVERTS, computeSieverts(0, 3, false, false, false))
                 .duration(30 * SECONDS)
                 .eut(TierEU.RECIPE_LV)
                 .noOptimize()
@@ -178,6 +184,7 @@ public class BioRecipeLoader {
             .special(BioItemList.getPetriDish(BioCultureLoader.WhineYeast))
             .fluidInputs(FluidRegistry.getFluidStack("potion.grapejuice", 100))
             .fluidOutputs(FluidRegistry.getFluidStack("potion.wine", 12))
+            .metadata(SIEVERTS, computeSieverts(0, 3, false, false, false))
             .duration(20 * SECONDS)
             .eut(TierEU.RECIPE_LV)
             .noOptimize()
@@ -187,6 +194,7 @@ public class BioRecipeLoader {
             .special(BioItemList.getPetriDish(BioCultureLoader.anaerobicOil))
             .fluidInputs(Materials.FermentedBiomass.getFluid(10000))
             .fluidOutputs(new FluidStack(FluidLoader.fulvicAcid, 1000))
+            .metadata(SIEVERTS, computeSieverts(0, 3, false, false, false))
             .duration(2 * MINUTES + 17 * SECONDS + 8 * TICKS)
             .eut(TierEU.RECIPE_LV)
             .noOptimize()

--- a/src/main/java/bartworks/system/material/processingLoaders/AdditionalRecipes.java
+++ b/src/main/java/bartworks/system/material/processingLoaders/AdditionalRecipes.java
@@ -15,6 +15,7 @@ package bartworks.system.material.processingLoaders;
 
 import static bartworks.API.recipe.BartWorksRecipeMaps.bacterialVatRecipes;
 import static bartworks.API.recipe.BartWorksRecipeMaps.bioLabRecipes;
+import static bartworks.util.BWRecipes.computeSieverts;
 import static gregtech.api.enums.Mods.Gendustry;
 import static gregtech.api.enums.OrePrefixes.bolt;
 import static gregtech.api.enums.OrePrefixes.crushed;
@@ -48,6 +49,7 @@ import static gregtech.api.util.GTRecipeConstants.ADDITIVE_AMOUNT;
 import static gregtech.api.util.GTRecipeConstants.COIL_HEAT;
 import static gregtech.api.util.GTRecipeConstants.FUEL_VALUE;
 import static gregtech.api.util.GTRecipeConstants.FUSION_THRESHOLD;
+import static gregtech.api.util.GTRecipeConstants.SIEVERTS;
 import static gregtech.api.util.GTRecipeConstants.UniversalChemical;
 
 import java.util.Arrays;
@@ -224,6 +226,7 @@ public class AdditionalRecipes {
                         .special(BioItemList.getPetriDish(bioCulture))
                         .fluidInputs(fluidStack)
                         .fluidOutputs(new FluidStack(bioCulture.getFluid(), 10))
+                        .metadata(SIEVERTS, computeSieverts(0, 3, false, false, false))
                         .duration(50 * SECONDS)
                         .eut(TierEU.RECIPE_MV)
                         .addTo(bacterialVatRecipes);

--- a/src/main/java/gregtech/api/recipe/RecipeMaps.java
+++ b/src/main/java/gregtech/api/recipe/RecipeMaps.java
@@ -1,5 +1,6 @@
 package gregtech.api.recipe;
 
+import static bartworks.util.BWRecipes.computeSieverts;
 import static gregtech.api.enums.Mods.Avaritia;
 import static gregtech.api.enums.Mods.GTNHIntergalactic;
 import static gregtech.api.enums.Mods.NEICustomDiagrams;
@@ -1238,7 +1239,8 @@ public final class RecipeMaps {
                 b -> BartWorksRecipeMaps.bacterialVatRecipes.doAdd(
                     b.copy()
                         .special(BioItemList.getPetriDish(BioCultureLoader.generalPurposeFermentingBacteria))
-                        .metadata(SIEVERTS, (int) GTUtility.getTier(b.getEUt())))));
+                        .metadata(SIEVERTS, computeSieverts(0, 3, false, false, false))
+                        .eut(b.getEUt()))));
         RecipeMaps.implosionRecipes.addDownstream(
             IRecipeMap.newRecipeMap(
                 b -> BartWorksRecipeMaps.electricImplosionCompressorRecipes.doAdd(


### PR DESCRIPTION
closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17345

Replaces Glass tier: 8 to proper voltage names, just like how glasses show tier names in their tooltip
![image](https://github.com/user-attachments/assets/3fb5ef3b-a1fd-4996-a7fd-110cb41e987a)
![image](https://github.com/user-attachments/assets/2c0c5dcb-70af-4e19-ab5e-1db12f4eb7c4)
![image](https://github.com/user-attachments/assets/73e4044f-1771-4304-8cf2-90c9291bef97)

Also adds glass tiers to most of the recipes so it doesn't display "Glass tier: ULV" since glasses starts at HV tier