### PR TITLE
Remove Construction Foam Cable Logic

### DIFF
--- a/src/main/java/gregtech/api/enums/Textures.java
+++ b/src/main/java/gregtech/api/enums/Textures.java
@@ -120,9 +120,7 @@ public class Textures {
         INSULATION_MEDIUM_PLUS,
         INSULATION_LARGE,
         INSULATION_HUGE,
-        CFOAM_FRESH,
 
-        CFOAM_HARDENED,
         SOLARPANEL,
         SOLARPANEL_8V,
         SOLARPANEL_LV,
@@ -1550,31 +1548,6 @@ public class Textures {
         // semicolon after the comment to reduce merge conflicts
         ;
 
-        /**
-         * Icon for Fresh CFoam
-         */
-        public static final ITexture[] FRESHFOAM = { TextureFactory.of(CFOAM_FRESH) };
-        /**
-         * Icons for Hardened CFoam 0 = No Color 1 - 16 = Colors
-         */
-        public static final ITexture[][] HARDENEDFOAMS = {
-            new ITexture[] { TextureFactory.of(CFOAM_HARDENED, Dyes.CONSTRUCTION_FOAM.mRGBa) },
-            new ITexture[] { TextureFactory.of(CFOAM_HARDENED, Dyes.VALUES[0].mRGBa) },
-            new ITexture[] { TextureFactory.of(CFOAM_HARDENED, Dyes.VALUES[1].mRGBa) },
-            new ITexture[] { TextureFactory.of(CFOAM_HARDENED, Dyes.VALUES[2].mRGBa) },
-            new ITexture[] { TextureFactory.of(CFOAM_HARDENED, Dyes.VALUES[3].mRGBa) },
-            new ITexture[] { TextureFactory.of(CFOAM_HARDENED, Dyes.VALUES[4].mRGBa) },
-            new ITexture[] { TextureFactory.of(CFOAM_HARDENED, Dyes.VALUES[5].mRGBa) },
-            new ITexture[] { TextureFactory.of(CFOAM_HARDENED, Dyes.VALUES[6].mRGBa) },
-            new ITexture[] { TextureFactory.of(CFOAM_HARDENED, Dyes.VALUES[7].mRGBa) },
-            new ITexture[] { TextureFactory.of(CFOAM_HARDENED, Dyes.VALUES[8].mRGBa) },
-            new ITexture[] { TextureFactory.of(CFOAM_HARDENED, Dyes.VALUES[9].mRGBa) },
-            new ITexture[] { TextureFactory.of(CFOAM_HARDENED, Dyes.VALUES[10].mRGBa) },
-            new ITexture[] { TextureFactory.of(CFOAM_HARDENED, Dyes.VALUES[11].mRGBa) },
-            new ITexture[] { TextureFactory.of(CFOAM_HARDENED, Dyes.VALUES[12].mRGBa) },
-            new ITexture[] { TextureFactory.of(CFOAM_HARDENED, Dyes.VALUES[13].mRGBa) },
-            new ITexture[] { TextureFactory.of(CFOAM_HARDENED, Dyes.VALUES[14].mRGBa) },
-            new ITexture[] { TextureFactory.of(CFOAM_HARDENED, Dyes.VALUES[15].mRGBa) } };
         /**
          * Machine Casings by Tier 0 = 8V, 1 = LV, 2 = MV, 3 = HV, 4 = EV, 5 = IV, 6 = IV, 7 = IV, 8 = IV, 9 = IV
          */

--- a/src/main/java/gregtech/api/interfaces/metatileentity/IConnectable.java
+++ b/src/main/java/gregtech/api/interfaces/metatileentity/IConnectable.java
@@ -15,9 +15,6 @@ public interface IConnectable {
     int CONNECTED_WEST = 0b00010000;
     int CONNECTED_EAST = 0b00100000;
     int CONNECTED_ALL = 0b00111111;
-    int HAS_FRESHFOAM = 0b01000000;
-    int HAS_HARDENEDFOAM = 0b10000000;
-    int HAS_FOAM = 0b11000000;
 
     /**
      * Try to connect to the Block at the specified side returns the connection state. Non-positive values for failed,

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
@@ -709,9 +709,6 @@ public class BaseMetaPipeEntity extends CommonBaseMetaTileEntity
 
     @Override
     public ITexture[] getTextureUncovered(ForgeDirection sideDirection) {
-        if ((mConnections & IConnectable.HAS_FRESHFOAM) != 0) return Textures.BlockIcons.FRESHFOAM;
-        if ((mConnections & IConnectable.HAS_HARDENEDFOAM) != 0) return Textures.BlockIcons.HARDENEDFOAMS[mColor];
-        if ((mConnections & IConnectable.HAS_FOAM) != 0) return Textures.BlockIcons.ERROR_RENDERING;
         int tConnections = mConnections;
         if (tConnections == IConnectable.CONNECTED_WEST || tConnections == IConnectable.CONNECTED_EAST)
             tConnections = IConnectable.CONNECTED_WEST | IConnectable.CONNECTED_EAST;

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
@@ -196,17 +196,10 @@ public class BaseMetaPipeEntity extends CommonBaseMetaTileEntity
             if (isServerSide && mTickTimer > 10) {
                 if (!doCoverThings()) return;
 
-                final byte oldConnections = mConnections;
-                // Mask-out connection direction bits to keep only Foam related connections
-                mConnections = (byte) (mMetaTileEntity.mConnections | (mConnections & ~IConnectable.CONNECTED_ALL));
-                // If foam not hardened, tries roll chance to harden
-                if ((mConnections & IConnectable.HAS_FOAM) == IConnectable.HAS_FRESHFOAM
-                    && getRandomNumber(1000) == 0) {
-                    mConnections = (byte) ((mConnections & ~IConnectable.HAS_FRESHFOAM)
-                        | IConnectable.HAS_HARDENEDFOAM);
-                }
-                if (mTickTimer > 12 && oldConnections != mConnections)
+                if (mTickTimer > 12 && mConnections != mMetaTileEntity.mConnections) {
+                    mConnections = mMetaTileEntity.mConnections;
                     GregTechAPI.causeCableUpdate(worldObj, xCoord, yCoord, zCoord);
+                }
             }
             mMetaTileEntity.onPreTick(this, mTickTimer);
             if (!hasValidMetaTileEntity()) return;

--- a/src/main/java/gregtech/api/metatileentity/MetaPipeEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaPipeEntity.java
@@ -238,7 +238,7 @@ public abstract class MetaPipeEntity extends CommonMetaTileEntity implements ICo
 
     @Override
     public float getExplosionResistance(ForgeDirection side) {
-        return (mConnections & IConnectable.HAS_FOAM) != 0 ? 50.0F : 5.0F;
+        return 5.0F;
     }
 
     @Override

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTECable.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTECable.java
@@ -166,7 +166,6 @@ public class MTECable extends MetaPipeEntity implements IMetaTileEntityCable {
         if (!(baseEntity.getNodePath() instanceof PowerNodePath powerPath)) return;
 
         if (isCoverOnSide(baseEntity, livingEntity)) return;
-        if ((baseEntity.mConnections & IConnectable.HAS_HARDENEDFOAM) == 1) return;
 
         final long amperage = powerPath.getAmperage();
         final long voltage = powerPath.getVoltage();

--- a/src/main/java/gregtech/common/render/GTRendererBlock.java
+++ b/src/main/java/gregtech/common/render/GTRendererBlock.java
@@ -12,8 +12,6 @@ import static gregtech.api.interfaces.metatileentity.IConnectable.CONNECTED_NORT
 import static gregtech.api.interfaces.metatileentity.IConnectable.CONNECTED_SOUTH;
 import static gregtech.api.interfaces.metatileentity.IConnectable.CONNECTED_UP;
 import static gregtech.api.interfaces.metatileentity.IConnectable.CONNECTED_WEST;
-import static gregtech.api.interfaces.metatileentity.IConnectable.HAS_FRESHFOAM;
-import static gregtech.api.interfaces.metatileentity.IConnectable.HAS_HARDENEDFOAM;
 import static gregtech.api.interfaces.metatileentity.IConnectable.NO_CONNECTION;
 import static net.minecraftforge.common.util.ForgeDirection.DOWN;
 import static net.minecraftforge.common.util.ForgeDirection.EAST;
@@ -171,9 +169,6 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
     public boolean renderPipeBlock(IBlockAccess aWorld, int aX, int aY, int aZ, Block aBlock,
         IPipeRenderedTileEntity aTileEntity, RenderBlocks aRenderer) {
         final byte aConnections = aTileEntity.getConnections();
-        if ((aConnections & (HAS_FRESHFOAM | HAS_HARDENEDFOAM)) != 0) {
-            return renderStandardBlock(aWorld, aX, aY, aZ, aBlock, aRenderer);
-        }
         final float thickness = aTileEntity.getThickNess();
         if (thickness >= 0.99F) {
             return renderStandardBlock(aWorld, aX, aY, aZ, aBlock, aRenderer);


### PR DESCRIPTION
This is an unfinished feature which was meant to mimic IC2's cable foaming feature. In IC2 you could apply foam onto a cable, which is comparable to a cable having a cover on all sides

The majority of the logic seems to be present to have the feature work, except the application of the foam itself onto GT cables

I propose removing this logic since its very unlikely any player would realistically use this over covers. There is some foam logic for color modulation, though I am unsure if it has any relation to the cable logic