### PR TITLE
Fix pipe dupe

### DIFF
--- a/src/main/java/gregtech/common/misc/DrillingLogicDelegate.java
+++ b/src/main/java/gregtech/common/misc/DrillingLogicDelegate.java
@@ -135,6 +135,13 @@ public class DrillingLogicDelegate {
             return;
         }
 
+        // Inspect block above the drill tip - if it's not pipe, don't refund pipe to the user to prevent duping.
+        targetBlock = aBaseMetaTileEntity.getBlockOffset(0, tipDepth+1, 0);
+        if (targetBlock == MINING_PIPE_BLOCK) {
+            // Return the pipe back to the machine (inputs allowed for this case!)
+            owner.pushOutputs(MINING_PIPE_STACK, 1, false, true);
+        }
+
         // Retract the pipe/tip
         int xCoord = aBaseMetaTileEntity.getXCoord();
         int yCoord = aBaseMetaTileEntity.getYCoord();
@@ -149,9 +156,6 @@ public class DrillingLogicDelegate {
         // Remove the old pipe tip
         aBaseMetaTileEntity.getWorld()
             .setBlock(xCoord, actualDrillY, zCoord, Blocks.air, 0, /* send to client without neighbour updates */ 2);
-
-        // Return the pipe back to the machine (inputs allowed for this case!)
-        owner.pushOutputs(MINING_PIPE_STACK, 1, false, true);
 
         tipDepth++;
     }

--- a/src/main/java/gregtech/common/misc/DrillingLogicDelegate.java
+++ b/src/main/java/gregtech/common/misc/DrillingLogicDelegate.java
@@ -136,8 +136,8 @@ public class DrillingLogicDelegate {
         }
 
         // Inspect block above the drill tip - if it's not pipe, don't refund pipe to the user to prevent duping.
-        targetBlock = aBaseMetaTileEntity.getBlockOffset(0, tipDepth+1, 0);
-        if (targetBlock == MINING_PIPE_BLOCK) {
+        targetBlock = aBaseMetaTileEntity.getBlockOffset(0, tipDepth + 1, 0);
+        if (targetBlock == MINING_PIPE_BLOCK || targetBlock == MINING_PIPE_TIP_BLOCK) {
             // Return the pipe back to the machine (inputs allowed for this case!)
             owner.pushOutputs(MINING_PIPE_STACK, 1, false, true);
         }

--- a/src/main/java/gregtech/common/misc/DrillingLogicDelegate.java
+++ b/src/main/java/gregtech/common/misc/DrillingLogicDelegate.java
@@ -10,6 +10,8 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.util.FakePlayer;
 
+import org.jetbrains.annotations.NotNull;
+
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.util.GTLog;
 import gregtech.api.util.GTModHandler;
@@ -130,15 +132,11 @@ public class DrillingLogicDelegate {
         }
 
         // Inspect target block - it should be a pipe tip, else something went wrong.
-        Block targetBlock = aBaseMetaTileEntity.getBlockOffset(0, tipDepth, 0);
-        if (targetBlock != MINING_PIPE_TIP_BLOCK && targetBlock != MINING_PIPE_BLOCK) {
+        if (!isMiningPipe(aBaseMetaTileEntity, tipDepth)) {
             return;
         }
 
-        // Inspect block above the drill tip - if it's not pipe or the miner, don't refund pipe to the user to prevent
-        // duping.
-        targetBlock = aBaseMetaTileEntity.getBlockOffset(0, tipDepth + 1, 0);
-        if (targetBlock == MINING_PIPE_BLOCK || targetBlock == MINING_PIPE_TIP_BLOCK || tipDepth == -1) {
+        if (isMiningPipe(aBaseMetaTileEntity, tipDepth + 1) || isLastPipeSegment()) {
             // Return the pipe back to the machine (inputs allowed for this case!)
             owner.pushOutputs(MINING_PIPE_STACK, 1, false, true);
         }
@@ -159,6 +157,15 @@ public class DrillingLogicDelegate {
             .setBlock(xCoord, actualDrillY, zCoord, Blocks.air, 0, /* send to client without neighbour updates */ 2);
 
         tipDepth++;
+    }
+
+    private boolean isLastPipeSegment() {
+        return tipDepth == -1;
+    }
+
+    private boolean isMiningPipe(@NotNull IGregTechTileEntity aBaseMetaTileEntity, int yOffset) {
+        Block pipeToRemove = aBaseMetaTileEntity.getBlockOffset(0, yOffset, 0);
+        return pipeToRemove == MINING_PIPE_BLOCK || pipeToRemove == MINING_PIPE_TIP_BLOCK;
     }
 
     /** Minings the block if it is possible. */

--- a/src/main/java/gregtech/common/misc/DrillingLogicDelegate.java
+++ b/src/main/java/gregtech/common/misc/DrillingLogicDelegate.java
@@ -135,9 +135,10 @@ public class DrillingLogicDelegate {
             return;
         }
 
-        // Inspect block above the drill tip - if it's not pipe, don't refund pipe to the user to prevent duping.
+        // Inspect block above the drill tip - if it's not pipe or the miner, don't refund pipe to the user to prevent
+        // duping.
         targetBlock = aBaseMetaTileEntity.getBlockOffset(0, tipDepth + 1, 0);
-        if (targetBlock == MINING_PIPE_BLOCK || targetBlock == MINING_PIPE_TIP_BLOCK) {
+        if (targetBlock == MINING_PIPE_BLOCK || targetBlock == MINING_PIPE_TIP_BLOCK || tipDepth == -1) {
             // Return the pipe back to the machine (inputs allowed for this case!)
             owner.pushOutputs(MINING_PIPE_STACK, 1, false, true);
         }


### PR DESCRIPTION
Adds a check if the block being replaced during retraction is in fact a mining pipe, before refunding it to the miner

see [here](https://files.jellejurre.dev/ShareX/Jurre/java_DHv3feXSTb.mp4)

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19130