### PR TITLE
Fix UUA time multiplier

### DIFF
--- a/src/main/java/gregtech/common/config/MachineStats.java
+++ b/src/main/java/gregtech/common/config/MachineStats.java
@@ -127,7 +127,7 @@ public class MachineStats {
         public int UUAPerUUM;
 
         @Config.Comment("Speed bonus delivered by the UUA.")
-        @Config.DefaultInt(40)
+        @Config.DefaultInt(4)
         @Config.RequiresMcRestart
         public int UUASpeedBonus;
     }


### PR DESCRIPTION
The multiplier seems to have mistakenly been 10x-ed, I suspect it being a mistake from the config migration but I cant find the exact PR