### PR TITLE
Partial Revert of #4120

### DIFF
--- a/src/main/java/gregtech/loaders/postload/recipes/FluidExtractorRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/FluidExtractorRecipes.java
@@ -562,6 +562,13 @@ public class FluidExtractorRecipes implements Runnable {
             .eut(TierEU.RECIPE_MV)
             .addTo(fluidExtractionRecipes);
 
+        GTValues.RA.stdBuilder()
+            .itemInputs(GTModHandler.getModItem(TinkerConstruct.ID, "oreBerries", 1L, 4))
+            .fluidOutputs(Materials.Aluminium.getMolten(1 * NUGGETS))
+            .duration(2 * SECONDS)
+            .eut(TierEU.RECIPE_HV)
+            .addTo(fluidExtractionRecipes);
+
         if (Forestry.isModLoaded()) {
             // Beecombs fluid extractor recipes
             // xenon


### PR DESCRIPTION
Instead of completely removing the Aluminium Oreberry fluid extraction recipe, it has been tiered up to HV to prevent tier bypassing.