### PR TITLE
Fix Incorrect bee allele definitions and elevate invalid definition logs to warnings.

### DIFF
--- a/src/main/java/gregtech/common/bees/GTAlleleHelper.java
+++ b/src/main/java/gregtech/common/bees/GTAlleleHelper.java
@@ -152,13 +152,13 @@ public class GTAlleleHelper extends AlleleHelper {
     public <T extends Enum<T> & IChromosomeType> void set(IAllele[] alleles, T chromosomeType, IAllele allele) {
 
         if (allele == null) {
-            GTMod.GT_FML_LOGGER.info("Allele is null!");
+            GTMod.GT_FML_LOGGER.warn("Allele is null!");
             return;
         }
 
         if (!chromosomeType.getAlleleClass()
             .isInstance(allele)) {
-            GTMod.GT_FML_LOGGER.info("chromosomeType is not an instance of allele!" + allele.getName());
+            GTMod.GT_FML_LOGGER.warn("chromosomeType is not an instance of allele!" + allele.getName());
             return;
         }
 

--- a/src/main/java/gregtech/loaders/misc/GTBeeDefinition.java
+++ b/src/main/java/gregtech/loaders/misc/GTBeeDefinition.java
@@ -87,6 +87,7 @@ import forestry.apiculture.genetics.Bee;
 import forestry.apiculture.genetics.IBeeDefinition;
 import forestry.apiculture.genetics.alleles.AlleleEffect;
 import forestry.core.genetics.alleles.AlleleHelper;
+import gregtech.GTMod;
 import gregtech.api.GregTechAPI;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
@@ -101,6 +102,7 @@ import gregtech.common.bees.GTBeeMutation;
 import gregtech.common.items.CombType;
 import gregtech.common.items.DropType;
 import gregtech.common.items.PropolisType;
+import gregtech.loaders.misc.bees.GTAlleleEffect;
 import gregtech.loaders.misc.bees.GTFlowers;
 import gtnhlanth.common.register.WerkstoffMaterialPool;
 
@@ -1719,7 +1721,7 @@ public enum GTBeeDefinition implements IBeeDefinition {
         beeSpecies.setHumidity(EnumHumidity.NORMAL);
         beeSpecies.setTemperature(COLD);
         beeSpecies.setHasEffect();
-    }, template -> AlleleHelper.instance.set(template, EFFECT, getEffect(EXTRABEES, "freezing")), new Consumer<>() {
+    }, template -> AlleleHelper.instance.set(template, EFFECT, getEffect(FORESTRY, "Glacial")), new Consumer<>() {
 
         @Override
         public void accept(GTBeeDefinition dis) {
@@ -1736,7 +1738,7 @@ public enum GTBeeDefinition implements IBeeDefinition {
             beeSpecies.setHumidity(EnumHumidity.NORMAL);
             beeSpecies.setTemperature(ICY);
             beeSpecies.setHasEffect();
-        }, template -> AlleleHelper.instance.set(template, EFFECT, getEffect(EXTRABEES, "freezing")), new Consumer<>() {
+        }, template -> AlleleHelper.instance.set(template, EFFECT, getEffect(FORESTRY, "Glacial")), new Consumer<>() {
 
             @Override
             public void accept(GTBeeDefinition dis) {

--- a/src/main/java/gregtech/loaders/misc/GTBeeDefinition.java
+++ b/src/main/java/gregtech/loaders/misc/GTBeeDefinition.java
@@ -2701,7 +2701,11 @@ public enum GTBeeDefinition implements IBeeDefinition {
             case GREGTECH -> "gregtech.effect" + name;
             default -> "forestry.effect" + name;
         };
-        return (IAlleleBeeEffect) AlleleManager.alleleRegistry.getAllele(s);
+        IAlleleBeeEffect allele = (IAlleleBeeEffect) AlleleManager.alleleRegistry.getAllele(s);
+        if (allele == null) {
+            GTMod.GT_FML_LOGGER.warn("Attempted to get unknown bee effect: " + s);
+        }
+        return allele;
     }
 
     static IAlleleFlowers getFlowers(byte modid, String name) {
@@ -2712,7 +2716,11 @@ public enum GTBeeDefinition implements IBeeDefinition {
             case GREGTECH -> "gregtech.flower" + name;
             default -> "forestry.flowers" + name;
         };
-        return (IAlleleFlowers) AlleleManager.alleleRegistry.getAllele(s);
+        IAlleleFlowers allele = (IAlleleFlowers) AlleleManager.alleleRegistry.getAllele(s);
+        if (allele == null) {
+            GTMod.GT_FML_LOGGER.warn("Attempted to get unknown bee flower: " + s);
+        }
+        return allele;
     }
 
     private static IAlleleBeeSpecies getSpecies(byte modid, String name) {
@@ -2725,6 +2733,7 @@ public enum GTBeeDefinition implements IBeeDefinition {
         };
         IAlleleBeeSpecies ret = (IAlleleBeeSpecies) AlleleManager.alleleRegistry.getAllele(s);
         if (ret == null) {
+            GTMod.GT_FML_LOGGER.warn("Attempted to get unknown bee species: " + s);
             ret = NAQUADRIA.species;
         }
 

--- a/src/main/java/gregtech/loaders/misc/GTBeeDefinition.java
+++ b/src/main/java/gregtech/loaders/misc/GTBeeDefinition.java
@@ -2704,6 +2704,7 @@ public enum GTBeeDefinition implements IBeeDefinition {
         IAlleleBeeEffect allele = (IAlleleBeeEffect) AlleleManager.alleleRegistry.getAllele(s);
         if (allele == null) {
             GTMod.GT_FML_LOGGER.warn("Attempted to get unknown bee effect: " + s);
+            allele = GTAlleleEffect.FORESTRY_BASE_EFFECT;
         }
         return allele;
     }

--- a/src/main/java/gregtech/loaders/misc/GTBranchDefinition.java
+++ b/src/main/java/gregtech/loaders/misc/GTBranchDefinition.java
@@ -22,7 +22,6 @@ import static forestry.core.genetics.alleles.EnumAllele.Tolerance;
 import static gregtech.loaders.misc.GTBeeDefinition.getEffect;
 import static gregtech.loaders.misc.GTBeeDefinition.getFlowers;
 import static gregtech.loaders.misc.GTBeeDefinitionReference.EXTRABEES;
-import static gregtech.loaders.misc.GTBeeDefinitionReference.MAGICBEES;
 
 import java.util.Arrays;
 import java.util.function.Consumer;
@@ -95,7 +94,7 @@ public enum GTBranchDefinition {
         AlleleHelper.instance.set(alleles, FLOWER_PROVIDER, Flowers.END);
         AlleleHelper.instance.set(alleles, FLOWERING, Flowering.AVERAGE);
         AlleleHelper.instance.set(alleles, SPEED, GTBees.speedBlinding);
-        AlleleHelper.instance.set(alleles, SPEED, getEffect(EXTRABEES, "radioactive"));
+        AlleleHelper.instance.set(alleles, EFFECT, getEffect(EXTRABEES, "radioactive"));
     }),
     TWILIGHT("Nemoris Obscuri", alleles -> {
         AlleleHelper.instance.set(alleles, TEMPERATURE_TOLERANCE, Tolerance.BOTH_1);
@@ -144,7 +143,7 @@ public enum GTBranchDefinition {
     INFUSEDSHARD("Infusa Shard", alleles -> {
         AlleleHelper.instance.set(alleles, TEMPERATURE_TOLERANCE, Tolerance.BOTH_1);
         AlleleHelper.instance.set(alleles, TOLERANT_FLYER, true);
-        AlleleHelper.instance.set(alleles, FLOWER_PROVIDER, getFlowers(MAGICBEES, "rock"));
+        AlleleHelper.instance.set(alleles, FLOWER_PROVIDER, getFlowers(EXTRABEES, "rock"));
         AlleleHelper.instance.set(alleles, FLOWERING, Flowering.FASTEST);
         AlleleHelper.instance.set(alleles, LIFESPAN, Lifespan.SHORTEST);
         AlleleHelper.instance.set(alleles, SPEED, Speed.FASTEST);


### PR DESCRIPTION
Fixes
- Fixes some invalid allele definitions for the Ledox and Callisto Ice bees.
- Fixes some invalid allele definitions for radioactive and infused shard branches.

These fixes should resolve these log entries:
```
[23:55:33] [Client thread/INFO] [GregTech GTNH/gregtech]: chromosomeType is not an instance of allele!Unstable
[23:55:33] [Client thread/INFO] [GregTech GTNH/gregtech]: chromosomeType is not an instance of allele!Unstable
[23:55:33] [Client thread/INFO] [GregTech GTNH/gregtech]: chromosomeType is not an instance of allele!Unstable
[23:55:33] [Client thread/INFO] [GregTech GTNH/gregtech]: chromosomeType is not an instance of allele!Unstable
[23:55:33] [Client thread/INFO] [GregTech GTNH/gregtech]: chromosomeType is not an instance of allele!Unstable
[23:55:33] [Client thread/INFO] [GregTech GTNH/gregtech]: chromosomeType is not an instance of allele!Unstable
[23:55:33] [Client thread/INFO] [GregTech GTNH/gregtech]: chromosomeType is not an instance of allele!Unstable
[23:55:33] [Client thread/INFO] [GregTech GTNH/gregtech]: chromosomeType is not an instance of allele!Unstable
[23:55:33] [Client thread/INFO] [GregTech GTNH/gregtech]: chromosomeType is not an instance of allele!Unstable
[23:55:33] [Client thread/INFO] [GregTech GTNH/gregtech]: Allele is null!
[23:55:33] [Client thread/INFO] [GregTech GTNH/gregtech]: Allele is null!
[23:55:33] [Client thread/INFO] [GregTech GTNH/gregtech]: Allele is null!
[23:55:33] [Client thread/INFO] [GregTech GTNH/gregtech]: Allele is null!
[23:55:33] [Client thread/INFO] [GregTech GTNH/gregtech]: Allele is null!
[23:55:33] [Client thread/INFO] [GregTech GTNH/gregtech]: Allele is null!
[23:55:33] [Client thread/INFO] [GregTech GTNH/gregtech]: Allele is null!
[23:55:33] [Client thread/INFO] [GregTech GTNH/gregtech]: Allele is null!
[23:55:33] [Client thread/INFO] [GregTech GTNH/gregtech]: Allele is null!
[23:55:33] [Client thread/INFO] [GregTech GTNH/gregtech]: Allele is null!
```

Changes
- Elevates incorrect allele definitions logs to warnings.
- Adds a warning log when attempting to get an unknown effect, flower or species allele.
- Unknown effect allele requests will now return the no effect allele instead of null (forestry.effectNone)

Remaining non-critical issues
- When Galaxy Space and Twilight Forest aren't loaded, the tree twister effect isn't registered to the registry, but the BarnardaC still tries to import it anyway. This doesn't happen when you load the modpack since TF and GS will always be loaded. The fallback to the no-effect allele in effect getter should handle this odd case anyway.

This PR should hopefully address: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17636