### PR TITLE
Make circuit names more consistent

### DIFF
--- a/src/main/java/gregtech/common/items/MetaGeneratedItem01.java
+++ b/src/main/java/gregtech/common/items/MetaGeneratedItem01.java
@@ -2755,7 +2755,7 @@ public class MetaGeneratedItem01 extends MetaGeneratedItemX32 {
         ItemList.Circuit_Master.set(
             addItem(
                 Circuit_Master.ID,
-                "Nanoprocessor Mainframe",
+                "Nano Mainframe",
                 "A Master Circuit",
                 OrePrefixes.circuit.get(Materials.LuV),
                 SubTag.NO_UNIFICATION));

--- a/src/main/java/gregtech/common/items/MetaGeneratedItem03.java
+++ b/src/main/java/gregtech/common/items/MetaGeneratedItem03.java
@@ -546,7 +546,7 @@ public class MetaGeneratedItem03 extends MetaGeneratedItemX32 {
         ItemList.Circuit_Nanoprocessor.set(
             addItem(
                 Circuit_Nanoprocessor.ID,
-                "Nanoprocessor",
+                "Nano Processor",
                 "An Advanced Circuit",
                 OrePrefixes.circuit.get(Materials.HV),
                 SubTag.NO_UNIFICATION));
@@ -554,7 +554,7 @@ public class MetaGeneratedItem03 extends MetaGeneratedItemX32 {
         ItemList.Circuit_Nanocomputer.set(
             addItem(
                 Circuit_Nanocomputer.ID,
-                "Nanoprocessor Assembly",
+                "Nano Assembly",
                 "An Extreme Circuit",
                 OrePrefixes.circuit.get(Materials.EV),
                 SubTag.NO_UNIFICATION));
@@ -562,7 +562,7 @@ public class MetaGeneratedItem03 extends MetaGeneratedItemX32 {
         ItemList.Circuit_Elitenanocomputer.set(
             addItem(
                 Circuit_Elitenanocomputer.ID,
-                "Elite Nanocomputer",
+                "Nano Supercomputer",
                 "An Elite Circuit",
                 OrePrefixes.circuit.get(Materials.IV),
                 SubTag.NO_UNIFICATION));
@@ -571,7 +571,7 @@ public class MetaGeneratedItem03 extends MetaGeneratedItemX32 {
         ItemList.Circuit_Quantumprocessor.set(
             addItem(
                 Circuit_Quantumprocessor.ID,
-                "Quantumprocessor",
+                "Quantum Processor",
                 "An Extreme Circuit",
                 OrePrefixes.circuit.get(Materials.EV),
                 SubTag.NO_UNIFICATION));
@@ -579,7 +579,7 @@ public class MetaGeneratedItem03 extends MetaGeneratedItemX32 {
         ItemList.Circuit_Quantumcomputer.set(
             addItem(
                 Circuit_Quantumcomputer.ID,
-                "Quantumprocessor Assembly",
+                "Quantum Assembly",
                 "An Elite Circuit",
                 OrePrefixes.circuit.get(Materials.IV),
                 SubTag.NO_UNIFICATION));
@@ -587,7 +587,7 @@ public class MetaGeneratedItem03 extends MetaGeneratedItemX32 {
         ItemList.Circuit_Masterquantumcomputer.set(
             addItem(
                 Circuit_Masterquantumcomputer.ID,
-                "Master Quantumcomputer",
+                "Quantum Supercomputer",
                 "A Master Circuit",
                 OrePrefixes.circuit.get(Materials.LuV),
                 SubTag.NO_UNIFICATION));
@@ -595,7 +595,7 @@ public class MetaGeneratedItem03 extends MetaGeneratedItemX32 {
         ItemList.Circuit_Quantummainframe.set(
             addItem(
                 Circuit_Quantummainframe.ID,
-                "Quantumprocessor Mainframe",
+                "Quantum Mainframe",
                 "An Ultimate Circuit",
                 OrePrefixes.circuit.get(Materials.ZPM),
                 SubTag.NO_UNIFICATION));
@@ -604,7 +604,7 @@ public class MetaGeneratedItem03 extends MetaGeneratedItemX32 {
         ItemList.Circuit_Crystalprocessor.set(
             addItem(
                 Circuit_Crystalprocessor.ID,
-                "Crystalprocessor",
+                "Crystal Processor",
                 "An Elite Circuit",
                 OrePrefixes.circuit.get(Materials.IV),
                 SubTag.NO_UNIFICATION));
@@ -612,7 +612,7 @@ public class MetaGeneratedItem03 extends MetaGeneratedItemX32 {
         ItemList.Circuit_Crystalcomputer.set(
             addItem(
                 Circuit_Crystalcomputer.ID,
-                "Crystalprocessor Assembly",
+                "Crystal Assembly",
                 "A Master Circuit",
                 OrePrefixes.circuit.get(Materials.LuV),
                 SubTag.NO_UNIFICATION));
@@ -620,7 +620,7 @@ public class MetaGeneratedItem03 extends MetaGeneratedItemX32 {
         ItemList.Circuit_Ultimatecrystalcomputer.set(
             addItem(
                 Circuit_Ultimatecrystalcomputer.ID,
-                "Ultimate Crystalcomputer",
+                "Crystal Supercomputer",
                 "An Ultimate Circuit",
                 OrePrefixes.circuit.get(Materials.ZPM),
                 SubTag.NO_UNIFICATION));
@@ -628,7 +628,7 @@ public class MetaGeneratedItem03 extends MetaGeneratedItemX32 {
         ItemList.Circuit_Crystalmainframe.set(
             addItem(
                 Circuit_Crystalmainframe.ID,
-                "Crystalprocessor Mainframe",
+                "Crystal Mainframe",
                 "A Super Circuit",
                 OrePrefixes.circuit.get(Materials.UV),
                 SubTag.NO_UNIFICATION));
@@ -640,7 +640,7 @@ public class MetaGeneratedItem03 extends MetaGeneratedItemX32 {
         ItemList.Circuit_Neuroprocessor.set(
             addItem(
                 Circuit_Neuroprocessor.ID,
-                "Wetwareprocessor",
+                "Wetware Processor",
                 "A Master Circuit",
                 OrePrefixes.circuit.get(Materials.LuV),
                 SubTag.NO_UNIFICATION));
@@ -648,7 +648,7 @@ public class MetaGeneratedItem03 extends MetaGeneratedItemX32 {
         ItemList.Circuit_Wetwarecomputer.set(
             addItem(
                 Circuit_Wetwarecomputer.ID,
-                "Wetwareprocessor Assembly",
+                "Wetware Assembly",
                 "An Ultimate Circuit",
                 OrePrefixes.circuit.get(Materials.ZPM),
                 SubTag.NO_UNIFICATION));
@@ -673,7 +673,7 @@ public class MetaGeneratedItem03 extends MetaGeneratedItemX32 {
         ItemList.Circuit_Bioprocessor.set(
             addItem(
                 Circuit_Bioprocessor.ID,
-                "Bioprocessor",
+                "Bioware Processor",
                 "An Ultimate Circuit",
                 OrePrefixes.circuit.get(Materials.ZPM),
                 SubTag.NO_UNIFICATION));
@@ -681,7 +681,7 @@ public class MetaGeneratedItem03 extends MetaGeneratedItemX32 {
         ItemList.Circuit_Biowarecomputer.set(
             addItem(
                 Circuit_Biowarecomputer.ID,
-                "Biowareprocessor Assembly",
+                "Bioware Assembly",
                 "A Super Circuit",
                 OrePrefixes.circuit.get(Materials.UV),
                 SubTag.NO_UNIFICATION));
@@ -697,7 +697,7 @@ public class MetaGeneratedItem03 extends MetaGeneratedItemX32 {
         ItemList.Circuit_Biomainframe.set(
             addItem(
                 Circuit_Biomainframe.ID,
-                "Bio Mainframe",
+                "Bioware Mainframe",
                 "A Bio Circuit",
                 OrePrefixes.circuit.get(Materials.UEV),
                 SubTag.NO_UNIFICATION));
@@ -749,7 +749,7 @@ public class MetaGeneratedItem03 extends MetaGeneratedItemX32 {
         ItemList.Circuit_OpticalComputer.set(
             addItem(
                 Circuit_OpticalComputer.ID,
-                "Optical Computer",
+                "Optical Supercomputer",
                 "An Optical Circuit",
                 OrePrefixes.circuit.get(Materials.UEV),
                 SubTag.NO_UNIFICATION));
@@ -782,7 +782,7 @@ public class MetaGeneratedItem03 extends MetaGeneratedItemX32 {
         ItemList.Circuit_ExoticComputer.set(
             addItem(
                 Circuit_ExoticComputer.ID,
-                "Exotic Computer",
+                "Exotic Supercomputer",
                 "An Exotic Circuit",
                 OrePrefixes.circuit.get(Materials.UIV),
                 SubTag.NO_UNIFICATION));
@@ -815,7 +815,7 @@ public class MetaGeneratedItem03 extends MetaGeneratedItemX32 {
         ItemList.Circuit_CosmicComputer.set(
             addItem(
                 Circuit_CosmicComputer.ID,
-                "Cosmic Computer",
+                "Cosmic Supercomputer",
                 "A Cosmic Circuit",
                 OrePrefixes.circuit.get(Materials.UMV),
                 SubTag.NO_UNIFICATION));
@@ -848,7 +848,7 @@ public class MetaGeneratedItem03 extends MetaGeneratedItemX32 {
         ItemList.Circuit_TranscendentComputer.set(
             addItem(
                 Circuit_TranscendentComputer.ID,
-                "Temporally Transcendent Computer",
+                "Temporally Transcendent Supercomputer",
                 "A circuit operating outside of known spacetime",
                 OrePrefixes.circuit.get(Materials.UXV),
                 SubTag.NO_UNIFICATION));


### PR DESCRIPTION
This PR changes a bunch of circuit names to be more consistent overall and more parseable in nei. Computers are renamed to supercomputers for consistency as well and because it sounds better imo. 

Full list of changes:

Nanoprocessor -> Nano Processor
Nanoprocessor Assembly -> Nano Assembly
Elite Nanocomputer -> Nano Supercomputer
Nanoprocessor Mainframe -> Nano Mainframe

Quantumprocessor -> Quantum Processor
Quantumprocessor Assembly -> Quantum Assembly
Master Quantumcomputer -> Quantum Supercomputer
Quantumprocessor Mainframe -> Quantum Mainframe

Crystalprocessor -> Crystal Processor
Crystalprocessor Assembly -> Crystal Assembly
Ultimate Crystalcomputer -> Crystal Supercomputer
Crystalprocessor Mainframe -> Crystal Mainframe

Wetwareprocessor -> Wetware Processor
Wetwareprocessor Assembly -> Wetware Assembly
Wetware Supercomputer -> no change
Wetware Mainframe -> no change

Bioprocessor -> Bioware Processor
Biowareprocessor Assembly -> Bioware Assembly
Bioware Supercomputer -> no change
Bio Mainframe -> Bioware Mainframe

Optical Computer -> Optical Supercomputer

Exotic Computer -> Exotic Supercomputer

Cosmic Computer -> Cosmic Supercomputer

Temporally Transcendent Computer -> Temporally Transcendent Supercomputer


As mentioned, these changes also make the circuits show up neatly in nei
Search key 'processor'
Before:
![image](https://github.com/user-attachments/assets/37ee5d97-cff1-4780-a66d-7500c98fea3c)

After:
![image](https://github.com/user-attachments/assets/a7f33ab6-c599-4514-91b6-923626925081)
