### PR TITLE
Fix multiblock tooltips

### DIFF
--- a/src/main/java/bartworks/common/tileentities/multis/MTEBioVat.java
+++ b/src/main/java/bartworks/common/tileentities/multis/MTEBioVat.java
@@ -339,11 +339,6 @@ public class MTEBioVat extends MTEEnhancedMultiBlockBase<MTEBioVat> implements I
     }
 
     @Override
-    public int getPollutionPerTick(ItemStack itemStack) {
-        return 0;
-    }
-
-    @Override
     public int getDamageToComponent(ItemStack itemStack) {
         return 0;
     }

--- a/src/main/java/bartworks/common/tileentities/multis/MTECircuitAssemblyLine.java
+++ b/src/main/java/bartworks/common/tileentities/multis/MTECircuitAssemblyLine.java
@@ -418,11 +418,6 @@ public class MTECircuitAssemblyLine extends MTEEnhancedMultiBlockBase<MTECircuit
     }
 
     @Override
-    public int getPollutionPerTick(ItemStack itemStack) {
-        return 0;
-    }
-
-    @Override
     public int getDamageToComponent(ItemStack itemStack) {
         return 0;
     }

--- a/src/main/java/bartworks/common/tileentities/multis/MTEDeepEarthHeatingPump.java
+++ b/src/main/java/bartworks/common/tileentities/multis/MTEDeepEarthHeatingPump.java
@@ -85,7 +85,8 @@ public class MTEDeepEarthHeatingPump extends MTEDrillerBase {
                     + "L/s of Superheated Steam")
             .addInfo("Coolant Heating Mode: Converts " + (long) (192 * 20) + "L/s Coolant to Hot Coolant")
             .addInfo("Each maintenance issue lowers output efficiency by 10%")
-            .addInfo("Explodes when it runs out of Distilled Water/Coolant");
+            .addInfo("Explodes when it runs out of Distilled Water/Coolant")
+            .addInfo("Base cycle time: 1 tick");
 
         tt.beginStructureBlock(3, 7, 3, false)
             .addController("Front bottom")
@@ -286,8 +287,13 @@ public class MTEDeepEarthHeatingPump extends MTEDrillerBase {
             this.mEUt = Integer.MAX_VALUE - 7;
         }
         this.mProgresstime = 0;
-        this.mMaxProgresstime = 1;
+        this.mMaxProgresstime = calculateMaxProgressTime(0);
         this.mEfficiency = this.getCurrentEfficiency(null);
         this.mEfficiencyIncrease = 10000;
+    }
+
+    @Override
+    public int calculateMaxProgressTime(int tier, boolean simulateWorking) {
+        return 1;
     }
 }

--- a/src/main/java/bartworks/common/tileentities/multis/MTEElectricImplosionCompressor.java
+++ b/src/main/java/bartworks/common/tileentities/multis/MTEElectricImplosionCompressor.java
@@ -477,11 +477,6 @@ public class MTEElectricImplosionCompressor extends MTEExtendedPowerMultiBlockBa
     }
 
     @Override
-    public int getPollutionPerTick(ItemStack itemStack) {
-        return 0;
-    }
-
-    @Override
     public int getDamageToComponent(ItemStack itemStack) {
         return 0;
     }

--- a/src/main/java/bartworks/common/tileentities/multis/MTEHighTempGasCooledReactor.java
+++ b/src/main/java/bartworks/common/tileentities/multis/MTEHighTempGasCooledReactor.java
@@ -378,11 +378,6 @@ public class MTEHighTempGasCooledReactor extends MTEEnhancedMultiBlockBase<MTEHi
     }
 
     @Override
-    public int getPollutionPerTick(ItemStack itemStack) {
-        return 0;
-    }
-
-    @Override
     public int getDamageToComponent(ItemStack itemStack) {
         return 0;
     }

--- a/src/main/java/bartworks/common/tileentities/multis/MTELESU.java
+++ b/src/main/java/bartworks/common/tileentities/multis/MTELESU.java
@@ -439,11 +439,6 @@ public class MTELESU extends MTEMultiBlockBase {
     }
 
     @Override
-    public int getPollutionPerTick(ItemStack itemStack) {
-        return 0;
-    }
-
-    @Override
     public int getDamageToComponent(ItemStack itemStack) {
         return 0;
     }

--- a/src/main/java/bartworks/common/tileentities/multis/MTEManualTrafo.java
+++ b/src/main/java/bartworks/common/tileentities/multis/MTEManualTrafo.java
@@ -282,11 +282,6 @@ public class MTEManualTrafo extends MTEEnhancedMultiBlockBase<MTEManualTrafo> {
     }
 
     @Override
-    public int getPollutionPerTick(ItemStack itemStack) {
-        return 0;
-    }
-
-    @Override
     public int getDamageToComponent(ItemStack itemStack) {
         return 0;
     }

