### PR TITLE
ISGRH block alpha overlay

### DIFF
--- a/src/main/java/gregtech/api/enums/Textures.java
+++ b/src/main/java/gregtech/api/enums/Textures.java
@@ -14,8 +14,12 @@ import gregtech.api.interfaces.IIconContainer;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GTUtility;
+import gregtech.api.util.client.ResourceUtils;
 
 public class Textures {
+
+    public static final String _OVERLAY = "_OVERLAY";
+    public static final String ICONSETS = "iconsets";
 
     public enum BlockIcons implements IIconContainer, Runnable {
 
@@ -1737,6 +1741,7 @@ public class Textures {
             TextureFactory.of(OVERLAY_ENERGY_IN, new short[] { 80, 80, 245, 0 }),
             TextureFactory.of(OVERLAY_ENERGY_IN, new short[] { 60, 60, 245, 0 }),
             TextureFactory.of(OVERLAY_ENERGY_IN, new short[] { 40, 40, 245, 0 }), };
+        public static final String TEXTURES_BLOCKS = "textures/blocks/";
         public static ITexture[] OVERLAYS_ENERGY_OUT = {
             TextureFactory.of(OVERLAY_ENERGY_OUT, new short[] { 180, 180, 180, 0 }),
             TextureFactory.of(OVERLAY_ENERGY_OUT, new short[] { 220, 220, 220, 0 }),
@@ -1960,22 +1965,42 @@ public class Textures {
 
         @Override
         public void run() {
-            mIcon = GregTechAPI.sBlockIcons.registerIcon(GregTech.getResourcePath("iconsets", this.toString()));
+            mIcon = GregTechAPI.sBlockIcons.registerIcon(GregTech.getResourcePath(ICONSETS, this.toString()));
         }
 
         public static class CustomIcon implements IIconContainer, Runnable {
 
-            protected IIcon mIcon;
-            protected String mIconName;
+            protected IIcon mIcon, mOverlay = null;
+            protected final String mIconName, mOverlayName;
+            protected final ResourceLocation overlayResLoc;
 
             public CustomIcon(String aIconName) {
                 mIconName = !aIconName.contains(":") ? GregTech.getResourcePath(aIconName) : aIconName;
+                mOverlayName = mIconName + _OVERLAY;
+                overlayResLoc = getResourceLocation(mOverlayName);
                 GregTechAPI.sGTBlockIconload.add(this);
             }
 
             @Override
             public void run() {
                 mIcon = GregTechAPI.sBlockIcons.registerIcon(mIconName);
+                // This makes the block _OVERLAY icon totally optional
+                mOverlay = ResourceUtils.resourceExists(overlayResLoc)
+                    ? GregTechAPI.sBlockIcons.registerIcon(mOverlayName)
+                    : null;
+            }
+
+            protected ResourceLocation getResourceLocation(String iconName) {
+                final String overlayDomain, overlayPath;
+                final int i = iconName.indexOf(':');
+                if (i >= 0) {
+                    overlayDomain = i > 1 ? iconName.substring(0, i) : "minecraft";
+                    overlayPath = TEXTURES_BLOCKS + iconName.substring(i + 1) + ".png";
+                } else {
+                    overlayDomain = "minecraft";
+                    overlayPath = TEXTURES_BLOCKS + iconName + ".png";
+                }
+                return new ResourceLocation(overlayDomain, overlayPath);
             }
 
             @Override
@@ -1985,7 +2010,7 @@ public class Textures {
 
             @Override
             public IIcon getOverlayIcon() {
-                return null;
+                return mOverlay;
             }
 
             @Override
@@ -2087,8 +2112,8 @@ public class Textures {
 
         @Override
         public void run() {
-            mIcon = GregTechAPI.sItemIcons.registerIcon(GregTech.getResourcePath("iconsets", this.toString()));
-            mOverlay = GregTechAPI.sItemIcons.registerIcon(GregTech.getResourcePath("iconsets", this + "_OVERLAY"));
+            mIcon = GregTechAPI.sItemIcons.registerIcon(GregTech.getResourcePath(ICONSETS, this.toString()));
+            mOverlay = GregTechAPI.sItemIcons.registerIcon(GregTech.getResourcePath(ICONSETS, this + _OVERLAY));
         }
 
         public static class CustomIcon implements IIconContainer, Runnable {
@@ -2119,7 +2144,7 @@ public class Textures {
             @Override
             public void run() {
                 mIcon = GregTechAPI.sItemIcons.registerIcon(GregTech.getResourcePath(mIconName));
-                mOverlay = GregTechAPI.sItemIcons.registerIcon(GregTech.getResourcePath(mIconName + "_OVERLAY"));
+                mOverlay = GregTechAPI.sItemIcons.registerIcon(GregTech.getResourcePath(mIconName + _OVERLAY));
             }
         }
     }

--- a/src/main/java/gregtech/api/util/client/ResourceUtils.java
+++ b/src/main/java/gregtech/api/util/client/ResourceUtils.java
@@ -1,0 +1,34 @@
+package gregtech.api.util.client;
+
+import java.io.IOException;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.resources.IResourceManager;
+import net.minecraft.util.ResourceLocation;
+
+import org.jetbrains.annotations.NotNull;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
+@SideOnly(Side.CLIENT)
+public class ResourceUtils {
+
+    /**
+     * Checks whether a resource exists.
+     *
+     * @param resLoc the {@link ResourceLocation} identifying the resource to check
+     * @return {@code true} if the resource exists; {@code false} otherwise
+     */
+    @SideOnly(Side.CLIENT)
+    public static boolean resourceExists(@NotNull ResourceLocation resLoc) {
+        final IResourceManager resMan = Minecraft.getMinecraft()
+            .getResourceManager();
+        try {
+            resMan.getResource(resLoc);
+            return true;
+        } catch (IOException ignored) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/gregtech/common/blocks/BlockOresAbstract.java
+++ b/src/main/java/gregtech/common/blocks/BlockOresAbstract.java
@@ -215,6 +215,11 @@ public abstract class BlockOresAbstract extends GTGenericBlock implements ITileE
     }
 
     @Override
+    public int getRenderBlockPass() {
+        return 1;
+    }
+
+    @Override
     public boolean canBeReplacedByLeaves(IBlockAccess aWorld, int aX, int aY, int aZ) {
         return false;
     }

--- a/src/main/java/gregtech/common/render/GTRenderedTexture.java
+++ b/src/main/java/gregtech/common/render/GTRenderedTexture.java
@@ -4,7 +4,6 @@ import static gregtech.api.util.LightingHelper.MAX_BRIGHTNESS;
 
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
-import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.tileentity.TileEntity;
@@ -144,7 +143,7 @@ public class GTRenderedTexture extends GTTextureBase implements ITexture, IColor
         final ExtendedFacing rotation = getExtendedFacing(aX, aY, aZ);
         renderFaceYNeg(aRenderer, aX, aY, aZ, mIconContainer.getIcon(), rotation);
         if (mIconContainer.getOverlayIcon() != null) {
-            Tessellator.instance.setColorRGBA(255, 255, 255, 255);
+            lighting.setupColor(ForgeDirection.DOWN, 0xffffff);
             renderFaceYNeg(aRenderer, aX, aY, aZ, mIconContainer.getOverlayIcon(), rotation);
         }
         aRenderer.enableAO = enableAO;

--- a/src/main/java/gregtech/common/render/GTRendererBlock.java
+++ b/src/main/java/gregtech/common/render/GTRendererBlock.java
@@ -56,6 +56,7 @@ import gregtech.common.blocks.BlockFrameBox;
 import gregtech.common.blocks.BlockMachines;
 import gregtech.common.blocks.BlockOresAbstract;
 import gregtech.common.blocks.TileEntityOres;
+import gregtech.mixin.interfaces.accessors.TesselatorAccessor;
 
 @ThreadSafeISBRH(perThread = true)
 public class GTRendererBlock implements ISimpleBlockRenderingHandler {
@@ -785,6 +786,7 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
         aRenderer.useInventoryTint = false;
 
         final TileEntity tileEntity = aWorld.getTileEntity(aX, aY, aZ);
+        final TesselatorAccessor tessAccess = (TesselatorAccessor) Tessellator.instance;
 
         // If this block does not have a TE, render it as a normal block.
         // Otherwise, render the TE instead.
@@ -799,7 +801,7 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
             textureArray[4] = texture;
             textureArray[5] = texture;
             renderStandardBlock(aWorld, aX, aY, aZ, aBlock, aRenderer, textureArray);
-            return true;
+            return tessAccess.gt5u$hasVertices();
         }
 
         if (aBlock instanceof IBlockWithTextures texturedBlock) {
@@ -807,7 +809,7 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
             ITexture[][] texture = texturedBlock.getTextures(meta);
             if (texture == null) return false;
             renderStandardBlock(aWorld, aX, aY, aZ, aBlock, aRenderer, texture);
-            return true;
+            return tessAccess.gt5u$hasVertices();
         }
 
         if (tileEntity == null) return false;
@@ -817,17 +819,17 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
             if ((metaTileEntity = ((IGregTechTileEntity) tileEntity).getMetaTileEntity()) != null
                 && metaTileEntity.renderInWorld(aWorld, aX, aY, aZ, aBlock, aRenderer)) {
                 aRenderer.enableAO = false;
-                return true;
+                return tessAccess.gt5u$hasVertices();
             }
         }
         if (tileEntity instanceof IPipeRenderedTileEntity
             && renderPipeBlock(aWorld, aX, aY, aZ, aBlock, (IPipeRenderedTileEntity) tileEntity, aRenderer)) {
             aRenderer.enableAO = false;
-            return true;
+            return tessAccess.gt5u$hasVertices();
         }
         if (renderStandardBlock(aWorld, aX, aY, aZ, aBlock, aRenderer)) {
             aRenderer.enableAO = false;
-            return true;
+            return tessAccess.gt5u$hasVertices();
         }
         return false;
     }

--- a/src/main/java/gregtech/mixin/interfaces/accessors/TesselatorAccessor.java
+++ b/src/main/java/gregtech/mixin/interfaces/accessors/TesselatorAccessor.java
@@ -3,4 +3,8 @@ package gregtech.mixin.interfaces.accessors;
 public interface TesselatorAccessor {
 
     boolean gt5u$isDrawing();
+
+    int gt5u$vertexCount();
+
+    boolean gt5u$hasVertices();
 }

--- a/src/mixin/java/gregtech/mixin/mixins/early/minecraft/accessors/TessellatorMixin.java
+++ b/src/mixin/java/gregtech/mixin/mixins/early/minecraft/accessors/TessellatorMixin.java
@@ -17,4 +17,17 @@ public class TessellatorMixin implements TesselatorAccessor {
     public boolean gt5u$isDrawing() {
         return this.isDrawing;
     }
+
+    @Shadow
+    private int vertexCount;
+
+    @Override
+    public int gt5u$vertexCount() {
+        return this.vertexCount;
+    }
+
+    @Override
+    public boolean gt5u$hasVertices() {
+        return this.vertexCount > 0;
+    }
 }


### PR DESCRIPTION
- #### Fix(ISBRH): have renderWorldBlock return true only if quads were added 
  
  Previously, `renderWorldBlock` always returned `true`, causing crashes
  when no quad vertices were added.
  In multipass rendering, some passes produce no vertices. Now,
  `renderWorldBlock` returns `true` only if quads were added 
  or `false` if none added, preventing crashes.
  
- #### Fix(GTRenderedTexture): do not tint bottom overlay icon
  
  The bottom overlay tint was incorrectly applied instead of being white
  (no tint). This fix ensures the bottom overlay is rendered without tint.
  
- #### Feat(BlockIcons/CustomIcon): support optional alpha blended _OVERLAY texture
  
  Adds support for optional alpha blended `_OVERLAY` textures on blocks
  using the `CustomIcon` `IIconContainer`.
  This typically concerns blocks using textures from the
  `blocks/materialicons/` path.
  
- #### Impr(BlockOresAbstract): render in alpha blended pass 1
  
  With rendering in alpha blended pass 1, ore blocks will benefit from
  alpha-blended optional `_OVERLAY` icons if provided.
  
### TODO
  
- Create some actual semi-transparent `_OVERLAY` textures for some ore blocks,
  to make use of this new rendering feature.
  