### PR TITLE
Fix: PreciseAssembler accepts Bronze Plated Bricks as high tier machine blocks

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -42,7 +42,7 @@ dependencies {
     api("com.github.GTNewHorizons:ModularUI:1.2.17:dev")
     api("com.github.GTNewHorizons:ModularUI2:2.2.0-1.7.10:dev")
     api("com.github.GTNewHorizons:waila:1.8.2:dev")
-    api("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-523-GTNH:dev")
+    api("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-525-GTNH:dev")
     api("com.github.GTNewHorizons:AE2FluidCraft-Rework:1.4.23-gtnh:dev")
     api('com.github.GTNewHorizons:Yamcl:0.6.0:dev')
     api("com.github.GTNewHorizons:Postea:1.0.13:dev")

--- a/src/main/java/goodgenerator/blocks/tileEntity/MTEPreciseAssembler.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/MTEPreciseAssembler.java
@@ -159,7 +159,8 @@ public class MTEPreciseAssembler extends MTEExtendedPowerMultiBlockBase<MTEPreci
                     withChannel(
                         "machine casing",
                         StructureUtility.ofBlocksTiered(
-                            (block, meta) -> (block == GregTechAPI.sBlockCasings1 && meta >= 0 && meta <= 9) ? meta : -2,
+                            (block, meta) -> (block == GregTechAPI.sBlockCasings1 && meta >= 0 && meta <= 9) ? meta
+                                : -2,
                             IntStream.range(0, 10)
                                 .mapToObj(
                                     meta -> org.apache.commons.lang3.tuple.Pair.of(GregTechAPI.sBlockCasings1, meta))

--- a/src/main/java/goodgenerator/blocks/tileEntity/MTEPreciseAssembler.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/MTEPreciseAssembler.java
@@ -159,7 +159,7 @@ public class MTEPreciseAssembler extends MTEExtendedPowerMultiBlockBase<MTEPreci
                     withChannel(
                         "machine casing",
                         StructureUtility.ofBlocksTiered(
-                            (block, meta) -> block == GregTechAPI.sBlockCasings1 ? meta : -2,
+                            (block, meta) -> (block == GregTechAPI.sBlockCasings1 && meta >= 0 && meta <= 9) ? meta : -2,
                             IntStream.range(0, 10)
                                 .mapToObj(
                                     meta -> org.apache.commons.lang3.tuple.Pair.of(GregTechAPI.sBlockCasings1, meta))


### PR DESCRIPTION
PreciseAssembler shall not accept Bronze Plated Bricks or any blocks  other than ?V Machine Casing now. Should retrieve fields from CoreMod to support UEV+ Machine Casing