### PR TITLE
Fix ActiveGTMachineMutationCondition

### DIFF
--- a/src/main/java/gregtech/loaders/misc/GTBees.java
+++ b/src/main/java/gregtech/loaders/misc/GTBees.java
@@ -10,6 +10,7 @@ import net.minecraft.world.biome.BiomeGenBase;
 
 import forestry.api.apiculture.EnumBeeChromosome;
 import forestry.api.apiculture.IAlleleBeeEffect;
+import forestry.api.apiculture.IBeeHousing;
 import forestry.api.core.IClimateProvider;
 import forestry.api.genetics.AlleleManager;
 import forestry.api.genetics.IAllele;
@@ -214,8 +215,15 @@ public class GTBees {
         @Override
         public float getChance(World world, int x, int y, int z, IAllele allele0, IAllele allele1, IGenome genome0,
             IGenome genome1, IClimateProvider climate) {
-            TileEntity tileEntity = world.getTileEntity(x, y - 1, z);
-            if (tileEntity instanceof BaseMetaTileEntity machine) {
+            TileEntity tile;
+            int depth = 0;
+            // Checks for the first non BeeHousing block below the given location, necessary for multiblocks
+            do {
+                ++depth;
+                tile = world.getTileEntity(x, y - depth, z);
+            } while (tile instanceof IBeeHousing);
+
+            if (tile instanceof BaseMetaTileEntity machine) {
                 if (machine.isActive()) {
                     return 1;
                 }


### PR DESCRIPTION
Fixes [#19125](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19125)
As I outlined in my diagnosis comment on the linked issue, the alveary is currently checking inside itself for the running GT machine. I borrowed some logic from forestry's [getItemStackFromBelowBlock](https://github.com/GTNewHorizons/ForestryMC/blob/e2c2ff8d300de1ed6a8a0dde89e1809303f97d0d/src/main/java/forestry/core/utils/BlockUtil.java#L259).  The mutation condition now goes down to find the first non BeeHousing block and checks if that is the running machine. The machinist bee can now be bred in the alveary and I have also tested this has not broken single block hives.
![Alveary](https://github.com/user-attachments/assets/06f6bf95-eb88-4062-a29c-74c52c9a8bef)
![Apiary](https://github.com/user-attachments/assets/8e767bd5-4ec0-4e67-b327-1ce6936b1e2e)

