### PR TITLE
Add a `Map<UUID,EntityPlayerMP>` in GTProxy

### DIFF
--- a/src/main/java/gregtech/common/GTProxy.java
+++ b/src/main/java/gregtech/common/GTProxy.java
@@ -2664,21 +2664,24 @@ public abstract class GTProxy implements IGTMod, IFuelHandler {
             // this should never happen
             return;
         }
-        PLAYERS_BY_UUID.put(
-            player.getGameProfile()
-                .getId(),
-            player);
+        final UUID UUID = player.getGameProfile()
+            .getId();
+        if (UUID != null) {
+            PLAYERS_BY_UUID.put(UUID, player);
+        }
     }
 
     @SubscribeEvent
     public void playerMap$onPlayerLeft(PlayerLoggedOutEvent event) {
-        if (!(event.player instanceof EntityPlayerMP playerMP)) {
+        if (!(event.player instanceof EntityPlayerMP player)) {
             // this should never happen
             return;
         }
-        PLAYERS_BY_UUID.remove(
-            playerMP.getGameProfile()
-                .getId());
+        final UUID UUID = player.getGameProfile()
+            .getId();
+        if (UUID != null) {
+            PLAYERS_BY_UUID.remove(UUID);
+        }
     }
 
     @SubscribeEvent
@@ -2687,10 +2690,11 @@ public abstract class GTProxy implements IGTMod, IFuelHandler {
             // this should never happen
             return;
         }
-        PLAYERS_BY_UUID.put(
-            player.getGameProfile()
-                .getId(),
-            player);
+        final UUID UUID = player.getGameProfile()
+            .getId();
+        if (UUID != null) {
+            PLAYERS_BY_UUID.put(UUID, player);
+        }
     }
 
     @SubscribeEvent
@@ -2699,10 +2703,11 @@ public abstract class GTProxy implements IGTMod, IFuelHandler {
             // this should never happen
             return;
         }
-        PLAYERS_BY_UUID.put(
-            player.getGameProfile()
-                .getId(),
-            player);
+        final UUID UUID = player.getGameProfile()
+            .getId();
+        if (UUID != null) {
+            PLAYERS_BY_UUID.put(UUID, player);
+        }
     }
 
     /**
@@ -2713,16 +2718,15 @@ public abstract class GTProxy implements IGTMod, IFuelHandler {
      */
     @Nullable
     public EntityPlayerMP getPlayerMP(UUID uuid) {
-        if (FMLCommonHandler.instance()
+        if (!FMLCommonHandler.instance()
             .getEffectiveSide()
             .isServer()) {
-            if (PLAYERS_BY_UUID != null) {
-                return PLAYERS_BY_UUID.get(uuid);
-            } else {
-                throw new NullPointerException("PLAYERS_BY_ID is null because the server is not running!");
-            }
-        } else {
             throw new RuntimeException("Tried to retrieve an EntityPlayerMP from outside of the server thread!");
+        }
+        if (PLAYERS_BY_UUID != null) {
+            return PLAYERS_BY_UUID.get(uuid);
+        } else {
+            throw new NullPointerException("PLAYERS_BY_ID is null because the server is not running!");
         }
     }
 

--- a/src/main/java/gregtech/common/GTProxy.java
+++ b/src/main/java/gregtech/common/GTProxy.java
@@ -741,7 +741,7 @@ public abstract class GTProxy implements IGTMod, IFuelHandler {
 
     private final ConcurrentMap<UUID, GTClientPreference> mClientPrefernces = new ConcurrentHashMap<>();
     /** A fast lookup for players. */
-    private static Map<UUID, EntityPlayerMP> PLAYERS_BY_ID;
+    private Map<UUID, EntityPlayerMP> PLAYERS_BY_ID;
 
     public GTSpawnEventHandler spawnEventHandler;
     public TetherManager tetherManager;


### PR DESCRIPTION
This is a useful thing to have and it's used by multiple feature that each implement it with their own sauce and some forget to clear it properly creating memory leaks.

I am making this PR right now so it can be used in : https://github.com/GTNewHorizons/GT5-Unofficial/pull/4466

If I make changes to others maps to make them use this new map, I'll do it in my PR : https://github.com/GTNewHorizons/GT5-Unofficial/pull/4541