### PR TITLE
Fix non gt item covers not working when sneaking

### DIFF
--- a/src/main/java/gregtech/mixin/Mixin.java
+++ b/src/main/java/gregtech/mixin/Mixin.java
@@ -61,6 +61,11 @@ public enum Mixin {
         .setApplyIf(() -> true)
         .setPhase(Phase.EARLY)
         .setSide(Side.BOTH)),
+    ItemMixinCoverFix(new Builder("Allow cover items to bypass sneak checks").addMixinClasses("minecraft.ItemMixin")
+        .addTargetedMod(VANILLA)
+        .setApplyIf(() -> true)
+        .setPhase(Phase.EARLY)
+        .setSide(Side.BOTH)),
 
     VanillaToolChanges(
         new Builder("Changes wooden tools to be a little faster").addMixinClasses("minecraft.ItemToolMaterialMixin")

--- a/src/mixin/java/gregtech/mixin/mixins/early/minecraft/ItemMixin.java
+++ b/src/mixin/java/gregtech/mixin/mixins/early/minecraft/ItemMixin.java
@@ -1,0 +1,26 @@
+package gregtech.mixin.mixins.early.minecraft;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.Item;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import com.llamalad7.mixinextras.sugar.Local;
+
+import gregtech.api.covers.CoverRegistry;
+
+@Mixin(Item.class)
+public class ItemMixin {
+
+    @ModifyReturnValue(method = "doesSneakBypassUse", at = @At("RETURN"), remap = false)
+    private boolean gt5u$checkCoverShift(boolean original, @Local(argsOnly = true) EntityPlayer player) {
+        // player.getHeldItem() has already been null checked
+        if (CoverRegistry.isCover(player.getHeldItem())) {
+            return true;
+        }
+        return original;
+    }
+
+}


### PR DESCRIPTION
Paper and facades for example use the default return value of `false` for `doesSneakBypassUse`

Might have some knock on effects though