### PR TITLE
Prevent LHE from consuming cold coolant

### DIFF
--- a/src/main/java/gregtech/api/registries/LHECoolantRegistry.java
+++ b/src/main/java/gregtech/api/registries/LHECoolantRegistry.java
@@ -30,7 +30,6 @@ public class LHECoolantRegistry {
         double superheatedThreshold) {
         var coolant = new LHECoolantInfo(coldFluidName, hotFluidName, steamMultiplier, superheatedThreshold);
 
-        lheCoolants.put(coldFluidName, coolant);
         lheCoolants.put(hotFluidName, coolant);
     }
 


### PR DESCRIPTION
This isn't used anywhere other than the LHE so removing the cold coolant from the map doesn't change anything. This stops the LHE from treating cold coolant as hot coolant.