### PR TITLE
More accurate Waila status line for steam machines with obstructed vents

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEBasicMachine.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEBasicMachine.java
@@ -41,6 +41,7 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.IFluidHandler;
 
 import org.apache.commons.lang3.tuple.Pair;
+import org.jetbrains.annotations.NotNull;
 
 import com.gtnewhorizons.modularui.api.drawable.IDrawable;
 import com.gtnewhorizons.modularui.api.math.Pos2d;
@@ -1185,7 +1186,7 @@ public abstract class MTEBasicMachine extends MTEBasicTank implements RecipeMapW
         final NBTTagCompound tag = accessor.getNBTData();
 
         if (tag.getBoolean("stutteringSingleBlock")) {
-            currenttip.add("Status: insufficient energy");
+            currenttip.add(StatCollector.translateToLocal(getWailaStutteringLine(tag)));
         } else {
             boolean isActive = tag.getBoolean("isActiveSingleBlock");
             if (isActive) {
@@ -1243,6 +1244,11 @@ public abstract class MTEBasicMachine extends MTEBasicTank implements RecipeMapW
                     .name()));
     }
 
+    private static @NotNull String getWailaStutteringLine(NBTTagCompound tag) {
+        return tag.getBoolean("blockedSteamVentSingleBlock") ? "GT5U.waila.status.obstructed_steam_vent"
+            : "GT5U.waila.status.insufficient_energy";
+    }
+
     @Override
     public void getWailaNBTData(EntityPlayerMP player, TileEntity tile, NBTTagCompound tag, World world, int x, int y,
         int z) {
@@ -1252,6 +1258,7 @@ public abstract class MTEBasicMachine extends MTEBasicTank implements RecipeMapW
         tag.setInteger("maxProgressSingleBlock", mMaxProgresstime);
         tag.setInteger("mainFacingSingleBlock", mMainFacing.ordinal());
         tag.setBoolean("stutteringSingleBlock", mStuttering);
+        tag.setBoolean("blockedSteamVentSingleBlock", cannotVentSteam());
 
         final IGregTechTileEntity tileEntity = getBaseMetaTileEntity();
         if (tileEntity != null) {
@@ -1565,7 +1572,7 @@ public abstract class MTEBasicMachine extends MTEBasicTank implements RecipeMapW
 
     protected GTTooltipDataCache.TooltipData getErrorTooltip() {
         if (isSteampowered()) {
-            if ((getBaseMetaTileEntity().getErrorDisplayID() & 64) != 0) {
+            if (cannotVentSteam()) {
                 return mTooltipCache.getData(STALLED_VENT_TOOLTIP);
             }
         }
@@ -1575,6 +1582,10 @@ public abstract class MTEBasicMachine extends MTEBasicTank implements RecipeMapW
                 StatCollector.translateToLocal(POWER_SOURCE_KEY + (isSteampowered() ? "steam" : "power")));
         }
         return null;
+    }
+
+    private boolean cannotVentSteam() {
+        return (getBaseMetaTileEntity().getErrorDisplayID() & 64) != 0;
     }
 
     protected static int getCapacityForTier(int tier) {

--- a/src/main/resources/assets/gregtech/lang/en_US.lang
+++ b/src/main/resources/assets/gregtech/lang/en_US.lang
@@ -854,6 +854,8 @@ GT5U.waila.producing=Producing:
 GT5U.waila.producing.andmore=  And %d More...
 GT5U.waila.generating.on=Generating Energy
 GT5U.waila.generating.off=Not Generating
+GT5U.waila.status.insufficient_energy=Status: Insufficient energy
+GT5U.waila.status.obstructed_steam_vent=Status: Obstructed steam vent
 
 
 achievement.flintpick=First Tools


### PR DESCRIPTION
Changes the "Status" line not to say "insufficient energy" if the steam machine is in fact blocked from venting but has plenty of energy.

### Before
![before](https://github.com/user-attachments/assets/8c4b9492-33bc-4bb6-b4f5-29875627c45e)

### After
![after](https://github.com/user-attachments/assets/d63774a4-facb-4ffe-8efd-24180c1daab2)
