### PR TITLE
[MUI2] Heat Sensor

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/compressor/MTEHeatSensor.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/compressor/MTEHeatSensor.java
@@ -31,7 +31,7 @@ import gregtech.common.tileentities.machines.multi.gui.MTEHeatSensorGuiBuilder;
 
 public class MTEHeatSensor extends MTEHatch {
 
-    protected float threshold = 0;
+    protected double threshold = 0;
     protected boolean inverted = false;
     private boolean isOn = false;
 
@@ -93,14 +93,14 @@ public class MTEHeatSensor extends MTEHatch {
 
     @Override
     public void loadNBTData(NBTTagCompound aNBT) {
-        threshold = aNBT.getFloat("mThreshold");
+        threshold = aNBT.getDouble("mThreshold");
         inverted = aNBT.getBoolean("mInverted");
         super.loadNBTData(aNBT);
     }
 
     @Override
     public void saveNBTData(NBTTagCompound aNBT) {
-        aNBT.setFloat("mThreshold", threshold);
+        aNBT.setDouble("mThreshold", threshold);
         aNBT.setBoolean("mInverted", inverted);
         super.saveNBTData(aNBT);
     }
@@ -144,11 +144,11 @@ public class MTEHeatSensor extends MTEHatch {
         return new ITexture[] { aBaseTexture, TextureFactory.of(textureFont) };
     }
 
-    public float getThreshold() {
+    public double getThreshold() {
         return threshold;
     }
 
-    public void setThreshold(float threshold) {
+    public void setThreshold(double threshold) {
         this.threshold = threshold;
     }
 
@@ -189,7 +189,7 @@ public class MTEHeatSensor extends MTEHatch {
                     .setPos(28, 12))
             .widget(
                 new NumericWidget().setBounds(0, 100)
-                    .setGetter(() -> (double) threshold)
+                    .setGetter(() -> threshold)
                     .setSetter((value) -> threshold = (float) value)
                     .setScrollValues(0.1, 0.01, 1.0)
                     .setMaximumFractionDigits(2)

--- a/src/main/java/gregtech/common/tileentities/machines/multi/gui/MTEHeatSensorGuiBuilder.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/gui/MTEHeatSensorGuiBuilder.java
@@ -7,7 +7,7 @@ import com.cleanroommc.modularui.factory.PosGuiData;
 import com.cleanroommc.modularui.screen.ModularPanel;
 import com.cleanroommc.modularui.screen.UISettings;
 import com.cleanroommc.modularui.value.sync.BooleanSyncValue;
-import com.cleanroommc.modularui.value.sync.IntSyncValue;
+import com.cleanroommc.modularui.value.sync.DoubleSyncValue;
 import com.cleanroommc.modularui.value.sync.PanelSyncManager;
 import com.cleanroommc.modularui.widgets.ToggleButton;
 import com.cleanroommc.modularui.widgets.layout.Flow;
@@ -61,7 +61,7 @@ public class MTEHeatSensorGuiBuilder {
                 new TextFieldWidget().setFormatAsInteger(true)
                     .setNumbers(0, 100)
                     .size(77, 12)
-                    .value(new IntSyncValue(() -> (int) sensor.getThreshold(), sensor::setThreshold))
+                    .value(new DoubleSyncValue(sensor::getThreshold, sensor::setThreshold))
                     .setFocusOnGuiOpen(true))
             .child(
                 IKey.lang("GT5U.gui.text.heat_sensor")


### PR DESCRIPTION
Adds MUI2 support to the Heat Sensor hatch

# MUI1
![image](https://github.com/user-attachments/assets/4eeb6869-c16c-4be9-818f-ed4cbb664d5e)

# MUI2
![image](https://github.com/user-attachments/assets/6cf02f2f-40a2-464f-9d79-9aed5bc6a2d1)

The UI code is copied almost verbatim from #4374 because the UI for both hatches are very very similar. 

Internally, the MUI1 implementation seems to have support for decimals because scrolling has support for tenths and hundredths, but in game I couldnt get it to display anything but a whole number in the text field. So im not sure if the MUI2 implementation should try for decimal support or not, but currently I have it as not
