### PR TITLE
Fix Barnarda C saplings AGAIN.

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoaderTreeFarm.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoaderTreeFarm.java
@@ -197,7 +197,7 @@ public class RecipeLoaderTreeFarm {
 
     private static void generateGalaxySpaceTrees() {
         MTETreeFarm.registerTreeProducts( // Barnarda C
-            GTModHandler.getModItem(Mods.GalaxySpace.ID, "barnardaCsapling", 1, 1),
+            GTModHandler.getModItem(Mods.GalaxySpace.ID, "barnardaCsapling", 1, 0),
             GTModHandler.getModItem(Mods.GalaxySpace.ID, "barnardaClog", 1, 0),
             GTModHandler.getModItem(Mods.GalaxySpace.ID, "barnardaCleaves", 1, 0),
             null);


### PR DESCRIPTION
Background: In the (distant) past, Barnarda C saplings came in two variants. If one obtained one naturally via leaf decay, the sapling would have a meta value of 1. However, if one spawned in a sapling through NEI or creative mode, the sapling would have a meta value 0. This lead to a bunch of incompatibilities, namely with the Tree Growth Simulator.

In https://github.com/GTNewHorizons/Galaxy-Space-GTNH/pull/125, saplings dropped by natural decay of Barnarda C leaves have been inadvertently changed from meta 1 to meta 0. This broke the TGS farming of them (again).

This PR fixes that. Hopefully for good; after the above refactor all saplings only have a meta of 0, and saplings with meta 1 can no longer be obtained in any way.

I have tested the TGS with this change, bot with spawned in and with naturally generated saplings (which as of now are the same item).

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19670.