### PR TITLE
Fix LSC wireless rebalance push wrong info.

### DIFF
--- a/src/main/java/kekztech/common/tileentities/MTELapotronicSuperCapacitor.java
+++ b/src/main/java/kekztech/common/tileentities/MTELapotronicSuperCapacitor.java
@@ -844,8 +844,8 @@ public class MTELapotronicSuperCapacitor extends MTEEnhancedMultiBlockBase<MTELa
                     ItemBlockLapotronicEnergyUnit.UMV_wireless_eu_cap
                         .multiply(BigInteger.valueOf(getUMVCapacitorCount()))));
 
-        if (transferred_eu.signum() == 1) {
-            inputLastTick += transferred_eu.longValue();
+        if (transferred_eu.signum() != 1) {
+            inputLastTick += Math.abs(transferred_eu.longValue());
         } else {
             outputLastTick += transferred_eu.longValue();
         }

--- a/src/main/java/kekztech/common/tileentities/MTELapotronicSuperCapacitor.java
+++ b/src/main/java/kekztech/common/tileentities/MTELapotronicSuperCapacitor.java
@@ -844,7 +844,7 @@ public class MTELapotronicSuperCapacitor extends MTEEnhancedMultiBlockBase<MTELa
                     ItemBlockLapotronicEnergyUnit.UMV_wireless_eu_cap
                         .multiply(BigInteger.valueOf(getUMVCapacitorCount()))));
 
-        if (transferred_eu.signum() != 1) {
+        if (transferred_eu.signum() == -1) {
             inputLastTick += Math.abs(transferred_eu.longValue());
         } else {
             outputLastTick += transferred_eu.longValue();


### PR DESCRIPTION
Output to wireless was pushed into inputLastTick.
Input from wireless was pushed indo outputLastTick and with negative statment.

Closes: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18335