### PR TITLE
Update structure size tooltips for Large Electric Compressor / HIP

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/compressor/MTEHIPCompressor.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/compressor/MTEHIPCompressor.java
@@ -268,7 +268,7 @@ public class MTEHIPCompressor extends MTEExtendedPowerMultiBlockBase<MTEHIPCompr
                     + "1"
                     + EnumChatFormatting.GRAY
                     + " parallels per voltage tier")
-            .beginStructureBlock(7, 5, 7, true)
+            .beginStructureBlock(15, 8, 7, false)
             .addController("Front Center")
             .addCasingInfoMin("Electric Compressor Casing", 95, false)
             .addCasingInfoMin("Compressor Pipe Casing", 60, false)

--- a/src/main/java/gregtech/common/tileentities/machines/multi/compressor/MTEIndustrialCompressor.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/compressor/MTEIndustrialCompressor.java
@@ -146,7 +146,7 @@ public class MTEIndustrialCompressor extends MTEExtendedPowerMultiBlockBase<MTEI
             .addInfo("100% faster than singleblock machines of the same voltage")
             .addInfo("Only uses 90% of the EU/t normally required")
             .addInfo("Gains 2 parallels per voltage tier")
-            .beginStructureBlock(7, 5, 7, true)
+            .beginStructureBlock(7, 8, 7, true)
             .addController("Front Center")
             .addCasingInfoMin("Electric Compressor Casing", 95, false)
             .addCasingInfoMin("Compressor Pipe Casing", 45, false)


### PR DESCRIPTION
These were incorrect (copy / paste oversight?).
Not sure if the (Hollow) part should stay for the HIP, as the structure is more complicated than "empty box".

![image](https://github.com/user-attachments/assets/c9c1708a-2f4b-422a-90c0-8233a32b3289)

![image](https://github.com/user-attachments/assets/2634f73b-6151-45a6-b3a0-e5a0a20be81a)
