### PR TITLE
Remove Compact Fusion force chunk loading

### DIFF
--- a/src/main/java/goodgenerator/blocks/tileEntity/MTELargeFusionComputer1.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/MTELargeFusionComputer1.java
@@ -61,8 +61,6 @@ public class MTELargeFusionComputer1 extends MTELargeFusionComputer {
                 "If the recipe requires a voltage tier over " + GTUtility.getColoredTierNameFromTier((byte) tier())
                     + EnumChatFormatting.GRAY
                     + " , you can't do it either")
-            .addInfo("Make sure the whole structure is built in the 3x3")
-            .addInfo("chunk area of the ring center (not controller).")
             .addInfo("It can run 64x recipes at most.")
             .addTecTechHatchInfo()
             .addCasingInfoMin("LuV Machine Casing", 1664, false)

--- a/src/main/java/goodgenerator/blocks/tileEntity/MTELargeFusionComputer2.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/MTELargeFusionComputer2.java
@@ -61,8 +61,6 @@ public class MTELargeFusionComputer2 extends MTELargeFusionComputer {
                 "If the recipe requires a voltage tier over " + GTUtility.getColoredTierNameFromTier((byte) tier())
                     + EnumChatFormatting.GRAY
                     + " , you can't do it either")
-            .addInfo("Make sure the whole structure is built in the 3x3")
-            .addInfo("chunk area of the ring center (not controller).")
             .addInfo("Startup < 160,000,000 EU: 128x Parallel")
             .addInfo("Startup >= 160,000,000 EU: 64x Parallel")
             .addTecTechHatchInfo()

--- a/src/main/java/goodgenerator/blocks/tileEntity/MTELargeFusionComputer3.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/MTELargeFusionComputer3.java
@@ -61,8 +61,6 @@ public class MTELargeFusionComputer3 extends MTELargeFusionComputer {
                 "If the recipe requires a voltage tier over " + GTUtility.getColoredTierNameFromTier((byte) tier())
                     + EnumChatFormatting.GRAY
                     + " , you can't do it either")
-            .addInfo("Make sure the whole structure is built in the 3x3")
-            .addInfo("chunk area of the ring center (not controller).")
             .addInfo("Startup < 160,000,000 EU: 192x Parallel")
             .addInfo("Startup < 320,000,000 EU: 128x Parallel")
             .addInfo("Startup >= 320,000,000 EU: 64x Parallel")

--- a/src/main/java/goodgenerator/blocks/tileEntity/MTELargeFusionComputer4.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/MTELargeFusionComputer4.java
@@ -58,8 +58,6 @@ public class MTELargeFusionComputer4 extends MTELargeFusionComputerPP {
                 "If the recipe requires a voltage tier over " + GTUtility.getColoredTierNameFromTier((byte) tier())
                     + EnumChatFormatting.GRAY
                     + " , you can't do it either")
-            .addInfo("Make sure the whole structure is built in the 3x3")
-            .addInfo("chunk area of the ring center (not controller).")
             .addInfo("Performs 4/4 overclock.")
             .addInfo("Startup < 160,000,000 EU: 256x Parallel")
             .addInfo("Startup < 320,000,000 EU: 192x Parallel")

--- a/src/main/java/goodgenerator/blocks/tileEntity/MTELargeFusionComputer5.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/MTELargeFusionComputer5.java
@@ -58,8 +58,6 @@ public class MTELargeFusionComputer5 extends MTELargeFusionComputerPP {
                 "If the recipe requires a voltage tier over " + GTUtility.getColoredTierNameFromTier((byte) tier())
                     + EnumChatFormatting.GRAY
                     + " , you can't do it either")
-            .addInfo("Make sure the whole structure is built in the 3x3")
-            .addInfo("chunk area of the ring center (not controller).")
             .addInfo("Performs 4/4 overclock.")
             .addInfo("Startup < 160,000,000 EU: 320x Parallel")
             .addInfo("Startup < 320,000,000 EU: 256x Parallel")

--- a/src/main/java/goodgenerator/blocks/tileEntity/base/MTELargeFusionComputer.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/base/MTELargeFusionComputer.java
@@ -14,10 +14,8 @@ import javax.annotation.Nullable;
 import net.minecraft.block.Block;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.StatCollector;
-import net.minecraft.world.ChunkCoordIntPair;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.FluidStack;
 
@@ -49,7 +47,6 @@ import gregtech.api.metatileentity.implementations.MTEHatch;
 import gregtech.api.metatileentity.implementations.MTEHatchEnergy;
 import gregtech.api.metatileentity.implementations.MTEHatchInput;
 import gregtech.api.metatileentity.implementations.MTEHatchOutput;
