### PR TITLE
Allow MTEs to dynamically modify the item dropped when broken

### DIFF
--- a/src/main/java/gregtech/api/interfaces/metatileentity/IMetaTileEntity.java
+++ b/src/main/java/gregtech/api/interfaces/metatileentity/IMetaTileEntity.java
@@ -222,6 +222,11 @@ public interface IMetaTileEntity extends ISidedInventory, IFluidTank, IFluidHand
     boolean shouldDropItemAt(int index);
 
     /**
+     * Override to change which items are dropped when block is broken.
+     */
+    ArrayList<ItemStack> getDroppedItem();
+
+    /**
      * @return if aIndex can be set to Zero stackSize, when being removed.
      */
     boolean setStackToZeroInsteadOfNull(int aIndex);

--- a/src/main/java/gregtech/api/metatileentity/CommonMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/CommonMetaTileEntity.java
@@ -253,6 +253,11 @@ public abstract class CommonMetaTileEntity implements IMetaTileEntity {
         return list;
     }
 
+    @Override
+    public ArrayList<ItemStack> getDroppedItem() {
+        return null;
+    }
+
     /**
      * Returns the fluid this block contains.
      */

--- a/src/main/java/gregtech/common/blocks/BlockMachines.java
+++ b/src/main/java/gregtech/common/blocks/BlockMachines.java
@@ -468,6 +468,10 @@ public class BlockMachines extends GTGenericBlock implements IDebugableBlock, IT
     public ArrayList<ItemStack> getDrops(World aWorld, int aX, int aY, int aZ, int aMeta, int aFortune) {
         final TileEntity tTileEntity = aWorld.getTileEntity(aX, aY, aZ);
         if (tTileEntity instanceof IGregTechTileEntity gtTE) {
+            IMetaTileEntity gtMTE = gtTE.getMetaTileEntity();
+            if (gtMTE != null && gtMTE.getDroppedItem() != null) {
+                return gtMTE.getDroppedItem();
+            }
             return gtTE.getDrops();
         }
         final IGregTechTileEntity tGregTechTileEntity = mTemporaryTileEntity.get();


### PR DESCRIPTION
In case you don't want it to drop the actual MTE. For example, I will use this to have a pipe which has a "ruined" state and will drop junk when broken.