### PR TITLE
Remove Aluminium Oreberry fluid extraction

### DIFF
--- a/src/main/java/gregtech/loaders/postload/recipes/FluidExtractorRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/FluidExtractorRecipes.java
@@ -559,13 +559,6 @@ public class FluidExtractorRecipes implements Runnable {
             .eut(TierEU.RECIPE_MV)
             .addTo(fluidExtractionRecipes);
 
-        GTValues.RA.stdBuilder()
-            .itemInputs(GTModHandler.getModItem(TinkerConstruct.ID, "oreBerries", 1L, 4))
-            .fluidOutputs(Materials.Aluminium.getMolten(16))
-            .duration(2 * SECONDS)
-            .eut(TierEU.RECIPE_MV)
-            .addTo(fluidExtractionRecipes);
-
         if (Forestry.isModLoaded()) {
             // Beecombs fluid extractor recipes
             // xenon


### PR DESCRIPTION
Partial revert of https://github.com/GTNewHorizons/GT5-Unofficial/pull/3502.

You're not intended to be able to skip the EBF entirely to make aluminium ingots & molten aluminium.