### PR TITLE
Remove BDM from SLAM, add MagMatter to and rebalance SSASS Magnetic Stab

### DIFF
--- a/src/main/java/goodgenerator/blocks/tileEntity/AntimatterForge.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/AntimatterForge.java
@@ -67,7 +67,7 @@ public class AntimatterForge extends MTEExtendedPowerMultiBlockBase<AntimatterFo
     implements ISurvivalConstructable, IOverclockDescriptionProvider {
 
     private static final FluidStack[] magneticUpgrades = { Materials.TengamPurified.getMolten(1L),
-        MaterialsUEVplus.Time.getMolten(1L) };
+        MaterialsUEVplus.Time.getMolten(1L), MaterialsUEVplus.MagMatter.getMolten(1L) };
     private static final FluidStack[] gravityUpgrades = { MaterialsUEVplus.SpaceTime.getMolten(1L),
         MaterialsUEVplus.Space.getMolten(1L), MaterialsUEVplus.Eternity.getMolten(1L) };
     private static final FluidStack[] containmentUpgrades = { GGMaterial.shirabon.getMolten(1),
@@ -520,7 +520,7 @@ public class AntimatterForge extends MTEExtendedPowerMultiBlockBase<AntimatterFo
 
         List<FluidStack> inputFluids = getStoredFluids();
         for (FluidStack inputFluid : inputFluids) {
-            setModifiers(inputFluid, -0.15f, magneticUpgrades, MAGNETIC_ID);
+            setModifiers(inputFluid, -0.1f, magneticUpgrades, MAGNETIC_ID);
             setModifiers(inputFluid, -0.05f, gravityUpgrades, GRAVITY_ID);
             setModifiers(inputFluid, 0.05f, containmentUpgrades, CONTAINMENT_ID);
             setModifiers(inputFluid, 0.05f, activationUpgrades, ACTIVATION_ID);

--- a/src/main/java/goodgenerator/blocks/tileEntity/AntimatterGenerator.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/AntimatterGenerator.java
@@ -189,8 +189,6 @@ public class AntimatterGenerator extends MTEExtendedPowerMultiBlockBase
             modifier = 1.02F;
         } else if (catalyst.isFluidEqual(Materials.SuperconductorUMVBase.getMolten(1L))) {
             modifier = 1.03F;
-        } else if (catalyst.isFluidEqual(MaterialsUEVplus.BlackDwarfMatter.getMolten(1L))) {
-            modifier = 1.04F;
         }
         long catalystCount = catalyst.amount;
         long generatedEU = 0;


### PR DESCRIPTION
BDM in the SLAM is entirely bait, it takes literally over a thousand EoHs to make roughly a third of the power they could make. It is also unnecessary - UMV SC provides more than enough power and has honestly enough difficulty in scaling.

Moving to SSASS, personally, I think there should be a symmetry between Gravity (the active EU consumption, uses spacetime>spacially enlarged>eternity) and Magnetic (passive EU consumption, uses tengam>tachyon). To do this, I add MagMatter as the UXV tier 3 fluid, so each is 3-tiered.

As a rebalance, the magnetic scaling is changed from -0.15/tier to -0.1/tier. This makes MagMatter identical to old Tachyon, so top-end balance from the 3rd tier is unchanged. A normal UMV pre-eternity sequencer loses a whole 3T net EU/t (out of ~60 at most), and the top-end without magmatter is now 611EU/t vs 722EU/t. Thus, to achieve the current top requires magmatter, but the balance of the lower tiers is noticabley less impacted.