### PR TITLE
Fix GT++ normal pipes not being craftable

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechConduits.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechConduits.java
@@ -17,7 +17,9 @@ import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.enums.TextureSet;
+import gregtech.api.enums.ToolDictNames;
 import gregtech.api.metatileentity.implementations.MTEFluidPipe;
+import gregtech.api.util.GTModHandler;
 import gregtech.api.util.GTOreDictUnificator;
 import gregtech.api.util.GTUtility;
 import gtPlusPlus.api.objects.Logger;
@@ -679,53 +681,28 @@ public class GregtechConduits {
         int eut = (int) (8 * vMulti);
 
         // Add the Four Shaped Recipes First
-        RecipeUtils.addShapedRecipe(
-            pipePlate,
-            pipePlate,
-            pipePlate,
-            "craftingToolHardHammer",
-            null,
-            "craftingToolWrench",
-            pipePlate,
-            pipePlate,
-            pipePlate,
-            ItemUtils.getItemStackOfAmountFromOreDict("pipe" + "Tiny" + output, 8));
+        GTModHandler.addCraftingRecipe(
+            ItemUtils.getItemStackOfAmountFromOreDict("pipe" + "Tiny" + output, 8),
+            GTModHandler.RecipeBits.BUFFERED,
+            new Object[] { "PPP", "h w", "PPP", 'P', pipePlate });
 
-        RecipeUtils.addShapedRecipe(
-            pipePlate,
-            "craftingToolWrench",
-            pipePlate,
-            pipePlate,
-            null,
-            pipePlate,
-            pipePlate,
-            "craftingToolHardHammer",
-            pipePlate,
-            ItemUtils.getItemStackOfAmountFromOreDict("pipe" + "Small" + output, 6));
+        GTModHandler.addCraftingRecipe(
+            ItemUtils.getItemStackOfAmountFromOreDict("pipe" + "Small" + output, 6),
+            GTModHandler.RecipeBits.BUFFERED,
+            new Object[] { "PWP", "P P", "PHP", 'P', pipePlate, 'H', ToolDictNames.craftingToolHardHammer, 'W',
+                ToolDictNames.craftingToolWrench });
 
-        RecipeUtils.addShapedRecipe(
-            pipePlate,
-            pipePlate,
-            pipePlate,
-            "craftingToolWrench",
-            null,
-            "craftingToolHardHammer",
-            pipePlate,
-            pipePlate,
-            pipePlate,
-            ItemUtils.getItemStackOfAmountFromOreDict("pipe" + "Medium" + output, 2));
+        GTModHandler.addCraftingRecipe(
+            ItemUtils.getItemStackOfAmountFromOreDict("pipe" + "Medium" + output, 2),
+            GTModHandler.RecipeBits.BUFFERED,
+            new Object[] { "PPP", "W H", "PPP", 'P', pipePlate, 'H', ToolDictNames.craftingToolHardHammer, 'W',
+                ToolDictNames.craftingToolWrench });
 
-        RecipeUtils.addShapedRecipe(
-            pipePlate,
-            "craftingToolHardHammer",
-            pipePlate,
-            pipePlate,
-            null,
-            pipePlate,
-            pipePlate,
-            "craftingToolWrench",
-            pipePlate,
-            ItemUtils.getItemStackOfAmountFromOreDict("pipe" + "Large" + output, 1));
+        GTModHandler.addCraftingRecipe(
+            ItemUtils.getItemStackOfAmountFromOreDict("pipe" + "Large" + output, 1),
+            GTModHandler.RecipeBits.BUFFERED,
+            new Object[] { "PHP", "P P", "PWP", 'P', pipePlate, 'H', ToolDictNames.craftingToolHardHammer, 'W',
+                ToolDictNames.craftingToolWrench });
 
         if (pipeIngot != null && ItemUtils.checkForInvalidItems(pipeIngot)) {
             // 1 Clay Plate = 1 Clay Dust = 2 Clay Ball

--- a/src/main/java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechConduits.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechConduits.java
@@ -17,7 +17,6 @@ import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.enums.TextureSet;
-import gregtech.api.enums.ToolDictNames;
 import gregtech.api.metatileentity.implementations.MTEFluidPipe;
 import gregtech.api.util.GTModHandler;
 import gregtech.api.util.GTOreDictUnificator;
@@ -689,20 +688,17 @@ public class GregtechConduits {
         GTModHandler.addCraftingRecipe(
             ItemUtils.getItemStackOfAmountFromOreDict("pipe" + "Small" + output, 6),
             GTModHandler.RecipeBits.BUFFERED,
-            new Object[] { "PWP", "P P", "PHP", 'P', pipePlate, 'H', ToolDictNames.craftingToolHardHammer, 'W',
-                ToolDictNames.craftingToolWrench });
+            new Object[] { "PwP", "P P", "PhP", 'P', pipePlate });
 
         GTModHandler.addCraftingRecipe(
             ItemUtils.getItemStackOfAmountFromOreDict("pipe" + "Medium" + output, 2),
             GTModHandler.RecipeBits.BUFFERED,
-            new Object[] { "PPP", "W H", "PPP", 'P', pipePlate, 'H', ToolDictNames.craftingToolHardHammer, 'W',
-                ToolDictNames.craftingToolWrench });
+            new Object[] { "PPP", "w h", "PPP", 'P', pipePlate });
 
         GTModHandler.addCraftingRecipe(
             ItemUtils.getItemStackOfAmountFromOreDict("pipe" + "Large" + output, 1),
             GTModHandler.RecipeBits.BUFFERED,
-            new Object[] { "PHP", "P P", "PWP", 'P', pipePlate, 'H', ToolDictNames.craftingToolHardHammer, 'W',
-                ToolDictNames.craftingToolWrench });
+            new Object[] { "PhP", "P P", "PwP", 'P', pipePlate });
 
         if (pipeIngot != null && ItemUtils.checkForInvalidItems(pipeIngot)) {
             // 1 Clay Plate = 1 Clay Dust = 2 Clay Ball


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20001

The GT++ recipe adders here seem to allow mirroring, which doesn't work when a recipe is explicitly mirrored to make something else like with these pipes. Used the conventional GTModHandler recipe adder instead