### PR TITLE
Cyclotron muffler

### DIFF
--- a/src/main/java/gregtech/common/pollution/PollutionConfig.java
+++ b/src/main/java/gregtech/common/pollution/PollutionConfig.java
@@ -320,9 +320,6 @@ public class PollutionConfig {
     public static int pollutionPerSecondMultiABS;
     @Config.Comment("pollution rate in gibbl/s for the Cyclotron")
     @Config.DefaultInt(200)
-    public static int pollutionPerSecondMultiCyclotron;
-    @Config.Comment("pollution rate in gibbl/s for the Zuhai - fishing port")
-    @Config.DefaultInt(20)
     public static int pollutionPerSecondMultiIndustrialFishingPond;
     // pollutionPerSecondMultiLargeRocketEngine;
     @Config.Comment("pollution rate in gibbl/s for the Large semifluid burner")

--- a/src/main/java/gregtech/common/pollution/PollutionConfig.java
+++ b/src/main/java/gregtech/common/pollution/PollutionConfig.java
@@ -318,8 +318,8 @@ public class PollutionConfig {
     @Config.Comment("pollution rate in gibbl/s for the Alloy blast furnace")
     @Config.DefaultInt(200)
     public static int pollutionPerSecondMultiABS;
-    @Config.Comment("pollution rate in gibbl/s for the Cyclotron")
-    @Config.DefaultInt(200)
+    @Config.Comment("pollution rate in gibbl/s for the Zuhai - fishing port")
+    @Config.DefaultInt(20)
     public static int pollutionPerSecondMultiIndustrialFishingPond;
     // pollutionPerSecondMultiLargeRocketEngine;
     @Config.Comment("pollution rate in gibbl/s for the Large semifluid burner")

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTECyclotron.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTECyclotron.java
@@ -35,7 +35,6 @@ import gregtech.api.metatileentity.implementations.MTEHatchOutputBus;
 import gregtech.api.recipe.RecipeMap;
 import gregtech.api.recipe.check.CheckRecipeResult;
 import gregtech.api.util.MultiblockTooltipBuilder;
-import gregtech.common.pollution.PollutionConfig;
 import gtPlusPlus.api.recipe.GTPPRecipeMaps;
 import gtPlusPlus.core.block.ModBlocks;
 import gtPlusPlus.core.item.chemistry.IonParticles;

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTECyclotron.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTECyclotron.java
@@ -311,7 +311,7 @@ public class MTECyclotron extends GTPPMultiBlockBase<MTECyclotron> implements IS
 
     @Override
     public int getPollutionPerSecond(ItemStack aStack) {
-        return PollutionConfig.pollutionPerSecondMultiCyclotron;
+        return 0;
     }
 
     @Override


### PR DESCRIPTION
Remove the cyclotron pollution config as the multi was reworked in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4032 to not need a muffler hatch.
After doing so, it can now form properly;
![image](https://github.com/user-attachments/assets/ecd43798-a271-4998-a9a8-6c21ac2a7a8a)

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19394