### PR TITLE
Refactor rock breaker for extensibility

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/basic/MTERockBreaker.java
+++ b/src/main/java/gregtech/common/tileentities/machines/basic/MTERockBreaker.java
@@ -16,25 +16,39 @@ import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_TOP_ROCK_BREAKER;
 import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_TOP_ROCK_BREAKER_ACTIVE;
 import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_TOP_ROCK_BREAKER_ACTIVE_GLOW;
 import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_TOP_ROCK_BREAKER_GLOW;
+import static gregtech.api.recipe.RecipeMaps.rockBreakerFakeRecipes;
+import static gregtech.api.util.GTRecipeBuilder.TICKS;
 
-import net.minecraft.init.Blocks;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.UnaryOperator;
+
+import net.minecraft.block.Block;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import org.apache.commons.lang3.ArrayUtils;
+
+import gregtech.api.enums.GTValues;
+import gregtech.api.enums.ItemList;
 import gregtech.api.enums.MachineType;
-import gregtech.api.enums.Materials;
-import gregtech.api.enums.OrePrefixes;
+import gregtech.api.enums.TierEU;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.implementations.MTEBasicMachine;
 import gregtech.api.recipe.RecipeMap;
-import gregtech.api.recipe.RecipeMaps;
 import gregtech.api.render.TextureFactory;
