### PR TITLE
Add correction for even more accurate subticking

### DIFF
--- a/src/main/java/gregtech/api/util/OverclockCalculator.java
+++ b/src/main/java/gregtech/api/util/OverclockCalculator.java
@@ -444,6 +444,7 @@ public class OverclockCalculator {
         int heatOverclocks = Math.min(heatOC ? (machineHeat - recipeHeat) / HEAT_OVERCLOCK_THRESHOLD : 0, overclocks);
         int regularOverclocks = overclocks - heatOverclocks;
 
+        double originalDuration = duration;
         int neededHeatOverclocks = (int) Math.max((Math.log(duration) / Math.log(durationDecreasePerHeatOC)), 0);
         duration /= Math.pow(durationDecreasePerHeatOC, heatOverclocks);
         neededOverclocks = (int) Math.max((Math.log(duration) / Math.log(durationDecreasePerOC)), 0);
@@ -460,7 +461,15 @@ public class OverclockCalculator {
             .pow(durationDecreasePerHeatOC, Math.max(heatOverclocks - neededHeatOverclocks, 0));
         int regularMultiplier = (int) Math
             .pow(durationDecreasePerOC, Math.max(regularOverclocks - neededOverclocks, 0));
+        double correctionMultiplier = 1.0;
+        if (heatOverclocks >= neededHeatOverclocks || regularOverclocks >= neededOverclocks) {
+            double criticalDecreasePerOC = heatOverclocks >= neededHeatOverclocks ? durationDecreasePerHeatOC
+                : durationDecreasePerOC;
+            int criticalOverclock = (int) (Math.log(originalDuration / 2) / Math.log(criticalDecreasePerOC));
+            double criticalDuration = originalDuration / Math.pow(criticalDecreasePerOC, criticalOverclock);
+            correctionMultiplier = Math.max(Math.pow(criticalDuration, -1), 1);
+        }
 
-        return heatMultiplier * regularMultiplier;
+        return heatMultiplier * regularMultiplier * correctionMultiplier;
     }
 }


### PR DESCRIPTION
Improves on https://github.com/GTNewHorizons/GT5-Unofficial/pull/4146 to deliver even more accurate subticking.

The previous PR could have issues where some overclocks, especially with overclock factors >2, would be low. With this correction, it will boost it and so arrive at a very, very close approximation of what the exact performance boost should be, given enough parallels. It does this by calculating the duration of the first overclock that goes below two ticks in duration. Then, it gets the inverse of this (minimum of 1) and adds that as a correction multiplier to the total returned. This differs from https://github.com/GTNewHorizons/GT5-Unofficial/pull/4163 in only calculating that single fractional bonus. This, with the floor of 1, prevents any regression in expected behaviours regarding hitting 1 tick or reducing parallel count.

Experimentally, removing the floor of 1 would produce a highly-accurate overclocking system for any OC factor (in terms of the ideal cumulative performance gain), but a sub-1 parallel multiplier is probably unwanted.

Here is a google sheet that allows for messing with the formulas. The top table is the current system based on the previous PR, and the bottom is the system using this PR. The Ideal Cumulative Gain column is the goal, where if we had fully continuous parallel and recipe duration values an overclock would always increase production by its OC factor.
https://docs.google.com/spreadsheets/d/1TeNAlSn0PrG4tUaZ7HQODQSuxsuos_o4yIv9emRWNEI/edit?gid=1527390161#gid=1527390161