### PR TITLE
Fix maintenance hatch right-click behavior from the wrong side.

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEHatchMaintenance.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEHatchMaintenance.java
@@ -176,8 +176,8 @@ public class MTEHatchMaintenance extends MTEHatch implements IAddUIWidgets, IAli
     @Override
     public boolean onRightclick(IGregTechTileEntity aBaseMetaTileEntity, EntityPlayer aPlayer, ForgeDirection side,
         float aX, float aY, float aZ) {
-        if (aBaseMetaTileEntity.isClientSide()) return true;
         if (side == aBaseMetaTileEntity.getFrontFacing()) {
+            if (aBaseMetaTileEntity.isClientSide()) return true;
             // only allow OC robot fake player
             if (aPlayer instanceof FakePlayer && !aPlayer.getGameProfile()
                 .getName()


### PR DESCRIPTION
Previously, the maintenance hatch `onRightClick` event would always return `true` on the client, regardless of which face of the hatch was clicked. This would consume the event, and not allow other client-side actions (for example, opening backpack-like UIs) to take place.

Now this check returns `true` only if the front face is clicked, otherwise it returns `false` and allows for other client-side interaction. This is consistent with server-side behavior.

Issue reported by @bldhf on discord [here](https://discord.com/channels/181078474394566657/181078474394566657/1309394517258014781). The problem here was that if the player is using a toolbox to fix maintenance issues, but accidentally clicks the wrong side of the hatch, the toolbox's "swing" animation still plays, although maintenance is not performed. Thus the player has no feedback about whether the action was successful.

With this fix, right-clicking the wrong side of the hatch opens the toolbox UI instead.