### PR TITLE
add structure channel desc and indicator item

### DIFF
--- a/src/main/java/bartworks/common/tileentities/multis/MTEBioVat.java
+++ b/src/main/java/bartworks/common/tileentities/multis/MTEBioVat.java
@@ -88,6 +88,7 @@ import gregtech.api.util.GTUtility;
 import gregtech.api.util.MultiblockTooltipBuilder;
 import gregtech.api.util.ParallelHelper;
 import gregtech.api.util.recipe.Sievert;
+import gregtech.common.misc.GTStructureChannels;
 
 public class MTEBioVat extends MTEEnhancedMultiBlockBase<MTEBioVat> implements ISurvivalConstructable {
 
@@ -167,7 +168,7 @@ public class MTEBioVat extends MTEEnhancedMultiBlockBase<MTEBioVat> implements I
             .addInputHatch("Any casing", 1)
             .addOutputHatch("Any casing", 1)
             .addEnergyHatch("Any casing", 1)
-            .addSubChannelUsage("glass", "Glass Tier")
+            .addSubChannelUsage(GTStructureChannels.BOROGLASS)
             .toolTipFinisher();
         return tt;
     }

--- a/src/main/java/bartworks/common/tileentities/multis/mega/MTEMegaBlastFurnace.java
+++ b/src/main/java/bartworks/common/tileentities/multis/mega/MTEMegaBlastFurnace.java
@@ -14,7 +14,6 @@
 package bartworks.common.tileentities.multis.mega;
 
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.transpose;
-import static com.gtnewhorizon.structurelib.structure.StructureUtility.withChannel;
 import static gregtech.api.enums.HatchElement.*;
 import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_FRONT_ELECTRIC_BLAST_FURNACE;
 import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_FRONT_ELECTRIC_BLAST_FURNACE_ACTIVE;
@@ -65,6 +64,7 @@ import gregtech.api.util.GTRecipe;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.MultiblockTooltipBuilder;
 import gregtech.api.util.OverclockCalculator;
+import gregtech.common.misc.GTStructureChannels;
 import gregtech.common.pollution.PollutionConfig;
 
 public class MTEMegaBlastFurnace extends MegaMultiBlockBase<MTEMegaBlastFurnace> implements ISurvivalConstructable {
@@ -83,9 +83,8 @@ public class MTEMegaBlastFurnace extends MegaMultiBlockBase<MTEMegaBlastFurnace>
         .addElement('m', Muffler.newAny(CASING_INDEX, 2))
         .addElement(
             'C',
-            withChannel(
-                "coil",
-                activeCoils(ofCoil(MTEMegaBlastFurnace::setCoilLevel, MTEMegaBlastFurnace::getCoilLevel))))
+            GTStructureChannels.HEATING_COIL
+                .use(activeCoils(ofCoil(MTEMegaBlastFurnace::setCoilLevel, MTEMegaBlastFurnace::getCoilLevel))))
         .addElement('g', chainAllGlasses(-1, (te, t) -> te.glassTier = t, te -> te.glassTier))
         .addElement(
             'b',
@@ -181,8 +180,8 @@ public class MTEMegaBlastFurnace extends MegaMultiBlockBase<MTEMegaBlastFurnace>
             .addOutputBus("Any bottom layer casing")
             .addOutputHatch("Any Heat Proof Machine Casing")
             .addStructureHint("This Mega Multiblock is too big to have its structure hologram displayed fully.")
-            .addSubChannelUsage("glass", "Glass Tier")
-            .addSubChannelUsage("coil", "Heating Coils Tier")
+            .addSubChannelUsage(GTStructureChannels.BOROGLASS)
+            .addSubChannelUsage(GTStructureChannels.HEATING_COIL, "Heating Coils Tier")
             .toolTipFinisher();
         return tt;
     }

--- a/src/main/java/bartworks/common/tileentities/multis/mega/MTEMegaChemicalReactor.java
+++ b/src/main/java/bartworks/common/tileentities/multis/mega/MTEMegaChemicalReactor.java
@@ -50,6 +50,7 @@ import gregtech.api.recipe.RecipeMaps;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.MultiblockTooltipBuilder;
+import gregtech.common.misc.GTStructureChannels;
 
 public class MTEMegaChemicalReactor extends MegaMultiBlockBase<MTEMegaChemicalReactor>
     implements ISurvivalConstructable {
@@ -86,7 +87,7 @@ public class MTEMegaChemicalReactor extends MegaMultiBlockBase<MTEMegaChemicalRe
             .addInputBus("Hint block ", 1)
             .addOutputBus("Hint block ", 1)
             .addOutputHatch("Hint block ", 1)
-            .addSubChannelUsage("glass", "Glass Tier")
+            .addSubChannelUsage(GTStructureChannels.BOROGLASS)
             .toolTipFinisher();
         return tt;
     }

--- a/src/main/java/bartworks/common/tileentities/multis/mega/MTEMegaDistillTower.java
+++ b/src/main/java/bartworks/common/tileentities/multis/mega/MTEMegaDistillTower.java
@@ -26,6 +26,7 @@ import static gregtech.api.util.GTStructureUtility.buildHatchAdder;
 import java.util.ArrayList;
 import java.util.List;
 
+import gregtech.common.misc.GTStructureChannels;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -318,7 +319,8 @@ public class MTEMegaDistillTower extends MegaMultiBlockBase<MTEMegaDistillTower>
     @Override
     public void construct(ItemStack stackSize, boolean hintsOnly) {
         this.buildPiece(STRUCTURE_PIECE_BASE, stackSize, hintsOnly, 7, 0, 0);
-        int tTotalHeight = Math.min(12, stackSize.stackSize + 2); // min 2 output layer, so at least 1 + 2 height
+        // min 2 output layer, so at least 1 + 2 height
+        int tTotalHeight = GTStructureChannels.STRUCTURE_HEIGHT.getValueClamped(stackSize, 3, 12);
         for (int i = 1; i < tTotalHeight - 1; i++) {
             this.buildPiece(STRUCTURE_PIECE_LAYER, stackSize, hintsOnly, 7, 5 * i, 0);
         }
@@ -332,7 +334,8 @@ public class MTEMegaDistillTower extends MegaMultiBlockBase<MTEMegaDistillTower>
         this.mHeight = 0;
         int built = this.survivialBuildPiece(STRUCTURE_PIECE_BASE, stackSize, 7, 0, 0, realBudget, env, false, true);
         if (built >= 0) return built;
-        int tTotalHeight = Math.min(12, stackSize.stackSize + 2); // min 2 output layer, so at least 1 + 2 height
+        // min 2 output layer, so at least 1 + 2 height
+        int tTotalHeight = GTStructureChannels.STRUCTURE_HEIGHT.getValueClamped(stackSize, 3, 12);
         for (int i = 1; i < tTotalHeight - 1; i++) {
             this.mHeight = i;
             built = this.survivialBuildPiece(

--- a/src/main/java/bartworks/common/tileentities/multis/mega/MTEMegaOilCracker.java
+++ b/src/main/java/bartworks/common/tileentities/multis/mega/MTEMegaOilCracker.java
@@ -15,7 +15,6 @@ package bartworks.common.tileentities.multis.mega;
 
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofBlock;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.transpose;
-import static com.gtnewhorizon.structurelib.structure.StructureUtility.withChannel;
 import static gregtech.api.enums.HatchElement.*;
 import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_FRONT_OIL_CRACKER;
 import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_FRONT_OIL_CRACKER_ACTIVE;
@@ -64,6 +63,7 @@ import gregtech.api.recipe.maps.OilCrackerBackend;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.MultiblockTooltipBuilder;
+import gregtech.common.misc.GTStructureChannels;
 import gregtech.common.tileentities.machines.IRecipeProcessingAwareHatch;
 import gregtech.common.tileentities.machines.MTEHatchInputME;
 
@@ -93,7 +93,8 @@ public class MTEMegaOilCracker extends MegaMultiBlockBase<MTEMegaOilCracker> imp
                         "ppppppppppppp", "ppppppppppppp", "ppppppppppppp", "ppmmmmmmmmmpp" }, }))
         .addElement(
             'c',
-            withChannel("coil", activeCoils(ofCoil(MTEMegaOilCracker::setCoilLevel, MTEMegaOilCracker::getCoilLevel))))
+            GTStructureChannels.HEATING_COIL
+                .use(activeCoils(ofCoil(MTEMegaOilCracker::setCoilLevel, MTEMegaOilCracker::getCoilLevel))))
 
         .addElement('p', ofBlock(GregTechAPI.sBlockCasings4, 1))
         .addElement(
@@ -166,7 +167,7 @@ public class MTEMegaOilCracker extends MegaMultiBlockBase<MTEMegaOilCracker> imp
             .addOutputHatch("Hint block", 2, 3)
             .addInputHatch("Steam/Hydrogen ONLY, Hint block", 4)
             .addInputBus("Optional, for programmed circuit automation. Hint block", 1)
-            .addSubChannelUsage("glass", "Glass Tier")
+            .addSubChannelUsage(GTStructureChannels.BOROGLASS)
             .toolTipFinisher();
         return tt;
     }

--- a/src/main/java/ggfab/mte/MTEAdvAssLine.java
+++ b/src/main/java/ggfab/mte/MTEAdvAssLine.java
@@ -98,6 +98,7 @@ import gregtech.api.util.OverclockCalculator;
 import gregtech.api.util.VoidProtectionHelper;
 import gregtech.api.util.shutdown.ShutDownReason;
 import gregtech.api.util.shutdown.ShutDownReasonRegistry;
+import gregtech.common.misc.GTStructureChannels;
 import gregtech.common.tileentities.machines.MTEHatchInputBusME;
 import gregtech.common.tileentities.machines.MTEHatchInputME;
 import mcp.mobius.waila.api.IWailaConfigHandler;
@@ -249,7 +250,8 @@ public class MTEAdvAssLine extends MTEExtendedPowerMultiBlockBase<MTEAdvAssLine>
     @Override
     public void construct(ItemStack stackSize, boolean hintsOnly) {
         buildPiece(STRUCTURE_PIECE_FIRST, stackSize, hintsOnly, 0, 1, 0);
-        int tLength = Math.min(stackSize.stackSize + 3, 16); // render 4 slices at minimal
+        int tLength = GTStructureChannels.STRUCTURE_LENGTH.getValueClamped(stackSize, 4, 17); // render 4 slices at
+                                                                                              // minimal
         for (int i = 1; i < tLength; i++) {
             buildPiece(STRUCTURE_PIECE_LATER, stackSize, hintsOnly, -i, 1, 0);
         }
@@ -260,7 +262,8 @@ public class MTEAdvAssLine extends MTEExtendedPowerMultiBlockBase<MTEAdvAssLine>
         if (mMachine) return -1;
         int build = survivialBuildPiece(STRUCTURE_PIECE_FIRST, stackSize, 0, 1, 0, elementBudget, env, false, true);
         if (build >= 0) return build;
-        int tLength = Math.min(stackSize.stackSize + 3, 16); // render 4 slices at minimal
+        int tLength = GTStructureChannels.STRUCTURE_LENGTH.getValueClamped(stackSize, 4, 17); // render 4 slices at
+                                                                                              // minimal
         for (int i = 1; i < tLength - 1; i++) {
             build = survivialBuildPiece(STRUCTURE_PIECE_LATER, stackSize, -i, 1, 0, elementBudget, env, false, true);
             if (build >= 0) return build;
@@ -341,7 +344,7 @@ public class MTEAdvAssLine extends MTEExtendedPowerMultiBlockBase<MTEAdvAssLine>
                 StatCollector.translateToLocal("GT5U.tooltip.structure.data_access_hatch"),
                 "Optional, next to controller",
                 2)
-            .addSubChannelUsage("glass", "Glass Tier")
+            .addSubChannelUsage(GTStructureChannels.BOROGLASS)
             .toolTipFinisher();
         return tt;
     }

--- a/src/main/java/goodgenerator/blocks/tileEntity/MTEComponentAssemblyLine.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/MTEComponentAssemblyLine.java
@@ -46,6 +46,7 @@ import gregtech.api.util.GTStructureUtility;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.MultiblockTooltipBuilder;
 import gregtech.api.util.OverclockCalculator;
+import gregtech.common.misc.GTStructureChannels;
 
 public class MTEComponentAssemblyLine extends MTEExtendedPowerMultiBlockBase<MTEComponentAssemblyLine>
     implements ISurvivalConstructable {
@@ -238,7 +239,7 @@ public class MTEComponentAssemblyLine extends MTEExtendedPowerMultiBlockBase<MTE
             .addEnergyHatch("Second-top layer", 3)
             .addMaintenanceHatch("Around the controller", 4)
             .addInputHatch("Bottom left and right corners", 5)
-            .addSubChannelUsage("glass", "Glass Tier")
+            .addSubChannelUsage(GTStructureChannels.BOROGLASS)
             .toolTipFinisher(EnumChatFormatting.AQUA + "MadMan310");
         return tt;
     }

--- a/src/main/java/goodgenerator/blocks/tileEntity/MTEPreciseAssembler.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/MTEPreciseAssembler.java
@@ -80,6 +80,7 @@ import gregtech.api.util.GTUtility;
 import gregtech.api.util.HatchElementBuilder;
 import gregtech.api.util.MultiblockTooltipBuilder;
 import gregtech.api.util.OverclockCalculator;
+import gregtech.common.misc.GTStructureChannels;
 import gregtech.common.tileentities.machines.IDualInputHatch;
 import gregtech.common.tileentities.machines.ISmartInputHatch;
 import mcp.mobius.waila.api.IWailaConfigHandler;
