### PR TITLE
Synchrotron is not symmetrical

### DIFF
--- a/src/main/java/gtnhlanth/common/tileentity/MTESynchrotron.java
+++ b/src/main/java/gtnhlanth/common/tileentity/MTESynchrotron.java
@@ -166,7 +166,7 @@ public class MTESynchrotron extends MTEExtendedPowerMultiBlockBase<MTESynchrotro
 
                     	},
                     	{
-                    		"  ccc   ccccccccccccccccc           ",
+                    		"  ccc  cccccccccccccccccc           ",
                     		" ckkkccc-----------------cc         ",
                     		"ck---kc-------------------cc        ",
                     		"ck---kc--------------------c        ",
@@ -374,8 +374,8 @@ public class MTESynchrotron extends MTEExtendedPowerMultiBlockBase<MTESynchrotro
 
                     	},
                     	{
-                    		"     ccccc             ccccc        ",
-                    		"    c-----cc         cc-----c       ",
+                    		"     ccccc             cccccc       ",
+                    		"    c-----cc         cc------c      ",
                     		"   c-------cc       cc-------cc     ",
                     		"   c-------cc       cc-------cc     ",
                     		"   c-------cc       cc-------cc     ",
@@ -390,7 +390,7 @@ public class MTESynchrotron extends MTEExtendedPowerMultiBlockBase<MTESynchrotro
                     		"    c--------ccccccc--------cccc    ",
                     		"    c--------ccccccc--------cccc    ",
                     		"    cc-----cccc   cccc------cc      ",
-                    		"      ccccc           cccccc        "
+                    		"      ccccc           ccccccc       "
 
                     	},
                     	{
@@ -400,7 +400,7 @@ public class MTESynchrotron extends MTEExtendedPowerMultiBlockBase<MTESynchrotro
                     		"    c---------kdkdk--------ccccccccc",
                     		"    c---------kdkdk--------ccccccccc",
                     		"     cc-------ccccc--------cccc     ",
-                    		"       ccccccc     cccccccc         "
+                    		"       ccccccc     cccccccccc       "
 
                     	},
                     	{
@@ -409,8 +409,8 @@ public class MTESynchrotron extends MTEExtendedPowerMultiBlockBase<MTESynchrotro
                     		"     cc---------------------------cg",
                     		"     c----------------------------cg",
                     		"     cc---------------------------cg",
-                    		"       c-------------------ccccccccc",
-                    		"        ccccccccccccccccccc         "
+                    		"      cc-------------------ccccccccc",
+                    		"        cccccccccccccccccccc        "
 
                     	},
                     	{
@@ -419,8 +419,8 @@ public class MTESynchrotron extends MTEExtendedPowerMultiBlockBase<MTESynchrotro
                     		"       c--------------------------cg",
                     		"      cc---------------------------b",
                     		"       c--------------------------cg",
-                    		"        c-----------------cccccccccc",
-                    		"         ccccccccccccccccc          "
+                    		"       cc-----------------cccccccccc",
+                    		"         ccccccccccccccccccc        "
 
                     	},
                     	{
@@ -430,7 +430,7 @@ public class MTESynchrotron extends MTEExtendedPowerMultiBlockBase<MTESynchrotro
                     		"        cc------------------------cg",
                     		"        cc------------------------cg",
                     		"         ccc-------------ccccccccccc",
-                    		"            ccccccccccccc           "
+                    		"            ccccccccccccccc         "
 
                     	},
                     	{


### PR DESCRIPTION
Duplicate of [dev branch version](https://github.com/GTNewHorizons/GT5-Unofficial/pull/4099)

The Synchrotron had some missing blocks on the bottom and top side. These have now been added. See the screenshots, where the neonite depicts the added blocks.

![image](https://github.com/user-attachments/assets/7069409f-c832-46bf-b25c-88c6b5eddef2)
![image](https://github.com/user-attachments/assets/b61e5bfc-1e0a-4daf-80cf-74e665b524ec)
![image](https://github.com/user-attachments/assets/a6825bce-72ef-4ba9-a4c9-c0d9000ef4c4)

