### PR TITLE
Distinguish wireless multiamp and wireless laser

### DIFF
--- a/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchWirelessMulti.java
+++ b/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchWirelessMulti.java
@@ -76,6 +76,12 @@ public class MTEHatchWirelessMulti extends MTEHatchEnergyMulti {
             aAmp);
     }
 
+    @Override
+    public int getHatchType() {
+        // If amperage is > 64, this is a "wireless laser" and should not be usable on multi-amp only machines
+        return maxAmperes <= 64 ? 1 : 2;
+    }
+
     public MTEHatchWirelessMulti(String aName, int aTier, int aAmp, String[] aDescription, ITexture[][][] aTextures) {
         super(aName, aTier, aAmp, aDescription, aTextures);
     }


### PR DESCRIPTION
Due to an oversight, multiamp-only machines like HILE can currently take the so-called "wireless laser" hatches and far exceed their intended power input. Fixes it.