### PR TITLE
Remove priest tier skip

### DIFF
--- a/src/main/java/gregtech/mixin/Mixin.java
+++ b/src/main/java/gregtech/mixin/Mixin.java
@@ -105,6 +105,12 @@ public enum Mixin {
         .setSide(Side.BOTH)
         .setApplyIf(() -> PollutionConfig.pollution && PollutionConfig.explosionPollutionAmount != 0F)
         .addTargetedMod(TargetedMod.VANILLA)),
+
+    VANILLA_TRADING(new Builder("Change Vanilla Trades").setPhase(Phase.EARLY)
+        .addMixinClasses("minecraft.VanillaTradingMixin")
+        .addTargetedMod(VANILLA)
+        .setApplyIf(() -> true)
+        .setSide(Side.BOTH)),
     POLLUTION_IC2_IRON_FURNACE(
         new Builder("Ic2 Iron Furnace Pollutes").addMixinClasses("ic2.MixinIC2IronFurnacePollution")
             .setPhase(Phase.LATE)

--- a/src/mixin/java/gregtech/mixin/mixins/early/minecraft/VanillaTradingMixin.java
+++ b/src/mixin/java/gregtech/mixin/mixins/early/minecraft/VanillaTradingMixin.java
@@ -1,0 +1,26 @@
+package gregtech.mixin.mixins.early.minecraft;
+
+import java.util.Random;
+
+import net.minecraft.entity.passive.EntityVillager;
+import net.minecraft.init.Items;
+import net.minecraft.item.Item;
+import net.minecraft.village.MerchantRecipeList;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+@Mixin(EntityVillager.class)
+public class VanillaTradingMixin {
+
+    @Inject(method = "func_146089_b", at = @At("HEAD"), locals = LocalCapture.CAPTURE_FAILHARD, cancellable = true)
+    private static void gt5u$removeEyeOfEnder(MerchantRecipeList p_146089_0_, Item p_146089_1_, Random p_146089_2_,
+        float p_146089_3_, CallbackInfo ci) {
+        if (p_146089_1_.equals(Items.ender_eye)) {
+            ci.cancel();
+        }
+    }
+}


### PR DESCRIPTION
Remove a long standing unintended tier skip that lets one access the end or TC infusion multiple tiers early by trading.

Since it can only be done via mixin and magic dev is always starved on devs this took us a few years. :P
For reference: https://github.com/GTNewHorizons/GT5-Unofficial/commit/1439043fb5aa0881a3112e30cdec4c5f4b1c3559

Goes together with a PR in mobsinfo as the vanilla data there is hardcoded and a PR in nhcoremod to add some replacements: ender pearls and lapis. That also reflects how the trade got changed in vanilla in later versions.

Those two PRs are linked below.

my first mixin :)

There are probably a lot of other trades that could see some improvements but this is just a small, limited fix.

![image](https://github.com/user-attachments/assets/3222cc8f-ce3c-488a-9198-860910f8bd15)
![image](https://github.com/user-attachments/assets/45d50e05-cba0-4f5d-9954-5f3051ff6d57)

