### PR TITLE
Add recipe for ceramic plate in compressor

### DIFF
--- a/src/main/java/goodgenerator/loader/RecipeLoader.java
+++ b/src/main/java/goodgenerator/loader/RecipeLoader.java
@@ -879,11 +879,11 @@ public class RecipeLoader {
             .addTo(extruderRecipes);
 
         GTValues.RA.stdBuilder()
-            .itemInputs(ItemRefer.Special_Ceramics_Dust.get(2))
+            .itemInputs(ItemRefer.Special_Ceramics_Dust.get(2), ItemList.Shape_Mold_Casing.get(0))
             .itemOutputs(ItemRefer.Special_Ceramics_Plate.get(1))
             .duration(20 * SECONDS)
             .eut(TierEU.RECIPE_HV)
-            .addTo(compressorRecipes);
+            .addTo(formingPressRecipes);
 
         // Advanced Recipe with netherite
         GTValues.RA.stdBuilder()


### PR DESCRIPTION
It doesn't make sense that it specifically needs a plate mold extruder and takes up a slot for no reason. Creating an alternate recipe for people who want to use it, while leaving the old one so it doesn't break bases.