### PR TITLE
fix crowbar train reversing/boosting compatibility

### DIFF
--- a/src/main/java/gregtech/api/items/MetaGeneratedTool.java
+++ b/src/main/java/gregtech/api/items/MetaGeneratedTool.java
@@ -847,7 +847,7 @@ public abstract class MetaGeneratedTool extends MetaBaseItem
     public boolean canLink(EntityPlayer aPlayer, ItemStack aStack, EntityMinecart cart) {
         if (!isItemStackUsable(aStack)) return false;
         IToolStats tStats = getToolStats(aStack);
-        return tStats != null && tStats.isCrowbar();
+        return tStats != null && tStats.isCrowbar() && aPlayer.isSneaking();
     }
 
     @Override
@@ -860,7 +860,7 @@ public abstract class MetaGeneratedTool extends MetaBaseItem
     public boolean canBoost(EntityPlayer aPlayer, ItemStack aStack, EntityMinecart cart) {
         if (!isItemStackUsable(aStack)) return false;
         IToolStats tStats = getToolStats(aStack);
-        return tStats != null && tStats.isCrowbar();
+        return tStats != null && tStats.isCrowbar() && !aPlayer.isSneaking();
     }
 
     @Override


### PR DESCRIPTION
This fixes how crowbars interact with Locomotives or the RC tunnel bore, not being able to flip them correctly.

The RC crowbar only links when crouching, and reverses a locomotive upon right-click otherwise.

Now the GT crowbar has the same behaviour in that regard.

That being said, in the long-term I'd argue this behaviour should be fixed inside the Railcraft crowbar, as the crowbar interface probably shouldn't block the reversing feature if someone accidently forgets the sneak check in their crowbar item.