### PR TITLE
Add a callback for RecipeMap that called when a recipe is added

### DIFF
--- a/src/main/java/gregtech/api/recipe/RecipeMapBackend.java
+++ b/src/main/java/gregtech/api/recipe/RecipeMapBackend.java
@@ -82,7 +82,7 @@ public class RecipeMapBackend {
      * @see #watchRecipeAdded(Consumer)
      */
     @Nullable
-    private Consumer<GTRecipe> recipeAddedCallback;
+    protected Consumer<GTRecipe> recipeAddedCallback;
 
     /**
      * Called when a {@link GTRecipeBuilder} is added.
@@ -90,7 +90,7 @@ public class RecipeMapBackend {
      * @see #watchRecipeBuilderAdded(Consumer)
      */
     @Nullable
-    private Consumer<GTRecipeBuilder> recipeBuilderAddedCallback;
+    protected Consumer<GTRecipeBuilder> recipeBuilderAddedCallback;
 
     public RecipeMapBackend(RecipeMapBackendPropertiesBuilder propertiesBuilder) {
         this.properties = propertiesBuilder.build();

--- a/src/main/java/gregtech/api/recipe/RecipeMapBackend.java
+++ b/src/main/java/gregtech/api/recipe/RecipeMapBackend.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -74,6 +75,14 @@ public class RecipeMapBackend {
      * All the properties specific to this backend.
      */
     protected final RecipeMapBackendProperties properties;
+
+    /**
+     * Called when a recipe is added.
+     *
+     * @see #watchRecipeAdded(Consumer)
+     */
+    @Nullable
+    private Consumer<GTRecipe> recipeAddedCallback;
 
     public RecipeMapBackend(RecipeMapBackendPropertiesBuilder propertiesBuilder) {
         this.properties = propertiesBuilder.build();
@@ -137,6 +146,9 @@ public class RecipeMapBackend {
         }
         recipesByCategory.computeIfAbsent(recipe.getRecipeCategory(), v -> new ArrayList<>())
             .add(recipe);
+        if(recipeAddedCallback != null) {
+            recipeAddedCallback.accept(recipe);
+        }
         for (FluidStack fluid : recipe.mFluidInputs) {
             if (fluid == null) continue;
             fluidIndex.put(
@@ -304,6 +316,18 @@ public class RecipeMapBackend {
      */
     public boolean containsInput(Fluid fluid) {
         return fluidIndex.containsKey(fluid.getName());
+    }
+
+    /**
+     * Calls the given callback when a recipe is added.
+     *
+     * @param callback the callback
+     */
+    public void watchRecipeAdded(Consumer<GTRecipe> callback) {
+        Consumer<GTRecipe> current = this.recipeAddedCallback;
+        this.recipeAddedCallback = current != null
+            ? current.andThen(callback)
+            : callback;
     }
 
     // region find recipe

--- a/src/main/java/gregtech/api/recipe/RecipeMapBackend.java
+++ b/src/main/java/gregtech/api/recipe/RecipeMapBackend.java
@@ -154,7 +154,7 @@ public class RecipeMapBackend {
         }
         recipesByCategory.computeIfAbsent(recipe.getRecipeCategory(), v -> new ArrayList<>())
             .add(recipe);
-        if(recipeAddedCallback != null) {
+        if (recipeAddedCallback != null) {
             recipeAddedCallback.accept(recipe);
         }
         for (FluidStack fluid : recipe.mFluidInputs) {
@@ -191,7 +191,7 @@ public class RecipeMapBackend {
      * Builds recipe from supplied recipe builder and adds it.
      */
     protected Collection<GTRecipe> doAdd(GTRecipeBuilder builder) {
-        if(recipeBuilderAddedCallback != null) {
+        if (recipeBuilderAddedCallback != null) {
             recipeBuilderAddedCallback.accept(builder);
         }
         Iterable<? extends GTRecipe> recipes = properties.recipeEmitter.apply(builder);
@@ -336,9 +336,7 @@ public class RecipeMapBackend {
      */
     public void watchRecipeAdded(Consumer<GTRecipe> callback) {
         Consumer<GTRecipe> current = this.recipeAddedCallback;
-        this.recipeAddedCallback = current != null
-            ? current.andThen(callback)
-            : callback;
+        this.recipeAddedCallback = current != null ? current.andThen(callback) : callback;
     }
 
     /**
@@ -348,9 +346,7 @@ public class RecipeMapBackend {
      */
     public void watchRecipeBuilderAdded(Consumer<GTRecipeBuilder> callback) {
         Consumer<GTRecipeBuilder> current = this.recipeBuilderAddedCallback;
-        this.recipeBuilderAddedCallback = current != null
-            ? current.andThen(callback)
-            : callback;
+        this.recipeBuilderAddedCallback = current != null ? current.andThen(callback) : callback;
     }
 
     // region find recipe

--- a/src/main/java/gregtech/api/recipe/RecipeMapBackend.java
+++ b/src/main/java/gregtech/api/recipe/RecipeMapBackend.java
@@ -84,6 +84,14 @@ public class RecipeMapBackend {
     @Nullable
     private Consumer<GTRecipe> recipeAddedCallback;
 
+    /**
+     * Called when a {@link GTRecipeBuilder} is added.
+     *
+     * @see #watchRecipeBuilderAdded(Consumer)
+     */
+    @Nullable
+    private Consumer<GTRecipeBuilder> recipeBuilderAddedCallback;
+
     public RecipeMapBackend(RecipeMapBackendPropertiesBuilder propertiesBuilder) {
         this.properties = propertiesBuilder.build();
         GregTechAPI.itemStackMultiMaps.add(itemIndex);
@@ -183,6 +191,9 @@ public class RecipeMapBackend {
      * Builds recipe from supplied recipe builder and adds it.
      */
     protected Collection<GTRecipe> doAdd(GTRecipeBuilder builder) {
+        if(recipeBuilderAddedCallback != null) {
+            recipeBuilderAddedCallback.accept(builder);
+        }
         Iterable<? extends GTRecipe> recipes = properties.recipeEmitter.apply(builder);
         Collection<GTRecipe> ret = new ArrayList<>();
         for (GTRecipe recipe : recipes) {
@@ -326,6 +337,18 @@ public class RecipeMapBackend {
     public void watchRecipeAdded(Consumer<GTRecipe> callback) {
         Consumer<GTRecipe> current = this.recipeAddedCallback;
         this.recipeAddedCallback = current != null
+            ? current.andThen(callback)
+            : callback;
+    }
+
+    /**
+     * Calls the given callback when a {@link GTRecipeBuilder} is added.
+     *
+     * @param callback the callback
+     */
+    public void watchRecipeBuilderAdded(Consumer<GTRecipeBuilder> callback) {
+        Consumer<GTRecipeBuilder> current = this.recipeBuilderAddedCallback;
+        this.recipeBuilderAddedCallback = current != null
             ? current.andThen(callback)
             : callback;
     }


### PR DESCRIPTION
This feature gives the convenience to the 3rd-party mods that need to either read or modify the existing recipes, so they don't need to iterate them after the mod that owns the machine initialized.