### PR TITLE
Add mod with "gregtechNH" modid for easier GT6 differentiation

### DIFF
--- a/src/main/java/gregtech/GTNHMod.java
+++ b/src/main/java/gregtech/GTNHMod.java
@@ -1,0 +1,9 @@
+package gregtech;
+
+import cpw.mods.fml.common.Mod;
+
+// Mod class to provide a mod id in the GTNH GT that makes resolving mod id collisions with GT6 easier
+@SuppressWarnings("unused")
+@Mod(modid = "gregtechNH", name = "GregTech GTNH", version = GT_Version.VERSION)
+public class GTNHMod {
+}

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -23,6 +23,13 @@
       ]
     },
     {
+      "modid": "gregtechNH",
+      "name": "GregTech GTNH",
+      "description": "",
+      "mcversion": "${minecraftVersion}",
+      "version": "${modVersion}"
+    },
+    {
       "modid": "ggfab",
       "name": "GigaGramFab",
       "description": "Production at scale",


### PR DESCRIPTION
So we have a modid we can reference in `@Optional` annotations that doesn't also match GT6