-import gregtech.api.util.GTOreDictUnificator;
+import gregtech.api.util.GTRecipeBuilder;
 import gregtech.api.util.GTUtility;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 
 public class MTERockBreaker extends MTEBasicMachine {
+
+    private static final Int2ObjectMap<Set<RockBreakerRecipe>> ROCK_BREAKER_RECIPES = new Int2ObjectOpenHashMap<>();
 
     public MTERockBreaker(int aID, String aName, String aNameRegional, int aTier) {
         super(
@@ -107,7 +121,7 @@ public class MTERockBreaker extends MTEBasicMachine {
 
     @Override
     public RecipeMap<?> getRecipeMap() {
-        return RecipeMaps.rockBreakerFakeRecipes;
+        return rockBreakerFakeRecipes;
     }
 
     @Override
@@ -125,65 +139,246 @@ public class MTERockBreaker extends MTEBasicMachine {
     @Override
     public int checkRecipe() {
         IGregTechTileEntity aBaseMetaTileEntity = getBaseMetaTileEntity();
-        if ((aBaseMetaTileEntity.getBlockOffset(0, -1, 0) != Blocks.soul_sand)
-            && ((aBaseMetaTileEntity.getBlockOffset(0, 0, 1) == Blocks.water)
-                || (aBaseMetaTileEntity.getBlockOffset(0, 0, -1) == Blocks.water)
-                || (aBaseMetaTileEntity.getBlockOffset(-1, 0, 0) == Blocks.water)
-                || (aBaseMetaTileEntity.getBlockOffset(1, 0, 0) == Blocks.water))) {
-            ItemStack tOutput = null;
-            if (aBaseMetaTileEntity.getBlockOffset(0, 1, 0) == Blocks.lava) {
-                tOutput = new ItemStack(Blocks.stone, 1);
-            } else if ((aBaseMetaTileEntity.getBlockOffset(0, 0, 1) == Blocks.lava)
-                || (aBaseMetaTileEntity.getBlockOffset(0, 0, -1) == Blocks.lava)
-                || (aBaseMetaTileEntity.getBlockOffset(-1, 0, 0) == Blocks.lava)
-                || (aBaseMetaTileEntity.getBlockOffset(1, 0, 0) == Blocks.lava)) {
-                    tOutput = new ItemStack(Blocks.cobblestone, 1);
+
+        Block topBlock = aBaseMetaTileEntity.getBlockOffset(0, 1, 0);
+        Block bottomBlock = aBaseMetaTileEntity.getBlockOffset(0, -1, 0);
+        Block[] sideBlocks = new Block[] { aBaseMetaTileEntity.getBlockOffset(0, 0, 1),
+            aBaseMetaTileEntity.getBlockOffset(0, 0, -1), aBaseMetaTileEntity.getBlockOffset(-1, 0, 0),
+            aBaseMetaTileEntity.getBlockOffset(1, 0, 0) };
+
+        // Lock to only recipes with the specified circuit. Prevents "collisions" when a recipe
+        // has the same in-world requirements but a differentiating item.
+        ItemStack circuitStack = getStackInSlot(getCircuitSlot());
+        int circuitNum = circuitStack == null ? -1 : circuitStack.getItemDamage();
+        Set<RockBreakerRecipe> potentialRecipes = ROCK_BREAKER_RECIPES.get(circuitNum);
+        if (potentialRecipes == null) {
+            potentialRecipes = ROCK_BREAKER_RECIPES.get(-1); // fallback for circuit with no recipes
+        }
+
+        for (RockBreakerRecipe recipe : potentialRecipes) {
+            if (!recipe.testInWorld(sideBlocks, topBlock, bottomBlock)) continue;
+            if (!recipe.testInputs(getInputAt(0))) continue;
+
+            // Found successful recipe
+            ItemStack output = recipe.getOutputItem();
+            if (canOutput(output)) {
+                if (recipe.isInputConsumed()) {
+                    getInputAt(0).stackSize -= 1;
                 }
-            if (tOutput != null) {
-                if (GTUtility.areStacksEqual(getStackInSlot(getCircuitSlot()), GTUtility.getIntegratedCircuit(1))) {
-                    if (GTUtility.areStacksEqual(
-                        getInputAt(0),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Redstone, 1L))) {
-                        tOutput = new ItemStack(Blocks.obsidian, 1);
-                        if (canOutput(tOutput)) {
-                            getInputAt(0).stackSize -= 1;
-                            calculateOverclockedNess(30, 128);
-                            // In case recipe is too OP for that machine
-                            if (mMaxProgresstime == Integer.MAX_VALUE - 1 && mEUt == Integer.MAX_VALUE - 1)
-                                return FOUND_RECIPE_BUT_DID_NOT_MEET_REQUIREMENTS;
-                            this.mOutputItems[0] = tOutput;
-                            return 2;
-                        }
-                    }
-                } else if (canOutput(tOutput)) {
-                    calculateOverclockedNess(30, 16);
-                    // In case recipe is too OP for that machine
-                    if (mMaxProgresstime == Integer.MAX_VALUE - 1 && mEUt == Integer.MAX_VALUE - 1)
-                        return FOUND_RECIPE_BUT_DID_NOT_MEET_REQUIREMENTS;
-                    this.mOutputItems[0] = tOutput;
-                    return 2;
-                }
+                calculateOverclockedNess((int) TierEU.RECIPE_LV, recipe.getDuration());
+                // In case recipe is too OP for that machine
+                if (mMaxProgresstime == Integer.MAX_VALUE - 1 && mEUt == Integer.MAX_VALUE - 1)
+                    return FOUND_RECIPE_BUT_DID_NOT_MEET_REQUIREMENTS;
+                this.mOutputItems[0] = output;
+                return 2;
             }
-        } else if ((aBaseMetaTileEntity.getBlockOffset(0, 0, 1) == Blocks.lava)
-            || (aBaseMetaTileEntity.getBlockOffset(0, 0, -1) == Blocks.lava)
-            || (aBaseMetaTileEntity.getBlockOffset(-1, 0, 0) == Blocks.lava)
-            || (aBaseMetaTileEntity.getBlockOffset(1, 0, 0) == Blocks.lava)) {
-                if (GTUtility.areStacksEqual(getStackInSlot(getCircuitSlot()), GTUtility.getIntegratedCircuit(1))) {
-                    if (GTUtility.areStacksEqual(getInputAt(0), new ItemStack(Blocks.packed_ice, 0))) {
-                        if ((aBaseMetaTileEntity.getBlockOffset(0, -1, 0) == Blocks.soul_sand)) {
-                            ItemStack tOutput = GTOreDictUnificator.get(OrePrefixes.block, Materials.Basalt, 1L);
-                            if (canOutput(tOutput)) {
-                                calculateOverclockedNess(30, 16);
-                                // In case recipe is too OP for that machine
-                                if (mMaxProgresstime == Integer.MAX_VALUE - 1 && mEUt == Integer.MAX_VALUE - 1)
-                                    return FOUND_RECIPE_BUT_DID_NOT_MEET_REQUIREMENTS;
-                                this.mOutputItems[0] = tOutput;
-                                return 2;
-                            }
-                        }
-                    }
-                }
-            }
+        }
+
         return 0;
+    }
+
+    public static void addRockBreakerRecipe(UnaryOperator<RockBreakerRecipe.Builder> u) {
+        RockBreakerRecipe recipe = u.apply(new RockBreakerRecipe.Builder())
+            .build();
+        // Organize by circuit for recipe differentiation
+        ROCK_BREAKER_RECIPES.computeIfAbsent(recipe.circuit, $ -> new HashSet<>())
+            .add(recipe);
+    }
+
+    public static class RockBreakerRecipe {
+
+        private final Block topBlock, bottomBlock;
+        private final Block[] sideBlocks, anywhereBlocks;
+        private final int circuit;
+        private final int duration;
+        private final ItemStack inputItem;
+        private final boolean inputConsumed;
+        private final ItemStack outputItem;
+
+        private RockBreakerRecipe(Block topBlock, Block bottomBlock, Block[] sideBlocks, Block[] anywhereBlocks,
+            int circuit, int duration, ItemStack inputItem, boolean inputConsumed, ItemStack outputItem) {
+            this.topBlock = topBlock;
+            this.bottomBlock = bottomBlock;
+            this.sideBlocks = sideBlocks;
+            this.anywhereBlocks = anywhereBlocks;
+            this.circuit = circuit;
+            this.duration = duration;
+            this.inputItem = inputItem;
+            this.inputConsumed = inputConsumed;
+            this.outputItem = outputItem;
+        }
+
+        public boolean testInWorld(Block[] sideBlocks, Block topBlock, Block bottomBlock) {
+            if (this.topBlock != null && this.topBlock != topBlock) {
+                return false;
+            }
+            if (this.bottomBlock != null && this.bottomBlock != bottomBlock) {
+                return false;
+            }
+
+            if (this.sideBlocks != null) {
+                for (Block sideBlock : this.sideBlocks) {
+                    if (!ArrayUtils.contains(sideBlocks, sideBlock)) {
+                        return false;
+                    }
+                }
+            }
+
+            if (this.anywhereBlocks != null) {
+                for (Block anywhereBlock : this.anywhereBlocks) {
+                    if (topBlock == anywhereBlock) continue;
+                    if (bottomBlock == anywhereBlock) continue;
+                    if (ArrayUtils.contains(sideBlocks, anywhereBlock)) continue;
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public boolean testInputs(ItemStack inputStack) {
+            if (inputItem != null) {
+                return GTUtility.areStacksEqual(inputStack, inputItem);
+            }
+            return true;
+        }
+
+        private int getDuration() {
+            return this.duration;
+        }
+
+        private boolean isInputConsumed() {
+            return this.inputConsumed;
+        }
+
+        private ItemStack getOutputItem() {
+            return this.outputItem.copy();
+        }
+
+        public static class Builder {
+
+            private Block topBlock, bottomBlock;
+            private Block[] sideBlocks, anywhereBlocks;
+            private int circuit = -1;
+            private int duration = 16 * TICKS;
+            private ItemStack inputItem;
+            private boolean inputConsumed;
+            private ItemStack outputItem;
+            private String recipeDescription = "IT'S FREE! Place Lava on Side";
+
+            /**
+             * @param block Require a specific block above the Rock Breaker.
+             */
+            public Builder topBlock(Block block) {
+                this.topBlock = block;
+                return this;
+            }
+
+            /**
+             * @param block Require a specific block below the Rock Breaker.
+             */
+            public Builder bottomBlock(Block block) {
+                this.bottomBlock = block;
+                return this;
+            }
+
+            /**
+             * @param blocks Require specific blocks on the side of the Rock Breaker.
+             */
+            public Builder sideBlocks(Block... blocks) {
+                this.sideBlocks = blocks;
+                return this;
+            }
+
+            /**
+             * @param blocks Require specific blocks on any side, top, or bottom of the Rock Breaker.
+             */
+            public Builder anywhereBlocks(Block... blocks) {
+                this.anywhereBlocks = blocks;
+                return this;
+            }
+
+            public Builder circuit(int number) {
+                this.circuit = number;
+                return this;
+            }
+
+            public Builder duration(int ticks) {
+                this.duration = ticks;
+                return this;
+            }
+
+            public Builder inputItem(ItemStack inputItem, boolean consumed) {
+                this.inputItem = inputItem;
+                this.inputConsumed = consumed;
+                return this;
+            }
+
+            public Builder outputItem(ItemStack outputItem) {
+                this.outputItem = outputItem;
+                return this;
+            }
+
+            /**
+             * @param desc A description to show in NEI if there are no recipe inputs.
+             *             For example: "IT'S FREE! Place Lava on Side"
+             */
+            public Builder recipeDescription(String desc) {
+                this.recipeDescription = desc;
+                return this;
+            }
+
+            public RockBreakerRecipe build() {
+                if (outputItem == null) {
+                    throw new IllegalArgumentException("Rock Breaker Output Item must be set!");
+                }
+                if (sideBlocks != null && sideBlocks.length > 4) {
+                    throw new IllegalArgumentException("Cannot have more than 4 Rock Breaker side blocks!");
+                }
+                if (anywhereBlocks != null && anywhereBlocks.length > 6) {
+                    throw new IllegalArgumentException("Cannot have more than 6 Rock Breaker anywhere blocks!");
+                }
+
+                addFakeRecipe();
+
+                return new RockBreakerRecipe(
+                    topBlock,
+                    bottomBlock,
+                    sideBlocks,
+                    anywhereBlocks,
+                    circuit,
+                    duration,
+                    inputItem,
+                    inputConsumed,
+                    outputItem);
+            }
+
+            private void addFakeRecipe() {
+                GTRecipeBuilder b = GTValues.RA.stdBuilder()
+                    .itemOutputs(this.outputItem.copy())
+                    .duration(this.duration)
+                    .eut(TierEU.RECIPE_LV)
+                    .ignoreCollision()
+                    .noOptimize()
+                    .fake();
+
+                List<ItemStack> inputs = new ArrayList<>();
+                if (this.inputItem != null) {
+                    if (this.inputConsumed) {
+                        inputs.add(this.inputItem.copy());
+                    } else {
+                        inputs.add(GTUtility.copyAmount(0, this.inputItem));
+                    }
+                } else {
+                    // Add the "IT'S FREE" item
+                    inputs.add(ItemList.Display_ITS_FREE.getWithName(1, this.recipeDescription));
+                }
+                if (this.circuit != -1) {
+                    inputs.add(GTUtility.getIntegratedCircuit(this.circuit));
+                }
+                b.itemInputs(inputs.toArray(new ItemStack[0]));
+                b.addTo(rockBreakerFakeRecipes);
+            }
+        }
     }
 }

--- a/src/main/java/gregtech/loaders/postload/GTPostLoad.java
+++ b/src/main/java/gregtech/loaders/postload/GTPostLoad.java
@@ -8,7 +8,6 @@ import static gregtech.api.enums.Mods.GalaxySpace;
 import static gregtech.api.enums.Mods.Thaumcraft;
 import static gregtech.api.recipe.RecipeMaps.fluidCannerRecipes;
 import static gregtech.api.recipe.RecipeMaps.massFabFakeRecipes;
-import static gregtech.api.recipe.RecipeMaps.rockBreakerFakeRecipes;
 import static gregtech.api.recipe.RecipeMaps.scannerFakeRecipes;
 import static gregtech.api.util.GTRecipeBuilder.MINUTES;
 import static gregtech.api.util.GTRecipeBuilder.SECONDS;
@@ -49,6 +48,7 @@ import gregtech.api.util.GTRecipeRegistrator;
 import gregtech.api.util.GTUtility;
 import gregtech.common.items.behaviors.BehaviourDataOrb;
 import gregtech.common.tileentities.machines.basic.MTEMassfabricator;
+import gregtech.common.tileentities.machines.basic.MTERockBreaker;
 import ic2.api.recipe.IRecipeInput;
 import ic2.api.recipe.RecipeOutput;
 
@@ -329,47 +329,34 @@ public class GTPostLoad {
 
         massFabFakeRecipes.add(MTEMassfabricator.uuaRecipe);
 
-        GTValues.RA.stdBuilder()
-            .itemInputs(ItemList.Display_ITS_FREE.getWithName(1L, "IT'S FREE! Place Lava on Side"))
-            .itemOutputs(new ItemStack(Blocks.cobblestone, 1))
-            .duration(16 * TICKS)
-            .eut(TierEU.RECIPE_LV)
-            .ignoreCollision()
-            .noOptimize()
-            .fake()
-            .addTo(rockBreakerFakeRecipes);
+        MTERockBreaker.addRockBreakerRecipe(
+            b -> b.recipeDescription("IT'S FREE! Place Lava on Side")
+                .sideBlocks(Blocks.water)
+                .topBlock(Blocks.lava)
+                .outputItem(new ItemStack(Blocks.stone, 1))
+                .duration(16 * TICKS));
 
-        GTValues.RA.stdBuilder()
-            .itemInputs(ItemList.Display_ITS_FREE.getWithName(1L, "IT'S FREE! Place Lava on Side"))
-            .itemOutputs(new ItemStack(Blocks.stone, 1))
-            .duration(16 * TICKS)
-            .eut(TierEU.RECIPE_LV)
-            .ignoreCollision()
-            .noOptimize()
-            .fake()
-            .addTo(rockBreakerFakeRecipes);
+        MTERockBreaker.addRockBreakerRecipe(
+            b -> b.recipeDescription("IT'S FREE! Place Lava on Side")
+                .sideBlocks(Blocks.water, Blocks.lava)
+                .outputItem(new ItemStack(Blocks.cobblestone, 1))
+                .duration(16 * TICKS));
 
-        GTValues.RA.stdBuilder()
-            .itemInputs(
-                GTOreDictUnificator.get(OrePrefixes.dust, Materials.Redstone, 1L),
-                GTUtility.getIntegratedCircuit(1))
-            .itemOutputs(new ItemStack(Blocks.obsidian, 1))
-            .duration(6 * SECONDS + 8 * TICKS)
-            .eut(TierEU.RECIPE_LV)
-            .ignoreCollision()
-            .noOptimize()
-            .fake()
-            .addTo(rockBreakerFakeRecipes);
+        MTERockBreaker.addRockBreakerRecipe(
+            b -> b.sideBlocks(Blocks.water)
+                .anywhereBlocks(Blocks.lava)
+                .inputItem(GTOreDictUnificator.get(OrePrefixes.dust, Materials.Redstone, 1L), true)
+                .circuit(1)
+                .outputItem(new ItemStack(Blocks.obsidian, 1))
+                .duration(6 * SECONDS + 8 * TICKS));
 
-        GTValues.RA.stdBuilder()
-            .itemInputs(new ItemStack(Blocks.packed_ice, 0), GTUtility.getIntegratedCircuit(1))
-            .itemOutputs(GTOreDictUnificator.get(OrePrefixes.block, Materials.Basalt, 1L))
-            .duration(16 * TICKS)
-            .eut(TierEU.RECIPE_LV)
-            .ignoreCollision()
-            .noOptimize()
-            .fake()
-            .addTo(rockBreakerFakeRecipes);
+        MTERockBreaker.addRockBreakerRecipe(
+            b -> b.sideBlocks(Blocks.lava)
+                .bottomBlock(Blocks.soul_sand)
+                .inputItem(new ItemStack(Blocks.packed_ice, 0), false)
+                .circuit(1)
+                .outputItem(GTOreDictUnificator.get(OrePrefixes.block, Materials.Basalt, 1L))
+                .duration(16 * TICKS));
     }
 
     public static void changeWoodenVanillaTools() {


### PR DESCRIPTION
Adds a new system to rock breaker for defining in-world interactions with an RA-like builder. No longer do you need to manually copy paste a large piece of logic to make rock breaker function and then still add a fake recipe