### PR TITLE
Remove second Description Line of Network Switch

### DIFF
--- a/src/main/java/tectech/thing/metaTileEntity/multi/MTENetworkSwitch.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/MTENetworkSwitch.java
@@ -220,8 +220,6 @@ public class MTENetworkSwitch extends TTMultiblockBase implements IConstructable
             // Switch With QoS
             .addInfo(translateToLocal("gt.blockmachines.multimachine.em.switch.desc.1")) // Used to route and
                                                                                          // distribute computation
-            .addInfo(translateToLocal("gt.blockmachines.multimachine.em.switch.desc.2")) // Needs a Parametrizer to
-                                                                                         // be configured
             .addTecTechHatchInfo()
 
             .beginStructureBlock(3, 3, 3, false)

--- a/src/main/resources/assets/tectech/lang/zh_CN.lang
+++ b/src/main/resources/assets/tectech/lang/zh_CN.lang
@@ -590,7 +590,6 @@ gt.blockmachines.multimachine.em.switch.name=QoS网络交换机
 gt.blockmachines.multimachine.em.switch.hint=1 - 基础仓室、光学接口或电子计算机机械方块
 gt.blockmachines.multimachine.em.switch.desc.0=QoS网络交换机的控制器方块
 gt.blockmachines.multimachine.em.switch.desc.1=用于路由和分发算力
-gt.blockmachines.multimachine.em.switch.desc.2=需要通过参数仪进行配置
 
 
 gt.blockmachines.multimachine.em.computer.name=量子计算机


### PR DESCRIPTION
https://github.com/GTNewHorizons/GT5-Unofficial/pull/3432 removed the en_US.lang value of the second Description Line, but neither the chinese, nor the actual call of that value in the Tooltip creation, which led to a wrong Tooltip. This removes both
![image](https://github.com/user-attachments/assets/68845915-f668-41f1-be5f-78e08b4ad1be)
fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18267
