### PR TITLE
Fix Ztones Having craftingTank OreDict

### DIFF
--- a/src/main/java/gregtech/loaders/load/GTItemIterator.java
+++ b/src/main/java/gregtech/loaders/load/GTItemIterator.java
@@ -176,6 +176,9 @@ public class GTItemIterator implements Runnable {
                             tItem.setMaxStackSize(OrePrefixes.stone.mDefaultStackSize);
                         }
                     }
+                    if (tName.equals("tile.tankBlock") && tBlock instanceof buildcraft.factory.BlockTank) {
+                        GTOreDictUnificator.registerOre(OreDictNames.craftingTank, new ItemStack(tItem, 1, 0));
+                    }
                 }
                 if (((tItem instanceof ItemFood)) && (tItem != ItemList.IC2_Food_Can_Filled.getItem())
                     && (tItem != ItemList.IC2_Food_Can_Spoiled.getItem())) {
@@ -268,10 +271,6 @@ public class GTItemIterator implements Runnable {
                     // buildcraft
                     case "tile.pumpBlock" -> GTOreDictUnificator
                         .registerOre(OreDictNames.craftingPump, new ItemStack(tItem, 1, 0));
-
-                    // buildcraft
-                    case "tile.tankBlock" -> GTOreDictUnificator
-                        .registerOre(OreDictNames.craftingTank, new ItemStack(tItem, 1, 0));
 
                 }
             }


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18734

Ztones and Buildcraft both use "tile.blockTank" as unlocalized names, causing the Ztones Tank block to get the oredict. Tested in latest nightly, all recipes are unchanged (as far as I can tell the oredict is unused but I kept it). Name plus instance check because just instance check includes all the IronTanks ones (steel, gold, diamond, etc.). Name before instance because the inverse ordering causes some null item to get it which kills the game.