### PR TITLE
Fix black hole utility hatch gui not opening

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/compressor/MTEBlackHoleUtility.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/compressor/MTEBlackHoleUtility.java
@@ -48,6 +48,11 @@ public class MTEBlackHoleUtility extends MTEHatch {
     }
 
     @Override
+    public boolean isAccessAllowed(EntityPlayer player) {
+        return true;
+    }
+
+    @Override
     public boolean isFacingValid(ForgeDirection facing) {
         return true;
     }


### PR DESCRIPTION
It works fine in dev environment. This method I have added is flagged as "identical to super", which it 100% is. I have no idea why reimplementing this method makes the gui work in full pack, nor do I want to.