### PR TITLE
Suppress missing warnings for removed gt++ items

### DIFF
--- a/src/main/java/gregtech/loaders/postload/MissingMappingsHandler.java
+++ b/src/main/java/gregtech/loaders/postload/MissingMappingsHandler.java
@@ -72,7 +72,9 @@ public class MissingMappingsHandler {
         .ignore("kekztech:kekztech_tfftstoragefieldblock4_block")
         .ignore("kekztech:kekztech_tfftstoragefieldblock5_block")
 
-        .ignore("miscutils:itemPlateMeatRaw");
+        .ignore("miscutils:itemPlateMeatRaw")
+        .ignore("miscutils:AAA_Broken")
+        .ignore("miscutils:item.empty");
 
     // spotless:on
 


### PR DESCRIPTION
Removed in #4402, suppresses the missing item warning for these intentionally removed items