### PR TITLE
Fix ME output hatch void protection again

### DIFF
--- a/src/functionalTest/java/gregtech/test/mock/MockIVoidableMachine.java
+++ b/src/functionalTest/java/gregtech/test/mock/MockIVoidableMachine.java
@@ -44,6 +44,11 @@ public class MockIVoidableMachine implements IVoidable {
     }
 
     @Override
+    public boolean canDumpFluidToME() {
+        return false;
+    }
+
+    @Override
     public VoidingMode getDefaultVoidingMode() {
         return VoidingMode.VOID_ALL;
     }

--- a/src/main/java/bartworks/common/tileentities/multis/mega/MTEMegaDistillTower.java
+++ b/src/main/java/bartworks/common/tileentities/multis/mega/MTEMegaDistillTower.java
@@ -56,6 +56,7 @@ import gregtech.api.recipe.RecipeMaps;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.MultiblockTooltipBuilder;
+import gregtech.common.tileentities.machines.MTEHatchOutputME;
 
 public class MTEMegaDistillTower extends MegaMultiBlockBase<MTEMegaDistillTower> implements ISurvivalConstructable {
 
@@ -389,6 +390,32 @@ public class MTEMegaDistillTower extends MegaMultiBlockBase<MTEMegaDistillTower>
     @Override
     protected ProcessingLogic createProcessingLogic() {
         return new ProcessingLogic().setMaxParallel(Configuration.Multiblocks.megaMachinesMax);
+    }
+
+    @Override
+    public boolean canDumpFluidToME() {
+
+        // All fluids can be dumped to ME only if each layer contains a ME Output Hatch.
+        for (List<MTEHatchOutput> tLayerOutputHatches : this.mOutputHatchesByLayer) {
+
+            boolean foundMEHatch = false;
+
+            for (IFluidStore tHatch : tLayerOutputHatches) {
+                if (tHatch instanceof MTEHatchOutputME tMEHatch) {
+                    if (tMEHatch.canAcceptFluid()) {
+                        foundMEHatch = true;
+                        break;
+                    }
+                }
+            }
+
+            // Exit if we didn't find a valid hatch on this layer.
+            if (!foundMEHatch) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     @Override

--- a/src/main/java/gregtech/api/interfaces/fluid/IFluidStore.java
+++ b/src/main/java/gregtech/api/interfaces/fluid/IFluidStore.java
@@ -19,11 +19,4 @@ public interface IFluidStore extends IFluidTank {
      * @return Whether to allow given fluid to be inserted into this.
      */
     boolean canStoreFluid(@Nonnull FluidStack fluidStack);
-
-    /**
-     * @return The amount of fluid that can be stored in this.
-     */
-    default int getAvailableSpace() {
-        return getCapacity() - getFluidAmount();
-    }
 }

--- a/src/main/java/gregtech/api/interfaces/tileentity/IVoidable.java
+++ b/src/main/java/gregtech/api/interfaces/tileentity/IVoidable.java
@@ -79,4 +79,11 @@ public interface IVoidable {
      *         as this might be called every tick and cause lag.
      */
     boolean canDumpItemToME();
+
+    /**
+     * @return If this machine has ability to dump fluid outputs to ME network.
+     *         This doesn't need to check if it can actually dump to ME,
+     *         as this might be called every tick and cause lag.
+     */
+    boolean canDumpFluidToME();
 }

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
@@ -109,6 +109,7 @@ import gregtech.common.tileentities.machines.MTEHatchCraftingInputME;
 import gregtech.common.tileentities.machines.MTEHatchInputBusME;
 import gregtech.common.tileentities.machines.MTEHatchInputME;
 import gregtech.common.tileentities.machines.MTEHatchOutputBusME;
+import gregtech.common.tileentities.machines.MTEHatchOutputME;
 import gregtech.common.tileentities.machines.multi.MTELargeTurbine;
 import it.unimi.dsi.fastutil.objects.Object2ReferenceOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Reference2ReferenceOpenHashMap;
@@ -2282,6 +2283,18 @@ public abstract class MTEMultiBlockBase extends MetaTileEntity
         for (MTEHatch tHatch : validMTEList(mOutputBusses)) {
             if (tHatch instanceof MTEHatchOutputBusME) {
                 if ((((MTEHatchOutputBusME) tHatch).canAcceptItem())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean canDumpFluidToME() {
+        for (IFluidStore tHatch : getFluidOutputSlots(new FluidStack[0])) {
+            if (tHatch instanceof MTEHatchOutputME) {
+                if ((((MTEHatchOutputME) tHatch).canAcceptFluid())) {
                     return true;
                 }
             }

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
@@ -1322,6 +1322,11 @@ public abstract class MTEMultiBlockBase extends MetaTileEntity
                 continue;
             }
             if (!tHatch.canStoreFluid(copiedFluidStack)) continue;
+
+            if (tHatch instanceof MTEHatchOutputME tMEHatch) {
+                if (!tMEHatch.canAcceptFluid()) continue;
+            }
+
             int tAmount = tHatch.fill(copiedFluidStack, false);
             if (tAmount >= copiedFluidStack.amount) {
                 boolean filled = tHatch.fill(copiedFluidStack, true) >= copiedFluidStack.amount;

--- a/src/main/java/gregtech/api/multitileentity/multiblock/base/Controller.java
+++ b/src/main/java/gregtech/api/multitileentity/multiblock/base/Controller.java
@@ -915,6 +915,11 @@ public abstract class Controller<C extends Controller<C, P>, P extends MuTEProce
     }
 
     @Override
+    public boolean canDumpFluidToME() {
+        return false;
+    }
+
+    @Override
     public boolean supportsInputSeparation() {
         return true;
     }

--- a/src/main/java/gregtech/api/util/OutputHatchWrapper.java
+++ b/src/main/java/gregtech/api/util/OutputHatchWrapper.java
@@ -62,4 +62,8 @@ public class OutputHatchWrapper implements IFluidStore {
     public boolean canStoreFluid(@NotNull FluidStack fluidStack) {
         return outputHatch.canStoreFluid(fluidStack) && filter.test(fluidStack);
     }
+
+    public MTEHatchOutput unwrap() {
+        return outputHatch;
+    }
 }

--- a/src/main/java/gregtech/api/util/OutputHatchWrapper.java
+++ b/src/main/java/gregtech/api/util/OutputHatchWrapper.java
@@ -62,9 +62,4 @@ public class OutputHatchWrapper implements IFluidStore {
     public boolean canStoreFluid(@NotNull FluidStack fluidStack) {
         return outputHatch.canStoreFluid(fluidStack) && filter.test(fluidStack);
     }
-
-    @Override
-    public int getAvailableSpace() {
-        return outputHatch.getAvailableSpace();
-    }
 }

--- a/src/main/java/gregtech/api/util/VoidProtectionHelper.java
+++ b/src/main/java/gregtech/api/util/VoidProtectionHelper.java
@@ -17,6 +17,7 @@ import gregtech.api.interfaces.fluid.IFluidStore;
 import gregtech.api.interfaces.tileentity.IVoidable;
 import gregtech.api.logic.FluidInventoryLogic;
 import gregtech.api.logic.ItemInventoryLogic;
+import gregtech.common.tileentities.machines.MTEHatchOutputME;
 
 /**
  * Helper class to calculate how many parallels of items / fluids can fit in the output buses / hatches.
@@ -255,7 +256,14 @@ public class VoidProtectionHelper {
         }
 
         for (IFluidStore tHatch : hatches) {
-            int tSpaceLeft = tHatch.getCapacity() - tHatch.getFluidAmount();
+            int tSpaceLeft;
+            if (tHatch instanceof MTEHatchOutputME tMEHatch) {
+                tSpaceLeft = tMEHatch.canAcceptFluid() ? Integer.MAX_VALUE : 0;
+            } else if (tHatch instanceof OutputHatchWrapper w && w.unwrap() instanceof MTEHatchOutputME tMEHatch) {
+                tSpaceLeft = tMEHatch.canAcceptFluid() ? Integer.MAX_VALUE : 0;
+            } else {
+                tSpaceLeft = tHatch.getCapacity() - tHatch.getFluidAmount();
+            }
 
             // check if hatch filled
             if (tSpaceLeft <= 0) continue;
@@ -289,7 +297,16 @@ public class VoidProtectionHelper {
             ParallelStackInfo<FluidStack> tParallel = aParallelQueue.poll();
             assert tParallel != null; // will always be true, specifying assert here to avoid IDE/compiler warnings
             Integer tCraftSize = tFluidOutputMap.get(tParallel.stack);
-            int tSpaceLeft = tHatch.getCapacity();
+
+            int tSpaceLeft;
+            if (tHatch instanceof MTEHatchOutputME tMEHatch) {
+                tSpaceLeft = tMEHatch.canAcceptFluid() ? Integer.MAX_VALUE : 0;
+            } else if (tHatch instanceof OutputHatchWrapper w && w.unwrap() instanceof MTEHatchOutputME tMEHatch) {
+                tSpaceLeft = tMEHatch.canAcceptFluid() ? Integer.MAX_VALUE : 0;
+            } else {
+                tSpaceLeft = tHatch.getCapacity();
+            }
+
             tParallel.batch += (tParallel.partial + tSpaceLeft) / tCraftSize;
             tParallel.partial = (tParallel.partial + tSpaceLeft) % tCraftSize;
             aParallelQueue.add(tParallel);

--- a/src/main/java/gregtech/api/util/VoidProtectionHelper.java
+++ b/src/main/java/gregtech/api/util/VoidProtectionHelper.java
@@ -214,7 +214,7 @@ public class VoidProtectionHelper {
                 return;
             }
         }
-        if (protectExcessFluid && fluidOutputs.length > 0) {
+        if (protectExcessFluid && fluidOutputs.length > 0 && !machine.canDumpFluidToME()) {
             maxParallel = Math.min(calculateMaxFluidParallels(), maxParallel);
             if (maxParallel <= 0) {
                 isFluidFull = true;
@@ -255,7 +255,7 @@ public class VoidProtectionHelper {
         }
 
         for (IFluidStore tHatch : hatches) {
-            int tSpaceLeft = tHatch.getAvailableSpace();
+            int tSpaceLeft = tHatch.getCapacity() - tHatch.getFluidAmount();
 
             // check if hatch filled
             if (tSpaceLeft <= 0) continue;
@@ -289,7 +289,7 @@ public class VoidProtectionHelper {
             ParallelStackInfo<FluidStack> tParallel = aParallelQueue.poll();
             assert tParallel != null; // will always be true, specifying assert here to avoid IDE/compiler warnings
             Integer tCraftSize = tFluidOutputMap.get(tParallel.stack);
-            int tSpaceLeft = tHatch.getAvailableSpace();
+            int tSpaceLeft = tHatch.getCapacity();
             tParallel.batch += (tParallel.partial + tSpaceLeft) / tCraftSize;
             tParallel.partial = (tParallel.partial + tSpaceLeft) % tCraftSize;
             aParallelQueue.add(tParallel);

--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchOutputME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchOutputME.java
@@ -161,16 +161,6 @@ public class MTEHatchOutputME extends MTEHatchOutput implements IPowerChannelSta
     }
 
     /**
-     * Get the available fluid space, up to max int.
-     */
-    @Override
-    public int getAvailableSpace() {
-        long availableSpace = getCacheCapacity() - getCachedAmount();
-        if (availableSpace > Integer.MAX_VALUE) availableSpace = Integer.MAX_VALUE;
-        return (int) availableSpace;
-    }
-
-    /**
      * Attempt to store fluid in connected ME network. Returns how much fluid is accepted (if the network was down e.g.)
      *
      * @param aFluid input fluid

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEDistillationTower.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEDistillationTower.java
@@ -47,6 +47,7 @@ import gregtech.api.recipe.RecipeMap;
 import gregtech.api.recipe.RecipeMaps;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.MultiblockTooltipBuilder;
+import gregtech.common.tileentities.machines.MTEHatchOutputME;
 
 public class MTEDistillationTower extends MTEEnhancedMultiBlockBase<MTEDistillationTower>
     implements ISurvivalConstructable {
@@ -290,6 +291,15 @@ public class MTEDistillationTower extends MTEEnhancedMultiBlockBase<MTEDistillat
             if (!dumpFluid(mOutputHatchesByLayer.get(i), tStack, true))
                 dumpFluid(mOutputHatchesByLayer.get(i), tStack, false);
         }
+    }
+
+    @Override
+    public boolean canDumpFluidToME() {
+        // All fluids can be dumped to ME only if each layer contains a ME Output Hatch.
+        return this.mOutputHatchesByLayer.stream()
+            .allMatch(
+                tLayerOutputHatches -> tLayerOutputHatches.stream()
+                    .anyMatch(tHatch -> (tHatch instanceof MTEHatchOutputME tMEHatch) && (tMEHatch.canAcceptFluid())));
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/advanced/MTEAdvDistillationTower.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/advanced/MTEAdvDistillationTower.java
@@ -53,6 +53,7 @@ import gregtech.api.recipe.RecipeMaps;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.MultiblockTooltipBuilder;
 import gregtech.common.pollution.PollutionConfig;
+import gregtech.common.tileentities.machines.MTEHatchOutputME;
 import gtPlusPlus.core.util.minecraft.ItemUtils;
 import gtPlusPlus.core.util.minecraft.PlayerUtils;
 import gtPlusPlus.xmod.gregtech.api.enums.GregtechItemList;
@@ -432,6 +433,15 @@ public class MTEAdvDistillationTower extends GTPPMultiBlockBase<MTEAdvDistillati
                 }
             }
         }
+    }
+
+    @Override
+    public boolean canDumpFluidToME() {
+        // All fluids can be dumped to ME only if each layer contains a ME Output Hatch.
+        return this.mOutputHatchesByLayer.stream()
+            .allMatch(
+                tLayerOutputHatches -> tLayerOutputHatches.stream()
+                    .anyMatch(tHatch -> (tHatch instanceof MTEHatchOutputME tMEHatch) && (tMEHatch.canAcceptFluid())));
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTENuclearReactor.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTENuclearReactor.java
@@ -47,7 +47,6 @@ import gregtech.api.util.GTRecipe;
 import gregtech.api.util.MultiblockTooltipBuilder;
 import gregtech.api.util.OverclockCalculator;
 import gregtech.api.util.shutdown.ShutDownReasonRegistry;
-import gregtech.common.tileentities.machines.MTEHatchOutputME;
 import gtPlusPlus.api.recipe.GTPPRecipeMaps;
 import gtPlusPlus.core.block.ModBlocks;
 import gtPlusPlus.core.material.MaterialsElements;
@@ -260,8 +259,7 @@ public class MTENuclearReactor extends GTPPMultiBlockBase<MTENuclearReactor> imp
     public boolean checkMachine(IGregTechTileEntity aBaseMetaTileEntity, ItemStack aStack) {
         mCasing = 0;
         if (checkPiece(mName, 3, 3, 0) && mCasing >= 27) {
-            if ((mOutputHatches.size() >= 3 || mOutputHatches.stream()
-                .anyMatch(h -> h instanceof MTEHatchOutputME)) && !mInputHatches.isEmpty()
+            if ((mOutputHatches.size() >= 3 || canDumpFluidToME()) && !mInputHatches.isEmpty()
                 && mDynamoHatches.size() == 4
                 && mMufflerHatches.size() == 4) {
                 this.turnCasingActive(false);


### PR DESCRIPTION
ME output hatch void protection had 4 different issues at different points:
1. Mixing ME output hatch + normal output hatch on a DT (or dangote, MDT, sparge tower) can't run with fluid void protection on
2. Multiple ME output hatches, or ME output hatch + unfiltered normal output hatch breaks fluid void protection fully
3. ME output hatch can only hold 1 fluid according to void protection, requiring multiple for multi fluid output
4. ME output hatch can void some but not all fluids of a recipe that outputs multiple fluids at once

ME output hatches gaining a limited capacity introduced bugs 1, 2, and 3.
#3585 fixed bug 1, but introduced bug 3. Bug 2 and 4 remained unfixed with that PR.

This PR fixes bugs 1, 2, and 3:
1. Fixed by the checks in `VoidProtectionHelper` in the second commit
    - By testing for an ME output hatch, we can check if some amount of fluid can be stored in this hatch, and proceed as usual if so. Previously, this code would always view an ME output hatch as not being able to hold any fluid
2. Fixed by the check in `MTEMultiBlockBase` in the second commit
    - By checking if the tested hatch is an ME output hatch, we can see if this hatch has room to hold a fluid. If it does, we can safely insert any amount of fluid into it. If it does not, then we skip this hatch to test others. Previously, this code would blindly fill an ME output hatch, as a call to `fill()` on these hatches always claims to accept all fluid, regardless of if it actually can due to the cross-over between forge fluid api and AE2 api
3. Fixed by reverting #3585
    - This PR conformed ME output hatches to normal void protection rules. However, this code is not written in a way that allows a single hatch to store multiple fluids
4. Not fixed by this PR
    - Fixing this I believe will require a more thorough rewrite. Basically, void protection assumes that an ME output hatch can hold any amount of fluid, since ME output hatches can be "overfilled" to try and avoid voiding fluids. However, when a recipe outputs multiple fluids, void protection makes this assumption, but fill logic tries to fill the hatch multiple times. This can lead to some of the later fill calls not being able to fit, as the hatch is not able to be overfilled by multiple fill calls.
    - Solution for later: Implement a transactional system to fill the ME output hatch with multiple fluids at a time, OR rewrite void protection to not need to make this assumption with ME output hatches

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17711