### PR TITLE
Add recipes for tiny GTPP pipes

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechConduits.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechConduits.java
@@ -768,7 +768,19 @@ public class GregtechConduits {
 
         int eut = (int) (8 * vMulti);
 
-        // Add the Three Shaped Recipes First
+        // Add the Four Shaped Recipes First
+        RecipeUtils.addShapedRecipe(
+            pipePlate,
+            pipePlate,
+            pipePlate,
+            "craftingToolHardHammer",
+            null,
+            "craftingToolWrench",
+            pipePlate,
+            pipePlate,
+            pipePlate,
+            ItemUtils.getItemStackOfAmountFromOreDict("pipe" + "Tiny" + output, 8));
+
         RecipeUtils.addShapedRecipe(
             pipePlate,
             "craftingToolWrench",


### PR DESCRIPTION
Resolves [Tiny Potin Fluid Pipe and others have no shaped crafting Recipe #19247](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19247).