### PR TITLE
Ender tank voiding fluids in gt tank input slot fix

### DIFF
--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -1941,7 +1941,7 @@ public class GTUtility {
         if (isStackInvalid(aStack)) return null;
         if (aCheckIFluidContainerItems && aStack.getItem() instanceof IFluidContainerItem
             && ((IFluidContainerItem) aStack.getItem()).getCapacity(aStack) > 0)
-            return ((IFluidContainerItem) aStack.getItem()).drain(copyAmount(1, aStack), Integer.MAX_VALUE, true);
+            return ((IFluidContainerItem) aStack.getItem()).drain(copyAmount(1, aStack), Integer.MAX_VALUE, false);
         FluidContainerData tData = sFilledContainerToData.get(new GTItemStack(aStack));
         return tData == null ? null : tData.fluid.copy();
     }


### PR DESCRIPTION
I accidentally discovered a bug that voids the contents of the ender tank each tick that it is in the gt tanks input slot and has more fluid than there is space in the tank.

The reason for that was that gt tanks on each tick create a copy of the item and drain all the fluid from the copy to get the fluid amount that could be inserted, if this amount is higher than the free capacity nothing happens. However the ender tank has shared storage so the copy drains the full ender storage every tick that the tank is in the input slot. (If there was free capacity for the contents of the tank it would get moved to the output slot and everything was fine)

This fixes that but im not sure if the code i changed was required for anything specific.
I tested the gt tanks with any other fluid containers and i didnt see anything broken.