### PR TITLE
Remove invalid CRIBs before use

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
@@ -1696,6 +1696,8 @@ public abstract class MTEMultiBlockBase extends MetaTileEntity
     }
 
     protected void startRecipeProcessing() {
+        mDualInputHatches.removeIf(mte -> mte == null || !((MetaTileEntity) mte).isValid());
+
         for (MTEHatchInputBus hatch : validMTEList(mInputBusses)) {
             if (hatch instanceof IRecipeProcessingAwareHatch aware) {
                 aware.startRecipeProcessing();


### PR DESCRIPTION
If a CRIB is invalidated because of chunk unloading, it won't be removed.
Then if the Multiblock consume some items, the difference may not be saved.(not confirmed!)
This PR add code to startRecipeProcessing() to remove invalid mDualInputHatches, 
just like what this method does to mInputBusses/mInputHatches(method 'validMTEList' will remove invalid MTE on iteration).

Actually, mDualInputHatches is hardly checked for isValid(), the only exception is PreciseAssembler.java. 
But PreciseAssembler does not remove invalid CRIBs, just ignore invalid ones.