### PR TITLE
make neutron accelerator hatch not an energy hatch

### DIFF
--- a/src/main/java/goodgenerator/blocks/tileEntity/GTMetaTileEntity/MTENeutronAccelerator.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/GTMetaTileEntity/MTENeutronAccelerator.java
@@ -3,40 +3,48 @@ package goodgenerator.blocks.tileEntity.GTMetaTileEntity;
 import static gregtech.api.enums.GTValues.V;
 import static gregtech.api.util.GTUtility.formatNumbers;
 
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumChatFormatting;
+import net.minecraftforge.common.util.ForgeDirection;
 
+import gregtech.api.enums.Textures;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.implementations.MTEHatchEnergy;
+import gregtech.api.metatileentity.implementations.MTEHatch;
 
-public class MTENeutronAccelerator extends MTEHatchEnergy {
+public class MTENeutronAccelerator extends MTEHatch {
 
     public MTENeutronAccelerator(int aID, String aName, String aNameRegional, int aTier) {
-        super(aID, aName, aNameRegional, aTier);
+        super(
+            aID,
+            aName,
+            aNameRegional,
+            aTier,
+            0,
+            new String[] { "Uses Energy to Accelerate the Neutrons!",
+                "Max consumption: " + EnumChatFormatting.YELLOW
+                    + formatNumbers(getMaxEUConsume(aTier))
+                    + EnumChatFormatting.WHITE
+                    + " EU/t",
+                "Every EU gets converted into 10-20 eV Neutron Kinetic Energy." });
     }
 
     public MTENeutronAccelerator(String aName, int aTier, String[] aDescription, ITexture[][][] aTextures) {
-        super(aName, aTier, aDescription, aTextures);
+        super(aName, aTier, 0, aDescription, aTextures);
     }
 
     public int getMaxEUConsume() {
+        return getMaxEUConsume(mTier);
+    }
+
+    private static int getMaxEUConsume(int mTier) {
         return (int) (V[mTier] * 8 / 10);
     }
 
     @Override
     public MetaTileEntity newMetaEntity(IGregTechTileEntity aTileEntity) {
         return new MTENeutronAccelerator(mName, mTier, this.getDescription(), mTextures);
-    }
-
-    @Override
-    public String[] getDescription() {
-        return new String[] { "Uses Energy to Accelerate the Neutrons!",
-            "Max consumption: " + EnumChatFormatting.YELLOW
-                + formatNumbers(this.getMaxEUConsume())
-                + EnumChatFormatting.WHITE
-                + " EU/t",
-            "Every EU gets converted into 10-20 eV Neutron Kinetic Energy." };
     }
 
     @Override
@@ -50,5 +58,62 @@ public class MTENeutronAccelerator extends MTEHatchEnergy {
             }
         }
         super.onPostTick(aBaseMetaTileEntity, aTick);
+    }
+
+    @Override
+    public ITexture[] getTexturesActive(ITexture aBaseTexture) {
+        return new ITexture[] { aBaseTexture, Textures.BlockIcons.OVERLAYS_ENERGY_IN_MULTI[mTier] };
+    }
+
+    @Override
+    public ITexture[] getTexturesInactive(ITexture aBaseTexture) {
+        return new ITexture[] { aBaseTexture, Textures.BlockIcons.OVERLAYS_ENERGY_IN_MULTI[mTier] };
+    }
+
+    @Override
+    public boolean isFacingValid(ForgeDirection facing) {
+        return true;
+    }
+
+    @Override
+    public boolean isEnetInput() {
+        return true;
+    }
+
+    @Override
+    public boolean isInputFacing(ForgeDirection side) {
+        return side == getBaseMetaTileEntity().getFrontFacing();
+    }
+
+    @Override
+    public boolean isValidSlot(int aIndex) {
+        return false;
+    }
+
+    @Override
+    public long maxEUInput() {
+        return V[mTier];
+    }
+
+    @Override
+    public long maxEUStore() {
+        return 512L + V[mTier] * 8L;
+    }
+
+    @Override
+    public long maxAmperesIn() {
+        return 2;
+    }
+
+    @Override
+    public boolean allowPullStack(IGregTechTileEntity aBaseMetaTileEntity, int aIndex, ForgeDirection side,
+        ItemStack aStack) {
+        return false;
+    }
+
+    @Override
+    public boolean allowPutStack(IGregTechTileEntity aBaseMetaTileEntity, int aIndex, ForgeDirection side,
+        ItemStack aStack) {
+        return false;
     }
 }


### PR DESCRIPTION
this hatch does not need to be an energy hatch at all. it just adds confusion over structure autoplace and NEI preview.

To date I do not know anybody that regularly uses this as an energy hatch for non-meme reasons.