### PR TITLE
Fix SLAM structure and Antimatter Multi Tooltips

### DIFF
--- a/src/main/java/goodgenerator/blocks/structures/AntimatterStructures.java
+++ b/src/main/java/goodgenerator/blocks/structures/AntimatterStructures.java
@@ -3368,7 +3368,7 @@ public class AntimatterStructures {
             "       A                   A       ", "       A                   A       ",
             "       C                   C       ", "      FCG                 GCF      ",
             "      DDGDDG           GDDGDD      ", "      DDGDDGDCDGGGGGDCDGDDGDD      ",
-            "     FDDDDDDDDDDDDDDDDDDDDDDDFF    " },
+            "     FDDDDDDDDDDDDDDDDDDDDDDDF     " },
         { "                CCC                ", "             EEEEEEEEE             ",
             "             E       E             ", "             E       E             ",
             "             E       E             ", "             E       E             ",

--- a/src/main/java/goodgenerator/blocks/tileEntity/AntimatterForge.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/AntimatterForge.java
@@ -292,6 +292,7 @@ public class AntimatterForge extends MTEExtendedPowerMultiBlockBase<AntimatterFo
                     + "+0.10"
                     + EnumChatFormatting.GRAY)
             .addInfo("Each stabilization can only use one of the fluids at a time")
+            .beginStructureBlock(53, 53, 47, false)
             .addCasingInfoMin("Antimatter Containment Casing", 512, false)
             .addCasingInfoMin("Magnetic Flux Casing", 2274, false)
             .addCasingInfoMin("Gravity Stabilization Casing", 623, false)

--- a/src/main/java/goodgenerator/blocks/tileEntity/AntimatterGenerator.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/AntimatterGenerator.java
@@ -342,6 +342,7 @@ public class AntimatterGenerator extends MTEExtendedPowerMultiBlockBase
             .addInfo("Enable wireless EU mode with screwdriver")
             .addInfo("Wireless mode requires SC UMV Base or better")
             .addInfo("Wireless mode uses hatch capacity limit")
+            .beginStructureBlock(35, 43, 35, false)
             .addCasingInfoMin("Transcendentally Reinforced Borosilicate Glass", 1008, false)
             .addCasingInfoMin("Magnetic Flux Casing", 4122, false)
             .addCasingInfoMin("Gravity Stabilization Casing", 2418, false)


### PR DESCRIPTION
The Shielded Lagrangian Activation Matrix had an errant frame box on the base of it

Before:
![image](https://github.com/user-attachments/assets/b2b4ff1d-1237-494b-bd47-106015ba8bf0)

After:
![image](https://github.com/user-attachments/assets/91bdeb01-605d-45ab-8b52-80095344f635)

I've also fixed the tooltips to include the structure dimensions (which also adds more standard text formatting) to the structure definition tooltip.

Before:
![image](https://github.com/user-attachments/assets/224edaf1-a10d-4e34-9a70-19d08fd82231)

After:
![image](https://github.com/user-attachments/assets/3454729a-9924-48dc-aadb-91d0a1a44f15)

(Also applies for the SSASS, dimensions w: 53, h: 53, l: 47)