### PR TITLE
Reduce allocations from Texture Building methods

### DIFF
--- a/src/main/java/gregtech/api/interfaces/ITextureBuilder.java
+++ b/src/main/java/gregtech/api/interfaces/ITextureBuilder.java
@@ -45,6 +45,12 @@ public interface ITextureBuilder {
     ITextureBuilder setFromSide(final ForgeDirection side);
 
     /**
+     * @param iconContainer The {@link IIconContainer}s to add
+     * @return {@link ITextureBuilder} for chaining
+     */
+    ITextureBuilder addIcon(final IIconContainer iconContainer);
+
+    /**
      * @param iconContainers The {@link IIconContainer}s to add
      * @return {@link ITextureBuilder} for chaining
      */
@@ -55,6 +61,12 @@ public interface ITextureBuilder {
      * @return {@link ITextureBuilder} for chaining
      */
     ITextureBuilder setRGBA(final short[] rgba);
+
+    /**
+     * @param iTexture The {@link ITexture} layer to add
+     * @return {@link ITextureBuilder} for chaining
+     */
+    ITextureBuilder addLayer(final ITexture iTexture);
 
     /**
      * @param iTextures The {@link ITexture} layers to add

--- a/src/main/java/gregtech/api/render/TextureFactory.java
+++ b/src/main/java/gregtech/api/render/TextureFactory.java
@@ -44,6 +44,17 @@ public final class TextureFactory {
     /**
      * Multi-layered {@link ITexture} factory
      *
+     * @param texture The layer of {@link ITexture} from bottom to top
+     * @return The instance of an {@link ITexture} implementation
+     */
+    public static ITexture of(final ITexture texture) {
+        return builder().addLayer(texture)
+            .build();
+    }
+
+    /**
+     * Multi-layered {@link ITexture} factory
+     *
      * @param textures The layers of {@link ITexture} from bottom to top
      * @return The instance of an {@link ITexture} implementation
      */

--- a/src/main/java/gregtech/common/render/GTTextureBuilder.java
+++ b/src/main/java/gregtech/common/render/GTTextureBuilder.java
@@ -53,6 +53,12 @@ public class GTTextureBuilder implements ITextureBuilder {
     }
 
     @Override
+    public ITextureBuilder addIcon(final IIconContainer iconContainer) {
+        this.iconContainerList.add(iconContainer);
+        return this;
+    }
+
+    @Override
     public ITextureBuilder addIcon(final IIconContainer... iconContainers) {
         this.iconContainerList.addAll(Arrays.asList(iconContainers));
         return this;
@@ -61,6 +67,12 @@ public class GTTextureBuilder implements ITextureBuilder {
     @Override
     public ITextureBuilder setRGBA(final short[] rgba) {
         this.rgba = rgba;
+        return this;
+    }
+
+    @Override
+    public ITextureBuilder addLayer(final ITexture iTexture) {
+        this.textureLayers.add(iTexture);
         return this;
     }
 

--- a/src/main/java/gregtech/common/render/GTTextureBuilder.java
+++ b/src/main/java/gregtech/common/render/GTTextureBuilder.java
@@ -1,8 +1,10 @@
 package gregtech.common.render;
 
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+
+import javax.annotation.Nullable;
 
 import net.minecraft.block.Block;
 import net.minecraftforge.common.util.ForgeDirection;
@@ -17,8 +19,8 @@ import gregtech.api.interfaces.ITextureBuilder;
 @SuppressWarnings({ "unused", "ClassWithTooManyFields" })
 public class GTTextureBuilder implements ITextureBuilder {
 
-    private final List<IIconContainer> iconContainerList;
-    private final List<ITexture> textureLayers;
+    private @Nullable List<IIconContainer> iconContainerList;
+    private @Nullable List<ITexture> textureLayers;
     private Block fromBlock;
     private int fromMeta;
     private ForgeDirection fromSide;
@@ -30,8 +32,6 @@ public class GTTextureBuilder implements ITextureBuilder {
     private Boolean worldCoord = null;
 
     public GTTextureBuilder() {
-        textureLayers = new ArrayList<>();
-        iconContainerList = new ArrayList<>();
         rgba = Dyes._NULL.getRGBA();
         allowAlpha = true;
         stdOrient = false;
@@ -54,13 +54,15 @@ public class GTTextureBuilder implements ITextureBuilder {
 
     @Override
     public ITextureBuilder addIcon(final IIconContainer iconContainer) {
-        this.iconContainerList.add(iconContainer);
+        if (iconContainerList == null) iconContainerList = new ArrayList<>(1);
+        iconContainerList.add(iconContainer);
         return this;
     }
 
     @Override
     public ITextureBuilder addIcon(final IIconContainer... iconContainers) {
-        this.iconContainerList.addAll(Arrays.asList(iconContainers));
+        if (iconContainerList == null) iconContainerList = new ArrayList<>(6);
+        Collections.addAll(iconContainerList, iconContainers);
         return this;
     }
 
@@ -72,13 +74,15 @@ public class GTTextureBuilder implements ITextureBuilder {
 
     @Override
     public ITextureBuilder addLayer(final ITexture iTexture) {
-        this.textureLayers.add(iTexture);
+        if (textureLayers == null) textureLayers = new ArrayList<>(1);
+        textureLayers.add(iTexture);
         return this;
     }
 
     @Override
     public ITextureBuilder addLayer(final ITexture... iTextures) {
-        this.textureLayers.addAll(Arrays.asList(iTextures));
+        if (textureLayers == null) textureLayers = new ArrayList<>();
+        Collections.addAll(textureLayers, iTextures);
         return this;
     }
 
@@ -129,7 +133,12 @@ public class GTTextureBuilder implements ITextureBuilder {
             else return new GTCopiedBlockTextureRender(fromBlock, fromSide.ordinal(), fromMeta, rgba, allowAlpha);
         }
         if (worldCoord != null) throw new IllegalStateException("worldCoord without from block");
-        if (!textureLayers.isEmpty()) return new GTMultiTextureRender(textureLayers.toArray(new ITexture[0]));
+        if (textureLayers != null && !textureLayers.isEmpty()) {
+            return new GTMultiTextureRender(textureLayers.toArray(new ITexture[0]));
+        }
+        if (iconContainerList == null) {
+            throw new IllegalStateException("Invalid sideIconContainer count");
+        }
         return switch (iconContainerList.size()) {
             case 1 -> new GTRenderedTexture(iconContainerList.get(0), rgba, glow, stdOrient, extFacing);
             case 6 -> new GTSidedTextureRender(


### PR DESCRIPTION
Add method overloads to avoid calling the vararg methods that creates an array for every invocation

Lazily allocate the lists and use appropriate sizes in GTTexturreBuilder