### PR TITLE
Widen Modifiers to `protected` in MTEHatchInputBusME and MTEHatchOutputBusME

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchInputBusME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchInputBusME.java
@@ -82,21 +82,21 @@ import mcp.mobius.waila.api.IWailaDataAccessor;
 public class MTEHatchInputBusME extends MTEHatchInputBus implements IConfigurationCircuitSupport,
     IRecipeProcessingAwareHatch, IAddGregtechLogo, IAddUIWidgets, IPowerChannelState, ISmartInputHatch, IDataCopyable {
 
-    private static final int SLOT_COUNT = 16;
+    protected static final int SLOT_COUNT = 16;
     public static final String COPIED_DATA_IDENTIFIER = "stockingBus";
-    private BaseActionSource requestSource = null;
-    private @Nullable AENetworkProxy gridProxy = null;
-    private final ItemStack[] shadowInventory = new ItemStack[SLOT_COUNT];
-    private final int[] savedStackSizes = new int[SLOT_COUNT];
-    private boolean processingRecipe = false;
-    private final boolean autoPullAvailable;
-    private boolean autoPullItemList = false;
-    private int minAutoPullStackSize = 1;
-    private int autoPullRefreshTime = 100;
-    private static final int CONFIG_WINDOW_ID = 10;
-    private boolean additionalConnection = false;
-    private boolean justHadNewItems = false;
-    private boolean expediteRecipeCheck = false;
+    protected BaseActionSource requestSource = null;
+    protected @Nullable AENetworkProxy gridProxy = null;
+    protected final ItemStack[] shadowInventory = new ItemStack[SLOT_COUNT];
+    protected final int[] savedStackSizes = new int[SLOT_COUNT];
+    protected boolean processingRecipe = false;
+    protected final boolean autoPullAvailable;
+    protected boolean autoPullItemList = false;
+    protected int minAutoPullStackSize = 1;
+    protected int autoPullRefreshTime = 100;
+    protected static final int CONFIG_WINDOW_ID = 10;
+    protected boolean additionalConnection = false;
+    protected boolean justHadNewItems = false;
+    protected boolean expediteRecipeCheck = false;
 
     public MTEHatchInputBusME(int aID, boolean autoPullAvailable, String aName, String aNameRegional) {
         super(
@@ -156,7 +156,7 @@ public class MTEHatchInputBusME extends MTEHatchInputBus implements IConfigurati
         return isOutputFacing(forgeDirection) ? AECableType.SMART : AECableType.NONE;
     }
 
-    private void updateValidGridProxySides() {
+    protected void updateValidGridProxySides() {
         if (additionalConnection) {
             getProxy().setValidSides(EnumSet.complementOf(EnumSet.of(ForgeDirection.UNKNOWN)));
         } else {
@@ -223,7 +223,7 @@ public class MTEHatchInputBusME extends MTEHatchInputBus implements IConfigurati
         getProxy().writeToNBT(aNBT);
     }
 
-    private void setAutoPullItemList(boolean pullItemList) {
+    protected void setAutoPullItemList(boolean pullItemList) {
         if (!autoPullAvailable) {
             return;
         }
@@ -392,7 +392,7 @@ public class MTEHatchInputBusME extends MTEHatchInputBus implements IConfigurati
         return tag;
     }
 
-    private int getManualSlot() {
+    protected int getManualSlot() {
         return SLOT_COUNT * 2 + 1;
     }
 
@@ -476,7 +476,7 @@ public class MTEHatchInputBusME extends MTEHatchInputBus implements IConfigurati
         return mInventory[aIndex];
     }
 
-    private BaseActionSource getRequestSource() {
+    protected BaseActionSource getRequestSource() {
         if (requestSource == null) requestSource = new MachineSource((IActionHost) getBaseMetaTileEntity());
         return requestSource;
     }
@@ -494,7 +494,7 @@ public class MTEHatchInputBusME extends MTEHatchInputBus implements IConfigurati
         updateAllInformationSlots();
     }
 
-    private void refreshItemList() {
+    protected void refreshItemList() {
         AENetworkProxy proxy = getProxy();
         try {
             IMEMonitor<IAEItemStack> sg = proxy.getStorage()
@@ -523,7 +523,7 @@ public class MTEHatchInputBusME extends MTEHatchInputBus implements IConfigurati
         } catch (final GridAccessException ignored) {}
     }
 
-    private void updateAllInformationSlots() {
+    protected void updateAllInformationSlots() {
         for (int index = 0; index < SLOT_COUNT; index++) {
             updateInformationSlot(index, mInventory[index]);
         }
@@ -863,7 +863,7 @@ public class MTEHatchInputBusME extends MTEHatchInputBus implements IConfigurati
         super.getWailaNBTData(player, tile, tag, world, x, y, z);
     }
 
-    private static String[] getDescriptionArray(boolean autoPullAvailable) {
+    protected static String[] getDescriptionArray(boolean autoPullAvailable) {
         List<String> strings = new ArrayList<>(8);
         strings.add("Advanced item input for Multiblocks");
         strings.add("Hatch Tier: " + TIER_COLORS[autoPullAvailable ? 6 : 3] + VN[autoPullAvailable ? 6 : 3]);

--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchOutputBusME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchOutputBusME.java
@@ -60,11 +60,11 @@ import mcp.mobius.waila.api.IWailaDataAccessor;
 
 public class MTEHatchOutputBusME extends MTEHatchOutputBus implements IPowerChannelState {
 
-    private static final long DEFAULT_CAPACITY = 1_600;
-    private long baseCapacity = DEFAULT_CAPACITY;
+    protected static final long DEFAULT_CAPACITY = 1_600;
+    protected long baseCapacity = DEFAULT_CAPACITY;
 
-    private BaseActionSource requestSource = null;
-    private @Nullable AENetworkProxy gridProxy = null;
+    protected BaseActionSource requestSource = null;
+    protected @Nullable AENetworkProxy gridProxy = null;
     final IItemList<IAEItemStack> itemCache = AEApi.instance()
         .storage()
         .createItemList();
@@ -116,7 +116,7 @@ public class MTEHatchOutputBusME extends MTEHatchOutputBus implements IPowerChan
         return aStack.stackSize == 0;
     }
 
-    private long getCachedAmount() {
+    protected long getCachedAmount() {
         long itemAmount = 0;
         for (IAEItemStack item : itemCache) {
             itemAmount += item.getStackSize();
@@ -124,7 +124,7 @@ public class MTEHatchOutputBusME extends MTEHatchOutputBus implements IPowerChan
         return itemAmount;
     }
 
-    private long getCacheCapacity() {
+    protected long getCacheCapacity() {
         ItemStack upgradeItemStack = mInventory[0];
         if (upgradeItemStack != null && upgradeItemStack.getItem() instanceof ItemBasicStorageCell) {
             return ((ItemBasicStorageCell) upgradeItemStack.getItem()).getBytesLong(upgradeItemStack) * 8;
@@ -158,7 +158,7 @@ public class MTEHatchOutputBusME extends MTEHatchOutputBus implements IPowerChan
         return stack.stackSize;
     }
 
-    private BaseActionSource getRequest() {
+    protected BaseActionSource getRequest() {
         if (requestSource == null) requestSource = new MachineSource((IActionHost) getBaseMetaTileEntity());
         return requestSource;
     }
@@ -168,7 +168,7 @@ public class MTEHatchOutputBusME extends MTEHatchOutputBus implements IPowerChan
         return isOutputFacing(forgeDirection) ? AECableType.SMART : AECableType.NONE;
     }
 
-    private void updateValidGridProxySides() {
+    protected void updateValidGridProxySides() {
         if (additionalConnection) {
             getProxy().setValidSides(EnumSet.complementOf(EnumSet.of(ForgeDirection.UNKNOWN)));
         } else {
@@ -222,7 +222,7 @@ public class MTEHatchOutputBusME extends MTEHatchOutputBus implements IPowerChan
         return this.gridProxy;
     }
 
-    private void flushCachedStack() {
+    protected void flushCachedStack() {
         AENetworkProxy proxy = getProxy();
         if (proxy == null) {
             return;


### PR DESCRIPTION
There are many special designs for both ME Input and Output Bus, like `MTEMultiBlockBase#getStoredInputs()` and `MTEMultiBlockBase#getItemOutputSlots()`.

This PR widens the modifiers of the methods to `protected`, so that we can better extend these MTEs.

For the actual instance of the extension, we'd like to make an OreDict filtered ME Input Bus, and the problem happened when accessing the private values.