### PR TITLE
Removes Crib, Cribus, & Proxy Restriction on Molecular Transformer

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/MTEIndustrialMolecularTransformer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/MTEIndustrialMolecularTransformer.java
@@ -133,7 +133,7 @@ public class MTEIndustrialMolecularTransformer extends GTPPMultiBlockBase<MTEInd
     public boolean checkMachine(IGregTechTileEntity aBaseMetaTileEntity, ItemStack aStack) {
         mCasing = 0;
         boolean aDidBuild = checkPiece(STRUCTURE_PIECE_MAIN, 3, 3, 0);
-        if (this.mInputBusses.size() != 1 || this.mOutputBusses.size() != 1 || this.mEnergyHatches.size() != 1) {
+        if (this.mOutputBusses.size() != 1 || this.mEnergyHatches.size() != 1) {
             return false;
         }
         // there are 16 slot that only allow casing, so we subtract this from the grand total required


### PR DESCRIPTION
## Change:
Allows for usage of these input busses while still maintaining the 1 hatch hard limit on them. Built & tested in game already.

This will close https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20299.

### In-Game Photo:
![image](https://github.com/user-attachments/assets/13b52b6b-5d62-4821-a042-58dc03bf9432)
