### PR TITLE
Fix fluid extractor and solidifier overdraw

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTELargeFluidExtractor.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTELargeFluidExtractor.java
@@ -205,7 +205,7 @@ public class MTELargeFluidExtractor extends MTEExtendedPowerMultiBlockBase<MTELa
     @Override
     protected void setProcessingLogicPower(ProcessingLogic logic) {
         logic.setAmperageOC(true);
-        logic.setAvailableVoltage(this.getMaxInputEu());
+        logic.setAvailableVoltage(GTUtility.roundUpVoltage(this.getMaxInputVoltage()));
         logic.setAvailableAmperage(1);
         logic.setEuModifier(getEUMultiplier());
         logic.setMaxParallel(getParallels());

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEMultiSolidifier.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEMultiSolidifier.java
@@ -324,6 +324,12 @@ public class MTEMultiSolidifier extends MTEExtendedPowerMultiBlockBase<MTEMultiS
     }
 
     @Override
+    protected void setProcessingLogicPower(ProcessingLogic logic) {
+        logic.setAvailableVoltage(GTUtility.roundUpVoltage(this.getMaxInputVoltage()));
+        logic.setAvailableAmperage(1L);
+    }
+
+    @Override
     public boolean onRunningTick(ItemStack aStack) {
         runningTickCounter++;
         if (runningTickCounter % 10 == 0 && speedup < 3) {


### PR DESCRIPTION
Prevent these multis from drawing 2A from single hatch, and shaper sometimes drawing even more than the hatches it has.