### PR TITLE
Fix bwMetaGeneratedItem0 shifting mod id

### DIFF
--- a/src/main/java/bartworks/MainMod.java
+++ b/src/main/java/bartworks/MainMod.java
@@ -43,6 +43,7 @@ import bartworks.common.loaders.RecipeLoader;
 import bartworks.common.loaders.RegisterServerCommands;
 import bartworks.common.loaders.StaticRecipeChangeLoaders;
 import bartworks.server.EventHandler.ServerEventHandler;
+import bartworks.system.material.CircuitGeneration.BWMetaItems;
 import bartworks.system.material.CircuitGeneration.CircuitImprintLoader;
 import bartworks.system.material.CircuitGeneration.CircuitPartLoader;
 import bartworks.system.material.Werkstoff;
@@ -123,6 +124,8 @@ public final class MainMod {
         WerkstoffLoader.setUp();
 
         BioCultureLoader.run();
+
+        BWMetaItems.init();
 
         Werkstoff.init();
         GregTechAPI.sAfterGTPostload.add(new CircuitPartLoader());

--- a/src/main/java/bartworks/system/material/CircuitGeneration/BWMetaItems.java
+++ b/src/main/java/bartworks/system/material/CircuitGeneration/BWMetaItems.java
@@ -62,9 +62,11 @@ public class BWMetaItems {
         return BWMetaItems.NEW_CIRCUIT_PARTS;
     }
 
-    private static final BWMetaItems.BW_GT_MetaGenCircuits NEW_CIRCUIT_PARTS = new BWMetaItems.BW_GT_MetaGenCircuits();
+    private static BWMetaItems.BW_GT_MetaGenCircuits NEW_CIRCUIT_PARTS;
 
-    static {
+    public static void init() {
+        NEW_CIRCUIT_PARTS = new BWMetaItems.BW_GT_MetaGenCircuits();
+
         BWMetaItems.NEW_CIRCUIT_PARTS.addItem(0, "Circuit Imprint", "", SubTag.NO_UNIFICATION, SubTag.NO_RECYCLING);
         BWMetaItems.NEW_CIRCUIT_PARTS.addItem(1, "Sliced Circuit", "", SubTag.NO_UNIFICATION, SubTag.NO_RECYCLING);
         BWMetaItems.NEW_CIRCUIT_PARTS


### PR DESCRIPTION
Class loading order caused this to get the GT modid instead of BW after a refactor