### PR TITLE
Refactor `MTEBasicMachineWithRecipe`

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEBasicMachineWithRecipe.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEBasicMachineWithRecipe.java
@@ -1,16 +1,13 @@
 package gregtech.api.metatileentity.implementations;
 
 import static gregtech.api.enums.GTValues.V;
-import static gregtech.api.enums.GTValues.VN;
 import static gregtech.api.enums.GTValues.ticksBetweenSounds;
 import static gregtech.api.objects.XSTR.XSTR_INSTANCE;
-import static gregtech.api.util.GTRecipeBuilder.WILDCARD;
 import static net.minecraftforge.common.util.ForgeDirection.UP;
 
 import java.util.Locale;
 
 import net.minecraft.block.Block;
-import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.util.ForgeDirection;
@@ -21,9 +18,6 @@ import com.gtnewhorizons.modularui.api.drawable.UITexture;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
-import gregtech.api.enums.ItemList;
-import gregtech.api.enums.Materials;
-import gregtech.api.enums.OrePrefixes;
 import gregtech.api.enums.ParticleFX;
 import gregtech.api.enums.SoundResource;
 import gregtech.api.enums.Textures.BlockIcons.CustomIcon;
@@ -35,7 +29,6 @@ import gregtech.api.metatileentity.BaseMetaTileEntity;
 import gregtech.api.recipe.BasicUIProperties;
 import gregtech.api.recipe.RecipeMap;
 import gregtech.api.render.TextureFactory;
-import gregtech.api.util.ExternalMaterials;
 import gregtech.api.util.GTModHandler;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.WorldSpawnedEventBuilder.ParticleEventBuilder;
