### PR TITLE
Improve how/when Crop Manager applies Weed-EX

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/basic/MTECropHarvestor.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/basic/MTECropHarvestor.java
@@ -40,6 +40,7 @@ import gtPlusPlus.core.util.minecraft.ItemUtils;
 import gtPlusPlus.xmod.gregtech.api.gui.GTPPUITextures;
 import gtPlusPlus.xmod.gregtech.common.blocks.textures.TexturesGtBlock;
 import ic2.api.crops.CropCard;
+import ic2.api.crops.Crops;
 import ic2.api.crops.ICropTile;
 import ic2.core.item.DamageHandler;
 
@@ -196,6 +197,7 @@ public class MTECropHarvestor extends MTEBasicTank {
         }
 
         // Process Cache
+        // Note: A full inventory would also prevent processSecondaryFunctions (e.g. weed-ex)
         if (!doesInventoryHaveSpace()) return;
 
         for (ICropTile tCrop : this.mCropCache) {
@@ -204,9 +206,10 @@ public class MTECropHarvestor extends MTEBasicTank {
                 break;
             }
             CropCard aCrop = tCrop.getCrop();
-            if (aCrop == null) continue;
 
             if (this.mModeAlternative) processSecondaryFunctions(tCrop);
+
+            if (aCrop == null) continue;
             if (!this.mHarvestEnabled) continue;
 
             if (aCrop.canBeHarvested(tCrop) && tCrop.getSize() == aCrop.getOptimalHavestSize(tCrop)) {
@@ -296,22 +299,11 @@ public class MTECropHarvestor extends MTEBasicTank {
         return false;
     }
 
-    public boolean hasWeedEX() {
+    public boolean consumeWeedEX(boolean aSimulate) {
         for (int i = SLOT_WEEDEX_1; i <= SLOT_WEEDEX_2; i++) {
             if (this.mInventory[i] != null) {
+                damage(i, 1, aSimulate);
                 return true;
-            }
-        }
-        return false;
-    }
-
-    public boolean consumeWeedEX(boolean aSimulate) {
-        if (hasWeedEX()) {
-            for (int i = SLOT_WEEDEX_1; i <= SLOT_WEEDEX_2; i++) {
-                if (this.mInventory[i] != null) {
-                    damage(i, 1, aSimulate);
-                    return true;
-                }
             }
         }
         return false;
@@ -321,6 +313,16 @@ public class MTECropHarvestor extends MTEBasicTank {
         if (!this.mModeAlternative) {
             return;
         }
+        if (consumeWeedEX(true) && this.getBaseMetaTileEntity()
+            .getUniversalEnergyStored() >= getMinimumStoredEU()
+            && getBaseMetaTileEntity().decreaseStoredEnergyUnits(powerUsageSecondary(), true)
+            && applyWeedEx(aCrop)) {
+            if (consumeWeedEX(false)) {
+                // Logger.INFO("Consumed Weed-EX.");
+            }
+        }
+        if (aCrop.getCrop() == null || aCrop.getCrop()
+            .equals(Crops.weed)) return;
         if (hasFertilizer() && consumeFertilizer(true)
             && this.getBaseMetaTileEntity()
                 .getUniversalEnergyStored() >= getMinimumStoredEU()
@@ -336,43 +338,45 @@ public class MTECropHarvestor extends MTEBasicTank {
             && applyHydration(aCrop)) {
             // Logger.INFO("Consumed Water.");
         }
-        if (hasWeedEX() && consumeWeedEX(true)
-            && this.getBaseMetaTileEntity()
-                .getUniversalEnergyStored() >= getMinimumStoredEU()
-            && getBaseMetaTileEntity().decreaseStoredEnergyUnits(powerUsageSecondary(), true)
-            && applyWeedEx(aCrop)) {
-            if (consumeWeedEX(false)) {
-                // Logger.INFO("Consumed Weed-EX.");
-            }
-        }
     }
 
     public boolean applyWeedEx(ICropTile aCrop) {
-        if (aCrop.getWeedExStorage() < 150) {
-            aCrop.setWeedExStorage(aCrop.getWeedExStorage() + 50);
-            boolean triggerDecline;
-            triggerDecline = aCrop.getWorld().rand.nextInt(3) == 0;
-            if (aCrop.getCrop() != null && aCrop.getCrop()
-                .isWeed(aCrop) && aCrop.getWeedExStorage() >= 75 && triggerDecline) {
-                switch (aCrop.getWorld().rand.nextInt(5)) {
-                    case 0:
-                        if (aCrop.getGrowth() > 0) {
-                            aCrop.setGrowth((byte) (aCrop.getGrowth() - 1));
-                        }
-                    case 1:
-                        if (aCrop.getGain() > 0) {
-                            aCrop.setGain((byte) (aCrop.getGain() - 1));
-                        }
-                    default:
-                        if (aCrop.getResistance() > 0) {
-                            aCrop.setResistance((byte) (aCrop.getResistance() - 1));
-                        }
-                }
+        boolean applyDose = aCrop.getWeedExStorage() < 150;
+        if (applyDose) aCrop.setWeedExStorage(aCrop.getWeedExStorage() + 50);
+
+        boolean triggerDecline = aCrop.getWorld().rand.nextInt(3) == 0;
+        CropCard cropType = aCrop.getCrop();
+        if (!triggerDecline || cropType == null) return applyDose;
+
+        // Should there already be a weed (an actual weed, not a weed-like plant) present, either
+        // because Weed-EX got added late or it spawned on new untracked crop sticks, slowly wither it
+        if (cropType.equals(Crops.weed)) {
+            if (aCrop.getSize() == 1) {
+                aCrop.reset();
+            } else {
+                aCrop.setSize((byte) (aCrop.getSize() - 1));
             }
             return true;
-        } else {
-            return false;
         }
+
+        // Affect weed-like crops when we apply a dose of Weed-EX that crosses the threshold
+        if (applyDose && cropType.isWeed(aCrop) && aCrop.getWeedExStorage() >= 75) {
+            switch (aCrop.getWorld().rand.nextInt(5)) {
+                case 0:
+                    if (aCrop.getGrowth() > 0) {
+                        aCrop.setGrowth((byte) (aCrop.getGrowth() - 1));
+                    }
+                case 1:
+                    if (aCrop.getGain() > 0) {
+                        aCrop.setGain((byte) (aCrop.getGain() - 1));
+                    }
+                default:
+                    if (aCrop.getResistance() > 0) {
+                        aCrop.setResistance((byte) (aCrop.getResistance() - 1));
+                    }
+            }
+        }
+        return applyDose;
     }
 
     public boolean applyFertilizer(ICropTile aCrop) {


### PR DESCRIPTION
Fixes [GTNH#15732](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15732) and relates to  [GTNH#18230](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18230)

The issue:
- No Weed-EX would be applied to empty crop sticks, causing weeds to still spawn on them ([GTNH#15732](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15732))
- Fixing just this would lead to a race condition: User places crop sticks, weeds appear before Weed-EX gets applied

With this pull request:
- CM will apply Weed-EX to empty crop sticks (as can be done manually), actually preventing natural weed spawns
- CM will lower the size of existing weeds (actual weeds, not weed-like crops) and remove them once they reach size 0
  - This has a 33% chance of happening every 5 seconds (which should be reasonably slow but fast enough to be effective)
  - Shrinking will consume a unit of Weed-EX, even if the "Weed-EX storage" was high enough and didn't get increased
- **Unchanged**: The decline of stats for other weed-like crops when Weed-EX gets topped up resulting in >=75 storage
- **Unchanged**: This will still only happen when secondary functions (hydration/fertilizing/Weed-EX) are enabled
- **Unfixed**: This does not fix the issue(?) of secondary functions being skipped when the output inventory is full
- **Unclear**: While Weed-EX is now applied to empty crop sticks, it might not prevent grown weeds from spreading to them like what happens in [GTNH#18230](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18230)? I didn't have it happen during a 20m test ([growth.webm](https://github.com/user-attachments/assets/9ab922ff-4711-47aa-99bc-76fb319e2292)) but that could be coincidence, and I don't know how/when weed-like crops spread weeds, that's IC2 code.

**TL:DR**: A Crop Manager with Weed-EX and secondary functions enabled will keep a field of (empty) crop sticks weed-free*
_(*) A weed could spawn on newly placed crop sticks before the CM detects it and applies Weed-EX, but it'll soon shrink away after which Weed-EX will be present to prevent future spawns._

Tested it using `./gradlew runClient` and it seem to work as expected:
- First video, 20m sped up 60x where you can see the LV Crop Manager keeping the 5x5 clear [growth.webm](https://github.com/user-attachments/assets/9ab922ff-4711-47aa-99bc-76fb319e2292)
- Second video, 83s sped up 10x where I added a second LV CM with Weed-EX [shrink.webm](https://github.com/user-attachments/assets/748c7580-ccc6-4abf-8c7e-bfeb195fa802)
