### PR TITLE
Reduce allocations from GTRecipe#mChances

### DIFF
--- a/src/main/java/gregtech/api/recipe/check/SingleRecipeCheck.java
+++ b/src/main/java/gregtech/api/recipe/check/SingleRecipeCheck.java
@@ -27,6 +27,7 @@ import gregtech.api.recipe.RecipeMap;
 import gregtech.api.util.GTRecipe;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.GTUtility.ItemId;
+import gregtech.api.util.extensions.ArrayExt;
 
 /**
  * Used by machines that are locked to a single recipe, for faster recipe checking.
@@ -394,8 +395,8 @@ public class SingleRecipeCheck {
             .fluids(fInputs)
             .voltage(GTValues.V[GTUtility.getTier(eut)])
             .find();
-        int[] chances = tag.getIntArray("chances");
-        if (chances.length == 0) chances = null;
+        // need call to ArrayExt.fixChancesArray for backward compat
+        int[] chances = ArrayExt.fixChancesArray(tag.hasKey("chances") ? tag.getIntArray("chances") : null, -1);
         if (found == null || !GTUtility.equals(inputs, found.mInputs)
             || !Arrays.equals(fInputs, found.mFluidInputs)
             || !GTUtility.equals(outputs, found.mOutputs)
@@ -450,7 +451,7 @@ public class SingleRecipeCheck {
     /**
      * Returns a human-friendly string representing the recipe.
      * The caller can choose whether to include inputs and/or outputs.
-     * 
+     *
      * @param recipe           GT recipe
      * @param includeInputs    if true, include item and fluid inputs.
      * @param includeOutputs   if true, include item and fluid outputs.

--- a/src/main/java/gregtech/api/util/GTRecipe.java
+++ b/src/main/java/gregtech/api/util/GTRecipe.java
@@ -68,9 +68,12 @@ public class GTRecipe implements Comparable<GTRecipe> {
      */
     public FluidStack[] mFluidInputs, mFluidOutputs;
     /**
-     * If you changed the amount of Array-Items inside the Output Array then the length of this Array must be larger or
-     * equal to the Output Array. A chance of 10000 equals 100%
+     * This array describes the % chance of obtention of each output, the values should range from 1 to 10000, 10000
+     * being 100% chance. If the array is null, the chances for all items default to 100%.
+     * If you change the amount of Array-Items inside the Output Array then the length of this Array must be larger or
+     * equal to the Output Array.
      */
