### PR TITLE
Change Strontium Processing Recipe 

### DIFF
--- a/src/main/java/gtPlusPlus/core/recipe/RecipesGregTech.java
+++ b/src/main/java/gtPlusPlus/core/recipe/RecipesGregTech.java
@@ -883,11 +883,12 @@ public class RecipesGregTech {
                 GTUtility.getIntegratedCircuit(21),
                 MaterialMisc.STRONTIUM_OXIDE.getDust(8),
                 MaterialsElements.getInstance().ALUMINIUM.getDust(8))
-            .itemOutputs(
-                MaterialsElements.getInstance().ALUMINIUM.getIngot(8),
-                MaterialsElements.getInstance().STRONTIUM.getIngot(8))
-            .fluidOutputs(MaterialsElements.getInstance().OXYGEN.getFluidStack(8000))
+            .fluidOutputs(
+                MaterialsElements.getInstance().OXYGEN.getFluidStack(8000),
+                MaterialsElements.getInstance().ALUMINIUM.getFluidStack(144 * 8),
+                MaterialsElements.getInstance().STRONTIUM.getFluidStack(144 * 8))
             .eut(TierEU.RECIPE_EV)
+            .noOptimize()
             .duration(2 * MINUTES)
             .addTo(alloyBlastSmelterRecipes);
 


### PR DESCRIPTION
Together with Selenium, strontium processing is the only recipe that has item output in the alloy blast smelter, this pr just changes to output the ingots in molten form instead for more consistency