### PR TITLE
Text de-hardcoding

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEHatchMaintenance.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEHatchMaintenance.java
@@ -13,6 +13,7 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.StatCollector;
 import net.minecraftforge.common.util.FakePlayer;
 import net.minecraftforge.common.util.ForgeDirection;
 
@@ -376,7 +377,8 @@ public class MTEHatchMaintenance extends MTEHatch implements IAddUIWidgets, IAli
                     .setBackground(GTUITextures.TRANSPARENT)
                     .setPos(79, 34))
                 .widget(
-                    new TextWidget("Click with Tool to repair.").setDefaultColor(COLOR_TEXT_GRAY.get())
+                    new TextWidget(StatCollector.translateToLocal("GT5U.gui.text.repair_tip"))
+                        .setDefaultColor(COLOR_TEXT_GRAY.get())
                         .setPos(8, 12));
         }
     }

--- a/src/main/java/gregtech/api/util/MultiblockTooltipBuilder.java
+++ b/src/main/java/gregtech/api/util/MultiblockTooltipBuilder.java
@@ -219,7 +219,6 @@ public class MultiblockTooltipBuilder {
                 + "L"
                 + EnumChatFormatting.GRAY
                 + ") "
-                + EnumChatFormatting.RED
                 + (hollow ? EnumChatFormatting.RED + TT_hollow : ""));
         sLines.add(EnumChatFormatting.WHITE + TT_structure + COLON);
         return this;

--- a/src/main/java/gregtech/common/items/ItemIntegratedCircuit.java
+++ b/src/main/java/gregtech/common/items/ItemIntegratedCircuit.java
@@ -40,7 +40,6 @@ import gregtech.api.items.GTGenericItem;
 import gregtech.api.net.GTPacketUpdateItem;
 import gregtech.api.objects.XSTR;
 import gregtech.api.util.GTConfig;
-import gregtech.api.util.GTLanguageManager;
 import gregtech.api.util.GTLog;
 import gregtech.api.util.GTModHandler;
 import gregtech.common.gui.modularui.uifactory.SelectItemUIFactory;
@@ -194,14 +193,11 @@ public class ItemIntegratedCircuit extends GTGenericItem implements INetworkUpda
     public void addAdditionalToolTips(List<String> aList, ItemStack aStack, EntityPlayer aPlayer) {
         super.addAdditionalToolTips(aList, aStack, aPlayer);
         aList.add(
-            GTLanguageManager.addStringLocalization(getUnlocalizedName() + ".configuration", "Configuration: ")
-                + getConfigurationString(getDamage(aStack)));
-        aList.add(
-            GTLanguageManager.addStringLocalization(getUnlocalizedName() + ".tooltip.0", "Right click to reconfigure"));
-        aList.add(
-            GTLanguageManager.addStringLocalization(
-                getUnlocalizedName() + ".tooltip.1",
-                "Needs a screwdriver or circuit programming tool"));
+            StatCollector.translateToLocalFormatted(
+                "GT5U.item.programmed_circuit.tooltip.0",
+                getConfigurationString(getDamage(aStack))));
+        aList.add(StatCollector.translateToLocal("GT5U.item.programmed_circuit.tooltip.1"));
+        aList.add(StatCollector.translateToLocal("GT5U.item.programmed_circuit.tooltip.2"));
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/plugin/agrichem/item/algae/ItemAlgaeBase.java
+++ b/src/main/java/gtPlusPlus/plugin/agrichem/item/algae/ItemAlgaeBase.java
@@ -14,6 +14,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.IIcon;
+import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 
 import cpw.mods.fml.common.registry.GameRegistry;
@@ -61,11 +62,18 @@ public class ItemAlgaeBase extends Item implements IAlgalItem {
         return EnumChatFormatting.UNDERLINE + super.getItemStackDisplayName(aStack);
     }
 
