### PR TITLE
Fix wireless detector covers redstone bug

### DIFF
--- a/src/main/java/gregtech/common/covers/redstone/CoverWirelessDoesWorkDetector.java
+++ b/src/main/java/gregtech/common/covers/redstone/CoverWirelessDoesWorkDetector.java
@@ -76,6 +76,8 @@ public class CoverWirelessDoesWorkDetector
         final long hash = hashCoverCoords(aTileEntity, side);
         setSignalAt(aCoverVariable.getUuid(), aCoverVariable.getFrequency(), hash, signal);
 
+        aTileEntity.setOutputRedstoneSignal(side, signal);
+
         return aCoverVariable;
     }
 

--- a/src/main/java/gregtech/common/covers/redstone/CoverWirelessFluidDetector.java
+++ b/src/main/java/gregtech/common/covers/redstone/CoverWirelessFluidDetector.java
@@ -51,6 +51,8 @@ public class CoverWirelessFluidDetector
         final long hash = hashCoverCoords(aTileEntity, side);
         setSignalAt(aCoverVariable.getUuid(), aCoverVariable.getFrequency(), hash, signal);
 
+        aTileEntity.setOutputRedstoneSignal(side, signal);
+
         return aCoverVariable;
     }
 

--- a/src/main/java/gregtech/common/covers/redstone/CoverWirelessItemDetector.java
+++ b/src/main/java/gregtech/common/covers/redstone/CoverWirelessItemDetector.java
@@ -59,6 +59,8 @@ public class CoverWirelessItemDetector
         final long hash = hashCoverCoords(aTileEntity, side);
         setSignalAt(aCoverVariable.getUuid(), aCoverVariable.getFrequency(), hash, signal);
 
+        aTileEntity.setOutputRedstoneSignal(side, signal);
+
         return aCoverVariable;
     }
 

--- a/src/main/java/gregtech/common/covers/redstone/CoverWirelessMaintenanceDetector.java
+++ b/src/main/java/gregtech/common/covers/redstone/CoverWirelessMaintenanceDetector.java
@@ -96,6 +96,8 @@ public class CoverWirelessMaintenanceDetector
         final long hash = hashCoverCoords(aTileEntity, side);
         setSignalAt(aCoverVariable.getUuid(), aCoverVariable.getFrequency(), hash, signal);
 
+        aTileEntity.setOutputRedstoneSignal(side, signal);
+
         return aCoverVariable;
     }
 


### PR DESCRIPTION
This PR addresses this issue: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18177

If i understand the code base correctly,
wireless detector covers are set to manipulate the tile entities redstone output in
addition to wirelessly transmitting the signal because
these 4 classes explicitly override the default method and return true instead.

if the opposite is intended, that the wireless detector covers only wirelessly work,
then i'm more than happy to adjust this PR.

An explanation of why the current behavior is erroneous can be found here:
https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18177#issuecomment-2509688359