### PR TITLE
Lower fluid for solidifying rounds from 18L to 16L

### DIFF
--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingShaping.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingShaping.java
@@ -191,7 +191,7 @@ public class ProcessingShaping implements gregtech.api.interfaces.IOreRecipeRegi
                             GTValues.RA.stdBuilder()
                                 .itemInputs(ItemList.Shape_Mold_Round.get(0L))
                                 .itemOutputs(GTOreDictUnificator.get(OrePrefixes.round, aMaterial, 1L))
-                                .fluidInputs(aMaterial.getMolten(18L))
+                                .fluidInputs(aMaterial.getMolten(16L))
                                 .duration(2 * SECONDS + 10 * TICKS)
                                 .eut(calculateRecipeEU(aMaterial, 2 * tVoltageMultiplier))
                                 .addTo(fluidSolidifierRecipes);


### PR DESCRIPTION
Resolves [Make Screw molding and Fluid recycling equivalent #17669](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17669), resolves [Fluid solidifier rounds 18L -> 16L #18983](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18983).