### PR TITLE
Replace Rhugnor with Radox in Compact MK4 Fusion Controller

### DIFF
--- a/src/main/java/goodgenerator/loader/RecipeLoader2.java
+++ b/src/main/java/goodgenerator/loader/RecipeLoader2.java
@@ -1555,8 +1555,8 @@ public class RecipeLoader2 {
                 MaterialsAlloy.TITANSTEEL.getPlateDense(8), ItemRefer.HiC_T4.get(8),
                 ItemList.Field_Generator_UHV.get(8),
                 GGMaterial.enrichedNaquadahAlloy.get(OrePrefixes.gearGtSmall, 64) },
-            new FluidStack[] { MaterialsElements.STANDALONE.RHUGNOR.getFluidStack(144),
-                GGMaterial.dalisenite.getMolten(1152), MaterialsAlloy.BOTMIUM.getFluidStack(288) },
+            new FluidStack[] { Materials.RadoxPolymer.getMolten(1296), GGMaterial.dalisenite.getMolten(1152),
+                MaterialsAlloy.BOTMIUM.getFluidStack(288) },
             ItemRefer.Compact_Fusion_MK4.get(1),
             6000,
             (int) TierEU.RECIPE_UV);


### PR DESCRIPTION
Rhugnor made Compact MK4 gated behind regular MK4, breaking the consistency of the other Compact Fusion controllers, which is that they're available at the same time as normal fusion, but at a very expensive cost.

Rhugnor is already used to craft the Compact MK5 controller, and Teflon was used in place of Radox, replacing a polymer for a more fitting tiered polymer.

![image](https://github.com/user-attachments/assets/1caf1686-c454-4f0e-97db-446cda3ecbe0)
