### PR TITLE
remove unnecessary recipes

### DIFF
--- a/src/main/java/gregtech/loaders/postload/recipes/ChemicalRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/ChemicalRecipes.java
@@ -4938,29 +4938,7 @@ public class ChemicalRecipes implements Runnable {
         // 2CH3COOH = CH3COCH3 + CO2 + H
 
         GTValues.RA.stdBuilder()
-            .itemInputs(GTUtility.copyAmount(0, Materials.Calcite.getDust(5)), GTUtility.getIntegratedCircuit(24))
-            .fluidInputs(Materials.AceticAcid.getFluid(2000))
-            .fluidOutputs(
-                Materials.Acetone.getFluid(1000),
-                Materials.CarbonDioxide.getGas(1000),
-                Materials.Water.getFluid(1000))
-            .duration(20 * SECONDS)
-            .eut(TierEU.RECIPE_HV)
-            .addTo(multiblockChemicalReactorRecipes);
-
-        GTValues.RA.stdBuilder()
             .itemInputs(GTUtility.copyAmount(0, Materials.Calcium.getDust(1)), GTUtility.getIntegratedCircuit(24))
-            .fluidInputs(Materials.AceticAcid.getFluid(2000))
-            .fluidOutputs(
-                Materials.Acetone.getFluid(1000),
-                Materials.CarbonDioxide.getGas(1000),
-                Materials.Water.getFluid(1000))
-            .duration(20 * SECONDS)
-            .eut(TierEU.RECIPE_HV)
-            .addTo(multiblockChemicalReactorRecipes);
-
-        GTValues.RA.stdBuilder()
-            .itemInputs(GTUtility.copyAmount(0, Materials.Quicklime.getDust(2)), GTUtility.getIntegratedCircuit(24))
             .fluidInputs(Materials.AceticAcid.getFluid(2000))
             .fluidOutputs(
                 Materials.Acetone.getFluid(1000),


### PR DESCRIPTION
Removes recipe with calcite and quicklime, recipes are HV, since LV you can get calcium from quicklime and from MV for the calcite so the recipes are essentially just useless duplicates
![image](https://github.com/user-attachments/assets/af502c77-ebf2-42c6-bb43-34f1892de7de)
![image](https://github.com/user-attachments/assets/2dae1fb2-1bfa-4a74-812f-c79312784a5a)