+    private String boolLoc(Boolean bool) {
+        return StatCollector.translateToLocal(bool ? "GT5U.generic.true" : "GT5U.generic.false");
+    }
+
     @Override
     public void addInformation(ItemStack aStack, EntityPlayer p_77624_2_, List aList, boolean p_77624_4_) {
         int aDam = aStack.getItemDamage();
         try {
-            aList.add(AlgaeDefinition.getByIndex(aDam).mSimpleName);
+            aList.add(
+                StatCollector.translateToLocal(
+                    "GTPP.algae." + AlgaeDefinition.getByIndex(aDam).mSimpleName.replace(" ", "_")
+                        .toLowerCase() + ".name"));
             if (!aStack.hasTagCompound() || aStack.getTagCompound()
                 .hasNoTags()) {
                 aStack = initNBT(aStack);
@@ -80,14 +88,15 @@ public class ItemAlgaeBase extends Item implements IAlgalItem {
                 byte mLifespan = aNBT.getByte("mLifespan");
                 int mGeneration = aNBT.getInteger("mGeneration");
 
-                aList.add("Requires Light: " + mRequiresLight);
-                aList.add("Salt Water: " + mSaltWater);
-                aList.add("Fresh Water: " + mFreshWater);
-                aList.add("Temp Tolerance: " + mTempTolerance);
-                aList.add("Growth: " + mFertility);
-                aList.add("Production: " + mProductionSpeed);
-                aList.add("Lifespan in days: " + mLifespan);
-                aList.add("Generation: " + mGeneration);
+                aList.add(
+                    StatCollector.translateToLocalFormatted("GTPP.tooltip.requires_light", boolLoc(mRequiresLight)));
+                aList.add(StatCollector.translateToLocalFormatted("GTPP.tooltip.salt_water", boolLoc(mSaltWater)));
+                aList.add(StatCollector.translateToLocalFormatted("GTPP.tooltip.fresh_water", boolLoc(mFreshWater)));
+                aList.add(StatCollector.translateToLocalFormatted("GTPP.tooltip.temp_tolerance", mTempTolerance));
+                aList.add(StatCollector.translateToLocalFormatted("GTPP.tooltip.growth", mFertility));
+                aList.add(StatCollector.translateToLocalFormatted("GTPP.tooltip.production", mProductionSpeed));
+                aList.add(StatCollector.translateToLocalFormatted("GTPP.tooltip.lifespan", mLifespan));
+                aList.add(StatCollector.translateToLocalFormatted("GTPP.tooltip.generation", mGeneration));
             }
         } catch (Exception e) {
             e.printStackTrace(GTLog.err);

--- a/src/main/java/tectech/thing/casing/ItemCasingsGodforge.java
+++ b/src/main/java/tectech/thing/casing/ItemCasingsGodforge.java
@@ -2,15 +2,15 @@ package tectech.thing.casing;
 
 import static net.minecraft.util.EnumChatFormatting.AQUA;
 import static net.minecraft.util.EnumChatFormatting.BOLD;
+import static net.minecraft.util.EnumChatFormatting.RED;
 
 import java.util.List;
 
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.EnumChatFormatting;
+import net.minecraft.util.StatCollector;
 
-import gregtech.api.util.GTLanguageManager;
 import gregtech.common.blocks.ItemCasings;
 import tectech.util.CommonValues;
 
@@ -25,100 +25,44 @@ public class ItemCasingsGodforge extends ItemCasings {
         tooltip.add(CommonValues.GODFORGE_MARK);
         switch (aStack.getItemDamage()) {
             case 0:
-                tooltip.add(
-                    GTLanguageManager.addStringLocalization(
-                        "godforge.casings.0.Tooltip.0",
-                        "Shielded by the event horizon of a singularity"));
-                tooltip.add(
-                    AQUA.toString() + BOLD
-                        + GTLanguageManager
-                            .addStringLocalization("godforge.casings.0.Tooltip.1", "Don't get too close..."));
+                tooltip.add(StatCollector.translateToLocal("tt.godforge.casings.0.Tooltip.0"));
+                tooltip.add(AQUA + "" + BOLD + StatCollector.translateToLocal("tt.godforge.casings.0.Tooltip.1"));
                 break;
             case 1:
-                tooltip.add(
-                    GTLanguageManager.addStringLocalization(
-                        "godforge.casings.1.Tooltip.0",
-                        "Designed to route stellar matter using spacetime distortion"));
-                tooltip.add(
-                    AQUA.toString() + BOLD
-                        + GTLanguageManager
-                            .addStringLocalization("godforge.casings.1.Tooltip.1", "Reality Distortion"));
+                tooltip.add(StatCollector.translateToLocal("tt.godforge.casings.1.Tooltip.0"));
+                tooltip.add(AQUA + "" + BOLD + StatCollector.translateToLocal("tt.godforge.casings.1.Tooltip.1"));
                 break;
             case 2:
-                tooltip.add(
-                    GTLanguageManager
-                        .addStringLocalization("godforge.casings.2.Tooltip.0", "Unaffected by gravitational forces"));
-                tooltip.add(
-                    AQUA.toString() + BOLD
-                        + GTLanguageManager.addStringLocalization(
-                            "godforge.casings.2.Tooltip.1",
-                            "Not even a black hole could tear it apart."));
+                tooltip.add(StatCollector.translateToLocal("tt.godforge.casings.2.Tooltip.0"));
+                tooltip.add(AQUA + "" + BOLD + StatCollector.translateToLocal("tt.godforge.casings.2.Tooltip.1"));
                 break;
             case 3:
-                tooltip.add(
-                    GTLanguageManager.addStringLocalization(
-                        "godforge.casings.3.Tooltip.0",
-                        "Creates enormous magnetic fields capable of constraining entire stars"));
-                tooltip.add(
-                    AQUA.toString() + BOLD
-                        + GTLanguageManager
-                            .addStringLocalization("godforge.casings.3.Tooltip.1", "It's super effective!"));
+                tooltip.add(StatCollector.translateToLocal("tt.godforge.casings.3.Tooltip.0"));
+                tooltip.add(AQUA + "" + BOLD + StatCollector.translateToLocal("tt.godforge.casings.3.Tooltip.1"));
                 break;
             case 4:
-                tooltip.add(
-                    GTLanguageManager.addStringLocalization(
-                        "godforge.casings.4.Tooltip.0",
-                        "Taps into streams of stellar matter to harness their heat energy"));
-                tooltip.add(
-                    AQUA.toString() + BOLD
-                        + GTLanguageManager.addStringLocalization("godforge.casings.4.Tooltip.1", "Turn up the heat!"));
+                tooltip.add(StatCollector.translateToLocal("tt.godforge.casings.4.Tooltip.0"));
+                tooltip.add(AQUA + "" + BOLD + StatCollector.translateToLocal("tt.godforge.casings.4.Tooltip.1"));
                 break;
             case 5:
-                tooltip.add(
-                    GTLanguageManager.addStringLocalization(
-                        "godforge.casings.5.Tooltip.0",
-                        "Controls the flow of gravitons to manipulate gravity"));
-                tooltip.add(
-                    AQUA.toString() + BOLD
-                        + GTLanguageManager.addStringLocalization(
-                            "godforge.casings.5.Tooltip.1",
-                            "Exponential scaling past 800 Galaxies"));
+                tooltip.add(StatCollector.translateToLocal("tt.godforge.casings.5.Tooltip.0"));
+                tooltip.add(AQUA + "" + BOLD + StatCollector.translateToLocal("tt.godforge.casings.5.Tooltip.1"));
                 break;
             case 6:
-                tooltip.add(
-                    GTLanguageManager.addStringLocalization(
-                        "godforge.casings.6.Tooltip.0",
-                        "Controls the flow of gravitons to manipulate gravity"));
-                tooltip.add(
-                    AQUA.toString() + BOLD
-                        + GTLanguageManager.addStringLocalization("godforge.casings.6.Tooltip.1", "Getting closer..."));
+                tooltip.add(StatCollector.translateToLocal("tt.godforge.casings.6.Tooltip.0"));
+                tooltip.add(AQUA + "" + BOLD + StatCollector.translateToLocal("tt.godforge.casings.6.Tooltip.1"));
                 break;
             case 7:
-                tooltip.add(
-                    GTLanguageManager.addStringLocalization(
-                        "godforge.casings.7.Tooltip.0",
-                        "Controls the flow of gravitons to manipulate gravity"));
-                tooltip.add(
-                    AQUA.toString() + BOLD
-                        + GTLanguageManager.addStringLocalization("godforge.casings.7.Tooltip.1", "Gravity Central"));
+                tooltip.add(StatCollector.translateToLocal("tt.godforge.casings.7.Tooltip.0"));
+                tooltip.add(AQUA + "" + BOLD + StatCollector.translateToLocal("tt.godforge.casings.7.Tooltip.1"));
                 break;
             case 8:
-                tooltip.add(
-                    GTLanguageManager.addStringLocalization(
-                        "godforge.casings.8.Tooltip.0",
-                        "Transfers and stores extreme amounts of heat without any loss"));
-                tooltip.add(
-                    AQUA.toString() + BOLD
-                        + GTLanguageManager.addStringLocalization("godforge.casings.8.Tooltip.1", "<<<Thermal<<<"));
-                tooltip.add(
-                    AQUA.toString() + BOLD
-                        + GTLanguageManager.addStringLocalization("godforge.casings.8.Tooltip.2", ">>>Wave>>>"));
+                tooltip.add(StatCollector.translateToLocal("tt.godforge.casings.8.Tooltip.0"));
+                tooltip.add(AQUA + "" + BOLD + StatCollector.translateToLocal("tt.godforge.casings.8.Tooltip.1"));
+                tooltip.add(AQUA + "" + BOLD + StatCollector.translateToLocal("tt.godforge.casings.8.Tooltip.2"));
                 break;
             default:
-                tooltip.add(
-                    EnumChatFormatting.RED.toString() + BOLD
-                        + GTLanguageManager
-                            .addStringLocalization("godforge.casings.Error.Tooltip", "Error, report to GTNH team"));
+                tooltip.add(RED + "" + BOLD + StatCollector.translateToLocal("tt.godforge.casings.Error.Tooltip"));
         }
     }
 }

--- a/src/main/java/tectech/thing/casing/ItemCasingsSpacetime.java
+++ b/src/main/java/tectech/thing/casing/ItemCasingsSpacetime.java
@@ -9,9 +9,8 @@ import java.util.List;
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.EnumChatFormatting;
+import net.minecraft.util.StatCollector;
 
-import gregtech.api.util.GTLanguageManager;
 import gregtech.common.blocks.ItemCasings;
 
 public class ItemCasingsSpacetime extends ItemCasings {
@@ -33,23 +32,15 @@ public class ItemCasingsSpacetime extends ItemCasings {
             case 7:
             case 8:
                 tooltip.add(
-                    GTLanguageManager.addStringLocalization(
-                        "EOH.Spacetime.Standard.Tooltip.0",
-                        "Supports an internal spacetime volume of up to ")
-                        + formatNumbers(pow(10, 5 + aStack.getItemDamage()))
-                        + "km³.");
+                    StatCollector.translateToLocalFormatted(
+                        "tt.eoh.spacetime.standard.tooltip.0",
+                        formatNumbers(pow(10, 5 + aStack.getItemDamage()))));
                 tooltip.add(
-                    EnumChatFormatting.AQUA.toString() + EnumChatFormatting.BOLD
-                        + GTLanguageManager.addStringLocalization(
-                            "EOH.Spacetime.Standard.Tooltip.1",
-                            "Capable of running recipes up to tier ")
-                        + (aStack.getItemDamage() + 1));
+                    StatCollector
+                        .translateToLocalFormatted("tt.eoh.spacetime.standard.tooltip.1", aStack.getItemDamage() + 1));
                 break;
             default:
-                tooltip.add(
-                    EnumChatFormatting.RED.toString() + EnumChatFormatting.BOLD
-                        + GTLanguageManager
-                            .addStringLocalization("EOH.TimeDilation.Error.Tooltip", "Error, report to GTNH team"));
+                tooltip.add(StatCollector.translateToLocal("tt.eoh.time_dilation.error.tooltip"));
         }
         tooltip.add(AuthorColen);
     }

