### PR TITLE
Neutral Ferrocene Chain

### DIFF
--- a/src/main/java/goodgenerator/loader/RecipeLoader2.java
+++ b/src/main/java/goodgenerator/loader/RecipeLoader2.java
@@ -950,14 +950,14 @@ public class RecipeLoader2 {
         CrackRecipeAdder.addUniversalDistillationRecipe(
             GGMaterial.ferroceneWaste.getFluidOrGas(1_000),
             new FluidStack[] { Materials.Water.getFluid(400), GGMaterial.diethylamine.getFluidOrGas(800),
-                GGMaterial.ether.getFluidOrGas(500) },
+                Materials.HydrochloricAcid.getFluid(200) },
             GTValues.NI,
             30 * SECONDS,
             TierEU.RECIPE_MV);
 
         CrackRecipeAdder.addUniversalDistillationRecipe(
             GGMaterial.ferroceneSolution.getFluidOrGas(2_000),
-            new FluidStack[] { GGMaterial.ether.getFluidOrGas(1_000) },
+            new FluidStack[] { GGMaterial.ether.getFluidOrGas(2_000) },
             GGMaterial.ferrocene.get(OrePrefixes.dust, 1),
             30 * SECONDS,
             TierEU.RECIPE_MV);


### PR DESCRIPTION
The full ferrocene chain is for some reason incredibly ether positive and mildly chlorine negative. Given the relative weakness of jet fuel I see no harm in making the chain balanced.

Full chain goes from being -2 kL chlorine and +4 kL ether to balanced.

Before:
![image](https://github.com/user-attachments/assets/371fd698-3d0d-4bbc-8cef-8efb0c8a25b7)

After:
![image](https://github.com/user-attachments/assets/9d7264da-00c7-4fd7-9c70-e6e9f2cb5f7c)

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19959