### PR TITLE
Remove Tiny/Small Dusts from lathe Recipes

### DIFF
--- a/src/main/java/bartworks/system/material/werkstoff_loaders/recipe/GemLoader.java
+++ b/src/main/java/bartworks/system/material/werkstoff_loaders/recipe/GemLoader.java
@@ -183,7 +183,8 @@ public class GemLoader implements IWerkstoffRunnable {
 
                 GTValues.RA.stdBuilder()
                     .itemInputs(werkstoff.get(plate))
-                    .itemOutputs(werkstoff.get(lens), werkstoff.get(dustSmall))
+                    .itemOutputs(werkstoff.get(lens), werkstoff.get(dust))
+                    .outputChances(10000, 2500)
                     .duration(60 * SECONDS)
                     .eut(TierEU.RECIPE_MV)
                     .addTo(latheRecipes);

--- a/src/main/java/bartworks/system/material/werkstoff_loaders/recipe/GemLoader.java
+++ b/src/main/java/bartworks/system/material/werkstoff_loaders/recipe/GemLoader.java
@@ -16,7 +16,6 @@ package bartworks.system.material.werkstoff_loaders.recipe;
 import static gregtech.api.enums.OrePrefixes.block;
 import static gregtech.api.enums.OrePrefixes.crushedPurified;
 import static gregtech.api.enums.OrePrefixes.dust;
-import static gregtech.api.enums.OrePrefixes.dustSmall;
 import static gregtech.api.enums.OrePrefixes.dustTiny;
 import static gregtech.api.enums.OrePrefixes.gem;
 import static gregtech.api.enums.OrePrefixes.gemChipped;

--- a/src/main/java/bartworks/system/material/werkstoff_loaders/recipe/SimpleMetalLoader.java
+++ b/src/main/java/bartworks/system/material/werkstoff_loaders/recipe/SimpleMetalLoader.java
@@ -13,14 +13,7 @@
 
 package bartworks.system.material.werkstoff_loaders.recipe;
 
-import static gregtech.api.enums.OrePrefixes.block;
-import static gregtech.api.enums.OrePrefixes.dustSmall;
-import static gregtech.api.enums.OrePrefixes.foil;
-import static gregtech.api.enums.OrePrefixes.gem;
-import static gregtech.api.enums.OrePrefixes.ingot;
-import static gregtech.api.enums.OrePrefixes.plate;
-import static gregtech.api.enums.OrePrefixes.stick;
-import static gregtech.api.enums.OrePrefixes.stickLong;
+import static gregtech.api.enums.OrePrefixes.*;
 import static gregtech.api.recipe.RecipeMaps.benderRecipes;
 import static gregtech.api.recipe.RecipeMaps.extruderRecipes;
 import static gregtech.api.recipe.RecipeMaps.hammerRecipes;
@@ -53,7 +46,8 @@ public class SimpleMetalLoader implements IWerkstoffRunnable {
 
                 GTValues.RA.stdBuilder()
                     .itemInputs(werkstoff.get(gem))
-                    .itemOutputs(werkstoff.get(stick), werkstoff.get(dustSmall, 2))
+                    .itemOutputs(werkstoff.get(stick), werkstoff.get(dust, 1))
+                    .outputChances(10000, 5000)
                     .duration(
                         (int) Math.max(
                             werkstoff.getStats()
@@ -142,7 +136,8 @@ public class SimpleMetalLoader implements IWerkstoffRunnable {
 
             GTValues.RA.stdBuilder()
                 .itemInputs(werkstoff.get(ingot))
-                .itemOutputs(werkstoff.get(stick), werkstoff.get(dustSmall, 2))
+                .itemOutputs(werkstoff.get(stick), werkstoff.get(dust, 1))
+                .outputChances(10000, 5000)
                 .duration(
                     (int) Math.max(
                         werkstoff.getStats()

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingGem.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingGem.java
@@ -369,7 +369,7 @@ public class ProcessingGem implements gregtech.api.interfaces.IOreRecipeRegistra
                             .itemOutputs(
                                 GTOreDictUnificator.get(OrePrefixes.bolt, aMaterial, 2L),
                                 GTOreDictUnificator.get(OrePrefixes.dust, aMaterial, 1L))
-                            .outputChances(10000, 5000)
+                            .outputChances(10000, 2500)
                             .duration(((int) Math.max(aMaterialMass, 1L)) * TICKS)
                             .eut(12)
                             .addTo(latheRecipes);

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingGem.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingGem.java
@@ -180,12 +180,13 @@ public class ProcessingGem implements gregtech.api.interfaces.IOreRecipeRegistra
                     if (aMaterial.getProcessingMaterialTierEU() < TierEU.IV) {
                         // Lathe recipes
                         if (GTOreDictUnificator.get(OrePrefixes.stick, aMaterial, 1L) != null
-                            && GTOreDictUnificator.get(OrePrefixes.dustSmall, aMaterial, 1L) != null) {
+                            && GTOreDictUnificator.get(OrePrefixes.dust, aMaterial, 1L) != null) {
                             GTValues.RA.stdBuilder()
                                 .itemInputs(GTUtility.copyAmount(1, aStack))
                                 .itemOutputs(
                                     GTOreDictUnificator.get(OrePrefixes.stick, aMaterial, 1L),
-                                    GTOreDictUnificator.get(OrePrefixes.dustSmall, aMaterial, 2L))
+                                    GTOreDictUnificator.get(OrePrefixes.dust, aMaterial, 1L))
+                                .outputChances(10000, 5000)
                                 .duration(((int) Math.max(aMaterialMass, 1L)) * TICKS)
                                 .eut(calculateRecipeEU(aMaterial, 16))
                                 .addTo(latheRecipes);
@@ -260,12 +261,13 @@ public class ProcessingGem implements gregtech.api.interfaces.IOreRecipeRegistra
                 if (!aNoWorking) {
                     // Lathe recipes
                     if (GTOreDictUnificator.get(OrePrefixes.bolt, aMaterial, 1L) != null
-                        && GTOreDictUnificator.get(OrePrefixes.dustTiny, aMaterial, 1L) != null) {
+                        && GTOreDictUnificator.get(OrePrefixes.dust, aMaterial, 1L) != null) {
                         GTValues.RA.stdBuilder()
                             .itemInputs(GTUtility.copyAmount(1, aStack))
                             .itemOutputs(
                                 GTOreDictUnificator.get(OrePrefixes.bolt, aMaterial, 1L),
-                                GTOreDictUnificator.get(OrePrefixes.dustTiny, aMaterial, 1L))
+                                GTOreDictUnificator.get(OrePrefixes.dust, aMaterial, 1L))
+                            .outputChances(10000, 1111)
                             .duration(((int) Math.max(aMaterialMass, 1L)) * TICKS)
                             .eut(8)
                             .addTo(latheRecipes);
@@ -361,12 +363,13 @@ public class ProcessingGem implements gregtech.api.interfaces.IOreRecipeRegistra
                 if (!aNoWorking) {
                     // Lathe recipes
                     if (GTOreDictUnificator.get(OrePrefixes.bolt, aMaterial, 1L) != null
-                        && GTOreDictUnificator.get(OrePrefixes.dustSmall, aMaterial, 1L) != null) {
+                        && GTOreDictUnificator.get(OrePrefixes.dust, aMaterial, 1L) != null) {
                         GTValues.RA.stdBuilder()
                             .itemInputs(GTUtility.copyAmount(1, aStack))
                             .itemOutputs(
                                 GTOreDictUnificator.get(OrePrefixes.bolt, aMaterial, 2L),
-                                GTOreDictUnificator.get(OrePrefixes.dustSmall, aMaterial, 1L))
+                                GTOreDictUnificator.get(OrePrefixes.dust, aMaterial, 1L))
+                            .outputChances(10000, 5000)
                             .duration(((int) Math.max(aMaterialMass, 1L)) * TICKS)
                             .eut(12)
                             .addTo(latheRecipes);

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingLens.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingLens.java
@@ -42,7 +42,8 @@ public class ProcessingLens implements gregtech.api.interfaces.IOreRecipeRegistr
                     .itemInputs(GTOreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L))
                     .itemOutputs(
                         GTOreDictUnificator.get(OrePrefixes.lens, aMaterial, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.dustSmall, aMaterial, 1L))
+                        GTOreDictUnificator.get(OrePrefixes.dust, aMaterial, 1L))
+                    .outputChances(10000, 2500)
                     .duration(1 * MINUTES)
                     .eut(TierEU.RECIPE_LV)
                     .addTo(latheRecipes);
@@ -68,12 +69,13 @@ public class ProcessingLens implements gregtech.api.interfaces.IOreRecipeRegistr
                 if (GTOreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L) != null) {
                     GTRecipeBuilder recipeBuilder = GTValues.RA.stdBuilder();
                     recipeBuilder.itemInputs(GTOreDictUnificator.get(OrePrefixes.plate, aMaterial, 1L));
-                    if (GTOreDictUnificator.get(OrePrefixes.dustSmall, aMaterial, 1L) == null) {
+                    if (GTOreDictUnificator.get(OrePrefixes.dust, aMaterial, 1L) == null) {
                         recipeBuilder.itemOutputs(GTOreDictUnificator.get(OrePrefixes.lens, aMaterial, 1L));
                     } else {
                         recipeBuilder.itemOutputs(
                             GTOreDictUnificator.get(OrePrefixes.lens, aMaterial, 1L),
-                            GTOreDictUnificator.get(OrePrefixes.dustSmall, aMaterial, 1L));
+                            GTOreDictUnificator.get(OrePrefixes.dust, aMaterial, 1L));
+                        recipeBuilder.outputChances(10000, 2500);
                     }
                     recipeBuilder.duration(1 * MINUTES)
                         .eut(TierEU.RECIPE_MV)

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingSaplings.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingSaplings.java
@@ -42,7 +42,8 @@ public class ProcessingSaplings implements gregtech.api.interfaces.IOreRecipeReg
             .itemInputs(GTUtility.copyAmount(1, aStack))
             .itemOutputs(
                 GTOreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1L),
-                GTOreDictUnificator.get(OrePrefixes.dustTiny, Materials.Wood, 1L))
+                GTOreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 1L))
+            .outputChances(10000, 1111)
             .duration(16 * TICKS)
             .eut(8)
             .addTo(latheRecipes);

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingStick.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingStick.java
@@ -45,14 +45,15 @@ public class ProcessingStick implements gregtech.api.interfaces.IOreRecipeRegist
 
             if ((aMaterial.contains(SubTag.CRYSTAL) ? GTOreDictUnificator.get(OrePrefixes.gem, aMaterial, 1L)
                 : GTOreDictUnificator.get(OrePrefixes.ingot, aMaterial, 1L)) != null
-                && GTOreDictUnificator.get(OrePrefixes.dustSmall, aMaterial.mMacerateInto, 1L) != null) {
+                && GTOreDictUnificator.get(OrePrefixes.dust, aMaterial.mMacerateInto, 1L) != null) {
                 GTValues.RA.stdBuilder()
                     .itemInputs(
                         aMaterial.contains(SubTag.CRYSTAL) ? GTOreDictUnificator.get(OrePrefixes.gem, aMaterial, 1L)
                             : GTOreDictUnificator.get(OrePrefixes.ingot, aMaterial, 1L))
                     .itemOutputs(
                         GTOreDictUnificator.get(OrePrefixes.stick, aMaterial, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.dustSmall, aMaterial.mMacerateInto, 2L))
+                        GTOreDictUnificator.get(OrePrefixes.dust, aMaterial.mMacerateInto, 1L))
+                    .outputChances(10000, 5000)
                     .duration(((int) Math.max(aMaterial.getMass() * 5L, 1L)) * TICKS)
                     .eut(calculateRecipeEU(aMaterial, 16))
                     .addTo(latheRecipes);

--- a/src/main/java/gregtech/loaders/postload/recipes/LatheRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/LatheRecipes.java
@@ -24,7 +24,8 @@ public class LatheRecipes implements Runnable {
             .itemInputs(new ItemStack(Blocks.wooden_slab, 1, GTValues.W))
             .itemOutputs(
                 new ItemStack(Items.bowl, 1),
-                GTOreDictUnificator.get(OrePrefixes.dustSmall, Materials.Wood, 1))
+                GTOreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 1))
+            .outputChances(10000, 2500)
             .duration(2 * SECONDS + 10 * TICKS)
             .eut(8)
             .addTo(latheRecipes);
@@ -34,6 +35,7 @@ public class LatheRecipes implements Runnable {
             .itemOutputs(
                 new ItemStack(Items.bowl, 1),
                 GTOreDictUnificator.get(OrePrefixes.dustSmall, Materials.Wood, 1))
+            .outputChances(10000, 2500)
             .duration(2 * SECONDS + 10 * TICKS)
             .eut(8)
             .addTo(latheRecipes);

--- a/src/main/java/gregtech/loaders/postload/recipes/LatheRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/LatheRecipes.java
@@ -22,9 +22,7 @@ public class LatheRecipes implements Runnable {
     public void run() {
         GTValues.RA.stdBuilder()
             .itemInputs(new ItemStack(Blocks.wooden_slab, 1, GTValues.W))
-            .itemOutputs(
-                new ItemStack(Items.bowl, 1),
-                GTOreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 1))
+            .itemOutputs(new ItemStack(Items.bowl, 1), GTOreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 1))
             .outputChances(10000, 2500)
             .duration(2 * SECONDS + 10 * TICKS)
             .eut(8)

--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/RecipeGenMetalRecipe.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/RecipeGenMetalRecipe.java
@@ -54,7 +54,8 @@ public class RecipeGenMetalRecipe extends RecipeGenBase {
             && ItemUtils.checkForInvalidItems(material.getRod(1))) {
             GTValues.RA.stdBuilder()
                 .itemInputs(material.getIngot(1))
-                .itemOutputs(material.getRod(1), material.getSmallDust(2))
+                .itemOutputs(material.getRod(1), material.getDust(1))
+                .outputChances(10000, 5000)
                 .duration(Math.max(material.getMass() / 8L, 1L))
                 .eut(material.vVoltageMultiplier)
                 .addTo(latheRecipes);


### PR DESCRIPTION
This PR aims to remove Tiny/Small Dusts from all Lathe Recipes. This is to hopefully help with the removal of Tiny and Small Dusts from Recipes as Stated in this [areas-of-interest](https://discord.com/channels/181078474394566657/1329023562979213353).

Here are some example recipes.
Before
<img width="225" alt="Lathe Before" src="https://github.com/user-attachments/assets/3355e94e-96db-426b-8d7b-461157a6a32f" />

After
<img width="225" alt="Lathe After" src="https://github.com/user-attachments/assets/5767739b-66f4-446b-82bf-e54d3d4473c2" />

