### PR TITLE
Add general missing mappings handler

### DIFF
--- a/src/main/java/gregtech/GTMod.java
+++ b/src/main/java/gregtech/GTMod.java
@@ -16,7 +16,6 @@ import java.util.Map;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.CraftingManager;
 import net.minecraft.item.crafting.FurnaceRecipes;
@@ -45,7 +44,6 @@ import cpw.mods.fml.common.event.FMLServerAboutToStartEvent;
 import cpw.mods.fml.common.event.FMLServerStartedEvent;
 import cpw.mods.fml.common.event.FMLServerStartingEvent;
 import cpw.mods.fml.common.event.FMLServerStoppingEvent;
-import cpw.mods.fml.common.registry.GameRegistry;
 import galacticgreg.SpaceDimRegisterer;
 import gregtech.api.GregTechAPI;
 import gregtech.api.enchants.EnchantmentEnderDamage;
@@ -109,6 +107,7 @@ import gregtech.loaders.postload.GTWorldgenloader;
 import gregtech.loaders.postload.ItemMaxStacksizeLoader;
 import gregtech.loaders.postload.MachineRecipeLoader;
 import gregtech.loaders.postload.MachineTooltipsLoader;
+import gregtech.loaders.postload.MissingMappingsHandler;
 import gregtech.loaders.postload.PosteaTransformers;
 import gregtech.loaders.postload.RecyclerBlacklistLoader;
 import gregtech.loaders.postload.ScrapboxDropLoader;
