### PR TITLE
Decrement single-use screwdriver on circuit change

### DIFF
--- a/src/main/java/gregtech/common/items/ItemIntegratedCircuit.java
+++ b/src/main/java/gregtech/common/items/ItemIntegratedCircuit.java
@@ -360,22 +360,18 @@ public class ItemIntegratedCircuit extends GTGenericItem implements INetworkUpda
             // Screwdriver
             for (int id : OreDictionary.getOreIDs(potentialStack)) {
                 if (id == screwdriverOreId) {
-                    if (potentialStack.getItem().equals(One_Use_craftingToolScrewdriver.getItem())) {
-                        potentialStack.stackSize -= 1;
-                        if (potentialStack.stackSize <= 0) {
+                    if (doDamage) {
+                        if (potentialStack.getItem()
+                            .equals(One_Use_craftingToolScrewdriver.getItem())) {
+                            potentialStack.stackSize -= 1;
+                        } else {
+                            potentialStack = potentialStack.getItem()
+                                .getContainerItem(potentialStack);
+                        }
+                        if (potentialStack != null && potentialStack.stackSize <= 0) {
                             mainInventory[i] = null;
                         } else {
                             mainInventory[i] = potentialStack;
-                        }
-                    } else {
-                        if (doDamage) {
-                            potentialStack = potentialStack.getItem()
-                                .getContainerItem(potentialStack);
-                            if (potentialStack != null && potentialStack.stackSize <= 0) {
-                                mainInventory[i] = null;
-                            } else {
-                                mainInventory[i] = potentialStack;
-                            }
                         }
                     }
                     return potentialStack;

--- a/src/main/java/gregtech/common/items/ItemIntegratedCircuit.java
+++ b/src/main/java/gregtech/common/items/ItemIntegratedCircuit.java
@@ -1,5 +1,6 @@
 package gregtech.common.items;
 
+import static ggfab.GGItemList.One_Use_craftingToolScrewdriver;
 import static gregtech.GTMod.GT_FML_LOGGER;
 import static gregtech.api.enums.Mods.GregTech;
 
@@ -359,13 +360,22 @@ public class ItemIntegratedCircuit extends GTGenericItem implements INetworkUpda
             // Screwdriver
             for (int id : OreDictionary.getOreIDs(potentialStack)) {
                 if (id == screwdriverOreId) {
-                    if (doDamage) {
-                        potentialStack = potentialStack.getItem()
-                            .getContainerItem(potentialStack);
-                        if (potentialStack != null && potentialStack.stackSize <= 0) {
+                    if (potentialStack.getItem().equals(One_Use_craftingToolScrewdriver.getItem())) {
+                        potentialStack.stackSize -= 1;
+                        if (potentialStack.stackSize <= 0) {
                             mainInventory[i] = null;
                         } else {
                             mainInventory[i] = potentialStack;
+                        }
+                    } else {
+                        if (doDamage) {
+                            potentialStack = potentialStack.getItem()
+                                .getContainerItem(potentialStack);
+                            if (potentialStack != null && potentialStack.stackSize <= 0) {
+                                mainInventory[i] = null;
+                            } else {
+                                mainInventory[i] = potentialStack;
+                            }
                         }
                     }
                     return potentialStack;


### PR DESCRIPTION
Before, changing a circuit with a single-use screwdriver would break the entire stack. Now it just breaks one.

See video [here](https://files.jellejurre.dev/ShareX/Jurre/java_uKxzNUpYNF.mp4)

closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19299