### PR TITLE
Adds recipe uses for Netherite and Prismatic combs

### DIFF
--- a/src/main/java/gregtech/loaders/postload/chains/NetheriteRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/chains/NetheriteRecipes.java
@@ -2,6 +2,7 @@ package gregtech.loaders.postload.chains;
 
 import static bartworks.API.recipe.BartWorksRecipeMaps.electricImplosionCompressorRecipes;
 import static gregtech.api.enums.Mods.EtFuturumRequiem;
+import static gregtech.api.enums.Mods.Forestry;
 import static gregtech.api.enums.Mods.ThaumicTinkerer;
 import static gregtech.api.recipe.RecipeMaps.*;
 import static gregtech.api.util.GTModHandler.getModItem;
@@ -35,6 +36,8 @@ import gregtech.api.recipe.metadata.CompressionTierKey;
 import gregtech.api.util.GTOreDictUnificator;
 import gregtech.api.util.GTRecipeConstants;
 import gregtech.api.util.GTUtility;
+import gregtech.common.items.CombType;
+import gregtech.loaders.misc.GTBees;
 import gtPlusPlus.core.material.MaterialMisc;
 import gtPlusPlus.core.util.minecraft.FluidUtils;
 import gtPlusPlus.xmod.gregtech.api.enums.GregtechItemList;
@@ -58,6 +61,18 @@ public class NetheriteRecipes {
                 .duration(15 * SECONDS)
                 .eut(TierEU.RECIPE_LuV)
                 .addTo(autoclaveRecipes);
+
+            if (Forestry.isModLoaded()) {
+                GTValues.RA.stdBuilder() // Prismarine + Comb
+                    .itemInputs(
+                        GregtechItemList.RedAlgaeBiomass.get(32),
+                        GTBees.combs.getStackForType(CombType.PRISMATIC, 32))
+                    .fluidInputs(Materials.Grade1PurifiedWater.getFluid(8000))
+                    .itemOutputs(GTOreDictUnificator.get(OrePrefixes.shard, MaterialsGTNH.Prismarine, 16))
+                    .duration(15 * SECONDS)
+                    .eut(TierEU.RECIPE_LuV)
+                    .addTo(autoclaveRecipes);
+            }
 
             GTValues.RA.stdBuilder() // Leaching
                 .itemInputs(GTOreDictUnificator.get(OrePrefixes.shard, MaterialsGTNH.Prismarine, 24))
@@ -359,6 +374,20 @@ public class NetheriteRecipes {
             .eut(TierEU.RECIPE_ZPM)
             .metadata(COIL_HEAT, 7500)
             .addTo(blastFurnaceRecipes);
+
+        if (Forestry.isModLoaded()) {
+            GTValues.RA.stdBuilder()
+                .itemInputs(
+                    ItemList.Netherite_Nanoparticles.get(1),
+                    GTBees.combs.getStackForType(CombType.NETHERITE, 32))
+                .fluidInputs(Materials.HellishMetal.getMolten(1 * INGOTS))
+                .itemOutputs(ItemList.Intensely_Bonded_Netherite_Nanoparticles.get(2))
+                .fluidOutputs(Materials.Thaumium.getMolten(2 * NUGGETS))
+                .duration(15 * SECONDS)
+                .eut(TierEU.RECIPE_ZPM)
+                .metadata(COIL_HEAT, 7500)
+                .addTo(blastFurnaceRecipes);
+        }
 
         NetheriteRecipes.addNetheriteParts();
     }


### PR DESCRIPTION
## Changes:
- Adds recipe for Netherite comb as a process aid for double output
- Adds recipe for Prismatic comb as a process aid for double output

In their current state the combs are otherwise useless, this brings them great purpose. This was ran past Noc ofc. 

### Netherite Comb Recipe:
<img width="329" height="378" alt="image" src="https://github.com/user-attachments/assets/d202e5e2-eae1-497a-b82a-c2104bcab0df" />

### Prismatic Comb Recipe:
<img width="341" height="389" alt="image" src="https://github.com/user-attachments/assets/9c179136-7ae3-4f25-9bb5-94a9f4250bc3" />