@@ -127,8 +128,7 @@ public class MTEPreciseAssembler extends MTEExtendedPowerMultiBlockBase<MTEPreci
                             { "CCCC~CCCC", "CMMMMMMMC", "CMMMMMMMC", "CMMMMMMMC", "CCCCCCCCC" } }))
                 .addElement(
                     'C',
-                    withChannel(
-                        "unit_casing",
+                    GTStructureChannels.PRASS_UNIT_CASING.use(
                         HatchElementBuilder.<MTEPreciseAssembler>builder()
                             .atLeast(
                                 InputBus,
@@ -159,8 +159,7 @@ public class MTEPreciseAssembler extends MTEExtendedPowerMultiBlockBase<MTEPreci
                 .addElement('G', chainAllGlasses(-1, (te, t) -> te.glassTier = t, te -> te.glassTier))
                 .addElement(
                     'M',
-                    withChannel(
-                        "machine_casing",
+                    GTStructureChannels.TIER_MACHINE_CASING.use(
                         StructureUtility.ofBlocksTiered(
                             (block, meta) -> (block == GregTechAPI.sBlockCasings1 && meta >= 0 && meta <= 9) ? meta
                                 : null,
@@ -371,9 +370,9 @@ public class MTEPreciseAssembler extends MTEExtendedPowerMultiBlockBase<MTEPreci
             .addEnergyHatch("Any Casing")
             .addMufflerHatch("Any Casing")
             .addMaintenanceHatch("Any Casing")
-            .addSubChannelUsage("glass", "Glass Tier")
-            .addSubChannelUsage("unit_casing", "Precise Electronic Unit Casing Tier")
-            .addSubChannelUsage("machine_casing", "Machine Casing Tier")
+            .addSubChannelUsage(GTStructureChannels.BOROGLASS)
+            .addSubChannelUsage(GTStructureChannels.PRASS_UNIT_CASING, "Precise Electronic Unit Casing Tier")
+            .addSubChannelUsage(GTStructureChannels.TIER_MACHINE_CASING, "Machine Casing Tier")
             .toolTipFinisher();
         return tt;
     }

--- a/src/main/java/goodgenerator/blocks/tileEntity/MTEYottaFluidTank.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/MTEYottaFluidTank.java
@@ -58,6 +58,7 @@ import gregtech.api.recipe.check.SimpleCheckRecipeResult;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.MultiblockTooltipBuilder;
+import gregtech.common.misc.GTStructureChannels;
 import tectech.TecTech;
 import tectech.thing.gui.TecTechUITextures;
 import tectech.thing.metaTileEntity.multi.base.INameFunction;
@@ -412,7 +413,7 @@ public class MTEYottaFluidTank extends MTETooltipMultiBlockBaseEM implements ICo
             .addCasingInfoRange("YOTTank Casing", 25, 43, false)
             .addInputHatch("Hint block with dot 1")
             .addOutputHatch("Hint block with dot 3")
-            .addSubChannelUsage("glass", "Glass Tier")
+            .addSubChannelUsage(GTStructureChannels.BOROGLASS)
             .toolTipFinisher();
         return tt;
     }

--- a/src/main/java/goodgenerator/loader/Loaders.java
+++ b/src/main/java/goodgenerator/loader/Loaders.java
@@ -62,6 +62,7 @@ import gregtech.api.enums.Textures;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GTOreDictUnificator;
+import gregtech.common.misc.GTStructureChannels;
 import gregtech.common.tileentities.generators.MTEDieselGenerator;
 import kekztech.common.blocks.BlockTFFTStorageField;
 
@@ -456,6 +457,12 @@ public class Loaders {
         GameRegistry.registerItem(huiCircuit, "huiCircuit", GoodGenerator.MOD_ID);
         GameRegistry.registerItem(circuitWrap, "circuitWrap", GoodGenerator.MOD_ID);
         GameRegistry.registerTileEntity(TileAntimatter.class, "AntimatterRender");
+
+        GTStructureChannels.PRASS_UNIT_CASING.registerAsIndicator(new ItemStack(impreciseUnitCasing), 1);
+        for (int i = 1; i < 6; i++) {
+            GTStructureChannels.PRASS_UNIT_CASING
+                .registerAsIndicator(new ItemStack(preciseUnitCasing, 1, i - 1), i + 1);
+        }
     }
 
     public static void compactMod() {

--- a/src/main/java/gregtech/GTMod.java
+++ b/src/main/java/gregtech/GTMod.java
@@ -88,6 +88,7 @@ import gregtech.common.config.OPStuff;
 import gregtech.common.config.Other;
 import gregtech.common.config.Worldgen;
 import gregtech.common.misc.GTCommand;
+import gregtech.common.misc.GTStructureChannels;
 import gregtech.common.misc.spaceprojects.commands.SPCommand;
 import gregtech.common.misc.spaceprojects.commands.SPMCommand;
 import gregtech.common.misc.spaceprojects.commands.SpaceProjectCommand;
@@ -343,6 +344,8 @@ public class GTMod implements IGTMod {
         if (Mods.HoloInventory.isModLoaded()) {
             HoloInventory.init();
         }
+
+        GTStructureChannels.register();
 
         LHECoolantRegistry.registerBaseCoolants();
 

--- a/src/main/java/gregtech/api/structure/CasingInfo.java
+++ b/src/main/java/gregtech/api/structure/CasingInfo.java
@@ -17,7 +17,7 @@ public class CasingInfo<MTE extends MTEMultiBlockBase & IAlignment & IStructureP
     public int dot;
     public ICasing casing;
     public IHatchElement<? super MTE>[] hatches;
-    public String channel;
+    public IStructureChannels channel;
     public ICasingGroup casingGroup;
 
     public Function<ICasingGroup, IStructureElement<MTE>> elementOverride;

--- a/src/main/java/gregtech/api/structure/IStructureChannels.java
+++ b/src/main/java/gregtech/api/structure/IStructureChannels.java
@@ -1,0 +1,43 @@
+package gregtech.api.structure;
+
+import net.minecraft.item.ItemStack;
+
+import com.gtnewhorizon.structurelib.alignment.constructable.ChannelDataAccessor;
+import com.gtnewhorizon.structurelib.structure.IStructureElement;
+import com.gtnewhorizon.structurelib.structure.StructureUtility;
+
+public interface IStructureChannels {
+
+    String get();
+
+    String getDefaultTooltip();
+
+    void registerAsIndicator(ItemStack indicator, int channelValue);
+
+    /**
+     * Get channel data of this channel fitted to given range (both ends inclusive)
+     * ex1: if given a min of 1 and max of 10, it will map channel data of 1 to 1, 2 to 2, ... 10 and any greater value
+     * to 10
+     * ex2: if given a min of 4 and max of 6, it will map channel data of 1 to 4, 2 to 5, 3 and any bigger value to 6
+     *
+     * @param trigger channel data holder
+     * @param min     minimal return value. inclusive
+     * @param max     maximal return value. inclusive
+     * @return fitted channel data
+     */
+    default int getValueClamped(ItemStack trigger, int min, int max) {
+        return Math.min(max, ChannelDataAccessor.getChannelData(trigger, get()) + min - 1);
+    }
+
+    default int getValue(ItemStack trigger) {
+        return ChannelDataAccessor.getChannelData(trigger, get());
+    }
+
+    default boolean hasValue(ItemStack trigger) {
+        return ChannelDataAccessor.hasSubChannel(trigger, get());
+    }
+
+    default <T> IStructureElement<T> use(IStructureElement<T> elem) {
+        return StructureUtility.withChannel(get(), elem);
+    }
+}

--- a/src/main/java/gregtech/api/structure/StructureWrapper.java
+++ b/src/main/java/gregtech/api/structure/StructureWrapper.java
@@ -1,7 +1,6 @@
 package gregtech.api.structure;
 
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.onElementPass;
-import static com.gtnewhorizon.structurelib.structure.StructureUtility.withChannel;
 
 import java.util.Arrays;
 import java.util.List;
@@ -312,7 +311,7 @@ public class StructureWrapper<MTE extends MTEMultiBlockBase & IAlignment & IStru
         }
 
         if (casing.channel != null) {
-            element = withChannel(casing.channel, element);
+            element = casing.channel.use(element);
         }
 
         if (casing.elementWrapper != null) {
@@ -426,7 +425,7 @@ public class StructureWrapper<MTE extends MTEMultiBlockBase & IAlignment & IStru
             return this;
         }
 
-        public CasingBuilder withChannel(String channel) {
+        public CasingBuilder withChannel(IStructureChannels channel) {
             casingInfo.channel = channel;
 
             return this;

--- a/src/main/java/gregtech/api/util/GTStructureUtility.java
+++ b/src/main/java/gregtech/api/util/GTStructureUtility.java
@@ -6,7 +6,6 @@ import static com.gtnewhorizon.structurelib.structure.IStructureElement.PlaceRes
 import static com.gtnewhorizon.structurelib.structure.IStructureElement.PlaceResult.SKIP;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.lazy;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofBlocksTiered;
-import static com.gtnewhorizon.structurelib.structure.StructureUtility.withChannel;
 import static com.gtnewhorizon.structurelib.util.ItemStackPredicate.NBTMode.EXACT;
 
 import java.util.Arrays;
@@ -60,6 +59,7 @@ import gregtech.common.blocks.BlockCasings5;
 import gregtech.common.blocks.BlockCyclotronCoils;
 import gregtech.common.blocks.BlockFrameBox;
 import gregtech.common.blocks.ItemMachines;
+import gregtech.common.misc.GTStructureChannels;
 import ic2.core.init.BlocksItems;
 import ic2.core.init.InternalName;
 
@@ -743,8 +743,7 @@ public class GTStructureUtility {
     /** support all Bart, Botania, Ic2, Thaumcraft glasses for multiblock structure **/
     public static <T> IStructureElement<T> chainAllGlasses(int notSet, BiConsumer<T, Integer> setter,
         Function<T, Integer> getter) {
-        return withChannel(
-            "glass",
+        return GTStructureChannels.BOROGLASS.use(
             lazy(t -> ofBlocksTiered(GlassTier::getGlassBlockTier, GlassTier.getGlassList(), notSet, setter, getter)));
     }
 

--- a/src/main/java/gregtech/api/util/GlassTier.java
+++ b/src/main/java/gregtech/api/util/GlassTier.java
@@ -37,6 +37,7 @@ import cpw.mods.fml.relauncher.SideOnly;
 import goodgenerator.loader.Loaders;
 import gregtech.api.GregTechAPI;
 import gregtech.api.enums.VoltageIndex;
+import gregtech.common.misc.GTStructureChannels;
 import tectech.thing.block.BlockGodforgeGlass;
 import tectech.thing.block.BlockQuantumGlass;
 
@@ -111,17 +112,22 @@ public class GlassTier {
             for (Pair<Block, Integer> glass : mainGlass) {
                 glassList.add(glass);
                 glassToTierAndIndex.put(glass, Pair.of(getGlassBlockTier(glass.getLeft(), glass.getRight()), ctr++));
+                GTStructureChannels.BOROGLASS
+                    .registerAsIndicator(new ItemStack(glass.getLeft(), 1, glass.getRight()), ctr);
             }
             for (Map.Entry<Pair<Integer, Integer>, Pair<Block, Integer>> entry : tierToGlass.entrySet()) {
                 if (entry.getKey()
                     .getRight() == 0) continue;
-                glassList.add(entry.getValue());
+                Pair<Block, Integer> glass = entry.getValue();
+                glassList.add(glass);
                 glassToTierAndIndex.put(
-                    entry.getValue(),
+                    glass,
                     Pair.of(
                         entry.getKey()
                             .getLeft(),
                         ctr++));
+                GTStructureChannels.BOROGLASS
+                    .registerAsIndicator(new ItemStack(glass.getLeft(), 1, glass.getRight()), ctr);
             }
             glassList.add(mainGlass.get(mainGlass.size() - 1));
         }
@@ -231,14 +237,10 @@ public class GlassTier {
 
             Integer tier = getGlassBlockTier(block, meta);
             if (tier == null) return;
-            int channelIdx = getGlassChannelValue(block, meta);
 
             event.toolTip.add(
                 StatCollector.translateToLocal("tooltip.glass_tier.0.name") + " "
                     + getColoredTierNameFromTier(tier.byteValue()));
-            event.toolTip
-                .add(StatCollector.translateToLocalFormatted("GT5U.tooltip.channelvalue", channelIdx, "glass"));
-
         }
     }
 }

--- a/src/main/java/gregtech/api/util/HatchElementBuilder.java
+++ b/src/main/java/gregtech/api/util/HatchElementBuilder.java
@@ -27,7 +27,6 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import com.gtnewhorizon.structurelib.StructureLibAPI;
-import com.gtnewhorizon.structurelib.alignment.constructable.ChannelDataAccessor;
 import com.gtnewhorizon.structurelib.structure.AutoPlaceEnvironment;
 import com.gtnewhorizon.structurelib.structure.IItemSource;
 import com.gtnewhorizon.structurelib.structure.IStructureElement;
@@ -42,6 +41,7 @@ import gregtech.api.interfaces.IHatchElement;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.common.blocks.ItemMachines;
+import gregtech.common.misc.GTStructureChannels;
 
 public class HatchElementBuilder<T> {
 
@@ -498,7 +498,7 @@ public class HatchElementBuilder<T> {
                 if (!StructureLibAPI.isBlockTriviallyReplaceable(world, x, y, z, env.getActor()))
                     return PlaceResult.REJECT;
                 if (mReject != null && mReject.test(t)) return PlaceResult.REJECT;
-                if (ChannelDataAccessor.hasSubChannel(trigger, "gt_no_hatch") && !mExclusive) {
+                if (GTStructureChannels.NO_HATCH.hasValue(trigger) && !mExclusive) {
                     String type = getHint();
                     env.getChatter()
                         .accept(new ChatComponentTranslation("GT5U.autoplace.error.no_hatch", type));

--- a/src/main/java/gregtech/api/util/MultiblockTooltipBuilder.java
+++ b/src/main/java/gregtech/api/util/MultiblockTooltipBuilder.java
@@ -20,6 +20,7 @@ import com.gtnewhorizon.structurelib.StructureLibAPI;
 
 import gregtech.GTMod;
 import gregtech.api.enums.GTValues;
+import gregtech.api.structure.IStructureChannels;
 
 /**
  * This makes it easier to build multi tooltips, with a standardized format. <br>
@@ -781,8 +782,22 @@ public class MultiblockTooltipBuilder {
      * @param purpose the purpose of subchannel
      * @return Instance this method was called on.
      */
-    public MultiblockTooltipBuilder addSubChannelUsage(String channel, String purpose) {
+    public MultiblockTooltipBuilder addSubChannelUsage(IStructureChannels channel, String purpose) {
         sLines.add(TAB + StatCollector.translateToLocalFormatted("GT5U.MBTT.subchannel", channel, purpose));
+        return this;
+    }
+
+    /**
+     * Use this method to add non-standard structural info.<br>
+     * (indent)info
+     *
+     * @param channel the name of subchannel
+     * @return Instance this method was called on.
+     */
+    public MultiblockTooltipBuilder addSubChannelUsage(IStructureChannels channel) {
+        sLines.add(
+            TAB + StatCollector
+                .translateToLocalFormatted("GT5U.MBTT.subchannel", channel, channel.getDefaultTooltip()));
         return this;
     }
 
@@ -812,7 +827,7 @@ public class MultiblockTooltipBuilder {
 
     /**
      * Useful for maintaining the flow when you need to run an arbitrary operation on the builder.
-     * 
+     *
      * @param fn The operation.
      * @return Instance this method was called on.
      */

--- a/src/main/java/gregtech/common/blocks/BlockCasings1.java
+++ b/src/main/java/gregtech/common/blocks/BlockCasings1.java
@@ -1,10 +1,12 @@
 package gregtech.common.blocks;
 
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Textures;
+import gregtech.common.misc.GTStructureChannels;
 
 /**
  * The casings are split into separate files because they are registered as regular blocks, and a regular block can have
@@ -39,6 +41,10 @@ public class BlockCasings1 extends BlockCasingsAbstract {
         register(13, ItemList.Casing_Dim_Injector, "Dimensional Injection Casing");
         register(14, ItemList.Casing_Dim_Bridge, "Dimensional Bridge");
         register(15, ItemList.Casing_Coil_Superconductor, "Superconducting Coil Block");
+
+        for (int i = 0; i < 10; i++) {
+            GTStructureChannels.TIER_MACHINE_CASING.registerAsIndicator(new ItemStack(this, 1, i), i + 1);
+        }
     }
 
     @Override

--- a/src/main/java/gregtech/common/blocks/BlockCasings11.java
+++ b/src/main/java/gregtech/common/blocks/BlockCasings11.java
@@ -5,12 +5,12 @@ import java.util.List;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
-import net.minecraft.util.StatCollector;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Textures;
+import gregtech.common.misc.GTStructureChannels;
 
 /**
  * The casings are split into separate files because they are registered as regular blocks, and a regular block can have
@@ -29,6 +29,10 @@ public class BlockCasings11 extends BlockCasingsAbstract {
         register(5, ItemList.Casing_Item_Pipe_Quantium, "Quantium Item Pipe Casing");
         register(6, ItemList.Casing_Item_Pipe_Fluxed_Electrum, "Fluxed Electrum Item Pipe Casing");
         register(7, ItemList.Casing_Item_Pipe_Black_Plutonium, "Black Plutonium Item Pipe Casing");
+
+        for (int i = 0; i < 8; i++) {
+            GTStructureChannels.ITEM_PIPE_CASING.registerAsIndicator(new ItemStack(this, 1, i), i + 1);
+        }
     }
 
     @Override
@@ -54,9 +58,5 @@ public class BlockCasings11 extends BlockCasingsAbstract {
     @Override
     public void addInformation(ItemStack stack, EntityPlayer player, List<String> tooltip, boolean advancedTooltips) {
         super.addInformation(stack, player, tooltip, advancedTooltips);
-
-        tooltip.add(
-            StatCollector
-                .translateToLocalFormatted("GT5U.tooltip.channelvalue", stack.getItemDamage() + 1, "item_pipe"));
     }
 }

--- a/src/main/java/gregtech/common/blocks/BlockCasings2.java
+++ b/src/main/java/gregtech/common/blocks/BlockCasings2.java
@@ -3,6 +3,7 @@ package gregtech.common.blocks;
 import net.minecraft.block.Block;
 import net.minecraft.entity.Entity;
 import net.minecraft.init.Blocks;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
@@ -11,6 +12,7 @@ import gregtech.api.enums.Dyes;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Textures;
 import gregtech.api.render.TextureFactory;
+import gregtech.common.misc.GTStructureChannels;
 
 /**
  * The casings are split into separate files because they are registered as regular blocks, and a regular block can have
@@ -42,10 +44,14 @@ public class BlockCasings2 extends BlockCasingsAbstract {
         register(9, ItemList.Casing_Assembler, "Assembler Machine Casing");
         register(10, ItemList.Casing_Pump, "Pump Machine Casing");
         register(11, ItemList.Casing_Motor, "Motor Machine Casing");
-        register(12, ItemList.Casing_Pipe_Bronze, "Bronze Pipe Casing", channelTooltip("pipe", 1));
-        register(13, ItemList.Casing_Pipe_Steel, "Steel Pipe Casing", channelTooltip("pipe", 2));
-        register(14, ItemList.Casing_Pipe_Titanium, "Titanium Pipe Casing", channelTooltip("pipe", 3));
-        register(15, ItemList.Casing_Pipe_TungstenSteel, "Tungstensteel Pipe Casing", channelTooltip("pipe", 4));
+        register(12, ItemList.Casing_Pipe_Bronze, "Bronze Pipe Casing");
+        register(13, ItemList.Casing_Pipe_Steel, "Steel Pipe Casing");
+        register(14, ItemList.Casing_Pipe_Titanium, "Titanium Pipe Casing");
+        register(15, ItemList.Casing_Pipe_TungstenSteel, "Tungstensteel Pipe Casing");
+
+        for (int i = 0; i < 4; i++) {
+            GTStructureChannels.PIPE_CASING.registerAsIndicator(new ItemStack(this, 1, i + 12), i + 1);
+        }
     }
 
     @Override

--- a/src/main/java/gregtech/common/blocks/BlockCasings5.java
+++ b/src/main/java/gregtech/common/blocks/BlockCasings5.java
@@ -24,7 +24,6 @@ import java.util.function.Supplier;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 
 import org.jetbrains.annotations.Nullable;
@@ -38,6 +37,7 @@ import gregtech.api.interfaces.IIconContainer;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.render.TextureFactory;
 import gregtech.common.config.Client;
+import gregtech.common.misc.GTStructureChannels;
 import gregtech.common.render.GTRendererBlock;
 
 /**
@@ -68,6 +68,10 @@ public class BlockCasings5 extends BlockCasingsAbstract implements IHeatingCoil,
         register(11, ItemList.Casing_Coil_Infinity, "Infinity Coil Block");
         register(12, ItemList.Casing_Coil_Hypogen, "Hypogen Coil Block");
         register(13, ItemList.Casing_Coil_Eternal, "Eternal Coil Block");
+
+        for (int i = 0; i < 14; i++) {
+            GTStructureChannels.HEATING_COIL.registerAsIndicator(new ItemStack(this, 1, i), i + 1);
+        }
     }
 
     @Override
@@ -232,7 +236,5 @@ public class BlockCasings5 extends BlockCasingsAbstract implements IHeatingCoil,
 
         HeatingCoilLevel coilLevel = BlockCasings5.getCoilHeatFromDamage(metadata);
         tooltip.add(COIL_HEAT_TOOLTIP.get() + coilLevel.getHeat() + COIL_UNIT_TOOLTIP.get());
-
-        tooltip.add(StatCollector.translateToLocalFormatted("GT5U.tooltip.channelvalue", metadata + 1, "coil"));
     }
 }

--- a/src/main/java/gregtech/common/blocks/BlockCasingsAbstract.java
+++ b/src/main/java/gregtech/common/blocks/BlockCasingsAbstract.java
@@ -191,8 +191,4 @@ public abstract class BlockCasingsAbstract extends GTGenericBlock
             }
         }
     }
-
-    public static Supplier<String> channelTooltip(String channel, int value) {
-        return translatedText("GT5U.tooltip.channelvalue", Integer.toString(value), channel);
-    }
 }

--- a/src/main/java/gregtech/common/blocks/BlockCyclotronCoils.java
+++ b/src/main/java/gregtech/common/blocks/BlockCyclotronCoils.java
@@ -1,14 +1,11 @@
 package gregtech.common.blocks;
 
-import java.util.List;
-
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
-import net.minecraft.util.StatCollector;
 
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Textures;
+import gregtech.common.misc.GTStructureChannels;
 
 public class BlockCyclotronCoils extends BlockCasingsAbstract {
 
@@ -26,6 +23,10 @@ public class BlockCyclotronCoils extends BlockCasingsAbstract {
         register(8, ItemList.Superconducting_Magnet_Solenoid_UEV, "UEV Solenoid Superconductor Coil");
         register(9, ItemList.Superconducting_Magnet_Solenoid_UIV, "UIV Solenoid Superconductor Coil");
         register(10, ItemList.Superconducting_Magnet_Solenoid_UMV, "UMV Solenoid Superconductor Coil");
+
+        for (int i = 0; i < 11; i++) {
+            GTStructureChannels.SOLENOID.registerAsIndicator(new ItemStack(this, 1, i), i + 1);
+        }
     }
 
     @Override
@@ -110,14 +111,5 @@ public class BlockCyclotronCoils extends BlockCasingsAbstract {
 
     public int getVoltageTier(int meta) {
         return meta + 2;
-    }
-
-    @Override
-    public void addInformation(ItemStack stack, EntityPlayer player, List<String> tooltip, boolean advancedTooltips) {
-        super.addInformation(stack, player, tooltip, advancedTooltips);
-
-        tooltip.add(
-            StatCollector
-                .translateToLocalFormatted("GT5U.tooltip.channelvalue", stack.getItemDamage() + 1, "solenoid"));
     }
 }

--- a/src/main/java/gregtech/common/misc/GTStructureChannels.java
+++ b/src/main/java/gregtech/common/misc/GTStructureChannels.java
@@ -1,0 +1,84 @@
+package gregtech.common.misc;
+
+import net.minecraft.item.ItemStack;
+
+import com.gtnewhorizon.structurelib.StructureLibAPI;
+
+import gregtech.api.enums.Mods;
+import gregtech.api.structure.IStructureChannels;
+
+/*
+ * To unofficial addon authors:
+ * Do not add to this enum with EnumHelper or equivalent. Just copy this class into your namespace, and replace
+ * the constants
+ */
+/*
+ * Dev notes:
+ * Q1: central manage indicator item or in each blocks' constructor?
+ * A1: before this is merged #4067 happens. we can build on this info and central manage it
+ * EDIT: I ended up with a registerAsIndicator() method here
+ * Q2: default tooltip in MBTT builder?
+ * A2: Yes
+ * Q3: multi specific tier managed here or in individual controller?
+ * A3: here, because it needs to be registered to a central location, so it would be nice to have a central location
+ * with an easy overview. Plus, it's possible these multi-specific tiers would be become reused by others as development
+ * carries on, e.g. PRASS_UNIT_CASING
+ */
+public enum GTStructureChannels implements IStructureChannels {
+
+    // Order of enum constants does not matter
+    QFT_MANIPULATOR("manipulator", "Manipulator Tier"),
+    QFT_SHIELDING("shielding", "Shielding Tier"),
+    HEATING_COIL("coil", "Heating Coils Tier"),
+    BOROGLASS("glass", "Glass Tier"),
+    PRASS_UNIT_CASING("unit_casing", "Precise Electronic Unit Casing Tier"),
+    METAL_MACHINE_CASING("casing", "Metal Machine Casing Tier"),
+    TIER_MACHINE_CASING("machine_casing", "Machine Casing Tier"),
+    SOLENOID("solenoid", "Solenoid Tier"),
+    LSC_CAPACITOR("capacitor", "Capacitor Tier"),
+    STRUCTURE_HEIGHT("height", "Structure Height"),
+    STRUCTURE_LENGTH("length", "Structure Length"),
+    PIPE_CASING("pipe", "Pipe Casing Tier"),
+    ITEM_PIPE_CASING("item_pipe", "Item Pipe Casing Tier"),
+    PSS_CELL("cell", "Vanadium Redox Power Cell Tier"),
+    SYNCHROTRON_ANTENNA("antenna", "Antenna Casing Tier"),
+    EOH_COMPRESSION("spacetime_compression", "Spacetime Compression Field Generator Tier"),
+    EOH_STABILISATION("stabilisation", "Stabilisation Field Generator Tier"),
+    EOH_DILATION("time_dilation", "Time Dilation Field Generator Tier"),
+    NO_HATCH("gt_no_hatch", ""),
+    TFFT_FIELD("field", "Storage Field Tier"),
+    //
+    ;
+
+    private final String channel;
+    private final String defaultTooltip;
+
+    GTStructureChannels(String aChannel, String defaultTooltip) {
+        channel = aChannel;
+        this.defaultTooltip = defaultTooltip;
+    }
+
+    @Override
+    public String get() {
+        return channel;
+    }
+
+    @Override
+    public String getDefaultTooltip() {
+        return defaultTooltip;
+    }
+
+    @Override
+    public void registerAsIndicator(ItemStack indicator, int channelValue) {
+        StructureLibAPI.registerChannelItem(get(), Mods.Names.GREG_TECH, channelValue, indicator);
+    }
+
+    public static void register() {
+        for (GTStructureChannels value : values()) {
+            StructureLibAPI.registerChannelDescription(
+                value.get(),
+                Mods.Names.GREG_TECH,
+                "channels." + Mods.GregTech.ID + "." + value.get());
+        }
+    }
+}

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEAssemblyLine.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEAssemblyLine.java
@@ -63,6 +63,7 @@ import gregtech.api.util.MultiblockTooltipBuilder;
 import gregtech.api.util.OverclockCalculator;
 import gregtech.api.util.ParallelHelper;
 import gregtech.api.util.VoidProtectionHelper;
+import gregtech.common.misc.GTStructureChannels;
 
 public class MTEAssemblyLine extends MTEExtendedPowerMultiBlockBase<MTEAssemblyLine> implements ISurvivalConstructable {
 
@@ -154,7 +155,7 @@ public class MTEAssemblyLine extends MTEExtendedPowerMultiBlockBase<MTEAssemblyL
                 StatCollector.translateToLocal("GT5U.tooltip.structure.data_access_hatch"),
                 "Optional, next to controller",
                 2)
-            .addSubChannelUsage("glass", "Glass Tier")
+            .addSubChannelUsage(GTStructureChannels.BOROGLASS)
             .toolTipFinisher();
         return tt;
     }
@@ -449,7 +450,7 @@ public class MTEAssemblyLine extends MTEExtendedPowerMultiBlockBase<MTEAssemblyL
     @Override
     public void construct(ItemStack stackSize, boolean hintsOnly) {
         buildPiece(STRUCTURE_PIECE_FIRST, stackSize, hintsOnly, 0, 1, 0);
-        int tLength = Math.min(stackSize.stackSize + 1, 16);
+        int tLength = GTStructureChannels.STRUCTURE_LENGTH.getValueClamped(stackSize, 2, 17);
         for (int i = 1; i < tLength; i++) {
             buildPiece(STRUCTURE_PIECE_LATER, stackSize, hintsOnly, -i, 1, 0);
         }
@@ -460,7 +461,7 @@ public class MTEAssemblyLine extends MTEExtendedPowerMultiBlockBase<MTEAssemblyL
         if (mMachine) return -1;
         int build = survivialBuildPiece(STRUCTURE_PIECE_FIRST, stackSize, 0, 1, 0, elementBudget, env, false, true);
         if (build >= 0) return build;
-        int tLength = Math.min(stackSize.stackSize + 1, 16);
+        int tLength = GTStructureChannels.STRUCTURE_LENGTH.getValueClamped(stackSize, 2, 17);
         for (int i = 1; i < tLength - 1; i++) {
             build = survivialBuildPiece(STRUCTURE_PIECE_LATER, stackSize, -i, 1, 0, elementBudget, env, false, true);
             if (build >= 0) return build;

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEDistillationTower.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEDistillationTower.java
@@ -21,6 +21,7 @@ import static gregtech.api.util.GTStructureUtility.ofHatchAdder;
 import java.util.ArrayList;
 import java.util.List;
 
+import gregtech.common.misc.GTStructureChannels;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.StatCollector;
@@ -308,7 +309,8 @@ public class MTEDistillationTower extends MTEEnhancedMultiBlockBase<MTEDistillat
     @Override
     public void construct(ItemStack stackSize, boolean hintsOnly) {
         buildPiece(STRUCTURE_PIECE_BASE, stackSize, hintsOnly, 1, 0, 0);
-        int tTotalHeight = Math.min(12, stackSize.stackSize + 2); // min 2 output layer, so at least 1 + 2 height
+        // min 2 output layer, so at least 1 + 2 height
+        int tTotalHeight = GTStructureChannels.STRUCTURE_HEIGHT.getValueClamped(stackSize, 3, 12);
         for (int i = 1; i < tTotalHeight - 1; i++) {
             buildPiece(STRUCTURE_PIECE_LAYER_HINT, stackSize, hintsOnly, 1, i, 0);
         }
@@ -321,7 +323,8 @@ public class MTEDistillationTower extends MTEEnhancedMultiBlockBase<MTEDistillat
         mHeight = 0;
         int built = survivialBuildPiece(STRUCTURE_PIECE_BASE, stackSize, 1, 0, 0, elementBudget, env, false, true);
         if (built >= 0) return built;
-        int tTotalHeight = Math.min(12, stackSize.stackSize + 2); // min 2 output layer, so at least 1 + 2 height
+        // min 2 output layer, so at least 1 + 2 height
+        int tTotalHeight = GTStructureChannels.STRUCTURE_HEIGHT.getValueClamped(stackSize, 3, 12);
         for (int i = 1; i < tTotalHeight - 1; i++) {
             mHeight = i;
             built = survivialBuildPiece(

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialBrewery.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialBrewery.java
@@ -39,6 +39,7 @@ import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.MultiblockTooltipBuilder;
 import gregtech.common.blocks.BlockCasings10;
+import gregtech.common.misc.GTStructureChannels;
 
 public class MTEIndustrialBrewery extends MTEExtendedPowerMultiBlockBase<MTEIndustrialBrewery>
     implements ISurvivalConstructable {
@@ -160,7 +161,7 @@ public class MTEIndustrialBrewery extends MTEExtendedPowerMultiBlockBase<MTEIndu
             .addOutputHatch("Any Wooden Casing", 1)
             .addEnergyHatch("Any Wooden Casing", 1)
             .addMaintenanceHatch("Any Wooden Casing", 1)
-            .addSubChannelUsage("glass", "Glass Tier")
+            .addSubChannelUsage(GTStructureChannels.BOROGLASS)
             .toolTipFinisher(AuthorFourIsTheNumber);
         return tt;
     }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialElectromagneticSeparator.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialElectromagneticSeparator.java
@@ -55,6 +55,7 @@ import gregtech.api.util.GTUtility;
 import gregtech.api.util.MultiblockTooltipBuilder;
 import gregtech.common.blocks.BlockCasings10;
 import gregtech.common.items.MetaGeneratedItem01;
+import gregtech.common.misc.GTStructureChannels;
 import gtPlusPlus.core.util.minecraft.PlayerUtils;
 import mcp.mobius.waila.api.IWailaConfigHandler;
 import mcp.mobius.waila.api.IWailaDataAccessor;
@@ -230,7 +231,7 @@ public class MTEIndustrialElectromagneticSeparator
             .addOutputBus("Any Casing", 1)
             .addEnergyHatch("Any Casing", 1)
             .addMaintenanceHatch("Any Casing", 1)
-            .addSubChannelUsage("glass", "Glass Tier")
+            .addSubChannelUsage(GTStructureChannels.BOROGLASS)
             .toolTipFinisher(GTValues.AuthorFourIsTheNumber, GTValues.authorBaps);
         return tt;
     }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialExtractor.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialExtractor.java
@@ -45,6 +45,7 @@ import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.MultiblockTooltipBuilder;
 import gregtech.common.blocks.BlockCasings4;
+import gregtech.common.misc.GTStructureChannels;
 import mcp.mobius.waila.api.IWailaConfigHandler;
 import mcp.mobius.waila.api.IWailaDataAccessor;
 
@@ -180,7 +181,7 @@ public class MTEIndustrialExtractor extends MTEExtendedPowerMultiBlockBase<MTEIn
             .addOutputBus("Any Stainless Steel Casing", 1)
             .addEnergyHatch("Any Stainless Steel Casing", 1)
             .addMaintenanceHatch("Any Stainless Steel Casing", 1)
-            .addSubChannelUsage("glass", "Glass Tier")
+            .addSubChannelUsage(GTStructureChannels.BOROGLASS)
             .toolTipFinisher(AuthorFourIsTheNumber);
         return tt;
     }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialLaserEngraver.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialLaserEngraver.java
@@ -55,6 +55,7 @@ import gregtech.api.util.GTUtility;
 import gregtech.api.util.MultiblockTooltipBuilder;
 import gregtech.api.util.OverclockCalculator;
 import gregtech.common.blocks.BlockCasings10;
+import gregtech.common.misc.GTStructureChannels;
 import gregtech.common.tileentities.render.TileEntityLaser;
 import gtPlusPlus.core.util.minecraft.PlayerUtils;
 import mcp.mobius.waila.api.IWailaConfigHandler;
@@ -257,7 +258,7 @@ public class MTEIndustrialLaserEngraver extends MTEExtendedPowerMultiBlockBase<M
             .addOutputHatch("Any Casing", 1)
             .addEnergyHatch("Any Casing", 1)
             .addMaintenanceHatch("Any Casing", 1)
-            .addSubChannelUsage("glass", "Glass Tier")
+            .addSubChannelUsage(GTStructureChannels.BOROGLASS)
             .toolTipFinisher(AuthorFourIsTheNumber);
         return tt;
     }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTELargeFluidExtractor.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTELargeFluidExtractor.java
@@ -3,7 +3,6 @@ package gregtech.common.tileentities.machines.multi;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofBlock;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.onElementPass;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.transpose;
-import static com.gtnewhorizon.structurelib.structure.StructureUtility.withChannel;
 import static gregtech.api.enums.GTValues.VN;
 import static gregtech.api.enums.HatchElement.Energy;
 import static gregtech.api.enums.HatchElement.InputBus;
@@ -54,6 +53,7 @@ import gregtech.api.recipe.RecipeMaps;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.MultiblockTooltipBuilder;
+import gregtech.common.misc.GTStructureChannels;
 import gtPlusPlus.xmod.gregtech.common.blocks.textures.TexturesGtBlock;
 
 public class MTELargeFluidExtractor extends MTEExtendedPowerMultiBlockBase<MTELargeFluidExtractor>
@@ -101,8 +101,7 @@ public class MTELargeFluidExtractor extends MTEExtendedPowerMultiBlockBase<MTELa
         .addElement('g', chainAllGlasses(-1, (te, t) -> te.glassTier = t, te -> te.glassTier))
         .addElement(
             'h',
-            withChannel(
-                "coil",
+            GTStructureChannels.HEATING_COIL.use(
                 activeCoils(
                     ofCoil(
                         MTELargeFluidExtractor::setCoilLevel,
@@ -110,8 +109,7 @@ public class MTELargeFluidExtractor extends MTEExtendedPowerMultiBlockBase<MTELa
         )
         .addElement(
             's',
-            withChannel(
-                "solenoid",
+            GTStructureChannels.SOLENOID.use(
                 ofSolenoidCoil(
                     MTELargeFluidExtractor::setSolenoidLevel,
                     MTELargeFluidExtractor::getSolenoidLevel))
@@ -300,9 +298,9 @@ public class MTELargeFluidExtractor extends MTEExtendedPowerMultiBlockBase<MTELa
             .addOutputHatch("Any Robust Tungstensteel Machine Casing", 1)
             .addEnergyHatch("Any Robust Tungstensteel Machine Casing", 1)
             .addMaintenanceHatch("Any Robust Tungstensteel Machine Casing", 1)
-            .addSubChannelUsage("glass", "Glass Tier")
-            .addSubChannelUsage("coil", "Heating Coils Tier")
-            .addSubChannelUsage("solenoid", "Solenoid Tier")
+            .addSubChannelUsage(GTStructureChannels.BOROGLASS)
+            .addSubChannelUsage(GTStructureChannels.HEATING_COIL, "Heating Coils Tier")
+            .addSubChannelUsage(GTStructureChannels.SOLENOID, "Solenoid Tier")
             .toolTipFinisher();
         // spotless:on
 

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEMultiAutoclave.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEMultiAutoclave.java
@@ -4,7 +4,6 @@ import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofBlock;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofBlocksTiered;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.onElementPass;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.transpose;
-import static com.gtnewhorizon.structurelib.structure.StructureUtility.withChannel;
 import static gregtech.api.enums.GTValues.AuthorVolence;
 import static gregtech.api.enums.HatchElement.Energy;
 import static gregtech.api.enums.HatchElement.InputBus;
@@ -67,6 +66,7 @@ import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.MultiblockTooltipBuilder;
 import gregtech.common.blocks.BlockCasings10;
+import gregtech.common.misc.GTStructureChannels;
 import mcp.mobius.waila.api.IWailaConfigHandler;
 import mcp.mobius.waila.api.IWailaDataAccessor;
 
@@ -162,8 +162,7 @@ public class MTEMultiAutoclave extends MTEExtendedPowerMultiBlockBase<MTEMultiAu
         .addElement('C', ofFrame(Materials.Polytetrafluoroethylene)) // PTFE Frame
         .addElement(
             'D',
-            withChannel(
-                "pipe",
+            GTStructureChannels.PIPE_CASING.use(
                 ofBlocksTiered(
                     MTEMultiAutoclave::getFluidTierFromMeta,
                     ImmutableList.of(
@@ -176,8 +175,7 @@ public class MTEMultiAutoclave extends MTEExtendedPowerMultiBlockBase<MTEMultiAu
                     MTEMultiAutoclave::getFluidPipeTier)))
         .addElement(
             'E',
-            withChannel(
-                "item_pipe",
+            GTStructureChannels.ITEM_PIPE_CASING.use(
                 ofBlocksTiered(
                     MTEMultiAutoclave::getItemPipeTierFromMeta,
                     ImmutableList.of(
@@ -194,7 +192,8 @@ public class MTEMultiAutoclave extends MTEExtendedPowerMultiBlockBase<MTEMultiAu
                     MTEMultiAutoclave::getItemPipeTier)))
         .addElement(
             'F',
-            withChannel("coil", activeCoils(ofCoil(MTEMultiAutoclave::setCoilLevel, MTEMultiAutoclave::getCoilLevel))))
+            GTStructureChannels.HEATING_COIL
+                .use(activeCoils(ofCoil(MTEMultiAutoclave::setCoilLevel, MTEMultiAutoclave::getCoilLevel))))
         .build();
 
     @Override
@@ -224,10 +223,10 @@ public class MTEMultiAutoclave extends MTEExtendedPowerMultiBlockBase<MTEMultiAu
             .addOutputHatch("Any Pressure Containment Casing", 1)
             .addEnergyHatch("Any Pressure Containment Casing", 1)
             .addMaintenanceHatch("Any Pressure Containment Casing", 1)
-            .addSubChannelUsage("glass", "Glass Tier")
-            .addSubChannelUsage("item_pipe", "Item Pipe Casing Tier")
-            .addSubChannelUsage("pipe", "Pipe Casing Tier")
-            .addSubChannelUsage("coil", "Heating Coils Tier")
+            .addSubChannelUsage(GTStructureChannels.BOROGLASS)
+            .addSubChannelUsage(GTStructureChannels.ITEM_PIPE_CASING, "Item Pipe Casing Tier")
+            .addSubChannelUsage(GTStructureChannels.PIPE_CASING, "Pipe Casing Tier")
+            .addSubChannelUsage(GTStructureChannels.HEATING_COIL, "Heating Coils Tier")
             .toolTipFinisher(AuthorVolence);
         return tt;
     }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEMultiLathe.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEMultiLathe.java
@@ -4,7 +4,6 @@ import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofBlock;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofBlocksTiered;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.onElementPass;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.transpose;
-import static com.gtnewhorizon.structurelib.structure.StructureUtility.withChannel;
 import static gregtech.api.enums.GTValues.AuthorVolence;
 import static gregtech.api.enums.HatchElement.Energy;
 import static gregtech.api.enums.HatchElement.InputBus;
@@ -58,6 +57,7 @@ import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.MultiblockTooltipBuilder;
 import gregtech.common.blocks.BlockCasings2;
+import gregtech.common.misc.GTStructureChannels;
 import mcp.mobius.waila.api.IWailaConfigHandler;
 import mcp.mobius.waila.api.IWailaDataAccessor;
 
@@ -120,8 +120,7 @@ public class MTEMultiLathe extends MTEExtendedPowerMultiBlockBase<MTEMultiLathe>
         .addElement('C', chainAllGlasses()) // Glass
         .addElement(
             'F',
-            withChannel(
-                "item_pipe",
+            GTStructureChannels.ITEM_PIPE_CASING.use(
                 ofBlocksTiered(
                     MTEMultiLathe::getTierFromMeta,
                     ImmutableList.of(
@@ -212,8 +211,8 @@ public class MTEMultiLathe extends MTEExtendedPowerMultiBlockBase<MTEMultiLathe>
                 StatCollector.translateToLocal("GT5U.tooltip.structure.four_item_pipe_casings"),
                 "Center of the glass",
                 4)
-            .addSubChannelUsage("glass", "Glass Tier")
-            .addSubChannelUsage("item_pipe", "Item Pipe Casings")
+            .addSubChannelUsage(GTStructureChannels.BOROGLASS)
+            .addSubChannelUsage(GTStructureChannels.ITEM_PIPE_CASING, "Item Pipe Casings")
             .toolTipFinisher(AuthorVolence);
         return tt;
     }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEMultiSolidifier.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEMultiSolidifier.java
@@ -64,6 +64,7 @@ import gregtech.api.util.GTRecipe;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.MultiblockTooltipBuilder;
 import gregtech.common.blocks.BlockCasings10;
+import gregtech.common.misc.GTStructureChannels;
 import gregtech.common.tileentities.machines.IDualInputInventory;
 import gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.MTEHatchSolidifier;
 import mcp.mobius.waila.api.IWailaConfigHandler;
@@ -211,7 +212,7 @@ public class MTEMultiSolidifier extends MTEExtendedPowerMultiBlockBase<MTEMultiS
             .addInputHatch("Any Casing", 1)
             .addEnergyHatch("Any Casing", 1)
             .addMaintenanceHatch("Any Casing", 1)
-            .addSubChannelUsage("glass", "Glass Tier")
+            .addSubChannelUsage(GTStructureChannels.BOROGLASS)
             .toolTipFinisher(AuthorOmdaCZ);
         return tt;
     }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTESolarFactory.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTESolarFactory.java
@@ -58,6 +58,7 @@ import gregtech.api.util.MultiblockTooltipBuilder;
 import gregtech.api.util.OverclockCalculator;
 import gregtech.api.util.ParallelHelper;
 import gregtech.api.util.recipe.SolarFactoryRecipeData;
+import gregtech.common.misc.GTStructureChannels;
 
 public class MTESolarFactory extends MTEExtendedPowerMultiBlockBase<MTESolarFactory>
     implements IConstructable, ISurvivalConstructable {
@@ -169,8 +170,7 @@ public class MTESolarFactory extends MTEExtendedPowerMultiBlockBase<MTESolarFact
         // P for Precise Electronic Unit Casing ^-^
         .addElement(
             'P',
-            withChannel(
-                "unit casing",
+            GTStructureChannels.PRASS_UNIT_CASING.use(
                 ofBlocksTiered(
                     (block, meta) -> block == Loaders.preciseUnitCasing ? meta : null,
                     ImmutableList.of(
@@ -413,6 +413,7 @@ public class MTESolarFactory extends MTEExtendedPowerMultiBlockBase<MTESolarFact
             .addOutputBus("Any Machine Casing")
             .addEnergyHatch("Any Machine Casing")
             .addMaintenanceHatch("Any Machine Casing")
+            .addSubChannelUsage(GTStructureChannels.PRASS_UNIT_CASING)
             .toolTipFinisher(GTValues.AuthorPureBluez);
         return tt;
     }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEWormholeGenerator.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEWormholeGenerator.java
@@ -70,6 +70,7 @@ import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.IGTHatchAdder;
 import gregtech.api.util.MultiblockTooltipBuilder;
+import gregtech.common.misc.GTStructureChannels;
 import gregtech.common.tileentities.render.TileEntityWormhole;
 import gtPlusPlus.xmod.gregtech.common.blocks.textures.TexturesGtBlock;
 import tectech.thing.casing.BlockGTCasingsTT;
@@ -1012,7 +1013,7 @@ public class MTEWormholeGenerator extends MTEEnhancedMultiBlockBase<MTEWormholeG
             .addInputBus("§61§r (dot 1)")
             .addDynamoHatch("§60§r - §64§r (laser only, dot 2)")
             .addEnergyHatch("§60§r - §64§r (laser only, dot 2)")
-            .addSubChannelUsage("glass", "Glass Tier")
+            .addSubChannelUsage(GTStructureChannels.BOROGLASS)
             .toolTipFinisher(GTValues.AuthorPineapple + EnumChatFormatting.GRAY + ", Rendering by: " + EnumChatFormatting.WHITE + "BucketBrigade");
         // spotless:on
 

--- a/src/main/java/gregtech/common/tileentities/machines/multi/compressor/MTEIndustrialCompressor.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/compressor/MTEIndustrialCompressor.java
@@ -38,6 +38,7 @@ import gregtech.api.util.GTRecipe;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.MultiblockTooltipBuilder;
 import gregtech.common.blocks.BlockCasings10;
+import gregtech.common.misc.GTStructureChannels;
 
 public class MTEIndustrialCompressor extends MTEExtendedPowerMultiBlockBase<MTEIndustrialCompressor>
     implements ISurvivalConstructable {
@@ -156,7 +157,7 @@ public class MTEIndustrialCompressor extends MTEExtendedPowerMultiBlockBase<MTEI
             .addOutputBus("Pipe Casings on Side", 2)
             .addEnergyHatch("Any Electric Compressor Casing", 1)
             .addMaintenanceHatch("Any Electric Compressor Casing", 1)
-            .addSubChannelUsage("glass", "Glass Tier")
+            .addSubChannelUsage(GTStructureChannels.BOROGLASS)
             .toolTipFinisher(AuthorFourIsTheNumber, Ollie);
         return tt;
     }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/compressor/MTENeutroniumCompressor.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/compressor/MTENeutroniumCompressor.java
@@ -46,6 +46,7 @@ import gregtech.api.util.GTRecipe;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.MultiblockTooltipBuilder;
 import gregtech.common.blocks.BlockCasings10;
+import gregtech.common.misc.GTStructureChannels;
 
 public class MTENeutroniumCompressor extends MTEExtendedPowerMultiBlockBase<MTENeutroniumCompressor>
     implements ISurvivalConstructable {
@@ -163,7 +164,7 @@ public class MTENeutroniumCompressor extends MTEExtendedPowerMultiBlockBase<MTEN
             .addOutputBus("Any Neutronium Casing", 1)
             .addEnergyHatch("Any Neutronium Casing", 1)
             .addMaintenanceHatch("Any Neutronium Casing", 1)
-            .addSubChannelUsage("glass", "Glass Tier")
+            .addSubChannelUsage(GTStructureChannels.BOROGLASS)
             .toolTipFinisher(AuthorFourIsTheNumber, Ollie);
         return tt;
     }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/blocks/GregtechMetaCasingBlocks2.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/blocks/GregtechMetaCasingBlocks2.java
@@ -15,6 +15,7 @@ import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GTLanguageManager;
 import gregtech.api.util.GTUtility;
 import gregtech.common.blocks.MaterialCasings;
+import gregtech.common.misc.GTStructureChannels;
 import gtPlusPlus.xmod.gregtech.api.enums.GregtechItemList;
 import gtPlusPlus.xmod.gregtech.common.blocks.textures.CasingTextureHandler2;
 import gtPlusPlus.xmod.gregtech.common.tileentities.machines.multi.storage.MTEPowerSubStation;
@@ -106,6 +107,8 @@ public class GregtechMetaCasingBlocks2 extends GregtechMetaCasingBlocksAbstract 
         GregtechItemList.Casing_CuttingFactoryFrame.set(new ItemStack(this, 1, 13));
 
         GregtechItemList.Casing_PLACEHOLDER_TreeFarmer.set(new ItemStack(this, 1, 15)); // Tree Farmer Textures
+
+        GTStructureChannels.PSS_CELL.registerAsIndicator(new ItemStack(this, 1, 7), 1);
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/blocks/GregtechMetaCasingBlocks3.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/blocks/GregtechMetaCasingBlocks3.java
@@ -16,6 +16,7 @@ import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GTLanguageManager;
 import gregtech.api.util.GTUtility;
 import gregtech.common.blocks.MaterialCasings;
+import gregtech.common.misc.GTStructureChannels;
 import gtPlusPlus.xmod.gregtech.api.enums.GregtechItemList;
 import gtPlusPlus.xmod.gregtech.common.blocks.textures.CasingTextureHandler3;
 import gtPlusPlus.xmod.gregtech.common.blocks.textures.TexturesGtBlock;
@@ -94,6 +95,10 @@ public class GregtechMetaCasingBlocks3 extends GregtechMetaCasingBlocksAbstract 
         GregtechItemList.Casing_Fusion_External.set(new ItemStack(this, 1, 12));
         GregtechItemList.Casing_Fusion_Internal.set(new ItemStack(this, 1, 13));
         GregtechItemList.Casing_Containment.set(new ItemStack(this, 1, 15));
+
+        for (int i = 4; i < 9; i++) {
+            GTStructureChannels.PSS_CELL.registerAsIndicator(new ItemStack(this, 1, i), i - 2);
+        }
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/blocks/GregtechMetaCasingBlocks5.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/blocks/GregtechMetaCasingBlocks5.java
@@ -11,6 +11,7 @@ import gregtech.api.enums.Textures;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GTLanguageManager;
 import gregtech.common.blocks.MaterialCasings;
+import gregtech.common.misc.GTStructureChannels;
 import gtPlusPlus.xmod.gregtech.api.enums.GregtechItemList;
 import gtPlusPlus.xmod.gregtech.common.blocks.textures.TexturesGrinderMultiblock;
 import gtPlusPlus.xmod.gregtech.common.blocks.textures.TexturesGtBlock;
@@ -70,6 +71,13 @@ public class GregtechMetaCasingBlocks5 extends GregtechMetaCasingBlocksAbstract 
         GregtechItemList.InfinityInfusedShieldingCore.set(new ItemStack(this, 1, 13));
         GregtechItemList.SpaceTimeBendingCore.set(new ItemStack(this, 1, 14));
         GregtechItemList.ForceFieldGlass.set(new ItemStack(this, 1, 15));
+
+        for (int i = 0; i < 4; i++) {
+            GTStructureChannels.QFT_MANIPULATOR.registerAsIndicator(new ItemStack(this, 1, i + 7), i + 1);
+        }
+        for (int i = 0; i < 4; i++) {
+            GTStructureChannels.QFT_SHIELDING.registerAsIndicator(new ItemStack(this, 1, i + 11), i + 1);
+        }
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/advanced/MTEAdvDistillationTower.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/advanced/MTEAdvDistillationTower.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import javax.annotation.Nonnull;
 
+import gregtech.common.misc.GTStructureChannels;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
@@ -200,7 +201,8 @@ public class MTEAdvDistillationTower extends GTPPMultiBlockBase<MTEAdvDistillati
     @Override
     public void construct(ItemStack stackSize, boolean hintsOnly) {
         buildPiece(STRUCTURE_PIECE_BASE, stackSize, hintsOnly, 1, 0, 0);
-        int tTotalHeight = Math.min(12, stackSize.stackSize + 2); // min 2 output layer, so at least 1 + 2 height
+        // min 2 output layer, so at least 1 + 2 height
+        int tTotalHeight = GTStructureChannels.STRUCTURE_HEIGHT.getValueClamped(stackSize, 3, 12);
         for (int i = 1; i < tTotalHeight - 1; i++) {
             buildPiece(STRUCTURE_PIECE_LAYER_HINT, stackSize, hintsOnly, 1, i, 0);
         }
@@ -212,7 +214,8 @@ public class MTEAdvDistillationTower extends GTPPMultiBlockBase<MTEAdvDistillati
         mHeight = 0;
         int built = survivialBuildPiece(STRUCTURE_PIECE_BASE, stackSize, 1, 0, 0, elementBudget, env, false, true);
         if (built >= 0) return built;
-        int tTotalHeight = Math.min(12, stackSize.stackSize + 2); // min 2 output layer, so at least 1 + 2 height
+        // min 2 output layer, so at least 1 + 2 height
+        int tTotalHeight = GTStructureChannels.STRUCTURE_HEIGHT.getValueClamped(stackSize, 3, 12);
         for (int i = 1; i < tTotalHeight - 1; i++) {
             mHeight = i;
             built = survivialBuildPiece(

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTEQuantumForceTransformer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTEQuantumForceTransformer.java
@@ -3,7 +3,6 @@ package gtPlusPlus.xmod.gregtech.common.tileentities.machines.multi.production;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.lazy;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofBlock;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.onElementPass;
-import static com.gtnewhorizon.structurelib.structure.StructureUtility.withChannel;
 import static gregtech.api.enums.HatchElement.Energy;
 import static gregtech.api.enums.HatchElement.ExoticEnergy;
 import static gregtech.api.enums.HatchElement.InputBus;
@@ -76,6 +75,7 @@ import gregtech.api.util.GTUtility;
 import gregtech.api.util.IGTHatchAdder;
 import gregtech.api.util.MultiblockTooltipBuilder;
 import gregtech.api.util.ParallelHelper;
+import gregtech.common.misc.GTStructureChannels;
 import gtPlusPlus.api.recipe.GTPPRecipeMaps;
 import gtPlusPlus.core.block.ModBlocks;
 import gtPlusPlus.core.material.MaterialsElements;
@@ -118,8 +118,7 @@ public class MTEQuantumForceTransformer extends MTEExtendedPowerMultiBlockBase<M
                 // spotless:on
         .addElement(
             'A',
-            withChannel(
-                "manipulator",
+            GTStructureChannels.QFT_MANIPULATOR.use(
                 StructureUtility.ofBlocksTiered(
                     craftingTierConverter(),
                     getAllCraftingTiers(),
@@ -128,8 +127,7 @@ public class MTEQuantumForceTransformer extends MTEExtendedPowerMultiBlockBase<M
                     MTEQuantumForceTransformer::getCraftingTier)))
         .addElement(
             'B',
-            withChannel(
-                "shielding",
+            GTStructureChannels.QFT_SHIELDING.use(
                 StructureUtility.ofBlocksTiered(
                     focusingTierConverter(),
                     getAllFocusingTiers(),
@@ -212,6 +210,8 @@ public class MTEQuantumForceTransformer extends MTEExtendedPowerMultiBlockBase<M
                     + "Bottom"
                     + EnumChatFormatting.GRAY
                     + " Layer")
+            .addSubChannelUsage(GTStructureChannels.QFT_SHIELDING)
+            .addSubChannelUsage(GTStructureChannels.QFT_MANIPULATOR)
             .toolTipFinisher(GTValues.AuthorBlueWeabo, EnumChatFormatting.GREEN + "Steelux");
         return tt;
     }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/chemplant/MTEChemicalPlant.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/chemplant/MTEChemicalPlant.java
@@ -2,7 +2,6 @@ package gtPlusPlus.xmod.gregtech.common.tileentities.machines.multi.production.c
 
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofChain;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.transpose;
-import static com.gtnewhorizon.structurelib.structure.StructureUtility.withChannel;
 import static gregtech.api.enums.HatchElement.InputBus;
 import static gregtech.api.enums.HatchElement.InputHatch;
 import static gregtech.api.enums.HatchElement.Maintenance;
@@ -63,6 +62,7 @@ import gregtech.api.recipe.check.SimpleCheckRecipeResult;
 import gregtech.api.util.GTRecipe;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.MultiblockTooltipBuilder;
+import gregtech.common.misc.GTStructureChannels;
 import gregtech.common.tileentities.machines.IDualInputHatch;
 import gtPlusPlus.api.recipe.GTPPRecipeMaps;
 import gtPlusPlus.core.item.chemistry.general.ItemGenericChemBase;
@@ -108,6 +108,7 @@ public class MTEChemicalPlant extends GTPPMultiBlockBase<MTEChemicalPlant> imple
                     + " to the Chemical Plant, however this tier already contains one.");
         }
         mTieredBlockRegistry.put(aTier, aCasingData);
+        GTStructureChannels.METAL_MACHINE_CASING.registerAsIndicator(new ItemStack(aBlock, 1, aMeta), aTier + 1);
         return true;
     }
 
@@ -149,10 +150,10 @@ public class MTEChemicalPlant extends GTPPMultiBlockBase<MTEChemicalPlant> imple
             .addOutputHatch("Bottom Casing", 1)
             .addEnergyHatch("Bottom Casing", 1)
             .addMaintenanceHatch("Bottom Casing", 1)
-            .addSubChannelUsage("casing", "metal machine casing (minimum 70)")
-            .addSubChannelUsage("machine", "tier machine casing")
-            .addSubChannelUsage("coil", "heating coil blocks")
-            .addSubChannelUsage("pipe", "pipe casing blocks")
+            .addSubChannelUsage(GTStructureChannels.METAL_MACHINE_CASING, "metal machine casing (minimum 70)")
+            .addSubChannelUsage(GTStructureChannels.TIER_MACHINE_CASING)
+            .addSubChannelUsage(GTStructureChannels.HEATING_COIL)
+            .addSubChannelUsage(GTStructureChannels.PIPE_CASING)
             .toolTipFinisher();
     }
 
@@ -183,8 +184,7 @@ public class MTEChemicalPlant extends GTPPMultiBlockBase<MTEChemicalPlant> imple
     @Override
     public IStructureDefinition<MTEChemicalPlant> getStructureDefinition() {
         if (STRUCTURE_DEFINITION == null) {
-            IStructureElement<MTEChemicalPlant> allCasingsElement = withChannel(
-                "casing",
+            IStructureElement<MTEChemicalPlant> allCasingsElement = GTStructureChannels.METAL_MACHINE_CASING.use(
                 ofChain(
                     IntStream.range(0, 8)
                         .mapToObj(MTEChemicalPlant::ofSolidCasing)
@@ -227,8 +227,7 @@ public class MTEChemicalPlant extends GTPPMultiBlockBase<MTEChemicalPlant> imple
                 .addElement('X', allCasingsElement)
                 .addElement(
                     'M',
-                    withChannel(
-                        "machine",
+                    GTStructureChannels.TIER_MACHINE_CASING.use(
                         addTieredBlock(
                             GregTechAPI.sBlockCasings1,
                             MTEChemicalPlant::setMachineMeta,
@@ -236,13 +235,11 @@ public class MTEChemicalPlant extends GTPPMultiBlockBase<MTEChemicalPlant> imple
                             10)))
                 .addElement(
                     'H',
-                    withChannel(
-                        "coil",
-                        activeCoils(ofCoil(MTEChemicalPlant::setCoilMeta, MTEChemicalPlant::getCoilMeta))))
+                    GTStructureChannels.HEATING_COIL
+                        .use(activeCoils(ofCoil(MTEChemicalPlant::setCoilMeta, MTEChemicalPlant::getCoilMeta))))
                 .addElement(
                     'P',
-                    withChannel(
-                        "pipe",
+                    GTStructureChannels.PIPE_CASING.use(
                         addTieredBlock(
                             GregTechAPI.sBlockCasings2,
                             MTEChemicalPlant::setPipeMeta,

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/storage/MTEPowerSubStation.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/storage/MTEPowerSubStation.java
@@ -6,7 +6,6 @@ import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofChain;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.onElementPass;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.onlyIf;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.transpose;
-import static com.gtnewhorizon.structurelib.structure.StructureUtility.withChannel;
 import static gregtech.api.enums.HatchElement.Dynamo;
 import static gregtech.api.enums.HatchElement.Energy;
 import static gregtech.api.enums.HatchElement.Maintenance;
@@ -34,7 +33,6 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.NotNull;
 
 import com.gtnewhorizon.structurelib.StructureLibAPI;
-import com.gtnewhorizon.structurelib.alignment.constructable.ChannelDataAccessor;
 import com.gtnewhorizon.structurelib.alignment.constructable.ISurvivalConstructable;
 import com.gtnewhorizon.structurelib.structure.AutoPlaceEnvironment;
 import com.gtnewhorizon.structurelib.structure.IStructureDefinition;
@@ -73,6 +71,7 @@ import gregtech.api.recipe.check.SimpleCheckRecipeResult;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.MultiblockTooltipBuilder;
+import gregtech.common.misc.GTStructureChannels;
 import gtPlusPlus.api.objects.Logger;
 import gtPlusPlus.core.block.ModBlocks;
 import gtPlusPlus.core.config.ASMConfiguration;
@@ -135,8 +134,8 @@ public class MTEPowerSubStation extends GTPPMultiBlockBase<MTEPowerSubStation> i
             .addCasingInfoMin("Sub-Station External Casings", 10, false)
             .addDynamoHatch("Any Casing", 1)
             .addEnergyHatch("Any Casing", 1)
-            .addSubChannelUsage("capacitor", "Vanadium Capacitor Cell Tier")
-            .addSubChannelUsage("height", "Height of structure")
+            .addSubChannelUsage(GTStructureChannels.PSS_CELL)
+            .addSubChannelUsage(GTStructureChannels.STRUCTURE_HEIGHT)
             .toolTipFinisher();
         return tt;
     }
@@ -268,8 +267,7 @@ public class MTEPowerSubStation extends GTPPMultiBlockBase<MTEPowerSubStation> i
                         .buildAndChain(onElementPass(x -> ++x.mCasing, ofBlock(ModBlocks.blockCasings2Misc, 8))))
                 .addElement(
                     'I',
-                    withChannel(
-                        "cell",
+                    GTStructureChannels.PSS_CELL.use(
                         ofChain(
                             onlyIf(
                                 x -> x.topState != TopState.NotTop,
@@ -294,8 +292,7 @@ public class MTEPowerSubStation extends GTPPMultiBlockBase<MTEPowerSubStation> i
                                         onElementPass(x -> ++x.cellCount[5], ofCell(9))))))))
                 .addElement(
                     'H',
-                    withChannel(
-                        "cell",
+                    GTStructureChannels.PSS_CELL.use(
                         // Adding this so preview looks correct
                         ofBlocksTiered(cellTierConverter(), getAllCellTiers(), -1, (te, t) -> {}, (te) -> -1)))
                 .build();
@@ -391,7 +388,7 @@ public class MTEPowerSubStation extends GTPPMultiBlockBase<MTEPowerSubStation> i
 
     @Override
     public void construct(ItemStack stackSize, boolean hintsOnly) {
-        int layer = Math.min(stackSize.stackSize + 3, 18);
+        int layer = GTStructureChannels.STRUCTURE_HEIGHT.getValueClamped(stackSize, 4, 18);
         log("Layer: " + layer);
         log("Building 0");
         buildPiece(mName + "bottom", stackSize, hintsOnly, 2, 0, 0);
@@ -409,7 +406,7 @@ public class MTEPowerSubStation extends GTPPMultiBlockBase<MTEPowerSubStation> i
     @Override
     public int survivalConstruct(ItemStack stackSize, int elementBudget, ISurvivalBuildEnvironment env) {
         if (mMachine) return -1;
-        int layer = Math.min(ChannelDataAccessor.getChannelData(stackSize, "height") + 3, 18);
+        int layer = GTStructureChannels.STRUCTURE_HEIGHT.getValueClamped(stackSize, 4, 18);
         int built;
         built = survivialBuildPiece(mName + "bottom", stackSize, 2, 0, 0, elementBudget, env, false, true);
         if (built >= 0) return built;

--- a/src/main/java/gtnhlanth/common/register/LanthItemList.java
+++ b/src/main/java/gtnhlanth/common/register/LanthItemList.java
@@ -12,6 +12,7 @@ import gregtech.api.enums.Textures;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GTLanguageManager;
 import gregtech.api.util.GTOreDictUnificator;
+import gregtech.common.misc.GTStructureChannels;
 import gtnhlanth.common.beamline.MTEBeamlinePipe;
 import gtnhlanth.common.block.BlockAntennaCasing;
 import gtnhlanth.common.block.BlockCasing;
@@ -183,5 +184,7 @@ public final class LanthItemList {
 
         }
 
+        GTStructureChannels.SYNCHROTRON_ANTENNA.registerAsIndicator(new ItemStack(ANTENNA_CASING_T1), 1);
+        GTStructureChannels.SYNCHROTRON_ANTENNA.registerAsIndicator(new ItemStack(ANTENNA_CASING_T2), 2);
     }
 }

--- a/src/main/java/gtnhlanth/common/tileentity/MTELINAC.java
+++ b/src/main/java/gtnhlanth/common/tileentity/MTELINAC.java
@@ -52,6 +52,7 @@ import gregtech.api.util.GTUtility;
 import gregtech.api.util.MultiblockTooltipBuilder;
 import gregtech.api.util.shutdown.ShutDownReason;
 import gregtech.api.util.shutdown.SimpleShutDownReason;
+import gregtech.common.misc.GTStructureChannels;
 import gtnhlanth.common.beamline.BeamInformation;
 import gtnhlanth.common.beamline.BeamLinePacket;
 import gtnhlanth.common.beamline.Particle;
@@ -205,7 +206,7 @@ public class MTELINAC extends MTEEnhancedMultiBlockBase<MTELINAC> implements ISu
             .addOutputHatch(addDotText(2))
             .addOtherStructurePart("Beamline Input Hatch", addDotText(3))
             .addOtherStructurePart("Beamline Output Hatch", addDotText(4))
-            .addSubChannelUsage("glass", "Glass Tier")
+            .addSubChannelUsage(GTStructureChannels.BOROGLASS)
             .toolTipFinisher();
         return tt;
     }

--- a/src/main/java/gtnhlanth/common/tileentity/MTESynchrotron.java
+++ b/src/main/java/gtnhlanth/common/tileentity/MTESynchrotron.java
@@ -1,7 +1,6 @@
 package gtnhlanth.common.tileentity;
 
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofBlock;
-import static com.gtnewhorizon.structurelib.structure.StructureUtility.withChannel;
 import static gregtech.api.enums.GTValues.VN;
 import static gregtech.api.enums.HatchElement.Energy;
 import static gregtech.api.enums.HatchElement.ExoticEnergy;
@@ -60,6 +59,7 @@ import gregtech.api.util.GTUtility;
 import gregtech.api.util.MultiblockTooltipBuilder;
 import gregtech.api.util.shutdown.ShutDownReason;
 import gregtech.api.util.shutdown.SimpleShutDownReason;
+import gregtech.common.misc.GTStructureChannels;
 import gtnhlanth.common.beamline.BeamInformation;
 import gtnhlanth.common.beamline.BeamLinePacket;
 import gtnhlanth.common.beamline.Particle;
@@ -460,7 +460,7 @@ public class MTESynchrotron extends MTEExtendedPowerMultiBlockBase<MTESynchrotro
                 // Adder overriden due to ExoticEnergy originally calling its own adder, giving false positives
                 .addElement('e', buildHatchAdder(MTESynchrotron.class).atLeast(ImmutableMap.of(Energy.or(ExoticEnergy), 4)).adder(MTESynchrotron::addEnergyInputToMachineList).dot(6).casingIndex(CASING_INDEX).build())
                 .addElement('n', ofBlock(LanthItemList.NIOBIUM_CAVITY_CASING, 0))
-                .addElement('a', withChannel("antenna", StructureUtility.ofBlocksTiered(
+                .addElement('a', GTStructureChannels.SYNCHROTRON_ANTENNA.use(StructureUtility.ofBlocksTiered(
                 		MTESynchrotron::getAntennaBlockTier,
                 		ImmutableList.of(
                 				Pair.of(LanthItemList.ANTENNA_CASING_T1, 0),
@@ -527,7 +527,8 @@ public class MTESynchrotron extends MTEExtendedPowerMultiBlockBase<MTESynchrotro
             .addInputHatch(addDotText(4))
             .addOutputHatch(addDotText(5))
             .addEnergyHatch(addDotText(6))
-            .addSubChannelUsage("glass", "Glass Tier")
+            .addSubChannelUsage(GTStructureChannels.BOROGLASS)
+            .addSubChannelUsage(GTStructureChannels.SYNCHROTRON_ANTENNA)
             .toolTipFinisher();
         return tt;
     }

--- a/src/main/java/gtnhlanth/common/tileentity/MTETargetChamber.java
+++ b/src/main/java/gtnhlanth/common/tileentity/MTETargetChamber.java
@@ -49,6 +49,7 @@ import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GTRecipe;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.MultiblockTooltipBuilder;
+import gregtech.common.misc.GTStructureChannels;
 import gtnhlanth.common.beamline.BeamInformation;
 import gtnhlanth.common.beamline.Particle;
 import gtnhlanth.common.hatch.MTEBusInputFocus;
@@ -203,7 +204,7 @@ public class MTETargetChamber extends MTEEnhancedMultiBlockBase<MTETargetChamber
             .addInputBus(addDotText(3))
             .addOutputBus(addDotText(4))
             .addOtherStructurePart("Beamline Input Hatch", addDotText(5))
-            .addSubChannelUsage("glass", "Glass Tier")
+            .addSubChannelUsage(GTStructureChannels.BOROGLASS)
             .toolTipFinisher();
         return tt;
     }

--- a/src/main/java/kekztech/common/blocks/BlockLapotronicEnergyUnit.java
+++ b/src/main/java/kekztech/common/blocks/BlockLapotronicEnergyUnit.java
@@ -17,6 +17,7 @@ import gregtech.api.enums.Textures;
 import gregtech.api.interfaces.IIconContainer;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GTUtility;
+import gregtech.common.misc.GTStructureChannels;
 import kekztech.common.itemBlocks.ItemBlockLapotronicEnergyUnit;
 
 public class BlockLapotronicEnergyUnit extends BaseGTUpdateableBlock {
@@ -85,6 +86,18 @@ public class BlockLapotronicEnergyUnit extends BaseGTUpdateableBlock {
         INSTANCE.setHardness(5.0f);
         INSTANCE.setResistance(6.0f);
         GameRegistry.registerBlock(INSTANCE, ItemBlockLapotronicEnergyUnit.class, blockName);
+
+        int value = 1;
+        GTStructureChannels.LSC_CAPACITOR.registerAsIndicator(new ItemStack(INSTANCE, 1, 6), value++);
+        GTStructureChannels.LSC_CAPACITOR.registerAsIndicator(new ItemStack(INSTANCE, 1, 7), value++);
+        GTStructureChannels.LSC_CAPACITOR.registerAsIndicator(new ItemStack(INSTANCE, 1, 1), value++);
+        GTStructureChannels.LSC_CAPACITOR.registerAsIndicator(new ItemStack(INSTANCE, 1, 2), value++);
+        GTStructureChannels.LSC_CAPACITOR.registerAsIndicator(new ItemStack(INSTANCE, 1, 3), value++);
+        GTStructureChannels.LSC_CAPACITOR.registerAsIndicator(new ItemStack(INSTANCE, 1, 4), value++);
+        GTStructureChannels.LSC_CAPACITOR.registerAsIndicator(new ItemStack(INSTANCE, 1, 5), value++);
+        GTStructureChannels.LSC_CAPACITOR.registerAsIndicator(new ItemStack(INSTANCE, 1, 8), value++);
+        GTStructureChannels.LSC_CAPACITOR.registerAsIndicator(new ItemStack(INSTANCE, 1, 9), value++);
+        GTStructureChannels.LSC_CAPACITOR.registerAsIndicator(new ItemStack(INSTANCE, 1, 10), value++);
 
         return INSTANCE;
     }

--- a/src/main/java/kekztech/common/tileentities/MTETankTFFT.java
+++ b/src/main/java/kekztech/common/tileentities/MTETankTFFT.java
@@ -36,7 +36,6 @@ import net.minecraftforge.fluids.FluidTankInfo;
 import org.jetbrains.annotations.NotNull;
 
 import com.gtnewhorizon.structurelib.StructureLibAPI;
-import com.gtnewhorizon.structurelib.alignment.constructable.ChannelDataAccessor;
 import com.gtnewhorizon.structurelib.alignment.constructable.ISurvivalConstructable;
 import com.gtnewhorizon.structurelib.structure.AutoPlaceEnvironment;
 import com.gtnewhorizon.structurelib.structure.IStructureDefinition;
@@ -62,6 +61,7 @@ import gregtech.api.util.GTUtility;
 import gregtech.api.util.IGTHatchAdder;
 import gregtech.api.util.MultiblockTooltipBuilder;
 import gregtech.common.items.ItemIntegratedCircuit;
+import gregtech.common.misc.GTStructureChannels;
 import kekztech.common.Blocks;
 
 public class MTETankTFFT extends MTEEnhancedMultiBlockBase<MTETankTFFT> implements ISurvivalConstructable {
@@ -147,7 +147,7 @@ public class MTETankTFFT extends MTEEnhancedMultiBlockBase<MTETankTFFT> implemen
         }
 
         private int getHint(ItemStack stack) {
-            return Math.min(Field.VALUES.length, ChannelDataAccessor.getChannelData(stack, "field"));
+            return GTStructureChannels.TFFT_FIELD.getValueClamped(stack, 0, Field.VALUES.length);
         }
 
         @Override
@@ -363,14 +363,14 @@ public class MTETankTFFT extends MTEEnhancedMultiBlockBase<MTETankTFFT> implemen
                 "Multi I/O Hatches",
                 "Instead of any casing or glass, has to touch storage field block")
             .addStructureInfo("Use MIOH with conduits or fluid storage buses to see all fluids at once.")
-            .addSubChannelUsage("glass", "Glass Tier")
+            .addSubChannelUsage(GTStructureChannels.BOROGLASS)
             .toolTipFinisher();
         return tt;
     }
 
     @Override
     public void construct(ItemStack stackSize, boolean hintsOnly) {
-        int layer = min(stackSize.stackSize + DEFAULT_LAYER_AMOUNT, MAX_LAYER_AMOUNT + 1);
+        int layer = GTStructureChannels.STRUCTURE_HEIGHT.getValueClamped(stackSize, DEFAULT_LAYER_AMOUNT - 1, MAX_LAYER_AMOUNT + 1);
         buildPiece(STRUCTURE_PIECE_TOP, stackSize, hintsOnly, 2, 2, 0);
         for (int i = -1; i >= 1 - layer; i--) buildPiece(STRUCTURE_PIECE_MID, stackSize, hintsOnly, 2, 2, i);
         buildPiece(STRUCTURE_PIECE_BOTTOM, stackSize, hintsOnly, 2, 2, -layer);
@@ -381,7 +381,7 @@ public class MTETankTFFT extends MTEEnhancedMultiBlockBase<MTETankTFFT> implemen
         if (mMachine) return -1;
         int build = survivialBuildPiece(STRUCTURE_PIECE_TOP, stackSize, 2, 2, 0, elementBudget, env, false, true);
         if (build >= 0) return build;
-        int layer = min(stackSize.stackSize + DEFAULT_LAYER_AMOUNT, MAX_LAYER_AMOUNT + 1);
+        int layer = GTStructureChannels.STRUCTURE_HEIGHT.getValueClamped(stackSize, DEFAULT_LAYER_AMOUNT - 1, MAX_LAYER_AMOUNT + 1);
         for (int i = -1; i >= 1 - layer; i--) {
             build = survivialBuildPiece(STRUCTURE_PIECE_MID, stackSize, 2, 2, i, elementBudget, env, false, true);
             if (build >= 0) return build;

--- a/src/main/java/kubatech/tileentity/gregtech/multiblock/MTEExtremeEntityCrusher.java
+++ b/src/main/java/kubatech/tileentity/gregtech/multiblock/MTEExtremeEntityCrusher.java
@@ -121,6 +121,7 @@ import gregtech.api.recipe.check.SimpleCheckRecipeResult;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.MultiblockTooltipBuilder;
+import gregtech.common.misc.GTStructureChannels;
 import kubatech.Tags;
 import kubatech.api.implementations.KubaTechGTMultiBlockBase;
 import kubatech.api.tileentity.CustomTileEntityPacketHandler;
@@ -290,7 +291,7 @@ public class MTEExtremeEntityCrusher extends KubaTechGTMultiBlockBase<MTEExtreme
             .addOutputHatch("Any bottom casing", 1)
             .addEnergyHatch("Any bottom casing", 1)
             .addMaintenanceHatch("Any bottom casing", 1)
-            .addSubChannelUsage("glass", "Glass Tier")
+            .addSubChannelUsage(GTStructureChannels.BOROGLASS)
             .toolTipFinisher(GTValues.AuthorKuba);
         return tt;
     }

--- a/src/main/java/kubatech/tileentity/gregtech/multiblock/MTEMegaIndustrialApiary.java
+++ b/src/main/java/kubatech/tileentity/gregtech/multiblock/MTEMegaIndustrialApiary.java
@@ -124,6 +124,7 @@ import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.GTUtility.ItemId;
 import gregtech.api.util.MultiblockTooltipBuilder;
+import gregtech.common.misc.GTStructureChannels;
 import ic2.core.init.BlocksItems;
 import ic2.core.init.InternalName;
 import kubatech.api.DynamicInventory;
@@ -339,7 +340,7 @@ public class MTEMegaIndustrialApiary extends KubaTechGTMultiBlockBase<MTEMegaInd
             .addOutputBus("Any casing", 1)
             .addEnergyHatch("Any casing", 1)
             .addMaintenanceHatch("Any casing", 1)
-            .addSubChannelUsage("glass", "Glass Tier")
+            .addSubChannelUsage(GTStructureChannels.BOROGLASS)
             .toolTipFinisher(GTValues.AuthorKuba, "Runakai");
         return tt;
     }

--- a/src/main/java/tectech/thing/casing/SpacetimeCompressionFieldCasing.java
+++ b/src/main/java/tectech/thing/casing/SpacetimeCompressionFieldCasing.java
@@ -19,6 +19,7 @@ import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GTLanguageManager;
 import gregtech.common.blocks.BlockCasingsAbstract;
 import gregtech.common.blocks.MaterialCasings;
+import gregtech.common.misc.GTStructureChannels;
 import tectech.thing.CustomItemList;
 import tectech.util.CommonValues;
 
@@ -48,6 +49,7 @@ public class SpacetimeCompressionFieldCasing extends BlockCasingsAbstract {
             GTLanguageManager.addStringLocalization(
                 getUnlocalizedName() + "." + i + ".name",
                 WHITE + CommonValues.EOH_TIER_FANCY_NAMES[i] + RESET + " Spacetime Compression Field Generator");
+            GTStructureChannels.EOH_COMPRESSION.registerAsIndicator(new ItemStack(this, 1, i), i + 1);
         }
 
         CustomItemList.SpacetimeCompressionFieldGeneratorTier0.set(new ItemStack(this, 1, 0));

--- a/src/main/java/tectech/thing/casing/StabilisationFieldCasing.java
+++ b/src/main/java/tectech/thing/casing/StabilisationFieldCasing.java
@@ -19,6 +19,7 @@ import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GTLanguageManager;
 import gregtech.common.blocks.BlockCasingsAbstract;
 import gregtech.common.blocks.MaterialCasings;
+import gregtech.common.misc.GTStructureChannels;
 import tectech.thing.CustomItemList;
 import tectech.util.CommonValues;
 
@@ -48,6 +49,7 @@ public class StabilisationFieldCasing extends BlockCasingsAbstract {
             GTLanguageManager.addStringLocalization(
                 getUnlocalizedName() + "." + i + ".name",
                 WHITE + CommonValues.EOH_TIER_FANCY_NAMES[i] + RESET + " Stabilisation Field Generator");
+            GTStructureChannels.EOH_STABILISATION.registerAsIndicator(new ItemStack(this, 1, i), i + 1);
         }
 
         CustomItemList.StabilisationFieldGeneratorTier0.set(new ItemStack(this, 1, 0));

--- a/src/main/java/tectech/thing/casing/TimeAccelerationFieldCasing.java
+++ b/src/main/java/tectech/thing/casing/TimeAccelerationFieldCasing.java
@@ -19,6 +19,7 @@ import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GTLanguageManager;
 import gregtech.common.blocks.BlockCasingsAbstract;
 import gregtech.common.blocks.MaterialCasings;
+import gregtech.common.misc.GTStructureChannels;
 import tectech.thing.CustomItemList;
 import tectech.util.CommonValues;
 
@@ -48,6 +49,7 @@ public class TimeAccelerationFieldCasing extends BlockCasingsAbstract {
             GTLanguageManager.addStringLocalization(
                 getUnlocalizedName() + "." + i + ".name",
                 WHITE + CommonValues.EOH_TIER_FANCY_NAMES[i] + RESET + " Time Dilation Field Generator");
+            GTStructureChannels.EOH_DILATION.registerAsIndicator(new ItemStack(this, 1, i), i + 1);
         }
 
         CustomItemList.TimeAccelerationFieldGeneratorTier0.set(new ItemStack(this, 1, 0));

--- a/src/main/java/tectech/thing/metaTileEntity/multi/MTEEyeOfHarmony.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/MTEEyeOfHarmony.java
@@ -3,7 +3,6 @@ package tectech.thing.metaTileEntity.multi;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofBlock;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofBlocksTiered;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.transpose;
-import static com.gtnewhorizon.structurelib.structure.StructureUtility.withChannel;
 import static gregtech.api.enums.HatchElement.InputBus;
 import static gregtech.api.enums.HatchElement.InputHatch;
 import static gregtech.api.enums.HatchElement.OutputBus;
@@ -78,6 +77,7 @@ import gregtech.api.util.GTLanguageManager;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.MultiblockTooltipBuilder;
 import gregtech.api.util.shutdown.ShutDownReason;
+import gregtech.common.misc.GTStructureChannels;
 import gregtech.common.tileentities.machines.MTEHatchInputBusME;
 import gregtech.common.tileentities.machines.MTEHatchOutputBusME;
 import gregtech.common.tileentities.machines.MTEHatchOutputME;
@@ -711,8 +711,7 @@ public class MTEEyeOfHarmony extends TTMultiblockBase implements IConstructable,
                         "                                 " } }))
         .addElement(
             'A',
-            withChannel(
-                "spacetime compression",
+            GTStructureChannels.EOH_COMPRESSION.use(
                 ofBlocksTiered(
                     (block, meta) -> block == TTCasingsContainer.SpacetimeCompressionFieldGenerators ? meta : null,
                     ImmutableList.of(
@@ -730,8 +729,7 @@ public class MTEEyeOfHarmony extends TTMultiblockBase implements IConstructable,
                     t -> t.spacetimeCompressionFieldMetadata)))
         .addElement(
             'S',
-            withChannel(
-                "stabilisation",
+            GTStructureChannels.EOH_STABILISATION.use(
                 ofBlocksTiered(
                     (block, meta) -> block == TTCasingsContainer.StabilisationFieldGenerators ? meta : null,
                     ImmutableList.of(
@@ -757,8 +755,7 @@ public class MTEEyeOfHarmony extends TTMultiblockBase implements IConstructable,
                 .buildAndChain(TTCasingsContainer.sBlockCasingsBA0, 12))
         .addElement(
             'E',
-            withChannel(
-                "time dilation",
+            GTStructureChannels.EOH_DILATION.use(
                 ofBlocksTiered(
                     (block, meta) -> block == TTCasingsContainer.TimeAccelerationFieldGenerator ? meta : null,
                     ImmutableList.of(
@@ -1132,6 +1129,9 @@ public class MTEEyeOfHarmony extends TTMultiblockBase implements IConstructable,
             .addStructureInfo("Requires " + EnumChatFormatting.GOLD + 1 + EnumChatFormatting.GRAY + " ME output hatch.")
             .addStructureInfo("Requires " + EnumChatFormatting.GOLD + 1 + EnumChatFormatting.GRAY + " input bus.")
             .addStructureInfo("Requires " + EnumChatFormatting.GOLD + 1 + EnumChatFormatting.GRAY + " ME output bus.")
+            .addSubChannelUsage(GTStructureChannels.EOH_STABILISATION)
+            .addSubChannelUsage(GTStructureChannels.EOH_DILATION)
+            .addSubChannelUsage(GTStructureChannels.EOH_COMPRESSION)
             .toolTipFinisher(EnumChatFormatting.GOLD, 87, GTValues.AuthorColen);
         return tt;
     }

--- a/src/main/resources/assets/gregtech/lang/en_US.lang
+++ b/src/main/resources/assets/gregtech/lang/en_US.lang
@@ -180,7 +180,6 @@ GT5U.MBTT.BoroGlassAny=Borosilicate Glass (any, mixed)
 GT5U.MBTT.BoroGlassTiered=Borosilicate Glass (any)
 
 GT5U.MBTT.subchannel=Uses sub channel §6%s§r§7 for §6%s
-GT5U.tooltip.channelvalue=Use value §6%d§r§7 for sub channel §6%s
 
 GT5U.cracker.io_side=Input/Output Hatches must be on opposite sides!
 
@@ -628,6 +627,27 @@ GT5U.recipe_filter.representation_slot.tooltip=§7Click to clear
 GT5U.type_filter.representation_slot.tooltip=§7Left click to cycle forward
 GT5U.type_filter.representation_slot.tooltip.1=§7Right click to cycle back
 GT5U.type_filter.representation_slot.tooltip.2=§7Click with an item to set filter
+
+channels.gregtech.manipulator=Decides the tier of QFT manipulator blocks. Starts at §6Neutron Pulse Manipulator§r at value 1 and ends at §6SpaceTime Continuum Ripper§r at value 4.
+channels.gregtech.shielding=Decides the tier of QFT shielding blocks. Starts at §6Neutron Shielding Core§r at value 1 and ends at §6SpaceTime Bending Core§r at value 4.
+channels.gregtech.coil=Decides the tier of heating coil. Starts at §6Cupronickel Coil§r at value 1 and ends at §6Eternal Coil§r at value 14.
+channels.gregtech.glass=Decides the tier of glass. This has many tiers and many substitutes for various tiers. Please refer to the tooltip of individual glass blocks.
+channels.gregtech.casing=Decides the tier of metallic machine casing.
+channels.gregtech.unit_casing=Decides the tier of Electronic Unit casing. Starts at §6Imprecise Electronic Unit Casing§r at value 1 and ends at §6MkIV§r at value 5.
+channels.gregtech.machine_casing=Decides the tier of Machine Casing. Starts at §6ULV machine casing§r at value 1 and ends at §6UHV machine casing§r at value 10.
+channels.gregtech.solenoid=Decides the tier of Solenoid Superconductor Coil. Starts at §6MV§r at value 1 and ends at §6UMV§r at value 11.
+channels.gregtech.capacitor=Decides the tier of Lapotronic Capacitor. Starts at §6Empty§r at value 1 and ends at §6UMV§r at value 10.
+channels.gregtech.height=Decides the height of repeatable slices. Valid range varies from multi to multi.
+channels.gregtech.length=Decides the length of repeatable slices. Valid range varies from multi to multi.
+channels.gregtech.pipe=Decides the tier of Pipe Casing. Starts at §6Bronze Pipe Casing§r at value 1 and ends at §6Tungsten Steel Pipe Casing§r at value 4.
+channels.gregtech.item_pipe=Decides the tier of Item Pipe Casing. Starts at §6Tin Item Pipe Casing§r at value 1 and ends at §6Black Plutonium Item Pipe Casing§r at value 8.
+channels.gregtech.cell=Decides the tier of Vanadium Redox Power Cell. Starts at §6EV§r at value 1 and ends at §6UHV§r at value 6.
+channels.gregtech.antenna=Decides the of Antenna Casing. Starts at §6T1§r at value 1 and ends at §6T2§r at value 2.
+channels.gregtech.spacetime_compression=Decides the tier of Spacetime Compression Field Generator. Starts at §6Crude Spacetime Compression Field Generator§r at value 1 and ends at §6Gallifreyan Spacetime Compression Field Generator§r at value 9.
+channels.gregtech.stabilisation=Decides the tier of Stabilisation Field Generator. Starts at §6Crude Stabilisation Field Generator§r at value 1 and ends at §6Gallifreyan Stabilisation Field Generator§r at value 9.
+channels.gregtech.time_dilation=Decides the tier of Time Dilation Field Generator. Starts at §6Crude Time Dilation Field Generator§r at value 1 and ends at §6Gallifreyan Time Dilation Field Generator§r at value 9.
+channels.gregtech.gt_no_hatch=When set, disable automatic hatch placement
+channels.gregtech.field=Decides the tier of T.F.F.T. Storage Field.
 
 GT5U.gui.select.current=Current:
 GT5U.gui.button.liquid_filling_OFF=§7Liquid Filling: §4OFF

--- a/src/main/resources/assets/kekztech/lang/en_US.lang
+++ b/src/main/resources/assets/kekztech/lang/en_US.lang
@@ -158,3 +158,5 @@ kekztech.infodata.tank.tfft.total=Total Capacity: %sL
 kekztech.infodata.tank.tfft.per_fluid_capacity=Per-Fluid Capacity: %sL
 kekztech.infodata.tank.tfft.running_cost=Running Cost: %dEU/t
 kekztech.infodata.tank.tfft.auto_voiding=Auto-voiding: %b
+
+kekztech.structure.glass_incompatible=§cGlass configuration incompatible

--- a/src/main/resources/assets/kekztech/lang/zh_CN.lang
+++ b/src/main/resources/assets/kekztech/lang/zh_CN.lang
@@ -91,3 +91,4 @@ achievement.tile.kekztech_lapotronicenergyunit_block.4=兰波顿电容(UV)
 achievement.tile.kekztech_lapotronicenergyunit_block.5.desc=捡起这个物品以在NEI内查看配方
 achievement.tile.kekztech_lapotronicenergyunit_block.5=终极电容(UHV)
 
+kekztech.structure.glass_incompatible=玻璃不兼容


### PR DESCRIPTION
depends on https://github.com/GTNewHorizons/StructureLib/pull/39 won't build without it

also include these changes
1. change some structure channel to use underscore over whitespace
2. made 3 kinds of DT, 2 kinds of AL, TFFT, LSC to use structure channels as their height/width. I might have made some off-by-one mistakes here and I'm not familiar with how some of these multis are used... so please help verify this is done correctly
3. LSC will try to autoplace capacitor if one is specified, but fallback to *any capacitor that can be used as limited by glass tier*. before this PR, it's the later one only.
4. added missing channel usage to tooltip multis 
5. removed casing block's own channel value tooltip, as it is now added via structurelib via structure channel indicator item.