### PR TITLE
Fix tectech EnderFluidLink cover ghost loading

### DIFF
--- a/src/main/java/tectech/mechanics/enderStorage/EnderLinkTank.java
+++ b/src/main/java/tectech/mechanics/enderStorage/EnderLinkTank.java
@@ -34,17 +34,14 @@ public class EnderLinkTank implements Serializable {
         D = d;
     }
 
-    public IFluidHandler getFluidHandler() {
+    public boolean shouldSave() {
         World world = DimensionManager.getWorld(D);
 
-        if (world == null) return null;
+        // If world is unloaded (null) or block doesn't exist (chunk unloaded), not safe to remove fluid handler
+        if (world == null || !world.blockExists(X, Y, Z)) return true;
 
         TileEntity tile = world.getTileEntity(X, Y, Z);
-        if (tile instanceof IFluidHandler fluidHandler) {
-            return fluidHandler;
-        } else {
-            return null;
-        }
+        return tile instanceof IFluidHandler;
     }
 
     @Override

--- a/src/main/java/tectech/mechanics/enderStorage/EnderWorldSavedData.java
+++ b/src/main/java/tectech/mechanics/enderStorage/EnderWorldSavedData.java
@@ -108,7 +108,7 @@ public class EnderWorldSavedData extends WorldSavedData {
         NBTTagList tanks = new NBTTagList();
 
         EnderLiquidTankLink.forEach((tank, tag) -> {
-            if (tank.getFluidHandler() != null) {
+            if (tank.shouldSave()) {
                 usedTags.add(tag);
                 NBTTagCompound entry = new NBTTagCompound();
                 entry.setTag("k", tank.save());


### PR DESCRIPTION
EnderFluidLink covers cause ghost-loading since getTileEntity loads the chunk.
Adding world.blockExists(X, Y, Z) check fixes this.

Also noticed, that if the world is null (which my understanding can happen if world is fully unloaded), it would cause data to not be saved and might void up to 64K of internal buffer. Since getFluidHandler() is really used only to check if that data should be saved (tank.getFluidHandler() != null), I decided to just go and rename it so it actually does what it's used for