### PR TITLE
Change a few tooltips

### DIFF
--- a/src/main/java/kubatech/tileentity/gregtech/multiblock/MTEDEFusionCrafter.java
+++ b/src/main/java/kubatech/tileentity/gregtech/multiblock/MTEDEFusionCrafter.java
@@ -137,7 +137,7 @@ public class MTEDEFusionCrafter extends KubaTechGTMultiBlockBase<MTEDEFusionCraf
     @Override
     protected MultiblockTooltipBuilder createTooltip() {
         MultiblockTooltipBuilder tt = new MultiblockTooltipBuilder();
-        tt.addMachineType("Fusion Crafter")
+        tt.addMachineType("Fusion Crafter, DEFC")
             .addInfo("Machine can be overclocked by using casings above the recipe tier:")
             .addInfo("Recipe time is divided by number of tiers above the recipe")
             .addInfo("Normal EU OC still applies !")

--- a/src/main/java/tectech/thing/metaTileEntity/multi/MTEActiveTransformer.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/MTEActiveTransformer.java
@@ -132,9 +132,6 @@ public class MTEActiveTransformer extends TTMultiblockBase implements ISurvivalC
                                                                                               // voltage
             .addInfo(translateToLocal("gt.blockmachines.multimachine.em.transformer.desc.2")) // Only 0.004% power
                                                                                               // loss, HAYO!
-            .addInfo(translateToLocal("gt.blockmachines.multimachine.em.transformer.desc.3")) // Will explode if
-                                                                                              // broken while
-                                                                                              // running
             .addTecTechHatchInfo()
             .beginStructureBlock(3, 3, 3, false)
             .addController(translateToLocal("tt.keyword.Structure.FrontCenter")) // Controller: Front center

--- a/src/main/resources/assets/tectech/lang/en_US.lang
+++ b/src/main/resources/assets/tectech/lang/en_US.lang
@@ -666,7 +666,6 @@ gt.blockmachines.multimachine.em.transformer.machinetype=Active Transformer, AT
 gt.blockmachines.multimachine.em.transformer.hint=1 - Energy IO Hatches or High Power Casing
 gt.blockmachines.multimachine.em.transformer.desc.1=Can transform to and from any voltage
 gt.blockmachines.multimachine.em.transformer.desc.2=Only 0.004% power loss, HAYO!
-gt.blockmachines.multimachine.em.transformer.desc.3=Will explode if broken while running
 
 gt.blockmachines.multimachine.tm.microwave.name=Microwave Grinder
 gt.blockmachines.multimachine.tm.microwave.hint.0=1 - Classic Hatches or Clean Stainless Steel Casing
@@ -790,7 +789,7 @@ gt.blockmachines.multimachine.em.research.desc.2=Needs to be fed with computatio
 gt.blockmachines.multimachine.em.research.desc.3=Does not consume the item until the Data Stick is written
 gt.blockmachines.multimachine.em.research.desc.4=Use screwdriver to change mode
 gt.blockmachines.multimachine.em.research.desc.5=Computation required in scanner mode follows the formula:
-gt.blockmachines.multimachine.em.research.desc.6=Recipe duration in seconds * (2 ^ Recipe voltage tier)
+gt.blockmachines.multimachine.em.research.desc.6=Recipe duration in seconds * (2 ^ (Recipe voltage tier - 1))
 gt.blockmachines.multimachine.em.research.mode.Assembly_line=Mode: Research Station
 gt.blockmachines.multimachine.em.research.mode.Scanner=Mode: Scanner
 


### PR DESCRIPTION
Adds `DEFC` to the machine type of the draconic evolution fusion crafter

and by request https://discord.com/channels/181078474394566657/181078474394566657/1337486536953823293
Removes the line about exploding from the AT since it no longer does that
Fixes Research Station scanner mode recipe duration line in the tooltip to match the actual formula