### PR TITLE
Improve forbidden isModLoaded and getModItem scripts

### DIFF
--- a/.github/workflows/test-forbidden-getmoditems.yml
+++ b/.github/workflows/test-forbidden-getmoditems.yml
@@ -15,4 +15,5 @@ jobs:
       - name: Detect forbidden getModItem calls
         shell: bash
         run: |
-          ! grep -E -r 'getModItem\(("(bartworks|galacticgreg|ggfab|GoodGenerator|gregtech|gtnhlanth|miscutils|kekztech|kubatech|tectech|gtneioreplugin)"|.*(BartWorks|GalactiGreg|GGFab|GoodGenerator|GregTech|GTNHLanthanides|GTPlusPlus|KekzTech|KubaTech|TecTech|NEIOrePlugin)\.ID)' src/main/java
+          ! grep -E -r 'getModItem\("(bartworks|galacticgreg|ggfab|GoodGenerator|gregtech|gtnhlanth|miscutils|kekztech|kubatech|tectech|gtneioreplugin)"' src/main/java
+          ! grep -E -r 'getModItem\(.*(BartWorks|GalactiGreg|GGFab|GoodGenerator|GregTech|GTNHLanthanides|GTPlusPlus|KekzTech|KubaTech|TecTech|NEIOrePlugin)\.ID' src/main/java

--- a/.github/workflows/test-forbidden-ismodloaded.yml
+++ b/.github/workflows/test-forbidden-ismodloaded.yml
@@ -16,3 +16,4 @@ jobs:
         shell: bash
         run: |
           ! grep -E -r '(BartWorks|GalactiGreg|GGFab|GoodGenerator|GTNHLanthanides|GregTech|GTPlusPlus|KekzTech|KubaTech|TecTech|NEIOrePlugin)\.isModLoaded' src/main/java
+          ! grep -E -r 'isModLoaded\(".*")' src/main/java


### PR DESCRIPTION
Improves the forbidden getModItems check for readability. Adds an additional check to the forbidden isModLoaded check to also forbid any manually typed modid (i.e., `Loader.isModLoaded("gregtech")` instead of `Mods.GregTech.isModLoaded()`)