### PR TITLE
Fix EIC NPE

### DIFF
--- a/src/main/java/bartworks/common/tileentities/multis/MTEElectricImplosionCompressor.java
+++ b/src/main/java/bartworks/common/tileentities/multis/MTEElectricImplosionCompressor.java
@@ -38,6 +38,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
@@ -162,7 +163,7 @@ public class MTEElectricImplosionCompressor extends MTEExtendedPowerMultiBlockBa
                 if (te.piston) {
                     Block candidate = world.getBlock(x, y, z);
                     int candidateMeta = world.getBlockMetadata(x, y, z);
-                    return getTierOfBlock(candidate, candidateMeta) != -1;
+                    return getTierOfBlock(candidate, candidateMeta) != null;
                 }
                 return true;
             }
@@ -237,6 +238,7 @@ public class MTEElectricImplosionCompressor extends MTEExtendedPowerMultiBlockBa
         return MTEElectricImplosionCompressor::getTierOfBlock;
     }
 
+    @Nullable
     private static Integer getTierOfBlock(Block block, int meta) {
         if (block == null) {
             return null;

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialExtractor.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialExtractor.java
@@ -12,6 +12,8 @@ import static gregtech.api.util.GTStructureUtility.chainAllGlasses;
 
 import java.util.List;
 
+import javax.annotation.Nullable;
+
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
@@ -85,6 +87,7 @@ public class MTEIndustrialExtractor extends MTEExtendedPowerMultiBlockBase<MTEIn
 
     private int itemPipeTier = -1;
 
+    @Nullable
     private static Integer getItemPipeTierFromMeta(Block block, Integer metaID) {
         if (block != GregTechAPI.sBlockCasings11) return null;
         if (metaID < 0 || metaID > 7) return null;

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEMultiAutoclave.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEMultiAutoclave.java
@@ -27,6 +27,7 @@ import java.text.DecimalFormat;
 import java.util.List;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
@@ -87,6 +88,7 @@ public class MTEMultiAutoclave extends MTEExtendedPowerMultiBlockBase<MTEMultiAu
     protected int itemPipeTier = 0;
     protected int fluidPipeTier = 0;
 
+    @Nullable
     private static Integer getItemPipeTierFromMeta(Block block, Integer metaID) {
         if (block != GregTechAPI.sBlockCasings11) return null;
         if (metaID < 0 || metaID > 7) return null;
@@ -101,6 +103,7 @@ public class MTEMultiAutoclave extends MTEExtendedPowerMultiBlockBase<MTEMultiAu
         return itemPipeTier;
     }
 
+    @Nullable
     private static Integer getFluidTierFromMeta(Block block, Integer metaID) {
         if (block != GregTechAPI.sBlockCasings2) return null;
         if (metaID < 12 || metaID > 15) return null;

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEMultiLathe.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEMultiLathe.java
@@ -20,6 +20,8 @@ import static gregtech.api.util.GTStructureUtility.chainAllGlasses;
 import java.text.DecimalFormat;
 import java.util.List;
 
+import javax.annotation.Nullable;
+
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -76,6 +78,7 @@ public class MTEMultiLathe extends MTEExtendedPowerMultiBlockBase<MTEMultiLathe>
     protected int pipeTier = -1;
 
     // get tier from block meta
+    @Nullable
     private static Integer getTierFromMeta(Block block, Integer metaID) {
         if (block != GregTechAPI.sBlockCasings11) return null;
         if (metaID < 0 || metaID > 7) return null;

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/MTEIndustrialMacerator.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/MTEIndustrialMacerator.java
@@ -14,6 +14,8 @@ import static gregtech.api.util.GTStructureUtility.buildHatchAdder;
 import java.util.List;
 import java.util.Random;
 
+import javax.annotation.Nullable;
+
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -69,6 +71,7 @@ public class MTEIndustrialMacerator extends GTPPMultiBlockBase<MTEIndustrialMace
     private static final int DEPTH_OFF_SET = 0;
     private static IStructureDefinition<MTEIndustrialMacerator> STRUCTURE_DEFINITION = null;
 
+    @Nullable
     private static Integer getStructureCasingTier(Block b, int m) {
         if (b == GregTechAPI.sBlockCasings4 && m == 2) return 1;
         if (b == ModBlocks.blockCasingsMisc && m == 7) return 2;

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/MTESteamCentrifuge.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/MTESteamCentrifuge.java
@@ -10,6 +10,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -112,18 +113,21 @@ public class MTESteamCentrifuge extends MTESteamMultiBase<MTESteamCentrifuge> im
         return null;
     }
 
+    @Nullable
     public static Integer getTierFireBoxCasing(Block block, int meta) {
         if (block == sBlockCasings3 && 13 == meta) return 1;
         if (block == sBlockCasings3 && 14 == meta) return 2;
         return null;
     }
 
+    @Nullable
     public static Integer getTierGearBoxCasing(Block block, int meta) {
         if (block == sBlockCasings2 && 2 == meta) return 1;
         if (block == sBlockCasings2 && 3 == meta) return 2;
         return null;
     }
 
+    @Nullable
     public static Integer getTierPipeCasing(Block block, int meta) {
         if (block == sBlockCasings2 && 12 == meta) return 1;
         if (block == sBlockCasings2 && 13 == meta) return 2;

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/MTESteamCompressor.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/MTESteamCompressor.java
@@ -12,6 +12,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -98,6 +99,7 @@ public class MTESteamCompressor extends MTESteamMultiBase<MTESteamCompressor> im
 
     private int tierMachineCasing = -1;
 
+    @Nullable
     public Integer getTierMachineCasing(Block block, int meta) {
         if (block == sBlockCasings1 && 10 == meta) {
             mCountCasing++;

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/MTESteamForgeHammer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/MTESteamForgeHammer.java
@@ -12,6 +12,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -106,12 +107,14 @@ public class MTESteamForgeHammer extends MTESteamMultiBase<MTESteamForgeHammer> 
 
     private int tierSimpleBlock = -1;
 
+    @Nullable
     public static Integer getTierSimpleBlock(Block block, int meta) {
         if (block == Blocks.iron_block && meta == 0) return 1;
         if (block == GregTechAPI.sBlockMetal6 && meta == 13) return 2;
         return null;
     }
 
+    @Nullable
     public Integer getTierMachineCasing(Block block, int meta) {
         if (block == sBlockCasings1 && 10 == meta) {
             tCountCasing++;
@@ -124,6 +127,7 @@ public class MTESteamForgeHammer extends MTESteamMultiBase<MTESteamForgeHammer> 
         return null;
     }
 
+    @Nullable
     public static Integer getTierPipeCasing(Block block, int meta) {
         if (block == sBlockCasings2 && 12 == meta) return 1;
         if (block == sBlockCasings2 && 13 == meta) return 2;

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/MTESteamMacerator.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/MTESteamMacerator.java
@@ -12,6 +12,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -94,6 +95,7 @@ public class MTESteamMacerator extends MTESteamMultiBase<MTESteamMacerator> impl
 
     private int tierMachineCasing = -1;
 
+    @Nullable
     public Integer getTierMachineCasing(Block block, int meta) {
         if (block == sBlockCasings1 && 10 == meta) {
             mCounCasing++;

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/MTESteamMixer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/MTESteamMixer.java
@@ -15,6 +15,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -106,6 +107,7 @@ public class MTESteamMixer extends MTESteamMultiBase<MTESteamMixer> implements I
 
     private int tierMachine = 1;
 
+    @Nullable
     public Integer getTierMachineCasing(Block block, int meta) {
         if (block == sBlockCasings1 && 10 == meta) {
             tCountCasing++;
@@ -118,12 +120,14 @@ public class MTESteamMixer extends MTESteamMultiBase<MTESteamMixer> implements I
         return null;
     }
 
+    @Nullable
     public static Integer getTierGearBoxCasing(Block block, int meta) {
         if (block == sBlockCasings2 && 2 == meta) return 1;
         if (block == sBlockCasings2 && 3 == meta) return 2;
         return null;
     }
 
+    @Nullable
     public static Integer getTierPipeCasing(Block block, int meta) {
         if (block == sBlockCasings2 && 12 == meta) return 1;
         if (block == sBlockCasings2 && 13 == meta) return 2;

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/MTESteamWasher.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/MTESteamWasher.java
@@ -11,6 +11,7 @@ import java.util.Collection;
 import java.util.List;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -115,6 +116,7 @@ public class MTESteamWasher extends MTESteamMultiBase<MTESteamWasher> implements
 
     private int tCountCasing = 0;
 
+    @Nullable
     public Integer getTierMachineCasing(Block block, int meta) {
         if (block == sBlockCasings1 && 10 == meta) {
             tCountCasing++;
@@ -127,12 +129,14 @@ public class MTESteamWasher extends MTESteamMultiBase<MTESteamWasher> implements
         return null;
     }
 
+    @Nullable
     public static Integer getTierGearBoxCasing(Block block, int meta) {
         if (block == sBlockCasings2 && 2 == meta) return 1;
         if (block == sBlockCasings2 && 3 == meta) return 2;
         return null;
     }
 
+    @Nullable
     public static Integer getTierPipeCasing(Block block, int meta) {
         if (block == sBlockCasings2 && 12 == meta) return 1;
         if (block == sBlockCasings2 && 13 == meta) return 2;

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/MTESteamWaterPump.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/steam/MTESteamWaterPump.java
@@ -10,6 +10,8 @@ import static gregtech.api.util.GTStructureUtility.buildHatchAdder;
 
 import java.util.List;
 
+import javax.annotation.Nullable;
+
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
@@ -149,6 +151,7 @@ public class MTESteamWaterPump extends MTESteamMultiBase<MTESteamWaterPump> impl
     }
     // spotless:on
 
+    @Nullable
     public static Integer getFrameTier(Block block, int meta) {
         if (block == GregTechAPI.sBlockFrames) {
             if (meta == Materials.Bronze.mMetaItemSubID) return 1;


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19477

In changing the tier functions to return null if the candidate is untiered, I missed one place the value was checked outside structure check - thus an NPE - in MTEElectricImplosionCompressor. To avoid this in the future, I just annotated the rest of the functions I touched with Nullable.