### PR TITLE
Correct recipe input order for UV motor CoAL recipe

### DIFF
--- a/src/main/java/goodgenerator/loader/ComponentAssemblyLineLoader.java
+++ b/src/main/java/goodgenerator/loader/ComponentAssemblyLineLoader.java
@@ -1023,9 +1023,9 @@ public class ComponentAssemblyLineLoader {
             .fluidInputs(
                 INDALLOY_140.getFluidStack(432 * L),
                 Lubricant.getFluid(96000),
-                Neutronium.getMolten(325 * L + 48),
                 Americium.getMolten(2304 * L),
                 Naquadria.getMolten(432 * L),
+                Neutronium.getMolten(325 * L + 48),
                 Samarium.getMolten(96 * L))
             .duration(24 * MINUTES)
             .eut(RECIPE_ZPM)


### PR DESCRIPTION
Very minor change, just fixes the display order of fluids per the CoAL recipe rules after #3869 