### PR TITLE
Adapt code to MUI2 updates

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -36,21 +36,21 @@
 dependencies {
     api("com.github.GTNewHorizons:StructureLib:1.4.10:dev")
     api("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev")
-    api("com.github.GTNewHorizons:NotEnoughItems:2.7.40-GTNH:dev")
+    api("com.github.GTNewHorizons:NotEnoughItems:2.7.44-GTNH:dev")
     api("com.github.GTNewHorizons:NotEnoughIds:2.1.9:dev")
-    api("com.github.GTNewHorizons:GTNHLib:0.6.21:dev")
+    api("com.github.GTNewHorizons:GTNHLib:0.6.22:dev")
     api("com.github.GTNewHorizons:ModularUI:1.2.18:dev")
-    api("com.github.GTNewHorizons:ModularUI2:2.2.8-1.7.10:dev")
+    api("com.github.GTNewHorizons:ModularUI2:2.2.10-1.7.10:dev")
     api("com.github.GTNewHorizons:waila:1.8.4:dev")
-    api("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-600-GTNH:dev")
-    api("com.github.GTNewHorizons:AE2FluidCraft-Rework:1.4.61-gtnh:dev")
+    api("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-602-GTNH:dev")
+    api("com.github.GTNewHorizons:AE2FluidCraft-Rework:1.4.65-gtnh:dev")
     api('com.github.GTNewHorizons:Yamcl:0.7.0:dev')
     api("com.github.GTNewHorizons:Postea:1.1.1:dev")
     api("com.github.GTNewHorizons:Galacticraft:3.3.6-GTNH:dev") { transitive = false }
 
     compileOnlyApi('com.github.GTNewHorizons:ThaumicTinkerer:2.11.12:dev')
     compileOnlyApi("com.github.GTNewHorizons:Mobs-Info:0.5.2-GTNH:dev")
-    compileOnlyApi("com.github.GTNewHorizons:Navigator:1.0.15:dev")
+    compileOnlyApi("com.github.GTNewHorizons:Navigator:1.0.16:dev")
     implementation('com.github.GTNewHorizons:Baubles-Expanded:2.1.7-GTNH:dev') {transitive=false}
     // Required to prevent an older bauble api from Extra Utilities from loading first in the javac classpath
     compileOnly('com.github.GTNewHorizons:Baubles-Expanded:2.1.7-GTNH:dev') {transitive=false}
@@ -59,7 +59,7 @@ dependencies {
 
     compileOnlyApi("com.github.GTNewHorizons:Avaritia:1.63:dev")
 
-    compileOnlyApi('com.github.GTNewHorizons:Angelica:1.0.0-beta41:api') { transitive = false }
+    compileOnlyApi('com.github.GTNewHorizons:Angelica:1.0.0-beta42:api') { transitive = false }
     compileOnlyApi("com.github.GTNewHorizons:AppleCore:3.3.4:dev") { transitive = false }
     compileOnlyApi("com.github.GTNewHorizons:BuildCraft:7.1.42:dev") { transitive = false }
     compileOnlyApi("com.github.GTNewHorizons:EnderIO:2.9.12:dev") { transitive = false }
@@ -89,12 +89,12 @@ dependencies {
     // https://www.curseforge.com/minecraft/mc-mods/advancedsolarpanels
     compileOnlyApi rfg.deobf('curse.maven:advsolar-362768:2885953')
     compileOnly('com.github.GTNewHorizons:ThaumicEnergistics:1.7.7-GTNH:dev') {transitive =  false}
-    compileOnly("com.github.GTNewHorizons:BloodMagic:1.7.23:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:BloodMagic:1.7.25:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:CraftTweaker:3.4.1:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:BetterLoadingScreen:1.7.0-GTNH:dev") { transitive = false }
     compileOnly rfg.deobf("curse.maven:biomes-o-plenty-220318:2499612")
 
-    compileOnly('com.github.GTNewHorizons:SC2:2.3.1:dev') {transitive=false}
+    compileOnly('com.github.GTNewHorizons:SC2:2.3.3:dev') {transitive=false}
     compileOnly('com.github.GTNewHorizons:Binnie:2.5.8:dev') {transitive = false}
     compileOnly('curse.maven:PlayerAPI-228969:2248928') {transitive=false}
     devOnlyNonPublishable('com.github.GTNewHorizons:BlockRenderer6343:1.3.14:dev'){transitive=false}

--- a/src/main/java/bartworks/common/tileentities/tiered/MTERadioHatch.java
+++ b/src/main/java/bartworks/common/tileentities/tiered/MTERadioHatch.java
@@ -35,13 +35,14 @@ import com.cleanroommc.modularui.api.drawable.IKey;
 import com.cleanroommc.modularui.api.widget.IWidget;
 import com.cleanroommc.modularui.factory.PosGuiData;
 import com.cleanroommc.modularui.screen.ModularPanel;
+import com.cleanroommc.modularui.screen.UISettings;
 import com.cleanroommc.modularui.value.sync.IntSyncValue;
 import com.cleanroommc.modularui.value.sync.LongSyncValue;
 import com.cleanroommc.modularui.value.sync.PanelSyncManager;
 import com.cleanroommc.modularui.value.sync.StringSyncValue;
 import com.cleanroommc.modularui.widget.sizer.Area;
-import com.cleanroommc.modularui.widgets.ItemSlot;
 import com.cleanroommc.modularui.widgets.ProgressWidget;
+import com.cleanroommc.modularui.widgets.slot.ItemSlot;
 import com.cleanroommc.modularui.widgets.slot.ModularSlot;
 import com.cleanroommc.modularui.widgets.textfield.TextFieldWidget;
 import com.gtnewhorizons.modularui.api.ModularUITextures;
@@ -364,7 +365,7 @@ public class MTERadioHatch extends MTEHatch implements RecipeMapWorkable, IAddGr
     }
 
     @Override
-    public ModularPanel buildUI(PosGuiData data, PanelSyncManager syncManager) {
+    public ModularPanel buildUI(PosGuiData data, PanelSyncManager syncManager, UISettings uiSettings) {
         IPanelHandler popupPanel = syncManager.panel("popup", (manager, handler) -> createShutterUI(syncManager), true);
         syncManager.registerSlotGroup("item_inv", 1);
         syncManager.syncValue("mass", new IntSyncValue(() -> mass, value -> mass = (byte) value));
@@ -374,7 +375,7 @@ public class MTERadioHatch extends MTEHatch implements RecipeMapWorkable, IAddGr
         syncManager.syncValue("color2", new IntSyncValue(() -> colorForGUI[2], c -> colorForGUI[2] = (short) c));
         syncManager.syncValue("coverage", 0, new IntSyncValue(() -> coverage, value -> coverage = (byte) value));
 
-        return GTGuis.mteTemplatePanelBuilder(this, data, syncManager)
+        return GTGuis.mteTemplatePanelBuilder(this, data, syncManager, uiSettings)
             .doesAddGregTechLogo(false)
             .build()
             .child(

--- a/src/main/java/gregtech/api/metatileentity/CommonMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/CommonMetaTileEntity.java
@@ -27,6 +27,7 @@ import com.cleanroommc.modularui.factory.PosGuiData;
 import com.cleanroommc.modularui.network.NetworkUtils;
 import com.cleanroommc.modularui.screen.ModularPanel;
 import com.cleanroommc.modularui.screen.ModularScreen;
+import com.cleanroommc.modularui.screen.UISettings;
 import com.cleanroommc.modularui.value.sync.PanelSyncManager;
 
 import cpw.mods.fml.relauncher.Side;
@@ -359,7 +360,7 @@ public abstract class CommonMetaTileEntity implements IMetaTileEntity {
 
     /**
      * Gets the first ItemStack in the bus, reading from the top left to bottom right
-     * 
+     *
      * @return the first ItemStack in the bus
      */
     public ItemStack getFirstStack() {
@@ -626,7 +627,7 @@ public abstract class CommonMetaTileEntity implements IMetaTileEntity {
      * @inheritDoc
      */
     @Override
-    public ModularPanel buildUI(PosGuiData data, PanelSyncManager syncManager) {
+    public ModularPanel buildUI(PosGuiData data, PanelSyncManager syncManager, UISettings uiSettings) {
         return null;
     }
 

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEHatchMagnet.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEHatchMagnet.java
@@ -9,8 +9,9 @@ import net.minecraftforge.common.util.ForgeDirection;
 
 import com.cleanroommc.modularui.factory.PosGuiData;
 import com.cleanroommc.modularui.screen.ModularPanel;
+import com.cleanroommc.modularui.screen.UISettings;
 import com.cleanroommc.modularui.value.sync.PanelSyncManager;
-import com.cleanroommc.modularui.widgets.ItemSlot;
+import com.cleanroommc.modularui.widgets.slot.ItemSlot;
 import com.cleanroommc.modularui.widgets.slot.ModularSlot;
 import com.gtnewhorizons.modularui.api.screen.ModularWindow;
 import com.gtnewhorizons.modularui.api.screen.UIBuildContext;
@@ -94,9 +95,9 @@ public class MTEHatchMagnet extends MTEHatch {
     }
 
     @Override
-    public ModularPanel buildUI(PosGuiData data, PanelSyncManager syncManager) {
+    public ModularPanel buildUI(PosGuiData data, PanelSyncManager syncManager, UISettings uiSettings) {
         syncManager.registerSlotGroup("item_inv", 1);
-        return GTGuis.mteTemplatePanelBuilder(this, data, syncManager)
+        return GTGuis.mteTemplatePanelBuilder(this, data, syncManager, uiSettings)
             .build()
             .child(
                 gridTemplate1by1(

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
@@ -58,6 +58,7 @@ import org.jetbrains.annotations.TestOnly;
 import com.cleanroommc.modularui.api.IGuiHolder;
 import com.cleanroommc.modularui.factory.PosGuiData;
 import com.cleanroommc.modularui.screen.ModularPanel;
+import com.cleanroommc.modularui.screen.UISettings;
 import com.cleanroommc.modularui.value.sync.PanelSyncManager;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -3530,8 +3531,8 @@ public abstract class MTEMultiBlockBase extends MetaTileEntity implements IContr
     }
 
     @Override
-    public final ModularPanel buildUI(PosGuiData guiData, PanelSyncManager syncManager) {
-        return getGui().build(guiData, syncManager);
+    public final ModularPanel buildUI(PosGuiData guiData, PanelSyncManager syncManager, UISettings uiSettings) {
+        return getGui().build(guiData, syncManager, uiSettings);
     }
 
     protected @NotNull MTEMultiBlockBaseGui getGui() {

--- a/src/main/java/gregtech/api/metatileentity/implementations/gui/MTEMultiBlockBaseGui.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/gui/MTEMultiBlockBaseGui.java
@@ -25,11 +25,12 @@ import org.jetbrains.annotations.NotNull;
 import com.cleanroommc.modularui.api.IPanelHandler;
 import com.cleanroommc.modularui.api.drawable.IKey;
 import com.cleanroommc.modularui.api.widget.IWidget;
-import com.cleanroommc.modularui.drawable.DrawableArray;
+import com.cleanroommc.modularui.drawable.DrawableStack;
 import com.cleanroommc.modularui.drawable.DynamicDrawable;
 import com.cleanroommc.modularui.drawable.UITexture;
 import com.cleanroommc.modularui.factory.PosGuiData;
 import com.cleanroommc.modularui.screen.ModularPanel;
+import com.cleanroommc.modularui.screen.UISettings;
 import com.cleanroommc.modularui.utils.Alignment;
 import com.cleanroommc.modularui.utils.Alignment.MainAxis;
 import com.cleanroommc.modularui.utils.Color;
@@ -45,7 +46,6 @@ import com.cleanroommc.modularui.widget.WidgetTree;
 import com.cleanroommc.modularui.widget.sizer.Area;
 import com.cleanroommc.modularui.widgets.ButtonWidget;
 import com.cleanroommc.modularui.widgets.CycleButtonWidget;
-import com.cleanroommc.modularui.widgets.ItemSlot;
 import com.cleanroommc.modularui.widgets.ListWidget;
 import com.cleanroommc.modularui.widgets.SlotGroupWidget;
 import com.cleanroommc.modularui.widgets.TextWidget;
@@ -53,6 +53,7 @@ import com.cleanroommc.modularui.widgets.ToggleButton;
 import com.cleanroommc.modularui.widgets.layout.Column;
 import com.cleanroommc.modularui.widgets.layout.Flow;
 import com.cleanroommc.modularui.widgets.layout.Row;
+import com.cleanroommc.modularui.widgets.slot.ItemSlot;
 import com.cleanroommc.modularui.widgets.slot.ModularSlot;
 import com.cleanroommc.modularui.widgets.textfield.TextFieldWidget;
 import com.gtnewhorizons.modularui.common.internal.network.NetworkUtils;
@@ -77,7 +78,7 @@ public class MTEMultiBlockBaseGui {
         this.base = base;
     }
 
-    public ModularPanel build(PosGuiData guiData, PanelSyncManager syncManager) {
+    public ModularPanel build(PosGuiData guiData, PanelSyncManager syncManager, UISettings uiSettings) {
 
         ModularPanel panel = new ModularPanel("MTEMultiblockBase").size(198, 181 + textBoxToInventoryGap)
             .padding(4);
@@ -120,8 +121,7 @@ public class MTEMultiBlockBaseGui {
 
         if (base.doesBindPlayerInventory()) {
             inventoryRow.child(
-                SlotGroupWidget.playerInventory(0)
-                    .leftRel(0)
+                SlotGroupWidget.playerInventory(false)
                     .marginLeft(4));
         }
 
@@ -547,13 +547,13 @@ public class MTEMultiBlockBaseGui {
                     if (base.supportsSingleRecipeLocking()) {
                         return GTGuiTextures.OVERLAY_BUTTON_RECIPE_LOCKED;
                     } else {
-                        return new DrawableArray(GTGuiTextures.OVERLAY_BUTTON_RECIPE_LOCKED_DISABLED);
+                        return new DrawableStack(GTGuiTextures.OVERLAY_BUTTON_RECIPE_LOCKED_DISABLED);
                     }
                 } else {
                     if (base.supportsSingleRecipeLocking()) {
                         return GTGuiTextures.OVERLAY_BUTTON_RECIPE_UNLOCKED;
                     } else {
-                        return new DrawableArray(GTGuiTextures.OVERLAY_BUTTON_RECIPE_UNLOCKED_DISABLED, forbidden);
+                        return new DrawableStack(GTGuiTextures.OVERLAY_BUTTON_RECIPE_UNLOCKED_DISABLED, forbidden);
                     }
                 }
             }))
@@ -587,14 +587,14 @@ public class MTEMultiBlockBaseGui {
                     if (base.supportsBatchMode()) {
                         return GTGuiTextures.OVERLAY_BUTTON_BATCH_MODE_ON;
                     } else {
-                        return new DrawableArray(GTGuiTextures.OVERLAY_BUTTON_BATCH_MODE_ON_DISABLED);
+                        return new DrawableStack(GTGuiTextures.OVERLAY_BUTTON_BATCH_MODE_ON_DISABLED);
                     }
                 } else {
 
                     if (base.supportsBatchMode()) {
                         return GTGuiTextures.OVERLAY_BUTTON_BATCH_MODE_OFF;
                     } else {
-                        return new DrawableArray(GTGuiTextures.OVERLAY_BUTTON_BATCH_MODE_OFF_DISABLED, forbidden);
+                        return new DrawableStack(GTGuiTextures.OVERLAY_BUTTON_BATCH_MODE_OFF_DISABLED, forbidden);
                     }
                 }
             }))
@@ -653,14 +653,14 @@ public class MTEMultiBlockBaseGui {
                     if (base.supportsInputSeparation()) {
                         return GTGuiTextures.OVERLAY_BUTTON_INPUT_SEPARATION_ON;
                     } else {
-                        return new DrawableArray(GTGuiTextures.OVERLAY_BUTTON_INPUT_SEPARATION_ON_DISABLED, forbidden);
+                        return new DrawableStack(GTGuiTextures.OVERLAY_BUTTON_INPUT_SEPARATION_ON_DISABLED, forbidden);
                     }
                 } else {
 
                     if (base.supportsInputSeparation()) {
                         return GTGuiTextures.OVERLAY_BUTTON_INPUT_SEPARATION_OFF;
                     } else {
-                        return new DrawableArray(GTGuiTextures.OVERLAY_BUTTON_INPUT_SEPARATION_OFF_DISABLED, forbidden);
+                        return new DrawableStack(GTGuiTextures.OVERLAY_BUTTON_INPUT_SEPARATION_OFF_DISABLED, forbidden);
                     }
                 }
             }))
@@ -704,7 +704,7 @@ public class MTEMultiBlockBaseGui {
                 new DynamicDrawable(
                     () -> base.supportsVoidProtection()
                         ? UITexture.fullImage(base.getVoidingMode().buttonOverlay.location)
-                        : new DrawableArray(
+                        : new DrawableStack(
                             UITexture.fullImage(base.getVoidingMode().buttonOverlay.location),
                             GTGuiTextures.OVERLAY_BUTTON_FORBIDDEN)))
             .tooltipBuilder(t -> {

--- a/src/main/java/gregtech/api/modularui2/GTGuis.java
+++ b/src/main/java/gregtech/api/modularui2/GTGuis.java
@@ -6,6 +6,7 @@ import org.jetbrains.annotations.NotNull;
 import com.cleanroommc.modularui.factory.GuiManager;
 import com.cleanroommc.modularui.factory.PosGuiData;
 import com.cleanroommc.modularui.screen.ModularPanel;
+import com.cleanroommc.modularui.screen.UISettings;
 import com.cleanroommc.modularui.value.sync.PanelSyncManager;
 
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
@@ -32,8 +33,8 @@ public final class GTGuis {
      * @see GTBaseGuiBuilder
      */
     public static GTBaseGuiBuilder mteTemplatePanelBuilder(IMetaTileEntity mte, PosGuiData data,
-        PanelSyncManager syncManager) {
-        return new GTBaseGuiBuilder(mte, data, syncManager);
+        PanelSyncManager syncManager, UISettings uiSettings) {
+        return new GTBaseGuiBuilder(mte, data, syncManager, uiSettings);
     }
 
     /**

--- a/src/main/java/gregtech/api/modularui2/MetaTileEntityGuiHandler.java
+++ b/src/main/java/gregtech/api/modularui2/MetaTileEntityGuiHandler.java
@@ -61,6 +61,12 @@ public final class MetaTileEntityGuiHandler extends AbstractUIFactory<PosGuiData
     }
 
     @Override
+    public boolean canInteractWith(EntityPlayer player, PosGuiData guiData) {
+        return super.canInteractWith(player, guiData) && guiData.getTileEntity() instanceof IGregTechTileEntity baseTE
+            && baseTE.canAccessData();
+    }
+
+    @Override
     public void writeGuiData(PosGuiData guiData, PacketBuffer buffer) {
         buffer.writeVarIntToBuffer(guiData.getX());
         buffer.writeVarIntToBuffer(guiData.getY());

--- a/src/main/java/gregtech/common/covers/Cover.java
+++ b/src/main/java/gregtech/common/covers/Cover.java
@@ -20,6 +20,7 @@ import org.jetbrains.annotations.NotNull;
 import com.cleanroommc.modularui.api.IGuiHolder;
 import com.cleanroommc.modularui.screen.ModularPanel;
 import com.cleanroommc.modularui.screen.ModularScreen;
+import com.cleanroommc.modularui.screen.UISettings;
 import com.cleanroommc.modularui.value.sync.PanelSyncManager;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.ByteArrayDataInput;
@@ -293,8 +294,8 @@ public class Cover implements IGuiHolder<CoverGuiData> {
      * @return UI panel to show
      */
     @Override
-    public final ModularPanel buildUI(CoverGuiData guiData, PanelSyncManager syncManager) {
-        return getCoverGui().createBasePanel(guiData, syncManager);
+    public final ModularPanel buildUI(CoverGuiData guiData, PanelSyncManager syncManager, UISettings uiSettings) {
+        return getCoverGui().createBasePanel(guiData, syncManager, uiSettings);
     }
 
     /**

--- a/src/main/java/gregtech/common/covers/gui/CoverFluidfilterGui.java
+++ b/src/main/java/gregtech/common/covers/gui/CoverFluidfilterGui.java
@@ -12,9 +12,9 @@ import com.cleanroommc.modularui.utils.fluid.FluidStackTank;
 import com.cleanroommc.modularui.value.sync.EnumSyncValue;
 import com.cleanroommc.modularui.value.sync.FluidSlotSyncHandler;
 import com.cleanroommc.modularui.value.sync.PanelSyncManager;
-import com.cleanroommc.modularui.widgets.FluidSlot;
 import com.cleanroommc.modularui.widgets.layout.Flow;
 import com.cleanroommc.modularui.widgets.layout.Grid;
+import com.cleanroommc.modularui.widgets.slot.FluidSlot;
 
 import gregtech.api.modularui2.CoverGuiData;
 import gregtech.api.modularui2.GTGuiTextures;

--- a/src/main/java/gregtech/common/covers/gui/CoverGui.java
+++ b/src/main/java/gregtech/common/covers/gui/CoverGui.java
@@ -4,6 +4,7 @@ import net.minecraft.item.ItemStack;
 
 import com.cleanroommc.modularui.network.NetworkUtils;
 import com.cleanroommc.modularui.screen.ModularPanel;
+import com.cleanroommc.modularui.screen.UISettings;
 import com.cleanroommc.modularui.utils.Alignment;
 import com.cleanroommc.modularui.value.sync.PanelSyncManager;
 import com.cleanroommc.modularui.widgets.layout.Flow;
@@ -43,7 +44,7 @@ public class CoverGui<T extends Cover> {
      * Override this method if you want to implement more customized GUI. Otherwise, implement {@link #addUIWidgets}
      * instead.
      */
-    public ModularPanel createBasePanel(CoverGuiData guiData, PanelSyncManager syncManager) {
+    public ModularPanel createBasePanel(CoverGuiData guiData, PanelSyncManager syncManager, UISettings uiSettings) {
         syncManager.addCloseListener(player -> {
             if (!NetworkUtils.isClient(player)) {
                 guiData.getTileEntity()

--- a/src/main/java/gregtech/common/covers/gui/CoverItemFilterGui.java
+++ b/src/main/java/gregtech/common/covers/gui/CoverItemFilterGui.java
@@ -4,9 +4,9 @@ import com.cleanroommc.modularui.api.drawable.IKey;
 import com.cleanroommc.modularui.utils.Alignment;
 import com.cleanroommc.modularui.value.sync.EnumSyncValue;
 import com.cleanroommc.modularui.value.sync.PanelSyncManager;
-import com.cleanroommc.modularui.widgets.ItemSlot;
 import com.cleanroommc.modularui.widgets.layout.Flow;
 import com.cleanroommc.modularui.widgets.slot.ModularSlot;
+import com.cleanroommc.modularui.widgets.slot.PhantomItemSlot;
 
 import gregtech.api.modularui2.CoverGuiData;
 import gregtech.api.modularui2.GTGuiTextures;
@@ -52,7 +52,7 @@ public class CoverItemFilterGui extends CoverGui<CoverItemFilter> {
                         .asWidget()
                         .marginTop(WIDGET_MARGIN))
                 .child(
-                    new ItemSlot().slot(new ModularSlot(cover.getFilter(), 0, true))
+                    new PhantomItemSlot().slot(new ModularSlot(cover.getFilter(), 0))
                         .marginTop(WIDGET_MARGIN)));
     }
 

--- a/src/main/java/gregtech/common/items/ItemRedstoneSniffer.java
+++ b/src/main/java/gregtech/common/items/ItemRedstoneSniffer.java
@@ -15,6 +15,7 @@ import com.cleanroommc.modularui.api.IGuiHolder;
 import com.cleanroommc.modularui.factory.GuiData;
 import com.cleanroommc.modularui.factory.GuiFactories;
 import com.cleanroommc.modularui.screen.ModularPanel;
+import com.cleanroommc.modularui.screen.UISettings;
 import com.cleanroommc.modularui.utils.serialization.IByteBufAdapter;
 import com.cleanroommc.modularui.value.sync.PanelSyncManager;
 
@@ -46,7 +47,7 @@ public class ItemRedstoneSniffer extends GTGenericItem implements IGuiHolder<Gui
     }
 
     @Override
-    public ModularPanel buildUI(GuiData guiData, PanelSyncManager guiSyncManager) {
+    public ModularPanel buildUI(GuiData guiData, PanelSyncManager guiSyncManager, UISettings uiSettings) {
         return new RedstoneSnifferGuiBuilder(guiData, guiSyncManager).build();
     }
 

--- a/src/main/java/gregtech/common/modularui2/factory/GTBaseGuiBuilder.java
+++ b/src/main/java/gregtech/common/modularui2/factory/GTBaseGuiBuilder.java
@@ -9,8 +9,8 @@ import com.cleanroommc.modularui.api.widget.IWidget;
 import com.cleanroommc.modularui.drawable.ItemDrawable;
 import com.cleanroommc.modularui.factory.PosGuiData;
 import com.cleanroommc.modularui.network.NetworkUtils;
-import com.cleanroommc.modularui.screen.ContainerCustomizer;
 import com.cleanroommc.modularui.screen.ModularPanel;
+import com.cleanroommc.modularui.screen.UISettings;
 import com.cleanroommc.modularui.value.sync.IntSyncValue;
 import com.cleanroommc.modularui.value.sync.PanelSyncHandler;
 import com.cleanroommc.modularui.value.sync.PanelSyncManager;
@@ -22,7 +22,6 @@ import com.cleanroommc.modularui.widgets.slot.ModularSlot;
 import gregtech.api.enums.ItemList;
 import gregtech.api.interfaces.IConfigurationCircuitSupport;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
-import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.modularui2.GTGuis;
 import gregtech.api.modularui2.GTWidgetThemes;
 import gregtech.api.util.item.GhostCircuitItemStackHandler;
@@ -38,8 +37,8 @@ import gregtech.common.modularui2.widget.GhostCircuitSlotWidget;
  * Example usage:
  * <pre>{@code
  *     @Overrride
- *     public ModularPanel buildUI(PosGuiData data, PanelSyncManager syncManager) {
- *         return GTGuis.mteTemplatePanelBuilder(this, data, syncManager)
+ *     public ModularPanel buildUI(PosGuiData data, PanelSyncManager syncManager, UISettings uiSettings) {
+ *         return GTGuis.mteTemplatePanelBuilder(this, data, syncManager, uiSettings)
  *             .setHeight(200)
  *             .doesBindPlayerInventory(false)
  *             .build()
@@ -55,6 +54,7 @@ public final class GTBaseGuiBuilder {
     private final IMetaTileEntity mte;
     private final PosGuiData posGuiData;
     private final PanelSyncManager syncManager;
+    private final UISettings uiSettings;
 
     private int width = 176;
     private int height = 166;
@@ -64,10 +64,11 @@ public final class GTBaseGuiBuilder {
     private boolean doesAddGhostCircuitSlot;
     private boolean doesAddGregTechLogo;
 
-    public GTBaseGuiBuilder(IMetaTileEntity mte, PosGuiData data, PanelSyncManager syncManager) {
+    public GTBaseGuiBuilder(IMetaTileEntity mte, PosGuiData data, PanelSyncManager syncManager, UISettings uiSettings) {
         this.mte = mte;
         this.posGuiData = data;
         this.syncManager = syncManager;
+        this.uiSettings = uiSettings;
         this.doesAddGhostCircuitSlot = mte instanceof IConfigurationCircuitSupport ccs && ccs.allowSelectCircuit();
         this.doesAddGregTechLogo = !this.doesAddGhostCircuitSlot;
     }
@@ -150,12 +151,6 @@ public final class GTBaseGuiBuilder {
         if (doesAddGregTechLogo) {
             panel.child(createGregTechLogo());
         }
-        syncManager.setContainerCustomizer(new ContainerCustomizer());
-        syncManager.getContainerCustomizer()
-            .setCanInteractWith($ -> {
-                IGregTechTileEntity gtTE = mte.getBaseMetaTileEntity();
-                return gtTE != null && gtTE.canAccessData();
-            });
         syncManager.addCloseListener($ -> mte.markDirty());
         return panel;
     }
@@ -188,7 +183,7 @@ public final class GTBaseGuiBuilder {
             IPanelHandler panel = syncManager.panel(panelKey, coverPanelBuilder(panelKey, side), true);
             column.child(new CoverTabButton(mte.getBaseMetaTileEntity(), side, panel));
         }
-        posGuiData.getNEISettings()
+        uiSettings.getNEISettings()
             .addNEIExclusionArea(column);
         return column;
     }
@@ -227,7 +222,7 @@ public final class GTBaseGuiBuilder {
         });
         syncManager.syncValue("selector_screen_selected", selectedSyncHandler);
         return new GhostCircuitSlotWidget(mte, selectedSyncHandler)
-            .slot(new ModularSlot(new GhostCircuitItemStackHandler(mte), 0, true))
+            .slot(new ModularSlot(new GhostCircuitItemStackHandler(mte), 0))
             .pos(ccs.getCircuitSlotX() - 1, ccs.getCircuitSlotY() - 1);
     }
 

--- a/src/main/java/gregtech/common/modularui2/sync/GhostCircuitSyncHandler.java
+++ b/src/main/java/gregtech/common/modularui2/sync/GhostCircuitSyncHandler.java
@@ -10,7 +10,7 @@ import net.minecraft.network.PacketBuffer;
 import com.cleanroommc.modularui.network.NetworkUtils;
 import com.cleanroommc.modularui.utils.MouseData;
 import com.cleanroommc.modularui.utils.item.IItemHandler;
-import com.cleanroommc.modularui.value.sync.ItemSlotSH;
+import com.cleanroommc.modularui.value.sync.PhantomItemSlotSH;
 import com.cleanroommc.modularui.widgets.slot.ModularSlot;
 
 import gregtech.api.util.item.GhostCircuitItemStackHandler;
@@ -20,7 +20,7 @@ import gregtech.common.items.ItemIntegratedCircuit;
  * Sync handler dedicated for {@link gregtech.common.modularui2.widget.GhostCircuitSlotWidget
  * GhostCircuitSlotWidget}.
  */
-public class GhostCircuitSyncHandler extends ItemSlotSH {
+public class GhostCircuitSyncHandler extends PhantomItemSlotSH {
 
     public static final int SYNC_CIRCUIT_CONFIG = 10;
 

--- a/src/main/java/gregtech/common/modularui2/widget/GhostCircuitSlotWidget.java
+++ b/src/main/java/gregtech/common/modularui2/widget/GhostCircuitSlotWidget.java
@@ -11,7 +11,7 @@ import com.cleanroommc.modularui.api.ITheme;
 import com.cleanroommc.modularui.api.drawable.IDrawable;
 import com.cleanroommc.modularui.api.drawable.IKey;
 import com.cleanroommc.modularui.api.widget.Interactable;
-import com.cleanroommc.modularui.drawable.DrawableArray;
+import com.cleanroommc.modularui.drawable.DrawableStack;
 import com.cleanroommc.modularui.screen.ModularPanel;
 import com.cleanroommc.modularui.screen.ModularScreen;
 import com.cleanroommc.modularui.screen.RichTooltip;
@@ -19,8 +19,8 @@ import com.cleanroommc.modularui.theme.WidgetTheme;
 import com.cleanroommc.modularui.utils.MouseData;
 import com.cleanroommc.modularui.value.sync.IntSyncValue;
 import com.cleanroommc.modularui.value.sync.ItemSlotSH;
-import com.cleanroommc.modularui.widgets.ItemSlot;
 import com.cleanroommc.modularui.widgets.slot.ModularSlot;
+import com.cleanroommc.modularui.widgets.slot.PhantomItemSlot;
 
 import gregtech.api.interfaces.IConfigurationCircuitSupport;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
@@ -33,7 +33,7 @@ import gregtech.common.modularui2.sync.GhostCircuitSyncHandler;
 /**
  * Item slot that appears on machines implementing {@link IConfigurationCircuitSupport}.
  */
-public class GhostCircuitSlotWidget extends ItemSlot {
+public class GhostCircuitSlotWidget extends PhantomItemSlot {
 
     private static final String GUI_ID = "circuit_selector";
 
@@ -51,7 +51,7 @@ public class GhostCircuitSlotWidget extends ItemSlot {
     @Override
     public IDrawable getCurrentBackground(ITheme theme, WidgetTheme widgetTheme) {
         IDrawable background = super.getCurrentBackground(theme, widgetTheme);
-        return new DrawableArray(background, GTGuiTextures.OVERLAY_SLOT_INT_CIRCUIT);
+        return new DrawableStack(background, GTGuiTextures.OVERLAY_SLOT_INT_CIRCUIT);
     }
 
     @Override
@@ -68,11 +68,6 @@ public class GhostCircuitSlotWidget extends ItemSlot {
     }
 
     @Override
-    public boolean onMouseRelease(int mouseButton) {
-        return true;
-    }
-
-    @Override
     public boolean onMouseScroll(ModularScreen.UpOrDown scrollDirection, int amount) {
         if (isSelectorPanelOpen()) return true;
         MouseData mouseData = MouseData.create(scrollDirection.modifier);
@@ -81,10 +76,7 @@ public class GhostCircuitSlotWidget extends ItemSlot {
     }
 
     @Override
-    public void onMouseDrag(int mouseButton, long timeSinceClick) {}
-
-    @Override
-    public ItemSlot slot(ModularSlot slot) {
+    public PhantomItemSlot slot(ModularSlot slot) {
         ItemSlotSH sh = new GhostCircuitSyncHandler(slot);
         isValidSyncHandler(sh);
         setSyncHandler(sh);

--- a/src/main/java/gregtech/common/tileentities/boilers/MTEBoiler.java
+++ b/src/main/java/gregtech/common/tileentities/boilers/MTEBoiler.java
@@ -15,15 +15,16 @@ import org.jetbrains.annotations.NotNull;
 import com.cleanroommc.modularui.api.widget.IWidget;
 import com.cleanroommc.modularui.factory.PosGuiData;
 import com.cleanroommc.modularui.screen.ModularPanel;
+import com.cleanroommc.modularui.screen.UISettings;
 import com.cleanroommc.modularui.utils.Alignment;
 import com.cleanroommc.modularui.utils.fluid.FluidStackTank;
 import com.cleanroommc.modularui.value.sync.DoubleSyncValue;
 import com.cleanroommc.modularui.value.sync.FluidSlotSyncHandler;
 import com.cleanroommc.modularui.value.sync.PanelSyncManager;
-import com.cleanroommc.modularui.widgets.FluidSlot;
-import com.cleanroommc.modularui.widgets.ItemSlot;
 import com.cleanroommc.modularui.widgets.ProgressWidget;
 import com.cleanroommc.modularui.widgets.layout.Flow;
+import com.cleanroommc.modularui.widgets.slot.FluidSlot;
+import com.cleanroommc.modularui.widgets.slot.ItemSlot;
 import com.cleanroommc.modularui.widgets.slot.ModularSlot;
 import com.gtnewhorizons.modularui.api.drawable.IDrawable;
 import com.gtnewhorizons.modularui.api.drawable.UITexture;
@@ -420,7 +421,7 @@ public abstract class MTEBoiler extends MTEBasicTank implements IGetTitleColor, 
     protected abstract GTGuiTheme getGuiTheme();
 
     @Override
-    public ModularPanel buildUI(PosGuiData data, PanelSyncManager syncManager) {
+    public ModularPanel buildUI(PosGuiData data, PanelSyncManager syncManager, UISettings uiSettings) {
         syncManager.registerSlotGroup("item_inv", 0);
         IWidget waterSlots = Flow.column()
             .coverChildren()
@@ -473,7 +474,7 @@ public abstract class MTEBoiler extends MTEBasicTank implements IGetTitleColor, 
                     .size(14)
                     .margin(2))
             .childIf(doesAddFuelSlot(), createFuelSlot());
-        return GTGuis.mteTemplatePanelBuilder(this, data, syncManager)
+        return GTGuis.mteTemplatePanelBuilder(this, data, syncManager, uiSettings)
             .build()
             .child(
                 Flow.row()

--- a/src/main/java/gregtech/common/tileentities/boilers/MTEBoilerLava.java
+++ b/src/main/java/gregtech/common/tileentities/boilers/MTEBoilerLava.java
@@ -30,7 +30,7 @@ import net.minecraftforge.fluids.IFluidContainerItem;
 import net.minecraftforge.fluids.IFluidHandler;
 import net.minecraftforge.fluids.IFluidTank;
 
-import com.cleanroommc.modularui.widgets.FluidSlot;
+import com.cleanroommc.modularui.widgets.slot.FluidSlot;
 import com.gtnewhorizons.modularui.api.drawable.IDrawable;
 import com.gtnewhorizons.modularui.api.widget.Widget;
 import com.gtnewhorizons.modularui.common.widget.FluidSlotWidget;

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEBrickedBlastFurnace.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEBrickedBlastFurnace.java
@@ -25,10 +25,11 @@ import org.lwjgl.input.Keyboard;
 
 import com.cleanroommc.modularui.factory.PosGuiData;
 import com.cleanroommc.modularui.screen.ModularPanel;
+import com.cleanroommc.modularui.screen.UISettings;
 import com.cleanroommc.modularui.value.sync.DoubleSyncValue;
 import com.cleanroommc.modularui.value.sync.PanelSyncManager;
-import com.cleanroommc.modularui.widgets.ItemSlot;
 import com.cleanroommc.modularui.widgets.SlotGroupWidget;
+import com.cleanroommc.modularui.widgets.slot.ItemSlot;
 import com.cleanroommc.modularui.widgets.slot.ModularSlot;
 import com.gtnewhorizon.structurelib.StructureLibAPI;
 import com.gtnewhorizon.structurelib.alignment.IAlignment;
@@ -570,9 +571,9 @@ public class MTEBrickedBlastFurnace extends MetaTileEntity implements IAlignment
     }
 
     @Override
-    public ModularPanel buildUI(PosGuiData data, PanelSyncManager syncManager) {
+    public ModularPanel buildUI(PosGuiData data, PanelSyncManager syncManager, UISettings uiSettings) {
         syncManager.registerSlotGroup("item_inv", 0);
-        return GTGuis.mteTemplatePanelBuilder(this, data, syncManager)
+        return GTGuis.mteTemplatePanelBuilder(this, data, syncManager, uiSettings)
             .build()
             .child(
                 SlotGroupWidget.builder()

--- a/src/main/java/gregtech/common/tileentities/machines/multi/purification/MTEHatchLensHousing.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/purification/MTEHatchLensHousing.java
@@ -4,8 +4,9 @@ import static gregtech.common.modularui2.util.CommonGuiComponents.gridTemplate1b
 
 import com.cleanroommc.modularui.factory.PosGuiData;
 import com.cleanroommc.modularui.screen.ModularPanel;
+import com.cleanroommc.modularui.screen.UISettings;
 import com.cleanroommc.modularui.value.sync.PanelSyncManager;
-import com.cleanroommc.modularui.widgets.ItemSlot;
+import com.cleanroommc.modularui.widgets.slot.ItemSlot;
 import com.cleanroommc.modularui.widgets.slot.ModularSlot;
 import com.gtnewhorizons.modularui.api.screen.ModularWindow;
 import com.gtnewhorizons.modularui.api.screen.UIBuildContext;
@@ -59,9 +60,9 @@ public class MTEHatchLensHousing extends MTEHatchInputBus {
     }
 
     @Override
-    public ModularPanel buildUI(PosGuiData data, PanelSyncManager syncManager) {
+    public ModularPanel buildUI(PosGuiData data, PanelSyncManager syncManager, UISettings uiSettings) {
         syncManager.registerSlotGroup("item_inv", 1);
-        return GTGuis.mteTemplatePanelBuilder(this, data, syncManager)
+        return GTGuis.mteTemplatePanelBuilder(this, data, syncManager, uiSettings)
             .build()
             .child(
                 gridTemplate1by1(

--- a/src/main/java/gtPlusPlus/core/tileentities/general/TileEntityDecayablesChest.java
+++ b/src/main/java/gtPlusPlus/core/tileentities/general/TileEntityDecayablesChest.java
@@ -16,13 +16,14 @@ import com.cleanroommc.modularui.api.IGuiHolder;
 import com.cleanroommc.modularui.api.drawable.IKey;
 import com.cleanroommc.modularui.factory.GuiData;
 import com.cleanroommc.modularui.screen.ModularPanel;
+import com.cleanroommc.modularui.screen.UISettings;
 import com.cleanroommc.modularui.utils.Alignment;
 import com.cleanroommc.modularui.utils.item.InvWrapper;
 import com.cleanroommc.modularui.value.sync.PanelSyncManager;
 import com.cleanroommc.modularui.value.sync.SyncHandlers;
-import com.cleanroommc.modularui.widgets.ItemSlot;
 import com.cleanroommc.modularui.widgets.SlotGroupWidget;
 import com.cleanroommc.modularui.widgets.TextWidget;
+import com.cleanroommc.modularui.widgets.slot.ItemSlot;
 import com.cleanroommc.modularui.widgets.slot.SlotGroup;
 
 import gtPlusPlus.api.objects.Logger;
@@ -388,7 +389,7 @@ public class TileEntityDecayablesChest extends TileEntity implements ISidedInven
     }
 
     @Override
-    public ModularPanel buildUI(GuiData data, PanelSyncManager syncManager) {
+    public ModularPanel buildUI(GuiData data, PanelSyncManager syncManager, UISettings uiSettings) {
         final SlotGroup SLOT_GROUP = new SlotGroup("decayables", 5);
         syncManager.registerSlotGroup(SLOT_GROUP);
         syncManager.addOpenListener(player -> {

--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/MTEHatchElementalDataOrbHolder.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/MTEHatchElementalDataOrbHolder.java
@@ -11,8 +11,9 @@ import net.minecraftforge.common.util.ForgeDirection;
 
 import com.cleanroommc.modularui.factory.PosGuiData;
 import com.cleanroommc.modularui.screen.ModularPanel;
+import com.cleanroommc.modularui.screen.UISettings;
 import com.cleanroommc.modularui.value.sync.PanelSyncManager;
-import com.cleanroommc.modularui.widgets.ItemSlot;
+import com.cleanroommc.modularui.widgets.slot.ItemSlot;
 import com.cleanroommc.modularui.widgets.slot.ModularSlot;
 import com.gtnewhorizons.modularui.api.screen.ModularWindow;
 import com.gtnewhorizons.modularui.api.screen.UIBuildContext;
@@ -206,9 +207,9 @@ public class MTEHatchElementalDataOrbHolder extends MTEHatch implements IConfigu
     }
 
     @Override
-    public ModularPanel buildUI(PosGuiData data, PanelSyncManager syncManager) {
+    public ModularPanel buildUI(PosGuiData data, PanelSyncManager syncManager, UISettings uiSettings) {
         syncManager.registerSlotGroup("item_inv", 4);
-        return GTGuis.mteTemplatePanelBuilder(this, data, syncManager)
+        return GTGuis.mteTemplatePanelBuilder(this, data, syncManager, uiSettings)
             .build()
             .child(
                 gridTemplate4by4(


### PR DESCRIPTION
Adapt to MUI2 breaking changes:
- `UISettings uiSettings` is a new argument to `buildUI` and we're propagating it everywhere in case we need it. Right now we're using it to add NEI exclusion zones.
- `DrawableArray` is renamed to `DrawableStack`
- `ModularSlot` doesn't have an argument that decides whether or not it's a phantom, instead you use it inside of a `PhantomItemSlot`
- Our instances of `AbstractUIFactory` can and should override `canInteractWith` instead of using the deleted `ContainerCustomizer`
- `SlotGroupWidget::playerInventory` requires you to specify whether or not the playerInventory is `positioned` which means that `leftRel(0.5f)` is applied to it. I take it to mean that if we were setting the `leftRel` to 0 previously we can remove that code and use `false`.

There are other changes we can do to write better MUI2 code by taking advantage of new features, but that can be done in separate PRs. I want this merged sooner so we can benefit from bug fixes.