### PR TITLE
Add Research Station to NEI Scanner List

### DIFF
--- a/src/main/java/tectech/thing/metaTileEntity/multi/MTEResearchStation.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/MTEResearchStation.java
@@ -16,6 +16,8 @@ import static net.minecraft.util.StatCollector.translateToLocal;
 import static net.minecraft.util.StatCollector.translateToLocalFormatted;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -53,6 +55,7 @@ import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.implementations.MTEHatch;
 import gregtech.api.metatileentity.implementations.MTEHatchEnergy;
+import gregtech.api.recipe.RecipeMap;
 import gregtech.api.recipe.check.CheckRecipeResult;
 import gregtech.api.recipe.check.CheckRecipeResultRegistry;
 import gregtech.api.recipe.check.SimpleCheckRecipeResult;
@@ -552,6 +555,12 @@ public class MTEResearchStation extends TTMultiblockBase implements ISurvivalCon
         aPlayer.addChatComponentMessage(
             new ChatComponentTranslation(
                 "gt.blockmachines.multimachine.em.research.mode." + machineType.replace(" ", "_")));
+    }
+
+    @Nonnull
+    @Override
+    public Collection<RecipeMap<?>> getAvailableRecipeMaps() {
+        return Arrays.asList(scannerFakeRecipes, TecTechRecipeMaps.researchStationFakeRecipes);
     }
 
     @Override


### PR DESCRIPTION
Adds the Research Station to the List of Scanners when looking up Scanner Recipes
![image](https://github.com/user-attachments/assets/9ee2b196-d545-46f8-92f8-e378925c1a6f)
if anything is done wrong, lmk, still very new to java and gtnh programming

closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18301

