### PR TITLE
Fix hatches incorrect redstone signals

### DIFF
--- a/src/main/java/goodgenerator/blocks/tileEntity/GTMetaTileEntity/MTENeutronSensor.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/GTMetaTileEntity/MTENeutronSensor.java
@@ -193,6 +193,11 @@ public class MTENeutronSensor extends MTEHatch {
     }
 
     @Override
+    public boolean hasSidedRedstoneOutputBehavior() {
+        return true;
+    }
+
+    @Override
     public boolean allowGeneralRedstoneOutput() {
         return true;
     }

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEBuffer.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEBuffer.java
@@ -399,6 +399,11 @@ public abstract class MTEBuffer extends MTETieredMachineBlock implements IAddUIW
     }
 
     @Override
+    public boolean hasSidedRedstoneOutputBehavior() {
+        return true;
+    }
+
+    @Override
     public boolean allowGeneralRedstoneOutput() {
         return true;
     }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTECleanroom.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTECleanroom.java
@@ -683,6 +683,11 @@ public class MTECleanroom extends MTETooltipMultiBlockBase
     }
 
     @Override
+    public boolean hasSidedRedstoneOutputBehavior() {
+        return true;
+    }
+
+    @Override
     public boolean allowGeneralRedstoneOutput() {
         return true;
     }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/compressor/MTEBlackHoleUtility.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/compressor/MTEBlackHoleUtility.java
@@ -58,6 +58,11 @@ public class MTEBlackHoleUtility extends MTEHatch {
     }
 
     @Override
+    public boolean hasSidedRedstoneOutputBehavior() {
+        return true;
+    }
+
+    @Override
     public boolean allowGeneralRedstoneOutput() {
         return true;
     }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/compressor/MTEHeatSensor.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/compressor/MTEHeatSensor.java
@@ -57,6 +57,11 @@ public class MTEHeatSensor extends MTEHatch {
     }
 
     @Override
+    public boolean hasSidedRedstoneOutputBehavior() {
+        return true;
+    }
+
+    @Override
     public boolean allowGeneralRedstoneOutput() {
         return true;
     }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/purification/MTEHatchDegasifierControl.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/purification/MTEHatchDegasifierControl.java
@@ -33,6 +33,11 @@ public class MTEHatchDegasifierControl extends MTEHatch {
     }
 
     @Override
+    public boolean hasSidedRedstoneOutputBehavior() {
+        return true;
+    }
+
+    @Override
     public boolean allowGeneralRedstoneOutput() {
         return true;
     }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/purification/MTEHatchLensIndicator.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/purification/MTEHatchLensIndicator.java
@@ -44,6 +44,11 @@ public class MTEHatchLensIndicator extends MTEHatch {
     }
 
     @Override
+    public boolean hasSidedRedstoneOutputBehavior() {
+        return true;
+    }
+
+    @Override
     public boolean allowGeneralRedstoneOutput() {
         return true;
     }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/purification/MTEHatchPHSensor.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/purification/MTEHatchPHSensor.java
@@ -59,6 +59,11 @@ public class MTEHatchPHSensor extends MTEHatch {
     }
 
     @Override
+    public boolean hasSidedRedstoneOutputBehavior() {
+        return true;
+    }
+
+    @Override
     public boolean allowGeneralRedstoneOutput() {
         return true;
     }


### PR DESCRIPTION
Fix: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19329
When they were placed, `mSidedRedstone` was incorrectly set to `{15, 15, 15, 15, 15, 15}`.
And also fixed other machines and hatches with the same issue.

![62816d77c478b416b042486f7e8e6e0b](https://github.com/user-attachments/assets/b2c41c18-a445-456b-bd2d-1690b56f4b8f)

https://github.com/user-attachments/assets/ad94966a-0439-4341-8c4d-694cdb61ac57

https://github.com/GTNewHorizons/GT5-Unofficial/blob/ad1946a5f582e85cc9fffaa43d1c0383814f7fe9/src/main/java/gregtech/api/metatileentity/CoverableTileEntity.java#L287-L295
https://github.com/GTNewHorizons/GT5-Unofficial/blob/ad1946a5f582e85cc9fffaa43d1c0383814f7fe9/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java#L1741-L1748
Also fixed the issue where removing a cover plate would unintentionally emit a redstone signal.