### PR TITLE
Fix NPE when unregistering server events

### DIFF
--- a/src/main/java/gregtech/common/GTProxy.java
+++ b/src/main/java/gregtech/common/GTProxy.java
@@ -1301,11 +1301,16 @@ public abstract class GTProxy implements IGTMod, IFuelHandler {
 
     public void onServerStopped() {
         WirelessChargerManager.clearChargerMap();
-        MinecraftForge.EVENT_BUS.unregister(spawnEventHandler);
+        if (spawnEventHandler != null) {
+            MinecraftForge.EVENT_BUS.unregister(spawnEventHandler);
+        }
+        if (tetherManager != null) {
+            FMLCommonHandler.instance()
+                .bus()
+                .unregister(tetherManager);
+            MinecraftForge.EVENT_BUS.unregister(tetherManager);
+        }
         spawnEventHandler = null;
-        FMLCommonHandler.instance()
-            .bus()
-            .unregister(tetherManager);
         tetherManager = null;
         PLAYERS_BY_UUID = null;
     }


### PR DESCRIPTION
apparently it is possible for forge to tun the server stopped event wihout running the server start, so it will cause a npe when unregistering the events because they are null