### PR TITLE
Correct Steam Grinder and Squsher multi tooltips to note structures are hollow.

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/MTESteamCompressor.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/MTESteamCompressor.java
@@ -273,7 +273,7 @@ public class MTESteamCompressor extends MTESteamMultiBase<MTESteamCompressor> im
             .addInfo("Only consumes steam at 62.5% of the L/s normally required")
             .addInfo("Processes up to 8 items at once")
             .addInfo(HIGH_PRESSURE_TOOLTIP_NOTICE)
-            .beginStructureBlock(3, 3, 4, false)
+            .beginStructureBlock(3, 3, 4, true)
             .addInputBus(EnumChatFormatting.GOLD + "1" + EnumChatFormatting.GRAY + " Any casing", 1)
             .addOutputBus(EnumChatFormatting.GOLD + "1" + EnumChatFormatting.GRAY + " Any casing", 1)
             .addStructureInfo(

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/MTESteamMacerator.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/MTESteamMacerator.java
@@ -272,7 +272,7 @@ public class MTESteamMacerator extends MTESteamMultiBase<MTESteamMacerator> impl
             .addInfo("Only consumes steam at 62.5% of the L/s normally required")
             .addInfo("Processes up to 8 items at once")
             .addInfo(HIGH_PRESSURE_TOOLTIP_NOTICE)
-            .beginStructureBlock(3, 3, 3, false)
+            .beginStructureBlock(3, 3, 3, true)
             .addInputBus(EnumChatFormatting.GOLD + "1" + EnumChatFormatting.GRAY + " Any casing", 1)
             .addOutputBus(EnumChatFormatting.GOLD + "1" + EnumChatFormatting.GRAY + " Any casing", 1)
             .addStructureInfo(


### PR DESCRIPTION
The tooltip for these two steam multis has hollow set to "false" when these multis are indeed hollow.

I believe this PR corrects this problem by toggling the bool from false to true. See: https://github.com/GTNewHorizons/GT5-Unofficial/blob/cf38a61c19ae951447b66fb6f4540d0c5803468f/src/main/java/gregtech/api/util/MultiblockTooltipBuilder.java#L189

```
     * @param hollow T/F, adds a (hollow) comment if true
     * @return Instance this method was called on.
     */
    public MultiblockTooltipBuilder beginStructureBlock(int w, int h, int l, boolean hollow) {
```

The multis are hollow:

Macerator
```
    private final String[][] shape = new String[][] { { "CCC", "CCC", "CCC" }, { "C~C", "C-C", "CCC" },
        { "CCC", "CCC", "CCC" } };
    // spotless:on
```

Compressor
```
    private final String[][] shape = new String[][] {
        { "CCC", "CCC", "CCC", "CCC" },
        { "C~C", "C-C", "C-C", "CCC" },
        { "CCC", "CCC", "CCC", "CCC" } };
```

Macerator hollow in-game.
![javaw_zQYnZ41fgX](https://github.com/user-attachments/assets/183618a7-6295-48bf-9ed9-1f1bbe88eaae)
https://i.imgur.com/9Qk6nBc.png

Squasher hollow in-game
![javaw_CgHyQppifZ](https://github.com/user-attachments/assets/b2bdfd69-cc42-495c-a1fb-c980d0b4fedb)
https://imgur.com/Z8uw1jg