### PR TITLE
Fix UCFE Scanner Info

### DIFF
--- a/src/main/java/goodgenerator/blocks/tileEntity/MTEUniversalChemicalFuelEngine.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/MTEUniversalChemicalFuelEngine.java
@@ -276,7 +276,7 @@ public class MTEUniversalChemicalFuelEngine extends MTETooltipMultiBlockBaseEM
     public String[] getInfoData() {
         String[] info = super.getInfoData();
         info[4] = "Currently generates: " + EnumChatFormatting.RED
-            + GTUtility.formatNumbers(this.getPowerFlow())
+            + GTUtility.formatNumbers(this.getPowerFlow() * tEff)
             + EnumChatFormatting.RESET
             + " EU/t";
         info[6] = "Problems: " + EnumChatFormatting.RED


### PR DESCRIPTION
The scanner info didn't take efficiency into account, now it matches the behavior of how energy is added to the dynamo.