### PR TITLE
Fix  Mass Fabricator Scrapbox Recipe

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechIndustrialMassFabricator.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechIndustrialMassFabricator.java
@@ -46,7 +46,7 @@ public class GregtechIndustrialMassFabricator {
 
         // Basic UUA2
         GTValues.RA.stdBuilder()
-            .itemInputs(GTUtility.getIntegratedCircuit(19), ItemList.IC2_Scrap.get(1L))
+            .itemInputs(GTUtility.getIntegratedCircuit(19), ItemList.IC2_Scrapbox.get(1L))
             .fluidOutputs(Materials.UUAmplifier.getFluid(1))
             .duration(9 * SECONDS)
             .eut(TierEU.RECIPE_LV)


### PR DESCRIPTION
was accidentally changed in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3834
![image](https://github.com/user-attachments/assets/c9fc8d97-53d0-45e2-bf4c-3100b61ec972)
