### PR TITLE
Add a config option to change temperature scales

### DIFF
--- a/src/main/java/bartworks/common/tileentities/multis/mega/MTEMegaBlastFurnace.java
+++ b/src/main/java/bartworks/common/tileentities/multis/mega/MTEMegaBlastFurnace.java
@@ -25,11 +25,14 @@ import static gregtech.api.util.GTStructureUtility.activeCoils;
 import static gregtech.api.util.GTStructureUtility.buildHatchAdder;
 import static gregtech.api.util.GTStructureUtility.chainAllGlasses;
 import static gregtech.api.util.GTStructureUtility.ofCoil;
+import static gregtech.api.util.TemperatureUtils.convertKelvinIncreaseToCurrentUnit;
+import static gregtech.api.util.TemperatureUtils.getTemperatureAsCurrentUnit;
 
 import java.util.Arrays;
 
 import javax.annotation.Nonnull;
 
+import gregtech.api.util.TemperatureUtils;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -159,10 +162,14 @@ public class MTEMegaBlastFurnace extends MegaMultiBlockBase<MTEMegaBlastFurnace>
         tt.addMachineType("Blast Furnace, MEBF, MBF")
             .addParallelInfo(Configuration.Multiblocks.megaMachinesMax)
             .addInfo("You can use some fluids to reduce recipe time. Place the circuit in the Input Bus")
-            .addInfo("Each 900K over the min. Heat required reduces power consumption by 5% (multiplicatively)")
-            .addInfo("Each 1800K over the min. Heat allows for an overclock to be upgraded to a perfect overclock.")
+            .addInfo(
+                "Each " + TemperatureUtils.getTemperatureAsCurrentUnit(900)
+                    + " over the min. Heat required reduces power consumption by 5% (multiplicatively)")
+            .addInfo(
+                "Each " + TemperatureUtils.getTemperatureAsCurrentUnit(1800)
+                    + " over the min. Heat allows for an overclock to be upgraded to a perfect overclock.")
             .addInfo("That means the EBF will reduce recipe time by a factor 4 instead of 2 (giving 100% efficiency).")
-            .addInfo("Additionally gives +100K for every tier past MV")
+            .addInfo("Additionally gives " + convertKelvinIncreaseToCurrentUnit(100) + " for every tier past MV")
             .addTecTechHatchInfo()
             .addGlassEnergyLimitInfo()
             .addMinGlassForLaser(VoltageIndex.UV)
@@ -259,9 +266,7 @@ public class MTEMegaBlastFurnace extends MegaMultiBlockBase<MTEMegaBlastFurnace>
     protected String[] getExtendedInfoData() {
         return new String[] { StatCollector.translateToLocal("GT5U.EBF.heat") + ": "
             + EnumChatFormatting.GREEN
-            + GTUtility.formatNumbers(this.mHeatingCapacity)
-            + EnumChatFormatting.RESET
-            + " K" };
+            + TemperatureUtils.getTemperatureAsCurrentUnit(this.mHeatingCapacity) };
     }
 
     @Override

--- a/src/main/java/bartworks/common/tileentities/multis/mega/MTEMegaBlastFurnace.java
+++ b/src/main/java/bartworks/common/tileentities/multis/mega/MTEMegaBlastFurnace.java
@@ -26,13 +26,11 @@ import static gregtech.api.util.GTStructureUtility.buildHatchAdder;
 import static gregtech.api.util.GTStructureUtility.chainAllGlasses;
 import static gregtech.api.util.GTStructureUtility.ofCoil;
 import static gregtech.api.util.TemperatureUtils.convertKelvinIncreaseToCurrentUnit;
-import static gregtech.api.util.TemperatureUtils.getTemperatureAsCurrentUnit;
 
 import java.util.Arrays;
 
 import javax.annotation.Nonnull;
 
-import gregtech.api.util.TemperatureUtils;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -68,6 +66,7 @@ import gregtech.api.util.GTRecipe;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.MultiblockTooltipBuilder;
 import gregtech.api.util.OverclockCalculator;
+import gregtech.api.util.TemperatureUtils;
 import gregtech.common.pollution.PollutionConfig;
 
 public class MTEMegaBlastFurnace extends MegaMultiBlockBase<MTEMegaBlastFurnace> implements ISurvivalConstructable {

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEFluidPipe.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEFluidPipe.java
@@ -8,7 +8,7 @@ import static gregtech.api.metatileentity.implementations.MTEFluidPipe.Border.LE
 import static gregtech.api.metatileentity.implementations.MTEFluidPipe.Border.RIGHT;
 import static gregtech.api.metatileentity.implementations.MTEFluidPipe.Border.TOP;
 import static gregtech.api.objects.XSTR.XSTR_INSTANCE;
-import static gregtech.api.util.GTUtility.getTemperatureAsUnit;
+import static gregtech.api.util.TemperatureUtils.getTemperatureAsCurrentUnit;
 import static net.minecraftforge.common.util.ForgeDirection.DOWN;
 import static net.minecraftforge.common.util.ForgeDirection.EAST;
 import static net.minecraftforge.common.util.ForgeDirection.NORTH;
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import gregtech.api.util.TemperatureUtils;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
@@ -923,7 +924,7 @@ public class MTEFluidPipe extends MetaPipeEntity {
                 + "%%% L/sec"
                 + EnumChatFormatting.GRAY);
         descriptions.add(
-            EnumChatFormatting.RED + "Heat Limit: " + getTemperatureAsUnit(mHeatResistance) + EnumChatFormatting.GRAY);
+            EnumChatFormatting.RED + "Heat Limit: " + TemperatureUtils.getTemperatureAsCurrentUnit(mHeatResistance) + EnumChatFormatting.GRAY);
         if (!mGasProof) {
             descriptions.add(EnumChatFormatting.DARK_GREEN + "Cannot handle gas" + EnumChatFormatting.GRAY);
         }

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEFluidPipe.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEFluidPipe.java
@@ -8,7 +8,6 @@ import static gregtech.api.metatileentity.implementations.MTEFluidPipe.Border.LE
 import static gregtech.api.metatileentity.implementations.MTEFluidPipe.Border.RIGHT;
 import static gregtech.api.metatileentity.implementations.MTEFluidPipe.Border.TOP;
 import static gregtech.api.objects.XSTR.XSTR_INSTANCE;
-import static gregtech.api.util.TemperatureUtils.getTemperatureAsCurrentUnit;
 import static net.minecraftforge.common.util.ForgeDirection.DOWN;
 import static net.minecraftforge.common.util.ForgeDirection.EAST;
 import static net.minecraftforge.common.util.ForgeDirection.NORTH;
