### PR TITLE
Add perfect Isolation to CRIB Tooltip

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchCraftingInputME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchCraftingInputME.java
@@ -352,7 +352,8 @@ public class MTEHatchCraftingInputME extends MTEHatchInputBus
                 "Processes patterns directly from ME",
                 supportFluids ? "It supports patterns including fluids"
                     : "It does not support patterns including fluids",
-                "Change ME connection behavior by right-clicking with wire cutter" });
+                "Change ME connection behavior by right-clicking with wire cutter",
+                "Ignores the contents of other buses or hatches", "Also ignores other patterns within the same bus" });
         disableSort = true;
         this.supportFluids = supportFluids;
     }


### PR DESCRIPTION
redid https://github.com/GTNewHorizons/GT5-Unofficial/pull/3643 , which got closed but never implemented. Also added the Info about patterns in the same bus not interferring
closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18349
![image](https://github.com/user-attachments/assets/1d750ae9-2d18-46a5-8059-4fa16db70f88)
