### PR TITLE
Fluid link covers adjustments

### DIFF
--- a/src/main/java/gregtech/common/gui/mui1/cover/EnderFluidLinkUIFactory.java
+++ b/src/main/java/gregtech/common/gui/mui1/cover/EnderFluidLinkUIFactory.java
@@ -123,9 +123,8 @@ public class EnderFluidLinkUIFactory extends CoverLegacyDataUIFactory {
         return switch (id) {
             case PUBLIC_BUTTON_ID -> CoverEnderFluidLink.testBit(coverVariable, PUBLIC_PRIVATE_MASK);
             case PRIVATE_BUTTON_ID -> !CoverEnderFluidLink.testBit(coverVariable, PUBLIC_PRIVATE_MASK);
-            case IMPORT_BUTTON_ID -> CoverEnderFluidLink.testBit(coverVariable, CoverEnderFluidLink.IMPORT_EXPORT_MASK);
-            case EXPORT_BUTTON_ID -> !CoverEnderFluidLink
-                .testBit(coverVariable, CoverEnderFluidLink.IMPORT_EXPORT_MASK);
+            case IMPORT_BUTTON_ID -> !CoverEnderFluidLink.testBit(coverVariable, CoverEnderFluidLink.IMPORT_EXPORT_MASK);
+            case EXPORT_BUTTON_ID -> CoverEnderFluidLink.testBit(coverVariable, CoverEnderFluidLink.IMPORT_EXPORT_MASK);
             default -> false;
         };
     }

--- a/src/main/java/gregtech/common/gui/mui1/cover/EnderFluidLinkUIFactory.java
+++ b/src/main/java/gregtech/common/gui/mui1/cover/EnderFluidLinkUIFactory.java
@@ -123,7 +123,8 @@ public class EnderFluidLinkUIFactory extends CoverLegacyDataUIFactory {
         return switch (id) {
             case PUBLIC_BUTTON_ID -> CoverEnderFluidLink.testBit(coverVariable, PUBLIC_PRIVATE_MASK);
             case PRIVATE_BUTTON_ID -> !CoverEnderFluidLink.testBit(coverVariable, PUBLIC_PRIVATE_MASK);
-            case IMPORT_BUTTON_ID -> !CoverEnderFluidLink.testBit(coverVariable, CoverEnderFluidLink.IMPORT_EXPORT_MASK);
+            case IMPORT_BUTTON_ID -> !CoverEnderFluidLink
+                .testBit(coverVariable, CoverEnderFluidLink.IMPORT_EXPORT_MASK);
             case EXPORT_BUTTON_ID -> CoverEnderFluidLink.testBit(coverVariable, CoverEnderFluidLink.IMPORT_EXPORT_MASK);
             default -> false;
         };

--- a/src/main/java/tectech/thing/cover/CoverEnderFluidLink.java
+++ b/src/main/java/tectech/thing/cover/CoverEnderFluidLink.java
@@ -33,7 +33,8 @@ public class CoverEnderFluidLink extends CoverLegacyData {
 
     private void transferFluid(IFluidHandler source, ForgeDirection coverSide, IFluidHandler target,
         ForgeDirection tSide) {
-        FluidStack fluidStack = source.drain(coverSide, CoverEnderFluidLink.L_PER_TICK, false);
+        int drainAmount = CoverEnderFluidLink.L_PER_TICK * getTickRate();
+        FluidStack fluidStack = source.drain(coverSide, drainAmount, false);
 
         if (fluidStack != null) {
             int fluidTransferred = target.fill(tSide, fluidStack, true);


### PR DESCRIPTION
- Swapped import/export GUI buttons to match actual logic
- If cover tickrate is decreased make cover do more work (8000 per tick * tick rate). Thus the tickrate will not affect the total amount of liquid transferred per unit of time