--- a/src/main/java/bartworks/common/tileentities/multis/MTEThoriumHighTempReactor.java
+++ b/src/main/java/bartworks/common/tileentities/multis/MTEThoriumHighTempReactor.java
@@ -308,11 +308,6 @@ public class MTEThoriumHighTempReactor extends MTEEnhancedMultiBlockBase<MTEThor
     }
 
     @Override
-    public int getPollutionPerTick(ItemStack itemStack) {
-        return 0;
-    }
-
-    @Override
     public int getDamageToComponent(ItemStack itemStack) {
         return 0;
     }

--- a/src/main/java/bartworks/common/tileentities/multis/MTEWindmill.java
+++ b/src/main/java/bartworks/common/tileentities/multis/MTEWindmill.java
@@ -408,11 +408,6 @@ public class MTEWindmill extends MTEEnhancedMultiBlockBase<MTEWindmill>
     }
 
     @Override
-    public int getPollutionPerTick(ItemStack itemStack) {
-        return 0;
-    }
-
-    @Override
     public int getDamageToComponent(ItemStack itemStack) {
         return 0;
     }

--- a/src/main/java/bartworks/common/tileentities/multis/mega/MTEMegaBlastFurnace.java
+++ b/src/main/java/bartworks/common/tileentities/multis/mega/MTEMegaBlastFurnace.java
@@ -187,7 +187,7 @@ public class MTEMegaBlastFurnace extends MegaMultiBlockBase<MTEMegaBlastFurnace>
                     + "Tech"
                     + EnumChatFormatting.GRAY
                     + " Laser Hatches.")
-            .addPollutionAmount(20 * this.getPollutionPerTick(null))
+            .addPollutionAmount(getPollutionPerSecond(null))
             .beginStructureBlock(15, 20, 15, true)
             .addController("3rd layer center")
             .addCasingInfoRange("Heat Proof Machine Casing", 0, 279, false)
@@ -272,8 +272,8 @@ public class MTEMegaBlastFurnace extends MegaMultiBlockBase<MTEMegaBlastFurnace>
     }
 
     @Override
-    public int getPollutionPerTick(ItemStack aStack) {
-        return polPtick;
+    public int getPollutionPerSecond(ItemStack aStack) {
+        return polPtick * 20;
     }
 
     public boolean addOutputHatchToTopList(IGregTechTileEntity aTileEntity, int aBaseCasingIndex) {

--- a/src/main/java/bwcrossmod/galacticgreg/MTEVoidMinerBase.java
+++ b/src/main/java/bwcrossmod/galacticgreg/MTEVoidMinerBase.java
@@ -104,10 +104,15 @@ public abstract class MTEVoidMinerBase extends MTEDrillerBase {
         }
         this.mOutputItems = new ItemStack[0];
         this.mProgresstime = 0;
-        this.mMaxProgresstime = 10;
+        this.mMaxProgresstime = calculateMaxProgressTime(0);
         this.mEfficiency = this.getCurrentEfficiency(null);
         this.mEfficiencyIncrease = 10000;
         this.mEUt = this.mEUt > 0 ? -this.mEUt : this.mEUt;
+    }
+
+    @Override
+    public int calculateMaxProgressTime(int tier, boolean simulateWorking) {
+        return 10;
     }
 
     @Override

--- a/src/main/java/goodgenerator/blocks/tileEntity/AntimatterGenerator.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/AntimatterGenerator.java
@@ -264,11 +264,6 @@ public class AntimatterGenerator extends MTEExtendedPowerMultiBlockBase
     }
 
     @Override
-    public int getPollutionPerTick(ItemStack aStack) {
-        return 0;
-    }
-
-    @Override
     public int getDamageToComponent(ItemStack aStack) {
         return 0;
     }

--- a/src/main/java/goodgenerator/blocks/tileEntity/MTEFuelRefineFactory.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/MTEFuelRefineFactory.java
@@ -185,7 +185,8 @@ public class MTEFuelRefineFactory extends MTETooltipMultiBlockBaseEM implements 
             .addInfo("But at what cost?")
             .addInfo("Produces naquadah fuels.")
             .addInfo("Needs field restriction coils to control the fatal radiation.")
-            .addInfo("Use higher tier coils to unlock more fuel types and reduce the processing times.")
+            .addInfo("Use higher tier coils to unlock more fuel types and perform more overclocks.")
+            .addInfo("Perform perfect overclocks.")
             .addTecTechHatchInfo()
             .beginStructureBlock(3, 15, 15, false)
             .addInputHatch("The casings adjacent to field restriction glass.")
@@ -257,7 +258,7 @@ public class MTEFuelRefineFactory extends MTETooltipMultiBlockBaseEM implements 
                 int overclockAmount = Tier - recipe.mSpecialValue;
                 return super.createOverclockCalculator(recipe).limitOverclockCount(overclockAmount);
             }
