### PR TITLE
Fix broken cosmic neutronium plasma

### DIFF
--- a/src/main/java/gregtech/loaders/preload/LoaderGTBlockFluid.java
+++ b/src/main/java/gregtech/loaders/preload/LoaderGTBlockFluid.java
@@ -1338,6 +1338,15 @@ public class LoaderGTBlockFluid implements Runnable {
                 GTOreDictUnificator.get(OrePrefixes.cellPlasma, Materials.Bedrockium, 1L),
                 ItemList.Cell_Empty.get(1L));
 
+        GTFluidFactory.builder("plasma.cosmicneutronium")
+            .withLocalizedName("Cosmic Neutronium Plasma")
+            .withStateAndTemperature(PLASMA, 10000)
+            .buildAndRegister()
+            .configureMaterials(Materials.CosmicNeutronium)
+            .registerBContainers(
+                GTOreDictUnificator.get(OrePrefixes.cellPlasma, Materials.CosmicNeutronium, 1L),
+                ItemList.Cell_Empty.get(1L));
+
         GTFluidFactory.builder("fieryblood")
             .withLocalizedName("Fiery Blood")
             .withStateAndTemperature(LIQUID, 6400)


### PR DESCRIPTION
Broken by https://github.com/GTNewHorizons/GT5-Unofficial/pull/3943

For some reason, giving a custom iconset to a material also breaks its plasma and requires you to manually register it. The same was done for bedrockium and infinity.