### PR TITLE
Refactor Hatch background texture code

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
@@ -63,7 +63,7 @@ public class BaseMetaPipeEntity extends CommonBaseMetaTileEntity
     public byte mConnections = IConnectable.NO_CONNECTION;
     protected MetaPipeEntity mMetaTileEntity;
     private boolean mWorkUpdate = false, mWorks = true;
-    private byte mColor = 0, oColor = 0, oStrongRedstone = 0, oRedstoneData = 63, oTextureData = 0, oUpdateData = 0;
+    private byte mColor = 0, oColor = 0, oStrongRedstone = 0, oRedstoneData = 63, oConnections = 0, oUpdateData = 0;
     private int oX = 0, oY = 0, oZ = 0;
     protected Node node;
     protected NodePath nodePath;
@@ -234,16 +234,29 @@ public class BaseMetaPipeEntity extends CommonBaseMetaTileEntity
                 }
 
                 if (mTickTimer > 10) {
-                    if (mConnections != oTextureData) sendBlockEvent((byte) 0, oTextureData = mConnections);
-                    byte tData = mMetaTileEntity.getUpdateData();
-                    if (tData != oUpdateData) sendBlockEvent((byte) 1, oUpdateData = tData);
-                    if (mColor != oColor) sendBlockEvent((byte) 2, oColor = mColor);
-                    tData = (byte) (((mSidedRedstone[0] > 0) ? 1 : 0) | ((mSidedRedstone[1] > 0) ? 2 : 0)
-                        | ((mSidedRedstone[2] > 0) ? 4 : 0)
-                        | ((mSidedRedstone[3] > 0) ? 8 : 0)
-                        | ((mSidedRedstone[4] > 0) ? 16 : 0)
-                        | ((mSidedRedstone[5] > 0) ? 32 : 0));
-                    if (tData != oRedstoneData) sendBlockEvent((byte) 3, oRedstoneData = tData);
+                    if (mConnections != oConnections) {
+                        oConnections = mConnections;
+                        sendBlockEvent(GregTechTileClientEvents.CHANGE_COMMON_DATA, oConnections);
+                    }
+
+                    byte updateData = mMetaTileEntity.getUpdateData();
+
+                    if (updateData != oUpdateData) {
+                        oUpdateData = updateData;
+                        sendBlockEvent(GregTechTileClientEvents.CHANGE_CUSTOM_DATA, oUpdateData);
+                    }
+
+                    if (mColor != oColor) {
+                        oColor = mColor;
+                        sendBlockEvent(GregTechTileClientEvents.CHANGE_COLOR, oColor);
+                    }
+
+                    byte redstone = getSidedRedstoneMask();
+
+                    if (redstone != oRedstoneData) {
+                        oRedstoneData = redstone;
+                        sendBlockEvent(GregTechTileClientEvents.CHANGE_REDSTONE_OUTPUT, oRedstoneData);
+                    }
                 }
 
                 if (mNeedsBlockUpdate) {
@@ -264,6 +277,11 @@ public class BaseMetaPipeEntity extends CommonBaseMetaTileEntity
 
     private void sendClientData() {
         if (mSendClientData) {
+            oConnections = mConnections;
+            oUpdateData = hasValidMetaTileEntity() ? mMetaTileEntity.getUpdateData() : 0;
+            oRedstoneData = getSidedRedstoneMask();
+            oColor = mColor;
+
             if (mMetaTileEntity instanceof ITemporaryTE) {
                 NW.sendPacketToAllPlayersInRange(
                     worldObj,
@@ -278,14 +296,11 @@ public class BaseMetaPipeEntity extends CommonBaseMetaTileEntity
                         getCoverAtSide(ForgeDirection.SOUTH).getCoverID(),
                         getCoverAtSide(ForgeDirection.WEST).getCoverID(),
                         getCoverAtSide(ForgeDirection.EAST).getCoverID(),
-                        oTextureData = mConnections,
-                        oUpdateData = hasValidMetaTileEntity() ? mMetaTileEntity.getUpdateData() : 0,
-                        oRedstoneData = (byte) (((mSidedRedstone[0] > 0) ? 1 : 0) | ((mSidedRedstone[1] > 0) ? 2 : 0)
-                            | ((mSidedRedstone[2] > 0) ? 4 : 0)
-                            | ((mSidedRedstone[3] > 0) ? 8 : 0)
-                            | ((mSidedRedstone[4] > 0) ? 16 : 0)
-                            | ((mSidedRedstone[5] > 0) ? 32 : 0)),
-                        oColor = mColor),
+                        oConnections,
+                        oUpdateData,
+                        oRedstoneData,
+                        oColor,
+                        GTPacketCreateTE.TYPE_META_PIPE),
                     xCoord,
                     zCoord);
             } else {
@@ -302,24 +317,21 @@ public class BaseMetaPipeEntity extends CommonBaseMetaTileEntity
                         getCoverAtSide(ForgeDirection.SOUTH).getCoverID(),
                         getCoverAtSide(ForgeDirection.WEST).getCoverID(),
                         getCoverAtSide(ForgeDirection.EAST).getCoverID(),
-                        oTextureData = mConnections,
-                        oUpdateData = hasValidMetaTileEntity() ? mMetaTileEntity.getUpdateData() : 0,
-                        oRedstoneData = (byte) (((mSidedRedstone[0] > 0) ? 1 : 0) | ((mSidedRedstone[1] > 0) ? 2 : 0)
-                            | ((mSidedRedstone[2] > 0) ? 4 : 0)
-                            | ((mSidedRedstone[3] > 0) ? 8 : 0)
-                            | ((mSidedRedstone[4] > 0) ? 16 : 0)
-                            | ((mSidedRedstone[5] > 0) ? 32 : 0)),
-                        oColor = mColor),
+                        oConnections,
+                        oUpdateData,
+                        oRedstoneData,
+                        oColor),
                     xCoord,
                     zCoord);
                 mSendClientData = false;
             }
         }
