### PR TITLE
Deprecate GTLanguageManager

### DIFF
--- a/src/main/java/gregtech/api/util/GTLanguageManager.java
+++ b/src/main/java/gregtech/api/util/GTLanguageManager.java
@@ -17,6 +17,10 @@ import cpw.mods.fml.common.registry.LanguageRegistry;
 import cpw.mods.fml.relauncher.ReflectionHelper;
 import gregtech.api.GregTechAPI;
 
+/**
+ * @deprecated Use standard translation with {@link StatCollector}.
+ */
+@Deprecated
 public class GTLanguageManager {
 
     /**

--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -92,6 +92,7 @@ import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.MathHelper;
 import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.StatCollector;
 import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldServer;
@@ -3761,10 +3762,18 @@ public class GTUtility {
         return rEUAmount;
     }
 
+    /**
+     * @deprecated Use standard translation with {@link StatCollector}.
+     */
+    @Deprecated
     public static String trans(String aKey, String aEnglish) {
         return GTLanguageManager.addStringLocalization("Interaction_DESCRIPTION_Index_" + aKey, aEnglish);
     }
 
+    /**
+     * @deprecated Use standard translation with {@link StatCollector}.
+     */
+    @Deprecated
     public static String getTrans(String aKey) {
         return GTLanguageManager.getTranslation("Interaction_DESCRIPTION_Index_" + aKey);
     }


### PR DESCRIPTION
Standard translations with StatCollector have been favored for a long time, so this PR formally deprecates the old system so that new works do not attempt to use it.

Moving away from using it entirely is a large amount of work that we can chip away over time. But ideally this prevents it from growing any more