### PR TITLE
Large Molecular Assembler sets idle EUt to the wrong variable

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTELargeMolecularAssembler.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTELargeMolecularAssembler.java
@@ -188,7 +188,7 @@ public class MTELargeMolecularAssembler extends MTEExtendedPowerMultiBlockBase<M
             mMaxProgresstime = 20;
             long craftingProgressTime = 20;
             long craftingEUt = EU_PER_TICK_CRAFTING;
-            mEUt = -EU_PER_TICK_BASIC;
+            lEUt = -EU_PER_TICK_BASIC;
             // Tier EU_PER_TICK_CRAFTING == 2
             int extraTier = Math.max(0, GTUtility.getTier(getMaxInputVoltage()) - 2);
             // The first two Overclocks reduce the Finish time to 0.5s and 0.25s


### PR DESCRIPTION
When actively crafting the power lEUt is set to the required power. This is not reset on idle, because the idle energy is set to the mEUt variable. Which from my understanding is replaced by lEUt because it inherits MTEExtendedPowerMultiBlockBase. Therefore mEUt should not be used in this context I think.

This causes that the multi always draws full power even when it should be idle as described [https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20086](here).