### PR TITLE
Fixes EFR Slab Conflict

### DIFF
--- a/src/main/java/gregtech/loaders/postload/recipes/CuttingRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/CuttingRecipes.java
@@ -115,12 +115,14 @@ public class CuttingRecipes implements Runnable {
 
         // stone slab recipes
         {
-            recipeWithClassicFluids(
-                new ItemStack[] { new ItemStack(Blocks.stone, 1, 0) },
-                new ItemStack[] { new ItemStack(Blocks.stone_slab, 2, 0) },
-                1 * SECONDS + 5 * TICKS,
-                8,
-                false);
+            if (EtFuturumRequiem.isModLoaded()) {
+                recipeWithClassicFluids(
+                    new ItemStack[] { getModItem(EtFuturumRequiem.ID, "smooth_stone", 1L, 0) },
+                    new ItemStack[] { new ItemStack(Blocks.stone_slab, 2, 0) },
+                    1 * SECONDS + 5 * TICKS,
+                    8,
+                    false);
+            }
 
             recipeWithClassicFluids(
                 new ItemStack[] { new ItemStack(Blocks.sandstone, 1, 0) },


### PR DESCRIPTION
### Changes:
- This just fixes the slab conflict, specifically the smooth stone slab cutting machine conflict. The only reason it's here and not in CoreMod is because this is where we are keeping specifically the slab cutting machine recipes for minecraft blocks & slabs, and the smooth stone slab is a minecraft slab.

This is cotangent with https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1311
This will help fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20488

Tested in latest