### PR TITLE
Fix Cover Text field text color

### DIFF
--- a/src/main/java/gregtech/api/modularui2/GTGuiThemes.java
+++ b/src/main/java/gregtech/api/modularui2/GTGuiThemes.java
@@ -48,9 +48,10 @@ public final class GTGuiThemes {
         .themedTexture(GTWidgetThemes.PICTURE_LOGO, GTTextureIds.PICTURE_GT_LOGO_STANDARD)
         .build();
     public static final GTGuiTheme COVER = GTGuiTheme.builder("gregtech:cover")
+        .parent(STANDARD)
         .textColor(0x555555)
         .customTextColor(GTWidgetThemes.TEXT_TITLE, 0x222222)
-        .parent(STANDARD)
+        .textField(Dyes.dyeWhite.toInt())
         .build();
     public static final GTGuiTheme BRONZE = GTGuiTheme.builder("gregtech:bronze")
         .parent(STANDARD)


### PR DESCRIPTION
I also moved around the parent theme declaration, which doesn't change anything but is more consistent.

This makes it so cover text fields have white text and not grey text.

The bug this mitigates is detailed here: https://discord.com/channels/181078474394566657/1303308397961019472/1375677334660714647

### Before
![image](https://github.com/user-attachments/assets/97c7b5bc-0264-45d3-a6d0-877239439d63)

###  After 
![image](https://github.com/user-attachments/assets/f5f328ac-7ed5-44fb-bd75-2822be6256ac)
