### PR TITLE
Make tierskipping an actual mechanic

### DIFF
--- a/src/main/java/bartworks/common/tileentities/multis/mega/MegaMultiBlockBase.java
+++ b/src/main/java/bartworks/common/tileentities/multis/mega/MegaMultiBlockBase.java
@@ -134,6 +134,7 @@ public abstract class MegaMultiBlockBase<T extends MegaMultiBlockBase<T>> extend
     protected void setProcessingLogicPower(ProcessingLogic logic) {
         logic.setAvailableVoltage(this.getMaxInputEu());
         logic.setAvailableAmperage(1);
+        logic.setUnlimitedTierSkips();
     }
 
     protected static class StructureElementAirNoHint<T> implements IStructureElement<T> {

--- a/src/main/java/goodgenerator/blocks/tileEntity/MTEComponentAssemblyLine.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/MTEComponentAssemblyLine.java
@@ -316,6 +316,7 @@ public class MTEComponentAssemblyLine extends MTEExtendedPowerMultiBlockBase<MTE
     protected void setProcessingLogicPower(ProcessingLogic logic) {
         logic.setAvailableVoltage(getMaxInputEu());
         logic.setAvailableAmperage(1);
+        logic.setUnlimitedTierSkips();
     }
 
     @Override

--- a/src/main/java/goodgenerator/blocks/tileEntity/MTEFuelRefineFactory.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/MTEFuelRefineFactory.java
@@ -226,6 +226,7 @@ public class MTEFuelRefineFactory extends MTETooltipMultiBlockBaseEM implements 
     protected void setProcessingLogicPower(ProcessingLogic logic) {
         logic.setAvailableVoltage(getMaxInputEu());
         logic.setAvailableAmperage(1);
+        logic.setUnlimitedTierSkips();
     }
 
     @Override

--- a/src/main/java/goodgenerator/blocks/tileEntity/MTENeutronActivator.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/MTENeutronActivator.java
@@ -144,6 +144,7 @@ public class MTENeutronActivator extends MTETooltipMultiBlockBaseEM implements I
         // we have infinite power
         logic.setAvailableVoltage(Long.MAX_VALUE);
         logic.setAvailableAmperage(1);
+        logic.setUnlimitedTierSkips();
     }
 
     @Override

--- a/src/main/java/goodgenerator/blocks/tileEntity/MTEPreciseAssembler.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/MTEPreciseAssembler.java
@@ -287,6 +287,7 @@ public class MTEPreciseAssembler extends MTEExtendedPowerMultiBlockBase<MTEPreci
         logic.setAvailableVoltage(getMachineVoltageLimit());
         logic.setAvailableAmperage(useSingleAmp ? 1 : getMaxInputAmps());
         logic.setAmperageOC(true);
