### PR TITLE
Fixed aDismantleable being Ignored in GTShapelessRecipe

### DIFF
--- a/src/main/java/gregtech/api/util/GTModHandler.java
+++ b/src/main/java/gregtech/api/util/GTModHandler.java
@@ -1362,6 +1362,7 @@ public class GTModHandler {
         if (sBufferCraftingRecipes && aBuffered) sBufferRecipeList.add(
             new GTShapelessRecipe(
                 GTUtility.copyOrNull(aResult),
+                aDismantleable,
                 aRemovable,
                 aKeepNBT,
                 overwriteNBT,
@@ -1371,6 +1372,7 @@ public class GTModHandler {
         else GameRegistry.addRecipe(
             new GTShapelessRecipe(
                 GTUtility.copyOrNull(aResult),
+                aDismantleable,
                 aRemovable,
                 aKeepNBT,
                 overwriteNBT,

--- a/src/main/java/gregtech/api/util/GTShapelessRecipe.java
+++ b/src/main/java/gregtech/api/util/GTShapelessRecipe.java
@@ -20,7 +20,7 @@ public class GTShapelessRecipe extends ShapelessOreRecipe implements IGTCrafting
     private final Enchantment[] mEnchantmentsAdded;
     private final int[] mEnchantmentLevelsAdded;
 
-    public GTShapelessRecipe(ItemStack aResult, boolean aRemovableByGT, boolean aKeepingNBT, boolean overwriteNBT,
+    public GTShapelessRecipe(ItemStack aResult, boolean aDismantleable, boolean aRemovableByGT, boolean aKeepingNBT, boolean overwriteNBT,
         Enchantment[] aEnchantmentsAdded, int[] aEnchantmentLevelsAdded, Object... aRecipe) {
         super(aResult, aRecipe);
         mEnchantmentsAdded = aEnchantmentsAdded;

--- a/src/main/java/gregtech/api/util/GTShapelessRecipe.java
+++ b/src/main/java/gregtech/api/util/GTShapelessRecipe.java
@@ -20,8 +20,8 @@ public class GTShapelessRecipe extends ShapelessOreRecipe implements IGTCrafting
     private final Enchantment[] mEnchantmentsAdded;
     private final int[] mEnchantmentLevelsAdded;
 
-    public GTShapelessRecipe(ItemStack aResult, boolean aDismantleable, boolean aRemovableByGT, boolean aKeepingNBT, boolean overwriteNBT,
-        Enchantment[] aEnchantmentsAdded, int[] aEnchantmentLevelsAdded, Object... aRecipe) {
+    public GTShapelessRecipe(ItemStack aResult, boolean aDismantleable, boolean aRemovableByGT, boolean aKeepingNBT,
+        boolean overwriteNBT, Enchantment[] aEnchantmentsAdded, int[] aEnchantmentLevelsAdded, Object... aRecipe) {
         super(aResult, aRecipe);
         mEnchantmentsAdded = aEnchantmentsAdded;
         mEnchantmentLevelsAdded = aEnchantmentLevelsAdded;


### PR DESCRIPTION
It should be mistakenly removed in <https://github.com/GTNewHorizons/GT5-Unofficial/commit/07cc2ec931b0e479026e78298a7bd926019c9334>.

[My mod injection](https://github.com/ElytraServers/gtnh-no-nerf/blob/master/src/mixin/java/cn/elytra/mod/gtnn/mixin/gt5u/DisassemblerReversedRecipe_GTShapelessRecipe_Mixin.java) depends on it to classify if a recipe is able to be disassembled.