### PR TITLE
Add throughput info for Multi-Amp and Laser hatches to scanner and Waila

### DIFF
--- a/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchEnergyMulti.java
+++ b/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchEnergyMulti.java
@@ -130,7 +130,8 @@ public class MTEHatchEnergyMulti extends MTEHatch {
     }
 
     @Override
-    public void getWailaNBTData(EntityPlayerMP player, TileEntity tile, NBTTagCompound tag, World world, int x, int y, int z) {
+    public void getWailaNBTData(EntityPlayerMP player, TileEntity tile, NBTTagCompound tag, World world, int x, int y,
+        int z) {
         super.getWailaNBTData(player, tile, tag, world, x, y, z);
         tag.setLong("amperage", Amperes);
     }
@@ -142,7 +143,9 @@ public class MTEHatchEnergyMulti extends MTEHatch {
         currenttip.add(
             translateToLocal("gt.blockmachines.hatch.energytunnel.desc.1") + ": "
                 + EnumChatFormatting.YELLOW
-                + GTUtility.formatNumbers(accessor.getNBTData().getLong("amperage") * V[mTier])
+                + GTUtility.formatNumbers(
+                    accessor.getNBTData()
+                        .getLong("amperage") * V[mTier])
                 + EnumChatFormatting.RESET
                 + " EU/t");
     }

--- a/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchEnergyMulti.java
+++ b/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchEnergyMulti.java
@@ -4,14 +4,20 @@ import static gregtech.api.enums.GTValues.V;
 import static net.minecraft.util.StatCollector.translateToLocal;
 import static net.minecraft.util.StatCollector.translateToLocalFormatted;
 
+import java.util.List;
+
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumChatFormatting;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.implementations.MTEHatch;
+import gregtech.api.util.GTUtility;
+import mcp.mobius.waila.api.IWailaConfigHandler;
+import mcp.mobius.waila.api.IWailaDataAccessor;
 import tectech.thing.metaTileEntity.Textures;
 import tectech.util.CommonValues;
 import tectech.util.TTUtility;
@@ -112,6 +118,32 @@ public class MTEHatchEnergyMulti extends MTEHatch {
     @Override
     public long maxWorkingAmperesIn() {
         return Amperes;
+    }
+
+    @Override
+    public boolean isGivingInformation() {
+        return true;
+    }
+
+    @Override
+    public void getWailaBody(ItemStack itemStack, List<String> currenttip, IWailaDataAccessor accessor,
+        IWailaConfigHandler config) {
+        super.getWailaBody(itemStack, currenttip, accessor, config);
+        currenttip.add(
+            translateToLocal("gt.blockmachines.hatch.energytunnel.desc.1") + ": "
+                + EnumChatFormatting.YELLOW
+                + GTUtility.formatNumbers(Amperes * V[mTier])
+                + EnumChatFormatting.RESET
+                + " EU/t");
+    }
+
+    @Override
+    public String[] getInfoData() {
+        return new String[] { translateToLocal("gt.blockmachines.hatch.energytunnel.desc.1") + ": "
+            + EnumChatFormatting.YELLOW
+            + GTUtility.formatNumbers(Amperes * V[mTier])
+            + EnumChatFormatting.RESET
+            + " EU/t" };
     }
 
     @Override

--- a/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchEnergyMulti.java
+++ b/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchEnergyMulti.java
@@ -7,8 +7,12 @@ import static net.minecraft.util.StatCollector.translateToLocalFormatted;
 import java.util.List;
 
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumChatFormatting;
+import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import gregtech.api.interfaces.ITexture;
@@ -126,13 +130,19 @@ public class MTEHatchEnergyMulti extends MTEHatch {
     }
 
     @Override
+    public void getWailaNBTData(EntityPlayerMP player, TileEntity tile, NBTTagCompound tag, World world, int x, int y, int z) {
+        super.getWailaNBTData(player, tile, tag, world, x, y, z);
+        tag.setLong("amperage", Amperes);
+    }
+
+    @Override
     public void getWailaBody(ItemStack itemStack, List<String> currenttip, IWailaDataAccessor accessor,
         IWailaConfigHandler config) {
         super.getWailaBody(itemStack, currenttip, accessor, config);
         currenttip.add(
             translateToLocal("gt.blockmachines.hatch.energytunnel.desc.1") + ": "
                 + EnumChatFormatting.YELLOW
-                + GTUtility.formatNumbers(Amperes * V[mTier])
+                + GTUtility.formatNumbers(accessor.getNBTData().getLong("amperage") * V[mTier])
                 + EnumChatFormatting.RESET
                 + " EU/t");
     }

--- a/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchEnergyTunnel.java
+++ b/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchEnergyTunnel.java
@@ -66,48 +66,13 @@ public class MTEHatchEnergyTunnel extends MTEHatchEnergyMulti implements IConnec
     }
 
     @Override
-    public boolean isSimpleMachine() {
-        return true;
-    }
-
-    @Override
-    public boolean isFacingValid(ForgeDirection facing) {
-        return true;
-    }
-
-    @Override
-    public boolean isAccessAllowed(EntityPlayer aPlayer) {
-        return true;
-    }
-
-    @Override
-    public boolean isInputFacing(ForgeDirection side) {
-        return side == getBaseMetaTileEntity().getFrontFacing();
-    }
-
-    @Override
-    public boolean isValidSlot(int aIndex) {
-        return false;
-    }
-
-    @Override
     public long getMinimumStoredEU() {
-        return V[mTier];
-    }
-
-    @Override
-    public long maxEUInput() {
         return V[mTier];
     }
 
     @Override
     public long maxEUStore() {
         return V[mTier] * 24L * Amperes;
-    }
-
-    @Override
-    public boolean isEnetOutput() {
-        return false;
     }
 
     @Override
@@ -126,23 +91,9 @@ public class MTEHatchEnergyTunnel extends MTEHatchEnergyMulti implements IConnec
     }
 
     @Override
