### PR TITLE
Make degasser not form without control hatch

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/purification/MTEPurificationUnitDegasser.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/purification/MTEPurificationUnitDegasser.java
@@ -722,6 +722,8 @@ public class MTEPurificationUnitDegasser extends MTEPurificationUnitBase<MTEPuri
         this.controlHatch = null;
         if (!checkPiece(STRUCTURE_PIECE_MAIN, STRUCTURE_X_OFFSET, STRUCTURE_Y_OFFSET, STRUCTURE_Z_OFFSET)) return false;
         if (casingCount < MIN_CASING) return false;
+        // Do not form without a valid control hatch
+        if (this.controlHatch == null || !this.controlHatch.isValid()) return false;
         return super.checkMachine(aBaseMetaTileEntity, aStack);
     }
 


### PR DESCRIPTION
This prevents a NPE in case users don't place a hatch when they intend to automate the machine with OpenComputers. Simply requiring a hatch to form fixes this issue and keeps the code using it simple and safe.

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18650