### PR TITLE
Extend render range

### DIFF
--- a/src/main/java/tectech/thing/block/TileEntityEyeOfHarmony.java
+++ b/src/main/java/tectech/thing/block/TileEntityEyeOfHarmony.java
@@ -26,6 +26,11 @@ public class TileEntityEyeOfHarmony extends TileEntity {
     private static final double EOH_STAR_FIELD_RADIUS = 13;
     private AxisAlignedBB boundingBox;
 
+    @Override
+    public double getMaxRenderDistanceSquared() {
+        return Double.MAX_VALUE;
+    }
+
     // Prevent culling when block is out of frame so model can remain active.
     @Override
     public AxisAlignedBB getRenderBoundingBox() {

--- a/src/main/java/tectech/thing/block/TileEntityForgeOfGods.java
+++ b/src/main/java/tectech/thing/block/TileEntityForgeOfGods.java
@@ -59,7 +59,7 @@ public class TileEntityForgeOfGods extends TileEntity {
 
     @Override
     public double getMaxRenderDistanceSquared() {
-        return 51200;
+        return Double.MAX_VALUE;
     }
 
     public void setStarRadius(float size) {


### PR DESCRIPTION
Drastically increases the range of EOH renderer, should always render now if the TE is loaded.