### PR TITLE
add the "Energized Wireless Dynamo Hatch"

### DIFF
--- a/src/main/java/gregtech/api/enums/MetaTileEntityIDs.java
+++ b/src/main/java/gregtech/api/enums/MetaTileEntityIDs.java
@@ -1458,6 +1458,7 @@ public enum MetaTileEntityIDs {
     BETTER_JUKEBOX_HV(14303),
     BETTER_JUKEBOX_EV(14304),
     BETTER_JUKEBOX_IV(14305),
+    WIRELESS_DYNAMO_ENERGIZED(15040),
     EV4AWirelessEnergyHatch(15065),
     EV16AWirelessEnergyHatch(15066),
     EV64AWirelessEnergyHatch(15067),

--- a/src/main/java/tectech/loader/thing/MachineLoader.java
+++ b/src/main/java/tectech/loader/thing/MachineLoader.java
@@ -465,6 +465,7 @@ import static tectech.thing.CustomItemList.eM_dynamoTunnel8_UMV;
 import static tectech.thing.CustomItemList.eM_dynamoTunnel8_UXV;
 import static tectech.thing.CustomItemList.eM_dynamoTunnel9001;
 import static tectech.thing.CustomItemList.eM_dynamoTunnel9_UXV;
+import static tectech.thing.CustomItemList.eM_dynamoWirelessMulti;
 import static tectech.thing.CustomItemList.eM_energyMulti16_EV;
 import static tectech.thing.CustomItemList.eM_energyMulti16_IV;
 import static tectech.thing.CustomItemList.eM_energyMulti16_LuV;
@@ -637,6 +638,7 @@ import tectech.thing.metaTileEntity.hatch.MTEHatchWirelessComputationInput;
 import tectech.thing.metaTileEntity.hatch.MTEHatchWirelessComputationOutput;
 import tectech.thing.metaTileEntity.hatch.MTEHatchWirelessDataItemsInput;
 import tectech.thing.metaTileEntity.hatch.MTEHatchWirelessDataItemsOutput;
+import tectech.thing.metaTileEntity.hatch.MTEHatchWirelessDynamoMulti;
 import tectech.thing.metaTileEntity.hatch.MTEHatchWirelessMulti;
 import tectech.thing.metaTileEntity.multi.MTEActiveTransformer;
 import tectech.thing.metaTileEntity.multi.MTEDataBank;
@@ -1589,6 +1591,17 @@ public class MachineLoader implements Runnable {
                 "Legendary Laser Target Hatch",
                 13,
                 (int) V[13]).getStackForm(1L));
+
+        // ===================================================================================================
+        // Multi AMP Wireless OUTPUTS
+        // ===================================================================================================
+        eM_dynamoWirelessMulti.set(
+            new MTEHatchWirelessDynamoMulti(
+                MetaTileEntityIDs.WIRELESS_DYNAMO_ENERGIZED.ID,
+                "hatch.wireless.transmitter.energized.tier.12",
+                "Energized Wireless Dynamo Hatch",
+                12,
+                65536).getStackForm(1L));
 
         // ===================================================================================================
         // Multi AMP Power OUTPUTS

