### PR TITLE
Fix Rocket engine pollution

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/generators/MTERocketFuelGeneratorBase.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/generators/MTERocketFuelGeneratorBase.java
@@ -233,7 +233,7 @@ public abstract class MTERocketFuelGeneratorBase extends MTEBasicTank implements
                         && aBaseMetaTileEntity.increaseStoredEnergyUnits(tFluidAmountToUse * tFuelValue, true)) {
                         int aSafeFloor = (int) Math.max(((tFluidAmountToUse * tConsumed) / 3), 1);
                         this.mFluid.amount -= aSafeFloor;
-                        Pollution.addPollution(getBaseMetaTileEntity(), 10 * getPollution());
+                        Pollution.addPollution(getBaseMetaTileEntity(), getPollution() / 2);
                     }
                 }
             }


### PR DESCRIPTION
Related issue: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16331
Related PR: https://github.com/GTNewHorizons/GTplusplus/pull/885

It seems that the basic running pollution for rocket engine is still based on tick. The previous PR only fix the pollution for fuel filling, not the fuel consuming

>>>
it was applying the pollution per tick instead of per second. (or more precisely 10x the amount every 10 ticks, instead of 0.5 the amount every 10 ticks)