### PR TITLE
Reduce runtime allocations by using the same zero length array singletons

### DIFF
--- a/src/main/java/bartworks/common/blocks/BWTileEntityContainer.java
+++ b/src/main/java/bartworks/common/blocks/BWTileEntityContainer.java
@@ -41,6 +41,7 @@ import bartworks.MainMod;
 import bartworks.common.tileentities.classic.TileEntityHeatedWaterPump;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import gregtech.api.enums.GTValues;
 import ic2.api.tile.IWrenchable;
 import ic2.core.IC2;
 import ic2.core.IHasGui;
@@ -199,6 +200,6 @@ public class BWTileEntityContainer extends BlockContainer implements ITileAddsIn
                 e.printStackTrace();
             }
         }
-        return new String[0];
+        return GTValues.emptyStringArray;
     }
 }

--- a/src/main/java/bartworks/common/tileentities/multis/mega/MegaMultiBlockBase.java
+++ b/src/main/java/bartworks/common/tileentities/multis/mega/MegaMultiBlockBase.java
@@ -16,6 +16,7 @@ import com.gtnewhorizon.structurelib.structure.IStructureElement;
 
 import bartworks.util.BWTooltipReference;
 import bartworks.util.BWUtil;
+import gregtech.api.enums.GTValues;
 import gregtech.api.logic.ProcessingLogic;
 import gregtech.api.metatileentity.implementations.MTEExtendedPowerMultiBlockBase;
 import gregtech.api.metatileentity.implementations.MTEHatch;
