### PR TITLE
add MBF abbreviation in Tooltip

### DIFF
--- a/src/main/java/bartworks/common/tileentities/multis/mega/MTEMegaBlastFurnace.java
+++ b/src/main/java/bartworks/common/tileentities/multis/mega/MTEMegaBlastFurnace.java
@@ -168,7 +168,7 @@ public class MTEMegaBlastFurnace extends MegaMultiBlockBase<MTEMegaBlastFurnace>
     @Override
     protected MultiblockTooltipBuilder createTooltip() {
         MultiblockTooltipBuilder tt = new MultiblockTooltipBuilder();
-        tt.addMachineType("Blast Furnace, MEBF")
+        tt.addMachineType("Blast Furnace, MEBF, MBF")
             .addParallelInfo(Configuration.Multiblocks.megaMachinesMax)
             .addInfo("You can use some fluids to reduce recipe time. Place the circuit in the Input Bus")
             .addInfo("Each 900K over the min. Heat required reduces power consumption by 5% (multiplicatively)")


### PR DESCRIPTION
added MBF as Multiblock Tooltip Name to Mega Blast Furnace
didnt remove MEBF due to many people being used to this name
closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18652