### PR TITLE
More gt recipe cleanup

### DIFF
--- a/src/main/java/gtPlusPlus/core/recipe/RecipesMachines.java
+++ b/src/main/java/gtPlusPlus/core/recipe/RecipesMachines.java
@@ -7,6 +7,7 @@ import static gregtech.api.enums.Mods.RemoteIO;
 import static gregtech.api.recipe.RecipeMaps.assemblerRecipes;
 import static gregtech.api.recipe.RecipeMaps.cutterRecipes;
 import static gregtech.api.recipe.RecipeMaps.distilleryRecipes;
+import static gregtech.api.util.GTModHandler.getModItem;
 import static gregtech.api.util.GTRecipeBuilder.HOURS;
 import static gregtech.api.util.GTRecipeBuilder.INGOTS;
 import static gregtech.api.util.GTRecipeBuilder.MINUTES;
@@ -1461,15 +1462,15 @@ public class RecipesMachines {
 
         // Industrial Wire Factory
         RecipeUtils.addShapedGregtechRecipe(
-            "plateZeron100",
-            CI.machineCasing_IV,
-            "plateZeron100",
-            CI.circuitTier5,
-            IV_MACHINE_Wiremill,
-            CI.circuitTier5,
-            "plateZeron100",
-            CI.machineCasing_IV,
-            "plateZeron100",
+            "plateBlueSteel",
+            ItemList.Casing_IV.get(1L),
+            "plateBlueSteel",
+            "circuitElite",
+            ItemList.Machine_IV_Wiremill.get(1L),
+            "circuitElite",
+            "plateBlueSteel",
+            ItemList.Casing_IV.get(1L),
+            "plateBlueSteel",
             RECIPE_IndustrialWireFactoryController);
 
         // Tiered Tanks
@@ -2130,27 +2131,15 @@ public class RecipesMachines {
         ItemStack centrifugeEV = ItemList.Machine_EV_Centrifuge.get(1);
 
         RecipeUtils.addShapedGregtechRecipe(
-            "craftingGeothermalGenerator",
-            centrifugeEV,
-            "craftingGeothermalGenerator",
-            "gearGtTitanium",
-            CI.getTieredCircuitOreDictName(6),
-            "gearGtTitanium",
-            "craftingGeothermalGenerator",
-            centrifugeEV,
-            "craftingGeothermalGenerator",
-            RECIPE_ThermalBoilerController);
-
-        RecipeUtils.addShapedGregtechRecipe(
-            "craftingGeothermalGenerator",
-            centrifugeEV,
-            "craftingGeothermalGenerator",
+            getModItem(RemoteIO.ID, "tile.machine", 1, 1),
+            ItemList.Machine_HV_Centrifuge.get(1L),
+            getModItem(RemoteIO.ID, "tile.machine", 1, 1),
             "gearGtTungstenSteel",
-            CI.getTieredCircuitOreDictName(5),
+            "circuitElite",
             "gearGtTungstenSteel",
-            "craftingGeothermalGenerator",
-            centrifugeEV,
-            "craftingGeothermalGenerator",
+            getModItem(RemoteIO.ID, "tile.machine", 1, 1),
+            ItemList.Machine_HV_Centrifuge.get(1L),
+            getModItem(RemoteIO.ID, "tile.machine", 1, 1),
             RECIPE_ThermalBoilerController);
 
         RecipeUtils.addShapedGregtechRecipe(

--- a/src/main/java/gtPlusPlus/xmod/gregtech/HandlerGT.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/HandlerGT.java
@@ -22,6 +22,7 @@ import gtPlusPlus.xmod.gregtech.loaders.ProcessingElectricSnips;
 import gtPlusPlus.xmod.gregtech.loaders.misc.AddCustomMachineToPA;
 import gtPlusPlus.xmod.gregtech.loaders.recipe.RecipeLoaderMolecularTransformer;
 import gtPlusPlus.xmod.gregtech.loaders.recipe.RecipeLoaderTreeFarm;
+import gtPlusPlus.xmod.gregtech.registration.gregtech.GregtechAdvancedBoilers;
 import gtPlusPlus.xmod.gregtech.registration.gregtech.GregtechConduits;
 
 public class HandlerGT {
@@ -61,6 +62,7 @@ public class HandlerGT {
 
         // Add recipes
         CokeAndPyrolyseOven.postInit();
+        GregtechAdvancedBoilers.addRecipes();
 
         // Register custom singles to the PA
         AddCustomMachineToPA.register();

--- a/src/main/java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechAdvancedBoilers.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechAdvancedBoilers.java
@@ -15,7 +15,6 @@ import gregtech.api.util.GTModHandler;
 import gregtech.api.util.GTOreDictUnificator;
 import gtPlusPlus.api.objects.Logger;
 import gtPlusPlus.core.item.ModItems;
-import gtPlusPlus.core.util.minecraft.ItemUtils;
 import gtPlusPlus.xmod.gregtech.api.enums.GregtechItemList;
 import gtPlusPlus.xmod.gregtech.common.tileentities.generators.MTEBoilerHV;
 import gtPlusPlus.xmod.gregtech.common.tileentities.generators.MTEBoilerLV;
@@ -36,13 +35,9 @@ public class GregtechAdvancedBoilers {
             .set(new MTEBoilerMV(Boiler_Advanced_MV.ID, "Advanced Boiler [MV]", 2).getStackForm(1L));
         GregtechItemList.Boiler_Advanced_HV
             .set(new MTEBoilerHV(Boiler_Advanced_HV.ID, "Advanced Boiler [HV]", 3).getStackForm(1L));
+    }
 
-        ItemStack chassisT1 = ItemUtils
-            .getItemStackWithMeta(true, "miscutils:itemBoilerChassis", "Boiler_Chassis_T1", 0, 1);
-        ItemStack chassisT2 = ItemUtils
-            .getItemStackWithMeta(true, "miscutils:itemBoilerChassis", "Boiler_Chassis_T1", 1, 1);
-        ItemStack chassisT3 = ItemUtils
-            .getItemStackWithMeta(true, "miscutils:itemBoilerChassis", "Boiler_Chassis_T1", 2, 1);
+    public static void addRecipes() {
 
         // Chassis Recipes
         GTModHandler.addCraftingRecipe(
@@ -74,7 +69,6 @@ public class GregtechAdvancedBoilers {
                 getModItem(IronTanks.ID, "titaniumTank", 1, 0) });
 
         // Boiler Recipes
-
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Boiler_Advanced_LV.get(1),
             GTModHandler.RecipeBits.NOT_REMOVABLE | GTModHandler.RecipeBits.REVERSIBLE
@@ -83,7 +77,6 @@ public class GregtechAdvancedBoilers {
                 new ItemStack(ModItems.itemBoilerChassis, 1, 0), 'M', ItemList.Casing_LV.get(1L), 'P',
                 GTOreDictUnificator.get(OrePrefixes.pipeHuge, Materials.Steel, 1L), 'B',
                 ItemList.Machine_Steel_Boiler.get(1L) });
-
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Boiler_Advanced_MV.get(1),
             GTModHandler.RecipeBits.NOT_REMOVABLE | GTModHandler.RecipeBits.REVERSIBLE
@@ -92,7 +85,6 @@ public class GregtechAdvancedBoilers {
                 new ItemStack(ModItems.itemBoilerChassis, 1, 1), 'M', ItemList.Casing_MV.get(1L), 'P',
                 GTOreDictUnificator.get(OrePrefixes.pipeHuge, Materials.StainlessSteel, 1L), 'B',
                 ItemList.Machine_Steel_Boiler.get(1L) });
-
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Boiler_Advanced_HV.get(1),
             GTModHandler.RecipeBits.NOT_REMOVABLE | GTModHandler.RecipeBits.REVERSIBLE

--- a/src/main/java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechAdvancedBoilers.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechAdvancedBoilers.java
@@ -3,6 +3,8 @@ package gtPlusPlus.xmod.gregtech.registration.gregtech;
 import static gregtech.api.enums.MetaTileEntityIDs.Boiler_Advanced_HV;
 import static gregtech.api.enums.MetaTileEntityIDs.Boiler_Advanced_LV;
 import static gregtech.api.enums.MetaTileEntityIDs.Boiler_Advanced_MV;
+import static gregtech.api.enums.Mods.IronTanks;
+import static gregtech.api.util.GTModHandler.getModItem;
 
 import net.minecraft.item.ItemStack;
 
@@ -10,7 +12,9 @@ import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.util.GTModHandler;
+import gregtech.api.util.GTOreDictUnificator;
 import gtPlusPlus.api.objects.Logger;
+import gtPlusPlus.core.item.ModItems;
 import gtPlusPlus.core.material.MaterialsAlloy;
 import gtPlusPlus.core.recipe.RecipesMachineComponents;
 import gtPlusPlus.core.util.minecraft.ItemUtils;
@@ -42,65 +46,56 @@ public class GregtechAdvancedBoilers {
         ItemStack chassisT3 = ItemUtils
             .getItemStackWithMeta(true, "miscutils:itemBoilerChassis", "Boiler_Chassis_T1", 2, 1);
 
-        // Make the Coil in each following recipe a hammer and a Screwdriver.
-
         // Chassis Recipes
         GTModHandler.addCraftingRecipe(
-            chassisT1,
-            GTModHandler.RecipeBits.DISMANTLEABLE | GTModHandler.RecipeBits.NOT_REMOVABLE
+            new ItemStack(ModItems.itemBoilerChassis, 1, 0),
+            GTModHandler.RecipeBits.NOT_REMOVABLE
                 | GTModHandler.RecipeBits.REVERSIBLE
                 | GTModHandler.RecipeBits.BUFFERED,
-            new Object[] { "WCW", "GMG", "WPW", 'M', ItemList.Hull_ULV, 'P',
-                OrePrefixes.pipeLarge.get(Materials.Bronze), 'C', OrePrefixes.circuit.get(Materials.ULV), 'W',
-                OrePrefixes.plate.get(Materials.Lead), 'G', OrePrefixes.pipeSmall.get(Materials.Copper) });
-
+            new Object[] { "DSD", "BTB", "DSD", 'D', GTOreDictUnificator.get(OrePrefixes.plateDouble, Materials.Lead, 1L), 'S',
+                GTOreDictUnificator.get(OrePrefixes.pipeMedium, Materials.Steel, 1L), 'B', GTOreDictUnificator.get(OrePrefixes.pipeMedium, Materials.Bronze, 1L), 'T',
+                getModItem(IronTanks.ID, "silverTank", 1, 0) });
         GTModHandler.addCraftingRecipe(
-            chassisT2,
-            GTModHandler.RecipeBits.DISMANTLEABLE | GTModHandler.RecipeBits.NOT_REMOVABLE
+            new ItemStack(ModItems.itemBoilerChassis, 1, 1),
+            GTModHandler.RecipeBits.NOT_REMOVABLE
                 | GTModHandler.RecipeBits.REVERSIBLE
                 | GTModHandler.RecipeBits.BUFFERED,
-            new Object[] { "WCW", "GMG", "WPW", 'M', ItemList.Hull_LV, 'P', OrePrefixes.pipeLarge.get(Materials.Steel),
-                'C', OrePrefixes.circuit.get(Materials.LV), 'W', OrePrefixes.plate.get(Materials.Steel), 'G',
-                OrePrefixes.pipeSmall.get(Materials.Bronze) });
-
+            new Object[] { "DSD", "BTB", "DSD", 'D', GTOreDictUnificator.get(OrePrefixes.plateDouble, Materials.StainlessSteel, 1L), 'S',
+                GTOreDictUnificator.get(OrePrefixes.pipeMedium, Materials.StainlessSteel, 1L), 'B', GTOreDictUnificator.get(OrePrefixes.pipeMedium, Materials.Steel, 1L), 'T',
+                getModItem(IronTanks.ID, "stainlesssteelTank", 1, 0) });
         GTModHandler.addCraftingRecipe(
-            chassisT3,
-            GTModHandler.RecipeBits.DISMANTLEABLE | GTModHandler.RecipeBits.NOT_REMOVABLE
+            new ItemStack(ModItems.itemBoilerChassis, 1, 2),
+            GTModHandler.RecipeBits.NOT_REMOVABLE
                 | GTModHandler.RecipeBits.REVERSIBLE
                 | GTModHandler.RecipeBits.BUFFERED,
-            new Object[] { "WCW", "GMG", "WPW", 'M', ItemList.Hull_MV, 'P',
-                OrePrefixes.pipeLarge.get(Materials.StainlessSteel), 'C', OrePrefixes.circuit.get(Materials.MV), 'W',
-                OrePrefixes.plate.get(Materials.Aluminium), 'G', OrePrefixes.pipeSmall.get(Materials.Steel) });
-
-        ItemStack pipeTier1 = ItemUtils.getItemStackOfAmountFromOreDict(RecipesMachineComponents.pipeTier7, 1);
-        ItemStack pipeTier2 = ItemUtils.getItemStackOfAmountFromOreDict(RecipesMachineComponents.pipeTier8, 1);
-        ItemStack pipeTier3 = ItemUtils.getItemStackOfAmountFromOreDict(RecipesMachineComponents.pipeTier9, 1);
+            new Object[] { "DSD", "BTB", "DSD", 'D', GTOreDictUnificator.get(OrePrefixes.plateDouble, Materials.Titanium, 1L), 'S',
+                GTOreDictUnificator.get(OrePrefixes.pipeMedium, Materials.Titanium, 1L), 'B', GTOreDictUnificator.get(OrePrefixes.pipeMedium, Materials.StainlessSteel, 1L), 'T',
+                getModItem(IronTanks.ID, "titaniumTank", 1, 0) });
 
         // Boiler Recipes
-        GTModHandler.addCraftingRecipe(
-            GregtechItemList.Boiler_Advanced_LV.get(1L),
-            GTModHandler.RecipeBits.DISMANTLEABLE | GTModHandler.RecipeBits.NOT_REMOVABLE
-                | GTModHandler.RecipeBits.REVERSIBLE
-                | GTModHandler.RecipeBits.BUFFERED,
-            new Object[] { "dCw", "WMW", "GPG", 'M', ItemList.Hull_LV, 'P', pipeTier1, 'C',
-                OrePrefixes.circuit.get(Materials.LV), 'W', chassisT1, 'G', OrePrefixes.gear.get(Materials.Steel) });
 
         GTModHandler.addCraftingRecipe(
-            GregtechItemList.Boiler_Advanced_MV.get(1L),
-            GTModHandler.RecipeBits.DISMANTLEABLE | GTModHandler.RecipeBits.NOT_REMOVABLE
+            GregtechItemList.Boiler_Advanced_LV.get(1),
+            GTModHandler.RecipeBits.NOT_REMOVABLE
                 | GTModHandler.RecipeBits.REVERSIBLE
                 | GTModHandler.RecipeBits.BUFFERED,
-            new Object[] { "dCw", "WMW", "GPG", 'M', ItemList.Hull_MV, 'P', pipeTier2, 'C',
-                OrePrefixes.circuit.get(Materials.MV), 'W', chassisT2, 'G',
-                MaterialsAlloy.SILICON_CARBIDE.getGear(1) });
+            new Object[] { "EXE", "CMC", "PBP", 'E', ItemList.Electric_Pump_LV.get(1L), 'X', "circuitBasic", 'C', new ItemStack(ModItems.itemBoilerChassis, 1, 0), 'M',
+                ItemList.Casing_LV.get(1L), 'P', GTOreDictUnificator.get(OrePrefixes.pipeHuge, Materials.Steel, 1L), 'B', ItemList.Machine_Steel_Boiler.get(1L) });
 
         GTModHandler.addCraftingRecipe(
-            GregtechItemList.Boiler_Advanced_HV.get(1L),
-            GTModHandler.RecipeBits.DISMANTLEABLE | GTModHandler.RecipeBits.NOT_REMOVABLE
+            GregtechItemList.Boiler_Advanced_MV.get(1),
+            GTModHandler.RecipeBits.NOT_REMOVABLE
                 | GTModHandler.RecipeBits.REVERSIBLE
                 | GTModHandler.RecipeBits.BUFFERED,
-            new Object[] { "dCw", "WMW", "GPG", 'M', ItemList.Hull_HV, 'P', pipeTier3, 'C',
-                OrePrefixes.circuit.get(Materials.HV), 'W', chassisT3, 'G',
-                MaterialsAlloy.SILICON_CARBIDE.getGear(1) });
+            new Object[] { "EXE", "CMC", "PBP", 'E', ItemList.Electric_Pump_MV.get(1L), 'X', "circuitGood", 'C', new ItemStack(ModItems.itemBoilerChassis, 1, 1), 'M',
+                ItemList.Casing_MV.get(1L), 'P', GTOreDictUnificator.get(OrePrefixes.pipeHuge, Materials.StainlessSteel, 1L), 'B', ItemList.Machine_Steel_Boiler.get(1L) });
+
+        GTModHandler.addCraftingRecipe(
+            GregtechItemList.Boiler_Advanced_HV.get(1),
+            GTModHandler.RecipeBits.NOT_REMOVABLE
+                | GTModHandler.RecipeBits.REVERSIBLE
+                | GTModHandler.RecipeBits.BUFFERED,
+            new Object[] { "EXE", "CMC", "PBP", 'E', ItemList.Electric_Pump_HV.get(1L), 'X', "circuitAdvanced", 'C', new ItemStack(ModItems.itemBoilerChassis, 1, 2), 'M',
+                ItemList.Casing_HV.get(1L), 'P', GTOreDictUnificator.get(OrePrefixes.pipeHuge, Materials.Titanium, 1L), 'B', ItemList.Machine_Steel_Boiler.get(1L) });
     }
 }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechAdvancedBoilers.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechAdvancedBoilers.java
