### PR TITLE
Fix SOFC Mk2 fuel efficiency

### DIFF
--- a/src/main/java/kekztech/common/tileentities/MTESOFuelCellMK2.java
+++ b/src/main/java/kekztech/common/tileentities/MTESOFuelCellMK2.java
@@ -97,7 +97,7 @@ public class MTESOFuelCellMK2 extends MTEEnhancedMultiBlockBase<MTESOFuelCellMK2
                     + "EU worth of fuel with up to 100% efficiency each second")
             .addInfo("Nitrobenzene and other gas fuels above 1M EU/bucket are more efficient")
             .addInfo("Steam production requires the SOFC to heat up completely first")
-            .addInfo("Outputs " + EU_PER_TICK + "EU/t and " + STEAM_PER_SEC + "L/s Steam")
+            .addInfo("Outputs " + EU_PER_TICK + "EU/t and " + STEAM_PER_SEC + "L/s Superheated Steam")
             .addInfo("Additionally, requires " + OXYGEN_PER_SEC + "L/s Oxygen gas")
             .beginStructureBlock(3, 3, 5, false)
             .addController("Front center")
@@ -158,7 +158,8 @@ public class MTESOFuelCellMK2 extends MTEEnhancedMultiBlockBase<MTESOFuelCellMK2
                 if ((liquid = GTUtility.getFluidForFilledItem(aFuel.getRepresentativeInput(0), true)) != null
                     && hatchFluid.isFluidEqual(liquid)) {
 
-                    liquid.amount = (EU_PER_TICK * 20) / aFuel.mSpecialValue / Math.max(1, aFuel.mSpecialValue / 1000);
+                    liquid.amount = (int) ((EU_PER_TICK * 20)
+                        / (aFuel.mSpecialValue * Math.max(1, (float) aFuel.mSpecialValue / 1000)));
 
                     if (super.depleteInput(liquid)) {
 
@@ -170,7 +171,7 @@ public class MTESOFuelCellMK2 extends MTEEnhancedMultiBlockBase<MTESOFuelCellMK2
 
                         super.mEUt = EU_PER_TICK;
                         super.mMaxProgresstime = 20;
-                        super.mEfficiencyIncrease = 80;
+                        super.mEfficiencyIncrease = 200;
                         if (super.mEfficiency == getMaxEfficiency(null)) {
                             super.addOutput(FluidRegistry.getFluidStack("ic2superheatedsteam", STEAM_PER_SEC));
                         }


### PR DESCRIPTION
SOFC Mk2 supposed to have extra fuel efficiency for fuels beyond 1M eu/bucket but due to int casting, it never happened.
Also fixed tooltip to say superheated steam, and decreased warmup period to be the same as LGT (50 seconds long)
![image](https://github.com/user-attachments/assets/6777de21-a301-4ccf-9df2-9ff10ed8cc40)