--- a/src/main/java/tectech/thing/CustomItemList.java
+++ b/src/main/java/tectech/thing/CustomItemList.java
@@ -135,7 +135,7 @@ public enum CustomItemList implements IItemContainer {
     eM_dynamoTunnel8_UXV,
     eM_dynamoTunnel9_UXV,
     eM_dynamoTunnel9001,
-
+    eM_dynamoWirelessMulti,
     eM_energyMulti4_EV,
     eM_energyMulti16_EV,
     eM_energyMulti64_EV,

--- a/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchWirelessDynamoMulti.java
+++ b/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchWirelessDynamoMulti.java
@@ -1,0 +1,137 @@
+package tectech.thing.metaTileEntity.hatch;
+
+import static com.gtnewhorizon.gtnhlib.util.AnimatedTooltipHandler.BOLD;
+import static com.gtnewhorizon.gtnhlib.util.AnimatedTooltipHandler.GRAY;
+import static com.gtnewhorizon.gtnhlib.util.AnimatedTooltipHandler.GREEN;
+import static com.gtnewhorizon.gtnhlib.util.AnimatedTooltipHandler.YELLOW;
+import static gregtech.api.enums.GTValues.AuthorColen;
+import static gregtech.api.enums.GTValues.V;
+import static gregtech.common.misc.WirelessNetworkManager.addEUToGlobalEnergyMap;
+import static gregtech.common.misc.WirelessNetworkManager.strongCheckOrAddUser;
+import static gregtech.common.misc.WirelessNetworkManager.ticks_between_energy_addition;
+import static net.minecraft.util.StatCollector.translateToLocal;
+
+import java.util.UUID;
+
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraftforge.common.util.ForgeDirection;
+
+import gregtech.api.interfaces.ITexture;
+import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
+import gregtech.api.metatileentity.MetaTileEntity;
+import gregtech.api.util.GTUtility;
+import tectech.thing.metaTileEntity.Textures;
+
+public class MTEHatchWirelessDynamoMulti extends MTEHatchDynamoMulti {
+
+    private UUID owner_uuid;
+
+    /***
+     * As opposed to the Energy Input equivalent, there is only one wireless dynamo multiamp.
+     * It has a maximum capacity of Long.MAX, meant to consolidate an LSC for power gen options.
+     * Takes in UMV amps 65k.
+     */
+    public MTEHatchWirelessDynamoMulti(int aID, String aName, String aNameRegional, int aTier, int aAmp) {
+        super(
+            aID,
+            aName,
+            aNameRegional,
+            aTier,
+            0,
+            new String[] { GRAY + "Stores energy globally in a network, up to 2^(2^31) EU.",
+                GRAY + "Does not connect to wires. This block accepts EU into the network.",
+                AuthorColen + GRAY + BOLD + " & " + GREEN + BOLD + "Chrom",
+                translateToLocal("gt.blockmachines.hatch.energytunnel.desc.1") + ": "
+                    + YELLOW
+                    + GTUtility.formatNumbers(aAmp * V[aTier])
+                    + GRAY
+                    + " EU/t" },
+            aAmp);
+    }
+
+    public MTEHatchWirelessDynamoMulti(String aName, int aTier, int aAmp, String[] aDescription,
+        ITexture[][][] aTextures) {
+        super(aName, aTier, aAmp, aDescription, aTextures);
+    }
+
+    @Override
+    public void saveNBTData(NBTTagCompound aNBT) {
+        super.saveNBTData(aNBT);
+        if (Amperes != maxAmperes) {
+            aNBT.setInteger("amperes", Amperes);
+        }
+    }
+
+    @Override
+    public void loadNBTData(NBTTagCompound aNBT) {
+        super.loadNBTData(aNBT);
+        int savedAmperes = aNBT.getInteger("amperes");
+        if (savedAmperes != 0) {
+            Amperes = savedAmperes;
+        }
+    }
+
+    @Override
+    public ITexture[] getTexturesActive(ITexture aBaseTexture) {
+        return new ITexture[] { aBaseTexture, Textures.OVERLAYS_ENERGY_IN_WIRELESS_LASER[mTier] };
+    }
+
+    @Override
+    public ITexture[] getTexturesInactive(ITexture aBaseTexture) {
+        return new ITexture[] { aBaseTexture, Textures.OVERLAYS_ENERGY_IN_WIRELESS_LASER[mTier] };
+    }
+
+    @Override
+    public boolean isEnetOutput() {
+        return false;
+    }
+
+    @Override
+    public long getMinimumStoredEU() {
+        return Amperes * V[mTier];
+    }
+
+    @Override
+    public long maxEUStore() {
+        return Long.MAX_VALUE;
+    }
+
+    @Override
+    public ConnectionType getConnectionType() {
+        return ConnectionType.WIRELESS;
+    }
+
+    @Override
+    public boolean isInputFacing(ForgeDirection side) {
+        return side == getBaseMetaTileEntity().getFrontFacing();
+    }
+
+    @Override
+    public MetaTileEntity newMetaEntity(IGregTechTileEntity aTileEntity) {
+        return new MTEHatchWirelessDynamoMulti(mName, mTier, Amperes, new String[] { "" }, mTextures);
+    }
+
+    @Override
+    public void onPreTick(IGregTechTileEntity aBaseMetaTileEntity, long aTick) {
+        super.onPreTick(aBaseMetaTileEntity, aTick);
+
+        if (aBaseMetaTileEntity.isServerSide()) {
+
+            // On first tick find the player name and attempt to add them to the map.
+            if (aTick == 1) {
+
+                // UUID and username of the owner.
+                owner_uuid = aBaseMetaTileEntity.getOwnerUuid();
+
+                strongCheckOrAddUser(owner_uuid);
+            }
+
+            // Every ticks_between_energy_addition ticks change the energy content of the machine.
+            if (aTick % ticks_between_energy_addition == 0L) {
+                addEUToGlobalEnergyMap(owner_uuid, getEUVar());
+                setEUVar(0L);
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
name subject to change.
A wireless dynamo hatch gated around UMV that has a throughput of umv 65k and a capacity of max long.

this will allow wireless dynamo hatches to be actually usable on late game power generation multis such as the LNR and the dyson

<img width="1360" height="335" alt="image" src="https://github.com/user-attachments/assets/d261f31b-c768-4062-9df0-b6730e9fce67" />