-        }.setOverclock(4.0, 4.0); // Set Overclock to be 4/4
+        }.enablePerfectOverclock();
     }
 
     @Override
@@ -302,11 +303,6 @@ public class MTEFuelRefineFactory extends MTETooltipMultiBlockBaseEM implements 
     @Override
     public int getMaxEfficiency(ItemStack aStack) {
         return 10000;
-    }
-
-    @Override
-    public int getPollutionPerTick(ItemStack aStack) {
-        return 0;
     }
 
     @Override

--- a/src/main/java/goodgenerator/blocks/tileEntity/MTELargeEssentiaSmeltery.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/MTELargeEssentiaSmeltery.java
@@ -368,7 +368,7 @@ public class MTELargeEssentiaSmeltery extends MTETooltipMultiBlockBaseEM
             .setEUt(getMaxInputEu())
             .setDuration(
                 (int) Math.ceil(this.mOutputAspects.visSize() * RECIPE_DURATION * (1 - this.nodeIncrease * 0.005)))
-            .setDurationDecreasePerOC(4)
+            .enablePerfectOC()
             .calculate();
 
         useLongPower = true;

--- a/src/main/java/goodgenerator/blocks/tileEntity/MTEMultiNqGenerator.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/MTEMultiNqGenerator.java
@@ -379,11 +379,6 @@ public class MTEMultiNqGenerator extends MTETooltipMultiBlockBaseEM implements I
     }
 
     @Override
-    public int getPollutionPerTick(ItemStack aStack) {
-        return 0;
-    }
-
-    @Override
     public int getDamageToComponent(ItemStack aStack) {
         return 0;
     }

--- a/src/main/java/goodgenerator/blocks/tileEntity/MTENeutronActivator.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/MTENeutronActivator.java
@@ -152,11 +152,6 @@ public class MTENeutronActivator extends MTETooltipMultiBlockBaseEM implements I
     }
 
     @Override
-    public int getPollutionPerTick(ItemStack aStack) {
-        return 0;
-    }
-
-    @Override
     public void loadNBTData(NBTTagCompound aNBT) {
         eV = aNBT.getInteger("mKeV");
         mCeil = aNBT.getInteger("mCeil");

--- a/src/main/java/goodgenerator/blocks/tileEntity/MTEUniversalChemicalFuelEngine.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/MTEUniversalChemicalFuelEngine.java
@@ -173,8 +173,8 @@ public class MTEUniversalChemicalFuelEngine extends MTETooltipMultiBlockBaseEM
     }
 
     @Override
