### PR TITLE
Add missing residue output to waterline catalyst recipes

### DIFF
--- a/src/main/java/gregtech/loaders/postload/chains/PurifiedWaterRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/chains/PurifiedWaterRecipes.java
@@ -254,6 +254,7 @@ public class PurifiedWaterRecipes {
                 .itemInputs(ItemList.Quark_Catalyst_Housing.get(1), quarks[i])
                 .fluidInputs(MaterialsUEVplus.ExcitedDTRC.getFluid(10000L))
                 .itemOutputs(catalystInputs[i])
+                .fluidOutputs(MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(5000L))
                 .metadata(COIL_HEAT, 10800)
                 .eut(TierEU.RECIPE_UMV)
                 .duration(5 * MINUTES)


### PR DESCRIPTION
As the title suggests, this PR adds the missing residue output to the waterline t8 quark-releasing catalysts, since it was missing.
![image](https://github.com/user-attachments/assets/cd9dfd2c-2ebd-40ff-b58f-f08d3f9ffdc7)
