### PR TITLE
Readd fluid inputs for HG-1223 in ABS

### DIFF
--- a/src/main/java/gtPlusPlus/core/recipe/RecipesGregTech.java
+++ b/src/main/java/gtPlusPlus/core/recipe/RecipesGregTech.java
@@ -718,6 +718,7 @@ public class RecipesGregTech {
                 MaterialsElements.getInstance().BARIUM.getDust(2),
                 MaterialsElements.getInstance().CALCIUM.getDust(2),
                 MaterialsElements.getInstance().COPPER.getDust(3))
+            .fluidInputs(Materials.Oxygen.getGas(8000), Materials.Mercury.getFluid(1000))
             .fluidOutputs(MaterialsAlloy.HG1223.getFluidStack(16 * 144))
             .eut(TierEU.RECIPE_LuV)
             .duration(2 * MINUTES)


### PR DESCRIPTION
This re-adds the oxygen and mercury fluid inputs to the HG-1223 recipe.
The removal was probably an oversight in [this commit](https://github.com/GTNewHorizons/GT5-Unofficial/commit/a8b46c11f5a02608101ef33ed39f103736ba5920#diff-6de3d07b73df9a6c67b322fd03663ef25a500726ef47163491b442d5337e11beL697) 4 months ago.

![image](https://github.com/user-attachments/assets/2557c15f-9edf-4450-8548-f88276bda0f6)