-    public int getPollutionPerTick(ItemStack aStack) {
-        return (int) Math.sqrt(this.getPowerFlow()) / 20;
+    public int getPollutionPerSecond(ItemStack aStack) {
+        return (int) Math.sqrt(this.getPowerFlow());
     }
 
     @Override

--- a/src/main/java/goodgenerator/blocks/tileEntity/base/MTETooltipMultiBlockBaseEM.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/base/MTETooltipMultiBlockBaseEM.java
@@ -3,8 +3,6 @@ package goodgenerator.blocks.tileEntity.base;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import net.minecraft.item.ItemStack;
-
 import org.lwjgl.input.Keyboard;
 
 import gregtech.api.interfaces.ISecondaryDescribable;
@@ -51,10 +49,5 @@ public abstract class MTETooltipMultiBlockBaseEM extends TTMultiblockBase implem
 
     public String[] getSecondaryDescription() {
         return getTooltip().getStructureInformation();
-    }
-
-    @Override
-    public int getPollutionPerTick(ItemStack itemStack) {
-        return getPollutionPerSecond(itemStack) / 20;
     }
 }

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
@@ -1007,6 +1007,8 @@ public abstract class MTEMultiBlockBase extends MetaTileEntity
 
     /**
      * Gets the pollution this Device outputs to a Muffler per tick (10000 = one Pullution Block)
+     * 
+     * @param aStack what is in controller
      */
     public int getPollutionPerTick(ItemStack aStack) {
         return getPollutionPerSecond(aStack) / 20;
@@ -1017,6 +1019,8 @@ public abstract class MTEMultiBlockBase extends MetaTileEntity
      * the code of the multiblock.
      *
      * This returns the unmodified raw pollution value, not the one after muffler discounts.
+     * 
+     * @param aStack what is in controller
      */
     public int getPollutionPerSecond(ItemStack aStack) {
         return 0;

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEConcreteBackfillerBase.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEConcreteBackfillerBase.java
@@ -92,11 +92,16 @@ public abstract class MTEConcreteBackfillerBase extends MTEDrillerBase {
             .getDisplayName();
 
         final MultiblockTooltipBuilder tt = new MultiblockTooltipBuilder();
+        final int baseCycleTime = calculateMaxProgressTime(getMinTier(), true);
         tt.addMachineType("Concrete Backfiller")
             .addInfo("Will fill in areas below it with light concrete. This goes through walls")
             .addInfo("Use it to remove any spawning locations beneath your base to reduce lag")
             .addInfo("Will pull back the pipes after it finishes that layer")
             .addInfo("Radius is " + getRadius() + " blocks")
+            .addInfo("Minimum energy hatch tier: " + GTUtility.getColoredTierNameFromTier((byte) getMinTier()))
+            .addInfo(
+                "Base cycle time: " + (baseCycleTime < 20 ? GTUtility.formatNumbers(baseCycleTime) + " ticks"
+                    : GTUtility.formatNumbers(baseCycleTime / 20.0) + " seconds"))
             .beginStructureBlock(3, 7, 3, false)
             .addController("Front bottom")
             .addOtherStructurePart(casings, "form the 3x1x3 Base")
@@ -129,8 +134,13 @@ public abstract class MTEConcreteBackfillerBase extends MTEDrillerBase {
         this.mEfficiencyIncrease = 10000;
         int tier = Math.max(1, GTUtility.getTier(getMaxInputVoltage()));
         this.mEUt = -6 * (1 << (tier << 1));
-        this.mMaxProgresstime = (workState == STATE_UPWARD ? 240 : 80) / (1 << tier);
+        this.mMaxProgresstime = calculateMaxProgressTime(tier);
         this.mMaxProgresstime = Math.max(1, this.mMaxProgresstime);
+    }
+
+    @Override
+    public int calculateMaxProgressTime(int tier, boolean simulateWorking) {
+        return (int) Math.max(1, (workState == STATE_UPWARD || simulateWorking ? 240 : 80) / Math.pow(2, tier));
     }
 
     @Override

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEDrillerBase.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEDrillerBase.java
@@ -704,6 +704,12 @@ public abstract class MTEDrillerBase extends MTEEnhancedMultiBlockBase<MTEDrille
 
     protected abstract void setElectricityStats();
 
+    public int calculateMaxProgressTime(int tier) {
+        return calculateMaxProgressTime(tier, false);
+    }
+
+    public abstract int calculateMaxProgressTime(int tier, boolean simulateWorking);
+
     public int getTotalConfigValue() {
         int config = 0;
         ArrayList<ItemStack> tCircuitList = getDataItems(1);

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEIntegratedOreFactory.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEIntegratedOreFactory.java
@@ -194,6 +194,7 @@ public class MTEIntegratedOreFactory extends MTEExtendedPowerMultiBlockBase<MTEI
             .addInfo("Processing time is dependent on mode.")
             .addInfo("Use a screwdriver to switch mode.")
             .addInfo("Sneak click with screwdriver to void the stone dust.")
+            .addPollutionAmount(getPollutionPerSecond(null))
             .beginStructureBlock(6, 12, 11, false)
             .addController("The third layer")
             .addStructureInfo("128 Advanced Iridium Plated Machine Casing")

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEMultiAutoclave.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEMultiAutoclave.java
@@ -10,7 +10,6 @@ import static gregtech.api.enums.HatchElement.Energy;
 import static gregtech.api.enums.HatchElement.InputBus;
 import static gregtech.api.enums.HatchElement.InputHatch;
 import static gregtech.api.enums.HatchElement.Maintenance;
-import static gregtech.api.enums.HatchElement.Muffler;
 import static gregtech.api.enums.HatchElement.OutputBus;
 import static gregtech.api.enums.HatchElement.OutputHatch;
 import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_FRONT_MULTI_AUTOCLAVE;
@@ -150,7 +149,7 @@ public class MTEMultiAutoclave extends MTEExtendedPowerMultiBlockBase<MTEMultiAu
         .addElement(
             'A',
             buildHatchAdder(MTEMultiAutoclave.class)
-                .atLeast(InputBus, OutputBus, InputHatch, OutputHatch, Maintenance, Muffler, Energy)
+                .atLeast(InputBus, OutputBus, InputHatch, OutputHatch, Maintenance, Energy)
                 .casingIndex(((BlockCasings10) GregTechAPI.sBlockCasings10).getTextureIndex(3))
                 .dot(1)
                 .buildAndChain(
@@ -215,7 +214,6 @@ public class MTEMultiAutoclave extends MTEExtendedPowerMultiBlockBase<MTEMultiAu
             .addOutputHatch("Any Pressure Containment Casing", 1)
             .addEnergyHatch("Any Pressure Containment Casing", 1)
             .addMaintenanceHatch("Any Pressure Containment Casing", 1)
-            .addMufflerHatch("Any Pressure Containment Casing", 1)
             .toolTipFinisher(AuthorVolence);
         return tt;
     }
@@ -234,7 +232,7 @@ public class MTEMultiAutoclave extends MTEExtendedPowerMultiBlockBase<MTEMultiAu
         mEnergyHatches.clear();
         setCoilLevel(HeatingCoilLevel.None);
         if (!checkPiece(STRUCTURE_PIECE_MAIN, 3, 6, 0)) return false;
-        return mCasingAmount >= 128 && mMufflerHatches.size() == 1;
+        return mCasingAmount >= 128;
     }
 
     @Override

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEMultiLathe.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEMultiLathe.java
@@ -8,7 +8,6 @@ import static gregtech.api.enums.GTValues.AuthorVolence;
 import static gregtech.api.enums.HatchElement.Energy;
 import static gregtech.api.enums.HatchElement.InputBus;
 import static gregtech.api.enums.HatchElement.Maintenance;
-import static gregtech.api.enums.HatchElement.Muffler;
 import static gregtech.api.enums.HatchElement.OutputBus;
 import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_FRONT_MULTI_LATHE;
 import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_FRONT_MULTI_LATHE_ACTIVE;
@@ -147,7 +146,7 @@ public class MTEMultiLathe extends MTEExtendedPowerMultiBlockBase<MTEMultiLathe>
                     { "ACCCCBA", "ACCCCBA", "ACCCCBA", "       " }, { "AAAAAAA", "AAAAAAA", "AAAAAAA", "AAAAAAA" } })))
         .addElement(
             'A',
-            buildHatchAdder(MTEMultiLathe.class).atLeast(InputBus, OutputBus, Maintenance, Muffler, Energy)
+            buildHatchAdder(MTEMultiLathe.class).atLeast(InputBus, OutputBus, Maintenance, Energy)
                 .casingIndex(((BlockCasings2) GregTechAPI.sBlockCasings2).getTextureIndex(0))
                 .dot(1)
                 .buildAndChain(onElementPass(MTEMultiLathe::onCasingAdded, ofBlock(GregTechAPI.sBlockCasings2, 0))))
