### PR TITLE
Fix modded music disk playback in the electric jukebox using the new GTNHLib api

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -38,7 +38,7 @@ dependencies {
     api("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev")
     api("com.github.GTNewHorizons:NotEnoughItems:2.6.51-GTNH:dev")
     api("com.github.GTNewHorizons:NotEnoughIds:2.1.6:dev")
-    api("com.github.GTNewHorizons:GTNHLib:0.5.21:dev")
+    api("com.github.GTNewHorizons:GTNHLib:0.5.22:dev")
     api("com.github.GTNewHorizons:ModularUI:1.2.17:dev")
     api("com.github.GTNewHorizons:ModularUI2:2.1.16-1.7.10:dev")
     api("com.github.GTNewHorizons:waila:1.8.2:dev")

--- a/src/main/java/gregtech/GTMod.java
+++ b/src/main/java/gregtech/GTMod.java
@@ -135,7 +135,7 @@ import ic2.api.recipe.RecipeOutput;
     version = "MC1710",
     guiFactory = "gregtech.client.GTGuiFactory",
     dependencies = " required-after:IC2;" + " required-after:structurelib;"
-        + " required-after:gtnhlib@[0.2.1,);"
+        + " required-after:gtnhlib@[0.5.22,);"
         + " required-after:modularui@[1.1.12,);"
         + " required-after:appliedenergistics2@[rv3-beta-258,);"
         + " after:dreamcraft;"


### PR DESCRIPTION
Make use of custom disk metadata to make playback of HEE and Botania disks possible - tested locally with both of these mods on the versions with the metadata PRs applied.

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18055