### PR TITLE
Unrefined Desh OreDict, Salt LCR Recipe, Thorns Recipe for TGS

### DIFF
--- a/src/main/java/gregtech/loaders/postload/CraftingRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/postload/CraftingRecipeLoader.java
@@ -2028,5 +2028,15 @@ public class CraftingRecipeLoader implements Runnable {
                     OrePrefixes.plate.get(Materials.InfusedAir), 'S', OrePrefixes.plate.get(Materials.SteelMagnetic),
                     'B', GTModHandler.getModItem(Thaumcraft.ID, "ItemBaubleBlanks", 1, 2), });
         }
+
+        if (TwilightForest.isModLoaded()) {
+            GTModHandler.addCraftingRecipe(
+                GTModHandler.getModItem(TwilightForest.ID, "tile.TFThorns", 1, 0),
+                bits_no_remove_buffered,
+                new Object[] { "TWT", "LWL", "TWT", 'T',
+                    GTModHandler.getModItem(TwilightForest.ID, "tile.TFThornRose", 1, 0), 'L',
+                    ItemList.TF_LiveRoot.get(1), 'W',
+                    GTModHandler.getModItem(TwilightForest.ID, "tile.TFLog", 1, 0), });
+        }
     }
 }

--- a/src/main/java/gregtech/loaders/postload/recipes/ChemicalRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/ChemicalRecipes.java
@@ -1903,6 +1903,17 @@ public class ChemicalRecipes implements Runnable {
             .eut(8)
             .addTo(UniversalChemical);
 
+        // 3NaOH + HCl = NaCl + H2O
+
+        GTValues.RA.stdBuilder()
+            .itemInputs(Materials.SodiumHydroxide.getDust(3))
+            .itemOutputs(Materials.Salt.getDust(1))
+            .fluidInputs(Materials.HydrochloricAcid.getFluid(1_000))
+            .fluidOutputs(Materials.Water.getFluid(1000))
+            .duration(2 * SECONDS)
+            .eut(8)
+            .addTo(chemicalReactorRecipes);
+
         // C3H6 + 2Cl = HCl + C3H5Cl
 
         GTValues.RA.stdBuilder()

--- a/src/main/java/gregtech/loaders/preload/LoaderGTOreDictionary.java
+++ b/src/main/java/gregtech/loaders/preload/LoaderGTOreDictionary.java
@@ -2,6 +2,7 @@ package gregtech.loaders.preload;
 
 import static gregtech.api.enums.Mods.AppliedEnergistics2;
 import static gregtech.api.enums.Mods.Botania;
+import static gregtech.api.enums.Mods.GalacticraftMars;
 import static gregtech.api.enums.Mods.IndustrialCraft2;
 import static gregtech.api.enums.Mods.NewHorizonsCoreMod;
 import static gregtech.api.enums.Mods.Railcraft;
@@ -415,5 +416,10 @@ public class LoaderGTOreDictionary implements Runnable {
             OrePrefixes.block,
             MaterialsBotania.BotaniaDragonstone,
             GTModHandler.getModItem(Botania.ID, "storage", 1L, 4));
+
+        GTOreDictUnificator.registerOre(
+            OrePrefixes.ore,
+            Materials.Desh,
+            GTModHandler.getModItem(GalacticraftMars.ID, "item.null", 1L, 0));
     }
 }


### PR DESCRIPTION
## Unrefined Desh Ore Dictionary Addition

Unrefined Desh has been given the OreDict tag of oreDesh as recommended by the issue. 

This will fix and close https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20245

### In-Game Photo
![image](https://github.com/user-attachments/assets/75cdc648-c98c-4cc5-8208-1879508bf134)

## Salt LCR Recipe

Salt has been given a balanced LCR recipe, as recommended by the issue. I made it LV so it was synonymous with the inverses of it's reaction, and I made it short because neutralization in real life is a much shorter process than the separation. 

This will fix and close https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20246

### In-Game Photo
![image](https://github.com/user-attachments/assets/345c9ed9-cfef-48fb-b81f-f8c92f0889d1)

## Thorns Recipe for TGS

"Thorns" item from Twilight Forest has been given a recipe so it's TGS recipe may be viable as there is currently no other way to get them. Items used: 3 Twlight forest wood, 4 thorn roses (to ensure they have unlocked the thorn area first), and 2 liveroot.

This will fix and close https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20249

### In-Game Photo:
![image](https://github.com/user-attachments/assets/a85a4acb-39d4-485e-9bb5-4149ba4ada16)
![image](https://github.com/user-attachments/assets/d6f62e10-5c28-44be-a094-e30a77db68b4)

