### PR TITLE
Fix lsc crash at full capacity

### DIFF
--- a/src/main/java/kekztech/common/tileentities/MTELapotronicSuperCapacitor.java
+++ b/src/main/java/kekztech/common/tileentities/MTELapotronicSuperCapacitor.java
@@ -845,6 +845,7 @@ public class MTELapotronicSuperCapacitor extends MTEEnhancedMultiBlockBase<MTELa
      * @return EU amount
      */
     private long getPowerToDraw(long hatchWatts) {
+        if (stored.compareTo(capacity) >= 0) return 0;
         final BigInteger remcapActual = capacity.subtract(stored);
         final BigInteger recampLimited = (MAX_LONG.compareTo(remcapActual) > 0) ? remcapActual : MAX_LONG;
         return min(hatchWatts, recampLimited.longValue());


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18453

For some reason the LSC can occasionally go above its max capacity with its stored EU. Adds a check to make sure a negative number doesn't get thrown into a place it shouldn't. Tested and confirmed to fix the reproduction case