### PR TITLE
Fix Industrial Apiaries Stackable Upgrades Always Using Max Values

### DIFF
--- a/src/main/java/gregtech/api/util/GTApiaryUpgrade.java
+++ b/src/main/java/gregtech/api/util/GTApiaryUpgrade.java
@@ -9,6 +9,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.MathHelper;
 import net.minecraft.world.biome.BiomeGenBase;
 
 import gregtech.api.enums.OrePrefixes;
@@ -33,7 +34,7 @@ public enum GTApiaryUpgrade {
         mods.energy *= 14.75;
     }),
     production(UNIQUE_INDEX.PRODUCTION_UPGRADE, 32209, 8, (mods, n) -> {
-        n = Math.max(n, 8);
+        n = MathHelper.clamp_int(n, 0, 8);
         mods.production = 4.f * (float) Math.pow(1.2d, n);
         mods.energy *= Math.pow(1.4f, n);
     }),
@@ -46,7 +47,7 @@ public enum GTApiaryUpgrade {
         mods.energy *= 1.05f;
     }),
     flowering(UNIQUE_INDEX.FLOWERING_UPGRADE, 32212, 8, (mods, n) -> {
-        n = Math.max(n, 8);
+        n = MathHelper.clamp_int(n, 0, 8);
         mods.flowering *= Math.pow(1.2f, n);
         mods.energy *= Math.pow(1.1f, n);
     }),
@@ -55,7 +56,7 @@ public enum GTApiaryUpgrade {
         mods.energy *= 1.5f;
     }),
     dryer(UNIQUE_INDEX.DRYER_UPGRADE, 32214, 16, (mods, n) -> {
-        n = Math.max(n, 16);
+        n = MathHelper.clamp_int(n, 0, 16);
         mods.humidity -= 0.125f * n;
         mods.energy *= Math.pow(1.025f, n);
     }),
@@ -64,7 +65,7 @@ public enum GTApiaryUpgrade {
         mods.energy *= 1.1f;
     }),
     humidifier(UNIQUE_INDEX.HUMIDIFIER_UPGRADE, 32216, 16, (mods, n) -> {
-        n = Math.max(n, 16);
+        n = MathHelper.clamp_int(n, 0, 16);
         mods.humidity += 0.125f * n;
         mods.energy *= Math.pow(1.05f, n);
     }),
@@ -81,12 +82,12 @@ public enum GTApiaryUpgrade {
         mods.energy *= 1.2f;
     }),
     cooler(UNIQUE_INDEX.COOLER_UPGRADE, 32220, 16, (mods, n) -> {
-        n = Math.max(n, 16);
+        n = MathHelper.clamp_int(n, 0, 16);
         mods.temperature -= 0.125f * n;
         mods.energy *= Math.pow(1.025f, n);
     }),
     lifespan(UNIQUE_INDEX.LIFESPAN_UPGRADE, 32221, 4, (mods, n) -> {
-        n = Math.max(n, 4);
+        n = MathHelper.clamp_int(n, 0, 4);
         mods.lifespan /= Math.pow(1.5f, n);
         mods.energy *= Math.pow(1.05f, n);
     }),
@@ -103,7 +104,7 @@ public enum GTApiaryUpgrade {
         mods.energy *= 1.20f;
     }),
     territory(UNIQUE_INDEX.TERRITORY_UPGRADE, 32225, 4, (mods, n) -> {
-        n = Math.max(n, 4);
+        n = MathHelper.clamp_int(n, 0, 4);
         mods.territory *= Math.pow(1.5f, n);
         mods.energy *= Math.pow(1.05f, n);
     }),
@@ -116,7 +117,7 @@ public enum GTApiaryUpgrade {
         mods.energy *= 1.05f;
     }),
     heater(UNIQUE_INDEX.HEATER_UPGRADE, 32228, 16, (mods, n) -> {
-        n = Math.max(n, 16);
+        n = MathHelper.clamp_int(n, 0, 16);
         mods.temperature += 0.125f * n;
         mods.energy *= Math.pow(1.025f, n);
     }),


### PR DESCRIPTION
Previously Industrial Apiaries used Math.max() for their stackable upgrades, this caused most upgrades to always apply at maximum potency, breaking jubilant checks for most bees.

Switched from using Math.max() to MathHelper.clamp_int() to allow most upgrades to function as normal again while maintaining the safety for overflows.

This change has been tested and provided some visual examples, you can see the right (Nightly 1010) always clamps to Hot with 1 temperature upgrade (These were both tested within a baseline Normal/Normal Biome). Where as In dev it no longer does. - This applies to all other upgrades as well but it was redundant to also provide visual examples.

![image](https://github.com/user-attachments/assets/81fd72c6-c02b-4e8d-8aee-94136cfedbff)
![image](https://github.com/user-attachments/assets/5e4d5c40-c477-4480-8280-4678f7f0bf55)
