### PR TITLE
Fix XLT Muffler Preview & Hologram Dots

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/MTELargerTurbineBase.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/MTELargerTurbineBase.java
@@ -101,7 +101,11 @@ public abstract class MTELargerTurbineBase extends GTPPMultiBlockBase<MTELargerT
                             .casingIndex(t.getCasingTextureIndex())
                             .dot(4)
                             .buildAndChain(t.getCasingBlock(), t.getCasingMeta())))
-                .addElement('m', lazy(t -> Muffler.newAny(t.getCasingTextureIndex(), 7)))
+                .addElement(
+                    'm',
+                    lazy(
+                        t -> t.requiresMufflers() ? Muffler.newAny(t.getCasingTextureIndex(), 7)
+                            : ofBlock(t.getCasingBlock(), t.getCasingMeta())))
                 .build();
         }
     };

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/MTELargerTurbineBase.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/MTELargerTurbineBase.java
@@ -74,7 +74,7 @@ public abstract class MTELargerTurbineBase extends GTPPMultiBlockBase<MTELargerT
                 // m = muffler
                 .addShape(
                     STRUCTURE_PIECE_MAIN,
-                    (new String[][] { { "ccchccc", "ccccccc", "ccmmmcc", "ccm~mcc", "ccmmmcc", "ccccccc", "ccchccc" },
+                    (new String[][] { { "ccchccc", "ccccccc", "ccmcmcc", "ccc~ccc", "ccmcmcc", "ccccccc", "ccchccc" },
                         { "ctchctc", "cscccsc", "cscccsc", "cscccsc", "cscccsc", "cscccsc", "ctchctc" },
                         { "ccchccc", "ccccccc", "ccccccc", "ccccccc", "ccccccc", "ccccccc", "ccchccc" },
                         { "ccchccc", "ccccccc", "ccccccc", "ccccccc", "ccccccc", "ccccccc", "ccchccc" },

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/MTELargerTurbineBase.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/MTELargerTurbineBase.java
@@ -101,13 +101,7 @@ public abstract class MTELargerTurbineBase extends GTPPMultiBlockBase<MTELargerT
                             .casingIndex(t.getCasingTextureIndex())
                             .dot(4)
                             .buildAndChain(t.getCasingBlock(), t.getCasingMeta())))
-                .addElement(
-                    'm',
-                    lazy(
-                        t -> buildHatchAdder(MTELargerTurbineBase.class).atLeast(Muffler)
-                            .casingIndex(t.getCasingTextureIndex())
-                            .dot(7)
-                            .buildAndChain(t.getCasingBlock(), t.getCasingMeta())))
+                .addElement('m', lazy(t -> Muffler.newAny(t.getCasingTextureIndex(), 7)))
                 .build();
         }
     };


### PR DESCRIPTION
Closes GTNewHorizons/GT-New-Horizons-Modpack#19606

Also subsequently fixes the following:
- Previews mistakenly showing Non XLT Gas Turbines require a muffler
- Hologram Projector dots mistakenly showing mufflers for Non XLT Gas Turbines

This limits the muffler layout for the XLT Gas Turbine to an X pattern as shown below:

![image](https://github.com/user-attachments/assets/99a7b3c5-3c52-4597-9e72-086ef570140f)

This is a breaking change that will affect all XLT multis in the following scenarios:
- Non XLT Gas Turbines which have mufflers will become invalid
- Any XLT Gas Turbine which does not follow the X pattern will become invalid

The X pattern has been chosen after viewing images of XLT setups. The vast majority already follow this pattern