+        logic.setMaxTierSkips(1);
     }
 
     public long getMachineVoltageLimit() {

--- a/src/main/java/goodgenerator/blocks/tileEntity/base/MTELargeFusionComputer.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/base/MTELargeFusionComputer.java
@@ -465,6 +465,7 @@ public abstract class MTELargeFusionComputer extends MTETooltipMultiBlockBaseEM
     protected void setProcessingLogicPower(ProcessingLogic logic) {
         logic.setAvailableVoltage(GTValues.V[tier()]);
         logic.setAvailableAmperage(getSingleHatchPower() * 32 / GTValues.V[tier()]);
+        logic.setUnlimitedTierSkips();
     }
 
     public int getChunkX() {

--- a/src/main/java/gregtech/api/logic/ProcessingLogic.java
+++ b/src/main/java/gregtech/api/logic/ProcessingLogic.java
@@ -47,6 +47,7 @@ public class ProcessingLogic {
     protected double speedBoost = 1.0;
     protected long availableVoltage;
     protected long availableAmperage;
+    protected int maxTierSkips;
     protected boolean protectItems;
     protected boolean protectFluids;
     protected double overClockTimeReduction = 2.0;
@@ -231,6 +232,20 @@ public class ProcessingLogic {
      */
     public ProcessingLogic setAvailableAmperage(long amperage) {
         this.availableAmperage = amperage;
+        return this;
+    }
+
+    /**
+     * Sets the max amount of tier skips, which is how many voltage tiers above the input voltage
+     * a recipe is valid. For unlimited tier skips, use {@link #setUnlimitedTierSkips()}
+     */
+    public ProcessingLogic setMaxTierSkips(int tierSkips) {
+        this.maxTierSkips = tierSkips;
+        return this;
+    }
+
+    public ProcessingLogic setUnlimitedTierSkips() {
+        this.maxTierSkips = Integer.MAX_VALUE;
         return this;
     }
 
@@ -527,6 +542,7 @@ public class ProcessingLogic {
         return new OverclockCalculator().setRecipeEUt(recipe.mEUt)
             .setAmperage(availableAmperage)
             .setEUt(availableVoltage)
+            .setMaxTierSkips(maxTierSkips)
             .setDuration(recipe.mDuration)
             .setDurationModifier(speedBoost)
             .setEUtDiscount(euModifier)

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
@@ -1014,7 +1014,8 @@ public abstract class MTEMultiBlockBase extends MetaTileEntity implements IContr
     protected void setProcessingLogicPower(ProcessingLogic logic) {
         logic.setAvailableVoltage(getAverageInputVoltage());
         logic.setAvailableAmperage(getMaxInputAmps());
-        logic.setAmperageOC(mExoticEnergyHatches.size() > 0 || mEnergyHatches.size() != 1);
+        logic.setMaxTierSkips(1);
+        logic.setAmperageOC(!mExoticEnergyHatches.isEmpty() || mEnergyHatches.size() != 1);
     }
 
     protected boolean supportsCraftingMEBuffer() {

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
@@ -1015,8 +1015,8 @@ public abstract class MTEMultiBlockBase extends MetaTileEntity implements IContr
         boolean useSingleAmp = mEnergyHatches.size() == 1 && mExoticEnergyHatches.isEmpty();
         logic.setAvailableVoltage(getAverageInputVoltage());
         logic.setAvailableAmperage(useSingleAmp ? 1 : getMaxInputAmps());
-        logic.setMaxTierSkips(1);
         logic.setAmperageOC(true);
+        logic.setMaxTierSkips(1);
     }
 
     protected boolean supportsCraftingMEBuffer() {

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
@@ -1012,10 +1012,11 @@ public abstract class MTEMultiBlockBase extends MetaTileEntity implements IContr
      * Unlike {@link #createProcessingLogic}, this method is called every time checking for recipes.
      */
     protected void setProcessingLogicPower(ProcessingLogic logic) {
+        boolean useSingleAmp = mEnergyHatches.size() == 1 && mExoticEnergyHatches.isEmpty();
         logic.setAvailableVoltage(getAverageInputVoltage());
-        logic.setAvailableAmperage(getMaxInputAmps());
+        logic.setAvailableAmperage(useSingleAmp ? 1 : getMaxInputAmps());
         logic.setMaxTierSkips(1);
-        logic.setAmperageOC(!mExoticEnergyHatches.isEmpty() || mEnergyHatches.size() != 1);
+        logic.setAmperageOC(true);
     }
 
     protected boolean supportsCraftingMEBuffer() {

--- a/src/main/java/gregtech/api/util/OverclockCalculator.java
+++ b/src/main/java/gregtech/api/util/OverclockCalculator.java
@@ -19,6 +19,8 @@ public class OverclockCalculator {
     protected Supplier<Double> durationUnderOneTickSupplier;
     /** The parallel the machine has when trying to overclock */
     protected int parallel = 1;
+    /** The max amount of tiers above the machine voltage a recipe is valid */
+    protected int maxTierSkip = 1;
 
     // Modifiers
     /** Energy modifier that is applied at the start of calculating overclocks, like GT++ machines */
@@ -174,6 +176,19 @@ public class OverclockCalculator {
         return this;
     }
 
+    /** Sets the max tiers above the machine's voltage a valid recipe can be */
+    @Nonnull
+    public OverclockCalculator setMaxTierSkips(int aMaxTierSkips) {
+        this.maxTierSkip = aMaxTierSkips;
+        return this;
+    }
+
+    @Nonnull
+    public OverclockCalculator setUnlimitedTierSkips() {
+        this.maxTierSkip = Integer.MAX_VALUE;
+        return this;
+    }
+
     /**
      * Sets the heat discount during OC calculation if HeatOC is used. Default: 0.95 = 5% discount Used like a EU/t
      * Discount
@@ -284,6 +299,11 @@ public class OverclockCalculator {
             throw new IllegalStateException("Tried to get performed overclocks before calculating");
         }
         return overclocks;
+    }
+
+    public boolean getAllowedTierSkip() {
+        if (this.maxTierSkip == Integer.MAX_VALUE) return true;
+        return recipeEUt <= machineVoltage * Math.pow(4, maxTierSkip);
     }
 
     /** Call this when all values have been put it. */

--- a/src/main/java/gregtech/api/util/ParallelHelper.java
+++ b/src/main/java/gregtech/api/util/ParallelHelper.java
@@ -396,7 +396,7 @@ public class ParallelHelper {
         double heatDiscountMultiplier = calculator.calculateHeatDiscountMultiplier();
 
         final int tRecipeEUt = (int) Math.ceil(recipe.mEUt * eutModifier * heatDiscountMultiplier);
-        if (availableEUt < tRecipeEUt) {
+        if (availableEUt < tRecipeEUt || !calculator.getAllowedTierSkip()) {
             result = CheckRecipeResultRegistry.insufficientPower(tRecipeEUt);
             return;
         }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEFusionComputer.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEFusionComputer.java
@@ -351,6 +351,7 @@ public abstract class MTEFusionComputer extends MTEEnhancedMultiBlockBase<MTEFus
         logic.setAvailableVoltage(GTValues.V[tier()]);
         logic.setAvailableAmperage(1);
         logic.setAmperageOC(false);
+        logic.setUnlimitedTierSkips();
     }
 
     public boolean turnCasingActive(boolean status) {

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialBrewery.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialBrewery.java
@@ -185,12 +185,6 @@ public class MTEIndustrialBrewery extends MTEExtendedPowerMultiBlockBase<MTEIndu
     }
 
     @Override
-    protected void setProcessingLogicPower(ProcessingLogic logic) {
-        logic.setAvailableVoltage(GTUtility.roundUpVoltage(this.getMaxInputVoltage()));
-        logic.setAvailableAmperage(1L);
-    }
-
-    @Override
     protected ProcessingLogic createProcessingLogic() {
         return new ProcessingLogic().setSpeedBonus(1F / 1.5F)
             .setMaxParallelSupplier(this::getTrueParallel);

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialElectromagneticSeparator.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialElectromagneticSeparator.java
@@ -394,17 +394,6 @@ public class MTEIndustrialElectromagneticSeparator
         return true;
     }
 
-    @Override
-    protected void setProcessingLogicPower(ProcessingLogic logic) {
-        // This fix works for normal energy hatches, preventing over-paralleling with 1 energy hatch
-        // However, it does not work with multiamp.
-
-        if (mExoticEnergyHatches.isEmpty()) {
-            logic.setAvailableVoltage(GTUtility.roundUpVoltage(this.getMaxInputVoltage()));
-            logic.setAvailableAmperage(1L);
-        } else super.setProcessingLogicPower(logic);
-    }
-
     private void findMagnet() {
         magnetTier = null;
         if (mMagHatch != null) {

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialExtractor.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialExtractor.java
@@ -267,10 +267,4 @@ public class MTEIndustrialExtractor extends MTEExtendedPowerMultiBlockBase<MTEIn
     public boolean supportsSingleRecipeLocking() {
         return true;
     }
-
-    @Override
-    protected void setProcessingLogicPower(ProcessingLogic logic) {
-        logic.setAvailableVoltage(GTUtility.roundUpVoltage(this.getMaxInputVoltage()));
-        logic.setAvailableAmperage(1L);
-    }
 }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialLaserEngraver.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialLaserEngraver.java
@@ -405,14 +405,6 @@ public class MTEIndustrialLaserEngraver extends MTEExtendedPowerMultiBlockBase<M
     }
 
     @Override
-    protected void setProcessingLogicPower(ProcessingLogic logic) {
-        if (mExoticEnergyHatches.isEmpty()) {
-            logic.setAvailableVoltage(GTUtility.roundUpVoltage(this.getMaxInputVoltage()));
-            logic.setAvailableAmperage(1L);
-        } else super.setProcessingLogicPower(logic);
-    }
-
-    @Override
     public void saveNBTData(NBTTagCompound aNBT) {
         aNBT.setBoolean("stopAllRendering", stopAllRendering);
         super.saveNBTData(aNBT);

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTELargeFluidExtractor.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTELargeFluidExtractor.java
@@ -196,9 +196,11 @@ public class MTELargeFluidExtractor extends MTEExtendedPowerMultiBlockBase<MTELa
 
     @Override
     protected void setProcessingLogicPower(ProcessingLogic logic) {
+        boolean useSingleAmp = mEnergyHatches.size() == 1 && mExoticEnergyHatches.isEmpty();
+        logic.setAvailableVoltage(getAverageInputVoltage());
+        logic.setAvailableAmperage(useSingleAmp ? 1 : getMaxInputAmps());
+        logic.setMaxTierSkips(1);
         logic.setAmperageOC(true);
-        logic.setAvailableVoltage(GTUtility.roundUpVoltage(this.getMaxInputVoltage()));
-        logic.setAvailableAmperage(1);
         logic.setEuModifier(getEUMultiplier());
         logic.setMaxParallel(getTrueParallel());
         logic.setSpeedBonus(1.0f / getSpeedBonus());

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEMultiAutoclave.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEMultiAutoclave.java
@@ -408,12 +408,6 @@ public class MTEMultiAutoclave extends MTEExtendedPowerMultiBlockBase<MTEMultiAu
     }
 
     @Override
-    protected void setProcessingLogicPower(ProcessingLogic logic) {
-        logic.setAvailableVoltage(GTUtility.roundUpVoltage(this.getMaxInputVoltage()));
-        logic.setAvailableAmperage(1L);
-    }
-
-    @Override
     public boolean onWireCutterRightClick(ForgeDirection side, ForgeDirection wrenchingSide, EntityPlayer aPlayer,
         float aX, float aY, float aZ, ItemStack aTool) {
         batchMode = !batchMode;

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEMultiCanner.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEMultiCanner.java
@@ -284,12 +284,6 @@ public class MTEMultiCanner extends MTEExtendedPowerMultiBlockBase<MTEMultiCanne
     }
 
     @Override
-    protected void setProcessingLogicPower(ProcessingLogic logic) {
-        logic.setAvailableVoltage(GTUtility.roundUpVoltage(this.getMaxInputVoltage()));
-        logic.setAvailableAmperage(1L);
-    }
-
-    @Override
     protected @NotNull MTEMultiCannerGui getGui() {
         return new MTEMultiCannerGui(this);
     }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEMultiLathe.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEMultiLathe.java
@@ -322,12 +322,6 @@ public class MTEMultiLathe extends MTEExtendedPowerMultiBlockBase<MTEMultiLathe>
     }
 
     @Override
-    protected void setProcessingLogicPower(ProcessingLogic logic) {
-        logic.setAvailableVoltage(GTUtility.roundUpVoltage(this.getMaxInputVoltage()));
-        logic.setAvailableAmperage(1L);
-    }
-
-    @Override
     public boolean onWireCutterRightClick(ForgeDirection side, ForgeDirection wrenchingSide, EntityPlayer aPlayer,
         float aX, float aY, float aZ, ItemStack aTool) {
         batchMode = !batchMode;

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEMultiSolidifier.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEMultiSolidifier.java
@@ -335,12 +335,6 @@ public class MTEMultiSolidifier extends MTEExtendedPowerMultiBlockBase<MTEMultiS
     }
 
     @Override
-    protected void setProcessingLogicPower(ProcessingLogic logic) {
-        logic.setAvailableVoltage(GTUtility.roundUpVoltage(this.getMaxInputVoltage()));
-        logic.setAvailableAmperage(1L);
-    }
-
-    @Override
     public boolean onRunningTick(ItemStack aStack) {
         runningTickCounter++;
         if (runningTickCounter % 10 == 0 && speedup < 3) {

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTENanoForge.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTENanoForge.java
@@ -252,6 +252,7 @@ public class MTENanoForge extends MTEExtendedPowerMultiBlockBase<MTENanoForge> i
         logic.setAvailableVoltage(getMaxInputEu());
         logic.setAvailableAmperage(1);
         logic.setAmperageOC(false);
+        logic.setUnlimitedTierSkips();
     }
 
     @Override

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEProcessingArray.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEProcessingArray.java
@@ -271,6 +271,7 @@ public class MTEProcessingArray extends MTEExtendedPowerMultiBlockBase<MTEProces
         logic.setAvailableVoltage(GTValues.V[tTier] * (mLastRecipeMap != null ? mLastRecipeMap.getAmperage() : 1));
         logic.setAvailableAmperage(getMaxParallelRecipes());
         logic.setAmperageOC(false);
+        logic.setMaxTierSkips(1);
     }
 
     private void setTierAndMult() {

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTETranscendentPlasmaMixer.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTETranscendentPlasmaMixer.java
@@ -233,6 +233,7 @@ public class MTETranscendentPlasmaMixer extends MTEEnhancedMultiBlockBase<MTETra
         logic.setAvailableVoltage(Long.MAX_VALUE);
         logic.setAvailableAmperage(1);
         logic.setAmperageOC(false);
+        logic.setUnlimitedTierSkips();
     }
 
     private static final int HORIZONTAL_OFFSET = 2;

--- a/src/main/java/gregtech/common/tileentities/machines/multi/compressor/MTEBlackHoleCompressor.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/compressor/MTEBlackHoleCompressor.java
@@ -648,14 +648,6 @@ public class MTEBlackHoleCompressor extends MTEExtendedPowerMultiBlockBase<MTEBl
     }
 
     @Override
-    protected void setProcessingLogicPower(ProcessingLogic logic) {
-        if (mExoticEnergyHatches.isEmpty()) {
-            logic.setAvailableVoltage(GTUtility.roundUpVoltage(this.getMaxInputVoltage()));
-            logic.setAvailableAmperage(1L);
-        } else super.setProcessingLogicPower(logic);
-    }
-
-    @Override
     public boolean isInputSeparationEnabled() {
         return true;
     }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/compressor/MTEHIPCompressor.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/compressor/MTEHIPCompressor.java
@@ -311,12 +311,6 @@ public class MTEHIPCompressor extends MTEExtendedPowerMultiBlockBase<MTEHIPCompr
     }
 
     @Override
-    protected void setProcessingLogicPower(ProcessingLogic logic) {
-        logic.setAvailableVoltage(GTUtility.roundUpVoltage(this.getMaxInputVoltage()));
-        logic.setAvailableAmperage(1L);
-    }
-
-    @Override
     public void saveNBTData(NBTTagCompound aNBT) {
         aNBT.setFloat("heat", heat);
         aNBT.setBoolean("cooling", overheated);

--- a/src/main/java/gregtech/common/tileentities/machines/multi/compressor/MTEIndustrialCompressor.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/compressor/MTEIndustrialCompressor.java
@@ -181,12 +181,6 @@ public class MTEIndustrialCompressor extends MTEExtendedPowerMultiBlockBase<MTEI
     }
 
     @Override
-    protected void setProcessingLogicPower(ProcessingLogic logic) {
-        logic.setAvailableVoltage(GTUtility.roundUpVoltage(this.getMaxInputVoltage()));
-        logic.setAvailableAmperage(1L);
-    }
-
-    @Override
     protected ProcessingLogic createProcessingLogic() {
         return new ProcessingLogic() {
 

--- a/src/main/java/gregtech/common/tileentities/machines/multi/compressor/MTENeutroniumCompressor.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/compressor/MTENeutroniumCompressor.java
@@ -189,12 +189,6 @@ public class MTENeutroniumCompressor extends MTEExtendedPowerMultiBlockBase<MTEN
     }
 
     @Override
-    protected void setProcessingLogicPower(ProcessingLogic logic) {
-        logic.setAvailableVoltage(GTUtility.roundUpVoltage(this.getMaxInputVoltage()));
-        logic.setAvailableAmperage(1L);
-    }
-
-    @Override
     protected ProcessingLogic createProcessingLogic() {
 
         return new ProcessingLogic() {

--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GTPPMultiBlockBase.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GTPPMultiBlockBase.java
@@ -348,12 +348,6 @@ public abstract class GTPPMultiBlockBase<T extends MTEExtendedPowerMultiBlockBas
         }
     }
 
-    @Override
-    protected void setProcessingLogicPower(ProcessingLogic logic) {
-        logic.setAvailableVoltage(GTUtility.roundUpVoltage(this.getMaxInputVoltage()));
-        logic.setAvailableAmperage(1L);
-    }
-
     public long getMaxInputEnergy() {
         long rEnergy = 0;
         if (mEnergyHatches.size() == 1) // so it only takes 1 amp is only 1 hatch is present so it works like most gt

--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GTPPMultiBlockBase.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GTPPMultiBlockBase.java
@@ -55,7 +55,6 @@ import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.items.MetaGeneratedTool;
-import gregtech.api.logic.ProcessingLogic;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.implementations.MTEExtendedPowerMultiBlockBase;
 import gregtech.api.metatileentity.implementations.MTEHatch;

--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/MTESteamMultiBase.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/MTESteamMultiBase.java
@@ -97,6 +97,7 @@ public abstract class MTESteamMultiBase<T extends MTESteamMultiBase<T>> extends 
         // We need to trick the GT_ParallelHelper we have enough amps for all recipe parallels.
         logic.setAvailableAmperage(getMaxParallelRecipes());
         logic.setAmperageOC(false);
+        logic.setMaxTierSkips(0);
     }
 
     public ArrayList<FluidStack> getAllSteamStacks() {

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTEQuantumForceTransformer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTEQuantumForceTransformer.java
@@ -499,6 +499,7 @@ public class MTEQuantumForceTransformer extends MTEExtendedPowerMultiBlockBase<M
     protected void setProcessingLogicPower(ProcessingLogic logic) {
         logic.setAvailableVoltage(getAverageInputVoltage());
         logic.setAvailableAmperage(getMaxInputAmps());
+        logic.setUnlimitedTierSkips();
     }
 
     private byte runningTick = 0;

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/mega/MTEMegaAlloyBlastSmelter.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/mega/MTEMegaAlloyBlastSmelter.java
@@ -191,6 +191,7 @@ public class MTEMegaAlloyBlastSmelter extends MTEExtendedPowerMultiBlockBase<MTE
     protected void setProcessingLogicPower(ProcessingLogic logic) {
         logic.setAvailableVoltage(getMaxInputEu());
         logic.setAvailableAmperage(1);
+        logic.setUnlimitedTierSkips();
     }
 
     @Override

--- a/src/main/java/gtnhintergalactic/tile/multi/elevatormodules/TileEntityModuleAssembler.java
+++ b/src/main/java/gtnhintergalactic/tile/multi/elevatormodules/TileEntityModuleAssembler.java
@@ -114,6 +114,7 @@ public abstract class TileEntityModuleAssembler extends TileEntityModuleBase imp
     protected void setProcessingLogicPower(ProcessingLogic logic) {
         logic.setAvailableVoltage(V[tTier]);
         logic.setAvailableAmperage(getMaxParallels());
+        logic.setMaxTierSkips(1);
     }
 
     /**

--- a/src/main/java/gtnhintergalactic/tile/multi/elevatormodules/TileEntityModuleResearch.java
+++ b/src/main/java/gtnhintergalactic/tile/multi/elevatormodules/TileEntityModuleResearch.java
@@ -106,6 +106,7 @@ public class TileEntityModuleResearch extends TileEntityModuleBase {
     protected void setProcessingLogicPower(ProcessingLogic logic) {
         logic.setAvailableVoltage(V[tTier]);
         logic.setAvailableAmperage(1);
+        logic.setMaxTierSkips(1);
     }
 
     /**

--- a/src/main/java/tectech/thing/metaTileEntity/multi/godforge/MTEExoticModule.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/godforge/MTEExoticModule.java
@@ -203,6 +203,7 @@ public class MTEExoticModule extends MTEBaseModule {
         logic.setAvailableVoltage(Long.MAX_VALUE);
         logic.setAvailableAmperage(Integer.MAX_VALUE);
         logic.setAmperageOC(false);
+        logic.setUnlimitedTierSkips();
         logic.setSpeedBonus(getSpeedBonus());
         logic.setEuModifier(getEnergyDiscount());
     }

--- a/src/main/java/tectech/thing/metaTileEntity/multi/godforge/MTEMoltenModule.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/godforge/MTEMoltenModule.java
@@ -106,6 +106,7 @@ public class MTEMoltenModule extends MTEBaseModule {
         logic.setAvailableVoltage(Long.MAX_VALUE);
         logic.setAvailableAmperage(Integer.MAX_VALUE);
         logic.setAmperageOC(false);
+        logic.setUnlimitedTierSkips();
         logic.setMaxParallel(getActualParallel());
         logic.setSpeedBonus(getSpeedBonus());
         logic.setEuModifier(getEnergyDiscount());

--- a/src/main/java/tectech/thing/metaTileEntity/multi/godforge/MTEPlasmaModule.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/godforge/MTEPlasmaModule.java
@@ -119,6 +119,7 @@ public class MTEPlasmaModule extends MTEBaseModule {
         logic.setAvailableVoltage(Long.MAX_VALUE);
         logic.setAvailableAmperage(Integer.MAX_VALUE);
         logic.setAmperageOC(false);
+        logic.setUnlimitedTierSkips();
         logic.setMaxParallel(getActualParallel());
         logic.setSpeedBonus(getSpeedBonus());
         logic.setEuModifier(getEnergyDiscount());

--- a/src/main/java/tectech/thing/metaTileEntity/multi/godforge/MTESmeltingModule.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/godforge/MTESmeltingModule.java
@@ -143,6 +143,7 @@ public class MTESmeltingModule extends MTEBaseModule {
         logic.setAvailableVoltage(Long.MAX_VALUE);
         logic.setAvailableAmperage(Integer.MAX_VALUE);
         logic.setAmperageOC(false);
+        logic.setUnlimitedTierSkips();
         logic.setMaxParallel(getActualParallel());
         logic.setSpeedBonus(getSpeedBonus());
         logic.setEuModifier(getEnergyDiscount());


### PR DESCRIPTION
Right now, the ability to tierskip (craft recipes with a voltage tier above the energy hatch tier) is mainly an artifact of how the processing logic calculates things. It is somewhat inconsistent in whether you can tierskip more than once, as it depends entirely on whether the multi has an energy discount or a specific method of draining its energy hatches. This PR makes tierskipping explicit, adding a new method to processing logic that dictates how many times a specific multi is allowed to tierskip. That is, a multi which has a max tierskip value of 1 will not be able to craft any recipes with an EU/t value of over 4 * the average voltage of the energy hatches (the check is recipe EU/t <= 4^tierskip * voltage). There is a helper method that sets unlimited tierskipping.

Affects Balance tag added since some multis which could double tierskip may no longer be able to. Generally, I gave all megas and some exotic multis (QFT, fusions, nano forge, gorge) unlimited tierskipping, and every other multi a limit of 1. In doing this, I also did a minor refactor to remove GT++'s special processing logic of setting the voltage to the sum of all hatches with 1 amp. Instead, I extended MTEMultiBlockBase's processing logic with the very nice handler that was in Precise Assembler that just checks if there is a single hatch, and then sets it to be 1A, else total amperage. All of the GT 2.7 multis which used the GT++ method as an override have had their override removed.

Tested the 1 hatch case on bender, the 8 hatch 2x tierskip case on both LCR and MCR, and the 8 hatch and multiamp cases on HILE.

Will allow for https://github.com/GTNewHorizons/GT5-Unofficial/pull/3872 to move forward.