@@ -15,8 +15,6 @@ import gregtech.api.util.GTModHandler;
 import gregtech.api.util.GTOreDictUnificator;
 import gtPlusPlus.api.objects.Logger;
 import gtPlusPlus.core.item.ModItems;
-import gtPlusPlus.core.material.MaterialsAlloy;
-import gtPlusPlus.core.recipe.RecipesMachineComponents;
 import gtPlusPlus.core.util.minecraft.ItemUtils;
 import gtPlusPlus.xmod.gregtech.api.enums.GregtechItemList;
 import gtPlusPlus.xmod.gregtech.common.tileentities.generators.MTEBoilerHV;
@@ -49,53 +47,59 @@ public class GregtechAdvancedBoilers {
         // Chassis Recipes
         GTModHandler.addCraftingRecipe(
             new ItemStack(ModItems.itemBoilerChassis, 1, 0),
-            GTModHandler.RecipeBits.NOT_REMOVABLE
-                | GTModHandler.RecipeBits.REVERSIBLE
+            GTModHandler.RecipeBits.NOT_REMOVABLE | GTModHandler.RecipeBits.REVERSIBLE
                 | GTModHandler.RecipeBits.BUFFERED,
-            new Object[] { "DSD", "BTB", "DSD", 'D', GTOreDictUnificator.get(OrePrefixes.plateDouble, Materials.Lead, 1L), 'S',
-                GTOreDictUnificator.get(OrePrefixes.pipeMedium, Materials.Steel, 1L), 'B', GTOreDictUnificator.get(OrePrefixes.pipeMedium, Materials.Bronze, 1L), 'T',
+            new Object[] { "DSD", "BTB", "DSD", 'D',
+                GTOreDictUnificator.get(OrePrefixes.plateDouble, Materials.Lead, 1L), 'S',
+                GTOreDictUnificator.get(OrePrefixes.pipeMedium, Materials.Steel, 1L), 'B',
+                GTOreDictUnificator.get(OrePrefixes.pipeMedium, Materials.Bronze, 1L), 'T',
                 getModItem(IronTanks.ID, "silverTank", 1, 0) });
         GTModHandler.addCraftingRecipe(
             new ItemStack(ModItems.itemBoilerChassis, 1, 1),
-            GTModHandler.RecipeBits.NOT_REMOVABLE
-                | GTModHandler.RecipeBits.REVERSIBLE
+            GTModHandler.RecipeBits.NOT_REMOVABLE | GTModHandler.RecipeBits.REVERSIBLE
                 | GTModHandler.RecipeBits.BUFFERED,
-            new Object[] { "DSD", "BTB", "DSD", 'D', GTOreDictUnificator.get(OrePrefixes.plateDouble, Materials.StainlessSteel, 1L), 'S',
-                GTOreDictUnificator.get(OrePrefixes.pipeMedium, Materials.StainlessSteel, 1L), 'B', GTOreDictUnificator.get(OrePrefixes.pipeMedium, Materials.Steel, 1L), 'T',
+            new Object[] { "DSD", "BTB", "DSD", 'D',
+                GTOreDictUnificator.get(OrePrefixes.plateDouble, Materials.StainlessSteel, 1L), 'S',
+                GTOreDictUnificator.get(OrePrefixes.pipeMedium, Materials.StainlessSteel, 1L), 'B',
+                GTOreDictUnificator.get(OrePrefixes.pipeMedium, Materials.Steel, 1L), 'T',
                 getModItem(IronTanks.ID, "stainlesssteelTank", 1, 0) });
         GTModHandler.addCraftingRecipe(
             new ItemStack(ModItems.itemBoilerChassis, 1, 2),
-            GTModHandler.RecipeBits.NOT_REMOVABLE
-                | GTModHandler.RecipeBits.REVERSIBLE
+            GTModHandler.RecipeBits.NOT_REMOVABLE | GTModHandler.RecipeBits.REVERSIBLE
                 | GTModHandler.RecipeBits.BUFFERED,
-            new Object[] { "DSD", "BTB", "DSD", 'D', GTOreDictUnificator.get(OrePrefixes.plateDouble, Materials.Titanium, 1L), 'S',
-                GTOreDictUnificator.get(OrePrefixes.pipeMedium, Materials.Titanium, 1L), 'B', GTOreDictUnificator.get(OrePrefixes.pipeMedium, Materials.StainlessSteel, 1L), 'T',
+            new Object[] { "DSD", "BTB", "DSD", 'D',
+                GTOreDictUnificator.get(OrePrefixes.plateDouble, Materials.Titanium, 1L), 'S',
+                GTOreDictUnificator.get(OrePrefixes.pipeMedium, Materials.Titanium, 1L), 'B',
+                GTOreDictUnificator.get(OrePrefixes.pipeMedium, Materials.StainlessSteel, 1L), 'T',
                 getModItem(IronTanks.ID, "titaniumTank", 1, 0) });
 
         // Boiler Recipes
 
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Boiler_Advanced_LV.get(1),
-            GTModHandler.RecipeBits.NOT_REMOVABLE
-                | GTModHandler.RecipeBits.REVERSIBLE
+            GTModHandler.RecipeBits.NOT_REMOVABLE | GTModHandler.RecipeBits.REVERSIBLE
                 | GTModHandler.RecipeBits.BUFFERED,
-            new Object[] { "EXE", "CMC", "PBP", 'E', ItemList.Electric_Pump_LV.get(1L), 'X', "circuitBasic", 'C', new ItemStack(ModItems.itemBoilerChassis, 1, 0), 'M',
-                ItemList.Casing_LV.get(1L), 'P', GTOreDictUnificator.get(OrePrefixes.pipeHuge, Materials.Steel, 1L), 'B', ItemList.Machine_Steel_Boiler.get(1L) });
+            new Object[] { "EXE", "CMC", "PBP", 'E', ItemList.Electric_Pump_LV.get(1L), 'X', "circuitBasic", 'C',
+                new ItemStack(ModItems.itemBoilerChassis, 1, 0), 'M', ItemList.Casing_LV.get(1L), 'P',
+                GTOreDictUnificator.get(OrePrefixes.pipeHuge, Materials.Steel, 1L), 'B',
+                ItemList.Machine_Steel_Boiler.get(1L) });
 
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Boiler_Advanced_MV.get(1),
-            GTModHandler.RecipeBits.NOT_REMOVABLE
-                | GTModHandler.RecipeBits.REVERSIBLE
+            GTModHandler.RecipeBits.NOT_REMOVABLE | GTModHandler.RecipeBits.REVERSIBLE
                 | GTModHandler.RecipeBits.BUFFERED,
-            new Object[] { "EXE", "CMC", "PBP", 'E', ItemList.Electric_Pump_MV.get(1L), 'X', "circuitGood", 'C', new ItemStack(ModItems.itemBoilerChassis, 1, 1), 'M',
-                ItemList.Casing_MV.get(1L), 'P', GTOreDictUnificator.get(OrePrefixes.pipeHuge, Materials.StainlessSteel, 1L), 'B', ItemList.Machine_Steel_Boiler.get(1L) });
+            new Object[] { "EXE", "CMC", "PBP", 'E', ItemList.Electric_Pump_MV.get(1L), 'X', "circuitGood", 'C',
+                new ItemStack(ModItems.itemBoilerChassis, 1, 1), 'M', ItemList.Casing_MV.get(1L), 'P',
+                GTOreDictUnificator.get(OrePrefixes.pipeHuge, Materials.StainlessSteel, 1L), 'B',
+                ItemList.Machine_Steel_Boiler.get(1L) });
 
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Boiler_Advanced_HV.get(1),
-            GTModHandler.RecipeBits.NOT_REMOVABLE
-                | GTModHandler.RecipeBits.REVERSIBLE
+            GTModHandler.RecipeBits.NOT_REMOVABLE | GTModHandler.RecipeBits.REVERSIBLE
                 | GTModHandler.RecipeBits.BUFFERED,
