### PR TITLE
Fixed GT++ Ores missing recipes

### DIFF
--- a/src/main/java/gtPlusPlus/core/common/CommonProxy.java
+++ b/src/main/java/gtPlusPlus/core/common/CommonProxy.java
@@ -113,13 +113,13 @@ public class CommonProxy implements IFuelHandler {
         CompatHandler.InitialiseHandlerThenAddRecipes();
         Logger.INFO("Loading Intermod staging.");
         CompatIntermodStaging.postInit(e);
+        // Moved last, to prevent recipes being generated post initialisation.
+        Logger.INFO("Loading Gregtech API recipes.");
+        CompatHandler.startLoadingGregAPIBasedRecipes();
         Logger.INFO("Loading queued recipes.");
         CompatHandler.runQueuedRecipes();
         Logger.INFO("Registering custom mob drops.");
         registerCustomMobDrops();
-        // Moved last, to prevent recipes being generated post initialisation.
-        Logger.INFO("Loading Gregtech API recipes.");
-        CompatHandler.startLoadingGregAPIBasedRecipes();
     }
 
     public void serverStarting(final FMLServerStartingEvent e) {


### PR DESCRIPTION
fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19702

The crafting recipes added in `startLoadingGregAPIBasedRecipes()` are all ignored because the list to store the recipes are already registered them at that time in `runQueuedRecipes()`.
One of the affected recipe is the related issue above.

I'm not sure if it will cause any weird problems with this change.