### PR TITLE
Cover UI crash fixes

### DIFF
--- a/src/main/java/gregtech/api/gui/modularui/GTUIInfos.java
+++ b/src/main/java/gregtech/api/gui/modularui/GTUIInfos.java
@@ -27,7 +27,6 @@ import gregtech.api.enums.GTValues;
 import gregtech.api.interfaces.tileentity.ICoverable;
 import gregtech.api.interfaces.tileentity.IHasWorldObjectAndCoords;
 import gregtech.api.net.GTPacketSendCoverData;
-import gregtech.api.objects.GTCoverNone;
 import gregtech.api.util.CoverBehaviorBase;
 
 public class GTUIInfos {
@@ -85,7 +84,6 @@ public class GTUIInfos {
                         final TileEntity te = world.getTileEntity(x, y, z);
                         if (!(te instanceof ICoverable gtTileEntity)) return null;
                         final CoverBehaviorBase<?> cover = gtTileEntity.getCoverBehaviorAtSideNew(side);
-                        if (cover instanceof GTCoverNone) return null;
                         return createCoverGuiContainer(
                             player,
                             cover::createWindow,

--- a/src/main/java/gregtech/api/gui/modularui/GTUIInfos.java
+++ b/src/main/java/gregtech/api/gui/modularui/GTUIInfos.java
@@ -27,6 +27,7 @@ import gregtech.api.enums.GTValues;
 import gregtech.api.interfaces.tileentity.ICoverable;
 import gregtech.api.interfaces.tileentity.IHasWorldObjectAndCoords;
 import gregtech.api.net.GTPacketSendCoverData;
+import gregtech.api.objects.GTCoverNone;
 import gregtech.api.util.CoverBehaviorBase;
 
 public class GTUIInfos {
@@ -84,6 +85,7 @@ public class GTUIInfos {
                         final TileEntity te = world.getTileEntity(x, y, z);
                         if (!(te instanceof ICoverable gtTileEntity)) return null;
                         final CoverBehaviorBase<?> cover = gtTileEntity.getCoverBehaviorAtSideNew(side);
+                        if (cover instanceof GTCoverNone) return null;
                         return createCoverGuiContainer(
                             player,
                             cover::createWindow,

--- a/src/main/java/gregtech/api/metatileentity/CoverableTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/CoverableTileEntity.java
@@ -9,9 +9,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.stream.IntStream;
 
@@ -22,7 +20,6 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
-import net.minecraft.network.PacketBuffer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.StatCollector;
@@ -30,11 +27,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.FluidRegistry;
 
-import org.jetbrains.annotations.NotNull;
-
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.io.ByteStreams;
 import com.gtnewhorizons.modularui.api.drawable.IDrawable;
 import com.gtnewhorizons.modularui.api.drawable.ItemDrawable;
 import com.gtnewhorizons.modularui.api.math.MainAxisAlignment;
@@ -43,7 +36,6 @@ import com.gtnewhorizons.modularui.api.screen.UIBuildContext;
 import com.gtnewhorizons.modularui.api.widget.Widget;
 import com.gtnewhorizons.modularui.common.widget.ButtonWidget;
 import com.gtnewhorizons.modularui.common.widget.Column;
-import com.gtnewhorizons.modularui.common.widget.FakeSyncWidget;
 import com.gtnewhorizons.modularui.common.widget.MultiChildWidget;
 
 import cpw.mods.fml.relauncher.Side;
@@ -65,8 +57,6 @@ import gregtech.api.util.ISerializableObject;
 import gregtech.common.GTClient;
 import gregtech.common.covers.CoverFluidfilter;
 import gregtech.common.covers.CoverInfo;
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
 import mcp.mobius.waila.api.IWailaConfigHandler;
 import mcp.mobius.waila.api.IWailaDataAccessor;
 
@@ -87,7 +77,6 @@ public abstract class CoverableTileEntity extends BaseTileEntity implements ICov
 
     protected short mID = 0;
     public long mTickTimer = 0;
-    private Map<ForgeDirection, ISerializableObject> clientCoverData = new HashMap<>();
 
     protected void writeCoverNBT(NBTTagCompound aNBT, boolean isDrop) {
         final NBTTagList tList = new NBTTagList();
@@ -746,7 +735,7 @@ public abstract class CoverableTileEntity extends BaseTileEntity implements ICov
                     return backgrounds.toArray(new IDrawable[] {});
                 }
             }.setOnClick((clickData, widget) -> onTabClicked(clickData, widget, direction))
-                .dynamicTooltip(() -> getCoverTabTooltip(direction, clientCoverData.get(direction)))
+                .dynamicTooltip(() -> getCoverTabTooltip(direction))
                 .setSize(COVER_TAB_WIDTH, COVER_TAB_HEIGHT))
                 .addChild(
                     new ItemDrawable(() -> getCoverItemAtSide(direction)).asWidget()
@@ -755,17 +744,10 @@ public abstract class CoverableTileEntity extends BaseTileEntity implements ICov
                             (COVER_TAB_HEIGHT - ICON_SIZE) / 2))
                 .setEnabled(widget -> getCoverItemAtSide(direction) != null));
         }
-
-        builder.widget(
-            new FakeSyncWidget<>(
-                this::collectCoverData,
-                data -> clientCoverData = data,
-                this::writeClientCoverData,
-                this::readClientCoverData));
     }
 
     @SideOnly(Side.CLIENT)
