### PR TITLE
Smoothen overclocks for fractional ticks

### DIFF
--- a/src/main/java/ggfab/mte/MTEAdvAssLine.java
+++ b/src/main/java/ggfab/mte/MTEAdvAssLine.java
@@ -754,6 +754,10 @@ public class MTEAdvAssLine extends MTEExtendedPowerMultiBlockBase<MTEAdvAssLine>
                 .setLaserOC(true)
                 .setMaxRegularOverclocks(getTier(inputVoltage) - getTier(recipe.mEUt));
 
+            double fractionalDuration = calculator.calculateFractionalDuration();
+            double fractionalMultiplier = Math.ceil(fractionalDuration) / fractionalDuration;
+            maxParallel = (int) Math.floor(maxParallel * fractionalMultiplier);
+
             // Disabled to disable overclocking under one tick.
             /*
              * double tickTimeAfterOC = calculator.calculateDurationUnderOneTick();

--- a/src/main/java/ggfab/mte/MTEAdvAssLine.java
+++ b/src/main/java/ggfab/mte/MTEAdvAssLine.java
@@ -744,10 +744,12 @@ public class MTEAdvAssLine extends MTEExtendedPowerMultiBlockBase<MTEAdvAssLine>
                 .setEUt(inputVoltage);
 
             if (!mExoticEnergyHatches.isEmpty()) {
-                normalOCCalculator
-                    .setCurrentParallel((int) Math.max(1 / normalOCCalculator.calculateDurationUnderOneTick(), 1))
+                double fractionalDuration = normalOCCalculator.calculateFractionalDuration();
+                double fractionalMultiplier = Math.ceil(fractionalDuration) / fractionalDuration;
+                maxParallel = (int) Math.floor(maxParallel * fractionalMultiplier);
+
+                normalOCCalculator.setCurrentParallel(maxParallel)
                     .calculate();
-                int normalOverclockCount = normalOCCalculator.getPerformedOverclocks();
 
                 calculator = new OverclockCalculator().setRecipeEUt(recipe.mEUt)
                     .setDurationUnderOneTickSupplier(() -> ((double) (recipe.mDuration) / recipe.mInputs.length))

--- a/src/main/java/gregtech/api/util/OverclockCalculator.java
+++ b/src/main/java/gregtech/api/util/OverclockCalculator.java
@@ -349,14 +349,14 @@ public class OverclockCalculator {
         calculatedConsumption = (long) Math.ceil(recipePower * Math.pow(eutIncreasePerOC, overclocks));
         duration /= Math.pow(durationDecreasePerHeatOC, heatOverclocks);
         duration /= Math.pow(durationDecreasePerOC, regularOverclocks);
-        calculatedDuration = (int) Math.max(duration, 1);
+        calculatedDuration = (int) Math.ceil(duration);
     }
 
     /**
      * Returns duration as a double to show how much it is overclocking too much to determine extra parallel. This
      * doesn't count as calculating
      */