-import gregtech.api.objects.GTChunkManager;
 import gregtech.api.objects.GTItemStack;
 import gregtech.api.objects.overclockdescriber.FusionOverclockDescriber;
 import gregtech.api.objects.overclockdescriber.OverclockDescriber;
@@ -73,7 +70,6 @@ public abstract class MTELargeFusionComputer extends MTETooltipMultiBlockBaseEM
 
     public static final String MAIN_NAME = "largeFusion";
     public static final int M = 1_000_000;
-    private boolean isLoadedChunk;
     public GTRecipe mLastRecipe;
     public int para;
     protected OverclockDescriber overclockDescriber;
@@ -235,45 +231,6 @@ public abstract class MTELargeFusionComputer extends MTETooltipMultiBlockBaseEM
 
     @Override
     public void onPostTick(IGregTechTileEntity aBaseMetaTileEntity, long aTick) {
-        if (aBaseMetaTileEntity.isServerSide() && !aBaseMetaTileEntity.isAllowedToWork()) {
-            // if machine has stopped, stop chunkloading
-            GTChunkManager.releaseTicket((TileEntity) aBaseMetaTileEntity);
-            this.isLoadedChunk = false;
-        } else if (aBaseMetaTileEntity.isServerSide() && aBaseMetaTileEntity.isAllowedToWork() && !this.isLoadedChunk) {
-            // load a 3x3 area when machine is running
-            GTChunkManager.releaseTicket((TileEntity) aBaseMetaTileEntity);
-            int offX = aBaseMetaTileEntity.getFrontFacing().offsetX;
-            int offZ = aBaseMetaTileEntity.getFrontFacing().offsetZ;
-            GTChunkManager.requestChunkLoad(
-                (TileEntity) aBaseMetaTileEntity,
-                new ChunkCoordIntPair(getChunkX() + offX, getChunkZ() + offZ));
-            GTChunkManager.requestChunkLoad(
-                (TileEntity) aBaseMetaTileEntity,
-                new ChunkCoordIntPair(getChunkX() + 1 + offX, getChunkZ() + 1 + offZ));
-            GTChunkManager.requestChunkLoad(
-                (TileEntity) aBaseMetaTileEntity,
-                new ChunkCoordIntPair(getChunkX() + 1 + offX, getChunkZ() + offZ));
-            GTChunkManager.requestChunkLoad(
-                (TileEntity) aBaseMetaTileEntity,
-                new ChunkCoordIntPair(getChunkX() + 1 + offX, getChunkZ() - 1 + offZ));
-            GTChunkManager.requestChunkLoad(
-                (TileEntity) aBaseMetaTileEntity,
-                new ChunkCoordIntPair(getChunkX() - 1 + offX, getChunkZ() + 1 + offZ));
-            GTChunkManager.requestChunkLoad(
-                (TileEntity) aBaseMetaTileEntity,
-                new ChunkCoordIntPair(getChunkX() - 1 + offX, getChunkZ() + offZ));
-            GTChunkManager.requestChunkLoad(
-                (TileEntity) aBaseMetaTileEntity,
-                new ChunkCoordIntPair(getChunkX() - 1 + offX, getChunkZ() - 1 + offZ));
-            GTChunkManager.requestChunkLoad(
-                (TileEntity) aBaseMetaTileEntity,
-                new ChunkCoordIntPair(getChunkX() + offX, getChunkZ() + 1 + offZ));
-            GTChunkManager.requestChunkLoad(
-                (TileEntity) aBaseMetaTileEntity,
-                new ChunkCoordIntPair(getChunkX() + offX, getChunkZ() - 1 + offZ));
-            this.isLoadedChunk = true;
-        }
-
         if (aBaseMetaTileEntity.isServerSide()) {
             mTotalRunTime++;
             if (mEfficiency < 0) mEfficiency = 0;
@@ -486,12 +443,6 @@ public abstract class MTELargeFusionComputer extends MTETooltipMultiBlockBaseEM
     protected void setProcessingLogicPower(ProcessingLogic logic) {
         logic.setAvailableVoltage(GTValues.V[tier()]);
         logic.setAvailableAmperage(getSingleHatchPower() * 32 / GTValues.V[tier()]);
-    }
-
-    @Override
-    public void onRemoval() {
-        if (this.isLoadedChunk) GTChunkManager.releaseTicket((TileEntity) getBaseMetaTileEntity());
-        super.onRemoval();
     }
 
     public int getChunkX() {


### PR DESCRIPTION
Removes force chunk loading from compact fusion reactors. Also removes the tooltip specifying that it should be built in a 3x3 chunk area, since this is no longer relevant (wasn't before either)