### PR TITLE
Skip TGS recipes with null sapling

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTETreeFarm.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTETreeFarm.java
@@ -685,6 +685,10 @@ public class MTETreeFarm extends GTPPMultiBlockBase<MTETreeFarm> implements ISur
      */
     public static void registerTreeProducts(ItemStack saplingIn, ItemStack log, ItemStack saplingOut, ItemStack leaves,
         ItemStack fruit) {
+        if (saplingIn == null) {
+            Logger.ERROR("Null sapling passed for registerTreeProducts()");
+            return;
+        }
         String key = Item.itemRegistry.getNameForObject(saplingIn.getItem()) + ":" + saplingIn.getItemDamage();
         EnumMap<Mode, ItemStack> map = new EnumMap<>(Mode.class);
         if (log != null) map.put(Mode.LOG, log);


### PR DESCRIPTION
Some of the trees with TGS recipes are not enabled in the EFR config for the pack. Hotfixing for now so that the pack will function (and this error was so hard to find that this log is way more useful anyway)