### PR TITLE
Fix overclock calculator speed overflow

### DIFF
--- a/src/main/java/gregtech/api/util/OverclockCalculator.java
+++ b/src/main/java/gregtech/api/util/OverclockCalculator.java
@@ -483,6 +483,6 @@ public class OverclockCalculator {
             correctionMultiplier = 1 / criticalDuration;
         }
 
-        return Math.ceil(heatMultiplier * regularMultiplier * correctionMultiplier);
+        return Math.ceil(heatMultiplier * correctionMultiplier * regularMultiplier);
     }
 }


### PR DESCRIPTION
This line of code in OverclockCalculator could overflow, since it was int * int * double.
Changed it to int * double * int so it cant overflow anymore.

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20275