### PR TITLE
fix end dust bee

### DIFF
--- a/src/main/java/gregtech/common/items/ItemComb.java
+++ b/src/main/java/gregtech/common/items/ItemComb.java
@@ -653,7 +653,7 @@ public class ItemComb extends Item implements IGT_ItemWithMaterialRenderer {
             CombType.ENDDUST,
             new ItemStack[] { GTModHandler.getModItem(MagicBees.ID, "wax", 1L, 0),
                 GTBees.propolis.getStackForType(PropolisType.End), GTBees.drop.getStackForType(DropType.ENDERGOO),
-                Materials.Endstone.getBlocks(4) },
+                GTOreDictUnificator.get(OrePrefixes.dust, Materials.Endstone, 1L) },
             new int[] { 20 * 100, 15 * 100, 10 * 100, 100 * 100 },
             Voltage.HV);
         addCentrifugeToItemStack(


### PR DESCRIPTION
a small fix but for multiple reasons actually:

First of all the end dust bee should give end(stone) dust. Second of all endstone blocks dont actually exist, only stone. The only reason this was working at all is an incorrect oredict added by the chisel mod, which resulted in this giving out certain chisel blocks. There is no gt block that matches the old call. Third and the main reason I am doing this, this call prevents me from fixed the chisel endstone exploit in https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/10099. So this is a preq to fixing that. Lastly I also set the amount to 1 as that was unusually and inconsistenyl high compared to all the other combs.