### PR TITLE
Disable CRIB pattern pushing when working disabled

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchCraftingInputME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchCraftingInputME.java
@@ -948,6 +948,7 @@ public class MTEHatchCraftingInputME extends MTEHatchInputBus
     @Override
     public boolean pushPattern(ICraftingPatternDetails patternDetails, InventoryCrafting table) {
         if (!isActive()) return false;
+        if (!getBaseMetaTileEntity().isAllowedToWork()) return false;
 
         if (!supportFluids) {
             for (int i = 0; i < table.getSizeInventory(); ++i) {


### PR DESCRIPTION
Currently there is no way to prevent AE from pushing patterns into a CRIB without using a toggle bus. This PR allows you to disable a CRIB by putting a controller cover on it. When disabled, CRIBs will still expose their patterns to AE but the patterns cannot be pushed (like a blocked interface).
