### PR TITLE
Respect storage cell restriction for hatch capacities

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchOutputBusME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchOutputBusME.java
@@ -3,6 +3,9 @@ package gregtech.common.tileentities.machines;
 import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_ME_HATCH;
 import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_ME_HATCH_ACTIVE;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -35,7 +38,9 @@ import appeng.api.networking.GridFlags;
 import appeng.api.networking.security.BaseActionSource;
 import appeng.api.networking.security.IActionHost;
 import appeng.api.networking.security.MachineSource;
+import appeng.api.storage.IMEInventoryHandler;
 import appeng.api.storage.IMEMonitor;
+import appeng.api.storage.StorageChannel;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.api.storage.data.IItemList;
 import appeng.api.util.AECableType;
@@ -45,6 +50,8 @@ import appeng.items.storage.ItemBasicStorageCell;
 import appeng.me.GridAccessException;
 import appeng.me.helpers.AENetworkProxy;
 import appeng.me.helpers.IGridProxyable;
+import appeng.me.storage.CellInventory;
+import appeng.me.storage.CellInventoryHandler;
 import appeng.util.Platform;
 import appeng.util.ReadableNumberConverter;
 import appeng.util.item.AEItemStack;
@@ -166,12 +173,51 @@ public class MTEHatchOutputBusME extends MTEHatchOutputBus implements IPowerChan
         return itemAmount;
     }
 
+    private static final MethodHandle GET_RESTRICTION_LONG;
+
+    static {
+        try {
+            Field field = CellInventory.class.getDeclaredField("restrictionLong");
+            field.setAccessible(true);
+            GET_RESTRICTION_LONG = MethodHandles.lookup()
+                .unreflectGetter(field);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException("Could not unreflect getter for CellInventory.restrictionLong", e);
+        }
+    }
+
+    private static long getRestrictionLong(CellInventory cellInventory) {
+        try {
+            return (long) GET_RESTRICTION_LONG.invokeExact(cellInventory);
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     protected long getCacheCapacity() {
         ItemStack upgradeItemStack = mInventory[0];
-        if (upgradeItemStack != null && upgradeItemStack.getItem() instanceof ItemBasicStorageCell) {
-            return ((ItemBasicStorageCell) upgradeItemStack.getItem()).getBytesLong(upgradeItemStack) * 8;
+
+        if (upgradeItemStack == null) return baseCapacity;
+        if (!(upgradeItemStack.getItem() instanceof ItemBasicStorageCell storageCell)) return baseCapacity;
+
+        final IMEInventoryHandler<?> inventory = AEApi.instance()
+            .registries()
+            .cell()
+            .getCellInventory(upgradeItemStack, null, StorageChannel.ITEMS);
+
+        long capacity = storageCell.getBytesLong(upgradeItemStack) * 8;
+
+        if (inventory instanceof CellInventoryHandler handler) {
+            final CellInventory cellInventory = (CellInventory) handler.getCellInv();
+
+            long restriction = getRestrictionLong(cellInventory);
+
+            if (restriction > 0) {
+                capacity = Math.min(capacity, restriction);
+            }
         }
-        return baseCapacity;
+
+        return capacity;
     }
 
     /**

--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchOutputME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchOutputME.java
@@ -3,6 +3,9 @@ package gregtech.common.tileentities.machines;
 import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_ME_FLUID_HATCH;
 import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_ME_FLUID_HATCH_ACTIVE;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -32,6 +35,8 @@ import net.minecraftforge.fluids.IFluidContainerItem;
 import org.jetbrains.annotations.NotNull;
 
 import com.glodblock.github.common.item.FCBaseItemCell;
+import com.glodblock.github.common.storage.FluidCellInventory;
+import com.glodblock.github.common.storage.FluidCellInventoryHandler;
 import com.glodblock.github.common.storage.IStorageFluidCell;
 import com.gtnewhorizons.modularui.api.screen.ModularWindow;
 import com.gtnewhorizons.modularui.api.screen.UIBuildContext;
@@ -47,7 +52,9 @@ import appeng.api.networking.security.IActionHost;
 import appeng.api.networking.security.MachineSource;
 import appeng.api.networking.security.PlayerSource;
 import appeng.api.storage.IMEInventory;
+import appeng.api.storage.IMEInventoryHandler;
 import appeng.api.storage.IMEMonitor;
+import appeng.api.storage.StorageChannel;
 import appeng.api.storage.data.IAEFluidStack;
 import appeng.api.storage.data.IItemList;
 import appeng.api.util.AECableType;
@@ -282,12 +289,51 @@ public class MTEHatchOutputME extends MTEHatchOutput implements IPowerChannelSta
         return fluidAmount;
     }
 
+    private static final MethodHandle GET_RESTRICTION_LONG;
+
+    static {
+        try {
+            Field field = FluidCellInventory.class.getDeclaredField("restrictionLong");
+            field.setAccessible(true);
+            GET_RESTRICTION_LONG = MethodHandles.lookup()
+                .unreflectGetter(field);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException("Could not unreflect getter for FluidCellInventory.restrictionLong", e);
+        }
+    }
+
+    private static long getRestrictionLong(FluidCellInventory cellInventory) {
+        try {
+            return (long) GET_RESTRICTION_LONG.invokeExact(cellInventory);
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     private long getCacheCapacity() {
         ItemStack upgradeItemStack = mInventory[0];
-        if (upgradeItemStack != null && upgradeItemStack.getItem() instanceof IStorageFluidCell) {
-            return ((FCBaseItemCell) upgradeItemStack.getItem()).getBytes(upgradeItemStack) * 2048;
+
+        if (upgradeItemStack == null) return baseCapacity;
+        if (!(upgradeItemStack.getItem() instanceof FCBaseItemCell storageCell)) return baseCapacity;
+
+        final IMEInventoryHandler<?> inventory = AEApi.instance()
+            .registries()
+            .cell()
+            .getCellInventory(upgradeItemStack, null, StorageChannel.FLUIDS);
+
+        long capacity = storageCell.getBytes(upgradeItemStack) * 2048;
+
+        if (inventory instanceof FluidCellInventoryHandler handler) {
+            final FluidCellInventory cellInventory = (FluidCellInventory) handler.getCellInv();
+
+            long restriction = getRestrictionLong(cellInventory);
+
+            if (restriction > 0) {
+                capacity = Math.min(capacity, restriction);
+            }
         }
-        return baseCapacity;
+
+        return capacity;
     }
 
     /**


### PR DESCRIPTION
AE cells can have their storage capacities limited, but ME output hatches and busses don't respect this limit. This PR just changes hatches to use the cell's capacity restriction, if set. This is useful for passive setups where you want to control the amount of items stored in an output hatch.

Testing done: (applies to busses/item cells and hatches/fluid cells)
- Make sure unconfigured hatches aren't broken
- Make sure pre-configured hatches aren't broken (hatches crafted with a storage component)
- Restrict the cell and make sure its capacity is reflected by the hatch
- Set the cell to 1, then set it to 0 to make sure its 0-capacity doesn't break the hatch