### PR TITLE
Lsc wireless info

### DIFF
--- a/src/main/java/kekztech/common/tileentities/MTELapotronicSuperCapacitor.java
+++ b/src/main/java/kekztech/common/tileentities/MTELapotronicSuperCapacitor.java
@@ -129,7 +129,7 @@ public class MTELapotronicSuperCapacitor extends MTEEnhancedMultiBlockBase<MTELa
 
     private final LongRunningAverage wirelessEnergyInputValues1h = new LongRunningAverage(3600 * 20);
     private final LongRunningAverage wirelessEnergyOutputValues1h = new LongRunningAverage(3600 * 20);
-    
+
     private final LongData wirelessEnergyInputValues5m = wirelessEnergyInputValues1h.view(5 * 60 * 20);
     private final LongData wirelessEnergyOutputValues5m = wirelessEnergyOutputValues1h.view(5 * 60 * 20);
 
@@ -923,14 +923,16 @@ public class MTELapotronicSuperCapacitor extends MTEEnhancedMultiBlockBase<MTELa
     }
 
     private String getWirelessTimeTo() {
-        BigInteger avgOutWireless = BigInteger.valueOf(wirelessEnergyOutputValues5m.avgLong()); 
-        BigInteger wirelessStored = new BigInteger(WirelessNetworkManager.getUserEU(global_energy_user_uuid).toString());
-        
+        BigInteger avgOutWireless = BigInteger.valueOf(wirelessEnergyOutputValues5m.avgLong());
+        BigInteger wirelessStored = new BigInteger(
+            WirelessNetworkManager.getUserEU(global_energy_user_uuid)
+                .toString());
+
         // If average output is greater than zero, calculate time to empty
         if (avgOutWireless.compareTo(BigInteger.ZERO) > 0) {
             BigInteger timeToEmptyTicks = wirelessStored.divide(avgOutWireless);
             BigInteger timeToEmptySeconds = timeToEmptyTicks.divide(BigInteger.valueOf(20));
-            
+
             long seconds = timeToEmptySeconds.longValueExact();
             return "Wireless Time to Empty: " + formatTime(seconds, false);
         } else {

--- a/src/main/java/kekztech/common/tileentities/MTELapotronicSuperCapacitor.java
+++ b/src/main/java/kekztech/common/tileentities/MTELapotronicSuperCapacitor.java
@@ -929,15 +929,15 @@ public class MTELapotronicSuperCapacitor extends MTEEnhancedMultiBlockBase<MTELa
         // If average output is greater than zero, calculate time to empty
         if (avgOutWireless.compareTo(BigInteger.ZERO) > 0) {
             BigInteger timeToEmptyTicks = wirelessStored.divide(avgOutWireless);
-            BigInteger timeToEmptySeconds = timeToEmptyTicks.divide(BigInteger.valueOf(20));  // Convert ticks to seconds if necessary
-    
-            // Format the time output
-            return "Wireless Time to Empty: " + formatTime(timeToEmptySeconds, false);
+            BigInteger timeToEmptySeconds = timeToEmptyTicks.divide(BigInteger.valueOf(20));
+            
+            long seconds = timeToEmptySeconds.longValueExact();
+            return "Wireless Time to Empty: " + formatTime(seconds, false);
         } else {
             return "Currently Filling Wireless";
         }
     }
-    
+
     private String getCapacityCache() {
         return capacity.compareTo(guiCapacityStoredReformatLimit) > 0 ? standardFormat.format(capacity)
             : numberFormat.format(capacity);

--- a/src/main/java/kekztech/common/tileentities/MTELapotronicSuperCapacitor.java
+++ b/src/main/java/kekztech/common/tileentities/MTELapotronicSuperCapacitor.java
@@ -127,8 +127,11 @@ public class MTELapotronicSuperCapacitor extends MTEEnhancedMultiBlockBase<MTELa
     private final LongData energyInputValues5m = energyInputValues1h.view(5 * 60 * 20);
     private final LongData energyOutputValues5m = energyOutputValues1h.view(5 * 60 * 20);
 
-    private Average wirelessEnergyInputValues5m = new Average();
-    private Average wirelessEnergyOutputValues5m = new Average();
+    private final LongRunningAverage wirelessEnergyInputValues1h = new LongRunningAverage(3600 * 20);
+    private final LongRunningAverage wirelessEnergyOutputValues1h = new LongRunningAverage(3600 * 20);
+    
+    private final LongData wirelessEnergyInputValues5m = wirelessEnergyInputValues1h.view(5 * 60 * 20);
+    private final LongData wirelessEnergyOutputValues5m = wirelessEnergyOutputValues1h.view(5 * 60 * 20);
 
     private final long max_passive_drain_eu_per_tick_per_uhv_cap = 1_000_000;
     private final long max_passive_drain_eu_per_tick_per_uev_cap = 100_000_000;

--- a/src/main/java/kekztech/common/tileentities/MTELapotronicSuperCapacitor.java
+++ b/src/main/java/kekztech/common/tileentities/MTELapotronicSuperCapacitor.java
@@ -923,25 +923,21 @@ public class MTELapotronicSuperCapacitor extends MTEEnhancedMultiBlockBase<MTELa
     }
 
     private String getWirelessTimeTo() {
-        double avgInWireless = wirelessEnergyInputValues5m.avgLong();
-        double avgOutWireless = wirelessEnergyOutputValues5m.avgLong();
-        double wirelessCap = WirelessNetworkManager.getCapacity(global_energy_user_uuid);
-        double wirelessStored = WirelessNetworkManager.getStored(global_energy_user_uuid);
-
-        if (avgInWireless >= avgOutWireless) {
-            // Calculate time to full if charging
-            if (avgInWireless > 0) {
-                double timeToFullWireless = (wirelessCap - wirelessStored) / (avgInWireless - (avgOutWireless)) / 20;
-                return "Wireless Time to Full: " + formatTime(timeToFullWireless, true);
-            }
-            return "Wireless Time to Something: Infinity years";
+        BigInteger avgOutWireless = BigInteger.valueOf(wirelessEnergyOutputValues5m.avgLong()); 
+        BigInteger wirelessStored = new BigInteger(WirelessNetworkManager.getUserEU(global_energy_user_uuid).toString());
+        
+        // If average output is greater than zero, calculate time to empty
+        if (avgOutWireless.compareTo(BigInteger.ZERO) > 0) {
+            BigInteger timeToEmptyTicks = wirelessStored.divide(avgOutWireless);
+            BigInteger timeToEmptySeconds = timeToEmptyTicks.divide(BigInteger.valueOf(20));  // Convert ticks to seconds if necessary
+    
+            // Format the time output
+            return "Wireless Time to Empty: " + formatTime(timeToEmptySeconds, false);
         } else {
-            // Calculate time to empty if discharging
-            double timeToEmptyWireless = wirelessStored / ((avgOutWireless) - avgInWireless) / 20;
-            return "Wireless Time to Empty: " + formatTime(timeToEmptyWireless, false);
+            return "Currently Filling Wireless";
         }
     }
-
+    
     private String getCapacityCache() {
         return capacity.compareTo(guiCapacityStoredReformatLimit) > 0 ? standardFormat.format(capacity)
             : numberFormat.format(capacity);

--- a/src/main/java/kekztech/common/tileentities/MTELapotronicSuperCapacitor.java
+++ b/src/main/java/kekztech/common/tileentities/MTELapotronicSuperCapacitor.java
@@ -923,8 +923,8 @@ public class MTELapotronicSuperCapacitor extends MTEEnhancedMultiBlockBase<MTELa
         double avgInWireless = wirelessEnergyInputValues5m.avgLong();
         double avgOutWireless = wirelessEnergyOutputValues5m.avgLong();
         double wirelessCap = WirelessNetworkManager.getCapacity(global_energy_user_uuid);
-        double wirelessStored = WirelessNetworkManager.getStored(global_energy_user_uuid); 
-    
+        double wirelessStored = WirelessNetworkManager.getStored(global_energy_user_uuid);
+
         if (avgInWireless >= avgOutWireless) {
             // Calculate time to full if charging
             if (avgInWireless > 0) {
@@ -937,7 +937,7 @@ public class MTELapotronicSuperCapacitor extends MTEEnhancedMultiBlockBase<MTELa
             double timeToEmptyWireless = wirelessStored / ((avgOutWireless) - avgInWireless) / 20;
             return "Wireless Time to Empty: " + formatTime(timeToEmptyWireless, false);
         }
-    }    
+    }
 
     private String getCapacityCache() {
         return capacity.compareTo(guiCapacityStoredReformatLimit) > 0 ? standardFormat.format(capacity)
@@ -1029,7 +1029,7 @@ public class MTELapotronicSuperCapacitor extends MTEEnhancedMultiBlockBase<MTELa
 
         ll.add("Avg Wireless EU IN (5 mins): " + nf.format(wirelessEnergyInputValues5m.avgLong()) + " EU/t");
         ll.add("Avg Wireless EU OUT (5 mins): " + nf.format(wirelessEnergyOutputValues5m.avgLong()) + " EU/t");
-                
+
         final String[] a = new String[ll.size()];
         return ll.toArray(a);
     }


### PR DESCRIPTION
The point of this PR is to add information into the LSC to show the rate of emptying for wireless power. Along with how much wireless power is being added or loss every five mins. Since the LSC already shows the information for this locally it makes sense that this information should be there at a wireless level which the player uses at UEV and onwards.