### PR TITLE
remove froth recycling Circuits

### DIFF
--- a/src/main/java/gtPlusPlus/api/recipe/GTPPRecipeMaps.java
+++ b/src/main/java/gtPlusPlus/api/recipe/GTPPRecipeMaps.java
@@ -62,7 +62,7 @@ public class GTPPRecipeMaps {
         .build();
     public static final RecipeMap<RecipeMapBackend> vacuumFurnaceRecipes = RecipeMapBuilder.of("gtpp.recipe.vacfurnace")
         .maxIO(9, 9, 3, 3)
-        .minInputs(1, 0)
+        .minInputs(0, 1)
         .neiSpecialInfoFormatter(HeatingCoilSpecialValueFormatter.INSTANCE)
         .frontend(LargeNEIFrontend::new)
         .disableOptimize()

--- a/src/main/java/gtPlusPlus/core/item/chemistry/MilledOreProcessing.java
+++ b/src/main/java/gtPlusPlus/core/item/chemistry/MilledOreProcessing.java
@@ -221,10 +221,9 @@ public class MilledOreProcessing extends ItemPackage {
     }
 
     private void addVacuumFurnaceRecipes() {
-        int aCircuitID = 1;
 
         GTValues.RA.stdBuilder()
-            .itemInputs(GTUtility.getIntegratedCircuit(aCircuitID++))
+            .itemInputs(GTUtility.getIntegratedCircuit(1))
             .itemOutputs(
                 GTOreDictUnificator.get(OrePrefixes.dust, Materials.Zinc, 64),
                 GTOreDictUnificator.get(OrePrefixes.dust, Materials.Zinc, 64),
@@ -241,7 +240,7 @@ public class MilledOreProcessing extends ItemPackage {
             .addTo(vacuumFurnaceRecipes);
 
         GTValues.RA.stdBuilder()
-            .itemInputs(GTUtility.getIntegratedCircuit(aCircuitID++))
+            .itemInputs(GTUtility.getIntegratedCircuit(1))
             .itemOutputs(
                 GTOreDictUnificator.get(OrePrefixes.dust, Materials.Copper, 64),
                 GTOreDictUnificator.get(OrePrefixes.dust, Materials.Copper, 64),
@@ -258,7 +257,6 @@ public class MilledOreProcessing extends ItemPackage {
             .addTo(vacuumFurnaceRecipes);
 
         GTValues.RA.stdBuilder()
-            .itemInputs(GTUtility.getIntegratedCircuit(aCircuitID++))
             .itemOutputs(
                 GTOreDictUnificator.get(OrePrefixes.dust, Materials.Nickel, 64),
                 GTOreDictUnificator.get(OrePrefixes.dust, Materials.Nickel, 64),
@@ -275,7 +273,6 @@ public class MilledOreProcessing extends ItemPackage {
             .addTo(vacuumFurnaceRecipes);
 
         GTValues.RA.stdBuilder()
-            .itemInputs(GTUtility.getIntegratedCircuit(aCircuitID++))
             .itemOutputs(
                 PTMetallicPowder.get(OrePrefixes.dust, 64),
                 PTMetallicPowder.get(OrePrefixes.dust, 64),
@@ -290,7 +287,6 @@ public class MilledOreProcessing extends ItemPackage {
             .addTo(vacuumFurnaceRecipes);
 
         GTValues.RA.stdBuilder()
-            .itemInputs(GTUtility.getIntegratedCircuit(aCircuitID++))
             .itemOutputs(
                 GTOreDictUnificator.get(OrePrefixes.dust, Materials.Iron, 64),
                 GTOreDictUnificator.get(OrePrefixes.dust, Materials.Iron, 64),
@@ -307,7 +303,6 @@ public class MilledOreProcessing extends ItemPackage {
             .addTo(vacuumFurnaceRecipes);
 
         GTValues.RA.stdBuilder()
-            .itemInputs(GTUtility.getIntegratedCircuit(aCircuitID++))
             .itemOutputs(
                 GTOreDictUnificator.get(OrePrefixes.dust, Materials.Redstone, 64),
                 GTOreDictUnificator.get(OrePrefixes.dust, Materials.Redstone, 64),
@@ -325,7 +320,6 @@ public class MilledOreProcessing extends ItemPackage {
             .addTo(vacuumFurnaceRecipes);
 
         GTValues.RA.stdBuilder()
-            .itemInputs(GTUtility.getIntegratedCircuit(aCircuitID++))
             .itemOutputs(
                 GTOreDictUnificator.get(OrePrefixes.dust, Materials.Manganese, 64),
                 GTOreDictUnificator.get(OrePrefixes.dust, Materials.Manganese, 64),
@@ -342,7 +336,6 @@ public class MilledOreProcessing extends ItemPackage {
             .addTo(vacuumFurnaceRecipes);
 
         GTValues.RA.stdBuilder()
-            .itemInputs(GTUtility.getIntegratedCircuit(aCircuitID++))
             .itemOutputs(
                 GTOreDictUnificator.get(OrePrefixes.dust, Materials.Calcium, 64),
                 GTOreDictUnificator.get(OrePrefixes.dust, Materials.Calcium, 64),
@@ -359,7 +352,6 @@ public class MilledOreProcessing extends ItemPackage {
             .addTo(vacuumFurnaceRecipes);
 
         GTValues.RA.stdBuilder()
-            .itemInputs(GTUtility.getIntegratedCircuit(aCircuitID++))
             .itemOutputs(
                 GTOreDictUnificator.get(OrePrefixes.dust, Materials.Aluminium, 64),
                 GTOreDictUnificator.get(OrePrefixes.dust, Materials.Aluminium, 64),
@@ -376,7 +368,6 @@ public class MilledOreProcessing extends ItemPackage {
             .addTo(vacuumFurnaceRecipes);
 
         GTValues.RA.stdBuilder()
-            .itemInputs(GTUtility.getIntegratedCircuit(aCircuitID++))
             .itemOutputs(
                 GTOreDictUnificator.get(OrePrefixes.dust, Materials.Magnesium, 64),
                 GTOreDictUnificator.get(OrePrefixes.dust, Materials.Magnesium, 46),
@@ -392,7 +383,6 @@ public class MilledOreProcessing extends ItemPackage {
             .addTo(vacuumFurnaceRecipes);
 
         GTValues.RA.stdBuilder()
-            .itemInputs(GTUtility.getIntegratedCircuit(aCircuitID++))
             .itemOutputs(
                 GTOreDictUnificator.get(OrePrefixes.dust, Materials.Erbium, 64),
                 GTOreDictUnificator.get(OrePrefixes.dust, Materials.Lanthanum, 32),


### PR DESCRIPTION
Removes most circuits from Froth recycling (exept 2, where recipe conflicts would happen) in the Vacuum Furnace, due to them just being annoying and not having any purpose
also changed the min. Inputs from 1 Item and 0 Fluids to 0 Items an 1 Fluid because every single recipe uses Fluids, but not every recipe uses Items anymore. This could also be removed entirely, but not sure if this would break anything.
![image](https://github.com/user-attachments/assets/f06f8aaa-cb66-4fff-946a-fe467c3d012c)
closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18621