### PR TITLE
Fix Living Crystal Chip progression skip using Beamline

### DIFF
--- a/src/main/java/gtnhlanth/loader/RecipeLoader.java
+++ b/src/main/java/gtnhlanth/loader/RecipeLoader.java
@@ -816,17 +816,33 @@ public class RecipeLoader {
 
                 for (ItemStack lens : OreDictionary.getOres("craftingLens" + lensColour.mName.replace(" ", ""))) {
 
-                    if (lens == null) continue;
+                    if (mask == MaskList.LCC) {
 
-                    GTValues.RA.stdBuilder()
-                        .itemInputs(
-                            new ItemStack(LanthItemList.maskMap.get(maskIngredient)),
-                            GTUtility.copyAmount(0, lens))
-                        .itemOutputs(new ItemStack(LanthItemList.maskMap.get(mask)))
-                        .requiresCleanRoom()
-                        .duration(120 * SECONDS)
-                        .eut(mask.getEngraverEUt())
-                        .addTo(WaferEngravingRecipes);
+                        GTValues.RA.stdBuilder()
+                            .itemInputs(
+                                new ItemStack(LanthItemList.maskMap.get(maskIngredient)),
+                                GTUtility.copyAmount(0, lens))
+                            .fluidInputs(
+                                // damage * 4 (chips per recipe) * 50 (L per chip normally) * 3 / 4 (75% of the cost)
+                                Materials.BioMediumSterilized.getFluid((mask.getDamage() + 1) * 4L * 50 * 3 / 4))
+                            .itemOutputs(new ItemStack(LanthItemList.maskMap.get(mask)))
+                            .requiresCleanRoom()
+                            .duration(120 * SECONDS)
+                            .eut(mask.getEngraverEUt())
+                            .addTo(WaferEngravingRecipes);
+
+                    } else {
+
+                        GTValues.RA.stdBuilder()
+                            .itemInputs(
+                                new ItemStack(LanthItemList.maskMap.get(maskIngredient)),
+                                GTUtility.copyAmount(0, lens))
+                            .itemOutputs(new ItemStack(LanthItemList.maskMap.get(mask)))
+                            .requiresCleanRoom()
+                            .duration(120 * SECONDS)
+                            .eut(mask.getEngraverEUt())
+                            .addTo(WaferEngravingRecipes);
+                    }
 
                 }
             }

--- a/src/main/java/gtnhlanth/loader/RecipeLoader.java
+++ b/src/main/java/gtnhlanth/loader/RecipeLoader.java
@@ -816,6 +816,7 @@ public class RecipeLoader {
 
                 for (ItemStack lens : OreDictionary.getOres("craftingLens" + lensColour.mName.replace(" ", ""))) {
 
+                    if (lens == null) continue;
                     if (mask == MaskList.LCC) {
 
                         GTValues.RA.stdBuilder()


### PR DESCRIPTION
The Living Crystal Circuit did not require bio catalyst, this is an oversight

Not only does this have implications for balance (It's generally too expensive to do LCC before QFT, removing the Bio Catalyst cost entirely makes Wetware SoCs way too cheap)
It also allows you to make the SoCs before you're supposed to, which is... generally not good when it comes to circuits

This PR makes the Living Crystal Chip mask require 11250L of Sterilized Bio Catalyst Medium, which is 3/4th of the required Bio Catalyst as you would need if you were making them with the original recipe
The actual required amount of BioCat will automatically change if the durability of the mask is changed
_These numbers were suggested by @serenibyss_

Before: 
![image](https://github.com/user-attachments/assets/f989d780-910c-43fd-86fe-e2b13aa663c0)
After: 
![image](https://github.com/user-attachments/assets/db4f5a70-d783-4025-8bea-4b8921e1ea13)



