### PR TITLE
Add a MultiAmp-only hatch identifier

### DIFF
--- a/src/main/java/gregtech/api/enums/HatchElement.java
+++ b/src/main/java/gregtech/api/enums/HatchElement.java
@@ -88,7 +88,15 @@ public enum HatchElement implements IHatchElement<MTEMultiBlockBase> {
             return t.getExoticEnergyHatches()
                 .size();
         }
-    },;
+    },
+    MultiAmpEnergy(MTEMultiBlockBase::addMultiAmpEnergyInputToMachineList) {
+
+        @Override
+        public long count(MTEMultiBlockBase t) {
+            return t.getExoticEnergyHatches()
+                .size();
+        }
+    };
 
     private final List<Class<? extends IMetaTileEntity>> mteClasses;
     private final IGTHatchAdder<MTEMultiBlockBase> adder;

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
@@ -120,6 +120,7 @@ import it.unimi.dsi.fastutil.objects.Reference2ReferenceOpenHashMap;
 import mcp.mobius.waila.api.IWailaConfigHandler;
 import mcp.mobius.waila.api.IWailaDataAccessor;
 import tectech.thing.metaTileEntity.hatch.MTEHatchEnergyMulti;
+import tectech.thing.metaTileEntity.hatch.MTEHatchEnergyTunnel;
 
 public abstract class MTEMultiBlockBase extends MetaTileEntity
     implements IControllerWithOptionalFeatures, IAddGregtechLogo, IAddUIWidgets, IBindPlayerInventoryUI {
@@ -1796,7 +1797,7 @@ public abstract class MTEMultiBlockBase extends MetaTileEntity
         if (aTileEntity == null) return false;
         IMetaTileEntity aMetaTileEntity = aTileEntity.getMetaTileEntity();
         if (aMetaTileEntity == null) return false;
-        if (aMetaTileEntity instanceof MTEHatchEnergyMulti hatch) {
+        if (aMetaTileEntity instanceof MTEHatchEnergyMulti hatch && hatch.getHatchType() == 1) {
             hatch.updateTexture(aBaseCasingIndex);
             hatch.updateCraftingIcon(this.getMachineCraftingIcon());
             return mExoticEnergyHatches.add(hatch);

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
@@ -120,7 +120,6 @@ import it.unimi.dsi.fastutil.objects.Reference2ReferenceOpenHashMap;
 import mcp.mobius.waila.api.IWailaConfigHandler;
 import mcp.mobius.waila.api.IWailaDataAccessor;
 import tectech.thing.metaTileEntity.hatch.MTEHatchEnergyMulti;
-import tectech.thing.metaTileEntity.hatch.MTEHatchEnergyTunnel;
 
 public abstract class MTEMultiBlockBase extends MetaTileEntity
     implements IControllerWithOptionalFeatures, IAddGregtechLogo, IAddUIWidgets, IBindPlayerInventoryUI {

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
@@ -119,6 +119,7 @@ import it.unimi.dsi.fastutil.objects.Object2ReferenceOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Reference2ReferenceOpenHashMap;
 import mcp.mobius.waila.api.IWailaConfigHandler;
 import mcp.mobius.waila.api.IWailaDataAccessor;
+import tectech.thing.metaTileEntity.hatch.MTEHatchEnergyMulti;
 
 public abstract class MTEMultiBlockBase extends MetaTileEntity
     implements IControllerWithOptionalFeatures, IAddGregtechLogo, IAddUIWidgets, IBindPlayerInventoryUI {
@@ -1787,6 +1788,18 @@ public abstract class MTEMultiBlockBase extends MetaTileEntity
             hatch.updateTexture(aBaseCasingIndex);
             hatch.updateCraftingIcon(this.getMachineCraftingIcon());
             return mEnergyHatches.add(hatch);
+        }
+        return false;
+    }
+
+    public boolean addMultiAmpEnergyInputToMachineList(IGregTechTileEntity aTileEntity, int aBaseCasingIndex) {
+        if (aTileEntity == null) return false;
+        IMetaTileEntity aMetaTileEntity = aTileEntity.getMetaTileEntity();
+        if (aMetaTileEntity == null) return false;
+        if (aMetaTileEntity instanceof MTEHatchEnergyMulti hatch) {
+            hatch.updateTexture(aBaseCasingIndex);
+            hatch.updateCraftingIcon(this.getMachineCraftingIcon());
+            return mExoticEnergyHatches.add(hatch);
         }
         return false;
     }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialElectromagneticSeparator.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialElectromagneticSeparator.java
@@ -129,7 +129,7 @@ public class MTEIndustrialElectromagneticSeparator
             'B',
             ofChain(
                 buildHatchAdder(MTEIndustrialElectromagneticSeparator.class)
-                    .atLeast(InputBus, OutputBus, Maintenance, Energy.or(ExoticEnergy))
+                    .atLeast(InputBus, OutputBus, Maintenance, Energy.or(MultiAmpEnergy))
                     .casingIndex(((BlockCasings10) GregTechAPI.sBlockCasings10).getTextureIndex(0))
                     .dot(1)
                     .buildAndChain(
@@ -259,12 +259,10 @@ public class MTEIndustrialElectromagneticSeparator
         if (mCasingAmount < MIN_CASING) return false;
         if (mMagHatch == null) return false;
 
-        // If there are exotic hatches, ensure there is only 1, and it is not laser. Only multiamp allowed
+        // If there are exotic hatches, ensure there is only 1.
         if (!mExoticEnergyHatches.isEmpty()) {
             if (!mEnergyHatches.isEmpty()) return false;
-            if (mExoticEnergyHatches.size() > 1) return false;
-            return mExoticEnergyHatches.get(0)
-                .maxWorkingAmperesIn() <= 64;
+            return (mExoticEnergyHatches.size() == 1);
         }
 
         // All checks passed!

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialLaserEngraver.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialLaserEngraver.java
@@ -77,7 +77,7 @@ public class MTEIndustrialLaserEngraver extends MTEExtendedPowerMultiBlockBase<M
         .addElement(
             'a',
             buildHatchAdder(MTEIndustrialLaserEngraver.class)
-                .atLeast(InputBus, OutputBus, InputHatch, OutputHatch, Maintenance, Energy, ExoticEnergy)
+                .atLeast(InputBus, OutputBus, InputHatch, OutputHatch, Maintenance, Energy, MultiAmpEnergy)
                 .casingIndex(((BlockCasings10) GregTechAPI.sBlockCasings10).getTextureIndex(1))
                 .dot(1)
                 .buildAndChain(
@@ -304,13 +304,11 @@ public class MTEIndustrialLaserEngraver extends MTEExtendedPowerMultiBlockBase<M
         if (laserSource == null) return false;
         if (!findLaserRenderer(base.getWorld(), base.getXCoord(), base.getYCoord(), base.getZCoord())) return false;
 
-        // If there are exotic hatches, ensure there is only 1, and it is not laser. Only multiamp allowed
+        // If there are exotic hatches, ensure there is only 1 and that the laser source requirement is met
         if (!mExoticEnergyHatches.isEmpty()) {
             if (laserSource.mTier < VoltageIndex.UEV) return false;
             if (!mEnergyHatches.isEmpty()) return false;
-            if (mExoticEnergyHatches.size() > 1) return false;
-            return mExoticEnergyHatches.get(0)
-                .maxWorkingAmperesIn() <= 64;
+            return (mExoticEnergyHatches.size() == 1);
         }
 
         return glassTier >= VoltageIndex.UMV || laserSource.mTier <= glassTier;

--- a/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchEnergyMulti.java
+++ b/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchEnergyMulti.java
@@ -57,6 +57,10 @@ public class MTEHatchEnergyMulti extends MTEHatch {
         Amperes = maxAmperes = aAmp;
     }
 
+    public int getHatchType() {
+        return 1;
+    }
+
     @Override
     public ITexture[] getTexturesActive(ITexture aBaseTexture) {
         return new ITexture[] { aBaseTexture, Textures.OVERLAYS_ENERGY_IN_POWER_TT[mTier] };

--- a/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchEnergyTunnel.java
+++ b/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchEnergyTunnel.java
@@ -54,6 +54,11 @@ public class MTEHatchEnergyTunnel extends MTEHatchEnergyMulti implements IConnec
     }
 
     @Override
+    public int getHatchType() {
+        return 2;
+    }
+
+    @Override
     public ITexture[] getTexturesActive(ITexture aBaseTexture) {
         return new ITexture[] { aBaseTexture, Textures.OVERLAYS_ENERGY_IN_LASER_TT[mTier] };
     }


### PR DESCRIPTION
Previously, allowing a multiblock to use exotic energy hatches would allow both multiamp and laser hatches in conjunction. There are now two multiblocks in the game which allow multiamp but not laser hatches, and I think this is a positive difference for balance purposes. These hatch types are at wildly different power levels! 

Anyways, previously the hatches were distinguished by checking the amperage count, which is pretty janky (and technically meant that you could use amp-limited laser hatches on the "multiamp only" machines 🤫).

This pr adds a hatch identifier called MultiAmpEnergy which is distinct from ExoticEnergy and implements it into HILE and MFE.