### PR TITLE
Remove redundant circuit for Samaric Residue Dust

### DIFF
--- a/src/main/java/gtnhlanth/loader/RecipeLoader.java
+++ b/src/main/java/gtnhlanth/loader/RecipeLoader.java
@@ -1496,9 +1496,7 @@ public class RecipeLoader {
             .addTo(mixerRecipes);
 
         GTValues.RA.stdBuilder()
-            .itemInputs(
-                GTUtility.getIntegratedCircuit(4),
-                WerkstoffMaterialPool.SaturatedMonaziteRareEarthMixture.get(OrePrefixes.dust, 4))
+            .itemInputs(WerkstoffMaterialPool.SaturatedMonaziteRareEarthMixture.get(OrePrefixes.dust, 4))
             .itemOutputs(WerkstoffMaterialPool.SamaricResidue.get(OrePrefixes.dust, 3))
             .fluidOutputs(Materials.Chloromethane.getGas(400))
             .eut(TierEU.RECIPE_EV)


### PR DESCRIPTION
The circuit does not separate this recipe from anything else.

Old

![image](https://github.com/user-attachments/assets/052c142f-e464-4821-8a81-7c24aee1bb52)

New

![image](https://github.com/user-attachments/assets/7faf3b3f-6973-4500-9f35-d9e06669fcef)

