### PR TITLE
Fix Degasser Scanner Info Bug

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/purification/MTEPurificationUnitDegasser.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/purification/MTEPurificationUnitDegasser.java
@@ -782,9 +782,21 @@ public class MTEPurificationUnitDegasser extends MTEPurificationUnitBase<MTEPuri
                     + "L "
                     + stack.getLocalizedName());
         }
-        info.add(generateInfoStringForBit(0, controlSignal.getBit(3) && isBit3Satisfied().satisfied ? new ControlBitStatus(null, true) : isBit0Satisfied()));
-        info.add(generateInfoStringForBit(1, controlSignal.getBit(3) && isBit3Satisfied().satisfied ? new ControlBitStatus(null, true) : isBit1Satisfied()));
-        info.add(generateInfoStringForBit(2, controlSignal.getBit(3) && isBit3Satisfied().satisfied ? new ControlBitStatus(null, true) : isBit2Satisfied()));
+        info.add(
+            generateInfoStringForBit(
+                0,
+                controlSignal.getBit(3) && isBit3Satisfied().satisfied ? new ControlBitStatus(null, true)
+                    : isBit0Satisfied()));
+        info.add(
+            generateInfoStringForBit(
+                1,
+                controlSignal.getBit(3) && isBit3Satisfied().satisfied ? new ControlBitStatus(null, true)
+                    : isBit1Satisfied()));
+        info.add(
+            generateInfoStringForBit(
+                2,
+                controlSignal.getBit(3) && isBit3Satisfied().satisfied ? new ControlBitStatus(null, true)
+                    : isBit2Satisfied()));
         info.add(generateInfoStringForBit(3, isBit3Satisfied()));
         return info.toArray(new String[] {});
     }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/purification/MTEPurificationUnitDegasser.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/purification/MTEPurificationUnitDegasser.java
@@ -782,9 +782,9 @@ public class MTEPurificationUnitDegasser extends MTEPurificationUnitBase<MTEPuri
                     + "L "
                     + stack.getLocalizedName());
         }
-        info.add(generateInfoStringForBit(0, isBit0Satisfied()));
-        info.add(generateInfoStringForBit(1, isBit1Satisfied()));
-        info.add(generateInfoStringForBit(2, isBit2Satisfied()));
+        info.add(generateInfoStringForBit(0, controlSignal.getBit(3) && isBit3Satisfied().satisfied ? new ControlBitStatus(null, true) : isBit0Satisfied()));
+        info.add(generateInfoStringForBit(1, controlSignal.getBit(3) && isBit3Satisfied().satisfied ? new ControlBitStatus(null, true) : isBit1Satisfied()));
+        info.add(generateInfoStringForBit(2, controlSignal.getBit(3) && isBit3Satisfied().satisfied ? new ControlBitStatus(null, true) : isBit2Satisfied()));
         info.add(generateInfoStringForBit(3, isBit3Satisfied()));
         return info.toArray(new String[] {});
     }


### PR DESCRIPTION
This PR fixes a small bug with the degasser scanner info, as previously it was misleading to players if bit 3 (4 ingame) was on. It would still check the other bits requirements, and in the scanner info show `NOT OK` if the other bits were on as well as bit 3, this PR just checks if bit 3 is on and is satisfied, and if so it just shortcuts the other bit satisfaction checks.