### PR TITLE
Fix multi smelter adding an empty output stack

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEMultiFurnace.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEMultiFurnace.java
@@ -205,7 +205,7 @@ public class MTEMultiFurnace extends MTEAbstractMultiFurnace<MTEMultiFurnace> im
         int remainingCost = finalParallel;
         for (ItemStack item : tInputList) {
             ItemStack smeltedOutput = GTModHandler.getSmeltingOutput(item, false, null);
-            if (smeltedOutput != null) {
+            if (smeltedOutput != null && remainingCost > 0) {
                 if (remainingCost >= item.stackSize) {
                     remainingCost -= item.stackSize;
                     smeltedOutput.stackSize *= item.stackSize;


### PR DESCRIPTION
Fixes an edge case where the multi smelter previously added an item stack with 0 items to the outputs.

Before:
![image](https://github.com/user-attachments/assets/bd7dc23a-7b1d-4ef2-bd5b-7f23c48381c2)

After:
![image](https://github.com/user-attachments/assets/0b9ff4da-843b-4056-adc0-084a69c3564e)