@@ -22,7 +21,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import gregtech.api.util.TemperatureUtils;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
@@ -61,6 +59,7 @@ import gregtech.api.metatileentity.MetaPipeEntity;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GTLog;
 import gregtech.api.util.GTUtility;
+import gregtech.api.util.TemperatureUtils;
 import gregtech.api.util.WorldSpawnedEventBuilder.ParticleEventBuilder;
 import gregtech.common.blocks.ItemMachines;
 import gregtech.common.config.Other;
@@ -924,7 +923,9 @@ public class MTEFluidPipe extends MetaPipeEntity {
                 + "%%% L/sec"
                 + EnumChatFormatting.GRAY);
         descriptions.add(
-            EnumChatFormatting.RED + "Heat Limit: " + TemperatureUtils.getTemperatureAsCurrentUnit(mHeatResistance) + EnumChatFormatting.GRAY);
+            EnumChatFormatting.RED + "Heat Limit: "
+                + TemperatureUtils.getTemperatureAsCurrentUnit(mHeatResistance)
+                + EnumChatFormatting.GRAY);
         if (!mGasProof) {
             descriptions.add(EnumChatFormatting.DARK_GREEN + "Cannot handle gas" + EnumChatFormatting.GRAY);
         }

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEFluidPipe.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEFluidPipe.java
@@ -8,6 +8,7 @@ import static gregtech.api.metatileentity.implementations.MTEFluidPipe.Border.LE
 import static gregtech.api.metatileentity.implementations.MTEFluidPipe.Border.RIGHT;
 import static gregtech.api.metatileentity.implementations.MTEFluidPipe.Border.TOP;
 import static gregtech.api.objects.XSTR.XSTR_INSTANCE;
+import static gregtech.api.util.GTUtility.getTemperatureAsUnit;
 import static net.minecraftforge.common.util.ForgeDirection.DOWN;
 import static net.minecraftforge.common.util.ForgeDirection.EAST;
 import static net.minecraftforge.common.util.ForgeDirection.NORTH;
@@ -38,6 +39,7 @@ import net.minecraftforge.fluids.IFluidHandler;
 
 import org.apache.commons.lang3.tuple.MutableTriple;
 
+import codechicken.translocator.TileLiquidTranslocator;
 import cpw.mods.fml.common.Optional;
 import gregtech.GTMod;
 import gregtech.api.enums.Dyes;
@@ -66,6 +68,7 @@ import gregtech.common.covers.CoverDrain;
 import gregtech.common.covers.CoverFluidRegulator;
 import mcp.mobius.waila.api.IWailaConfigHandler;
 import mcp.mobius.waila.api.IWailaDataAccessor;
+import tconstruct.smeltery.logic.FaucetLogic;
 
 public class MTEFluidPipe extends MetaPipeEntity {
 
@@ -729,13 +732,13 @@ public class MTEFluidPipe extends MetaPipeEntity {
     @Optional.Method(modid = Mods.Names.TINKER_CONSTRUCT)
     private boolean isTConstructFaucet(TileEntity tTileEntity) {
         // Tinker Construct Faucets return a null tank info, so check the class
-        return tTileEntity instanceof tconstruct.smeltery.logic.FaucetLogic;
+        return tTileEntity instanceof FaucetLogic;
     }
 
     @Optional.Method(modid = Mods.Names.TRANSLOCATOR)
     private boolean isTranslocator(TileEntity tTileEntity) {
         // Translocators return a TankInfo, but it's of 0 length - so check the class if we see this pattern
-        return tTileEntity instanceof codechicken.translocator.TileLiquidTranslocator;
+        return tTileEntity instanceof TileLiquidTranslocator;
     }
 
     @Override
@@ -920,10 +923,7 @@ public class MTEFluidPipe extends MetaPipeEntity {
                 + "%%% L/sec"
                 + EnumChatFormatting.GRAY);
         descriptions.add(
-            EnumChatFormatting.RED + "Heat Limit: %%%"
-                + GTUtility.formatNumbers(mHeatResistance)
-                + "%%% K"
-                + EnumChatFormatting.GRAY);
+            EnumChatFormatting.RED + "Heat Limit: " + getTemperatureAsUnit(mHeatResistance) + EnumChatFormatting.GRAY);
         if (!mGasProof) {
             descriptions.add(EnumChatFormatting.DARK_GREEN + "Cannot handle gas" + EnumChatFormatting.GRAY);
         }

--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -4953,4 +4953,43 @@ public class GTUtility {
     public static float getClientReachDistance() {
         return Minecraft.getMinecraft().playerController.getBlockReachDistance();
     }
+
+    /**
+     *
+     * @param temp Temperature in Kelvin as an int
+     * @return String in the format "T X" where T is an integer and X is an abbreviation for the currently configured
+     *         unit. Will clamp values to max/min int if there is an over/underflow in the conversion.
+     */
+    public static String getTemperatureAsUnit(int temp) {
+        return (switch (GTMod.gregtechproxy.tooltipTemperatureUnits) {
+            case Celsius -> formatNumbers(safeInt(temp - 273, 0)) + " C";
+            case Fahrenheit -> formatNumbers(safeInt((long) (((double) temp / ((double) 5 / 9)) - 459.67), 0)) + " F";
+            case Rankine -> formatNumbers(safeInt((long) ((double) temp * ((double) 9 / 5)), 0)) + " R";
+            case Delisle -> formatNumbers(safeInt((long) ((373.15 - (double) temp) * ((double) 3 / 2)), 0)) + " D";
+            case Newton -> formatNumbers(safeInt((long) (((double) temp - 273.15) * 0.33), 0)) + " N";
+            case Reaumur -> formatNumbers(safeInt((long) (((double) temp - 273.15) * 0.8), 0)) + " Re";
+            case Romer -> formatNumbers(safeInt((long) ((((double) temp - 273.15) * ((double) 21 / 40)) + 7.5), 0))
+                + " Ro";
+            default -> formatNumbers(temp) + " K";
+        });
+    }
+
+    /**
+     *
+     * @param temp Temperature in Kelvin as a long
+     * @return String in the format "T X" where T is an integer and X is an abbreviation for the currently configured
+     *         unit.
+     */
+    public static String getTemperatureAsUnit(long temp) {
+        return (switch (GTMod.gregtechproxy.tooltipTemperatureUnits) {
+            case Celsius -> formatNumbers(temp - 273) + " C";
+            case Fahrenheit -> formatNumbers((long) (((double) temp / ((double) 5 / 9)) - 459.67)) + " F";
+            case Rankine -> formatNumbers((long) ((double) temp * ((double) 9 / 5))) + " R";
+            case Delisle -> formatNumbers((long) ((373.15 - (double) temp) * ((double) 3 / 2))) + " D";
+            case Newton -> formatNumbers((long) (((double) temp - 273.15) * 0.33)) + " N";
+            case Reaumur -> formatNumbers((long) (((double) temp - 273.15) * 0.8)) + " Re";
+            case Romer -> formatNumbers((long) ((((double) temp - 273.15) * ((double) 21 / 40)) + 7.5)) + " Ro";
+            default -> formatNumbers(temp) + " K";
+        });
+    }
 }

--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -4954,42 +4954,4 @@ public class GTUtility {
         return Minecraft.getMinecraft().playerController.getBlockReachDistance();
     }
 
-    /**
-     *
-     * @param temp Temperature in Kelvin as an int
-     * @return String in the format "T X" where T is an integer and X is an abbreviation for the currently configured
-     *         unit. Will clamp values to max/min int if there is an over/underflow in the conversion.
-     */
-    public static String getTemperatureAsUnit(int temp) {
-        return (switch (GTMod.gregtechproxy.tooltipTemperatureUnits) {
-            case Celsius -> formatNumbers(safeInt(temp - 273, 0)) + " C";
-            case Fahrenheit -> formatNumbers(safeInt((long) (((double) temp / ((double) 5 / 9)) - 459.67), 0)) + " F";
-            case Rankine -> formatNumbers(safeInt((long) ((double) temp * ((double) 9 / 5)), 0)) + " R";
-            case Delisle -> formatNumbers(safeInt((long) ((373.15 - (double) temp) * ((double) 3 / 2)), 0)) + " D";
-            case Newton -> formatNumbers(safeInt((long) (((double) temp - 273.15) * 0.33), 0)) + " N";
-            case Reaumur -> formatNumbers(safeInt((long) (((double) temp - 273.15) * 0.8), 0)) + " Re";
-            case Romer -> formatNumbers(safeInt((long) ((((double) temp - 273.15) * ((double) 21 / 40)) + 7.5), 0))
-                + " Ro";
-            default -> formatNumbers(temp) + " K";
-        });
-    }
-
-    /**
-     *
-     * @param temp Temperature in Kelvin as a long
-     * @return String in the format "T X" where T is an integer and X is an abbreviation for the currently configured
-     *         unit.
-     */
-    public static String getTemperatureAsUnit(long temp) {
-        return (switch (GTMod.gregtechproxy.tooltipTemperatureUnits) {
-            case Celsius -> formatNumbers(temp - 273) + " C";
-            case Fahrenheit -> formatNumbers((long) (((double) temp / ((double) 5 / 9)) - 459.67)) + " F";
-            case Rankine -> formatNumbers((long) ((double) temp * ((double) 9 / 5))) + " R";
-            case Delisle -> formatNumbers((long) ((373.15 - (double) temp) * ((double) 3 / 2))) + " D";
-            case Newton -> formatNumbers((long) (((double) temp - 273.15) * 0.33)) + " N";
-            case Reaumur -> formatNumbers((long) (((double) temp - 273.15) * 0.8)) + " Re";
-            case Romer -> formatNumbers((long) ((((double) temp - 273.15) * ((double) 21 / 40)) + 7.5)) + " Ro";
-            default -> formatNumbers(temp) + " K";
-        });
-    }
 }

