### PR TITLE
Fix Fortune Rich Ores Yielding Less Than Expected

### DIFF
--- a/src/main/java/gregtech/common/blocks/TileEntityOres.java
+++ b/src/main/java/gregtech/common/blocks/TileEntityOres.java
@@ -335,7 +335,7 @@ public class TileEntityOres extends TileEntity implements IAllSidedTexturedTileE
                         // if not shouldFortune and isNatural then get normal drops
                         // if shouldFortune and not isNatural then get normal drops
                         if (shouldFortune && this.mNatural && aFortune > 0) {
-                            int aMinAmount = 1;
+                            int aMinAmount = tIsRich ? 2 : 1;
                             // Max applicable fortune
                             if (aFortune > 3) aFortune = 3;
                             int amount = aMinAmount


### PR DESCRIPTION
Closes GTNewHorizons/GT-New-Horizons-Modpack#19534

All rich ores will now drop a minimum of 2 raw ore when fortune is applied. This will affect balance slightly

The current average ore drops:
|| Ores | Rich Ores | Difference |
| --- | --- | --- | --- |
| Normal | 1 | 2 | 2x |
| Fortune 1 | 1.5 | 2 | 1.33x |
| Fortune 2 | 2 | 3 | 1.5x |
| Fortune 3 | 2.5 | 4 | 1.6x |

The new average ore drops:
|| Ores | Rich Ores | Difference |
| --- | --- | --- | --- |
| Normal | 1 | 2 | 2x |
| Fortune 1 | 1.5 | 3 | 2x |
| Fortune 2 | 2 | 4 | 2x |
| Fortune 3 | 2.5 | 5 | 2x |