### PR TITLE
Add fake recipes for quantum computer components

### DIFF
--- a/src/main/java/gregtech/api/recipe/RecipeMaps.java
+++ b/src/main/java/gregtech/api/recipe/RecipeMaps.java
@@ -68,6 +68,7 @@ import gregtech.api.recipe.maps.PurificationUnitOzonationFrontend;
 import gregtech.api.recipe.maps.PurificationUnitParticleExtractorFrontend;
 import gregtech.api.recipe.maps.PurificationUnitPhAdjustmentFrontend;
 import gregtech.api.recipe.maps.PurificationUnitPlasmaHeaterFrontend;
+import gregtech.api.recipe.maps.QuantumComputerFrontend;
 import gregtech.api.recipe.maps.RecyclerBackend;
 import gregtech.api.recipe.maps.ReplicatorBackend;
 import gregtech.api.recipe.maps.SpaceProjectFrontend;
@@ -228,6 +229,13 @@ public final class RecipeMaps {
             }
         })
         .progressBar(GTUITextures.PROGRESSBAR_MACERATE)
+        .build();
+    public static final RecipeMap<RecipeMapBackend> quantumComputerFakeRecipes = RecipeMapBuilder
+        .of("gt.recipe.quantumcomputer")
+        .maxIO(1, 0, 0, 0)
+        .minInputs(1, 0)
+        .dontUseProgressBar()
+        .frontend(QuantumComputerFrontend::new)
         .build();
     public static final RecipeMap<ReplicatorBackend> replicatorRecipes = RecipeMapBuilder
         .of("gt.recipe.replicator", ReplicatorBackend::new)

--- a/src/main/java/gregtech/api/recipe/RecipeMaps.java
+++ b/src/main/java/gregtech/api/recipe/RecipeMaps.java
@@ -91,6 +91,7 @@ import gtPlusPlus.core.block.ModBlocks;
 import gtPlusPlus.core.item.ModItems;
 import mods.railcraft.common.blocks.aesthetics.cube.EnumCube;
 import mods.railcraft.common.items.RailcraftToolItems;
