### PR TITLE
Remove duplicate stone dust recipe

### DIFF
--- a/src/main/java/gregtech/loaders/preload/LoaderGTBlockFluid.java
+++ b/src/main/java/gregtech/loaders/preload/LoaderGTBlockFluid.java
@@ -2037,13 +2037,6 @@ public class LoaderGTBlockFluid implements Runnable {
         }
 
         GTValues.RA.stdBuilder()
-            .itemInputs(new ItemStack(Blocks.cobblestone, 1, WILDCARD))
-            .itemOutputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.Stone, 1L))
-            .duration(20 * SECONDS)
-            .eut(2)
-            .addTo(maceratorRecipes);
-
-        GTValues.RA.stdBuilder()
             .itemInputs(new ItemStack(Blocks.gravel, 1, WILDCARD))
             .itemOutputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.Stone, 1L), new ItemStack(Items.flint, 1))
             .outputChances(10000, 1000)


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18459

Autogen catches cobblestone with a 4.9s recipe, while there is a 20s recipe defined manually. Removed the 20s recipe, as it was not being selected and to keep parity with the smooth stone macerating recipe (also 4.9s)