### PR TITLE
Fix ME Output Hatch void protection checks

### DIFF
--- a/src/functionalTest/java/gregtech/test/mock/MockIVoidableMachine.java
+++ b/src/functionalTest/java/gregtech/test/mock/MockIVoidableMachine.java
@@ -44,11 +44,6 @@ public class MockIVoidableMachine implements IVoidable {
     }
 
     @Override
-    public boolean canDumpFluidToME() {
-        return false;
-    }
-
-    @Override
     public VoidingMode getDefaultVoidingMode() {
         return VoidingMode.VOID_ALL;
     }

--- a/src/main/java/bartworks/common/tileentities/multis/mega/MTEMegaDistillTower.java
+++ b/src/main/java/bartworks/common/tileentities/multis/mega/MTEMegaDistillTower.java
@@ -56,7 +56,6 @@ import gregtech.api.recipe.RecipeMaps;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.MultiblockTooltipBuilder;
-import gregtech.common.tileentities.machines.MTEHatchOutputME;
 
 public class MTEMegaDistillTower extends MegaMultiBlockBase<MTEMegaDistillTower> implements ISurvivalConstructable {
 
@@ -390,32 +389,6 @@ public class MTEMegaDistillTower extends MegaMultiBlockBase<MTEMegaDistillTower>
     @Override
     protected ProcessingLogic createProcessingLogic() {
         return new ProcessingLogic().setMaxParallel(Configuration.Multiblocks.megaMachinesMax);
-    }
-
-    @Override
-    public boolean canDumpFluidToME() {
-
-        // All fluids can be dumped to ME only if each layer contains a ME Output Hatch.
-        for (List<MTEHatchOutput> tLayerOutputHatches : this.mOutputHatchesByLayer) {
-
-            boolean foundMEHatch = false;
-
-            for (IFluidStore tHatch : tLayerOutputHatches) {
-                if (tHatch instanceof MTEHatchOutputME tMEHatch) {
-                    if (tMEHatch.canAcceptFluid()) {
-                        foundMEHatch = true;
-                        break;
-                    }
-                }
-            }
-
-            // Exit if we didn't find a valid hatch on this layer.
-            if (!foundMEHatch) {
-                return false;
-            }
-        }
-
-        return true;
     }
 
     @Override

--- a/src/main/java/gregtech/api/interfaces/fluid/IFluidStore.java
+++ b/src/main/java/gregtech/api/interfaces/fluid/IFluidStore.java
@@ -19,4 +19,11 @@ public interface IFluidStore extends IFluidTank {
      * @return Whether to allow given fluid to be inserted into this.
      */
     boolean canStoreFluid(@Nonnull FluidStack fluidStack);
+
+    /**
+     * @return The amount of fluid that can be stored in this.
+     */
+    default int getAvailableSpace() {
+        return getCapacity() - getFluidAmount();
+    }
 }

--- a/src/main/java/gregtech/api/interfaces/tileentity/IVoidable.java
+++ b/src/main/java/gregtech/api/interfaces/tileentity/IVoidable.java
@@ -79,11 +79,4 @@ public interface IVoidable {
      *         as this might be called every tick and cause lag.
      */
     boolean canDumpItemToME();
-
-    /**
-     * @return If this machine has ability to dump fluid outputs to ME network.
-     *         This doesn't need to check if it can actually dump to ME,
-     *         as this might be called every tick and cause lag.
-     */
-    boolean canDumpFluidToME();
 }

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
@@ -109,7 +109,6 @@ import gregtech.common.tileentities.machines.MTEHatchCraftingInputME;
 import gregtech.common.tileentities.machines.MTEHatchInputBusME;
 import gregtech.common.tileentities.machines.MTEHatchInputME;
 import gregtech.common.tileentities.machines.MTEHatchOutputBusME;
-import gregtech.common.tileentities.machines.MTEHatchOutputME;
 import gregtech.common.tileentities.machines.multi.MTELargeTurbine;
 import it.unimi.dsi.fastutil.objects.Object2ReferenceOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Reference2ReferenceOpenHashMap;
@@ -2283,18 +2282,6 @@ public abstract class MTEMultiBlockBase extends MetaTileEntity
         for (MTEHatch tHatch : validMTEList(mOutputBusses)) {
             if (tHatch instanceof MTEHatchOutputBusME) {
                 if ((((MTEHatchOutputBusME) tHatch).canAcceptItem())) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    @Override
-    public boolean canDumpFluidToME() {
-        for (IFluidStore tHatch : getFluidOutputSlots(new FluidStack[0])) {
-            if (tHatch instanceof MTEHatchOutputME) {
-                if ((((MTEHatchOutputME) tHatch).canAcceptFluid())) {
                     return true;
                 }
             }

--- a/src/main/java/gregtech/api/multitileentity/multiblock/base/Controller.java
+++ b/src/main/java/gregtech/api/multitileentity/multiblock/base/Controller.java
@@ -915,11 +915,6 @@ public abstract class Controller<C extends Controller<C, P>, P extends MuTEProce
     }
 
     @Override
-    public boolean canDumpFluidToME() {
-        return false;
-    }
-
-    @Override
     public boolean supportsInputSeparation() {
         return true;
     }

--- a/src/main/java/gregtech/api/util/OutputHatchWrapper.java
+++ b/src/main/java/gregtech/api/util/OutputHatchWrapper.java
@@ -62,4 +62,9 @@ public class OutputHatchWrapper implements IFluidStore {
     public boolean canStoreFluid(@NotNull FluidStack fluidStack) {
         return outputHatch.canStoreFluid(fluidStack) && filter.test(fluidStack);
     }
+
+    @Override
+    public int getAvailableSpace() {
+        return outputHatch.getAvailableSpace();
+    }
 }

--- a/src/main/java/gregtech/api/util/VoidProtectionHelper.java
+++ b/src/main/java/gregtech/api/util/VoidProtectionHelper.java
@@ -214,7 +214,7 @@ public class VoidProtectionHelper {
                 return;
             }
         }
-        if (protectExcessFluid && fluidOutputs.length > 0 && !machine.canDumpFluidToME()) {
+        if (protectExcessFluid && fluidOutputs.length > 0) {
             maxParallel = Math.min(calculateMaxFluidParallels(), maxParallel);
             if (maxParallel <= 0) {
                 isFluidFull = true;
@@ -255,7 +255,7 @@ public class VoidProtectionHelper {
         }
 
         for (IFluidStore tHatch : hatches) {
-            int tSpaceLeft = tHatch.getCapacity() - tHatch.getFluidAmount();
+            int tSpaceLeft = tHatch.getAvailableSpace();
 
             // check if hatch filled
             if (tSpaceLeft <= 0) continue;
@@ -289,7 +289,7 @@ public class VoidProtectionHelper {
             ParallelStackInfo<FluidStack> tParallel = aParallelQueue.poll();
             assert tParallel != null; // will always be true, specifying assert here to avoid IDE/compiler warnings
             Integer tCraftSize = tFluidOutputMap.get(tParallel.stack);
-            int tSpaceLeft = tHatch.getCapacity();
+            int tSpaceLeft = tHatch.getAvailableSpace();
             tParallel.batch += (tParallel.partial + tSpaceLeft) / tCraftSize;
             tParallel.partial = (tParallel.partial + tSpaceLeft) % tCraftSize;
             aParallelQueue.add(tParallel);

--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchOutputME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchOutputME.java
@@ -161,6 +161,16 @@ public class MTEHatchOutputME extends MTEHatchOutput implements IPowerChannelSta
     }
 
     /**
+     * Get the available fluid space, up to max int.
+     */
+    @Override
+    public int getAvailableSpace() {
+        long availableSpace = getCacheCapacity() - getCachedAmount();
+        if (availableSpace > Integer.MAX_VALUE) availableSpace = Integer.MAX_VALUE;
+        return (int) availableSpace;
+    }
+
+    /**
      * Attempt to store fluid in connected ME network. Returns how much fluid is accepted (if the network was down e.g.)
      *
      * @param aFluid input fluid

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEDistillationTower.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEDistillationTower.java
@@ -47,7 +47,6 @@ import gregtech.api.recipe.RecipeMap;
 import gregtech.api.recipe.RecipeMaps;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.MultiblockTooltipBuilder;
-import gregtech.common.tileentities.machines.MTEHatchOutputME;
 
 public class MTEDistillationTower extends MTEEnhancedMultiBlockBase<MTEDistillationTower>
     implements ISurvivalConstructable {
@@ -291,15 +290,6 @@ public class MTEDistillationTower extends MTEEnhancedMultiBlockBase<MTEDistillat
             if (!dumpFluid(mOutputHatchesByLayer.get(i), tStack, true))
                 dumpFluid(mOutputHatchesByLayer.get(i), tStack, false);
         }
-    }
-
-    @Override
-    public boolean canDumpFluidToME() {
-        // All fluids can be dumped to ME only if each layer contains a ME Output Hatch.
-        return this.mOutputHatchesByLayer.stream()
-            .allMatch(
-                tLayerOutputHatches -> tLayerOutputHatches.stream()
-                    .anyMatch(tHatch -> (tHatch instanceof MTEHatchOutputME tMEHatch) && (tMEHatch.canAcceptFluid())));
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/advanced/MTEAdvDistillationTower.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/advanced/MTEAdvDistillationTower.java
@@ -53,7 +53,6 @@ import gregtech.api.recipe.RecipeMaps;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.MultiblockTooltipBuilder;
 import gregtech.common.pollution.PollutionConfig;
-import gregtech.common.tileentities.machines.MTEHatchOutputME;
 import gtPlusPlus.core.util.minecraft.ItemUtils;
 import gtPlusPlus.core.util.minecraft.PlayerUtils;
 import gtPlusPlus.xmod.gregtech.api.enums.GregtechItemList;
@@ -433,15 +432,6 @@ public class MTEAdvDistillationTower extends GTPPMultiBlockBase<MTEAdvDistillati
                 }
             }
         }
-    }
-
-    @Override
-    public boolean canDumpFluidToME() {
-        // All fluids can be dumped to ME only if each layer contains a ME Output Hatch.
-        return this.mOutputHatchesByLayer.stream()
-            .allMatch(
-                tLayerOutputHatches -> tLayerOutputHatches.stream()
-                    .anyMatch(tHatch -> (tHatch instanceof MTEHatchOutputME tMEHatch) && (tMEHatch.canAcceptFluid())));
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTENuclearReactor.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTENuclearReactor.java
@@ -47,6 +47,7 @@ import gregtech.api.util.GTRecipe;
 import gregtech.api.util.MultiblockTooltipBuilder;
 import gregtech.api.util.OverclockCalculator;
 import gregtech.api.util.shutdown.ShutDownReasonRegistry;
+import gregtech.common.tileentities.machines.MTEHatchOutputME;
 import gtPlusPlus.api.recipe.GTPPRecipeMaps;
 import gtPlusPlus.core.block.ModBlocks;
 import gtPlusPlus.core.material.MaterialsElements;
@@ -259,7 +260,8 @@ public class MTENuclearReactor extends GTPPMultiBlockBase<MTENuclearReactor> imp
     public boolean checkMachine(IGregTechTileEntity aBaseMetaTileEntity, ItemStack aStack) {
         mCasing = 0;
         if (checkPiece(mName, 3, 3, 0) && mCasing >= 27) {
-            if ((mOutputHatches.size() >= 3 || canDumpFluidToME()) && !mInputHatches.isEmpty()
+            if ((mOutputHatches.size() >= 3 || mOutputHatches.stream()
+                .anyMatch(h -> h instanceof MTEHatchOutputME)) && !mInputHatches.isEmpty()
                 && mDynamoHatches.size() == 4
                 && mMufflerHatches.size() == 4) {
                 this.turnCasingActive(false);


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17711

Additionally, fixes void protection for machines when only ME output hatches are present. There is still a bug in void protection when ME output hatches and normal output hatches are mixed, but this was also a bug before, and needs a deeper rewrite which I will do after freeze.