### PR TITLE
Seperate ME busses and hatches by color

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -36,12 +36,12 @@
 dependencies {
     api("com.github.GTNewHorizons:StructureLib:1.4.10:dev")
     api("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev")
-    api("com.github.GTNewHorizons:NotEnoughItems:2.7.48-GTNH:dev")
+    api("com.github.GTNewHorizons:NotEnoughItems:2.7.49-GTNH:dev")
     api("com.github.GTNewHorizons:NotEnoughIds:2.1.9:dev")
     api("com.github.GTNewHorizons:GTNHLib:0.6.25:dev")
     api("com.github.GTNewHorizons:ModularUI:1.2.18:dev")
     api("com.github.GTNewHorizons:ModularUI2:2.2.15-1.7.10:dev")
-    api("com.github.GTNewHorizons:waila:1.8.6:dev")
+    api("com.github.GTNewHorizons:waila:1.8.7:dev")
     api("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-619-GTNH:dev")
     api("com.github.GTNewHorizons:AE2FluidCraft-Rework:1.4.76-gtnh:dev")
     api('com.github.GTNewHorizons:Yamcl:0.7.0:dev')
@@ -59,7 +59,7 @@ dependencies {
 
     compileOnlyApi("com.github.GTNewHorizons:Avaritia:1.63:dev")
 
-    compileOnlyApi('com.github.GTNewHorizons:Angelica:1.0.0-beta43:api') { transitive = false }
+    compileOnlyApi('com.github.GTNewHorizons:Angelica:1.0.0-beta44:api') { transitive = false }
     compileOnlyApi("com.github.GTNewHorizons:AppleCore:3.3.4:dev") { transitive = false }
     compileOnlyApi("com.github.GTNewHorizons:BuildCraft:7.1.42:dev") { transitive = false }
     compileOnlyApi("com.github.GTNewHorizons:EnderIO:2.9.16:dev") { transitive = false }
@@ -89,7 +89,7 @@ dependencies {
     // https://www.curseforge.com/minecraft/mc-mods/advancedsolarpanels
     compileOnlyApi rfg.deobf('curse.maven:advsolar-362768:2885953')
     compileOnly('com.github.GTNewHorizons:ThaumicEnergistics:1.7.7-GTNH:dev') {transitive =  false}
-    compileOnly("com.github.GTNewHorizons:BloodMagic:1.7.31:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:BloodMagic:1.7.32:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:CraftTweaker:3.4.2:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:BetterLoadingScreen:1.7.0-GTNH:dev") { transitive = false }
     compileOnly rfg.deobf("curse.maven:biomes-o-plenty-220318:2499612")

--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchCraftingInputME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchCraftingInputME.java
@@ -520,7 +520,7 @@ public class MTEHatchCraftingInputME extends MTEHatchInputBus
         if (color == -1) {
             proxy.setColor(AEColor.Transparent);
         } else {
-            proxy.setColor(AEColor.values()[Dyes.transformDyeIndex(this.getColor())]);
+            proxy.setColor(AEColor.values()[Dyes.transformDyeIndex(color)]);
         }
         if (proxy.getNode() != null) {
             proxy.getNode()

--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchCraftingInputME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchCraftingInputME.java
@@ -71,6 +71,7 @@ import appeng.api.storage.IMEMonitor;
 import appeng.api.storage.data.IAEFluidStack;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.api.util.AECableType;
+import appeng.api.util.AEColor;
 import appeng.api.util.DimensionalCoord;
 import appeng.api.util.IInterfaceViewable;
 import appeng.core.AppEng;
@@ -87,6 +88,7 @@ import appeng.util.PatternMultiplierHelper;
 import appeng.util.Platform;
 import appeng.util.ReadableNumberConverter;
 import gregtech.GTMod;
+import gregtech.api.enums.Dyes;
 import gregtech.api.enums.ItemList;
 import gregtech.api.gui.modularui.GTUITextures;
 import gregtech.api.interfaces.IConfigurationCircuitSupport;
@@ -508,6 +510,21 @@ public class MTEHatchCraftingInputME extends MTEHatchInputBus
     }
 
     @Override
+    public void onColorChangeServer(byte aColor) {
+        updateAE2ProxyColor();
+    }
+
+    public void updateAE2ProxyColor() {
+        this.getProxy()
+            .setColor(AEColor.values()[Dyes.transformDyeIndex(this.getColor())]);
+        AENetworkProxy proxy = getProxy();
+        if (proxy.getNode() != null) {
+            proxy.getNode()
+                .updateState();
+        }
+    }
+
+    @Override
     public AECableType getCableConnectionType(ForgeDirection forgeDirection) {
         return isOutputFacing(forgeDirection) ? AECableType.SMART : AECableType.NONE;
     }
@@ -707,6 +724,7 @@ public class MTEHatchCraftingInputME extends MTEHatchInputBus
         disablePatternOptimization = aNBT.getBoolean("disablePatternOptimization");
 
         getProxy().readFromNBT(aNBT);
+        updateAE2ProxyColor();
     }
 
     @Override

--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchCraftingInputME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchCraftingInputME.java
@@ -515,9 +515,8 @@ public class MTEHatchCraftingInputME extends MTEHatchInputBus
     }
 
     public void updateAE2ProxyColor() {
-        this.getProxy()
-            .setColor(AEColor.values()[Dyes.transformDyeIndex(this.getColor())]);
         AENetworkProxy proxy = getProxy();
+        proxy.setColor(AEColor.values()[Dyes.transformDyeIndex(this.getColor())]);
         if (proxy.getNode() != null) {
             proxy.getNode()
                 .updateState();

--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchCraftingInputME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchCraftingInputME.java
@@ -516,7 +516,12 @@ public class MTEHatchCraftingInputME extends MTEHatchInputBus
 
     public void updateAE2ProxyColor() {
         AENetworkProxy proxy = getProxy();
-        proxy.setColor(AEColor.values()[Dyes.transformDyeIndex(this.getColor())]);
+        byte color = this.getColor();
+        if (color == -1) {
+            proxy.setColor(AEColor.Transparent);
+        } else {
+            proxy.setColor(AEColor.values()[Dyes.transformDyeIndex(this.getColor())]);
+        }
         if (proxy.getNode() != null) {
             proxy.getNode()
                 .updateState();

--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchInputBusME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchInputBusME.java
@@ -169,9 +169,8 @@ public class MTEHatchInputBusME extends MTEHatchInputBus
     }
 
     public void updateAE2ProxyColor() {
-        this.getProxy()
-            .setColor(AEColor.values()[Dyes.transformDyeIndex(this.getColor())]);
         AENetworkProxy proxy = getProxy();
+        proxy.setColor(AEColor.values()[Dyes.transformDyeIndex(this.getColor())]);
         if (proxy.getNode() != null) {
             proxy.getNode()
                 .updateState();

--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchInputBusME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchInputBusME.java
@@ -170,7 +170,12 @@ public class MTEHatchInputBusME extends MTEHatchInputBus
 
     public void updateAE2ProxyColor() {
         AENetworkProxy proxy = getProxy();
-        proxy.setColor(AEColor.values()[Dyes.transformDyeIndex(this.getColor())]);
+        byte color = this.getColor();
+        if (color == -1) {
+            proxy.setColor(AEColor.Transparent);
+        } else {
+            proxy.setColor(AEColor.values()[Dyes.transformDyeIndex(this.getColor())]);
+        }
         if (proxy.getNode() != null) {
             proxy.getNode()
                 .updateState();

--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchInputBusME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchInputBusME.java
@@ -174,7 +174,7 @@ public class MTEHatchInputBusME extends MTEHatchInputBus
         if (color == -1) {
             proxy.setColor(AEColor.Transparent);
         } else {
-            proxy.setColor(AEColor.values()[Dyes.transformDyeIndex(this.getColor())]);
+            proxy.setColor(AEColor.values()[Dyes.transformDyeIndex(color)]);
         }
         if (proxy.getNode() != null) {
             proxy.getNode()

--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchInputBusME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchInputBusME.java
@@ -54,11 +54,13 @@ import appeng.api.networking.security.MachineSource;
 import appeng.api.storage.IMEMonitor;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.api.util.AECableType;
+import appeng.api.util.AEColor;
 import appeng.core.localization.WailaText;
 import appeng.me.GridAccessException;
 import appeng.me.helpers.AENetworkProxy;
 import appeng.me.helpers.IGridProxyable;
 import appeng.util.item.AEItemStack;
+import gregtech.api.enums.Dyes;
 import gregtech.api.enums.ItemList;
 import gregtech.api.gui.modularui.GTUITextures;
 import gregtech.api.interfaces.IConfigurationCircuitSupport;
@@ -158,6 +160,21 @@ public class MTEHatchInputBusME extends MTEHatchInputBus
     public void onEnableWorking() {
         if (expediteRecipeCheck) {
             justHadNewItems = true;
+        }
+    }
+
+    @Override
+    public void onColorChangeServer(byte aColor) {
+        updateAE2ProxyColor();
+    }
+
+    public void updateAE2ProxyColor() {
+        this.getProxy()
+            .setColor(AEColor.values()[Dyes.transformDyeIndex(this.getColor())]);
+        AENetworkProxy proxy = getProxy();
+        if (proxy.getNode() != null) {
+            proxy.getNode()
+                .updateState();
         }
     }
 
@@ -293,7 +310,7 @@ public class MTEHatchInputBusME extends MTEHatchInputBus
             autoPullRefreshTime = aNBT.getInteger("refreshTime");
         }
         getProxy().readFromNBT(aNBT);
-
+        updateAE2ProxyColor();
     }
 
     @Override

--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchInputME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchInputME.java
@@ -183,7 +183,7 @@ public class MTEHatchInputME extends MTEHatchInput implements IPowerChannelState
         if (color == -1) {
             proxy.setColor(AEColor.Transparent);
         } else {
-            proxy.setColor(AEColor.values()[Dyes.transformDyeIndex(this.getColor())]);
+            proxy.setColor(AEColor.values()[Dyes.transformDyeIndex(color)]);
         }
         if (proxy.getNode() != null) {
             proxy.getNode()

--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchInputME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchInputME.java
@@ -179,7 +179,12 @@ public class MTEHatchInputME extends MTEHatchInput implements IPowerChannelState
 
     public void updateAE2ProxyColor() {
         AENetworkProxy proxy = getProxy();
-        proxy.setColor(AEColor.values()[Dyes.transformDyeIndex(this.getColor())]);
+        byte color = this.getColor();
+        if (color == -1) {
+            proxy.setColor(AEColor.Transparent);
+        } else {
+            proxy.setColor(AEColor.values()[Dyes.transformDyeIndex(this.getColor())]);
+        }
         if (proxy.getNode() != null) {
             proxy.getNode()
                 .updateState();

--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchInputME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchInputME.java
@@ -178,9 +178,8 @@ public class MTEHatchInputME extends MTEHatchInput implements IPowerChannelState
     }
 
     public void updateAE2ProxyColor() {
-        this.getProxy()
-            .setColor(AEColor.values()[Dyes.transformDyeIndex(this.getColor())]);
         AENetworkProxy proxy = getProxy();
+        proxy.setColor(AEColor.values()[Dyes.transformDyeIndex(this.getColor())]);
         if (proxy.getNode() != null) {
             proxy.getNode()
                 .updateState();

--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchInputME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchInputME.java
@@ -59,11 +59,13 @@ import appeng.api.networking.security.MachineSource;
 import appeng.api.storage.IMEMonitor;
 import appeng.api.storage.data.IAEFluidStack;
 import appeng.api.util.AECableType;
+import appeng.api.util.AEColor;
 import appeng.core.localization.WailaText;
 import appeng.me.GridAccessException;
 import appeng.me.helpers.AENetworkProxy;
 import appeng.me.helpers.IGridProxyable;
 import appeng.util.item.AEFluidStack;
+import gregtech.api.enums.Dyes;
 import gregtech.api.enums.ItemList;
 import gregtech.api.gui.modularui.GTUITextures;
 import gregtech.api.interfaces.IDataCopyable;
@@ -167,6 +169,21 @@ public class MTEHatchInputME extends MTEHatchInput implements IPowerChannelState
     public void onEnableWorking() {
         if (expediteRecipeCheck) {
             justHadNewFluids = true;
+        }
+    }
+
+    @Override
+    public void onColorChangeServer(byte aColor) {
+        updateAE2ProxyColor();
+    }
+
+    public void updateAE2ProxyColor() {
+        this.getProxy()
+            .setColor(AEColor.values()[Dyes.transformDyeIndex(this.getColor())]);
+        AENetworkProxy proxy = getProxy();
+        if (proxy.getNode() != null) {
+            proxy.getNode()
+                .updateState();
         }
     }
 
@@ -617,6 +634,7 @@ public class MTEHatchInputME extends MTEHatchInput implements IPowerChannelState
             autoPullRefreshTime = aNBT.getInteger("refreshTime");
         }
         getProxy().readFromNBT(aNBT);
+        updateAE2ProxyColor();
     }
 
     @Override

--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchOutputBusME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchOutputBusME.java
@@ -323,7 +323,7 @@ public class MTEHatchOutputBusME extends MTEHatchOutputBus implements IPowerChan
         if (color == -1) {
             proxy.setColor(AEColor.Transparent);
         } else {
-            proxy.setColor(AEColor.values()[Dyes.transformDyeIndex(this.getColor())]);
+            proxy.setColor(AEColor.values()[Dyes.transformDyeIndex(color)]);
         }
         if (proxy.getNode() != null) {
             proxy.getNode()

--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchOutputBusME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchOutputBusME.java
@@ -39,6 +39,7 @@ import appeng.api.storage.IMEMonitor;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.api.storage.data.IItemList;
 import appeng.api.util.AECableType;
+import appeng.api.util.AEColor;
 import appeng.items.contents.CellConfig;
 import appeng.items.storage.ItemBasicStorageCell;
 import appeng.me.GridAccessException;
@@ -50,6 +51,7 @@ import appeng.util.item.AEItemStack;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import gregtech.GTMod;
+import gregtech.api.enums.Dyes;
 import gregtech.api.enums.ItemList;
 import gregtech.api.interfaces.IMEConnectable;
 import gregtech.api.interfaces.ITexture;
@@ -311,6 +313,21 @@ public class MTEHatchOutputBusME extends MTEHatchOutputBus implements IPowerChan
     }
 
     @Override
+    public void onColorChangeServer(byte aColor) {
+        updateAE2ProxyColor();
+    }
+
+    public void updateAE2ProxyColor() {
+        this.getProxy()
+            .setColor(AEColor.values()[Dyes.transformDyeIndex(this.getColor())]);
+        AENetworkProxy proxy = getProxy();
+        if (proxy.getNode() != null) {
+            proxy.getNode()
+                .updateState();
+        }
+    }
+
+    @Override
     public boolean isLocked() {
         return !this.lockedItems.isEmpty();
     }
@@ -472,6 +489,7 @@ public class MTEHatchOutputBusME extends MTEHatchOutputBus implements IPowerChan
         baseCapacity = aNBT.getLong("baseCapacity");
         hadCell = aNBT.getBoolean("hadCell");
         getProxy().readFromNBT(aNBT);
+        updateAE2ProxyColor();
     }
 
     @Override

--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchOutputBusME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchOutputBusME.java
@@ -318,9 +318,8 @@ public class MTEHatchOutputBusME extends MTEHatchOutputBus implements IPowerChan
     }
 
     public void updateAE2ProxyColor() {
-        this.getProxy()
-            .setColor(AEColor.values()[Dyes.transformDyeIndex(this.getColor())]);
         AENetworkProxy proxy = getProxy();
+        proxy.setColor(AEColor.values()[Dyes.transformDyeIndex(this.getColor())]);
         if (proxy.getNode() != null) {
             proxy.getNode()
                 .updateState();

--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchOutputBusME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchOutputBusME.java
@@ -319,7 +319,12 @@ public class MTEHatchOutputBusME extends MTEHatchOutputBus implements IPowerChan
 
     public void updateAE2ProxyColor() {
         AENetworkProxy proxy = getProxy();
-        proxy.setColor(AEColor.values()[Dyes.transformDyeIndex(this.getColor())]);
+        byte color = this.getColor();
+        if (color == -1) {
+            proxy.setColor(AEColor.Transparent);
+        } else {
+            proxy.setColor(AEColor.values()[Dyes.transformDyeIndex(this.getColor())]);
+        }
         if (proxy.getNode() != null) {
             proxy.getNode()
                 .updateState();

--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchOutputME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchOutputME.java
@@ -368,7 +368,12 @@ public class MTEHatchOutputME extends MTEHatchOutput implements IPowerChannelSta
 
     public void updateAE2ProxyColor() {
         AENetworkProxy proxy = getProxy();
-        proxy.setColor(AEColor.values()[Dyes.transformDyeIndex(this.getColor())]);
+        byte color = this.getColor();
+        if (color == -1) {
+            proxy.setColor(AEColor.Transparent);
+        } else {
+            proxy.setColor(AEColor.values()[Dyes.transformDyeIndex(this.getColor())]);
+        }
         if (proxy.getNode() != null) {
             proxy.getNode()
                 .updateState();

--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchOutputME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchOutputME.java
@@ -367,9 +367,8 @@ public class MTEHatchOutputME extends MTEHatchOutput implements IPowerChannelSta
     }
 
     public void updateAE2ProxyColor() {
-        this.getProxy()
-            .setColor(AEColor.values()[Dyes.transformDyeIndex(this.getColor())]);
         AENetworkProxy proxy = getProxy();
+        proxy.setColor(AEColor.values()[Dyes.transformDyeIndex(this.getColor())]);
         if (proxy.getNode() != null) {
             proxy.getNode()
                 .updateState();

--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchOutputME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchOutputME.java
@@ -51,6 +51,7 @@ import appeng.api.storage.IMEMonitor;
 import appeng.api.storage.data.IAEFluidStack;
 import appeng.api.storage.data.IItemList;
 import appeng.api.util.AECableType;
+import appeng.api.util.AEColor;
 import appeng.core.stats.Stats;
 import appeng.items.contents.CellConfig;
 import appeng.me.GridAccessException;
@@ -60,6 +61,7 @@ import appeng.util.ReadableNumberConverter;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import gregtech.GTMod;
+import gregtech.api.enums.Dyes;
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.ItemList;
 import gregtech.api.interfaces.IMEConnectable;
@@ -360,6 +362,21 @@ public class MTEHatchOutputME extends MTEHatchOutput implements IPowerChannelSta
     }
 
     @Override
+    public void onColorChangeServer(byte aColor) {
+        updateAE2ProxyColor();
+    }
+
+    public void updateAE2ProxyColor() {
+        this.getProxy()
+            .setColor(AEColor.values()[Dyes.transformDyeIndex(this.getColor())]);
+        AENetworkProxy proxy = getProxy();
+        if (proxy.getNode() != null) {
+            proxy.getNode()
+                .updateState();
+        }
+    }
+
+    @Override
     public boolean isValidSlot(int aIndex) {
         return true;
     }
@@ -625,6 +642,7 @@ public class MTEHatchOutputME extends MTEHatchOutput implements IPowerChannelSta
         baseCapacity = aNBT.getLong("baseCapacity");
         hadCell = aNBT.getBoolean("hadCell");
         getProxy().readFromNBT(aNBT);
+        updateAE2ProxyColor();
     }
 
     @Override

--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchOutputME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchOutputME.java
@@ -372,7 +372,7 @@ public class MTEHatchOutputME extends MTEHatchOutput implements IPowerChannelSta
         if (color == -1) {
             proxy.setColor(AEColor.Transparent);
         } else {
-            proxy.setColor(AEColor.values()[Dyes.transformDyeIndex(this.getColor())]);
+            proxy.setColor(AEColor.values()[Dyes.transformDyeIndex(color)]);
         }
         if (proxy.getNode() != null) {
             proxy.getNode()


### PR DESCRIPTION
fixes this problem:
![image](https://github.com/user-attachments/assets/032066d5-fcc2-49af-b269-13f330abb135)

proof:
https://files.jellejurre.dev/ShareX/Jurre/java_R0TZX7F0X1.mp4

Fixes this for the adv/normal stocking input bus, adv/normal stocking hatch, output bus, output hatch, crafting input bus/buffer