### PR TITLE
Restore MTEHatchEnergy inventory size + description constructor

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEHatchEnergy.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEHatchEnergy.java
@@ -23,6 +23,12 @@ public class MTEHatchEnergy extends MTEHatch {
             new String[] { "Energy Injector for Multiblocks", "Accepts up to 2 Amps" });
     }
 
+    @SuppressWarnings("unused") // needed in an addon
+    public MTEHatchEnergy(int aID, String aName, String aNameRegional, int aTier, int aInventorySize,
+        String[] aDescriptionArray) {
+        super(aID, aName, aNameRegional, aTier, aInventorySize, aDescriptionArray);
+    }
+
     public MTEHatchEnergy(String aName, int aTier, String[] aDescription, ITexture[][][] aTextures) {
         super(aName, aTier, 0, aDescription, aTextures);
     }


### PR DESCRIPTION
Needed for an addon here: https://github.com/Nxer/Twist-Space-Technology-Mod/blob/main/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/singleBlock/hatch/GT_Hatch_BufferedEnergyHatch.java

Was removed in #3961 