### PR TITLE
Fix ME hatches voiding

### DIFF
--- a/src/main/java/bartworks/common/tileentities/multis/mega/MTEMegaDistillTower.java
+++ b/src/main/java/bartworks/common/tileentities/multis/mega/MTEMegaDistillTower.java
@@ -398,7 +398,7 @@ public class MTEMegaDistillTower extends MegaMultiBlockBase<MTEMegaDistillTower>
 
             for (IFluidStore tHatch : tLayerOutputHatches) {
                 if (tHatch instanceof MTEHatchOutputME tMEHatch) {
-                    if (tMEHatch.canAcceptFluid()) {
+                    if (tMEHatch.canFillFluid()) {
                         foundMEHatch = true;
                         break;
                     }

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
@@ -1353,7 +1353,7 @@ public abstract class MTEMultiBlockBase extends MetaTileEntity
             if (!tHatch.canStoreFluid(copiedFluidStack)) continue;
 
             if (tHatch instanceof MTEHatchOutputME tMEHatch) {
-                if (!tMEHatch.canAcceptFluid()) continue;
+                if (!tMEHatch.canFillFluid()) continue;
             }
 
             int tAmount = tHatch.fill(copiedFluidStack, false);

--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchOutputME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchOutputME.java
@@ -155,10 +155,17 @@ public class MTEHatchOutputME extends MTEHatchOutput implements IPowerChannelSta
     }
 
     /**
-     * Check if the internal cache can still fit more fluids in it
+     * Check if the internal cache can still fit more fluids in it for a recipe check
      */
     public boolean canAcceptFluid() {
-        return getCachedAmount() < getCacheCapacity() || lastInputTick == tickCounter;
+        return getCachedAmount() < getCacheCapacity();
+    }
+
+    /**
+     * Check if there is space for fluids or if we can overfill.
+     */
+    public boolean canFillFluid() {
+        return canAcceptFluid() || lastInputTick == tickCounter;
     }
 
     /**

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEDistillationTower.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEDistillationTower.java
@@ -302,7 +302,7 @@ public class MTEDistillationTower extends MTEEnhancedMultiBlockBase<MTEDistillat
         return this.mOutputHatchesByLayer.stream()
             .allMatch(
                 tLayerOutputHatches -> tLayerOutputHatches.stream()
-                    .anyMatch(tHatch -> (tHatch instanceof MTEHatchOutputME tMEHatch) && (tMEHatch.canAcceptFluid())));
+                    .anyMatch(tHatch -> (tHatch instanceof MTEHatchOutputME tMEHatch) && (tMEHatch.canFillFluid())));
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/advanced/MTEAdvDistillationTower.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/advanced/MTEAdvDistillationTower.java
@@ -453,7 +453,7 @@ public class MTEAdvDistillationTower extends GTPPMultiBlockBase<MTEAdvDistillati
         return this.mOutputHatchesByLayer.stream()
             .allMatch(
                 tLayerOutputHatches -> tLayerOutputHatches.stream()
-                    .anyMatch(tHatch -> (tHatch instanceof MTEHatchOutputME tMEHatch) && (tMEHatch.canAcceptFluid())));
+                    .anyMatch(tHatch -> (tHatch instanceof MTEHatchOutputME tMEHatch) && (tMEHatch.canFillFluid())));
     }
 
     @Override


### PR DESCRIPTION
When doing a recipe checks, if the previous craft had filled up the me hatch, it will say there is still space for more fluids. Which is true *for that tick,* not in the future when the craft is completed.   This should fix that.