### PR TITLE
Change computation formula in Research Station for scanner mode

### DIFF
--- a/src/main/java/tectech/thing/metaTileEntity/multi/MTEResearchStation.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/MTEResearchStation.java
@@ -8,6 +8,7 @@ import static gregtech.api.enums.HatchElement.Energy;
 import static gregtech.api.enums.HatchElement.Maintenance;
 import static gregtech.api.recipe.RecipeMaps.scannerFakeRecipes;
 import static gregtech.api.util.GTStructureUtility.buildHatchAdder;
+import static gregtech.api.util.GTUtility.getTier;
 import static gregtech.api.util.GTUtility.validMTEList;
 import static mcp.mobius.waila.api.SpecialChars.GREEN;
 import static mcp.mobius.waila.api.SpecialChars.RED;
@@ -221,15 +222,13 @@ public class MTEResearchStation extends TTMultiblockBase implements ISurvivalCon
                                 }
                                 this.tRecipe = assRecipe;
                                 // Set property
-                                computationRequired = computationRemaining = (long) assRecipe.mResearchTime
-                                    * assRecipe.mResearchVoltage
-                                    / 30;
-
+                                computationRequired = computationRemaining = (long) (assRecipe.mResearchTime
+                                    * Math.pow(2, getTier(assRecipe.mResearchVoltage) - 1));
                                 mMaxProgresstime = 20;
                                 mEfficiencyIncrease = 10000;
                                 eRequiredData = 1;
                                 eAmpereFlow = 1;
-                                mEUt = (int) -TierEU.RECIPE_UV;
+                                mEUt = -Math.max(assRecipe.mResearchVoltage, (int) TierEU.RECIPE_UV);
                                 eHolders.get(0)
                                     .getBaseMetaTileEntity()
                                     .setActive(true);

--- a/src/main/resources/assets/tectech/lang/en_US.lang
+++ b/src/main/resources/assets/tectech/lang/en_US.lang
@@ -786,7 +786,7 @@ gt.blockmachines.multimachine.em.research.desc.2=Needs to be fed with computatio
 gt.blockmachines.multimachine.em.research.desc.3=Does not consume the item until the Data Stick is written
 gt.blockmachines.multimachine.em.research.desc.4=Use screwdriver to change mode
 gt.blockmachines.multimachine.em.research.desc.5=Computation required in scanner mode follows the formula:
-gt.blockmachines.multimachine.em.research.desc.6=(Recipe duration in seconds * Recipe voltage) / 30
+gt.blockmachines.multimachine.em.research.desc.6=Recipe duration in seconds * (2 ^ Recipe voltage tier)
 gt.blockmachines.multimachine.em.research.mode.Assembly_line=Mode: Research Station
 gt.blockmachines.multimachine.em.research.mode.Scanner=Mode: Scanner
 


### PR DESCRIPTION
The 4/4 scaling of voltages for scanner mode made lategame scanner recipes perform worse than in the singleblock, this changes it to 2/4 which is closer to the original formula.

Also changes scanner mode energy usage to use recipe voltage eu per tick (or UV if below)