### PR TITLE
No Free Computation

### DIFF
--- a/src/main/java/tectech/thing/metaTileEntity/multi/MTEQuantumComputer.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/MTEQuantumComputer.java
@@ -263,7 +263,7 @@ public class MTEQuantumComputer extends TTMultiblockBase implements ISurvivalCon
             return SimpleCheckRecipeResult.ofFailure("no_computing");
         }
         if (overclock.getStatus(true).isOk && overvolt.getStatus(true).isOk) {
-            float eut = V[7] * (float) overClockRatio * (float) overVoltageRatio;
+            float eut = Math.max(V[6], V[7] * (float) overClockRatio * (float) overVoltageRatio);
             if (eut < Integer.MAX_VALUE - 7) {
                 mEUt = -(int) eut;
             } else {


### PR DESCRIPTION
Sets a minimum EU/t for the Quantum Computer and Computer Racks (0.25A ZPM). This is to prevent players from setting overclock to zero and getting even a tiny bit of computation for absolutely free.