### PR TITLE
Minor refactor to multi item outputting

### DIFF
--- a/src/main/java/bartworks/common/tileentities/multis/MTEHighTempGasCooledReactor.java
+++ b/src/main/java/bartworks/common/tileentities/multis/MTEHighTempGasCooledReactor.java
@@ -330,7 +330,7 @@ public class MTEHighTempGasCooledReactor extends MTEEnhancedMultiBlockBase<MTEHi
                     HTGRMaterials.MATERIALS_PER_FUEL * this.fueltype + HTGRMaterials.USABLE_FUEL_INDEX);
                 boolean storedAll = false;
                 for (MTEHatchOutputBus tHatch : validMTEList(mOutputBusses)) {
-                    if (tHatch.storeAll(iStack)) {
+                    if (tHatch.storePartial(iStack)) {
                         storedAll = true;
                         break;
                     }

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
@@ -726,6 +726,7 @@ public abstract class MTEMultiBlockBase extends MetaTileEntity
                         addFluidOutputs(mOutputFluids);
                         mOutputFluids = null;
                     }
+                    outputAfterRecipe();
                     mEfficiency = Math.max(
                         0,
                         Math.min(
@@ -754,6 +755,10 @@ public abstract class MTEMultiBlockBase extends MetaTileEntity
             }
             if (mMaxProgresstime <= 0) mEfficiency = Math.max(0, mEfficiency - 1000);
         }
+    }
+
+    protected void outputAfterRecipe() {
+
     }
 
     public boolean polluteEnvironment(int aPollutionLevel) {
@@ -1490,10 +1495,9 @@ public abstract class MTEMultiBlockBase extends MetaTileEntity
         if (GTUtility.isStackInvalid(aStack)) return false;
         aStack = GTUtility.copyOrNull(aStack);
 
-        final List<MTEHatchOutputBus> filteredBuses = filterValidMTEs(mOutputBusses);
-        if (dumpItem(filteredBuses, aStack, true) || dumpItem(filteredBuses, aStack, false)) {
-            return true;
-        }
+        final List<MTEHatchOutputBus> validBusses = filterValidMTEs(mOutputBusses);
+        if (dumpItem(validBusses, aStack, true, false)) return true;
+        if (dumpItem(validBusses, aStack, false, false)) return true;
 
         boolean outputSuccess = true;
         final List<MTEHatchOutput> filteredHatches = filterValidMTEs(mOutputHatches);
@@ -1516,13 +1520,32 @@ public abstract class MTEMultiBlockBase extends MetaTileEntity
         }
     }
 
