### PR TITLE
Adds NC Circuit to Netherite Comb EBF Recipe

### DIFF
--- a/src/main/java/gregtech/loaders/postload/chains/NetheriteRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/chains/NetheriteRecipes.java
@@ -378,6 +378,7 @@ public class NetheriteRecipes {
         if (Forestry.isModLoaded()) {
             GTValues.RA.stdBuilder()
                 .itemInputs(
+                    GTUtility.getIntegratedCircuit(1),
                     ItemList.Netherite_Nanoparticles.get(1),
                     GTBees.combs.getStackForType(CombType.NETHERITE, 32))
                 .fluidInputs(Materials.HellishMetal.getMolten(1 * INGOTS))


### PR DESCRIPTION
## Changes:
- As title indicates, the current comb recipe was conflicting with the non-comb version, this will create a clear distinction.

### In-Game Photo:
<img width="330" height="274" alt="image" src="https://github.com/user-attachments/assets/c400b75e-36b9-4e0b-aaef-1575aa9dba3d" />
