### PR TITLE
Add missing number formatting to some godforge ui elements

### DIFF
--- a/src/main/java/tectech/thing/metaTileEntity/multi/godforge/MTEForgeOfGods.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/godforge/MTEForgeOfGods.java
@@ -1645,7 +1645,8 @@ public class MTEForgeOfGods extends TTMultiblockBase implements IConstructable, 
                 () -> gravitonShardsAvailable,
                 () -> completeUpgrade(upgrade),
                 () -> respecUpgrade(upgrade),
-                () -> isUpgradeActive(upgrade)));
+                () -> isUpgradeActive(upgrade),
+                () -> formattingMode));
 
         if (upgrade.hasExtraCost()) {
             builder.widget(
@@ -2929,9 +2930,9 @@ public class MTEForgeOfGods extends TTMultiblockBase implements IConstructable, 
 
     private Text storedFuel() {
         if (internalBattery == 0) {
-            return new Text(stellarFuelAmount + "/" + neededStartupFuel);
+            return new Text(formattingMode.format(stellarFuelAmount) + "/" + formattingMode.format(neededStartupFuel));
         }
-        return new Text(internalBattery + "/" + maxBatteryCharge);
+        return new Text(formattingMode.format(internalBattery) + "/" + formattingMode.format(maxBatteryCharge));
     }
 
     private Text storedFuelHeaderText() {
@@ -3127,7 +3128,9 @@ public class MTEForgeOfGods extends TTMultiblockBase implements IConstructable, 
         }
         sum = progress * (progress + 1) / 2;
         return new Text(
-            translateToLocal("gt.blockmachines.multimachine.FOG.shardgain") + ": " + EnumChatFormatting.GRAY + sum);
+            translateToLocal("gt.blockmachines.multimachine.FOG.shardgain") + ": "
+                + EnumChatFormatting.GRAY
+                + formattingMode.format(sum));
     }
 
     private Text totalMilestoneProgress(int milestoneID) {

--- a/src/main/java/tectech/thing/metaTileEntity/multi/godforge/MTEForgeOfGods.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/godforge/MTEForgeOfGods.java
@@ -2925,7 +2925,7 @@ public class MTEForgeOfGods extends TTMultiblockBase implements IConstructable, 
     }
 
     private Text fuelUsage() {
-        return new Text(fuelConsumption + " L/5s");
+        return new Text(formattingMode.format(fuelConsumption) + " L/5s");
     }
 
     private Text storedFuel() {

--- a/src/main/java/tectech/thing/metaTileEntity/multi/godforge/util/ForgeOfGodsUI.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/godforge/util/ForgeOfGodsUI.java
@@ -566,7 +566,7 @@ public class ForgeOfGodsUI {
     }
 
     public static Widget getIndividualUpgradeGroup(ForgeOfGodsUpgrade upgrade, Supplier<Integer> shardGetter,
-        Runnable complete, Runnable respec, Supplier<Boolean> check) {
+        Runnable complete, Runnable respec, Supplier<Boolean> check, Supplier<MilestoneFormatter> formatGetter) {
         MultiChildWidget widget = new MultiChildWidget();
         widget.setSize(upgrade.getWindowSize());
 
@@ -633,7 +633,7 @@ public class ForgeOfGodsUI {
 
         // Available shards amount
         widget.addChild(
-            TextWidget.dynamicText(() -> getAvailableShardsText(upgrade, shardGetter))
+            TextWidget.dynamicText(() -> getAvailableShardsText(upgrade, shardGetter, formatGetter))
                 .setTextAlignment(Alignment.Center)
                 .setScale(0.7f)
                 .setMaxWidth(90)
@@ -690,12 +690,15 @@ public class ForgeOfGodsUI {
                 EnumChatFormatting.GRAY + translateToLocal("fog.button.materialrequirements.tooltip.clickhere"));
     }
 
-    private static Text getAvailableShardsText(ForgeOfGodsUpgrade upgrade, Supplier<Integer> shardGetter) {
+    private static Text getAvailableShardsText(ForgeOfGodsUpgrade upgrade, Supplier<Integer> shardGetter,
+        Supplier<MilestoneFormatter> formatGetter) {
         EnumChatFormatting enoughShards = EnumChatFormatting.RED;
         if (shardGetter.get() >= upgrade.getShardCost()) {
             enoughShards = EnumChatFormatting.GREEN;
         }
-        return new Text(enoughShards + Integer.toString(shardGetter.get()));
+        return new Text(
+            enoughShards + formatGetter.get()
+                .format(shardGetter.get()));
     }
 
     private static List<String> constructionStatusString(Supplier<Boolean> check) {


### PR DESCRIPTION
As the title suggests, this PR applies number formatting to a couple more numbers (hopefully I didn't miss any). 

![image](https://github.com/user-attachments/assets/6f526202-2028-4fe2-a89b-9a78c0379557)
![image](https://github.com/user-attachments/assets/064b9b62-ced7-400b-bacb-676a21aebe75)
![image](https://github.com/user-attachments/assets/eb47a976-1b35-4fa8-a9de-abd91abb6dbb)
![image](https://github.com/user-attachments/assets/2c1a8f66-59e4-4bce-ba70-a3599b7c59bf)

All numbers are formatted based on the general toggle
https://github.com/user-attachments/assets/560ed7d6-a977-46ab-b848-9f8a5666d455