-    public boolean allowPullStack(IGregTechTileEntity aBaseMetaTileEntity, int aIndex, ForgeDirection side,
-        ItemStack aStack) {
-        return false;
-    }
-
-    @Override
-    public boolean allowPutStack(IGregTechTileEntity aBaseMetaTileEntity, int aIndex, ForgeDirection side,
-        ItemStack aStack) {
-        return false;
-    }
-
-    @Override
     public void saveNBTData(NBTTagCompound aNBT) {
         super.saveNBTData(aNBT);
-        if (Amperes != maxAmperes) {
-            aNBT.setInteger("amperes", Amperes);
-        }
+        aNBT.setInteger("amperes", Amperes);
     }
 
     @Override

--- a/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchEnergyTunnel.java
+++ b/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchEnergyTunnel.java
@@ -93,7 +93,9 @@ public class MTEHatchEnergyTunnel extends MTEHatchEnergyMulti implements IConnec
     @Override
     public void saveNBTData(NBTTagCompound aNBT) {
         super.saveNBTData(aNBT);
-        aNBT.setInteger("amperes", Amperes);
+        if (Amperes != maxAmperes) {
+            aNBT.setInteger("amperes", Amperes);
+        }
     }
 
     @Override

--- a/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchWirelessMulti.java
+++ b/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchWirelessMulti.java
@@ -129,43 +129,13 @@ public class MTEHatchWirelessMulti extends MTEHatchEnergyMulti implements IWirel
     }
 
     @Override
-    public boolean isSimpleMachine() {
-        return true;
-    }
-
-    @Override
-    public boolean isFacingValid(ForgeDirection facing) {
-        return true;
-    }
-
-    @Override
-    public boolean isAccessAllowed(EntityPlayer aPlayer) {
-        return true;
-    }
-
-    @Override
     public boolean isEnetInput() {
-        return false;
-    }
-
-    @Override
-    public boolean isInputFacing(ForgeDirection side) {
-        return side == getBaseMetaTileEntity().getFrontFacing();
-    }
-
-    @Override
-    public boolean isValidSlot(int aIndex) {
         return false;
     }
 
     @Override
     public long getMinimumStoredEU() {
         return Amperes * V[mTier];
-    }
-
-    @Override
-    public long maxEUInput() {
-        return V[mTier];
     }
 
     @Override
@@ -179,25 +149,8 @@ public class MTEHatchWirelessMulti extends MTEHatchEnergyMulti implements IWirel
     }
 
     @Override
-    public long maxWorkingAmperesIn() {
-        return Amperes;
-    }
-
-    @Override
     public MetaTileEntity newMetaEntity(IGregTechTileEntity aTileEntity) {
         return new MTEHatchWirelessMulti(mName, mTier, Amperes, mDescriptionArray, mTextures);
-    }
-
-    @Override
-    public boolean allowPullStack(IGregTechTileEntity aBaseMetaTileEntity, int aIndex, ForgeDirection side,
-        ItemStack aStack) {
-        return false;
-    }
-
-    @Override
-    public boolean allowPutStack(IGregTechTileEntity aBaseMetaTileEntity, int aIndex, ForgeDirection side,
-        ItemStack aStack) {
-        return false;
     }
 
     @Override


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18846

Exactly as the title sounds.
Since I was touching these classes, I also removed a few methods identical to super from the laser hatch and multiamp wireless classes.
Here is what it looks like in game:
Multiamp hatch set to 125 amps with the screwdriver:
![image](https://github.com/user-attachments/assets/2461a85b-f29c-481b-8544-6f98a3d4367a)


Multiamp wireless:
![image](https://github.com/user-attachments/assets/690e027c-3f1c-4f84-a0ad-22b5649bf3cc)
![image](https://github.com/user-attachments/assets/39415d7e-d4ae-4853-a4a9-7899c4a66fc2)

In my testing the Waila and scanner info saves correctly when world is exited or when chunks are unloaded and reloaded