@@ -747,17 +746,7 @@ public class GTMod implements IGTMod {
 
     @Mod.EventHandler
     public void onMissingMappings(FMLMissingMappingsEvent event) {
-        for (FMLMissingMappingsEvent.MissingMapping mapping : event.getAll()) {
-            if (mapping.type == GameRegistry.Type.BLOCK) {
-                if ("dreamcraft:gt.blockcasingsNH".equals(mapping.name)) {
-                    mapping.remap(GregTechAPI.sBlockCasingsNH);
-                }
-            } else if (mapping.type == GameRegistry.Type.ITEM) {
-                if ("dreamcraft:gt.blockcasingsNH".equals(mapping.name)) {
-                    mapping.remap(Item.getItemFromBlock(GregTechAPI.sBlockCasingsNH));
-                }
-            }
-        }
+        MissingMappingsHandler.handleMappings(event.getAll());
     }
 
     public static void logStackTrace(Throwable t) {

--- a/src/main/java/gregtech/loaders/postload/MissingMappingsHandler.java
+++ b/src/main/java/gregtech/loaders/postload/MissingMappingsHandler.java
@@ -1,0 +1,111 @@
+package gregtech.loaders.postload;
+
+import static gregtech.api.enums.Mods.GTPlusPlus;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import net.minecraft.block.Block;
+import net.minecraft.item.Item;
+
+import cpw.mods.fml.common.event.FMLMissingMappingsEvent;
+import cpw.mods.fml.common.registry.GameRegistry;
+import gregtech.api.GregTechAPI;
+import kubatech.loaders.BlockLoader;
+
+public class MissingMappingsHandler {
+
+    // spotless:off
+
+    private static final Remapper REMAPPER = new Remapper()
+        // Block remappings
+        .remapBlock("dreamcraft:gt.blockcasingsNH", GregTechAPI.sBlockCasingsNH)
+        .remapBlock("miscutils:oreCryolite", GameRegistry.findBlock(GTPlusPlus.ID, "oreCryoliteF"))
+        .remapBlock("miscutils:oreFluorite", GameRegistry.findBlock(GTPlusPlus.ID, "oreFluoriteF"))
+        .remapBlock("EMT:EMT_GTBLOCK_CASEING", BlockLoader.defcCasingBlock)
+
+        // Item remappings
+        .remapItem("miscutils:Ammonium", GameRegistry.findItem(GTPlusPlus.ID, "itemCellAmmonium"))
+        .remapItem("miscutils:Hydroxide", GameRegistry.findItem(GTPlusPlus.ID, "itemCellHydroxide"))
+        .remapItem("miscutils:BerylliumHydroxide", GameRegistry.findItem(GTPlusPlus.ID, "itemCellBerylliumHydroxide"))
+        .remapItem("miscutils:Bromine", GameRegistry.findItem(GTPlusPlus.ID, "itemCellBromine"))
+        .remapItem("miscutils:Krypton", GameRegistry.findItem(GTPlusPlus.ID, "itemCellKrypton"))
+        .remapItem("miscutils:itemCellZirconiumTetrafluoride", GameRegistry.findItem(GTPlusPlus.ID, "ZirconiumTetrafluoride"))
+        .remapItem("miscutils:Li2BeF4", GameRegistry.findItem(GTPlusPlus.ID, "itemCellLithiumTetrafluoroberyllate"))
+
+        .remapItem("miscutils:itemDustTinyCryolite", GameRegistry.findItem(GTPlusPlus.ID, "itemDustTinyCryoliteF"))
+        .remapItem("miscutils:itemDustSmallCryolite", GameRegistry.findItem(GTPlusPlus.ID, "itemDustSmallCryoliteF"))
+        .remapItem("miscutils:itemDustCryolite", GameRegistry.findItem(GTPlusPlus.ID, "itemDustCryoliteF"))
+        .remapItem("miscutils:dustPureCryolite", GameRegistry.findItem(GTPlusPlus.ID, "dustPureCryoliteF"))
+        .remapItem("miscutils:dustImpureCryolite", GameRegistry.findItem(GTPlusPlus.ID, "dustImpureCryoliteF"))
+        .remapItem("miscutils:crushedCryolite", GameRegistry.findItem(GTPlusPlus.ID, "crushedCryoliteF"))
+        .remapItem("miscutils:crushedPurifiedCryolite", GameRegistry.findItem(GTPlusPlus.ID, "crushedPurifiedCryoliteF"))
+        .remapItem("miscutils:crushedCentrifugedCryolite", GameRegistry.findItem(GTPlusPlus.ID, "crushedCentrifugedCryoliteF"))
+
+        .remapItem("miscutils:itemDustTinyFluorite", GameRegistry.findItem(GTPlusPlus.ID, "itemDustTinyFluoriteF"))
+        .remapItem("miscutils:itemDustSmallFluorite", GameRegistry.findItem(GTPlusPlus.ID, "itemDustSmallFluoriteF"))
+        .remapItem("miscutils:itemDustFluorite", GameRegistry.findItem(GTPlusPlus.ID, "itemDustFluoriteF"))
+        .remapItem("miscutils:dustPureFluorite", GameRegistry.findItem(GTPlusPlus.ID, "dustPureFluoriteF"))
+        .remapItem("miscutils:dustImpureFluorite", GameRegistry.findItem(GTPlusPlus.ID, "dustImpureFluoriteF"))
+        .remapItem("miscutils:crushedFluorite", GameRegistry.findItem(GTPlusPlus.ID, "crushedFluoriteF"))
+        .remapItem("miscutils:crushedPurifiedFluorite", GameRegistry.findItem(GTPlusPlus.ID, "crushedPurifiedFluoriteF"))
+        .remapItem("miscutils:crushedCentrifugedFluorite", GameRegistry.findItem(GTPlusPlus.ID, "crushedCentrifugedFluoriteF"))
+
+        // Ignores
+        .ignore("kekztech:kekztech_tfftcasingblock_block")
+        .ignore("kekztech:kekztech_tfftmultihatch_block")
+        .ignore("kekztech:kekztech_tfftstoragefieldblock1_block")
+        .ignore("kekztech:kekztech_tfftstoragefieldblock2_block")
+        .ignore("kekztech:kekztech_tfftstoragefieldblock3_block")
+        .ignore("kekztech:kekztech_tfftstoragefieldblock4_block")
+        .ignore("kekztech:kekztech_tfftstoragefieldblock5_block")
+
+        .ignore("miscutils:itemPlateMeatRaw");
+
+    // spotless:on
+
+    public static void handleMappings(List<FMLMissingMappingsEvent.MissingMapping> mappings) {
+        for (FMLMissingMappingsEvent.MissingMapping mapping : mappings) {
+            if (REMAPPER.ignoreMappings.contains(mapping.name) || mapping.name.startsWith("Australia:")) {
+                mapping.ignore();
+                continue;
+            }
+
+            if (mapping.type == GameRegistry.Type.BLOCK) {
+                Block block = REMAPPER.blockRemappings.get(mapping.name);
+                if (block != null) {
+                    mapping.remap(block);
+                }
+            } else if (mapping.type == GameRegistry.Type.ITEM) {
+                Item item = REMAPPER.itemRemappings.get(mapping.name);
+                if (item != null) {
+                    mapping.remap(item);
+                }
+            }
+        }
+    }
+
+    private static class Remapper {
+
+        private final Map<String, Item> itemRemappings = new HashMap<>();
+        private final Map<String, Block> blockRemappings = new HashMap<>();
+        private final List<String> ignoreMappings = new ArrayList<>();
+
+        public Remapper remapBlock(String oldName, Block newBlock) {
+            blockRemappings.put(oldName, newBlock);
+            return remapItem(oldName, Item.getItemFromBlock(newBlock));
+        }
+
+        public Remapper remapItem(String oldName, Item newItem) {
+            itemRemappings.put(oldName, newItem);
+            return this;
+        }
+
+        public Remapper ignore(String oldName) {
+            ignoreMappings.add(oldName);
+            return this;
+        }
+    }
+}

--- a/src/main/java/gtPlusPlus/GTplusplus.java
+++ b/src/main/java/gtPlusPlus/GTplusplus.java
@@ -1,15 +1,10 @@
 package gtPlusPlus;
 
-import static gregtech.api.enums.Mods.GTPlusPlus;
 import static gregtech.api.enums.Mods.Names;
 import static gregtech.api.enums.Mods.Thaumcraft;
 
-import java.util.HashMap;
-
-import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.launchwrapper.Launch;
 
@@ -21,12 +16,9 @@ import cpw.mods.fml.common.Mod.EventHandler;
 import cpw.mods.fml.common.SidedProxy;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLLoadCompleteEvent;
-import cpw.mods.fml.common.event.FMLMissingMappingsEvent;
-import cpw.mods.fml.common.event.FMLMissingMappingsEvent.MissingMapping;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import cpw.mods.fml.common.event.FMLServerStartingEvent;
-import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import gregtech.api.GregTechAPI;
@@ -279,98 +271,6 @@ public class GTplusplus {
         Material.invalidMaterials.add(Materials.Soularium);
         Material.invalidMaterials.add(Materials.PhasedIron);
 
-    }
-
-    private static final HashMap<String, Item> sMissingItemMappings = new HashMap<>();
-    private static final HashMap<String, Block> sMissingBlockMappings = new HashMap<>();
-
-    private static void processMissingMappings() {
-        sMissingItemMappings.put("miscutils:Ammonium", GameRegistry.findItem(GTPlusPlus.ID, "itemCellAmmonium"));
-        sMissingItemMappings.put("miscutils:Hydroxide", GameRegistry.findItem(GTPlusPlus.ID, "itemCellHydroxide"));
-        sMissingItemMappings.put(
-            "miscutils:BerylliumHydroxide",
-            GameRegistry.findItem(GTPlusPlus.ID, "itemCellmiscutils:BerylliumHydroxide"));
-        sMissingItemMappings.put("miscutils:Bromine", GameRegistry.findItem(GTPlusPlus.ID, "itemCellBromine"));
-        sMissingItemMappings.put("miscutils:Krypton", GameRegistry.findItem(GTPlusPlus.ID, "itemCellKrypton"));
-        sMissingItemMappings.put(
-            "miscutils:itemCellZirconiumTetrafluoride",
-            GameRegistry.findItem(GTPlusPlus.ID, "ZirconiumTetrafluoride"));
-        sMissingItemMappings
-            .put("miscutils:Li2BeF4", GameRegistry.findItem(GTPlusPlus.ID, "itemCellLithiumTetrafluoroberyllate"));
-
-        // Cryolite
-        sMissingBlockMappings.put("miscutils:oreCryolite", GameRegistry.findBlock(GTPlusPlus.ID, "oreCryoliteF"));
-        sMissingItemMappings
-            .put("miscutils:itemDustTinyCryolite", GameRegistry.findItem(GTPlusPlus.ID, "itemDustTinyCryoliteF"));
-        sMissingItemMappings
-            .put("miscutils:itemDustSmallCryolite", GameRegistry.findItem(GTPlusPlus.ID, "itemDustSmallCryoliteF"));
-        sMissingItemMappings
-            .put("miscutils:itemDustCryolite", GameRegistry.findItem(GTPlusPlus.ID, "itemDustCryoliteF"));
-        sMissingItemMappings
-            .put("miscutils:dustPureCryolite", GameRegistry.findItem(GTPlusPlus.ID, "dustPureCryoliteF"));
-        sMissingItemMappings
-            .put("miscutils:dustImpureCryolite", GameRegistry.findItem(GTPlusPlus.ID, "dustImpureCryoliteF"));
-        sMissingItemMappings.put("miscutils:crushedCryolite", GameRegistry.findItem(GTPlusPlus.ID, "crushedCryoliteF"));
-        sMissingItemMappings
-            .put("miscutils:crushedPurifiedCryolite", GameRegistry.findItem(GTPlusPlus.ID, "crushedPurifiedCryoliteF"));
-        sMissingItemMappings.put(
-            "miscutils:crushedCentrifugedCryolite",
-            GameRegistry.findItem(GTPlusPlus.ID, "crushedCentrifugedCryoliteF"));
-        sMissingItemMappings.put("miscutils:oreCryolite", GameRegistry.findItem(GTPlusPlus.ID, "oreCryoliteF"));
-
-        // Fluorite
-        sMissingBlockMappings.put("miscutils:oreFluorite", GameRegistry.findBlock(GTPlusPlus.ID, "oreFluoriteF"));
-        sMissingItemMappings
-            .put("miscutils:itemDustTinyFluorite", GameRegistry.findItem(GTPlusPlus.ID, "itemDustTinyFluoriteF"));
-        sMissingItemMappings
-            .put("miscutils:itemDustSmallFluorite", GameRegistry.findItem(GTPlusPlus.ID, "itemDustSmallFluoriteF"));
-        sMissingItemMappings
-            .put("miscutils:itemDustFluorite", GameRegistry.findItem(GTPlusPlus.ID, "itemDustFluoriteF"));
-        sMissingItemMappings
-            .put("miscutils:dustPureFluorite", GameRegistry.findItem(GTPlusPlus.ID, "dustPureFluoriteF"));
-        sMissingItemMappings
-            .put("miscutils:dustImpureFluorite", GameRegistry.findItem(GTPlusPlus.ID, "dustImpureFluoriteF"));
-        sMissingItemMappings.put("miscutils:crushedFluorite", GameRegistry.findItem(GTPlusPlus.ID, "crushedFluoriteF"));
-        sMissingItemMappings
-            .put("miscutils:crushedPurifiedFluorite", GameRegistry.findItem(GTPlusPlus.ID, "crushedPurifiedFluoriteF"));
-        sMissingItemMappings.put(
-            "miscutils:crushedCentrifugedFluorite",
-            GameRegistry.findItem(GTPlusPlus.ID, "crushedCentrifugedFluoriteF"));
-        sMissingItemMappings.put("miscutils:oreFluorite", GameRegistry.findItem(GTPlusPlus.ID, "oreFluoriteF"));
-    }
-
-    @EventHandler
-    public void missingMapping(FMLMissingMappingsEvent event) {
-        processMissingMappings();
-        for (MissingMapping mapping : event.getAll()) {
-            if (mapping.name.startsWith("Australia:")) {
-                mapping.ignore();
-                continue;
-            }
-            if (mapping.type == GameRegistry.Type.ITEM) {
-                Item aReplacement = sMissingItemMappings.get(mapping.name);
-                if (aReplacement != null) {
-                    remap(aReplacement, mapping);
-                }
-
-            } else if (mapping.type == GameRegistry.Type.BLOCK) {
-                Block aReplacement = sMissingBlockMappings.get(mapping.name);
-                if (aReplacement != null) {
-                    remap(aReplacement, mapping);
-                }
-
-            }
-        }
-    }
-
-    private static void remap(Item item, FMLMissingMappingsEvent.MissingMapping mapping) {
-        mapping.remap(item);
-        Logger.INFO("Remapping item " + mapping.name + " to " + GTPlusPlus.ID + ":" + item.getUnlocalizedName());
-    }
-
-    private static void remap(Block block, FMLMissingMappingsEvent.MissingMapping mapping) {
-        mapping.remap(block);
-        Logger.INFO("Remapping block " + mapping.name + " to " + GTPlusPlus.ID + ":" + block.getUnlocalizedName());
     }
 
     private static void fixVanillaOreDict() {

--- a/src/main/java/kekztech/KekzCore.java
+++ b/src/main/java/kekztech/KekzCore.java
@@ -1,17 +1,11 @@
 package kekztech;
 
-import java.util.List;
-import java.util.Set;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-
-import com.google.common.collect.ImmutableSet;
 
 import cpw.mods.fml.common.Mod;
 import cpw.mods.fml.common.SidedProxy;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
-import cpw.mods.fml.common.event.FMLMissingMappingsEvent;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import gregtech.GT_Version;
@@ -63,25 +57,5 @@ public class KekzCore {
     @Mod.EventHandler
     public void postInit(FMLPostInitializationEvent event) {
         proxy.postInit(event);
-    }
-
-    @Mod.EventHandler
-    public void onMissingMapping(FMLMissingMappingsEvent event) {
-        List<FMLMissingMappingsEvent.MissingMapping> missingMappings = event.get();
-
-        // intentionally not a static final field to save a bit of ram.
-        Set<String> removedStuff = ImmutableSet.of(
-            MODID + ":kekztech_tfftcasingblock_block",
-            MODID + ":kekztech_tfftmultihatch_block",
-            MODID + ":kekztech_tfftstoragefieldblock1_block",
-            MODID + ":kekztech_tfftstoragefieldblock2_block",
-            MODID + ":kekztech_tfftstoragefieldblock3_block",
-            MODID + ":kekztech_tfftstoragefieldblock4_block",
-            MODID + ":kekztech_tfftstoragefieldblock5_block");
-
-        for (FMLMissingMappingsEvent.MissingMapping mapping : missingMappings) {
-            if (removedStuff.contains(mapping.name)) mapping.ignore();
-            else mapping.warn(); // we don't know what happened. probably warn the user.
-        }
     }
 }

--- a/src/main/java/kubatech/kubatech.java
+++ b/src/main/java/kubatech/kubatech.java
@@ -35,7 +35,6 @@ import cpw.mods.fml.common.Mod;
 import cpw.mods.fml.common.SidedProxy;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLLoadCompleteEvent;
-import cpw.mods.fml.common.event.FMLMissingMappingsEvent;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import cpw.mods.fml.common.event.FMLServerAboutToStartEvent;
@@ -44,10 +43,8 @@ import cpw.mods.fml.common.event.FMLServerStartingEvent;
 import cpw.mods.fml.common.event.FMLServerStoppedEvent;
 import cpw.mods.fml.common.event.FMLServerStoppingEvent;
 import cpw.mods.fml.common.network.simpleimpl.SimpleNetworkWrapper;
-import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 import kubatech.api.enums.ItemList;
-import kubatech.loaders.BlockLoader;
 import kubatech.network.CustomTileEntityPacket;
 import kubatech.network.LoadConfigPacket;
 
@@ -163,16 +160,6 @@ public class kubatech {
     @Mod.EventHandler
     public void loadComplete(FMLLoadCompleteEvent event) {
         proxy.loadComplete(event);
-    }
-
-    @Mod.EventHandler
-    public void missingMappings(FMLMissingMappingsEvent event) {
-        for (FMLMissingMappingsEvent.MissingMapping missingMapping : event.getAll()) {
-            if (missingMapping.name.equals("EMT:EMT_GTBLOCK_CASEING")) {
-                if (missingMapping.type == GameRegistry.Type.BLOCK) missingMapping.remap(BlockLoader.defcCasingBlock);
-                else missingMapping.remap(Item.getItemFromBlock(BlockLoader.defcCasingBlock));
-            }
-        }
     }
 
     public static void debug(String message) {


### PR DESCRIPTION
Organizes the missing mappings handlers into one place, and makes a small remapper class to make adding more here easy. We should use this whenever removing things in the future to avoid the message saying something was removed