### PR TITLE
Add EoH pity

### DIFF
--- a/src/main/java/tectech/thing/metaTileEntity/multi/MTEEyeOfHarmony.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/MTEEyeOfHarmony.java
@@ -1441,7 +1441,7 @@ public class MTEEyeOfHarmony extends TTMultiblockBase implements IConstructable,
     private double previousRecipeChance;
     private long currentRecipeRocketTier;
 
-    private void outputFailedChance() {
+    private void outputFailedChance(double currentBaseChance) {
         long failedParallelAmount = parallelAmount - successfulParallelAmount;
         if (failedParallelAmount > 0) {
             // 2^Tier spacetime released upon recipe failure.
@@ -1451,13 +1451,13 @@ public class MTEEyeOfHarmony extends TTMultiblockBase implements IConstructable,
                     * pow(SPACETIME_FAILURE_BASE, currentRecipeRocketTier + 1)) * failedParallelAmount));
             // Add chance to pity if previous recipe is equal to current one, else reset pity
             if (previousRecipeChance == successChance) {
-                pityChance += successChance;
+                pityChance += (1 - successChance) * successChance;
             } else {
                 pityChance = successChance;
             }
         } else {
             // Recipe succeeded, reset pity
-            pityChance = 0;
+            pityChance = currentBaseChance;
         }
         super.outputAfterRecipe_EM();
     }
@@ -1506,7 +1506,7 @@ public class MTEEyeOfHarmony extends TTMultiblockBase implements IConstructable,
         startEU = 0;
         outputEU_BigInt = BigInteger.ZERO;
 
-        outputFailedChance();
+        outputFailedChance(currentBaseChance);
         previousRecipeChance = currentBaseChance;
 
         if (successfulParallelAmount > 0) {

--- a/src/main/java/tectech/thing/metaTileEntity/multi/MTEEyeOfHarmony.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/MTEEyeOfHarmony.java
@@ -806,7 +806,7 @@ public class MTEEyeOfHarmony extends TTMultiblockBase implements IConstructable,
         if (parallelAmount > 1) {
             chance -= stellarPlasmaOverflowProbabilityAdjustment;
         } else {
-            if (pityChance >= 1) {
+            if (chance == previousRecipeChance && pityChance >= 1) {
                 chance = 1;
             }
             chance -= (hydrogenOverflowProbabilityAdjustment + heliumOverflowProbabilityAdjustment);
@@ -1449,13 +1449,15 @@ public class MTEEyeOfHarmony extends TTMultiblockBase implements IConstructable,
                 MaterialsUEVplus.SpaceTime.getMolten(1),
                 (long) ((successChance * MOLTEN_SPACETIME_PER_FAILURE_TIER
                     * pow(SPACETIME_FAILURE_BASE, currentRecipeRocketTier + 1)) * failedParallelAmount));
-            // Add chance to pity if previous recipe is equal to current one, else reset pity
-            if (previousRecipeChance == successChance) {
-                pityChance += (1 - successChance) * successChance;
-            } else {
-                pityChance = successChance;
+            if (parallelAmount == 1) {
+                // Add chance to pity if previous recipe is equal to current one, else reset pity
+                if (previousRecipeChance == successChance) {
+                    pityChance += (1 - successChance) * successChance;
+                } else {
+                    pityChance = successChance;
+                }
             }
-        } else {
+        } else if (parallelAmount == 1) {
             // Recipe succeeded, reset pity
             pityChance = currentBaseChance;
         }

--- a/src/main/java/tectech/thing/metaTileEntity/multi/MTEEyeOfHarmony.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/MTEEyeOfHarmony.java
@@ -806,6 +806,9 @@ public class MTEEyeOfHarmony extends TTMultiblockBase implements IConstructable,
         if (parallelAmount > 1) {
             chance -= stellarPlasmaOverflowProbabilityAdjustment;
         } else {
+            if (pityChance >= 1) {
+                chance = 1;
+            }
             chance -= (hydrogenOverflowProbabilityAdjustment + heliumOverflowProbabilityAdjustment);
         }
 
@@ -1434,6 +1437,8 @@ public class MTEEyeOfHarmony extends TTMultiblockBase implements IConstructable,
     }
 
     private double successChance;
+    private double pityChance;
+    private double previousRecipeChance;
     private long currentRecipeRocketTier;
 
     private void outputFailedChance() {
@@ -1444,6 +1449,15 @@ public class MTEEyeOfHarmony extends TTMultiblockBase implements IConstructable,
                 MaterialsUEVplus.SpaceTime.getMolten(1),
                 (long) ((successChance * MOLTEN_SPACETIME_PER_FAILURE_TIER
                     * pow(SPACETIME_FAILURE_BASE, currentRecipeRocketTier + 1)) * failedParallelAmount));
+            // Add chance to pity if previous recipe is equal to current one, else reset pity
+            if (previousRecipeChance == successChance) {
+                pityChance += successChance;
+            } else {
+                pityChance = successChance;
+            }
+        } else {
+            // Recipe succeeded, reset pity
+            pityChance = 0;
         }
         super.outputAfterRecipe_EM();
     }
