### PR TITLE
Fix Cleanroom NPE

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTECleanroom.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTECleanroom.java
@@ -285,8 +285,12 @@ public class MTECleanroom extends MTETooltipMultiBlockBase
         if ((allowedMask & MASK_FILTER) != 0 && block == FILTER_BLOCK && meta == FILTER_META)
             return CleanroomBlockType.FILTER;
 
-        if ((allowedMask & MASK_GLASS) != 0 && getGlassBlockTier(block, meta) >= MIN_GLASS_TIER)
-            return CleanroomBlockType.GLASS;
+        if ((allowedMask & MASK_GLASS) != 0) {
+            Integer glassTier = getGlassBlockTier(block, meta);
+            if (glassTier != null && glassTier >= MIN_GLASS_TIER) {
+                return CleanroomBlockType.GLASS;
+            }
+        }
 
         if ((allowedMask & MASK_OTHER) != 0 && (ALLOWED_BLOCKS.contains(block.getUnlocalizedName())
             || ALLOWED_BLOCKS.contains(block.getUnlocalizedName() + ":" + meta))) return CleanroomBlockType.OTHER;


### PR DESCRIPTION
Another quick null check - cleanroom is the only thing outside of structuredefs directly calling the glass tier function.