### PR TITLE
Prospector scanner recipe fix

### DIFF
--- a/src/main/java/detrav/enums/IDDetraveMetaGeneratedTool01.java
+++ b/src/main/java/detrav/enums/IDDetraveMetaGeneratedTool01.java
@@ -2,7 +2,6 @@ package detrav.enums;
 
 public enum IDDetraveMetaGeneratedTool01 {
 
-    ProspectorScannerULV(0),
     ProspectorScannerLV(2),
     ProspectorScannerMV(4),
     ProspectorScannerHV(6),

--- a/src/main/java/detrav/items/DetravMetaGeneratedTool01.java
+++ b/src/main/java/detrav/items/DetravMetaGeneratedTool01.java
@@ -11,7 +11,6 @@ import static detrav.enums.IDDetraveMetaGeneratedTool01.ProspectorScannerLV;
 import static detrav.enums.IDDetraveMetaGeneratedTool01.ProspectorScannerLuV;
 import static detrav.enums.IDDetraveMetaGeneratedTool01.ProspectorScannerMV;
 import static detrav.enums.IDDetraveMetaGeneratedTool01.ProspectorScannerUHV;
-import static detrav.enums.IDDetraveMetaGeneratedTool01.ProspectorScannerULV;
 import static detrav.enums.IDDetraveMetaGeneratedTool01.ProspectorScannerUV;
 import static detrav.enums.IDDetraveMetaGeneratedTool01.ProspectorScannerZPM;
 import static gregtech.api.enums.Mods.NewHorizonsCoreMod;
@@ -47,15 +46,6 @@ public class DetravMetaGeneratedTool01 extends MetaGeneratedTool {
     public DetravMetaGeneratedTool01() {
         super("detrav.metatool.01");
         INSTANCE = this;
-        addTool(
-            ProspectorScannerULV.ID,
-            "Prospector's Scanner(ULV)",
-            "",
-            new DetravProspector(0),
-            DetravToolDictNames.craftingToolProspector.toString(),
-            new TCAspects.TC_AspectStack(TCAspects.INSTRUMENTUM, 2L),
-            new TCAspects.TC_AspectStack(TCAspects.METALLUM, 4L),
-            new TCAspects.TC_AspectStack(TCAspects.PERFODIO, 4L));
         addTool(
             ProspectorScannerLV.ID,
             "Prospector's Scanner(LV)",
@@ -298,13 +288,6 @@ public class DetravMetaGeneratedTool01 extends MetaGeneratedTool {
         ItemStack dStack;
         if (NewHorizonsCoreMod.isModLoaded()) {
             // Materials at tiers
-            list.add(
-                getToolWithStats(
-                    ProspectorScannerULV.ID,
-                    1,
-                    Materials.Polycaprolactam,
-                    Materials.Polycaprolactam,
-                    null));
             list.add(getToolWithStats(ProspectorScannerLV.ID, 1, Materials.Steel, Materials.Steel, null));
             list.add(getToolWithStats(ProspectorScannerLV.ID, 1, Materials.Bronze, Materials.Steel, null));
             list.add(getToolWithStats(ProspectorScannerMV.ID, 1, Materials.Manyullyn, Materials.Aluminium, null));
@@ -346,7 +329,6 @@ public class DetravMetaGeneratedTool01 extends MetaGeneratedTool {
         }
 
         // Steel for comparison
-        list.add(getToolWithStats(ProspectorScannerULV.ID, 1, Materials.Steel, Materials.Steel, null));
         list.add(getToolWithStats(ProspectorScannerLV.ID, 1, Materials.Steel, Materials.Steel, null));
         list.add(getToolWithStats(ProspectorScannerMV.ID, 1, Materials.Steel, Materials.Steel, null));
         list.add(getToolWithStats(ProspectorScannerHV.ID, 1, Materials.Steel, Materials.Steel, null));

--- a/src/main/java/detrav/items/processing/ProcessingDetravToolProspector.java
+++ b/src/main/java/detrav/items/processing/ProcessingDetravToolProspector.java
@@ -26,7 +26,7 @@ import gregtech.api.util.GTModHandler;
 public class ProcessingDetravToolProspector implements gregtech.api.interfaces.IOreRecipeRegistrator {
 
     public ProcessingDetravToolProspector() {
-
+        OrePrefixes.toolHeadDrill.add(this);
     }
 
     public void registerOre(OrePrefixes aPrefix, Materials material, String aOreDictName, String aModName,


### PR DESCRIPTION
Readds the prospector scanner recipes which were accidentally removed in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3203

Also removes the ULV Prospector Scanner, as that never had a recipe.

For https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18483

chochem will do the second part in NHCoremod