### PR TITLE
Fix the Sound of Saplings from GT++

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/bop/blocks/base/SaplingBase.java
+++ b/src/main/java/gtPlusPlus/xmod/bop/blocks/base/SaplingBase.java
@@ -46,6 +46,7 @@ public class SaplingBase extends BlockSapling {
         this.setBlockName(blockName);
         ItemUtils.addItemToOreDictionary(ItemUtils.getSimpleStack(this), "treeSapling", true);
         this.setCreativeTab(AddToCreativeTab.tabBOP);
+        this.setStepSound(Block.soundTypeGrass);
     }
 
     /**


### PR DESCRIPTION
The saplings including Rainforest Oak Sapling and Pine Sapling are sound like stones when placing and destroying, and this commit fixes them.