### PR TITLE
Fix bad XL turbine muffler logic

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/MTELargerTurbineBase.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/turbines/MTELargerTurbineBase.java
@@ -31,7 +31,6 @@ import com.gtnewhorizon.structurelib.structure.IStructureDefinition;
 import com.gtnewhorizon.structurelib.structure.ISurvivalBuildEnvironment;
 import com.gtnewhorizon.structurelib.structure.StructureDefinition;
 
-import gregtech.GTMod;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.Textures;
 import gregtech.api.interfaces.ITexture;
@@ -186,9 +185,6 @@ public abstract class MTELargerTurbineBase extends GTPPMultiBlockBase<MTELargerT
     }
 
     private boolean requiresMufflers() {
-        if (!GTMod.gregtechproxy.mPollution) {
-            return false;
-        }
         return getPollutionPerSecond(null) > 0;
     }
 


### PR DESCRIPTION
https://github.com/GTNewHorizons/GT5-Unofficial/pull/4235 revealed a flaw in xl turbine logic. Pollution config should not be checked for requiresMufflers(), because structures require mufflers whether or not pollution is enabled. This was also causing the tooltip to be wrong previously, as well as explaining inconsistent muffler behavior in the past.