### PR TITLE
Change scanner to respect fake recipe item count

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/basic/MTEScanner.java
+++ b/src/main/java/gregtech/common/tileentities/machines/basic/MTEScanner.java
@@ -349,14 +349,16 @@ public class MTEScanner extends MTEBasicMachine {
             if (ItemList.Tool_DataStick.isStackEqual(getSpecialSlot(), false, true)) {
                 for (GTRecipe.RecipeAssemblyLine tRecipe : GTRecipe.RecipeAssemblyLine.sAssemblylineRecipes) {
                     if (GTUtility.areStacksEqual(tRecipe.mResearchItem, aStack, true)) {
-                        boolean failScanner = true;
+                        GTRecipe matchingRecipe = null;
+
                         for (GTRecipe scannerRecipe : scannerFakeRecipes.getAllRecipes()) {
                             if (GTUtility.areStacksEqual(scannerRecipe.mInputs[0], aStack, true)) {
-                                failScanner = false;
+                                matchingRecipe = scannerRecipe;
                                 break;
                             }
                         }
-                        if (failScanner) {
+
+                        if (matchingRecipe == null || aStack.stackSize < matchingRecipe.mInputs[0].stackSize) {
                             return FOUND_RECIPE_BUT_DID_NOT_MEET_REQUIREMENTS;
                         }
 
@@ -364,7 +366,7 @@ public class MTEScanner extends MTEBasicMachine {
 
                         // Use Assline Utils
                         if (AssemblyLineUtils.setAssemblyLineRecipeOnDataStick(this.mOutputItems[0], tRecipe)) {
-                            aStack.stackSize -= 1;
+                            aStack.stackSize -= matchingRecipe.mInputs[0].stackSize;
                             calculateOverclockedNess(30, tRecipe.mResearchTime);
                             // In case recipe is too OP for that machine
                             if (mMaxProgresstime == Integer.MAX_VALUE - 1 && mEUt == Integer.MAX_VALUE - 1)


### PR DESCRIPTION
The scanner previously consumed 1 item from its input, regardless of how many items were in the fake recipe's inputs. There are several items (stem cells for example) whose recipe produces several items. Stem cells in particular are only consumed in multiples of 16 (except for a few biolab-related recipes), meaning there are 15 items left behind after scanning. It'd be nice to update the scanner recipe to consume the whole batch instead of forcing the player to throw them away.

This change was tested by temporarily bumping a recipe to use 4 input items. There shouldn't be any side effects since all scanner recipes use 1 item by default.

Test recipe:
![2024-12-16_13 44 49](https://github.com/user-attachments/assets/a987165e-3edf-4634-b0db-b6fc6d1ca504)

With one input:
![2024-12-16_13 45 15](https://github.com/user-attachments/assets/77a902b0-6cd9-42c9-9abc-a6fe8ae089fd)

With three inputs:
![2024-12-16_13 45 17](https://github.com/user-attachments/assets/bf096872-ea87-4721-942b-7b9852658980)

With four inputs:
![2024-12-16_13 45 20](https://github.com/user-attachments/assets/cf2f7d19-f4c0-4241-a412-42c51b0eed8b)
