### PR TITLE
Improve performance of registering EEC events

### DIFF
--- a/src/main/java/kubatech/tileentity/gregtech/multiblock/MTEExtremeEntityCrusher.java
+++ b/src/main/java/kubatech/tileentity/gregtech/multiblock/MTEExtremeEntityCrusher.java
@@ -98,6 +98,7 @@ import WayofTime.alchemicalWizardry.api.soulNetwork.SoulNetworkHandler;
 import WayofTime.alchemicalWizardry.api.tile.IBloodAltar;
 import WayofTime.alchemicalWizardry.common.rituals.RitualEffectWellOfSuffering;
 import WayofTime.alchemicalWizardry.common.tileEntity.TEMasterStone;
+import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.eventhandler.EventPriority;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.relauncher.Side;
@@ -152,7 +153,9 @@ public class MTEExtremeEntityCrusher extends KubaTechGTMultiBlockBase<MTEExtreme
     public MTEExtremeEntityCrusher(String aName) {
         super(aName);
         weaponCache = new WeaponCache(mInventory);
-        if (BloodMagic.isModLoaded() && eventHandler == null) {
+        if (BloodMagic.isModLoaded() && FMLCommonHandler.instance()
+            .getEffectiveSide()
+            .isServer()) {
             eventHandler = new EECEventHandler();
             MinecraftForge.EVENT_BUS.register(eventHandler);
         }

--- a/src/main/java/kubatech/tileentity/gregtech/multiblock/MTEExtremeEntityCrusher.java
+++ b/src/main/java/kubatech/tileentity/gregtech/multiblock/MTEExtremeEntityCrusher.java
@@ -141,6 +141,7 @@ public class MTEExtremeEntityCrusher extends KubaTechGTMultiBlockBase<MTEExtreme
     public static final int MOB_SPAWN_INTERVAL = 55;
     public final Random rand = new FastRandom();
     private final WeaponCache weaponCache;
+    private EECEventHandler eventHandler;
 
     @SuppressWarnings("unused")
     public MTEExtremeEntityCrusher(int aID, String aName, String aNameRegional) {
@@ -151,12 +152,15 @@ public class MTEExtremeEntityCrusher extends KubaTechGTMultiBlockBase<MTEExtreme
     public MTEExtremeEntityCrusher(String aName) {
         super(aName);
         weaponCache = new WeaponCache(mInventory);
-        if (BloodMagic.isModLoaded()) MinecraftForge.EVENT_BUS.register(this);
+        if (BloodMagic.isModLoaded() && eventHandler == null) {
+            eventHandler = new EECEventHandler();
+            MinecraftForge.EVENT_BUS.register(eventHandler);
+        }
     }
 
     @Override
     public void onRemoval() {
-        if (BloodMagic.isModLoaded()) MinecraftForge.EVENT_BUS.unregister(this);
+        if (eventHandler != null) MinecraftForge.EVENT_BUS.unregister(eventHandler);
         if (getBaseMetaTileEntity().isClientSide() && entityRenderer != null) {
             entityRenderer.setDead();
         }
@@ -164,7 +168,7 @@ public class MTEExtremeEntityCrusher extends KubaTechGTMultiBlockBase<MTEExtreme
 
     @Override
     public void onUnload() {
-        if (BloodMagic.isModLoaded()) MinecraftForge.EVENT_BUS.unregister(this);
+        if (eventHandler != null) MinecraftForge.EVENT_BUS.unregister(eventHandler);
     }
 
     private static final String WellOfSufferingRitualName = "AW013Suffering";
@@ -178,13 +182,13 @@ public class MTEExtremeEntityCrusher extends KubaTechGTMultiBlockBase<MTEExtreme
             STRUCTURE_PIECE_MAIN,
             transpose(
                 new String[][] { // spotless:off
-                    { "ccccc", "ccccc", "ccccc", "ccccc", "ccccc" },
-                    { "fgggf", "g---g", "g---g", "g---g", "fgggf" },
-                    { "fgggf", "g---g", "g---g", "g---g", "fgggf" },
-                    { "fgggf", "g---g", "g---g", "g---g", "fgggf" },
-                    { "fgggf", "g---g", "g---g", "g---g", "fgggf" },
-                    { "fgggf", "gsssg", "gsssg", "gsssg", "fgggf" },
-                    { "CC~CC", "CCCCC", "CCCCC", "CCCCC", "CCCCC" },
+                    {"ccccc", "ccccc", "ccccc", "ccccc", "ccccc"},
+                    {"fgggf", "g---g", "g---g", "g---g", "fgggf"},
+                    {"fgggf", "g---g", "g---g", "g---g", "fgggf"},
+                    {"fgggf", "g---g", "g---g", "g---g", "fgggf"},
+                    {"fgggf", "g---g", "g---g", "g---g", "fgggf"},
+                    {"fgggf", "gsssg", "gsssg", "gsssg", "fgggf"},
+                    {"CC~CC", "CCCCC", "CCCCC", "CCCCC", "CCCCC"},
                 })) // spotless:on
         .addElement('c', onElementPass(t -> t.mCasing++, ofBlock(GregTechAPI.sBlockCasings2, 0)))
         .addElement(
@@ -424,53 +428,61 @@ public class MTEExtremeEntityCrusher extends KubaTechGTMultiBlockBase<MTEExtreme
         } else return super.onSolderingToolRightClick(side, wrenchingSide, aPlayer, aX, aY, aZ, aTool);
     }
 
-    @SuppressWarnings("unused")
-    @SubscribeEvent(priority = EventPriority.LOWEST)
-    public void onRitualPerform(RitualRunEvent event) {
-        if (!isInRitualMode) return;
-        if (masterStoneRitual == null) return;
-        if (this.mMaxProgresstime == 0) return;
-        if (event.mrs.equals(masterStoneRitual) && event.ritualKey.equals(WellOfSufferingRitualName)) {
-            Rituals ritual = Rituals.ritualMap.get(WellOfSufferingRitualName);
-            if (ritual != null && ritual.effect instanceof RitualEffectWellOfSuffering effect) {
-                event.setCanceled(true); // we will handle that
-                String owner = event.mrs.getOwner();
-                int currentEssence = SoulNetworkHandler.getCurrentEssence(owner);
-                World world = event.mrs.getWorld();
-                int x = event.mrs.getXCoord();
-                int y = event.mrs.getYCoord();
-                int z = event.mrs.getZCoord();
+    // We place the event handler in an inner
+    // class to prevent high costs of registering
+    // the event because forge event bus reflects
+    // through all the methods and super of the class
+    // in order to find the @SubscribeEvent annotations
+    public class EECEventHandler {
 
-                if (world.getWorldTime() % RitualEffectWellOfSuffering.timeDelay != 0) return;
+        @SuppressWarnings("unused")
+        @SubscribeEvent(priority = EventPriority.LOWEST)
+        public void onRitualPerform(RitualRunEvent event) {
+            if (!isInRitualMode) return;
+            if (masterStoneRitual == null) return;
+            if (mMaxProgresstime == 0) return;
+            if (event.mrs.equals(masterStoneRitual) && event.ritualKey.equals(WellOfSufferingRitualName)) {
+                Rituals ritual = Rituals.ritualMap.get(WellOfSufferingRitualName);
+                if (ritual != null && ritual.effect instanceof RitualEffectWellOfSuffering effect) {
+                    event.setCanceled(true); // we will handle that
+                    String owner = event.mrs.getOwner();
+                    int currentEssence = SoulNetworkHandler.getCurrentEssence(owner);
+                    World world = event.mrs.getWorld();
+                    int x = event.mrs.getXCoord();
+                    int y = event.mrs.getYCoord();
+                    int z = event.mrs.getZCoord();
 
-                if (tileAltar == null || tileAltar.isInvalid()) {
-                    tileAltar = null;
-                    for (int i = -5; i <= 5; i++) for (int j = -5; j <= 5; j++) for (int k = -10; k <= 10; k++)
-                        if (world.getTileEntity(x + i, y + k, z + j) instanceof IBloodAltar)
-                            tileAltar = world.getTileEntity(x + i, y + k, z + j);
+                    if (world.getWorldTime() % RitualEffectWellOfSuffering.timeDelay != 0) return;
+
+                    if (tileAltar == null || tileAltar.isInvalid()) {
+                        tileAltar = null;
+                        for (int i = -5; i <= 5; i++) for (int j = -5; j <= 5; j++) for (int k = -10; k <= 10; k++)
+                            if (world.getTileEntity(x + i, y + k, z + j) instanceof IBloodAltar)
+                                tileAltar = world.getTileEntity(x + i, y + k, z + j);
+                    }
+                    if (tileAltar == null) return;
+
+                    if (currentEssence < effect.getCostPerRefresh() * 100) {
+                        SoulNetworkHandler.causeNauseaToPlayer(owner);
+                        return;
+                    }
+
+                    ((IBloodAltar) tileAltar).sacrificialDaggerCall(
+                        100 * RitualEffectWellOfSuffering.amount
+                            * (effect.canDrainReagent(
+                                event.mrs,
+                                ReagentRegistry.offensaReagent,
+                                RitualEffectWellOfSuffering.offensaDrain,
+                                true) ? 2 : 1)
+                            * (effect.canDrainReagent(
+                                event.mrs,
+                                ReagentRegistry.tenebraeReagent,
+                                RitualEffectWellOfSuffering.tennebraeDrain,
+                                true) ? 2 : 1),
+                        true);
+
+                    SoulNetworkHandler.syphonFromNetwork(owner, effect.getCostPerRefresh() * 100);
                 }
-                if (tileAltar == null) return;
-
-                if (currentEssence < effect.getCostPerRefresh() * 100) {
-                    SoulNetworkHandler.causeNauseaToPlayer(owner);
-                    return;
-                }
-
-                ((IBloodAltar) tileAltar).sacrificialDaggerCall(
-                    100 * RitualEffectWellOfSuffering.amount
-                        * (effect.canDrainReagent(
-                            event.mrs,
-                            ReagentRegistry.offensaReagent,
-                            RitualEffectWellOfSuffering.offensaDrain,
-                            true) ? 2 : 1)
-                        * (effect.canDrainReagent(
-                            event.mrs,
-                            ReagentRegistry.tenebraeReagent,
-                            RitualEffectWellOfSuffering.tennebraeDrain,
-                            true) ? 2 : 1),
-                    true);
-
-                SoulNetworkHandler.syphonFromNetwork(owner, effect.getCostPerRefresh() * 100);
             }
         }
     }


### PR DESCRIPTION
When registering an event, forge's event subscriber uses reflection to loop through the declared method of the class including its super methods. For a class like an MTE this is very expensive.

What I did instead is encapsulate the event listener method into an inner class and only register that inner class to the event bus.

Moreover the event is now only registered on the server side because the associated event is only fired on the server. Therefore it eliminate all possible freeeze on the client side.

The quick and dirty "benchmarking" that I made shows that registering the inner class is now 200 times faster than registering the whole MTE class. And it only happens on the server side whereas before it fired on the both server and client, so we could say that's it's 400 times faster.