@@ -248,7 +247,6 @@ public class MTEMultiLathe extends MTEExtendedPowerMultiBlockBase<MTEMultiLathe>
             .addOutputBus("Any Solid Steel Casing", 1)
             .addEnergyHatch("Any Solid Steel Casing", 1)
             .addMaintenanceHatch("Any Solid Steel Casing", 1)
-            .addMufflerHatch("Any Solid Steel Casing", 1)
             .addOtherStructurePart("4 Item Pipe Casings", "Center of the glass", 4)
             .toolTipFinisher(AuthorVolence);
         return tt;
@@ -292,10 +290,7 @@ public class MTEMultiLathe extends MTEExtendedPowerMultiBlockBase<MTEMultiLathe>
         getBaseMetaTileEntity().sendBlockEvent(GregTechTileClientEvents.CHANGE_CUSTOM_DATA, getUpdateData());
         if (!checkPiece(STRUCTURE_PIECE_BODY, 3, 4, -1) && !checkPiece(STRUCTURE_PIECE_BODY_ALT, 3, 4, -1))
             return false;
-        return this.mMaintenanceHatches.size() == 1 && pipeTier > 0
-            && !mEnergyHatches.isEmpty()
-            && mCasingAmount >= 42
-            && mMufflerHatches.size() == 1;
+        return this.mMaintenanceHatches.size() == 1 && pipeTier > 0 && !mEnergyHatches.isEmpty() && mCasingAmount >= 42;
     }
 
     public float speedBoost(float speedBoost, byte voltageTier) {

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEOilDrillInfinite.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEOilDrillInfinite.java
@@ -29,6 +29,8 @@ public class MTEOilDrillInfinite extends MTEOilDrillBase {
         final MultiblockTooltipBuilder tt = new MultiblockTooltipBuilder();
         tt.addMachineType("Pump, FDP")
             .addInfo("Works on " + getRangeInChunks() + "x" + getRangeInChunks() + " chunks")
+            .addInfo("Minimum energy hatch tier: " + GTUtility.getColoredTierNameFromTier((byte) getMinTier()))
+            .addInfo("Base cycle time: 1 tick")
             .beginStructureBlock(3, 7, 3, false)
             .addController("Front bottom")
             .addOtherStructurePart(casings, "form the 3x1x3 Base")

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEOreDrillingPlantBase.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEOreDrillingPlantBase.java
@@ -1,6 +1,5 @@
 package gregtech.common.tileentities.machines.multi;
 
-import static gregtech.api.enums.GTValues.TIER_COLORS;
 import static gregtech.api.enums.GTValues.VN;
 import static gregtech.api.enums.HatchElement.Energy;
 import static gregtech.api.enums.HatchElement.InputBus;
@@ -487,10 +486,12 @@ public abstract class MTEOreDrillingPlantBase extends MTEDrillerBase implements 
         this.mMaxProgresstime = calculateMaxProgressTime(tier);
     }
 
-    private int calculateMaxProgressTime(int tier) {
-        return Math.max(
+    @Override
+    public int calculateMaxProgressTime(int tier, boolean simulateWorking) {
+        return (int) Math.max(
             1,
-            ((workState == STATE_DOWNWARD || workState == STATE_AT_BOTTOM) ? getBaseProgressTime() : 80) / (1 << tier));
+            ((workState == STATE_DOWNWARD || workState == STATE_AT_BOTTOM || simulateWorking) ? getBaseProgressTime()
+                : 80) / Math.pow(2, tier));
     }
 
     private ItemStack[] getOutputByDrops(Collection<ItemStack> oreBlockDrops) {
@@ -611,7 +612,7 @@ public abstract class MTEOreDrillingPlantBase extends MTEDrillerBase implements 
             .getDisplayName();
 
         final MultiblockTooltipBuilder tt = new MultiblockTooltipBuilder();
-        final int baseCycleTime = calculateMaxProgressTime(getMinTier());
+        final int baseCycleTime = calculateMaxProgressTime(getMinTier(), true);
         tt.addMachineType("Miner, MBM")
             .addInfo("Use a Screwdriver to configure block radius")
             .addInfo("Maximum radius is " + GTUtility.formatNumbers((long) getRadiusInChunks() << 4) + " blocks")
@@ -620,10 +621,10 @@ public abstract class MTEOreDrillingPlantBase extends MTEDrillerBase implements 
             .addInfo("In chunk mode, working area center is the chunk corner nearest to the drill")
             .addInfo("Gives ~3x as much crushed ore vs normal processing")
             .addInfo("Fortune bonus of " + GTUtility.formatNumbers(mTier + 3) + ". Only works on small ores")
-            .addInfo("Minimum energy hatch tier: " + TIER_COLORS[getMinTier()] + VN[getMinTier()])
+            .addInfo("Minimum energy hatch tier: " + GTUtility.getColoredTierNameFromTier((byte) getMinTier()))
             .addInfo(
                 "Base cycle time: " + (baseCycleTime < 20 ? GTUtility.formatNumbers(baseCycleTime) + " ticks"
-                    : GTUtility.formatNumbers(baseCycleTime / 20) + " seconds"))
+                    : GTUtility.formatNumbers(baseCycleTime / 20.0) + " seconds"))
             .beginStructureBlock(3, 7, 3, false)
             .addController("Front bottom")
             .addOtherStructurePart(casings, "form the 3x1x3 Base")

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEResearchCompleter.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEResearchCompleter.java
@@ -300,11 +300,6 @@ public class MTEResearchCompleter extends MTEEnhancedMultiBlockBase<MTEResearchC
     }
 
     @Override
