### PR TITLE
Fix Wrong Nether/Fluix Quartz Seed Amount in Autoclave

### DIFF
--- a/src/main/java/gregtech/loaders/postload/recipes/AutoclaveRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/AutoclaveRecipes.java
@@ -47,12 +47,12 @@ public class AutoclaveRecipes implements Runnable {
         certusQuartzTag.setInteger("progress", 0);
         certusQuartzSeed.setTagCompound(certusQuartzTag);
 
-        final ItemStack netherQuartzSeed = getModItem(AppliedEnergistics2.ID, "item.ItemCrystalSeed", 2L, 600);
+        final ItemStack netherQuartzSeed = getModItem(AppliedEnergistics2.ID, "item.ItemCrystalSeed", 1L, 600);
         NBTTagCompound netherQuartzTag = new NBTTagCompound();
         netherQuartzTag.setInteger("progress", 600);
         netherQuartzSeed.setTagCompound(netherQuartzTag);
 
-        final ItemStack fluixSeed = getModItem(AppliedEnergistics2.ID, "item.ItemCrystalSeed", 2L, 1200);
+        final ItemStack fluixSeed = getModItem(AppliedEnergistics2.ID, "item.ItemCrystalSeed", 1L, 1200);
         NBTTagCompound fluixTag = new NBTTagCompound();
         fluixTag.setInteger("progress", 1200);
         fluixSeed.setTagCompound(fluixTag);


### PR DESCRIPTION
When fixing the recipe inputs for autoclave, I accidentally forgot to change the 2L for these two seeds (certus is correct). This corrects the unintended nerf.