### PR TITLE
Add Missing Units to NEI for Steam Machines

### DIFF
--- a/src/main/java/gregtech/api/objects/overclockdescriber/SteamOverclockDescriber.java
+++ b/src/main/java/gregtech/api/objects/overclockdescriber/SteamOverclockDescriber.java
@@ -50,11 +50,11 @@ public class SteamOverclockDescriber extends OverclockDescriber {
 
     private String getTotalPowerString(OverclockCalculator calculator) {
         return GTUtility.formatNumbers(convertEUToSteam(calculator.getConsumption() * calculator.getDuration()))
-            + " Steam";
+            + " L of Steam";
     }
 
     private String getSteamUsageString(OverclockCalculator calculator) {
-        return GTUtility.formatNumbers(20 * convertEUToSteam(calculator.getConsumption())) + " L/s Steam";
+        return GTUtility.formatNumbers(20 * convertEUToSteam(calculator.getConsumption())) + " L/s of Steam";
     }
 
     private static long convertEUToSteam(long eu) {

--- a/src/main/java/gregtech/api/objects/overclockdescriber/SteamOverclockDescriber.java
+++ b/src/main/java/gregtech/api/objects/overclockdescriber/SteamOverclockDescriber.java
@@ -49,12 +49,13 @@ public class SteamOverclockDescriber extends OverclockDescriber {
     }
 
     private String getTotalPowerString(OverclockCalculator calculator) {
-        return GTUtility.formatNumbers(convertEUToSteam(calculator.getConsumption() * calculator.getDuration()))
-            + " L of Steam";
+        long steamTotal = convertEUToSteam(calculator.getConsumption() * calculator.getDuration());
+        return StatCollector.translateToLocalFormatted("GT5U.steam_total", GTUtility.formatNumbers(steamTotal));
     }
 
     private String getSteamUsageString(OverclockCalculator calculator) {
-        return GTUtility.formatNumbers(20 * convertEUToSteam(calculator.getConsumption())) + " L/s of Steam";
+        long steamUsage = 20 * convertEUToSteam(calculator.getConsumption());
+        return StatCollector.translateToLocalFormatted("GT5U.steam_usage", GTUtility.formatNumbers(steamUsage));
     }
 
     private static long convertEUToSteam(long eu) {

--- a/src/main/resources/assets/gregtech/lang/en_US.lang
+++ b/src/main/resources/assets/gregtech/lang/en_US.lang
@@ -1795,6 +1795,9 @@ GT5U.interface.coverTabs.redstone.unknown=<unknown>
 GT5U.steam_variant.bronze=Bronze
 GT5U.steam_variant.steel=Steel
 
+GT5U.steam_total=%s L of Steam
+GT5U.steam_usage=%s L/s of Steam
+
 GT5U.biomes.humidity=Humidity:
 
 # NEI options


### PR DESCRIPTION
Also adds the word "of" to sound more natural.

![image](https://github.com/user-attachments/assets/927dba55-2274-4395-91d9-7ffa1b697190)