### PR TITLE
Disable redstone control on the superchest/quantumchest itself

### DIFF
--- a/src/main/java/gregtech/common/tileentities/storage/MTEDigitalChestBase.java
+++ b/src/main/java/gregtech/common/tileentities/storage/MTEDigitalChestBase.java
@@ -294,7 +294,7 @@ public abstract class MTEDigitalChestBase extends MTETieredMachineBlock
     @Override
     public void onPostTick(IGregTechTileEntity aBaseMetaTileEntity, long aTimer) {
 
-        if (getBaseMetaTileEntity().isServerSide() && getBaseMetaTileEntity().isAllowedToWork()) {
+        if (getBaseMetaTileEntity().isServerSide()) {
             if ((getItemCount() <= 0)) {
                 setItemStack(null);
                 setItemCount(0);


### PR DESCRIPTION
Allows usage of redstone controlled covers on the superchest (superchest disabled IO before this PR so any redstone controled cover would be enabled while the chest was disabled)

now works the same as supertanks