### PR TITLE
Fix Large HP Steam Turbine ignoring loose flow setting

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTELargeTurbineHPSteam.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTELargeTurbineHPSteam.java
@@ -28,7 +28,6 @@ import gregtech.api.util.TurbineStatCalculator;
 public class MTELargeTurbineHPSteam extends MTELargeTurbine {
 
     public boolean achievement = false;
-    private boolean looseFit = false;
 
     public MTELargeTurbineHPSteam(int aID, String aName, String aNameRegional) {
         super(aID, aName, aNameRegional);


### PR DESCRIPTION
`looseFit` field hides inherited field with the same name. It is hardset to false, and flow calculations use it instead of the inherited modifiable field.
Haven't built it and haven't tested it. Review required.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18358