+    @Nullable
     public int[] mChances;
     /**
      * An Item that needs to be inside the Special Slot, like for example the Copy Slot inside the Printer. This is only
@@ -171,7 +174,7 @@ public class GTRecipe implements Comparable<GTRecipe> {
         this.mOutputs = mOutputs;
         this.mFluidInputs = mFluidInputs;
         this.mFluidOutputs = mFluidOutputs;
-        this.mChances = mChances;
+        this.mChances = ArrayExt.fixChancesArray(mChances, -1);
         this.mSpecialItems = mSpecialItems;
         this.mDuration = mDuration;
         this.mEUt = mEUt;
@@ -199,15 +202,12 @@ public class GTRecipe implements Comparable<GTRecipe> {
         else aFluidInputs = ArrayExt.removeNullFluids(aFluidInputs);
         if (aFluidOutputs == null) aFluidOutputs = GTValues.emptyFluidStackArray;
         else aFluidOutputs = ArrayExt.removeNullFluids(aFluidOutputs);
-        if (aChances == null) aChances = new int[aOutputs.length];
-        else if (aChances.length < aOutputs.length) aChances = Arrays.copyOf(aChances, aOutputs.length);
 
         GTOreDictUnificator.setStackArray(true, true, aInputs);
         GTOreDictUnificator.setStackArray(true, true, aOutputs);
 
         for (final ItemStack s : aOutputs) GTUtility.updateItemStack(s);
 
-        for (int i = 0; i < aChances.length; i++) if (aChances[i] <= 0) aChances[i] = 10000;
         for (int i = 0; i < aFluidInputs.length; i++) aFluidInputs[i] = aFluidInputs[i].copy();
         for (int i = 0; i < aFluidOutputs.length; i++) aFluidOutputs[i] = aFluidOutputs[i].copy();
 
@@ -248,7 +248,7 @@ public class GTRecipe implements Comparable<GTRecipe> {
         mInputs = aInputs;
         mOutputs = aOutputs;
         mSpecialItems = aSpecialItems;
-        mChances = aChances;
+        mChances = ArrayExt.fixChancesArray(aChances, aOutputs.length);
         mFluidInputs = aFluidInputs;
         mFluidOutputs = aFluidOutputs;
         mDuration = aDuration;
@@ -797,7 +797,7 @@ public class GTRecipe implements Comparable<GTRecipe> {
     }
 
     public GTRecipe setChances(int... aChances) {
-        this.mChances = aChances;
+        this.mChances = ArrayExt.fixChancesArray(aChances, -1);
         return this;
     }
 

--- a/src/main/java/gregtech/api/util/GTRecipe.java
+++ b/src/main/java/gregtech/api/util/GTRecipe.java
@@ -192,13 +192,13 @@ public class GTRecipe implements Comparable<GTRecipe> {
     public GTRecipe(boolean aOptimize, ItemStack[] aInputs, ItemStack[] aOutputs, Object aSpecialItems, int[] aChances,
         FluidStack[] aFluidInputs, FluidStack[] aFluidOutputs, int aDuration, int aEUt, int aSpecialValue) {
         if (aInputs == null) aInputs = GTValues.emptyItemStackArray;
-        else aInputs = GTRecipeBuilder.removeTrailingNulls(aInputs);
+        else aInputs = ArrayExt.removeTrailingNulls(aInputs);
         if (aOutputs == null) aOutputs = GTValues.emptyItemStackArray;
-        else aOutputs = GTRecipeBuilder.removeTrailingNulls(aOutputs);
+        else aOutputs = ArrayExt.removeTrailingNulls(aOutputs);
         if (aFluidInputs == null) aFluidInputs = GTValues.emptyFluidStackArray;
-        else aFluidInputs = GTRecipeBuilder.removeNullFluids(aFluidInputs);
+        else aFluidInputs = ArrayExt.removeNullFluids(aFluidInputs);
         if (aFluidOutputs == null) aFluidOutputs = GTValues.emptyFluidStackArray;
-        else aFluidOutputs = GTRecipeBuilder.removeNullFluids(aFluidOutputs);
+        else aFluidOutputs = ArrayExt.removeNullFluids(aFluidOutputs);
         if (aChances == null) aChances = new int[aOutputs.length];
         else if (aChances.length < aOutputs.length) aChances = Arrays.copyOf(aChances, aOutputs.length);
 
@@ -777,22 +777,22 @@ public class GTRecipe implements Comparable<GTRecipe> {
 
     public GTRecipe setInputs(ItemStack... aInputs) {
         // TODO determine if we need this without trailing nulls call
-        this.mInputs = GTRecipeBuilder.removeTrailingNulls(aInputs);
+        this.mInputs = ArrayExt.removeTrailingNulls(aInputs);
         return this;
     }
 
     public GTRecipe setOutputs(ItemStack... aOutputs) {
-        this.mOutputs = GTRecipeBuilder.removeTrailingNulls(aOutputs);
+        this.mOutputs = ArrayExt.removeTrailingNulls(aOutputs);
         return this;
     }
 
     public GTRecipe setFluidInputs(FluidStack... aInputs) {
-        this.mFluidInputs = GTRecipeBuilder.removeTrailingNulls(aInputs);
+        this.mFluidInputs = ArrayExt.removeTrailingNulls(aInputs);
         return this;
     }
 
     public GTRecipe setFluidOutputs(FluidStack... aOutputs) {
-        this.mFluidOutputs = GTRecipeBuilder.removeTrailingNulls(aOutputs);
+        this.mFluidOutputs = ArrayExt.removeTrailingNulls(aOutputs);
         return this;
     }
 

--- a/src/main/java/gregtech/api/util/GTRecipeBuilder.java
+++ b/src/main/java/gregtech/api/util/GTRecipeBuilder.java
@@ -151,93 +151,8 @@ public class GTRecipeBuilder {
 
     // region helper methods
 
-    /**
-     * Returns a copy of the array without the null elements.
-     * Returns the singleton {@link gregtech.api.enums.GTValues#emptyFluidStackArray} if the array is empty.
-     */
-    @Nonnull
-    static FluidStack[] removeNullFluids(@Nonnull FluidStack[] fluids) {
-        if (fluids.length == 0) return GTValues.emptyFluidStackArray;
-        int count = 0;
-        for (final FluidStack f : fluids) {
-            if (f != null) count++;
-        }
-        if (count == 0) return GTValues.emptyFluidStackArray;
-        final FluidStack[] a = new FluidStack[count];
-        int i = 0;
-        for (final FluidStack f : fluids) {
-            if (f != null) {
-                a[i] = f;
-                i++;
-            }
-        }
-        return a;
-    }
-
-    /**
-     * Returns a copy of the array without any null elements at the end.
-     * Returns the singleton {@link gregtech.api.enums.GTValues#emptyItemStackArray} if the array is empty.
-     */
-    @Nonnull
-    static ItemStack[] removeTrailingNulls(@Nonnull ItemStack[] array) {
-        if (array.length == 0) return GTValues.emptyItemStackArray;
-        int nullIndex = -1;
-        for (int i = array.length - 1; i >= 0; i--) {
-            if (array[i] == null) {
-                nullIndex = i;
-            } else {
-                break;
-            }
-        }
-        if (nullIndex == -1) {
-            // array has no trailing null
-            final ItemStack[] a = new ItemStack[array.length];
-            System.arraycopy(array, 0, a, 0, array.length);
-            return a;
-        } else if (nullIndex == 0) {
-            // array has no element
-            return GTValues.emptyItemStackArray;
-        } else {
-            // array has trailing nulls that needs removing
-            final ItemStack[] a = new ItemStack[nullIndex];
-            System.arraycopy(array, 0, a, 0, nullIndex);
-            return a;
-        }
-    }
-
-    /**
-     * Returns a copy of the array without any null elements at the end.
-     * Returns the singleton {@link gregtech.api.enums.GTValues#emptyFluidStackArray} if the array is empty.
-     */
-    @Nonnull
-    static FluidStack[] removeTrailingNulls(@Nonnull FluidStack[] array) {
-        if (array.length == 0) return GTValues.emptyFluidStackArray;
-        int nullIndex = -1;
-        for (int i = array.length - 1; i >= 0; i--) {
-            if (array[i] == null) {
-                nullIndex = i;
-            } else {
-                break;
-            }
-        }
-        if (nullIndex == -1) {
-            // array has no trailing null
-            final FluidStack[] a = new FluidStack[array.length];
-            System.arraycopy(array, 0, a, 0, array.length);
-            return a;
-        } else if (nullIndex == 0) {
-            // array has no element
-            return GTValues.emptyFluidStackArray;
-        } else {
-            // array has trailing nulls that needs removing
-            final FluidStack[] a = new FluidStack[nullIndex];
-            System.arraycopy(array, 0, a, 0, nullIndex);
-            return a;
-        }
-    }
-
     private static ItemStack[] fixItemArray(ItemStack[] inputs, boolean aUnsafe) {
-        return GTOreDictUnificator.setStackArray(true, aUnsafe, removeTrailingNulls(inputs));
+        return GTOreDictUnificator.setStackArray(true, aUnsafe, ArrayExt.removeTrailingNulls(inputs));
     }
 
     public static GTRecipeBuilder builder() {
@@ -338,7 +253,7 @@ public class GTRecipeBuilder {
     public GTRecipeBuilder itemInputsUnified(ItemStack... inputs) {
         if (skip) return this;
         if (debugNull() && containsNull(inputs)) handleNullRecipeComponents("itemInputUnified");
-        inputsBasic = removeTrailingNulls(inputs);
+        inputsBasic = ArrayExt.removeTrailingNulls(inputs);
         inputsOreDict = null;
         alts = null;
         return this;
@@ -434,14 +349,14 @@ public class GTRecipeBuilder {
     public GTRecipeBuilder fluidInputs(FluidStack... fluidInputs) {
         if (skip) return this;
         if (debugNull() && containsNull(fluidInputs)) handleNullRecipeComponents("fluidInputs");
-        this.fluidInputs = removeNullFluids(fluidInputs);
+        this.fluidInputs = ArrayExt.removeNullFluids(fluidInputs);
         return this;
     }
 
     public GTRecipeBuilder fluidOutputs(FluidStack... fluidOutputs) {
         if (skip) return this;
         if (debugNull() && containsNull(fluidOutputs)) handleNullRecipeComponents("fluidOutputs");
-        this.fluidOutputs = removeNullFluids(fluidOutputs);
+        this.fluidOutputs = ArrayExt.removeNullFluids(fluidOutputs);
         return this;
     }
 

--- a/src/main/java/gregtech/api/util/extensions/ArrayExt.java
+++ b/src/main/java/gregtech/api/util/extensions/ArrayExt.java
@@ -1,8 +1,10 @@
 package gregtech.api.util.extensions;
 
+import java.util.Arrays;
 import java.util.function.IntFunction;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
@@ -199,5 +201,38 @@ public class ArrayExt {
             System.arraycopy(array, 0, a, 0, nullIndex);
             return a;
         }
+    }
+
+    /**
+     * Fixes the recipe chances array. It will return null if the array is null or if the array doesn't use any
+     * meaningful % chances value.
+     * The values of the returned array will be contained in the interval [1;10000]. It may return the same array
+     * instance or a new instance.
+     *
+     * @param chances     the input chances array to fix
+     * @param expectedLen the expected length of the returned array, can be -1 if you don't need to set the length
+     */
+    @Nullable
+    public static int[] fixChancesArray(@Nullable int[] chances, int expectedLen) {
+        if (chances == null) return null;
+        boolean valid = false;
+        final int len = expectedLen == -1 ? chances.length : Math.min(chances.length, expectedLen);
+        for (int i = 0; i < len; i++) {
+            final int chance = chances[i];
+            if (chance > 0 && chance < 10000) {
+                valid = true;
+                break;
+            }
+        }
+        if (!valid) return null;
+        final boolean needCopy = expectedLen != -1 && expectedLen != chances.length;
+        final int[] array = needCopy ? Arrays.copyOf(chances, expectedLen) : chances;
+        for (int i = 0, len2 = array.length; i < len2; i++) {
+            final int chance = array[i];
+            if (chance <= 0 || chance > 10000) {
+                array[i] = 10000;
+            }
+        }
+        return array;
     }
 }

--- a/src/main/java/gregtech/api/util/extensions/ArrayExt.java
+++ b/src/main/java/gregtech/api/util/extensions/ArrayExt.java
@@ -2,9 +2,12 @@ package gregtech.api.util.extensions;
 
 import java.util.function.IntFunction;
 
+import javax.annotation.Nonnull;
+
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
+import gregtech.api.enums.GTValues;
 import gregtech.api.util.GTUtility;
 
 public class ArrayExt {
@@ -90,6 +93,29 @@ public class ArrayExt {
         return newArr;
     }
 
+    /**
+     * Returns a copy of the array without the null elements.
+     * Returns the singleton {@link gregtech.api.enums.GTValues#emptyFluidStackArray} if the array is empty.
+     */
+    @Nonnull
+    public static FluidStack[] removeNullFluids(@Nonnull FluidStack[] fluids) {
+        if (fluids.length == 0) return GTValues.emptyFluidStackArray;
+        int count = 0;
+        for (final FluidStack f : fluids) {
+            if (f != null) count++;
+        }
+        if (count == 0) return GTValues.emptyFluidStackArray;
+        final FluidStack[] a = new FluidStack[count];
+        int i = 0;
+        for (final FluidStack f : fluids) {
+            if (f != null) {
+                a[i] = f;
+                i++;
+            }
+        }
+        return a;
+    }
+
     public static <T> T[] withoutTrailingNulls(T[] array, IntFunction<T[]> arrayFactory) {
         int firstNull = -1;
         for (int i = array.length - 1; i >= 0; i--) {
@@ -110,6 +136,68 @@ public class ArrayExt {
             T[] newArray = arrayFactory.apply(firstNull);
             System.arraycopy(array, 0, newArray, 0, firstNull);
             return newArray;
+        }
+    }
+
+    /**
+     * Returns a copy of the array without any null elements at the end.
+     * Returns the singleton {@link gregtech.api.enums.GTValues#emptyItemStackArray} if the array is empty.
+     */
+    @Nonnull
+    public static ItemStack[] removeTrailingNulls(@Nonnull ItemStack[] array) {
+        if (array.length == 0) return GTValues.emptyItemStackArray;
+        int nullIndex = -1;
+        for (int i = array.length - 1; i >= 0; i--) {
+            if (array[i] == null) {
+                nullIndex = i;
+            } else {
+                break;
+            }
+        }
+        if (nullIndex == -1) {
+            // array has no trailing null
+            final ItemStack[] a = new ItemStack[array.length];
+            System.arraycopy(array, 0, a, 0, array.length);
+            return a;
+        } else if (nullIndex == 0) {
+            // array has no element
+            return GTValues.emptyItemStackArray;
+        } else {
+            // array has trailing nulls that needs removing
+            final ItemStack[] a = new ItemStack[nullIndex];
+            System.arraycopy(array, 0, a, 0, nullIndex);
+            return a;
+        }
+    }
+
+    /**
+     * Returns a copy of the array without any null elements at the end.
+     * Returns the singleton {@link gregtech.api.enums.GTValues#emptyFluidStackArray} if the array is empty.
+     */
+    @Nonnull
+    public static FluidStack[] removeTrailingNulls(@Nonnull FluidStack[] array) {
+        if (array.length == 0) return GTValues.emptyFluidStackArray;
+        int nullIndex = -1;
+        for (int i = array.length - 1; i >= 0; i--) {
+            if (array[i] == null) {
+                nullIndex = i;
+            } else {
+                break;
+            }
+        }
+        if (nullIndex == -1) {
+            // array has no trailing null
+            final FluidStack[] a = new FluidStack[array.length];
+            System.arraycopy(array, 0, a, 0, array.length);
+            return a;
+        } else if (nullIndex == 0) {
+            // array has no element
+            return GTValues.emptyFluidStackArray;
+        } else {
+            // array has trailing nulls that needs removing
+            final FluidStack[] a = new FluidStack[nullIndex];
+            System.arraycopy(array, 0, a, 0, nullIndex);
+            return a;
         }
     }
 }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/purification/MTEPurificationUnitBase.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/purification/MTEPurificationUnitBase.java
@@ -378,22 +378,24 @@ public abstract class MTEPurificationUnitBase<T extends MTEExtendedPowerMultiBlo
             fluidOutputs[i].amount *= effectiveParallel;
         }
 
-        ItemStack[] itemOutputs = new ItemStack[this.currentRecipe.mOutputs.length];
+        ItemStack[] recipeOutputs = this.currentRecipe.mOutputs;
+        ItemStack[] itemOutputs = new ItemStack[recipeOutputs.length];
+        int[] mChances = this.currentRecipe.mChances;
 
         // If this recipe has random item outputs, roll on it and add to outputs
-        if (this.currentRecipe.mChances != null) {
+        if (mChances != null) {
             // Roll on each output individually
-            for (int i = 0; i < this.currentRecipe.mOutputs.length; ++i) {
+            for (int i = 0; i < recipeOutputs.length; ++i) {
                 // Recipes store probabilities as a value ranging from 1-10000
                 int roll = random.nextInt(10000);
-                if (roll <= this.currentRecipe.mChances[i]) {
-                    itemOutputs[i] = this.currentRecipe.mOutputs[i].copy();
+                if (roll <= mChances[i]) {
+                    itemOutputs[i] = recipeOutputs[i].copy();
                 }
             }
         } else {
             // Guaranteed item output
-            for (int i = 0; i < this.currentRecipe.mOutputs.length; ++i) {
-                itemOutputs[i] = this.currentRecipe.mOutputs[i].copy();
+            for (int i = 0; i < recipeOutputs.length; ++i) {
+                itemOutputs[i] = recipeOutputs[i].copy();
             }
         }
 

--- a/src/main/java/gtnhintergalactic/tile/multi/elevatormodules/TileEntityModuleMiner.java
+++ b/src/main/java/gtnhintergalactic/tile/multi/elevatormodules/TileEntityModuleMiner.java
@@ -447,8 +447,14 @@ public abstract class TileEntityModuleMiner extends TileEntityModuleBase impleme
 
         // Randomly generate ore stacks with the given chances, ores and size
         Map<GTUtility.ItemId, Long> outputs = new HashMap<>();
-        int totalChance = Arrays.stream(tRecipe.mChances)
-            .sum();
+
+        int totalChance = 0;
+        if (tRecipe.mChances == null) {
+            totalChance = tRecipe.mOutputs.length * 10000;
+        } else {
+            for (int mChance : tRecipe.mChances) totalChance += mChance;
+        }
+
         try {
             for (int i = 0; i < data.maxSize * parallels; i++) {
                 int bonusStackChance = 0;

--- a/src/test/java/gregtech/api/util/ArrayExtTest.java
+++ b/src/test/java/gregtech/api/util/ArrayExtTest.java
@@ -1,0 +1,47 @@
+package gregtech.api.util;
+import gregtech.api.util.extensions.ArrayExt;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ArrayExtTest {
+
+    @Test
+    void testFixChancesArray() {
+
+        assertNull(ArrayExt.fixChancesArray(null, -1000));
+        assertNull(ArrayExt.fixChancesArray(null, -1));
+        assertNull(ArrayExt.fixChancesArray(null, 42));
+
+        assertNull(ArrayExt.fixChancesArray(new int[0], -1000));
+        assertNull(ArrayExt.fixChancesArray(new int[0], -1));
+        assertNull(ArrayExt.fixChancesArray(new int[0], 0));
+        assertNull(ArrayExt.fixChancesArray(new int[0], 42));
+
+        assertNull(ArrayExt.fixChancesArray(new int[] {-1,-511,0,0,10000}, -1000));
+        assertNull(ArrayExt.fixChancesArray(new int[] {-1,-511,0,0,10000}, -1));
+        assertNull(ArrayExt.fixChancesArray(new int[] {-1,-511,0,0,10000}, 5));
+        assertNull(ArrayExt.fixChancesArray(new int[] {-1,-511,0,0,10000}, 42));
+
+        int[] expected, actual;
+
+        expected = new int[] {5,5,5,5};
+        actual =  ArrayExt.fixChancesArray(new int[] {5,5,5,5}, -1);
+        assertArrayEquals(expected, actual);
+
+        expected = new int[] {5,5,5,5};
+        actual =  ArrayExt.fixChancesArray(new int[] {5,5,5,5}, 4);
+        assertArrayEquals(expected, actual);
+
+        expected = new int[] {5,5,5,5,10000,10000,10000,10000};
+        actual =  ArrayExt.fixChancesArray(new int[] {5,5,5,5}, 8);
+        assertArrayEquals(expected, actual);
+
+        expected = new int[] {10000,10000,10000,10000,5,5,5,5};
+        actual =  ArrayExt.fixChancesArray(new int[] {0,0,0,0,5,5,5,5}, -1);
+        assertArrayEquals(expected, actual);
+
+        assertNull(ArrayExt.fixChancesArray(new int[] {0,0,0,0,5,5,5,5}, 3));
+
+    }
+
+}


### PR DESCRIPTION
This array describes the % chance of obtention of each recipe output, the values range from 1 to 10000, 10000 being 100% chance.

I changed the behavior of the array so that it's null if the recipe doesn't use %chances e.g if the array doesn't have any value that's different from 100% chance.