### PR TITLE
Fix pipe collisions

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
@@ -1304,7 +1304,7 @@ public class BaseMetaPipeEntity extends CommonBaseMetaTileEntity
 
     @Override
     public float getThickNess() {
-        if (canAccessData()) return mMetaTileEntity.getThickNess();
+        if (canAccessData()) return mMetaTileEntity.getThickness();
         return 1.0F;
     }
 

--- a/src/main/java/gregtech/api/metatileentity/CoverableTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/CoverableTileEntity.java
@@ -206,7 +206,7 @@ public abstract class CoverableTileEntity extends BaseTileEntity implements ICov
     public final ITexture getCoverTexture(ForgeDirection side) {
         final Cover cover = getCoverAtSide(side);
         if (!cover.isValid()) return null;
-        if (GTMod.instance.isClientSide() && (GTClient.hideValue & 0x1) != 0) {
+        if (GTMod.instance.isClientSide() && GTClient.shouldHideThings()) {
             return Textures.BlockIcons.HIDDEN_TEXTURE[0]; // See through
         }
         final ITexture coverTexture = this instanceof BaseMetaPipeEntity ? cover.getSpecialFaceTexture()

--- a/src/main/java/gregtech/api/metatileentity/MetaPipeEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaPipeEntity.java
@@ -432,7 +432,8 @@ public abstract class MetaPipeEntity extends CommonMetaTileEntity implements ICo
 
     private boolean boundingBoxShouldBeFullBlock() {
         // While holding tool, make it full block.
-        return GTMod.instance.isClientSide() && (GTClient.hideValue & 0x2) != 0 || getCollisionThickness() == 1;
+        return (GTMod.instance.isClientSide() && GTClient.shouldForceFullBlockBoundingBoxes())
+            || getCollisionThickness() == 1;
     }
 
     /**

--- a/src/main/java/gregtech/api/metatileentity/MetaPipeEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaPipeEntity.java
@@ -106,7 +106,18 @@ public abstract class MetaPipeEntity extends CommonMetaTileEntity implements ICo
     /**
      * For Pipe Rendering
      */
-    public abstract float getThickNess();
+    public float getThickness() {
+        // If we are holding a soldering iron, minimize the rendered thickness of the pipe.
+        if (GTMod.instance.isClientSide() && (GTClient.hideValue & 0x1) != 0) return 0.0625F;
+        return getCollisionThickness();
+    }
+
+    /**
+     * For Bounding Box collision checks
+     * The bounding box is unaffected in case a soldering iron is held and the render thickness of the pipe is
+     * minimized.
+     */
+    public abstract float getCollisionThickness();
 
     /**
      * For Pipe Rendering
@@ -421,14 +432,14 @@ public abstract class MetaPipeEntity extends CommonMetaTileEntity implements ICo
 
     private boolean boundingBoxShouldBeFullBlock() {
         // While holding tool, make it full block.
-        return GTMod.instance.isClientSide() && (GTClient.hideValue & 0x2) != 0 || getThickNess() == 1;
+        return GTMod.instance.isClientSide() && (GTClient.hideValue & 0x2) != 0 || getCollisionThickness() == 1;
     }
 
     /**
      * Gets the bounding box that corresponds to the rendered pipe.
      */
     private @NotNull AxisAlignedBB getPhysicalCollisionBoundingBox(int x, int y, int z) {
-        final float space = (1f - getThickNess()) / 2;
+        final float space = (1f - getCollisionThickness()) / 2;
         float yStart = space;
         float yEnd = 1f - space;
         float zStart = space;

--- a/src/main/java/gregtech/api/metatileentity/MetaPipeEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaPipeEntity.java
@@ -108,7 +108,7 @@ public abstract class MetaPipeEntity extends CommonMetaTileEntity implements ICo
      */
     public float getThickness() {
         // If we are holding a soldering iron, minimize the rendered thickness of the pipe.
-        if (GTMod.instance.isClientSide() && (GTClient.hideValue & 0x1) != 0) return 0.0625F;
+        if (GTMod.instance.isClientSide() && GTClient.shouldHideThings()) return 0.0625F;
         return getCollisionThickness();
     }
 

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTECable.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTECable.java
@@ -43,7 +43,6 @@ import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GTGCCompat;
 import gregtech.api.util.GTModHandler;
 import gregtech.api.util.GTUtility;
-import gregtech.common.GTClient;
 import gregtech.common.blocks.ItemMachines;
 import gregtech.common.covers.Cover;
 import gregtech.common.covers.CoverSolarPanel;
@@ -113,7 +112,7 @@ public class MTECable extends MetaPipeEntity implements IMetaTileEntityCable {
         if (!mInsulated) return new ITexture[] { TextureFactory
             .of(mMaterial.mIconSet.mTextures[TextureSet.INDEX_wire], Dyes.getModulation(colorIndex, mMaterial.mRGBa)) };
         if (active) {
-            float tThickNess = getThickNess();
+            float tThickNess = getThickness();
             if (tThickNess < 0.124F) return new ITexture[] { TextureFactory
                 .of(Textures.BlockIcons.INSULATION_FULL, Dyes.getModulation(colorIndex, Dyes.CABLE_INSULATION.mRGBa)) };
             if (tThickNess < 0.374F) // 0.375 x1
@@ -528,8 +527,7 @@ public class MTECable extends MetaPipeEntity implements IMetaTileEntityCable {
     }
 
     @Override
-    public float getThickNess() {
-        if (GTMod.instance.isClientSide() && (GTClient.hideValue & 0x1) != 0) return 0.0625F;
+    public float getCollisionThickness() {
         return mThickNess;
     }
 

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEFluidPipe.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEFluidPipe.java
@@ -59,7 +59,6 @@ import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GTLog;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.WorldSpawnedEventBuilder.ParticleEventBuilder;
-import gregtech.common.GTClient;
 import gregtech.common.blocks.ItemMachines;
 import gregtech.common.config.Other;
 import gregtech.common.covers.Cover;
@@ -157,7 +156,7 @@ public class MTEFluidPipe extends MetaPipeEntity {
     public ITexture[] getTexture(IGregTechTileEntity aBaseMetaTileEntity, ForgeDirection side, int aConnections,
         int colorIndex, boolean aConnected, boolean redstoneLevel) {
         if (side == ForgeDirection.UNKNOWN) return Textures.BlockIcons.ERROR_RENDERING;
-        final float tThickNess = getThickNess();
+        final float tThickNess = getThickness();
         if (mDisableInput == 0)
             return new ITexture[] { aConnected ? getBaseTexture(tThickNess, mPipeAmount, mMaterial, colorIndex)
                 : TextureFactory.of(
@@ -935,8 +934,7 @@ public class MTEFluidPipe extends MetaPipeEntity {
     }
 
     @Override
-    public float getThickNess() {
-        if (GTMod.instance.isClientSide() && (GTClient.hideValue & 0x1) != 0) return 0.0625F;
+    public float getCollisionThickness() {
         return mThickNess;
     }
 

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEFrame.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEFrame.java
@@ -72,7 +72,12 @@ public class MTEFrame extends MetaPipeEntity implements ITemporaryTE {
     }
 
     @Override
-    public final float getThickNess() {
+    public final float getThickness() {
+        return 1.0F;
+    }
+
+    @Override
+    public float getCollisionThickness() {
         return 1.0F;
     }
 

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEItemPipe.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEItemPipe.java
@@ -29,7 +29,6 @@ import gregtech.api.metatileentity.BaseMetaPipeEntity;
 import gregtech.api.metatileentity.MetaPipeEntity;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GTUtility;
-import gregtech.common.GTClient;
 import gregtech.common.covers.Cover;
 
 public class MTEItemPipe extends MetaPipeEntity implements IMetaTileEntityItemPipe {
@@ -85,7 +84,7 @@ public class MTEItemPipe extends MetaPipeEntity implements IMetaTileEntityItemPi
         int aColorIndex, boolean aConnected, boolean redstoneLevel) {
         if (mIsRestrictive) {
             if (aConnected) {
-                float tThickNess = getThickNess();
+                float tThickNess = getThickness();
                 if (tThickNess < 0.124F) return new ITexture[] { TextureFactory.of(
                     mMaterial.mIconSet.mTextures[OrePrefixes.pipe.mTextureIndex],
                     Dyes.getModulation(aColorIndex, mMaterial.mRGBa)), TextureFactory.of(PIPE_RESTRICTOR) };
@@ -114,7 +113,7 @@ public class MTEItemPipe extends MetaPipeEntity implements IMetaTileEntityItemPi
                 Dyes.getModulation(aColorIndex, mMaterial.mRGBa)), TextureFactory.of(PIPE_RESTRICTOR) };
         }
         if (aConnected) {
-            float tThickNess = getThickNess();
+            float tThickNess = getThickness();
             if (tThickNess < 0.124F) return new ITexture[] { TextureFactory.of(
                 mMaterial.mIconSet.mTextures[OrePrefixes.pipe.mTextureIndex],
                 Dyes.getModulation(aColorIndex, mMaterial.mRGBa)) };
@@ -412,8 +411,7 @@ public class MTEItemPipe extends MetaPipeEntity implements IMetaTileEntityItemPi
     }
 
     @Override
-    public float getThickNess() {
-        if (GTMod.instance.isClientSide() && (GTClient.hideValue & 0x1) != 0) return 0.0625F;
+    public float getCollisionThickness() {
         return mThickNess;
     }
 }

--- a/src/main/java/gregtech/common/GTClient.java
+++ b/src/main/java/gregtech/common/GTClient.java
@@ -880,6 +880,11 @@ public class GTClient extends GTProxy implements Runnable {
                 hideValue = newHideValue;
                 changeDetected = 5;
             }
+            final boolean newForceFullBlockBoundingBoxes = shouldHeldItemForceFullBlockBoundingBoxes();
+            if (newForceFullBlockBoundingBoxes != forceFullBlockBoundingBoxes) {
+                forceFullBlockBoundingBoxes = newForceFullBlockBoundingBoxes;
+                changeDetected = 5;
+            }
             mAnimationTick++;
             if (mAnimationTick % 50L == 0L) {
                 mAnimationDirection = !mAnimationDirection;
@@ -990,28 +995,39 @@ public class GTClient extends GTProxy implements Runnable {
             final int[] ids = OreDictionary.getOreIDs(tCurrentItem);
             int hide = 0;
             for (int i : ids) {
-                if (OreDictionary.getOreName(i)
-                    .equals("craftingToolSolderingIron")) {
+                String oreName = OreDictionary.getOreName(i);
+                if (oreName != null && oreName.equals("craftingToolSolderingIron")) {
                     hide |= 0x1;
                     break;
                 }
-            }
-            if (GTUtility.isStackInList(tCurrentItem, GregTechAPI.sWrenchList)
-                || GTUtility.isStackInList(tCurrentItem, GregTechAPI.sHardHammerList)
-                || GTUtility.isStackInList(tCurrentItem, GregTechAPI.sSoftHammerList)
-                || GTUtility.isStackInList(tCurrentItem, GregTechAPI.sWireCutterList)
-                || GTUtility.isStackInList(tCurrentItem, GregTechAPI.sSolderingToolList)
-                || GTUtility.isStackInList(tCurrentItem, GregTechAPI.sCrowbarList)
-                || CoverRegistry.isCover(tCurrentItem)
-                || (tCurrentItem.getItem() instanceof ItemMachines
-                    && GregTechAPI.METATILEENTITIES[tCurrentItem.getItemDamage()] instanceof MetaPipeEntity
-                    && player.isSneaking())) {
-                hide |= 0x2;
             }
             return hide;
         } catch (Exception e) {
             return 0;
         }
+    }
+
+    private static boolean forceFullBlockBoundingBoxes;
+
+    public static boolean shouldForceFullBlockBoundingBoxes() {
+        return forceFullBlockBoundingBoxes;
+    }
+
+    private static boolean shouldHeldItemForceFullBlockBoundingBoxes() {
+        final EntityPlayer player = Minecraft.getMinecraft().thePlayer;
+        if (player == null) return false;
+        final ItemStack tCurrentItem = player.getCurrentEquippedItem();
+        if (tCurrentItem == null) return false;
+        return GTUtility.isStackInList(tCurrentItem, GregTechAPI.sWrenchList)
+            || GTUtility.isStackInList(tCurrentItem, GregTechAPI.sHardHammerList)
+            || GTUtility.isStackInList(tCurrentItem, GregTechAPI.sSoftHammerList)
+            || GTUtility.isStackInList(tCurrentItem, GregTechAPI.sWireCutterList)
+            || GTUtility.isStackInList(tCurrentItem, GregTechAPI.sSolderingToolList)
+            || GTUtility.isStackInList(tCurrentItem, GregTechAPI.sCrowbarList)
+            || CoverRegistry.isCover(tCurrentItem)
+            || (tCurrentItem.getItem() instanceof ItemMachines
+                && GregTechAPI.METATILEENTITIES[tCurrentItem.getItemDamage()] instanceof MetaPipeEntity
+                && player.isSneaking());
     }
 
     public static void recieveChunkPollutionPacket(ChunkCoordIntPair chunk, int pollution) {

--- a/src/main/java/gregtech/common/GTClient.java
+++ b/src/main/java/gregtech/common/GTClient.java
@@ -880,11 +880,7 @@ public class GTClient extends GTProxy implements Runnable {
                 hideThings = newHideValue;
                 changeDetected = 5;
             }
-            final boolean newForceFullBlockBoundingBoxes = shouldHeldItemForceFullBlockBoundingBoxes();
-            if (newForceFullBlockBoundingBoxes != forceFullBlockBoundingBoxes) {
-                forceFullBlockBoundingBoxes = newForceFullBlockBoundingBoxes;
-                changeDetected = 5;
-            }
+            forceFullBlockBoundingBoxes = shouldHeldItemForceFullBlockBoundingBoxes();
             mAnimationTick++;
             if (mAnimationTick % 50L == 0L) {
                 mAnimationDirection = !mAnimationDirection;

--- a/src/main/java/gregtech/common/GTClient.java
+++ b/src/main/java/gregtech/common/GTClient.java
@@ -875,9 +875,9 @@ public class GTClient extends GTProxy implements Runnable {
             GTMusicSystem.ClientSystem.tick();
 
             if (changeDetected > 0) changeDetected--;
-            final int newHideValue = shouldHeldItemHideThings();
-            if (newHideValue != hideValue) {
-                hideValue = newHideValue;
+            final boolean newHideValue = shouldHeldItemHideThings();
+            if (newHideValue != hideThings) {
+                hideThings = newHideValue;
                 changeDetected = 5;
             }
             final boolean newForceFullBlockBoundingBoxes = shouldHeldItemForceFullBlockBoundingBoxes();
@@ -973,7 +973,11 @@ public class GTClient extends GTProxy implements Runnable {
         return renderTickTime;
     }
 
-    public static int hideValue = 0;
+    private static boolean hideThings = false;
+
+    public static boolean shouldHideThings() {
+        return hideThings;
+    }
 
     /**
      * <p>
@@ -986,25 +990,19 @@ public class GTClient extends GTProxy implements Runnable {
      */
     public static int changeDetected = 0;
 
-    private static int shouldHeldItemHideThings() {
-        try {
-            final EntityPlayer player = Minecraft.getMinecraft().thePlayer;
-            if (player == null) return 0;
-            final ItemStack tCurrentItem = player.getCurrentEquippedItem();
-            if (tCurrentItem == null) return 0;
-            final int[] ids = OreDictionary.getOreIDs(tCurrentItem);
-            int hide = 0;
-            for (int i : ids) {
-                String oreName = OreDictionary.getOreName(i);
-                if (oreName != null && oreName.equals("craftingToolSolderingIron")) {
-                    hide |= 0x1;
-                    break;
-                }
+    private static boolean shouldHeldItemHideThings() {
+        final EntityPlayer player = Minecraft.getMinecraft().thePlayer;
+        if (player == null) return false;
+        final ItemStack tCurrentItem = player.getCurrentEquippedItem();
+        if (tCurrentItem == null) return false;
+        final int[] ids = OreDictionary.getOreIDs(tCurrentItem);
+        for (int i : ids) {
+            String oreName = OreDictionary.getOreName(i);
+            if (oreName != null && oreName.equals("craftingToolSolderingIron")) {
+                return true;
             }
-            return hide;
-        } catch (Exception e) {
-            return 0;
         }
+        return false;
     }
 
     private static boolean forceFullBlockBoundingBoxes;

--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/GTPPMTECable.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/GTPPMTECable.java
@@ -94,7 +94,7 @@ public class GTPPMTECable extends MTECable implements IMetaTileEntityCable {
         if (!mInsulated) return new ITexture[] { TextureFactory
             .of(wireMaterial.mIconSet.mTextures[TextureSet.INDEX_wire], Dyes.getModulation(aColorIndex, vRGB)) };
         if (aConnected) {
-            float tThickNess = getThickNess();
+            float tThickNess = getThickness();
             if (tThickNess < 0.124F) return new ITexture[] { TextureFactory.of(
                 Textures.BlockIcons.INSULATION_FULL,
                 Dyes.getModulation(aColorIndex, Dyes.CABLE_INSULATION.mRGBa)) };

--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/GTPPMTEFluidPipe.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/GTPPMTEFluidPipe.java
@@ -63,7 +63,7 @@ public class GTPPMTEFluidPipe extends MTEFluidPipe {
     @Override
     public ITexture[] getTexture(IGregTechTileEntity aBaseMetaTileEntity, ForgeDirection side, int aConnections,
         int aColorIndex, boolean aConnected, boolean aRedstone) {
-        float tThickNess = getThickNess();
+        float tThickNess = getThickness();
         if (mDisableInput == 0)
             return new ITexture[] { aConnected ? getBaseTexture(tThickNess, mPipeAmount, mMaterial, aColorIndex)
                 : TextureFactory.of(

--- a/src/main/java/gtnhlanth/common/beamline/MTEBeamlinePipe.java
+++ b/src/main/java/gtnhlanth/common/beamline/MTEBeamlinePipe.java
@@ -12,7 +12,6 @@ import net.minecraftforge.common.util.ForgeDirection;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
-import gregtech.GTMod;
 import gregtech.api.enums.Dyes;
 import gregtech.api.enums.Textures;
 import gregtech.api.interfaces.ITexture;
@@ -86,10 +85,7 @@ public class MTEBeamlinePipe extends MetaPipeEntity implements IConnectsToBeamli
     public void saveNBTData(NBTTagCompound arg0) {}
 
     @Override
-    public float getThickNess() {
-        if (GTMod.instance.isClientSide() && GTClient.hideValue == 1) {
-            return 0.0625F;
-        }
+    public float getCollisionThickness() {
         return 0.5f;
     }
 

--- a/src/main/java/tectech/thing/metaTileEntity/pipe/MTEBaseFactoryPipe.java
+++ b/src/main/java/tectech/thing/metaTileEntity/pipe/MTEBaseFactoryPipe.java
@@ -11,7 +11,6 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import gregtech.GTMod;
 import gregtech.api.enums.Dyes;
 import gregtech.api.enums.Textures.BlockIcons.CustomIcon;
 import gregtech.api.interfaces.IIconContainer;
@@ -109,10 +108,7 @@ public abstract class MTEBaseFactoryPipe extends MetaPipeEntity implements IActi
     }
 
     @Override
-    public float getThickNess() {
-        if (GTMod.instance.isClientSide() && GTClient.hideValue == 1) {
-            return 0.0625F;
-        }
+    public float getCollisionThickness() {
         return mThickness;
     }
 

--- a/src/main/java/tectech/thing/metaTileEntity/pipe/MTEPipeBlockData.java
+++ b/src/main/java/tectech/thing/metaTileEntity/pipe/MTEPipeBlockData.java
@@ -31,6 +31,11 @@ public class MTEPipeBlockData extends MTEPipeData {
     }
 
     @Override
+    public float getCollisionThickness() {
+        return 1f;
+    }
+
+    @Override
     public float getExplosionResistance(ForgeDirection side) {
         return 1000.0f;
     }

--- a/src/main/java/tectech/thing/metaTileEntity/pipe/MTEPipeBlockData.java
+++ b/src/main/java/tectech/thing/metaTileEntity/pipe/MTEPipeBlockData.java
@@ -26,7 +26,7 @@ public class MTEPipeBlockData extends MTEPipeData {
     }
 
     @Override
-    public float getThickNess() {
+    public float getThickness() {
         return 1f;
     }
 

--- a/src/main/java/tectech/thing/metaTileEntity/pipe/MTEPipeBlockLaser.java
+++ b/src/main/java/tectech/thing/metaTileEntity/pipe/MTEPipeBlockLaser.java
@@ -26,7 +26,12 @@ public class MTEPipeBlockLaser extends MTEPipeLaser {
     }
 
     @Override
-    public float getThickNess() {
+    public float getThickness() {
+        return 1f;
+    }
+
+    @Override
+    public float getCollisionThickness() {
         return 1f;
     }
 

--- a/src/main/java/tectech/thing/metaTileEntity/pipe/MTEPipeData.java
+++ b/src/main/java/tectech/thing/metaTileEntity/pipe/MTEPipeData.java
@@ -12,7 +12,6 @@ import net.minecraftforge.common.util.ForgeDirection;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
-import gregtech.GTMod;
 import gregtech.api.enums.Dyes;
 import gregtech.api.enums.Textures;
 import gregtech.api.interfaces.ITexture;
@@ -254,10 +253,7 @@ public class MTEPipeData extends MetaPipeEntity implements IConnectsToDataPipe, 
     }
 
     @Override
-    public float getThickNess() {
-        if (GTMod.instance.isClientSide() && GTClient.hideValue == 1) {
-            return 0.0625F;
-        }
+    public float getCollisionThickness() {
         return 0.375f;
     }
 

--- a/src/main/java/tectech/thing/metaTileEntity/pipe/MTEPipeLaser.java
+++ b/src/main/java/tectech/thing/metaTileEntity/pipe/MTEPipeLaser.java
@@ -12,7 +12,6 @@ import net.minecraftforge.common.util.ForgeDirection;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
-import gregtech.GTMod;
 import gregtech.api.enums.Dyes;
 import gregtech.api.enums.Textures;
 import gregtech.api.interfaces.ITexture;
@@ -233,10 +232,7 @@ public class MTEPipeLaser extends MetaPipeEntity implements IConnectsToEnergyTun
     }
 
     @Override
-    public float getThickNess() {
-        if (GTMod.instance.isClientSide() && GTClient.hideValue == 1) {
-            return 0.0625F;
-        }
+    public float getCollisionThickness() {
         return 0.5f;
     }
 

--- a/src/main/java/tectech/thing/metaTileEntity/pipe/MTEPipeLaserMirror.java
+++ b/src/main/java/tectech/thing/metaTileEntity/pipe/MTEPipeLaserMirror.java
@@ -10,7 +10,6 @@ import net.minecraftforge.common.util.ForgeDirection;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
-import gregtech.GTMod;
 import gregtech.api.enums.Dyes;
 import gregtech.api.enums.Textures;
 import gregtech.api.interfaces.ITexture;
@@ -195,10 +194,7 @@ public class MTEPipeLaserMirror extends MTEPipeLaser {
     }
 
     @Override
-    public float getThickNess() {
-        if (GTMod.instance.isClientSide() && GTClient.hideValue == 1) {
-            return 0.0625F;
-        }
+    public float getCollisionThickness() {
         return 0.6f;
     }
 


### PR DESCRIPTION
Fixes several issues with pipe collisions introduced in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3983

The issues were:
- Falling through pipes if switching to a tool while on top of them.
- Fixing the previous issue revealed another one where we would also fall through pipes if switching away from a soldering iron since we were now using their minimized bounding boxes.

To fix this, regular bounding boxes are always used for collision checks.

Example of buggy behavior: https://imgur.com/a/wPB9LG9

Also cleans up the GTClient.hideValue "global variable" and split it into it's 2 actual use cases (one of which was needlessly triggering texture updates) and provides getter methods for those use cases with meaningful names.