### PR TITLE
Restore gem implosion

### DIFF
--- a/src/main/java/bartworks/system/material/werkstoff_loaders/recipe/GemLoader.java
+++ b/src/main/java/bartworks/system/material/werkstoff_loaders/recipe/GemLoader.java
@@ -28,26 +28,31 @@ import static gregtech.api.enums.OrePrefixes.ore;
 import static gregtech.api.enums.OrePrefixes.plate;
 import static gregtech.api.recipe.RecipeMaps.compressorRecipes;
 import static gregtech.api.recipe.RecipeMaps.hammerRecipes;
+import static gregtech.api.recipe.RecipeMaps.implosionRecipes;
 import static gregtech.api.recipe.RecipeMaps.laserEngraverRecipes;
 import static gregtech.api.recipe.RecipeMaps.latheRecipes;
 import static gregtech.api.recipe.RecipeMaps.sifterRecipes;
 import static gregtech.api.util.GTRecipeBuilder.MINUTES;
 import static gregtech.api.util.GTRecipeBuilder.SECONDS;
 import static gregtech.api.util.GTRecipeBuilder.TICKS;
+import static gregtech.api.util.GTRecipeConstants.ADDITIVE_AMOUNT;
 
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.oredict.OreDictionary;
 
 import bartworks.system.material.Werkstoff;
+import bartworks.system.material.WerkstoffLoader;
 import bartworks.system.material.werkstoff_loaders.IWerkstoffRunnable;
 import bartworks.util.BWColorUtil;
 import gregtech.api.GregTechAPI;
 import gregtech.api.enums.GTValues;
+import gregtech.api.enums.Materials;
 import gregtech.api.enums.Textures;
 import gregtech.api.enums.TierEU;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GTModHandler;
+import gregtech.api.util.GTOreDictUnificator;
 import gregtech.common.covers.CoverLens;
 
 public class GemLoader implements IWerkstoffRunnable {
@@ -132,6 +137,48 @@ public class GemLoader implements IWerkstoffRunnable {
                 .duration(3 * SECONDS + 4 * TICKS)
                 .eut(16)
                 .addTo(hammerRecipes);
+
+            if (!werkstoff.contains(WerkstoffLoader.NO_BLAST)) {
+                GTValues.RA.stdBuilder()
+                    .itemInputs(werkstoff.get(gemFlawless, 3))
+                    .itemOutputs(werkstoff.get(gemExquisite), GTOreDictUnificator.get(dustTiny, Materials.DarkAsh, 2))
+                    .duration(20 * TICKS)
+                    .eut(TierEU.RECIPE_LV)
+                    .metadata(ADDITIVE_AMOUNT, 8)
+                    .addTo(implosionRecipes);
+
+                GTValues.RA.stdBuilder()
+                    .itemInputs(werkstoff.get(gem, 3))
+                    .itemOutputs(werkstoff.get(gemFlawless), GTOreDictUnificator.get(dustTiny, Materials.DarkAsh, 2))
+                    .duration(20 * TICKS)
+                    .eut(TierEU.RECIPE_LV)
+                    .metadata(ADDITIVE_AMOUNT, 8)
+                    .addTo(implosionRecipes);
+
+                GTValues.RA.stdBuilder()
+                    .itemInputs(werkstoff.get(gemFlawed, 3))
+                    .itemOutputs(werkstoff.get(gem), GTOreDictUnificator.get(dustTiny, Materials.DarkAsh, 2))
+                    .duration(20 * TICKS)
+                    .eut(TierEU.RECIPE_LV)
+                    .metadata(ADDITIVE_AMOUNT, 8)
+                    .addTo(implosionRecipes);
+
+                GTValues.RA.stdBuilder()
+                    .itemInputs(werkstoff.get(gemChipped, 3))
+                    .itemOutputs(werkstoff.get(gemFlawed), GTOreDictUnificator.get(dustTiny, Materials.DarkAsh, 2))
+                    .duration(20 * TICKS)
+                    .eut(TierEU.RECIPE_LV)
+                    .metadata(ADDITIVE_AMOUNT, 8)
+                    .addTo(implosionRecipes);
+
+                GTValues.RA.stdBuilder()
+                    .itemInputs(werkstoff.get(dust, 4))
+                    .itemOutputs(werkstoff.get(gem, 3), GTOreDictUnificator.get(dustTiny, Materials.DarkAsh, 8))
+                    .duration(20 * TICKS)
+                    .eut(TierEU.RECIPE_LV)
+                    .metadata(ADDITIVE_AMOUNT, 24)
+                    .addTo(implosionRecipes);
+            }
 
             if (werkstoff.hasItemType(plate)) {
 

--- a/src/main/java/gregtech/loaders/postload/recipes/ImplosionCompressorRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/ImplosionCompressorRecipes.java
@@ -13,7 +13,6 @@ import gregtech.api.enums.OrePrefixes;
 import gregtech.api.enums.TierEU;
 import gregtech.api.util.GTOreDictUnificator;
 import gregtech.api.util.GTRecipeConstants;
-import gtnhlanth.common.register.WerkstoffMaterialPool;
 
 public class ImplosionCompressorRecipes implements Runnable {
 
@@ -35,16 +34,6 @@ public class ImplosionCompressorRecipes implements Runnable {
                 GTOreDictUnificator.get(OrePrefixes.plateAlloy, Materials.Iridium, 1L),
                 GTOreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 4L))
             .metadata(GTRecipeConstants.ADDITIVE_AMOUNT, 8)
-            .duration(1 * SECONDS)
-            .eut(TierEU.RECIPE_LV)
-            .addTo(implosionRecipes);
-
-        GTValues.RA.stdBuilder()
-            .itemInputs(WerkstoffMaterialPool.LanthanumHexaboride.get(OrePrefixes.dust, 4))
-            .itemOutputs(
-                WerkstoffMaterialPool.LanthanumHexaboride.get(OrePrefixes.gem, 3),
-                GTOreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 12L))
-            .metadata(GTRecipeConstants.ADDITIVE_AMOUNT, 4)
             .duration(1 * SECONDS)
             .eut(TierEU.RECIPE_LV)
             .addTo(implosionRecipes);


### PR DESCRIPTION
Reverts part of one of my collision removal prs https://github.com/GTNewHorizons/GT5-Unofficial/pull/3191, also reverts https://github.com/GTNewHorizons/GT5-Unofficial/pull/3604 (no longer necessary). I failed to do a good job checking this one and dropped many rather important bartworks gem recipes (notably tiberium).

I am not sure which collision exactly was being caused by the implosion recipes (I suspect something to do with salt, since it exists in both gt and bartworks) -  if there is a collision, it should no longer be considered an issue as it would be a true duplicate, to be resolved by MaterialsLib. 

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18400