+import tectech.thing.CustomItemList;
 
 @SuppressWarnings("SimplifyOptionalCallChains")
 public final class RecipeMaps {
@@ -236,6 +237,9 @@ public final class RecipeMaps {
         .minInputs(1, 0)
         .dontUseProgressBar()
         .frontend(QuantumComputerFrontend::new)
+        .neiHandlerInfo(
+            builder -> builder.setMaxRecipesPerPage(4)
+                .setDisplayStack(CustomItemList.Machine_Multi_Computer.get(1)))
         .build();
     public static final RecipeMap<ReplicatorBackend> replicatorRecipes = RecipeMapBuilder
         .of("gt.recipe.replicator", ReplicatorBackend::new)

--- a/src/main/java/gregtech/api/recipe/maps/QuantumComputerFrontend.java
+++ b/src/main/java/gregtech/api/recipe/maps/QuantumComputerFrontend.java
@@ -1,19 +1,28 @@
 package gregtech.api.recipe.maps;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+
 import gregtech.api.recipe.BasicUIPropertiesBuilder;
 import gregtech.api.recipe.NEIRecipePropertiesBuilder;
 import gregtech.api.recipe.RecipeMapFrontend;
 import gregtech.api.util.GTRecipeConstants;
+import gregtech.api.util.MethodsReturnNonnullByDefault;
 import gregtech.api.util.recipe.QuantumComputerRecipeData;
 import gregtech.nei.RecipeDisplayInfo;
 import gregtech.nei.formatter.INEISpecialInfoFormatter;
 
-import java.util.ArrayList;
-import java.util.List;
-
+@ParametersAreNonnullByDefault
+@MethodsReturnNonnullByDefault
 public class QuantumComputerFrontend extends RecipeMapFrontend {
-    public QuantumComputerFrontend(BasicUIPropertiesBuilder uiPropertiesBuilder, NEIRecipePropertiesBuilder neiPropertiesBuilder) {
-        super(uiPropertiesBuilder, neiPropertiesBuilder.neiSpecialInfoFormatter(new QuantumComputerMetaDataFormatter()));
+
+    public QuantumComputerFrontend(BasicUIPropertiesBuilder uiPropertiesBuilder,
+        NEIRecipePropertiesBuilder neiPropertiesBuilder) {
+        super(
+            uiPropertiesBuilder,
+            neiPropertiesBuilder.neiSpecialInfoFormatter(new QuantumComputerMetaDataFormatter()));
     }
 
     private static class QuantumComputerMetaDataFormatter implements INEISpecialInfoFormatter {

--- a/src/main/java/gregtech/api/recipe/maps/QuantumComputerFrontend.java
+++ b/src/main/java/gregtech/api/recipe/maps/QuantumComputerFrontend.java
@@ -24,11 +24,14 @@ public class QuantumComputerFrontend extends RecipeMapFrontend {
 
             QuantumComputerRecipeData data = recipeInfo.recipe.getMetadata(GTRecipeConstants.QUANTUM_COMPUTER_DATA);
             if (data != null) {
-                result.add("Heating Constant: " + data.heatConstant);
-                result.add("Cooling Constant: " + data.coolConstant);
-                result.add("Computation: " + data.computation);
+                // If this is false, it's a cooling component.
+                if (data.subZero) {
+                    result.add("Cooling Constant: " + data.coolConstant);
+                } else {
+                    result.add("Heating Constant: " + data.heatConstant);
+                    result.add("Computation: " + data.computation);
+                }
                 result.add("Maximum Heat: " + data.maxHeat);
-                result.add("Sub-Zero: " + data.subZero);
             }
             return result;
         }

--- a/src/main/java/gregtech/api/recipe/maps/QuantumComputerFrontend.java
+++ b/src/main/java/gregtech/api/recipe/maps/QuantumComputerFrontend.java
@@ -26,10 +26,10 @@ public class QuantumComputerFrontend extends RecipeMapFrontend {
             if (data != null) {
                 // If this is false, it's a cooling component.
                 if (data.subZero) {
-                    result.add("Cooling Constant: " + data.coolConstant);
-                } else {
                     result.add("Heating Constant: " + data.heatConstant);
                     result.add("Computation: " + data.computation);
+                } else {
+                    result.add("Cooling Constant: " + data.coolConstant);
                 }
                 result.add("Maximum Heat: " + data.maxHeat);
             }

--- a/src/main/java/gregtech/api/recipe/maps/QuantumComputerFrontend.java
+++ b/src/main/java/gregtech/api/recipe/maps/QuantumComputerFrontend.java
@@ -5,6 +5,8 @@ import java.util.List;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import net.minecraft.util.StatCollector;
+
 import gregtech.api.recipe.BasicUIPropertiesBuilder;
 import gregtech.api.recipe.NEIRecipePropertiesBuilder;
 import gregtech.api.recipe.RecipeMapFrontend;
@@ -35,12 +37,12 @@ public class QuantumComputerFrontend extends RecipeMapFrontend {
             if (data != null) {
                 // If this is false, it's a cooling component.
                 if (data.subZero) {
-                    result.add("Heating Constant: " + data.heatConstant);
-                    result.add("Computation: " + data.computation);
+                    result.add(StatCollector.translateToLocalFormatted("GT5U.nei.qc.heating", data.heatConstant));
+                    result.add(StatCollector.translateToLocalFormatted("GT5U.nei.qc.computation", data.computation));
                 } else {
-                    result.add("Cooling Constant: " + data.coolConstant);
+                    result.add(StatCollector.translateToLocalFormatted("GT5U.nei.qc.cooling", data.coolConstant));
                 }
-                result.add("Maximum Heat: " + data.maxHeat);
+                result.add(StatCollector.translateToLocalFormatted("GT5U.nei.qc.maxheat", data.maxHeat));
             }
             return result;
         }

--- a/src/main/java/gregtech/api/recipe/maps/QuantumComputerFrontend.java
+++ b/src/main/java/gregtech/api/recipe/maps/QuantumComputerFrontend.java
@@ -1,0 +1,36 @@
+package gregtech.api.recipe.maps;
+
+import gregtech.api.recipe.BasicUIPropertiesBuilder;
+import gregtech.api.recipe.NEIRecipePropertiesBuilder;
+import gregtech.api.recipe.RecipeMapFrontend;
+import gregtech.api.util.GTRecipeConstants;
+import gregtech.api.util.recipe.QuantumComputerRecipeData;
+import gregtech.nei.RecipeDisplayInfo;
+import gregtech.nei.formatter.INEISpecialInfoFormatter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class QuantumComputerFrontend extends RecipeMapFrontend {
+    public QuantumComputerFrontend(BasicUIPropertiesBuilder uiPropertiesBuilder, NEIRecipePropertiesBuilder neiPropertiesBuilder) {
+        super(uiPropertiesBuilder, neiPropertiesBuilder.neiSpecialInfoFormatter(new QuantumComputerMetaDataFormatter()));
+    }
+
+    private static class QuantumComputerMetaDataFormatter implements INEISpecialInfoFormatter {
+
+        @Override
+        public List<String> format(RecipeDisplayInfo recipeInfo) {
+            List<String> result = new ArrayList<>();
+
+            QuantumComputerRecipeData data = recipeInfo.recipe.getMetadata(GTRecipeConstants.QUANTUM_COMPUTER_DATA);
+            if (data != null) {
+                result.add("Heating Constant: " + data.heatConstant);
+                result.add("Cooling Constant: " + data.coolConstant);
+                result.add("Computation: " + data.computation);
+                result.add("Maximum Heat: " + data.maxHeat);
+                result.add("Sub-Zero: " + data.subZero);
+            }
+            return result;
+        }
+    }
+}

--- a/src/main/java/gregtech/api/util/GTRecipeConstants.java
+++ b/src/main/java/gregtech/api/util/GTRecipeConstants.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Optional;
 
+import gregtech.api.util.recipe.QuantumComputerRecipeData;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
@@ -110,6 +111,11 @@ public class GTRecipeConstants {
      * For Microwave.
      */
     public static final RecipeMetadataKey<Boolean> ON_FIRE = SimpleRecipeMetadataKey.create(Boolean.class, "on_fire");
+
+    /**
+     * Values of items used in quantum computer, used to show NEI recipes
+     */
+    public static final RecipeMetadataKey<QuantumComputerRecipeData> QUANTUM_COMPUTER_DATA = SimpleRecipeMetadataKey.create(QuantumComputerRecipeData.class, "quantum_computer_data");
 
     /**
      * Nano Forge Tier.

--- a/src/main/java/gregtech/api/util/GTRecipeConstants.java
+++ b/src/main/java/gregtech/api/util/GTRecipeConstants.java
@@ -10,7 +10,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Optional;
 
-import gregtech.api.util.recipe.QuantumComputerRecipeData;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
@@ -27,6 +26,7 @@ import gregtech.api.recipe.RecipeCategories;
 import gregtech.api.recipe.RecipeMaps;
 import gregtech.api.recipe.RecipeMetadataKey;
 import gregtech.api.recipe.metadata.SimpleRecipeMetadataKey;
+import gregtech.api.util.recipe.QuantumComputerRecipeData;
 import gregtech.api.util.recipe.Scanning;
 import gregtech.api.util.recipe.Sievert;
 import gregtech.common.items.IDMetaItem03;
@@ -115,7 +115,8 @@ public class GTRecipeConstants {
     /**
      * Values of items used in quantum computer, used to show NEI recipes
      */
-    public static final RecipeMetadataKey<QuantumComputerRecipeData> QUANTUM_COMPUTER_DATA = SimpleRecipeMetadataKey.create(QuantumComputerRecipeData.class, "quantum_computer_data");
+    public static final RecipeMetadataKey<QuantumComputerRecipeData> QUANTUM_COMPUTER_DATA = SimpleRecipeMetadataKey
+        .create(QuantumComputerRecipeData.class, "quantum_computer_data");
 
     /**
      * Nano Forge Tier.

--- a/src/main/java/gregtech/api/util/recipe/QuantumComputerRecipeData.java
+++ b/src/main/java/gregtech/api/util/recipe/QuantumComputerRecipeData.java
@@ -1,0 +1,15 @@
+package gregtech.api.util.recipe;
+
+public class QuantumComputerRecipeData {
+
+    public final float heatConstant, coolConstant, computation, maxHeat;
+    public final boolean subZero;
+
+    public QuantumComputerRecipeData(float heatConstant, float coolConstant, float computation, float maxHeat, boolean subZero) {
+        this.heatConstant = heatConstant;
+        this.coolConstant = coolConstant;
+        this.computation = computation;
+        this.maxHeat = maxHeat;
+        this.subZero = subZero;
+    }
+}

--- a/src/main/java/gregtech/api/util/recipe/QuantumComputerRecipeData.java
+++ b/src/main/java/gregtech/api/util/recipe/QuantumComputerRecipeData.java
@@ -5,7 +5,8 @@ public class QuantumComputerRecipeData {
     public final float heatConstant, coolConstant, computation, maxHeat;
     public final boolean subZero;
 
-    public QuantumComputerRecipeData(float heatConstant, float coolConstant, float computation, float maxHeat, boolean subZero) {
+    public QuantumComputerRecipeData(float heatConstant, float coolConstant, float computation, float maxHeat,
+        boolean subZero) {
         this.heatConstant = heatConstant;
         this.coolConstant = coolConstant;
         this.computation = computation;

--- a/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchRack.java
+++ b/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchRack.java
@@ -3,13 +3,18 @@ package tectech.thing.metaTileEntity.hatch;
 import static gregtech.api.enums.Mods.GraviSuite;
 import static gregtech.api.enums.Mods.NewHorizonsCoreMod;
 import static gregtech.api.enums.Mods.OpenComputers;
+import static gregtech.api.recipe.RecipeMaps.quantumComputerFakeRecipes;
 import static gregtech.api.util.GTModHandler.getModItem;
+import static gregtech.api.util.GTRecipeConstants.QUANTUM_COMPUTER_DATA;
 import static net.minecraft.util.StatCollector.translateToLocal;
 import static net.minecraft.util.StatCollector.translateToLocalFormatted;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import gregtech.api.enums.GTValues;
+import gregtech.api.util.GTModHandler;
+import gregtech.api.util.recipe.QuantumComputerRecipeData;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
@@ -331,7 +336,7 @@ public class MTEHatchRack extends MTEHatch implements IAddGregtechLogo, IAddUIWi
         new RackComponent(ItemList.Circuit_Wetwaresupercomputer.get(1), 200, 42, -1f, 4000, true); // UV
         new RackComponent(ItemList.Circuit_Wetwaremainframe.get(1), 220, 40, -1f, 4000, true); // UHV
 
-        new RackComponent("IC2:ic2.reactorVent", 0, -1, 40f, 2000, false); // Heat Vent
+        new RackComponent(GTModHandler.getIC2Item("reactorVent", 1), 0, -1, 40f, 2000, false); // Heat Vent
         new RackComponent("IC2:ic2.reactorVentCore", 0, -1, 80f, 4000, false); // Reactor Heat Vent
         new RackComponent("IC2:ic2.reactorVentGold", 0, -1, 120f, 6000, false); // Overclocked Heat Vent
         new RackComponent("IC2:ic2.reactorVentDiamond", 0, -1, 160f, 8000, false); // Advanced Heat Vent
@@ -373,6 +378,14 @@ public class MTEHatchRack extends MTEHatch implements IAddGregtechLogo, IAddUIWi
         RackComponent(ItemStack is, float computation, float heatConstant, float coolConstant, float maxHeat,
             boolean subZero) {
             this(TTUtility.getUniqueIdentifier(is), computation, heatConstant, coolConstant, maxHeat, subZero);
+
+            GTValues.RA.stdBuilder()
+                .itemInputs(is)
+                .metadata(QUANTUM_COMPUTER_DATA, new QuantumComputerRecipeData(heatConstant, coolConstant, computation, maxHeat, subZero))
+                .duration(0)
+                .eut(0)
+                .fake()
+                .addTo(quantumComputerFakeRecipes);
         }
 
         RackComponent(String is, float computation, float heatConstant, float coolConstant, float maxHeat,

--- a/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchRack.java
+++ b/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchRack.java
@@ -337,9 +337,9 @@ public class MTEHatchRack extends MTEHatch implements IAddGregtechLogo, IAddUIWi
         new RackComponent(ItemList.Circuit_Wetwaremainframe.get(1), 220, 40, -1f, 4000, true); // UHV
 
         new RackComponent(GTModHandler.getIC2Item("reactorVent", 1), 0, -1, 40f, 2000, false); // Heat Vent
-        new RackComponent("IC2:ic2.reactorVentCore", 0, -1, 80f, 4000, false); // Reactor Heat Vent
-        new RackComponent("IC2:ic2.reactorVentGold", 0, -1, 120f, 6000, false); // Overclocked Heat Vent
-        new RackComponent("IC2:ic2.reactorVentDiamond", 0, -1, 160f, 8000, false); // Advanced Heat Vent
+        new RackComponent(GTModHandler.getIC2Item("reactorVentCore", 1), 0, -1, 80f, 4000, false); // Reactor Heat Vent
+        new RackComponent(GTModHandler.getIC2Item("reactorVentGold", 1), 0, -1, 120f, 6000, false); // Overclocked Heat Vent
+        new RackComponent(GTModHandler.getIC2Item("reactorVentDiamond", 1), 0, -1, 160f, 8000, false); // Advanced Heat Vent
 
         if (NewHorizonsCoreMod.isModLoaded()) {
             // GTNH-GT5u circuits (these components causes crashes when used with the original GT5u)

--- a/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchRack.java
+++ b/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchRack.java
@@ -12,9 +12,6 @@ import static net.minecraft.util.StatCollector.translateToLocalFormatted;
 import java.util.HashMap;
 import java.util.Map;
 
-import gregtech.api.enums.GTValues;
-import gregtech.api.util.GTModHandler;
-import gregtech.api.util.recipe.QuantumComputerRecipeData;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
@@ -32,6 +29,7 @@ import com.gtnewhorizons.modularui.common.widget.SlotWidget;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import gregtech.api.enums.GTValues;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Textures;
 import gregtech.api.gui.modularui.GTUIInfos;
@@ -42,6 +40,8 @@ import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.implementations.MTEHatch;
 import gregtech.api.render.TextureFactory;
+import gregtech.api.util.GTModHandler;
+import gregtech.api.util.recipe.QuantumComputerRecipeData;
 import gregtech.mixin.interfaces.accessors.EntityPlayerMPAccessor;
 import tectech.TecTech;
 import tectech.loader.ConfigHandler;
@@ -338,8 +338,10 @@ public class MTEHatchRack extends MTEHatch implements IAddGregtechLogo, IAddUIWi
 
         new RackComponent(GTModHandler.getIC2Item("reactorVent", 1), 0, -1, 40f, 2000, false); // Heat Vent
         new RackComponent(GTModHandler.getIC2Item("reactorVentCore", 1), 0, -1, 80f, 4000, false); // Reactor Heat Vent
-        new RackComponent(GTModHandler.getIC2Item("reactorVentGold", 1), 0, -1, 120f, 6000, false); // Overclocked Heat Vent
-        new RackComponent(GTModHandler.getIC2Item("reactorVentDiamond", 1), 0, -1, 160f, 8000, false); // Advanced Heat Vent
+        new RackComponent(GTModHandler.getIC2Item("reactorVentGold", 1), 0, -1, 120f, 6000, false); // Overclocked Heat
+                                                                                                    // Vent
+        new RackComponent(GTModHandler.getIC2Item("reactorVentDiamond", 1), 0, -1, 160f, 8000, false); // Advanced Heat
+                                                                                                       // Vent
 
         if (NewHorizonsCoreMod.isModLoaded()) {
             // GTNH-GT5u circuits (these components causes crashes when used with the original GT5u)
@@ -381,7 +383,9 @@ public class MTEHatchRack extends MTEHatch implements IAddGregtechLogo, IAddUIWi
 
             GTValues.RA.stdBuilder()
                 .itemInputs(is)
-                .metadata(QUANTUM_COMPUTER_DATA, new QuantumComputerRecipeData(heatConstant, coolConstant, computation, maxHeat, subZero))
+                .metadata(
+                    QUANTUM_COMPUTER_DATA,
+                    new QuantumComputerRecipeData(heatConstant, coolConstant, computation, maxHeat, subZero))
                 .duration(0)
                 .eut(0)
                 .fake()

--- a/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchRack.java
+++ b/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchRack.java
@@ -355,15 +355,15 @@ public class MTEHatchRack extends MTEHatch implements IAddGregtechLogo, IAddUIWi
             new RackComponent(ItemList.Circuit_OpticalComputer.get(1), 240, 22, -1f, 8000, true); // UEV
             new RackComponent(ItemList.Circuit_OpticalMainframe.get(1), 260, 20, -1f, 8000, true); // UIV
 
-            new RackComponent("dreamcraft:item.PikoCircuit", 260, 12, -1f, 9500, true); // UMV
-            new RackComponent("dreamcraft:item.QuantumCircuit", 320, 10, -1f, 10000, true); // UXV
+            new RackComponent(getModItem(NewHorizonsCoreMod.ID, "item.PikoCircuit", 1), 260, 12, -1f, 9500, true); // UMV
+            new RackComponent(getModItem(NewHorizonsCoreMod.ID, "item.QuantumCircuit", 1), 320, 10, -1f, 10000, true); // UXV
         }
 
         if (OpenComputers.isModLoaded()) {
-            new RackComponent("OpenComputers:item.oc.CPU2", 80, 46, -1f, 2000, true); // CPU T3
-            new RackComponent("OpenComputers:item.oc.GraphicsCard2", 100, 44, -1f, 2000, true); // GPU T3
-            new RackComponent("OpenComputers:item.oc.APU1", 120, 42, -1f, 2000, true); // APU T3
-            new RackComponent("OpenComputers:item.oc.APU2", 240, 40, -1f, 2000, true); // APU Creative
+            new RackComponent(getModItem(OpenComputers.ID, "item", 1, 43), 80, 46, -1f, 2000, true); // CPU T3
+            new RackComponent(getModItem(OpenComputers.ID, "item", 1, 10), 100, 44, -1f, 2000, true); // GPU T3
+            new RackComponent(getModItem(OpenComputers.ID, "item", 1, 102), 120, 42, -1f, 2000, true); // APU T3
+            new RackComponent(getModItem(OpenComputers.ID, "item", 1, 103), 240, 40, -1f, 2000, true); // APU Creative
         }
 
         if (GraviSuite.isModLoaded()) {

--- a/src/main/java/tectech/thing/metaTileEntity/multi/MTEQuantumComputer.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/MTEQuantumComputer.java
@@ -17,7 +17,6 @@ import java.util.List;
 
 import javax.annotation.Nonnull;
 
-import gregtech.api.recipe.RecipeMap;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -43,6 +42,7 @@ import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.implementations.MTEHatch;
+import gregtech.api.recipe.RecipeMap;
 import gregtech.api.recipe.check.CheckRecipeResult;
 import gregtech.api.recipe.check.CheckRecipeResultRegistry;
 import gregtech.api.recipe.check.SimpleCheckRecipeResult;

--- a/src/main/java/tectech/thing/metaTileEntity/multi/MTEQuantumComputer.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/MTEQuantumComputer.java
@@ -5,6 +5,7 @@ import static com.gtnewhorizon.structurelib.structure.StructureUtility.transpose
 import static gregtech.api.enums.GTValues.V;
 import static gregtech.api.enums.HatchElement.Energy;
 import static gregtech.api.enums.HatchElement.Maintenance;
+import static gregtech.api.recipe.RecipeMaps.quantumComputerFakeRecipes;
 import static gregtech.api.util.GTStructureUtility.buildHatchAdder;
 import static gregtech.api.util.GTUtility.validMTEList;
 import static net.minecraft.util.StatCollector.translateToLocal;
@@ -16,6 +17,7 @@ import java.util.List;
 
 import javax.annotation.Nonnull;
 
+import gregtech.api.recipe.RecipeMap;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -157,6 +159,11 @@ public class MTEQuantumComputer extends TTMultiblockBase implements ISurvivalCon
         super(aName);
         eCertainMode = 5;
         eCertainStatus = -128; // no-brain value
+    }
+
+    @Override
+    public RecipeMap<?> getRecipeMap() {
+        return quantumComputerFakeRecipes;
     }
 
     @Override

--- a/src/main/resources/assets/gregtech/lang/en_US.lang
+++ b/src/main/resources/assets/gregtech/lang/en_US.lang
@@ -755,6 +755,10 @@ GT5U.nei.tier=Tier: %s
 GT5U.nei.start_eu=Start: %s EU (MK %s)
 GT5U.nei.stages=Stages: %s
 GT5U.nei.fuel=Fuel Value: %s EU
+GT5U.nei.qc.heating=Heating Constant: %s
+GT5U.nei.qc.cooling=Cooling Constant: %s
+GT5U.nei.qc.computation= Computation: %s
+GT5U.nei.qc.maxheat= Maximum Heat: %s
 
 GT5U.config.colormodulation=Color Modulator
 GT5U.config.colormodulation.cable_insulation=Cable Insulation

--- a/src/main/resources/assets/gregtech/lang/en_US.lang
+++ b/src/main/resources/assets/gregtech/lang/en_US.lang
@@ -288,6 +288,7 @@ gt.recipe.purificationplantplasmaheating=Temperature Fluctuation
 gt.recipe.purificationplantuvtreatment=High Energy Laser Treatment
 gt.recipe.purificationplantdegasifier=Degassing
 gt.recipe.purificationplantquarkextractor=Baryonic Perfection
+gt.recipe.quantumcomputer=Quantum Computer Components
 
 # Recipe categories
 gt.recipe.category.arc_furnace_recycling=Arc Furnace Recycling

--- a/src/main/resources/assets/gregtech/lang/en_US.lang
+++ b/src/main/resources/assets/gregtech/lang/en_US.lang
@@ -757,8 +757,8 @@ GT5U.nei.stages=Stages: %s
 GT5U.nei.fuel=Fuel Value: %s EU
 GT5U.nei.qc.heating=Heating Constant: %s
 GT5U.nei.qc.cooling=Cooling Constant: %s
-GT5U.nei.qc.computation= Computation: %s
-GT5U.nei.qc.maxheat= Maximum Heat: %s
+GT5U.nei.qc.computation=Computation: %s
+GT5U.nei.qc.maxheat=Maximum Heat: %s
 
 GT5U.config.colormodulation=Color Modulator
 GT5U.config.colormodulation.cable_insulation=Cable Insulation

--- a/src/main/resources/assets/gregtech/lang/en_US.lang
+++ b/src/main/resources/assets/gregtech/lang/en_US.lang
@@ -288,7 +288,7 @@ gt.recipe.purificationplantplasmaheating=Temperature Fluctuation
 gt.recipe.purificationplantuvtreatment=High Energy Laser Treatment
 gt.recipe.purificationplantdegasifier=Degassing
 gt.recipe.purificationplantquarkextractor=Baryonic Perfection
-gt.recipe.quantumcomputer=Quantum Computer Components
+gt.recipe.quantumcomputer=QC Components
 
 # Recipe categories
 gt.recipe.category.arc_furnace_recycling=Arc Furnace Recycling


### PR DESCRIPTION
It irks me that QC has all of these different items that can be used with different stats and no way to view them in game. Fixes that. It hooks into the adder for new components, so if you add or adjust components, changes will be reflected here.

![image](https://github.com/user-attachments/assets/31335413-8524-496e-bb96-872b0f12b658)
![image](https://github.com/user-attachments/assets/0bdf00f5-afd5-467d-9080-b53b4cbab225)

This is not nearly enough to make Quantum Computer even remotely approachable, but it's a start.
