### PR TITLE
Fix mapiary crash on removing bees

### DIFF
--- a/src/main/java/kubatech/tileentity/gregtech/multiblock/MTEMegaIndustrialApiary.java
+++ b/src/main/java/kubatech/tileentity/gregtech/multiblock/MTEMegaIndustrialApiary.java
@@ -334,7 +334,8 @@ public class MTEMegaIndustrialApiary extends KubaTechGTMultiBlockBase<MTEMegaInd
      */
     protected void onStorageContentChanged(boolean ignoreFlowerCheck) {
         flowerRequiredMap = mStorage.stream()
-            .collect(Collectors.toMap(BeeSimulator::getFlowerType, BeeSimulator::getFlowerTypeDescription));
+            .collect(
+                Collectors.toMap(BeeSimulator::getFlowerType, BeeSimulator::getFlowerTypeDescription, (k1, k2) -> k1));
         flowerRequiredMap.remove("");
 
         if (!ignoreFlowerCheck) {


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19952

Collectors.toMap() throws an exception with duplicate keys, this now lets it merge them (take the first value, since in this case all k/v pairs should be identical)