### PR TITLE
Nanochip assembly complex nei & waila changes

### DIFF
--- a/src/main/java/gregtech/api/recipe/check/CheckRecipeResultRegistry.java
+++ b/src/main/java/gregtech/api/recipe/check/CheckRecipeResultRegistry.java
@@ -117,6 +117,13 @@ public final class CheckRecipeResultRegistry {
     public static final CheckRecipeResult NO_SEE_SKY = SimpleCheckRecipeResult.ofFailure("no_see_sky");
 
     /**
+     * Etching Array Missing Energy and/or Wrong Particle
+     */
+    public static final CheckRecipeResult WRONG_PARTICLE = SimpleCheckRecipeResult.ofFailure("gtnhlanth.wrongparticle");
+
+    public static final CheckRecipeResult LOW_ENERGY = SimpleCheckRecipeResult.ofFailure("gtnhlanth.toolowenergy");
+
+    /**
      * Machine is waiting for the main controller to start the cycle.
      */
     @Nonnull

--- a/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/MTENanochipAssemblyComplex.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/MTENanochipAssemblyComplex.java
@@ -16,6 +16,7 @@ import static gregtech.api.util.GTUtility.filterValidMTEs;
 import static gregtech.common.tileentities.machines.multi.nanochip.util.AssemblyComplexStructureString.MAIN_OFFSET_X;
 import static gregtech.common.tileentities.machines.multi.nanochip.util.AssemblyComplexStructureString.MAIN_OFFSET_Y;
 import static gregtech.common.tileentities.machines.multi.nanochip.util.AssemblyComplexStructureString.MAIN_OFFSET_Z;
+import static gtnhlanth.util.DescTextLocalization.addDotText;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -198,7 +199,7 @@ public class MTENanochipAssemblyComplex extends MTEExtendedPowerMultiBlockBase<M
 
     @Override
     protected MultiblockTooltipBuilder createTooltip() {
-        return new MultiblockTooltipBuilder()
+        return new MultiblockTooltipBuilder().addMachineType("NAC, Nanochip-Assembly-Complex")
             .addInfo("Creates Circuits out of Circuit Components (" + TOOLTIP_CC + "s) at lightning speed")
             .addInfo("Convert items to " + TOOLTIP_CC + "s in the control room")
             .addInfo("Convert finished Circuit " + TOOLTIP_CC + "s back to items in the control room")
@@ -213,6 +214,7 @@ public class MTENanochipAssemblyComplex extends MTEExtendedPowerMultiBlockBase<M
             .addStructureInfo("Any control room base casing - Input bus")
             .addStructureInfo("Any control room base casing - Vacuum Conveyor Output")
             .addStructureInfo("Any control room base casing - Output bus")
+            .addOtherStructurePart("Energy Hatch Above Controller, Center of 3x3", addDotText(1))
             .toolTipFinisher("GregTech");
     }
 

--- a/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/MTENanochipAssemblyComplex.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/MTENanochipAssemblyComplex.java
@@ -115,7 +115,8 @@ public class MTENanochipAssemblyComplex extends MTEExtendedPowerMultiBlockBase<M
                 .atLeast(Energy, ExoticEnergy)
                 .casingIndex(CASING_INDEX_BASE)
                 .dot(1)
-                .buildAndChain(GregTechAPI.sBlockCasings8, 10))
+                .build())
+
         // Vacuum conveyor hatches that the main controller cares about go in specific slots
         .addElement(
             'H',

--- a/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/modules/AssemblyMatrix.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/modules/AssemblyMatrix.java
@@ -10,18 +10,15 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import gregtech.api.enums.GTValues;
-import mcp.mobius.waila.api.IWailaConfigHandler;
-import mcp.mobius.waila.api.IWailaDataAccessor;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
-
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
+
 import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.NotNull;
 
@@ -30,6 +27,7 @@ import com.gtnewhorizon.structurelib.structure.ISurvivalBuildEnvironment;
 
 import goodgenerator.loader.Loaders;
 import gregtech.api.GregTechAPI;
+import gregtech.api.enums.GTValues;
 import gregtech.api.enums.Materials;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
@@ -43,6 +41,8 @@ import gregtech.api.util.MultiblockTooltipBuilder;
 import gregtech.common.tileentities.machines.multi.nanochip.MTENanochipAssemblyModuleBase;
 import gregtech.common.tileentities.machines.multi.nanochip.util.CircuitComponent;
 import gregtech.common.tileentities.machines.multi.nanochip.util.ModuleStructureDefinition;
+import mcp.mobius.waila.api.IWailaConfigHandler;
+import mcp.mobius.waila.api.IWailaDataAccessor;
 
 public class AssemblyMatrix extends MTENanochipAssemblyModuleBase<AssemblyMatrix> {
 
@@ -142,7 +142,8 @@ public class AssemblyMatrix extends MTENanochipAssemblyModuleBase<AssemblyMatrix
 
     @Override
     protected MultiblockTooltipBuilder createTooltip() {
-        return new MultiblockTooltipBuilder().addInfo(NAC_MODULE)
+        return new MultiblockTooltipBuilder().addMachineType("NAC Module")
+            .addInfo(NAC_MODULE)
             .addInfo("Assembles your Circuit Part " + TOOLTIP_CC + "s into Circuit " + TOOLTIP_CC + "s")
             .addInfo("Outputs into the VCO with the color of the first input in NEI")
             .addStructureInfo("Any base casing - Vacuum Conveyor Input")
@@ -165,14 +166,14 @@ public class AssemblyMatrix extends MTENanochipAssemblyModuleBase<AssemblyMatrix
 
     @Override
     public void getWailaNBTData(EntityPlayerMP player, TileEntity tile, NBTTagCompound tag, World world, int x, int y,
-                                int z) {
+        int z) {
         super.getWailaNBTData(player, tile, tag, world, x, y, z);
         tag.setInteger("tier", machineTier + 1);
     }
 
     @Override
     public void getWailaBody(ItemStack itemStack, List<String> currentTip, IWailaDataAccessor accessor,
-                             IWailaConfigHandler config) {
+        IWailaConfigHandler config) {
         super.getWailaBody(itemStack, currentTip, accessor, config);
         final NBTTagCompound tag = accessor.getNBTData();
         currentTip.add(
@@ -189,7 +190,7 @@ public class AssemblyMatrix extends MTENanochipAssemblyModuleBase<AssemblyMatrix
         System.arraycopy(origin, 0, ret, 0, origin.length);
         ret[origin.length] = StatCollector.translateToLocal("scanner.info.CASS.tier")
             + (machineTier >= 0 ? GTValues.VN[machineTier + 1]
-            : StatCollector.translateToLocal("scanner.info.CASS.tier.none"));
+                : StatCollector.translateToLocal("scanner.info.CASS.tier.none"));
         return ret;
     }
 

--- a/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/modules/AssemblyMatrix.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/modules/AssemblyMatrix.java
@@ -6,12 +6,21 @@ import static gregtech.api.util.GTStructureUtility.ofFrame;
 import static gregtech.common.tileentities.machines.multi.nanochip.MTENanochipAssemblyComplex.NAC_MODULE;
 import static gregtech.common.tileentities.machines.multi.nanochip.MTENanochipAssemblyComplex.TOOLTIP_CC;
 
+import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import mcp.mobius.waila.api.IWailaConfigHandler;
+import mcp.mobius.waila.api.IWailaDataAccessor;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumChatFormatting;
+import net.minecraft.util.StatCollector;
+import net.minecraft.world.World;
 import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.NotNull;
 
@@ -150,6 +159,37 @@ public class AssemblyMatrix extends MTENanochipAssemblyModuleBase<AssemblyMatrix
         int machineTier = getCasingTier();
         if (machineTier >= recipeTier) return CheckRecipeResultRegistry.SUCCESSFUL;
         return CheckRecipeResultRegistry.insufficientMachineTier(recipeTier);
+    }
+
+    @Override
+    public void getWailaNBTData(EntityPlayerMP player, TileEntity tile, NBTTagCompound tag, World world, int x, int y,
+                                int z) {
+        super.getWailaNBTData(player, tile, tag, world, x, y, z);
+        tag.setInteger("tier", machineTier);
+    }
+
+    @Override
+    public void getWailaBody(ItemStack itemStack, List<String> currentTip, IWailaDataAccessor accessor,
+                             IWailaConfigHandler config) {
+        super.getWailaBody(itemStack, currentTip, accessor, config);
+        final NBTTagCompound tag = accessor.getNBTData();
+        currentTip.add(
+            StatCollector.translateToLocal("GT5U.machines.tier") + ": "
+                + EnumChatFormatting.WHITE
+                + tag.getInteger("tier")
+                + EnumChatFormatting.RESET);
+    }
+
+    @Override
+    public String[] getInfoData() {
+
+        return new String[]{
+                StatCollector.translateToLocal("GT5U.machines.tier")
+                + ": "
+                + EnumChatFormatting.WHITE
+                + machineTier
+                + EnumChatFormatting.RESET,
+    };
     }
 
     public static void registerLocalName(ItemStack stack, CircuitComponent component) {

--- a/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/modules/BoardProcessor.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/modules/BoardProcessor.java
@@ -99,7 +99,8 @@ public class BoardProcessor extends MTENanochipAssemblyModuleBase<BoardProcessor
 
     @Override
     protected MultiblockTooltipBuilder createTooltip() {
-        return new MultiblockTooltipBuilder().addInfo(NAC_MODULE)
+        return new MultiblockTooltipBuilder().addMachineType("NAC Module")
+            .addInfo(NAC_MODULE)
             .addInfo("Processes your Board " + TOOLTIP_CC + "s")
             .addInfo("Outputs into the VCO with the same color as the input VCI")
             .addStructureInfo("Any base casing - Vacuum Conveyor Input")

--- a/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/modules/CuttingChamber.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/modules/CuttingChamber.java
@@ -104,7 +104,8 @@ public class CuttingChamber extends MTENanochipAssemblyModuleBase<CuttingChamber
 
     @Override
     protected MultiblockTooltipBuilder createTooltip() {
-        return new MultiblockTooltipBuilder().addInfo(NAC_MODULE)
+        return new MultiblockTooltipBuilder().addMachineType("NAC Module")
+            .addInfo(NAC_MODULE)
             .addInfo("Cuts your Wafer " + TOOLTIP_CC + "s")
             .addInfo("Outputs into the VCO with the same color as the input VCI")
             .addStructureInfo("Any base casing - Vacuum Conveyor Input")

--- a/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/modules/EtchingArray.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/modules/EtchingArray.java
@@ -52,7 +52,7 @@ public class EtchingArray extends MTENanochipAssemblyModuleBase<EtchingArray> {
     private final ArrayList<MTEHatchInputBeamline> mInputBeamline = new ArrayList<>();
 
     float inputEnergy = 1;
-    int requiredEnergy = 1234;
+    int requiredEnergy = 1;
     int requiredParticle = 0;
 
     public static final IStructureDefinition<EtchingArray> STRUCTURE_DEFINITION = ModuleStructureDefinition

--- a/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/modules/EtchingArray.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/modules/EtchingArray.java
@@ -53,6 +53,7 @@ public class EtchingArray extends MTENanochipAssemblyModuleBase<EtchingArray> {
 
     float inputEnergy = 1;
     int requiredEnergy = 1234;
+    int requiredParticle = 0;
 
     public static final IStructureDefinition<EtchingArray> STRUCTURE_DEFINITION = ModuleStructureDefinition
         .<EtchingArray>builder()
@@ -112,7 +113,7 @@ public class EtchingArray extends MTENanochipAssemblyModuleBase<EtchingArray> {
         float inputEnergy = inputInfo.getEnergy();
         Particle inputParticle = Particle.getParticleFromId(inputInfo.getParticleId());
 
-        if (inputParticle != Particle.getParticleFromId(0)) {
+        if (inputParticle != Particle.getParticleFromId(requiredParticle)) {
             return CheckRecipeResultRegistry.WRONG_PARTICLE;
         }
 

--- a/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/modules/EtchingArray.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/modules/EtchingArray.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 
 import javax.annotation.Nullable;
 
+import gregtech.common.blocks.BlockCasings8;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.StatCollector;
 
@@ -28,7 +29,6 @@ import gregtech.api.recipe.RecipeMaps;
 import gregtech.api.recipe.check.CheckRecipeResult;
 import gregtech.api.recipe.check.CheckRecipeResultRegistry;
 import gregtech.api.util.MultiblockTooltipBuilder;
-import gregtech.common.blocks.BlockCasings4;
 import gregtech.common.tileentities.machines.multi.nanochip.MTENanochipAssemblyModuleBase;
 import gregtech.common.tileentities.machines.multi.nanochip.util.CircuitComponent;
 import gregtech.common.tileentities.machines.multi.nanochip.util.ModuleStructureDefinition;
@@ -73,7 +73,7 @@ public class EtchingArray extends MTENanochipAssemblyModuleBase<EtchingArray> {
         .addElement(
             'H',
             buildHatchAdder(EtchingArray.class).hatchClass(MTEHatchInputBeamline.class)
-                .casingIndex(((BlockCasings4) GregTechAPI.sBlockCasings4).getTextureIndex(0))
+                .casingIndex(((BlockCasings8) GregTechAPI.sBlockCasings8).getTextureIndex(10))
                 .dot(1)
                 .adder(EtchingArray::addBeamLineInputHatch)
                 .build())

--- a/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/modules/EtchingArray.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/modules/EtchingArray.java
@@ -12,8 +12,6 @@ import java.util.ArrayList;
 import javax.annotation.Nullable;
 
 import gregtech.api.util.GTRecipe;
-import gregtech.api.util.GTUtility;
-import gregtech.api.util.shutdown.SimpleShutDownReason;
 import net.minecraft.item.ItemStack;
 
 import org.jetbrains.annotations.NotNull;
@@ -54,6 +52,7 @@ public class EtchingArray extends MTENanochipAssemblyModuleBase<EtchingArray> {
     private final ArrayList<MTEHatchInputBeamline> mInputBeamline = new ArrayList<>();
 
     float inputEnergy = 1;
+    int requiredEnergy = 1234;
 
     public static final IStructureDefinition<EtchingArray> STRUCTURE_DEFINITION = ModuleStructureDefinition
         .<EtchingArray>builder()
@@ -117,7 +116,7 @@ public class EtchingArray extends MTENanochipAssemblyModuleBase<EtchingArray> {
             return CheckRecipeResultRegistry.WRONG_PARTICLE;
         }
 
-        if (inputEnergy <= 1234) {
+        if (inputEnergy <= requiredEnergy) {
             return CheckRecipeResultRegistry.LOW_ENERGY;
         }
 

--- a/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/modules/EtchingArray.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/modules/EtchingArray.java
@@ -5,14 +5,13 @@ import static gregtech.api.util.GTStructureUtility.buildHatchAdder;
 import static gregtech.api.util.GTStructureUtility.ofFrame;
 import static gregtech.common.tileentities.machines.multi.nanochip.MTENanochipAssemblyComplex.NAC_MODULE;
 import static gregtech.common.tileentities.machines.multi.nanochip.MTENanochipAssemblyComplex.TOOLTIP_CC;
+import static gtnhlanth.util.DescTextLocalization.addDotText;
 
 import java.util.ArrayList;
 
 import javax.annotation.Nullable;
 
-import gregtech.common.blocks.BlockCasings8;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.StatCollector;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -29,6 +28,7 @@ import gregtech.api.recipe.RecipeMaps;
 import gregtech.api.recipe.check.CheckRecipeResult;
 import gregtech.api.recipe.check.CheckRecipeResultRegistry;
 import gregtech.api.util.MultiblockTooltipBuilder;
+import gregtech.common.blocks.BlockCasings8;
 import gregtech.common.tileentities.machines.multi.nanochip.MTENanochipAssemblyModuleBase;
 import gregtech.common.tileentities.machines.multi.nanochip.util.CircuitComponent;
 import gregtech.common.tileentities.machines.multi.nanochip.util.ModuleStructureDefinition;
@@ -167,12 +167,13 @@ public class EtchingArray extends MTENanochipAssemblyModuleBase<EtchingArray> {
 
     @Override
     protected MultiblockTooltipBuilder createTooltip() {
-        return new MultiblockTooltipBuilder().addInfo(NAC_MODULE)
+        return new MultiblockTooltipBuilder().addMachineType("NAC Module")
+            .addInfo(NAC_MODULE)
             .addInfo("Etches your Chip " + TOOLTIP_CC + "s")
             .addInfo("Outputs into the VCO with the same color as the input VCI")
             .addStructureInfo("Any base casing - Vacuum Conveyor Input")
             .addStructureInfo("Any base casing - Vacuum Conveyor Output")
-            .addOtherStructurePart(StatCollector.translateToLocal("GT5U.tooltip.structure.laser_source_hatch"), "x1", 1)
+            .addOtherStructurePart("Beamline Input Hatch", addDotText(1))
             .toolTipFinisher("GregTech");
     }
 

--- a/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/modules/EtchingArray.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/modules/EtchingArray.java
@@ -11,6 +11,9 @@ import java.util.ArrayList;
 
 import javax.annotation.Nullable;
 
+import gregtech.api.util.GTRecipe;
+import gregtech.api.util.GTUtility;
+import gregtech.api.util.shutdown.SimpleShutDownReason;
 import net.minecraft.item.ItemStack;
 
 import org.jetbrains.annotations.NotNull;
@@ -101,9 +104,8 @@ public class EtchingArray extends MTENanochipAssemblyModuleBase<EtchingArray> {
         return null;
     }
 
-    @NotNull
     @Override
-    public CheckRecipeResult checkProcessing() {
+    public @NotNull CheckRecipeResult validateRecipe(@NotNull GTRecipe recipe) {
 
         BeamInformation inputInfo = this.getInputInformation();
         if (inputInfo == null) return CheckRecipeResultRegistry.NO_RECIPE;
@@ -111,8 +113,13 @@ public class EtchingArray extends MTENanochipAssemblyModuleBase<EtchingArray> {
         float inputEnergy = inputInfo.getEnergy();
         Particle inputParticle = Particle.getParticleFromId(inputInfo.getParticleId());
 
-        if (inputEnergy <= 1234) return CheckRecipeResultRegistry.NO_RECIPE;
-        if (inputParticle != Particle.getParticleFromId(0)) return CheckRecipeResultRegistry.NO_RECIPE;
+        if (inputParticle != Particle.getParticleFromId(0)) {
+            return CheckRecipeResultRegistry.WRONG_PARTICLE;
+        }
+
+        if (inputEnergy <= 1234) {
+            return CheckRecipeResultRegistry.LOW_ENERGY;
+        }
 
         return CheckRecipeResultRegistry.SUCCESSFUL;
 

--- a/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/modules/OpticalOrganizer.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/modules/OpticalOrganizer.java
@@ -100,7 +100,8 @@ public class OpticalOrganizer extends MTENanochipAssemblyModuleBase<OpticalOrgan
 
     @Override
     protected MultiblockTooltipBuilder createTooltip() {
-        return new MultiblockTooltipBuilder().addInfo(NAC_MODULE)
+        return new MultiblockTooltipBuilder().addMachineType("NAC Module")
+            .addInfo(NAC_MODULE)
             .addInfo("Optimizes your Optical " + TOOLTIP_CC + "s")
             .addInfo("Outputs into the VCO with the same color as the input VCI")
             .addStructureInfo("Any base casing - Vacuum Conveyor Input")

--- a/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/modules/SMDProcessor.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/modules/SMDProcessor.java
@@ -89,7 +89,8 @@ public class SMDProcessor extends MTENanochipAssemblyModuleBase<SMDProcessor> {
 
     @Override
     protected MultiblockTooltipBuilder createTooltip() {
-        return new MultiblockTooltipBuilder().addInfo(NAC_MODULE)
+        return new MultiblockTooltipBuilder().addMachineType("NAC Module")
+            .addInfo(NAC_MODULE)
             .addInfo("Processes your SMD " + TOOLTIP_CC + "s")
             .addInfo("Outputs into the VCO with the same color as the input VCI")
             .addStructureInfo("Any base casing - Vacuum Conveyor Input")

--- a/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/modules/Splitter.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/modules/Splitter.java
@@ -171,7 +171,7 @@ public class Splitter extends MTENanochipAssemblyModuleBase<Splitter> {
     @Override
     protected MultiblockTooltipBuilder createTooltip() {
         final MultiblockTooltipBuilder tt = new MultiblockTooltipBuilder();
-        tt.addMachineType("Splitter")
+        tt.addMachineType("Splitter, NAC Module")
             .addInfo(NAC_MODULE)
             .addInfo("Splits inputs of the same " + rainbowColor(false) + " evenly into their respective outputs")
             .addInfo("You can add Rules to override what " + rainbowColor(false) + " inputs will go to")

--- a/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/modules/SuperconductorSplitter.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/modules/SuperconductorSplitter.java
@@ -163,7 +163,8 @@ public class SuperconductorSplitter extends MTENanochipAssemblyModuleBase<Superc
 
     @Override
     protected MultiblockTooltipBuilder createTooltip() {
-        return new MultiblockTooltipBuilder().addInfo(NAC_MODULE)
+        return new MultiblockTooltipBuilder().addMachineType("NAC Module")
+            .addInfo(NAC_MODULE)
             .addInfo("Splits your Superconductor " + TOOLTIP_CC + "s")
             .addInfo(
                 "Requires " + EnumChatFormatting.BLUE + "1000L/s Super Coolant" + EnumChatFormatting.GRAY + " to run")

--- a/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/modules/WireTracer.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/modules/WireTracer.java
@@ -94,7 +94,8 @@ public class WireTracer extends MTENanochipAssemblyModuleBase<WireTracer> {
 
     @Override
     protected MultiblockTooltipBuilder createTooltip() {
-        return new MultiblockTooltipBuilder().addInfo(NAC_MODULE)
+        return new MultiblockTooltipBuilder().addMachineType("NAC Module")
+            .addInfo(NAC_MODULE)
             .addInfo("Traces your Wire " + TOOLTIP_CC + "s")
             .addInfo("Outputs into the VCO with the same color as the input VCI")
             .addStructureInfo("Any base casing - Vacuum Conveyor Input")

--- a/src/main/resources/assets/gtnhlanth/lang/en_US.lang
+++ b/src/main/resources/assets/gtnhlanth/lang/en_US.lang
@@ -15,6 +15,8 @@ GT5U.gui.text.gtnhlanth.inscoolant=Insufficient coolant in machine!
 GT5U.gui.text.gtnhlanth.noaccel=Particle type can't be accelerated!
 GT5U.gui.text.gtnhlanth.low_input_eut=Input EU/t too low to produce  photons!
 GT5U.gui.text.gtnhlanth.scerror=Math error, broken recipe?
+GT5U.gui.text.gtnhlanth.wrongparticle=Incorrect Particle!
+GT5U.gui.text.gtnhlanth.toolowenergy=Below Required Energy!
 
 # NEI
 value.disstank=Ratio: %s:1


### PR DESCRIPTION
Adds Tier in Waila and scanner for Assembler Matrix
![image](https://github.com/user-attachments/assets/a0dc3823-bca4-4d9b-85a6-fb63f15fc4ce)
![image](https://github.com/user-attachments/assets/478fec35-ec83-4a43-9a54-a12f83dd24b7)

Main controller energy hatch is now only energy hatch allowed

Added Machine Types for all the NAC-Related 
![image](https://github.com/user-attachments/assets/a98fa2bd-ca42-4b43-b86e-b93e54a932eb)
![image](https://github.com/user-attachments/assets/36a2ee35-db85-43ca-bfc0-5220ade98aab)

Also explained where the energy hatch is located on main controller in tooltip
![image](https://github.com/user-attachments/assets/99a99322-67f2-40a1-a83a-80afc010ef6a)

Added Custom Error Messages for Low Energy and Incorrect Particle
![image](https://github.com/user-attachments/assets/6ac84149-f7e3-49f8-84d8-06f10fc7b82d)
![image](https://github.com/user-attachments/assets/c6a55dea-5752-46d2-8af0-1620190f4b67)




