### PR TITLE
Force background machine update threads to complete before starting next tick

### DIFF
--- a/src/main/java/gregtech/common/GTProxy.java
+++ b/src/main/java/gregtech/common/GTProxy.java
@@ -136,6 +136,7 @@ import gregtech.api.objects.GTChunkManager;
 import gregtech.api.objects.GTUODimensionList;
 import gregtech.api.objects.ItemData;
 import gregtech.api.recipe.RecipeMaps;
+import gregtech.api.threads.RunnableMachineUpdate;
 import gregtech.api.util.GTBlockMap;
 import gregtech.api.util.GTCLSCompat;
 import gregtech.api.util.GTChunkAssociatedData;
@@ -1918,9 +1919,11 @@ public class GTProxy implements IFuelHandler {
     public void onServerTickEvent(TickEvent.ServerTickEvent aEvent) {
         if (aEvent.side.isServer()) {
             if (aEvent.phase == TickEvent.Phase.START) {
+                RunnableMachineUpdate.onBeforeTickLockLocked();
                 TICK_LOCK.lock();
             } else {
                 TICK_LOCK.unlock();
+                RunnableMachineUpdate.onAfterTickLockReleased();
                 GTMusicSystem.ServerSystem.tick();
             }
         }


### PR DESCRIPTION
Whenever a casing block or any other block that could be a part of a GT multiblock gets placed or removed, a task is posted for background thread processing to recursively scan any attached multiblock component blocks and mark any found MTE for updating. If many such blocks are placed at the same time (ie via builders wand or automatic placing), a very large number of such tasks can be posted.

The task itself can effectively only work between ticks, so for servers with MSPT close to or above 50, each of these tasks can take a VERY long time to complete. There was a scenario on delta where structure checks were essentially disabled for hours after someone built an MDT using a builders wand. Not only can it cause delay, it can also cause memory buildup.

This PR will prevent the server from processing a new tick until all pending background checks have completed. This will make structure checks behave as intended and prevent the memory buildup, but at the cost of a potential lag spike. 

I intend to make a followup PR merging these tasks when they effectively check the same area.