### PR TITLE
Fix godforge item consumption issue

### DIFF
--- a/src/main/java/tectech/thing/metaTileEntity/multi/godforge/MTEForgeOfGods.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/godforge/MTEForgeOfGods.java
@@ -520,7 +520,7 @@ public class MTEForgeOfGods extends TTMultiblockBase implements IConstructable, 
                                 if (itemStack != null && itemStack.isItemEqual(itemToAbsorb)) {
                                     int stacksize = itemStack.stackSize;
                                     if (inputBus instanceof MTEHatchInputBusME meBus) {
-                                        ItemStack realItem = meBus.getRealInventory()[i + 16];
+                                        ItemStack realItem = meBus.getStackInSlot(i);
                                         if (realItem == null) {
                                             break;
                                         }


### PR DESCRIPTION
When graviton shards (or star fuel) are fed to the godforge via a stocking bus and they aren't in slot 1 or 2, they don't get consumed properly.
This PR fixes that.