### PR TITLE
Change to MultiBlockBase drainEnergy

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
@@ -1336,13 +1336,20 @@ public abstract class MTEMultiBlockBase extends MetaTileEntity
     }
 
     public boolean drainEnergyInput(long aEU) {
-        if (aEU <= 0) return true;
-        for (MTEHatchEnergy tHatch : validMTEList(mEnergyHatches)) {
-            if (tHatch.getBaseMetaTileEntity()
-                .decreaseStoredEnergyUnits(aEU, false)) return true;
-        }
-        return false;
+    if (aEU <= 0) return true; 
+
+    for (MTEHatchEnergy tHatch : validMTEList(mEnergyHatches)) {
+        long tDrain = Math.min(tHatch.getBaseMetaTileEntity().getStoredEU(), aEU);
+        tHatch.getBaseMetaTileEntity().decreaseStoredEnergyUnits(tDrain, false);//basicly copied from ExoticEnergyInputHelper, makes machine use all hatches for power
+        aEU -= tDrain;
+        
+        if (aEU <= 0) return true; 
     }
+
+    return false;
+}
+
+
 
     protected static boolean dumpFluid(List<MTEHatchOutput> aOutputHatches, FluidStack copiedFluidStack,
         boolean restrictiveHatchesOnly) {


### PR DESCRIPTION
Allows them to use all power in all hatches instead of trying to use single hatch and on fail trying to use next one.