--- a/src/main/java/tectech/thing/casing/ItemCasingsStabilisation.java
+++ b/src/main/java/tectech/thing/casing/ItemCasingsStabilisation.java
@@ -7,9 +7,8 @@ import java.util.List;
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.EnumChatFormatting;
+import net.minecraft.util.StatCollector;
 
-import gregtech.api.util.GTLanguageManager;
 import gregtech.common.blocks.ItemCasings;
 
 public class ItemCasingsStabilisation extends ItemCasings {
@@ -30,17 +29,10 @@ public class ItemCasingsStabilisation extends ItemCasings {
             case 6:
             case 7:
             case 8:
-                tooltip.add(
-                    EnumChatFormatting.AQUA.toString() + EnumChatFormatting.BOLD
-                        + GTLanguageManager.addStringLocalization(
-                            "EOH.Stability.Tooltip.0",
-                            "Increases stability of spacetime field."));
+                tooltip.add(StatCollector.translateToLocal("tt.eoh.stability.tooltip"));
                 break;
             default:
-                tooltip.add(
-                    EnumChatFormatting.RED.toString() + EnumChatFormatting.BOLD
-                        + GTLanguageManager
-                            .addStringLocalization("EOH.TimeDilation.Error.Tooltip", "Error, report to GTNH team"));
+                tooltip.add(StatCollector.translateToLocal("tt.eoh.time_dilation.error.tooltip"));
         }
         tooltip.add(AuthorColen);
     }

