### PR TITLE
Add output hatch check to MTEBioVat

### DIFF
--- a/src/main/java/bartworks/common/tileentities/multis/MTEBioVat.java
+++ b/src/main/java/bartworks/common/tileentities/multis/MTEBioVat.java
@@ -324,7 +324,8 @@ public class MTEBioVat extends MTEEnhancedMultiBlockBase<MTEBioVat> implements I
 
         return this.mCasing >= 19 && this.mRadHatches.size() <= 1
             && !this.mEnergyHatches.isEmpty()
-            && this.mMaintenanceHatches.size() == 1;
+            && this.mMaintenanceHatches.size() == 1
+            && this.mOutputHatches.size() == 1;
     }
 
     @Override

--- a/src/main/java/bartworks/common/tileentities/multis/MTEBioVat.java
+++ b/src/main/java/bartworks/common/tileentities/multis/MTEBioVat.java
@@ -295,8 +295,7 @@ public class MTEBioVat extends MTEEnhancedMultiBlockBase<MTEBioVat> implements I
     }
 
     public FluidStack getStoredFluidOutputs() {
-        // Only one output Hatch
-        assert this.mOutputHatches.size() == 1;
+        // Only one output Hatch, enforced in checkMachine.
         return this.mOutputHatches.get(0)
             .getFluid();
     }


### PR DESCRIPTION
Bio vat now refuses to form if there's not exactly 1 output hatch
We were already asserting this in getStoredFluidOutputs, but asserts don't work in outputs, and it's better to just not form.

It refuses to run without output hatch, and runs fine even without raido hatch, see:  https://files.jellejurre.dev/ShareX/Jurre/java_2dMz0rEZV5.mp4

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19621