@@ -172,322 +165,7 @@ public class MTEBasicMachineWithRecipe extends MTEBasicMachine {
         this.progressBarTexture = mRecipes.getFrontend()
             .getUIProperties().progressBarTexture;
 
-        if (aRecipe == null) return;
-
-        // TODO: CHECK
-        for (int i = 3; i < aRecipe.length; i++) {
-            if (!(aRecipe[i] instanceof X)) continue;
-
-            // spotless:off
-            aRecipe[i] = switch ((X) aRecipe[i]) {
-                case CIRCUIT -> switch (this.mTier) {
-                    case  0 -> OrePrefixes.circuit.get(Materials.ULV);
-                    case  1 -> OrePrefixes.circuit.get(Materials.LV);
-                    case  2 -> OrePrefixes.circuit.get(Materials.MV);
-                    case  3 -> OrePrefixes.circuit.get(Materials.HV);
-                    case  4 -> OrePrefixes.circuit.get(Materials.EV);
-                    case  5 -> OrePrefixes.circuit.get(Materials.IV);
-                    case  6 -> OrePrefixes.circuit.get(Materials.LuV);
-                    case  7 -> OrePrefixes.circuit.get(Materials.ZPM);
-                    case  8 -> OrePrefixes.circuit.get(Materials.UV);
-                    default -> OrePrefixes.circuit.get(Materials.UHV);
-                };
-
-                case BETTER_CIRCUIT -> switch (this.mTier) {
-                    case  0 -> OrePrefixes.circuit.get(Materials.LV);
-                    case  1 -> OrePrefixes.circuit.get(Materials.MV);
-                    case  2 -> OrePrefixes.circuit.get(Materials.HV);
-                    case  3 -> OrePrefixes.circuit.get(Materials.EV);
-                    case  4 -> OrePrefixes.circuit.get(Materials.IV);
-                    case  5 -> OrePrefixes.circuit.get(Materials.LuV);
-                    case  6 -> OrePrefixes.circuit.get(Materials.ZPM);
-                    case  7 -> OrePrefixes.circuit.get(Materials.UV);
-                    default -> OrePrefixes.circuit.get(Materials.UHV);
-                };
-
-                case HULL -> switch (this.mTier) {
-                    case  0 -> ItemList.Hull_ULV;
-                    case  1 -> ItemList.Hull_LV;
-                    case  2 -> ItemList.Hull_MV;
-                    case  3 -> ItemList.Hull_HV;
-                    case  4 -> ItemList.Hull_EV;
-                    case  5 -> ItemList.Hull_IV;
-                    case  6 -> ItemList.Hull_LuV;
-                    case  7 -> ItemList.Hull_ZPM;
-                    case  8 -> ItemList.Hull_UV;
-                    default -> ItemList.Hull_MAX;
-                };
-
-                case WIRE -> switch (this.mTier) {
-                    case  0 -> OrePrefixes.cableGt01.get(Materials.Lead);
-                    case  1 -> OrePrefixes.cableGt01.get(Materials.Tin);
-                    case  2 -> OrePrefixes.cableGt01.get(Materials.AnyCopper);
-                    case  3 -> OrePrefixes.cableGt01.get(Materials.Gold);
-                    case  4 -> OrePrefixes.cableGt01.get(Materials.Aluminium);
-                    case  5 -> OrePrefixes.cableGt01.get(Materials.Platinum);
-                    case  6 -> OrePrefixes.cableGt01.get(Materials.NiobiumTitanium);
-                    case  7 -> OrePrefixes.cableGt01.get(Materials.Naquadah);
-                    case  8 -> OrePrefixes.cableGt04.get(Materials.NaquadahAlloy);
-                    default -> OrePrefixes.wireGt01.get(Materials.SuperconductorUHV);
-                };
-
-                case WIRE4 -> switch (this.mTier) {
-                    case  0 -> OrePrefixes.cableGt04.get(Materials.Lead);
-                    case  1 -> OrePrefixes.cableGt04.get(Materials.Tin);
-                    case  2 -> OrePrefixes.cableGt04.get(Materials.AnyCopper);
-                    case  3 -> OrePrefixes.cableGt04.get(Materials.Gold);
-                    case  4 -> OrePrefixes.cableGt04.get(Materials.Aluminium);
-                    case  5 -> OrePrefixes.cableGt04.get(Materials.Platinum);
-                    case  6 -> OrePrefixes.cableGt04.get(Materials.NiobiumTitanium);
-                    case  7 -> OrePrefixes.cableGt04.get(Materials.Naquadah);
-                    case  8 -> OrePrefixes.wireGt01.get(Materials.SuperconductorUHV);
-                    default -> OrePrefixes.wireGt04.get(Materials.SuperconductorUHV);
-                };
-
-                case STICK_DISTILLATION -> OrePrefixes.stick.get(Materials.Blaze);
-
-                case GLASS -> switch (this.mTier) {
-                    case 0, 1, 2, 3    -> new ItemStack(Blocks.glass, 1, WILDCARD);
-                    case 4, 5, 6, 7, 8 -> "blockGlass" + VN[aTier];
-                    default            -> "blockGlass" + VN[8];
-                };
-
-                case PLATE -> switch (this.mTier) {
-                    case 0, 1 -> OrePrefixes.plate.get(Materials.Steel);
-                    case 2    -> OrePrefixes.plate.get(Materials.Aluminium);
-                    case 3    -> OrePrefixes.plate.get(Materials.StainlessSteel);
-                    case 4    -> OrePrefixes.plate.get(Materials.Titanium);
-                    case 5    -> OrePrefixes.plate.get(Materials.TungstenSteel);
-                    case 6    -> OrePrefixes.plate.get(Materials.HSSG);
-                    case 7    -> OrePrefixes.plate.get(Materials.HSSE);
-                    default   -> OrePrefixes.plate.get(Materials.Neutronium);
-                };
-
-                case PIPE -> switch (this.mTier) {
-                    case 0, 1 -> OrePrefixes.pipeMedium.get(Materials.Bronze);
-                    case 2    -> OrePrefixes.pipeMedium.get(Materials.Steel);
-                    case 3    -> OrePrefixes.pipeMedium.get(Materials.StainlessSteel);
-                    case 4    -> OrePrefixes.pipeMedium.get(Materials.Titanium);
-                    case 5    -> OrePrefixes.pipeMedium.get(Materials.TungstenSteel);
-                    case 6    -> OrePrefixes.pipeSmall.get(Materials.Ultimate);
-                    case 7    -> OrePrefixes.pipeMedium.get(Materials.Ultimate);
-                    case 8    -> OrePrefixes.pipeLarge.get(Materials.Ultimate);
-                    default   -> OrePrefixes.pipeHuge.get(Materials.Ultimate);
-                };
-
-                case COIL_HEATING -> switch (this.mTier) {
-                    case 0, 1 -> OrePrefixes.wireGt02.get(Materials.AnyCopper);
-                    case 2    -> OrePrefixes.wireGt02.get(Materials.Cupronickel);
-                    case 3    -> OrePrefixes.wireGt02.get(Materials.Kanthal);
-                    case 4    -> OrePrefixes.wireGt02.get(Materials.Nichrome);
-                    case 5    -> OrePrefixes.wireGt02.get(Materials.TPV);
-                    case 6    -> OrePrefixes.wireGt02.get(Materials.HSSG);
-                    case 7    -> OrePrefixes.wireGt02.get(Materials.Naquadah);
-                    case 8    -> OrePrefixes.wireGt02.get(Materials.NaquadahAlloy);
-                    case 9    -> OrePrefixes.wireGt04.get(Materials.NaquadahAlloy);
-                    default   -> OrePrefixes.wireGt08.get(Materials.NaquadahAlloy);
-                };
-
-                case COIL_HEATING_DOUBLE -> switch (this.mTier) {
-                    case 0, 1 -> OrePrefixes.wireGt04.get(Materials.AnyCopper);
-                    case 2    -> OrePrefixes.wireGt04.get(Materials.Cupronickel);
-                    case 3    -> OrePrefixes.wireGt04.get(Materials.Kanthal);
-                    case 4    -> OrePrefixes.wireGt04.get(Materials.Nichrome);
-                    case 5    -> OrePrefixes.wireGt04.get(Materials.TPV);
-                    case 6    -> OrePrefixes.wireGt04.get(Materials.HSSG);
-                    case 7    -> OrePrefixes.wireGt04.get(Materials.Naquadah);
-                    case 8    -> OrePrefixes.wireGt04.get(Materials.NaquadahAlloy);
-                    case 9    -> OrePrefixes.wireGt08.get(Materials.NaquadahAlloy);
-                    default   -> OrePrefixes.wireGt16.get(Materials.NaquadahAlloy);
-                };
-
-                case STICK_MAGNETIC -> switch (this.mTier) {
-                    case 0, 1       -> OrePrefixes.stick.get(Materials.IronMagnetic);
-                    case 2, 3       -> OrePrefixes.stick.get(Materials.SteelMagnetic);
-                    case 4, 5       -> OrePrefixes.stick.get(Materials.NeodymiumMagnetic);
-                    case 6, 7, 8, 9 -> OrePrefixes.stick.get(Materials.SamariumMagnetic);
-                    default         -> OrePrefixes.stick.get(Materials.TengamAttuned);
-                };
-
-                case STICK_ELECTROMAGNETIC -> switch (this.mTier) {
-                    case 0, 1 -> OrePrefixes.stick.get(Materials.AnyIron);
-                    case 2, 3 -> OrePrefixes.stick.get(Materials.Steel);
-                    case 4    -> OrePrefixes.stick.get(Materials.Neodymium);
-                    default   -> OrePrefixes.stick.get(Materials.VanadiumGallium);
-                };
-
-                case COIL_ELECTRIC -> switch (this.mTier) {
-                    case 0  -> OrePrefixes.wireGt01.get(Materials.Lead);
-                    case 1  -> OrePrefixes.wireGt02.get(Materials.Tin);
-                    case 2  -> OrePrefixes.wireGt02.get(Materials.AnyCopper);
-                    case 3  -> OrePrefixes.wireGt04.get(Materials.AnyCopper);
-                    case 4  -> OrePrefixes.wireGt08.get(Materials.AnnealedCopper);
-                    case 5  -> OrePrefixes.wireGt16.get(Materials.AnnealedCopper);
-                    case 6  -> OrePrefixes.wireGt04.get(Materials.YttriumBariumCuprate);
-                    case 7  -> OrePrefixes.wireGt08.get(Materials.Iridium);
-                    default -> OrePrefixes.wireGt16.get(Materials.Osmium);
-                };
-
-                case ROBOT_ARM -> switch (this.mTier) {
-                    case 0, 1 -> ItemList.Robot_Arm_LV;
-                    case 2    -> ItemList.Robot_Arm_MV;
-                    case 3    -> ItemList.Robot_Arm_HV;
-                    case 4    -> ItemList.Robot_Arm_EV;
-                    case 5    -> ItemList.Robot_Arm_IV;
-                    case 6    -> ItemList.Robot_Arm_LuV;
-                    case 7    -> ItemList.Robot_Arm_ZPM;
-                    case 8    -> ItemList.Robot_Arm_UV;
-                    case 9    -> ItemList.Robot_Arm_UHV;
-                    case 10   -> ItemList.Robot_Arm_UEV;
-                    case 11   -> ItemList.Robot_Arm_UIV;
-                    case 12   -> ItemList.Robot_Arm_UMV;
-                    case 13   -> ItemList.Robot_Arm_UXV;
-                    default   ->  ItemList.Robot_Arm_MAX;
-                };
-
-                case PUMP -> switch (this.mTier) {
-                    case 0, 1 -> ItemList.Electric_Pump_LV;
-                    case 2    -> ItemList.Electric_Pump_MV;
-                    case 3    -> ItemList.Electric_Pump_HV;
-                    case 4    -> ItemList.Electric_Pump_EV;
-                    case 5    -> ItemList.Electric_Pump_IV;
-                    case 6    -> ItemList.Electric_Pump_LuV;
-                    case 7    -> ItemList.Electric_Pump_ZPM;
-                    case 8    -> ItemList.Electric_Pump_UV;
-                    case 9    -> ItemList.Electric_Pump_UHV;
-                    case 10   -> ItemList.Electric_Pump_UEV;
-                    case 11   -> ItemList.Electric_Pump_UIV;
-                    case 12   -> ItemList.Electric_Pump_UMV;
-                    case 13   -> ItemList.Electric_Pump_UXV;
-                    default   -> ItemList.Electric_Pump_MAX;
-                };
-
-                case MOTOR -> switch (this.mTier) {
-                    case 0, 1 -> ItemList.Electric_Motor_LV;
-                    case 2    -> ItemList.Electric_Motor_MV;
-                    case 3    -> ItemList.Electric_Motor_HV;
-                    case 4    -> ItemList.Electric_Motor_EV;
-                    case 5    -> ItemList.Electric_Motor_IV;
-                    case 6    -> ItemList.Electric_Motor_LuV;
-                    case 7    -> ItemList.Electric_Motor_ZPM;
-                    case 8    -> ItemList.Electric_Motor_UV;
-                    case 9    -> ItemList.Electric_Motor_UHV;
-                    case 10   -> ItemList.Electric_Motor_UEV;
-                    case 11   -> ItemList.Electric_Motor_UIV;
-                    case 12   -> ItemList.Electric_Motor_UMV;
-                    case 13   -> ItemList.Electric_Motor_UXV;
-                    default   -> ItemList.Electric_Motor_MAX;
-                };
-
-                case PISTON -> switch (this.mTier) {
-                    case 0, 1 -> ItemList.Electric_Piston_LV;
-                    case 2    -> ItemList.Electric_Piston_MV;
-                    case 3    -> ItemList.Electric_Piston_HV;
-                    case 4    -> ItemList.Electric_Piston_EV;
-                    case 5    -> ItemList.Electric_Piston_IV;
-                    case 6    -> ItemList.Electric_Piston_LuV;
-                    case 7    -> ItemList.Electric_Piston_ZPM;
-                    case 8    -> ItemList.Electric_Piston_UV;
-                    case 9    -> ItemList.Electric_Piston_UHV;
-                    case 10   -> ItemList.Electric_Piston_UEV;
-                    case 11   -> ItemList.Electric_Piston_UIV;
-                    case 12   -> ItemList.Electric_Piston_UMV;
-                    case 13   -> ItemList.Electric_Piston_UXV;
-                    default   -> ItemList.Electric_Piston_MAX;
-                };
-
-                case CONVEYOR -> switch (this.mTier) {
-                    case 0, 1 -> ItemList.Conveyor_Module_LV;
-                    case 2    -> ItemList.Conveyor_Module_MV;
-                    case 3    -> ItemList.Conveyor_Module_HV;
-                    case 4    -> ItemList.Conveyor_Module_EV;
-                    case 5    -> ItemList.Conveyor_Module_IV;
-                    case 6    -> ItemList.Conveyor_Module_LuV;
-                    case 7    -> ItemList.Conveyor_Module_ZPM;
-                    case 8    -> ItemList.Conveyor_Module_UV;
-                    case 9    -> ItemList.Conveyor_Module_UHV;
-                    case 10   -> ItemList.Conveyor_Module_UEV;
-                    case 11   -> ItemList.Conveyor_Module_UIV;
-                    case 12   -> ItemList.Conveyor_Module_UMV;
-                    case 13   -> ItemList.Conveyor_Module_UXV;
-                    default   -> ItemList.Conveyor_Module_MAX;
-                };
-
-                case EMITTER -> switch (this.mTier) {
-                    case 0, 1 -> ItemList.Emitter_LV;
-                    case 2    -> ItemList.Emitter_MV;
-                    case 3    -> ItemList.Emitter_HV;
-                    case 4    -> ItemList.Emitter_EV;
-                    case 5    -> ItemList.Emitter_IV;
-                    case 6    -> ItemList.Emitter_LuV;
-                    case 7    -> ItemList.Emitter_ZPM;
-                    case 8    -> ItemList.Emitter_UV;
-                    case 9    -> ItemList.Emitter_UHV;
-                    case 10   -> ItemList.Emitter_UEV;
-                    case 11   -> ItemList.Emitter_UIV;
-                    case 12   -> ItemList.Emitter_UMV;
-                    case 13   -> ItemList.Emitter_UXV;
-                    default   -> ItemList.Emitter_MAX;
-                };
-
-                case SENSOR -> switch (this.mTier) {
-                    case 0, 1 -> ItemList.Sensor_LV;
-                    case 2    -> ItemList.Sensor_MV;
-                    case 3    -> ItemList.Sensor_HV;
-                    case 4    -> ItemList.Sensor_EV;
-                    case 5    -> ItemList.Sensor_IV;
-                    case 6    -> ItemList.Sensor_LuV;
-                    case 7    -> ItemList.Sensor_ZPM;
-                    case 8    -> ItemList.Sensor_UV;
-                    case 9    -> ItemList.Sensor_UHV;
-                    case 10   -> ItemList.Sensor_UEV;
-                    case 11   -> ItemList.Sensor_UIV;
-                    case 12   -> ItemList.Sensor_UMV;
-                    case 13   -> ItemList.Sensor_UXV;
-                    default   -> ItemList.Sensor_MAX;
-                };
-
-                case FIELD_GENERATOR -> switch (this.mTier) {
-                    case 0, 1 -> ItemList.Field_Generator_LV;
-                    case 2    -> ItemList.Field_Generator_MV;
-                    case 3    -> ItemList.Field_Generator_HV;
-                    case 4    -> ItemList.Field_Generator_EV;
-                    case 5    -> ItemList.Field_Generator_IV;
-                    case 6    -> ItemList.Field_Generator_LuV;
-                    case 7    -> ItemList.Field_Generator_ZPM;
-                    case 8    -> ItemList.Field_Generator_UV;
-                    case 9    -> ItemList.Field_Generator_UHV;
-                    case 10   -> ItemList.Field_Generator_UEV;
-                    case 11   -> ItemList.Field_Generator_UIV;
-                    case 12   -> ItemList.Field_Generator_UMV;
-                    case 13   -> ItemList.Field_Generator_UXV;
-                    default   -> ItemList.Field_Generator_MAX;
-                };
-
-                case ROTOR -> switch (this.mTier) {
-                    case 0, 1 -> OrePrefixes.rotor.get(Materials.Tin);
-                    case 2    -> OrePrefixes.rotor.get(Materials.Bronze);
-                    case 3    -> OrePrefixes.rotor.get(Materials.Steel);
-                    case 4    -> OrePrefixes.rotor.get(Materials.StainlessSteel);
-                    case 5    -> OrePrefixes.rotor.get(Materials.TungstenSteel);
-                    case 6    -> OrePrefixes.rotor.get(ExternalMaterials.getRhodiumPlatedPalladium());
-                    case 7    -> OrePrefixes.rotor.get(Materials.Iridium);
-                    default   -> OrePrefixes.rotor.get(Materials.Osmium);
-                };
-
-                default -> throw new IllegalArgumentException("MISSING TIER MAPPING FOR: " + aRecipe[i] + " AT TIER " + this.mTier);
-            };
-            // spotless:on
-        }
-
-        if (!GTModHandler.addCraftingRecipe(
-            getStackForm(1),
-            GTModHandler.RecipeBits.DISMANTLEABLE | GTModHandler.RecipeBits.BUFFERED
-                | GTModHandler.RecipeBits.NOT_REMOVABLE
-                | GTModHandler.RecipeBits.REVERSIBLE,
-            aRecipe)) {
-            throw new IllegalArgumentException("INVALID CRAFTING RECIPE FOR: " + getStackForm(1).getDisplayName());
-        }
+        GTModHandler.addMachineCraftingRecipe(getStackForm(1), aRecipe, this.mTier);
     }
 
     /**

--- a/src/main/java/gregtech/api/util/GTModHandler.java
+++ b/src/main/java/gregtech/api/util/GTModHandler.java
@@ -28,8 +28,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import javax.annotation.Nullable;
-
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
@@ -51,6 +49,8 @@ import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.oredict.ShapedOreRecipe;
 import net.minecraftforge.oredict.ShapelessOreRecipe;
+
+import org.jetbrains.annotations.Nullable;
 
 import cpw.mods.fml.common.registry.GameRegistry;
 import gregtech.api.GregTechAPI;
@@ -583,9 +583,13 @@ public class GTModHandler {
             aRecipe);
     }
 
-    public static boolean addMachineCraftingRecipe(ItemStack aResult, long aBitMask, Object[] aRecipe,
+    public static void addMachineCraftingRecipe(ItemStack aResult, Object @Nullable [] aRecipe, int machineTier) {
+        addMachineCraftingRecipe(aResult, RecipeBits.BITSD, aRecipe, machineTier);
+    }
+
+    public static void addMachineCraftingRecipe(ItemStack aResult, long aBitMask, Object @Nullable [] aRecipe,
         int machineTier) {
-        if (aRecipe == null) return true;
+        if (aRecipe == null) return;
 
         for (int i = 3; i < aRecipe.length; i++) {
             if (!(aRecipe[i] instanceof MTEBasicMachineWithRecipe.X)) continue;
@@ -892,15 +896,9 @@ public class GTModHandler {
             // spotless:on
         }
 
-        if (!GTModHandler.addCraftingRecipe(
-            aResult,
-            GTModHandler.RecipeBits.DISMANTLEABLE | GTModHandler.RecipeBits.BUFFERED
-                | GTModHandler.RecipeBits.NOT_REMOVABLE
-                | GTModHandler.RecipeBits.REVERSIBLE,
-            aRecipe)) {
+        if (!GTModHandler.addCraftingRecipe(aResult, aBitMask, aRecipe)) {
             throw new IllegalArgumentException("INVALID CRAFTING RECIPE FOR: " + aResult.getDisplayName());
         }
-        return true;
     }
 
     /**

--- a/src/main/java/gregtech/loaders/load/MTERecipeLoader.java
+++ b/src/main/java/gregtech/loaders/load/MTERecipeLoader.java
@@ -46,10 +46,6 @@ public class MTERecipeLoader implements Runnable {
     private static final String aTextMotorWire = "EWE";
     private static final String aTextWirePump = "WPW";
 
-    private static final long bits = GTModHandler.RecipeBits.NOT_REMOVABLE | GTModHandler.RecipeBits.REVERSIBLE
-        | GTModHandler.RecipeBits.BUFFERED;
-    private static final long bitsd = GTModHandler.RecipeBits.DISMANTLEABLE | bits;
-
     private static void registerMachineTypes() {
         registerAlloySmelter();
         registerArcFurnace();
@@ -98,7 +94,6 @@ public class MTERecipeLoader implements Runnable {
     private static void registerAlloySmelter() {
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_LV_AlloySmelter.get(1),
-            bitsd,
             new Object[] { "ECE", aTextCableHull, aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'C',
                 MTEBasicMachineWithRecipe.X.COIL_HEATING_DOUBLE },
@@ -106,7 +101,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_MV_AlloySmelter.get(1),
-            bitsd,
             new Object[] { "ECE", aTextCableHull, aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'C',
                 MTEBasicMachineWithRecipe.X.COIL_HEATING_DOUBLE },
@@ -114,7 +108,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_HV_AlloySmelter.get(1),
-            bitsd,
             new Object[] { "ECE", aTextCableHull, aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'C',
                 MTEBasicMachineWithRecipe.X.COIL_HEATING_DOUBLE },
@@ -122,7 +115,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_EV_AlloySmelter.get(1),
-            bitsd,
             new Object[] { "ECE", aTextCableHull, aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'C',
                 MTEBasicMachineWithRecipe.X.COIL_HEATING_DOUBLE },
@@ -130,7 +122,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_IV_AlloySmelter.get(1),
-            bitsd,
             new Object[] { "ECE", aTextCableHull, aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'C',
                 MTEBasicMachineWithRecipe.X.COIL_HEATING_DOUBLE },
@@ -141,7 +132,6 @@ public class MTERecipeLoader implements Runnable {
     private static void registerArcFurnace() {
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_LV_ArcFurnace.get(1),
-            bitsd,
             new Object[] { "WGW", aTextCableHull, aTextPlate, 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PLATE, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE4, 'G', OrePrefixes.cell.get(Materials.Graphite) },
@@ -149,7 +139,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_MV_ArcFurnace.get(1),
-            bitsd,
             new Object[] { "WGW", aTextCableHull, aTextPlate, 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PLATE, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE4, 'G', OrePrefixes.cell.get(Materials.Graphite) },
@@ -157,7 +146,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_HV_ArcFurnace.get(1),
-            bitsd,
             new Object[] { "WGW", aTextCableHull, aTextPlate, 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PLATE, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE4, 'G', OrePrefixes.cell.get(Materials.Graphite) },
@@ -165,7 +153,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_EV_ArcFurnace.get(1),
-            bitsd,
             new Object[] { "WGW", aTextCableHull, aTextPlate, 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PLATE, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE4, 'G', OrePrefixes.cell.get(Materials.Graphite) },
@@ -173,7 +160,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_IV_ArcFurnace.get(1),
-            bitsd,
             new Object[] { "WGW", aTextCableHull, aTextPlate, 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PLATE, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE4, 'G', OrePrefixes.cell.get(Materials.Graphite) },
@@ -184,7 +170,6 @@ public class MTERecipeLoader implements Runnable {
     private static void registerAssembler() {
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_LV_Assembler.get(1),
-            bitsd,
             new Object[] { "ACA", "VMV", aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'V',
                 MTEBasicMachineWithRecipe.X.CONVEYOR, 'A', MTEBasicMachineWithRecipe.X.ROBOT_ARM, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE },
@@ -192,7 +177,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_MV_Assembler.get(1),
-            bitsd,
             new Object[] { "ACA", "VMV", aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'V',
                 MTEBasicMachineWithRecipe.X.CONVEYOR, 'A', MTEBasicMachineWithRecipe.X.ROBOT_ARM, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE },
@@ -200,7 +184,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_HV_Assembler.get(1),
-            bitsd,
             new Object[] { "ACA", "VMV", aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'V',
                 MTEBasicMachineWithRecipe.X.CONVEYOR, 'A', MTEBasicMachineWithRecipe.X.ROBOT_ARM, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE },
@@ -208,7 +191,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_EV_Assembler.get(1),
-            bitsd,
             new Object[] { "ACA", "VMV", aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'V',
                 MTEBasicMachineWithRecipe.X.CONVEYOR, 'A', MTEBasicMachineWithRecipe.X.ROBOT_ARM, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE },
@@ -216,7 +198,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_IV_Assembler.get(1),
-            bitsd,
             new Object[] { "ACA", "VMV", aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'V',
                 MTEBasicMachineWithRecipe.X.CONVEYOR, 'A', MTEBasicMachineWithRecipe.X.ROBOT_ARM, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE },
@@ -226,7 +207,6 @@ public class MTERecipeLoader implements Runnable {
     private static void registerAutoclave() {
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_LV_Autoclave.get(1),
-            bitsd,
             new Object[] { "IGI", "IMI", "CPC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PUMP, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE, 'I', MTEBasicMachineWithRecipe.X.PLATE, 'G',
@@ -235,7 +215,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_MV_Autoclave.get(1),
-            bitsd,
             new Object[] { "IGI", "IMI", "CPC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PUMP, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE, 'I', MTEBasicMachineWithRecipe.X.PLATE, 'G',
@@ -244,7 +223,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_HV_Autoclave.get(1),
-            bitsd,
             new Object[] { "IGI", "IMI", "CPC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PUMP, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE, 'I', MTEBasicMachineWithRecipe.X.PLATE, 'G',
@@ -253,7 +231,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_EV_Autoclave.get(1),
-            bitsd,
             new Object[] { "IGI", "IMI", "CPC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PUMP, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE, 'I', MTEBasicMachineWithRecipe.X.PLATE, 'G',
@@ -262,7 +239,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_IV_Autoclave.get(1),
-            bitsd,
             new Object[] { "IGI", "IMI", "CPC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PUMP, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE, 'I', MTEBasicMachineWithRecipe.X.PLATE, 'G',
@@ -274,7 +250,6 @@ public class MTERecipeLoader implements Runnable {
     private static void registerBendingMachine() {
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_LV_Bender.get(1),
-            bitsd,
             new Object[] { aTextPlateWrench, aTextCableHull, aTextMotorWire, 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE },
@@ -282,7 +257,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_MV_Bender.get(1),
-            bitsd,
             new Object[] { aTextPlateWrench, aTextCableHull, aTextMotorWire, 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE },
@@ -290,7 +264,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_HV_Bender.get(1),
-            bitsd,
             new Object[] { aTextPlateWrench, aTextCableHull, aTextMotorWire, 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE },
@@ -298,7 +271,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_EV_Bender.get(1),
-            bitsd,
             new Object[] { aTextPlateWrench, aTextCableHull, aTextMotorWire, 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE },
@@ -306,7 +278,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_IV_Bender.get(1),
-            bitsd,
             new Object[] { aTextPlateWrench, aTextCableHull, aTextMotorWire, 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE },
@@ -316,7 +287,6 @@ public class MTERecipeLoader implements Runnable {
     private static void registerCanner() {
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_LV_Canner.get(1),
-            bitsd,
             new Object[] { aTextWirePump, aTextCableHull, "GGG", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PUMP, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE, 'G', MTEBasicMachineWithRecipe.X.GLASS },
@@ -324,7 +294,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_MV_Canner.get(1),
-            bitsd,
             new Object[] { aTextWirePump, aTextCableHull, "GGG", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PUMP, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE, 'G', MTEBasicMachineWithRecipe.X.GLASS },
@@ -332,7 +301,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_HV_Canner.get(1),
-            bitsd,
             new Object[] { aTextWirePump, aTextCableHull, "GGG", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PUMP, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE, 'G', MTEBasicMachineWithRecipe.X.GLASS },
@@ -340,7 +308,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_EV_Canner.get(1),
-            bitsd,
             new Object[] { aTextWirePump, aTextCableHull, "GGG", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PUMP, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE, 'G', MTEBasicMachineWithRecipe.X.GLASS },
@@ -348,7 +315,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_IV_Canner.get(1),
-            bitsd,
             new Object[] { aTextWirePump, aTextCableHull, "GGG", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PUMP, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE, 'G', MTEBasicMachineWithRecipe.X.GLASS },
@@ -358,7 +324,6 @@ public class MTERecipeLoader implements Runnable {
     private static void registerCentrifuge() {
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_LV_Centrifuge.get(1),
-            bitsd,
             new Object[] { "CEC", aTextWireHull, "CEC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE },
@@ -366,7 +331,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_MV_Centrifuge.get(1),
-            bitsd,
             new Object[] { "CEC", aTextWireHull, "CEC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE },
@@ -374,7 +338,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_HV_Centrifuge.get(1),
-            bitsd,
             new Object[] { "CEC", aTextWireHull, "CEC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE },
@@ -382,7 +345,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_EV_Centrifuge.get(1),
-            bitsd,
             new Object[] { "CEC", aTextWireHull, "CEC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE },
@@ -390,7 +352,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_IV_Centrifuge.get(1),
-            bitsd,
             new Object[] { "CEC", aTextWireHull, "CEC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE },
@@ -400,7 +361,6 @@ public class MTERecipeLoader implements Runnable {
     private static void registerChemicalBath() {
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_LV_ChemicalBath.get(1),
-            bitsd,
             new Object[] { "VGW", "PGV", aTextCableHull, 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PUMP, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'G',
@@ -409,7 +369,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_MV_ChemicalBath.get(1),
-            bitsd,
             new Object[] { "VGW", "PGV", aTextCableHull, 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PUMP, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'G',
@@ -418,7 +377,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_HV_ChemicalBath.get(1),
-            bitsd,
             new Object[] { "VGW", "PGV", aTextCableHull, 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PUMP, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'G',
@@ -427,7 +385,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_EV_ChemicalBath.get(1),
-            bitsd,
             new Object[] { "VGW", "PGV", aTextCableHull, 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PUMP, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'G',
@@ -436,7 +393,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_IV_ChemicalBath.get(1),
-            bitsd,
             new Object[] { "VGW", "PGV", aTextCableHull, 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PUMP, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'G',
@@ -448,7 +404,6 @@ public class MTERecipeLoader implements Runnable {
     private static void registerChemicalReactor() {
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_LV_ChemicalReactor.get(1),
-            bitsd,
             new Object[] { "GRG", "WEW", aTextCableHull, 'M', MTEBasicMachineWithRecipe.X.HULL, 'R',
                 MTEBasicMachineWithRecipe.X.ROTOR, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'G',
@@ -457,7 +412,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_MV_ChemicalReactor.get(1),
-            bitsd,
             new Object[] { "GRG", "WEW", aTextCableHull, 'M', MTEBasicMachineWithRecipe.X.HULL, 'R',
                 MTEBasicMachineWithRecipe.X.ROTOR, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'G',
@@ -466,7 +420,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_HV_ChemicalReactor.get(1),
-            bitsd,
             new Object[] { "GRG", "WEW", aTextCableHull, 'M', MTEBasicMachineWithRecipe.X.HULL, 'R',
                 MTEBasicMachineWithRecipe.X.ROTOR, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'G',
@@ -475,7 +428,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_EV_ChemicalReactor.get(1),
-            bitsd,
             new Object[] { "GRG", "WEW", aTextCableHull, 'M', MTEBasicMachineWithRecipe.X.HULL, 'R',
                 MTEBasicMachineWithRecipe.X.ROTOR, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'G',
@@ -484,7 +436,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_IV_ChemicalReactor.get(1),
-            bitsd,
             new Object[] { "GRG", "WEW", aTextCableHull, 'M', MTEBasicMachineWithRecipe.X.HULL, 'R',
                 MTEBasicMachineWithRecipe.X.ROTOR, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'G',
@@ -495,7 +446,6 @@ public class MTERecipeLoader implements Runnable {
     private static void registerCircuitAssembler() {
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_LV_CircuitAssembler.get(1),
-            bitsd,
             new Object[] { "ACE", "VMV", aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'V',
                 MTEBasicMachineWithRecipe.X.CONVEYOR, 'A', MTEBasicMachineWithRecipe.X.ROBOT_ARM, 'C',
                 MTEBasicMachineWithRecipe.X.BETTER_CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'E',
@@ -504,7 +454,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_MV_CircuitAssembler.get(1),
-            bitsd,
             new Object[] { "ACE", "VMV", aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'V',
                 MTEBasicMachineWithRecipe.X.CONVEYOR, 'A', MTEBasicMachineWithRecipe.X.ROBOT_ARM, 'C',
                 MTEBasicMachineWithRecipe.X.BETTER_CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'E',
@@ -513,7 +462,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_HV_CircuitAssembler.get(1),
-            bitsd,
             new Object[] { "ACE", "VMV", aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'V',
                 MTEBasicMachineWithRecipe.X.CONVEYOR, 'A', MTEBasicMachineWithRecipe.X.ROBOT_ARM, 'C',
                 MTEBasicMachineWithRecipe.X.BETTER_CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'E',
@@ -522,7 +470,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_EV_CircuitAssembler.get(1),
-            bitsd,
             new Object[] { "ACE", "VMV", aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'V',
                 MTEBasicMachineWithRecipe.X.CONVEYOR, 'A', MTEBasicMachineWithRecipe.X.ROBOT_ARM, 'C',
                 MTEBasicMachineWithRecipe.X.BETTER_CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'E',
@@ -531,7 +478,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_IV_CircuitAssembler.get(1),
-            bitsd,
             new Object[] { "ACE", "VMV", aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'V',
                 MTEBasicMachineWithRecipe.X.CONVEYOR, 'A', MTEBasicMachineWithRecipe.X.ROBOT_ARM, 'C',
                 MTEBasicMachineWithRecipe.X.BETTER_CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'E',
@@ -540,7 +486,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_LuV_CircuitAssembler.get(1),
-            bitsd,
             new Object[] { "ACE", "VMV", aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'V',
                 MTEBasicMachineWithRecipe.X.CONVEYOR, 'A', MTEBasicMachineWithRecipe.X.ROBOT_ARM, 'C',
                 MTEBasicMachineWithRecipe.X.BETTER_CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'E',
@@ -549,7 +494,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_ZPM_CircuitAssembler.get(1),
-            bitsd,
             new Object[] { "ACE", "VMV", aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'V',
                 MTEBasicMachineWithRecipe.X.CONVEYOR, 'A', MTEBasicMachineWithRecipe.X.ROBOT_ARM, 'C',
                 MTEBasicMachineWithRecipe.X.BETTER_CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'E',
@@ -558,7 +502,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_UV_CircuitAssembler.get(1),
-            bitsd,
             new Object[] { "ACE", "VMV", aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'V',
                 MTEBasicMachineWithRecipe.X.CONVEYOR, 'A', MTEBasicMachineWithRecipe.X.ROBOT_ARM, 'C',
                 MTEBasicMachineWithRecipe.X.BETTER_CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'E',
@@ -570,7 +513,6 @@ public class MTERecipeLoader implements Runnable {
     private static void registerCompressor() {
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_LV_Compressor.get(1),
-            bitsd,
             new Object[] { aTextWireCoil, aTextPlateMotor, aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PISTON, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE },
@@ -578,7 +520,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_MV_Compressor.get(1),
-            bitsd,
             new Object[] { aTextWireCoil, aTextPlateMotor, aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PISTON, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE },
@@ -586,7 +527,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_HV_Compressor.get(1),
-            bitsd,
             new Object[] { aTextWireCoil, aTextPlateMotor, aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PISTON, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE },
@@ -594,7 +534,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_EV_Compressor.get(1),
-            bitsd,
             new Object[] { aTextWireCoil, aTextPlateMotor, aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PISTON, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE },
@@ -602,7 +541,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_IV_Compressor.get(1),
-            bitsd,
             new Object[] { aTextWireCoil, aTextPlateMotor, aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PISTON, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE },
@@ -613,7 +551,6 @@ public class MTERecipeLoader implements Runnable {
     private static void registerCuttingMachine() {
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_LV_Cutter.get(1),
-            bitsd,
             new Object[] { "WCG", "VMB", "CWE", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'G',
@@ -622,7 +559,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_MV_Cutter.get(1),
-            bitsd,
             new Object[] { "WCG", "VMB", "CWE", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'G',
@@ -631,7 +567,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_HV_Cutter.get(1),
-            bitsd,
             new Object[] { "WCG", "VMB", "CWE", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'G',
@@ -640,7 +575,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_EV_Cutter.get(1),
-            bitsd,
             new Object[] { "WCG", "VMB", "CWE", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'G',
@@ -649,7 +583,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_IV_Cutter.get(1),
-            bitsd,
             new Object[] { "WCG", "VMB", "CWE", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'G',
@@ -661,7 +594,6 @@ public class MTERecipeLoader implements Runnable {
     private static void registerDistillery() {
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_LV_Distillery.get(1),
-            bitsd,
             new Object[] { "GBG", aTextCableHull, aTextWirePump, 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PUMP, 'B', MTEBasicMachineWithRecipe.X.PIPE, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'G',
@@ -670,7 +602,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_MV_Distillery.get(1),
-            bitsd,
             new Object[] { "GBG", aTextCableHull, aTextWirePump, 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PUMP, 'B', MTEBasicMachineWithRecipe.X.PIPE, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'G',
@@ -679,7 +610,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_HV_Distillery.get(1),
-            bitsd,
             new Object[] { "GBG", aTextCableHull, aTextWirePump, 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PUMP, 'B', MTEBasicMachineWithRecipe.X.PIPE, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'G',
@@ -688,7 +618,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_EV_Distillery.get(1),
-            bitsd,
             new Object[] { "GBG", aTextCableHull, aTextWirePump, 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PUMP, 'B', MTEBasicMachineWithRecipe.X.PIPE, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'G',
@@ -697,7 +626,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_IV_Distillery.get(1),
-            bitsd,
             new Object[] { "GBG", aTextCableHull, aTextWirePump, 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PUMP, 'B', MTEBasicMachineWithRecipe.X.PIPE, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'G',
@@ -709,7 +637,6 @@ public class MTERecipeLoader implements Runnable {
     private static void registerElectricFurnace() {
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_LV_E_Furnace.get(1),
-            bitsd,
             new Object[] { "ECE", aTextCableHull, aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'C',
                 MTEBasicMachineWithRecipe.X.COIL_HEATING },
@@ -717,7 +644,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_MV_E_Furnace.get(1),
-            bitsd,
             new Object[] { "ECE", aTextCableHull, aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'C',
                 MTEBasicMachineWithRecipe.X.COIL_HEATING },
@@ -725,7 +651,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_HV_E_Furnace.get(1),
-            bitsd,
             new Object[] { "ECE", aTextCableHull, aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'C',
                 MTEBasicMachineWithRecipe.X.COIL_HEATING },
@@ -733,7 +658,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_EV_E_Furnace.get(1),
-            bitsd,
             new Object[] { "ECE", aTextCableHull, aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'C',
                 MTEBasicMachineWithRecipe.X.COIL_HEATING },
@@ -741,7 +665,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_IV_E_Furnace.get(1),
-            bitsd,
             new Object[] { "ECE", aTextCableHull, aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'C',
                 MTEBasicMachineWithRecipe.X.COIL_HEATING },
@@ -752,7 +675,6 @@ public class MTERecipeLoader implements Runnable {
     private static void registerElectrolyser() {
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_LV_Electrolyzer.get(1),
-            bitsd,
             new Object[] { "IGI", "IMI", "CWC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE, 'I', OrePrefixes.wireGt01.get(Materials.Gold), 'G',
@@ -761,7 +683,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_MV_Electrolyzer.get(1),
-            bitsd,
             new Object[] { "IGI", "IMI", "CWC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE, 'I', OrePrefixes.wireGt01.get(Materials.Silver), 'G',
@@ -770,7 +691,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_HV_Electrolyzer.get(1),
-            bitsd,
             new Object[] { "IGI", "IMI", "CWC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE, 'I', OrePrefixes.wireGt01.get(Materials.Electrum), 'G',
@@ -779,7 +699,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_EV_Electrolyzer.get(1),
-            bitsd,
             new Object[] { "IGI", "IMI", "CWC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE, 'I', OrePrefixes.wireGt01.get(Materials.Platinum), 'G',
@@ -788,7 +707,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_IV_Electrolyzer.get(1),
-            bitsd,
             new Object[] { "IGI", "IMI", "CWC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE, 'I', OrePrefixes.wireGt01.get(Materials.HSSG), 'G',
@@ -800,7 +718,6 @@ public class MTERecipeLoader implements Runnable {
     private static void registerElectromagneticSeparator() {
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_LV_ElectromagneticSeparator.get(1),
-            bitsd,
             new Object[] { "VWZ", "WMS", "CWZ", 'M', MTEBasicMachineWithRecipe.X.HULL, 'S',
                 MTEBasicMachineWithRecipe.X.STICK_ELECTROMAGNETIC, 'Z', MTEBasicMachineWithRecipe.X.COIL_ELECTRIC, 'V',
                 MTEBasicMachineWithRecipe.X.CONVEYOR, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
@@ -809,7 +726,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_MV_ElectromagneticSeparator.get(1),
-            bitsd,
             new Object[] { "VWZ", "WMS", "CWZ", 'M', MTEBasicMachineWithRecipe.X.HULL, 'S',
                 MTEBasicMachineWithRecipe.X.STICK_ELECTROMAGNETIC, 'Z', MTEBasicMachineWithRecipe.X.COIL_ELECTRIC, 'V',
                 MTEBasicMachineWithRecipe.X.CONVEYOR, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
@@ -818,7 +734,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_HV_ElectromagneticSeparator.get(1),
-            bitsd,
             new Object[] { "VWZ", "WMS", "CWZ", 'M', MTEBasicMachineWithRecipe.X.HULL, 'S',
                 MTEBasicMachineWithRecipe.X.STICK_ELECTROMAGNETIC, 'Z', MTEBasicMachineWithRecipe.X.COIL_ELECTRIC, 'V',
                 MTEBasicMachineWithRecipe.X.CONVEYOR, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
@@ -827,7 +742,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_EV_ElectromagneticSeparator.get(1),
-            bitsd,
             new Object[] { "VWZ", "WMS", "CWZ", 'M', MTEBasicMachineWithRecipe.X.HULL, 'S',
                 MTEBasicMachineWithRecipe.X.STICK_ELECTROMAGNETIC, 'Z', MTEBasicMachineWithRecipe.X.COIL_ELECTRIC, 'V',
                 MTEBasicMachineWithRecipe.X.CONVEYOR, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
@@ -836,7 +750,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_IV_ElectromagneticSeparator.get(1),
-            bitsd,
             new Object[] { "VWZ", "WMS", "CWZ", 'M', MTEBasicMachineWithRecipe.X.HULL, 'S',
                 MTEBasicMachineWithRecipe.X.STICK_ELECTROMAGNETIC, 'Z', MTEBasicMachineWithRecipe.X.COIL_ELECTRIC, 'V',
                 MTEBasicMachineWithRecipe.X.CONVEYOR, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
@@ -848,7 +761,6 @@ public class MTERecipeLoader implements Runnable {
     private static void registerExtractor() {
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_LV_Extractor.get(1),
-            bitsd,
             new Object[] { "GCG", "EMP", aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.PISTON, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'G',
@@ -857,7 +769,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_MV_Extractor.get(1),
-            bitsd,
             new Object[] { "GCG", "EMP", aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.PISTON, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'G',
@@ -866,7 +777,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_HV_Extractor.get(1),
-            bitsd,
             new Object[] { "GCG", "EMP", aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.PISTON, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'G',
@@ -875,7 +785,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_EV_Extractor.get(1),
-            bitsd,
             new Object[] { "GCG", "EMP", aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.PISTON, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'G',
@@ -884,7 +793,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_IV_Extractor.get(1),
-            bitsd,
             new Object[] { "GCG", "EMP", aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.PISTON, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'G',
@@ -896,7 +804,6 @@ public class MTERecipeLoader implements Runnable {
     private static void registerExtruder() {
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_LV_Extruder.get(1),
-            bitsd,
             new Object[] { "CCE", "XMP", "CCE", 'M', MTEBasicMachineWithRecipe.X.HULL, 'X',
                 MTEBasicMachineWithRecipe.X.PISTON, 'E', MTEBasicMachineWithRecipe.X.CIRCUIT, 'P',
                 MTEBasicMachineWithRecipe.X.PIPE, 'C', MTEBasicMachineWithRecipe.X.COIL_HEATING_DOUBLE },
@@ -904,7 +811,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_MV_Extruder.get(1),
-            bitsd,
             new Object[] { "CCE", "XMP", "CCE", 'M', MTEBasicMachineWithRecipe.X.HULL, 'X',
                 MTEBasicMachineWithRecipe.X.PISTON, 'E', MTEBasicMachineWithRecipe.X.CIRCUIT, 'P',
                 MTEBasicMachineWithRecipe.X.PIPE, 'C', MTEBasicMachineWithRecipe.X.COIL_HEATING_DOUBLE },
@@ -912,7 +818,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_HV_Extruder.get(1),
-            bitsd,
             new Object[] { "CCE", "XMP", "CCE", 'M', MTEBasicMachineWithRecipe.X.HULL, 'X',
                 MTEBasicMachineWithRecipe.X.PISTON, 'E', MTEBasicMachineWithRecipe.X.CIRCUIT, 'P',
                 MTEBasicMachineWithRecipe.X.PIPE, 'C', MTEBasicMachineWithRecipe.X.COIL_HEATING_DOUBLE },
@@ -920,7 +825,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_EV_Extruder.get(1),
-            bitsd,
             new Object[] { "CCE", "XMP", "CCE", 'M', MTEBasicMachineWithRecipe.X.HULL, 'X',
                 MTEBasicMachineWithRecipe.X.PISTON, 'E', MTEBasicMachineWithRecipe.X.CIRCUIT, 'P',
                 MTEBasicMachineWithRecipe.X.PIPE, 'C', MTEBasicMachineWithRecipe.X.COIL_HEATING_DOUBLE },
@@ -928,7 +832,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_IV_Extruder.get(1),
-            bitsd,
             new Object[] { "CCE", "XMP", "CCE", 'M', MTEBasicMachineWithRecipe.X.HULL, 'X',
                 MTEBasicMachineWithRecipe.X.PISTON, 'E', MTEBasicMachineWithRecipe.X.CIRCUIT, 'P',
                 MTEBasicMachineWithRecipe.X.PIPE, 'C', MTEBasicMachineWithRecipe.X.COIL_HEATING_DOUBLE },
@@ -939,7 +842,6 @@ public class MTERecipeLoader implements Runnable {
     private static void registerFermenter() {
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_LV_Fermenter.get(1),
-            bitsd,
             new Object[] { aTextWirePump, "GMG", aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PUMP, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE, 'G', MTEBasicMachineWithRecipe.X.GLASS },
@@ -947,7 +849,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_MV_Fermenter.get(1),
-            bitsd,
             new Object[] { aTextWirePump, "GMG", aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PUMP, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE, 'G', MTEBasicMachineWithRecipe.X.GLASS },
@@ -955,7 +856,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_HV_Fermenter.get(1),
-            bitsd,
             new Object[] { aTextWirePump, "GMG", aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PUMP, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE, 'G', MTEBasicMachineWithRecipe.X.GLASS },
@@ -963,7 +863,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_EV_Fermenter.get(1),
-            bitsd,
             new Object[] { aTextWirePump, "GMG", aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PUMP, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE, 'G', MTEBasicMachineWithRecipe.X.GLASS },
@@ -971,7 +870,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_IV_Fermenter.get(1),
-            bitsd,
             new Object[] { aTextWirePump, "GMG", aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PUMP, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE, 'G', MTEBasicMachineWithRecipe.X.GLASS },
@@ -982,7 +880,6 @@ public class MTERecipeLoader implements Runnable {
     private static void registerFluidCanner() {
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_LV_FluidCanner.get(1),
-            bitsd,
             new Object[] { "GCG", "GMG", "WPW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PUMP, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE, 'G', MTEBasicMachineWithRecipe.X.GLASS },
@@ -990,7 +887,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_MV_FluidCanner.get(1),
-            bitsd,
             new Object[] { "GCG", "GMG", "WPW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PUMP, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE, 'G', MTEBasicMachineWithRecipe.X.GLASS },
@@ -998,7 +894,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_HV_FluidCanner.get(1),
-            bitsd,
             new Object[] { "GCG", "GMG", "WPW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PUMP, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE, 'G', MTEBasicMachineWithRecipe.X.GLASS },
@@ -1006,7 +901,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_EV_FluidCanner.get(1),
-            bitsd,
             new Object[] { "GCG", "GMG", "WPW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PUMP, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE, 'G', MTEBasicMachineWithRecipe.X.GLASS },
@@ -1014,7 +908,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_IV_FluidCanner.get(1),
-            bitsd,
             new Object[] { "GCG", "GMG", "WPW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PUMP, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE, 'G', MTEBasicMachineWithRecipe.X.GLASS },
@@ -1025,7 +918,6 @@ public class MTERecipeLoader implements Runnable {
     private static void registerFluidExtractor() {
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_LV_FluidExtractor.get(1),
-            bitsd,
             new Object[] { "GEG", "TPT", "CMC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.PISTON, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'T', MTEBasicMachineWithRecipe.X.WIRE, 'G',
@@ -1034,7 +926,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_MV_FluidExtractor.get(1),
-            bitsd,
             new Object[] { "GEG", "TPT", "CMC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.PISTON, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'T', MTEBasicMachineWithRecipe.X.WIRE, 'G',
@@ -1043,7 +934,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_HV_FluidExtractor.get(1),
-            bitsd,
             new Object[] { "GEG", "TPT", "CMC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.PISTON, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'T', MTEBasicMachineWithRecipe.X.WIRE, 'G',
@@ -1052,7 +942,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_EV_FluidExtractor.get(1),
-            bitsd,
             new Object[] { "GEG", "TPT", "CMC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.PISTON, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'T', MTEBasicMachineWithRecipe.X.WIRE, 'G',
@@ -1061,7 +950,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_IV_FluidExtractor.get(1),
-            bitsd,
             new Object[] { "GEG", "TPT", "CMC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.PISTON, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'T', MTEBasicMachineWithRecipe.X.WIRE, 'G',
@@ -1073,7 +961,6 @@ public class MTERecipeLoader implements Runnable {
     private static void registerFluidHeater() {
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_LV_FluidHeater.get(1),
-            bitsd,
             new Object[] { "OGO", aTextPlateMotor, aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PUMP, 'O', MTEBasicMachineWithRecipe.X.COIL_HEATING_DOUBLE, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'G',
@@ -1082,7 +969,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_MV_FluidHeater.get(1),
-            bitsd,
             new Object[] { "OGO", aTextPlateMotor, aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PUMP, 'O', MTEBasicMachineWithRecipe.X.COIL_HEATING_DOUBLE, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'G',
@@ -1091,7 +977,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_HV_FluidHeater.get(1),
-            bitsd,
             new Object[] { "OGO", aTextPlateMotor, aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PUMP, 'O', MTEBasicMachineWithRecipe.X.COIL_HEATING_DOUBLE, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'G',
@@ -1100,7 +985,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_EV_FluidHeater.get(1),
-            bitsd,
             new Object[] { "OGO", aTextPlateMotor, aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PUMP, 'O', MTEBasicMachineWithRecipe.X.COIL_HEATING_DOUBLE, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'G',
@@ -1109,7 +993,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_IV_FluidHeater.get(1),
-            bitsd,
             new Object[] { "OGO", aTextPlateMotor, aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PUMP, 'O', MTEBasicMachineWithRecipe.X.COIL_HEATING_DOUBLE, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'G',
@@ -1120,7 +1003,6 @@ public class MTERecipeLoader implements Runnable {
     private static void registerFluidSolidifier() {
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_LV_FluidSolidifier.get(1),
-            bitsd,
             new Object[] { "PGP", aTextWireHull, "CBC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PUMP, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE, 'G', MTEBasicMachineWithRecipe.X.GLASS, 'B',
@@ -1129,7 +1011,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_MV_FluidSolidifier.get(1),
-            bitsd,
             new Object[] { "PGP", aTextWireHull, "CBC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PUMP, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE, 'G', MTEBasicMachineWithRecipe.X.GLASS, 'B',
@@ -1138,7 +1019,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_HV_FluidSolidifier.get(1),
-            bitsd,
             new Object[] { "PGP", aTextWireHull, "CBC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PUMP, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE, 'G', MTEBasicMachineWithRecipe.X.GLASS, 'B',
@@ -1147,7 +1027,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_EV_FluidSolidifier.get(1),
-            bitsd,
             new Object[] { "PGP", aTextWireHull, "CBC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PUMP, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE, 'G', MTEBasicMachineWithRecipe.X.GLASS, 'B',
@@ -1156,7 +1035,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_IV_FluidSolidifier.get(1),
-            bitsd,
             new Object[] { "PGP", aTextWireHull, "CBC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PUMP, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE, 'G', MTEBasicMachineWithRecipe.X.GLASS, 'B',
@@ -1168,7 +1046,6 @@ public class MTERecipeLoader implements Runnable {
     private static void registerForgeHammer() {
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_LV_Hammer.get(1),
-            bitsd,
             new Object[] { aTextWirePump, aTextCableHull, "WAW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PISTON, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE, 'O', MTEBasicMachineWithRecipe.X.COIL_HEATING_DOUBLE, 'A',
@@ -1177,7 +1054,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_MV_Hammer.get(1),
-            bitsd,
             new Object[] { aTextWirePump, aTextCableHull, "WAW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PISTON, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE, 'O', MTEBasicMachineWithRecipe.X.COIL_HEATING_DOUBLE, 'A',
@@ -1186,7 +1062,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_HV_Hammer.get(1),
-            bitsd,
             new Object[] { aTextWirePump, aTextCableHull, "WAW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PISTON, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE, 'O', MTEBasicMachineWithRecipe.X.COIL_HEATING_DOUBLE, 'A',
@@ -1195,7 +1070,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_EV_Hammer.get(1),
-            bitsd,
             new Object[] { aTextWirePump, aTextCableHull, "WAW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PISTON, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE, 'O', MTEBasicMachineWithRecipe.X.COIL_HEATING_DOUBLE, 'A',
@@ -1204,7 +1078,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_IV_Hammer.get(1),
-            bitsd,
             new Object[] { aTextWirePump, aTextCableHull, "WAW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PISTON, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE, 'O', MTEBasicMachineWithRecipe.X.COIL_HEATING_DOUBLE, 'A',
@@ -1216,7 +1089,6 @@ public class MTERecipeLoader implements Runnable {
     private static void registerFormingPress() {
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_LV_Press.get(1),
-            bitsd,
             new Object[] { aTextWirePump, aTextCableHull, aTextWirePump, 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PISTON, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE },
@@ -1224,7 +1096,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_MV_Press.get(1),
-            bitsd,
             new Object[] { aTextWirePump, aTextCableHull, aTextWirePump, 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PISTON, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE },
@@ -1232,7 +1103,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_HV_Press.get(1),
-            bitsd,
             new Object[] { aTextWirePump, aTextCableHull, aTextWirePump, 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PISTON, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE },
@@ -1240,7 +1110,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_EV_Press.get(1),
-            bitsd,
             new Object[] { aTextWirePump, aTextCableHull, aTextWirePump, 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PISTON, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE },
@@ -1248,7 +1117,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_IV_Press.get(1),
-            bitsd,
             new Object[] { aTextWirePump, aTextCableHull, aTextWirePump, 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PISTON, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE },
@@ -1258,7 +1126,6 @@ public class MTERecipeLoader implements Runnable {
     private static void registerLaserEngraver() {
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_LV_LaserEngraver.get(1),
-            bitsd,
             new Object[] { "PEP", aTextCableHull, aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.EMITTER, 'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE },
@@ -1266,7 +1133,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_MV_LaserEngraver.get(1),
-            bitsd,
             new Object[] { "PEP", aTextCableHull, aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.EMITTER, 'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE },
@@ -1274,7 +1140,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_HV_LaserEngraver.get(1),
-            bitsd,
             new Object[] { "PEP", aTextCableHull, aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.EMITTER, 'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE },
@@ -1282,7 +1147,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_EV_LaserEngraver.get(1),
-            bitsd,
             new Object[] { "PEP", aTextCableHull, aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.EMITTER, 'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE },
@@ -1290,7 +1154,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_IV_LaserEngraver.get(1),
-            bitsd,
             new Object[] { "PEP", aTextCableHull, aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.EMITTER, 'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE },
@@ -1301,7 +1164,6 @@ public class MTERecipeLoader implements Runnable {
     private static void registerLathe() {
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_LV_Lathe.get(1),
-            bitsd,
             new Object[] { aTextWireCoil, "EMD", "CWP", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'D',
@@ -1310,7 +1172,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_MV_Lathe.get(1),
-            bitsd,
             new Object[] { aTextWireCoil, "EMD", "CWP", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'D',
@@ -1319,7 +1180,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_HV_Lathe.get(1),
-            bitsd,
             new Object[] { aTextWireCoil, "EMD", "CWP", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'D',
@@ -1328,7 +1188,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_EV_Lathe.get(1),
-            bitsd,
             new Object[] { aTextWireCoil, "EMD", "CWP", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'D',
@@ -1337,7 +1196,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_IV_Lathe.get(1),
-            bitsd,
             new Object[] { aTextWireCoil, "EMD", "CWP", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'D',
@@ -1349,7 +1207,6 @@ public class MTERecipeLoader implements Runnable {
     private static void registerMacerator() {
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_LV_Macerator.get(1),
-            bitsd,
             new Object[] { "PEG", "WWM", "CCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'G',
@@ -1358,7 +1215,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_MV_Macerator.get(1),
-            bitsd,
             new Object[] { "PEG", "WWM", "CCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'G',
@@ -1367,7 +1223,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_HV_Macerator.get(1),
-            bitsd,
             new Object[] { "PEG", "WWM", "CCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'G',
@@ -1376,7 +1231,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_EV_Macerator.get(1),
-            bitsd,
             new Object[] { "PEG", "WWM", "CCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'G',
@@ -1385,7 +1239,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_IV_Macerator.get(1),
-            bitsd,
             new Object[] { "PEG", "WWM", "CCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'G',
@@ -1397,7 +1250,6 @@ public class MTERecipeLoader implements Runnable {
     private static void registerMatterAmplifier() {
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_LV_Amplifab.get(1),
-            bitsd,
             new Object[] { aTextWirePump, aTextPlateMotor, "CPC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PUMP, 'C', MTEBasicMachineWithRecipe.X.BETTER_CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE4 },
@@ -1405,7 +1257,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_MV_Amplifab.get(1),
-            bitsd,
             new Object[] { aTextWirePump, aTextPlateMotor, "CPC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PUMP, 'C', MTEBasicMachineWithRecipe.X.BETTER_CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE4 },
@@ -1413,7 +1264,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_HV_Amplifab.get(1),
-            bitsd,
             new Object[] { aTextWirePump, aTextPlateMotor, "CPC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PUMP, 'C', MTEBasicMachineWithRecipe.X.BETTER_CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE4 },
@@ -1421,7 +1271,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_EV_Amplifab.get(1),
-            bitsd,
             new Object[] { aTextWirePump, aTextPlateMotor, "CPC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PUMP, 'C', MTEBasicMachineWithRecipe.X.BETTER_CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE4 },
@@ -1429,7 +1278,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_IV_Amplifab.get(1),
-            bitsd,
             new Object[] { aTextWirePump, aTextPlateMotor, "CPC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PUMP, 'C', MTEBasicMachineWithRecipe.X.BETTER_CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE4 },
@@ -1440,7 +1288,6 @@ public class MTERecipeLoader implements Runnable {
     private static void registerMicrowave() {
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_LV_Microwave.get(1),
-            bitsd,
             new Object[] { "LWC", "LMR", "LEC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'R', MTEBasicMachineWithRecipe.X.EMITTER, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'L',
@@ -1449,7 +1296,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_MV_Microwave.get(1),
-            bitsd,
             new Object[] { "LWC", "LMR", "LEC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'R', MTEBasicMachineWithRecipe.X.EMITTER, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'L',
@@ -1458,7 +1304,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_HV_Microwave.get(1),
-            bitsd,
             new Object[] { "LWC", "LMR", "LEC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'R', MTEBasicMachineWithRecipe.X.EMITTER, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'L',
@@ -1467,7 +1312,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_EV_Microwave.get(1),
-            bitsd,
             new Object[] { "LWC", "LMR", "LEC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'R', MTEBasicMachineWithRecipe.X.EMITTER, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'L',
@@ -1476,7 +1320,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_IV_Microwave.get(1),
-            bitsd,
             new Object[] { "LWC", "LMR", "LEC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'R', MTEBasicMachineWithRecipe.X.EMITTER, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'L',
@@ -1488,7 +1331,6 @@ public class MTERecipeLoader implements Runnable {
     private static void registerMixer() {
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_LV_Mixer.get(1),
-            bitsd,
             new Object[] { "GRG", "GEG", aTextCableHull, 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'R', MTEBasicMachineWithRecipe.X.ROTOR, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'G', MTEBasicMachineWithRecipe.X.GLASS },
@@ -1496,7 +1338,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_MV_Mixer.get(1),
-            bitsd,
             new Object[] { "GRG", "GEG", aTextCableHull, 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'R', MTEBasicMachineWithRecipe.X.ROTOR, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'G', MTEBasicMachineWithRecipe.X.GLASS },
@@ -1504,7 +1345,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_HV_Mixer.get(1),
-            bitsd,
             new Object[] { "GRG", "GEG", aTextCableHull, 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'R', MTEBasicMachineWithRecipe.X.ROTOR, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'G', MTEBasicMachineWithRecipe.X.GLASS },
@@ -1512,7 +1352,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_EV_Mixer.get(1),
-            bitsd,
             new Object[] { "GRG", "GEG", aTextCableHull, 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'R', MTEBasicMachineWithRecipe.X.ROTOR, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'G', MTEBasicMachineWithRecipe.X.GLASS },
@@ -1520,7 +1359,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_IV_Mixer.get(1),
-            bitsd,
             new Object[] { "GRG", "GEG", aTextCableHull, 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'R', MTEBasicMachineWithRecipe.X.ROTOR, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'G', MTEBasicMachineWithRecipe.X.GLASS },
@@ -1530,7 +1368,6 @@ public class MTERecipeLoader implements Runnable {
     private static void registerOreWasher() {
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_LV_OreWasher.get(1),
-            bitsd,
             new Object[] { "RGR", "CEC", aTextWireHull, 'M', MTEBasicMachineWithRecipe.X.HULL, 'R',
                 MTEBasicMachineWithRecipe.X.ROTOR, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'G',
@@ -1539,7 +1376,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_MV_OreWasher.get(1),
-            bitsd,
             new Object[] { "RGR", "CEC", aTextWireHull, 'M', MTEBasicMachineWithRecipe.X.HULL, 'R',
                 MTEBasicMachineWithRecipe.X.ROTOR, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'G',
@@ -1548,7 +1384,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_HV_OreWasher.get(1),
-            bitsd,
             new Object[] { "RGR", "CEC", aTextWireHull, 'M', MTEBasicMachineWithRecipe.X.HULL, 'R',
                 MTEBasicMachineWithRecipe.X.ROTOR, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'G',
@@ -1557,7 +1392,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_EV_OreWasher.get(1),
-            bitsd,
             new Object[] { "RGR", "CEC", aTextWireHull, 'M', MTEBasicMachineWithRecipe.X.HULL, 'R',
                 MTEBasicMachineWithRecipe.X.ROTOR, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'G',
@@ -1566,7 +1400,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_IV_OreWasher.get(1),
-            bitsd,
             new Object[] { "RGR", "CEC", aTextWireHull, 'M', MTEBasicMachineWithRecipe.X.HULL, 'R',
                 MTEBasicMachineWithRecipe.X.ROTOR, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'G',
@@ -1578,7 +1411,6 @@ public class MTERecipeLoader implements Runnable {
     private static void registerOven() {
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_LV_Oven.get(1),
-            bitsd,
             new Object[] { "CEC", aTextCableHull, "WEW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'C',
                 MTEBasicMachineWithRecipe.X.COIL_HEATING },
@@ -1586,7 +1418,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_MV_Oven.get(1),
-            bitsd,
             new Object[] { "CEC", aTextCableHull, "WEW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'C',
                 MTEBasicMachineWithRecipe.X.COIL_HEATING },
@@ -1594,7 +1425,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_HV_Oven.get(1),
-            bitsd,
             new Object[] { "CEC", aTextCableHull, "WEW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'C',
                 MTEBasicMachineWithRecipe.X.COIL_HEATING },
@@ -1602,7 +1432,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_EV_Oven.get(1),
-            bitsd,
             new Object[] { "CEC", aTextCableHull, "WEW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'C',
                 MTEBasicMachineWithRecipe.X.COIL_HEATING },
@@ -1610,7 +1439,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_IV_Oven.get(1),
-            bitsd,
             new Object[] { "CEC", aTextCableHull, "WEW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'C',
                 MTEBasicMachineWithRecipe.X.COIL_HEATING },
@@ -1621,7 +1449,6 @@ public class MTERecipeLoader implements Runnable {
     private static void registerPlasmaArcFurnace() {
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_LV_PlasmaArcFurnace.get(1),
-            bitsd,
             new Object[] { "WGW", aTextCableHull, "TPT", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PLATE, 'C', MTEBasicMachineWithRecipe.X.BETTER_CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE4, 'T', MTEBasicMachineWithRecipe.X.PUMP, 'G',
@@ -1630,7 +1457,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_MV_PlasmaArcFurnace.get(1),
-            bitsd,
             new Object[] { "WGW", aTextCableHull, "TPT", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PLATE, 'C', MTEBasicMachineWithRecipe.X.BETTER_CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE4, 'T', MTEBasicMachineWithRecipe.X.PUMP, 'G',
@@ -1639,7 +1465,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_HV_PlasmaArcFurnace.get(1),
-            bitsd,
             new Object[] { "WGW", aTextCableHull, "TPT", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PLATE, 'C', MTEBasicMachineWithRecipe.X.BETTER_CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE4, 'T', MTEBasicMachineWithRecipe.X.PUMP, 'G',
@@ -1648,7 +1473,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_EV_PlasmaArcFurnace.get(1),
-            bitsd,
             new Object[] { "WGW", aTextCableHull, "TPT", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PLATE, 'C', MTEBasicMachineWithRecipe.X.BETTER_CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE4, 'T', MTEBasicMachineWithRecipe.X.PUMP, 'G',
@@ -1657,7 +1481,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_IV_PlasmaArcFurnace.get(1),
-            bitsd,
             new Object[] { "WGW", aTextCableHull, "TPT", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PLATE, 'C', MTEBasicMachineWithRecipe.X.BETTER_CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE4, 'T', MTEBasicMachineWithRecipe.X.PUMP, 'G',
@@ -1669,7 +1492,6 @@ public class MTERecipeLoader implements Runnable {
     private static void registerPolarizer() {
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_LV_Polarizer.get(1),
-            bitsd,
             new Object[] { "ZSZ", aTextWireHull, "ZSZ", 'M', MTEBasicMachineWithRecipe.X.HULL, 'S',
                 MTEBasicMachineWithRecipe.X.STICK_ELECTROMAGNETIC, 'Z', MTEBasicMachineWithRecipe.X.COIL_ELECTRIC, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE },
@@ -1677,7 +1499,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_MV_Polarizer.get(1),
-            bitsd,
             new Object[] { "ZSZ", aTextWireHull, "ZSZ", 'M', MTEBasicMachineWithRecipe.X.HULL, 'S',
                 MTEBasicMachineWithRecipe.X.STICK_ELECTROMAGNETIC, 'Z', MTEBasicMachineWithRecipe.X.COIL_ELECTRIC, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE },
@@ -1685,7 +1506,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_HV_Polarizer.get(1),
-            bitsd,
             new Object[] { "ZSZ", aTextWireHull, "ZSZ", 'M', MTEBasicMachineWithRecipe.X.HULL, 'S',
                 MTEBasicMachineWithRecipe.X.STICK_ELECTROMAGNETIC, 'Z', MTEBasicMachineWithRecipe.X.COIL_ELECTRIC, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE },
@@ -1693,7 +1513,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_EV_Polarizer.get(1),
-            bitsd,
             new Object[] { "ZSZ", aTextWireHull, "ZSZ", 'M', MTEBasicMachineWithRecipe.X.HULL, 'S',
                 MTEBasicMachineWithRecipe.X.STICK_ELECTROMAGNETIC, 'Z', MTEBasicMachineWithRecipe.X.COIL_ELECTRIC, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE },
@@ -1701,7 +1520,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_IV_Polarizer.get(1),
-            bitsd,
             new Object[] { "ZSZ", aTextWireHull, "ZSZ", 'M', MTEBasicMachineWithRecipe.X.HULL, 'S',
                 MTEBasicMachineWithRecipe.X.STICK_ELECTROMAGNETIC, 'Z', MTEBasicMachineWithRecipe.X.COIL_ELECTRIC, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE },
@@ -1712,7 +1530,6 @@ public class MTERecipeLoader implements Runnable {
     private static void registerPrinter() {
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_LV_Printer.get(1),
-            bitsd,
             new Object[] { aTextMotorWire, aTextCableHull, "WEW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE },
@@ -1720,7 +1537,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_MV_Printer.get(1),
-            bitsd,
             new Object[] { aTextMotorWire, aTextCableHull, "WEW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE },
@@ -1728,7 +1544,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_HV_Printer.get(1),
-            bitsd,
             new Object[] { aTextMotorWire, aTextCableHull, "WEW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE },
@@ -1736,7 +1551,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_EV_Printer.get(1),
-            bitsd,
             new Object[] { aTextMotorWire, aTextCableHull, "WEW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE },
@@ -1744,7 +1558,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_IV_Printer.get(1),
-            bitsd,
             new Object[] { aTextMotorWire, aTextCableHull, "WEW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE },
@@ -1752,7 +1565,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_LuV_Printer.get(1),
-            bitsd,
             new Object[] { aTextMotorWire, aTextCableHull, "WEW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE },
@@ -1760,7 +1572,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_ZPM_Printer.get(1),
-            bitsd,
             new Object[] { aTextMotorWire, aTextCableHull, "WEW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE },
@@ -1768,7 +1579,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_UV_Printer.get(1),
-            bitsd,
             new Object[] { aTextMotorWire, aTextCableHull, "WEW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE },
@@ -1779,7 +1589,6 @@ public class MTERecipeLoader implements Runnable {
     private static void registerRecycler() {
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_LV_Recycler.get(1),
-            bitsd,
             new Object[] { "GCG", aTextPlateMotor, aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PISTON, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE, 'G', OrePrefixes.dust.get(Materials.Glowstone) },
@@ -1787,7 +1596,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_MV_Recycler.get(1),
-            bitsd,
             new Object[] { "GCG", aTextPlateMotor, aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PISTON, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE, 'G', OrePrefixes.dust.get(Materials.Glowstone) },
@@ -1795,7 +1603,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_HV_Recycler.get(1),
-            bitsd,
             new Object[] { "GCG", aTextPlateMotor, aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PISTON, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE, 'G', OrePrefixes.dust.get(Materials.Glowstone) },
@@ -1803,7 +1610,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_EV_Recycler.get(1),
-            bitsd,
             new Object[] { "GCG", aTextPlateMotor, aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PISTON, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE, 'G', OrePrefixes.dust.get(Materials.Glowstone) },
@@ -1811,7 +1617,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_IV_Recycler.get(1),
-            bitsd,
             new Object[] { "GCG", aTextPlateMotor, aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PISTON, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE, 'G', OrePrefixes.dust.get(Materials.Glowstone) },
@@ -1822,7 +1627,6 @@ public class MTERecipeLoader implements Runnable {
     private static void registerSifter() {
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_LV_Sifter.get(1),
-            bitsd,
             new Object[] { "WFW", aTextPlateMotor, "CFC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PISTON, 'F', OreDictNames.craftingFilter, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE },
@@ -1830,7 +1634,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_MV_Sifter.get(1),
-            bitsd,
             new Object[] { "WFW", aTextPlateMotor, "CFC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PISTON, 'F', OreDictNames.craftingFilter, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE },
@@ -1838,7 +1641,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_HV_Sifter.get(1),
-            bitsd,
             new Object[] { "WFW", aTextPlateMotor, "CFC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PISTON, 'F', OreDictNames.craftingFilter, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE },
@@ -1846,7 +1648,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_EV_Sifter.get(1),
-            bitsd,
             new Object[] { "WFW", aTextPlateMotor, "CFC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PISTON, 'F', OreDictNames.craftingFilter, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE },
@@ -1854,7 +1655,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_IV_Sifter.get(1),
-            bitsd,
             new Object[] { "WFW", aTextPlateMotor, "CFC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PISTON, 'F', OreDictNames.craftingFilter, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE },
@@ -1865,7 +1665,6 @@ public class MTERecipeLoader implements Runnable {
     private static void registerSlicer() {
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_LV_Slicer.get(1),
-            bitsd,
             new Object[] { aTextWireCoil, "PMV", aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PISTON, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE },
@@ -1873,7 +1672,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_MV_Slicer.get(1),
-            bitsd,
             new Object[] { aTextWireCoil, "PMV", aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PISTON, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE },
@@ -1881,7 +1679,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_HV_Slicer.get(1),
-            bitsd,
             new Object[] { aTextWireCoil, "PMV", aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PISTON, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE },
@@ -1889,7 +1686,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_EV_Slicer.get(1),
-            bitsd,
             new Object[] { aTextWireCoil, "PMV", aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PISTON, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE },
@@ -1897,7 +1693,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_IV_Slicer.get(1),
-            bitsd,
             new Object[] { aTextWireCoil, "PMV", aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                 MTEBasicMachineWithRecipe.X.PISTON, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE },
@@ -1908,7 +1703,6 @@ public class MTERecipeLoader implements Runnable {
     private static void registerThermalCentrifuge() {
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_LV_ThermalCentrifuge.get(1),
-            bitsd,
             new Object[] { "CEC", "OMO", "WEW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE, 'O', MTEBasicMachineWithRecipe.X.COIL_HEATING_DOUBLE },
@@ -1916,7 +1710,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_MV_ThermalCentrifuge.get(1),
-            bitsd,
             new Object[] { "CEC", "OMO", "WEW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE, 'O', MTEBasicMachineWithRecipe.X.COIL_HEATING_DOUBLE },
@@ -1924,7 +1717,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_HV_ThermalCentrifuge.get(1),
-            bitsd,
             new Object[] { "CEC", "OMO", "WEW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE, 'O', MTEBasicMachineWithRecipe.X.COIL_HEATING_DOUBLE },
@@ -1932,7 +1724,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_EV_ThermalCentrifuge.get(1),
-            bitsd,
             new Object[] { "CEC", "OMO", "WEW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE, 'O', MTEBasicMachineWithRecipe.X.COIL_HEATING_DOUBLE },
@@ -1940,7 +1731,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_IV_ThermalCentrifuge.get(1),
-            bitsd,
             new Object[] { "CEC", "OMO", "WEW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE, 'O', MTEBasicMachineWithRecipe.X.COIL_HEATING_DOUBLE },
@@ -1951,7 +1741,6 @@ public class MTERecipeLoader implements Runnable {
     private static void registerUnpackager() {
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_LV_Unboxinator.get(1),
-            bitsd,
             new Object[] { "BCB", "VMR", aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'R',
                 MTEBasicMachineWithRecipe.X.ROBOT_ARM, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'B',
@@ -1960,7 +1749,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_MV_Unboxinator.get(1),
-            bitsd,
             new Object[] { "BCB", "VMR", aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'R',
                 MTEBasicMachineWithRecipe.X.ROBOT_ARM, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'B',
@@ -1969,7 +1757,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_HV_Unboxinator.get(1),
-            bitsd,
             new Object[] { "BCB", "VMR", aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'R',
                 MTEBasicMachineWithRecipe.X.ROBOT_ARM, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'B',
@@ -1978,7 +1765,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_EV_Unboxinator.get(1),
-            bitsd,
             new Object[] { "BCB", "VMR", aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'R',
                 MTEBasicMachineWithRecipe.X.ROBOT_ARM, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'B',
@@ -1987,7 +1773,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_IV_Unboxinator.get(1),
-            bitsd,
             new Object[] { "BCB", "VMR", aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'R',
                 MTEBasicMachineWithRecipe.X.ROBOT_ARM, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'B',
@@ -1996,7 +1781,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_LuV_Unboxinator.get(1),
-            bitsd,
             new Object[] { "BCB", "VMR", aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'R',
                 MTEBasicMachineWithRecipe.X.ROBOT_ARM, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'B',
@@ -2005,7 +1789,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_ZPM_Unboxinator.get(1),
-            bitsd,
             new Object[] { "BCB", "VMR", aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'R',
                 MTEBasicMachineWithRecipe.X.ROBOT_ARM, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'B',
@@ -2014,7 +1797,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_UV_Unboxinator.get(1),
-            bitsd,
             new Object[] { "BCB", "VMR", aTextWireCoil, 'M', MTEBasicMachineWithRecipe.X.HULL, 'R',
                 MTEBasicMachineWithRecipe.X.ROBOT_ARM, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR, 'C',
                 MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'B',
@@ -2025,7 +1807,6 @@ public class MTERecipeLoader implements Runnable {
     private static void registerWiremill() {
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_LV_Wiremill.get(1),
-            bitsd,
             new Object[] { aTextMotorWire, aTextCableHull, aTextMotorWire, 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE },
@@ -2033,7 +1814,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_MV_Wiremill.get(1),
-            bitsd,
             new Object[] { aTextMotorWire, aTextCableHull, aTextMotorWire, 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE },
@@ -2041,7 +1821,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_HV_Wiremill.get(1),
-            bitsd,
             new Object[] { aTextMotorWire, aTextCableHull, aTextMotorWire, 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE },
@@ -2049,7 +1828,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_EV_Wiremill.get(1),
-            bitsd,
             new Object[] { aTextMotorWire, aTextCableHull, aTextMotorWire, 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE },
@@ -2057,7 +1835,6 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addMachineCraftingRecipe(
             ItemList.Machine_IV_Wiremill.get(1),
-            bitsd,
             new Object[] { aTextMotorWire, aTextCableHull, aTextMotorWire, 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                 MTEBasicMachineWithRecipe.X.MOTOR, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
                 MTEBasicMachineWithRecipe.X.WIRE },
@@ -2067,276 +1844,276 @@ public class MTERecipeLoader implements Runnable {
     private static void registerShapedCraftingRecipes() {
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_Pipe_Polytetrafluoroethylene.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { "PIP", "IFI", "PIP", 'P', OrePrefixes.plate.get(Materials.Polytetrafluoroethylene), 'F',
                 OrePrefixes.frameGt.get(Materials.Polytetrafluoroethylene), 'I',
                 OrePrefixes.pipeMedium.get(Materials.Polytetrafluoroethylene) });
 
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_Pipe_Polybenzimidazole.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { "PIP", "IFI", "PIP", 'P', OrePrefixes.plate.get(Materials.Polybenzimidazole), 'F',
                 OrePrefixes.frameGt.get(Materials.Polybenzimidazole), 'I',
                 OrePrefixes.pipeMedium.get(Materials.Polybenzimidazole) });
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_ULV.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { aTextPlate, aTextPlateWrench, aTextPlate, 'P',
                 OrePrefixes.plate.get(Materials.WroughtIron) });
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_LV.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { aTextPlate, aTextPlateWrench, aTextPlate, 'P', OrePrefixes.plate.get(Materials.Steel) });
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_MV.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { aTextPlate, aTextPlateWrench, aTextPlate, 'P', OrePrefixes.plate.get(Materials.Aluminium) });
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_HV.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { aTextPlate, aTextPlateWrench, aTextPlate, 'P',
                 OrePrefixes.plate.get(Materials.StainlessSteel) });
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_EV.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { aTextPlate, aTextPlateWrench, aTextPlate, 'P', OrePrefixes.plate.get(Materials.Titanium) });
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_IV.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { aTextPlate, aTextPlateWrench, aTextPlate, 'P',
                 OrePrefixes.plate.get(Materials.TungstenSteel) });
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_LuV.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { aTextPlate, aTextPlateWrench, aTextPlate, 'P',
                 OrePrefixes.plate.get(ExternalMaterials.getRhodiumPlatedPalladium()) });
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_ZPM.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { aTextPlate, aTextPlateWrench, aTextPlate, 'P', OrePrefixes.plate.get(Materials.Iridium) });
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_UV.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { aTextPlate, aTextPlateWrench, aTextPlate, 'P', OrePrefixes.plate.get(Materials.Osmium) });
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_MAX.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { aTextPlate, aTextPlateWrench, aTextPlate, 'P',
                 OrePrefixes.plate.get(Materials.Neutronium) });
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_BronzePlatedBricks.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { "PhP", "PBP", aTextPlateWrench, 'P', OrePrefixes.plate.get(Materials.Bronze), 'B',
                 new ItemStack(Blocks.brick_block, 1) });
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_SolidSteel.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { "PhP", "PFP", aTextPlateWrench, 'P', OrePrefixes.plate.get(Materials.Steel), 'F',
                 OrePrefixes.frameGt.get(Materials.Steel) });
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_StableTitanium.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { "PhP", "PFP", aTextPlateWrench, 'P', OrePrefixes.plate.get(Materials.Titanium), 'F',
                 OrePrefixes.frameGt.get(Materials.Titanium) });
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_HeatProof.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { "PhP", "PFP", aTextPlateWrench, 'P', OrePrefixes.plate.get(Materials.Invar), 'F',
                 OrePrefixes.frameGt.get(Materials.Invar) });
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_FrostProof.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { "PhP", "PFP", aTextPlateWrench, 'P', OrePrefixes.plate.get(Materials.Aluminium), 'F',
                 OrePrefixes.frameGt.get(Materials.Aluminium) });
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_CleanStainlessSteel.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { "PhP", "PFP", aTextPlateWrench, 'P', OrePrefixes.plate.get(Materials.StainlessSteel), 'F',
                 OrePrefixes.frameGt.get(Materials.StainlessSteel) });
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_RobustTungstenSteel.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { "PhP", "PFP", aTextPlateWrench, 'P', OrePrefixes.plate.get(Materials.TungstenSteel), 'F',
                 OrePrefixes.frameGt.get(Materials.TungstenSteel) });
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_MiningOsmiridium.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { "PhP", "PFP", aTextPlateWrench, 'P', OrePrefixes.plate.get(Materials.Osmiridium), 'F',
                 OrePrefixes.frameGt.get(Materials.Osmiridium) });
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_MiningNeutronium.get(3L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { "PhP", "PFP", aTextPlateWrench, 'P', OrePrefixes.plate.get(Materials.Neutronium), 'F',
                 OrePrefixes.frameGt.get(Materials.Neutronium) });
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_MiningBlackPlutonium.get(2L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { "PhP", "PFP", aTextPlateWrench, 'P', OrePrefixes.plate.get(Materials.BlackPlutonium), 'F',
                 OrePrefixes.frameGt.get(Materials.BlackPlutonium) });
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_Turbine.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { "PhP", "PFP", aTextPlateWrench, 'P', OrePrefixes.plate.get(Materials.Magnalium), 'F',
                 OrePrefixes.frameGt.get(Materials.BlueSteel) });
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_Turbine1.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { "PhP", "PFP", aTextPlateWrench, 'P', OrePrefixes.plate.get(Materials.StainlessSteel), 'F',
                 ItemList.Casing_Turbine });
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_Turbine2.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { "PhP", "PFP", aTextPlateWrench, 'P', OrePrefixes.plate.get(Materials.Titanium), 'F',
                 ItemList.Casing_Turbine });
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_Turbine3.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { "PhP", "PFP", aTextPlateWrench, 'P', OrePrefixes.plate.get(Materials.TungstenSteel), 'F',
                 ItemList.Casing_Turbine });
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_Pipe_Bronze.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { "PIP", "IFI", "PIP", 'P', OrePrefixes.plate.get(Materials.Bronze), 'F',
                 OrePrefixes.frameGt.get(Materials.Bronze), 'I', OrePrefixes.pipeMedium.get(Materials.Bronze) });
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_Pipe_Steel.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { "PIP", "IFI", "PIP", 'P', OrePrefixes.plate.get(Materials.Steel), 'F',
                 OrePrefixes.frameGt.get(Materials.Steel), 'I', OrePrefixes.pipeMedium.get(Materials.Steel) });
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_Pipe_Titanium.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { "PIP", "IFI", "PIP", 'P', OrePrefixes.plate.get(Materials.Titanium), 'F',
                 OrePrefixes.frameGt.get(Materials.Titanium), 'I', OrePrefixes.pipeMedium.get(Materials.Titanium) });
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_Pipe_TungstenSteel.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { "PIP", "IFI", "PIP", 'P', OrePrefixes.plate.get(Materials.TungstenSteel), 'F',
                 OrePrefixes.frameGt.get(Materials.TungstenSteel), 'I',
                 OrePrefixes.pipeMedium.get(Materials.TungstenSteel) });
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_Gearbox_Bronze.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { "PhP", "GFG", aTextPlateWrench, 'P', OrePrefixes.plate.get(Materials.Bronze), 'F',
                 OrePrefixes.frameGt.get(Materials.Bronze), 'G', OrePrefixes.gearGt.get(Materials.Bronze) });
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_Gearbox_Steel.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { "PhP", "GFG", aTextPlateWrench, 'P', OrePrefixes.plate.get(Materials.Steel), 'F',
                 OrePrefixes.frameGt.get(Materials.Steel), 'G', OrePrefixes.gearGt.get(Materials.Steel) });
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_Gearbox_Titanium.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { "PhP", "GFG", aTextPlateWrench, 'P', OrePrefixes.plate.get(Materials.Steel), 'F',
                 OrePrefixes.frameGt.get(Materials.Titanium), 'G', OrePrefixes.gearGt.get(Materials.Titanium) });
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_Gearbox_TungstenSteel.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { "PhP", "GFG", aTextPlateWrench, 'P', OrePrefixes.plate.get(Materials.Steel), 'F',
                 OrePrefixes.frameGt.get(Materials.TungstenSteel), 'G', ItemList.Robot_Arm_IV });
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_Grate.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { "PVP", "PFP", aTextPlateMotor, 'P', new ItemStack(Blocks.iron_bars, 1), 'F',
                 OrePrefixes.frameGt.get(Materials.Steel), 'M', ItemList.Electric_Motor_MV, 'V',
                 OrePrefixes.rotor.get(Materials.Steel) });
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_Assembler.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { "PVP", "PFP", aTextPlateMotor, 'P', OrePrefixes.circuit.get(Materials.ZPM), 'F',
                 OrePrefixes.frameGt.get(Materials.TungstenSteel), 'M', ItemList.Electric_Motor_IV, 'V',
                 OrePrefixes.circuit.get(Materials.LuV) });
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_Firebox_Bronze.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { "PSP", "SFS", "PSP", 'P', OrePrefixes.plate.get(Materials.Bronze), 'F',
                 OrePrefixes.frameGt.get(Materials.Bronze), 'S', OrePrefixes.stick.get(Materials.Bronze) });
         GTModHandler.addCraftingRecipe(
             ItemList.WoodenCasing.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { "PSP", "PFP", "PSP", 'F', OrePrefixes.gear.get(Materials.Wood), 'P',
                 OrePrefixes.frameGt.get(Materials.Wood), 'S', OrePrefixes.screw.get(Materials.Wood) });
         GTModHandler.addCraftingRecipe(
             ItemList.Hatch_Output_ULV.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { "ASA", "AFA", "APA", 'S', GTModHandler.getModItem(BuildCraftFactory.ID, "tankBlock", 1L, 0),
                 'F', ItemList.Hull_ULV.get(1L), 'A', OrePrefixes.plate.get(Materials.Rubber), 'P',
                 OrePrefixes.ring.get(Materials.Rubber) });
         GTModHandler.addCraftingRecipe(
             ItemList.Hatch_Input_ULV.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { "ASA", "AFA", "APA", 'S', GTModHandler.getModItem(BuildCraftFactory.ID, "tankBlock", 1L, 0),
                 'F', ItemList.Hull_ULV.get(1L), 'A', OrePrefixes.plate.get(Materials.Rubber), 'P',
                 OrePrefixes.gear.get(Materials.Rubber) });
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_Firebox_Steel.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { "PSP", "SFS", "PSP", 'P', OrePrefixes.plate.get(Materials.Steel), 'F',
                 OrePrefixes.frameGt.get(Materials.Steel), 'S', OrePrefixes.stick.get(Materials.Steel) });
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_Firebox_Titanium.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { "PSP", "SFS", "PSP", 'P', OrePrefixes.plate.get(Materials.Titanium), 'F',
                 OrePrefixes.frameGt.get(Materials.Titanium), 'S', OrePrefixes.stick.get(Materials.Titanium) });
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_Firebox_TungstenSteel.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { "PSP", "SFS", "PSP", 'P', OrePrefixes.plate.get(Materials.TungstenSteel), 'F',
                 OrePrefixes.frameGt.get(Materials.TungstenSteel), 'S',
                 OrePrefixes.stick.get(Materials.TungstenSteel) });
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_Stripes_A.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { "Y  ", " M ", "  B", 'M', ItemList.Casing_SolidSteel, 'Y', Dyes.dyeYellow, 'B',
                 Dyes.dyeBlack });
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_Stripes_B.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { "  Y", " M ", "B  ", 'M', ItemList.Casing_SolidSteel, 'Y', Dyes.dyeYellow, 'B',
                 Dyes.dyeBlack });
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_RadioactiveHazard.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { " YB", " M ", "   ", 'M', ItemList.Casing_SolidSteel, 'Y', Dyes.dyeYellow, 'B',
                 Dyes.dyeBlack });
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_BioHazard.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { " Y ", " MB", "   ", 'M', ItemList.Casing_SolidSteel, 'Y', Dyes.dyeYellow, 'B',
                 Dyes.dyeBlack });
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_ExplosionHazard.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { " Y ", " M ", "  B", 'M', ItemList.Casing_SolidSteel, 'Y', Dyes.dyeYellow, 'B',
                 Dyes.dyeBlack });
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_FireHazard.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { " Y ", " M ", " B ", 'M', ItemList.Casing_SolidSteel, 'Y', Dyes.dyeYellow, 'B',
                 Dyes.dyeBlack });
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_AcidHazard.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { " Y ", " M ", "B  ", 'M', ItemList.Casing_SolidSteel, 'Y', Dyes.dyeYellow, 'B',
                 Dyes.dyeBlack });
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_MagicHazard.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { " Y ", "BM ", "   ", 'M', ItemList.Casing_SolidSteel, 'Y', Dyes.dyeYellow, 'B',
                 Dyes.dyeBlack });
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_FrostHazard.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { "BY ", " M ", "   ", 'M', ItemList.Casing_SolidSteel, 'Y', Dyes.dyeYellow, 'B',
                 Dyes.dyeBlack });
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_NoiseHazard.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { "   ", " M ", "BY ", 'M', ItemList.Casing_SolidSteel, 'Y', Dyes.dyeYellow, 'B',
                 Dyes.dyeBlack });
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_Advanced_Iridium.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { "PhP", "PFP", aTextPlateWrench, 'P', OrePrefixes.plate.get(Materials.Iridium), 'F',
                 OrePrefixes.frameGt.get(Materials.Iridium) });
 
@@ -2348,20 +2125,20 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addCraftingRecipe(
             ItemList.Hull_Bronze.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { aTextPlate, "PhP", aTextPlate, 'P', OrePrefixes.plate.get(Materials.Bronze) });
         GTModHandler.addCraftingRecipe(
             ItemList.Hull_Bronze_Bricks.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { aTextPlate, "PhP", "BBB", 'P', OrePrefixes.plate.get(Materials.Bronze), 'B',
                 new ItemStack(Blocks.brick_block, 1) });
         GTModHandler.addCraftingRecipe(
             ItemList.Hull_HP.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { aTextPlate, "PhP", aTextPlate, 'P', OrePrefixes.plate.get(Materials.Steel) });
         GTModHandler.addCraftingRecipe(
             ItemList.Hull_HP_Bricks.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { aTextPlate, "PhP", "BBB", 'P', OrePrefixes.plate.get(Materials.WroughtIron), 'B',
                 new ItemStack(Blocks.brick_block, 1) });
 
@@ -2484,128 +2261,106 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addCraftingRecipe(
             ItemList.Transformer_LV_ULV.get(1L),
-            bitsd,
             new Object[] { " BB", "CM ", " BB", 'M', ItemList.Hull_ULV, 'C', OrePrefixes.cableGt01.get(Materials.Tin),
                 'B', OrePrefixes.cableGt01.get(Materials.Lead) });
         GTModHandler.addCraftingRecipe(
             ItemList.Transformer_MV_LV.get(1L),
-            bitsd,
             new Object[] { " BB", "CM ", " BB", 'M', ItemList.Hull_LV, 'C',
                 OrePrefixes.cableGt01.get(Materials.AnyCopper), 'B', OrePrefixes.cableGt01.get(Materials.Tin) });
         GTModHandler.addCraftingRecipe(
             ItemList.Transformer_HV_MV.get(1L),
-            bitsd,
             new Object[] { "KBB", "CM ", "KBB", 'M', ItemList.Hull_MV, 'C', OrePrefixes.cableGt01.get(Materials.Gold),
                 'B', OrePrefixes.cableGt01.get(Materials.AnyCopper), 'K',
                 OrePrefixes.componentCircuit.get(Materials.Inductor) });
         GTModHandler.addCraftingRecipe(
             ItemList.Transformer_EV_HV.get(1L),
-            bitsd,
             new Object[] { "KBB", "CM ", "KBB", 'M', ItemList.Hull_HV, 'C',
                 OrePrefixes.cableGt01.get(Materials.Aluminium), 'B', OrePrefixes.cableGt01.get(Materials.Gold), 'K',
                 ItemList.Circuit_Chip_ULPIC });
         GTModHandler.addCraftingRecipe(
             ItemList.Transformer_IV_EV.get(1L),
-            bitsd,
             new Object[] { "KBB", "CM ", "KBB", 'M', ItemList.Hull_EV, 'C',
                 OrePrefixes.cableGt01.get(Materials.Tungsten), 'B', OrePrefixes.cableGt01.get(Materials.Aluminium), 'K',
                 ItemList.Circuit_Chip_LPIC });
         GTModHandler.addCraftingRecipe(
             ItemList.Transformer_LuV_IV.get(1L),
-            bitsd,
             new Object[] { "KBB", "CM ", "KBB", 'M', ItemList.Hull_IV, 'C',
                 OrePrefixes.cableGt01.get(Materials.VanadiumGallium), 'B',
                 OrePrefixes.cableGt01.get(Materials.Tungsten), 'K', ItemList.Circuit_Chip_PIC });
         GTModHandler.addCraftingRecipe(
             ItemList.Transformer_ZPM_LuV.get(1L),
-            bitsd,
             new Object[] { "KBB", "CM ", "KBB", 'M', ItemList.Hull_LuV, 'C',
                 OrePrefixes.cableGt01.get(Materials.Naquadah), 'B',
                 OrePrefixes.cableGt01.get(Materials.VanadiumGallium), 'K', ItemList.Circuit_Chip_HPIC });
         GTModHandler.addCraftingRecipe(
             ItemList.Transformer_UV_ZPM.get(1L),
-            bitsd,
             new Object[] { "KBB", "CM ", "KBB", 'M', ItemList.Hull_ZPM, 'C',
                 OrePrefixes.cableGt01.get(Materials.NaquadahAlloy), 'B', OrePrefixes.cableGt01.get(Materials.Naquadah),
                 'K', ItemList.Circuit_Chip_UHPIC });
         GTModHandler.addCraftingRecipe(
             ItemList.Transformer_MAX_UV.get(1L),
-            bitsd,
             new Object[] { "KBB", "CM ", "KBB", 'M', ItemList.Hull_UV, 'C',
                 OrePrefixes.wireGt01.get(Materials.Bedrockium), 'B', OrePrefixes.cableGt01.get(Materials.NaquadahAlloy),
                 'K', ItemList.Circuit_Chip_NPIC });
 
         GTModHandler.addCraftingRecipe(
             ItemList.Hatch_Dynamo_ULV.get(1L),
-            bitsd,
             new Object[] { "XOL", "SMP", "XOL", 'M', ItemList.Hull_ULV, 'S', OrePrefixes.spring.get(Materials.Lead),
                 'X', OrePrefixes.circuit.get(Materials.ULV), 'O', ItemList.ULV_Coil, 'L',
                 OrePrefixes.cell.get(Materials.Lubricant), 'P', OrePrefixes.rotor.get(Materials.Lead) });
         GTModHandler.addCraftingRecipe(
             ItemList.Hatch_Dynamo_LV.get(1L),
-            bitsd,
             new Object[] { "XOL", "SMP", "XOL", 'M', ItemList.Hull_LV, 'S', OrePrefixes.spring.get(Materials.Tin), 'X',
                 OrePrefixes.circuit.get(Materials.LV), 'O', ItemList.LV_Coil, 'L',
                 OrePrefixes.cell.get(Materials.Lubricant), 'P', ItemList.Electric_Pump_LV });
         GTModHandler.addCraftingRecipe(
             ItemList.Hatch_Dynamo_MV.get(1L),
-            bitsd,
             new Object[] { "XOL", "SMP", "XOL", 'M', ItemList.Hull_MV, 'S', OrePrefixes.spring.get(Materials.Copper),
                 'X', ItemList.Circuit_Chip_ULPIC, 'O', ItemList.MV_Coil, 'L', OrePrefixes.cell.get(Materials.Lubricant),
                 'P', ItemList.Electric_Pump_MV });
         GTModHandler.addCraftingRecipe(
             ItemList.Hatch_Energy_ULV.get(1L),
-            bitsd,
             new Object[] { "COL", "XMP", "COL", 'M', ItemList.Hull_ULV, 'C', OrePrefixes.cableGt01.get(Materials.Lead),
                 'X', OrePrefixes.circuit.get(Materials.ULV), 'O', ItemList.ULV_Coil, 'L',
                 OrePrefixes.cell.get(Materials.Lubricant), 'P', OrePrefixes.rotor.get(Materials.Lead) });
         GTModHandler.addCraftingRecipe(
             ItemList.Hatch_Energy_LV.get(1L),
-            bitsd,
             new Object[] { "COL", "XMP", "COL", 'M', ItemList.Hull_LV, 'C', OrePrefixes.cableGt01.get(Materials.Tin),
                 'X', OrePrefixes.circuit.get(Materials.LV), 'O', ItemList.LV_Coil, 'L',
                 OrePrefixes.cell.get(Materials.Lubricant), 'P', ItemList.Electric_Pump_LV });
         GTModHandler.addCraftingRecipe(
             ItemList.Hatch_Energy_MV.get(1L),
-            bitsd,
             new Object[] { "XOL", "CMP", "XOL", 'M', ItemList.Hull_MV, 'C', OrePrefixes.cableGt01.get(Materials.Copper),
                 'X', ItemList.Circuit_Chip_ULPIC, 'O', ItemList.MV_Coil, 'L', OrePrefixes.cell.get(Materials.Lubricant),
                 'P', ItemList.Electric_Pump_MV });
         GTModHandler.addCraftingRecipe(
             ItemList.Hatch_Maintenance.get(1L),
-            bitsd,
             new Object[] { "dwx", "hMc", "fsr", 'M', ItemList.Hull_LV });
 
         GTModHandler.addCraftingRecipe(
             ItemList.Hatch_DataAccess_EV.get(1L),
-            bitsd,
             new Object[] { "COC", "OMO", "COC", 'M', ItemList.Hull_EV, 'O', ItemList.Tool_DataStick, 'C',
                 OrePrefixes.circuit.get(Materials.IV) });
         GTModHandler.addCraftingRecipe(
             ItemList.Hatch_DataAccess_LuV.get(1L),
-            bitsd,
             new Object[] { "COC", "OMO", "COC", 'M', ItemList.Hull_LuV, 'O', ItemList.Tool_DataOrb, 'C',
                 OrePrefixes.circuit.get(Materials.ZPM) });
         GTModHandler.addCraftingRecipe(
             ItemList.Hatch_DataAccess_UV.get(1L),
-            bitsd,
             new Object[] { "CRC", "OMO", "CRC", 'M', ItemList.Hull_UV, 'O', ItemList.Tool_DataOrb, 'C',
                 OrePrefixes.circuit.get(Materials.UHV), 'R', ItemList.Robot_Arm_UV });
 
         GTModHandler.addCraftingRecipe(
             ItemList.Hatch_AutoMaintenance.get(1L),
-            bitsd,
             new Object[] { "CHC", "AMA", "CHC", 'M', ItemList.Hull_LuV, 'H', ItemList.Hatch_Maintenance, 'A',
                 ItemList.Robot_Arm_LuV, 'C', OrePrefixes.circuit.get(Materials.ZPM) });
 
         GTModHandler.addCraftingRecipe(
             ItemList.Hatch_Muffler_LV.get(1L),
-            bitsd,
             new Object[] { "MX ", "PR ", 'M', ItemList.Hull_LV, 'P', OrePrefixes.pipeMedium.get(Materials.Bronze), 'R',
                 OrePrefixes.rotor.get(Materials.Bronze), 'X', ItemList.Electric_Motor_LV });
         GTModHandler.addCraftingRecipe(
             ItemList.Hatch_Muffler_MV.get(1L),
-            bitsd,
             new Object[] { "MX ", "PR ", 'M', ItemList.Hull_MV, 'P', OrePrefixes.pipeMedium.get(Materials.Steel), 'R',
                 OrePrefixes.rotor.get(Materials.Steel), 'X', ItemList.Electric_Motor_MV });
 
@@ -2655,520 +2410,425 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_Bronze_Boiler.get(1L),
-            bitsd,
             new Object[] { aTextPlate, "PwP", "BFB", 'F', OreDictNames.craftingIronFurnace, 'P',
                 OrePrefixes.plate.get(Materials.Bronze), 'B', new ItemStack(Blocks.brick_block, 1) });
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_Steel_Boiler.get(1L),
-            bitsd,
             new Object[] { aTextPlate, "PwP", "BFB", 'F', OreDictNames.craftingIronFurnace, 'P',
                 OrePrefixes.plate.get(Materials.Steel), 'B', new ItemStack(Blocks.brick_block, 1) });
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_Steel_Boiler_Lava.get(1L),
-            bitsd,
             new Object[] { aTextPlate, "PTP", aTextPlateMotor, 'M', ItemList.Hull_HP, 'P',
                 OrePrefixes.plate.get(Materials.Steel), 'T',
                 GTModHandler.getModItem(BuildCraftFactory.ID, "tankBlock", 1L, 0) });
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_Bronze_Boiler_Solar.get(1L),
-            bitsd,
             new Object[] { "GGG", "SSS", aTextPlateMotor, 'M', ItemList.Hull_Bronze_Bricks, 'P',
                 OrePrefixes.pipeSmall.get(Materials.Bronze), 'S', OrePrefixes.plateDouble.get(Materials.Silver), 'G',
                 new ItemStack(Blocks.glass, 1) });
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_HP_Solar.get(1L),
-            bitsd,
             new Object[] { "GGG", "SSS", aTextPlateMotor, 'M', ItemList.Hull_HP_Bricks, 'P',
                 OrePrefixes.pipeSmall.get(Materials.Steel), 'S', OrePrefixes.plateTriple.get(Materials.Silver), 'G',
                 GTModHandler.getModItem(IndustrialCraft2.ID, "blockAlloyGlass", 1L) });
 
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_Bronze_Furnace.get(1L),
-            bitsd,
             new Object[] { "XXX", "XMX", "XFX", 'M', ItemList.Hull_Bronze_Bricks, 'X',
                 OrePrefixes.pipeSmall.get(Materials.Bronze), 'F', OreDictNames.craftingFurnace });
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_HP_Furnace.get(1L),
-            bitsd,
             new Object[] { "XSX", "PMP", "XXX", 'M', ItemList.Machine_Bronze_Furnace, 'X',
                 OrePrefixes.pipeSmall.get(Materials.WroughtIron), 'P', OrePrefixes.plate.get(Materials.WroughtIron),
                 'S', OrePrefixes.plate.get(Materials.Steel) });
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_Bronze_Macerator.get(1L),
-            bitsd,
             new Object[] { "DXD", "XMX", "PXP", 'M', ItemList.Hull_Bronze, 'X',
                 OrePrefixes.pipeSmall.get(Materials.Bronze), 'P', OreDictNames.craftingPiston, 'D',
                 OrePrefixes.gem.get(Materials.Diamond) });
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_HP_Macerator.get(1L),
-            bitsd,
             new Object[] { "PSP", "XMX", "PPP", 'M', ItemList.Machine_Bronze_Macerator, 'X',
                 OrePrefixes.pipeSmall.get(Materials.WroughtIron), 'P', OrePrefixes.plate.get(Materials.WroughtIron),
                 'S', OrePrefixes.plate.get(Materials.Steel) });
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_Bronze_Extractor.get(1L),
-            bitsd,
             new Object[] { "XXX", "PMG", "XXX", 'M', ItemList.Hull_Bronze, 'X',
                 OrePrefixes.pipeSmall.get(Materials.Bronze), 'P', OreDictNames.craftingPiston, 'G',
                 new ItemStack(Blocks.glass, 1) });
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_HP_Extractor.get(1L),
-            bitsd,
             new Object[] { "XSX", "PMP", "XXX", 'M', ItemList.Machine_Bronze_Extractor, 'X',
                 OrePrefixes.pipeSmall.get(Materials.WroughtIron), 'P', OrePrefixes.plate.get(Materials.WroughtIron),
                 'S', OrePrefixes.plate.get(Materials.Steel) });
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_Bronze_Hammer.get(1L),
-            bitsd,
             new Object[] { "XPX", "XMX", "XAX", 'M', ItemList.Hull_Bronze, 'X',
                 OrePrefixes.pipeSmall.get(Materials.Bronze), 'P', OreDictNames.craftingPiston, 'A',
                 OreDictNames.craftingAnvil });
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_HP_Hammer.get(1L),
-            bitsd,
             new Object[] { "PSP", "XMX", "PPP", 'M', ItemList.Machine_Bronze_Hammer, 'X',
                 OrePrefixes.pipeSmall.get(Materials.WroughtIron), 'P', OrePrefixes.plate.get(Materials.WroughtIron),
                 'S', OrePrefixes.plate.get(Materials.Steel) });
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_Bronze_Compressor.get(1L),
-            bitsd,
             new Object[] { "XXX", aTextPlateMotor, "XXX", 'M', ItemList.Hull_Bronze, 'X',
                 OrePrefixes.pipeSmall.get(Materials.Bronze), 'P', OreDictNames.craftingPiston });
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_HP_Compressor.get(1L),
-            bitsd,
             new Object[] { "XSX", "PMP", "XXX", 'M', ItemList.Machine_Bronze_Compressor, 'X',
                 OrePrefixes.pipeSmall.get(Materials.WroughtIron), 'P', OrePrefixes.plate.get(Materials.WroughtIron),
                 'S', OrePrefixes.plate.get(Materials.Steel) });
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_Bronze_AlloySmelter.get(1L),
-            bitsd,
             new Object[] { "XXX", "FMF", "XXX", 'M', ItemList.Hull_Bronze_Bricks, 'X',
                 OrePrefixes.pipeSmall.get(Materials.Bronze), 'F', OreDictNames.craftingFurnace });
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_HP_AlloySmelter.get(1L),
-            bitsd,
             new Object[] { "PSP", "PMP", "PXP", 'M', ItemList.Machine_Bronze_AlloySmelter, 'X',
                 OrePrefixes.pipeSmall.get(Materials.WroughtIron), 'P', OrePrefixes.plate.get(Materials.WroughtIron),
                 'S', OrePrefixes.plate.get(Materials.Steel) });
 
         GTModHandler.addCraftingRecipe(
             ItemList.Battery_Buffer_1by1_ULV.get(1L),
-            bitsd,
             new Object[] { aTextWireChest, aTextWireHull, 'M', ItemList.Hull_ULV, 'W',
                 OrePrefixes.wireGt01.get(Materials.Lead), 'T', OreDictNames.craftingChest });
         GTModHandler.addCraftingRecipe(
             ItemList.Battery_Buffer_1by1_LV.get(1L),
-            bitsd,
             new Object[] { aTextWireChest, aTextWireHull, 'M', ItemList.Hull_LV, 'W',
                 OrePrefixes.wireGt01.get(Materials.Tin), 'T', OreDictNames.craftingChest });
         GTModHandler.addCraftingRecipe(
             ItemList.Battery_Buffer_1by1_MV.get(1L),
-            bitsd,
             new Object[] { aTextWireChest, aTextWireHull, 'M', ItemList.Hull_MV, 'W',
                 OrePrefixes.wireGt01.get(Materials.AnyCopper), 'T', OreDictNames.craftingChest });
         GTModHandler.addCraftingRecipe(
             ItemList.Battery_Buffer_1by1_HV.get(1L),
-            bitsd,
             new Object[] { aTextWireChest, aTextWireHull, 'M', ItemList.Hull_HV, 'W',
                 OrePrefixes.wireGt01.get(Materials.Gold), 'T', OreDictNames.craftingChest });
         GTModHandler.addCraftingRecipe(
             ItemList.Battery_Buffer_1by1_EV.get(1L),
-            bitsd,
             new Object[] { aTextWireChest, aTextWireHull, 'M', ItemList.Hull_EV, 'W',
                 OrePrefixes.wireGt01.get(Materials.Aluminium), 'T', OreDictNames.craftingChest });
         GTModHandler.addCraftingRecipe(
             ItemList.Battery_Buffer_1by1_IV.get(1L),
-            bitsd,
             new Object[] { aTextWireChest, aTextWireHull, 'M', ItemList.Hull_IV, 'W',
                 OrePrefixes.wireGt01.get(Materials.Tungsten), 'T', OreDictNames.craftingChest });
         GTModHandler.addCraftingRecipe(
             ItemList.Battery_Buffer_1by1_LuV.get(1L),
-            bitsd,
             new Object[] { aTextWireChest, aTextWireHull, 'M', ItemList.Hull_LuV, 'W',
                 OrePrefixes.wireGt01.get(Materials.VanadiumGallium), 'T', OreDictNames.craftingChest });
         GTModHandler.addCraftingRecipe(
             ItemList.Battery_Buffer_1by1_ZPM.get(1L),
-            bitsd,
             new Object[] { aTextWireChest, aTextWireHull, 'M', ItemList.Hull_ZPM, 'W',
                 OrePrefixes.wireGt01.get(Materials.Naquadah), 'T', OreDictNames.craftingChest });
         GTModHandler.addCraftingRecipe(
             ItemList.Battery_Buffer_1by1_UV.get(1L),
-            bitsd,
             new Object[] { aTextWireChest, aTextWireHull, 'M', ItemList.Hull_UV, 'W',
                 OrePrefixes.wireGt01.get(Materials.NaquadahAlloy), 'T', OreDictNames.craftingChest });
         GTModHandler.addCraftingRecipe(
             ItemList.Battery_Buffer_1by1_UHV.get(1L),
-            bitsd,
             new Object[] { aTextWireChest, aTextWireHull, 'M', ItemList.Hull_MAX, 'W',
                 OrePrefixes.wireGt01.get(Materials.SuperconductorUHV), 'T', OreDictNames.craftingChest });
 
         GTModHandler.addCraftingRecipe(
             ItemList.Battery_Buffer_2by2_ULV.get(1L),
-            bitsd,
             new Object[] { aTextWireChest, aTextWireHull, 'M', ItemList.Hull_ULV, 'W',
                 OrePrefixes.wireGt04.get(Materials.Lead), 'T', OreDictNames.craftingChest });
         GTModHandler.addCraftingRecipe(
             ItemList.Battery_Buffer_2by2_LV.get(1L),
-            bitsd,
             new Object[] { aTextWireChest, aTextWireHull, 'M', ItemList.Hull_LV, 'W',
                 OrePrefixes.wireGt04.get(Materials.Tin), 'T', OreDictNames.craftingChest });
         GTModHandler.addCraftingRecipe(
             ItemList.Battery_Buffer_2by2_MV.get(1L),
-            bitsd,
             new Object[] { aTextWireChest, aTextWireHull, 'M', ItemList.Hull_MV, 'W',
                 OrePrefixes.wireGt04.get(Materials.AnyCopper), 'T', OreDictNames.craftingChest });
         GTModHandler.addCraftingRecipe(
             ItemList.Battery_Buffer_2by2_HV.get(1L),
-            bitsd,
             new Object[] { aTextWireChest, aTextWireHull, 'M', ItemList.Hull_HV, 'W',
                 OrePrefixes.wireGt04.get(Materials.Gold), 'T', OreDictNames.craftingChest });
         GTModHandler.addCraftingRecipe(
             ItemList.Battery_Buffer_2by2_EV.get(1L),
-            bitsd,
             new Object[] { aTextWireChest, aTextWireHull, 'M', ItemList.Hull_EV, 'W',
                 OrePrefixes.wireGt04.get(Materials.Aluminium), 'T', OreDictNames.craftingChest });
         GTModHandler.addCraftingRecipe(
             ItemList.Battery_Buffer_2by2_IV.get(1L),
-            bitsd,
             new Object[] { aTextWireChest, aTextWireHull, 'M', ItemList.Hull_IV, 'W',
                 OrePrefixes.wireGt04.get(Materials.Tungsten), 'T', OreDictNames.craftingChest });
         GTModHandler.addCraftingRecipe(
             ItemList.Battery_Buffer_2by2_LuV.get(1L),
-            bitsd,
             new Object[] { aTextWireChest, aTextWireHull, 'M', ItemList.Hull_LuV, 'W',
                 OrePrefixes.wireGt04.get(Materials.VanadiumGallium), 'T', OreDictNames.craftingChest });
         GTModHandler.addCraftingRecipe(
             ItemList.Battery_Buffer_2by2_ZPM.get(1L),
-            bitsd,
             new Object[] { aTextWireChest, aTextWireHull, 'M', ItemList.Hull_ZPM, 'W',
                 OrePrefixes.wireGt04.get(Materials.Naquadah), 'T', OreDictNames.craftingChest });
         GTModHandler.addCraftingRecipe(
             ItemList.Battery_Buffer_2by2_UV.get(1L),
-            bitsd,
             new Object[] { aTextWireChest, aTextWireHull, 'M', ItemList.Hull_UV, 'W',
                 OrePrefixes.wireGt04.get(Materials.NaquadahAlloy), 'T', OreDictNames.craftingChest });
         GTModHandler.addCraftingRecipe(
             ItemList.Battery_Buffer_2by2_UHV.get(1L),
-            bitsd,
             new Object[] { aTextWireChest, aTextWireHull, 'M', ItemList.Hull_MAX, 'W',
                 OrePrefixes.wireGt04.get(Materials.SuperconductorUHV), 'T', OreDictNames.craftingChest });
 
         GTModHandler.addCraftingRecipe(
             ItemList.Battery_Buffer_3by3_ULV.get(1L),
-            bitsd,
             new Object[] { aTextWireChest, aTextWireHull, 'M', ItemList.Hull_ULV, 'W',
                 OrePrefixes.wireGt08.get(Materials.Lead), 'T', OreDictNames.craftingChest });
         GTModHandler.addCraftingRecipe(
             ItemList.Battery_Buffer_3by3_LV.get(1L),
-            bitsd,
             new Object[] { aTextWireChest, aTextWireHull, 'M', ItemList.Hull_LV, 'W',
                 OrePrefixes.wireGt08.get(Materials.Tin), 'T', OreDictNames.craftingChest });
         GTModHandler.addCraftingRecipe(
             ItemList.Battery_Buffer_3by3_MV.get(1L),
-            bitsd,
             new Object[] { aTextWireChest, aTextWireHull, 'M', ItemList.Hull_MV, 'W',
                 OrePrefixes.wireGt08.get(Materials.AnyCopper), 'T', OreDictNames.craftingChest });
         GTModHandler.addCraftingRecipe(
             ItemList.Battery_Buffer_3by3_HV.get(1L),
-            bitsd,
             new Object[] { aTextWireChest, aTextWireHull, 'M', ItemList.Hull_HV, 'W',
                 OrePrefixes.wireGt08.get(Materials.Gold), 'T', OreDictNames.craftingChest });
         GTModHandler.addCraftingRecipe(
             ItemList.Battery_Buffer_3by3_EV.get(1L),
-            bitsd,
             new Object[] { aTextWireChest, aTextWireHull, 'M', ItemList.Hull_EV, 'W',
                 OrePrefixes.wireGt08.get(Materials.Aluminium), 'T', OreDictNames.craftingChest });
         GTModHandler.addCraftingRecipe(
             ItemList.Battery_Buffer_3by3_IV.get(1L),
-            bitsd,
             new Object[] { aTextWireChest, aTextWireHull, 'M', ItemList.Hull_IV, 'W',
                 OrePrefixes.wireGt08.get(Materials.Tungsten), 'T', OreDictNames.craftingChest });
         GTModHandler.addCraftingRecipe(
             ItemList.Battery_Buffer_3by3_LuV.get(1L),
-            bitsd,
             new Object[] { aTextWireChest, aTextWireHull, 'M', ItemList.Hull_LuV, 'W',
                 OrePrefixes.wireGt08.get(Materials.VanadiumGallium), 'T', OreDictNames.craftingChest });
         GTModHandler.addCraftingRecipe(
             ItemList.Battery_Buffer_3by3_ZPM.get(1L),
-            bitsd,
             new Object[] { aTextWireChest, aTextWireHull, 'M', ItemList.Hull_ZPM, 'W',
                 OrePrefixes.wireGt08.get(Materials.Naquadah), 'T', OreDictNames.craftingChest });
         GTModHandler.addCraftingRecipe(
             ItemList.Battery_Buffer_3by3_UV.get(1L),
-            bitsd,
             new Object[] { aTextWireChest, aTextWireHull, 'M', ItemList.Hull_UV, 'W',
                 OrePrefixes.wireGt08.get(Materials.NaquadahAlloy), 'T', OreDictNames.craftingChest });
         GTModHandler.addCraftingRecipe(
             ItemList.Battery_Buffer_3by3_UHV.get(1L),
-            bitsd,
             new Object[] { aTextWireChest, aTextWireHull, 'M', ItemList.Hull_MAX, 'W',
                 OrePrefixes.wireGt08.get(Materials.SuperconductorUHV), 'T', OreDictNames.craftingChest });
 
         GTModHandler.addCraftingRecipe(
             ItemList.Battery_Buffer_4by4_ULV.get(1L),
-            bitsd,
             new Object[] { aTextWireChest, aTextWireHull, 'M', ItemList.Hull_ULV, 'W',
                 OrePrefixes.wireGt16.get(Materials.Lead), 'T', OreDictNames.craftingChest });
         GTModHandler.addCraftingRecipe(
             ItemList.Battery_Buffer_4by4_LV.get(1L),
-            bitsd,
             new Object[] { aTextWireChest, aTextWireHull, 'M', ItemList.Hull_LV, 'W',
                 OrePrefixes.wireGt16.get(Materials.Tin), 'T', OreDictNames.craftingChest });
         GTModHandler.addCraftingRecipe(
             ItemList.Battery_Buffer_4by4_MV.get(1L),
-            bitsd,
             new Object[] { aTextWireChest, aTextWireHull, 'M', ItemList.Hull_MV, 'W',
                 OrePrefixes.wireGt16.get(Materials.AnyCopper), 'T', OreDictNames.craftingChest });
         GTModHandler.addCraftingRecipe(
             ItemList.Battery_Buffer_4by4_HV.get(1L),
-            bitsd,
             new Object[] { aTextWireChest, aTextWireHull, 'M', ItemList.Hull_HV, 'W',
                 OrePrefixes.wireGt16.get(Materials.Gold), 'T', OreDictNames.craftingChest });
         GTModHandler.addCraftingRecipe(
             ItemList.Battery_Buffer_4by4_EV.get(1L),
-            bitsd,
             new Object[] { aTextWireChest, aTextWireHull, 'M', ItemList.Hull_EV, 'W',
                 OrePrefixes.wireGt16.get(Materials.Aluminium), 'T', OreDictNames.craftingChest });
         GTModHandler.addCraftingRecipe(
             ItemList.Battery_Buffer_4by4_IV.get(1L),
-            bitsd,
             new Object[] { aTextWireChest, aTextWireHull, 'M', ItemList.Hull_IV, 'W',
                 OrePrefixes.wireGt16.get(Materials.Tungsten), 'T', OreDictNames.craftingChest });
         GTModHandler.addCraftingRecipe(
             ItemList.Battery_Buffer_4by4_LuV.get(1L),
-            bitsd,
             new Object[] { aTextWireChest, aTextWireHull, 'M', ItemList.Hull_LuV, 'W',
                 OrePrefixes.wireGt16.get(Materials.VanadiumGallium), 'T', OreDictNames.craftingChest });
         GTModHandler.addCraftingRecipe(
             ItemList.Battery_Buffer_4by4_ZPM.get(1L),
-            bitsd,
             new Object[] { aTextWireChest, aTextWireHull, 'M', ItemList.Hull_ZPM, 'W',
                 OrePrefixes.wireGt16.get(Materials.Naquadah), 'T', OreDictNames.craftingChest });
         GTModHandler.addCraftingRecipe(
             ItemList.Battery_Buffer_4by4_UV.get(1L),
-            bitsd,
             new Object[] { aTextWireChest, aTextWireHull, 'M', ItemList.Hull_UV, 'W',
                 OrePrefixes.wireGt16.get(Materials.NaquadahAlloy), 'T', OreDictNames.craftingChest });
         GTModHandler.addCraftingRecipe(
             ItemList.Battery_Buffer_4by4_UHV.get(1L),
-            bitsd,
             new Object[] { aTextWireChest, aTextWireHull, 'M', ItemList.Hull_MAX, 'W',
                 OrePrefixes.wireGt16.get(Materials.SuperconductorUHV), 'T', OreDictNames.craftingChest });
 
         GTModHandler.addCraftingRecipe(
             ItemList.Battery_Charger_4by4_ULV.get(1L),
-            bitsd,
             new Object[] { aTextWireChest, aTextWireHull, "BCB", 'M', ItemList.Hull_ULV, 'W',
                 OrePrefixes.wireGt16.get(Materials.Lead), 'T', OreDictNames.craftingChest, 'B',
                 ItemList.Battery_RE_ULV_Tantalum, 'C', OrePrefixes.circuit.get(Materials.ULV) });
         GTModHandler.addCraftingRecipe(
             ItemList.Battery_Charger_4by4_LV.get(1L),
-            bitsd,
             new Object[] { aTextWireChest, aTextWireHull, "BCB", 'M', ItemList.Hull_LV, 'W',
                 OrePrefixes.wireGt16.get(Materials.Tin), 'T', OreDictNames.craftingChest, 'B',
                 ItemList.Battery_RE_LV_Lithium, 'C', OrePrefixes.circuit.get(Materials.LV) });
         GTModHandler.addCraftingRecipe(
             ItemList.Battery_Charger_4by4_MV.get(1L),
-            bitsd,
             new Object[] { aTextWireChest, aTextWireHull, "BCB", 'M', ItemList.Hull_MV, 'W',
                 OrePrefixes.wireGt16.get(Materials.AnyCopper), 'T', OreDictNames.craftingChest, 'B',
                 ItemList.Battery_RE_MV_Lithium, 'C', OrePrefixes.circuit.get(Materials.MV) });
         GTModHandler.addCraftingRecipe(
             ItemList.Battery_Charger_4by4_HV.get(1L),
-            bitsd,
             new Object[] { aTextWireChest, aTextWireHull, "BCB", 'M', ItemList.Hull_HV, 'W',
                 OrePrefixes.wireGt16.get(Materials.Gold), 'T', OreDictNames.craftingChest, 'B',
                 ItemList.Battery_RE_HV_Lithium, 'C', OrePrefixes.circuit.get(Materials.HV) });
         GTModHandler.addCraftingRecipe(
             ItemList.Battery_Charger_4by4_EV.get(1L),
-            bitsd,
             new Object[] { aTextWireChest, aTextWireHull, "BCB", 'M', ItemList.Hull_EV, 'W',
                 OrePrefixes.wireGt16.get(Materials.Aluminium), 'T', OreDictNames.craftingChest, 'B',
                 OrePrefixes.battery.get(Materials.EV), 'C', OrePrefixes.circuit.get(Materials.EV) });
         GTModHandler.addCraftingRecipe(
             ItemList.Battery_Charger_4by4_IV.get(1L),
-            bitsd,
             new Object[] { aTextWireChest, aTextWireHull, "BCB", 'M', ItemList.Hull_IV, 'W',
                 OrePrefixes.wireGt16.get(Materials.Tungsten), 'T', OreDictNames.craftingChest, 'B',
                 OrePrefixes.battery.get(Materials.IV), 'C', OrePrefixes.circuit.get(Materials.IV) });
         GTModHandler.addCraftingRecipe(
             ItemList.Battery_Charger_4by4_LuV.get(1L),
-            bitsd,
             new Object[] { aTextWireChest, aTextWireHull, "BCB", 'M', ItemList.Hull_LuV, 'W',
                 OrePrefixes.wireGt16.get(Materials.VanadiumGallium), 'T', OreDictNames.craftingChest, 'B',
                 OrePrefixes.battery.get(Materials.LuV), 'C', OrePrefixes.circuit.get(Materials.LuV) });
         GTModHandler.addCraftingRecipe(
             ItemList.Battery_Charger_4by4_ZPM.get(1L),
-            bitsd,
             new Object[] { aTextWireChest, aTextWireHull, "BCB", 'M', ItemList.Hull_ZPM, 'W',
                 OrePrefixes.wireGt16.get(Materials.Naquadah), 'T', OreDictNames.craftingChest, 'B',
                 OrePrefixes.battery.get(Materials.ZPM), 'C', OrePrefixes.circuit.get(Materials.ZPM) });
         GTModHandler.addCraftingRecipe(
             ItemList.Battery_Charger_4by4_UV.get(1L),
-            bitsd,
             new Object[] { aTextWireChest, aTextWireHull, "BCB", 'M', ItemList.Hull_UV, 'W',
                 OrePrefixes.wireGt16.get(Materials.NaquadahAlloy), 'T', OreDictNames.craftingChest, 'B', ItemList.ZPM2,
                 'C', OrePrefixes.circuit.get(Materials.UV) });
         GTModHandler.addCraftingRecipe(
             ItemList.Battery_Charger_4by4_UHV.get(1L),
-            bitsd,
             new Object[] { aTextWireChest, aTextWireHull, "BCB", 'M', ItemList.Hull_MAX, 'W',
                 OrePrefixes.wireGt16.get(Materials.SuperconductorUHV), 'T', OreDictNames.craftingChest, 'B',
                 ItemList.ZPM2, 'C', OrePrefixes.circuit.get(Materials.UHV) });
 
         GTModHandler.addCraftingRecipe(
             ItemList.Locker_ULV.get(1L),
-            bitsd,
             new Object[] { "T", "M", 'M', ItemList.Battery_Buffer_2by2_ULV, 'T', OreDictNames.craftingChest });
         GTModHandler.addCraftingRecipe(
             ItemList.Locker_LV.get(1L),
-            bitsd,
             new Object[] { "T", "M", 'M', ItemList.Battery_Buffer_2by2_LV, 'T', OreDictNames.craftingChest });
         GTModHandler.addCraftingRecipe(
             ItemList.Locker_MV.get(1L),
-            bitsd,
             new Object[] { "T", "M", 'M', ItemList.Battery_Buffer_2by2_MV, 'T', OreDictNames.craftingChest });
         GTModHandler.addCraftingRecipe(
             ItemList.Locker_HV.get(1L),
-            bitsd,
             new Object[] { "T", "M", 'M', ItemList.Battery_Buffer_2by2_HV, 'T', OreDictNames.craftingChest });
         GTModHandler.addCraftingRecipe(
             ItemList.Locker_EV.get(1L),
-            bitsd,
             new Object[] { "T", "M", 'M', ItemList.Battery_Buffer_2by2_EV, 'T', OreDictNames.craftingChest });
         GTModHandler.addCraftingRecipe(
             ItemList.Locker_IV.get(1L),
-            bitsd,
             new Object[] { "T", "M", 'M', ItemList.Battery_Buffer_2by2_IV, 'T', OreDictNames.craftingChest });
         GTModHandler.addCraftingRecipe(
             ItemList.Locker_LuV.get(1L),
-            bitsd,
             new Object[] { "T", "M", 'M', ItemList.Battery_Buffer_2by2_LuV, 'T', OreDictNames.craftingChest });
         GTModHandler.addCraftingRecipe(
             ItemList.Locker_ZPM.get(1L),
-            bitsd,
             new Object[] { "T", "M", 'M', ItemList.Battery_Buffer_2by2_ZPM, 'T', OreDictNames.craftingChest });
         GTModHandler.addCraftingRecipe(
             ItemList.Locker_UV.get(1L),
-            bitsd,
             new Object[] { "T", "M", 'M', ItemList.Battery_Buffer_2by2_UV, 'T', OreDictNames.craftingChest });
         GTModHandler.addCraftingRecipe(
             ItemList.Locker_MAX.get(1L),
-            bitsd,
             new Object[] { "T", "M", 'M', ItemList.Battery_Buffer_2by2_UHV, 'T', OreDictNames.craftingChest });
 
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_LV_Scanner.get(1L),
-            bitsd,
             new Object[] { "CTC", aTextWireHull, "CRC", 'M', ItemList.Hull_LV, 'T', ItemList.Emitter_LV, 'R',
                 ItemList.Sensor_LV, 'C', OrePrefixes.circuit.get(Materials.MV), 'W',
                 OrePrefixes.cableGt01.get(Materials.Tin) });
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_MV_Scanner.get(1L),
-            bitsd,
             new Object[] { "CTC", aTextWireHull, "CRC", 'M', ItemList.Hull_MV, 'T', ItemList.Emitter_MV, 'R',
                 ItemList.Sensor_MV, 'C', OrePrefixes.circuit.get(Materials.HV), 'W',
                 OrePrefixes.cableGt01.get(Materials.AnyCopper) });
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_HV_Scanner.get(1L),
-            bitsd,
             new Object[] { "CTC", aTextWireHull, "CRC", 'M', ItemList.Hull_HV, 'T', ItemList.Emitter_HV, 'R',
                 ItemList.Sensor_HV, 'C', OrePrefixes.circuit.get(Materials.EV), 'W',
                 OrePrefixes.cableGt01.get(Materials.Gold) });
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_EV_Scanner.get(1L),
-            bitsd,
             new Object[] { "CTC", aTextWireHull, "CRC", 'M', ItemList.Hull_EV, 'T', ItemList.Emitter_EV, 'R',
                 ItemList.Sensor_EV, 'C', OrePrefixes.circuit.get(Materials.IV), 'W',
                 OrePrefixes.cableGt01.get(Materials.Aluminium) });
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_IV_Scanner.get(1L),
-            bitsd,
             new Object[] { "CTC", aTextWireHull, "CRC", 'M', ItemList.Hull_IV, 'T', ItemList.Emitter_IV, 'R',
                 ItemList.Sensor_IV, 'C', OrePrefixes.circuit.get(Materials.LuV), 'W',
                 OrePrefixes.cableGt01.get(Materials.Tungsten) });
 
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_LV_Boxinator.get(1L),
-            bitsd,
             new Object[] { "BCB", "RMV", aTextWireCoil, 'M', ItemList.Hull_LV, 'R', ItemList.Robot_Arm_LV, 'V',
                 ItemList.Conveyor_Module_LV, 'C', OrePrefixes.circuit.get(Materials.LV), 'W',
                 OrePrefixes.cableGt01.get(Materials.Tin), 'B', OreDictNames.craftingChest });
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_MV_Boxinator.get(1L),
-            bitsd,
             new Object[] { "BCB", "RMV", aTextWireCoil, 'M', ItemList.Hull_MV, 'R', ItemList.Robot_Arm_MV, 'V',
                 ItemList.Conveyor_Module_MV, 'C', OrePrefixes.circuit.get(Materials.MV), 'W',
                 OrePrefixes.cableGt01.get(Materials.AnyCopper), 'B', OreDictNames.craftingChest });
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_HV_Boxinator.get(1L),
-            bitsd,
             new Object[] { "BCB", "RMV", aTextWireCoil, 'M', ItemList.Hull_HV, 'R', ItemList.Robot_Arm_HV, 'V',
                 ItemList.Conveyor_Module_HV, 'C', OrePrefixes.circuit.get(Materials.HV), 'W',
                 OrePrefixes.cableGt01.get(Materials.Gold), 'B', OreDictNames.craftingChest });
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_EV_Boxinator.get(1L),
-            bitsd,
             new Object[] { "BCB", "RMV", aTextWireCoil, 'M', ItemList.Hull_EV, 'R', ItemList.Robot_Arm_EV, 'V',
                 ItemList.Conveyor_Module_EV, 'C', OrePrefixes.circuit.get(Materials.EV), 'W',
                 OrePrefixes.cableGt01.get(Materials.Aluminium), 'B', OreDictNames.craftingChest });
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_IV_Boxinator.get(1L),
-            bitsd,
             new Object[] { "BCB", "RMV", aTextWireCoil, 'M', ItemList.Hull_IV, 'R', ItemList.Robot_Arm_IV, 'V',
                 ItemList.Conveyor_Module_IV, 'C', OrePrefixes.circuit.get(Materials.IV), 'W',
                 OrePrefixes.cableGt01.get(Materials.Tungsten), 'B', OreDictNames.craftingChest });
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_LuV_Boxinator.get(1L),
-            bitsd,
             new Object[] { "BCB", "RMV", aTextWireCoil, 'M', ItemList.Hull_LuV, 'R', ItemList.Robot_Arm_LuV, 'V',
                 ItemList.Conveyor_Module_LuV, 'C', OrePrefixes.circuit.get(Materials.LuV), 'W',
                 OrePrefixes.cableGt01.get(Materials.VanadiumGallium), 'B', OreDictNames.craftingChest });
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_ZPM_Boxinator.get(1L),
-            bitsd,
             new Object[] { "BCB", "RMV", aTextWireCoil, 'M', ItemList.Hull_ZPM, 'R', ItemList.Robot_Arm_ZPM, 'V',
                 ItemList.Conveyor_Module_ZPM, 'C', OrePrefixes.circuit.get(Materials.ZPM), 'W',
                 OrePrefixes.cableGt01.get(Materials.Naquadah), 'B', OreDictNames.craftingChest });
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_UV_Boxinator.get(1L),
-            bitsd,
             new Object[] { "BCB", "RMV", aTextWireCoil, 'M', ItemList.Hull_UV, 'R', ItemList.Robot_Arm_UV, 'V',
                 ItemList.Conveyor_Module_UV, 'C', OrePrefixes.circuit.get(Materials.UV), 'W',
                 OrePrefixes.cableGt01.get(Materials.NaquadahAlloy), 'B', OreDictNames.craftingChest });
 
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_LV_RockBreaker.get(1L),
-            bitsd,
             new Object[] { "PED", aTextWireHull, "GGG", 'M', ItemList.Hull_LV, 'D', OreDictNames.craftingGrinder, 'E',
                 ItemList.Electric_Motor_LV, 'P', ItemList.Electric_Piston_LV, 'C',
                 OrePrefixes.circuit.get(Materials.LV), 'W', OrePrefixes.cableGt01.get(Materials.Tin), 'G',
                 new ItemStack(Blocks.glass, 1) });
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_MV_RockBreaker.get(1L),
-            bitsd,
             new Object[] { "PED", aTextWireHull, "GGG", 'M', ItemList.Hull_MV, 'D', OreDictNames.craftingGrinder, 'E',
                 ItemList.Electric_Motor_MV, 'P', ItemList.Electric_Piston_MV, 'C',
                 OrePrefixes.circuit.get(Materials.MV), 'W', OrePrefixes.cableGt01.get(Materials.AnyCopper), 'G',
                 new ItemStack(Blocks.glass, 1) });
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_HV_RockBreaker.get(1L),
-            bitsd,
             new Object[] { "PED", aTextWireHull, "GGG", 'M', ItemList.Hull_HV, 'D', OreDictNames.craftingGrinder, 'E',
                 ItemList.Electric_Motor_HV, 'P', ItemList.Electric_Piston_HV, 'C',
                 OrePrefixes.circuit.get(Materials.HV), 'W', OrePrefixes.cableGt01.get(Materials.Gold), 'G',
                 new ItemStack(Blocks.glass, 1) });
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_EV_RockBreaker.get(1L),
-            bitsd,
             new Object[] { "PED", aTextWireHull, "GGG", 'M', ItemList.Hull_EV, 'D', OreDictNames.craftingGrinder, 'E',
                 ItemList.Electric_Motor_EV, 'P', ItemList.Electric_Piston_EV, 'C',
                 OrePrefixes.circuit.get(Materials.EV), 'W', OrePrefixes.cableGt01.get(Materials.Aluminium), 'G',
                 new ItemStack(Blocks.glass, 1) });
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_IV_RockBreaker.get(1L),
-            bitsd,
             new Object[] { "PED", aTextWireHull, "GGG", 'M', ItemList.Hull_IV, 'D', OreDictNames.craftingGrinder, 'E',
                 ItemList.Electric_Motor_IV, 'P', ItemList.Electric_Piston_IV, 'C',
                 OrePrefixes.circuit.get(Materials.IV), 'W', OrePrefixes.cableGt01.get(Materials.Tungsten), 'G',
@@ -3176,222 +2836,185 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_LV_Massfab.get(1L),
-            bitsd,
             new Object[] { "CFC", aTextWireHull, "CFC", 'M', ItemList.Hull_LV, 'F', ItemList.Field_Generator_LV, 'C',
                 OrePrefixes.circuit.get(Materials.MV), 'W', OrePrefixes.cableGt04.get(Materials.Tin) });
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_MV_Massfab.get(1L),
-            bitsd,
             new Object[] { "CFC", aTextWireHull, "CFC", 'M', ItemList.Hull_MV, 'F', ItemList.Field_Generator_MV, 'C',
                 OrePrefixes.circuit.get(Materials.HV), 'W', OrePrefixes.cableGt04.get(Materials.AnyCopper) });
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_HV_Massfab.get(1L),
-            bitsd,
             new Object[] { "CFC", aTextWireHull, "CFC", 'M', ItemList.Hull_HV, 'F', ItemList.Field_Generator_HV, 'C',
                 OrePrefixes.circuit.get(Materials.EV), 'W', OrePrefixes.cableGt04.get(Materials.Gold) });
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_EV_Massfab.get(1L),
-            bitsd,
             new Object[] { "CFC", aTextWireHull, "CFC", 'M', ItemList.Hull_EV, 'F', ItemList.Field_Generator_EV, 'C',
                 OrePrefixes.circuit.get(Materials.IV), 'W', OrePrefixes.cableGt04.get(Materials.Aluminium) });
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_IV_Massfab.get(1L),
-            bitsd,
             new Object[] { "CFC", aTextWireHull, "CFC", 'M', ItemList.Hull_IV, 'F', ItemList.Field_Generator_IV, 'C',
                 OrePrefixes.circuit.get(Materials.LuV), 'W', OrePrefixes.cableGt04.get(Materials.Tungsten) });
 
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_LV_Replicator.get(1L),
-            bitsd,
             new Object[] { "EFE", aTextCableHull, aTextMotorWire, 'M', ItemList.Hull_LV, 'F',
                 ItemList.Field_Generator_LV, 'E', ItemList.Emitter_LV, 'C', OrePrefixes.circuit.get(Materials.MV), 'W',
                 OrePrefixes.cableGt04.get(Materials.Tin) });
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_MV_Replicator.get(1L),
-            bitsd,
             new Object[] { "EFE", aTextCableHull, aTextMotorWire, 'M', ItemList.Hull_MV, 'F',
                 ItemList.Field_Generator_MV, 'E', ItemList.Emitter_MV, 'C', OrePrefixes.circuit.get(Materials.HV), 'W',
                 OrePrefixes.cableGt04.get(Materials.AnyCopper) });
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_HV_Replicator.get(1L),
-            bitsd,
             new Object[] { "EFE", aTextCableHull, aTextMotorWire, 'M', ItemList.Hull_HV, 'F',
                 ItemList.Field_Generator_HV, 'E', ItemList.Emitter_HV, 'C', OrePrefixes.circuit.get(Materials.EV), 'W',
                 OrePrefixes.cableGt04.get(Materials.Gold) });
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_EV_Replicator.get(1L),
-            bitsd,
             new Object[] { "EFE", aTextCableHull, aTextMotorWire, 'M', ItemList.Hull_EV, 'F',
                 ItemList.Field_Generator_EV, 'E', ItemList.Emitter_EV, 'C', OrePrefixes.circuit.get(Materials.IV), 'W',
                 OrePrefixes.cableGt04.get(Materials.Aluminium) });
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_IV_Replicator.get(1L),
-            bitsd,
             new Object[] { "EFE", aTextCableHull, aTextMotorWire, 'M', ItemList.Hull_IV, 'F',
                 ItemList.Field_Generator_IV, 'E', ItemList.Emitter_IV, 'C', OrePrefixes.circuit.get(Materials.LuV), 'W',
                 OrePrefixes.cableGt04.get(Materials.Tungsten) });
 
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_LV_Brewery.get(1L),
-            bitsd,
             new Object[] { "GPG", aTextWireHull, "CBC", 'M', ItemList.Hull_LV, 'P', ItemList.Electric_Pump_LV, 'B',
                 new ItemStack(Items.brewing_stand, 0), 'C', OrePrefixes.circuit.get(Materials.LV), 'W',
                 OrePrefixes.cableGt01.get(Materials.Tin), 'G', new ItemStack(Blocks.glass, 1) });
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_MV_Brewery.get(1L),
-            bitsd,
             new Object[] { "GPG", aTextWireHull, "CBC", 'M', ItemList.Hull_MV, 'P', ItemList.Electric_Pump_MV, 'B',
                 new ItemStack(Items.brewing_stand, 0), 'C', OrePrefixes.circuit.get(Materials.MV), 'W',
                 OrePrefixes.cableGt01.get(Materials.AnyCopper), 'G', new ItemStack(Blocks.glass, 1) });
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_HV_Brewery.get(1L),
-            bitsd,
             new Object[] { "GPG", aTextWireHull, "CBC", 'M', ItemList.Hull_HV, 'P', ItemList.Electric_Pump_HV, 'B',
                 new ItemStack(Items.brewing_stand, 0), 'C', OrePrefixes.circuit.get(Materials.HV), 'W',
                 OrePrefixes.cableGt01.get(Materials.Gold), 'G', new ItemStack(Blocks.glass, 1) });
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_EV_Brewery.get(1L),
-            bitsd,
             new Object[] { "GPG", aTextWireHull, "CBC", 'M', ItemList.Hull_EV, 'P', ItemList.Electric_Pump_EV, 'B',
                 new ItemStack(Items.brewing_stand, 0), 'C', OrePrefixes.circuit.get(Materials.EV), 'W',
                 OrePrefixes.cableGt01.get(Materials.Aluminium), 'G', new ItemStack(Blocks.glass, 1) });
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_IV_Brewery.get(1L),
-            bitsd,
             new Object[] { "GPG", aTextWireHull, "CBC", 'M', ItemList.Hull_IV, 'P', ItemList.Electric_Pump_IV, 'B',
                 new ItemStack(Items.brewing_stand, 0), 'C', OrePrefixes.circuit.get(Materials.IV), 'W',
                 OrePrefixes.cableGt01.get(Materials.Tungsten), 'G', new ItemStack(Blocks.glass, 1) });
 
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_LV_Miner.get(1L),
-            bitsd,
             new Object[] { "EEE", aTextWireHull, "CSC", 'M', ItemList.Hull_LV, 'E', ItemList.Electric_Motor_LV, 'C',
                 OrePrefixes.circuit.get(Materials.LV), 'W', OrePrefixes.cableGt01.get(Materials.Tin), 'S',
                 ItemList.Sensor_LV });
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_MV_Miner.get(1L),
-            bitsd,
             new Object[] { "PEP", aTextWireHull, "CSC", 'M', ItemList.Hull_MV, 'E', ItemList.Electric_Motor_MV, 'P',
                 ItemList.Electric_Piston_MV, 'C', OrePrefixes.circuit.get(Materials.MV), 'W',
                 OrePrefixes.cableGt02.get(Materials.Copper), 'S', ItemList.Sensor_MV });
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_HV_Miner.get(1L),
-            bitsd,
             new Object[] { "RPR", aTextWireHull, "CSC", 'M', ItemList.Hull_HV, 'E', ItemList.Electric_Motor_HV, 'P',
                 ItemList.Electric_Piston_HV, 'R', ItemList.Robot_Arm_HV, 'C', OrePrefixes.circuit.get(Materials.HV),
                 'W', OrePrefixes.cableGt04.get(Materials.Gold), 'S', ItemList.Sensor_HV });
 
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_Multi_BlastFurnace.get(1L),
-            bitsd,
             new Object[] { "FFF", aTextCableHull, aTextWireCoil, 'M', ItemList.Casing_HeatProof, 'F',
                 OreDictNames.craftingIronFurnace, 'C', OrePrefixes.circuit.get(Materials.LV), 'W',
                 OrePrefixes.cableGt01.get(Materials.Tin) });
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_Multi_VacuumFreezer.get(1L),
-            bitsd,
             new Object[] { aTextPlate, aTextCableHull, aTextWireCoil, 'M', ItemList.Casing_FrostProof, 'P',
                 ItemList.Electric_Pump_HV, 'C', OrePrefixes.circuit.get(Materials.EV), 'W',
                 OrePrefixes.cableGt01.get(Materials.Gold) });
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_Multi_ImplosionCompressor.get(1L),
-            bitsd,
             new Object[] { "OOO", aTextCableHull, aTextWireCoil, 'M', ItemList.Casing_SolidSteel, 'O',
                 Ic2Items.reinforcedStone, 'C', OrePrefixes.circuit.get(Materials.HV), 'W',
                 OrePrefixes.cableGt01.get(Materials.Gold) });
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_Multi_Furnace.get(1L),
-            bitsd,
             new Object[] { "FFF", aTextCableHull, aTextWireCoil, 'M', ItemList.Casing_HeatProof, 'F',
                 OreDictNames.craftingIronFurnace, 'C', OrePrefixes.circuit.get(Materials.HV), 'W',
                 OrePrefixes.cableGt01.get(Materials.AnnealedCopper) });
 
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_Multi_LargeBoiler_Bronze.get(1L),
-            bitsd,
             new Object[] { aTextWireCoil, aTextCableHull, aTextWireCoil, 'M', ItemList.Casing_Firebox_Bronze, 'C',
                 OrePrefixes.circuit.get(Materials.MV), 'W', OrePrefixes.cableGt01.get(Materials.Tin) });
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_Multi_LargeBoiler_Steel.get(1L),
-            bitsd,
             new Object[] { aTextWireCoil, aTextCableHull, aTextWireCoil, 'M', ItemList.Casing_Firebox_Steel, 'C',
                 OrePrefixes.circuit.get(Materials.HV), 'W', OrePrefixes.cableGt01.get(Materials.AnyCopper) });
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_Multi_LargeBoiler_Titanium.get(1L),
-            bitsd,
             new Object[] { aTextWireCoil, aTextCableHull, aTextWireCoil, 'M', ItemList.Casing_Firebox_Titanium, 'C',
                 OrePrefixes.circuit.get(Materials.EV), 'W', OrePrefixes.cableGt01.get(Materials.Gold) });
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_Multi_LargeBoiler_TungstenSteel.get(1L),
-            bitsd,
             new Object[] { aTextWireCoil, aTextCableHull, aTextWireCoil, 'M', ItemList.Casing_Firebox_TungstenSteel,
                 'C', OrePrefixes.circuit.get(Materials.IV), 'W', OrePrefixes.cableGt01.get(Materials.Aluminium) });
 
         GTModHandler.addCraftingRecipe(
             ItemList.Generator_Diesel_LV.get(1L),
-            bitsd,
             new Object[] { "PCP", "EME", "GWG", 'M', ItemList.Hull_LV, 'P', ItemList.Electric_Piston_LV, 'E',
                 ItemList.Electric_Motor_LV, 'C', OrePrefixes.circuit.get(Materials.LV), 'W',
                 OrePrefixes.cableGt01.get(Materials.Tin), 'G', OrePrefixes.gearGt.get(Materials.Steel) });
         GTModHandler.addCraftingRecipe(
             ItemList.Generator_Diesel_MV.get(1L),
-            bitsd,
             new Object[] { "PCP", "EME", "GWG", 'M', ItemList.Hull_MV, 'P', ItemList.Electric_Piston_MV, 'E',
                 ItemList.Electric_Motor_MV, 'C', OrePrefixes.circuit.get(Materials.MV), 'W',
                 OrePrefixes.cableGt01.get(Materials.AnyCopper), 'G', OrePrefixes.gearGt.get(Materials.Aluminium) });
         GTModHandler.addCraftingRecipe(
             ItemList.Generator_Diesel_HV.get(1L),
-            bitsd,
             new Object[] { "PCP", "EME", "GWG", 'M', ItemList.Hull_HV, 'P', ItemList.Electric_Piston_HV, 'E',
                 ItemList.Electric_Motor_HV, 'C', OrePrefixes.circuit.get(Materials.HV), 'W',
                 OrePrefixes.cableGt01.get(Materials.Gold), 'G', OrePrefixes.gearGt.get(Materials.StainlessSteel) });
 
         GTModHandler.addCraftingRecipe(
             ItemList.Generator_Gas_Turbine_LV.get(1L),
-            bitsd,
             new Object[] { "CRC", "RMR", aTextMotorWire, 'M', ItemList.Hull_LV, 'E', ItemList.Electric_Motor_LV, 'R',
                 OrePrefixes.rotor.get(Materials.Tin), 'C', OrePrefixes.circuit.get(Materials.LV), 'W',
                 OrePrefixes.cableGt01.get(Materials.Tin) });
         GTModHandler.addCraftingRecipe(
             ItemList.Generator_Gas_Turbine_MV.get(1L),
-            bitsd,
             new Object[] { "CRC", "RMR", aTextMotorWire, 'M', ItemList.Hull_MV, 'E', ItemList.Electric_Motor_MV, 'R',
                 OrePrefixes.rotor.get(Materials.Bronze), 'C', OrePrefixes.circuit.get(Materials.MV), 'W',
                 OrePrefixes.cableGt01.get(Materials.AnyCopper) });
         GTModHandler.addCraftingRecipe(
             ItemList.Generator_Gas_Turbine_HV.get(1L),
-            bitsd,
             new Object[] { "CRC", "RMR", aTextMotorWire, 'M', ItemList.Hull_HV, 'E', ItemList.Electric_Motor_HV, 'R',
                 OrePrefixes.rotor.get(Materials.Steel), 'C', OrePrefixes.circuit.get(Materials.HV), 'W',
                 OrePrefixes.cableGt01.get(Materials.Gold) });
         GTModHandler.addCraftingRecipe(
             ItemList.Generator_Gas_Turbine_EV.get(1L),
-            bitsd,
             new Object[] { "CRC", "RMR", aTextMotorWire, 'M', ItemList.Hull_EV, 'E', ItemList.Electric_Motor_EV, 'R',
                 OrePrefixes.rotor.get(Materials.Titanium), 'C', OrePrefixes.circuit.get(Materials.EV), 'W',
                 OrePrefixes.cableGt01.get(Materials.Aluminium) });
         GTModHandler.addCraftingRecipe(
             ItemList.Generator_Gas_Turbine_IV.get(1L),
-            bitsd,
             new Object[] { "CRC", "RMR", aTextMotorWire, 'M', ItemList.Hull_IV, 'E', ItemList.Electric_Motor_IV, 'R',
                 OrePrefixes.rotor.get(Materials.TungstenSteel), 'C', OrePrefixes.circuit.get(Materials.IV), 'W',
                 OrePrefixes.cableGt01.get(Materials.Tungsten) });
 
         GTModHandler.addCraftingRecipe(
             ItemList.Generator_Steam_Turbine_LV.get(1L),
-            bitsd,
             new Object[] { "PCP", "RMR", aTextMotorWire, 'M', ItemList.Hull_LV, 'E', ItemList.Electric_Motor_LV, 'R',
                 OrePrefixes.rotor.get(Materials.Tin), 'C', OrePrefixes.circuit.get(Materials.LV), 'W',
                 OrePrefixes.cableGt01.get(Materials.Tin), 'P', OrePrefixes.pipeMedium.get(Materials.Bronze) });
         GTModHandler.addCraftingRecipe(
             ItemList.Generator_Steam_Turbine_MV.get(1L),
-            bitsd,
             new Object[] { "PCP", "RMR", aTextMotorWire, 'M', ItemList.Hull_MV, 'E', ItemList.Electric_Motor_MV, 'R',
                 OrePrefixes.rotor.get(Materials.Bronze), 'C', OrePrefixes.circuit.get(Materials.MV), 'W',
                 OrePrefixes.cableGt01.get(Materials.AnyCopper), 'P', OrePrefixes.pipeMedium.get(Materials.Steel) });
         GTModHandler.addCraftingRecipe(
             ItemList.Generator_Steam_Turbine_HV.get(1L),
-            bitsd,
             new Object[] { "PCP", "RMR", aTextMotorWire, 'M', ItemList.Hull_HV, 'E', ItemList.Electric_Motor_HV, 'R',
                 OrePrefixes.rotor.get(Materials.Steel), 'C', OrePrefixes.circuit.get(Materials.HV), 'W',
                 OrePrefixes.cableGt01.get(Materials.Gold), 'P', OrePrefixes.pipeMedium.get(Materials.StainlessSteel) });
@@ -3399,201 +3022,168 @@ public class MTERecipeLoader implements Runnable {
         if (!Thaumcraft.isModLoaded()) {
             GTModHandler.addCraftingRecipe(
                 ItemList.MagicEnergyConverter_LV.get(1L),
-                bitsd,
                 new Object[] { "CTC", "FMF", "CBC", 'M', ItemList.Hull_LV, 'B', new ItemStack(Blocks.beacon), 'C',
                     OrePrefixes.circuit.get(Materials.HV), 'T', ItemList.Field_Generator_LV, 'F',
                     OrePrefixes.plate.get(Materials.Platinum) });
             GTModHandler.addCraftingRecipe(
                 ItemList.MagicEnergyConverter_MV.get(1L),
-                bitsd,
                 new Object[] { "CTC", "FMF", "CBC", 'M', ItemList.Hull_MV, 'B', new ItemStack(Blocks.beacon), 'C',
                     OrePrefixes.circuit.get(Materials.EV), 'T', ItemList.Field_Generator_MV, 'F',
                     OrePrefixes.plate.get(Materials.Iridium) });
             GTModHandler.addCraftingRecipe(
                 ItemList.MagicEnergyConverter_HV.get(1L),
-                bitsd,
                 new Object[] { "CTC", "FMF", "CBC", 'M', ItemList.Hull_HV, 'B', new ItemStack(Blocks.beacon), 'C',
                     OrePrefixes.circuit.get(Materials.IV), 'T', ItemList.Field_Generator_HV, 'F',
                     OrePrefixes.plate.get(Materials.Neutronium) });
 
             GTModHandler.addCraftingRecipe(
                 ItemList.MagicEnergyAbsorber_LV.get(1L),
-                bitsd,
                 new Object[] { "CTC", "FMF", "CBC", 'M', ItemList.Hull_LV, 'B',
                     ItemList.MagicEnergyConverter_LV.get(1L), 'C', OrePrefixes.circuit.get(Materials.HV), 'T',
                     ItemList.Field_Generator_LV, 'F', OrePrefixes.plate.get(Materials.Platinum) });
             GTModHandler.addCraftingRecipe(
                 ItemList.MagicEnergyAbsorber_MV.get(1L),
-                bitsd,
                 new Object[] { "CTC", "FMF", "CBC", 'M', ItemList.Hull_MV, 'B',
                     ItemList.MagicEnergyConverter_MV.get(1L), 'C', OrePrefixes.circuit.get(Materials.EV), 'T',
                     ItemList.Field_Generator_MV, 'F', OrePrefixes.plate.get(Materials.Iridium) });
             GTModHandler.addCraftingRecipe(
                 ItemList.MagicEnergyAbsorber_HV.get(1L),
-                bitsd,
                 new Object[] { "CTC", "FMF", "CBC", 'M', ItemList.Hull_HV, 'B',
                     ItemList.MagicEnergyConverter_MV.get(1L), 'C', OrePrefixes.circuit.get(Materials.IV), 'T',
                     ItemList.Field_Generator_HV, 'F', OrePrefixes.plate.get(Materials.Europium) });
             GTModHandler.addCraftingRecipe(
                 ItemList.MagicEnergyAbsorber_EV.get(1L),
-                bitsd,
                 new Object[] { "CTC", "FMF", "CBC", 'M', ItemList.Hull_HV, 'B',
                     ItemList.MagicEnergyConverter_HV.get(1L), 'C', OrePrefixes.circuit.get(Materials.LuV), 'T',
                     ItemList.Field_Generator_EV, 'F', OrePrefixes.plate.get(Materials.Neutronium) });
         }
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_Fusion_Coil.get(1L),
-            bitsd,
             new Object[] { "CTC", "FMF", "CTC", 'M', ItemList.Casing_Coil_Superconductor, 'C',
                 OrePrefixes.circuit.get(Materials.LuV), 'F', ItemList.Field_Generator_MV, 'T',
                 ItemList.Neutron_Reflector });
 
         GTModHandler.addCraftingRecipe(
             ItemList.Generator_Plasma_EV.get(1L),
-            bitsd,
             new Object[] { "UCU", "FMF", aTextWireCoil, 'M', ItemList.Hull_LuV, 'F', ItemList.Field_Generator_HV, 'C',
                 OrePrefixes.circuit.get(Materials.IV), 'W', OrePrefixes.cableGt04.get(Materials.Tungsten), 'U',
                 OrePrefixes.stick.get(Materials.Plutonium241) });
         GTModHandler.addCraftingRecipe(
             ItemList.Generator_Plasma_IV.get(1L),
-            bitsd,
             new Object[] { "UCU", "FMF", aTextWireCoil, 'M', ItemList.Hull_ZPM, 'F', ItemList.Field_Generator_EV, 'C',
                 OrePrefixes.circuit.get(Materials.LuV), 'W', OrePrefixes.wireGt04.get(Materials.VanadiumGallium), 'U',
                 OrePrefixes.stick.get(Materials.Europium) });
         GTModHandler.addCraftingRecipe(
             ItemList.Generator_Plasma_LuV.get(1L),
-            bitsd,
             new Object[] { "UCU", "FMF", aTextWireCoil, 'M', ItemList.Hull_UV, 'F', ItemList.Field_Generator_IV, 'C',
                 OrePrefixes.circuit.get(Materials.ZPM), 'W', OrePrefixes.wireGt04.get(Materials.Naquadah), 'U',
                 OrePrefixes.stick.get(Materials.Americium) });
 
         GTModHandler.addCraftingRecipe(
             ItemList.Distillation_Tower.get(1L),
-            bitsd,
             new Object[] { "CBC", "FMF", "CBC", 'M', ItemList.Hull_HV, 'B',
                 OrePrefixes.pipeLarge.get(Materials.StainlessSteel), 'C', OrePrefixes.circuit.get(Materials.EV), 'F',
                 ItemList.Electric_Pump_HV });
 
         GTModHandler.addCraftingRecipe(
             ItemList.LargeSteamTurbine.get(1L),
-            bitsd,
             new Object[] { "CPC", aTextPlateMotor, "BPB", 'M', ItemList.Hull_HV, 'B',
                 OrePrefixes.pipeLarge.get(Materials.Steel), 'C', OrePrefixes.circuit.get(Materials.HV), 'P',
                 OrePrefixes.gearGt.get(Materials.Steel) });
         GTModHandler.addCraftingRecipe(
             ItemList.LargeGasTurbine.get(1L),
-            bitsd,
             new Object[] { "CPC", aTextPlateMotor, "BPB", 'M', ItemList.Hull_EV, 'B',
                 OrePrefixes.pipeLarge.get(Materials.StainlessSteel), 'C', OrePrefixes.circuit.get(Materials.EV), 'P',
                 OrePrefixes.gearGt.get(Materials.StainlessSteel) });
 
         GTModHandler.addCraftingRecipe(
             ItemList.Pump_LV.get(1L),
-            bitsd,
             new Object[] { "CPC", aTextPlateMotor, "BPB", 'M', ItemList.Hull_LV, 'B',
                 OrePrefixes.pipeLarge.get(Materials.Bronze), 'C', OrePrefixes.circuit.get(Materials.LV), 'P',
                 ItemList.Electric_Pump_LV });
         GTModHandler.addCraftingRecipe(
             ItemList.Pump_MV.get(1L),
-            bitsd,
             new Object[] { "CPC", aTextPlateMotor, "BPB", 'M', ItemList.Hull_MV, 'B',
                 OrePrefixes.pipeLarge.get(Materials.Steel), 'C', OrePrefixes.circuit.get(Materials.MV), 'P',
                 ItemList.Electric_Pump_MV });
         GTModHandler.addCraftingRecipe(
             ItemList.Pump_HV.get(1L),
-            bitsd,
             new Object[] { "CPC", aTextPlateMotor, "BPB", 'M', ItemList.Hull_HV, 'B',
                 OrePrefixes.pipeLarge.get(Materials.StainlessSteel), 'C', OrePrefixes.circuit.get(Materials.HV), 'P',
                 ItemList.Electric_Pump_HV });
 
         GTModHandler.addCraftingRecipe(
             ItemList.MobRep_LV.get(1L),
-            bitsd,
             new Object[] { "EEE", " M ", "CCC", 'M', ItemList.Hull_LV, 'E', ItemList.Emitter_LV.get(1L), 'C',
                 OrePrefixes.circuit.get(Materials.LV) });
         GTModHandler.addCraftingRecipe(
             ItemList.MobRep_MV.get(1L),
-            bitsd,
             new Object[] { "EEE", " M ", "CCC", 'M', ItemList.Hull_MV, 'E', ItemList.Emitter_MV.get(1L), 'C',
                 OrePrefixes.circuit.get(Materials.MV) });
         GTModHandler.addCraftingRecipe(
             ItemList.MobRep_HV.get(1L),
-            bitsd,
             new Object[] { "EEE", " M ", "CCC", 'M', ItemList.Hull_HV, 'E', ItemList.Emitter_HV.get(1L), 'C',
                 OrePrefixes.circuit.get(Materials.HV) });
         GTModHandler.addCraftingRecipe(
             ItemList.MobRep_EV.get(1L),
-            bitsd,
             new Object[] { "EEE", " M ", "CCC", 'M', ItemList.Hull_EV, 'E', ItemList.Emitter_EV.get(1L), 'C',
                 OrePrefixes.circuit.get(Materials.EV) });
         GTModHandler.addCraftingRecipe(
             ItemList.MobRep_IV.get(1L),
-            bitsd,
             new Object[] { "EEE", " M ", "CCC", 'M', ItemList.Hull_IV, 'E', ItemList.Emitter_IV.get(1L), 'C',
                 OrePrefixes.circuit.get(Materials.IV) });
         GTModHandler.addCraftingRecipe(
             ItemList.MobRep_LuV.get(1L),
-            bitsd,
             new Object[] { "EEE", " M ", "CCC", 'M', ItemList.Hull_LuV, 'E', ItemList.Emitter_LuV.get(1L), 'C',
                 OrePrefixes.circuit.get(Materials.LuV) });
         GTModHandler.addCraftingRecipe(
             ItemList.MobRep_ZPM.get(1L),
-            bitsd,
             new Object[] { "EEE", " M ", "CCC", 'M', ItemList.Hull_ZPM, 'E', ItemList.Emitter_ZPM.get(1L), 'C',
                 OrePrefixes.circuit.get(Materials.ZPM) });
         GTModHandler.addCraftingRecipe(
             ItemList.MobRep_UV.get(1L),
-            bitsd,
             new Object[] { "EEE", " M ", "CCC", 'M', ItemList.Hull_UV, 'E', ItemList.Emitter_UV.get(1L), 'C',
                 OrePrefixes.circuit.get(Materials.UV) });
 
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_Multi_HeatExchanger.get(1L),
-            bitsd,
             new Object[] { aTextWireCoil, aTextCableHull, aTextWireCoil, 'M', ItemList.Casing_Pipe_Titanium, 'C',
                 OrePrefixes.pipeMedium.get(Materials.Titanium), 'W', ItemList.Electric_Pump_EV });
 
         GTModHandler.addCraftingRecipe(
             ItemList.Charcoal_Pile.get(1L),
-            bitsd,
             new Object[] { "EXE", "EME", "hCw", 'M', ItemList.Hull_HP_Bricks, 'E',
                 OrePrefixes.plate.get(Materials.AnyBronze), 'C', new ItemStack(Items.flint_and_steel, 1), 'X',
                 OrePrefixes.rotor.get(Materials.Steel), });
 
         GTModHandler.addCraftingRecipe(
             ItemList.Seismic_Prospector_Adv_LV.get(1L),
-            bitsd,
             new Object[] { "WWW", "EME", "CXC", 'M', ItemList.Hull_LV, 'W',
                 OrePrefixes.plateDouble.get(Materials.Steel), 'E', OrePrefixes.circuit.get(Materials.LV), 'C',
                 ItemList.Sensor_LV, 'X', OrePrefixes.cableGt02.get(Materials.Tin) });
         GTModHandler.addCraftingRecipe(
             ItemList.Seismic_Prospector_Adv_MV.get(1L),
-            bitsd,
             new Object[] { "WWW", "EME", "CXC", 'M', ItemList.Hull_MV, 'W',
                 OrePrefixes.plateDouble.get(Materials.BlackSteel), 'E', OrePrefixes.circuit.get(Materials.MV), 'C',
                 ItemList.Sensor_MV, 'X', OrePrefixes.cableGt02.get(Materials.Copper) });
         GTModHandler.addCraftingRecipe(
             ItemList.Seismic_Prospector_Adv_HV.get(1L),
-            bitsd,
             new Object[] { "WWW", "EME", "CXC", 'M', ItemList.Hull_HV, 'W',
                 OrePrefixes.plateDouble.get(Materials.StainlessSteel), 'E', OrePrefixes.circuit.get(Materials.HV), 'C',
                 ItemList.Sensor_HV, 'X', OrePrefixes.cableGt04.get(Materials.Gold) });
         GTModHandler.addCraftingRecipe(
             ItemList.Seismic_Prospector_Adv_EV.get(1L),
-            bitsd,
             new Object[] { "WWW", "EME", "CXC", 'M', ItemList.Hull_EV, 'W',
                 OrePrefixes.plateDouble.get(Materials.VanadiumSteel), 'E', OrePrefixes.circuit.get(Materials.EV), 'C',
                 ItemList.Sensor_EV, 'X', OrePrefixes.cableGt04.get(Materials.Aluminium) });
 
         GTModHandler.addCraftingRecipe(
             ItemList.ConcreteBackfiller1.get(1L),
-            bitsd,
             new Object[] { "WPW", "EME", "CQC", 'M', ItemList.Hull_MV, 'W', OrePrefixes.frameGt.get(Materials.Steel),
                 'E', OrePrefixes.circuit.get(Materials.MV), 'C', ItemList.Electric_Motor_MV, 'P',
                 OrePrefixes.pipeLarge.get(Materials.Steel), 'Q', ItemList.Electric_Pump_MV });
         GTModHandler.addCraftingRecipe(
             ItemList.ConcreteBackfiller2.get(1L),
-            bitsd,
             new Object[] { "WPW", "EME", "CQC", 'M', ItemList.ConcreteBackfiller1, 'W',
                 OrePrefixes.frameGt.get(Materials.Titanium), 'E', OrePrefixes.circuit.get(Materials.EV), 'C',
                 ItemList.Electric_Motor_EV, 'P', OrePrefixes.pipeLarge.get(Materials.Steel), 'Q',
@@ -3601,79 +3191,66 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addCraftingRecipe(
             ItemList.PyrolyseOven.get(1L),
-            bitsd,
             new Object[] { "WEP", "EME", "WCP", 'M', ItemList.Hull_MV, 'W', ItemList.Electric_Piston_MV, 'P',
                 OrePrefixes.wireGt04.get(Materials.Cupronickel), 'E', OrePrefixes.circuit.get(Materials.MV), 'C',
                 ItemList.Electric_Pump_MV });
 
         GTModHandler.addCraftingRecipe(
             ItemList.OilCracker.get(1L),
-            bitsd,
             new Object[] { aTextWireCoil, "EME", aTextWireCoil, 'M', ItemList.Hull_HV, 'W',
                 ItemList.Casing_Coil_Cupronickel, 'E', OrePrefixes.circuit.get(Materials.HV), 'C',
                 ItemList.Electric_Pump_HV });
 
         GTModHandler.addCraftingRecipe(
             ItemList.MicroTransmitter_HV.get(1L),
-            bitsd,
             new Object[] { "CPC", aTextCableHull, "GBG", 'M', ItemList.Hull_HV, 'B', ItemList.Battery_RE_HV_Lithium,
                 'C', ItemList.Emitter_HV, 'G', OrePrefixes.circuit.get(Materials.HV), 'P',
                 ItemList.Field_Generator_HV });
         GTModHandler.addCraftingRecipe(
             ItemList.MicroTransmitter_EV.get(1L),
-            bitsd,
             new Object[] { "CPC", aTextCableHull, "GBG", 'M', ItemList.Hull_EV, 'B',
                 GTModHandler.getIC2Item("lapotronCrystal", 1L, WILDCARD), 'C', ItemList.Emitter_EV, 'G',
                 OrePrefixes.circuit.get(Materials.EV), 'P', ItemList.Field_Generator_EV });
         GTModHandler.addCraftingRecipe(
             ItemList.MicroTransmitter_IV.get(1L),
-            bitsd,
             new Object[] { "CPC", aTextCableHull, "GBG", 'M', ItemList.Hull_IV, 'B', ItemList.Energy_LapotronicOrb, 'C',
                 ItemList.Emitter_IV, 'G', OrePrefixes.circuit.get(Materials.IV), 'P', ItemList.Field_Generator_IV });
         GTModHandler.addCraftingRecipe(
             ItemList.MicroTransmitter_LUV.get(1L),
-            bitsd,
             new Object[] { "CPC", aTextCableHull, "GBG", 'M', ItemList.Hull_LuV, 'B', ItemList.Energy_LapotronicOrb2,
                 'C', ItemList.Emitter_LuV, 'G', OrePrefixes.circuit.get(Materials.LuV), 'P',
                 ItemList.Field_Generator_LuV });
         GTModHandler.addCraftingRecipe(
             ItemList.MicroTransmitter_ZPM.get(1L),
-            bitsd,
             new Object[] { "CPC", aTextCableHull, "GBG", 'M', ItemList.Hull_ZPM, 'B', ItemList.Energy_Module, 'C',
                 ItemList.Emitter_ZPM, 'G', OrePrefixes.circuit.get(Materials.ZPM), 'P', ItemList.Field_Generator_ZPM });
         GTModHandler.addCraftingRecipe(
             ItemList.MicroTransmitter_UV.get(1L),
-            bitsd,
             new Object[] { "CPC", aTextCableHull, "GBG", 'M', ItemList.Hull_UV, 'B', ItemList.Energy_Module, 'C',
                 ItemList.Emitter_UV, 'G', OrePrefixes.circuit.get(Materials.UV), 'P', ItemList.Field_Generator_UV });
 
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_Multi_Assemblyline.get(1L),
-            bitsd,
             new Object[] { aTextWireCoil, "EME", aTextWireCoil, 'M', ItemList.Hull_IV, 'W', ItemList.Casing_Assembler,
                 'E', OrePrefixes.circuit.get(Materials.IV), 'C', ItemList.Robot_Arm_IV });
 
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_Multi_DieselEngine.get(1L),
-            bitsd,
             new Object[] { "PCP", "EME", "GWG", 'M', ItemList.Hull_EV, 'P', ItemList.Electric_Piston_EV, 'E',
                 ItemList.Electric_Motor_EV, 'C', OrePrefixes.circuit.get(Materials.IV), 'W',
                 OrePrefixes.cableGt01.get(Materials.TungstenSteel), 'G', OrePrefixes.gearGt.get(Materials.Titanium) });
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_EngineIntake.get(4L),
-            bitsd,
             new Object[] { "PhP", "RFR", aTextPlateWrench, 'R', OrePrefixes.pipeMedium.get(Materials.Titanium), 'F',
                 ItemList.Casing_StableTitanium, 'P', OrePrefixes.rotor.get(Materials.Titanium) });
 
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_Multi_ExtremeDieselEngine.get(1L),
-            bitsd,
             new Object[] { "PCP", "EME", "GWG", 'M', ItemList.Hull_IV, 'P', ItemList.Electric_Piston_IV, 'E',
                 ItemList.Electric_Motor_IV, 'C', OrePrefixes.circuit.get(Materials.LuV), 'W',
                 OrePrefixes.cableGt01.get(Materials.HSSG), 'G', OrePrefixes.gearGt.get(Materials.TungstenSteel) });
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_ExtremeEngineIntake.get(4L),
-            bitsd,
             new Object[] { "PhP", "RFR", aTextPlateWrench, 'R', OrePrefixes.pipeMedium.get(Materials.TungstenSteel),
                 'F', ItemList.Casing_RobustTungstenSteel, 'P', OrePrefixes.rotor.get(Materials.TungstenSteel) });
 
@@ -3681,7 +3258,6 @@ public class MTERecipeLoader implements Runnable {
         if (GTMod.proxy.mEnableCleanroom) {
             GTModHandler.addCraftingRecipe(
                 ItemList.Machine_Multi_Cleanroom.get(1L),
-                bitsd,
                 new Object[] { "FFF", "RHR", "MCM", 'H', ItemList.Hull_HV, 'F', ItemList.Component_Filter, 'R',
                     OrePrefixes.rotor.get(Materials.StainlessSteel), 'M', ItemList.Electric_Motor_HV, 'C',
                     OrePrefixes.circuit.get(Materials.HV) });
@@ -3693,23 +3269,19 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_HV_LightningRod.get(1L),
-            bitsd,
             new Object[] { "LTL", "TMT", "LTL", 'M', ItemList.Hull_LuV, 'L', ItemList.Energy_LapotronicOrb, 'T',
                 ItemList.Transformer_ZPM_LuV });
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_EV_LightningRod.get(1L),
-            bitsd,
             new Object[] { "LTL", "TMT", "LTL", 'M', ItemList.Hull_ZPM, 'L', ItemList.Energy_LapotronicOrb2, 'T',
                 ItemList.Transformer_UV_ZPM });
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_IV_LightningRod.get(1L),
-            bitsd,
             new Object[] { "LTL", "TMT", "LTL", 'M', ItemList.Hull_UV, 'L', ItemList.ZPM2, 'T',
                 ItemList.Transformer_MAX_UV });
 
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_Multi_LargeChemicalReactor.get(1L),
-            bitsd,
             new Object[] { "CRC", "PMP", "CBC", 'C', OrePrefixes.circuit.get(Materials.HV), 'R',
                 OrePrefixes.rotor.get(Materials.StainlessSteel), 'P',
                 OrePrefixes.pipeLarge.get(Materials.Polytetrafluoroethylene), 'M', ItemList.Electric_Motor_HV, 'B',
@@ -3718,7 +3290,7 @@ public class MTERecipeLoader implements Runnable {
         // Add Drone down link hatch
         GTModHandler.addCraftingRecipe(
             ItemList.Hatch_DroneDownLink.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { " S ", "CMC", "RRR", 'M', ItemList.Hatch_Maintenance, 'S', ItemList.Sensor_IV, 'R',
                 new ItemStack(GregTechAPI.sBlockReinforced, 1, 9), 'C', ItemList.Conveyor_Module_EV });
 
@@ -3742,19 +3314,19 @@ public class MTERecipeLoader implements Runnable {
 
         GTModHandler.addCraftingRecipe(
             ItemList.MagLevPython_MV.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { "CCC", "CHC", "CMC", 'C', ItemList.MV_Coil, 'H', ItemList.Hull_MV, 'M',
                 OrePrefixes.block.get(Materials.SteelMagnetic) });
 
         GTModHandler.addCraftingRecipe(
             ItemList.MagLevPython_HV.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { "CCC", "CHC", "CMC", 'C', ItemList.HV_Coil, 'H', ItemList.Hull_HV, 'M',
                 OrePrefixes.block.get(Materials.SteelMagnetic) });
 
         GTModHandler.addCraftingRecipe(
             ItemList.MagLevPython_EV.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { "CCC", "CHC", "CMC", 'C', ItemList.EV_Coil, 'H', ItemList.Hull_EV, 'M',
                 OrePrefixes.block.get(Materials.NeodymiumMagnetic) });
     }
@@ -3762,43 +3334,43 @@ public class MTERecipeLoader implements Runnable {
     private static void registerShapelessCraftingRecipes() {
         GTModHandler.addShapelessCraftingRecipe(
             ItemList.Casing_SolidSteel.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { ItemList.Casing_Stripes_A });
         GTModHandler.addShapelessCraftingRecipe(
             ItemList.Casing_SolidSteel.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { ItemList.Casing_Stripes_B });
         GTModHandler.addShapelessCraftingRecipe(
             ItemList.Casing_SolidSteel.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { ItemList.Casing_RadioactiveHazard });
         GTModHandler.addShapelessCraftingRecipe(
             ItemList.Casing_SolidSteel.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { ItemList.Casing_BioHazard });
         GTModHandler.addShapelessCraftingRecipe(
             ItemList.Casing_SolidSteel.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { ItemList.Casing_ExplosionHazard });
         GTModHandler.addShapelessCraftingRecipe(
             ItemList.Casing_SolidSteel.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { ItemList.Casing_FireHazard });
         GTModHandler.addShapelessCraftingRecipe(
             ItemList.Casing_SolidSteel.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { ItemList.Casing_AcidHazard });
         GTModHandler.addShapelessCraftingRecipe(
             ItemList.Casing_SolidSteel.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { ItemList.Casing_MagicHazard });
         GTModHandler.addShapelessCraftingRecipe(
             ItemList.Casing_SolidSteel.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { ItemList.Casing_FrostHazard });
         GTModHandler.addShapelessCraftingRecipe(
             ItemList.Casing_SolidSteel.get(1L),
-            bits,
+            GTModHandler.RecipeBits.BITS,
             new Object[] { ItemList.Casing_NoiseHazard });
 
         if (Forestry.isModLoaded() && Gendustry.isModLoaded()) {


### PR DESCRIPTION
Removes a lot of code duplication.

Also removes small bug where the bitmask wasn't used and defaulted to `BITSD`. I added a method without the bitmask argument that defaults to `BITSD` and otherwise uses the provided bitmask.