-            new Object[] { "EXE", "CMC", "PBP", 'E', ItemList.Electric_Pump_HV.get(1L), 'X', "circuitAdvanced", 'C', new ItemStack(ModItems.itemBoilerChassis, 1, 2), 'M',
-                ItemList.Casing_HV.get(1L), 'P', GTOreDictUnificator.get(OrePrefixes.pipeHuge, Materials.Titanium, 1L), 'B', ItemList.Machine_Steel_Boiler.get(1L) });
+            new Object[] { "EXE", "CMC", "PBP", 'E', ItemList.Electric_Pump_HV.get(1L), 'X', "circuitAdvanced", 'C',
+                new ItemStack(ModItems.itemBoilerChassis, 1, 2), 'M', ItemList.Casing_HV.get(1L), 'P',
+                GTOreDictUnificator.get(OrePrefixes.pipeHuge, Materials.Titanium, 1L), 'B',
+                ItemList.Machine_Steel_Boiler.get(1L) });
     }
 }


### PR DESCRIPTION
removes several gt recipe manipulations in nhcoremod by directly changing things in gt. This already by itself fixes a bit of recycling. But I also moved the advanced boiler and chassis recipes from init to postinit so that all the itemdata is around to have actually proper recycling recipes.

Goes together with a NHcoremod PR:

example of fixed recycling:
![image](https://github.com/user-attachments/assets/51a6ab8f-6d38-486d-bb39-9dc36cdc9567)

compared to 12 bronze, 8 lead, and 4 copper before.