### PR TITLE
Fix turbine efficiency in electric air filter

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEAirFilterBase.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEAirFilterBase.java
@@ -54,10 +54,7 @@ import gregtech.api.recipe.check.CheckRecipeResult;
 import gregtech.api.recipe.check.CheckRecipeResultRegistry;
 import gregtech.api.render.RenderOverlay;
 import gregtech.api.render.TextureFactory;
-import gregtech.api.util.GTModHandler;
-import gregtech.api.util.GTUtility;
-import gregtech.api.util.GTUtilityClient;
-import gregtech.api.util.MultiblockTooltipBuilder;
+import gregtech.api.util.*;
 import gregtech.common.items.MetaGeneratedTool01;
 import gregtech.common.pollution.Pollution;
 
@@ -72,7 +69,7 @@ public abstract class MTEAirFilterBase extends MTEEnhancedMultiBlockBase<MTEAirF
 
     private static final Random RANDOM = new XSTR();
 
-    protected int baseEff = 0;
+    protected float baseEff = 0;
     protected int multiTier = 0;
     protected int chunkIndex = 0;
     protected boolean hasPollution = false;
@@ -296,7 +293,9 @@ public abstract class MTEAirFilterBase extends MTEEnhancedMultiBlockBase<MTEAirF
         if (damage == -1) {
             return CheckRecipeResultRegistry.NO_TURBINE_FOUND;
         }
-        baseEff = GTUtility.safeInt((long) ((50.0F + 10.0F * damage) * 100));
+
+        TurbineStatCalculator turbine = new TurbineStatCalculator((MetaGeneratedTool) aStack.getItem(), aStack);
+        baseEff = turbine.getEfficiency();
         tickCounter = 0; // resetting the counter in case of a power failure, etc
 
         // scan the inventory to search for filter if none has been loaded previously
@@ -401,7 +400,7 @@ public abstract class MTEAirFilterBase extends MTEEnhancedMultiBlockBase<MTEAirF
     }
 
     public void cleanPollution() {
-        int cleaningRate = getPollutionCleaningRatePerSecond(baseEff / 10000f, mEfficiency / 10000f, isFilterLoaded);
+        int cleaningRate = getPollutionCleaningRatePerSecond(baseEff, mEfficiency / 10000f, isFilterLoaded);
         if (cleaningRate > 0) {
             World world = this.getBaseMetaTileEntity()
                 .getWorld();
@@ -633,8 +632,7 @@ public abstract class MTEAirFilterBase extends MTEEnhancedMultiBlockBase<MTEAirF
             StatCollector.translateToLocalFormatted(
                 "GT5U.infodata.air_filter.pollution_reduction",
                 EnumChatFormatting.GREEN
-                    + Integer.toString(
-                        getPollutionCleaningRatePerTick(baseEff / 10000f, mEfficiency / 10000f, isFilterLoaded))
+                    + Integer.toString(getPollutionCleaningRatePerTick(baseEff, mEfficiency / 10000f, isFilterLoaded))
                     + EnumChatFormatting.RESET),
             StatCollector.translateToLocalFormatted("GT5U.infodata.air_filter.has_filter", isFilterLoaded),
             StatCollector


### PR DESCRIPTION
Fixes the turbine efficiency to use the new formula.
Using 8 mufflers, no filter, basic steel rotor:

Before:
![image](https://github.com/user-attachments/assets/4f68aba6-c4ce-41ae-b2e0-b92c3d446582)
![image](https://github.com/user-attachments/assets/bdfb7ba7-14a8-41c0-9e71-cd8bf76f324f)
![image](https://github.com/user-attachments/assets/b6a3fa4a-75d5-4b98-845d-c89cf1e2771c)
(Difference: 111753787 - 111753403=384 gbl, 19gbl/t)

After:
![image](https://github.com/user-attachments/assets/652b22af-f84a-4518-91fe-30065563d444)
![image](https://github.com/user-attachments/assets/d1e66099-90a0-4eb2-8c93-0330c611dbe2)
![image](https://github.com/user-attachments/assets/7a9a2dca-1418-4d94-af84-832f8fbc6841)
(Difference: 63602707-63602299=408 gbl, 20gbl/t)

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19531