--- a/src/main/java/tectech/thing/casing/ItemCasingsTimeAcceleration.java
+++ b/src/main/java/tectech/thing/casing/ItemCasingsTimeAcceleration.java
@@ -7,9 +7,8 @@ import java.util.List;
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.EnumChatFormatting;
+import net.minecraft.util.StatCollector;
 
-import gregtech.api.util.GTLanguageManager;
 import gregtech.common.blocks.ItemCasings;
 
 public class ItemCasingsTimeAcceleration extends ItemCasings {
@@ -30,16 +29,10 @@ public class ItemCasingsTimeAcceleration extends ItemCasings {
             case 6:
             case 7:
             case 8:
-                tooltip.add(
-                    EnumChatFormatting.AQUA.toString() + EnumChatFormatting.BOLD
-                        + GTLanguageManager
-                            .addStringLocalization("EOH.TimeDilation.Standard.Tooltip", "Time dilation in a box."));
+                tooltip.add(StatCollector.translateToLocal("tt.eoh.time_dilation.standard.tooltip"));
                 break;
             default:
-                tooltip.add(
-                    EnumChatFormatting.RED.toString() + EnumChatFormatting.BOLD
-                        + GTLanguageManager
-                            .addStringLocalization("EOH.TimeDilation.Error.Tooltip", "Error, report to GTNH team"));
+                tooltip.add(StatCollector.translateToLocal("tt.eoh.time_dilation.error.tooltip"));
         }
         tooltip.add(AuthorColen);
     }

