### PR TITLE
remove over 1000 recipes that were pure bloat

### DIFF
--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingPlate.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingPlate.java
@@ -146,25 +146,11 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
                         new Object[] { "h", // craftingToolHardHammer
                             "X", "X", 'X', OrePrefixes.ingot.get(aMaterial) });
 
-                    // Only added if IC2 Forge Hammer is enabled in Recipes.cfg: B:ic2forgehammer_true=false
-                    GTModHandler.addCraftingRecipe(
-                        aMaterial.getPlates(1),
-                        tBits, // DO_NOT_CHECK_FOR_COLLISIONS|BUFFERED|ONLY_ADD_IF_RESULT_IS_NOT_NULL|NOT_REMOVABLE
-                        new Object[] { "H", // craftingToolForgeHammer
-                            "X", 'H', ToolDictNames.craftingToolForgeHammer, 'X', OrePrefixes.ingot.get(aMaterial) });
-
                     GTModHandler.addCraftingRecipe(
                         aMaterial.getPlates(1),
                         tBits, // DO_NOT_CHECK_FOR_COLLISIONS|BUFFERED|ONLY_ADD_IF_RESULT_IS_NOT_NULL|NOT_REMOVABLE
                         new Object[] { "h", // craftingToolHardHammer
                             "X", 'X', OrePrefixes.gem.get(aMaterial) });
-
-                    // Only added if IC2 Forge Hammer is enabled in Recipes.cfg: B:ic2forgehammer_true=false
-                    GTModHandler.addCraftingRecipe(
-                        aMaterial.getPlates(1),
-                        tBits, // DO_NOT_CHECK_FOR_COLLISIONS|BUFFERED|ONLY_ADD_IF_RESULT_IS_NOT_NULL|NOT_REMOVABLE
-                        new Object[] { "H", // craftingToolForgeHammer
-                            "X", 'H', ToolDictNames.craftingToolForgeHammer, 'X', OrePrefixes.gem.get(aMaterial) });
                 }
             }
 
@@ -276,12 +262,6 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
                     DO_NOT_CHECK_FOR_COLLISIONS | BUFFERED,
                     new Object[] { "I", "B", "h", // craftingToolHardHammer
                         'I', OrePrefixes.plateDouble.get(aMaterial), 'B', aPlateStack });
-
-                GTModHandler.addShapelessCraftingRecipe(
-                    GTUtility.copyAmount(1, aStack),
-                    DO_NOT_CHECK_FOR_COLLISIONS | BUFFERED,
-                    new Object[] { gregtech.api.enums.ToolDictNames.craftingToolForgeHammer, aPlateStack, aPlateStack,
-                        aPlateStack });
             }
         }
 
@@ -334,12 +314,6 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
                     DO_NOT_CHECK_FOR_COLLISIONS | BUFFERED,
                     new Object[] { "I", "B", "h", // craftingToolHardHammer
                         'I', OrePrefixes.plateTriple.get(aMaterial), 'B', aPlateStack });
-
-                GTModHandler.addShapelessCraftingRecipe(
-                    GTUtility.copyAmount(1, aStack),
-                    DO_NOT_CHECK_FOR_COLLISIONS | BUFFERED,
-                    new Object[] { gregtech.api.enums.ToolDictNames.craftingToolForgeHammer, aPlateStack, aPlateStack,
-                        aPlateStack, aPlateStack });
             }
         }
     }
@@ -380,12 +354,6 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
                     DO_NOT_CHECK_FOR_COLLISIONS | BUFFERED,
                     new Object[] { "I", "B", "h", // craftingToolHardHammer
                         'I', OrePrefixes.plateQuadruple.get(aMaterial), 'B', aPlateStack });
-
-                GTModHandler.addShapelessCraftingRecipe(
-                    GTUtility.copyAmount(1, aStack),
-                    DO_NOT_CHECK_FOR_COLLISIONS | BUFFERED,
-                    new Object[] { ToolDictNames.craftingToolForgeHammer, aPlateStack, aPlateStack, aPlateStack,
-                        aPlateStack, aPlateStack });
             }
         }
     }
@@ -451,13 +419,6 @@ public class ProcessingPlate implements gregtech.api.interfaces.IOreRecipeRegist
                     GTOreDictUnificator.get(OrePrefixes.itemCasing, aMaterial, 1L),
                     tBits, // DO_NOT_CHECK_FOR_COLLISIONS|BUFFERED|ONLY_ADD_IF_RESULT_IS_NOT_NULL|NOT_REMOVABLE
                     new Object[] { "h X", 'X', OrePrefixes.plate.get(aMaterial) });
-
-                // Only added if IC2 Forge Hammer is enabled in Recipes.cfg: B:ic2forgehammer_true=false
-                GTModHandler.addCraftingRecipe(
-                    GTOreDictUnificator.get(OrePrefixes.itemCasing, aMaterial, 1L),
-                    tBits, // DO_NOT_CHECK_FOR_COLLISIONS|BUFFERED|ONLY_ADD_IF_RESULT_IS_NOT_NULL|NOT_REMOVABLE
-                    new Object[] { "H X", 'H', ToolDictNames.craftingToolForgeHammer, 'X',
-                        OrePrefixes.plate.get(aMaterial) });
             }
         }
 

--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/RecipeGenShapedCrafting.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/RecipeGenShapedCrafting.java
@@ -39,13 +39,6 @@ public class RecipeGenShapedCrafting extends RecipeGenBase {
                 GTModHandler.RecipeBits.DO_NOT_CHECK_FOR_COLLISIONS | GTModHandler.RecipeBits.BUFFERED,
                 new Object[] { "h", "B", "I", 'I', material.getIngot(1), 'B', material.getIngot(1) });
 
-        if (ItemUtils.checkForInvalidItems(material.getPlate(1))
-            && ItemUtils.checkForInvalidItems(material.getIngot(1)))
-            GTModHandler.addShapelessCraftingRecipe(
-                material.getPlate(1),
-                new Object[] { gregtech.api.enums.ToolDictNames.craftingToolForgeHammer, material.getIngot(1),
-                    material.getIngot(1) });
-
         // Double Plate Shaped/Shapeless
         if (ItemUtils.checkForInvalidItems(material.getPlateDouble(1))
             && ItemUtils.checkForInvalidItems(material.getPlate(1)))
@@ -53,13 +46,6 @@ public class RecipeGenShapedCrafting extends RecipeGenBase {
                 material.getPlateDouble(1),
                 GTModHandler.RecipeBits.DO_NOT_CHECK_FOR_COLLISIONS | GTModHandler.RecipeBits.BUFFERED,
                 new Object[] { "I", "B", "h", 'I', material.getPlate(1), 'B', material.getPlate(1) });
-
-        if (ItemUtils.checkForInvalidItems(material.getPlateDouble(1))
-            && ItemUtils.checkForInvalidItems(material.getPlate(1)))
-            GTModHandler.addShapelessCraftingRecipe(
-                material.getPlateDouble(1),
-                new Object[] { gregtech.api.enums.ToolDictNames.craftingToolForgeHammer, material.getPlate(1),
-                    material.getPlate(1) });
 
         // Ring Recipe
         if (!material.isRadioactive && ItemUtils.checkForInvalidItems(material.getRing(1))


### PR DESCRIPTION
closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18699

removes all the recipes that have the ic2 hammer as input. it is not obtainable in gtnh and this is all just bloat from old gt.