### PR TITLE
Minor Godforge fixes

### DIFF
--- a/src/main/java/tectech/thing/metaTileEntity/multi/godforge/MTEForgeOfGods.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/godforge/MTEForgeOfGods.java
@@ -2973,9 +2973,11 @@ public class MTEForgeOfGods extends TTMultiblockBase implements IConstructable, 
             while (gravitonShardsAvailable >= 64) {
                 addOutput(GTOreDictUnificator.get(OrePrefixes.gem, MaterialsUEVplus.GravitonShard, 64));
                 gravitonShardsAvailable -= 64;
+                gravitonShardsSpent += 64;
             }
             addOutput(
                 GTOreDictUnificator.get(OrePrefixes.gem, MaterialsUEVplus.GravitonShard, gravitonShardsAvailable));
+            gravitonShardsSpent += gravitonShardsAvailable;
             gravitonShardsAvailable = 0;
         }
     }

--- a/src/main/java/tectech/thing/metaTileEntity/multi/godforge/util/ForgeOfGodsUI.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/godforge/util/ForgeOfGodsUI.java
@@ -304,7 +304,7 @@ public class ForgeOfGodsUI {
                     .setPos(7, 140)
                     .setSize(150, 15))
             .widget(
-                TextWidget.dynamicText(() -> inversionInfoText(inversionGetter.get()))
+                TextWidget.dynamicText(() -> inversionHeaderText(inversionGetter.get()))
                     .setDefaultColor(EnumChatFormatting.WHITE)
                     .setTextAlignment(Alignment.CenterLeft)
                     .setPos(7, 155)


### PR DESCRIPTION
Fixes the inversion header in the info window containing the wrong text and fixes graviton shard ejection dispensing infinite shards for free 