### PR TITLE
Refactor recipemap backend modification callbacks

### DIFF
--- a/src/main/java/gregtech/api/interfaces/IRecipeMap.java
+++ b/src/main/java/gregtech/api/interfaces/IRecipeMap.java
@@ -17,19 +17,6 @@ import gregtech.api.util.GTUtility;
 public interface IRecipeMap {
 
     /**
-     * Add a downstream recipe map that will get to handle the original builder.
-     * <p>
-     * Downstream recipe maps got passed the recipe builder after parent recipe map is done with its business. Notice
-     * at this time the original recipe builder might be modified by the parent recipe map in some form, but it will
-     * remain as valid.
-     * <p>
-     * A downstream will only be invoked if parent recipe map added something.
-     *
-     * @param downstream the downstream recipe map to add
-     */
-    void addDownstream(IRecipeMap downstream);
-
-    /**
      * Actually add the recipe represented by the builder. CAN modify the builder's internal states!!!
      */
     @Nonnull
@@ -38,8 +25,6 @@ public interface IRecipeMap {
     /**
      * Return a variant of this recipe map that will perform a deep copy on input recipe builder before doing anything
      * to it.
-     * <p>
-     * The returned recipe map will not have any downstreams, but can accept new downstreams.
      */
     default IRecipeMap deepCopyInput() {
         return newRecipeMap(b -> doAdd(b.copy()));
@@ -48,13 +33,6 @@ public interface IRecipeMap {
     static IRecipeMap newRecipeMap(Function<? super GTRecipeBuilder, Collection<GTRecipe>> func) {
         return new IRecipeMap() {
 
-            private final Collection<IRecipeMap> downstreams = new ArrayList<>();
-
-            @Override
-            public void addDownstream(IRecipeMap downstream) {
-                downstreams.add(downstream);
-            }
-
             @Nonnull
             @Override
             public Collection<GTRecipe> doAdd(GTRecipeBuilder builder) {
@@ -62,11 +40,6 @@ public interface IRecipeMap {
                 Collection<GTRecipe> out = func.apply(builder);
                 ret.add(out);
                 builder.clearInvalid();
-                if (!out.isEmpty()) {
-                    for (IRecipeMap downstream : downstreams) {
-                        ret.add(downstream.doAdd(builder));
-                    }
-                }
                 return GTUtility.concat(ret);
             }
         };

--- a/src/main/java/gregtech/api/recipe/RecipeMap.java
+++ b/src/main/java/gregtech/api/recipe/RecipeMap.java
@@ -6,6 +6,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -107,9 +108,20 @@ public final class RecipeMap<B extends RecipeMapBackend> implements IRecipeMap {
         return frontend.getUIProperties().amperage;
     }
 
-    @Override
-    public void addDownstream(IRecipeMap downstream) {
-        backend.addDownstream(downstream);
+    /**
+     * Callback called before the recipe builder emits recipes. Can edit this builder to change this recipe, or
+     * use this information to add recipes elsewhere.
+     */
+    public void appendBuilderTransformer(Consumer<? super GTRecipeBuilder> builderTransformer) {
+        backend.properties.appendBuilderTransformer(builderTransformer);
+    }
+
+    /**
+     * Callback called after the recipe builder emits recipes, but before it is added to the map. Can edit this recipe
+     * for this map, or use this information to add recipes elsewhere.
+     */
+    public void appendRecipeTransformer(Consumer<? super GTRecipe> recipeTransformer) {
+        backend.properties.appendRecipeTransformer(recipeTransformer);
     }
 
     // region add recipe

--- a/src/main/java/gregtech/api/recipe/RecipeMapBackendProperties.java
+++ b/src/main/java/gregtech/api/recipe/RecipeMapBackendProperties.java
@@ -1,5 +1,6 @@
 package gregtech.api.recipe;
 
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 import javax.annotation.Nullable;
@@ -46,16 +47,16 @@ public final class RecipeMapBackendProperties {
      */
     public final Function<? super GTRecipeBuilder, ? extends Iterable<? extends GTRecipe>> recipeEmitter;
 
-    /**
-     * Runs a custom hook on all recipes added <b>via builder</b>.
-     */
     @Nullable
-    public final Function<? super GTRecipe, ? extends GTRecipe> recipeTransformer;
+    private Consumer<? super GTRecipeBuilder> builderTransformer;
+    @Nullable
+    private Consumer<? super GTRecipe> recipeTransformer;
 
     RecipeMapBackendProperties(int minItemInputs, int minFluidInputs, boolean specialSlotSensitive,
         boolean disableOptimize,
         Function<? super GTRecipeBuilder, ? extends Iterable<? extends GTRecipe>> recipeEmitter,
-        @Nullable Function<? super GTRecipe, ? extends GTRecipe> recipeTransformer) {
+        @Nullable Consumer<? super GTRecipeBuilder> builderTransformer,
+        @Nullable Consumer<? super GTRecipe> recipeTransformer) {
         if (minItemInputs < 0 || minFluidInputs < 0) {
             throw new IllegalArgumentException("minItemInputs and minFluidInputs cannot be negative");
         }
@@ -64,6 +65,43 @@ public final class RecipeMapBackendProperties {
         this.specialSlotSensitive = specialSlotSensitive;
         this.disableOptimize = disableOptimize;
         this.recipeEmitter = recipeEmitter;
+        this.builderTransformer = builderTransformer;
         this.recipeTransformer = recipeTransformer;
+    }
+
+    public void appendBuilderTransformer(Consumer<? super GTRecipeBuilder> builderTransformer) {
+        if (this.builderTransformer == null) {
+            this.builderTransformer = builderTransformer;
+        } else {
+            Consumer<? super GTRecipeBuilder> t = this.builderTransformer;
+            this.builderTransformer = b -> {
+                t.accept(b);
+                builderTransformer.accept(b);
+            };
+        }
+    }
+
+    public void appendRecipeTransformer(Consumer<? super GTRecipe> recipeTransformer) {
+        if (this.recipeTransformer == null) {
+            this.recipeTransformer = recipeTransformer;
+        } else {
+            Consumer<? super GTRecipe> t = this.recipeTransformer;
+            this.recipeTransformer = r -> {
+                t.accept(r);
+                recipeTransformer.accept(r);
+            };
+        }
+    }
+
+    public void transformBuilder(GTRecipeBuilder builder) {
+        if (builderTransformer != null) {
+            builderTransformer.accept(builder);
+        }
+    }
+
+    public void transformRecipe(GTRecipe recipe) {
+        if (recipeTransformer != null) {
+            recipeTransformer.accept(recipe);
+        }
     }
 }

--- a/src/main/java/gregtech/api/recipe/RecipeMapBuilder.java
+++ b/src/main/java/gregtech/api/recipe/RecipeMapBuilder.java
@@ -119,6 +119,16 @@ public final class RecipeMapBuilder<B extends RecipeMapBackend> {
     }
 
     /**
+     * Transformer which allows you to modify the recipe builder before it emits recipes.
+     * <br>
+     * Allows modification of the builder to modify this recipe, or adding recipes to other places based on the builder.
+     */
+    public RecipeMapBuilder<B> builderTransformer(Consumer<? super GTRecipeBuilder> builderTransformer) {
+        backendPropertiesBuilder.builderTransformer(builderTransformer);
+        return this;
+    }
+
+    /**
      * Changes how recipes are emitted by a particular recipe builder. Can emit multiple recipe per builder.
      */
     public RecipeMapBuilder<B> recipeEmitter(
@@ -164,52 +174,13 @@ public final class RecipeMapBuilder<B extends RecipeMapBackend> {
     }
 
     /**
-     * Runs a custom hook on all recipes added <b>via builder</b>. For more complicated behavior,
-     * use {@link #recipeEmitter}.
-     * <p>
-     * Recipes added via one of the overloads of addRecipe will NOT be affected by this function.
+     * Transformer which allows for modification of a recipe after it is "finalized" but before it is added to the map.
+     * <br>
+     * Allows modification of the recipe to change this map's recipe, or add this recipe copied and/or edited elsewhere.
      */
-    public RecipeMapBuilder<B> recipeTransformer(Function<? super GTRecipe, ? extends GTRecipe> recipeTransformer) {
+    public RecipeMapBuilder<B> recipeTransformer(Consumer<? super GTRecipe> recipeTransformer) {
         backendPropertiesBuilder.recipeTransformer(recipeTransformer);
         return this;
-    }
-
-    /**
-     * Runs a custom hook on all recipes added <b>via builder</b>. For more complicated behavior,
-     * use {@link #recipeEmitter}.
-     * <p>
-     * Recipes added via one of the overloads of addRecipe will NOT be affected by this function.
-     */
-    public RecipeMapBuilder<B> recipeTransformer(Consumer<GTRecipe> recipeTransformer) {
-        return recipeTransformer(withIdentityReturn(recipeTransformer));
-    }
-
-    /**
-     * Runs a custom hook on all recipes added <b>via builder</b>. For more complicated behavior,
-     * use {@link #recipeEmitter}.
-     * <p>
-     * Recipes added via one of the overloads of addRecipe will NOT be affected by this function.
-     * <p>
-     * Unlike {@link #recipeTransformer(Function)}, this one will not replace the existing special handler.
-     * The supplied function will be given the output of existing handler when a recipe is added.
-     */
-    public RecipeMapBuilder<B> chainRecipeTransformer(
-        Function<? super GTRecipe, ? extends GTRecipe> recipeTransformer) {
-        backendPropertiesBuilder.chainRecipeTransformer(recipeTransformer);
-        return this;
-    }
-
-    /**
-     * Runs a custom hook on all recipes added <b>via builder</b>. For more complicated behavior,
-     * use {@link #recipeEmitter}.
-     * <p>
-     * Recipes added via one of the overloads of addRecipe will NOT be affected by this function.
-     * <p>
-     * Unlike {@link #recipeTransformer(Function)}, this one will not replace the existing special handler.
-     * The supplied function will be given the output of existing handler when a recipe is added.
-     */
-    public RecipeMapBuilder<B> chainRecipeTransformer(Consumer<GTRecipe> recipeTransformer) {
-        return chainRecipeTransformer(withIdentityReturn(recipeTransformer));
     }
 
     // endregion

--- a/src/main/java/gregtech/api/recipe/RecipeMaps.java
+++ b/src/main/java/gregtech/api/recipe/RecipeMaps.java
@@ -44,7 +44,6 @@ import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.enums.TierEU;
 import gregtech.api.gui.modularui.GTUITextures;
-import gregtech.api.interfaces.IRecipeMap;
 import gregtech.api.objects.ItemData;
 import gregtech.api.recipe.maps.AssemblerBackend;
 import gregtech.api.recipe.maps.AssemblyLineFrontend;
@@ -1214,38 +1213,36 @@ public final class RecipeMaps {
         .build();
 
     static {
-        RecipeMaps.dieselFuels.addDownstream(
-            IRecipeMap.newRecipeMap(
-                b -> b.build()
-                    .map(
-                        r -> RecipeMaps.largeBoilerFakeFuels.getBackend()
-                            .addDieselRecipe(r))
-                    .map(Collections::singletonList)
-                    .orElse(Collections.emptyList())));
-        RecipeMaps.dieselFuels.addDownstream(IRecipeMap.newRecipeMap(b -> {
-            if (b.getMetadataOrDefault(FUEL_VALUE, 0) < 1500) return Collections.emptyList();
-            return b.addTo(RecipeMaps.extremeDieselFuels);
-        }));
-        RecipeMaps.denseLiquidFuels.addDownstream(
-            IRecipeMap.newRecipeMap(
-                b -> b.build()
-                    .map(
-                        r -> RecipeMaps.largeBoilerFakeFuels.getBackend()
-                            .addDenseLiquidRecipe(r))
-                    .map(Collections::singletonList)
-                    .orElse(Collections.emptyList())));
-        RecipeMaps.fermentingRecipes.addDownstream(
-            IRecipeMap.newRecipeMap(
-                b -> BartWorksRecipeMaps.bacterialVatRecipes.doAdd(
-                    b.copy()
-                        .special(BioItemList.getPetriDish(BioCultureLoader.generalPurposeFermentingBacteria))
-                        .metadata(GLASS, 3)
-                        .eut(b.getEUt()))));
-        RecipeMaps.implosionRecipes.addDownstream(
-            IRecipeMap.newRecipeMap(
-                b -> BartWorksRecipeMaps.electricImplosionCompressorRecipes.doAdd(
-                    b.copy()
-                        .duration(1 * TICK)
-                        .eut(TierEU.RECIPE_UEV))));
+        RecipeMaps.dieselFuels.appendBuilderTransformer(b -> {
+            b.copy()
+                .build()
+                .ifPresent(
+                    r -> RecipeMaps.largeBoilerFakeFuels.getBackend()
+                        .addDieselRecipe(r));
+            if (b.getMetadataOrDefault(FUEL_VALUE, 0) >= 1500) {
+                b.copy()
+                    .addTo(RecipeMaps.extremeDieselFuels);
+            }
+        });
+
+        RecipeMaps.denseLiquidFuels.appendBuilderTransformer(
+            b -> b.copy()
+                .build()
+                .ifPresent(
+                    r -> RecipeMaps.largeBoilerFakeFuels.getBackend()
+                        .addDenseLiquidRecipe(r)));
+
+        RecipeMaps.fermentingRecipes.appendBuilderTransformer(
+            b -> b.copy()
+                .special(BioItemList.getPetriDish(BioCultureLoader.generalPurposeFermentingBacteria))
+                .metadata(GLASS, 3)
+                .eut(b.getEUt())
+                .addTo(BartWorksRecipeMaps.bacterialVatRecipes));
+
+        RecipeMaps.implosionRecipes.appendBuilderTransformer(
+            b -> b.copy()
+                .duration(1 * TICK)
+                .eut(TierEU.RECIPE_UEV)
+                .addTo(BartWorksRecipeMaps.electricImplosionCompressorRecipes));
     }
 }

--- a/src/main/java/gregtech/api/recipe/RecipeMaps.java
+++ b/src/main/java/gregtech/api/recipe/RecipeMaps.java
@@ -477,6 +477,12 @@ public final class RecipeMaps {
         .maxIO(0, 0, 1, 1)
         .minInputs(0, 1)
         .progressBar(GTUITextures.PROGRESSBAR_ARROW_MULTIPLE)
+        .builderTransformer(
+            b -> b.copy()
+                .special(BioItemList.getPetriDish(BioCultureLoader.generalPurposeFermentingBacteria))
+                .metadata(GLASS, 3)
+                .eut(b.getEUt())
+                .addTo(BartWorksRecipeMaps.bacterialVatRecipes))
         .build();
     public static final RecipeMap<RecipeMapBackend> fluidSolidifierRecipes = RecipeMapBuilder
         .of("gt.recipe.fluidsolidifier")
@@ -744,6 +750,11 @@ public final class RecipeMaps {
                 .setInputs(input, GTModHandler.getIC2Item("industrialTnt", tITNT, null));
             return coll.getAll();
         })
+        .builderTransformer(
+            b -> b.copy()
+                .duration(1 * TICK)
+                .eut(TierEU.RECIPE_UEV)
+                .addTo(BartWorksRecipeMaps.electricImplosionCompressorRecipes))
         .build();
     public static final RecipeMap<RecipeMapBackend> vacuumFreezerRecipes = RecipeMapBuilder
         .of("gt.recipe.vacuumfreezer")
@@ -1028,6 +1039,17 @@ public final class RecipeMaps {
     public static final RecipeMap<FuelBackend> dieselFuels = RecipeMapBuilder
         .of("gt.recipe.dieselgeneratorfuel", FuelBackend::new)
         .maxIO(1, 1, 0, 0)
+        .builderTransformer(b -> {
+            b.copy()
+                .build()
+                .ifPresent(
+                    r -> RecipeMaps.largeBoilerFakeFuels.getBackend()
+                        .addDieselRecipe(r));
+            if (b.getMetadataOrDefault(FUEL_VALUE, 0) >= 1500) {
+                b.copy()
+                    .addTo(RecipeMaps.extremeDieselFuels);
+            }
+        })
         .neiSpecialInfoFormatter(FuelSpecialValueFormatter.INSTANCE)
         .build();
     public static final RecipeMap<FuelBackend> extremeDieselFuels = RecipeMapBuilder
@@ -1048,6 +1070,12 @@ public final class RecipeMaps {
     public static final RecipeMap<FuelBackend> denseLiquidFuels = RecipeMapBuilder
         .of("gt.recipe.semifluidboilerfuels", FuelBackend::new)
         .maxIO(1, 1, 0, 0)
+        .builderTransformer(
+            b -> b.copy()
+                .build()
+                .ifPresent(
+                    r -> RecipeMaps.largeBoilerFakeFuels.getBackend()
+                        .addDenseLiquidRecipe(r)))
         .disableRegisterNEI()
         .build();
     public static final RecipeMap<FuelBackend> plasmaFuels = RecipeMapBuilder
@@ -1211,38 +1239,4 @@ public final class RecipeMaps {
         .neiRecipeBackgroundSize(170, 60)
         .neiHandlerInfo(builder -> builder.setDisplayStack(GTModHandler.getIC2Item("nuclearReactor", 1, null)))
         .build();
-
-    static {
-        RecipeMaps.dieselFuels.appendBuilderTransformer(b -> {
-            b.copy()
-                .build()
-                .ifPresent(
-                    r -> RecipeMaps.largeBoilerFakeFuels.getBackend()
-                        .addDieselRecipe(r));
-            if (b.getMetadataOrDefault(FUEL_VALUE, 0) >= 1500) {
-                b.copy()
-                    .addTo(RecipeMaps.extremeDieselFuels);
-            }
-        });
-
-        RecipeMaps.denseLiquidFuels.appendBuilderTransformer(
-            b -> b.copy()
-                .build()
-                .ifPresent(
-                    r -> RecipeMaps.largeBoilerFakeFuels.getBackend()
-                        .addDenseLiquidRecipe(r)));
-
-        RecipeMaps.fermentingRecipes.appendBuilderTransformer(
-            b -> b.copy()
-                .special(BioItemList.getPetriDish(BioCultureLoader.generalPurposeFermentingBacteria))
-                .metadata(GLASS, 3)
-                .eut(b.getEUt())
-                .addTo(BartWorksRecipeMaps.bacterialVatRecipes));
-
-        RecipeMaps.implosionRecipes.appendBuilderTransformer(
-            b -> b.copy()
-                .duration(1 * TICK)
-                .eut(TierEU.RECIPE_UEV)
-                .addTo(BartWorksRecipeMaps.electricImplosionCompressorRecipes));
-    }
 }


### PR DESCRIPTION
Motivations:
- Downstream recipe maps are a convoluted design for their purpose
- There is no way to easily modify recipes as they are being added outside of 5u, for instance in external addons or in cases where load order makes creating this supplier complicated, resulting in code cruft with a static block in the recipemaps class

Changes:
- Remove downstream recipe maps
- Add a "builder transformer," which accepts the GTRecipeBuilder before it has emitted its recipes. This can be edited to change the recipes in this map, or the data can be used to create recipes in other maps
- Refactor the recipe transformer, simplifying it from a Recipe->Recipe function to a Consumer, as well as allowing recipe transformers to be attached outside of the recipemap builder

Recipe addition flow:
- Call the builder transformer
- Emit recipes from the builder
- Perform validation checks on each recipe
- Run the recipe transformer on each recipe
- Add the recipes to the map