### PR TITLE
ME Hatch capacity syncing for MM

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchOutputBusME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchOutputBusME.java
@@ -479,6 +479,20 @@ public class MTEHatchOutputBusME extends MTEHatchOutputBus implements IPowerChan
     }
 
     @Override
+    public NBTTagCompound getDescriptionData() {
+        NBTTagCompound tag = new NBTTagCompound();
+
+        tag.setLong("baseCapacity", baseCapacity);
+
+        return tag;
+    }
+
+    @Override
+    public void onDescriptionPacket(NBTTagCompound data) {
+        baseCapacity = data.getLong("baseCapacity");
+    }
+
+    @Override
     public boolean isGivingInformation() {
         return true;
     }

--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchOutputBusME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchOutputBusME.java
@@ -482,6 +482,9 @@ public class MTEHatchOutputBusME extends MTEHatchOutputBus implements IPowerChan
     public NBTTagCompound getDescriptionData() {
         NBTTagCompound tag = new NBTTagCompound();
 
+        // Sync the hatch capacity to the client so that MM can show its exchanging preview properly
+        // This is only called when the hatch is placed since it will never change over its lifetime
+
         tag.setLong("baseCapacity", baseCapacity);
 
         return tag;

--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchOutputME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchOutputME.java
@@ -634,6 +634,9 @@ public class MTEHatchOutputME extends MTEHatchOutput implements IPowerChannelSta
     public NBTTagCompound getDescriptionData() {
         NBTTagCompound tag = new NBTTagCompound();
 
+        // Sync the hatch capacity to the client so that MM can show its exchanging preview properly
+        // This is only called when the hatch is placed since it will never change over its lifetime
+
         tag.setLong("baseCapacity", baseCapacity);
 
         return tag;

--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchOutputME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchOutputME.java
@@ -631,6 +631,20 @@ public class MTEHatchOutputME extends MTEHatchOutput implements IPowerChannelSta
     }
 
     @Override
+    public NBTTagCompound getDescriptionData() {
+        NBTTagCompound tag = new NBTTagCompound();
+
+        tag.setLong("baseCapacity", baseCapacity);
+
+        return tag;
+    }
+
+    @Override
+    public void onDescriptionPacket(NBTTagCompound data) {
+        baseCapacity = data.getLong("baseCapacity");
+    }
+
+    @Override
     public boolean isGivingInformation() {
         return true;
     }


### PR DESCRIPTION
I've fixed ME hatch exchanging in MM, but since the preview is calculated on the client it won't show that the ME hatch will be replaced. This change just syncs it to the client so that the preview works properly.