### PR TITLE
Add ways to modify ingredients shown on NEI

### DIFF
--- a/src/main/java/goodgenerator/loader/NaquadahReworkRecipeLoader.java
+++ b/src/main/java/goodgenerator/loader/NaquadahReworkRecipeLoader.java
@@ -49,6 +49,7 @@ import static gregtech.api.util.GTRecipeBuilder.SECONDS;
 import static gregtech.api.util.GTRecipeBuilder.TICKS;
 import static gregtech.api.util.GTRecipeConstants.COIL_HEAT;
 import static gregtech.api.util.GTRecipeConstants.NKE_RANGE;
+import static gregtech.api.util.GTRecipeConstants.QFT_CATALYST;
 import static gregtech.api.util.GTRecipeConstants.QFT_FOCUS_TIER;
 import static gregtech.api.util.GTRecipeConstants.UniversalChemical;
 import static gregtech.common.items.MetaGeneratedItem01.registerCauldronCleaningFor;
@@ -94,8 +95,7 @@ public class NaquadahReworkRecipeLoader {
             .itemInputs(
                 naquadahEarth.get(OrePrefixes.dust, 32),
                 Materials.Sodium.getDust(64),
-                Materials.Carbon.getDust(1),
-                GTUtility.copyAmount(0, GenericChem.mSimpleNaquadahCatalyst))
+                Materials.Carbon.getDust(1))
             .itemOutputs(
                 inertNaquadah.get(OrePrefixes.dust, 1),
                 Materials.Titanium.getDust(64),
@@ -107,6 +107,7 @@ public class NaquadahReworkRecipeLoader {
                 Materials.Oxygen.getGas(100L))
             .duration(10 * SECONDS)
             .eut(GTValues.VP[10])
+            .metadata(QFT_CATALYST, GTUtility.copyAmount(0, GenericChem.mSimpleNaquadahCatalyst))
             .metadata(QFT_FOCUS_TIER, 2)
             .addTo(quantumForceTransformerRecipes);
         // Enriched Naquadah (UIV)
@@ -114,21 +115,18 @@ public class NaquadahReworkRecipeLoader {
             .itemInputs(
                 enrichedNaquadahEarth.get(OrePrefixes.dust, 32),
                 Materials.Zinc.getDust(64),
-                Materials.Carbon.getDust(1),
-                GTUtility.copyAmount(0, GenericChem.mSimpleNaquadahCatalyst))
+                Materials.Carbon.getDust(1))
             .itemOutputs(inertEnrichedNaquadah.get(OrePrefixes.dust, 1), Materials.Trinium.getDust(64))
             .fluidInputs(Materials.SulfuricAcid.getFluid(16000), Materials.Oxygen.getGas(100L))
             .fluidOutputs(wasteLiquid.getFluidOrGas(32000))
             .duration(10 * SECONDS)
             .eut(GTValues.VP[11])
+            .metadata(QFT_CATALYST, GTUtility.copyAmount(0, GenericChem.mSimpleNaquadahCatalyst))
             .metadata(QFT_FOCUS_TIER, 2)
             .addTo(quantumForceTransformerRecipes);
         // Naquadria (UMV)
         GTValues.RA.stdBuilder()
-            .itemInputs(
-                naquadriaEarth.get(OrePrefixes.dust, 32),
-                Materials.Magnesium.getDust(64),
-                GTUtility.copyAmount(0, GenericChem.mAdvancedNaquadahCatalyst))
+            .itemInputs(naquadriaEarth.get(OrePrefixes.dust, 32), Materials.Magnesium.getDust(64))
             .itemOutputs(
                 inertNaquadria.get(OrePrefixes.dust, 1),
                 Materials.Barium.getDust(64),
@@ -140,6 +138,7 @@ public class NaquadahReworkRecipeLoader {
                 Materials.Oxygen.getGas(100L))
             .duration(5 * SECONDS)
             .eut(GTValues.VP[12])
+            .metadata(QFT_CATALYST, GTUtility.copyAmount(0, GenericChem.mAdvancedNaquadahCatalyst))
             .metadata(QFT_FOCUS_TIER, 3)
             .addTo(quantumForceTransformerRecipes);
 

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
@@ -969,8 +969,8 @@ public abstract class MTEMultiBlockBase extends MetaTileEntity
     }
 
     /**
-     * Override to perform additional checkRecipe logic. It gets called after CRIBs and before ordinal hatches.
-     * 
+     * Override to perform additional checkRecipe logic. It gets called after CRIBs and before ordinary hatches.
+     *
      * @param lastResult Last result of checkRecipe. It might contain interesting info about failure, so don't blindly
      *                   overwrite it. Refer to {@link #doCheckRecipe} for how to handle it.
      * @return Result of the checkRecipe.

--- a/src/main/java/gregtech/api/recipe/NEIRecipeProperties.java
+++ b/src/main/java/gregtech/api/recipe/NEIRecipeProperties.java
@@ -1,10 +1,14 @@
 package gregtech.api.recipe;
 
 import java.util.Comparator;
+import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
 
 import com.gtnewhorizons.modularui.api.math.Pos2d;
 import com.gtnewhorizons.modularui.api.math.Size;
@@ -68,6 +72,23 @@ public final class NEIRecipeProperties {
     public final boolean renderRealStackSizes;
 
     /**
+     * Specifies what item inputs get displayed on NEI.
+     */
+    public final Function<GTRecipe, ItemStack[]> itemInputsGetter;
+    /**
+     * Specifies what fluid inputs get displayed on NEI.
+     */
+    public final Function<GTRecipe, FluidStack[]> fluidInputsGetter;
+    /**
+     * Specifies what item outputs get displayed on NEI.
+     */
+    public final Function<GTRecipe, ItemStack[]> itemOutputsGetter;
+    /**
+     * Specifies what fluid outputs get displayed on NEI.
+     */
+    public final Function<GTRecipe, FluidStack[]> fluidOutputsGetter;
+
+    /**
      * Comparator for NEI recipe sort. {@link GTRecipe#compareTo(GTRecipe)} by default.
      */
     public final Comparator<GTRecipe> comparator;
@@ -75,6 +96,8 @@ public final class NEIRecipeProperties {
     NEIRecipeProperties(boolean registerNEI, @Nullable UnaryOperator<HandlerInfo.Builder> handlerInfoCreator,
         Size recipeBackgroundSize, Pos2d recipeBackgroundOffset, INEISpecialInfoFormatter neiSpecialInfoFormatter,
         boolean unificateOutput, boolean useCustomFilter, boolean renderRealStackSizes,
+        Function<GTRecipe, ItemStack[]> itemInputsGetter, Function<GTRecipe, FluidStack[]> fluidInputsGetter,
+        Function<GTRecipe, ItemStack[]> itemOutputsGetter, Function<GTRecipe, FluidStack[]> fluidOutputsGetter,
         Comparator<GTRecipe> comparator) {
         this.registerNEI = registerNEI;
         this.handlerInfoCreator = handlerInfoCreator;
@@ -84,6 +107,10 @@ public final class NEIRecipeProperties {
         this.unificateOutput = unificateOutput;
         this.useCustomFilter = useCustomFilter;
         this.renderRealStackSizes = renderRealStackSizes;
+        this.itemInputsGetter = itemInputsGetter;
+        this.fluidInputsGetter = fluidInputsGetter;
+        this.itemOutputsGetter = itemOutputsGetter;
+        this.fluidOutputsGetter = fluidOutputsGetter;
         this.comparator = comparator;
     }
 }

--- a/src/main/java/gregtech/api/recipe/NEIRecipePropertiesBuilder.java
+++ b/src/main/java/gregtech/api/recipe/NEIRecipePropertiesBuilder.java
@@ -1,10 +1,14 @@
 package gregtech.api.recipe;
 
 import java.util.Comparator;
+import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
 
 import com.gtnewhorizons.modularui.api.math.Pos2d;
 import com.gtnewhorizons.modularui.api.math.Size;
@@ -36,6 +40,11 @@ public final class NEIRecipePropertiesBuilder {
     private boolean useCustomFilter;
     private boolean renderRealStackSizes = true;
 
+    private Function<GTRecipe, ItemStack[]> itemInputsGetter = recipe -> recipe.mInputs;
+    private Function<GTRecipe, FluidStack[]> fluidInputsGetter = recipe -> recipe.mFluidInputs;
+    private Function<GTRecipe, ItemStack[]> itemOutputsGetter = recipe -> recipe.mOutputs;
+    private Function<GTRecipe, FluidStack[]> fluidOutputsGetter = recipe -> recipe.mFluidOutputs;
+
     private Comparator<GTRecipe> comparator = GTRecipe::compareTo;
 
     NEIRecipePropertiesBuilder() {}
@@ -50,6 +59,10 @@ public final class NEIRecipePropertiesBuilder {
             unificateOutput,
             useCustomFilter,
             renderRealStackSizes,
+            itemInputsGetter,
+            fluidInputsGetter,
+            itemOutputsGetter,
+            fluidOutputsGetter,
             comparator);
     }
 
@@ -90,6 +103,26 @@ public final class NEIRecipePropertiesBuilder {
 
     public NEIRecipePropertiesBuilder disableRenderRealStackSizes() {
         this.renderRealStackSizes = false;
+        return this;
+    }
+
+    public NEIRecipePropertiesBuilder itemInputsGetter(Function<GTRecipe, ItemStack[]> itemInputsGetter) {
+        this.itemInputsGetter = itemInputsGetter;
+        return this;
+    }
+
+    public NEIRecipePropertiesBuilder fluidInputsGetter(Function<GTRecipe, FluidStack[]> fluidInputsGetter) {
+        this.fluidInputsGetter = fluidInputsGetter;
+        return this;
+    }
+
+    public NEIRecipePropertiesBuilder itemOutputsGetter(Function<GTRecipe, ItemStack[]> itemOutputsGetter) {
+        this.itemOutputsGetter = itemOutputsGetter;
+        return this;
+    }
+
+    public NEIRecipePropertiesBuilder fluidOutputsGetter(Function<GTRecipe, FluidStack[]> fluidOutputsGetter) {
+        this.fluidOutputsGetter = fluidOutputsGetter;
         return this;
     }
 

--- a/src/main/java/gregtech/api/recipe/RecipeMapBuilder.java
+++ b/src/main/java/gregtech/api/recipe/RecipeMapBuilder.java
@@ -11,6 +11,9 @@ import java.util.function.UnaryOperator;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
+
 import com.gtnewhorizons.modularui.api.drawable.FallbackableUITexture;
 import com.gtnewhorizons.modularui.api.drawable.IDrawable;
 import com.gtnewhorizons.modularui.api.drawable.UITexture;
@@ -472,6 +475,38 @@ public final class RecipeMapBuilder<B extends RecipeMapBackend> {
      */
     public RecipeMapBuilder<B> disableRenderRealStackSizes() {
         neiPropertiesBuilder.disableRenderRealStackSizes();
+        return this;
+    }
+
+    /**
+     * Allows modifying what item inputs get displayed on NEI, without affecting GTRecipe object on backend.
+     */
+    public RecipeMapBuilder<B> neiItemInputsGetter(Function<GTRecipe, ItemStack[]> itemInputsGetter) {
+        neiPropertiesBuilder.itemInputsGetter(itemInputsGetter);
+        return this;
+    }
+
+    /**
+     * Allows modifying what fluid inputs get displayed on NEI, without affecting GTRecipe object on backend.
+     */
+    public RecipeMapBuilder<B> neiFluidInputsGetter(Function<GTRecipe, FluidStack[]> fluidInputsGetter) {
+        neiPropertiesBuilder.fluidInputsGetter(fluidInputsGetter);
+        return this;
+    }
+
+    /**
+     * Allows modifying what item outputs get displayed on NEI, without affecting GTRecipe object on backend.
+     */
+    public RecipeMapBuilder<B> neiItemOutputsGetter(Function<GTRecipe, ItemStack[]> itemOutputsGetter) {
+        neiPropertiesBuilder.itemOutputsGetter(itemOutputsGetter);
+        return this;
+    }
+
+    /**
+     * Allows modifying what fluid outputs get displayed on NEI, without affecting GTRecipe object on backend.
+     */
+    public RecipeMapBuilder<B> neiFluidOutputsGetter(Function<GTRecipe, FluidStack[]> fluidOutputsGetter) {
+        neiPropertiesBuilder.fluidOutputsGetter(fluidOutputsGetter);
         return this;
     }
 

--- a/src/main/java/gregtech/api/util/GTRecipe.java
+++ b/src/main/java/gregtech/api/util/GTRecipe.java
@@ -39,7 +39,6 @@ import gregtech.api.recipe.metadata.IRecipeMetadataStorage;
 import gregtech.api.util.extensions.ArrayExt;
 import gregtech.common.tileentities.machines.MTEHatchInputBusME;
 import gregtech.common.tileentities.machines.MTEHatchInputME;
-import gregtech.nei.GTNEIDefaultHandler;
 import ic2.core.Ic2Items;
 import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
@@ -381,18 +380,6 @@ public class GTRecipe implements Comparable<GTRecipe> {
     public ItemStack getOutput(int aIndex) {
         if (aIndex < 0 || aIndex >= mOutputs.length) return null;
         return GTUtility.copyOrNull(mOutputs[aIndex]);
-    }
-
-    /**
-     * Dictates the ItemStacks displayed in the output slots of any NEI page handled by the default GT NEI handler.
-     * Override to make shown items differ from a GTRecipe's item output array
-     *
-     * @see GTNEIDefaultHandler
-     * @param i Slot index
-     * @return ItemStack to be displayed in the slot
-     */
-    public ItemStack getRepresentativeOutput(int i) {
-        return getOutput(i);
     }
 
     public int getOutputChance(int aIndex) {

--- a/src/main/java/gregtech/api/util/GTRecipeConstants.java
+++ b/src/main/java/gregtech/api/util/GTRecipeConstants.java
@@ -168,8 +168,8 @@ public class GTRecipeConstants {
     /**
      * QFT catalyst meta.
      */
-    public static final RecipeMetadataKey<Integer> QFT_CATALYST_META = SimpleRecipeMetadataKey
-        .create(Integer.class, "qft_catalyst_meta");
+    public static final RecipeMetadataKey<ItemStack> QFT_CATALYST = SimpleRecipeMetadataKey
+        .create(ItemStack.class, "qft_catalyst");
 
     /**
      * Tier of advanced compression (HIP/black hole)

--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -4660,11 +4660,6 @@ public class GTUtility {
         return signal;
     }
 
-    public static ItemStack getNaniteAsCatalyst(Materials material) {
-        ItemStack aItem = material.getNanite(1);
-        return new ItemStack(aItem.getItem(), 0, aItem.getItemDamage());
-    }
-
     public static Stream<NBTTagCompound> streamCompounds(NBTTagList list) {
         if (list == null) return Stream.empty();
         return IntStream.range(0, list.tagCount())

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEPCBFactory.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEPCBFactory.java
@@ -541,7 +541,7 @@ public class MTEPCBFactory extends MTEExtendedPowerMultiBlockBase<MTEPCBFactory>
 
     @Override
     public RecipeMap<?> getRecipeMap() {
-        return RecipeMaps.pcbFactoryRecipesNoNanites;
+        return RecipeMaps.pcbFactoryRecipes;
     }
 
     @Override

--- a/src/main/java/gregtech/loaders/postload/chains/PCBFactoryRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/chains/PCBFactoryRecipes.java
@@ -5,6 +5,7 @@ import static gregtech.api.recipe.metadata.PCBFactoryUpgrade.BIO;
 import static gregtech.api.util.GTRecipeBuilder.MINUTES;
 import static gregtech.api.util.GTRecipeBuilder.SECONDS;
 import static gregtech.api.util.GTRecipeConstants.AssemblyLine;
+import static gregtech.api.util.GTRecipeConstants.PCB_NANITE_MATERIAL;
 import static gregtech.api.util.GTRecipeConstants.RESEARCH_ITEM;
 import static gregtech.api.util.GTRecipeConstants.SCANNING;
 import static gtPlusPlus.core.material.MaterialsAlloy.QUANTUM;
@@ -134,7 +135,6 @@ public class PCBFactoryRecipes {
             GTValues.RA.stdBuilder()
                 .itemInputs(
                     GTUtility.getIntegratedCircuit(2),
-                    GTUtility.getNaniteAsCatalyst(Materials.Silver),
                     PCBFactoryManager.getPlasticMaterialFromTier(tier)
                         .getPlates(1),
                     GTOreDictUnificator
@@ -147,6 +147,7 @@ public class PCBFactoryRecipes {
                 .duration((int) Math.ceil(500 / Math.sqrt(Math.pow(1.5, tier - 1.5))))
                 .eut((int) GTValues.VP[tier + 1] * 3 / 4)
                 .metadata(TIER, 2)
+                .metadata(PCB_NANITE_MATERIAL, Materials.Silver)
                 .addTo(RecipeMaps.pcbFactoryRecipes);
         }
         for (int tier = 1; tier <= PCBFactoryManager.mTiersOfPlastics; tier++) {
@@ -160,7 +161,6 @@ public class PCBFactoryRecipes {
             GTValues.RA.stdBuilder()
                 .itemInputs(
                     GTUtility.getIntegratedCircuit(3),
-                    GTUtility.getNaniteAsCatalyst(Materials.Gold),
                     PCBFactoryManager.getPlasticMaterialFromTier(tier)
                         .getPlates(1),
                     GTOreDictUnificator
@@ -173,6 +173,7 @@ public class PCBFactoryRecipes {
                 .duration((int) Math.ceil(400 / Math.sqrt(Math.pow(1.5, tier - 1.5))))
                 .eut((int) GTValues.VP[tier + 1] * 3 / 4)
                 .metadata(TIER, 3)
+                .metadata(PCB_NANITE_MATERIAL, Materials.Gold)
                 .addTo(RecipeMaps.pcbFactoryRecipes);
         }
 
@@ -212,7 +213,6 @@ public class PCBFactoryRecipes {
             GTValues.RA.stdBuilder()
                 .itemInputs(
                     GTUtility.getIntegratedCircuit(2),
-                    GTUtility.getNaniteAsCatalyst(Materials.Silver),
                     PCBFactoryManager.getPlasticMaterialFromTier(tier)
                         .getPlates(1),
                     GTOreDictUnificator.get(OrePrefixes.foil, Materials.Gold, (long) (16 * (Math.sqrt(tier - 1)))),
@@ -224,6 +224,7 @@ public class PCBFactoryRecipes {
                 .duration((int) Math.ceil(500 / Math.sqrt(Math.pow(1.5, tier - 2.5))))
                 .eut((int) GTValues.VP[tier + 1] * 3 / 4)
                 .metadata(TIER, 2)
+                .metadata(PCB_NANITE_MATERIAL, Materials.Silver)
                 .addTo(RecipeMaps.pcbFactoryRecipes);
         }
         for (int tier = 2; tier <= PCBFactoryManager.mTiersOfPlastics; tier++) {
@@ -237,7 +238,6 @@ public class PCBFactoryRecipes {
             GTValues.RA.stdBuilder()
                 .itemInputs(
                     GTUtility.getIntegratedCircuit(3),
-                    GTUtility.getNaniteAsCatalyst(Materials.Gold),
                     PCBFactoryManager.getPlasticMaterialFromTier(tier)
                         .getPlates(1),
                     GTOreDictUnificator.get(OrePrefixes.foil, Materials.Gold, (long) (16 * (Math.sqrt(tier - 1)))),
@@ -249,6 +249,7 @@ public class PCBFactoryRecipes {
                 .duration((int) Math.ceil(400 / Math.sqrt(Math.pow(1.5, tier - 2.5))))
                 .eut((int) GTValues.VP[tier + 1] * 3 / 4)
                 .metadata(TIER, 3)
+                .metadata(PCB_NANITE_MATERIAL, Materials.Gold)
                 .addTo(RecipeMaps.pcbFactoryRecipes);
         }
 
@@ -289,7 +290,6 @@ public class PCBFactoryRecipes {
             GTValues.RA.stdBuilder()
                 .itemInputs(
                     GTUtility.getIntegratedCircuit(2),
-                    GTUtility.getNaniteAsCatalyst(Materials.Silver),
                     PCBFactoryManager.getPlasticMaterialFromTier(tier)
                         .getPlates(1),
                     GTOreDictUnificator.get(OrePrefixes.foil, Materials.Aluminium, (long) (16 * (Math.sqrt(tier - 2)))),
@@ -302,6 +302,7 @@ public class PCBFactoryRecipes {
                 .duration((int) Math.ceil(500 / Math.sqrt(Math.pow(1.5, tier - 3.5))))
                 .eut((int) GTValues.VP[tier + 1] * 3 / 4)
                 .metadata(TIER, 2)
+                .metadata(PCB_NANITE_MATERIAL, Materials.Silver)
                 .addTo(RecipeMaps.pcbFactoryRecipes);
         }
         for (int tier = 3; tier <= PCBFactoryManager.mTiersOfPlastics; tier++) {
@@ -315,7 +316,6 @@ public class PCBFactoryRecipes {
             GTValues.RA.stdBuilder()
                 .itemInputs(
                     GTUtility.getIntegratedCircuit(3),
-                    GTUtility.getNaniteAsCatalyst(Materials.Gold),
                     PCBFactoryManager.getPlasticMaterialFromTier(tier)
                         .getPlates(1),
                     GTOreDictUnificator.get(OrePrefixes.foil, Materials.Aluminium, (long) (16 * (Math.sqrt(tier - 2)))),
@@ -328,6 +328,7 @@ public class PCBFactoryRecipes {
                 .duration((int) Math.ceil(400 / Math.sqrt(Math.pow(1.5, tier - 3.5))))
                 .eut((int) GTValues.VP[tier + 1] * 3 / 4)
                 .metadata(TIER, 3)
+                .metadata(PCB_NANITE_MATERIAL, Materials.Gold)
                 .addTo(RecipeMaps.pcbFactoryRecipes);
         }
 
@@ -367,7 +368,6 @@ public class PCBFactoryRecipes {
             GTValues.RA.stdBuilder()
                 .itemInputs(
                     GTUtility.getIntegratedCircuit(2),
-                    GTUtility.getNaniteAsCatalyst(Materials.Silver),
                     PCBFactoryManager.getPlasticMaterialFromTier(tier)
                         .getPlates(1),
                     GTOreDictUnificator.get(OrePrefixes.foil, Materials.Palladium, (long) (16 * (Math.sqrt(tier - 3)))),
@@ -379,6 +379,7 @@ public class PCBFactoryRecipes {
                 .duration((int) Math.ceil(500 / Math.sqrt(Math.pow(1.5, tier - 4.5))))
                 .eut((int) GTValues.VP[tier + 1] * 3 / 4)
                 .metadata(TIER, 2)
+                .metadata(PCB_NANITE_MATERIAL, Materials.Silver)
                 .addTo(RecipeMaps.pcbFactoryRecipes);
         }
         for (int tier = 4; tier <= PCBFactoryManager.mTiersOfPlastics; tier++) {
@@ -392,7 +393,6 @@ public class PCBFactoryRecipes {
             GTValues.RA.stdBuilder()
                 .itemInputs(
                     GTUtility.getIntegratedCircuit(3),
-                    GTUtility.getNaniteAsCatalyst(Materials.Gold),
                     PCBFactoryManager.getPlasticMaterialFromTier(tier)
                         .getPlates(1),
                     GTOreDictUnificator.get(OrePrefixes.foil, Materials.Palladium, (long) (16 * (Math.sqrt(tier - 3)))),
@@ -404,6 +404,7 @@ public class PCBFactoryRecipes {
                 .duration((int) Math.ceil(400 / Math.sqrt(Math.pow(1.5, tier - 4.5))))
                 .eut((int) GTValues.VP[tier + 1] * 3 / 4)
                 .metadata(TIER, 3)
+                .metadata(PCB_NANITE_MATERIAL, Materials.Gold)
                 .addTo(RecipeMaps.pcbFactoryRecipes);
         }
 
@@ -447,7 +448,6 @@ public class PCBFactoryRecipes {
             GTValues.RA.stdBuilder()
                 .itemInputs(
                     GTUtility.getIntegratedCircuit(2),
-                    GTUtility.getNaniteAsCatalyst(Materials.Silver),
                     PCBFactoryManager.getPlasticMaterialFromTier(tier)
                         .getPlates(1),
                     GTOreDictUnificator
@@ -462,6 +462,7 @@ public class PCBFactoryRecipes {
                 .duration((int) Math.ceil(500 / Math.sqrt(Math.pow(1.5, tier - 5.5))))
                 .eut((int) GTValues.VP[tier + 1] * 3 / 4)
                 .metadata(TIER, 2)
+                .metadata(PCB_NANITE_MATERIAL, Materials.Silver)
                 .metadata(UPGRADE, BIO)
                 .addTo(RecipeMaps.pcbFactoryRecipes);
         }
@@ -476,7 +477,6 @@ public class PCBFactoryRecipes {
             GTValues.RA.stdBuilder()
                 .itemInputs(
                     GTUtility.getIntegratedCircuit(3),
-                    GTUtility.getNaniteAsCatalyst(Materials.Gold),
                     PCBFactoryManager.getPlasticMaterialFromTier(tier)
                         .getPlates(1),
                     GTOreDictUnificator
@@ -491,6 +491,7 @@ public class PCBFactoryRecipes {
                 .duration((int) Math.ceil(400 / Math.sqrt(Math.pow(1.5, tier - 5.5))))
                 .eut((int) GTValues.VP[tier + 1] * 3 / 4)
                 .metadata(TIER, 3)
+                .metadata(PCB_NANITE_MATERIAL, Materials.Gold)
                 .metadata(UPGRADE, BIO)
                 .addTo(RecipeMaps.pcbFactoryRecipes);
         }
@@ -537,7 +538,6 @@ public class PCBFactoryRecipes {
             GTValues.RA.stdBuilder()
                 .itemInputs(
                     GTUtility.getIntegratedCircuit(2),
-                    GTUtility.getNaniteAsCatalyst(Materials.Silver),
                     PCBFactoryManager.getPlasticMaterialFromTier(tier)
                         .getPlates(1),
                     GTOreDictUnificator.get(
@@ -554,6 +554,7 @@ public class PCBFactoryRecipes {
                 .duration((int) Math.ceil(500 / Math.sqrt(Math.pow(1.5, tier - 6.5))))
                 .eut((int) GTValues.VP[tier + 1] * 3 / 4)
                 .metadata(TIER, 2)
+                .metadata(PCB_NANITE_MATERIAL, Materials.Silver)
                 .metadata(UPGRADE, BIO)
                 .addTo(RecipeMaps.pcbFactoryRecipes);
         }
@@ -568,7 +569,6 @@ public class PCBFactoryRecipes {
             GTValues.RA.stdBuilder()
                 .itemInputs(
                     GTUtility.getIntegratedCircuit(3),
-                    GTUtility.getNaniteAsCatalyst(Materials.Gold),
                     PCBFactoryManager.getPlasticMaterialFromTier(tier)
                         .getPlates(1),
                     GTOreDictUnificator.get(
@@ -585,6 +585,7 @@ public class PCBFactoryRecipes {
                 .duration((int) Math.ceil(400 / Math.sqrt(Math.pow(1.5, tier - 6.5))))
                 .eut((int) GTValues.VP[tier + 1] * 3 / 4)
                 .metadata(TIER, 3)
+                .metadata(PCB_NANITE_MATERIAL, Materials.Gold)
                 .metadata(UPGRADE, BIO)
                 .addTo(RecipeMaps.pcbFactoryRecipes);
         }
@@ -631,7 +632,6 @@ public class PCBFactoryRecipes {
             GTValues.RA.stdBuilder()
                 .itemInputs(
                     GTUtility.getIntegratedCircuit(2),
-                    GTUtility.getNaniteAsCatalyst(Materials.Silver),
                     PCBFactoryManager.getPlasticMaterialFromTier(tier)
                         .getPlates(1),
                     new ItemStack(
@@ -649,6 +649,7 @@ public class PCBFactoryRecipes {
                 .duration((int) Math.ceil(500 / Math.sqrt(Math.pow(1.5, tier - 6.5))))
                 .eut((int) GTValues.VP[tier + 1] * 3 / 4)
                 .metadata(TIER, 2)
+                .metadata(PCB_NANITE_MATERIAL, Materials.Silver)
                 .addTo(RecipeMaps.pcbFactoryRecipes);
         }
         for (int tier = 7; tier <= PCBFactoryManager.mTiersOfPlastics; tier++) {
@@ -662,7 +663,6 @@ public class PCBFactoryRecipes {
             GTValues.RA.stdBuilder()
                 .itemInputs(
                     GTUtility.getIntegratedCircuit(3),
-                    GTUtility.getNaniteAsCatalyst(Materials.Gold),
                     PCBFactoryManager.getPlasticMaterialFromTier(tier)
                         .getPlates(1),
                     new ItemStack(
@@ -680,6 +680,7 @@ public class PCBFactoryRecipes {
                 .duration((int) Math.ceil(400 / Math.sqrt(Math.pow(1.5, tier - 6.5))))
                 .eut((int) GTValues.VP[tier + 1] * 3 / 4)
                 .metadata(TIER, 3)
+                .metadata(PCB_NANITE_MATERIAL, Materials.Gold)
                 .addTo(RecipeMaps.pcbFactoryRecipes);
         }
     }

--- a/src/main/java/gregtech/nei/GTNEIDefaultHandler.java
+++ b/src/main/java/gregtech/nei/GTNEIDefaultHandler.java
@@ -570,9 +570,17 @@ public class GTNEIDefaultHandler extends TemplateRecipeHandler {
                         .getItemHandler() == itemInputsInventory) {
                         int i = widget.getMcSlot()
                             .getSlotIndex();
-                        Object input = aRecipe instanceof GTRecipe.GTRecipe_WithAlt
-                            ? ((GTRecipe.GTRecipe_WithAlt) aRecipe).getAltRepresentativeInput(i)
-                            : aRecipe.getRepresentativeInput(i);
+                        final Object input;
+                        if (aRecipe instanceof GTRecipe.GTRecipe_WithAlt withAltRecipe) {
+                            input = withAltRecipe.getRepresentativeInput(i);
+                        } else {
+                            ItemStack[] inputs = GTNEIDefaultHandler.this.neiProperties.itemInputsGetter.apply(aRecipe);
+                            if (i < inputs.length && inputs[i] != null) {
+                                input = inputs[i];
+                            } else {
+                                input = null;
+                            }
+                        }
                         if (input != null) {
                             mInputs.add(
                                 new FixedPositionedStack(
@@ -586,11 +594,12 @@ public class GTNEIDefaultHandler extends TemplateRecipeHandler {
                         .getItemHandler() == itemOutputsInventory) {
                             int i = widget.getMcSlot()
                                 .getSlotIndex();
-                            ItemStack output = aRecipe.getRepresentativeOutput(i);
-                            if (output != null) {
+                            ItemStack[] outputs = GTNEIDefaultHandler.this.neiProperties.itemOutputsGetter
+                                .apply(aRecipe);
+                            if (i < outputs.length && outputs[i] != null) {
                                 mOutputs.add(
                                     new FixedPositionedStack(
-                                        output,
+                                        outputs[i],
                                         GTNEIDefaultHandler.this.neiProperties.renderRealStackSizes,
                                         widget.getPos().x + 1,
                                         widget.getPos().y + 1,
@@ -612,11 +621,12 @@ public class GTNEIDefaultHandler extends TemplateRecipeHandler {
                                 .getItemHandler() == fluidInputsInventory) {
                                     int i = widget.getMcSlot()
                                         .getSlotIndex();
-                                    if (aRecipe.mFluidInputs.length > i && aRecipe.mFluidInputs[i] != null
-                                        && aRecipe.mFluidInputs[i].getFluid() != null) {
+                                    FluidStack[] inputs = GTNEIDefaultHandler.this.neiProperties.fluidInputsGetter
+                                        .apply(aRecipe);
+                                    if (inputs.length > i && inputs[i] != null && inputs[i].getFluid() != null) {
                                         mInputs.add(
                                             new FixedPositionedStack(
-                                                GTUtility.getFluidDisplayStack(aRecipe.mFluidInputs[i], true),
+                                                GTUtility.getFluidDisplayStack(inputs[i], true),
                                                 GTNEIDefaultHandler.this.neiProperties.renderRealStackSizes,
                                                 widget.getPos().x + 1,
                                                 widget.getPos().y + 1));
@@ -625,11 +635,12 @@ public class GTNEIDefaultHandler extends TemplateRecipeHandler {
                                     .getItemHandler() == fluidOutputsInventory) {
                                         int i = widget.getMcSlot()
                                             .getSlotIndex();
-                                        if (aRecipe.mFluidOutputs.length > i && aRecipe.mFluidOutputs[i] != null
-                                            && aRecipe.mFluidOutputs[i].getFluid() != null) {
+                                        FluidStack[] outputs = GTNEIDefaultHandler.this.neiProperties.fluidOutputsGetter
+                                            .apply(aRecipe);
+                                        if (outputs.length > i && outputs[i] != null && outputs[i].getFluid() != null) {
                                             mOutputs.add(
                                                 new FixedPositionedStack(
-                                                    GTUtility.getFluidDisplayStack(aRecipe.mFluidOutputs[i], true),
+                                                    GTUtility.getFluidDisplayStack(outputs[i], true),
                                                     GTNEIDefaultHandler.this.neiProperties.renderRealStackSizes,
                                                     widget.getPos().x + 1,
                                                     widget.getPos().y + 1));

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTEQuantumForceTransformer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTEQuantumForceTransformer.java
@@ -438,7 +438,7 @@ public class MTEQuantumForceTransformer extends MTEExtendedPowerMultiBlockBase<M
 
     @Override
     public RecipeMap<?> getRecipeMap() {
-        return GTPPRecipeMaps.quantumForceTransformerRecipesNoCatalysts;
+        return GTPPRecipeMaps.quantumForceTransformerRecipes;
     }
 
     @Override
@@ -461,25 +461,25 @@ public class MTEQuantumForceTransformer extends MTEExtendedPowerMultiBlockBase<M
                 }
 
                 int numberOfCatalyst = 0;
-                int catalystMeta = recipe.getMetadataOrDefault(GTRecipeConstants.QFT_CATALYST_META, -1);
-                if (catalystMeta != -1) {
-                    if (catalystHounsings.isEmpty()) {
-                        return SimpleCheckRecipeResult.ofFailure("no_catalyst");
+                ItemStack requiredCatalyst = recipe.getMetadata(GTRecipeConstants.QFT_CATALYST);
+                assert requiredCatalyst != null;
+                int catalystMeta = requiredCatalyst.getItemDamage();
+                if (catalystHounsings.isEmpty()) {
+                    return SimpleCheckRecipeResult.ofFailure("no_catalyst");
+                }
+                boolean catalystsFound = false;
+                for (MTEHatchBulkCatalystHousing catalystHousing : catalystHounsings) {
+                    ItemStack storedCatalysts = catalystHousing.getItemStack();
+                    int storedCatalystMeta = catalystHousing.getStoredCatalystMeta();
+                    if (storedCatalysts == null || storedCatalystMeta != catalystMeta) {
+                        continue;
                     }
-                    boolean catalystsFound = false;
-                    for (MTEHatchBulkCatalystHousing catalystHousing : catalystHounsings) {
-                        ItemStack storedCatalysts = catalystHousing.getItemStack();
-                        int storedCatalystMeta = catalystHousing.getStoredCatalystMeta();
-                        if (storedCatalysts == null || storedCatalystMeta != catalystMeta) {
-                            continue;
-                        }
-                        numberOfCatalyst = catalystHousing.getItemCount();
-                        catalystsFound = true;
-                        break;
-                    }
-                    if (!catalystsFound) {
-                        return SimpleCheckRecipeResult.ofFailure("no_catalyst");
-                    }
+                    numberOfCatalyst = catalystHousing.getItemCount();
+                    catalystsFound = true;
+                    break;
+                }
+                if (!catalystsFound) {
+                    return SimpleCheckRecipeResult.ofFailure("no_catalyst");
                 }
 
                 mMaxParallel = numberOfCatalyst;

--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoaderChemicalSkips.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoaderChemicalSkips.java
@@ -11,6 +11,7 @@ import static gregtech.api.util.GTRecipeBuilder.MINUTES;
 import static gregtech.api.util.GTRecipeBuilder.SECONDS;
 import static gregtech.api.util.GTRecipeBuilder.TICKS;
 import static gregtech.api.util.GTRecipeConstants.FUSION_THRESHOLD;
+import static gregtech.api.util.GTRecipeConstants.QFT_CATALYST;
 import static gregtech.api.util.GTRecipeConstants.QFT_FOCUS_TIER;
 import static gtPlusPlus.api.recipe.GTPPRecipeMaps.quantumForceTransformerRecipes;
 
@@ -70,9 +71,7 @@ public class RecipeLoaderChemicalSkips {
         ItemStack biocells = GTUtility.copyAmountUnsafe(64 * 32, ItemList.Circuit_Chip_Biocell.get(1));
         // Platline
         GTValues.RA.stdBuilder()
-            .itemInputs(
-                WerkstoffLoader.PTMetallicPowder.get(OrePrefixes.dust, 32),
-                ItemUtils.getSimpleStack(GenericChem.mPlatinumGroupCatalyst, 0))
+            .itemInputs(WerkstoffLoader.PTMetallicPowder.get(OrePrefixes.dust, 32))
             .itemOutputs(
                 Materials.Platinum.getDust(64),
                 Materials.Palladium.getDust(64),
@@ -82,46 +81,42 @@ public class RecipeLoaderChemicalSkips {
                 WerkstoffLoader.Ruthenium.get(OrePrefixes.dust, 64))
             .duration(20 * SECONDS)
             .eut(TierEU.RECIPE_UV)
+            .metadata(QFT_CATALYST, GTUtility.copyAmount(0, GenericChem.mPlatinumGroupCatalyst))
             .metadata(QFT_FOCUS_TIER, 1)
             .addTo(quantumForceTransformerRecipes);
         // Partial platline (from Pd, Os, Ir, Rh and leach)
         GTValues.RA.stdBuilder()
-            .itemInputs(
-                WerkstoffLoader.PDMetallicPowder.get(OrePrefixes.dust, 32),
-                ItemUtils.getSimpleStack(GenericChem.mPlatinumGroupCatalyst, 0))
+            .itemInputs(WerkstoffLoader.PDMetallicPowder.get(OrePrefixes.dust, 32))
             .itemOutputs(
                 Materials.Palladium.getDust(64),
                 Materials.Platinum.getDust(64),
                 WerkstoffLoader.LuVTierMaterial.get(OrePrefixes.dust, 64))
             .duration(20 * SECONDS)
             .eut(TierEU.RECIPE_UV)
+            .metadata(QFT_CATALYST, GTUtility.copyAmount(0, GenericChem.mPlatinumGroupCatalyst))
             .metadata(QFT_FOCUS_TIER, 1)
             .addTo(quantumForceTransformerRecipes);
         GTValues.RA.stdBuilder()
-            .itemInputs(
-                WerkstoffLoader.IrLeachResidue.get(OrePrefixes.dust, 32),
-                ItemUtils.getSimpleStack(GenericChem.mPlatinumGroupCatalyst, 0))
+            .itemInputs(WerkstoffLoader.IrLeachResidue.get(OrePrefixes.dust, 32))
             .itemOutputs(
                 Materials.Iridium.getDust(64),
                 Materials.Platinum.getDust(64),
                 Materials.Osmiridium.getDust(64))
             .duration(20 * SECONDS)
             .eut(TierEU.RECIPE_UV)
+            .metadata(QFT_CATALYST, GTUtility.copyAmount(0, GenericChem.mPlatinumGroupCatalyst))
             .metadata(QFT_FOCUS_TIER, 1)
             .addTo(quantumForceTransformerRecipes);
         GTValues.RA.stdBuilder()
-            .itemInputs(
-                WerkstoffLoader.IrOsLeachResidue.get(OrePrefixes.dust, 32),
-                ItemUtils.getSimpleStack(GenericChem.mPlatinumGroupCatalyst, 0))
+            .itemInputs(WerkstoffLoader.IrOsLeachResidue.get(OrePrefixes.dust, 32))
             .itemOutputs(Materials.Osmium.getDust(64), Materials.Iridium.getDust(64), Materials.Osmiridium.getDust(64))
             .duration(20 * SECONDS)
             .eut(TierEU.RECIPE_UV)
+            .metadata(QFT_CATALYST, GTUtility.copyAmount(0, GenericChem.mPlatinumGroupCatalyst))
             .metadata(QFT_FOCUS_TIER, 1)
             .addTo(quantumForceTransformerRecipes);
         GTValues.RA.stdBuilder()
-            .itemInputs(
-                WerkstoffLoader.CrudeRhMetall.get(OrePrefixes.dust, 32),
-                ItemUtils.getSimpleStack(GenericChem.mPlatinumGroupCatalyst, 0))
+            .itemInputs(WerkstoffLoader.CrudeRhMetall.get(OrePrefixes.dust, 32))
             .itemOutputs(
                 WerkstoffLoader.Rhodium.get(OrePrefixes.dust, 64),
                 Materials.Palladium.getDust(64),
@@ -129,12 +124,11 @@ public class RecipeLoaderChemicalSkips {
                 WerkstoffLoader.LuVTierMaterial.get(OrePrefixes.dust, 64))
             .duration(20 * SECONDS)
             .eut(TierEU.RECIPE_UV)
+            .metadata(QFT_CATALYST, GTUtility.copyAmount(0, GenericChem.mPlatinumGroupCatalyst))
             .metadata(QFT_FOCUS_TIER, 1)
             .addTo(quantumForceTransformerRecipes);
         GTValues.RA.stdBuilder()
-            .itemInputs(
-                WerkstoffLoader.LeachResidue.get(OrePrefixes.dust, 32),
-                ItemUtils.getSimpleStack(GenericChem.mPlatinumGroupCatalyst, 0))
+            .itemInputs(WerkstoffLoader.LeachResidue.get(OrePrefixes.dust, 32))
             .itemOutputs(
                 Materials.Iridium.getDust(64),
                 Materials.Osmium.getDust(64),
@@ -142,11 +136,12 @@ public class RecipeLoaderChemicalSkips {
                 WerkstoffLoader.Ruthenium.get(OrePrefixes.dust, 64))
             .duration(20 * SECONDS)
             .eut(TierEU.RECIPE_UV)
+            .metadata(QFT_CATALYST, GTUtility.copyAmount(0, GenericChem.mPlatinumGroupCatalyst))
             .metadata(QFT_FOCUS_TIER, 1)
             .addTo(quantumForceTransformerRecipes);
         // Early Plastics
         GTValues.RA.stdBuilder()
-            .itemInputs(Materials.Carbon.getDust(64), ItemUtils.getSimpleStack(GenericChem.mPlasticPolymerCatalyst, 0))
+            .itemInputs(Materials.Carbon.getDust(64))
             .fluidInputs(
                 Materials.Oxygen.getGas(1000 * 16),
                 Materials.Hydrogen.getGas(1000 * 16),
@@ -161,11 +156,12 @@ public class RecipeLoaderChemicalSkips {
                 Materials.Polybenzimidazole.getMolten(144 * 64))
             .duration(20 * SECONDS)
             .eut(TierEU.RECIPE_ZPM)
+            .metadata(QFT_CATALYST, GTUtility.copyAmount(0, GenericChem.mPlasticPolymerCatalyst))
             .metadata(QFT_FOCUS_TIER, 1)
             .addTo(quantumForceTransformerRecipes);
         // Early Rubbers/Cable Materials
         GTValues.RA.stdBuilder()
-            .itemInputs(Materials.Carbon.getDust(64), ItemUtils.getSimpleStack(GenericChem.mRubberPolymerCatalyst, 0))
+            .itemInputs(Materials.Carbon.getDust(64))
             .fluidInputs(
                 Materials.Oxygen.getGas(1000 * 16),
                 Materials.Hydrogen.getGas(1000 * 16),
@@ -177,15 +173,13 @@ public class RecipeLoaderChemicalSkips {
                 Materials.Rubber.getMolten(144 * 256))
             .duration(20 * SECONDS)
             .eut(TierEU.RECIPE_ZPM)
+            .metadata(QFT_CATALYST, GTUtility.copyAmount(0, GenericChem.mRubberPolymerCatalyst))
             .metadata(QFT_FOCUS_TIER, 1)
             .noBuffer()
             .addTo(quantumForceTransformerRecipes);
         // Glues and Solders
         GTValues.RA.stdBuilder()
-            .itemInputs(
-                Materials.Carbon.getDust(32),
-                Materials.Bismuth.getDust(32),
-                ItemUtils.getSimpleStack(GenericChem.mAdhesionPromoterCatalyst, 0))
+            .itemInputs(Materials.Carbon.getDust(32), Materials.Bismuth.getDust(32))
             .itemOutputs(ItemList.StableAdhesive.get(1))
             .fluidInputs(Materials.Oxygen.getGas(10000), Materials.Hydrogen.getGas(10000))
             .fluidOutputs(
@@ -195,15 +189,12 @@ public class RecipeLoaderChemicalSkips {
                 Materials.SolderingAlloy.getMolten(144 * 128))
             .duration(20 * SECONDS)
             .eut(TierEU.RECIPE_UV)
+            .metadata(QFT_CATALYST, GTUtility.copyAmount(0, GenericChem.mAdhesionPromoterCatalyst))
             .metadata(QFT_FOCUS_TIER, 1)
             .addTo(quantumForceTransformerRecipes);
         // Titanium, Tungsten, Indium
         GTValues.RA.stdBuilder()
-            .itemInputs(
-                Materials.Lead.getDust(16),
-                Materials.Bauxite.getDust(32),
-                Materials.Tungstate.getDust(16),
-                ItemUtils.getSimpleStack(GenericChem.mTitaTungstenIndiumCatalyst, 0))
+            .itemInputs(Materials.Lead.getDust(16), Materials.Bauxite.getDust(32), Materials.Tungstate.getDust(16))
             .itemOutputs(
                 Materials.Titanium.getDust(64),
                 Materials.TungstenSteel.getDust(64),
@@ -211,14 +202,11 @@ public class RecipeLoaderChemicalSkips {
                 Materials.Indium.getDust(64))
             .duration(20 * SECONDS)
             .eut(TierEU.RECIPE_UV)
+            .metadata(QFT_CATALYST, GTUtility.copyAmount(0, GenericChem.mTitaTungstenIndiumCatalyst))
             .metadata(QFT_FOCUS_TIER, 1)
             .addTo(quantumForceTransformerRecipes);
         GTValues.RA.stdBuilder()
-            .itemInputs(
-                Materials.Rutile.getDust(32),
-                Materials.Scheelite.getDust(16),
-                Materials.Ilmenite.getDust(16),
-                ItemUtils.getSimpleStack(GenericChem.mTitaTungstenIndiumCatalyst, 0))
+            .itemInputs(Materials.Rutile.getDust(32), Materials.Scheelite.getDust(16), Materials.Ilmenite.getDust(16))
             .itemOutputs(
                 Materials.Titanium.getDust(64),
                 Materials.TungstenSteel.getDust(64),
@@ -228,14 +216,12 @@ public class RecipeLoaderChemicalSkips {
                 MaterialsElements.getInstance().HAFNIUM.getDust(64))
             .duration(20 * SECONDS)
             .eut(TierEU.RECIPE_UV)
+            .metadata(QFT_CATALYST, GTUtility.copyAmount(0, GenericChem.mTitaTungstenIndiumCatalyst))
             .metadata(QFT_FOCUS_TIER, 1)
             .addTo(quantumForceTransformerRecipes);
         // Thorium, Uranium, Plutonium
         GTValues.RA.stdBuilder()
-            .itemInputs(
-                Materials.Thorium.getDust(32),
-                Materials.Uranium.getDust(32),
-                ItemUtils.getSimpleStack(GenericChem.mRadioactivityCatalyst, 0))
+            .itemInputs(Materials.Thorium.getDust(32), Materials.Uranium.getDust(32))
             .itemOutputs(
                 MaterialsElements.getInstance().THORIUM232.getDust(64),
                 MaterialsElements.getInstance().URANIUM233.getDust(64),
@@ -245,13 +231,12 @@ public class RecipeLoaderChemicalSkips {
                 Materials.Plutonium241.getDust(64))
             .duration(20 * SECONDS)
             .eut(TierEU.RECIPE_UV)
+            .metadata(QFT_CATALYST, GTUtility.copyAmount(0, GenericChem.mRadioactivityCatalyst))
             .metadata(QFT_FOCUS_TIER, 1)
             .addTo(quantumForceTransformerRecipes);
         // Monaline
         GTValues.RA.stdBuilder()
-            .itemInputs(
-                Materials.Monazite.getDust(32),
-                ItemUtils.getSimpleStack(GenericChem.mRareEarthGroupCatalyst, 0))
+            .itemInputs(Materials.Monazite.getDust(32))
             .itemOutputs(
                 Materials.Cerium.getDust(64),
                 Materials.Gadolinium.getDust(64),
@@ -261,13 +246,12 @@ public class RecipeLoaderChemicalSkips {
                 ItemList.SuperconductorComposite.get(1))
             .duration(20 * SECONDS)
             .eut(TierEU.RECIPE_UHV)
+            .metadata(QFT_CATALYST, GTUtility.copyAmount(0, GenericChem.mRareEarthGroupCatalyst))
             .metadata(QFT_FOCUS_TIER, 2)
             .addTo(quantumForceTransformerRecipes);
         // Bastline
         GTValues.RA.stdBuilder()
-            .itemInputs(
-                Materials.Bastnasite.getDust(32),
-                ItemUtils.getSimpleStack(GenericChem.mRareEarthGroupCatalyst, 0))
+            .itemInputs(Materials.Bastnasite.getDust(32))
             .itemOutputs(
                 Materials.Holmium.getDust(64),
                 Materials.Cerium.getDust(64),
@@ -276,13 +260,12 @@ public class RecipeLoaderChemicalSkips {
                 Materials.Lanthanum.getDust(64))
             .duration(20 * SECONDS)
             .eut(TierEU.RECIPE_UHV)
+            .metadata(QFT_CATALYST, GTUtility.copyAmount(0, GenericChem.mRareEarthGroupCatalyst))
             .metadata(QFT_FOCUS_TIER, 2)
             .addTo(quantumForceTransformerRecipes);
         // Bastline from Cerium-rich mixture
         GTValues.RA.stdBuilder()
-            .itemInputs(
-                WerkstoffMaterialPool.CeriumRichMixture.get(OrePrefixes.dust, 16),
-                ItemUtils.getSimpleStack(GenericChem.mRareEarthGroupCatalyst, 0))
+            .itemInputs(WerkstoffMaterialPool.CeriumRichMixture.get(OrePrefixes.dust, 16))
             .itemOutputs(
                 Materials.Holmium.getDust(64),
                 Materials.Cerium.getDust(64),
@@ -291,6 +274,7 @@ public class RecipeLoaderChemicalSkips {
                 Materials.Lanthanum.getDust(64))
             .duration(20 * SECONDS)
             .eut(TierEU.RECIPE_UHV)
+            .metadata(QFT_CATALYST, GTUtility.copyAmount(0, GenericChem.mRareEarthGroupCatalyst))
             .metadata(QFT_FOCUS_TIER, 2)
             .addTo(quantumForceTransformerRecipes);
         // Stem Cells
@@ -298,19 +282,18 @@ public class RecipeLoaderChemicalSkips {
             .itemInputs(
                 Materials.Calcium.getDust(32),
                 Materials.MeatRaw.getDust(32),
-                getModItem(NewHorizonsCoreMod.ID, "GTNHBioItems", 32, 2),
-                ItemUtils.getSimpleStack(GenericChem.mRawIntelligenceCatalyst, 0))
+                getModItem(NewHorizonsCoreMod.ID, "GTNHBioItems", 32, 2))
             .itemOutputs(stemcells)
             .fluidOutputs(
                 Materials.GrowthMediumRaw.getFluid(1000 * 1024),
                 Materials.GrowthMediumSterilized.getFluid(1000 * 512))
             .duration(20 * SECONDS)
             .eut(TierEU.RECIPE_UEV)
+            .metadata(QFT_CATALYST, GTUtility.copyAmount(0, GenericChem.mRawIntelligenceCatalyst))
             .metadata(QFT_FOCUS_TIER, 3)
             .addTo(quantumForceTransformerRecipes);
         // Unknown Particles
         GTValues.RA.stdBuilder()
-            .itemInputs(ItemUtils.getSimpleStack(GenericChem.mParticleAccelerationCatalyst, 0))
             .itemOutputs(
                 Particle.getBaseParticle(Particle.UNKNOWN),
                 Particle.getBaseParticle(Particle.GRAVITON),
@@ -320,14 +303,12 @@ public class RecipeLoaderChemicalSkips {
             .fluidOutputs(FluidUtils.getFluidStack("plasma.hydrogen", 1000))
             .duration(5 * SECONDS)
             .eut(TierEU.RECIPE_UEV)
+            .metadata(QFT_CATALYST, GTUtility.copyAmount(0, GenericChem.mParticleAccelerationCatalyst))
             .metadata(QFT_FOCUS_TIER, 3)
             .addTo(quantumForceTransformerRecipes);
         // Lategame Plastics (Missing Radox Polymer and Heavy Radox)
         GTValues.RA.stdBuilder()
-            .itemInputs(
-                Materials.Carbon.getDust(64),
-                Materials.Osmium.getDust(24),
-                ItemUtils.getSimpleStack(GenericChem.mUltimatePlasticCatalyst, 0))
+            .itemInputs(Materials.Carbon.getDust(64), Materials.Osmium.getDust(24))
             .fluidInputs(Materials.Hydrogen.getGas(1000 * 16), Materials.Nitrogen.getGas(1000 * 16))
             .fluidOutputs(
                 FluidUtils.getFluidStack("xenoxene", 1000 * 16),
@@ -336,15 +317,13 @@ public class RecipeLoaderChemicalSkips {
                 MaterialsKevlar.Kevlar.getMolten(144 * 64))
             .duration(20 * SECONDS)
             .eut(TierEU.RECIPE_UIV)
+            .metadata(QFT_CATALYST, GTUtility.copyAmount(0, GenericChem.mUltimatePlasticCatalyst))
             .metadata(QFT_FOCUS_TIER, 4)
             .addTo(quantumForceTransformerRecipes);
         if (Mods.Forestry.isModLoaded()) {
             // Lategame Kevlar using Kevlar bee comb
             GTValues.RA.stdBuilder()
-                .itemInputs(
-                    GTBees.combs.getStackForType(CombType.KEVLAR, 24),
-                    Materials.Carbon.getDust(64),
-                    ItemUtils.getSimpleStack(GenericChem.mUltimatePlasticCatalyst, 0))
+                .itemInputs(GTBees.combs.getStackForType(CombType.KEVLAR, 24), Materials.Carbon.getDust(64))
                 .fluidInputs(Materials.Nitrogen.getGas(1000 * 16), Materials.Hydrogen.getGas(1000 * 16))
                 .fluidOutputs(
                     MaterialsKevlar.PolyurethaneResin.getFluid(1000 * 32),
@@ -352,6 +331,7 @@ public class RecipeLoaderChemicalSkips {
                     MaterialsKevlar.Kevlar.getMolten(144 * 64))
                 .duration(20 * SECONDS)
                 .eut(TierEU.RECIPE_UIV)
+                .metadata(QFT_CATALYST, GTUtility.copyAmount(0, GenericChem.mUltimatePlasticCatalyst))
                 .metadata(QFT_FOCUS_TIER, 4)
                 .addTo(quantumForceTransformerRecipes);
             // Platline skip using Platline Combs (Palladium, Osmium, Iridium, Platinum)
@@ -360,8 +340,7 @@ public class RecipeLoaderChemicalSkips {
                     GTBees.combs.getStackForType(CombType.PLATINUM, 32),
                     GTBees.combs.getStackForType(CombType.PALLADIUM, 32),
                     GTBees.combs.getStackForType(CombType.OSMIUM, 32),
-                    GTBees.combs.getStackForType(CombType.IRIDIUM, 32),
-                    ItemUtils.getSimpleStack(GenericChem.mPlatinumGroupCatalyst, 0))
+                    GTBees.combs.getStackForType(CombType.IRIDIUM, 32))
                 .fluidOutputs(
                     Materials.Osmium.getMolten(144 * 256),
                     Materials.Palladium.getMolten(144 * 256),
@@ -369,15 +348,13 @@ public class RecipeLoaderChemicalSkips {
                     Materials.Platinum.getMolten(144 * 256))
                 .duration(20 * SECONDS)
                 .eut(TierEU.RECIPE_UV)
+                .metadata(QFT_CATALYST, GTUtility.copyAmount(0, GenericChem.mPlatinumGroupCatalyst))
                 .metadata(QFT_FOCUS_TIER, 1)
                 .addTo(quantumForceTransformerRecipes);
         }
         // Bio Cells and Mutated Solder
         GTValues.RA.stdBuilder()
-            .itemInputs(
-                ItemList.Circuit_Chip_Stemcell.get(16),
-                Materials.InfinityCatalyst.getDust(4),
-                ItemUtils.getSimpleStack(GenericChem.mBiologicalIntelligenceCatalyst, 0))
+            .itemInputs(ItemList.Circuit_Chip_Stemcell.get(16), Materials.InfinityCatalyst.getDust(4))
             .itemOutputs(biocells)
             .fluidOutputs(
                 MaterialMisc.MUTATED_LIVING_SOLDER.getFluidStack(144 * 128),
@@ -385,13 +362,12 @@ public class RecipeLoaderChemicalSkips {
                 Materials.BioMediumRaw.getFluid(1000 * 512))
             .duration(20 * SECONDS)
             .eut(TierEU.RECIPE_UIV)
+            .metadata(QFT_CATALYST, GTUtility.copyAmount(0, GenericChem.mBiologicalIntelligenceCatalyst))
             .metadata(QFT_FOCUS_TIER, 4)
             .addTo(quantumForceTransformerRecipes);
         // Rare Particles
         GTValues.RA.stdBuilder()
-            .itemInputs(
-                ItemUtils.getSimpleStack(GenericChem.mSynchrotronCapableCatalyst, 0),
-                GregtechItemList.Laser_Lens_Special.get(1))
+            .itemInputs(GregtechItemList.Laser_Lens_Special.get(1))
             .itemOutputs(
                 Particle.getBaseParticle(Particle.Z_BOSON),
                 Particle.getBaseParticle(Particle.W_BOSON),
@@ -405,6 +381,7 @@ public class RecipeLoaderChemicalSkips {
                 new FluidStack(MaterialsElements.STANDALONE.CELESTIAL_TUNGSTEN.getPlasma(), 30000))
             .duration(3 * MINUTES + 20 * SECONDS)
             .eut(TierEU.RECIPE_UIV)
+            .metadata(QFT_CATALYST, GTUtility.copyAmount(0, GenericChem.mSynchrotronCapableCatalyst))
             .metadata(QFT_FOCUS_TIER, 4)
             .addTo(quantumForceTransformerRecipes);
 
@@ -413,10 +390,7 @@ public class RecipeLoaderChemicalSkips {
             ItemStack seaweed = GTUtility
                 .copyAmountUnsafe(64 * 32, getModItem(GalaxySpace.ID, "tcetiedandelions", 1, 4));
             GTValues.RA.stdBuilder()
-                .itemInputs(
-                    GTOreDictUnificator.get("cropSeaweed", 64),
-                    Materials.Mytryl.getDust(16),
-                    ItemUtils.getSimpleStack(GenericChem.mAlgagenicGrowthPromoterCatalyst, 0))
+                .itemInputs(GTOreDictUnificator.get("cropSeaweed", 64), Materials.Mytryl.getDust(16))
                 .itemOutputs(seaweed, getModItem(NewHorizonsCoreMod.ID, "item.TCetiESeaweedExtract", 16))
                 .fluidInputs(FluidUtils.getFluidStack("unknowwater", 25_000))
                 .fluidOutputs(
@@ -424,6 +398,7 @@ public class RecipeLoaderChemicalSkips {
                     FluidUtils.getFluidStack("iodine", 64_000))
                 .duration(20 * SECONDS)
                 .eut(TierEU.RECIPE_UIV)
+                .metadata(QFT_CATALYST, GTUtility.copyAmount(0, GenericChem.mAlgagenicGrowthPromoterCatalyst))
                 .metadata(QFT_FOCUS_TIER, 4)
                 .addTo(quantumForceTransformerRecipes);
 

--- a/src/main/java/gtnhlanth/common/tileentity/recipe/beamline/BeamlineRecipeAdder2.java
+++ b/src/main/java/gtnhlanth/common/tileentity/recipe/beamline/BeamlineRecipeAdder2.java
@@ -1,6 +1,8 @@
 package gtnhlanth.common.tileentity.recipe.beamline;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.StatCollector;
@@ -11,6 +13,7 @@ import gregtech.api.recipe.RecipeMapBackend;
 import gregtech.api.recipe.RecipeMapBuilder;
 import gregtech.api.util.GTUtility;
 import gtnhlanth.common.beamline.Particle;
+import gtnhlanth.common.register.LanthItemList;
 
 public class BeamlineRecipeAdder2 {
 
@@ -47,8 +50,13 @@ public class BeamlineRecipeAdder2 {
 
         );
         })
-        // .slotOverlays(null)
-
+        .neiItemOutputsGetter(recipe -> {
+            RecipeSC scRecipe = (RecipeSC) recipe;
+            ItemStack particleStack = new ItemStack(LanthItemList.PARTICLE_ITEM, 1, scRecipe.particleId);
+            List<ItemStack> ret = new ArrayList<>(Arrays.asList(recipe.mOutputs));
+            ret.add(particleStack);
+            return ret.toArray(new ItemStack[0]);
+        })
         .build();
 
     public final RecipeMap<RecipeMapBackend> TargetChamberRecipes = RecipeMapBuilder.of("gtnhlanth.recipe.tc")
@@ -84,7 +92,14 @@ public class BeamlineRecipeAdder2 {
 
         );
         }))
-        // .slotOverlays(null)
+        .neiItemInputsGetter(recipe -> {
+            RecipeTC recipeTC = (RecipeTC) recipe;
+            ItemStack particleStack = new ItemStack(LanthItemList.PARTICLE_ITEM, 1, recipeTC.particleId);
+            List<ItemStack> ret = new ArrayList<>();
+            ret.add(particleStack);
+            ret.addAll(Arrays.asList(recipe.mInputs));
+            return ret.toArray(new ItemStack[0]);
+        })
         .progressBar(GTUITextures.PROGRESSBAR_ASSEMBLY_LINE_1)
         .progressBarPos(108, 22)
         .neiTransferRect(100, 22, 28, 18)

--- a/src/main/java/gtnhlanth/common/tileentity/recipe/beamline/RecipeSC.java
+++ b/src/main/java/gtnhlanth/common/tileentity/recipe/beamline/RecipeSC.java
@@ -1,15 +1,9 @@
 package gtnhlanth.common.tileentity.recipe.beamline;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-
-import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
 import gregtech.api.util.GTRecipe;
-import gregtech.api.util.GTUtility;
-import gtnhlanth.common.register.LanthItemList;
 
 public class RecipeSC extends GTRecipe {
 
@@ -30,21 +24,5 @@ public class RecipeSC extends GTRecipe {
         this.maxEnergy = maxEnergy;
         this.focus = focus;
         this.energyRatio = energyRatio;
-    }
-
-    @Override
-    public ItemStack getRepresentativeOutput(int aIndex) {
-
-        ItemStack particleStack = new ItemStack(LanthItemList.PARTICLE_ITEM);
-
-        Items.ender_pearl.setDamage(particleStack, this.particleId);
-
-        ArrayList<ItemStack> mOutputsWithParticle = new ArrayList<>(Arrays.asList(mOutputs));
-        mOutputsWithParticle.add(particleStack);
-
-        ItemStack[] mOutputsWithParticleArray = mOutputsWithParticle.toArray(new ItemStack[0]);
-
-        if (aIndex < 0 || aIndex >= mOutputsWithParticleArray.length) return null;
-        return GTUtility.copyOrNull(mOutputsWithParticleArray[aIndex]);
     }
 }

--- a/src/main/java/gtnhlanth/common/tileentity/recipe/beamline/RecipeTC.java
+++ b/src/main/java/gtnhlanth/common/tileentity/recipe/beamline/RecipeTC.java
@@ -1,14 +1,8 @@
 package gtnhlanth.common.tileentity.recipe.beamline;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-
-import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 
 import gregtech.api.util.GTRecipe;
-import gregtech.api.util.GTUtility;
-import gtnhlanth.common.register.LanthItemList;
 
 public class RecipeTC extends GTRecipe {
 
@@ -50,22 +44,4 @@ public class RecipeTC extends GTRecipe {
 
         this.focusItem = aFocusItem;
     }
-
-    @Override
-    public ItemStack getRepresentativeInput(int aIndex) {
-
-        ArrayList<ItemStack> mInputsWithParticle = new ArrayList<>();
-
-        ItemStack particleStack = new ItemStack(LanthItemList.PARTICLE_ITEM);
-        Items.ender_pearl.setDamage(particleStack, this.particleId);
-
-        mInputsWithParticle.add(particleStack);
-        mInputsWithParticle.addAll(Arrays.asList(mInputs));
-
-        ItemStack[] mInputsWithParticleArray = mInputsWithParticle.toArray(new ItemStack[0]);
-
-        if (aIndex < 0 || aIndex >= mInputsWithParticleArray.length) return null;
-        return GTUtility.copyOrNull(mInputsWithParticleArray[aIndex]);
-    }
-
 }


### PR DESCRIPTION
This PR adds ways to modify ingredients shown on NEI per recipemap in order to remove workarounds:
- Source and Target Chamber recipes use custom recipe class to have additional information and add particle item to NEI without adding it to the actual recipe. While the latter use case is somewhat intended, the former should be eventually migrated to metadata. Leaving the latter makes migration to RA2 style impossible.
- QFT and PCB Factory recipes have been changed to not have non-consumable items in item inputs and instead have them in metadata. To make NEI visual recipes to still have NC items, two separated recipemaps were created. Having two maps that serve the almost the same mechanism is confusing and prone to bugs.

New method introduced in this PR addresses those issues and hopefully provides more flexible design in future recipe logic.