### PR TITLE
Widen Modifiers to `protected` in ParallelHelper and OverclockCalculator

### DIFF
--- a/src/main/java/gregtech/api/util/OverclockCalculator.java
+++ b/src/main/java/gregtech/api/util/OverclockCalculator.java
@@ -8,70 +8,70 @@ public class OverclockCalculator {
 
     // Basic properties
     /** EUt the recipe originally runs at */
-    private long recipeEUt = 0;
+    protected long recipeEUt = 0;
     /** Voltage of the machine */
-    private long machineVoltage = 0;
+    protected long machineVoltage = 0;
     /** Amperage of the machine */
-    private long machineAmperage = 1;
+    protected long machineAmperage = 1;
     /** Duration of the recipe */
-    private int duration = 0;
+    protected int duration = 0;
     /** A supplier used for machines which have a custom way of calculating base duration, like Neutron Activator */
-    private Supplier<Double> durationUnderOneTickSupplier;
+    protected Supplier<Double> durationUnderOneTickSupplier;
     /** The parallel the machine has when trying to overclock */
-    private int parallel = 1;
+    protected int parallel = 1;
 
     // Modifiers
     /** Energy modifier that is applied at the start of calculating overclocks, like GT++ machines */
-    private double eutModifier = 1.00;
+    protected double eutModifier = 1.00;
     /** Duration modifier that is applied at the start of calculating overclocks, like GT++ machines */
-    private double durationModifier = 1.00;
+    protected double durationModifier = 1.00;
 
     // Overclock parameters
     /** How much the energy would be multiplied by per overclock available */
-    private double eutIncreasePerOC = 4;
+    protected double eutIncreasePerOC = 4;
     /** How much the duration would be divided by per overclock made that isn't an overclock from HEAT */
-    private double durationDecreasePerOC = 2;
+    protected double durationDecreasePerOC = 2;
     /** Whether the multi should use laser overclocks. */
-    private boolean laserOC;
+    protected boolean laserOC;
     /** Whether the multi should use amperage to overclock normally. */
-    private boolean amperageOC;
+    protected boolean amperageOC;
     /** Maximum number of overclocks to perform. Defaults to no limit. */
-    private int maxOverclocks = Integer.MAX_VALUE;
+    protected int maxOverclocks = Integer.MAX_VALUE;
     /** Maximum number of regular overclocks to perform before exotic (e.g. laser) overclocks. Defaults to no limit. */
-    private int maxRegularOverclocks = Integer.MAX_VALUE;
+    protected int maxRegularOverclocks = Integer.MAX_VALUE;
     /** How many overclocks have been performed */
-    private int overclocks = 0;
+    protected int overclocks = 0;
     /** Should we actually try to calculate overclocking */
-    private boolean noOverclock;
+    protected boolean noOverclock;
     /** The parallel the machine actually used. */
-    private int currentParallel;
+    protected int currentParallel;
 
     // Heat parameters
     /** The min heat required for the recipe */
-    private int recipeHeat = 0;
+    protected int recipeHeat = 0;
     /** The heat the machine has when starting the recipe */
-    private int machineHeat = 0;
+    protected int machineHeat = 0;
     /** How much the duration should be divided by for each 1800K above recipe heat */
-    private final double durationDecreasePerHeatOC = 4;
+    protected final double durationDecreasePerHeatOC = 4;
     /** Whether to enable overclocking with heat like the EBF every 1800 heat difference */
-    private boolean heatOC;
+    protected boolean heatOC;
     /** Whether to enable heat discounts every 900 heat difference */
-    private boolean heatDiscount;
+    protected boolean heatDiscount;
     /** The value used for discount final eut per 900 heat */
-    private double heatDiscountExponent = 0.95;
+    protected double heatDiscountExponent = 0.95;
 
     // Results
     /** variable to check whether the overclocks have been calculated */
-    private boolean calculated;
+    protected boolean calculated;
     /** The calculated duration result. */
-    private int calculatedDuration;
+    protected int calculatedDuration;
     /** The calculated energy consumption result. */
-    private long calculatedConsumption;
+    protected long calculatedConsumption;
 
     // Constants
-    private static final int HEAT_DISCOUNT_THRESHOLD = 900;
-    private static final int HEAT_OVERCLOCK_THRESHOLD = 1800;
-    private static final double LOG4 = Math.log(4);
+    protected static final int HEAT_DISCOUNT_THRESHOLD = 900;
+    protected static final int HEAT_OVERCLOCK_THRESHOLD = 1800;
+    protected static final double LOG4 = Math.log(4);
 
     /** Creates calculator that doesn't do OC at all. Will use recipe duration. */
     public static OverclockCalculator ofNoOverclock(@Nonnull GTRecipe recipe) {
@@ -302,7 +302,7 @@ public class OverclockCalculator {
         return Math.pow(heatDiscountExponent, heatDiscounts);
     }
 
-    private void calculateOverclock() {
+    protected void calculateOverclock() {
         // Determine the base duration, using the custom supplier if available.
         double duration = durationUnderOneTickSupplier != null ? durationUnderOneTickSupplier.get()
             : this.duration * durationModifier;

--- a/src/main/java/gregtech/api/util/ParallelHelper.java
+++ b/src/main/java/gregtech/api/util/ParallelHelper.java
@@ -21,111 +21,111 @@ import gregtech.api.recipe.check.SingleRecipeCheck;
 @SuppressWarnings({ "unused", "UnusedReturnValue" })
 public class ParallelHelper {
 
-    private static final double MAX_BATCH_MODE_TICK_TIME = 128;
+    protected static final double MAX_BATCH_MODE_TICK_TIME = 128;
     /**
      * Machine used for calculation
      */
-    private IVoidable machine;
+    protected IVoidable machine;
     /**
      * Machine used for single recipe locking calculation
      */
-    private IRecipeLockable singleRecipeMachine;
+    protected IRecipeLockable singleRecipeMachine;
     /**
      * Is locked to a single recipe?
      */
-    private boolean isRecipeLocked;
+    protected boolean isRecipeLocked;
     /**
      * Recipe used when trying to calculate parallels
      */
-    private GTRecipe recipe;
+    protected GTRecipe recipe;
     /**
      * EUt available to the multiblock (This should be the total eut available)
      */
-    private long availableEUt;
+    protected long availableEUt;
     /**
      * The current parallel possible for the multiblock
      */
-    private int currentParallel = 0;
+    protected int currentParallel = 0;
     /**
      * The maximum possible parallel possible for the multiblock
      */
-    private int maxParallel = 1;
+    protected int maxParallel = 1;
     /**
      * The Batch Modifier applied when batch mode is enabled. 1 does nothing. 2 doubles max possible
      * parallel, but also duration
      */
-    private int batchModifier = 1;
+    protected int batchModifier = 1;
     /**
      * The inputs of the multiblock for the current recipe check
      */
-    private ItemStack[] itemInputs;
+    protected ItemStack[] itemInputs;
     /**
      * The outputs of the recipe with the applied parallel
      */
-    private ItemStack[] itemOutputs;
+    protected ItemStack[] itemOutputs;
     /**
      * The inputs of the multiblock for the current recipe check
      */
-    private FluidStack[] fluidInputs;
+    protected FluidStack[] fluidInputs;
     /**
      * The outputs of the recipe with the applied parallel
      */
-    private FluidStack[] fluidOutputs;
+    protected FluidStack[] fluidOutputs;
     /**
      * Does the multi have void protection enabled for items
      */
-    private boolean protectExcessItem;
+    protected boolean protectExcessItem;
     /**
      * Does the multi have void protection enabled for fluids
      */
-    private boolean protectExcessFluid;
+    protected boolean protectExcessFluid;
     /**
      * Should the Parallel Helper automatically consume for the multi
      */
-    private boolean consume;
+    protected boolean consume;
     /**
      * Is batch mode turned on?
      */
-    private boolean batchMode;
+    protected boolean batchMode;
     /**
      * Should the Parallel Helper automatically calculate the outputs of the recipe with current parallel?
      */
-    private boolean calculateOutputs;
+    protected boolean calculateOutputs;
     /**
      * Has the Parallel Helper been built?
      */
-    private boolean built;
+    protected boolean built;
     /**
      * What is the duration multiplier with batch mode enabled
      */
-    private double durationMultiplier;
+    protected double durationMultiplier;
     /**
      * Modifier which is applied on the recipe eut. Useful for GT++ machines
      */
-    private double eutModifier = 1;
+    protected double eutModifier = 1;
     /**
      * Multiplier that is applied on the output chances
      */
-    private double chanceMultiplier = 1;
+    protected double chanceMultiplier = 1;
     /**
      * Method for calculating max parallel from given inputs.
      */
-    private MaxParallelCalculator maxParallelCalculator = GTRecipe::maxParallelCalculatedByInputs;
+    protected MaxParallelCalculator maxParallelCalculator = GTRecipe::maxParallelCalculatedByInputs;
     /**
      * Method for consuming inputs after determining how many parallels it can execute.
      */
-    private InputConsumer inputConsumer = GTRecipe::consumeInput;
+    protected InputConsumer inputConsumer = GTRecipe::consumeInput;
 
     /**
      * Calculator to use for overclocking
      */
-    private OverclockCalculator calculator;
+    protected OverclockCalculator calculator;
     @Nonnull
-    private CheckRecipeResult result = CheckRecipeResultRegistry.NONE;
+    protected CheckRecipeResult result = CheckRecipeResultRegistry.NONE;
 
-    private Function<Integer, ItemStack[]> customItemOutputCalculation;
+    protected Function<Integer, ItemStack[]> customItemOutputCalculation;
 
-    private Function<Integer, FluidStack[]> customFluidOutputCalculation;
+    protected Function<Integer, FluidStack[]> customFluidOutputCalculation;
 
     public ParallelHelper() {}
 
@@ -533,7 +533,7 @@ public class ParallelHelper {
         fluidInputs = fluidInputsToUse;
     }
 
-    private void calculateItemOutputs(ItemStack[] truncatedItemOutputs) {
+    protected void calculateItemOutputs(ItemStack[] truncatedItemOutputs) {
         if (customItemOutputCalculation != null) {
             itemOutputs = customItemOutputCalculation.apply(currentParallel);
             return;
@@ -554,7 +554,7 @@ public class ParallelHelper {
         itemOutputs = itemOutputsList.toArray(new ItemStack[0]);
     }
 
-    private void calculateFluidOutputs(FluidStack[] truncatedFluidOutputs) {
+    protected void calculateFluidOutputs(FluidStack[] truncatedFluidOutputs) {
         if (customFluidOutputCalculation != null) {
             fluidOutputs = customFluidOutputCalculation.apply(currentParallel);
             return;


### PR DESCRIPTION
Twist have its own customization on these things, but due to `private` restriction, it is very ugly.

I'm currently working on this and trying to make it better, so I need to first make them open for child classes.

P.S.: Hope that AT for mods will be available sooooooooon.