### PR TITLE
Fix nether quartz block conflict

### DIFF
--- a/src/main/java/gregtech/api/util/GTRecipeRegistrator.java
+++ b/src/main/java/gregtech/api/util/GTRecipeRegistrator.java
@@ -179,7 +179,10 @@ public class GTRecipeRegistrator {
             || aData.mMaterial.mAmount <= 0
             || GTUtility.getFluidForFilledItem(aStack, false) != null
             || aData.mMaterial.mMaterial.mSubTags.contains(SubTag.NO_RECIPES)) return;
-        registerReverseMacerating(GTUtility.copyAmount(1, aStack), aData, aData.mPrefix == null);
+        // Prevents registering a quartz block -> 9x quartz dust recipe
+        if (!GTUtility.areStacksEqual(new ItemStack(Blocks.quartz_block, 1), aStack)) {
+            registerReverseMacerating(GTUtility.copyAmount(1, aStack), aData, aData.mPrefix == null);
+        }
         if (!GTUtility.areStacksEqual(GTModHandler.getIC2Item("iridiumOre", 1L), aStack)) {
             registerReverseSmelting(
                 GTUtility.copyAmount(1, aStack),

--- a/src/main/java/gregtech/loaders/postload/recipes/Pulverizer.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/Pulverizer.java
@@ -69,6 +69,27 @@ public class Pulverizer implements Runnable {
                 .addTo(maceratorRecipes);
         }
 
+        GTValues.RA.stdBuilder()
+            .itemInputs(new ItemStack(Blocks.quartz_block, 1))
+            .itemOutputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.NetherQuartz, 4))
+            .duration(19 * SECONDS + 12 * TICKS)
+            .eut(4)
+            .addTo(maceratorRecipes);
+
+        GTValues.RA.stdBuilder()
+            .itemInputs(new ItemStack(Blocks.quartz_block, 1, 1))
+            .itemOutputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.NetherQuartz, 4))
+            .duration(19 * SECONDS + 12 * TICKS)
+            .eut(4)
+            .addTo(maceratorRecipes);
+
+        GTValues.RA.stdBuilder()
+            .itemInputs(new ItemStack(Blocks.quartz_block, 1, 2))
+            .itemOutputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.NetherQuartz, 4))
+            .duration(19 * SECONDS + 12 * TICKS)
+            .eut(4)
+            .addTo(maceratorRecipes);
+
         // marbe dust( stone dust
         GTValues.RA.stdBuilder()
             .itemInputs(GTOreDictUnificator.get(OrePrefixes.block, Materials.Marble, 1))


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18218
Adds an explicit exception to autogen and manually instantiated recipes for the 3 quartz blocks.