### PR TITLE
fix bug in werkstoff recipe autogen

### DIFF
--- a/src/main/java/bartworks/system/material/werkstoff_loaders/recipe/MoltenCellLoader.java
+++ b/src/main/java/bartworks/system/material/werkstoff_loaders/recipe/MoltenCellLoader.java
@@ -110,8 +110,10 @@ public class MoltenCellLoader implements IWerkstoffRunnable {
                 .itemOutputs(werkstoff.get(ingot))
                 .fluidInputs(werkstoff.getMolten(144))
                 .duration(
-                    (int) werkstoff.getStats()
-                        .getMass())
+                    Math.max(
+                        1,
+                        (int) werkstoff.getStats()
+                            .getMass()))
                 .eut(
                     werkstoff.getStats()
                         .getMass() > 128 ? 64 : 30)
@@ -122,8 +124,10 @@ public class MoltenCellLoader implements IWerkstoffRunnable {
                 .itemOutputs(werkstoff.get(nugget))
                 .fluidInputs(werkstoff.getMolten(16))
                 .duration(
-                    (int) ((double) werkstoff.getStats()
-                        .getMass() / 9D))
+                    Math.max(
+                        1,
+                        (int) ((double) werkstoff.getStats()
+                            .getMass() / 9D)))
                 .eut(
                     werkstoff.getStats()
                         .getMass() > 128 ? 64 : 30)


### PR DESCRIPTION
maybe dont give recipes 0 duration. cant wait for the day we remove werkstoff though :P

fixes the broken recipes in https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18380
the nei error was already fixed by a questbook update it seems, so this closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18380