### PR TITLE
Add proper support for dense steam to steam valve and regulator

### DIFF
--- a/src/main/java/gregtech/common/covers/CoverSteamRegulator.java
+++ b/src/main/java/gregtech/common/covers/CoverSteamRegulator.java
@@ -3,7 +3,6 @@ package gregtech.common.covers;
 import net.minecraftforge.fluids.FluidStack;
 
 import gregtech.api.interfaces.ITexture;
-import gregtech.api.util.GTModHandler;
 
 public class CoverSteamRegulator extends CoverFluidRegulator {
 
@@ -13,11 +12,6 @@ public class CoverSteamRegulator extends CoverFluidRegulator {
 
     @Override
     protected boolean canTransferFluid(FluidStack fluid) {
-        if (fluid == null) return false;
-        String fluidname = fluid.getFluid()
-            .getName();
-        return GTModHandler.isAnySteam(fluid) || GTModHandler.isSuperHeatedSteam(fluid)
-            || fluidname.equals("supercriticalsteam")
-            || fluidname.equals("densesupercriticalsteam");
+        return CoverSteamValve.isFluidCompatible(fluid);
     }
 }

--- a/src/main/java/gregtech/common/covers/CoverSteamValve.java
+++ b/src/main/java/gregtech/common/covers/CoverSteamValve.java
@@ -3,6 +3,7 @@ package gregtech.common.covers;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.FluidStack;
 
+import gregtech.api.enums.Materials;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.tileentity.ICoverable;
 import gregtech.api.util.GTModHandler;
@@ -21,11 +22,17 @@ public class CoverSteamValve extends CoverPump {
 
     @Override
     protected boolean canTransferFluid(FluidStack fluid) {
-        if (fluid == null) return false;
+        return isFluidCompatible(fluid);
+    }
+
+    public static boolean isFluidCompatible(FluidStack fluid) {
+        if (fluid == null || fluid.getFluid() == null) return false;
         String fluidname = fluid.getFluid()
             .getName();
         return GTModHandler.isAnySteam(fluid) || GTModHandler.isSuperHeatedSteam(fluid)
             || fluidname.equals("supercriticalsteam")
-            || fluidname.equals("densesupercriticalsteam");
+            || fluid.getFluid() == Materials.DenseSteam.mGas
+            || fluid.getFluid() == Materials.DenseSuperheatedSteam.mGas
+            || fluid.getFluid() == Materials.DenseSupercriticalSteam.mGas;
     }
 }


### PR DESCRIPTION
There is no reason it shouldn't since it already supports dense steam, which turns into dense sh steam at a 1:1 ratio.
- Adds more effective support for dense steams to the valve and regulator.
- Standardizes the fluid check between both cover types to a single location.

https://github.com/user-attachments/assets/682195e5-363a-4d37-9aa9-7d6c21bd46c5