### PR TITLE
if shift click on select item mui, then close after callback

### DIFF
--- a/src/main/java/gregtech/common/gui/modularui/uifactory/SelectItemUIFactory.java
+++ b/src/main/java/gregtech/common/gui/modularui/uifactory/SelectItemUIFactory.java
@@ -173,6 +173,10 @@ public class SelectItemUIFactory {
                     setSelected(UNSELECTED, widget);
                 }
                 selectedCallback.accept(getCandidate(getSelected()));
+                if (clickData.shift) {
+                    widget.getWindow()
+                        .tryClose();
+                }
             })
                 .setSynced(false, false)
                 .dynamicTooltip(() -> getItemTooltips(index))


### PR DESCRIPTION
If the player shift clicks a circuit in the ghost circuit selector, it should confirm it at the same time so the player does not have to manually close the window.