--- a/src/main/resources/assets/gregtech/lang/en_US.lang
+++ b/src/main/resources/assets/gregtech/lang/en_US.lang
@@ -99,7 +99,6 @@ GTPP.tooltip.catalyst.active_reaction_agent=Active Reaction Agent
 GTPP.tooltip.milling_ball.tumble=Tumble Tumble Tumble
 
 # Infinite Spray Can
-
 item.GT5U.infinite_spray_can.name.solvent=Infinite Spray Can %cSolvent%c
 item.GT5U.infinite_spray_can.name.colored=Infinite Spray Can %c%s%c
 
@@ -124,7 +123,30 @@ GT5U.infinite_spray_can.color.Cable Insulation=Cable Insulation
 GT5U.infinite_spray_can.color.Construction Foam=Construction Foam
 GT5U.infinite_spray_can.color.Machine Metal=Machine Metal
 
+GT5U.generic.true=True
+GT5U.generic.false=False
 
+# Algae
+GTPP.algae.euglenoids.name=Euglenoids
+GTPP.algae.golden-brown_algae.name=Golden-Brown Algae
+GTPP.algae.fire_algae.name=Fire Algae
+GTPP.algae.green_algae.name=Green Algae
+GTPP.algae.red_algae.name=Red Algae
+GTPP.algae.brown_algae.name=Brown Algae
+GTPP.algae.yellow-green_algae.name=Yellow-Green Algae
+
+GTPP.algae.tooltip.requires_light=Requires Light: %s
+GTPP.algae.tooltip.salt_water=Salt Water: %s
+GTPP.algae.tooltip.fresh_water=Fresh Water: %s
+GTPP.algae.tooltip.temp_tolerance=Temp Tolerance: %d
+GTPP.algae.tooltip.growth=Growth: %d
+GTPP.algae.tooltip.production=Production: %d
+GTPP.algae.tooltip.lifespan=Lifespan in days: %d
+GTPP.algae.tooltip.generation=Generation: %d
+
+# Power Goggles
+GT5U.power_goggles.open_config_gui=Open Goggles Config
+GT5U.power_goggles.toggle_power_chart=Toggle Power Chart
 
 GT5U.autoplace.error.no_hatch=§cSuggested to place hatch §4%s§c but none was found
 GT5U.autoplace.error.no_mte.id=§cSuggested to place machine with meta ID §4%s§c but none was found
