### PR TITLE
Fix fuel values for rocket fuel

### DIFF
--- a/src/main/java/gtPlusPlus/core/item/chemistry/RecipeLoaderRocketFuels.java
+++ b/src/main/java/gtPlusPlus/core/item/chemistry/RecipeLoaderRocketFuels.java
@@ -178,8 +178,8 @@ public class RecipeLoaderRocketFuels {
     private static void addRocketFuelsToMap() {
         addFuelRecipe(GTPPFluids.RP1RocketFuel, 512);
         addFuelRecipe(GTPPFluids.DenseHydrazineFuelMixture, 1024);
-        addFuelRecipe(GTPPFluids.H8N4C2O4RocketFuel, 2048);
-        addFuelRecipe(GTPPFluids.CN3H7O3RocketFuel, 4196);
+        addFuelRecipe(GTPPFluids.CN3H7O3RocketFuel, 2048);
+        addFuelRecipe(GTPPFluids.H8N4C2O4RocketFuel, 4196);
     }
 
     private static void addFuelRecipe(Fluid fluid, int fuelValue) {


### PR DESCRIPTION
Before
![image](https://github.com/user-attachments/assets/e81d2d42-b5dd-4879-825c-a15a506af9a2)
![image](https://github.com/user-attachments/assets/d3b0a3ca-8779-4ed8-afae-550d4752d7a0)

After
![image](https://github.com/user-attachments/assets/50f2b03a-95a6-40a3-83e8-d2d52cfa1481)
![image](https://github.com/user-attachments/assets/39524c6c-4ab3-409b-9d67-3b00f1b17012)
Do note that 
purple = CN3H7O3 = t6 chemplant
green = H8N4C2O4 = t7 chemplant

Fixes a tiny mistake that slipped through in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3970