### PR TITLE
Move beamline multis to checkProcessing()

### DIFF
--- a/src/main/java/gtnhlanth/common/tileentity/MTELINAC.java
+++ b/src/main/java/gtnhlanth/common/tileentity/MTELINAC.java
@@ -25,6 +25,8 @@ import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 
+import org.jetbrains.annotations.NotNull;
+
 import com.gtnewhorizon.structurelib.StructureLib;
 import com.gtnewhorizon.structurelib.alignment.constructable.ISurvivalConstructable;
 import com.gtnewhorizon.structurelib.structure.IStructureDefinition;
@@ -40,6 +42,8 @@ import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.implementations.MTEEnhancedMultiBlockBase;
 import gregtech.api.metatileentity.implementations.MTEHatchEnergy;
+import gregtech.api.recipe.check.CheckRecipeResult;
+import gregtech.api.recipe.check.CheckRecipeResultRegistry;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.MultiblockTooltipBuilder;
@@ -246,8 +250,9 @@ public class MTELINAC extends MTEEnhancedMultiBlockBase<MTELINAC> implements ISu
         return false;
     }
 
+    @NotNull
     @Override
-    public boolean checkRecipe(ItemStack itemStack) {
+    public CheckRecipeResult checkProcessing() {
 
         float tempFactor = 0;
         // Focus as determined by multi properties
@@ -277,7 +282,7 @@ public class MTELINAC extends MTEEnhancedMultiBlockBase<MTELINAC> implements ISu
         if (tFluidInputs.isEmpty()) {
             this.doRandomMaintenanceDamage(); // Penalise letting coolant run dry
             this.stopMachine(SimpleShutDownReason.ofCritical("gtnhlanth.nocoolant"));
-            return false;
+            return CheckRecipeResultRegistry.NO_RECIPE;
         }
 
         // Coolant input
@@ -291,12 +296,12 @@ public class MTELINAC extends MTEEnhancedMultiBlockBase<MTELINAC> implements ISu
         this.mEfficiencyIncrease = 10000;
 
         if (this.getInputInformation() == null) {
-            return false;
+            return CheckRecipeResultRegistry.NO_RECIPE;
         }
 
         if (this.getInputInformation()
             .getEnergy() == 0) {
-            return false;
+            return CheckRecipeResultRegistry.NO_RECIPE;
         }
 
         particleId = this.getInputInformation()
@@ -305,7 +310,7 @@ public class MTELINAC extends MTEEnhancedMultiBlockBase<MTELINAC> implements ISu
 
         if (!inputParticle.canAccelerate()) {
             stopMachine(SimpleShutDownReason.ofCritical("gtnhlanth.noaccel"));
-            return false;
+            return CheckRecipeResultRegistry.NO_RECIPE;
         }
 
         mMaxProgresstime = 1 * TickTime.SECOND;
@@ -364,7 +369,7 @@ public class MTELINAC extends MTEEnhancedMultiBlockBase<MTELINAC> implements ISu
         if (Util.coolantFluidCheck(primFluid, fluidConsumed)) {
 
             this.stopMachine(SimpleShutDownReason.ofCritical("gtnhlanth.inscoolant"));
-            return false;
+            return CheckRecipeResultRegistry.NO_RECIPE;
 
         }
 
@@ -374,17 +379,17 @@ public class MTELINAC extends MTEEnhancedMultiBlockBase<MTELINAC> implements ISu
             primFluid.getFluid()
                 .getName());
 
-        if (Objects.isNull(fluidOutput)) return false;
+        if (Objects.isNull(fluidOutput)) return CheckRecipeResultRegistry.NO_RECIPE;
 
         FluidStack fluidOutputStack = new FluidStack(fluidOutput, fluidConsumed);
 
-        if (Objects.isNull(fluidOutputStack)) return false;
+        if (Objects.isNull(fluidOutputStack)) return CheckRecipeResultRegistry.NO_RECIPE;
 
         this.addFluidOutputs(new FluidStack[] { fluidOutputStack });
 
         outputAfterRecipe();
 
-        return true;
+        return CheckRecipeResultRegistry.SUCCESSFUL;
     }
 
     private void outputAfterRecipe() {
@@ -402,18 +407,7 @@ public class MTELINAC extends MTEEnhancedMultiBlockBase<MTELINAC> implements ISu
     }
 
     @Override
