### PR TITLE
Add Oredict Tag to Beamline Masks

### DIFF
--- a/src/main/java/gregtech/api/enums/OrePrefixes.java
+++ b/src/main/java/gregtech/api/enums/OrePrefixes.java
@@ -592,7 +592,10 @@ public enum OrePrefixes {
         false, false, 0, M * 1, 64, -1),
     // subatomic particles
     particle("A Subatomic Particle", "", "", false, false, true, false, false, false, false, false, false, false, 0, -1,
-        64, -1);
+        64, -1),
+    // Beamline Masks
+    mask("A Photolithographic Mask", "", "", false, false, true, false, false, false, false, false, false, false, 0, -1,
+        1, -1);
 
     public static final ImmutableList<OrePrefixes> CELL_TYPES = ImmutableList.of(
         cell,

--- a/src/main/java/gtnhlanth/common/register/LanthItemList.java
+++ b/src/main/java/gtnhlanth/common/register/LanthItemList.java
@@ -7,7 +7,9 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 
 import cpw.mods.fml.common.registry.GameRegistry;
+import gregtech.api.enums.OrePrefixes;
 import gregtech.api.util.GTLanguageManager;
+import gregtech.api.util.GTOreDictUnificator;
 import gtnhlanth.common.beamline.MTEBeamlinePipe;
 import gtnhlanth.common.block.BlockAntennaCasing;
 import gtnhlanth.common.block.BlockCasing;
@@ -162,6 +164,14 @@ public final class LanthItemList {
                 mask.getDamage(),
                 descSpectrum);
             GameRegistry.registerItem(maskItem, maskItem.getUnlocalizedName());
+
+            if (!mask.getName()
+                .contains("blank")) {
+                GTOreDictUnificator.registerOre(
+                    OrePrefixes.mask + mask.getName()
+                        .toUpperCase(),
+                    new ItemStack(maskItem));
+            }
 
             GTLanguageManager.addStringLocalization(maskItem.getUnlocalizedName() + ".name", "Mask (" + english + ")");
 


### PR DESCRIPTION
This PR adds Oredict tags to masks for more variety in their handling during automation.
![image](https://github.com/user-attachments/assets/b828d25c-9775-419b-b0b4-845bc3899a09)
![image](https://github.com/user-attachments/assets/23fea04d-f425-4e9e-b278-957c3037eb30)


