### PR TITLE
Reduce Naquadria plasma amount in stellar catalyst

### DIFF
--- a/src/main/java/gregtech/loaders/postload/recipes/MixerRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/MixerRecipes.java
@@ -1614,7 +1614,7 @@ public class MixerRecipes implements Runnable {
                     MaterialsUEVplus.DimensionallyTranscendentExoticCatalyst.getFluid(1000L),
                     Materials.Lead.getPlasma(1000),
                     Materials.Thorium.getPlasma(1000),
-                    Materials.Naquadria.getPlasma(1000L),
+                    Materials.Naquadria.getPlasma(100L),
                     MaterialsUEVplus.RawStarMatter.getFluid(25L))
                 .fluidOutputs(MaterialsUEVplus.DimensionallyTranscendentStellarCatalyst.getFluid(1000L))
                 .duration(41 * MINUTES + 40 * SECONDS)

--- a/src/main/java/gregtech/loaders/postload/recipes/TranscendentPlasmaMixerRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/TranscendentPlasmaMixerRecipes.java
@@ -123,7 +123,7 @@ public class TranscendentPlasmaMixerRecipes implements Runnable {
                 Materials.Tin.getPlasma(1000),
                 Materials.Lead.getPlasma(1000),
                 Materials.Thorium.getPlasma(1000),
-                Materials.Naquadria.getPlasma(1000L),
+                Materials.Naquadria.getPlasma(100L),
                 MaterialsUEVplus.RawStarMatter.getFluid(25L))
             .fluidOutputs(MaterialsUEVplus.ExcitedDTSC.getFluid(1000L))
             .duration(100)


### PR DESCRIPTION
Reduces naq* plasma consumption of stellar catalyst by 10x since it was requiring too much energy to make, skewing the energy value of the catalyst significantly.