--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -4953,5 +4953,4 @@ public class GTUtility {
     public static float getClientReachDistance() {
         return Minecraft.getMinecraft().playerController.getBlockReachDistance();
     }
-
 }

--- a/src/main/java/gregtech/api/util/TemperatureUtils.java
+++ b/src/main/java/gregtech/api/util/TemperatureUtils.java
@@ -1,0 +1,87 @@
+package gregtech.api.util;
+
+import static gregtech.api.util.GTUtility.formatNumbers;
+import static gregtech.api.util.GTUtility.safeInt;
+
+import gregtech.GTMod;
+
+public class TemperatureUtils {
+
+    /**
+     *
+     * @param temp Temperature in Kelvin as an int
+     * @return String in the format "T X" where T is an integer and X is an abbreviation for the currently configured
+     *         unit. Will clamp values to max/min int if there is an over/underflow in the conversion.
+     */
+    public static String getTemperatureAsCurrentUnit(int temp) {
+        return switch (GTMod.gregtechproxy.tooltipTemperatureUnits) {
+            case Celsius -> formatNumbers(safeInt(temp - 273, 0)) + " C";
+            case Fahrenheit -> formatNumbers(safeInt((long) (((double) temp / ((double) 5 / 9)) - 459.67), 0)) + " F";
+            case Rankine -> formatNumbers(safeInt((long) ((double) temp * ((double) 9 / 5)), 0)) + " R";
+            case Delisle -> formatNumbers(safeInt((long) ((373.15 - (double) temp) * ((double) 3 / 2)), 0)) + " D";
+            case Newton -> formatNumbers(safeInt((long) (((double) temp - 273.15) * 0.33), 0)) + " N";
+            case Reaumur -> formatNumbers(safeInt((long) (((double) temp - 273.15) * 0.8), 0)) + " Ré";
+            case Romer -> formatNumbers(safeInt((long) ((((double) temp - 273.15) * ((double) 21 / 40)) + 7.5), 0))
+                + " Rø";
+            default -> formatNumbers(temp) + " K";
+        };
+    }
+
+    /**
+     *
+     * @param temp Temperature in Kelvin as a long
+     * @return String in the format "T X" where T is an integer and X is an abbreviation for the currently configured
+     *         unit.
+     */
+    public static String getTemperatureAsCurrentUnit(long temp) {
+        return switch (GTMod.gregtechproxy.tooltipTemperatureUnits) {
+            case Celsius -> formatNumbers(temp - 273) + " C";
+            case Fahrenheit -> formatNumbers((long) (((double) temp / ((double) 5 / 9)) - 459.67)) + " F";
+            case Rankine -> formatNumbers((long) ((double) temp * ((double) 9 / 5))) + " R";
+            case Delisle -> formatNumbers((long) ((373.15 - (double) temp) * ((double) 3 / 2))) + " D";
+            case Newton -> formatNumbers((long) (((double) temp - 273.15) * 0.33)) + " N";
+            case Reaumur -> formatNumbers((long) (((double) temp - 273.15) * 0.8)) + " Ré";
+            case Romer -> formatNumbers((long) ((((double) temp - 273.15) * ((double) 21 / 40)) + 7.5)) + " Rø";
+            default -> formatNumbers(temp) + " K";
+        };
+    }
+
+    /**
+     *
+     * @param increase Temperature increase in Kelvin as long
+     * @return String in the format "+T X" where T is an integer and X is an abbreviation for the currently configured
+     *         unit. The + sign will be automatically converted to a - sign if T is negative.
+     */
+    public static String convertKelvinIncreaseToCurrentUnit(long increase) {
+        String temp = switch (GTMod.gregtechproxy.tooltipTemperatureUnits) {
+            case Celsius -> formatNumbers(increase) + " C";
+            case Fahrenheit -> formatNumbers((double) increase * 1.8) + " F";
+            case Rankine -> formatNumbers((double) increase * 1.8) + " R";
+            case Delisle -> formatNumbers((double) increase * -1.5) + " D";
+            case Newton -> formatNumbers((double) increase * 0.33) + " N";
+            case Reaumur -> formatNumbers((double) increase * 0.8) + " Ré";
+            case Romer -> formatNumbers((double) increase * 0.525) + " Rø";
+            default -> GTUtility.formatNumbers(increase) + " K";
+        };
+        if (temp.toCharArray()[0] == '-') {
+            return temp;
+        } else return "+" + temp;
+    }
+
+    /**
+     *
+     * @return The name of the currently configured temperature measurement
+     */
+    public static String getCurrentTemperatureUnitName() {
+        return switch (GTMod.gregtechproxy.tooltipTemperatureUnits) {
+            case Celsius -> "Celsius";
+            case Fahrenheit -> "Fahrenheit";
+            case Rankine -> "Rankine";
+            case Delisle -> "Delisle";
+            case Newton -> "Newton";
+            case Reaumur -> "Réaumur";
+            case Romer -> "Rømer";
+            default -> "Kelvin";
+        };
+    }
+}