@@ -769,6 +791,7 @@ GT5U.gui.text.too_uncertain=Too Uncertain.
 GT5U.gui.text.invalid_parameters=Invalid Parameters.
 GT5U.gui.text.enabled=§aEnabled§f
 GT5U.gui.text.disabled=§cDisabled§f
+GT5U.gui.text.repair_tip=Click with Tool to repair.
 
 
 GT5U.gui.config.client=Client
@@ -810,6 +833,10 @@ GT5U.item.programmed_circuit.no_screwdriver.1=Your thumb is not a screwdriver. T
 GT5U.item.programmed_circuit.no_screwdriver.2=Chuck Norris stares at the circuit until it reprograms itself. You do not.
 GT5U.item.programmed_circuit.select.header=Reprogram Circuit
 
+GT5U.item.programmed_circuit.tooltip.0=Configuration %s
+GT5U.item.programmed_circuit.tooltip.1=Right click to reconfigure
+GT5U.item.programmed_circuit.tooltip.2=Needs a screwdriver or programming tool
+
 GT5U.item.cable.max_voltage=Max Voltage
 GT5U.item.cable.max_amperage=Max Amperage
 GT5U.item.cable.loss=Loss/Meter/Ampere
@@ -825,8 +852,6 @@ GT5U.item.pipe.gas_proof.no=No
 GT5U.item.pipe.amount=Pipe Amount
 GT5U.item.pipe.empty=Empty
 GT5U.item.pipe.swap=Pipe Swapped:
-
-GT5U.item.programmed_circuit.select.header=Reprogram Circuit
 
 gt.behaviour.paintspray.infinite.gui.header=Select a Color
 gt.behaviour.paintspray.infinite.gui.lock_error=§eSpray can is §clocked§e! §bSneak middle-click to unlock.

