### PR TITLE
solidifier hatch-  1x to 4x fluid amount

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEMultiSolidifier.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEMultiSolidifier.java
@@ -448,17 +448,17 @@ public class MTEMultiSolidifier extends MTEExtendedPowerMultiBlockBase<MTEMultiS
     @Nonnull
     @Override
     protected CheckRecipeResult checkRecipeForCustomHatches(CheckRecipeResult lastResult) {
-        for (MTEHatchInput solidifierHatch : mInputHatches) {
-            if (solidifierHatch instanceof MTEHatchSolidifier hatch) {
-                ItemStack mold = hatch.getMold();
-                FluidStack fluid = solidifierHatch.getFluid();
+        for (MTEHatchInput hatch : mInputHatches) {
+            if (hatch instanceof MTEHatchSolidifier solidifierHatch) {
+                ItemStack mold = solidifierHatch.getMold();
+                FluidStack[] fluids = solidifierHatch.getStoredFluid();
 
-                if (mold != null && fluid != null) {
+                if (mold != null && fluids.length != 0) {
                     List<ItemStack> inputItems = new ArrayList<>();
                     inputItems.add(mold);
 
                     processingLogic.setInputItems(inputItems);
-                    processingLogic.setInputFluids(fluid);
+                    processingLogic.setInputFluids(fluids);
 
                     CheckRecipeResult foundResult = processingLogic.process();
                     if (foundResult.wasSuccessful()) {

--- a/src/main/java/gtPlusPlus/core/recipe/RecipesMachines.java
+++ b/src/main/java/gtPlusPlus/core/recipe/RecipesMachines.java
@@ -3396,8 +3396,9 @@ public class RecipesMachines {
     }
 
     private static void solidifierHatches() {
-        ItemStack[] mSuperBusesInput = new ItemStack[] { ItemList.Hatch_Input_IV.get(1),
-            ItemList.Hatch_Input_LuV.get(1), ItemList.Hatch_Input_ZPM.get(1), ItemList.Hatch_Input_UV.get(1), };
+        ItemStack[] mSuperBusesInput = new ItemStack[] { ItemList.Hatch_Input_Multi_2x2_IV.get(1),
+            ItemList.Hatch_Input_Multi_2x2_LuV.get(1), ItemList.Hatch_Input_Multi_2x2_ZPM.get(1),
+            ItemList.Hatch_Input_Multi_2x2_UV.get(1), };
 
         ItemStack[] mSolidifierHatches = new ItemStack[] { GregtechItemList.Hatch_Solidifier_I.get(1),
             GregtechItemList.Hatch_Solidifier_II.get(1), GregtechItemList.Hatch_Solidifier_III.get(1),
@@ -3412,7 +3413,7 @@ public class RecipesMachines {
                     CI.getSensor(componentTier, 1),
                     CI.getFluidRegulator(componentTier, 1),
                     CI.getTieredComponent(OrePrefixes.circuit, componentTier + 1, 4),
-                    ItemUtils.getSimpleStack(Blocks.chest))
+                    ItemList.Hatch_Input_Bus_ULV.get(1))
                 .itemOutputs(mSolidifierHatches[i])
                 .fluidInputs(CI.getTieredFluid(componentTier, 144 * 2))
                 .duration(30 * SECONDS)

--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/MTEHatchSolidifier.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/MTEHatchSolidifier.java
@@ -76,11 +76,29 @@ public class MTEHatchSolidifier extends MTEHatchMultiInput {
     @Override
     public void onFirstTick(IGregTechTileEntity aBaseMetaTileEntity) {
         super.onFirstTick(aBaseMetaTileEntity);
-        ItemStack oldMoldSlot = getStackInSlot(2);
+
         if (getSizeInventory() > 1) {
+            boolean migrated = false;
+
+            if (getMold() != null) {
+                for (ItemStack mold : solidifierMolds) {
+                    if (mold.getItem() == getMold().getItem()) {
+                        migrated = true;
+                        break;
+                    }
+                }
+            }
+
+            if (migrated) {
+                return;
+            }
+
+            ItemStack oldMoldSlot = getStackInSlot(2);
+
             for (int i = 1; i < getSizeInventory(); i++) {
                 setInventorySlotContents(i, null);
             }
+
             setInventorySlotContents(0, oldMoldSlot);
         }
     }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/MTEHatchSolidifier.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/MTEHatchSolidifier.java
@@ -15,12 +15,13 @@ import gregtech.api.gui.modularui.GTUITextures;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.implementations.MTEHatchInput;
+import gregtech.api.metatileentity.implementations.MTEHatchMultiInput;
 import gregtech.api.util.GTUtility;
 
-public class MTEHatchSolidifier extends MTEHatchInput {
+public class MTEHatchSolidifier extends MTEHatchMultiInput {
 
-    static final int moldSlot = 2;
+    static final int moldSlot = 0;
+
     static final ItemStack[] solidifierMolds = { ItemList.Shape_Mold_Bottle.get(1), ItemList.Shape_Mold_Plate.get(1),
         ItemList.Shape_Mold_Ingot.get(1), ItemList.Shape_Mold_Casing.get(1), ItemList.Shape_Mold_Gear.get(1),
         ItemList.Shape_Mold_Gear_Small.get(1), ItemList.Shape_Mold_Credit.get(1), ItemList.Shape_Mold_Nugget.get(1),
@@ -38,14 +39,14 @@ public class MTEHatchSolidifier extends MTEHatchInput {
         GGItemList.Shape_One_Use_craftingToolHardHammer.get(1), GGItemList.Shape_One_Use_craftingToolSoftHammer.get(1),
         GGItemList.Shape_One_Use_craftingToolScrewdriver.get(1), GGItemList.Shape_One_Use_craftingToolSaw.get(1) };
 
-    public MTEHatchSolidifier(int aID, String aName, String aNameRegional, int aTier) {
-        super(aID, aName, aNameRegional, aTier);
+    public MTEHatchSolidifier(int aID, int aSlot, String aName, String aNameRegional, int aTier) {
+        super(aID, aSlot, aName, aNameRegional, aTier);
     }
 
     @Override
     public String[] getDescription() {
         return new String[] {
-            "Fluid Input with Mold for " + EnumChatFormatting.YELLOW + "Fluid Shaper" + EnumChatFormatting.RESET,
+            "4x Fluid Input with Mold for " + EnumChatFormatting.YELLOW + "Fluid Shaper" + EnumChatFormatting.RESET,
             "Capacity: " + GTUtility.formatNumbers(getCapacity()) + "L",
             "Added by: " + EnumChatFormatting.AQUA
                 + "Quetz4l"
@@ -69,7 +70,19 @@ public class MTEHatchSolidifier extends MTEHatchInput {
         public boolean isItemValidPhantom(ItemStack stack) {
             return super.isItemValidPhantom(stack) && getBaseMetaTileEntity().isItemValidForSlot(getSlotIndex(), stack);
         }
+    }
 
+    // Migration from 1x to 4x solidifier hatch. Migrates the mold, but does not fluid.
+    @Override
+    public void onFirstTick(IGregTechTileEntity aBaseMetaTileEntity) {
+        super.onFirstTick(aBaseMetaTileEntity);
+        ItemStack oldMoldSlot = getStackInSlot(2);
+        if (getSizeInventory() > 1) {
+            for (int i = 1; i < getSizeInventory(); i++) {
+                setInventorySlotContents(i, null);
+            }
+            setInventorySlotContents(0, oldMoldSlot);
+        }
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/MTEIndustrialMultiMachine.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/MTEIndustrialMultiMachine.java
@@ -410,18 +410,18 @@ public class MTEIndustrialMultiMachine extends GTPPMultiBlockBase<MTEIndustrialM
             }
 
             // Logic for MTEHatchInput
-            for (MTEHatchInput solidifierHatch : mInputHatches) {
-                if (solidifierHatch instanceof MTEHatchSolidifier) {
-                    ItemStack mold = ((MTEHatchSolidifier) solidifierHatch).getMold();
-                    FluidStack fluid = solidifierHatch.getFluid();
+            for (MTEHatchInput hatch : mInputHatches) {
+                if (hatch instanceof MTEHatchSolidifier solidifierHatch) {
+                    ItemStack mold = solidifierHatch.getMold();
+                    FluidStack[] fluids = solidifierHatch.getStoredFluid();
 
-                    if (mold != null && fluid != null) {
+                    if (mold != null && fluids.length != 0) {
                         List<ItemStack> inputItems = new ArrayList<>();
                         inputItems.add(mold);
                         inputItems.add(GTUtility.getIntegratedCircuit(22));
 
-                        processingLogic.setInputItems(inputItems.toArray(new ItemStack[0]));
-                        processingLogic.setInputFluids(fluid);
+                        processingLogic.setInputItems(inputItems);
+                        processingLogic.setInputFluids(fluids);
 
                         CheckRecipeResult foundResult = processingLogic.process();
                         if (foundResult.wasSuccessful()) {

--- a/src/main/java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechCustomHatches.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechCustomHatches.java
@@ -324,16 +324,16 @@ public class GregtechCustomHatches {
 
     private static void run6() {
         GregtechItemList.Hatch_Solidifier_I.set(
-            new MTEHatchSolidifier(Hatch_Solidifier_I.ID, "hatch.solidifier.tier.05", "Solidifier Hatch I", 5)
+            new MTEHatchSolidifier(Hatch_Solidifier_I.ID, 4, "hatch.solidifier.tier.05", "Solidifier Hatch I", 5)
                 .getStackForm(1L));
         GregtechItemList.Hatch_Solidifier_II.set(
-            new MTEHatchSolidifier(Hatch_Solidifier_II.ID, "hatch.solidifier.tier.06", "Solidifier Hatch II", 6)
+            new MTEHatchSolidifier(Hatch_Solidifier_II.ID, 4, "hatch.solidifier.tier.06", "Solidifier Hatch II", 6)
                 .getStackForm(1L));
         GregtechItemList.Hatch_Solidifier_III.set(
-            new MTEHatchSolidifier(Hatch_Solidifier_III.ID, "hatch.solidifier.tier.07", "Solidifier Hatch III", 7)
+            new MTEHatchSolidifier(Hatch_Solidifier_III.ID, 4, "hatch.solidifier.tier.07", "Solidifier Hatch III", 7)
                 .getStackForm(1L));
         GregtechItemList.Hatch_Solidifier_IV.set(
-            new MTEHatchSolidifier(Hatch_Solidifier_IV.ID, "hatch.solidifier.tier.08", "Solidifier Hatch IV", 8)
+            new MTEHatchSolidifier(Hatch_Solidifier_IV.ID, 4, "hatch.solidifier.tier.08", "Solidifier Hatch IV", 8)
                 .getStackForm(1L));
     }
 


### PR DESCRIPTION
The hatch with 1 fluid really slowed down a lot while сrafting through me orders, as the fluid alternated very often and сrafted a little at a time. The 4x should improve the situation and correct this nuisance

* When it migrates, it'll destroy all liquids and cells inside. The mold will retain.
* In the recipe replaced the chest with ulv input bas and 1x hatch with 4x hatch

![image](https://github.com/user-attachments/assets/8c9903cf-9d91-4161-8791-77151fb52915)


https://github.com/user-attachments/assets/162630cb-1b72-478d-b5c7-184f93e4e800

