### PR TITLE
Fix XLT / LT Fluid Dupe + Voiding

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTELargeTurbineGas.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTELargeTurbineGas.java
@@ -133,6 +133,9 @@ public class MTELargeTurbineGas extends MTELargeTurbine {
             FluidStack firstFuelType = new FluidStack(aFluids.get(0), 0); // Identify a SINGLE type of fluid to process.
                                                                           // Doesn't matter which one. Ignore the rest!
             int fuelValue = getFuelValue(firstFuelType);
+            if (fuelValue <= 0) {
+                return 0;
+            }
 
             if (turbine.getOptimalGasEUt() < fuelValue) {
                 // turbine too weak and/or fuel too powerful

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTELargeTurbinePlasma.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTELargeTurbinePlasma.java
@@ -130,6 +130,10 @@ public class MTELargeTurbinePlasma extends MTELargeTurbine {
             FluidStack firstFuelType = new FluidStack(aFluids.get(0), 0); // Identify a SINGLE type of fluid to process.
             // Doesn't matter which one. Ignore the rest!
             int fuelValue = getFuelValue(firstFuelType);
+            if (fuelValue <= 0) {
+                return 0;
+            }
+
             actualOptimalFlow = GTUtility.safeInt(
                 (long) Math.ceil(
                     (double) (looseFit ? turbine.getOptimalLoosePlasmaFlow() : turbine.getOptimalPlasmaFlow()) * 20

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/MTELargeTurbineGas.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/MTELargeTurbineGas.java
@@ -116,6 +116,10 @@ public class MTELargeTurbineGas extends MTELargerTurbineBase {
                                                                           // Doesn't matter which one. Ignore the rest!
             int fuelValue = getFuelValue(firstFuelType);
             // log("Fuel Value of "+aFluids.get(0).getLocalizedName()+" is "+fuelValue+"eu");
+            if (fuelValue <= 0) {
+                return 0;
+            }
+
             if (turbine.getOptimalGasEUt() < fuelValue) {
                 // turbine too weak and/or fuel too powerful
                 // at least consume 1L

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/MTELargerTurbinePlasma.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/MTELargerTurbinePlasma.java
@@ -216,6 +216,10 @@ public class MTELargerTurbinePlasma extends MTELargerTurbineBase {
             FluidStack firstFuelType = new FluidStack(aFluids.get(0), 0); // Identify a SINGLE type of fluid to process.
             // Doesn't matter which one. Ignore the rest!
             int fuelValue = getFuelValue(firstFuelType);
+            if (fuelValue <= 0) {
+                return 0;
+            }
+
             actualOptimalFlow = GTUtility.safeInt(
                 (long) ((getSpeedMultiplier()
                     * (isLooseMode() ? turbine.getOptimalLoosePlasmaFlow() : turbine.getOptimalPlasmaFlow())


### PR DESCRIPTION
Fixes a fluid dupe / void bug with Gas & Plasma XLT / LT multis when using invalid fuels

This is caused by not validating that `fuelValue` can be 0. Any invalid fuel will return 0. This leads to a division by 0 when calculating `actualOptimalFlow`. Depending on the multi, turbines, and mode, the fluids will either be voided, duped, or nothing will happen

The following scenarios can happen with invalid fuel:
- XLT
  - Always dupes if on `Tight`
  - Nothing happens if on `Loose`
- LT
  - Dupe & Void dependent on turbine's Overflow Efficiency(?)
  - Nothing happens if on `Loose`