### PR TITLE
THTR Tooltip and Default WA Mode

### DIFF
--- a/src/main/java/bartworks/common/tileentities/multis/MTEThoriumHighTempReactor.java
+++ b/src/main/java/bartworks/common/tileentities/multis/MTEThoriumHighTempReactor.java
@@ -135,7 +135,7 @@ public class MTEThoriumHighTempReactor extends MTEEnhancedMultiBlockBase<MTEThor
     @Override
     protected MultiblockTooltipBuilder createTooltip() {
         final MultiblockTooltipBuilder tt = new MultiblockTooltipBuilder();
-        tt.addMachineType("High Temperature Reactor")
+        tt.addMachineType("High Temperature Reactor, THTR")
             .addInfo("Needs to be primed with " + GTUtility.formatNumbers(HELIUM_NEEDED) + " of helium")
             .addInfo("Needs a constant supply of coolant while running")
             .addInfo("Needs at least 100k Fuel pebbles to start operation (can hold up to 675k pebbles)")

--- a/src/main/java/gregtech/common/tileentities/machines/basic/MTEWorldAccelerator.java
+++ b/src/main/java/gregtech/common/tileentities/machines/basic/MTEWorldAccelerator.java
@@ -83,7 +83,7 @@ public class MTEWorldAccelerator extends MTETieredMachineBlock {
         return _mRadiusTierOverride;
     }
 
-    private byte mMode = 0; // 0: RandomTicks around 1: TileEntities with range 1
+    private byte mMode = 1; // 0: RandomTicks around 1: TileEntities with range 1
     private static Textures.BlockIcons.CustomIcon _mGTIco_Norm_Idle;
     private static Textures.BlockIcons.CustomIcon _mGTIco_Norm_Active;
     private static Textures.BlockIcons.CustomIcon _mGTIco_TE_Idle;


### PR DESCRIPTION
Two very small changes.
1) Add THTR to the machine type of the Thorium High Temperature Reactor, so it comes up with an NEI search
2) Change the default mode of the WA to TE mode which accounts for 95% of use cases. Saves having to ALWAYS screwdriver it.