### PR TITLE
Remove Chemical Plant Manual

### DIFF
--- a/src/main/java/gtPlusPlus/core/handler/BookHandler.java
+++ b/src/main/java/gtPlusPlus/core/handler/BookHandler.java
@@ -9,7 +9,6 @@ import java.util.Map;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 
-import gregtech.api.enums.GTValues;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.util.GTModHandler;
@@ -29,7 +28,6 @@ public class BookHandler {
     public static BookTemplate book_ModularBauble;
     public static BookTemplate book_MultiMachineManual;
     public static BookTemplate book_NuclearManual;
-    public static BookTemplate book_MultiChemicalPlant;
 
     public static void run() {
 
@@ -210,205 +208,6 @@ public class BookHandler {
                     Fission Fuel
                     Processing Plant----------------------
                     This structure is used to produce the Molten Salts required to run a Liquid Fluorine Thorium Reactor [LFTR].""" });
-
-        book_MultiChemicalPlant = writeBookTemplate(
-            "book_Multi_ChemicalPlant",
-            "Chemical Plant Manual",
-            "Alkalus",
-            new String[] {
-
-                // Intro
-                "This book will explain how the Chemical Plant is constructed, which blocks are valid to upgrade it and also how the upgrades work.",
-
-                // Info
-                """
-                    Solid Casings = Plant tier
-                    Machine Casings = Hatch tier
-                    Higher tier coils  More Speed
-                    T1 50% , T2 100% , T3 150%, etc
-                    """, """
-                    Higher tier pipe casings boost parallel
-                    and reduce catalyst consumption.
-                    +2 parallel per tier, 20% extra chance of
-                    not damaging catalyst per tier.""", """
-                    Awakened Draconium Coil (or above) with
-                    Tungstensteel Pipe Casing
-                    does not damage catalyst at all.""",
-
-                // Machine Casings
-                """
-                    Valid Solid Machine Casings:
-                    1 - Strong Bronze
-                    2 - Solid Steel
-                    3 - Sturdy Aluminium
-                    4 - Clean Stainless Steel
-                    5 - Stable Titanium
-                    6 - Robust Tungstensteel
-                    7 - Vigorous Laurenium
-                    8 - Rugged Botmium""",
-
-                // Machine Casings
-                "Valid Tiered Machine Casings:" + "\n"
-                    + "\n"
-                    + "1 - "
-                    + GTValues.VN[0]
-                    + "\n"
-                    + "2 - "
-                    + GTValues.VN[1]
-                    + "\n"
-                    + "3 - "
-                    + GTValues.VN[2]
-                    + "\n"
-                    + "4 - "
-                    + GTValues.VN[3]
-                    + "\n"
-                    + "5 - "
-                    + GTValues.VN[4]
-                    + "\n"
-                    + "6 - "
-                    + GTValues.VN[5]
-                    + "\n"
-                    + "7 - "
-                    + GTValues.VN[6]
-                    + "\n"
-                    + "8 - "
-                    + GTValues.VN[7]
-                    + "\n"
-                    + "9 - "
-                    + GTValues.VN[8]
-                    + "\n"
-                    + "10 - "
-                    + GTValues.VN[9],
-
-                // Pipe Casings
-                """
-                    Valid Pipe Casings:
-
-                    1 - Bronze
-                    2 - Steel
-                    3 - Titanium
-                    4 - Tungstensteel""",
-
-                // Coils
-                """
-                    Valid Coils:
-
-                    1 - Cupronickel
-                    2 - Kanthal
-                    3 - Nichrome
-                    4 - TPV-Alloy
-                    5 - HSS-G
-                    6 - HSS-S
-                    7 - Naquadah
-                    8 - Naquadah Alloy
-                    9 - Trinium
-                    10 - Fluxed Electrum""", """
-                    11 - Awakened Draconium
-                    12 - Infinity
-                    13 - Hypogen
-                    14 - Eternal""",
-
-                // Requirements
-                """
-                    Multiblock Requirements:
-
-                    27x Coils
-                    18x Pipe Casings
-                    57x Tiered Machine Casings
-                    70+ Solid Casings
-                    1x Catalyst Housing (Catalysts cannot go inside an Input Bus)""",
-
-                // Construction Guide
-                """
-                    Construction Guide Pt1:
-
-                    Controller is placed on a middle casing in the bottom layer
-                    Hatches can only be placed on the bottom layer edges""", """
-                    Construction Guide Pt2:
-
-                    7x7x7 Hollow frame of solid casings
-                    5x1x5 layer of solid casings (fills in top layer)
-                    5x1x5 layer of machine casings (fills in bottom layer)""", """
-                    Construction Guide Pt3:
-                    In the central 3x5x3:
-                    3x1x3 layer of Coils, surrounded by ring of Machine Casings
-                    3x1x3 layer of Pipe Casings
-                    3x1x3 layer of Coils
-                    3x1x3 layer of Pipe Casings
-                    3x1x3 layer of Coils, surrounded by ring of Machine Casings""",
-
-                // Construction Guide Info
-                """
-                    Information:
-
-                    A = Air
-                    X = Solid Casing
-                    M = Machine Casing
-                    P = Pipe Casing
-                    C = Coil Casing""", """
-                    Layer 1:
-
-                    XXXXXXX
-                    XMMMMMX
-                    XMMMMMX
-                    XMMMMMX
-                    XMMMMMX
-                    XMMMMMX
-                    XXXXXXX""", """
-                    Layer 2:
-
-                    XAAAAAX
-                    AMMMMMA
-                    AMCCCMA
-                    AMCCCMA
-                    AMCCCMA
-                    AMMMMMA
-                    XAAAAAX""", """
-                    Layer 3:
-
-                    XAAAAAX
-                    AAAAAAA
-                    AAPPPAA
-                    AAPPPAA
-                    AAPPPAA
-                    AAAAAAA
-                    XAAAAAX""", """
-                    Layer 4:
-
-                    XAAAAAX
-                    AAAAAAA
-                    AACCCAA
-                    AACCCAA
-                    AACCCAA
-                    AAAAAAA
-                    XAAAAAX""", """
-                    Layer 5:
-
-                    XAAAAAX
-                    AAAAAAA
-                    AAPPPAA
-                    AAPPPAA
-                    AAPPPAA
-                    AAAAAAA
-                    XAAAAAX""", """
-                    Layer 6:
-
-                    XAAAAAX
-                    AMMMMMA
-                    AMCCCMA
-                    AMCCCMA
-                    AMCCCMA
-                    AMMMMMA
-                    XAAAAAX""", """
-                    Layer 7:
-
-                    XXXXXXX
-                    XXXXXXX
-                    XXXXXXX
-                    XXXXXXX
-                    XXXXXXX
-                    XXXXXXX
-                    XXXXXXX""", });
     }
 
     public static ItemStack ItemBookWritten_ThermalBoiler;
@@ -416,7 +215,6 @@ public class BookHandler {
     public static ItemStack ItemBookWritten_ModularBaubles;
     public static ItemStack ItemBookWritten_MultiPowerStorage;
     public static ItemStack ItemBookWritten_MultiMachineManual;
-    public static ItemStack ItemBookWritten_MultiChemicalPlant;
 
     public static void runLater() {
         ItemBookWritten_ThermalBoiler = new ItemStack(ModItems.itemCustomBook, 1, 0);
@@ -424,7 +222,6 @@ public class BookHandler {
         ItemBookWritten_ModularBaubles = new ItemStack(ModItems.itemCustomBook, 1, 2);
         ItemBookWritten_MultiMachineManual = new ItemStack(ModItems.itemCustomBook, 1, 3);
         ItemBookWritten_NuclearManual = new ItemStack(ModItems.itemCustomBook, 1, 4);
-        ItemBookWritten_MultiChemicalPlant = new ItemStack(ModItems.itemCustomBook, 1, 5);
 
         // Multiblock Manuals
         RecipeUtils.addShapelessGregtechRecipe(
@@ -443,10 +240,6 @@ public class BookHandler {
             new ItemStack[] { new ItemStack(Items.writable_book),
                 GTOreDictUnificator.get(OrePrefixes.dust, Materials.Uranium, 1) },
             ItemBookWritten_NuclearManual);
-        RecipeUtils.addShapelessGregtechRecipe(
-            new ItemStack[] { new ItemStack(Items.writable_book),
-                GTOreDictUnificator.get(OrePrefixes.wireGt01, Materials.Copper, 1) },
-            ItemBookWritten_MultiChemicalPlant);
 
         for (int i = 0; i < mBookKeeperCount; i++) {
             ItemStack bookstack = new ItemStack(ModItems.itemCustomBook, 1, i);


### PR DESCRIPTION
Closes [Remove Chemical Plant Manual and remove the warning that tells players not to use Chemical Plant Multblock preview in NEI #20108](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20108).