### PR TITLE
Fix waila for steam machine parallel

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/MTESteamCentrifuge.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/MTESteamCentrifuge.java
@@ -367,7 +367,7 @@ public class MTESteamCentrifuge extends MTESteamMultiBase<MTESteamCentrifuge> im
     public String[] getInfoData() {
         ArrayList<String> info = new ArrayList<>(Arrays.asList(super.getInfoData()));
         info.add("Machine Tier: " + EnumChatFormatting.YELLOW + tierMachine);
-        info.add("Parallel: " + EnumChatFormatting.YELLOW + getMaxParallelRecipes());
+        info.add("Parallel: " + EnumChatFormatting.YELLOW + getTrueParallel());
         return info.toArray(new String[0]);
     }
 

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/MTESteamCompressor.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/MTESteamCompressor.java
@@ -329,7 +329,7 @@ public class MTESteamCompressor extends MTESteamMultiBase<MTESteamCompressor> im
         int z) {
         super.getWailaNBTData(player, tile, tag, world, x, y, z);
         tag.setInteger("tierMachine", tierMachine);
-        tag.setInteger("parallel", getMaxParallelRecipes());
+        tag.setInteger("parallel", getTrueParallel());
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/MTESteamForgeHammer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/MTESteamForgeHammer.java
@@ -389,7 +389,7 @@ public class MTESteamForgeHammer extends MTESteamMultiBase<MTESteamForgeHammer> 
         int z) {
         super.getWailaNBTData(player, tile, tag, world, x, y, z);
         tag.setInteger("tierMachine", tierMachine);
-        tag.setInteger("parallel", getMaxParallelRecipes());
+        tag.setInteger("parallel", getTrueParallel());
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/MTESteamMacerator.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/MTESteamMacerator.java
@@ -328,7 +328,7 @@ public class MTESteamMacerator extends MTESteamMultiBase<MTESteamMacerator> impl
         int z) {
         super.getWailaNBTData(player, tile, tag, world, x, y, z);
         tag.setInteger("tierMachine", tierMachine);
-        tag.setInteger("parallel", getMaxParallelRecipes());
+        tag.setInteger("parallel", getTrueParallel());
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/MTESteamMixer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/MTESteamMixer.java
@@ -390,7 +390,7 @@ public class MTESteamMixer extends MTESteamMultiBase<MTESteamMixer> implements I
         int z) {
         super.getWailaNBTData(player, tile, tag, world, x, y, z);
         tag.setInteger("tierMachine", tierMachine);
-        tag.setInteger("parallel", getMaxParallelRecipes());
+        tag.setInteger("parallel", getTrueParallel());
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/MTESteamWasher.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/MTESteamWasher.java
@@ -417,7 +417,7 @@ public class MTESteamWasher extends MTESteamMultiBase<MTESteamWasher> implements
         int z) {
         super.getWailaNBTData(player, tile, tag, world, x, y, z);
         tag.setInteger("tierMachine", tierMachine);
-        tag.setInteger("parallel", getMaxParallelRecipes());
+        tag.setInteger("parallel", getTrueParallel());
         tag.setInteger("mode", machineMode);
     }
 


### PR DESCRIPTION
Was using the old getMaxParallelRecipes to display parallel info in WAILA, rather than getTrueParallel.