### PR TITLE
fix SC Turbine giving Steam instead of SH Steam

### DIFF
--- a/src/main/java/goodgenerator/blocks/tileEntity/MTESupercriticalFluidTurbine.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/MTESupercriticalFluidTurbine.java
@@ -68,7 +68,7 @@ public class MTESupercriticalFluidTurbine extends MTELargeTurbineBase {
         }
         if (totalFlow <= 0) return 0;
         tEU = totalFlow;
-        addOutput(GTModHandler.getSteam(totalFlow));
+        addOutput(FluidRegistry.getFluidStack("ic2superheatedsteam", totalFlow));
         if (totalFlow == realOptFlow) {
             tEU = GTUtility
                 .safeInt((long) (tEU * (looseFit ? turbine.getLooseSteamEfficiency() : turbine.getSteamEfficiency())));

--- a/src/main/java/goodgenerator/blocks/tileEntity/MTESupercriticalFluidTurbine.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/MTESupercriticalFluidTurbine.java
@@ -148,7 +148,7 @@ public class MTESupercriticalFluidTurbine extends MTELargeTurbineBase {
         tt.addMachineType("Supercritical Steam Turbine")
             .addInfo("Needs a Turbine, place inside controller")
             .addInfo("Use Supercritical Steam to generate power.")
-            .addInfo("Outputs 1L of Steam per 1L of SC Steam as well as producing power")
+            .addInfo("Outputs 1L of SH Steam per 1L of SC Steam as well as producing power")
             .addInfo("Power output depends on turbine and fitting")
             .addInfo("Use screwdriver to adjust fitting of turbine")
             .beginStructureBlock(3, 3, 4, true)

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/MTELargeTurbineSCSteam.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/MTELargeTurbineSCSteam.java
@@ -9,7 +9,6 @@ import net.minecraftforge.fluids.FluidStack;
 import gregtech.api.enums.Materials;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
-import gregtech.api.util.GTModHandler;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.TurbineStatCalculator;
 import gtPlusPlus.core.lib.GTPPCore;
@@ -118,7 +117,8 @@ public class MTELargeTurbineSCSteam extends MTELargerTurbineBase {
         if (isUsingDenseSteam) {
             addOutput(Materials.DenseSuperheatedSteam.getGas((long) steamFlowForNextSteam));
         } else {
-            addOutput(GTModHandler.getSteam(totalFlow * 100));
+            addOutput(FluidRegistry.getFluidStack("ic2superheatedsteam", totalFlow));
+
         }
         if (totalFlow != realOptFlow) {
             float efficiency = 1.0f - Math.abs((totalFlow - (float) realOptFlow) / (float) realOptFlow);


### PR DESCRIPTION
(XL) SC Turbine only gave superheated steam when it was given dense supercritical steam, now it always gives SH steam. This also affects regular SC Turbine