### PR TITLE
Fix NPE in getWailaNBTData

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/CoverableTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/CoverableTileEntity.java
@@ -492,7 +492,7 @@ public abstract class CoverableTileEntity extends BaseTileEntity implements ICov
         // While we have some cover data on the client (enough to render it); we don't have all the information we want,
         // such as details on the fluid filter, so send it all here.
         for (final Cover cover : covers) {
-            if (cover.isValid()) {
+            if (cover != null && cover.isValid()) {
                 NW.sendToPlayer(new GTPacketSendCoverData(cover, this, cover.getSide()), player);
             }
         }


### PR DESCRIPTION
This will happen only once, everytime player place a machine block.
```
[22:32:18] [Server thread/ERROR] [GregTech GTNH]: Could not call getWailaNBTData on gregtech.api.metatileentity.BaseMetaTileEntity@61f83076
java.lang.NullPointerException
	at gregtech.api.metatileentity.CoverableTileEntity.getWailaNBTData(CoverableTileEntity.java:497) ~[CoverableTileEntity.class:?]
	at gregtech.api.metatileentity.BaseMetaTileEntity.getWailaNBTData(BaseMetaTileEntity.java:624) ~[BaseMetaTileEntity.class:?]
	at gregtech.crossmod.waila.GregtechWailaDataProvider.getNBTData(GregtechWailaDataProvider.java:58) [GregtechWailaDataProvider.class:?]
	at mcp.mobius.waila.network.Message0x01TERequest.channelRead0(Message0x01TERequest.java:121) [Message0x01TERequest.class:?]
	at mcp.mobius.waila.network.Message0x01TERequest.channelRead0(Message0x01TERequest.java:27) [Message0x01TERequest.class:?]
	at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:98) [SimpleChannelInboundHandler.class:?]
	at io.netty.channel.DefaultChannelHandlerContext.invokeChannelRead(DefaultChannelHandlerContext.java:337) [DefaultChannelHandlerContext.class:?]
	at io.netty.channel.DefaultChannelHandlerContext.fireChannelRead(DefaultChannelHandlerContext.java:323) [DefaultChannelHandlerContext.class:?]
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103) [MessageToMessageDecoder.class:?]
	at io.netty.handler.codec.MessageToMessageCodec.channelRead(MessageToMessageCodec.java:111) [MessageToMessageCodec.class:?]
	at io.netty.channel.DefaultChannelHandlerContext.invokeChannelRead(DefaultChannelHandlerContext.java:337) [DefaultChannelHandlerContext.class:?]
	at io.netty.channel.DefaultChannelHandlerContext.fireChannelRead(DefaultChannelHandlerContext.java:323) [DefaultChannelHandlerContext.class:?]
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:785) [DefaultChannelPipeline.class:?]
	at io.netty.channel.embedded.EmbeddedChannel.writeInbound(EmbeddedChannel.java:169) [EmbeddedChannel.class:?]
	at cpw.mods.fml.common.network.internal.FMLProxyPacket.processPacket(FMLProxyPacket.java:86) [FMLProxyPacket.class:?]
	at net.minecraft.network.NetworkManager.processReceivedPackets(NetworkManager.java:241) [NetworkManager.class:?]
	at net.minecraft.network.NetworkSystem.networkTick(NetworkSystem.java:182) [NetworkSystem.class:?]
	at net.minecraft.server.MinecraftServer.updateTimeLightAndEntities(MinecraftServer.java:726) [MinecraftServer.class:?]
	at net.minecraft.server.MinecraftServer.tick(MinecraftServer.java:614) [MinecraftServer.class:?]
	at net.minecraft.server.integrated.IntegratedServer.tick(IntegratedServer.java:118) [IntegratedServer.class:?]
	at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:485) [MinecraftServer.class:?]
	at net.minecraft.server.MinecraftServer$2.run(MinecraftServer.java:752) [MinecraftServer$2.class:?]
```