### PR TITLE
Change Semifluid generator EBF gating

### DIFF
--- a/src/main/java/gtPlusPlus/core/recipe/RecipesMachines.java
+++ b/src/main/java/gtPlusPlus/core/recipe/RecipesMachines.java
@@ -1576,7 +1576,7 @@ public class RecipesMachines {
                 CI.getTieredMachineHull(1, 1),
                 CI.getElectricMotor(1, 2),
                 CI.getElectricPiston(1, 2),
-                GTOreDictUnificator.get(OrePrefixes.cableGt01, Materials.Cobalt, 1L),
+                GTOreDictUnificator.get(OrePrefixes.cableGt01, Materials.Tin, 1L),
                 GTOreDictUnificator.get(OrePrefixes.circuit, Materials.LV, 1L),
                 CI.getGear(1, 2))
             .itemOutputs(GregtechItemList.Generator_SemiFluid_LV.get(1))
@@ -1650,7 +1650,7 @@ public class RecipesMachines {
             CI.bits,
             new Object[] { "PCP", "EME", "GWG", 'M', ItemList.Hull_LV, 'P', ItemList.Electric_Piston_LV, 'E',
                 ItemList.Electric_Motor_LV, 'C', OrePrefixes.circuit.get(Materials.LV), 'W',
-                OrePrefixes.cableGt01.get(Materials.Cobalt), 'G', MaterialsAlloy.TUMBAGA.getGear(2) });
+                OrePrefixes.cableGt01.get(Materials.Tin), 'G', MaterialsAlloy.TUMBAGA.getGear(2) });
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Generator_SemiFluid_MV.get(1L),
             CI.bits,


### PR DESCRIPTION
Unlike all other LV generators, semifluid is gated after EBF for needing cobalt, this is not a major problem but makes the recipes inconsistent, and also if you gate semifluid behind combustion and gas, you're kinda tunneling people into into using combustion or gas.
Not all generators need to be equal in strength, but you should have the freedom to choose which you prefer the most, and if you're forced to use gas or combustion, it's unlikely you'd ever swap to semifluid.