### PR TITLE
Fix circuit 9 Heavy Oil

### DIFF
--- a/src/main/java/gregtech/loaders/postload/recipes/DistilleryRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/DistilleryRecipes.java
@@ -543,9 +543,9 @@ public class DistilleryRecipes implements Runnable {
             .itemInputs(GTUtility.getIntegratedCircuit(9))
             .fluidInputs(Materials.OilHeavy.getFluid(1000))
             .fluidOutputs(
-                Materials.SulfuricHeavyFuel.getFluid(450),
-                Materials.SulfuricLightFuel.getFluid(150),
-                Materials.SulfuricNaphtha.getFluid(300),
+                Materials.SulfuricHeavyFuel.getFluid(1000),
+                Materials.SulfuricLightFuel.getFluid(450),
+                Materials.SulfuricNaphtha.getFluid(150),
                 MaterialsKevlar.NaphthenicAcid.getFluid(50),
                 Materials.SulfuricGas.getGas(600))
             .duration(5 * SECONDS)


### PR DESCRIPTION
fixes the values of circuit 9 Heavy Oil Distillation not being 10x the Amount of Circuit 1
(if the amounts are to much and circuit 1 should be adjusted according to circuit 9, lmk)
closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18440

for reference: 
![image](https://github.com/user-attachments/assets/91ff7a8e-3816-4d0b-937b-c02c2d99474b)