+
         sendCoverDataIfNeeded();
     }
 
     public final void receiveMetaTileEntityData(short aID, int aCover0, int aCover1, int aCover2, int aCover3,
-        int aCover4, int aCover5, byte aTextureData, byte aUpdateData, byte aRedstoneData, byte aColorData) {
+        int aCover4, int aCover5, byte aConnections, byte aUpdateData, byte aRedstoneData, byte aColorData) {
         issueTextureUpdate();
         if (aID > 0 && mID != aID) {
             mID = aID;
@@ -328,7 +340,7 @@ public class BaseMetaPipeEntity extends CommonBaseMetaTileEntity
 
         CoverRegistry.cover(this, aCover0, aCover1, aCover2, aCover3, aCover4, aCover5);
 
-        receiveClientEvent(GregTechTileClientEvents.CHANGE_COMMON_DATA, aTextureData);
+        receiveClientEvent(GregTechTileClientEvents.CHANGE_COMMON_DATA, aConnections);
         receiveClientEvent(GregTechTileClientEvents.CHANGE_CUSTOM_DATA, aUpdateData);
         receiveClientEvent(GregTechTileClientEvents.CHANGE_COLOR, aColorData);
         receiveClientEvent(GregTechTileClientEvents.CHANGE_REDSTONE_OUTPUT, aRedstoneData);

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
@@ -71,7 +71,6 @@ import gregtech.api.interfaces.tileentity.IEnergyConnected;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.interfaces.tileentity.IGregtechWailaProvider;
 import gregtech.api.metatileentity.implementations.MTEBasicMachine;
-import gregtech.api.metatileentity.implementations.MTEHatch;
 import gregtech.api.net.GTPacketTileEntity;
 import gregtech.api.objects.blockupdate.BlockUpdateHandler;
 import gregtech.api.util.GTLog;
@@ -554,31 +553,36 @@ public class BaseMetaTileEntity extends CommonBaseMetaTileEntity
                 }
 
                 if (mTickTimer > 10) {
-                    byte tData = (byte) ((mFacing.ordinal() & 7) | (mActive ? 8 : 0)
+                    byte textureData = (byte) ((mFacing.ordinal() & 7) | (mActive ? 8 : 0)
                         | (mRedstone ? 16 : 0)
                         | (mLockUpgrade ? 32 : 0)
                         | (mWorks ? 64 : 0)
                         | (mMuffler ? 128 : 0));
-                    if (tData != oTextureData)
-                        sendBlockEvent(GregTechTileClientEvents.CHANGE_COMMON_DATA, oTextureData = tData);
 
-                    tData = mMetaTileEntity.getUpdateData();
-                    if (tData != oUpdateData)
-                        sendBlockEvent(GregTechTileClientEvents.CHANGE_CUSTOM_DATA, oUpdateData = tData);
-                    if (mMetaTileEntity instanceof MTEHatch) {
-                        tData = ((MTEHatch) mMetaTileEntity).getTexturePage();
-                        if (tData != oTexturePage) sendBlockEvent(
-                            GregTechTileClientEvents.CHANGE_CUSTOM_DATA,
-                            (byte) ((oTexturePage = tData) | 0x80)); // set last bit as a flag for page
+                    if (textureData != oTextureData) {
+                        oTextureData = textureData;
+                        sendBlockEvent(GregTechTileClientEvents.CHANGE_COMMON_DATA, oTextureData);
                     }
-                    if (mColor != oColor) sendBlockEvent(GregTechTileClientEvents.CHANGE_COLOR, oColor = mColor);
-                    tData = (byte) (((mSidedRedstone[0] > 0) ? 1 : 0) | ((mSidedRedstone[1] > 0) ? 2 : 0)
-                        | ((mSidedRedstone[2] > 0) ? 4 : 0)
-                        | ((mSidedRedstone[3] > 0) ? 8 : 0)
-                        | ((mSidedRedstone[4] > 0) ? 16 : 0)
-                        | ((mSidedRedstone[5] > 0) ? 32 : 0));
-                    if (tData != oRedstoneData)
-                        sendBlockEvent(GregTechTileClientEvents.CHANGE_REDSTONE_OUTPUT, oRedstoneData = tData);
+
+                    byte updateData = mMetaTileEntity.getUpdateData();
+
+                    if (updateData != oUpdateData) {
+                        oUpdateData = updateData;
+                        sendBlockEvent(GregTechTileClientEvents.CHANGE_CUSTOM_DATA, oUpdateData);
+                    }
+
+                    if (mColor != oColor) {
+                        oColor = mColor;
+                        sendBlockEvent(GregTechTileClientEvents.CHANGE_COLOR, oColor);
+                    }
+
+                    byte redstone = getSidedRedstoneMask();
+
+                    if (redstone != oRedstoneData) {
+                        oRedstoneData = redstone;
+                        sendBlockEvent(GregTechTileClientEvents.CHANGE_REDSTONE_OUTPUT, oRedstoneData);
+                    }
+
                     if (mLightValue != oLightValue) {
                         worldObj.setLightValue(EnumSkyBlock.Block, xCoord, yCoord, zCoord, mLightValue);
                         worldObj.updateLightByType(EnumSkyBlock.Block, xCoord, yCoord, zCoord);
@@ -629,6 +633,17 @@ public class BaseMetaTileEntity extends CommonBaseMetaTileEntity
 
     private void sendClientData() {
         if (mSendClientData) {
+            oTextureData = (byte) ((mFacing.ordinal() & 7) | (mActive ? 8 : 0)
+                | (mRedstone ? 16 : 0)
+                | (mLockUpgrade ? 32 : 0)
+                | (mWorks ? 64 : 0));
+
+            oUpdateData = hasValidMetaTileEntity() ? mMetaTileEntity.getUpdateData() : 0;
+
+            oRedstoneData = getSidedRedstoneMask();
+
+            oColor = mColor;
+
             NW.sendPacketToAllPlayersInRange(
                 worldObj,
                 new GTPacketTileEntity(
@@ -642,20 +657,10 @@ public class BaseMetaTileEntity extends CommonBaseMetaTileEntity
                     getCoverAtSide(ForgeDirection.SOUTH).getCoverID(),
                     getCoverAtSide(ForgeDirection.WEST).getCoverID(),
                     getCoverAtSide(ForgeDirection.EAST).getCoverID(),
-                    oTextureData = (byte) ((mFacing.ordinal() & 7) | (mActive ? 8 : 0)
-                        | (mRedstone ? 16 : 0)
-                        | (mLockUpgrade ? 32 : 0)
-                        | (mWorks ? 64 : 0)),
-                    oTexturePage = (hasValidMetaTileEntity() && mMetaTileEntity instanceof MTEHatch)
-                        ? ((MTEHatch) mMetaTileEntity).getTexturePage()
-                        : 0,
-                    oUpdateData = hasValidMetaTileEntity() ? mMetaTileEntity.getUpdateData() : 0,
-                    oRedstoneData = (byte) (((mSidedRedstone[0] > 0) ? 1 : 0) | ((mSidedRedstone[1] > 0) ? 2 : 0)
-                        | ((mSidedRedstone[2] > 0) ? 4 : 0)
-                        | ((mSidedRedstone[3] > 0) ? 8 : 0)
-                        | ((mSidedRedstone[4] > 0) ? 16 : 0)
-                        | ((mSidedRedstone[5] > 0) ? 32 : 0)),
-                    oColor = mColor),
+                    oTextureData,
+                    oUpdateData,
+                    oRedstoneData,
+                    oColor),
                 xCoord,
                 zCoord);
             mSendClientData = false;
@@ -664,8 +669,7 @@ public class BaseMetaTileEntity extends CommonBaseMetaTileEntity
     }
 
     public final void receiveMetaTileEntityData(short aID, int aCover0, int aCover1, int aCover2, int aCover3,
-        int aCover4, int aCover5, byte aTextureData, byte aTexturePage, byte aUpdateData, byte aRedstoneData,
-        byte aColorData) {
+        int aCover4, int aCover5, byte aTextureData, byte aUpdateData, byte aRedstoneData, byte aColorData) {
         issueTextureUpdate();
         if (mID != aID && aID > 0) {
             mID = aID;
@@ -676,7 +680,6 @@ public class BaseMetaTileEntity extends CommonBaseMetaTileEntity
 
         receiveClientEvent(GregTechTileClientEvents.CHANGE_COMMON_DATA, aTextureData);
         receiveClientEvent(GregTechTileClientEvents.CHANGE_CUSTOM_DATA, aUpdateData & 0x7F);
-        receiveClientEvent(GregTechTileClientEvents.CHANGE_CUSTOM_DATA, aTexturePage | 0x80);
         receiveClientEvent(GregTechTileClientEvents.CHANGE_COLOR, aColorData);
         receiveClientEvent(GregTechTileClientEvents.CHANGE_REDSTONE_OUTPUT, aRedstoneData);
     }
@@ -708,10 +711,7 @@ public class BaseMetaTileEntity extends CommonBaseMetaTileEntity
                 }
                 case GregTechTileClientEvents.CHANGE_CUSTOM_DATA -> {
                     if (hasValidMetaTileEntity()) {
-                        if ((aValue & 0x80) == 0) // Is texture index
-                            mMetaTileEntity.onValueUpdate((byte) (aValue & 0x7F));
-                        else if (mMetaTileEntity instanceof MTEHatch) // is texture page and hatch
-                            ((MTEHatch) mMetaTileEntity).onTexturePageUpdate((byte) (aValue & 0x7F));
+                        mMetaTileEntity.onValueUpdate((byte) (aValue & 0x7F));
                     }
                 }
                 case GregTechTileClientEvents.CHANGE_COLOR -> {

--- a/src/main/java/gregtech/api/metatileentity/CoverableTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/CoverableTileEntity.java
@@ -329,6 +329,18 @@ public abstract class CoverableTileEntity extends BaseTileEntity implements ICov
         mSidedRedstone[5] = (byte) ((packedRedstoneValue & 32) == 32 ? 15 : 0);
     }
 
+    public byte getSidedRedstoneMask() {
+        byte redstone = 0;
+
+        for (int i = 0; i < 6; i++) {
+            if (mSidedRedstone[i] > 0) {
+                redstone |= (byte) (0b1 << i);
+            }
+        }
+
+        return redstone;
+    }
+
     @Override
     public void setOutputRedstoneSignal(ForgeDirection side, byte strength) {
         final byte cappedStrength = (byte) Math.min(Math.max(0, strength), 15);

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEFrame.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEFrame.java
@@ -14,6 +14,7 @@ import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.MetaPipeEntity;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GTLanguageManager;
+import gregtech.api.util.GTUtility;
 
 public class MTEFrame extends MetaPipeEntity implements ITemporaryTE {
 
@@ -35,7 +36,7 @@ public class MTEFrame extends MetaPipeEntity implements ITemporaryTE {
 
     @Override
     public byte getTileEntityBaseType() {
-        return (byte) (mMaterial == null ? 4 : (byte) (4) + Math.max(0, Math.min(3, mMaterial.mToolQuality)));
+        return (byte) (4 + (mMaterial == null ? 0 : GTUtility.clamp(mMaterial.mToolQuality, 0, 3)));
     }
 
     @Override

--- a/src/main/java/gregtech/api/net/GTPacketCreateTE.java
+++ b/src/main/java/gregtech/api/net/GTPacketCreateTE.java
@@ -16,16 +16,16 @@ import io.netty.buffer.ByteBuf;
 public class GTPacketCreateTE extends GTPacket {
 
     private int mX, mZ, mC0, mC1, mC2, mC3, mC4, mC5;
-    private short mY, mID, mRID;
-    private byte mTexture, mTexturePage, mUpdate, mRedstone, mColor;
+    private short mY, mID;
+    private byte mCommon, mUpdate, mRedstone, mColor, mType;
 
-    public GTPacketCreateTE() {
-        super();
-    }
+    public static final byte TYPE_META_TILE = 0;
+    public static final byte TYPE_META_PIPE = 1;
 
-    public GTPacketCreateTE(int aX, short aY, int aZ, short aRID, short aID, int aC0, int aC1, int aC2, int aC3,
-        int aC4, int aC5, byte aTexture, byte aTexturePage, byte aUpdate, byte aRedstone, byte aColor) {
-        super();
+    public GTPacketCreateTE() {}
+
+    public GTPacketCreateTE(int aX, short aY, int aZ, short aID, int aC0, int aC1, int aC2, int aC3, int aC4, int aC5,
+        byte aCommon, byte aUpdate, byte aRedstone, byte aColor, byte aType) {
         mX = aX;
         mY = aY;
         mZ = aZ;
@@ -35,39 +35,12 @@ public class GTPacketCreateTE extends GTPacket {
         mC3 = aC3;
         mC4 = aC4;
         mC5 = aC5;
-        mRID = aRID;
         mID = aID;
-        mTexture = aTexture;
-        mTexturePage = aTexturePage;
+        mCommon = aCommon;
         mUpdate = aUpdate;
         mRedstone = aRedstone;
         mColor = aColor;
-    }
-
-    public GTPacketCreateTE(int aX, short aY, int aZ, short aID, int aC0, int aC1, int aC2, int aC3, int aC4, int aC5,
-        byte aTexture, byte aTexturePage, byte aUpdate, byte aRedstone, byte aColor) {
-        this(
-            aX,
-            aY,
-            aZ,
-            (short) 0,
-            aID,
-            aC0,
-            aC1,
-            aC2,
-            aC3,
-            aC4,
-            aC5,
-            aTexture,
-            aTexturePage,
-            aUpdate,
-            aRedstone,
-            aColor);
-    }
-
-    public GTPacketCreateTE(int aX, short aY, int aZ, short aID, int aC0, int aC1, int aC2, int aC3, int aC4, int aC5,
-        byte aTexture, byte aUpdate, byte aRedstone, byte aColor) {
-        this(aX, aY, aZ, (short) 0, aID, aC0, aC1, aC2, aC3, aC4, aC5, aTexture, (byte) 0, aUpdate, aRedstone, aColor);
+        mType = aType;
     }
 
     @Override
@@ -81,7 +54,6 @@ public class GTPacketCreateTE extends GTPacket {
         aOut.writeShort(mY);
         aOut.writeInt(mZ);
 
-        aOut.writeShort(mRID);
         aOut.writeShort(mID);
 
         aOut.writeInt(mC0);
@@ -91,11 +63,12 @@ public class GTPacketCreateTE extends GTPacket {
         aOut.writeInt(mC4);
         aOut.writeInt(mC5);
 
-        aOut.writeByte(mTexture);
-        aOut.writeByte(mTexturePage);
+        aOut.writeByte(mCommon);
         aOut.writeByte(mUpdate);
         aOut.writeByte(mRedstone);
         aOut.writeByte(mColor);
+
+        aOut.writeByte(mType);
     }
 
     @Override
@@ -105,8 +78,7 @@ public class GTPacketCreateTE extends GTPacket {
             aData.readInt(),
             aData.readShort(),
             aData.readInt(),
-            // Registry & ID
-            aData.readShort(),
+            // ID
             aData.readShort(),
             // Covers
             aData.readInt(),
@@ -120,6 +92,7 @@ public class GTPacketCreateTE extends GTPacket {
             aData.readByte(),
             aData.readByte(),
             aData.readByte(),
+            // TE type
             aData.readByte());
     }
 
@@ -130,22 +103,23 @@ public class GTPacketCreateTE extends GTPacket {
             final TileEntity tileEntity = world.getTileEntity(mX, mY, mZ);
             if (tileEntity == null) {
                 try {
-                    if (mTexturePage != 0) // It's a MetaTileEntity
-                    {
-                        BaseMetaTileEntity newTileEntity = getBaseMetaTileEntity();
-                        ((WorldClient) world).setTileEntity(mX, mY, mZ, newTileEntity);
-                    } else // Otherwise it's a MetaPipeEntity
-                    {
-                        BaseMetaPipeEntity newTileEntity = getBaseMetaPipeEntity();
-                        ((WorldClient) world).setTileEntity(mX, mY, mZ, newTileEntity);
+                    switch (mType) {
+                        case TYPE_META_TILE -> {
+                            BaseMetaTileEntity newTileEntity = getBaseMetaTileEntity();
+                            ((WorldClient) world).setTileEntity(mX, mY, mZ, newTileEntity);
+                        }
+                        case TYPE_META_PIPE -> {
+                            BaseMetaPipeEntity newTileEntity = getBaseMetaPipeEntity();
+                            ((WorldClient) world).setTileEntity(mX, mY, mZ, newTileEntity);
+                        }
                     }
                 } catch (Exception e) {
                     GTMod.GT_FML_LOGGER.error("Exception creating Tile Entity at ({}, {}, {})", mX, mY, mZ);
                 }
             } else {
                 try {
-                    if (tileEntity instanceof BaseMetaTileEntity)
-                        ((BaseMetaTileEntity) tileEntity).receiveMetaTileEntityData(
+                    if (tileEntity instanceof BaseMetaTileEntity tile) {
+                        tile.receiveMetaTileEntityData(
                             mID,
                             mC0,
                             mC1,
@@ -153,13 +127,12 @@ public class GTPacketCreateTE extends GTPacket {
                             mC3,
                             mC4,
                             mC5,
-                            mTexture,
-                            mTexturePage,
+                            mCommon,
                             mUpdate,
                             mRedstone,
                             mColor);
-                    else if (tileEntity instanceof BaseMetaPipeEntity)
-                        ((BaseMetaPipeEntity) tileEntity).receiveMetaTileEntityData(
+                    } else if (tileEntity instanceof BaseMetaPipeEntity pipe) {
+                        pipe.receiveMetaTileEntityData(
                             mID,
                             mC0,
                             mC1,
@@ -167,10 +140,11 @@ public class GTPacketCreateTE extends GTPacket {
                             mC3,
                             mC4,
                             mC5,
-                            mTexture,
+                            mCommon,
                             mUpdate,
                             mRedstone,
                             mColor);
+                    }
                 } catch (Exception e) {
                     GTMod.GT_FML_LOGGER.error(
                         "Exception setting tile entity data for tile entity {} at ({}, {}, {})",
@@ -186,27 +160,14 @@ public class GTPacketCreateTE extends GTPacket {
     @NotNull
     private BaseMetaPipeEntity getBaseMetaPipeEntity() {
         BaseMetaPipeEntity newTileEntity = new BaseMetaPipeEntity();
-        newTileEntity
-            .receiveMetaTileEntityData(mID, mC0, mC1, mC2, mC3, mC4, mC5, mTexture, mUpdate, mRedstone, mColor);
+        newTileEntity.receiveMetaTileEntityData(mID, mC0, mC1, mC2, mC3, mC4, mC5, mCommon, mUpdate, mRedstone, mColor);
         return newTileEntity;
     }
 
     @NotNull
     private BaseMetaTileEntity getBaseMetaTileEntity() {
         BaseMetaTileEntity newTileEntity = new BaseMetaTileEntity();
-        newTileEntity.receiveMetaTileEntityData(
-            mID,
-            mC0,
-            mC1,
-            mC2,
-            mC3,
-            mC4,
-            mC5,
-            mTexture,
-            mTexturePage,
-            mUpdate,
-            mRedstone,
-            mColor);
+        newTileEntity.receiveMetaTileEntityData(mID, mC0, mC1, mC2, mC3, mC4, mC5, mCommon, mUpdate, mRedstone, mColor);
         return newTileEntity;
     }
 }

--- a/src/main/java/gregtech/api/net/GTPacketTileEntity.java
+++ b/src/main/java/gregtech/api/net/GTPacketTileEntity.java
@@ -13,17 +13,13 @@ import io.netty.buffer.ByteBuf;
 public class GTPacketTileEntity extends GTPacket {
 
     private int mX, mZ, mC0, mC1, mC2, mC3, mC4, mC5;
-    private short mY, mID, mRID;
-    private byte mTexture, mTexturePage, mUpdate, mRedstone, mColor;
+    private short mY, mID;
+    private byte mCommon, mUpdate, mRedstone, mColor;
 
-    public GTPacketTileEntity() {
-        super();
-    }
+    public GTPacketTileEntity() {}
 
-    // For multi tiles
-    public GTPacketTileEntity(int aX, short aY, int aZ, short aRID, short aID, int aC0, int aC1, int aC2, int aC3,
-        int aC4, int aC5, byte aTexture, byte aTexturePage, byte aUpdate, byte aRedstone, byte aColor) {
-        super();
+    public GTPacketTileEntity(int aX, short aY, int aZ, short aID, int aC0, int aC1, int aC2, int aC3, int aC4, int aC5,
+        byte aCommon, byte aUpdate, byte aRedstone, byte aColor) {
         mX = aX;
         mY = aY;
         mZ = aZ;
@@ -33,41 +29,11 @@ public class GTPacketTileEntity extends GTPacket {
         mC3 = aC3;
         mC4 = aC4;
         mC5 = aC5;
-        mRID = aRID;
         mID = aID;
-        mTexture = aTexture;
-        mTexturePage = aTexturePage;
+        mCommon = aCommon;
         mUpdate = aUpdate;
         mRedstone = aRedstone;
         mColor = aColor;
-    }
-
-    // For meta tiles
-    public GTPacketTileEntity(int aX, short aY, int aZ, short aID, int aC0, int aC1, int aC2, int aC3, int aC4, int aC5,
-        byte aTexture, byte aTexturePage, byte aUpdate, byte aRedstone, byte aColor) {
-        this(
-            aX,
-            aY,
-            aZ,
-            (short) 0,
-            aID,
-            aC0,
-            aC1,
-            aC2,
-            aC3,
-            aC4,
-            aC5,
-            aTexture,
-            aTexturePage,
-            aUpdate,
-            aRedstone,
-            aColor);
-    }
-
-    // For pipes
-    public GTPacketTileEntity(int aX, short aY, int aZ, short aID, int aC0, int aC1, int aC2, int aC3, int aC4, int aC5,
-        byte aTexture, byte aUpdate, byte aRedstone, byte aColor) {
-        this(aX, aY, aZ, (short) 0, aID, aC0, aC1, aC2, aC3, aC4, aC5, aTexture, (byte) 0, aUpdate, aRedstone, aColor);
     }
 
     @Override
@@ -76,7 +42,6 @@ public class GTPacketTileEntity extends GTPacket {
         aOut.writeShort(mY);
         aOut.writeInt(mZ);
 
-        aOut.writeShort(mRID);
         aOut.writeShort(mID);
 
         aOut.writeInt(mC0);
@@ -86,8 +51,7 @@ public class GTPacketTileEntity extends GTPacket {
         aOut.writeInt(mC4);
         aOut.writeInt(mC5);
 
-        aOut.writeByte(mTexture);
-        aOut.writeByte(mTexturePage);
+        aOut.writeByte(mCommon);
         aOut.writeByte(mUpdate);
         aOut.writeByte(mRedstone);
         aOut.writeByte(mColor);
@@ -100,8 +64,7 @@ public class GTPacketTileEntity extends GTPacket {
             aData.readInt(),
             aData.readShort(),
             aData.readInt(),
-            // Registry & ID
-            aData.readShort(),
+            // ID
             aData.readShort(),
             // Covers
             aData.readInt(),
@@ -114,7 +77,6 @@ public class GTPacketTileEntity extends GTPacket {
             aData.readByte(),
             aData.readByte(),
             aData.readByte(),
-            aData.readByte(),
             aData.readByte());
     }
 
@@ -123,21 +85,11 @@ public class GTPacketTileEntity extends GTPacket {
         if (aWorld == null) return;
         final TileEntity tTileEntity = aWorld.getTileEntity(mX, mY, mZ);
         try {
-            if (tTileEntity instanceof BaseMetaTileEntity) ((BaseMetaTileEntity) tTileEntity).receiveMetaTileEntityData(
-                mID,
-                mC0,
-                mC1,
-                mC2,
-                mC3,
-                mC4,
-                mC5,
-                mTexture,
-                mTexturePage,
-                mUpdate,
-                mRedstone,
-                mColor);
-            else if (tTileEntity instanceof BaseMetaPipeEntity) ((BaseMetaPipeEntity) tTileEntity)
-                .receiveMetaTileEntityData(mID, mC0, mC1, mC2, mC3, mC4, mC5, mTexture, mUpdate, mRedstone, mColor);
+            if (tTileEntity instanceof BaseMetaTileEntity tile) {
+                tile.receiveMetaTileEntityData(mID, mC0, mC1, mC2, mC3, mC4, mC5, mCommon, mUpdate, mRedstone, mColor);
+            } else if (tTileEntity instanceof BaseMetaPipeEntity pipe) {
+                pipe.receiveMetaTileEntityData(mID, mC0, mC1, mC2, mC3, mC4, mC5, mCommon, mUpdate, mRedstone, mColor);
+            }
         } catch (Exception e) {
             GTMod.GT_FML_LOGGER.error(
                 "Exception setting tile entity data for tile entity {} at ({}, {}, {})",


### PR DESCRIPTION
This changes the way that hatch backgrounds are synced to the client. Previously it used a combination of block events and GT packets, but now everything is handled by the hatch itself.

I also sorted out some strange code in the GT TE packets - the create packet was using the texture field as a hacky way to determine the packet pipe/tile type. The base tiles also had a lot of related ugly code that I cleaned up since I was in there already.

Functional changes:
- None

Code changes:
- Minor cleanup for MTEFrame
- Moved texture page sync logic out of base tiles and into MTEHatch
- Renamed TextureData -> Common or Connections where relevant since pipes were using the field to sync their connections
- Clean up the sync code in the base tile and pipe entities (should have zero logic changes)
- Removed a redunant field from the GT tile packets (looks like it was for mutes)

Testing done:
- Make sure it works
- Make sure hatches save their texture when the world is reloaded and when the player starts viewing the chunk (performed on a server with SU chunk loading and a low render distance)
- Make sure the packet changes didn't break TE updating or frame TE creation
- Sanity test the sync code (texture data, update data, color, and redstone for tiles and pipes)

depends on: https://github.com/GTNewHorizons/GT5-Unofficial/pull/4172
