### PR TITLE
Add missing super.invalidate()

### DIFF
--- a/src/main/java/kubatech/tileentity/TeaStorageTile.java
+++ b/src/main/java/kubatech/tileentity/TeaStorageTile.java
@@ -79,5 +79,6 @@ public class TeaStorageTile extends TileEntity {
     @Override
     public void invalidate() {
         if (teaNetwork != null) teaNetwork.unregisterTeaStorageExtender(this);
+        super.invalidate();
     }
 }


### PR DESCRIPTION
Missing super.invalidate() call will prevent TE from being removed when block desroyed.