### PR TITLE
Fix console error spam

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchCraftingInputME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchCraftingInputME.java
@@ -730,7 +730,8 @@ public class MTEHatchCraftingInputME extends MTEHatchInputBus
         getProxy().readFromNBT(aNBT);
         updateAE2ProxyColor();
 
-        for (int i = 0; i < getSizeInventory(); i++) {
+        // Sync inventories to ensure that the real inventory matches what AE2 is seeing.
+        for (int i = 0; i < MAX_PATTERN_COUNT; i++) {
             if (internalInventory[i] == null) continue;
             mInventory[i] = internalInventory[i].pattern;
         }


### PR DESCRIPTION
```
[16:13:44] [Server thread/ERROR] [GregTech GTNH]: java.lang.ArrayIndexOutOfBoundsException: Index 36 out of bounds for length 36
        at Launch//gregtech.common.tileentities.machines.MTEHatchCraftingInputME.loadNBTData(MTEHatchCraftingInputME.java:734)
        at Launch//gregtech.api.metatileentity.CommonBaseMetaTileEntity.loadMetaTileNBT(CommonBaseMetaTileEntity.java:166)
        at Launch//gregtech.api.metatileentity.BaseMetaTileEntity.setInitialValuesAsNBT(BaseMetaTileEntity.java:206)
        at Launch//gregtech.api.metatileentity.BaseMetaTileEntity.func_145839_a(BaseMetaTileEntity.java:164)
        at Launch//net.minecraft.tileentity.TileEntity.func_145827_c(TileEntity.java:116)
        at Launch//net.minecraft.world.chunk.storage.AnvilChunkLoader.loadEntities(AnvilChunkLoader.java:496)
        at Launch//net.minecraftforge.common.chunkio.ChunkIOProvider.callStage2(ChunkIOProvider.java:41)
        at Launch//net.minecraftforge.common.chunkio.ChunkIOProvider.callStage2(ChunkIOProvider.java:12)
        at Launch//net.minecraftforge.common.util.AsynchronousExecutor.skipQueue(AsynchronousExecutor.java:344)
        at Launch//net.minecraftforge.common.util.AsynchronousExecutor.getSkipQueue(AsynchronousExecutor.java:302)
        at Launch//net.minecraftforge.common.chunkio.ChunkIOExecutor.syncChunkLoad(ChunkIOExecutor.java:12)
        at Launch//net.minecraft.world.gen.ChunkProviderServer.loadChunk(ChunkProviderServer.java:126)
        at Launch//net.minecraft.world.gen.ChunkProviderServer.func_73158_c(ChunkProviderServer.java:101)
        at Launch//net.minecraft.world.gen.ChunkProviderServer.func_73154_d(ChunkProviderServer.java:199)
        at Launch//net.minecraft.world.World.func_72964_e(World.java:419)
        at Launch//net.minecraft.world.WorldServer.func_147456_g(WorldServer.java:313)
        at Launch//net.minecraft.world.WorldServer.func_72835_b(WorldServer.java:183)
        at Launch//net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:625)
        at Launch//net.minecraft.server.dedicated.DedicatedServer.func_71190_q(DedicatedServer.java:334)
        at Launch//net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:547)
        at Launch//net.minecraft.server.MinecraftServer.run(MinecraftServer.java:427)
        at Launch//net.minecraft.server.MinecraftServer$2.run(MinecraftServer.java:685)
```