### PR TITLE
Fix integer division in LINAC energy calculation

### DIFF
--- a/src/main/java/gtnhlanth/common/tileentity/MTELINAC.java
+++ b/src/main/java/gtnhlanth/common/tileentity/MTELINAC.java
@@ -351,7 +351,7 @@ public class MTELINAC extends MTEEnhancedMultiBlockBase<MTELINAC> implements ISu
         // 1A of full power if one energy hatch, 4A if two
         long voltage = (this.mEnergyHatches.size() == 1) ? this.getMaxInputVoltage() : this.getMaxInputPower();
 
-        machineEnergy = (float) Math.max(length / 4 * Math.pow(voltage, 1.0 / 3.0), 50); // Minimum of 50keV
+        machineEnergy = (float) Math.max(length / 4.0 * Math.pow(voltage, 1.0 / 3.0), 50); // Minimum of 50keV
 
         inputEnergy = this.getInputInformation()
             .getEnergy();


### PR DESCRIPTION
Changed length/4 component of LINAC output energy calculation to use floats. Integer division added significant confusion to people assuming this is float division. Integer division effectively makes half the lengths useless, and given the overall float cast was probably unintentional. Other length calculations are fine.

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19140