### PR TITLE
fix voltage not using gt formatter for battery buffers

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -36,12 +36,12 @@
 dependencies {
     api("com.github.GTNewHorizons:StructureLib:1.4.10:dev")
     api("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev")
-    api("com.github.GTNewHorizons:NotEnoughItems:2.7.48-GTNH:dev")
+    api("com.github.GTNewHorizons:NotEnoughItems:2.7.49-GTNH:dev")
     api("com.github.GTNewHorizons:NotEnoughIds:2.1.9:dev")
     api("com.github.GTNewHorizons:GTNHLib:0.6.25:dev")
     api("com.github.GTNewHorizons:ModularUI:1.2.18:dev")
     api("com.github.GTNewHorizons:ModularUI2:2.2.15-1.7.10:dev")
-    api("com.github.GTNewHorizons:waila:1.8.6:dev")
+    api("com.github.GTNewHorizons:waila:1.8.7:dev")
     api("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-619-GTNH:dev")
     api("com.github.GTNewHorizons:AE2FluidCraft-Rework:1.4.76-gtnh:dev")
     api('com.github.GTNewHorizons:Yamcl:0.7.0:dev')
@@ -59,7 +59,7 @@ dependencies {
 
     compileOnlyApi("com.github.GTNewHorizons:Avaritia:1.63:dev")
 
-    compileOnlyApi('com.github.GTNewHorizons:Angelica:1.0.0-beta43:api') { transitive = false }
+    compileOnlyApi('com.github.GTNewHorizons:Angelica:1.0.0-beta44:api') { transitive = false }
     compileOnlyApi("com.github.GTNewHorizons:AppleCore:3.3.4:dev") { transitive = false }
     compileOnlyApi("com.github.GTNewHorizons:BuildCraft:7.1.42:dev") { transitive = false }
     compileOnlyApi("com.github.GTNewHorizons:EnderIO:2.9.16:dev") { transitive = false }
@@ -89,7 +89,7 @@ dependencies {
     // https://www.curseforge.com/minecraft/mc-mods/advancedsolarpanels
     compileOnlyApi rfg.deobf('curse.maven:advsolar-362768:2885953')
     compileOnly('com.github.GTNewHorizons:ThaumicEnergistics:1.7.7-GTNH:dev') {transitive =  false}
-    compileOnly("com.github.GTNewHorizons:BloodMagic:1.7.31:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:BloodMagic:1.7.32:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:CraftTweaker:3.4.2:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:BetterLoadingScreen:1.7.0-GTNH:dev") { transitive = false }
     compileOnly rfg.deobf("curse.maven:biomes-o-plenty-220318:2499612")

--- a/src/main/java/gregtech/api/items/MetaBaseItem.java
+++ b/src/main/java/gregtech/api/items/MetaBaseItem.java
@@ -246,15 +246,14 @@ public abstract class MetaBaseItem extends GTGenericItem
                     aList.add(
                         EnumChatFormatting.AQUA + translateToLocal("gt.item.desc.empty") + EnumChatFormatting.GRAY);
                 } else {
-                    int voltageTier = (int) Math.max(1, Math.min(tStats[2], V.length - 1));
+                    int voltageTier = (int) GTUtility.clamp(tStats[2], 0, V.length - 1);
                     aList.add(
                         EnumChatFormatting.AQUA
                             + translateToLocalFormatted(
                                 "gt.item.desc.eu_info",
                                 formatNumbers(tCharge),
                                 formatNumbers(Math.abs(tStats[0])),
-                                "" + formatNumbers(
-                                    V[(int) (tStats[2] >= 0 ? tStats[2] < V.length ? tStats[2] : V.length - 1 : 1)]))
+                                formatNumbers(V[voltageTier]))
                             + EnumChatFormatting.GRAY);
                 }
             }