-    private boolean dumpItem(List<MTEHatchOutputBus> outputBuses, ItemStack itemStack, boolean restrictiveBusesOnly) {
+    /**
+     * Outputs a stack to the multi's output busses. Does not add items to output hatches.
+     * 
+     * @param stack    The stack to output. Any rejected items will remain in the stack.
+     * @param simulate When true the method will behave the same but the busses will not be updated
+     * @return True when all items were output, false otherwise
+     */
+    public boolean addOutputPartial(ItemStack stack, boolean simulate) {
+        if (GTUtility.isStackInvalid(stack)) return false;
+
+        final List<MTEHatchOutputBus> validBusses = filterValidMTEs(mOutputBusses);
+
+        if (dumpItem(validBusses, stack, true, simulate)) return true;
+        if (dumpItem(validBusses, stack, false, simulate)) return true;
+
+        return false;
+    }
+
+    private boolean dumpItem(List<MTEHatchOutputBus> outputBuses, ItemStack itemStack, boolean restrictiveBusesOnly,
+        boolean simulate) {
         for (MTEHatchOutputBus outputBus : outputBuses) {
             if (restrictiveBusesOnly && !outputBus.isLocked()) {
                 continue;
             }
 
-            if (outputBus.storeAll(itemStack)) {
+            if (outputBus.storePartial(itemStack, simulate)) {
                 return true;
             }
         }

--- a/src/main/java/gtnhlanth/common/tileentity/MTELINAC.java
+++ b/src/main/java/gtnhlanth/common/tileentity/MTELINAC.java
@@ -301,11 +301,11 @@ public class MTELINAC extends MTEEnhancedMultiBlockBase<MTELINAC> implements ISu
         FluidStack fluidOutputStack = new FluidStack(fluidOutput, fluidConsumed);
         this.addFluidOutputs(new FluidStack[] { fluidOutputStack });
 
-        outputAfterRecipe();
+        outputPacketAfterRecipe();
         return CheckRecipeResultRegistry.SUCCESSFUL;
     }
 
-    private void outputAfterRecipe() {
+    private void outputPacketAfterRecipe() {
         if (!mOutputBeamline.isEmpty()) {
             BeamLinePacket packet = new BeamLinePacket(
                 new BeamInformation(outputEnergy, outputRate, outputParticleID, outputFocus));

--- a/src/main/java/gtnhlanth/common/tileentity/MTESourceChamber.java
+++ b/src/main/java/gtnhlanth/common/tileentity/MTESourceChamber.java
@@ -210,7 +210,7 @@ public class MTESourceChamber extends MTEEnhancedMultiBlockBase<MTESourceChamber
         this.mOutputItems = tRecipe.mOutputs;
         this.updateSlots();
 
-        outputAfterRecipe();
+        outputPacketAfterRecipe();
         return CheckRecipeResultRegistry.SUCCESSFUL;
     }
 
@@ -219,7 +219,7 @@ public class MTESourceChamber extends MTEEnhancedMultiBlockBase<MTESourceChamber
         return DescTextLocalization.addText("SourceChamber.hint", 7);
     }
 
-    private void outputAfterRecipe() {
+    private void outputPacketAfterRecipe() {
         if (!mOutputBeamline.isEmpty()) {
             BeamLinePacket packet = new BeamLinePacket(
                 new BeamInformation(outputEnergy, outputRate, outputParticle, outputFocus));

--- a/src/main/java/gtnhlanth/common/tileentity/MTESynchrotron.java
+++ b/src/main/java/gtnhlanth/common/tileentity/MTESynchrotron.java
@@ -682,11 +682,11 @@ public class MTESynchrotron extends MTEExtendedPowerMultiBlockBase<MTESynchrotro
         FluidStack fluidOutputStack = new FluidStack(fluidOutput, CONSUMED_FLUID);
         this.addFluidOutputs(new FluidStack[] { fluidOutputStack });
 
-        outputAfterRecipe();
+        outputPacketAfterRecipe();
         return CheckRecipeResultRegistry.SUCCESSFUL;
     }
 
-    private void outputAfterRecipe() {
+    private void outputPacketAfterRecipe() {
         if (!this.mOutputBeamline.isEmpty()) {
             BeamLinePacket packet = new BeamLinePacket(
                 new BeamInformation(this.outputEnergy, this.outputRate, this.outputParticleID, this.outputFocus));

--- a/src/main/java/kubatech/tileentity/gregtech/multiblock/MTEExtremeIndustrialGreenhouse.java
+++ b/src/main/java/kubatech/tileentity/gregtech/multiblock/MTEExtremeIndustrialGreenhouse.java
@@ -687,7 +687,7 @@ public class MTEExtremeIndustrialGreenhouse extends KubaTechGTMultiBlockBase<MTE
         for (MTEHatchOutputBus tHatch : validMTEList(mOutputBusses)) {
             if (!(tHatch instanceof MTEHatchOutputBusME)) continue;
             for (ItemStack stack : bucket.tryRemoveSeed(bucket.getSeedCount(), false)) {
-                ((MTEHatchOutputBusME) tHatch).store(stack);
+                ((MTEHatchOutputBusME) tHatch).storePartial(stack);
             }
             return true;
         }
@@ -701,7 +701,7 @@ public class MTEExtremeIndustrialGreenhouse extends KubaTechGTMultiBlockBase<MTE
         if (helper.getMaxParallel() > 0) {
             for (ItemStack toOutput : bucket.tryRemoveSeed(helper.getMaxParallel(), false)) {
                 for (MTEHatchOutputBus tHatch : validMTEList(mOutputBusses)) {
-                    if (tHatch.storeAll(toOutput)) break;
+                    if (tHatch.storePartial(toOutput)) break;
                 }
             }
         }

--- a/src/main/java/tectech/thing/metaTileEntity/multi/MTEEyeOfHarmony.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/MTEEyeOfHarmony.java
@@ -1532,12 +1532,12 @@ public class MTEEyeOfHarmony extends TTMultiblockBase implements IConstructable,
         while (amount >= Integer.MAX_VALUE) {
             ItemStack tmpItem = item.copy();
             tmpItem.stackSize = Integer.MAX_VALUE;
-            ((MTEHatchOutputBusME) mOutputBusses.get(0)).store(tmpItem);
+            ((MTEHatchOutputBusME) mOutputBusses.get(0)).storePartial(tmpItem);
             amount -= Integer.MAX_VALUE;
         }
         ItemStack tmpItem = item.copy();
         tmpItem.stackSize = (int) amount;
-        ((MTEHatchOutputBusME) mOutputBusses.get(0)).store(tmpItem);
+        ((MTEHatchOutputBusME) mOutputBusses.get(0)).storePartial(tmpItem);
     }
 
     private void outputFluidToAENetwork(FluidStack fluid, long amount) {


### PR DESCRIPTION
This change just cleans up the existing item output methods in MTEMultiBlockBase, normal output busses, and ME output busses. This change allows multis with custom processing logic to output their items without voiding, but it only guarantees that one output 'request' will work.

This was tested in a new multi on which requires this behaviour.

Testing done:
- Make sure fluid-only outputs aren't broken (LCR, w/ and w/o voiding)
- Make sure item-only outputs aren't broken (EBF, w/ and w/o voiding)
- Test simulated output with partitioned output ME bus and filtered normal bus
- Test simulated output with unfiltered busses
