### PR TITLE
Fix an LCR collision

### DIFF
--- a/src/main/java/gregtech/loaders/postload/recipes/ChemicalRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/ChemicalRecipes.java
@@ -4797,7 +4797,7 @@ public class ChemicalRecipes implements Runnable {
 
         GTValues.RA.stdBuilder()
             .itemInputs(
-                GTUtility.getIntegratedCircuit(8),
+                GTUtility.getIntegratedCircuit(7),
                 GTOreDictUnificator.get(OrePrefixes.dust, Materials.Silver, 9),
                 GTOreDictUnificator.get(OrePrefixes.dust, Materials.Aluminiumoxide, 9))
             .fluidInputs(Materials.Ethylene.getGas(9000), Materials.Oxygen.getGas(9000))


### PR DESCRIPTION
Not sure when this one popped up. Conflicts with a recipe for acetic acid and recipe cannot be performed. It's a 9x recipe, so I would put it on circuit 9... but that conflicts with polyethylene.