### PR TITLE
Fix Laser Engraver NEI recipes

### DIFF
--- a/src/main/java/gregtech/api/recipe/RecipeMaps.java
+++ b/src/main/java/gregtech/api/recipe/RecipeMaps.java
@@ -319,10 +319,15 @@ public final class RecipeMaps {
             (index, isFluid, isOutput,
                 isSpecial) -> !isFluid && !isOutput && index != 0 ? GTUITextures.OVERLAY_SLOT_LENS : null)
         // Add a simple ordering so lower tier purified water is displayed first, otherwise it gets really confusing
+        // NEI Catalyst search requires recipes to be sorted by voltage tier. Therefore, we first sort by voltage tier,
+        // then by water tier, then the default comparator.
         .neiRecipeComparator(
-            (a, b) -> Comparator.comparing(PurifiedWaterHelpers::getWaterTierFromRecipe)
-                .thenComparing(GTRecipe::compareTo)
-                .compare(a, b))
+            (a, b) ->
+                Comparator.<GTRecipe, Integer>comparing(recipe -> recipe.mEUt)
+                    .thenComparing(
+                        Comparator.comparing(PurifiedWaterHelpers::getWaterTierFromRecipe)
+                        .thenComparing(GTRecipe::compareTo))
+                    .compare(a, b))
         .build();
     public static final RecipeMap<RecipeMapBackend> mixerRecipes = RecipeMapBuilder.of("gt.recipe.mixer")
         .maxIO(9, 4, 1, 1)


### PR DESCRIPTION
Fixes GTNewHorizons/Gt-New-Horizons-Modpack#18150

Bug was caused by NEI recipe order not sorted by tiers. The catalyst comparer finds the lowest and highest recipe for each tier when filtering assuming the recipe list is sorted by tier. 

Since this recipe list was not sorted by voltage tier, but by water tier, nearly all recipes were filtered out.

To rectify, I first sort by voltage tier, then water tier, then the default comparator. Tested locally.