--- a/src/main/resources/assets/tectech/lang/en_US.lang
+++ b/src/main/resources/assets/tectech/lang/en_US.lang
@@ -1918,6 +1918,33 @@ tt.eoh.fancy_names.tipler=Tipler
 tt.eoh.fancy_names.gallifreyan=Gallifreyan
 tt.eoh.fancy_names.unknown=Unknown
 
+tt.godforge.casings.Error.Tooltip=Error, report to GTNH team
+tt.godforge.casings.0.Tooltip.0=Shielded by the event horizon of a singularity
+tt.godforge.casings.0.Tooltip.1=Don't get too close...
+tt.godforge.casings.1.Tooltip.0=Designed to route stellar matter using spacetime distortion
+tt.godforge.casings.1.Tooltip.1=Reality Distortion
+tt.godforge.casings.2.Tooltip.0=Unaffected by gravitational forces
+tt.godforge.casings.2.Tooltip.1=Not even a black hole could tear it apart.
+tt.godforge.casings.3.Tooltip.0=Creates enormous magnetic fields capable of constraining entire stars
+tt.godforge.casings.3.Tooltip.1=It's super effective!
+tt.godforge.casings.4.Tooltip.0=Taps into streams of stellar matter to harness their heat energy
+tt.godforge.casings.4.Tooltip.1=Turn up the heat!
+tt.godforge.casings.5.Tooltip.0=Controls the flow of gravitons to manipulate gravity
+tt.godforge.casings.5.Tooltip.1=Exponential scaling past 800 Galaxies
+tt.godforge.casings.6.Tooltip.0=Controls the flow of gravitons to manipulate gravity
+tt.godforge.casings.6.Tooltip.1=Getting closer...
+tt.godforge.casings.7.Tooltip.0=Controls the flow of gravitons to manipulate gravity
+tt.godforge.casings.7.Tooltip.1=Gravity Central
+tt.godforge.casings.8.Tooltip.0=Transfers and stores extreme amounts of heat without any loss
+tt.godforge.casings.8.Tooltip.1=<<<Thermal<<<
+tt.godforge.casings.8.Tooltip.2=>>>Wave>>>
+
+tt.eoh.stability.tooltip=§b§lIncreases stability of spacetime field.
+tt.eoh.time_dilation.standard.tooltip=§b§lTime dilation in a box.
+tt.eoh.time_dilation.error.tooltip=§c§lError, report to GTNH team
+tt.eoh.spacetime.standard.tooltip.0=Supports an internal spacetime volume of up to %d km³.
+tt.eoh.spacetime.standard.tooltip.1=§b§lCapable of running recipes up to tier %d
+
 # Info data
 
 tt.infodata.multi.energy_hatches=Energy Hatches: %s EU / %s EU


### PR DESCRIPTION
This PR makes several (unintentionally) hardcoded text localizable, with some minor related cleanups.

### Changes:

#### `MTEHatchMaintenance.java`, `ItemAlgaeBase.java`
Necessary changes to de-hardcode displayed texts from them.

#### `MultiblockTooltipBuilder.java`
Deleted an `EnumChatFormatting.RED` to prevent `§c§c` because we only need one.

#### `ItemIntegratedCircuit.java`, `ItemCasingsGodforge.java`, `ItemCasingsSpacetime.java`, `ItemCasingsStabilisation.java`, `ItemCasingsTimeAcceleration.java`
Migrated to `StatCollector`. They did consider their localizability and use `GTLanguageManager`, but for some reason, like using it directly in switch statements (I assume that was the cause but not sure), they had never actually written those lines to GregTech.lang. I lowkey want to take more away from the deprecated GTLanguageManager but ended up keeping those working ones untouched, don't want no ka-booms.

Also, changes to en_US.lang, of course.

Please check for any possible flaws, ask questions, make change requests or directly push to this PR, because some approaches might be hella clumsy.

I'll continue hunting for more hardcoded texts during gameplay and commit to it before its merge.