### PR TITLE
Move ingot macerating and ingot/dust fluid extracting out of recycling

### DIFF
--- a/src/main/java/gregtech/api/util/GTRecipeRegistrator.java
+++ b/src/main/java/gregtech/api/util/GTRecipeRegistrator.java
@@ -206,7 +206,7 @@ public class GTRecipeRegistrator {
      * @param isRecycling     whether to put in recycling tab.
      */
     public static void registerReverseFluidSmelting(ItemStack aStack, Materials aMaterial, long aMaterialAmount,
-        MaterialStack aByproduct, Boolean isRecycling) {
+        MaterialStack aByproduct, boolean isRecycling) {
         if (aStack == null || aMaterial == null
             || aMaterial.mSmeltInto.mStandardMoltenFluid == null
             || !aMaterial.contains(SubTag.SMELTING_TO_FLUID)

--- a/src/main/java/gregtech/api/util/GTRecipeRegistrator.java
+++ b/src/main/java/gregtech/api/util/GTRecipeRegistrator.java
@@ -181,7 +181,7 @@ public class GTRecipeRegistrator {
             || aData.mMaterial.mMaterial.mSubTags.contains(SubTag.NO_RECIPES)) return;
         // Prevents registering a quartz block -> 9x quartz dust recipe
         if (!GTUtility.areStacksEqual(new ItemStack(Blocks.quartz_block, 1), aStack)) {
-            registerReverseMacerating(GTUtility.copyAmount(1, aStack), aData, aData.mPrefix == null);
+            registerReverseMacerating(GTUtility.copyAmount(1, aStack), aData, aData.mPrefix == null, true);
         }
         if (!GTUtility.areStacksEqual(GTModHandler.getIC2Item("iridiumOre", 1L), aStack)) {
             registerReverseSmelting(
@@ -193,7 +193,8 @@ public class GTRecipeRegistrator {
                 GTUtility.copyAmount(1, aStack),
                 aData.mMaterial.mMaterial,
                 aData.mMaterial.mAmount,
-                aData.getByProduct(0));
+                aData.getByProduct(0),
+                true);
             registerReverseArcSmelting(GTUtility.copyAmount(1, aStack), aData);
         }
     }
@@ -202,9 +203,10 @@ public class GTRecipeRegistrator {
      * @param aStack          the stack to be recycled.
      * @param aMaterial       the Material.
      * @param aMaterialAmount the amount of it in Material Units.
+     * @param isRecycling     whether to put in recycling tab.
      */
     public static void registerReverseFluidSmelting(ItemStack aStack, Materials aMaterial, long aMaterialAmount,
-        MaterialStack aByproduct) {
+        MaterialStack aByproduct, Boolean isRecycling) {
         if (aStack == null || aMaterial == null
             || aMaterial.mSmeltInto.mStandardMoltenFluid == null
             || !aMaterial.contains(SubTag.SMELTING_TO_FLUID)
@@ -232,9 +234,9 @@ public class GTRecipeRegistrator {
         }
         builder.fluidOutputs(aMaterial.mSmeltInto.getMolten((L * aMaterialAmount) / (M * aStack.stackSize)))
             .duration((int) Math.max(1, (24 * aMaterialAmount) / M))
-            .eut(powerUsage)
-            .recipeCategory(RecipeCategories.fluidExtractorRecycling)
-            .addTo(fluidExtractionRecipes);
+            .eut(powerUsage);
+        if (isRecycling) builder.recipeCategory(RecipeCategories.fluidExtractorRecycling);
+        builder.addTo(fluidExtractionRecipes);
     }
 
     /**
@@ -355,7 +357,8 @@ public class GTRecipeRegistrator {
     }
 
     public static void registerReverseMacerating(ItemStack aStack, Materials aMaterial, long aMaterialAmount,
-        MaterialStack aByProduct01, MaterialStack aByProduct02, MaterialStack aByProduct03, boolean aAllowHammer) {
+        MaterialStack aByProduct01, MaterialStack aByProduct02, MaterialStack aByProduct03, boolean aAllowHammer,
+        boolean isRecycling) {
         registerReverseMacerating(
             aStack,
             new ItemData(
@@ -363,10 +366,12 @@ public class GTRecipeRegistrator {
                 aByProduct01,
                 aByProduct02,
                 aByProduct03),
-            aAllowHammer);
+            aAllowHammer,
+            isRecycling);
     }
 
-    public static void registerReverseMacerating(ItemStack aStack, ItemData aData, boolean aAllowHammer) {
+    public static void registerReverseMacerating(ItemStack aStack, ItemData aData, boolean aAllowHammer,
+        boolean isRecycling) {
         if (aStack == null || aData == null) return;
         aData = new ItemData(aData);
 
@@ -401,9 +406,9 @@ public class GTRecipeRegistrator {
                     .itemOutputs(outputsArray)
                     .duration(
                         (aData.mMaterial.mMaterial == Materials.Marble ? 1 : (int) Math.max(16, tAmount / M)) * TICKS)
-                    .eut(4)
-                    .recipeCategory(RecipeCategories.maceratorRecycling)
-                    .addTo(maceratorRecipes);
+                    .eut(4);
+                if (isRecycling) recipeBuilder.recipeCategory(RecipeCategories.maceratorRecycling);
+                recipeBuilder.addTo(maceratorRecipes);
             }
         }
 

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingDust.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingDust.java
@@ -70,7 +70,8 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                         .addTo(cannerRecipes);
                 }
                 if (!aMaterial.mBlastFurnaceRequired) {
-                    GTRecipeRegistrator.registerReverseFluidSmelting(aStack, aMaterial, aPrefix.mMaterialAmount, null);
+                    GTRecipeRegistrator
+                        .registerReverseFluidSmelting(aStack, aMaterial, aPrefix.mMaterialAmount, null, false);
                     if (aMaterial.mSmeltInto.mArcSmeltInto != aMaterial) {
                         GTRecipeRegistrator.registerReverseArcSmelting(
                             GTUtility.copyAmount(1, aStack),
@@ -518,7 +519,8 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                     .eut(4)
                     .addTo(packagerRecipes);
                 if (!aMaterial.mBlastFurnaceRequired) {
-                    GTRecipeRegistrator.registerReverseFluidSmelting(aStack, aMaterial, aPrefix.mMaterialAmount, null);
+                    GTRecipeRegistrator
+                        .registerReverseFluidSmelting(aStack, aMaterial, aPrefix.mMaterialAmount, null, true);
                     if (aMaterial.mSmeltInto.mArcSmeltInto != aMaterial) {
                         GTRecipeRegistrator.registerReverseArcSmelting(
                             GTUtility.copyAmount(1, aStack),
@@ -538,7 +540,8 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                     .eut(4)
                     .addTo(packagerRecipes);
                 if (!aMaterial.mBlastFurnaceRequired) {
-                    GTRecipeRegistrator.registerReverseFluidSmelting(aStack, aMaterial, aPrefix.mMaterialAmount, null);
+                    GTRecipeRegistrator
+                        .registerReverseFluidSmelting(aStack, aMaterial, aPrefix.mMaterialAmount, null, true);
                     if (aMaterial.mSmeltInto.mArcSmeltInto != aMaterial) {
                         GTRecipeRegistrator.registerReverseArcSmelting(
                             GTUtility.copyAmount(1, aStack),

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingIngot.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingIngot.java
@@ -74,9 +74,17 @@ public class ProcessingIngot implements gregtech.api.interfaces.IOreRecipeRegist
                 }
                 // Reverse recipes
                 {
-                    GTRecipeRegistrator.registerReverseFluidSmelting(aStack, aMaterial, aPrefix.mMaterialAmount, null);
                     GTRecipeRegistrator
-                        .registerReverseMacerating(aStack, aMaterial, aPrefix.mMaterialAmount, null, null, null, false);
+                        .registerReverseFluidSmelting(aStack, aMaterial, aPrefix.mMaterialAmount, null, false);
+                    GTRecipeRegistrator.registerReverseMacerating(
+                        aStack,
+                        aMaterial,
+                        aPrefix.mMaterialAmount,
+                        null,
+                        null,
+                        null,
+                        false,
+                        false);
                     if (aMaterial.mSmeltInto.mArcSmeltInto != aMaterial) {
                         GTRecipeRegistrator.registerReverseArcSmelting(
                             GTUtility.copyAmount(1, aStack),

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingNugget.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingNugget.java
@@ -66,9 +66,9 @@ public class ProcessingNugget implements gregtech.api.interfaces.IOreRecipeRegis
             }
         }
 
-        GTRecipeRegistrator.registerReverseFluidSmelting(aStack, aMaterial, aPrefix.mMaterialAmount, null);
+        GTRecipeRegistrator.registerReverseFluidSmelting(aStack, aMaterial, aPrefix.mMaterialAmount, null, true);
         GTRecipeRegistrator
-            .registerReverseMacerating(aStack, aMaterial, aPrefix.mMaterialAmount, null, null, null, false);
+            .registerReverseMacerating(aStack, aMaterial, aPrefix.mMaterialAmount, null, null, null, false, true);
         if (!aMaterial.contains(SubTag.NO_SMELTING)
             && GTOreDictUnificator.get(OrePrefixes.ingot, aMaterial, 1L) != null) {
             GTValues.RA.stdBuilder()


### PR DESCRIPTION
Title. These are basic materials and should not be considered "recycling", this leads to constant confusion among new players trying to find recipes for (e.g.) molten tin. Changed the fluid extractor and macerator recycling methods to take an isRecycling boolean.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16639
^ even though it's already closed due to stale 🥹 