### PR TITLE
Add multiplate tag for Bartworks materials

### DIFF
--- a/src/main/java/bartworks/system/material/Werkstoff.java
+++ b/src/main/java/bartworks/system/material/Werkstoff.java
@@ -695,7 +695,7 @@ public class Werkstoff implements IColorModulationContainer, ISubTagContainer {
         /*
          * dust 1 metal 10 (ingot, nugget) gem 100 ore 1000 cell 10000 plasma 100000 molten 1000000 crafting metal
          * 10000000 (sticks, plates) meta crafting metal 100000000 (gears, screws, bolts, springs) multiple ingotWorth
-         * stuff 1000000000 (double, triple, quadruple, ingot/plates)
+         * stuff 1000000000 (double and dense plates) 1000000000 (triple, quadruple and quintuple plates)
          */
         private boolean isExtension;
         private static final NonNullWrappedHashMap<OrePrefixes, Integer> prefixLogic = new NonNullWrappedHashMap<>(0);
@@ -759,10 +759,12 @@ public class Werkstoff implements IColorModulationContainer, ISubTagContainer {
             Werkstoff.GenerationFeatures.prefixLogic.put(OrePrefixes.wireFine, 0b100000000);
 
             Werkstoff.GenerationFeatures.prefixLogic.put(OrePrefixes.plateDouble, 0x200);
-            Werkstoff.GenerationFeatures.prefixLogic.put(OrePrefixes.plateTriple, 0x200);
-            Werkstoff.GenerationFeatures.prefixLogic.put(OrePrefixes.plateQuadruple, 0x200);
-            Werkstoff.GenerationFeatures.prefixLogic.put(OrePrefixes.plateQuintuple, 0x200);
             Werkstoff.GenerationFeatures.prefixLogic.put(OrePrefixes.plateDense, 0x200);
+
+            Werkstoff.GenerationFeatures.prefixLogic.put(OrePrefixes.plateTriple, 0x400);
+            Werkstoff.GenerationFeatures.prefixLogic.put(OrePrefixes.plateQuadruple, 0x400);
+            Werkstoff.GenerationFeatures.prefixLogic.put(OrePrefixes.plateQuintuple, 0x400);
+
             Werkstoff.GenerationFeatures.prefixLogic.put(OrePrefixes.blockCasing, 0x380);
             Werkstoff.GenerationFeatures.prefixLogic.put(OrePrefixes.blockCasingAdvanced, 0x380);
         }
@@ -969,8 +971,16 @@ public class Werkstoff implements IColorModulationContainer, ISubTagContainer {
             return this;
         }
 
-        public Werkstoff.GenerationFeatures addMultipleIngotMetalWorkingItems() {
+        public Werkstoff.GenerationFeatures addDoubleAndDensePlates() {
             this.toGenerate = this.toGenerate | 0x200;
+            return this;
+        }
+
+        /**
+         * Due to rebolted casings, double plates had to be excluded from this
+         */
+        public Werkstoff.GenerationFeatures addMultiPlates() {
+            this.toGenerate = this.toGenerate | 0x400;
             return this;
         }
 

--- a/src/main/java/bartworks/system/material/WerkstoffLoader.java
+++ b/src/main/java/bartworks/system/material/WerkstoffLoader.java
@@ -1347,7 +1347,7 @@ public class WerkstoffLoader {
             .addMixerRecipes((short) 1)
             .addSimpleMetalWorkingItems()
             .addCraftingMetalWorkingItems()
-            .addMultipleIngotMetalWorkingItems()
+            .addDoubleAndDensePlates()
             .addMetaSolidifierRecipes()
             .addMetalCraftingSolidifierRecipes(),
         88,
@@ -1385,7 +1385,7 @@ public class WerkstoffLoader {
             .addMixerRecipes((short) 1)
             .addSimpleMetalWorkingItems()
             .addCraftingMetalWorkingItems()
-            .addMultipleIngotMetalWorkingItems()
+            .addDoubleAndDensePlates()
             .addMetaSolidifierRecipes()
             .addMetalCraftingSolidifierRecipes(),
         90,
@@ -1417,7 +1417,7 @@ public class WerkstoffLoader {
             .addMixerRecipes()
             .addSimpleMetalWorkingItems()
             .addCraftingMetalWorkingItems()
-            .addMultipleIngotMetalWorkingItems()
+            .addDoubleAndDensePlates()
             .addMetaSolidifierRecipes()
             .addMetalCraftingSolidifierRecipes(),
         92,
@@ -1480,7 +1480,7 @@ public class WerkstoffLoader {
             .addCraftingMetalWorkingItems()
             .addMolten()
             .addSimpleMetalWorkingItems()
-            .addMultipleIngotMetalWorkingItems()
+            .addDoubleAndDensePlates()
             .addMetaSolidifierRecipes()
             .addMetalCraftingSolidifierRecipes(),
         96,
@@ -1968,11 +1968,13 @@ public class WerkstoffLoader {
             WerkstoffLoader.items.put(wireFine, new BWMetaGeneratedItems(wireFine));
         }
         if ((WerkstoffLoader.toGenerateGlobal & 0b1000000000) != 0) {
+            WerkstoffLoader.items.put(plateDense, new BWMetaGeneratedItems(plateDense));;
+        }
+        if ((WerkstoffLoader.toGenerateGlobal & 0b10000000000) != 0) {
             WerkstoffLoader.items.put(plateDouble, new BWMetaGeneratedItems(plateDouble));
             WerkstoffLoader.items.put(plateTriple, new BWMetaGeneratedItems(plateTriple));
             WerkstoffLoader.items.put(plateQuadruple, new BWMetaGeneratedItems(plateQuadruple));
             WerkstoffLoader.items.put(plateQuintuple, new BWMetaGeneratedItems(plateQuintuple));
-            WerkstoffLoader.items.put(plateDense, new BWMetaGeneratedItems(plateDense));;
         }
         ENABLED_ORE_PREFIXES.addAll(WerkstoffLoader.items.keySet());
         ENABLED_ORE_PREFIXES.add(ore);

--- a/src/main/java/goodgenerator/items/GGMaterial.java
+++ b/src/main/java/goodgenerator/items/GGMaterial.java
@@ -284,7 +284,7 @@ public class GGMaterial implements Runnable {
             .addMetalItems()
             .addCraftingMetalWorkingItems()
             .addSimpleMetalWorkingItems()
-            .addMultipleIngotMetalWorkingItems()
+            .addDoubleAndDensePlates()
             .addMetaSolidifierRecipes()
             .addMetalCraftingSolidifierRecipes(),
         OffsetID + 21,
@@ -314,7 +314,7 @@ public class GGMaterial implements Runnable {
             .addMetalItems()
             .addCraftingMetalWorkingItems()
             .addSimpleMetalWorkingItems()
-            .addMultipleIngotMetalWorkingItems()
+            .addDoubleAndDensePlates()
             .addMetaSolidifierRecipes()
             .addMetalCraftingSolidifierRecipes(),
         OffsetID + 23,
@@ -1075,7 +1075,7 @@ public class GGMaterial implements Runnable {
             .addMetalItems()
             .addCraftingMetalWorkingItems()
             .addSimpleMetalWorkingItems()
-            .addMultipleIngotMetalWorkingItems()
+            .addDoubleAndDensePlates()
             .addMetaSolidifierRecipes()
             .addMetalCraftingSolidifierRecipes()
             .addMixerRecipes((short) 3),
@@ -1201,7 +1201,7 @@ public class GGMaterial implements Runnable {
             .addMetalItems()
             .addCraftingMetalWorkingItems()
             .addSimpleMetalWorkingItems()
-            .addMultipleIngotMetalWorkingItems()
+            .addDoubleAndDensePlates()
             .addMetaSolidifierRecipes()
             .addMetalCraftingSolidifierRecipes()
             .addMixerRecipes((short) 7),
@@ -1231,7 +1231,7 @@ public class GGMaterial implements Runnable {
             .addMetalItems()
             .addCraftingMetalWorkingItems()
             .addSimpleMetalWorkingItems()
-            .addMultipleIngotMetalWorkingItems()
+            .addDoubleAndDensePlates()
             .addMetaSolidifierRecipes()
             .addMetalCraftingSolidifierRecipes(),
         OffsetID + 96,
@@ -1446,7 +1446,7 @@ public class GGMaterial implements Runnable {
             .addMolten()
             .addMetalItems()
             .addCraftingMetalWorkingItems()
-            .addMultipleIngotMetalWorkingItems()
+            .addDoubleAndDensePlates()
             .addMetaSolidifierRecipes()
             .addMetalCraftingSolidifierRecipes()
             .addMixerRecipes((short) 6),
@@ -1472,7 +1472,7 @@ public class GGMaterial implements Runnable {
             .addMetalItems()
             .addCraftingMetalWorkingItems()
             .addSimpleMetalWorkingItems()
-            .addMultipleIngotMetalWorkingItems()
+            .addDoubleAndDensePlates()
             .addMetaSolidifierRecipes()
             .addMetalCraftingSolidifierRecipes()
             .addMixerRecipes((short) 4),
@@ -1497,7 +1497,7 @@ public class GGMaterial implements Runnable {
             .addMetalItems()
             .addCraftingMetalWorkingItems()
             .addSimpleMetalWorkingItems()
-            .addMultipleIngotMetalWorkingItems()
+            .addDoubleAndDensePlates()
             .addMetaSolidifierRecipes()
             .addMetalCraftingSolidifierRecipes(),
         OffsetID + 110,
@@ -1519,7 +1519,8 @@ public class GGMaterial implements Runnable {
             .addMetalItems()
             .addCraftingMetalWorkingItems()
             .addSimpleMetalWorkingItems()
-            .addMultipleIngotMetalWorkingItems()
+            .addDoubleAndDensePlates()
+            .addMultiPlates()
             .addMetaSolidifierRecipes()
             .addMetalCraftingSolidifierRecipes(),
         OffsetID + 111,

--- a/src/main/java/gtnhlanth/common/register/WerkstoffMaterialPool.java
+++ b/src/main/java/gtnhlanth/common/register/WerkstoffMaterialPool.java
@@ -1894,7 +1894,7 @@ public class WerkstoffMaterialPool implements Runnable {
         new Werkstoff.GenerationFeatures().disable()
             .onlyDust()
             .addMetalItems()
-            .addMultipleIngotMetalWorkingItems()
+            .addDoubleAndDensePlates()
             .addCraftingMetalWorkingItems()
             .enforceUnification(),
         offsetID3b + 1,


### PR DESCRIPTION
Similarly to the GT5u one. Double plates had to be grouped together with dense plates due to rebolted casings, since otherwise all materials would kept triple, quadruple and quintuple plates, making this change pointless