### PR TITLE
Generate recycling recipes for nuclear gt++ mats

### DIFF
--- a/src/main/java/gtPlusPlus/core/material/MaterialGenerator.java
+++ b/src/main/java/gtPlusPlus/core/material/MaterialGenerator.java
@@ -291,9 +291,9 @@ public class MaterialGenerator {
             if (!disableOptionalRecipes) {
                 new RecipeGenShapedCrafting(matInfo);
                 new RecipeGenMaterialProcessing(matInfo);
-                new RecipeGenRecycling(matInfo);
             }
 
+            new RecipeGenRecycling(matInfo);
             new RecipeGenFluids(matInfo);
             new RecipeGenMetalRecipe(matInfo);
             new RecipeGenDustGeneration(matInfo, disableOptionalRecipes);


### PR DESCRIPTION
Materials like curium, fermium and neptunium cannot be turned into dust. This PR fixes that.