### PR TITLE
Add throughput in WAILA to laser source hatch

### DIFF
--- a/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchDynamoMulti.java
+++ b/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchDynamoMulti.java
@@ -3,13 +3,23 @@ package tectech.thing.metaTileEntity.hatch;
 import static gregtech.api.enums.GTValues.V;
 import static net.minecraft.util.StatCollector.translateToLocal;
 
+import java.util.List;
+
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumChatFormatting;
+import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.implementations.MTEHatch;
+import gregtech.api.util.GTUtility;
+import mcp.mobius.waila.api.IWailaConfigHandler;
+import mcp.mobius.waila.api.IWailaDataAccessor;
 import tectech.thing.metaTileEntity.Textures;
 import tectech.util.CommonValues;
 
@@ -93,6 +103,41 @@ public class MTEHatchDynamoMulti extends MTEHatch {
     @Override
     public long maxAmperesOut() {
         return Amperes;
+    }
+
+    @Override
+    public boolean isGivingInformation() {
+        return true;
+    }
+
+    @Override
+    public void getWailaNBTData(EntityPlayerMP player, TileEntity tile, NBTTagCompound tag, World world, int x, int y,
+        int z) {
+        super.getWailaNBTData(player, tile, tag, world, x, y, z);
+        tag.setLong("amperage", Amperes);
+    }
+
+    @Override
+    public void getWailaBody(ItemStack itemStack, List<String> currenttip, IWailaDataAccessor accessor,
+        IWailaConfigHandler config) {
+        super.getWailaBody(itemStack, currenttip, accessor, config);
+        currenttip.add(
+            translateToLocal("gt.blockmachines.hatch.dynamotunnel.desc.1") + ": "
+                + EnumChatFormatting.YELLOW
+                + GTUtility.formatNumbers(
+                    accessor.getNBTData()
+                        .getLong("amperage") * V[mTier])
+                + EnumChatFormatting.RESET
+                + " EU/t");
+    }
+
+    @Override
+    public String[] getInfoData() {
+        return new String[] { translateToLocal("gt.blockmachines.hatch.dynamotunnel.desc.1") + ": "
+            + EnumChatFormatting.YELLOW
+            + GTUtility.formatNumbers(Amperes * V[mTier])
+            + EnumChatFormatting.RESET
+            + " EU/t" };
     }
 
     @Override


### PR DESCRIPTION
Add throughput to waila tooltip and prospectors scanner for laser source hatch, since #3867 miss that (and basically copypasted from there)

Before:

![image](https://github.com/user-attachments/assets/a82e6840-bcdf-412b-bc26-825cc37e5944)

After:

![image](https://github.com/user-attachments/assets/69c93af8-b544-40bd-ab1e-f1f3b74ac422)
