### PR TITLE
Fix MUI2 phantom circuit slot

### DIFF
--- a/src/main/java/gregtech/common/modularui2/sync/GhostCircuitSyncHandler.java
+++ b/src/main/java/gregtech/common/modularui2/sync/GhostCircuitSyncHandler.java
@@ -10,10 +10,10 @@ import net.minecraft.network.PacketBuffer;
 import com.cleanroommc.modularui.network.NetworkUtils;
 import com.cleanroommc.modularui.utils.MouseData;
 import com.cleanroommc.modularui.utils.item.IItemHandler;
+import com.cleanroommc.modularui.value.sync.ItemSlotSH;
 import com.cleanroommc.modularui.value.sync.PhantomItemSlotSH;
 import com.cleanroommc.modularui.widgets.slot.ModularSlot;
-import com.cleanroommc.modularui.value.sync.ItemSlotSH;
-    
+
 import gregtech.api.util.item.GhostCircuitItemStackHandler;
 import gregtech.common.items.ItemIntegratedCircuit;
 
@@ -58,10 +58,10 @@ public class GhostCircuitSyncHandler extends PhantomItemSlotSH {
         if (handler.getCircuitConfig() != config) {
             handler.setCircuitConfig(config);
             syncToClient(ItemSlotSH.SYNC_ITEM, buf -> {
-                buf.writeBoolean(false);//onlyAmountChanged
+                buf.writeBoolean(false);// onlyAmountChanged
                 NetworkUtils.writeItemStack(buf, handler.getStackInSlot(0));
-                buf.writeBoolean(false);//init
-                buf.writeBoolean(false);//force sync
+                buf.writeBoolean(false);// init
+                buf.writeBoolean(false);// force sync
             });
         }
     }

--- a/src/main/java/gregtech/common/modularui2/sync/GhostCircuitSyncHandler.java
+++ b/src/main/java/gregtech/common/modularui2/sync/GhostCircuitSyncHandler.java
@@ -12,7 +12,8 @@ import com.cleanroommc.modularui.utils.MouseData;
 import com.cleanroommc.modularui.utils.item.IItemHandler;
 import com.cleanroommc.modularui.value.sync.PhantomItemSlotSH;
 import com.cleanroommc.modularui.widgets.slot.ModularSlot;
-
+import com.cleanroommc.modularui.value.sync.ItemSlotSH;
+    
 import gregtech.api.util.item.GhostCircuitItemStackHandler;
 import gregtech.common.items.ItemIntegratedCircuit;
 
@@ -56,10 +57,11 @@ public class GhostCircuitSyncHandler extends PhantomItemSlotSH {
         GhostCircuitItemStackHandler handler = getGhostCircuitHandler();
         if (handler.getCircuitConfig() != config) {
             handler.setCircuitConfig(config);
-            syncToClient(1, buf -> {
-                buf.writeBoolean(false);
+            syncToClient(ItemSlotSH.SYNC_ITEM, buf -> {
+                buf.writeBoolean(false);//onlyAmountChanged
                 NetworkUtils.writeItemStack(buf, handler.getStackInSlot(0));
-                buf.writeBoolean(false);
+                buf.writeBoolean(false);//init
+                buf.writeBoolean(false);//force sync
             });
         }
     }

--- a/src/main/java/gregtech/common/modularui2/widget/GhostCircuitSlotWidget.java
+++ b/src/main/java/gregtech/common/modularui2/widget/GhostCircuitSlotWidget.java
@@ -19,9 +19,9 @@ import com.cleanroommc.modularui.theme.WidgetTheme;
 import com.cleanroommc.modularui.utils.MouseData;
 import com.cleanroommc.modularui.value.sync.IntSyncValue;
 import com.cleanroommc.modularui.value.sync.ItemSlotSH;
+import com.cleanroommc.modularui.value.sync.PhantomItemSlotSH;
 import com.cleanroommc.modularui.widgets.slot.ModularSlot;
 import com.cleanroommc.modularui.widgets.slot.PhantomItemSlot;
-import com.cleanroommc.modularui.value.sync.PhantomItemSlotSH;
 
 import gregtech.api.interfaces.IConfigurationCircuitSupport;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;

--- a/src/main/java/gregtech/common/modularui2/widget/GhostCircuitSlotWidget.java
+++ b/src/main/java/gregtech/common/modularui2/widget/GhostCircuitSlotWidget.java
@@ -21,6 +21,7 @@ import com.cleanroommc.modularui.value.sync.IntSyncValue;
 import com.cleanroommc.modularui.value.sync.ItemSlotSH;
 import com.cleanroommc.modularui.widgets.slot.ModularSlot;
 import com.cleanroommc.modularui.widgets.slot.PhantomItemSlot;
+import com.cleanroommc.modularui.value.sync.PhantomItemSlotSH;
 
 import gregtech.api.interfaces.IConfigurationCircuitSupport;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
@@ -61,7 +62,7 @@ public class GhostCircuitSlotWidget extends PhantomItemSlot {
                 openSelectorPanel();
             } else {
                 MouseData mouseData = MouseData.create(mouseButton);
-                getSyncHandler().syncToServer(2, mouseData::writeToPacket);
+                getSyncHandler().syncToServer(PhantomItemSlotSH.SYNC_CLICK, mouseData::writeToPacket);
             }
         }
         return Result.SUCCESS;
@@ -71,7 +72,7 @@ public class GhostCircuitSlotWidget extends PhantomItemSlot {
     public boolean onMouseScroll(ModularScreen.UpOrDown scrollDirection, int amount) {
         if (isSelectorPanelOpen()) return true;
         MouseData mouseData = MouseData.create(scrollDirection.modifier);
-        getSyncHandler().syncToServer(3, mouseData::writeToPacket);
+        getSyncHandler().syncToServer(PhantomItemSlotSH.SYNC_SCROLL, mouseData::writeToPacket);
         return true;
     }
 


### PR DESCRIPTION
GT Phantom Circuit Slot is broken after MUI2 breaking change.
And https://github.com/GTNewHorizons/GT5-Unofficial/pull/4325 did not fix the part of GT Phantom Circuit  Slot.
MUI2 now use different new magic numbers for phantom slot sync.
```
public static final int SYNC_CLICK = 100;
public static final int SYNC_SCROLL = 101;
public static final int SYNC_ITEM_SIMPLE = 102;
```
So the old magic numbers for non-phantom slot no more works.
This PR will adapt those.

New MUI2 also add a new boolean arg to the data of ItemSlotSH.SYNC_ITEM.

```
 @Override
    public void readOnClient(int id, PacketBuffer buf) {
        if (id == SYNC_ITEM) {
            boolean onlyAmountChanged = buf.readBoolean();
            this.lastStoredItem = NetworkUtils.readItemStack(buf);
            onSlotUpdate(this.lastStoredItem, onlyAmountChanged, true, buf.readBoolean());
            if (buf.readBoolean()) {
                // force sync
                this.slot.putStack(this.lastStoredItem);//<------------- newly added!!!!!!!!!
            }
        } else if (id == SYNC_ENABLED) {
            setEnabled(buf.readBoolean(), false);
        }
    }
```
This PR write an extra boolean to fix this.


I'm not sure if there're other PRs trying to fix the same issue.
Please close my PR if so.