-    public int getPollutionPerTick(ItemStack itemStack) {
-        return 0;
-    }
-
-    @Override
     public int getDamageToComponent(ItemStack itemStack) {
         return 0;
     }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GTPPMultiBlockBase.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GTPPMultiBlockBase.java
@@ -1390,7 +1390,7 @@ public abstract class GTPPMultiBlockBase<T extends MTEExtendedPowerMultiBlockBas
                     .dynamicString(
                         () -> StatCollector.translateToLocal("GTPP.multiblock.pollution") + ": "
                             + EnumChatFormatting.RED
-                            + (getPollutionPerTick(null) * 20)
+                            + getPollutionPerSecond(null)
                             + EnumChatFormatting.RESET
                             + "/sec")
                     .setTextAlignment(Alignment.CenterLeft)

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/MTEIsaMill.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/MTEIsaMill.java
@@ -86,6 +86,7 @@ public class MTEIsaMill extends GTPPMultiBlockBase<MTEIsaMill> implements ISurvi
         MultiblockTooltipBuilder tt = new MultiblockTooltipBuilder();
         tt.addMachineType(getMachineType())
             .addInfo("Grind ores.")
+            .addInfo("Perform perfect overclocks")
             .addPollutionAmount(getPollutionPerSecond(null))
             .beginStructureBlock(3, 3, 7, false)
             .addController("Front Center")

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/MTESpargeTower.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/MTESpargeTower.java
@@ -378,11 +378,6 @@ public class MTESpargeTower extends GTPPMultiBlockBase<MTESpargeTower> implement
     }
 
     @Override
-    public int getPollutionPerTick(ItemStack aStack) {
-        return 0;
-    }
-
-    @Override
     public int getDamageToComponent(ItemStack aStack) {
         return 0;
     }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTEElementalDuplicator.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTEElementalDuplicator.java
@@ -73,6 +73,7 @@ public class MTEElementalDuplicator extends GTPPMultiBlockBase<MTEElementalDupli
         tt.addMachineType(getMachineType())
             .addInfo("Produces Elemental Material from UU Matter")
             .addInfo("Speed: +100% | EU Usage: 100% | Parallel: 8 * Tier")