-    protected List<String> getCoverTabTooltip(ForgeDirection side, ISerializableObject coverData) {
+    protected List<String> getCoverTabTooltip(ForgeDirection side) {
         final String[] SIDE_TOOLTIPS = new String[] { "GT5U.interface.coverTabs.down", "GT5U.interface.coverTabs.up",
             "GT5U.interface.coverTabs.north", "GT5U.interface.coverTabs.south", "GT5U.interface.coverTabs.west",
             "GT5U.interface.coverTabs.east" };
@@ -782,7 +764,7 @@ public abstract class CoverableTileEntity extends BaseTileEntity implements ICov
                 + StatCollector.translateToLocal(SIDE_TOOLTIPS[side.ordinal()])
                 + (coverHasGUI ? EnumChatFormatting.RESET + ": " : ": " + EnumChatFormatting.RESET)
                 + tooltip.get(0));
-        builder.addAll(coverInfo.getAdditionalTooltip(coverData));
+        builder.addAll(coverInfo.getAdditionalTooltip(coverInfo.getCoverData()));
         builder.addAll(
             IntStream.range(1, tooltip.size())
                 .mapToObj(index -> EnumChatFormatting.GRAY + tooltip.get(index))
@@ -794,52 +776,5 @@ public abstract class CoverableTileEntity extends BaseTileEntity implements ICov
         if (isClientSide()) return;
         widget.getContext()
             .openSyncedWindow(side.ordinal() + COVER_WINDOW_ID_START);
-    }
-
-    @NotNull
-    private Map<ForgeDirection, ISerializableObject> collectCoverData() {
-        final ImmutableMap.Builder<ForgeDirection, ISerializableObject> builder = ImmutableMap.builder();
-        for (final ForgeDirection direction : ForgeDirection.VALID_DIRECTIONS) {
-            final CoverInfo coverInfo = getCoverInfoAtSide(direction);
-            if (coverInfo.isValid()) {
-                builder.put(direction, coverInfo.getCoverData());
-            }
-        }
-
-        return builder.build();
-    }
-
-    private void writeClientCoverData(@NotNull PacketBuffer buffer,
-        @NotNull Map<ForgeDirection, ISerializableObject> dataMap) {
-        buffer.writeInt(dataMap.size());
-        dataMap.forEach((direction, serializableObject) -> {
-            final ByteBuf individualBuffer = Unpooled.buffer();
-            serializableObject.writeToByteBuf(individualBuffer);
-
-            buffer.writeByte(direction.ordinal());
-            buffer.writeInt(individualBuffer.array().length);
-            buffer.writeBytes(individualBuffer.array());
-        });
-    }
-
-    @NotNull
-    private Map<ForgeDirection, ISerializableObject> readClientCoverData(@NotNull PacketBuffer buffer) {
-        ImmutableMap.Builder<ForgeDirection, ISerializableObject> builder = ImmutableMap.builder();
-        final int size = buffer.readInt();
-        for (int i = 0; i < size; i++) {
-            final ForgeDirection direction = ForgeDirection.getOrientation(buffer.readByte());
-            final int length = buffer.readInt();
-            final byte[] object = buffer.readBytes(length)
-                .array();
-
-            // noinspection UnstableApiUsage
-            builder.put(
-                direction,
-                getCoverInfoAtSide(direction).getCoverBehavior()
-                    .createDataObject()
-                    .readFromPacket(ByteStreams.newDataInput(object), null));
-        }
-
-        return builder.build();
     }
 }