-    public double calculateDurationUnderOneTick() {
+    public double calculateFractionalDuration() {
         // Determine the base duration, using the custom supplier if available.
         double duration = durationUnderOneTickSupplier != null ? durationUnderOneTickSupplier.get()
             : this.duration * durationModifier;

--- a/src/main/java/gregtech/api/util/ParallelHelper.java
+++ b/src/main/java/gregtech/api/util/ParallelHelper.java
@@ -404,10 +404,10 @@ public class ParallelHelper {
         // Save the original max parallel before calculating our overclocking under 1 tick
         int originalMaxParallel = maxParallel;
         calculator.setParallel(originalMaxParallel);
-        double tickTimeAfterOC = calculator.calculateDurationUnderOneTick();
-        if (tickTimeAfterOC < 1) {
-            maxParallel = GTUtility.safeInt((long) (maxParallel / tickTimeAfterOC), 0);
-        }
+
+        double fractionalDuration = calculator.calculateFractionalDuration();
+        double fractionalMultiplier = Math.ceil(fractionalDuration) / fractionalDuration;
+        maxParallel = (int) Math.floor(maxParallel * fractionalMultiplier);
 
         int maxParallelBeforeBatchMode = maxParallel;
         if (batchMode) {

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEAssemblyLine.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEAssemblyLine.java
@@ -267,10 +267,9 @@ public class MTEAssemblyLine extends MTEExtendedPowerMultiBlockBase<MTEAssemblyL
                 .setDuration(tRecipe.mDuration)
                 .setParallel(originalMaxParallel);
 
-            double tickTimeAfterOC = calculator.calculateDurationUnderOneTick();
-            if (tickTimeAfterOC < 1) {
-                maxParallel = GTUtility.safeInt((long) (maxParallel / tickTimeAfterOC), 0);
-            }
+            double fractionalDuration = calculator.calculateFractionalDuration();
+            double fractionalMultiplier = Math.ceil(fractionalDuration) / fractionalDuration;
+            maxParallel = (int) Math.floor(maxParallel * fractionalMultiplier);
 
             int maxParallelBeforeBatchMode = maxParallel;
             if (isBatchModeEnabled()) {

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEIntegratedOreFactory.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEIntegratedOreFactory.java
@@ -280,11 +280,9 @@ public class MTEIntegratedOreFactory extends MTEExtendedPowerMultiBlockBase<MTEI
             .setDuration(getTime(sMode))
             .setParallel(originalMaxParallel);
 
-        double tickTimeAfterOC = calculator.calculateDurationUnderOneTick();
-
-        if (tickTimeAfterOC < 1) {
-            maxParallel = GTUtility.safeInt((long) (maxParallel / tickTimeAfterOC), 0);
-        }
+        double fractionalDuration = calculator.calculateFractionalDuration();
+        double fractionalMultiplier = Math.ceil(fractionalDuration) / fractionalDuration;
+        maxParallel = (int) Math.floor(maxParallel * fractionalMultiplier);
 
         int maxParallelBeforeBatchMode = maxParallel;
         if (isBatchModeEnabled()) {

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEMultiFurnace.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEMultiFurnace.java
@@ -169,11 +169,9 @@ public class MTEMultiFurnace extends MTEAbstractMultiFurnace<MTEMultiFurnace> im
             .setDuration(RECIPE_DURATION)
             .setParallel(originalMaxParallel);
 
-        double tickTimeAfterOC = calculator.calculateDurationUnderOneTick();
-
-        if (tickTimeAfterOC < 1) {
-            maxParallel = GTUtility.safeInt((long) (maxParallel / tickTimeAfterOC), 0);
-        }
+        double fractionalDuration = calculator.calculateFractionalDuration();
+        double fractionalMultiplier = Math.ceil(fractionalDuration) / fractionalDuration;
+        maxParallel = (int) Math.floor(maxParallel * fractionalMultiplier);
 
         int maxParallelBeforeBatchMode = maxParallel;
         if (isBatchModeEnabled()) {

--- a/src/test/java/gregtech/overclock/GT_OverclockCalculator_UnitTest.java
+++ b/src/test/java/gregtech/overclock/GT_OverclockCalculator_UnitTest.java
@@ -237,7 +237,7 @@ class GT_OverclockCalculator_UnitTest {
             .setEUt(V[6])
             .setDuration(77)
             .calculate();
-        assertEquals((int) (77 / Math.pow(2, 5)), calculator.getDuration(), messageDuration);
+        assertEquals((int) Math.ceil(77 / Math.pow(2, 5)), calculator.getDuration(), messageDuration);
         assertEquals(VP[6], calculator.getConsumption(), messageEUt);
     }
 
@@ -283,7 +283,7 @@ class GT_OverclockCalculator_UnitTest {
             .setDurationModifier(0.9)
             .setDuration(1024)
             .calculate();
-        assertEquals((int) (1024 * 0.9f / Math.pow(2, 5)), calculator.getDuration(), messageDuration);
+        assertEquals((int) Math.ceil(1024 * 0.9f / Math.pow(2, 5)), calculator.getDuration(), messageDuration);
         assertEquals(VP[6], calculator.getConsumption(), messageEUt);
     }
 
@@ -295,7 +295,7 @@ class GT_OverclockCalculator_UnitTest {
             .setDuration(2048)
             .enablePerfectOC()
             .calculate();
-        assertEquals((int) ((2048 * 0.9f) / Math.pow(4, 5)), calculator.getDuration(), messageDuration);
+        assertEquals((int) Math.ceil((2048 * 0.9f) / Math.pow(4, 5)), calculator.getDuration(), messageDuration);
         assertEquals(VP[6], calculator.getConsumption(), messageEUt);
     }
 
@@ -354,7 +354,7 @@ class GT_OverclockCalculator_UnitTest {
             .setEUt(V[5])
             .setDuration(30)
             .calculate();
-        assertEquals(1, calculator.getDuration(), messageDuration);
+        assertEquals(2, calculator.getDuration(), messageDuration);
         assertEquals(16 * Math.pow(4, 7), calculator.getConsumption(), messageEUt);
     }
 
@@ -387,7 +387,7 @@ class GT_OverclockCalculator_UnitTest {
             .setMachineHeat(15500)
             .setEUt(V[12] * 1_048_576)
             .setDuration(250);
-        calculator.setCurrentParallel((int) (256 / calculator.calculateDurationUnderOneTick()))
+        calculator.setCurrentParallel((int) (256 / calculator.calculateFractionalDuration()))
             .calculate();
         assertEquals(Math.ceil((((long) 1920 * 256) * Math.pow(4, 14)) * heatDiscount), calculator.getConsumption());
     }
@@ -423,7 +423,7 @@ class GT_OverclockCalculator_UnitTest {
     void testNoOverclockCorrectWithUnderOneTickLogic_Test() {
         OverclockCalculator calculator = OverclockCalculator.ofNoOverclock(2_693_264_510L, 100)
             .setParallel(24 * 64);
-        assertEquals(100, calculator.calculateDurationUnderOneTick());
+        assertEquals(100, calculator.calculateFractionalDuration());
     }
 
     @Test
@@ -547,7 +547,7 @@ class GT_OverclockCalculator_UnitTest {
 
     @Test
     void overclockWithAbnormalDurationDecrease_Test() {
-        int expectedDuration = (int) Math.floor(1024 / Math.pow(2.1, 5));
+        int expectedDuration = (int) Math.ceil(1024 / Math.pow(2.1, 5));
         OverclockCalculator calculator = new OverclockCalculator().setRecipeEUt(VP[1])
             .setEUt(V[6])
             .setDuration(1024)
@@ -591,7 +591,7 @@ class GT_OverclockCalculator_UnitTest {
             .setDurationModifier(speedBoost)
             .setEUtDiscount(eutDiscount)
             .setParallel(maxParallel);
-        double tickTimeAfterOC = calculator.calculateDurationUnderOneTick();
+        double tickTimeAfterOC = calculator.calculateFractionalDuration();
         maxParallel = GTUtility.safeInt((long) (maxParallel / tickTimeAfterOC), 0);
         calculator.setCurrentParallel(maxParallel)
             .calculate();


### PR DESCRIPTION
Similar in concept to [Change subtick calculator from duration to a multiplier calculator #4146](https://github.com/GTNewHorizons/GT5-Unofficial/pull/4146), which changes the subtick calculator from using durations to a multiplier-based approach. However, this PR also addresses a potential exploit (see dev chat for details) and supports any fractional tick duration—not just those under 1 tick.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19290