--- a/src/main/java/gregtech/api/items/MetaBaseItem.java
+++ b/src/main/java/gregtech/api/items/MetaBaseItem.java
@@ -246,16 +246,15 @@ public abstract class MetaBaseItem extends GTGenericItem
                     aList.add(
                         EnumChatFormatting.AQUA + translateToLocal("gt.item.desc.empty") + EnumChatFormatting.GRAY);
                 } else {
-                    aList
-                        .add(
-                            EnumChatFormatting.AQUA
-                                + translateToLocalFormatted(
-                                    "gt.item.desc.eu_info",
-                                    formatNumbers(tCharge),
-                                    formatNumbers(Math.abs(tStats[0])),
-                                    "" + V[(int) (tStats[2] >= 0 ? tStats[2] < V.length ? tStats[2] : V.length - 1
-                                        : 1)])
-                                + EnumChatFormatting.GRAY);
+                    aList.add(
+                        EnumChatFormatting.AQUA
+                            + translateToLocalFormatted(
+                                "gt.item.desc.eu_info",
+                                formatNumbers(tCharge),
+                                formatNumbers(Math.abs(tStats[0])),
+                                "" + formatNumbers(
+                                    V[(int) (tStats[2] >= 0 ? tStats[2] < V.length ? tStats[2] : V.length - 1 : 1)]))
+                            + EnumChatFormatting.GRAY);
                 }
             }
         }

--- a/src/main/java/gregtech/api/items/MetaBaseItem.java
+++ b/src/main/java/gregtech/api/items/MetaBaseItem.java
@@ -246,14 +246,14 @@ public abstract class MetaBaseItem extends GTGenericItem
                     aList.add(
                         EnumChatFormatting.AQUA + translateToLocal("gt.item.desc.empty") + EnumChatFormatting.GRAY);
                 } else {
+                    int voltageTier = (int) Math.max(1, Math.min(tStats[2], V.length - 1));
                     aList.add(
                         EnumChatFormatting.AQUA
                             + translateToLocalFormatted(
-                                "gt.item.desc.eu_info",
-                                formatNumbers(tCharge),
-                                formatNumbers(Math.abs(tStats[0])),
-                                "" + formatNumbers(
-                                    V[(int) (tStats[2] >= 0 ? tStats[2] < V.length ? tStats[2] : V.length - 1 : 1)]))
+                            "gt.item.desc.eu_info",
+                            formatNumbers(tCharge),
+                            formatNumbers(Math.abs(tStats[0])),
+                            formatNumbers(V[voltageTier]))
                             + EnumChatFormatting.GRAY);
                 }
             }

--- a/src/main/java/gregtech/api/items/MetaBaseItem.java
+++ b/src/main/java/gregtech/api/items/MetaBaseItem.java
@@ -253,7 +253,8 @@ public abstract class MetaBaseItem extends GTGenericItem
                                 "gt.item.desc.eu_info",
                                 formatNumbers(tCharge),
                                 formatNumbers(Math.abs(tStats[0])),
-                                formatNumbers(V[voltageTier]))
+                                "" + formatNumbers(
+                                    V[(int) (tStats[2] >= 0 ? tStats[2] < V.length ? tStats[2] : V.length - 1 : 1)]))
                             + EnumChatFormatting.GRAY);
                 }
             }

--- a/src/main/java/gregtech/api/items/MetaBaseItem.java
+++ b/src/main/java/gregtech/api/items/MetaBaseItem.java
@@ -250,10 +250,10 @@ public abstract class MetaBaseItem extends GTGenericItem
                     aList.add(
                         EnumChatFormatting.AQUA
                             + translateToLocalFormatted(
-                            "gt.item.desc.eu_info",
-                            formatNumbers(tCharge),
-                            formatNumbers(Math.abs(tStats[0])),
-                            formatNumbers(V[voltageTier]))
+                                "gt.item.desc.eu_info",
+                                formatNumbers(tCharge),
+                                formatNumbers(Math.abs(tStats[0])),
+                                formatNumbers(V[voltageTier]))
                             + EnumChatFormatting.GRAY);
                 }
             }


### PR DESCRIPTION
adds proper formatting for the voltage of battery buffers using gtUtility.formatNumbers(), for better readability

closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20016