--- a/src/main/java/gregtech/api/util/TemperatureUtils.java
+++ b/src/main/java/gregtech/api/util/TemperatureUtils.java
@@ -14,7 +14,7 @@ public class TemperatureUtils {
      *         unit. Will clamp values to max/min int if there is an over/underflow in the conversion.
      */
     public static String getTemperatureAsCurrentUnit(int temp) {
-        return switch (GTMod.gregtechproxy.tooltipTemperatureUnits) {
+        return switch (GTMod.gregtechproxy.temperatureUnitSystem) {
             case Celsius -> formatNumbers(safeInt(temp - 273, 0)) + " C";
             case Fahrenheit -> formatNumbers(safeInt((long) (((double) temp / ((double) 5 / 9)) - 459.67), 0)) + " F";
             case Rankine -> formatNumbers(safeInt((long) ((double) temp * ((double) 9 / 5)), 0)) + " R";
@@ -34,7 +34,7 @@ public class TemperatureUtils {
      *         unit.
      */
     public static String getTemperatureAsCurrentUnit(long temp) {
-        return switch (GTMod.gregtechproxy.tooltipTemperatureUnits) {
+        return switch (GTMod.gregtechproxy.temperatureUnitSystem) {
             case Celsius -> formatNumbers(temp - 273) + " C";
             case Fahrenheit -> formatNumbers((long) (((double) temp / ((double) 5 / 9)) - 459.67)) + " F";
             case Rankine -> formatNumbers((long) ((double) temp * ((double) 9 / 5))) + " R";
@@ -53,7 +53,7 @@ public class TemperatureUtils {
      *         unit. The + sign will be automatically converted to a - sign if T is negative.
      */
     public static String convertKelvinIncreaseToCurrentUnit(long increase) {
-        String temp = switch (GTMod.gregtechproxy.tooltipTemperatureUnits) {
+        String temp = switch (GTMod.gregtechproxy.temperatureUnitSystem) {
             case Celsius -> formatNumbers(increase) + " C";
             case Fahrenheit -> formatNumbers((double) increase * 1.8) + " F";
             case Rankine -> formatNumbers((double) increase * 1.8) + " R";
@@ -61,7 +61,7 @@ public class TemperatureUtils {
             case Newton -> formatNumbers((double) increase * 0.33) + " N";
             case Reaumur -> formatNumbers((double) increase * 0.8) + " Ré";
             case Romer -> formatNumbers((double) increase * 0.525) + " Rø";
-            default -> GTUtility.formatNumbers(increase) + " K";
+            default -> formatNumbers(increase) + " K";
         };
         if (temp.toCharArray()[0] == '-') {
             return temp;
@@ -73,7 +73,7 @@ public class TemperatureUtils {
      * @return The name of the currently configured temperature measurement
      */
     public static String getCurrentTemperatureUnitName() {
-        return switch (GTMod.gregtechproxy.tooltipTemperatureUnits) {
+        return switch (GTMod.gregtechproxy.temperatureUnitSystem) {
             case Celsius -> "Celsius";
             case Fahrenheit -> "Fahrenheit";
             case Rankine -> "Rankine";

--- a/src/main/java/gregtech/common/GTProxy.java
+++ b/src/main/java/gregtech/common/GTProxy.java
@@ -612,7 +612,20 @@ public abstract class GTProxy implements IGTMod, IFuelHandler {
         Item
     }
 
+    public enum TooltipTemperatureUnits {
+        Kelvin,
+        Celsius,
+        Fahrenheit,
+        Rankine,
+        Delisle,
+        Newton,
+        Reaumur,
+        Romer
+    }
+
     public OreDropSystem oreDropSystem = OreDropSystem.FortuneItem;
+
+    public TooltipTemperatureUnits tooltipTemperatureUnits = TooltipTemperatureUnits.Kelvin;
 
     /**
      * This enables ambient-occlusion smooth lighting on tiles

--- a/src/main/java/gregtech/common/GTProxy.java
+++ b/src/main/java/gregtech/common/GTProxy.java
@@ -612,7 +612,7 @@ public abstract class GTProxy implements IGTMod, IFuelHandler {
         Item
     }
 
-    public enum TooltipTemperatureUnits {
+    public enum TemperatureUnitSystem {
         Kelvin,
         Celsius,
         Fahrenheit,
@@ -625,7 +625,7 @@ public abstract class GTProxy implements IGTMod, IFuelHandler {
 
     public OreDropSystem oreDropSystem = OreDropSystem.FortuneItem;
 
-    public TooltipTemperatureUnits tooltipTemperatureUnits = TooltipTemperatureUnits.Kelvin;
+    public TemperatureUnitSystem temperatureUnitSystem = TemperatureUnitSystem.Kelvin;
 
     /**
      * This enables ambient-occlusion smooth lighting on tiles

--- a/src/main/java/gregtech/common/blocks/BlockCasings5.java
+++ b/src/main/java/gregtech/common/blocks/BlockCasings5.java
@@ -16,6 +16,7 @@ import static gregtech.api.enums.HeatingCoilLevel.UMV;
 import static gregtech.api.enums.HeatingCoilLevel.UV;
 import static gregtech.api.enums.HeatingCoilLevel.UXV;
 import static gregtech.api.enums.HeatingCoilLevel.ZPM;
+import static gregtech.api.util.TemperatureUtils.getCurrentTemperatureUnitName;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -47,7 +48,7 @@ import gregtech.common.render.GTRendererBlock;
 public class BlockCasings5 extends BlockCasingsAbstract implements IHeatingCoil, IBlockWithTextures {
 
     public static final Supplier<String> COIL_HEAT_TOOLTIP = translatedText("gt.coilheattooltip");
-    public static final Supplier<String> COIL_UNIT_TOOLTIP = translatedText("gt.coilunittooltip");
+    public static final Supplier<String> COIL_UNIT_TOOLTIP = () -> " " + getCurrentTemperatureUnitName();
 
     public static final int ACTIVE_OFFSET = 16;
 
@@ -231,7 +232,7 @@ public class BlockCasings5 extends BlockCasingsAbstract implements IHeatingCoil,
         int metadata = stack.getItemDamage();
 
         HeatingCoilLevel coilLevel = BlockCasings5.getCoilHeatFromDamage(metadata);
-        tooltip.add(COIL_HEAT_TOOLTIP.get() + coilLevel.getHeat() + COIL_UNIT_TOOLTIP.get());
+        tooltip.add(COIL_HEAT_TOOLTIP.get() + " " + coilLevel.getHeat() + COIL_UNIT_TOOLTIP.get());
 
         tooltip.add(StatCollector.translateToLocalFormatted("GT5U.tooltip.channelvalue", metadata + 1, "coil"));
     }

--- a/src/main/java/gregtech/common/config/Gregtech.java
+++ b/src/main/java/gregtech/common/config/Gregtech.java
@@ -372,6 +372,11 @@ public class Gregtech {
         @Config.DefaultBoolean(true)
         @Config.RequiresMcRestart
         public boolean loggingExplosions;
+
+        @Config.LangKey("GT5U.gui.config.client.preference.tooltip_temperature")
+        @Config.DefaultEnum("Kelvin")
+        @Config.RequiresMcRestart
+        public GTProxy.TooltipTemperatureUnits tooltipTemperature = GTProxy.TooltipTemperatureUnits.Kelvin;
     }
 
     @Config.LangKey("GT5U.gui.config.gregtech.harvest_level")

--- a/src/main/java/gregtech/common/config/Gregtech.java
+++ b/src/main/java/gregtech/common/config/Gregtech.java
@@ -376,7 +376,7 @@ public class Gregtech {
         @Config.LangKey("GT5U.gui.config.client.preference.tooltip_temperature")
         @Config.DefaultEnum("Kelvin")
         @Config.RequiresMcRestart
-        public GTProxy.TooltipTemperatureUnits tooltipTemperature = GTProxy.TooltipTemperatureUnits.Kelvin;
+        public GTProxy.TemperatureUnitSystem temperatureSystem = GTProxy.TemperatureUnitSystem.Kelvin;
     }
 
     @Config.LangKey("GT5U.gui.config.gregtech.harvest_level")

--- a/src/main/java/gregtech/common/items/ItemFluidDisplay.java
+++ b/src/main/java/gregtech/common/items/ItemFluidDisplay.java
@@ -62,9 +62,10 @@ public class ItemFluidDisplay extends GTGenericItem {
                         + EnumChatFormatting.GRAY);
             }
             aList.add(
-                EnumChatFormatting.RED + StatCollector.translateToLocalFormatted(
-                    "GT5U.tooltip.fluid.temperature",
-                    GTUtility.formatNumbers(aNBT.getLong("mFluidDisplayHeat"))) + EnumChatFormatting.GRAY);
+                EnumChatFormatting.RED + StatCollector.translateToLocal("GT5U.tooltip.fluid.temperature")
+                    + " "
+                    + GTUtility.getTemperatureAsUnit(aNBT.getLong("mFluidDisplayHeat"))
+                    + EnumChatFormatting.GRAY);
             aList.add(
                 EnumChatFormatting.GREEN
                     + StatCollector.translateToLocalFormatted(

--- a/src/main/java/gregtech/common/items/ItemFluidDisplay.java
+++ b/src/main/java/gregtech/common/items/ItemFluidDisplay.java
@@ -1,5 +1,7 @@
 package gregtech.common.items;
 
+import static gregtech.api.util.TemperatureUtils.getTemperatureAsCurrentUnit;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -64,7 +66,7 @@ public class ItemFluidDisplay extends GTGenericItem {
             aList.add(
                 EnumChatFormatting.RED + StatCollector.translateToLocal("GT5U.tooltip.fluid.temperature")
                     + " "
-                    + GTUtility.getTemperatureAsUnit(aNBT.getLong("mFluidDisplayHeat"))
+                    + getTemperatureAsCurrentUnit(aNBT.getLong("mFluidDisplayHeat"))
                     + EnumChatFormatting.GRAY);
             aList.add(
                 EnumChatFormatting.GREEN

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEElectricBlastFurnace.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEElectricBlastFurnace.java
@@ -18,9 +18,12 @@ import static gregtech.api.util.GTStructureUtility.activeCoils;
 import static gregtech.api.util.GTStructureUtility.buildHatchAdder;
 import static gregtech.api.util.GTStructureUtility.ofCoil;
 import static gregtech.api.util.GTUtility.validMTEList;
+import static gregtech.api.util.TemperatureUtils.convertKelvinIncreaseToCurrentUnit;
+import static gregtech.api.util.TemperatureUtils.getTemperatureAsCurrentUnit;
 
 import javax.annotation.Nonnull;
 
+import gregtech.api.util.TemperatureUtils;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -105,10 +108,14 @@ public class MTEElectricBlastFurnace extends MTEAbstractMultiFurnace<MTEElectric
         MultiblockTooltipBuilder tt = new MultiblockTooltipBuilder();
         tt.addMachineType("Blast Furnace, EBF")
             .addInfo("You can use some fluids to reduce recipe time. Place the circuit in the Input Bus")
-            .addInfo("Each 900K over the min. Heat required reduces power consumption by 5% (multiplicatively)")
-            .addInfo("Each 1800K over the min. Heat allows for an overclock to be upgraded to a perfect overclock.")
+            .addInfo(
+                "Each " + TemperatureUtils.getTemperatureAsCurrentUnit(900)
+                    + " over the min. Heat required reduces power consumption by 5% (multiplicatively)")
+            .addInfo(
+                "Each " + TemperatureUtils.getTemperatureAsCurrentUnit(1800)
+                    + " over the min. Heat allows for an overclock to be upgraded to a perfect overclock.")
             .addInfo("That means the EBF will reduce recipe time by a factor 4 instead of 2 (giving 100% efficiency).")
-            .addInfo("Additionally gives +100K for every tier past MV")
+            .addInfo("Additionally gives " + convertKelvinIncreaseToCurrentUnit(100) + " for every tier past MV")
             .addPollutionAmount(getPollutionPerSecond(null))
             .beginStructureBlock(3, 4, 3, true)
             .addController("Front bottom")
@@ -261,9 +268,7 @@ public class MTEElectricBlastFurnace extends MTEAbstractMultiFurnace<MTEElectric
                 + " %",
             StatCollector.translateToLocal("GT5U.EBF.heat") + ": "
                 + EnumChatFormatting.GREEN
-                + GTUtility.formatNumbers(mHeatingCapacity)
-                + EnumChatFormatting.RESET
-                + " K",
+                + TemperatureUtils.getTemperatureAsCurrentUnit(mHeatingCapacity),
             StatCollector.translateToLocal("GT5U.multiblock.pollution") + ": "
                 + EnumChatFormatting.GREEN
                 + getAveragePollutionPercentage()

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEElectricBlastFurnace.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEElectricBlastFurnace.java
@@ -19,11 +19,9 @@ import static gregtech.api.util.GTStructureUtility.buildHatchAdder;
 import static gregtech.api.util.GTStructureUtility.ofCoil;
 import static gregtech.api.util.GTUtility.validMTEList;
 import static gregtech.api.util.TemperatureUtils.convertKelvinIncreaseToCurrentUnit;
-import static gregtech.api.util.TemperatureUtils.getTemperatureAsCurrentUnit;
 
 import javax.annotation.Nonnull;
 
-import gregtech.api.util.TemperatureUtils;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -56,6 +54,7 @@ import gregtech.api.util.GTRecipe;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.MultiblockTooltipBuilder;
 import gregtech.api.util.OverclockCalculator;
+import gregtech.api.util.TemperatureUtils;
 
 public class MTEElectricBlastFurnace extends MTEAbstractMultiFurnace<MTEElectricBlastFurnace>
     implements ISurvivalConstructable {

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEPlasmaForge.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEPlasmaForge.java
@@ -20,6 +20,7 @@ import static gregtech.api.util.GTStructureUtility.activeCoils;
 import static gregtech.api.util.GTStructureUtility.buildHatchAdder;
 import static gregtech.api.util.GTStructureUtility.ofCoil;
 import static gregtech.api.util.GTUtility.validMTEList;
+import static gregtech.api.util.TemperatureUtils.getTemperatureAsCurrentUnit;
 import static net.minecraft.util.StatCollector.translateToLocal;
 
 import java.util.ArrayList;
@@ -30,6 +31,7 @@ import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import gregtech.api.util.TemperatureUtils;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -999,9 +1001,7 @@ public class MTEPlasmaForge extends MTEExtendedPowerMultiBlockBase<MTEPlasmaForg
                 + EnumChatFormatting.RESET,
             StatCollector.translateToLocal("GT5U.EBF.heat") + ": "
                 + EnumChatFormatting.GREEN
-                + GTUtility.formatNumbers(mHeatingCapacity)
-                + EnumChatFormatting.RESET
-                + " K",
+                + TemperatureUtils.getTemperatureAsCurrentUnit(mHeatingCapacity),
             StatCollector.translateToLocalFormatted(
                 "GT5U.infodata.plasma_forge.ticks_run_fuel_discount",
                 EnumChatFormatting.GREEN + GTUtility.formatNumbers(running_time) + EnumChatFormatting.RESET,

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEPlasmaForge.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEPlasmaForge.java
@@ -20,7 +20,6 @@ import static gregtech.api.util.GTStructureUtility.activeCoils;
 import static gregtech.api.util.GTStructureUtility.buildHatchAdder;
 import static gregtech.api.util.GTStructureUtility.ofCoil;
 import static gregtech.api.util.GTUtility.validMTEList;
-import static gregtech.api.util.TemperatureUtils.getTemperatureAsCurrentUnit;
 import static net.minecraft.util.StatCollector.translateToLocal;
 
 import java.util.ArrayList;
@@ -31,7 +30,6 @@ import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import gregtech.api.util.TemperatureUtils;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -87,6 +85,7 @@ import gregtech.api.util.GTUtility;
 import gregtech.api.util.MultiblockTooltipBuilder;
 import gregtech.api.util.OverclockCalculator;
 import gregtech.api.util.ParallelHelper;
+import gregtech.api.util.TemperatureUtils;
 import tectech.thing.gui.TecTechUITextures;
 
 public class MTEPlasmaForge extends MTEExtendedPowerMultiBlockBase<MTEPlasmaForge> implements ISurvivalConstructable {

--- a/src/main/java/gregtech/common/tileentities/machines/multi/purification/MTEPurificationUnitPlasmaHeater.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/purification/MTEPurificationUnitPlasmaHeater.java
@@ -15,6 +15,8 @@ import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_FRONT_LARGE_CHEMICA
 import static gregtech.api.recipe.RecipeMaps.purificationPlasmaHeatingRecipes;
 import static gregtech.api.util.GTRecipeBuilder.SECONDS;
 import static gregtech.api.util.GTStructureUtility.ofFrame;
+import static gregtech.api.util.TemperatureUtils.convertKelvinIncreaseToCurrentUnit;
+import static gregtech.api.util.TemperatureUtils.getTemperatureAsCurrentUnit;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -286,15 +288,14 @@ public class MTEPurificationUnitPlasmaHeater extends MTEPurificationUnitBase<MTE
             .addSeparator()
             .addInfo(
                 "Complete heating cycles by first heating the water to " + EnumChatFormatting.RED
-                    + HEATING_POINT
-                    + "K"
+                    + getTemperatureAsCurrentUnit(HEATING_POINT)
                     + EnumChatFormatting.GRAY
                     + ",")
             .addInfo(
-                "and then cooling it back down to " + EnumChatFormatting.RED + "0K" + EnumChatFormatting.GRAY + ".")
+                "and then cooling it back down to " + EnumChatFormatting.RED + getTemperatureAsCurrentUnit(0) + EnumChatFormatting.GRAY + ".")
             .addInfo(
                 "Initial temperature is reset to " + EnumChatFormatting.RED
-                    + "0K"
+                    + getTemperatureAsCurrentUnit(0)
                     + EnumChatFormatting.GRAY
                     + " on recipe start.")
             .addInfo(
@@ -306,8 +307,7 @@ public class MTEPurificationUnitPlasmaHeater extends MTEPurificationUnitBase<MTE
                     + ".")
             .addInfo(
                 "If the temperature ever reaches " + EnumChatFormatting.RED
-                    + MAX_TEMP
-                    + "K"
+                    + getTemperatureAsCurrentUnit(MAX_TEMP)
                     + EnumChatFormatting.GRAY
                     + " the recipe will fail and output steam.")
             .addSeparator()
@@ -333,8 +333,7 @@ public class MTEPurificationUnitPlasmaHeater extends MTEPurificationUnitBase<MTE
                     + EnumChatFormatting.GRAY
                     + "the temperature by "
                     + EnumChatFormatting.RED
-                    + PLASMA_TEMP_PER_LITER
-                    + "K"
+                    + convertKelvinIncreaseToCurrentUnit(PLASMA_TEMP_PER_LITER)
                     + EnumChatFormatting.GRAY
                     + " per liter of plasma consumed.")
             .addInfo(
@@ -342,8 +341,7 @@ public class MTEPurificationUnitPlasmaHeater extends MTEPurificationUnitBase<MTE
                     + EnumChatFormatting.GRAY
                     + "the temperature by "
                     + EnumChatFormatting.RED
-                    + -COOLANT_TEMP_PER_LITER
-                    + "K"
+                    + convertKelvinIncreaseToCurrentUnit(-COOLANT_TEMP_PER_LITER)
                     + EnumChatFormatting.GRAY
                     + " per liter of coolant consumed.")
             .addSeparator()

--- a/src/main/java/gregtech/common/tileentities/machines/multi/purification/MTEPurificationUnitPlasmaHeater.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/purification/MTEPurificationUnitPlasmaHeater.java
@@ -292,7 +292,10 @@ public class MTEPurificationUnitPlasmaHeater extends MTEPurificationUnitBase<MTE
                     + EnumChatFormatting.GRAY
                     + ",")
             .addInfo(
-                "and then cooling it back down to " + EnumChatFormatting.RED + getTemperatureAsCurrentUnit(0) + EnumChatFormatting.GRAY + ".")
+                "and then cooling it back down to " + EnumChatFormatting.RED
+                    + getTemperatureAsCurrentUnit(0)
+                    + EnumChatFormatting.GRAY
+                    + ".")
             .addInfo(
                 "Initial temperature is reset to " + EnumChatFormatting.RED
                     + getTemperatureAsCurrentUnit(0)

--- a/src/main/java/gregtech/loaders/preload/GTPreLoad.java
+++ b/src/main/java/gregtech/loaders/preload/GTPreLoad.java
@@ -407,7 +407,7 @@ public class GTPreLoad {
             Blocks.mob_spawner.setHardness(500.0F)
                 .setResistance(6000000.0F);
         }
-        GTMod.gregtechproxy.tooltipTemperatureUnits = Gregtech.general.tooltipTemperature;
+        GTMod.gregtechproxy.temperatureUnitSystem = Gregtech.general.temperatureSystem;
 
         // machines
         GTValues.ticksBetweenSounds = Gregtech.machines.ticksBetweenSounds;

--- a/src/main/java/gregtech/loaders/preload/GTPreLoad.java
+++ b/src/main/java/gregtech/loaders/preload/GTPreLoad.java
@@ -407,6 +407,7 @@ public class GTPreLoad {
             Blocks.mob_spawner.setHardness(500.0F)
                 .setResistance(6000000.0F);
         }
+        GTMod.gregtechproxy.tooltipTemperatureUnits = Gregtech.general.tooltipTemperature;
 
         // machines
         GTValues.ticksBetweenSounds = Gregtech.machines.ticksBetweenSounds;

--- a/src/main/java/gregtech/nei/formatter/HeatingCoilSpecialValueFormatter.java
+++ b/src/main/java/gregtech/nei/formatter/HeatingCoilSpecialValueFormatter.java
@@ -1,17 +1,15 @@
 package gregtech.nei.formatter;
 
-import static gregtech.api.util.TemperatureUtils.getTemperatureAsCurrentUnit;
-
 import java.util.Collections;
 import java.util.List;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import gregtech.api.util.TemperatureUtils;
 import net.minecraft.util.StatCollector;
 
 import gregtech.api.enums.HeatingCoilLevel;
 import gregtech.api.util.MethodsReturnNonnullByDefault;
+import gregtech.api.util.TemperatureUtils;
 import gregtech.nei.RecipeDisplayInfo;
 
 @ParametersAreNonnullByDefault

--- a/src/main/java/gregtech/nei/formatter/HeatingCoilSpecialValueFormatter.java
+++ b/src/main/java/gregtech/nei/formatter/HeatingCoilSpecialValueFormatter.java
@@ -1,14 +1,16 @@
 package gregtech.nei.formatter;
 
+import static gregtech.api.util.TemperatureUtils.getTemperatureAsCurrentUnit;
+
 import java.util.Collections;
 import java.util.List;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import gregtech.api.util.TemperatureUtils;
 import net.minecraft.util.StatCollector;
 
 import gregtech.api.enums.HeatingCoilLevel;
-import gregtech.api.util.GTUtility;
 import gregtech.api.util.MethodsReturnNonnullByDefault;
 import gregtech.nei.RecipeDisplayInfo;
 
@@ -22,9 +24,10 @@ public class HeatingCoilSpecialValueFormatter implements INEISpecialInfoFormatte
     public List<String> format(RecipeDisplayInfo recipeInfo) {
         int heat = recipeInfo.recipe.mSpecialValue;
         return Collections.singletonList(
-            StatCollector.translateToLocalFormatted(
-                "GT5U.nei.heat_capacity",
-                GTUtility.formatNumbers(heat),
-                HeatingCoilLevel.getDisplayNameFromHeat(heat, false)));
+            StatCollector.translateToLocal("GT5U.nei.heat_capacity") + " "
+                + TemperatureUtils.getTemperatureAsCurrentUnit(heat)
+                + " ("
+                + HeatingCoilLevel.getDisplayNameFromHeat(heat, false)
+                + ")");
     }
 }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/advanced/MTEAdvEBF.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/advanced/MTEAdvEBF.java
@@ -15,6 +15,7 @@ import static gregtech.api.util.GTStructureUtility.activeCoils;
 import static gregtech.api.util.GTStructureUtility.buildHatchAdder;
 import static gregtech.api.util.GTStructureUtility.ofCoil;
 import static gregtech.api.util.GTUtility.validMTEList;
+import static gregtech.api.util.TemperatureUtils.getTemperatureAsCurrentUnit;
 
 import java.util.ArrayList;
 import java.util.Objects;
@@ -48,7 +49,6 @@ import gregtech.api.recipe.RecipeMaps;
 import gregtech.api.recipe.check.CheckRecipeResult;
 import gregtech.api.recipe.check.CheckRecipeResultRegistry;
 import gregtech.api.util.GTRecipe;
-import gregtech.api.util.GTUtility;
 import gregtech.api.util.MultiblockTooltipBuilder;
 import gregtech.api.util.OverclockCalculator;
 import gregtech.api.util.shutdown.ShutDownReasonRegistry;
@@ -118,9 +118,7 @@ public class MTEAdvEBF extends GTPPMultiBlockBase<MTEAdvEBF> implements ISurviva
     public String[] getExtraInfoData() {
         return new String[] { StatCollector.translateToLocal("GT5U.EBF.heat") + ": "
             + EnumChatFormatting.GREEN
-            + GTUtility.formatNumbers(mHeatingCapacity.getHeat())
-            + EnumChatFormatting.RESET
-            + " K" };
+            + getTemperatureAsCurrentUnit(mHeatingCapacity.getHeat()) };
     }
 
     @Override

--- a/src/main/resources/assets/gregtech/lang/en_US.lang
+++ b/src/main/resources/assets/gregtech/lang/en_US.lang
@@ -778,6 +778,7 @@ GT5U.gui.config.client.color_modulation.construction_foam=Construction Foam
 GT5U.gui.config.client.color_modulation.machine_metal=Machine Metal (Default GUI Color)
 GT5U.gui.config.client.interface=Interface
 GT5U.gui.config.client.preference=Preference
+GT5U.gui.config.client.preference.tooltip_temperature=Tooltip Temperature Measurement Units
 GT5U.gui.config.client.render=Render
 GT5U.gui.config.client.waila=Waila
 GT5U.gui.config.client.nei=NEI
@@ -2109,7 +2110,7 @@ GT5U.tooltip.structure.lens_indicator=Lens Indicator
 
 GT5U.tooltip.fluid.registry=Registry: %s
 GT5U.tooltip.fluid.amount=Amount: %s L
-GT5U.tooltip.fluid.temperature=Temperature: %s K
+GT5U.tooltip.fluid.temperature=Temperature:
 GT5U.tooltip.fluid.stat=State: %s
 GT5U.tooltip.fluid.stat.gas=Gas
 GT5U.tooltip.fluid.stat.liquid=Liquid

--- a/src/main/resources/assets/gregtech/lang/en_US.lang
+++ b/src/main/resources/assets/gregtech/lang/en_US.lang
@@ -778,7 +778,7 @@ GT5U.gui.config.client.color_modulation.construction_foam=Construction Foam
 GT5U.gui.config.client.color_modulation.machine_metal=Machine Metal (Default GUI Color)
 GT5U.gui.config.client.interface=Interface
 GT5U.gui.config.client.preference=Preference
-GT5U.gui.config.client.preference.tooltip_temperature=Tooltip Temperature Measurement Units
+GT5U.gui.config.client.preference.tooltip_temperature=Temperature Measurement Units
 GT5U.gui.config.client.render=Render
 GT5U.gui.config.client.waila=Waila
 GT5U.gui.config.client.nei=NEI
@@ -891,7 +891,7 @@ GT5U.multiblock.itemPipeTier=Item Pipe Tier
 GT5U.multiblock.coilLevel=Heating Coil Level
 
 # NEI recipe handlers
-GT5U.nei.heat_capacity=Heat Capacity: %s K (%s)
+GT5U.nei.heat_capacity=Heat Capacity:
 GT5U.nei.tier=Tier: %s
 GT5U.nei.start_eu=Start: %s EU (MK %s)
 GT5U.nei.stages=Stages: %s
@@ -2121,8 +2121,7 @@ GT5U.tooltip.mega_apiary.only_producer=Will only be produced in mega Apiary
 GT5U.tooltip.electric.tier=Tier: %d
 GT5U.tooltip.electric.tier.s=Tier: %s
 
-gt.coilheattooltip=Base Heating Capacity =
-gt.coilunittooltip= Kelvin
+gt.coilheattooltip=Base Heating Capacity:
 
 GT5U.tootlip.tool.turbine.steam=Steam
 GT5U.tootlip.tool.turbine.loose=Loose

--- a/src/main/resources/assets/gregtech/lang/zh_CN.lang
+++ b/src/main/resources/assets/gregtech/lang/zh_CN.lang
@@ -1180,7 +1180,7 @@ GTPP.MBTT.SteamOutputBus=输出总线(蒸汽)
 
 
 GT5U.tooltip.fluid.amount=数量: %s L
-GT5U.tooltip.fluid.temperature=温度: %s K
+GT5U.tooltip.fluid.temperature=温度:
 GT5U.tooltip.fluid.stat=状态: %s
 GT5U.tooltip.fluid.stat.gas=气体
 GT5U.tooltip.fluid.stat.liquid=液体


### PR DESCRIPTION
Exactly as the title describes. Uses the scales and conversion formulas from [this wikipedia article](https://en.wikipedia.org/wiki/Conversion_of_scales_of_temperature)
Meaning the user can switch between these units, at will (requiring a restart):
- Kelvin
- Celsius
- Fahrenheit
- Rankine
- Delisle
- Newton
- Réaumur
- Rømer

Here are a couple screenshots of new tooltips with Delisle, as an example:
T5 Waterline controller
![image](https://github.com/user-attachments/assets/83568186-872f-436d-b5f9-679aa2a63eed)
EBF
![image](https://github.com/user-attachments/assets/61d12557-4af1-4f07-bbfd-467eb6ccfcfe)
Delisle is has high temperatures low on the scale and low temperatures high on the scale, so the numbers look a bit funny at first sight.

I definitely didnt get *every* usage of temperature put under the config, but I fixed every one I saw. Please tell me if you can think of an especially obscure one or one I didnt find!
