### PR TITLE
Fix water overwriting other fluids in laser engraver

### DIFF
--- a/src/main/java/gregtech/api/util/GTRecipeConstants.java
+++ b/src/main/java/gregtech/api/util/GTRecipeConstants.java
@@ -14,6 +14,8 @@ import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
+import org.apache.commons.lang3.ArrayUtils;
+
 import cpw.mods.fml.common.registry.GameRegistry;
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.Materials;
@@ -342,16 +344,18 @@ public class GTRecipeConstants {
                 return GTUtility.concat(
                     builder.copy()
                         .itemInputs(itemInputs)
-                        .fluidInputs(GTModHandler.getDistilledWater(100L))
+                        .fluidInputs(ArrayUtils.addAll(builder.fluidInputs, GTModHandler.getDistilledWater(100L)))
                         .addTo(RecipeMaps.laserEngraverRecipes),
                     builder.copy()
                         .itemInputs(itemInputs)
-                        .fluidInputs(Materials.Grade1PurifiedWater.getFluid(100L))
+                        .fluidInputs(
+                            ArrayUtils.addAll(builder.fluidInputs, Materials.Grade1PurifiedWater.getFluid(100L)))
                         .duration(halfBoostedRecipeTime)
                         .addTo(RecipeMaps.laserEngraverRecipes),
                     builder.copy()
                         .itemInputs(itemInputs)
-                        .fluidInputs(Materials.Grade2PurifiedWater.getFluid(100L))
+                        .fluidInputs(
+                            ArrayUtils.addAll(builder.fluidInputs, Materials.Grade2PurifiedWater.getFluid(100L)))
                         .duration(boostedRecipeTime)
                         .addTo(RecipeMaps.laserEngraverRecipes));
             }
@@ -359,11 +363,13 @@ public class GTRecipeConstants {
                 // Require purified water for europium wafers, at least grade 3
                 return GTUtility.concat(
                     builder.copy()
-                        .fluidInputs(Materials.Grade3PurifiedWater.getFluid(100L))
+                        .fluidInputs(
+                            ArrayUtils.addAll(builder.fluidInputs, Materials.Grade3PurifiedWater.getFluid(100L)))
                         .duration(recipeTime)
                         .addTo(RecipeMaps.laserEngraverRecipes),
                     builder.copy()
-                        .fluidInputs(Materials.Grade4PurifiedWater.getFluid(100L))
+                        .fluidInputs(
+                            ArrayUtils.addAll(builder.fluidInputs, Materials.Grade4PurifiedWater.getFluid(100L)))
                         .duration(boostedRecipeTime)
                         .addTo(RecipeMaps.laserEngraverRecipes));
             }
@@ -371,11 +377,13 @@ public class GTRecipeConstants {
                 // Require purified water for americium wafers, at least grade 5
                 return GTUtility.concat(
                     builder.copy()
-                        .fluidInputs(Materials.Grade5PurifiedWater.getFluid(100L))
+                        .fluidInputs(
+                            ArrayUtils.addAll(builder.fluidInputs, Materials.Grade5PurifiedWater.getFluid(100L)))
                         .duration(recipeTime)
                         .addTo(RecipeMaps.laserEngraverRecipes),
                     builder.copy()
-                        .fluidInputs(Materials.Grade6PurifiedWater.getFluid(100L))
+                        .fluidInputs(
+                            ArrayUtils.addAll(builder.fluidInputs, Materials.Grade6PurifiedWater.getFluid(100L)))
                         .duration(boostedRecipeTime)
                         .addTo(RecipeMaps.laserEngraverRecipes));
             }
@@ -384,15 +392,18 @@ public class GTRecipeConstants {
                 // T1 masks require grade 1, 2 or 3 purified water
                 return GTUtility.concat(
                     builder.copy()
-                        .fluidInputs(Materials.Grade1PurifiedWater.getFluid(32000L))
+                        .fluidInputs(
+                            ArrayUtils.addAll(builder.fluidInputs, Materials.Grade1PurifiedWater.getFluid(32000L)))
                         .duration(recipeTime)
                         .addTo(RecipeMaps.laserEngraverRecipes),
                     builder.copy()
-                        .fluidInputs(Materials.Grade2PurifiedWater.getFluid(32000L))
+                        .fluidInputs(
+                            ArrayUtils.addAll(builder.fluidInputs, Materials.Grade2PurifiedWater.getFluid(32000L)))
                         .duration(halfBoostedRecipeTime)
                         .addTo(RecipeMaps.laserEngraverRecipes),
                     builder.copy()
-                        .fluidInputs(Materials.Grade3PurifiedWater.getFluid(32000L))
+                        .fluidInputs(
+                            ArrayUtils.addAll(builder.fluidInputs, Materials.Grade3PurifiedWater.getFluid(32000L)))
                         .duration(boostedRecipeTime)
                         .addTo(RecipeMaps.laserEngraverRecipes));
             }
@@ -400,11 +411,13 @@ public class GTRecipeConstants {
                 // T2 masks require grade 4 or 5 purified water
                 return GTUtility.concat(
                     builder.copy()
-                        .fluidInputs(Materials.Grade4PurifiedWater.getFluid(32000L))
+                        .fluidInputs(
+                            ArrayUtils.addAll(builder.fluidInputs, Materials.Grade4PurifiedWater.getFluid(32000L)))
                         .duration(recipeTime)
                         .addTo(RecipeMaps.laserEngraverRecipes),
                     builder.copy()
-                        .fluidInputs(Materials.Grade5PurifiedWater.getFluid(32000L))
+                        .fluidInputs(
+                            ArrayUtils.addAll(builder.fluidInputs, Materials.Grade5PurifiedWater.getFluid(32000L)))
                         .duration(boostedRecipeTime)
                         .addTo(RecipeMaps.laserEngraverRecipes));
             }
@@ -412,15 +425,18 @@ public class GTRecipeConstants {
                 // T3 masks require grade 6, 7 or 8 purified water
                 return GTUtility.concat(
                     builder.copy()
-                        .fluidInputs(Materials.Grade6PurifiedWater.getFluid(32000L))
+                        .fluidInputs(
+                            ArrayUtils.addAll(builder.fluidInputs, Materials.Grade6PurifiedWater.getFluid(32000L)))
                         .duration(recipeTime)
                         .addTo(RecipeMaps.laserEngraverRecipes),
                     builder.copy()
-                        .fluidInputs(Materials.Grade7PurifiedWater.getFluid(32000L))
+                        .fluidInputs(
+                            ArrayUtils.addAll(builder.fluidInputs, Materials.Grade7PurifiedWater.getFluid(32000L)))
                         .duration(halfBoostedRecipeTime)
                         .addTo(RecipeMaps.laserEngraverRecipes),
                     builder.copy()
-                        .fluidInputs(Materials.Grade8PurifiedWater.getFluid(32000L))
+                        .fluidInputs(
+                            ArrayUtils.addAll(builder.fluidInputs, Materials.Grade8PurifiedWater.getFluid(32000L)))
                         .duration(boostedRecipeTime)
                         .addTo(RecipeMaps.laserEngraverRecipes));
             }


### PR DESCRIPTION
Distilled and Graded water were overwriting any other fluids, this is an issue since it doesn't allow other fluids

This PR is required for my next one, which will be fixing a pretty big progression skip