### PR TITLE
Fix multiblocks displaying output x 0

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
@@ -2507,12 +2507,12 @@ public abstract class MTEMultiBlockBase extends MetaTileEntity
         };
 
         int lines = 0;
-        int MAX_LINES = 5;
+        int MAX_LINES = 10;
 
         if (mOutputItems != null) {
             HashMap<String, Long> nameToAmount = new HashMap<>();
             for (var item : mOutputItems) {
-                if (item == null) continue;
+                if (item == null || item.stackSize <= 0) continue;
                 nameToAmount.merge(item.getDisplayName(), (long) item.stackSize, Long::sum);
             }
             for (Map.Entry<String, Long> entry : nameToAmount.entrySet()) {
@@ -2535,7 +2535,7 @@ public abstract class MTEMultiBlockBase extends MetaTileEntity
         if (mOutputFluids != null) {
             HashMap<String, Long> nameToAmount = new HashMap<>();
             for (var fluid : mOutputFluids) {
-                if (fluid == null) continue;
+                if (fluid == null || fluid.amount <= 0) continue;
                 nameToAmount.merge(fluid.getLocalizedName(), (long) fluid.amount, Long::sum);
             }
             for (Map.Entry<String, Long> entry : nameToAmount.entrySet()) {


### PR DESCRIPTION
Fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17889
This pr also extends max output lines from 5 to 10 since the ui is scrollable now