-    public void stopMachine() {
-
-        outputFocus = 0;
-        outputEnergy = 0;
-        outputParticle = 0;
-        outputRate = 0;
-        machineTemp = 0;
-        super.stopMachine();
-    }
-
-    @Override
-    public void stopMachine(ShutDownReason reason) {
+    public void stopMachine(@NotNull ShutDownReason reason) {
 
         outputFocus = 0;
         outputEnergy = 0;

--- a/src/main/java/gtnhlanth/common/tileentity/MTETargetChamber.java
+++ b/src/main/java/gtnhlanth/common/tileentity/MTETargetChamber.java
@@ -24,6 +24,8 @@ import net.minecraft.util.StatCollector;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.FluidStack;
 
+import org.jetbrains.annotations.NotNull;
+
 import com.gtnewhorizon.structurelib.alignment.constructable.ISurvivalConstructable;
 import com.gtnewhorizon.structurelib.structure.IStructureDefinition;
 import com.gtnewhorizon.structurelib.structure.ISurvivalBuildEnvironment;
@@ -38,6 +40,8 @@ import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.implementations.MTEEnhancedMultiBlockBase;
 import gregtech.api.metatileentity.implementations.MTEHatchEnergy;
 import gregtech.api.recipe.RecipeMap;
+import gregtech.api.recipe.check.CheckRecipeResult;
+import gregtech.api.recipe.check.CheckRecipeResultRegistry;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GTRecipe;
 import gregtech.api.util.GTUtility;
@@ -226,8 +230,9 @@ public class MTETargetChamber extends MTEEnhancedMultiBlockBase<MTETargetChamber
         return BeamlineRecipeAdder2.instance.TargetChamberRecipes;
     }
 
+    @NotNull
     @Override
-    public boolean checkRecipe(ItemStack itemStack) {
+    public CheckRecipeResult checkProcessing() {
 
         inputEnergy = 0;
         inputRate = 0;
@@ -272,25 +277,26 @@ public class MTETargetChamber extends MTEEnhancedMultiBlockBase<MTETargetChamber
             })
             .find();
 
-        if (tRecipe == null) return false;
+        if (tRecipe == null) return CheckRecipeResultRegistry.NO_RECIPE;
 
         BeamInformation inputInfo = this.getInputInformation();
 
-        if (inputInfo == null) return false;
+        if (inputInfo == null) return CheckRecipeResultRegistry.NO_RECIPE;
 
         inputEnergy = inputInfo.getEnergy();
         inputRate = inputInfo.getRate();
         inputParticle = inputInfo.getParticleId();
         inputFocus = inputInfo.getFocus();
 
-        if (inputEnergy < tRecipe.minEnergy || inputEnergy > tRecipe.maxEnergy) return false;
+        if (inputEnergy < tRecipe.minEnergy || inputEnergy > tRecipe.maxEnergy)
+            return CheckRecipeResultRegistry.NO_RECIPE;
 
-        if (inputFocus < tRecipe.minFocus) return false;
+        if (inputFocus < tRecipe.minFocus) return CheckRecipeResultRegistry.NO_RECIPE;
 
-        if (inputParticle != tRecipe.particleId) return false;
+        if (inputParticle != tRecipe.particleId) return CheckRecipeResultRegistry.NO_RECIPE;
 
         if (tRecipe.focusItem != null) {
-            if (tRecipe.focusItem.getItem() != tFocusItem.getItem()) return false;
+            if (tRecipe.focusItem.getItem() != tFocusItem.getItem()) return CheckRecipeResultRegistry.NO_RECIPE;
         }
 
         int focusDurabilityDepletion = 1;
@@ -321,13 +327,14 @@ public class MTETargetChamber extends MTEEnhancedMultiBlockBase<MTETargetChamber
         // over the rate. E.g., 100a, 10r
         // would equal 50 seconds
 
-        if (this.mMaxProgresstime == Integer.MAX_VALUE - 1 && this.mEUt == Integer.MAX_VALUE - 1) return false;
+        if (this.mMaxProgresstime == Integer.MAX_VALUE - 1 && this.mEUt == Integer.MAX_VALUE - 1)
+            return CheckRecipeResultRegistry.NO_RECIPE;
 
         double maxParallel = tRecipe
             .maxParallelCalculatedByInputs(batchAmount, new FluidStack[] {}, tItemsWithFocusItemArray);
 
         if (maxParallel < 1) // Insufficient items
-            return false;
+            return CheckRecipeResultRegistry.NO_RECIPE;
 
         if (batchAmount > maxParallel) batchAmount = (int) maxParallel;
 
@@ -358,7 +365,7 @@ public class MTETargetChamber extends MTEEnhancedMultiBlockBase<MTETargetChamber
 
         this.updateSlots();
 
-        return true;
+        return CheckRecipeResultRegistry.SUCCESSFUL;
     }
 
     private BeamInformation getInputInformation() {


### PR DESCRIPTION
Moves beamline multis to `checkProcessing()` over the deprecated `checkRecipe()`

Also removes a few overrides of the deprecated `stopMachine()`, which were unnecessary