### PR TITLE
Bring Item Holders' descriptions in line with other covers.

### DIFF
--- a/src/main/java/gregtech/common/items/MetaGeneratedItem01.java
+++ b/src/main/java/gregtech/common/items/MetaGeneratedItem01.java
@@ -2933,19 +2933,19 @@ public class MetaGeneratedItem01 extends MetaGeneratedItemX32 {
             addItem(
                 Cover_Chest_Basic.ID,
                 "Basic Item Holder",
-                "Hold a few item for use within machine GUI",
+                "Holds 9 item for use within machine GUI (as Cover)",
                 new TCAspects.TC_AspectStack(TCAspects.VACUOS, 2L)));
         ItemList.Cover_Chest_Good.set(
             addItem(
                 Cover_Chest_Good.ID,
                 "Good Item Holder",
-                "Hold a few item for use within machine GUI",
+                "Hold 12 item for use within machine GUI (as Cover)",
                 new TCAspects.TC_AspectStack(TCAspects.VACUOS, 2L)));
         ItemList.Cover_Chest_Advanced.set(
             addItem(
                 Cover_Chest_Advanced.ID,
                 "Advanced Item Holder",
-                "Hold a few item for use within machine GUI",
+                "Hold 15 item for use within machine GUI (as Cover)",
                 new TCAspects.TC_AspectStack(TCAspects.VACUOS, 2L)));
 
         ItemList.Cover_Screen.set(

--- a/src/main/java/gregtech/common/items/MetaGeneratedItem01.java
+++ b/src/main/java/gregtech/common/items/MetaGeneratedItem01.java
@@ -2939,13 +2939,13 @@ public class MetaGeneratedItem01 extends MetaGeneratedItemX32 {
             addItem(
                 Cover_Chest_Good.ID,
                 "Good Item Holder",
-                "Hold 12 item for use within machine GUI (as Cover)",
+                "Holds 12 item for use within machine GUI (as Cover)",
                 new TCAspects.TC_AspectStack(TCAspects.VACUOS, 2L)));
         ItemList.Cover_Chest_Advanced.set(
             addItem(
                 Cover_Chest_Advanced.ID,
                 "Advanced Item Holder",
-                "Hold 15 item for use within machine GUI (as Cover)",
+                "Holds 15 item for use within machine GUI (as Cover)",
                 new TCAspects.TC_AspectStack(TCAspects.VACUOS, 2L)));
 
         ItemList.Cover_Screen.set(


### PR DESCRIPTION
Adds "(as Covers)" and specifies the exact amount of storage slots you get from each tier (every other cover has the exact functionality values on them)
QoL to the new 2.7 feature, so hopefully this simple PR won't cause more bugs :clueless:
Tested on nightly 753
![image](https://github.com/user-attachments/assets/861621e0-5032-4829-ab4d-8d2f2152b8d0)
