### PR TITLE
Fix lag probably caused by crib

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchCraftingInputME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchCraftingInputME.java
@@ -187,7 +187,7 @@ public class MTEHatchCraftingInputME extends MTEHatchInputBus
 
         public boolean isItemEmpty() {
             updateSlotItems();
-            return itemInventory.isEmpty() && sharedItemGetter.getSharedItem().length == 0;
+            return itemInventory.isEmpty();
         }
 
         public boolean isFluidEmpty() {
@@ -201,13 +201,13 @@ public class MTEHatchCraftingInputME extends MTEHatchInputBus
 
         @Override
         public ItemStack[] getItemInputs() {
-            if (isItemEmpty()) return new ItemStack[0];
+            if (isEmpty()) return new ItemStack[0];
             return ArrayUtils.addAll(itemInventory.toArray(new ItemStack[0]), sharedItemGetter.getSharedItem());
         }
 
         @Override
         public FluidStack[] getFluidInputs() {
-            if (isFluidEmpty()) return new FluidStack[0];
+            if (isEmpty()) return new FluidStack[0];
             return fluidInventory.toArray(new FluidStack[0]);
         }
 


### PR DESCRIPTION
This is a more proper fix for https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16579 in replace of https://github.com/GTNewHorizons/GT5-Unofficial/pull/2654/commits/d079d89fb2ad30dda4270a95c9eb418032467f3a which causes significant lag due to frequent recipe check triggered by existing catalysts in crib