### PR TITLE
Change double plate max stack size to 64

### DIFF
--- a/src/main/java/gtPlusPlus/core/item/base/plates/BaseItemPlateDouble.java
+++ b/src/main/java/gtPlusPlus/core/item/base/plates/BaseItemPlateDouble.java
@@ -7,6 +7,5 @@ public class BaseItemPlateDouble extends BaseItemComponent {
 
     public BaseItemPlateDouble(final Material material) {
         super(material, BaseItemComponent.ComponentTypes.PLATEDOUBLE);
-        this.setMaxStackSize(32);
     }
 }


### PR DESCRIPTION
This limit seems to be arbitrary. All the other plate types stack to 64; Why shouldn't these?

For some bizarre reason during testing for #4008 i could stack the related plates to 64 without any issues but they only stack to 32 in full pack, so this also closes [#19404](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19404)

I looked through assembly line recipes with double plates and it looks like no additional changes have to be made.