### PR TITLE
Water > Distilled Water Distillery Recipe Tweak

### DIFF
--- a/src/main/java/gregtech/loaders/postload/recipes/DistilleryRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/DistilleryRecipes.java
@@ -97,11 +97,10 @@ public class DistilleryRecipes implements Runnable {
             .addTo(distilleryRecipes);
 
         GTValues.RA.stdBuilder()
-            .itemInputs(GTUtility.getIntegratedCircuit(5))
-            .fluidInputs(Materials.Water.getFluid(5))
-            .fluidOutputs(GTModHandler.getDistilledWater(5))
-            .duration(16 * TICKS)
-            .eut(10)
+            .fluidInputs(Materials.Water.getFluid(10))
+            .fluidOutputs(GTModHandler.getDistilledWater(10))
+            .duration(1 * SECONDS + 5 * TICKS)
+            .eut(8)
             .addTo(distilleryRecipes);
 
         GTValues.RA.stdBuilder()


### PR DESCRIPTION
Related Issue: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18746

Changes:

* Ghost Circuit 5 removed (Water has no other distillery recipes, ghost circuit is unneeded)
* 5L / 0.8s changed to 10L / 1.25s (or 6.25L/s to 8L/s)
* 10EU / t changed to 8EU / t (or 160EU to 200EU total EU cost)