--- a/src/main/java/gregtech/api/metatileentity/CoverableTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/CoverableTileEntity.java
@@ -66,6 +66,9 @@ public abstract class CoverableTileEntity extends BaseTileEntity implements ICov
         .mapToInt(Enum::ordinal)
         .mapToObj(i -> "mCoverData" + i)
         .toArray(String[]::new);
+    private static final String[] COVER_DIRECTION_NAMES = new String[] { "GT5U.interface.coverTabs.down",
+        "GT5U.interface.coverTabs.up", "GT5U.interface.coverTabs.north", "GT5U.interface.coverTabs.south",
+        "GT5U.interface.coverTabs.west", "GT5U.interface.coverTabs.east" };
 
     // New Cover Information
     protected final CoverInfo[] coverInfos = new CoverInfo[] { null, null, null, null, null, null };
@@ -748,9 +751,6 @@ public abstract class CoverableTileEntity extends BaseTileEntity implements ICov
 
     @SideOnly(Side.CLIENT)
     protected List<String> getCoverTabTooltip(ForgeDirection side) {
-        final String[] SIDE_TOOLTIPS = new String[] { "GT5U.interface.coverTabs.down", "GT5U.interface.coverTabs.up",
-            "GT5U.interface.coverTabs.north", "GT5U.interface.coverTabs.south", "GT5U.interface.coverTabs.west",
-            "GT5U.interface.coverTabs.east" };
         final CoverInfo coverInfo = getCoverInfoAtSide(side);
         final ItemStack coverItem = coverInfo.getDisplayStack();
         if (coverItem == null) return Collections.emptyList();
@@ -761,7 +761,7 @@ public abstract class CoverableTileEntity extends BaseTileEntity implements ICov
         final ImmutableList.Builder<String> builder = ImmutableList.builder();
         builder.add(
             (coverHasGUI ? EnumChatFormatting.UNDERLINE : EnumChatFormatting.DARK_GRAY)
-                + StatCollector.translateToLocal(SIDE_TOOLTIPS[side.ordinal()])
+                + StatCollector.translateToLocal(COVER_DIRECTION_NAMES[side.ordinal()])
                 + (coverHasGUI ? EnumChatFormatting.RESET + ": " : ": " + EnumChatFormatting.RESET)
                 + tooltip.get(0));
         builder.addAll(coverInfo.getAdditionalTooltip(coverInfo.getCoverData()));

--- a/src/main/java/gregtech/api/objects/GTCoverNone.java
+++ b/src/main/java/gregtech/api/objects/GTCoverNone.java
@@ -7,6 +7,9 @@ import net.minecraft.item.ItemStack;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.Fluid;
 
+import com.gtnewhorizons.modularui.api.screen.ModularWindow;
+
+import gregtech.api.gui.modularui.CoverUIBuildContext;
 import gregtech.api.interfaces.tileentity.ICoverable;
 import gregtech.api.util.CoverBehavior;
 import gregtech.api.util.ISerializableObject;
@@ -232,6 +235,12 @@ public class GTCoverNone extends CoverBehavior {
     @Override
     protected ItemStack getDropImpl(ForgeDirection side, int aCoverID,
         ISerializableObject.LegacyCoverData aCoverVariable, ICoverable aTileEntity) {
+        return null;
+    }
+
+    @Override
+    public ModularWindow createWindow(CoverUIBuildContext buildContext) {
+        // Cancel opening the UI.
         return null;
     }
 }

--- a/src/main/java/gregtech/common/blocks/BlockMachines.java
+++ b/src/main/java/gregtech/common/blocks/BlockMachines.java
@@ -388,7 +388,7 @@ public class BlockMachines extends GTGenericBlock implements IDebugableBlock, IT
             if ((!aWorld.isRemote) && !gtTE.isUseableByPlayer(aPlayer)) {
                 return true;
             }
-            return ((IGregTechTileEntity) tTileEntity).onRightclick(aPlayer, side, aOffsetX, aOffsetY, aOffsetZ);
+            return gtTE.onRightclick(aPlayer, side, aOffsetX, aOffsetY, aOffsetZ);
         }
         return false;
     }


### PR DESCRIPTION
Fixes 2 separate crashes identified in https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18343.

One was about caching cover data before it was set and needed, the other was about opening a cover UI before we had received that cover's data.