@@ -1480,6 +1494,9 @@ public class MTEEyeOfHarmony extends TTMultiblockBase implements IConstructable,
     public void outputAfterRecipe_EM() {
         recipeRunning = false;
         eRequiredData = 0L;
+        double currentBaseChance = currentRecipe.getBaseRecipeSuccessChance()
+            - timeAccelerationFieldMetadata * TIME_ACCEL_DECREASE_CHANCE_PER_TIER
+            + stabilisationFieldMetadata * STABILITY_INCREASE_PROBABILITY_DECREASE_YIELD_PER_TIER;
 
         destroyRenderBlock();
 
@@ -1490,6 +1507,7 @@ public class MTEEyeOfHarmony extends TTMultiblockBase implements IConstructable,
         outputEU_BigInt = BigInteger.ZERO;
 
         outputFailedChance();
+        previousRecipeChance = currentBaseChance;
 
         if (successfulParallelAmount > 0) {
             for (ItemStackLong itemStack : outputItems) {
@@ -1702,6 +1720,8 @@ public class MTEEyeOfHarmony extends TTMultiblockBase implements IConstructable,
     private static final String SUCCESSFUL_PARALLEL_AMOUNT_NBT_TAG = EYE_OF_HARMONY + "successfulParallelAmount";
     private static final String ASTRAL_ARRAY_AMOUNT_NBT_TAG = EYE_OF_HARMONY + "astralArrayAmount";
     private static final String CALCULATED_EU_INPUT_NBT_TAG = EYE_OF_HARMONY + "usedEU";
+    private static final String EXTRA_PITY_CHANCE_BOOST_NBT_TAG = EYE_OF_HARMONY + "pityChance";
+    private static final String PREVIOUS_RECIPE_CHANCE_NBT_TAG = EYE_OF_HARMONY + "previousChance";
 
     // Sub tags, less specific names required.
     private static final String STACK_SIZE = "stackSize";
@@ -1763,6 +1783,8 @@ public class MTEEyeOfHarmony extends TTMultiblockBase implements IConstructable,
         aNBT.setLong(ASTRAL_ARRAY_AMOUNT_NBT_TAG, astralArrayAmount);
         aNBT.setByteArray(CALCULATED_EU_OUTPUT_NBT_TAG, outputEU_BigInt.toByteArray());
         aNBT.setByteArray(CALCULATED_EU_INPUT_NBT_TAG, usedEU.toByteArray());
+        aNBT.setDouble(EXTRA_PITY_CHANCE_BOOST_NBT_TAG, pityChance);
+        aNBT.setDouble(PREVIOUS_RECIPE_CHANCE_NBT_TAG, previousRecipeChance);
 
         // Store damage values/stack sizes of GT items being outputted.
         NBTTagCompound itemStackListNBTTag = new NBTTagCompound();
@@ -1835,6 +1857,8 @@ public class MTEEyeOfHarmony extends TTMultiblockBase implements IConstructable,
             outputEU_BigInt = new BigInteger(aNBT.getByteArray(CALCULATED_EU_OUTPUT_NBT_TAG));
         if (aNBT.hasKey(CALCULATED_EU_INPUT_NBT_TAG))
             usedEU = new BigInteger(aNBT.getByteArray(CALCULATED_EU_INPUT_NBT_TAG));
+        pityChance = aNBT.getDouble(EXTRA_PITY_CHANCE_BOOST_NBT_TAG);
+        previousRecipeChance = aNBT.getDouble(PREVIOUS_RECIPE_CHANCE_NBT_TAG);
 
         // Load damage values/stack sizes of GT items being outputted and convert back to items.
         NBTTagCompound tempItemTag = aNBT.getCompoundTag(ITEM_OUTPUT_NBT_TAG);


### PR DESCRIPTION
This PR adds a pity system to the eye of harmony to prevent multi-day wait times due to sheer bad luck. 

The pity system works like this: 
there is a counter that starts at the base success chance of the current recipe. If a recipe fails, (1 - successChance) * successChance is added to it. Once the counter reaches a value >= 1, the next roll is a guaranteed success, which also resets the pity counter. Any successes before the guaranteed roll reset the counter as well. 
If the player switches the recipe to be processed, the counter resets to the new base value, even if its >= 1. 
The pity guarantee can be cancelled out by overlflow penalties, as they apply after the pity is applied, they do not reset the counter however, so the guarantee is shifted to the next recipe cycle.
If parallels are greater than one, pity doesnt apply.

This spreadsheet made by xeno visualizes examples of how the system works: https://docs.google.com/spreadsheets/d/1N9R-dK-b29Gm7yRHUnnTjapnkFAecmfzwyQWE5kwcTw/edit?gid=0#gid=0
