### PR TITLE
fix many broken and incorrect recycling recipes and fixes several infinite material loops

### DIFF
--- a/src/main/java/bartworks/system/material/WerkstoffLoader.java
+++ b/src/main/java/bartworks/system/material/WerkstoffLoader.java
@@ -127,7 +127,6 @@ import cpw.mods.fml.common.ProgressManager;
 import cpw.mods.fml.common.registry.GameRegistry;
 import gregtech.api.enums.Element;
 import gregtech.api.enums.FluidState;
-import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.enums.SubTag;
@@ -1986,28 +1985,6 @@ public class WerkstoffLoader {
             }
         }
         addFakeItemDataToInWorldBlocksAndCleanUpFakeData();
-        addVanillaCasingsToGTOreDictUnificator();
-    }
-
-    public static void addVanillaCasingsToGTOreDictUnificator() {
-        GTOreDictUnificator
-            .addAssociation(OrePrefixes.blockCasing, Materials.Aluminium, ItemList.Casing_FrostProof.get(1L), false);
-        GTOreDictUnificator
-            .addAssociation(OrePrefixes.blockCasing, Materials.Nickel, ItemList.Casing_HeatProof.get(1L), false);
-        GTOreDictUnificator
-            .addAssociation(OrePrefixes.blockCasing, Materials.Lead, ItemList.Casing_RadiationProof.get(1L), false);
-        GTOreDictUnificator
-            .addAssociation(OrePrefixes.blockCasing, Materials.Steel, ItemList.Casing_SolidSteel.get(1L), false);
-        GTOreDictUnificator.addAssociation(
-            OrePrefixes.blockCasing,
-            Materials.TungstenSteel,
-            ItemList.Casing_RobustTungstenSteel.get(1L),
-            false);
-        GTOreDictUnificator.addAssociation(
-            OrePrefixes.blockCasing,
-            Materials.Polytetrafluoroethylene,
-            ItemList.Casing_Chemically_Inert.get(1L),
-            false);
     }
 
     /**


### PR DESCRIPTION
- readds broken recycling recipe for frost proof machine casing
- readds broken recycling recipe for heat proof machine casing
- readds broken recycling recipe for robust tungstensteel casing
- readds broken recycling recipe for solid steel machine casing
- fixes recycling recipe for extreme engine casing (fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18173)
- fixes recycling recipe for turbodyne casing
- fixes recycling recipe for EBF controller
- fixes recycling recipe for multismelter
- fixes recycling recipe for forge casing
- fixes recycling recipes for 10 different yellow stripes and hazard blocks
- fixes recycling recipe for implosion compressor
- fixes recycling recipe for steam turbine housing
- fixes recycling recipe for electric locomotive

all the by removing some very questionable BW code.