### PR TITLE
Fix Maceration stack tooltip.

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/MTEIndustrialMacerator.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/MTEIndustrialMacerator.java
@@ -108,11 +108,11 @@ public class MTEIndustrialMacerator extends GTPPMultiBlockBase<MTEIndustrialMace
             .addController("Bottom center")
             .addCasingInfoMin("Maceration Stack Casings (After upgrade)", 26, false)
             .addCasingInfoMin("Stable Titanium Casings (Before upgrade)", 26, false)
-            .addInputBus("Bottom casing", 1)
+            .addInputBus("Any casing", 1)
             .addEnergyHatch("Any casing", 1)
             .addMaintenanceHatch("Any casing", 1)
-            .addOutputBus("One per layer except bottom layer", 2)
-            .addMufflerHatch("Any casing except bottom layer", 2)
+            .addOutputBus("Any casing", 1)
+            .addMufflerHatch("Any casing", 1)
             .toolTipFinisher();
         return tt;
     }


### PR DESCRIPTION
For a while (at least since 2.7.4) I/O hatches on the mac stack could go anywhere. This updates the tooltip to properly say that.

Thanks to @kohta on discord for pointing out the error.