### PR TITLE
[Memory-opti:static allocations:16 MB] Only allocate owner/ stacktrace ArrayLists in GTRecipes when config is ON

### DIFF
--- a/src/main/java/bartworks/API/recipe/DynamicGTRecipe.java
+++ b/src/main/java/bartworks/API/recipe/DynamicGTRecipe.java
@@ -25,8 +25,8 @@ public class DynamicGTRecipe extends GTRecipe {
             aEUt,
             aSpecialValue);
         if (originalRecipe != null) {
-            this.owners = new ArrayList<>(originalRecipe.owners);
-            this.stackTraces = new ArrayList<>(originalRecipe.stackTraces);
+            this.owners = originalRecipe.owners == null ? null : new ArrayList<>(originalRecipe.owners);
+            this.stackTraces = originalRecipe.stackTraces == null ? null : new ArrayList<>(originalRecipe.stackTraces);
             this.setOwner(MainMod.MOD_ID);
         }
     }

--- a/src/main/java/gregtech/api/recipe/RecipeMapFrontend.java
+++ b/src/main/java/gregtech/api/recipe/RecipeMapFrontend.java
@@ -30,7 +30,6 @@ import com.gtnewhorizons.modularui.common.widget.ProgressBar;
 import com.gtnewhorizons.modularui.common.widget.SlotWidget;
 
 import codechicken.nei.PositionedStack;
-import gregtech.GTMod;
 import gregtech.api.enums.SteamVariant;
 import gregtech.api.gui.GUIColorOverride;
 import gregtech.api.gui.modularui.GTUITextures;
@@ -246,7 +245,7 @@ public class RecipeMapFrontend {
 
     protected void drawRecipeOwnerInfo(RecipeDisplayInfo recipeInfo) {
         GTRecipe recipe = recipeInfo.recipe;
-        if (GTMod.gregtechproxy.mNEIRecipeOwner) {
+        if (recipe.owners != null) {
             if (recipe.owners.size() > 1) {
                 recipeInfo.drawText(
                     EnumChatFormatting.ITALIC + trans("273", "Original Recipe by: ")
@@ -265,8 +264,7 @@ public class RecipeMapFrontend {
                             .getName());
             }
         }
-        if (GTMod.gregtechproxy.mNEIRecipeOwnerStackTrace && recipe.stackTraces != null
-            && !recipe.stackTraces.isEmpty()) {
+        if (recipe.stackTraces != null && !recipe.stackTraces.isEmpty()) {
             recipeInfo.drawText("stackTrace:");
             // todo: good way to show all stacktraces
             for (String stackTrace : recipe.stackTraces.get(0)) {

--- a/src/main/java/gregtech/api/util/GTRecipe.java
+++ b/src/main/java/gregtech/api/util/GTRecipe.java
@@ -123,12 +123,14 @@ public class GTRecipe implements Comparable<GTRecipe> {
     /**
      * Stores which mod added this recipe
      */
-    public List<ModContainer> owners = new ArrayList<>();
+    @Nullable
+    public List<ModContainer> owners = GTMod.gregtechproxy.mNEIRecipeOwner ? new ArrayList<>() : null;
     /**
      * Stores stack traces where this recipe was added
      */
     // BW wants to overwrite it, so no final
-    public List<List<String>> stackTraces = new ArrayList<>();
+    @Nullable
+    public List<List<String>> stackTraces = GTMod.gregtechproxy.mNEIRecipeOwnerStackTrace ? new ArrayList<>() : null;
 
     /** Used for simple cache validation */
     private ItemStack[] inputsAtCacheTime = null;
@@ -153,7 +155,7 @@ public class GTRecipe implements Comparable<GTRecipe> {
         mEnabled = aRecipe.mEnabled;
         mHidden = aRecipe.mHidden;
         metadataStorage = EmptyRecipeMetadataStorage.INSTANCE;
-        owners = new ArrayList<>(aRecipe.owners);
+        owners = aRecipe.owners == null ? null : new ArrayList<>(aRecipe.owners);
         reloadOwner();
     }
 
@@ -712,11 +714,13 @@ public class GTRecipe implements Comparable<GTRecipe> {
         "gregtech.common.GTRecipeAdder");
 
     public void reloadOwner() {
-        setOwner(
-            Loader.instance()
-                .activeModContainer());
+        if (owners != null) {
+            setOwner(
+                Loader.instance()
+                    .activeModContainer());
+        }
 
-        if (GTMod.gregtechproxy.mNEIRecipeOwnerStackTrace) {
+        if (stackTraces != null) {
             List<String> toAdd = new ArrayList<>();
             for (StackTraceElement stackTrace : Thread.currentThread()
                 .getStackTrace()) {
@@ -744,6 +748,7 @@ public class GTRecipe implements Comparable<GTRecipe> {
     }
 
     public void setOwner(ModContainer newOwner) {
+        if (owners == null) return;
         ModContainer oldOwner = !owners.isEmpty() ? this.owners.get(owners.size() - 1) : null;
         if (newOwner != null && newOwner != oldOwner) {
             owners.add(newOwner);
@@ -754,6 +759,7 @@ public class GTRecipe implements Comparable<GTRecipe> {
      * Use in case {@link Loader#activeModContainer()} isn't helpful
      */
     public void setOwner(String modId) {
+        if (owners == null) return;
         for (ModContainer mod : Loader.instance()
             .getModList()) {
             if (mod.getModId()

--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/RecipeGenMultisUsingFluidInsteadOfCells.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/RecipeGenMultisUsingFluidInsteadOfCells.java
@@ -166,7 +166,7 @@ public class RecipeGenMultisUsingFluidInsteadOfCells {
                     x.mDuration,
                     x.mEUt,
                     x.mSpecialValue);
-                aNewRecipe.owners = new ArrayList<>(x.owners);
+                aNewRecipe.owners = x.owners == null ? null : new ArrayList<>(x.owners);
 
                 // add all recipes to an intermediate array
                 deDuplicationInputArray.add(aNewRecipe);


### PR DESCRIPTION
For every `GTRecipe` instantiated it did create two ArrayLists that contains the mod container that created the recipe and the stacktrace of where that recipe was created. This is displayed in NEI when some configs are turned ON but as it turns out, the lists are always created whatever the configs.

I changed the code to only create the relevent objects when the associated configs are ON, it results in 16 MB of ram saved.

Before :
![image](https://github.com/user-attachments/assets/fb1d6d4b-6229-44c3-ba71-17491c3738b1)

After :
![image](https://github.com/user-attachments/assets/870caf5f-aca9-4912-991e-2c74516bb7df)

As we can see from the screenshots above, in the full pack it does successfully create the exact same amount of GTRecipes.