### PR TITLE
Widen the Voltage enum in ItemComb

### DIFF
--- a/src/main/java/gregtech/common/items/ItemComb.java
+++ b/src/main/java/gregtech/common/items/ItemComb.java
@@ -1147,7 +1147,7 @@ public class ItemComb extends Item implements IGT_ItemWithMaterialRenderer {
         }
     }
 
-    enum Voltage {
+    public enum Voltage {
 
         ULV,
         LV,


### PR DESCRIPTION
There are methods like `addProcessGT` and `addCentrifugeToMaterial` using `Voltage` enum as its paramter, but the enum itself is not public.
This problem cause other mods are not able to add/modify the comb recipes.