### PR TITLE
fix a few recipe conflicts II

### DIFF
--- a/src/main/java/gtnhlanth/loader/RecipeLoader.java
+++ b/src/main/java/gtnhlanth/loader/RecipeLoader.java
@@ -171,7 +171,7 @@ public class RecipeLoader {
                 ItemList.Conveyor_Module_LuV.get(4),
                 GTUtility.copyAmount(2, LanthItemList.BEAMLINE_PIPE),
                 GTOreDictUnificator.get(OrePrefixes.cableGt04, Materials.VanadiumGallium, 2),
-                GTUtility.getIntegratedCircuit(16)
+                GTUtility.getIntegratedCircuit(15)
 
             )
             .itemOutputs(LanthItemList.SOURCE_CHAMBER)
@@ -190,7 +190,7 @@ public class RecipeLoader {
                 ItemList.Electric_Pump_LuV.get(2),
                 GTUtility.copyAmount(2, LanthItemList.BEAMLINE_PIPE),
                 GTOreDictUnificator.get(OrePrefixes.cableGt08, Materials.VanadiumGallium, 2),
-                GTUtility.getIntegratedCircuit(16)
+                GTUtility.getIntegratedCircuit(15)
 
             )
             .itemOutputs(LanthItemList.LINAC)
@@ -209,7 +209,7 @@ public class RecipeLoader {
                 GTOreDictUnificator.get(OrePrefixes.circuit, Materials.UV, 2),
                 GTUtility.copyAmount(2, LanthItemList.BEAMLINE_PIPE),
                 GTOreDictUnificator.get(OrePrefixes.cableGt02, Materials.VanadiumGallium, 1),
-                GTUtility.getIntegratedCircuit(16)
+                GTUtility.getIntegratedCircuit(15)
 
             )
             .itemOutputs(LanthItemList.TARGET_CHAMBER)
@@ -228,7 +228,7 @@ public class RecipeLoader {
                 GTOreDictUnificator.get(OrePrefixes.circuit, Materials.UV, 8),
                 GTUtility.copyAmount(8, LanthItemList.BEAMLINE_PIPE),
                 GTOreDictUnificator.get(OrePrefixes.cableGt08, Materials.NiobiumTitanium, 8),
-                GTUtility.getIntegratedCircuit(16))
+                GTUtility.getIntegratedCircuit(15))
             .itemOutputs(LanthItemList.SYNCHROTRON)
             .duration(60 * GTRecipeBuilder.SECONDS)
             .eut(TierEU.RECIPE_ZPM)


### PR DESCRIPTION
fix proper recipe conflicts for beamline blocks and wraps.

fixes part of https://discord.com/channels/181078474394566657/522098956491030558/1315089195945033771

found with the nei custom diagram and checked with it afterwards.