@@ -33,7 +34,7 @@ public abstract class MegaMultiBlockBase<T extends MegaMultiBlockBase<T>> extend
     }
 
     protected String[] getExtendedInfoData() {
-        return new String[0];
+        return GTValues.emptyStringArray;
     }
 
     protected long[] getCurrentInfoData() {

--- a/src/main/java/bartworks/system/material/gtenhancement/PlatinumSludgeOverHaul.java
+++ b/src/main/java/bartworks/system/material/gtenhancement/PlatinumSludgeOverHaul.java
@@ -1078,7 +1078,7 @@ public class PlatinumSludgeOverHaul {
         if (input instanceof List || input instanceof Object[]) {
             Set lists = new HashSet(), stacks = new HashSet();
             List ip = input instanceof List ? (List) input : new ArrayList();
-            Object[] ip2 = input instanceof Object[] ? (Object[]) input : new Object[0];
+            Object[] ip2 = input instanceof Object[] ? (Object[]) input : GTValues.emptyObjectArray;
 
             for (Object o : ip) {
                 if (o instanceof List) lists.add(o);

--- a/src/main/java/bwcrossmod/galacticgreg/MTEVoidMinerBase.java
+++ b/src/main/java/bwcrossmod/galacticgreg/MTEVoidMinerBase.java
@@ -118,7 +118,7 @@ public abstract class MTEVoidMinerBase<T extends MTEVoidMinerBase<T>> extends MT
 
     protected void setElectricityStats() {
         this.mEUt = -Math.abs(Math.toIntExact(GTValues.V[this.getMinTier()]));
-        this.mOutputItems = new ItemStack[0];
+        this.mOutputItems = GTValues.emptyItemStackArray;
         this.mProgresstime = 0;
         this.mMaxProgresstime = 10;
         this.mEfficiency = this.getCurrentEfficiency(null);

--- a/src/main/java/bwcrossmod/openComputers/TileEntityGTDataServer.java
+++ b/src/main/java/bwcrossmod/openComputers/TileEntityGTDataServer.java
@@ -30,6 +30,7 @@ import bartworks.API.ITileAddsInformation;
 import bartworks.API.ITileHasDifferentTextureSides;
 import bartworks.API.SideReference;
 import cpw.mods.fml.common.Optional;
+import gregtech.api.enums.GTValues;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Mods;
 import gregtech.api.util.GTUtility;
@@ -122,7 +123,7 @@ public class TileEntityGTDataServer extends TileEntity
 
     @Override
     public String[] getInfoData() {
-        return new String[0];
+        return GTValues.emptyStringArray;
     }
 
     @Override
@@ -130,7 +131,7 @@ public class TileEntityGTDataServer extends TileEntity
 
     @Override
     public int[] getAccessibleSlotsFromSide(int p_94128_1_) {
-        return new int[0];
+        return GTValues.emptyIntArray;
     }
 
     @Override

--- a/src/main/java/detrav/items/tools/DetravToolElectricProspectorBase.java
+++ b/src/main/java/detrav/items/tools/DetravToolElectricProspectorBase.java
@@ -19,6 +19,7 @@ import net.minecraftforge.event.world.BlockEvent;
 import detrav.enums.Textures01;
 import detrav.items.behaviours.BehaviourDetravToolElectricProspector;
 import gregtech.api.damagesources.GTDamageSources;
+import gregtech.api.enums.GTValues;
 import gregtech.api.enums.SoundResource;
 import gregtech.api.interfaces.IIconContainer;
 import gregtech.api.interfaces.IToolStats;
@@ -93,7 +94,7 @@ public class DetravToolElectricProspectorBase implements IToolStats {
 
     @Override
     public int[] getEnchantmentLevels(ItemStack itemStack) {
-        return new int[0];
+        return GTValues.emptyIntArray;
     }
 
     public String getMiningSound() {

--- a/src/main/java/gregtech/api/enums/GTValues.java
+++ b/src/main/java/gregtech/api/enums/GTValues.java
@@ -449,8 +449,10 @@ public class GTValues {
     public static final IFluidTank[] emptyFluidTank = new IFluidTank[0];
     public static final GTFluidTank[] emptyFluidTankGT = new GTFluidTank[0];
     public static final FluidTankInfo[] emptyFluidTankInfo = new FluidTankInfo[0];
-    public static final FluidStack[] emptyFluidStack = new FluidStack[0];
+    public static final FluidStack[] emptyFluidStackArray = new FluidStack[0];
     public static final ItemStack[] emptyItemStackArray = new ItemStack[0];
+    public static final String[] emptyStringArray = new String[0];
+    public static final Object[] emptyObjectArray = new Object[0];
     public static final IIconContainer[] emptyIconContainerArray = new IIconContainer[3];
 
     /**

--- a/src/main/java/gregtech/api/logic/ProcessingLogic.java
+++ b/src/main/java/gregtech/api/logic/ProcessingLogic.java
@@ -15,6 +15,7 @@ import javax.annotation.Nullable;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
+import gregtech.api.enums.GTValues;
 import gregtech.api.interfaces.tileentity.IRecipeLockable;
 import gregtech.api.interfaces.tileentity.IVoidable;
 import gregtech.api.objects.GTDualInputPattern;
@@ -377,10 +378,10 @@ public class ProcessingLogic {
         }
 
         if (inputItems == null) {
-            inputItems = new ItemStack[0];
+            inputItems = GTValues.emptyItemStackArray;
         }
         if (inputFluids == null) {
-            inputFluids = new FluidStack[0];
+            inputFluids = GTValues.emptyFluidStackArray;
         }
 
         if (activeDualInv != null) {

--- a/src/main/java/gregtech/api/metatileentity/CommonBaseMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/CommonBaseMetaTileEntity.java
@@ -18,6 +18,7 @@ import com.gtnewhorizons.modularui.api.screen.UIBuildContext;
 
 import gregtech.GTMod;
 import gregtech.api.GregTechAPI;
+import gregtech.api.enums.GTValues;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.SoundResource;
 import gregtech.api.gui.modularui.GUITextureSet;
@@ -315,7 +316,7 @@ public abstract class CommonBaseMetaTileEntity extends CoverableTileEntity imple
     @Override
     public String[] getDescription() {
         if (canAccessData()) return getMetaTileEntity().getDescription();
-        return new String[0];
+        return GTValues.emptyStringArray;
     }
 
     @Override

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEBasicMachine.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEBasicMachine.java
@@ -60,6 +60,7 @@ import com.gtnewhorizons.modularui.common.widget.SlotWidget;
 
 import gregtech.GTMod;
 import gregtech.api.covers.CoverRegistry;
+import gregtech.api.enums.GTValues;
 import gregtech.api.enums.SoundResource;
 import gregtech.api.enums.SteamVariant;
 import gregtech.api.gui.modularui.CircularGaugeDrawable;
@@ -1382,7 +1383,7 @@ public abstract class MTEBasicMachine extends MTEBasicTank implements RecipeMapW
     @Override
     protected SlotWidget createChargerSlot(int x, int y) {
         if (isSteampowered()) {
-            return (SlotWidget) createChargerSlot(x, y, UNUSED_SLOT_TOOLTIP, new String[0])
+            return (SlotWidget) createChargerSlot(x, y, UNUSED_SLOT_TOOLTIP, GTValues.emptyStringArray)
                 .setBackground(getGUITextureSet().getItemSlot());
         } else {
             return super.createChargerSlot(x, y);

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
@@ -92,6 +92,7 @@ import cpw.mods.fml.common.network.ByteBufUtils;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import gregtech.GTMod;
+import gregtech.api.enums.GTValues;
 import gregtech.api.enums.SoundResource;
 import gregtech.api.enums.StructureError;
 import gregtech.api.enums.VoidingMode;
@@ -2664,7 +2665,7 @@ public abstract class MTEMultiBlockBase extends MetaTileEntity implements IContr
 
     @Override
     public boolean canDumpFluidToME() {
-        for (IFluidStore tHatch : getFluidOutputSlots(new FluidStack[0])) {
+        for (IFluidStore tHatch : getFluidOutputSlots(GTValues.emptyFluidStackArray)) {
             if (tHatch instanceof MTEHatchOutputME) {
                 if (((MTEHatchOutputME) tHatch).isFluidLocked()) {
                     return false;

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTETieredMachineBlock.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTETieredMachineBlock.java
@@ -34,7 +34,7 @@ public abstract class MTETieredMachineBlock extends MetaTileEntity {
         String aDescription, ITexture... aTextures) {
         super(aID, aName, aNameRegional, aInvSlotCount);
         mTier = (byte) Math.max(0, Math.min(aTier, 14));
-        mDescriptionArray = aDescription == null ? new String[0] : new String[] { aDescription };
+        mDescriptionArray = aDescription == null ? GTValues.emptyStringArray : new String[] { aDescription };
         // must always be the last call!
         if (GT.isClientSide()) mTextures = getTextureSet(aTextures);
         else mTextures = null;
@@ -44,7 +44,7 @@ public abstract class MTETieredMachineBlock extends MetaTileEntity {
         String[] aDescription, ITexture... aTextures) {
         super(aID, aName, aNameRegional, aInvSlotCount);
         mTier = (byte) Math.max(0, Math.min(aTier, 15));
-        mDescriptionArray = aDescription == null ? new String[0] : aDescription;
+        mDescriptionArray = aDescription == null ? GTValues.emptyStringArray : aDescription;
 
         // must always be the last call!
         if (GT.isClientSide()) mTextures = getTextureSet(aTextures);
@@ -55,7 +55,7 @@ public abstract class MTETieredMachineBlock extends MetaTileEntity {
         ITexture[][][] aTextures) {
         super(aName, aInvSlotCount);
         mTier = (byte) aTier;
-        mDescriptionArray = aDescription == null ? new String[0] : aDescription;
+        mDescriptionArray = aDescription == null ? GTValues.emptyStringArray : aDescription;
         mTextures = aTextures;
     }
 

--- a/src/main/java/gregtech/api/objects/GTUODimensionList.java
+++ b/src/main/java/gregtech/api/objects/GTUODimensionList.java
@@ -61,6 +61,7 @@ import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 
 import gregtech.api.enums.Dimensions;
+import gregtech.api.enums.GTValues;
 import gregtech.api.enums.UndergroundFluidNames;
 
 public class GTUODimensionList {
@@ -69,7 +70,7 @@ public class GTUODimensionList {
     private String fCategory;
     private final BiMap<String, GTUODimension> fDimensionList;
 
-    public int[] blackList = new int[0];
+    public int[] blackList = GTValues.emptyIntArray;
 
     public GTUODimensionList() {
         fDimensionList = HashBiMap.create();

--- a/src/main/java/gregtech/api/recipe/FindRecipeQuery.java
+++ b/src/main/java/gregtech/api/recipe/FindRecipeQuery.java
@@ -9,6 +9,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
+import gregtech.api.enums.GTValues;
 import gregtech.api.util.GTRecipe;
 import gregtech.api.util.MethodsReturnNonnullByDefault;
 
@@ -72,10 +73,10 @@ public final class FindRecipeQuery {
      */
     public Stream<GTRecipe> findAll() {
         if (items == null) {
-            items = new ItemStack[0];
+            items = GTValues.emptyItemStackArray;
         }
         if (fluids == null) {
-            fluids = new FluidStack[0];
+            fluids = GTValues.emptyFluidStackArray;
         }
 
         return recipeMap.getBackend()

--- a/src/main/java/gregtech/api/util/GTRecipe.java
+++ b/src/main/java/gregtech/api/util/GTRecipe.java
@@ -23,6 +23,7 @@ import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.ModContainer;
 import gregtech.GTMod;
 import gregtech.api.GregTechAPI;
+import gregtech.api.enums.GTValues;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
 import gregtech.api.metatileentity.implementations.MTEHatchInput;
@@ -45,9 +46,6 @@ import it.unimi.dsi.fastutil.objects.Reference2LongMap;
 import it.unimi.dsi.fastutil.objects.Reference2LongOpenHashMap;
 
 public class GTRecipe implements Comparable<GTRecipe> {
-
-    static final ItemStack[] ZERO_LEN_ITEMSTACK = new ItemStack[0];
-    static final FluidStack[] ZERO_LEN_FLUIDSTACK = new FluidStack[0];
 
     private static ItemStack dataStick;
     private static ItemStack dataOrb;
@@ -193,13 +191,13 @@ public class GTRecipe implements Comparable<GTRecipe> {
 
     public GTRecipe(boolean aOptimize, ItemStack[] aInputs, ItemStack[] aOutputs, Object aSpecialItems, int[] aChances,
         FluidStack[] aFluidInputs, FluidStack[] aFluidOutputs, int aDuration, int aEUt, int aSpecialValue) {
-        if (aInputs == null) aInputs = ZERO_LEN_ITEMSTACK;
+        if (aInputs == null) aInputs = GTValues.emptyItemStackArray;
         else aInputs = GTRecipeBuilder.removeTrailingNulls(aInputs);
-        if (aOutputs == null) aOutputs = ZERO_LEN_ITEMSTACK;
+        if (aOutputs == null) aOutputs = GTValues.emptyItemStackArray;
         else aOutputs = GTRecipeBuilder.removeTrailingNulls(aOutputs);
-        if (aFluidInputs == null) aFluidInputs = ZERO_LEN_FLUIDSTACK;
+        if (aFluidInputs == null) aFluidInputs = GTValues.emptyFluidStackArray;
         else aFluidInputs = GTRecipeBuilder.removeNullFluids(aFluidInputs);
-        if (aFluidOutputs == null) aFluidOutputs = ZERO_LEN_FLUIDSTACK;
+        if (aFluidOutputs == null) aFluidOutputs = GTValues.emptyFluidStackArray;
         else aFluidOutputs = GTRecipeBuilder.removeNullFluids(aFluidOutputs);
         if (aChances == null) aChances = new int[aOutputs.length];
         else if (aChances.length < aOutputs.length) aChances = Arrays.copyOf(aChances, aOutputs.length);

--- a/src/main/java/gregtech/api/util/GTRecipeBuilder.java
+++ b/src/main/java/gregtech/api/util/GTRecipeBuilder.java
@@ -86,12 +86,12 @@ public class GTRecipeBuilder {
         ENABLE_COLLISION_CHECK = Boolean.getBoolean("gt.recipebuilder.recipe_collision_check");
     }
 
-    protected ItemStack[] inputsBasic = GTRecipe.ZERO_LEN_ITEMSTACK;
+    protected ItemStack[] inputsBasic = GTValues.emptyItemStackArray;
     protected Object[] inputsOreDict;
-    protected ItemStack[] outputs = GTRecipe.ZERO_LEN_ITEMSTACK;
+    protected ItemStack[] outputs = GTValues.emptyItemStackArray;
     protected ItemStack[][] alts;
-    protected FluidStack[] fluidInputs = GTRecipe.ZERO_LEN_FLUIDSTACK;
-    protected FluidStack[] fluidOutputs = GTRecipe.ZERO_LEN_FLUIDSTACK;
+    protected FluidStack[] fluidInputs = GTValues.emptyFluidStackArray;
+    protected FluidStack[] fluidOutputs = GTValues.emptyFluidStackArray;
     protected int[] chances;
     protected Object special;
     protected int duration = -1;
@@ -153,16 +153,16 @@ public class GTRecipeBuilder {
 
     /**
      * Returns a copy of the array without the null elements.
-     * Returns the singleton {@link gregtech.api.util.GTRecipe#ZERO_LEN_FLUIDSTACK} if the array is empty.
+     * Returns the singleton {@link gregtech.api.enums.GTValues#emptyFluidStackArray} if the array is empty.
      */
     @Nonnull
     static FluidStack[] removeNullFluids(@Nonnull FluidStack[] fluids) {
-        if (fluids.length == 0) return GTRecipe.ZERO_LEN_FLUIDSTACK;
+        if (fluids.length == 0) return GTValues.emptyFluidStackArray;
         int count = 0;
         for (final FluidStack f : fluids) {
             if (f != null) count++;
         }
-        if (count == 0) return GTRecipe.ZERO_LEN_FLUIDSTACK;
+        if (count == 0) return GTValues.emptyFluidStackArray;
         final FluidStack[] a = new FluidStack[count];
         int i = 0;
         for (final FluidStack f : fluids) {
@@ -176,11 +176,11 @@ public class GTRecipeBuilder {
 
     /**
      * Returns a copy of the array without any null elements at the end.
-     * Returns the singleton {@link gregtech.api.util.GTRecipe#ZERO_LEN_ITEMSTACK} if the array is empty.
+     * Returns the singleton {@link gregtech.api.enums.GTValues#emptyItemStackArray} if the array is empty.
      */
     @Nonnull
     static ItemStack[] removeTrailingNulls(@Nonnull ItemStack[] array) {
-        if (array.length == 0) return GTRecipe.ZERO_LEN_ITEMSTACK;
+        if (array.length == 0) return GTValues.emptyItemStackArray;
         int nullIndex = -1;
         for (int i = array.length - 1; i >= 0; i--) {
             if (array[i] == null) {
@@ -196,7 +196,7 @@ public class GTRecipeBuilder {
             return a;
         } else if (nullIndex == 0) {
             // array has no element
-            return GTRecipe.ZERO_LEN_ITEMSTACK;
+            return GTValues.emptyItemStackArray;
         } else {
             // array has trailing nulls that needs removing
             final ItemStack[] a = new ItemStack[nullIndex];
@@ -207,11 +207,11 @@ public class GTRecipeBuilder {
 
     /**
      * Returns a copy of the array without any null elements at the end.
-     * Returns the singleton {@link gregtech.api.util.GTRecipe#ZERO_LEN_FLUIDSTACK} if the array is empty.
+     * Returns the singleton {@link gregtech.api.enums.GTValues#emptyFluidStackArray} if the array is empty.
      */
     @Nonnull
     static FluidStack[] removeTrailingNulls(@Nonnull FluidStack[] array) {
-        if (array.length == 0) return GTRecipe.ZERO_LEN_FLUIDSTACK;
+        if (array.length == 0) return GTValues.emptyFluidStackArray;
         int nullIndex = -1;
         for (int i = array.length - 1; i >= 0; i--) {
             if (array[i] == null) {
@@ -227,7 +227,7 @@ public class GTRecipeBuilder {
             return a;
         } else if (nullIndex == 0) {
             // array has no element
-            return GTRecipe.ZERO_LEN_FLUIDSTACK;
+            return GTValues.emptyFluidStackArray;
         } else {
             // array has trailing nulls that needs removing
             final FluidStack[] a = new FluidStack[nullIndex];
@@ -395,21 +395,21 @@ public class GTRecipeBuilder {
                 alts[i] = list.toArray(new ItemStack[0]);
             } else if (input == null) {
                 handleNullRecipeComponents("recipe oredict input");
-                alts[i] = new ItemStack[0];
+                alts[i] = GTValues.emptyItemStackArray;
             } else {
                 throw new IllegalArgumentException("index " + i + ", unexpected type: " + input.getClass());
             }
         }
         ArrayList<ItemStack> list = new ArrayList<>(alts.length);
         for (final ItemStack[] ss : alts) list.add(ss.length > 0 ? ss[0] : null);
-        inputsBasic = list.isEmpty() ? GTRecipe.ZERO_LEN_ITEMSTACK : list.toArray(new ItemStack[0]);
+        inputsBasic = list.isEmpty() ? GTValues.emptyItemStackArray : list.toArray(new ItemStack[0]);
         return this;
     }
 
     public GTRecipeBuilder itemOutputs(ItemStack... outputs) {
         if (skip) return this;
         if (debugNull() && containsNull(outputs)) handleNullRecipeComponents("itemOutputs");
-        this.outputs = ArrayExt.isArrayEmpty(outputs) ? GTRecipe.ZERO_LEN_ITEMSTACK : outputs;
+        this.outputs = ArrayExt.isArrayEmpty(outputs) ? GTValues.emptyItemStackArray : outputs;
         if (chances != null && chances.length != outputs.length) {
             throw new IllegalArgumentException("Output chances array and items array length differs");
         }
@@ -423,7 +423,7 @@ public class GTRecipeBuilder {
     public GTRecipeBuilder itemOutputs(ItemStack[] outputs, int[] chances) {
         if (skip) return this;
         if (debugNull() && containsNull(outputs)) handleNullRecipeComponents("itemOutputs");
-        this.outputs = ArrayExt.isArrayEmpty(outputs) ? GTRecipe.ZERO_LEN_ITEMSTACK : outputs;
+        this.outputs = ArrayExt.isArrayEmpty(outputs) ? GTValues.emptyItemStackArray : outputs;
         this.chances = chances;
         if (chances != null && chances.length != outputs.length) {
             throw new IllegalArgumentException("Output chances array and items array length differs");

--- a/src/main/java/gregtech/api/util/ParallelHelper.java
+++ b/src/main/java/gregtech/api/util/ParallelHelper.java
@@ -10,6 +10,7 @@ import javax.annotation.Nonnull;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
+import gregtech.api.enums.GTValues;
 import gregtech.api.interfaces.tileentity.IRecipeLockable;
 import gregtech.api.interfaces.tileentity.IVoidable;
 import gregtech.api.objects.XSTR;
@@ -376,10 +377,10 @@ public class ParallelHelper {
             return;
         }
         if (itemInputs == null) {
-            itemInputs = new ItemStack[0];
+            itemInputs = GTValues.emptyItemStackArray;
         }
         if (fluidInputs == null) {
-            fluidInputs = new FluidStack[0];
+            fluidInputs = GTValues.emptyFluidStackArray;
         }
 
         if (!consume) {
@@ -425,10 +426,10 @@ public class ParallelHelper {
 
         final ItemStack[] truncatedItemOutputs = recipe.mOutputs != null
             ? Arrays.copyOfRange(recipe.mOutputs, 0, Math.min(machine.getItemOutputLimit(), recipe.mOutputs.length))
-            : new ItemStack[0];
+            : GTValues.emptyItemStackArray;
         final FluidStack[] truncatedFluidOutputs = recipe.mFluidOutputs != null ? Arrays
             .copyOfRange(recipe.mFluidOutputs, 0, Math.min(machine.getFluidOutputLimit(), recipe.mFluidOutputs.length))
-            : new FluidStack[0];
+            : GTValues.emptyFluidStackArray;
 
         SingleRecipeCheck recipeCheck = null;
         SingleRecipeCheck.Builder tSingleRecipeCheckBuilder = null;

--- a/src/main/java/gregtech/api/util/VoidProtectionHelper.java
+++ b/src/main/java/gregtech/api/util/VoidProtectionHelper.java
@@ -12,6 +12,7 @@ import net.minecraftforge.fluids.FluidStack;
 
 import com.gtnewhorizon.gtnhlib.util.map.ItemStackMap;
 
+import gregtech.api.enums.GTValues;
 import gregtech.api.interfaces.fluid.IFluidStore;
 import gregtech.api.interfaces.tileentity.IVoidable;
 import gregtech.common.tileentities.machines.MTEHatchOutputME;
@@ -161,10 +162,10 @@ public class VoidProtectionHelper {
      */
     private void determineParallel() {
         if (itemOutputs == null) {
-            itemOutputs = new ItemStack[0];
+            itemOutputs = GTValues.emptyItemStackArray;
         }
         if (fluidOutputs == null) {
-            fluidOutputs = new FluidStack[0];
+            fluidOutputs = GTValues.emptyFluidStackArray;
         }
 
         // Don't check IVoidable#protectsExcessItem nor #protectsExcessFluid here,

--- a/src/main/java/gregtech/common/GTProxy.java
+++ b/src/main/java/gregtech/common/GTProxy.java
@@ -1979,7 +1979,7 @@ public abstract class GTProxy implements IGTMod, IFuelHandler {
             tEvent = i$.next();
             sizeStep--;
             if (sizeStep == 0) {
-                GT_FML_LOGGER.info("Baking : " + size + "%", new Object[0]);
+                GT_FML_LOGGER.info("Baking : " + size + "%");
                 sizeStep = mEvents.size() / 20 - 1;
                 size += 5;
             }

--- a/src/main/java/gregtech/common/items/MetaGeneratedItem03.java
+++ b/src/main/java/gregtech/common/items/MetaGeneratedItem03.java
@@ -303,7 +303,7 @@ public class MetaGeneratedItem03 extends MetaGeneratedItemX32 implements IItemFi
             OrePrefixes.rawOre,
             OrePrefixes.plateSuperdense);
         INSTANCE = this;
-        Object[] o = new Object[0];
+        Object[] o = GTValues.emptyObjectArray;
         ItemList.Item_Power_Goggles.set(
             new ItemPowerGoggles("Power_Goggles", "Power Goggles", "For when you need to look at power storage 24/7"));
         /*

--- a/src/main/java/gregtech/common/modularui2/widget/GTProgressWidget.java
+++ b/src/main/java/gregtech/common/modularui2/widget/GTProgressWidget.java
@@ -9,6 +9,7 @@ import com.cleanroommc.modularui.theme.WidgetTheme;
 import com.cleanroommc.modularui.widgets.ProgressWidget;
 
 import codechicken.nei.recipe.GuiCraftingRecipe;
+import gregtech.api.enums.GTValues;
 import gregtech.api.recipe.RecipeMap;
 import gregtech.common.modularui2.theme.ProgressbarWidgetTheme;
 
@@ -39,7 +40,7 @@ public class GTProgressWidget extends ProgressWidget implements Interactable {
     public GTProgressWidget neiTransferRect(String transferRectID, Object[] transferRectArgs,
         String transferRectTooltip) {
         this.transferRectID = transferRectID;
-        this.transferRectArgs = transferRectArgs == null ? new Object[0] : transferRectArgs;
+        this.transferRectArgs = transferRectArgs == null ? GTValues.emptyObjectArray : transferRectArgs;
         if (transferRectTooltip != null) {
             tooltipBuilder(tooltip -> tooltip.add(transferRectTooltip));
         }
@@ -54,7 +55,10 @@ public class GTProgressWidget extends ProgressWidget implements Interactable {
      *                       ICraftingHandler.getRecipeHandler}.
      */
     public GTProgressWidget neiTransferRect(String transferRectID) {
-        return neiTransferRect(transferRectID, new Object[0], StatCollector.translateToLocal("nei.recipe.tooltip"));
+        return neiTransferRect(
+            transferRectID,
+            GTValues.emptyObjectArray,
+            StatCollector.translateToLocal("nei.recipe.tooltip"));
     }
 
     /**

--- a/src/main/java/gregtech/common/tileentities/boilers/MTEBoilerSolar.java
+++ b/src/main/java/gregtech/common/tileentities/boilers/MTEBoilerSolar.java
@@ -18,6 +18,7 @@ import com.gtnewhorizons.modularui.api.widget.Widget;
 import com.gtnewhorizons.modularui.common.widget.SlotWidget;
 
 import gregtech.api.enums.Dyes;
+import gregtech.api.enums.GTValues;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.Textures.BlockIcons;
 import gregtech.api.interfaces.ITexture;
@@ -49,7 +50,7 @@ public class MTEBoilerSolar extends MTEBoiler {
     private int mRunTimeTicks = 0;
 
     public MTEBoilerSolar(int aID, String aName, String aNameRegional) {
-        super(aID, aName, aNameRegional, new String[0]);
+        super(aID, aName, aNameRegional, GTValues.emptyStringArray);
     }
 
     public MTEBoilerSolar(String aName, int aTier, String[] aDescription, ITexture[][][] aTextures) {

--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchCraftingInputME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchCraftingInputME.java
@@ -88,6 +88,7 @@ import appeng.util.Platform;
 import appeng.util.ReadableNumberConverter;
 import gregtech.GTMod;
 import gregtech.api.enums.Dyes;
+import gregtech.api.enums.GTValues;
 import gregtech.api.enums.ItemList;
 import gregtech.api.gui.modularui.GTUITextures;
 import gregtech.api.interfaces.IConfigurationCircuitSupport;
@@ -212,13 +213,13 @@ public class MTEHatchCraftingInputME extends MTEHatchInputBus
 
         @Override
         public ItemStack[] getItemInputs() {
-            if (isItemEmpty()) return new ItemStack[0];
+            if (isItemEmpty()) return GTValues.emptyItemStackArray;
             return itemInventory.toArray(new ItemStack[0]);
         }
 
         @Override
         public FluidStack[] getFluidInputs() {
-            if (isEmpty()) return new FluidStack[0];
+            if (isEmpty()) return GTValues.emptyFluidStackArray;
             return fluidInventory.toArray(new FluidStack[0]);
         }
 
@@ -231,7 +232,7 @@ public class MTEHatchCraftingInputME extends MTEHatchInputBus
             GTDualInputPattern dualInputs = new GTDualInputPattern();
 
             ItemStack[] inputItems = this.parentMTE.getSharedItems();
-            FluidStack[] inputFluids = new FluidStack[0];
+            FluidStack[] inputFluids = GTValues.emptyFluidStackArray;
 
             for (IAEItemStack singleInput : this.getPatternDetails()
                 .getInputs()) {

--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchCraftingInputSlave.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchCraftingInputSlave.java
@@ -22,6 +22,7 @@ import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import gregtech.api.enums.GTValues;
 import gregtech.api.enums.ItemList;
 import gregtech.api.interfaces.IDataCopyable;
 import gregtech.api.interfaces.ITexture;
@@ -168,7 +169,7 @@ public class MTEHatchCraftingInputSlave extends MTEHatchInputBus implements IDua
 
     @Override
     public ItemStack[] getSharedItems() {
-        return getMaster() != null ? getMaster().getSharedItems() : new ItemStack[0];
+        return getMaster() != null ? getMaster().getSharedItems() : GTValues.emptyItemStackArray;
     }
 
     @Override

--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchInputME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchInputME.java
@@ -66,6 +66,7 @@ import appeng.me.helpers.AENetworkProxy;
 import appeng.me.helpers.IGridProxyable;
 import appeng.util.item.AEFluidStack;
 import gregtech.api.enums.Dyes;
+import gregtech.api.enums.GTValues;
 import gregtech.api.enums.ItemList;
 import gregtech.api.gui.modularui.GTUITextures;
 import gregtech.api.interfaces.IDataCopyable;
@@ -117,8 +118,6 @@ public class MTEHatchInputME extends MTEHatchInput implements IPowerChannelState
     private boolean expediteRecipeCheck = false;
 
     protected static final int CONFIG_WINDOW_ID = 10;
-
-    protected static final FluidStack[] EMPTY_FLUID_STACK = new FluidStack[0];
 
     public MTEHatchInputME(int aID, boolean autoPullAvailable, String aName, String aNameRegional) {
         super(aID, 1, aName, aNameRegional, autoPullAvailable ? 9 : 8, getDescriptionArray(autoPullAvailable));
@@ -232,12 +231,12 @@ public class MTEHatchInputME extends MTEHatchInput implements IPowerChannelState
 
     public FluidStack[] getStoredFluids() {
         if (!processingRecipe) {
-            return EMPTY_FLUID_STACK;
+            return GTValues.emptyFluidStackArray;
         }
 
         AENetworkProxy proxy = getProxy();
         if (proxy == null || !proxy.isActive()) {
-            return EMPTY_FLUID_STACK;
+            return GTValues.emptyFluidStackArray;
         }
 
         updateAllInformationSlots();

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEAssemblyLine.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEAssemblyLine.java
@@ -216,8 +216,8 @@ public class MTEAssemblyLine extends MTEExtendedPowerMultiBlockBase<MTEAssemblyL
             GT_FML_LOGGER.info("Stick accepted, " + availableRecipes.size() + " Data Sticks found");
         }
 
-        int[] tStacks = new int[0];
-        FluidStack[] tFluids = new FluidStack[0];
+        int[] tStacks = GTValues.emptyIntArray;
+        FluidStack[] tFluids = GTValues.emptyFluidStackArray;
         long averageVoltage = getAverageInputVoltage();
         int maxParallel = 1;
         long maxAmp = getMaxInputAmps();

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTELargeMolecularAssembler.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTELargeMolecularAssembler.java
@@ -382,7 +382,7 @@ public class MTELargeMolecularAssembler extends MTEExtendedPowerMultiBlockBase<M
         if (dataTitle == null || dataTitle.isEmpty()) {
             dataTitle = DATA_ORB_TITLE;
             BehaviourDataOrb.setDataName(dataOrb, dataTitle);
-            BehaviourDataOrb.setNBTInventory(dataOrb, new ItemStack[0]);
+            BehaviourDataOrb.setNBTInventory(dataOrb, GTValues.emptyItemStackArray);
         }
         if (!dataTitle.equals(DATA_ORB_TITLE)) {
             cachedDataOrb = null;

--- a/src/main/java/gregtech/common/tools/GTTool.java
+++ b/src/main/java/gregtech/common/tools/GTTool.java
@@ -16,6 +16,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.event.world.BlockEvent;
 
 import gregtech.api.damagesources.GTDamageSources;
+import gregtech.api.enums.GTValues;
 import gregtech.api.enums.SoundResource;
 import gregtech.api.interfaces.IToolStats;
 import gregtech.api.items.MetaGeneratedTool;
@@ -25,7 +26,6 @@ public abstract class GTTool implements IToolStats {
     public static final Enchantment[] FORTUNE_ENCHANTMENT = { Enchantment.fortune };
     public static final Enchantment[] LOOTING_ENCHANTMENT = { Enchantment.looting };
     public static final Enchantment[] ZERO_ENCHANTMENTS = new Enchantment[0];
-    public static final int[] ZERO_ENCHANTMENT_LEVELS = new int[0];
 
     @Override
     public int getToolDamagePerBlockBreak() {
@@ -158,7 +158,7 @@ public abstract class GTTool implements IToolStats {
 
     @Override
     public int[] getEnchantmentLevels(ItemStack aStack) {
-        return ZERO_ENCHANTMENT_LEVELS;
+        return GTValues.emptyIntArray;
     }
 
     @Override

--- a/src/main/java/gregtech/loaders/misc/bees/GTFlowers.java
+++ b/src/main/java/gregtech/loaders/misc/bees/GTFlowers.java
@@ -20,6 +20,7 @@ import forestry.api.genetics.IFlowerProvider;
 import forestry.api.genetics.IIndividual;
 import forestry.api.genetics.IPollinatable;
 import forestry.api.genetics.ISpeciesRoot;
+import gregtech.api.enums.GTValues;
 import gregtech.api.util.GTLanguageManager;
 
 public enum GTFlowers implements IFlowerProvider, IAlleleFlowers, IChromosomeType {
@@ -70,7 +71,7 @@ public enum GTFlowers implements IFlowerProvider, IAlleleFlowers, IChromosomeTyp
         if (this == GTFlowers.FLAMING) {
             return new ItemStack[] { new ItemStack(Blocks.fire) };
         }
-        return new ItemStack[0];
+        return GTValues.emptyItemStackArray;
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/core/tileentities/base/TileEntityBase.java
+++ b/src/main/java/gtPlusPlus/core/tileentities/base/TileEntityBase.java
@@ -257,7 +257,7 @@ public class TileEntityBase extends TileEntity
     @Override
     public int[] getAccessibleSlotsFromSide(int ordinalSide) {
         if (canAccessData()) return mInventory.getAccessibleSlotsFromSide(ordinalSide);
-        return new int[0];
+        return GTValues.emptyIntArray;
     }
 
     /**
@@ -1169,7 +1169,7 @@ public class TileEntityBase extends TileEntity
 
     @Override
     public String[] getDescription() {
-        return this.canAccessData() ? this.mMetaTileEntity.getDescription() : new String[0];
+        return this.canAccessData() ? this.mMetaTileEntity.getDescription() : GTValues.emptyStringArray;
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GTPPMultiBlockBase.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GTPPMultiBlockBase.java
@@ -131,7 +131,7 @@ public abstract class GTPPMultiBlockBase<T extends MTEExtendedPowerMultiBlockBas
     }
 
     public String[] getExtraInfoData() {
-        return new String[0];
+        return GTValues.emptyStringArray;
     }
 
     @Override
@@ -145,7 +145,7 @@ public abstract class GTPPMultiBlockBase<T extends MTEExtendedPowerMultiBlockBas
         String[] extra = getExtraInfoData();
 
         if (extra == null) {
-            extra = new String[0];
+            extra = GTValues.emptyStringArray;
         }
         mInfo.addAll(Arrays.asList(extra));
 

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/automation/MTETesseractGenerator.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/automation/MTETesseractGenerator.java
@@ -22,6 +22,7 @@ import net.minecraftforge.fluids.IFluidHandler;
 
 import org.apache.commons.lang3.ArrayUtils;
 
+import gregtech.api.enums.GTValues;
 import gregtech.api.enums.Textures;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.tileentity.IDigitalChest;
@@ -384,7 +385,7 @@ public class MTETesseractGenerator extends MTEBasicTank {
                     .getBackFacing());
         if ((tTileEntity == null) || (!this.getBaseMetaTileEntity()
             .isAllowedToWork())) {
-            return new int[0];
+            return GTValues.emptyIntArray;
         }
         if ((tTileEntity instanceof ISidedInventory)) {
             return ((ISidedInventory) tTileEntity).getAccessibleSlotsFromSide(ordinalSide);
@@ -540,7 +541,7 @@ public class MTETesseractGenerator extends MTEBasicTank {
                     .getBackFacing());
         if ((tTileEntity == null) || (!this.getBaseMetaTileEntity()
             .isAllowedToWork())) {
-            return new FluidTankInfo[0];
+            return GTValues.emptyFluidTankInfo;
         }
         return tTileEntity.getTankInfo(aSide);
     }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/automation/MTETesseractTerminal.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/automation/MTETesseractTerminal.java
@@ -15,6 +15,7 @@ import net.minecraftforge.fluids.FluidTankInfo;
 
 import org.apache.commons.lang3.ArrayUtils;
 
+import gregtech.api.enums.GTValues;
 import gregtech.api.enums.Textures;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
@@ -340,7 +341,7 @@ public class MTETesseractTerminal extends MTEBasicTank {
         final MTETesseractGenerator tTileEntity = this.getTesseract(this.mFrequency, false);
         if ((tTileEntity == null) || (!this.getBaseMetaTileEntity()
             .isAllowedToWork())) {
-            return new int[0];
+            return GTValues.emptyIntArray;
         }
         return tTileEntity.getAccessibleSlotsFromSide(ordinalSide);
     }
@@ -450,7 +451,7 @@ public class MTETesseractTerminal extends MTEBasicTank {
         final MTETesseractGenerator tTileEntity = this.getTesseract(this.mFrequency, false);
         if ((tTileEntity == null) || (!this.getBaseMetaTileEntity()
             .isAllowedToWork())) {
-            return new FluidTankInfo[0];
+            return GTValues.emptyFluidTankInfo;
         }
         return tTileEntity.getTankInfo(aSide);
     }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTETreeFarm.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTETreeFarm.java
@@ -42,7 +42,6 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemShears;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumChatFormatting;
-import net.minecraftforge.fluids.FluidStack;
 
 import com.gtnewhorizon.structurelib.alignment.constructable.ISurvivalConstructable;
 import com.gtnewhorizon.structurelib.structure.IStructureDefinition;
@@ -310,10 +309,10 @@ public class MTETreeFarm extends GTPPMultiBlockBase<MTETreeFarm> implements ISur
             @Nonnull
             public CheckRecipeResult process() {
                 if (inputItems == null) {
-                    inputItems = new ItemStack[0];
+                    inputItems = GTValues.emptyItemStackArray;
                 }
                 if (inputFluids == null) {
-                    inputFluids = new FluidStack[0];
+                    inputFluids = GTValues.emptyFluidStackArray;
                 }
 
                 ItemStack sapling = findSapling();

--- a/src/main/java/gtnhlanth/api/recipe/LanthanidesRecipeMaps.java
+++ b/src/main/java/gtnhlanth/api/recipe/LanthanidesRecipeMaps.java
@@ -8,6 +8,7 @@ import java.util.List;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.StatCollector;
 
+import gregtech.api.enums.GTValues;
 import gregtech.api.gui.modularui.GTUITextures;
 import gregtech.api.recipe.RecipeMap;
 import gregtech.api.recipe.RecipeMapBackend;
@@ -79,7 +80,7 @@ public class LanthanidesRecipeMaps {
         })
         .neiItemOutputsGetter(recipe -> {
             SourceChamberMetadata metadata = recipe.getMetadata(SOURCE_CHAMBER_METADATA);
-            if (metadata == null) return new ItemStack[0];
+            if (metadata == null) return GTValues.emptyItemStackArray;
             ItemStack particleStack = new ItemStack(LanthItemList.PARTICLE_ITEM, 1, metadata.particleID);
             List<ItemStack> ret = new ArrayList<>(Arrays.asList(recipe.mOutputs));
             ret.add(particleStack);
@@ -123,7 +124,7 @@ public class LanthanidesRecipeMaps {
         }))
         .neiItemInputsGetter(recipe -> {
             TargetChamberMetadata metadata = recipe.getMetadata(TARGET_CHAMBER_METADATA);
-            if (metadata == null) return new ItemStack[0];
+            if (metadata == null) return GTValues.emptyItemStackArray;
             ItemStack particleStack = new ItemStack(LanthItemList.PARTICLE_ITEM, 1, metadata.particleID);
             List<ItemStack> ret = new ArrayList<>();
             ret.add(particleStack);

--- a/src/main/java/kubatech/commands/CommandHandler.java
+++ b/src/main/java/kubatech/commands/CommandHandler.java
@@ -38,6 +38,8 @@ import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.StatCollector;
 
+import gregtech.api.enums.GTValues;
+
 public class CommandHandler extends CommandBase {
 
     enum Translations {
@@ -121,7 +123,9 @@ public class CommandHandler extends CommandBase {
             chatcomponenttranslation2.getChatStyle()
                 .setColor(EnumChatFormatting.RED);
             sender.addChatMessage(chatcomponenttranslation2);
-        } else cmd.processCommand(sender, args.length > 1 ? Arrays.copyOfRange(args, 1, args.length) : new String[0]);
+        } else cmd.processCommand(
+            sender,
+            args.length > 1 ? Arrays.copyOfRange(args, 1, args.length) : GTValues.emptyStringArray);
     }
 
     @Override

--- a/src/main/java/tectech/recipe/TTRecipeAdder.java
+++ b/src/main/java/tectech/recipe/TTRecipeAdder.java
@@ -25,18 +25,15 @@ import tectech.thing.CustomItemList;
 
 public class TTRecipeAdder extends RecipeAdder {
 
-    public static final ItemStack[] nullItem = new ItemStack[0];
-    public static final FluidStack[] nullFluid = new FluidStack[0];
-
     @Deprecated
     public static boolean addResearchableAssemblylineRecipe(ItemStack aResearchItem, int totalComputationRequired,
         int computationRequiredPerSec, int researchEUt, int researchAmperage, ItemStack[] aInputs,
         FluidStack[] aFluidInputs, ItemStack aOutput, int assDuration, int assEUt) {
         if (aInputs == null) {
-            aInputs = nullItem;
+            aInputs = GTValues.emptyItemStackArray;
         }
         if (aFluidInputs == null) {
-            aFluidInputs = nullFluid;
+            aFluidInputs = GTValues.emptyFluidStackArray;
         }
         if (aResearchItem == null || totalComputationRequired <= 0 || aOutput == null || aInputs.length > 16) {
             return false;
@@ -103,10 +100,10 @@ public class TTRecipeAdder extends RecipeAdder {
         int computationRequiredPerSec, int researchEUt, int researchAmperage, Object[] aInputs,
         FluidStack[] aFluidInputs, ItemStack aOutput, int assDuration, int assEUt) {
         if (aInputs == null) {
-            aInputs = nullItem;
+            aInputs = GTValues.emptyItemStackArray;
         }
         if (aFluidInputs == null) {
-            aFluidInputs = nullFluid;
+            aFluidInputs = GTValues.emptyFluidStackArray;
         }
         if (aResearchItem == null || totalComputationRequired <= 0
             || aOutput == null

--- a/src/main/java/tectech/thing/metaTileEntity/multi/MTEMicrowave.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/MTEMicrowave.java
@@ -42,7 +42,6 @@ import gregtech.api.util.shutdown.ShutDownReason;
 import gregtech.api.util.shutdown.ShutDownReasonRegistry;
 import tectech.Reference;
 import tectech.loader.MainLoader;
-import tectech.recipe.TTRecipeAdder;
 import tectech.thing.metaTileEntity.multi.base.INameFunction;
 import tectech.thing.metaTileEntity.multi.base.IStatusFunction;
 import tectech.thing.metaTileEntity.multi.base.LedStatus;
@@ -204,7 +203,7 @@ public class MTEMicrowave extends TTMultiblockBase implements ISurvivalConstruct
             damagingFactor >>= 1;
         } while (damagingFactor > 0);
 
-        mOutputItems = itemsToOutput.toArray(TTRecipeAdder.nullItem);
+        mOutputItems = itemsToOutput.toArray(new ItemStack[0]);
 
         if (remainingTime.get() <= 0) {
             mte.getWorld()

--- a/src/main/java/tectech/thing/metaTileEntity/multi/MTEResearchStation.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/MTEResearchStation.java
@@ -34,7 +34,6 @@ import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
-import net.minecraftforge.fluids.FluidStack;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -47,6 +46,7 @@ import com.gtnewhorizons.modularui.common.widget.FakeSyncWidget;
 import com.gtnewhorizons.modularui.common.widget.SlotWidget;
 import com.gtnewhorizons.modularui.common.widget.TextWidget;
 
+import gregtech.api.enums.GTValues;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
@@ -257,8 +257,8 @@ public class MTEResearchStation extends TTMultiblockBase implements ISurvivalCon
                                     holdItem.copy(),
                                     (int) (tData.mMaterial.mMaterial.getMass() * 8192L),
                                     (int) TierEU.RECIPE_UV,
-                                    new ItemStack[0],
-                                    new FluidStack[0],
+                                    GTValues.emptyItemStackArray,
+                                    GTValues.emptyFluidStackArray,
                                     holdItem.copy(),
                                     1,
                                     30); // make fake recipe


### PR DESCRIPTION
Change has been done where possible

Funny regex to find the candidates :
`(?<!toArray\()\s*new\s+\w+\s*\[\s*0\s*\]`