### PR TITLE
fix Space Project NEI GUI

### DIFF
--- a/src/main/java/gregtech/api/recipe/maps/SpaceProjectFrontend.java
+++ b/src/main/java/gregtech/api/recipe/maps/SpaceProjectFrontend.java
@@ -13,15 +13,12 @@ import net.minecraft.util.EnumChatFormatting;
 
 import com.gtnewhorizons.modularui.api.drawable.IDrawable;
 import com.gtnewhorizons.modularui.api.forge.IItemHandlerModifiable;
-import com.gtnewhorizons.modularui.api.math.Alignment;
 import com.gtnewhorizons.modularui.api.math.Pos2d;
 import com.gtnewhorizons.modularui.api.screen.ModularWindow;
 import com.gtnewhorizons.modularui.common.widget.DrawableWidget;
 import com.gtnewhorizons.modularui.common.widget.ProgressBar;
 
-import appeng.util.ReadableNumberConverter;
 import codechicken.lib.gui.GuiDraw;
-import codechicken.nei.PositionedStack;
 import gregtech.api.gui.modularui.GTUITextures;
 import gregtech.api.recipe.BasicUIPropertiesBuilder;
 import gregtech.api.recipe.NEIRecipePropertiesBuilder;
@@ -85,19 +82,7 @@ public class SpaceProjectFrontend extends RecipeMapFrontend {
 
     @Override
     public void drawNEIOverlays(GTNEIDefaultHandler.CachedDefaultRecipe neiCachedRecipe) {
-        for (PositionedStack stack : neiCachedRecipe.mInputs) {
-            if (stack instanceof GTNEIDefaultHandler.FixedPositionedStack pStack && stack.item != null
-                && !pStack.isFluid()) {
-                int stackSize = ((GTNEIDefaultHandler.FixedPositionedStack) stack).realStackSize;
-                String displayString;
-                if (stack.item.stackSize > 9999) {
-                    displayString = ReadableNumberConverter.INSTANCE.toWideReadableForm(stackSize);
-                } else {
-                    displayString = String.valueOf(stackSize);
-                }
-                drawNEIOverlayText(displayString, stack, 0xffffff, 0.5f, true, Alignment.BottomRight);
-            }
-        }
+        super.drawNEIOverlays(neiCachedRecipe);
         if (neiCachedRecipe.mRecipe instanceof FakeSpaceProjectRecipe) {
             ISpaceProject project = SpaceProjectManager
                 .getProject(((FakeSpaceProjectRecipe) neiCachedRecipe.mRecipe).projectName);


### PR DESCRIPTION
Not sure why it was coded like that, but it caused the input items number to render 2 times like shown:
![image](https://github.com/user-attachments/assets/62f0593c-3111-48ee-ae2c-2ab9480afed8)

This PR fixes this:
![image](https://github.com/user-attachments/assets/d0a20d2c-09f3-4d2f-9737-ab598a858ac4)

If this would break things or there was a really good reason its coded like this and therefore rendering twice, lmk.
fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17773