### PR TITLE
Thorium tetra tidy

### DIFF
--- a/src/main/java/goodgenerator/items/GGMaterial.java
+++ b/src/main/java/goodgenerator/items/GGMaterial.java
@@ -237,6 +237,7 @@ public class GGMaterial implements Runnable {
         OffsetID + 18,
         TextureSet.SET_FLUID);
 
+    @Deprecated(forRemoval = true) // use GT++ ThoriumTetraFluoride
     public static final Werkstoff thoriumTetrafluoride = new Werkstoff(
         new short[] { 0x15, 0x6a, 0x6a },
         "Thorium Tetrafluoride",

--- a/src/main/java/goodgenerator/items/GGMaterial.java
+++ b/src/main/java/goodgenerator/items/GGMaterial.java
@@ -237,7 +237,7 @@ public class GGMaterial implements Runnable {
         OffsetID + 18,
         TextureSet.SET_FLUID);
 
-    @Deprecated(forRemoval = true) // use GT++ ThoriumTetraFluoride
+    @Deprecated // use GT++ ThoriumTetraFluoride
     public static final Werkstoff thoriumTetrafluoride = new Werkstoff(
         new short[] { 0x15, 0x6a, 0x6a },
         "Thorium Tetrafluoride",

--- a/src/main/java/goodgenerator/loader/RecipeLoader.java
+++ b/src/main/java/goodgenerator/loader/RecipeLoader.java
@@ -54,6 +54,7 @@ import gregtech.api.util.GTRecipeConstants;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.recipe.Scanning;
 import gtPlusPlus.core.material.MaterialsElements;
+import gtPlusPlus.core.material.nuclear.MaterialsFluorides;
 
 public class RecipeLoader {
 
@@ -335,7 +336,7 @@ public class RecipeLoader {
         GTValues.RA.stdBuilder()
             .itemInputs(GGMaterial.thoriumHydroxide.get(OrePrefixes.dust, 9), GTUtility.getIntegratedCircuit(1))
             .fluidInputs(Materials.HydrofluoricAcid.getFluid(4000))
-            .fluidOutputs(GGMaterial.thoriumTetrafluoride.getFluidOrGas(1000))
+            .fluidOutputs(MaterialsFluorides.THORIUM_TETRAFLUORIDE.getFluidStack(1000))
             .duration(20 * SECONDS)
             .eut(TierEU.RECIPE_LV)
             .addTo(UniversalChemical);
@@ -1495,7 +1496,7 @@ public class RecipeLoader {
 
         GTValues.RA.stdBuilder()
             .itemInputs(GTUtility.getIntegratedCircuit(1))
-            .fluidInputs(GGMaterial.thoriumTetrafluoride.getFluidOrGas(1000))
+            .fluidInputs(MaterialsFluorides.THORIUM_TETRAFLUORIDE.getFluidStack(1000))
             .itemOutputs(GTOreDictUnificator.get(OrePrefixes.dustSmall, Materials.Thorium, 1))
             .fluidOutputs(GGMaterial.thorium232Tetrafluoride.getFluidOrGas(750))
             .duration(5 * SECONDS)


### PR DESCRIPTION
Fixes: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18903

Simply replaces the crafting recipe and sole usage of the Good Generators Thorium Tetrafluoride with the version from GT++, and marks the GG version as depreciated. The GT++ version is the already the default which tanked fluids and cells automatically revert to.