+            .addInfo("Perform perfect overclocks")
             .addInfo("Maximum 1x of each bus/hatch.")
             .addInfo("Requires circuit 1-16 in your Data Orb Repository")
             .addInfo("depending on what Data Orb you want to prioritize")

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTEFrothFlotationCell.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTEFrothFlotationCell.java
@@ -77,6 +77,7 @@ public class MTEFrothFlotationCell extends GTPPMultiBlockBase<MTEFrothFlotationC
         MultiblockTooltipBuilder tt = new MultiblockTooltipBuilder();
         tt.addMachineType(getMachineType())
             .addInfo("Process that milled ore!")
+            .addInfo("Perform perfect overclocks")
             .addInfo("You can only ever process one type of material per controller")
             .addPollutionAmount(getPollutionPerSecond(null))
             .beginStructureBlock(7, 9, 7, true)

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTELargeRocketEngine.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTELargeRocketEngine.java
@@ -479,8 +479,8 @@ public class MTELargeRocketEngine extends GTPPMultiBlockBase<MTELargeRocketEngin
     }
 
     @Override
-    public int getPollutionPerTick(final ItemStack aStack) {
-        return 75 * (this.euProduction / 10000);
+    public int getPollutionPerSecond(ItemStack aStack) {
+        return 1500 * (this.euProduction / 10000);
     }
 
     @Override
@@ -491,7 +491,6 @@ public class MTELargeRocketEngine extends GTPPMultiBlockBase<MTELargeRocketEngin
     @Override
     public String[] getExtraInfoData() {
         return new String[] { "Rocket Engine", "Current Air: " + getAir(),
-            "Current Pollution: " + getPollutionPerTick(null),
             "Time until next fuel consumption: " + this.freeFuelTicks,
             "Current Output: " + this.lEUt * this.mEfficiency / 10000 + " EU/t",
             "Fuel Consumption: " + (this.fuelConsumption) + "L/s", "Fuel Value: " + this.fuelValue + " EU/L",

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTEMassFabricator.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTEMassFabricator.java
@@ -106,6 +106,7 @@ public class MTEMassFabricator extends GTPPMultiBlockBase<MTEMassFabricator> imp
         tt.addMachineType(getMachineType())
             .addInfo("Speed: +0% | EU Usage: 80%")
             .addInfo("Parallel: Scrap = 64 | UU = 8 * Tier")
+            .addInfo("Perform perfect overclocks")
             .addInfo("Produces UU-A, UU-M & Scrap")
             .addInfo("Change mode with screwdriver")
             .addPollutionAmount(getPollutionPerSecond(null))

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTENuclearReactor.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTENuclearReactor.java
@@ -292,8 +292,8 @@ public class MTENuclearReactor extends GTPPMultiBlockBase<MTENuclearReactor> imp
     }
 
     @Override
-    public int getPollutionPerTick(final ItemStack aStack) {
-        return 0;
+    public int getPollutionPerSecond(ItemStack aStack) {
+        return 4000;
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTESolarTower.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTESolarTower.java
@@ -592,11 +592,6 @@ public class MTESolarTower extends GTPPMultiBlockBase<MTESolarTower> implements 
     }
 
     @Override
-    public int getPollutionPerTick(final ItemStack aStack) {
-        return 0;
-    }
-
-    @Override
     public boolean explodesOnComponentBreak(final ItemStack aStack) {
         return false;
     }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/chemplant/MTEChemicalPlant.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/chemplant/MTEChemicalPlant.java
@@ -520,11 +520,6 @@ public class MTEChemicalPlant extends GTPPMultiBlockBase<MTEChemicalPlant> imple
     }
 
     @Override
-    public int getPollutionPerTick(final ItemStack aStack) {
-        return 0;
-    }
-
-    @Override
     public boolean explodesOnComponentBreak(final ItemStack aStack) {
         return false;
     }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/mega/MTEMegaAlloyBlastSmelter.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/mega/MTEMegaAlloyBlastSmelter.java
@@ -304,6 +304,7 @@ public class MTEMegaAlloyBlastSmelter extends MTEExtendedPowerMultiBlockBase<MTE
                 EnumChatFormatting.ITALIC + "\"all it does is make metals hot\""
                     + EnumChatFormatting.RESET
                     + EnumChatFormatting.GRAY)
+            .addPollutionAmount(getPollutionPerSecond(null))
             .beginStructureBlock(11, 20, 11, false)
             .addMaintenanceHatch("Around the controller", 2)
             .addOtherStructurePart("Input Bus, Output Bus, Input Hatch, Output Bus, Energy Hatch", "Bottom Casing", 1)

--- a/src/main/java/gtnhlanth/common/tileentity/MTEDigester.java
+++ b/src/main/java/gtnhlanth/common/tileentity/MTEDigester.java
@@ -149,8 +149,8 @@ public class MTEDigester extends MTEEnhancedMultiBlockBase<MTEDigester> implemen
     }
 
     @Override
