### PR TITLE
Rotating machines break adjacent enets

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
@@ -1166,13 +1166,14 @@ public class BaseMetaTileEntity extends CommonMetaTileEntity
             for (final ForgeDirection side : ForgeDirection.VALID_DIRECTIONS) {
                 if (outputsEnergyTo(side, false) || inputEnergyFrom(side, false)) {
                     final IGregTechTileEntity TE = getIGregTechTileEntityAtSide(side);
-                    if (TE instanceof BaseMetaPipeEntity) {
-                        final Node node = ((BaseMetaPipeEntity) TE).getNode();
+                    if (TE instanceof BaseMetaPipeEntity pipe
+                        && (pipe.getConnections() & side.getOpposite().flag) != 0) {
+                        final Node node = pipe.getNode();
                         if (node == null) {
-                            new GenerateNodeMapPower((BaseMetaPipeEntity) TE);
+                            new GenerateNodeMapPower(pipe);
                         } else if (node.mCreationTime != time) {
                             GenerateNodeMap.clearNodeMap(node, -1);
-                            new GenerateNodeMapPower((BaseMetaPipeEntity) TE);
+                            new GenerateNodeMapPower(pipe);
                         }
                     }
                 }


### PR DESCRIPTION
When you have a power-accepting machine next to a terminal cable (cable with only one connection to another cable), rotating the machine will cause the cable to lose its enet grid. If the machine is connected to the cable this bug is mitigated.

This causes any machines on the cable to powerfail, since the cable won't transfer any power.

fixes: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18544