### PR TITLE
Add onPlayerDestroyItem event when using a tool on a machine

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
@@ -33,6 +33,7 @@ import net.minecraft.world.EnumSkyBlock;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.BiomeGenBase;
 import net.minecraftforge.common.util.ForgeDirection;
+import net.minecraftforge.event.ForgeEventFactory;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTankInfo;
@@ -1528,6 +1529,8 @@ public class BaseMetaTileEntity extends CommonMetaTileEntity
                                     zCoord);
                                 cableUpdateDelay = 10;
                             }
+
+                        if (tCurrentItem.stackSize == 0) ForgeEventFactory.onPlayerDestroyItem(aPlayer, tCurrentItem);
                         return true;
                     }
 
@@ -1553,6 +1556,8 @@ public class BaseMetaTileEntity extends CommonMetaTileEntity
                                 xCoord,
                                 yCoord,
                                 zCoord);
+                            if (tCurrentItem.stackSize == 0)
+                                ForgeEventFactory.onPlayerDestroyItem(aPlayer, tCurrentItem);
                         }
                         return true;
                     }
@@ -1576,6 +1581,8 @@ public class BaseMetaTileEntity extends CommonMetaTileEntity
                                 xCoord,
                                 yCoord,
                                 zCoord);
+                            if (tCurrentItem.stackSize == 0)
+                                ForgeEventFactory.onPlayerDestroyItem(aPlayer, tCurrentItem);
                         }
                         return true;
                     }
@@ -1600,6 +1607,8 @@ public class BaseMetaTileEntity extends CommonMetaTileEntity
                                 xCoord,
                                 yCoord,
                                 zCoord);
+                            if (tCurrentItem.stackSize == 0)
+                                ForgeEventFactory.onPlayerDestroyItem(aPlayer, tCurrentItem);
                         }
                         return true;
                     }
@@ -1634,6 +1643,7 @@ public class BaseMetaTileEntity extends CommonMetaTileEntity
                                 zCoord);
                             issueBlockUpdate();
                         }
+                        if (tCurrentItem.stackSize == 0) ForgeEventFactory.onPlayerDestroyItem(aPlayer, tCurrentItem);
                         doEnetUpdate();
                         cableUpdateDelay = 10;
                         return true;
@@ -1651,6 +1661,8 @@ public class BaseMetaTileEntity extends CommonMetaTileEntity
                                 xCoord,
                                 yCoord,
                                 zCoord);
+                            if (tCurrentItem.stackSize == 0)
+                                ForgeEventFactory.onPlayerDestroyItem(aPlayer, tCurrentItem);
                         }
                         doEnetUpdate();
                         cableUpdateDelay = 10;
@@ -1694,6 +1706,8 @@ public class BaseMetaTileEntity extends CommonMetaTileEntity
                                     yCoord,
                                     zCoord);
                                 dropCover(coverSide, side, false);
+                                if (tCurrentItem.stackSize == 0)
+                                    ForgeEventFactory.onPlayerDestroyItem(aPlayer, tCurrentItem);
                             }
                             return true;
                         } else if (GTUtility.isStackInList(tCurrentItem, GregTechAPI.sJackhammerList)) {
@@ -1718,6 +1732,8 @@ public class BaseMetaTileEntity extends CommonMetaTileEntity
                                             aPlayer,
                                             StatCollector.translateToLocal("gt.cover.info.chat.tick_rate_not_allowed"));
                                     }
+                                    if (tCurrentItem.stackSize == 0)
+                                        ForgeEventFactory.onPlayerDestroyItem(aPlayer, tCurrentItem);
                                     return true;
                                 }
                             }


### PR DESCRIPTION
The code that right clicking on a machine with a tool goes through does not call the onPlayerDestroyItem event when the tool breaks due to us canceling the default action. Tested with InventoryBogoSorter's refill feature.