### PR TITLE
Refactor and optimize stocking hatches

### DIFF
--- a/src/main/java/ggfab/mte/MTEAdvAssLine.java
+++ b/src/main/java/ggfab/mte/MTEAdvAssLine.java
@@ -633,7 +633,7 @@ public class MTEAdvAssLine extends MTEExtendedPowerMultiBlockBase<MTEAdvAssLine>
         MTEHatchInputBus inputBus = mInputBusses.get(index);
         if (!inputBus.isValid()) return null;
         if (inputBus instanceof MTEHatchInputBusME meBus) {
-            ItemStack item = meBus.getFirstShadowItemStack(true);
+            ItemStack item = meBus.getFirstValidStack(true);
             if (item == null) return null;
             GTUtility.ItemId id = GTUtility.ItemId.createNoCopy(item);
             if (!curBatchItemsFromME.containsKey(id)) return null;
@@ -648,7 +648,7 @@ public class MTEAdvAssLine extends MTEExtendedPowerMultiBlockBase<MTEAdvAssLine>
         MTEHatchInput inputHatch = mInputHatches.get(index);
         if (!inputHatch.isValid()) return null;
         if (inputHatch instanceof MTEHatchInputME meHatch) {
-            FluidStack fluid = meHatch.getFirstShadowFluidStack(true);
+            FluidStack fluid = meHatch.getFirstValidStack(true);
             if (fluid == null) return null;
             if (!curBatchFluidsFromME.containsKey(fluid.getFluid())) return null;
             return curBatchFluidsFromME.get(fluid.getFluid());

--- a/src/main/java/gregtech/api/util/GTDataUtils.java
+++ b/src/main/java/gregtech/api/util/GTDataUtils.java
@@ -1,6 +1,7 @@
 package gregtech.api.util;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -42,6 +43,26 @@ public class GTDataUtils {
         return out;
     }
 
+    public static <T> T[] withoutNulls(T[] array) {
+        if (array.length == 0) return array;
+
+        int nonNullCount = GTDataUtils.countNonNulls(array);
+
+        if (nonNullCount == array.length) return array;
+
+        T[] out = Arrays.copyOf(array, nonNullCount);
+
+        int j = 0, l = array.length;
+
+        for (int i = 0; i < l; i++) {
+            T t = array[i];
+
+            if (t != null) out[j++] = t;
+        }
+
+        return out;
+    }
+
     public static <T> int findIndex(T[] array, T value) {
         for (int i = 0; i < array.length; i++) {
             if (array[i] == value) return i;
@@ -65,5 +86,17 @@ public class GTDataUtils {
         l.removeIf(t -> !set.add(t));
 
         return set;
+    }
+
+    public static int countNonNulls(Object[] array) {
+        int l = array.length;
+        int count = 0;
+
+        // noinspection ForLoopReplaceableByForEach
+        for (int i = 0; i < l; i++) {
+            if (array[i] != null) count++;
+        }
+
+        return count;
     }
 }

--- a/src/main/java/gregtech/api/util/GTRecipe.java
+++ b/src/main/java/gregtech/api/util/GTRecipe.java
@@ -1006,7 +1006,7 @@ public class GTRecipe implements Comparable<GTRecipe> {
                 if (!inputBus.isValid()) return null;
                 ItemStack slotStack;
                 if (inputBus instanceof MTEHatchInputBusME meBus) {
-                    slotStack = meBus.getFirstShadowItemStack(true);
+                    slotStack = meBus.getFirstValidStack(true);
                 } else {
                     slotStack = inputBus.getFirstStack();
                 }
@@ -1053,7 +1053,7 @@ public class GTRecipe implements Comparable<GTRecipe> {
                 MTEHatchInputBus inputBus = inputBusses.get(i);
                 if (!inputBus.isValid()) return 0;
                 if (inputBus instanceof MTEHatchInputBusME meBus) {
-                    ItemStack item = meBus.getFirstShadowItemStack(true);
+                    ItemStack item = meBus.getFirstValidStack(true);
                     if (item == null) return 0;
                     GTUtility.ItemId id = GTUtility.ItemId.createNoCopy(item);
                     itemConsumptionsFromME.merge(id, (long) itemConsumptions[i], Long::sum);
@@ -1102,7 +1102,7 @@ public class GTRecipe implements Comparable<GTRecipe> {
                 MTEHatchInput inputHatch = inputHatches.get(i);
                 if (!inputHatch.isValid()) return 0;
                 if (inputHatch instanceof MTEHatchInputME meHatch) {
-                    FluidStack fluid = meHatch.getFirstShadowFluidStack(true);
+                    FluidStack fluid = meHatch.getFirstValidStack(true);
                     if (fluid == null) return 0;
                     if (!GTUtility.areFluidsEqual(fluid, fluidConsumptions[i])) return 0;
                     fluidConsumptionsFromME.merge(fluid.getFluid(), (long) fluidConsumptions[i].amount, Long::sum);
@@ -1151,7 +1151,7 @@ public class GTRecipe implements Comparable<GTRecipe> {
                 if (!inputBus.isValid()) continue;
                 ItemStack item;
                 if (inputBus instanceof MTEHatchInputBusME meBus) {
-                    ItemStack itemStack = meBus.getFirstShadowItemStack(true);
+                    ItemStack itemStack = meBus.getFirstValidStack(true);
                     item = inputsFromME.get(GTUtility.ItemId.createNoCopy(itemStack));
                 } else {
                     item = inputBus.getFirstStack();
@@ -1174,7 +1174,7 @@ public class GTRecipe implements Comparable<GTRecipe> {
                 if (!inputHatch.isValid()) continue;
                 FluidStack fluid;
                 if (inputHatch instanceof MTEHatchInputME meHatch) {
-                    FluidStack fluidStack = meHatch.getFirstShadowFluidStack(true);
+                    FluidStack fluidStack = meHatch.getFirstValidStack(true);
                     fluid = fluidsFromME.get(fluidStack.getFluid());
                 } else if (inputHatch instanceof MTEHatchMultiInput multiInput) {
                     fluid = multiInput.getFluid();

--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchInputBusME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchInputBusME.java
@@ -5,6 +5,7 @@ import static gregtech.api.enums.GTValues.VN;
 import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_ME_INPUT_HATCH;
 import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_ME_INPUT_HATCH_ACTIVE;
 
+import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -12,6 +13,8 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 
@@ -20,15 +23,37 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
+import net.minecraft.network.PacketBuffer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
+import net.minecraftforge.common.util.Constants;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import org.jetbrains.annotations.NotNull;
+
+import appeng.api.config.Actionable;
+import appeng.api.implementations.IPowerChannelState;
+import appeng.api.networking.GridFlags;
+import appeng.api.networking.energy.IEnergyGrid;
+import appeng.api.networking.security.BaseActionSource;
+import appeng.api.networking.security.IActionHost;
+import appeng.api.networking.security.MachineSource;
+import appeng.api.storage.IMEMonitor;
+import appeng.api.storage.data.IAEItemStack;
+import appeng.api.util.AECableType;
+import appeng.api.util.AEColor;
+import appeng.core.localization.WailaText;
+import appeng.me.GridAccessException;
+import appeng.me.helpers.AENetworkProxy;
+import appeng.me.helpers.IGridProxyable;
+import appeng.util.Platform;
+import appeng.util.item.AEItemStack;
 import com.gtnewhorizons.modularui.api.ModularUITextures;
 import com.gtnewhorizons.modularui.api.drawable.IDrawable;
+import com.gtnewhorizons.modularui.api.forge.IItemHandlerModifiable;
 import com.gtnewhorizons.modularui.api.math.Alignment;
 import com.gtnewhorizons.modularui.api.math.Color;
 import com.gtnewhorizons.modularui.api.math.Size;
@@ -43,23 +68,7 @@ import com.gtnewhorizons.modularui.common.widget.SlotGroup;
 import com.gtnewhorizons.modularui.common.widget.SlotWidget;
 import com.gtnewhorizons.modularui.common.widget.TextWidget;
 import com.gtnewhorizons.modularui.common.widget.textfield.NumericWidget;
-
-import appeng.api.config.Actionable;
-import appeng.api.config.PowerMultiplier;
-import appeng.api.implementations.IPowerChannelState;
-import appeng.api.networking.GridFlags;
-import appeng.api.networking.security.BaseActionSource;
-import appeng.api.networking.security.IActionHost;
-import appeng.api.networking.security.MachineSource;
-import appeng.api.storage.IMEMonitor;
-import appeng.api.storage.data.IAEItemStack;
-import appeng.api.util.AECableType;
-import appeng.api.util.AEColor;
-import appeng.core.localization.WailaText;
-import appeng.me.GridAccessException;
-import appeng.me.helpers.AENetworkProxy;
-import appeng.me.helpers.IGridProxyable;
-import appeng.util.item.AEItemStack;
+import gregtech.api.GregTechAPI;
 import gregtech.api.enums.Dyes;
 import gregtech.api.enums.ItemList;
 import gregtech.api.gui.modularui.GTUITextures;
@@ -77,6 +86,7 @@ import gregtech.api.recipe.check.CheckRecipeResult;
 import gregtech.api.recipe.check.CheckRecipeResultRegistry;
 import gregtech.api.recipe.check.SimpleCheckRecipeResult;
 import gregtech.api.render.TextureFactory;
+import gregtech.api.util.GTDataUtils;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.shutdown.ShutDownReasonRegistry;
 import gregtech.common.gui.modularui.widget.AESlotWidget;
@@ -91,8 +101,7 @@ public class MTEHatchInputBusME extends MTEHatchInputBus
     public static final String COPIED_DATA_IDENTIFIER = "stockingBus";
     protected BaseActionSource requestSource = null;
     protected @Nullable AENetworkProxy gridProxy = null;
-    protected final ItemStack[] shadowInventory = new ItemStack[SLOT_COUNT];
-    protected final int[] savedStackSizes = new int[SLOT_COUNT];
+    protected final Slot[] slots = new Slot[SLOT_COUNT];
     protected boolean processingRecipe = false;
     protected final boolean autoPullAvailable;
     protected boolean autoPullItemList = false;
@@ -109,7 +118,7 @@ public class MTEHatchInputBusME extends MTEHatchInputBus
             aName,
             aNameRegional,
             autoPullAvailable ? 6 : 3,
-            SLOT_COUNT * 2 + 2,
+            2,
             getDescriptionArray(autoPullAvailable));
         this.autoPullAvailable = autoPullAvailable;
         disableSort = true;
@@ -117,7 +126,7 @@ public class MTEHatchInputBusME extends MTEHatchInputBus
 
     public MTEHatchInputBusME(String aName, boolean autoPullAvailable, int aTier, String[] aDescription,
         ITexture[][][] aTextures) {
-        super(aName, aTier, SLOT_COUNT * 2 + 2, aDescription, aTextures);
+        super(aName, aTier, 2, aDescription, aTextures);
         this.autoPullAvailable = autoPullAvailable;
         disableSort = true;
     }
@@ -153,7 +162,13 @@ public class MTEHatchInputBusME extends MTEHatchInputBus
     protected boolean isAllowedToWork() {
         IGregTechTileEntity igte = getBaseMetaTileEntity();
 
-        return igte != null && igte.isAllowedToWork();
+        if (igte == null || !igte.isAllowedToWork()) return false;
+
+        AENetworkProxy proxy = getProxy();
+
+        if (!proxy.isActive()) return false;
+
+        return true;
     }
 
     @Override
@@ -228,7 +243,7 @@ public class MTEHatchInputBusME extends MTEHatchInputBus
     }
 
     @Override
-    public AENetworkProxy getProxy() {
+    public @NotNull AENetworkProxy getProxy() {
         if (gridProxy == null) {
             if (getBaseMetaTileEntity() instanceof IGridProxyable) {
                 gridProxy = new AENetworkProxy(
@@ -249,26 +264,40 @@ public class MTEHatchInputBusME extends MTEHatchInputBus
 
     @Override
     public boolean isPowered() {
-        return getProxy() != null && getProxy().isPowered();
+        return getProxy().isPowered();
     }
 
     @Override
     public boolean isActive() {
-        return getProxy() != null && getProxy().isActive();
+        return getProxy().isActive();
     }
 
     @Override
     public void saveNBTData(NBTTagCompound aNBT) {
         super.saveNBTData(aNBT);
-        int[] sizes = new int[16];
-        for (int i = 0; i < 16; ++i) sizes[i] = mInventory[i + 16] == null ? 0 : mInventory[i + 16].stackSize;
-        aNBT.setIntArray("sizes", sizes);
+
+        aNBT.setInteger("version", 1);
         aNBT.setBoolean("autoStock", autoPullItemList);
         aNBT.setInteger("minAutoPullStackSize", minAutoPullStackSize);
         aNBT.setBoolean("additionalConnection", additionalConnection);
         aNBT.setBoolean("expediteRecipeCheck", expediteRecipeCheck);
         aNBT.setInteger("refreshTime", autoPullRefreshTime);
         getProxy().writeToNBT(aNBT);
+
+        NBTTagList slotList = new NBTTagList();
+        aNBT.setTag("slots", slotList);
+
+        for (int i = 0; i < slots.length; i++) {
+            Slot slot = slots[i];
+
+            if (slot == null) continue;
+
+            NBTTagCompound tag = new NBTTagCompound();
+            slot.writeToNBT(tag);
+            tag.setInteger("index", i);
+
+            slotList.appendTag(tag);
+        }
     }
 
     protected void setAutoPullItemList(boolean pullItemList) {
@@ -276,15 +305,17 @@ public class MTEHatchInputBusME extends MTEHatchInputBus
             return;
         }
 
-        autoPullItemList = pullItemList;
-        if (!autoPullItemList) {
-            for (int i = 0; i < SLOT_COUNT; i++) {
-                mInventory[i] = null;
+        if (autoPullItemList != pullItemList) {
+            autoPullItemList = pullItemList;
+
+            Arrays.fill(slots, null);
+
+            if (autoPullItemList) {
+                refreshItemList();
             }
-        } else {
-            refreshItemList();
+
+            updateAllInformationSlots();
         }
-        updateAllInformationSlots();
     }
 
     public boolean doFastRecipeCheck() {
@@ -294,18 +325,7 @@ public class MTEHatchInputBusME extends MTEHatchInputBus
     @Override
     public void loadNBTData(NBTTagCompound aNBT) {
         super.loadNBTData(aNBT);
-        if (aNBT.hasKey("sizes")) {
-            int[] sizes = aNBT.getIntArray("sizes");
-            if (sizes.length == 16) {
-                for (int i = 0; i < 16; ++i) {
-                    if (sizes[i] != 0 && mInventory[i] != null) {
-                        ItemStack s = mInventory[i].copy();
-                        s.stackSize = sizes[i];
-                        mInventory[i + 16] = s;
-                    }
-                }
-            }
-        }
+
         autoPullItemList = aNBT.getBoolean("autoStock");
         minAutoPullStackSize = aNBT.getInteger("minAutoPullStackSize");
         additionalConnection = aNBT.getBoolean("additionalConnection");
@@ -315,6 +335,55 @@ public class MTEHatchInputBusME extends MTEHatchInputBus
         }
         getProxy().readFromNBT(aNBT);
         updateAE2ProxyColor();
+
+        Arrays.fill(slots, null);
+
+        switch (aNBT.getInteger("version")) {
+            case 0 -> {
+                int[] sizes = aNBT.hasKey("sizes") ? aNBT.getIntArray("sizes") : new int[0];
+
+                final NBTTagList inventory = aNBT.getTagList("Inventory", Constants.NBT.TAG_COMPOUND);
+
+                ItemStack[] oldInventory = new ItemStack[SLOT_COUNT * 2 + 2];
+
+                // Copy of the current mInventory loading code, because otherwise the upper stacks are discarded due to
+                // the reduced mInventory size.
+                //noinspection unchecked
+                for (NBTTagCompound tag : (List<NBTTagCompound>) inventory.tagList) {
+                    oldInventory[tag.getInteger("IntSlot")] = GTUtility.loadItem(tag);
+                }
+
+                // Migrate the circuit and manual slots
+                mInventory[0] = oldInventory[SLOT_COUNT * 2];
+                mInventory[1] = oldInventory[SLOT_COUNT * 2 + 1];
+
+                // Migrate the config from the old system (raw item stacks) to the new system (dedicated slot objects)
+                for (int i = 0; i < SLOT_COUNT; i++) {
+                    if (oldInventory[i] != null) {
+                        Slot slot = new Slot(oldInventory[i]);
+
+                        if (i < sizes.length && sizes[i] > 0) {
+                            slot.extracted = slot.config.copy();
+                            slot.extractedAmount = sizes[i];
+                        }
+
+                        slots[i] = slot;
+                    }
+                }
+            }
+            case 1 -> {
+                NBTTagList slotList = aNBT.getTagList("slots", Constants.NBT.TAG_COMPOUND);
+
+                //noinspection unchecked
+                for (NBTTagCompound tag : (List<NBTTagCompound>) slotList.tagList) {
+                    Slot slot = Slot.readFromNBT(tag);
+
+                    if (slot != null) {
+                        slots[tag.getInteger("index")] = slot;
+                    }
+                }
+            }
+        }
     }
 
     @Override
@@ -324,7 +393,7 @@ public class MTEHatchInputBusME extends MTEHatchInputBus
 
     @Override
     public String[] getInfoData() {
-        return new String[] { (getProxy() != null && getProxy().isActive())
+        return new String[] { getProxy().isActive()
             ? StatCollector.translateToLocal("GT5U.infodata.hatch.crafting_input_me.bus.online")
             : StatCollector
                 .translateToLocalFormatted("GT5U.infodata.hatch.crafting_input_me.bus.offline", getAEDiagnostics()) };
@@ -333,13 +402,18 @@ public class MTEHatchInputBusME extends MTEHatchInputBus
     @Override
     public boolean allowPullStack(IGregTechTileEntity aBaseMetaTileEntity, int aIndex, ForgeDirection side,
         ItemStack aStack) {
-        return false;
+        return aIndex == getManualSlot();
     }
 
     @Override
     public boolean allowPutStack(IGregTechTileEntity aBaseMetaTileEntity, int aIndex, ForgeDirection side,
         ItemStack aStack) {
-        return false;
+        return aIndex == getManualSlot();
+    }
+
+    @Override
+    public boolean isValidSlot(int aIndex) {
+        return aIndex == getManualSlot();
     }
 
     @Override
@@ -396,14 +470,16 @@ public class MTEHatchInputBusME extends MTEHatchInputBus
     @Override
     public boolean pasteCopiedData(EntityPlayer player, NBTTagCompound nbt) {
         if (nbt == null || !COPIED_DATA_IDENTIFIER.equals(nbt.getString("type"))) return false;
+
         ItemStack circuit = GTUtility.loadItem(nbt, "circuit");
         if (GTUtility.isStackInvalid(circuit)) circuit = null;
+        setInventorySlotContents(getCircuitSlot(), circuit);
 
         if (autoPullAvailable) {
             setAutoPullItemList(nbt.getBoolean("autoPull"));
             minAutoPullStackSize = nbt.getInteger("minStackSize");
-            // Data sticks created before refreshTime was implemented should not cause stocking buses to
-            // spam divide by zero errors
+            // Data sticks created before refreshTime was implemented should not cause stocking buses to spam divide by
+            // zero errors
             if (nbt.hasKey("refreshTime")) {
                 autoPullRefreshTime = nbt.getInteger("refreshTime");
             }
@@ -411,14 +487,17 @@ public class MTEHatchInputBusME extends MTEHatchInputBus
         }
 
         additionalConnection = nbt.getBoolean("additionalConnection");
+
         if (!autoPullItemList) {
-            NBTTagList stockingItems = nbt.getTagList("itemsToStock", 10);
+            NBTTagList stockingItems = nbt.getTagList("itemsToStock", Constants.NBT.TAG_COMPOUND);
+            Arrays.fill(slots, null);
             for (int i = 0; i < stockingItems.tagCount(); i++) {
-                this.mInventory[i] = GTUtility.loadItem(stockingItems.getCompoundTagAt(i));
+                slots[i] = new Slot(GTUtility.loadItem(stockingItems.getCompoundTagAt(i)));
             }
         }
-        setInventorySlotContents(getCircuitSlot(), circuit);
+
         updateValidGridProxySides();
+        updateAllInformationSlots();
         return true;
     }
 
@@ -433,24 +512,28 @@ public class MTEHatchInputBusME extends MTEHatchInputBus
         tag.setBoolean("additionalConnection", additionalConnection);
         tag.setTag("circuit", GTUtility.saveItem(getStackInSlot(getCircuitSlot())));
 
-        NBTTagList stockingItems = new NBTTagList();
-
         if (!autoPullItemList) {
-            for (int index = 0; index < SLOT_COUNT; index++) {
-                stockingItems.appendTag(GTUtility.saveItem(mInventory[index]));
+            NBTTagList stockingItems = new NBTTagList();
+
+            for (Slot slot : slots) {
+                if (slot == null) continue;
+
+                stockingItems.appendTag(slot.config.writeToNBT(new NBTTagCompound()));
             }
+
             tag.setTag("itemsToStock", stockingItems);
         }
+
         return tag;
     }
 
     protected int getManualSlot() {
-        return SLOT_COUNT * 2 + 1;
+        return 1;
     }
 
     @Override
     public int getCircuitSlot() {
-        return SLOT_COUNT * 2;
+        return 0;
     }
 
     @Override
@@ -480,79 +563,48 @@ public class MTEHatchInputBusME extends MTEHatchInputBus
 
     public void setRecipeCheck(boolean value) {
         expediteRecipeCheck = value;
-    }
 
-    @Override
-    public void setInventorySlotContents(int aIndex, ItemStack aStack) {
-        if (expediteRecipeCheck && aStack != null) {
-            justHadNewItems = true;
+        IGregTechTileEntity igte = getBaseMetaTileEntity();
+
+        // Changing this field requires a structure check/update, so let's do that automatically
+        if (igte.isServerSide()) {
+            GregTechAPI.causeMachineUpdate(igte.getWorld(), igte.getXCoord(), igte.getYCoord(), igte.getZCoord());
         }
-        super.setInventorySlotContents(aIndex, aStack);
     }
 
     @Override
-    public ItemStack getStackInSlot(int aIndex) {
-        if (!processingRecipe) return super.getStackInSlot(aIndex);
+    public int getSizeInventory() {
+        // Add fake slots so that multis can detect the stocked items properly
+        // 0 & 1: circuit and manual slot
+        // 2 to 10: stocked items
+        return SLOT_COUNT + 2;
+    }
 
-        if (aIndex < 0 || aIndex > mInventory.length) return null;
+    @Override
+    public ItemStack getStackInSlot(int slotIndex) {
+        if (!processingRecipe) return null;
 
-        // Display slots
-        if (aIndex >= SLOT_COUNT && aIndex < SLOT_COUNT * 2) return null;
+        if (slotIndex < 0 || slotIndex >= getSizeInventory()) return null;
 
-        if (aIndex == getCircuitSlot() || aIndex == getManualSlot()) return mInventory[aIndex];
+        if (slotIndex == getCircuitSlot() || slotIndex == getManualSlot()) return mInventory[slotIndex];
 
-        if (mInventory[aIndex] != null) {
+        slotIndex -= 2;
 
-            AENetworkProxy proxy = getProxy();
-            if (proxy == null || !proxy.isActive()) {
-                return null;
-            }
-
-            if (!isAllowedToWork()) {
-                this.shadowInventory[aIndex] = null;
-                this.savedStackSizes[aIndex] = 0;
-                super.setInventorySlotContents(aIndex + SLOT_COUNT, null);
-                return null;
-            }
-
-            try {
-                IMEMonitor<IAEItemStack> sg = proxy.getStorage()
-                    .getItemInventory();
-
-                IAEItemStack request = AEItemStack.create(mInventory[aIndex]);
-                request.setStackSize(Integer.MAX_VALUE);
-
-                IAEItemStack result = sg.extractItems(request, Actionable.SIMULATE, getRequestSource());
-
-                if (result != null) {
-                    this.shadowInventory[aIndex] = result.getItemStack();
-                    this.savedStackSizes[aIndex] = this.shadowInventory[aIndex].stackSize;
-                    this.setInventorySlotContents(aIndex + SLOT_COUNT, this.shadowInventory[aIndex]);
-                    return this.shadowInventory[aIndex];
-                } else {
-                    // Request failed
-                    this.setInventorySlotContents(aIndex + SLOT_COUNT, null);
-                    return null;
-                }
-            } catch (final GridAccessException ignored) {}
+        if (!isAllowedToWork()) {
             return null;
-        } else {
-            // AE available but no items requested
-            this.setInventorySlotContents(aIndex + SLOT_COUNT, null);
         }
-        return mInventory[aIndex];
+
+        Slot slot = GTDataUtils.getIndexSafe(slots, slotIndex);
+
+        if (slot == null) return null;
+
+        // Must pass the reference out to the multi
+        return slot.extracted;
     }
 
     protected BaseActionSource getRequestSource() {
         if (requestSource == null) requestSource = new MachineSource((IActionHost) getBaseMetaTileEntity());
         return requestSource;
-    }
-
-    @Override
-    public void onExplosion() {
-        for (int i = 0; i < SLOT_COUNT; i++) {
-            mInventory[i] = null;
-        }
     }
 
     @Override
@@ -562,177 +614,185 @@ public class MTEHatchInputBusME extends MTEHatchInputBus
     }
 
     protected void refreshItemList() {
-        if (!isActive()) return;
-        AENetworkProxy proxy = getProxy();
+        if (!isAllowedToWork()) return;
+
+        IMEMonitor<IAEItemStack> sg;
+        Iterator<IAEItemStack> iterator;
+
         try {
-            IMEMonitor<IAEItemStack> sg = proxy.getStorage()
-                .getItemInventory();
-            Iterator<IAEItemStack> iterator = sg.getStorageList()
-                .iterator();
-            int index = 0;
-            while (iterator.hasNext() && index < SLOT_COUNT) {
-                IAEItemStack currItem = iterator.next();
-                if (currItem.getStackSize() >= minAutoPullStackSize) {
-                    ItemStack itemstack = GTUtility.copyAmount(1, currItem.getItemStack());
-                    if (expediteRecipeCheck) {
-                        ItemStack previous = this.mInventory[index];
-                        if (itemstack != null) {
-                            justHadNewItems = !ItemStack.areItemStacksEqual(itemstack, previous);
-                        }
-                    }
-                    this.mInventory[index] = itemstack;
-                    index++;
-                }
-            }
-            for (int i = index; i < SLOT_COUNT; i++) {
-                mInventory[i] = null;
+            sg = getProxy().getStorage().getItemInventory();
+            iterator = sg.getStorageList().iterator();
+        } catch (final GridAccessException ignored) {
+            return;
+        }
+
+        int index = 0;
+
+        Arrays.fill(slots, null);
+
+        while (iterator.hasNext() && index < SLOT_COUNT) {
+            IAEItemStack curr = iterator.next();
+
+            if (curr.getStackSize() < minAutoPullStackSize) continue;
+
+            Slot oldSlot = slots[index];
+
+            // Prevent weird reference problems by copying the slot
+            if (oldSlot != null) oldSlot = oldSlot.copy();
+
+            setSlotConfig(index, GTUtility.copyAmount(1, curr.getItemStack()));
+
+            Slot newSlot = slots[index];
+
+            if (newSlot != null) {
+                newSlot.extracted = curr.getItemStack();
+                newSlot.extractedAmount = newSlot.extracted.stackSize;
             }
 
-        } catch (final GridAccessException ignored) {}
+            if (!Objects.equals(oldSlot, newSlot)) {
+                justHadNewItems = true;
+            }
+
+            index++;
+        }
     }
 
     protected void updateAllInformationSlots() {
-        for (int index = 0; index < SLOT_COUNT; index++) {
-            updateInformationSlot(index, mInventory[index]);
+        AENetworkProxy proxy = getProxy();
+
+        boolean isActive = isAllowedToWork() && proxy.isActive();
+
+        if (isActive) {
+            try {
+                for (int index = 0; index < SLOT_COUNT; index++) {
+                    updateInformationSlot(index);
+                }
+            } catch (GridAccessException e) {
+                // :P
+            }
+        } else {
+            for (Slot slot : slots) {
+                if (slot == null) continue;
+
+                slot.resetExtracted();
+            }
         }
     }
 
     @Override
     public CheckRecipeResult endRecipeProcessing(MTEMultiBlockBase controller) {
         CheckRecipeResult checkRecipeResult = CheckRecipeResultRegistry.SUCCESSFUL;
-        for (int i = 0; i < SLOT_COUNT; ++i) {
-            if (savedStackSizes[i] != 0) {
-                ItemStack oldStack = shadowInventory[i];
-                if (oldStack == null || oldStack.stackSize < savedStackSizes[i]) {
-                    AENetworkProxy proxy = getProxy();
-                    try {
-                        IMEMonitor<IAEItemStack> sg = proxy.getStorage()
-                            .getItemInventory();
-                        IAEItemStack request = AEItemStack.create(mInventory[i]);
-                        int toExtract = savedStackSizes[i] - (oldStack == null ? 0 : oldStack.stackSize);
-                        request.setStackSize(toExtract);
-                        IAEItemStack result = sg.extractItems(request, Actionable.MODULATE, getRequestSource());
-                        proxy.getEnergy()
-                            .extractAEPower(request.getStackSize(), Actionable.MODULATE, PowerMultiplier.CONFIG);
-                        setInventorySlotContents(i + SLOT_COUNT, oldStack);
-                        if (result == null || result.getStackSize() != toExtract) {
-                            controller.stopMachine(ShutDownReasonRegistry.CRITICAL_NONE);
-                            checkRecipeResult = SimpleCheckRecipeResult
-                                .ofFailurePersistOnShutdown("stocking_bus_fail_extraction");
-                        }
-                    } catch (final GridAccessException ignored) {
-                        controller.stopMachine(ShutDownReasonRegistry.CRITICAL_NONE);
-                        checkRecipeResult = SimpleCheckRecipeResult
-                            .ofFailurePersistOnShutdown("stocking_hatch_fail_extraction");
-                    }
-                }
-                savedStackSizes[i] = 0;
-                shadowInventory[i] = null;
-                if (mInventory[i + SLOT_COUNT] != null && mInventory[i + SLOT_COUNT].stackSize <= 0) {
-                    mInventory[i + SLOT_COUNT] = null;
-                }
+
+        IMEMonitor<IAEItemStack> sg;
+        IEnergyGrid energy;
+
+        try {
+            sg = getProxy().getStorage().getItemInventory();
+            energy = getProxy().getEnergy();
+        } catch (GridAccessException e) {
+            controller.stopMachine(ShutDownReasonRegistry.CRITICAL_NONE);
+            return SimpleCheckRecipeResult.ofFailurePersistOnShutdown("stocking_bus_fail_extraction");
+        }
+
+        for (Slot slot : slots) {
+            if (slot == null || slot.extracted == null || slot.extractedAmount == 0) continue;
+
+            int toExtract = slot.extractedAmount - slot.extracted.stackSize;
+
+            if (toExtract <= 0) continue;
+
+            IAEItemStack request = AEItemStack.create(slot.extracted);
+            request.setStackSize(toExtract);
+
+            IAEItemStack result = Platform.poweredExtraction(energy, sg, request, getRequestSource());
+
+            if (result == null || result.getStackSize() != toExtract) {
+                controller.stopMachine(ShutDownReasonRegistry.CRITICAL_NONE);
+                checkRecipeResult = SimpleCheckRecipeResult.ofFailurePersistOnShutdown("stocking_bus_fail_extraction");
             }
         }
+
         processingRecipe = false;
+
         return checkRecipeResult;
     }
 
-    /**
-     * Update the right side of the GUI, which shows the amounts of items set on the left side
-     */
-    public ItemStack updateInformationSlot(int aIndex, ItemStack aStack) {
-        if (aIndex >= 0 && aIndex < SLOT_COUNT) {
-            if (aStack == null) {
-                super.setInventorySlotContents(aIndex + SLOT_COUNT, null);
-            } else {
-                AENetworkProxy proxy = getProxy();
-                if (!proxy.isActive()) {
-                    super.setInventorySlotContents(aIndex + SLOT_COUNT, null);
-                    return null;
-                }
-
-                if (!isAllowedToWork()) {
-                    this.shadowInventory[aIndex] = null;
-                    this.savedStackSizes[aIndex] = 0;
-                    super.setInventorySlotContents(aIndex + SLOT_COUNT, null);
-                    return null;
-                }
-
-                try {
-                    IMEMonitor<IAEItemStack> sg = proxy.getStorage()
-                        .getItemInventory();
-                    IAEItemStack request = AEItemStack.create(mInventory[aIndex]);
-                    request.setStackSize(Integer.MAX_VALUE);
-                    IAEItemStack result = sg.extractItems(request, Actionable.SIMULATE, getRequestSource());
-                    ItemStack s = (result != null) ? result.getItemStack() : null;
-                    // We want to track changes in any ItemStack to notify any connected controllers to make a recipe
-                    // check early
-                    if (expediteRecipeCheck) {
-                        ItemStack previous = getStackInSlot(aIndex + SLOT_COUNT);
-                        if (s != null) {
-                            justHadNewItems = !ItemStack.areItemStacksEqual(s, previous);
-                        }
-                    }
-                    setInventorySlotContents(aIndex + SLOT_COUNT, s);
-                    return s;
-                } catch (final GridAccessException ignored) {}
-            }
-        }
-        return null;
+    public void setSlotConfig(int index, ItemStack config) {
+        slots[index] = config == null ? null : new Slot(config.copy());
     }
 
     /**
-     * Used to avoid slot update.
+     * Polls the AE network to update the available items for the given slot.
      */
-    public ItemStack getShadowItemStack(int index) {
-        if (index < 0 || index >= shadowInventory.length) {
+    public void updateInformationSlot(int index) throws GridAccessException {
+        Slot slot = GTDataUtils.getIndexSafe(slots, index);
+
+        if (slot == null) return;
+
+        if (!isAllowedToWork()) {
+            slot.resetExtracted();
+            return;
+        }
+
+        IMEMonitor<IAEItemStack> sg = getProxy().getStorage().getItemInventory();
+
+        IAEItemStack request = AEItemStack.create(slot.config);
+        request.setStackSize(Integer.MAX_VALUE);
+
+        IAEItemStack result = sg.extractItems(request, Actionable.SIMULATE, getRequestSource());
+
+        ItemStack previous = slot.extracted;
+
+        slot.extracted = result != null ? result.getItemStack() : null;
+        slot.extractedAmount = slot.extracted == null ? 0 : slot.extracted.stackSize;
+
+        // We want to track changes in any ItemStack to notify any connected controllers to make a recipe check early
+        if (expediteRecipeCheck && slot.extracted != null) {
+            justHadNewItems = !ItemStack.areItemStacksEqual(slot.extracted, previous);
+        }
+    }
+
+    /**
+     * Gets the first non-null shadow item stack.
+     *
+     * @return The first shadow item stack, or null if this doesn't exist.
+     */
+    public ItemStack getFirstValidStack() {
+        return getFirstValidStack(false);
+    }
+
+    /**
+     * Gets the first non-null extracted item stack.
+     *
+     * @param slotsMustMatch When true, every slot in this input bus must be the same (ignores stack sizes).
+     * @return The first extracted item stack, or null if this doesn't exist.
+     */
+    public ItemStack getFirstValidStack(boolean slotsMustMatch) {
+        if (slotsMustMatch) {
+            ItemStack firstValid = null;
+
+            for (Slot slot : slots) {
+                if (slot == null || slot.extracted == null) continue;
+
+                if (firstValid == null) {
+                    firstValid = slot.extracted;
+                } else {
+                    if (!GTUtility.areStacksEqual(firstValid, slot.extracted)) {
+                        return null;
+                    }
+                }
+            }
+
+            return firstValid;
+        } else {
+            for (Slot slot : slots) {
+                if (slot == null || slot.extracted == null) continue;
+
+                return slot.extracted;
+            }
+
             return null;
         }
-        return shadowInventory[index];
-    }
-
-    public int getShadowInventorySize() {
-        return shadowInventory.length;
-    }
-
-    /**
-     * Gets the first non-null shadow item stack.
-     *
-     * @return The first shadow item stack, or null if this doesn't exist.
-     */
-    public ItemStack getFirstShadowItemStack() {
-        return getFirstShadowItemStack(false);
-    }
-
-    /**
-     * Gets the first non-null shadow item stack.
-     *
-     * @param hasToMatchGhost Whether the first item stack returned has to match the first non-null ghost stack
-     * @return The first shadow item stack, or null if this doesn't exist.
-     */
-    public ItemStack getFirstShadowItemStack(boolean hasToMatchGhost) {
-        ItemStack itemStack;
-        ItemStack lockedSlot = null;
-        if (hasToMatchGhost) {
-            byte slotToCheck = 0;
-            do {
-                lockedSlot = mInventory[slotToCheck];
-                slotToCheck++;
-            } while (lockedSlot == null && slotToCheck < getSizeInventory());
-            if (lockedSlot == null) return null;
-        }
-        byte slotToCheck = 0;
-        do {
-            itemStack = getShadowItemStack(slotToCheck);
-            slotToCheck++;
-        } while ((itemStack == null || !(hasToMatchGhost && lockedSlot.getItem() == itemStack.getItem()))
-            && slotToCheck < getSizeInventory());
-        return itemStack;
-    }
-
-    @Override
-    public boolean isValidSlot(int aIndex) {
-        return aIndex == getManualSlot();
     }
 
     @Override
@@ -740,20 +800,28 @@ public class MTEHatchInputBusME extends MTEHatchInputBus
         return 179;
     }
 
+    private boolean containsSuchStack(ItemStack tStack) {
+        return Stream.of(slots)
+            .filter(Objects::nonNull)
+            .anyMatch(slot -> GTUtility.areStacksEqual(slot.config, tStack));
+    }
+
     @Override
     public void addUIWidgets(ModularWindow.Builder builder, UIBuildContext buildContext) {
-        final SlotWidget[] aeSlotWidgets = new SlotWidget[16];
-
         if (autoPullAvailable) {
             buildContext.addSyncedWindow(CONFIG_WINDOW_ID, this::createStackSizeConfigurationWindow);
         }
 
+        SlotItemHandler configItemHandler = new SlotItemHandler();
+
+        builder.widget(new SlotSyncWidget());
+
         builder.widget(
-            SlotGroup.ofItemHandler(inventoryHandler, 4)
+            SlotGroup.ofItemHandler(configItemHandler, 4)
                 .startFromSlot(0)
                 .endAtSlot(15)
                 .phantom(true)
-                .slotCreator(index -> new BaseSlot(inventoryHandler, index, true) {
+                .slotCreator(index -> new BaseSlot(configItemHandler, index, true) {
 
                     @Override
                     public boolean isEnabled() {
@@ -765,17 +833,17 @@ public class MTEHatchInputBusME extends MTEHatchInputBus
                     @Override
                     protected void phantomClick(ClickData clickData, ItemStack cursorStack) {
                         if (clickData.mouseButton != 0 || !getMcSlot().isEnabled()) return;
-                        final int aSlotIndex = getMcSlot().getSlotIndex();
-                        if (cursorStack == null) {
-                            getMcSlot().putStack(null);
-                        } else {
-                            if (containsSuchStack(cursorStack)) return;
-                            getMcSlot().putStack(GTUtility.copyAmount(1, cursorStack));
-                        }
+
+                        if (cursorStack != null && containsSuchStack(cursorStack)) return;
+
+                        setSlotConfig(slot.getSlotIndex(), GTUtility.copyAmount(1, cursorStack));
+
                         if (getBaseMetaTileEntity().isServerSide()) {
-                            final ItemStack newInfo = updateInformationSlot(aSlotIndex, cursorStack);
-                            aeSlotWidgets[getMcSlot().getSlotIndex()].getMcSlot()
-                                .putStack(newInfo);
+                            try {
+                                updateInformationSlot(slot.getSlotIndex());
+                            } catch (GridAccessException e) {
+                                // :P
+                            }
                         }
                     }
 
@@ -800,13 +868,6 @@ public class MTEHatchInputBusME extends MTEHatchInputBus
                                 .singletonList(StatCollector.translateToLocal("modularui.phantom.single.clear"));
                         }
                     }
-
-                    private boolean containsSuchStack(ItemStack tStack) {
-                        for (int i = 0; i < 16; ++i) {
-                            if (GTUtility.areStacksEqual(mInventory[i], tStack, false)) return true;
-                        }
-                        return false;
-                    }
                 }.dynamicTooltip(() -> {
                     if (autoPullItemList) {
                         return Collections.singletonList(
@@ -819,13 +880,12 @@ public class MTEHatchInputBusME extends MTEHatchInputBus
                 .build()
                 .setPos(7, 9))
             .widget(
-                SlotGroup.ofItemHandler(inventoryHandler, 4)
+                SlotGroup.ofItemHandler(configItemHandler, 4)
                     .startFromSlot(16)
                     .endAtSlot(31)
                     .phantom(true)
                     .background(GTUITextures.SLOT_DARK_GRAY)
-                    .widgetCreator(
-                        slot -> aeSlotWidgets[slot.getSlotIndex() - 16] = new AESlotWidget(slot).disableInteraction())
+                    .widgetCreator(slot -> new AESlotWidget(slot).disableInteraction())
                     .build()
                     .setPos(97, 9))
             .widget(
@@ -941,8 +1001,7 @@ public class MTEHatchInputBusME extends MTEHatchInputBus
                             : GTUITextures.OVERLAY_BUTTON_CROSS)
                     .setBackground(GTUITextures.BUTTON_STANDARD)
                     .setPos(53, 87)
-                    .setSize(16, 16)
-                    .addTooltip(StatCollector.translateToLocal("GT5U.machines.stocking_bus.hatch_warning")));
+                    .setSize(16, 16));
         return builder.build();
     }
 
@@ -1008,5 +1067,167 @@ public class MTEHatchInputBusME extends MTEHatchInputBus
         strings.add("Change ME connection behavior by right-clicking with wire cutter.");
         strings.add("Configuration data can be copy/pasted using a data stick.");
         return strings.toArray(new String[0]);
+    }
+
+    protected static class Slot {
+        /** The item to pull into this slot. */
+        public ItemStack config;
+
+        /** The amount of stuff initially in the ME system when the recipe check started. */
+        public int extractedAmount;
+        /**
+         * The extracted stack (almost certainly equal to config). This is shared as a reference to the multiblock,
+         * which decrements the stored amount as it gets consumed. After the recipe check has finished, the amount in
+         * this stack is compared to {@link #extractedAmount} and the difference is subtracted from the ME system. If
+         * this operation fails, the machine is shut down.
+         */
+        public ItemStack extracted;
+
+        public Slot(ItemStack config) {
+            this.config = config;
+        }
+
+        /** Resets the extracted amount. */
+        public void resetExtracted() {
+            extracted = null;
+            extractedAmount = 0;
+        }
+
+        @Override
+        public final boolean equals(Object o) {
+            if (!(o instanceof Slot slot)) return false;
+
+            return extractedAmount == slot.extractedAmount && Objects.equals(config, slot.config) && Objects.equals(extracted, slot.extracted);
+        }
+
+        public Slot copy() {
+            Slot copy = new Slot(this.config);
+
+            copy.extracted = this.extracted;
+            copy.extractedAmount = this.extractedAmount;
+
+            return copy;
+        }
+
+        public void writeToNBT(NBTTagCompound tag) {
+            tag.setTag("config", config.writeToNBT(new NBTTagCompound()));
+            if (extracted != null) {
+                tag.setTag("extracted", extracted.writeToNBT(new NBTTagCompound()));
+                tag.setInteger("extractedAmount", extractedAmount);
+            }
+        }
+
+        public static Slot readFromNBT(NBTTagCompound tag) {
+            Slot slot = new Slot(ItemStack.loadItemStackFromNBT(tag.getCompoundTag("config")));
+
+            if (slot.config == null) return null;
+
+            if (tag.hasKey("extracted")) {
+                slot.extracted = ItemStack.loadItemStackFromNBT(tag.getCompoundTag("extracted"));
+                slot.extractedAmount = tag.getInteger("extractedAmount");
+            }
+
+            return slot;
+        }
+    }
+
+    private class SlotItemHandler implements IItemHandlerModifiable {
+
+        @Override
+        public int getSlots() {
+            return SLOT_COUNT * 2;
+        }
+
+        @Override
+        public ItemStack getStackInSlot(int slotIndex) {
+            boolean forConfig = slotIndex < SLOT_COUNT;
+            slotIndex %= SLOT_COUNT;
+
+            Slot slot = GTDataUtils.getIndexSafe(slots, slotIndex);
+
+            if (slot == null) return null;
+
+            return forConfig ? slot.config : GTUtility.copyAmountUnsafe(slot.extractedAmount, slot.extracted);
+        }
+
+        @Override
+        public @org.jetbrains.annotations.Nullable ItemStack insertItem(int slot, @Nullable ItemStack stack, boolean simulate) {
+            return stack;
+        }
+
+        @Override
+        public @org.jetbrains.annotations.Nullable ItemStack extractItem(int slot, int amount, boolean simulate) {
+            return null;
+        }
+
+        @Override
+        public int getSlotLimit(int slot) {
+            return Integer.MAX_VALUE;
+        }
+
+        @Override
+        public void setStackInSlot(int slotIndex, ItemStack stack) {
+            // do nothing
+        }
+    }
+
+    private class SlotSyncWidget extends FakeSyncWidget.ListSyncer<Slot> {
+
+        public SlotSyncWidget() {
+            super(
+                () -> GTDataUtils.mapToList(slots, slot -> slot == null ? null : slot.copy()),
+                slots2 -> System.arraycopy(slots2.toArray(new Slot[0]), 0, slots, 0, SLOT_COUNT),
+                SlotSyncWidget::writeSlot,
+                SlotSyncWidget::readSlot);
+        }
+
+        private static int counter = 0;
+        private static final int NOT_NULL = 0b1 << counter++;
+        private static final int EXTRACTED_SET = 0b1 << counter++;
+
+        private static void writeSlot(PacketBuffer buffer, Slot slot) {
+            int flags = 0;
+
+            if (slot != null) {
+                flags |= NOT_NULL;
+                if (slot.extracted != null) {
+                    flags |= EXTRACTED_SET;
+                }
+            }
+
+            buffer.writeByte(flags);
+
+            try {
+                if (slot != null) {
+                    buffer.writeItemStackToBuffer(slot.config);
+
+                    if (slot.extracted != null) {
+                        buffer.writeItemStackToBuffer(slot.extracted);
+                        buffer.writeInt(slot.extractedAmount);
+                    }
+                }
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        private static Slot readSlot(PacketBuffer buffer) {
+            int flags = buffer.readByte();
+
+            if ((flags & NOT_NULL) == 0) return null;
+
+            try {
+                Slot slot = new Slot(buffer.readItemStackFromBuffer());
+
+                if ((flags & EXTRACTED_SET) != 0) {
+                    slot.extracted = buffer.readItemStackFromBuffer();
+                    slot.extractedAmount = buffer.readInt();
+                }
+
+                return slot;
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
     }
 }

--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchInputBusME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchInputBusME.java
@@ -34,23 +34,6 @@ import net.minecraftforge.common.util.ForgeDirection;
 
 import org.jetbrains.annotations.NotNull;
 
-import appeng.api.config.Actionable;
-import appeng.api.implementations.IPowerChannelState;
-import appeng.api.networking.GridFlags;
-import appeng.api.networking.energy.IEnergyGrid;
-import appeng.api.networking.security.BaseActionSource;
-import appeng.api.networking.security.IActionHost;
-import appeng.api.networking.security.MachineSource;
-import appeng.api.storage.IMEMonitor;
-import appeng.api.storage.data.IAEItemStack;
-import appeng.api.util.AECableType;
-import appeng.api.util.AEColor;
-import appeng.core.localization.WailaText;
-import appeng.me.GridAccessException;
-import appeng.me.helpers.AENetworkProxy;
-import appeng.me.helpers.IGridProxyable;
-import appeng.util.Platform;
-import appeng.util.item.AEItemStack;
 import com.gtnewhorizons.modularui.api.ModularUITextures;
 import com.gtnewhorizons.modularui.api.drawable.IDrawable;
 import com.gtnewhorizons.modularui.api.forge.IItemHandlerModifiable;
@@ -68,6 +51,24 @@ import com.gtnewhorizons.modularui.common.widget.SlotGroup;
 import com.gtnewhorizons.modularui.common.widget.SlotWidget;
 import com.gtnewhorizons.modularui.common.widget.TextWidget;
 import com.gtnewhorizons.modularui.common.widget.textfield.NumericWidget;
+
+import appeng.api.config.Actionable;
+import appeng.api.implementations.IPowerChannelState;
+import appeng.api.networking.GridFlags;
+import appeng.api.networking.energy.IEnergyGrid;
+import appeng.api.networking.security.BaseActionSource;
+import appeng.api.networking.security.IActionHost;
+import appeng.api.networking.security.MachineSource;
+import appeng.api.storage.IMEMonitor;
+import appeng.api.storage.data.IAEItemStack;
+import appeng.api.util.AECableType;
+import appeng.api.util.AEColor;
+import appeng.core.localization.WailaText;
+import appeng.me.GridAccessException;
+import appeng.me.helpers.AENetworkProxy;
+import appeng.me.helpers.IGridProxyable;
+import appeng.util.Platform;
+import appeng.util.item.AEItemStack;
 import gregtech.api.GregTechAPI;
 import gregtech.api.enums.Dyes;
 import gregtech.api.enums.ItemList;
@@ -113,13 +114,7 @@ public class MTEHatchInputBusME extends MTEHatchInputBus
     protected boolean expediteRecipeCheck = false;
 
     public MTEHatchInputBusME(int aID, boolean autoPullAvailable, String aName, String aNameRegional) {
-        super(
-            aID,
-            aName,
-            aNameRegional,
-            autoPullAvailable ? 6 : 3,
-            2,
-            getDescriptionArray(autoPullAvailable));
+        super(aID, aName, aNameRegional, autoPullAvailable ? 6 : 3, 2, getDescriptionArray(autoPullAvailable));
         this.autoPullAvailable = autoPullAvailable;
         disableSort = true;
     }
@@ -348,7 +343,7 @@ public class MTEHatchInputBusME extends MTEHatchInputBus
 
                 // Copy of the current mInventory loading code, because otherwise the upper stacks are discarded due to
                 // the reduced mInventory size.
-                //noinspection unchecked
+                // noinspection unchecked
                 for (NBTTagCompound tag : (List<NBTTagCompound>) inventory.tagList) {
                     oldInventory[tag.getInteger("IntSlot")] = GTUtility.loadItem(tag);
                 }
@@ -374,7 +369,7 @@ public class MTEHatchInputBusME extends MTEHatchInputBus
             case 1 -> {
                 NBTTagList slotList = aNBT.getTagList("slots", Constants.NBT.TAG_COMPOUND);
 
-                //noinspection unchecked
+                // noinspection unchecked
                 for (NBTTagCompound tag : (List<NBTTagCompound>) slotList.tagList) {
                     Slot slot = Slot.readFromNBT(tag);
 
@@ -393,10 +388,11 @@ public class MTEHatchInputBusME extends MTEHatchInputBus
 
     @Override
     public String[] getInfoData() {
-        return new String[] { getProxy().isActive()
-            ? StatCollector.translateToLocal("GT5U.infodata.hatch.crafting_input_me.bus.online")
-            : StatCollector
-                .translateToLocalFormatted("GT5U.infodata.hatch.crafting_input_me.bus.offline", getAEDiagnostics()) };
+        return new String[] {
+            getProxy().isActive() ? StatCollector.translateToLocal("GT5U.infodata.hatch.crafting_input_me.bus.online")
+                : StatCollector.translateToLocalFormatted(
+                    "GT5U.infodata.hatch.crafting_input_me.bus.offline",
+                    getAEDiagnostics()) };
     }
 
     @Override
@@ -620,8 +616,10 @@ public class MTEHatchInputBusME extends MTEHatchInputBus
         Iterator<IAEItemStack> iterator;
 
         try {
-            sg = getProxy().getStorage().getItemInventory();
-            iterator = sg.getStorageList().iterator();
+            sg = getProxy().getStorage()
+                .getItemInventory();
+            iterator = sg.getStorageList()
+                .iterator();
         } catch (final GridAccessException ignored) {
             return;
         }
@@ -687,7 +685,8 @@ public class MTEHatchInputBusME extends MTEHatchInputBus
         IEnergyGrid energy;
 
         try {
-            sg = getProxy().getStorage().getItemInventory();
+            sg = getProxy().getStorage()
+                .getItemInventory();
             energy = getProxy().getEnergy();
         } catch (GridAccessException e) {
             controller.stopMachine(ShutDownReasonRegistry.CRITICAL_NONE);
@@ -734,7 +733,8 @@ public class MTEHatchInputBusME extends MTEHatchInputBus
             return;
         }
 
-        IMEMonitor<IAEItemStack> sg = getProxy().getStorage().getItemInventory();
+        IMEMonitor<IAEItemStack> sg = getProxy().getStorage()
+            .getItemInventory();
 
         IAEItemStack request = AEItemStack.create(slot.config);
         request.setStackSize(Integer.MAX_VALUE);
@@ -1070,6 +1070,7 @@ public class MTEHatchInputBusME extends MTEHatchInputBus
     }
 
     protected static class Slot {
+
         /** The item to pull into this slot. */
         public ItemStack config;
 
@@ -1097,7 +1098,8 @@ public class MTEHatchInputBusME extends MTEHatchInputBus
         public final boolean equals(Object o) {
             if (!(o instanceof Slot slot)) return false;
 
-            return extractedAmount == slot.extractedAmount && Objects.equals(config, slot.config) && Objects.equals(extracted, slot.extracted);
+            return extractedAmount == slot.extractedAmount && Objects.equals(config, slot.config)
+                && Objects.equals(extracted, slot.extracted);
         }
 
         public Slot copy() {
@@ -1151,7 +1153,8 @@ public class MTEHatchInputBusME extends MTEHatchInputBus
         }
 
         @Override
-        public @org.jetbrains.annotations.Nullable ItemStack insertItem(int slot, @Nullable ItemStack stack, boolean simulate) {
+        public @org.jetbrains.annotations.Nullable ItemStack insertItem(int slot, @Nullable ItemStack stack,
+            boolean simulate) {
             return stack;
         }
 

--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchInputME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchInputME.java
@@ -5,14 +5,17 @@ import static gregtech.api.enums.GTValues.VN;
 import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_ME_INPUT_FLUID_HATCH;
 import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_ME_INPUT_FLUID_HATCH_ACTIVE;
 
+import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 
@@ -21,38 +24,22 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
+import net.minecraft.network.PacketBuffer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
+import net.minecraftforge.common.util.Constants;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.FluidStack;
-
-import com.gtnewhorizons.modularui.api.ModularUITextures;
-import com.gtnewhorizons.modularui.api.drawable.IDrawable;
-import com.gtnewhorizons.modularui.api.drawable.Text;
-import com.gtnewhorizons.modularui.api.math.Alignment;
-import com.gtnewhorizons.modularui.api.math.Color;
-import com.gtnewhorizons.modularui.api.math.Pos2d;
-import com.gtnewhorizons.modularui.api.math.Size;
-import com.gtnewhorizons.modularui.api.screen.ModularWindow;
-import com.gtnewhorizons.modularui.api.screen.UIBuildContext;
-import com.gtnewhorizons.modularui.api.widget.Interactable;
-import com.gtnewhorizons.modularui.common.fluid.FluidStackTank;
-import com.gtnewhorizons.modularui.common.widget.ButtonWidget;
-import com.gtnewhorizons.modularui.common.widget.CycleButtonWidget;
-import com.gtnewhorizons.modularui.common.widget.DrawableWidget;
-import com.gtnewhorizons.modularui.common.widget.FakeSyncWidget;
-import com.gtnewhorizons.modularui.common.widget.FluidSlotWidget;
-import com.gtnewhorizons.modularui.common.widget.SlotGroup;
-import com.gtnewhorizons.modularui.common.widget.TextWidget;
-import com.gtnewhorizons.modularui.common.widget.textfield.NumericWidget;
+import net.minecraftforge.fluids.FluidTankInfo;
+import net.minecraftforge.fluids.IFluidTank;
 
 import appeng.api.config.Actionable;
-import appeng.api.config.PowerMultiplier;
 import appeng.api.implementations.IPowerChannelState;
 import appeng.api.networking.GridFlags;
+import appeng.api.networking.energy.IEnergyGrid;
 import appeng.api.networking.security.BaseActionSource;
 import appeng.api.networking.security.IActionHost;
 import appeng.api.networking.security.MachineSource;
@@ -64,7 +51,27 @@ import appeng.core.localization.WailaText;
 import appeng.me.GridAccessException;
 import appeng.me.helpers.AENetworkProxy;
 import appeng.me.helpers.IGridProxyable;
+import appeng.util.Platform;
 import appeng.util.item.AEFluidStack;
+import com.gtnewhorizons.modularui.api.ModularUITextures;
+import com.gtnewhorizons.modularui.api.drawable.IDrawable;
+import com.gtnewhorizons.modularui.api.drawable.Text;
+import com.gtnewhorizons.modularui.api.math.Alignment;
+import com.gtnewhorizons.modularui.api.math.Color;
+import com.gtnewhorizons.modularui.api.math.Pos2d;
+import com.gtnewhorizons.modularui.api.math.Size;
+import com.gtnewhorizons.modularui.api.screen.ModularWindow;
+import com.gtnewhorizons.modularui.api.screen.UIBuildContext;
+import com.gtnewhorizons.modularui.api.widget.Interactable;
+import com.gtnewhorizons.modularui.common.widget.ButtonWidget;
+import com.gtnewhorizons.modularui.common.widget.CycleButtonWidget;
+import com.gtnewhorizons.modularui.common.widget.DrawableWidget;
+import com.gtnewhorizons.modularui.common.widget.FakeSyncWidget;
+import com.gtnewhorizons.modularui.common.widget.FluidSlotWidget;
+import com.gtnewhorizons.modularui.common.widget.SlotGroup;
+import com.gtnewhorizons.modularui.common.widget.TextWidget;
+import com.gtnewhorizons.modularui.common.widget.textfield.NumericWidget;
+import gregtech.api.GregTechAPI;
 import gregtech.api.enums.Dyes;
 import gregtech.api.enums.ItemList;
 import gregtech.api.gui.modularui.GTUITextures;
@@ -81,8 +88,10 @@ import gregtech.api.recipe.check.CheckRecipeResult;
 import gregtech.api.recipe.check.CheckRecipeResultRegistry;
 import gregtech.api.recipe.check.SimpleCheckRecipeResult;
 import gregtech.api.render.TextureFactory;
+import gregtech.api.util.GTDataUtils;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.shutdown.ShutDownReasonRegistry;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import mcp.mobius.waila.api.IWailaConfigHandler;
 import mcp.mobius.waila.api.IWailaDataAccessor;
 
@@ -92,14 +101,7 @@ public class MTEHatchInputME extends MTEHatchInput implements IPowerChannelState
     private static final int SLOT_COUNT = 16;
     public static final String COPIED_DATA_IDENTIFIER = "stockingHatch";
 
-    protected final FluidStack[] storedFluids = new FluidStack[SLOT_COUNT];
-    protected final FluidStack[] storedInformationFluids = new FluidStack[SLOT_COUNT];
-
-    // these two fields should ALWAYS be mutated simultaneously
-    // in most cases, you should call setSavedFluid() instead of trying to write to the array directly
-    // a desync of these two fields can lead to catastrophe
-    protected final FluidStack[] shadowStoredFluids = new FluidStack[SLOT_COUNT];
-    private final int[] savedStackSizes = new int[SLOT_COUNT];
+    protected final Slot[] slots = new Slot[SLOT_COUNT];
 
     private boolean additionalConnection = false;
 
@@ -119,6 +121,7 @@ public class MTEHatchInputME extends MTEHatchInput implements IPowerChannelState
     protected static final int CONFIG_WINDOW_ID = 10;
 
     protected static final FluidStack[] EMPTY_FLUID_STACK = new FluidStack[0];
+    protected static final FluidTankInfo[] EMPTY_FLUID_TANK_INFOS = new FluidTankInfo[0];
 
     public MTEHatchInputME(int aID, boolean autoPullAvailable, String aName, String aNameRegional) {
         super(aID, 1, aName, aNameRegional, autoPullAvailable ? 9 : 8, getDescriptionArray(autoPullAvailable));
@@ -192,68 +195,122 @@ public class MTEHatchInputME extends MTEHatchInput implements IPowerChannelState
     }
 
     private void refreshFluidList() {
-        AENetworkProxy proxy = getProxy();
-        if (proxy == null || !proxy.isActive()) {
+        if (!isAllowedToWork()) return;
+
+        IMEMonitor<IAEFluidStack> sg;
+        Iterator<IAEFluidStack> iterator;
+
+        try {
+            sg = getProxy().getStorage().getFluidInventory();
+            iterator = sg.getStorageList().iterator();
+        } catch (final GridAccessException ignored) {
             return;
         }
 
-        try {
-            IMEMonitor<IAEFluidStack> sg = proxy.getStorage()
-                .getFluidInventory();
-            Iterator<IAEFluidStack> iterator = sg.getStorageList()
-                .iterator();
+        int index = 0;
 
-            int index = 0;
-            while (iterator.hasNext() && index < SLOT_COUNT) {
-                IAEFluidStack currItem = iterator.next();
-                if (currItem.getStackSize() >= minAutoPullAmount) {
-                    FluidStack fluidStack = GTUtility.copyAmount(1, currItem.getFluidStack());
-                    if (expediteRecipeCheck) {
-                        FluidStack previous = storedFluids[index];
-                        if (fluidStack != null && previous != null) {
-                            justHadNewFluids = !fluidStack.isFluidEqual(previous);
-                        }
-                    }
-                    storedFluids[index] = fluidStack;
-                    index++;
-                }
+        Arrays.fill(slots, null);
+
+        while (iterator.hasNext() && index < SLOT_COUNT) {
+            IAEFluidStack curr = iterator.next();
+
+            if (curr.getStackSize() < minAutoPullAmount) continue;
+
+            Slot oldSlot = slots[index];
+
+            // Prevent weird reference problems by copying the slot
+            if (oldSlot != null) oldSlot = oldSlot.copy();
+
+            setSlotConfig(index, GTUtility.copyAmount(1, curr.getFluidStack()));
+
+            Slot newSlot = slots[index];
+
+            if (newSlot != null) {
+                newSlot.extracted = curr.getFluidStack();
+                newSlot.extractedAmount = newSlot.extracted.amount;
             }
 
-            for (int i = index; i < SLOT_COUNT; i++) {
-                storedFluids[i] = null;
+            if (!Objects.equals(oldSlot, newSlot)) {
+                justHadNewFluids = true;
             }
-        } catch (final GridAccessException ignored) {}
-    }
 
-    protected void setSavedFluid(int i, FluidStack stack) {
-        shadowStoredFluids[i] = stack;
-        savedStackSizes[i] = stack == null ? 0 : stack.amount;
+            index++;
+        }
     }
 
     public FluidStack[] getStoredFluids() {
-        if (!processingRecipe) {
+        if (!isAllowedToWork()) {
             return EMPTY_FLUID_STACK;
         }
 
-        AENetworkProxy proxy = getProxy();
-        if (proxy == null || !proxy.isActive()) {
-            return EMPTY_FLUID_STACK;
-        }
+        if (processingRecipe) {
+            List<FluidStack> fluids = new ObjectArrayList<>(GTDataUtils.countNonNulls(slots));
 
-        updateAllInformationSlots();
+            for (Slot slot : slots) {
+                if (slot == null) continue;
 
-        for (int i = 0; i < SLOT_COUNT; i++) {
-            if (storedFluids[i] == null) {
-                setSavedFluid(i, null);
-                continue;
+                // Must pass the reference out to the multi
+                if (slot.extracted != null) fluids.add(slot.extracted);
             }
 
-            FluidStack fluidStackWithAmount = storedInformationFluids[i];
+            return fluids.toArray(new FluidStack[0]);
+        } else {
+            List<FluidStack> fluids = new ObjectArrayList<>(GTDataUtils.countNonNulls(slots));
 
-            setSavedFluid(i, fluidStackWithAmount);
+            for (Slot slot : slots) {
+                if (slot == null) continue;
+
+                // The caller should only use this to determine the configuration.
+                // If it wants to know more, it can query AE itself.
+                fluids.add(GTUtility.copyAmount(1, slot.config));
+            }
+
+            return fluids.toArray(new FluidStack[0]);
+        }
+    }
+
+    @Override
+    public FluidTankInfo[] getTankInfo(ForgeDirection side) {
+        if (side != ForgeDirection.UNKNOWN || !isAllowedToWork()) {
+            return EMPTY_FLUID_TANK_INFOS;
         }
 
-        return shadowStoredFluids;
+        if (processingRecipe) {
+            List<FluidTankInfo> tanks = new ObjectArrayList<>(GTDataUtils.countNonNulls(slots));
+
+            for (Slot slot : slots) {
+                if (slot == null) continue;
+
+                if (slot.extracted != null) tanks.add(new FluidTankInfo(slot.extracted, Integer.MAX_VALUE));
+            }
+
+            return tanks.toArray(new FluidTankInfo[0]);
+        } else {
+            IMEMonitor<IAEFluidStack> sg;
+
+            try {
+                sg = getProxy().getStorage().getFluidInventory();
+            } catch (GridAccessException e) {
+                return EMPTY_FLUID_TANK_INFOS;
+            }
+
+            List<FluidTankInfo> tanks = new ObjectArrayList<>(GTDataUtils.countNonNulls(slots));
+
+            for (Slot slot : slots) {
+                if (slot == null) continue;
+
+                IAEFluidStack request = AEFluidStack.create(slot.config);
+                request.setStackSize(Integer.MAX_VALUE);
+
+                IAEFluidStack result = sg.extractItems(request, Actionable.SIMULATE, getRequestSource());
+
+                if (result == null) continue;
+
+                tanks.add(new FluidTankInfo(result.getFluidStack(), Integer.MAX_VALUE));
+            }
+
+            return tanks.toArray(new FluidTankInfo[0]);
+        }
     }
 
     @Override
@@ -268,20 +325,57 @@ public class MTEHatchInputME extends MTEHatchInput implements IPowerChannelState
 
     public void setRecipeCheck(boolean value) {
         expediteRecipeCheck = value;
+
+        IGregTechTileEntity igte = getBaseMetaTileEntity();
+
+        // Changing this field requires a structure check/update, so let's do that automatically
+        if (igte.isServerSide()) {
+            GregTechAPI.causeMachineUpdate(igte.getWorld(), igte.getXCoord(), igte.getYCoord(), igte.getZCoord());
+        }
     }
 
     @Override
-    public FluidStack drain(ForgeDirection side, FluidStack aFluid, boolean doDrain) {
+    public FluidStack drain(ForgeDirection side, FluidStack fluid, boolean doDrain) {
         // this is an ME input hatch. allowing draining via logistics would be very wrong (and against
         // canTankBeEmptied()) but we do need to support draining from controller, which uses the UNKNOWN direction.
         if (side != ForgeDirection.UNKNOWN) return null;
-        FluidStack stored = getMatchingFluidStack(aFluid);
-        if (stored == null) return null;
-        FluidStack drained = GTUtility.copyAmount(Math.min(stored.amount, aFluid.amount), stored);
-        if (doDrain) {
-            stored.amount -= drained.amount;
+
+        if (processingRecipe) {
+            // When processing a recipe, we just extract from the slot fake stacks
+            Slot slot = getMatchingSlot(fluid, true);
+            if (slot == null) return null;
+
+            int toDrain = Math.min(slot.extracted.amount, fluid.amount);
+
+            FluidStack drained = GTUtility.copyAmount(toDrain, slot.extracted);
+
+            if (doDrain) {
+                slot.extracted.amount -= toDrain;
+            }
+
+            return drained;
+        } else {
+            // Outside of processing a recipe, we need to extract everything manually
+            Slot slot = getMatchingSlot(fluid, false);
+            if (slot == null) return null;
+
+            IAEFluidStack request = AEFluidStack.create(fluid);
+
+            IMEMonitor<IAEFluidStack> sg;
+            IEnergyGrid energy;
+
+            try {
+                AENetworkProxy proxy = getProxy();
+                sg = proxy.getStorage().getFluidInventory();
+                energy = proxy.getEnergy();
+            } catch (GridAccessException e) {
+                return null;
+            }
+
+            IAEFluidStack result = Platform.poweredExtraction(energy, sg, request, getRequestSource());
+
+            return result == null ? null : result.getFluidStack();
         }
-        return drained;
     }
 
     @Override
@@ -293,40 +387,41 @@ public class MTEHatchInputME extends MTEHatchInput implements IPowerChannelState
     @Override
     public CheckRecipeResult endRecipeProcessing(MTEMultiBlockBase controller) {
         CheckRecipeResult checkRecipeResult = CheckRecipeResultRegistry.SUCCESSFUL;
-        AENetworkProxy proxy = getProxy();
 
-        for (int i = 0; i < SLOT_COUNT; ++i) {
-            FluidStack oldStack = shadowStoredFluids[i];
-            int toExtract = savedStackSizes[i] - (oldStack != null ? oldStack.amount : 0);
+        IMEMonitor<IAEFluidStack> sg;
+        IEnergyGrid energy;
+
+        try {
+            AENetworkProxy proxy = getProxy();
+            sg = proxy.getStorage().getFluidInventory();
+            energy = proxy.getEnergy();
+        } catch (GridAccessException e) {
+            controller.stopMachine(ShutDownReasonRegistry.CRITICAL_NONE);
+            return SimpleCheckRecipeResult.ofFailurePersistOnShutdown("stocking_hatch_fail_extraction");
+        }
+
+        for (int i = 0; i < SLOT_COUNT; i++) {
+            Slot slot = slots[i];
+
+            if (slot == null || slot.extracted == null || slot.extractedAmount == 0) continue;
+
+            int toExtract = slot.extractedAmount - slot.extracted.amount;
+
             if (toExtract <= 0) continue;
 
-            try {
-                IMEMonitor<IAEFluidStack> sg = proxy.getStorage()
-                    .getFluidInventory();
+            IAEFluidStack request = AEFluidStack.create(slot.extracted);
+            request.setStackSize(toExtract);
 
-                IAEFluidStack request = AEFluidStack.create(storedFluids[i]);
-                request.setStackSize(toExtract);
-                IAEFluidStack extractionResult = sg.extractItems(request, Actionable.MODULATE, getRequestSource());
-                proxy.getEnergy()
-                    .extractAEPower(toExtract, Actionable.MODULATE, PowerMultiplier.CONFIG);
+            IAEFluidStack result = Platform.poweredExtraction(energy, sg, request, getRequestSource());
 
-                if (extractionResult == null || extractionResult.getStackSize() != toExtract) {
-                    controller.stopMachine(ShutDownReasonRegistry.CRITICAL_NONE);
-                    checkRecipeResult = SimpleCheckRecipeResult
-                        .ofFailurePersistOnShutdown("stocking_hatch_fail_extraction");
-                }
-            } catch (GridAccessException ignored) {
+            if (result == null || result.getStackSize() != toExtract) {
                 controller.stopMachine(ShutDownReasonRegistry.CRITICAL_NONE);
-                checkRecipeResult = SimpleCheckRecipeResult
-                    .ofFailurePersistOnShutdown("stocking_hatch_fail_extraction");
-            }
-            setSavedFluid(i, null);
-            if (storedInformationFluids[i] != null && storedInformationFluids[i].amount <= 0) {
-                storedInformationFluids[i] = null;
+                checkRecipeResult = SimpleCheckRecipeResult.ofFailurePersistOnShutdown("stocking_hatch_fail_extraction");
             }
         }
 
         processingRecipe = false;
+
         return checkRecipeResult;
     }
 
@@ -409,64 +504,76 @@ public class MTEHatchInputME extends MTEHatchInput implements IPowerChannelState
             return;
         }
 
-        autoPullFluidList = pullFluidList;
-        if (!autoPullFluidList) {
-            Arrays.fill(storedFluids, null);
-        } else {
-            refreshFluidList();
+        if (autoPullFluidList != pullFluidList) {
+            autoPullFluidList = pullFluidList;
+
+            Arrays.fill(slots, null);
+
+            if (autoPullFluidList) {
+                refreshFluidList();
+            }
         }
-        updateAllInformationSlots();
     }
 
     public boolean doFastRecipeCheck() {
         return expediteRecipeCheck;
     }
 
-    private void updateAllInformationSlots() {
-        for (int index = 0; index < SLOT_COUNT; index++) {
-            updateInformationSlot(index);
+    protected void updateAllInformationSlots() {
+        AENetworkProxy proxy = getProxy();
+
+        boolean isActive = isAllowedToWork() && proxy.isActive();
+
+        if (isActive) {
+            try {
+                for (int index = 0; index < SLOT_COUNT; index++) {
+                    updateInformationSlot(index);
+                }
+            } catch (GridAccessException e) {
+                // :P
+            }
+        } else {
+            for (Slot slot : slots) {
+                if (slot == null) continue;
+
+                slot.resetExtracted();
+            }
         }
     }
 
-    public void updateInformationSlot(int index) {
-        if (index < 0 || index >= SLOT_COUNT) {
-            return;
-        }
+    public void setSlotConfig(int index, FluidStack config) {
+        slots[index] = config == null ? null : new Slot(config.copy());
+    }
 
-        FluidStack fluidStack = storedFluids[index];
-        if (fluidStack == null) {
-            storedInformationFluids[index] = null;
-            return;
-        }
+    /**
+     * Polls the AE network to update the available items for the given slot.
+     */
+    public void updateInformationSlot(int index) throws GridAccessException {
+        Slot slot = GTDataUtils.getIndexSafe(slots, index);
 
-        AENetworkProxy proxy = getProxy();
-        if (proxy == null || !proxy.isActive()) {
-            storedInformationFluids[index] = null;
-            return;
-        }
+        if (slot == null) return;
 
         if (!isAllowedToWork()) {
-            storedInformationFluids[index] = null;
+            slot.resetExtracted();
             return;
         }
 
-        try {
-            IMEMonitor<IAEFluidStack> sg = proxy.getStorage()
-                .getFluidInventory();
-            IAEFluidStack request = AEFluidStack.create(fluidStack);
-            request.setStackSize(Integer.MAX_VALUE);
-            IAEFluidStack result = sg.extractItems(request, Actionable.SIMULATE, getRequestSource());
-            FluidStack resultFluid = (result != null) ? result.getFluidStack() : null;
-            // We want to track if any FluidStack is modified to notify any connected controllers to make a recipe check
-            // early
-            if (expediteRecipeCheck) {
-                FluidStack previous = storedInformationFluids[index];
-                if (resultFluid != null) {
-                    justHadNewFluids = !resultFluid.isFluidEqual(previous);
-                }
-            }
-            storedInformationFluids[index] = resultFluid;
-        } catch (final GridAccessException ignored) {}
+        IMEMonitor<IAEFluidStack> sg = getProxy().getStorage().getFluidInventory();
+
+        IAEFluidStack request = AEFluidStack.create(slot.config);
+        request.setStackSize(Integer.MAX_VALUE);
+
+        IAEFluidStack result = sg.extractItems(request, Actionable.SIMULATE, getRequestSource());
+
+        FluidStack previous = slot.extracted;
+
+        slot.extracted = result != null ? result.getFluidStack() : null;
+        slot.extractedAmount = slot.extracted == null ? 0 : slot.extracted.amount;
+
+        // We want to track changes in any FluidStack to notify any connected controllers to make a recipe check early
+        if (expediteRecipeCheck && slot.extracted != null) {
+            justHadNewFluids = !GTUtility.areFluidsEqual(slot.extracted, previous);
+        }
     }
 
     private BaseActionSource getRequestSource() {
@@ -474,7 +581,7 @@ public class MTEHatchInputME extends MTEHatchInput implements IPowerChannelState
         return requestSource;
     }
 
-    public FluidStack getMatchingFluidStack(FluidStack fluidStack) {
+    protected Slot getMatchingSlot(FluidStack fluidStack, boolean requireExtracted) {
         if (fluidStack == null) return null;
 
         AENetworkProxy proxy = getProxy();
@@ -482,89 +589,62 @@ public class MTEHatchInputME extends MTEHatchInput implements IPowerChannelState
             return null;
         }
 
-        for (int i = 0; i < storedFluids.length; i++) {
-            if (storedFluids[i] == null) {
-                continue;
-            }
+        for (int i = 0; i < slots.length; i++) {
+            Slot slot = slots[i];
 
-            if (GTUtility.areFluidsEqual(fluidStack, storedFluids[i], false)) {
-                updateInformationSlot(i);
-                if (storedInformationFluids[i] != null) {
-                    setSavedFluid(i, storedInformationFluids[i]);
-                    return shadowStoredFluids[i];
-                }
+            if (slot == null) continue;
 
-                setSavedFluid(i, null);
-                return null;
-            }
+            if (requireExtracted && (slot.extracted == null || slot.extractedAmount == 0)) continue;
+
+            if (!GTUtility.areFluidsEqual(slot.config, fluidStack)) continue;
+
+            return slot;
         }
+
         return null;
     }
 
     /**
-     * Used to avoid slot update.
+     * Gets the first non-null shadow fluid stack.
+     *
+     * @return The first shadow fluid stack, or null if this doesn't exist.
      */
-    public FluidStack getShadowFluidStack(int index) {
-        if (index < 0 || index >= storedFluids.length) {
+    public FluidStack getFirstValidStack() {
+        return getFirstValidStack(false);
+    }
+
+    /**
+     * Gets the first non-null shadow fluid stack.
+     *
+     * @param slotsMustMatch When true, every fluid in this input hatch must be the same (ignores amounts).
+     * @return The first extracted fluid stack, or null if this doesn't exist.
+     */
+    public FluidStack getFirstValidStack(boolean slotsMustMatch) {
+        if (slotsMustMatch) {
+            FluidStack firstValid = null;
+
+            for (Slot slot : slots) {
+                if (slot == null || slot.extracted == null) continue;
+
+                if (firstValid == null) {
+                    firstValid = slot.extracted;
+                } else {
+                    if (!GTUtility.areFluidsEqual(firstValid, slot.extracted)) {
+                        return null;
+                    }
+                }
+            }
+
+            return firstValid;
+        } else {
+            for (Slot slot : slots) {
+                if (slot == null || slot.extracted == null) continue;
+
+                return slot.extracted;
+            }
+
             return null;
         }
-
-        return shadowStoredFluids[index];
-    }
-
-    /**
-     * Gets the first non-null shadow fluid stack.
-     *
-     * @return The first shadow fluid stack, or null if this doesn't exist.
-     */
-    public FluidStack getFirstShadowFluidStack() {
-        return getFirstShadowFluidStack(false);
-    }
-
-    /**
-     * Gets the first non-null shadow fluid stack.
-     *
-     * @param hasToMatchGhost Whether the first fluid stack returned has to match the first non-null ghost stack
-     * @return The first shadow fluid stack, or null if this doesn't exist.
-     */
-    public FluidStack getFirstShadowFluidStack(boolean hasToMatchGhost) {
-        FluidStack fluidStack;
-        FluidStack lockedSlot = null;
-        if (hasToMatchGhost) {
-            byte slotToCheck = 0;
-            do {
-                lockedSlot = storedFluids[slotToCheck];
-                slotToCheck++;
-            } while (lockedSlot == null && slotToCheck < storedFluids.length);
-            if (lockedSlot == null) return null;
-        }
-        byte slotToCheck = 0;
-        do {
-            fluidStack = getShadowFluidStack(slotToCheck);
-            slotToCheck++;
-        } while ((fluidStack == null || !(hasToMatchGhost && lockedSlot.getFluid() == fluidStack.getFluid()))
-            && slotToCheck < getShadowStoredFluidsSize());
-        return fluidStack;
-    }
-
-    public int getShadowStoredFluidsSize() {
-        return shadowStoredFluids.length;
-    }
-
-    public int getFluidSlot(FluidStack fluidStack) {
-        if (fluidStack == null) return -1;
-
-        for (int i = 0; i < storedFluids.length; i++) {
-            if (storedFluids[i] == null) {
-                continue;
-            }
-
-            if (GTUtility.areFluidsEqual(fluidStack, storedFluids[i], false)) {
-                return i;
-            }
-        }
-
-        return -1;
     }
 
     @Override
@@ -591,45 +671,33 @@ public class MTEHatchInputME extends MTEHatchInput implements IPowerChannelState
     public void saveNBTData(NBTTagCompound aNBT) {
         super.saveNBTData(aNBT);
 
-        NBTTagList nbtTagList = new NBTTagList();
-        for (int i = 0; i < SLOT_COUNT; i++) {
-            FluidStack fluidStack = storedFluids[i];
-            if (fluidStack == null) {
-                continue;
-            }
-            NBTTagCompound fluidTag = fluidStack.writeToNBT(new NBTTagCompound());
-            if (storedInformationFluids[i] != null)
-                fluidTag.setInteger("informationAmount", storedInformationFluids[i].amount);
-            nbtTagList.appendTag(fluidTag);
-        }
-
-        aNBT.setTag("storedFluids", nbtTagList);
+        aNBT.setInteger("version", 1);
         aNBT.setBoolean("autoPull", autoPullFluidList);
         aNBT.setInteger("minAmount", minAutoPullAmount);
         aNBT.setBoolean("additionalConnection", additionalConnection);
         aNBT.setBoolean("expediteRecipeCheck", expediteRecipeCheck);
         aNBT.setInteger("refreshTime", autoPullRefreshTime);
         getProxy().writeToNBT(aNBT);
+
+        NBTTagList slotList = new NBTTagList();
+        aNBT.setTag("slots", slotList);
+
+        for (int i = 0; i < slots.length; i++) {
+            Slot slot = slots[i];
+
+            if (slot == null) continue;
+
+            NBTTagCompound tag = new NBTTagCompound();
+            slot.writeToNBT(tag);
+            tag.setInteger("index", i);
+
+            slotList.appendTag(tag);
+        }
     }
 
     @Override
     public void loadNBTData(NBTTagCompound aNBT) {
         super.loadNBTData(aNBT);
-        if (aNBT.hasKey("storedFluids")) {
-            NBTTagList nbtTagList = aNBT.getTagList("storedFluids", 10);
-            int c = Math.min(nbtTagList.tagCount(), SLOT_COUNT);
-            for (int i = 0; i < c; i++) {
-                NBTTagCompound nbtTagCompound = nbtTagList.getCompoundTagAt(i);
-                FluidStack fluidStack = GTUtility.loadFluid(nbtTagCompound);
-                storedFluids[i] = fluidStack;
-
-                if (nbtTagCompound.hasKey("informationAmount")) {
-                    int informationAmount = nbtTagCompound.getInteger("informationAmount");
-                    storedInformationFluids[i] = GTUtility.copyAmount(informationAmount, fluidStack);
-                }
-            }
-        }
-
         minAutoPullAmount = aNBT.getInteger("minAmount");
         autoPullFluidList = aNBT.getBoolean("autoPull");
         additionalConnection = aNBT.getBoolean("additionalConnection");
@@ -639,6 +707,38 @@ public class MTEHatchInputME extends MTEHatchInput implements IPowerChannelState
         }
         getProxy().readFromNBT(aNBT);
         updateAE2ProxyColor();
+
+        switch (aNBT.getInteger("version")) {
+            case 0 -> {
+                if (aNBT.hasKey("storedFluids")) {
+                    NBTTagList nbtTagList = aNBT.getTagList("storedFluids", 10);
+                    int c = Math.min(nbtTagList.tagCount(), SLOT_COUNT);
+                    for (int i = 0; i < c; i++) {
+                        NBTTagCompound nbtTagCompound = nbtTagList.getCompoundTagAt(i);
+                        FluidStack fluidStack = GTUtility.loadFluid(nbtTagCompound);
+
+                        Slot slot = new Slot(fluidStack);
+                        slots[i] = slot;
+
+                        if (nbtTagCompound.hasKey("informationAmount")) {
+                            int informationAmount = nbtTagCompound.getInteger("informationAmount");
+                            slot.extracted = GTUtility.copyAmount(informationAmount, fluidStack);
+                            slot.extractedAmount = informationAmount;
+                        }
+                    }
+                }
+            }
+            case 1 -> {
+                NBTTagList slotList = aNBT.getTagList("slots", Constants.NBT.TAG_COMPOUND);
+
+                //noinspection unchecked
+                for (NBTTagCompound tag : (List<NBTTagCompound>) slotList.tagList) {
+                    Slot slot = Slot.readFromNBT(tag);
+
+                    if (slot != null) slots[tag.getInteger("index")] = slot;
+                }
+            }
+        }
     }
 
     @Override
@@ -673,11 +773,14 @@ public class MTEHatchInputME extends MTEHatchInput implements IPowerChannelState
 
         if (!autoPullFluidList) {
             NBTTagList stockingFluids = nbt.getTagList("fluidsToStock", 10);
+            Arrays.fill(slots, null);
             for (int i = 0; i < stockingFluids.tagCount(); i++) {
-                storedFluids[i] = GTUtility.loadFluid(stockingFluids.getCompoundTagAt(i));
+                slots[i] = new Slot(GTUtility.loadFluid(stockingFluids.getCompoundTagAt(i)));
             }
         }
+
         updateValidGridProxySides();
+        updateAllInformationSlots();
         return true;
     }
 
@@ -691,17 +794,18 @@ public class MTEHatchInputME extends MTEHatchInput implements IPowerChannelState
         tag.setInteger("refreshTime", autoPullRefreshTime);
         tag.setBoolean("expediteRecipeCheck", expediteRecipeCheck);
 
-        NBTTagList stockingFluids = new NBTTagList();
         if (!autoPullFluidList) {
-            for (int index = 0; index < SLOT_COUNT; index++) {
-                FluidStack fluidStack = storedFluids[index];
-                if (fluidStack == null) {
-                    continue;
-                }
-                stockingFluids.appendTag(fluidStack.writeToNBT(new NBTTagCompound()));
+            NBTTagList stockingFluids = new NBTTagList();
+
+            for (Slot slot : slots) {
+                if (slot == null) continue;
+
+                stockingFluids.appendTag(slot.config.writeToNBT(new NBTTagCompound()));
             }
+
             tag.setTag("fluidsToStock", stockingFluids);
         }
+
         return tag;
     }
 
@@ -733,12 +837,9 @@ public class MTEHatchInputME extends MTEHatchInput implements IPowerChannelState
     }
 
     public boolean containsSuchStack(FluidStack tStack) {
-        for (int i = 0; i < 16; ++i) {
-            if (GTUtility.areFluidsEqual(storedFluids[i], tStack, false)) {
-                return true;
-            }
-        }
-        return false;
+        return Stream.of(slots)
+            .filter(Objects::nonNull)
+            .anyMatch(slot -> GTUtility.areFluidsEqual(slot.config, tStack));
     }
 
     @Override
@@ -752,10 +853,12 @@ public class MTEHatchInputME extends MTEHatchInput implements IPowerChannelState
             buildContext.addSyncedWindow(CONFIG_WINDOW_ID, this::createStackSizeConfigurationWindow);
         }
 
+        builder.widget(new SlotSyncWidget());
+
         builder.widget(
             SlotGroup.ofFluidTanks(
                 IntStream.range(0, SLOT_COUNT)
-                    .mapToObj(index -> createTankForFluidStack(storedFluids, index, 1))
+                    .mapToObj(ConfigFluidTank::new)
                     .collect(Collectors.toList()),
                 4)
                 .phantom(true)
@@ -766,15 +869,17 @@ public class MTEHatchInputME extends MTEHatchInput implements IPowerChannelState
                         if (clickData.mouseButton != 0 || autoPullFluidList) return;
 
                         FluidStack heldFluid = getFluidForPhantomItem(cursorStack);
-                        if (cursorStack == null) {
-                            storedFluids[slotIndex] = null;
-                        } else {
-                            if (containsSuchStack(heldFluid)) return;
-                            storedFluids[slotIndex] = heldFluid;
-                        }
+
+                        if (heldFluid != null && containsSuchStack(heldFluid)) return;
+
+                        setSlotConfig(slotIndex, GTUtility.copyAmount(1, heldFluid));
+
                         if (getBaseMetaTileEntity().isServerSide()) {
-                            updateInformationSlot(slotIndex);
-                            detectAndSendChanges(false);
+                            try {
+                                updateInformationSlot(slotIndex);
+                            } catch (GridAccessException e) {
+                                // :P
+                            }
                         }
                     }
 
@@ -818,7 +923,7 @@ public class MTEHatchInputME extends MTEHatchInput implements IPowerChannelState
         builder.widget(
             SlotGroup.ofFluidTanks(
                 IntStream.range(0, SLOT_COUNT)
-                    .mapToObj(index -> createTankForFluidStack(storedInformationFluids, index, Integer.MAX_VALUE))
+                    .mapToObj(ExtractedFluidTank::new)
                     .collect(Collectors.toList()),
                 4)
                 .phantom(true)
@@ -908,16 +1013,6 @@ public class MTEHatchInputME extends MTEHatchInput implements IPowerChannelState
                 .setPos(23, 84));
     }
 
-    private FluidStackTank createTankForFluidStack(FluidStack[] fluidStacks, int slotIndex, int capacity) {
-        return new FluidStackTank(() -> fluidStacks[slotIndex], (stack) -> {
-            if (getBaseMetaTileEntity().isServerSide()) {
-                return;
-            }
-
-            fluidStacks[slotIndex] = stack;
-        }, capacity);
-    }
-
     protected ModularWindow createStackSizeConfigurationWindow(final EntityPlayer player) {
         final int WIDTH = 78;
         final int HEIGHT = 115;
@@ -971,8 +1066,7 @@ public class MTEHatchInputME extends MTEHatchInput implements IPowerChannelState
                             : GTUITextures.OVERLAY_BUTTON_CROSS)
                     .setBackground(GTUITextures.BUTTON_STANDARD)
                     .setPos(53, 87)
-                    .setSize(16, 16)
-                    .addTooltip(StatCollector.translateToLocal("GT5U.machines.stocking_bus.hatch_warning")));
+                    .setSize(16, 16));
         return builder.build();
     }
 
@@ -1038,5 +1132,222 @@ public class MTEHatchInputME extends MTEHatchInput implements IPowerChannelState
         strings.add("Change ME connection behavior by right-clicking with wire cutter.");
         strings.add("Configuration data can be copy/pasted using a data stick.");
         return strings.toArray(new String[0]);
+    }
+
+    protected static class Slot {
+        /** The fluid to pull into this slot. */
+        public FluidStack config;
+
+        /** The amount of stuff initially in the ME system when the recipe check started. */
+        public int extractedAmount;
+        /**
+         * The extracted stack (almost certainly equal to config). This is shared as a reference to the multiblock,
+         * which decrements the stored amount as it gets consumed. After the recipe check has finished, the amount in
+         * this stack is compared to {@link #extractedAmount} and the difference is subtracted from the ME system. If
+         * this operation fails, the machine is shut down.
+         */
+        public FluidStack extracted;
+
+        public Slot(FluidStack config) {
+            this.config = config;
+        }
+
+        public void resetExtracted() {
+            extracted = null;
+            extractedAmount = 0;
+        }
+
+        public FluidStack getOriginalExtracted() {
+            return extracted == null ? null : GTUtility.copyAmount(extractedAmount, extracted);
+        }
+
+        @Override
+        public final boolean equals(Object o) {
+            if (!(o instanceof Slot slot)) return false;
+
+            return extractedAmount == slot.extractedAmount && Objects.equals(config, slot.config) && Objects.equals(extracted, slot.extracted);
+        }
+
+        public Slot copy() {
+            Slot copy = new Slot(this.config);
+
+            copy.extracted = this.extracted;
+            copy.extractedAmount = this.extractedAmount;
+
+            return copy;
+        }
+
+        public void writeToNBT(NBTTagCompound tag) {
+            tag.setTag("config", config.writeToNBT(new NBTTagCompound()));
+            if (extracted != null) {
+                tag.setTag("extracted", extracted.writeToNBT(new NBTTagCompound()));
+                tag.setInteger("extractedAmount", extractedAmount);
+            }
+        }
+
+        public static Slot readFromNBT(NBTTagCompound tag) {
+            Slot slot = new Slot(FluidStack.loadFluidStackFromNBT(tag.getCompoundTag("config")));
+
+            if (slot.config == null) return null;
+
+            if (tag.hasKey("extracted")) {
+                slot.extracted = FluidStack.loadFluidStackFromNBT(tag.getCompoundTag("extracted"));
+                slot.extractedAmount = tag.getInteger("extractedAmount");
+            }
+
+            return slot;
+        }
+    }
+
+    protected class ConfigFluidTank implements IFluidTank {
+
+        private final int slotIndex;
+
+        public ConfigFluidTank(int slotIndex) {
+            this.slotIndex = slotIndex;
+        }
+
+        @Override
+        public FluidStack getFluid() {
+            Slot slot = GTDataUtils.getIndexSafe(slots, slotIndex);
+
+            if (slot == null) return null;
+
+            return slot.config;
+        }
+
+        @Override
+        public int getFluidAmount() {
+            Slot slot = GTDataUtils.getIndexSafe(slots, slotIndex);
+
+            return slot == null ? 0 : 1;
+        }
+
+        @Override
+        public int getCapacity() {
+            return 1;
+        }
+
+        @Override
+        public FluidTankInfo getInfo() {
+            return new FluidTankInfo(this);
+        }
+
+        @Override
+        public int fill(FluidStack resource, boolean doFill) {
+            return 0;
+        }
+
+        @Override
+        public FluidStack drain(int maxDrain, boolean doDrain) {
+            return null;
+        }
+    }
+
+    protected class ExtractedFluidTank implements IFluidTank {
+
+        private final int slotIndex;
+
+        public ExtractedFluidTank(int slotIndex) {
+            this.slotIndex = slotIndex;
+        }
+
+        @Override
+        public FluidStack getFluid() {
+            Slot slot = GTDataUtils.getIndexSafe(slots, slotIndex);
+
+            if (slot == null) return null;
+
+            return slot.getOriginalExtracted();
+        }
+
+        @Override
+        public int getFluidAmount() {
+            Slot slot = GTDataUtils.getIndexSafe(slots, slotIndex);
+
+            if (slot == null) return 0;
+
+            return slot.extractedAmount;
+        }
+
+        @Override
+        public int getCapacity() {
+            return Integer.MAX_VALUE;
+        }
+
+        @Override
+        public FluidTankInfo getInfo() {
+            return new FluidTankInfo(this);
+        }
+
+        @Override
+        public int fill(FluidStack resource, boolean doFill) {
+            return 0;
+        }
+
+        @Override
+        public FluidStack drain(int maxDrain, boolean doDrain) {
+            return null;
+        }
+    }
+
+    private class SlotSyncWidget extends FakeSyncWidget.ListSyncer<Slot> {
+
+        public SlotSyncWidget() {
+            super(
+                () -> GTDataUtils.mapToList(slots, slot -> slot == null ? null : slot.copy()),
+                slots2 -> System.arraycopy(slots2.toArray(new Slot[0]), 0, slots, 0, SLOT_COUNT),
+                SlotSyncWidget::writeSlot,
+                SlotSyncWidget::readSlot);
+        }
+
+        private static int counter = 0;
+        private static final int NOT_NULL = 0b1 << counter++;
+        private static final int EXTRACTED_SET = 0b1 << counter++;
+
+        private static void writeSlot(PacketBuffer buffer, Slot slot) {
+            int flags = 0;
+
+            if (slot != null) {
+                flags |= NOT_NULL;
+                if (slot.extracted != null) {
+                    flags |= EXTRACTED_SET;
+                }
+            }
+
+            buffer.writeByte(flags);
+
+            try {
+                if (slot != null) {
+                    buffer.writeNBTTagCompoundToBuffer(slot.config.writeToNBT(new NBTTagCompound()));
+
+                    if (slot.extracted != null) {
+                        buffer.writeNBTTagCompoundToBuffer(slot.extracted.writeToNBT(new NBTTagCompound()));
+                        buffer.writeInt(slot.extractedAmount);
+                    }
+                }
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        private static Slot readSlot(PacketBuffer buffer) {
+            int flags = buffer.readByte();
+
+            if ((flags & NOT_NULL) == 0) return null;
+
+            try {
+                Slot slot = new Slot(FluidStack.loadFluidStackFromNBT(buffer.readNBTTagCompoundFromBuffer()));
+
+                if ((flags & EXTRACTED_SET) != 0) {
+                    slot.extracted = FluidStack.loadFluidStackFromNBT(buffer.readNBTTagCompoundFromBuffer());
+                    slot.extractedAmount = buffer.readInt();
+                }
+
+                return slot;
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
     }
 }

--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchInputME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchInputME.java
@@ -36,23 +36,6 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTankInfo;
 import net.minecraftforge.fluids.IFluidTank;
 
-import appeng.api.config.Actionable;
-import appeng.api.implementations.IPowerChannelState;
-import appeng.api.networking.GridFlags;
-import appeng.api.networking.energy.IEnergyGrid;
-import appeng.api.networking.security.BaseActionSource;
-import appeng.api.networking.security.IActionHost;
-import appeng.api.networking.security.MachineSource;
-import appeng.api.storage.IMEMonitor;
-import appeng.api.storage.data.IAEFluidStack;
-import appeng.api.util.AECableType;
-import appeng.api.util.AEColor;
-import appeng.core.localization.WailaText;
-import appeng.me.GridAccessException;
-import appeng.me.helpers.AENetworkProxy;
-import appeng.me.helpers.IGridProxyable;
-import appeng.util.Platform;
-import appeng.util.item.AEFluidStack;
 import com.gtnewhorizons.modularui.api.ModularUITextures;
 import com.gtnewhorizons.modularui.api.drawable.IDrawable;
 import com.gtnewhorizons.modularui.api.drawable.Text;
@@ -71,6 +54,24 @@ import com.gtnewhorizons.modularui.common.widget.FluidSlotWidget;
 import com.gtnewhorizons.modularui.common.widget.SlotGroup;
 import com.gtnewhorizons.modularui.common.widget.TextWidget;
 import com.gtnewhorizons.modularui.common.widget.textfield.NumericWidget;
+
+import appeng.api.config.Actionable;
+import appeng.api.implementations.IPowerChannelState;
+import appeng.api.networking.GridFlags;
+import appeng.api.networking.energy.IEnergyGrid;
+import appeng.api.networking.security.BaseActionSource;
+import appeng.api.networking.security.IActionHost;
+import appeng.api.networking.security.MachineSource;
+import appeng.api.storage.IMEMonitor;
+import appeng.api.storage.data.IAEFluidStack;
+import appeng.api.util.AECableType;
+import appeng.api.util.AEColor;
+import appeng.core.localization.WailaText;
+import appeng.me.GridAccessException;
+import appeng.me.helpers.AENetworkProxy;
+import appeng.me.helpers.IGridProxyable;
+import appeng.util.Platform;
+import appeng.util.item.AEFluidStack;
 import gregtech.api.GregTechAPI;
 import gregtech.api.enums.Dyes;
 import gregtech.api.enums.ItemList;
@@ -201,8 +202,10 @@ public class MTEHatchInputME extends MTEHatchInput implements IPowerChannelState
         Iterator<IAEFluidStack> iterator;
 
         try {
-            sg = getProxy().getStorage().getFluidInventory();
-            iterator = sg.getStorageList().iterator();
+            sg = getProxy().getStorage()
+                .getFluidInventory();
+            iterator = sg.getStorageList()
+                .iterator();
         } catch (final GridAccessException ignored) {
             return;
         }
@@ -289,7 +292,8 @@ public class MTEHatchInputME extends MTEHatchInput implements IPowerChannelState
             IMEMonitor<IAEFluidStack> sg;
 
             try {
-                sg = getProxy().getStorage().getFluidInventory();
+                sg = getProxy().getStorage()
+                    .getFluidInventory();
             } catch (GridAccessException e) {
                 return EMPTY_FLUID_TANK_INFOS;
             }
@@ -366,7 +370,8 @@ public class MTEHatchInputME extends MTEHatchInput implements IPowerChannelState
 
             try {
                 AENetworkProxy proxy = getProxy();
-                sg = proxy.getStorage().getFluidInventory();
+                sg = proxy.getStorage()
+                    .getFluidInventory();
                 energy = proxy.getEnergy();
             } catch (GridAccessException e) {
                 return null;
@@ -393,7 +398,8 @@ public class MTEHatchInputME extends MTEHatchInput implements IPowerChannelState
 
         try {
             AENetworkProxy proxy = getProxy();
-            sg = proxy.getStorage().getFluidInventory();
+            sg = proxy.getStorage()
+                .getFluidInventory();
             energy = proxy.getEnergy();
         } catch (GridAccessException e) {
             controller.stopMachine(ShutDownReasonRegistry.CRITICAL_NONE);
@@ -416,7 +422,8 @@ public class MTEHatchInputME extends MTEHatchInput implements IPowerChannelState
 
             if (result == null || result.getStackSize() != toExtract) {
                 controller.stopMachine(ShutDownReasonRegistry.CRITICAL_NONE);
-                checkRecipeResult = SimpleCheckRecipeResult.ofFailurePersistOnShutdown("stocking_hatch_fail_extraction");
+                checkRecipeResult = SimpleCheckRecipeResult
+                    .ofFailurePersistOnShutdown("stocking_hatch_fail_extraction");
             }
         }
 
@@ -558,7 +565,8 @@ public class MTEHatchInputME extends MTEHatchInput implements IPowerChannelState
             return;
         }
 
-        IMEMonitor<IAEFluidStack> sg = getProxy().getStorage().getFluidInventory();
+        IMEMonitor<IAEFluidStack> sg = getProxy().getStorage()
+            .getFluidInventory();
 
         IAEFluidStack request = AEFluidStack.create(slot.config);
         request.setStackSize(Integer.MAX_VALUE);
@@ -731,7 +739,7 @@ public class MTEHatchInputME extends MTEHatchInput implements IPowerChannelState
             case 1 -> {
                 NBTTagList slotList = aNBT.getTagList("slots", Constants.NBT.TAG_COMPOUND);
 
-                //noinspection unchecked
+                // noinspection unchecked
                 for (NBTTagCompound tag : (List<NBTTagCompound>) slotList.tagList) {
                     Slot slot = Slot.readFromNBT(tag);
 
@@ -1135,6 +1143,7 @@ public class MTEHatchInputME extends MTEHatchInput implements IPowerChannelState
     }
 
     protected static class Slot {
+
         /** The fluid to pull into this slot. */
         public FluidStack config;
 
@@ -1165,7 +1174,8 @@ public class MTEHatchInputME extends MTEHatchInput implements IPowerChannelState
         public final boolean equals(Object o) {
             if (!(o instanceof Slot slot)) return false;
 
-            return extractedAmount == slot.extractedAmount && Objects.equals(config, slot.config) && Objects.equals(extracted, slot.extracted);
+            return extractedAmount == slot.extractedAmount && Objects.equals(config, slot.config)
+                && Objects.equals(extracted, slot.extracted);
         }
 
         public Slot copy() {

--- a/src/main/resources/assets/gregtech/lang/en_US.lang
+++ b/src/main/resources/assets/gregtech/lang/en_US.lang
@@ -1236,7 +1236,6 @@ GT5U.machines.stocking_bus.auto_pull.tooltip.2=Right-Click to edit additional pa
 GT5U.machines.stocking_bus.min_stack_size=Min Stack Size
 GT5U.machines.stocking_bus.refresh_time=Slot Refresh Time (Ticks)
 GT5U.machines.stocking_bus.force_check=Recipe Check on change
-GT5U.machines.stocking_bus.hatch_warning=Requires a fresh structure check to apply (Reboot/Replace controller)
 GT5U.machines.stocking_bus.auto_pull_toggle.enabled=Automatic Item Pull Enabled
 GT5U.machines.stocking_bus.auto_pull_toggle.disabled=Automatic Item Pull Disabled
 GT5U.machines.stocking_hatch.auto_pull.tooltip.1=Click to toggle automatic fluid pulling from ME.


### PR DESCRIPTION
This is a refactor for stocking hatches and busses that tries to replace some of the unmaintainable code with something that should be more understandable. In the process, some unnecessary AE operations were removed, which should speed things up by around 2x-3x. None of the mechanics were changed.

Code changes:
- Remove the existing config code and replace it with a custom slot-based system (see Slot in both hatches)
- Change NBT format for both hatches (with migration code for old format)
- Remove AE ops from getStackInSlot (for busses)
- Cause a structure check when the expedite recipe check tickbox is switched, and remove the tooltip warning
- Change the inventory layout for busses (0 and 1 are circuits, 2 through 10 are for the stocked items)
- Allow hatches to drain fluids even outside of recipe checks
- Populate the phantom/extracted stacks with the already fetched stack when auto pull is enabled (no functional change, it just looks nicer since this wasn't done previously)

Testing done:
- Make sure manual configuration works properly
- Make sure old hatches migrate their config properly
- Make sure circuits + manual slots are migrated and used in recipe checks properly
- Make sure data stick copying works (old sticks still work since the format hasn't changed)
- Make sure auto pull works as expected
- Make sure checking 'recipe check on change' causes connected multis to update
- Make sure multis still work (EBF, AL, AAL, and mega oil cracker)
- Make sure colour input separation works