-    public int getPollutionPerTick(ItemStack aStack) {
-        return 20;
+    public int getPollutionPerSecond(ItemStack aStack) {
+        return 400;
     }
 
     @Override
@@ -207,6 +207,8 @@ public class MTEDigester extends MTEEnhancedMultiBlockBase<MTEDigester> implemen
         final MultiblockTooltipBuilder tt = new MultiblockTooltipBuilder();
         tt.addMachineType("Digester")
             .addInfo("Input ores and fluid, output water.")
+            .addInfo("Perform perfect overclocks")
+            .addPollutionAmount(getPollutionPerSecond(null))
             .addController("Front bottom")
             .addInputHatch("Hint block with dot 1")
             .addInputBus("Hint block with dot 1")

--- a/src/main/java/kekztech/common/tileentities/MTELapotronicSuperCapacitor.java
+++ b/src/main/java/kekztech/common/tileentities/MTELapotronicSuperCapacitor.java
@@ -1230,11 +1230,6 @@ public class MTELapotronicSuperCapacitor extends MTEEnhancedMultiBlockBase<MTELa
     }
 
     @Override
-    public int getPollutionPerTick(ItemStack stack) {
-        return 0;
-    }
-
-    @Override
     public int getDamageToComponent(ItemStack stack) {
         return 0;
     }

--- a/src/main/java/kekztech/common/tileentities/MTESOFuelCellMK1.java
+++ b/src/main/java/kekztech/common/tileentities/MTESOFuelCellMK1.java
@@ -199,11 +199,6 @@ public class MTESOFuelCellMK1 extends MTEEnhancedMultiBlockBase<MTESOFuelCellMK1
     }
 
     @Override
-    public int getPollutionPerTick(ItemStack stack) {
-        return 0;
-    }
-
-    @Override
     public int getDamageToComponent(ItemStack stack) {
         return 0;
     }

--- a/src/main/java/kekztech/common/tileentities/MTESOFuelCellMK2.java
+++ b/src/main/java/kekztech/common/tileentities/MTESOFuelCellMK2.java
@@ -201,11 +201,6 @@ public class MTESOFuelCellMK2 extends MTEEnhancedMultiBlockBase<MTESOFuelCellMK2
     }
 
     @Override
-    public int getPollutionPerTick(ItemStack stack) {
-        return 0;
-    }
-
-    @Override
     public int getDamageToComponent(ItemStack stack) {
         return 0;
     }

--- a/src/main/java/kekztech/common/tileentities/MTETankTFFT.java
+++ b/src/main/java/kekztech/common/tileentities/MTETankTFFT.java
@@ -593,11 +593,6 @@ public class MTETankTFFT extends MTEEnhancedMultiBlockBase<MTETankTFFT> implemen
     }
 
     @Override
-    public int getPollutionPerTick(ItemStack stack) {
-        return 0;
-    }
-
-    @Override
     public int getDamageToComponent(ItemStack stack) {
         return 0;
     }

--- a/src/main/java/kubatech/tileentity/gregtech/multiblock/MTEDEFusionCrafter.java
+++ b/src/main/java/kubatech/tileentity/gregtech/multiblock/MTEDEFusionCrafter.java
@@ -235,10 +235,6 @@ public class MTEDEFusionCrafter extends KubaTechGTMultiBlockBase<MTEDEFusionCraf
         return 10000;
     }
 
-    public int getPollutionPerTick(ItemStack aStack) {
-        return 0;
-    }
-
     public int getDamageToComponent(ItemStack aStack) {
         return 0;
     }

--- a/src/main/java/tectech/thing/metaTileEntity/multi/base/TTMultiblockBase.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/base/TTMultiblockBase.java
@@ -654,17 +654,6 @@ public abstract class TTMultiblockBase extends MTEExtendedPowerMultiBlockBase<TT
     }
 
     /**
-     * get pollution per tick
-     *
-     * @param itemStack what is in controller
-     * @return how much pollution is produced
-     */
-    @Override
-    public int getPollutionPerTick(ItemStack itemStack) {
-        return 0;
-    }
-
-    /**
      * EM pollution per tick
      *
      * @param itemStack - item in controller


### PR DESCRIPTION
- Add pollution tooltip to multis that produce pollution
- Remove muffler hatch requirement from multis that dont produce pollution: Industrial autoclave and lathe
- - LFTR is in the same condition, but it seems it should produce pollution in theory. 4000 pollution/sec is added to it.
- Add perfect oc tooltip to multis that have perfect oc
- - LES is the exception; I dont know why it has perfect oc and scalable parallels at the same time
- Add min energy hatch tier and base cycle time to oil pumps, backfillers and DEHP
- Some pollution code cleanup