### PR TITLE
fix incorrect oredicts for RecipeLoaderAgriculturalChem

### DIFF
--- a/src/main/java/gtPlusPlus/core/item/chemistry/RecipeLoaderAgriculturalChem.java
+++ b/src/main/java/gtPlusPlus/core/item/chemistry/RecipeLoaderAgriculturalChem.java
@@ -77,9 +77,9 @@ public class RecipeLoaderAgriculturalChem {
         processOreDict("listAllmeatraw", mMeats);
         processOreDict("listAllfishraw", mFish);
         processOreDict("listAllfruit", mFruits);
-        processOreDict("listAllVeggie", mVege);
+        processOreDict("listAllveggie", mVege);
         processOreDict("listAllnut", mNuts);
-        processOreDict("listAllSeed", mSeeds);
+        processOreDict("listAllseed", mSeeds);
         processOreDict("brickPeat", mPeat);
         processOreDict("bone", mBones);
         processOreDict("dustBone", mBoneMeal);


### PR DESCRIPTION
Here are the correct ore dict names for listAllveggie and listAllseed, However they didn't match up in 2.8.0-beta-1 resulting in lots of missing recipes for Fermentation Base in the Chemical Plant.

Here are the oredict entries taken from 2.8.0-beta-1.
<img width="469" height="344" alt="Screenshot 2025-07-18 183605" src="https://github.com/user-attachments/assets/77ce3659-ec3f-4c28-9db8-6d224ecfd1aa" />
<img width="409" height="190" alt="Screenshot 2025-07-18 183521" src="https://github.com/user-attachments/assets/d7043435-7035-4fa2-a49d-e1a239006c16" />
