### PR TITLE
Fix Antimatter Sequencer Tricoder info showing wrong information.

### DIFF
--- a/src/main/java/goodgenerator/blocks/tileEntity/AntimatterForge.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/AntimatterForge.java
@@ -771,7 +771,7 @@ public class AntimatterForge extends MTEExtendedPowerMultiBlockBase<AntimatterFo
                 + EnumChatFormatting.LIGHT_PURPLE
                 + GTUtility.formatNumbers(this.guiActiveEnergy)
                 + EnumChatFormatting.RESET
-                + " EU/t",
+                + " EU/s",
             StatCollector.translateToLocal("gui.AntimatterForge.3") + ": "
                 + EnumChatFormatting.AQUA
                 + GTUtility.formatNumbers(this.guiAntimatterChange)


### PR DESCRIPTION
Showing active consumption as per tick instead of per operation.