### PR TITLE
Fix confusing black hole exploit

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/compressor/MTEBlackHoleCompressor.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/compressor/MTEBlackHoleCompressor.java
@@ -495,6 +495,8 @@ public class MTEBlackHoleCompressor extends MTEExtendedPowerMultiBlockBase<MTEBl
         // Loop through all items and look for the Activation and Deactivation Catalysts
         // Deactivation resets stability to 100 and catalyzing cost to 1
 
+        if (this.maxProgresstime() != 0) return;
+
         for (MTEHatchInputBus bus : filterValidMTEs(mInputBusses)) {
             for (int i = 0; i < bus.getSizeInventory(); i++) {
                 ItemStack inputItem = bus.getStackInSlot(i);


### PR DESCRIPTION
I've seen some mentions of being able to collapse black hole while it's running. Honestly no idea how it's possible for this check to run during a recipe since it should only occur during recipe check. This should be a harmless check that will always prevent it though.