### PR TITLE
Deprecate the Tool Casting Machine

### DIFF
--- a/src/main/java/ggfab/GigaGramFab.java
+++ b/src/main/java/ggfab/GigaGramFab.java
@@ -4,6 +4,8 @@ import static gregtech.api.enums.ToolDictNames.*;
 import static gregtech.common.items.IDMetaTool01.*;
 import static gregtech.common.items.MetaGeneratedTool01.INSTANCE;
 
+import net.minecraft.util.EnumChatFormatting;
+
 import com.gtnewhorizon.gtnhlib.config.ConfigException;
 import com.gtnewhorizon.gtnhlib.config.ConfigurationManager;
 
@@ -19,7 +21,6 @@ import ggfab.mte.MTEAdvAssLine;
 import ggfab.mte.MTELinkedInputBus;
 import ggfab.util.GGUtils;
 import gregtech.api.GregTechAPI;
-import gregtech.api.enums.ItemList;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.enums.SoundResource;
 import gregtech.api.metatileentity.implementations.MTEBasicMachineWithRecipe;
@@ -55,13 +56,15 @@ public class GigaGramFab {
                 .set(new MTEAdvAssLine(13532, "ggfab.machine.adv_assline", "Advanced Assembly Line").getStackForm(1));
             GGItemList.LinkedInputBus.set(
                 new MTELinkedInputBus(13533, "ggfab.machine.linked_input_bus", "Linked Input Bus", 5).getStackForm(1));
+
             GGItemList.ToolCast_MV.set(
                 new MTEBasicMachineWithRecipe(
                     13534,
                     "ggfab.toolcast.tier.mv",
                     "Basic Tool Casting Machine",
                     2,
-                    "Cheap Crafting Tool for you!",
+                    new String[] { EnumChatFormatting.YELLOW + "DEPRECATED! Will be removed in next major update.",
+                        EnumChatFormatting.GRAY + "Cheap Crafting Tool for you!" },
                     GGFabRecipeMaps.toolCastRecipes,
                     1,
                     4,
@@ -69,17 +72,15 @@ public class GigaGramFab {
                     SoundResource.NONE,
                     MTEBasicMachineWithRecipe.SpecialEffects.MAIN_RANDOM_SPARKS,
                     "TOOL_CAST",
-                    new Object[] { "PGP", "WMW", "CBC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
-                        MTEBasicMachineWithRecipe.X.PUMP, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
-                        MTEBasicMachineWithRecipe.X.WIRE, 'G', MTEBasicMachineWithRecipe.X.GLASS, 'B',
-                        ItemList.Shape_Empty.get(1L) }).getStackForm(1L));
+                    null).getStackForm(1L));
             GGItemList.ToolCast_HV.set(
                 new MTEBasicMachineWithRecipe(
                     13535,
                     "ggfab.toolcast.tier.hv",
                     "Advanced Tool Casting Machine",
                     3,
-                    "Cheap Crafting Tool for you!",
+                    new String[] { EnumChatFormatting.YELLOW + "DEPRECATED! Will be removed in next major update.",
+                        EnumChatFormatting.GRAY + "Cheap Crafting Tool for you!" },
                     GGFabRecipeMaps.toolCastRecipes,
                     1,
                     4,
@@ -87,17 +88,15 @@ public class GigaGramFab {
                     SoundResource.NONE,
                     MTEBasicMachineWithRecipe.SpecialEffects.MAIN_RANDOM_SPARKS,
                     "TOOL_CAST",
-                    new Object[] { "PGP", "WMW", "CBC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
-                        MTEBasicMachineWithRecipe.X.PUMP, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
-                        MTEBasicMachineWithRecipe.X.WIRE, 'G', MTEBasicMachineWithRecipe.X.GLASS, 'B',
-                        ItemList.Shape_Empty.get(1L) }).getStackForm(1L));
+                    null).getStackForm(1L));
             GGItemList.ToolCast_EV.set(
                 new MTEBasicMachineWithRecipe(
                     13536,
                     "ggfab.toolcast.tier.ev",
                     "Master Tool Casting Machine",
                     4,
-                    "Cheap Crafting Tool for you!",
+                    new String[] { EnumChatFormatting.YELLOW + "DEPRECATED! Will be removed in next major update.",
+                        EnumChatFormatting.GRAY + "Cheap Crafting Tool for you!" },
                     GGFabRecipeMaps.toolCastRecipes,
                     1,
                     4,
@@ -105,10 +104,7 @@ public class GigaGramFab {
                     SoundResource.NONE,
                     MTEBasicMachineWithRecipe.SpecialEffects.MAIN_RANDOM_SPARKS,
                     "TOOL_CAST",
-                    new Object[] { "PGP", "WMW", "CBC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
-                        MTEBasicMachineWithRecipe.X.PUMP, 'C', MTEBasicMachineWithRecipe.X.CIRCUIT, 'W',
-                        MTEBasicMachineWithRecipe.X.WIRE, 'G', MTEBasicMachineWithRecipe.X.GLASS, 'B',
-                        ItemList.Shape_Empty.get(1L) }).getStackForm(1L));
+                    null).getStackForm(1L));
             long plate = OrePrefixes.plate.mMaterialAmount, ingot = OrePrefixes.ingot.mMaterialAmount,
                 screw = OrePrefixes.screw.mMaterialAmount, rod = OrePrefixes.stick.mMaterialAmount;
             GigaGramFabAPI.addSingleUseToolType(craftingToolFile, INSTANCE.mToolStats.get((short) FILE.ID), 2 * plate);

--- a/src/main/java/ggfab/SingleUseToolRecipeLoader.java
+++ b/src/main/java/ggfab/SingleUseToolRecipeLoader.java
@@ -8,7 +8,6 @@ import java.util.List;
 
 import net.minecraft.item.ItemStack;
 
-import ggfab.api.GGFabRecipeMaps;
 import ggfab.api.GigaGramFabAPI;
 import ggfab.items.SingleUseTool;
 import gregtech.api.enums.GTValues;
@@ -16,6 +15,7 @@ import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.TierEU;
 import gregtech.api.interfaces.IToolStats;
+import gregtech.api.recipe.RecipeMaps;
 import gregtech.api.util.GTModHandler;
 import gregtech.api.util.GTUtility;
 
@@ -94,8 +94,8 @@ class SingleUseToolRecipeLoader implements Runnable {
             ItemStack output = singleUseTool.tool.get(0L);
             output.stackSize = (int) outputQuantity; // This is a safe cast since it is between 128 and 256
             List<ItemStack> outputs = new ArrayList<>();
-            int maxStackSize = output.getMaxStackSize();
-            while (output.stackSize > maxStackSize) outputs.add(output.splitStack(maxStackSize));
+            // int maxStackSize = output.getMaxStackSize();
+            // while (output.stackSize > maxStackSize) outputs.add(output.splitStack(maxStackSize));
             outputs.add(output);
 
             GTValues.RA.stdBuilder()
@@ -104,7 +104,7 @@ class SingleUseToolRecipeLoader implements Runnable {
                 .itemOutputs(outputs.toArray(new ItemStack[0]))
                 .eut(TierEU.RECIPE_MV)
                 .duration(recipeDuration)
-                .addTo(GGFabRecipeMaps.toolCastRecipes);
+                .addTo(RecipeMaps.fluidSolidifierRecipes);
         }
     }
 }

--- a/src/main/java/ggfab/SingleUseToolRecipeLoader.java
+++ b/src/main/java/ggfab/SingleUseToolRecipeLoader.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import net.minecraft.item.ItemStack;
 
+import ggfab.api.GGFabRecipeMaps;
 import ggfab.api.GigaGramFabAPI;
 import ggfab.items.SingleUseTool;
 import gregtech.api.enums.GTValues;
@@ -21,9 +22,16 @@ import gregtech.api.util.GTUtility;
 
 class SingleUseToolRecipeLoader implements Runnable {
 
+    /*
+     * MARKED FOR DEPRECATION, will be moved to just the fluid solidifer.
+     * REMOVE TOOLCAST SEGMENT IN NEXT MAJOR UPDATE
+     */
     public static final int RECIPE_DURATION = 6 * SECONDS;
     public static final int OUTPUT_QUANTITY_MIN = 2 * 64;
     public static final int OUTPUT_QUANTITY_MAX = 4 * 64;
+    public static final int SOLIDIFER_RECIPE_DURATION = 2 * SECONDS;
+    public static final int SOLIDIFIER_QUANTITY_MIN = 32;
+    public static final int SOLIDIFIER_QUANTITY_MAX = 64;
 
     @Override
     public void run() {
@@ -56,6 +64,14 @@ class SingleUseToolRecipeLoader implements Runnable {
         return (double) outputQuantity / (long) OUTPUT_QUANTITY_MAX;
     }
 
+    private static double findDivisorSolidifier(long fluidPerCraft, long outputQuantity) {
+        for (long i = outputQuantity / SOLIDIFIER_QUANTITY_MAX; i < Math.min(fluidPerCraft, outputQuantity); i++) {
+            if (fluidPerCraft % i == 0 && outputQuantity % i == 0 && outputQuantity / i <= SOLIDIFIER_QUANTITY_MAX)
+                return (double) i;
+        }
+        return (double) outputQuantity / (long) SOLIDIFIER_QUANTITY_MAX;
+    }
+
     private void addSingleUseToolRecipes(Materials material, List<SingleUseTool> singleUseTools) {
         if (material.mStandardMoltenFluid == null) {
             throw new IllegalArgumentException("material does not have molten fluid form");
@@ -75,7 +91,26 @@ class SingleUseToolRecipeLoader implements Runnable {
             long fluidPerCraft = toolCost * INGOTS / GTValues.M;
             long recipeDuration = RECIPE_DURATION;
             long outputQuantity = (long) (material.mDurability * durabilityMultiplier * 100 / damagePerCraft);
+            long solidifierFluidPerCraft = toolCost * INGOTS / GTValues.M;
+            long solidifierRecipeDuration = SOLIDIFER_RECIPE_DURATION;
+            long solidifierOutputQuantity = (long) (material.mDurability * durabilityMultiplier * 100 / damagePerCraft);
 
+            if (solidifierOutputQuantity > SOLIDIFIER_QUANTITY_MAX) {
+                // Too much output — scale down.
+                double divisor = findDivisorSolidifier(fluidPerCraft, outputQuantity);
+                solidifierFluidPerCraft = Math.max((long) (solidifierFluidPerCraft / divisor), 1L);
+                solidifierRecipeDuration = Math.max((long) (solidifierRecipeDuration / divisor), 1L);
+                solidifierOutputQuantity = Math
+                    .min((long) (solidifierOutputQuantity / divisor), SOLIDIFIER_QUANTITY_MAX);
+            } else if (solidifierOutputQuantity < SOLIDIFIER_QUANTITY_MIN) {
+                // Too little output — scale up.
+                long multiplier = GTUtility.ceilDiv(SOLIDIFIER_QUANTITY_MIN, outputQuantity);
+                solidifierFluidPerCraft *= multiplier;
+                solidifierRecipeDuration *= multiplier;
+                solidifierOutputQuantity *= multiplier;
+            }
+
+            // MARKED FOR DEPRECATION, REMOVE IN NEXT MAJOR UPDATE
             if (outputQuantity > OUTPUT_QUANTITY_MAX) {
                 // Too much output — scale down.
                 double divisor = findDivisor(fluidPerCraft, outputQuantity);
@@ -93,9 +128,10 @@ class SingleUseToolRecipeLoader implements Runnable {
             // Split into stacks
             ItemStack output = singleUseTool.tool.get(0L);
             output.stackSize = (int) outputQuantity; // This is a safe cast since it is between 128 and 256
+
             List<ItemStack> outputs = new ArrayList<>();
-            // int maxStackSize = output.getMaxStackSize();
-            // while (output.stackSize > maxStackSize) outputs.add(output.splitStack(maxStackSize));
+            int maxStackSize = output.getMaxStackSize();
+            while (output.stackSize > maxStackSize) outputs.add(output.splitStack(maxStackSize));
             outputs.add(output);
 
             GTValues.RA.stdBuilder()
@@ -104,6 +140,17 @@ class SingleUseToolRecipeLoader implements Runnable {
                 .itemOutputs(outputs.toArray(new ItemStack[0]))
                 .eut(TierEU.RECIPE_MV)
                 .duration(recipeDuration)
+                .addTo(GGFabRecipeMaps.toolCastRecipes);
+
+            ItemStack solidifierOutput = singleUseTool.tool.get(0L);
+            solidifierOutput.stackSize = (int) solidifierOutputQuantity;
+
+            GTValues.RA.stdBuilder()
+                .fluidInputs(material.getMolten(solidifierFluidPerCraft))
+                .itemInputs(singleUseTool.mold.get(0L))
+                .itemOutputs(solidifierOutput)
+                .eut(TierEU.RECIPE_MV)
+                .duration(solidifierRecipeDuration)
                 .addTo(RecipeMaps.fluidSolidifierRecipes);
         }
     }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEMultiSolidifier.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEMultiSolidifier.java
@@ -16,8 +16,6 @@ import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_FRONT_MULTI_CANNER_
 import static gregtech.api.util.GTStructureUtility.buildHatchAdder;
 import static gregtech.api.util.GTStructureUtility.chainAllGlasses;
 
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -181,7 +179,7 @@ public class MTEMultiSolidifier extends MTEExtendedPowerMultiBlockBase<MTEMultiS
     @Override
     protected MultiblockTooltipBuilder createTooltip() {
         MultiblockTooltipBuilder tt = new MultiblockTooltipBuilder();
-        tt.addMachineType("Fluid Solidifier, Tool Casting Machine")
+        tt.addMachineType("Fluid Solidifier")
             .addInfo(
                 "Can use " + EnumChatFormatting.YELLOW
                     + "Solidifier Hatches"
@@ -281,26 +279,6 @@ public class MTEMultiSolidifier extends MTEExtendedPowerMultiBlockBase<MTEMultiS
     protected ProcessingLogic createProcessingLogic() {
         return new ProcessingLogic() {
 
-            RecipeMap<?> currentRecipeMap = RecipeMaps.fluidSolidifierRecipes;
-
-            // Override is needed so that switching recipe maps does not stop recipe locking.
-            @Override
-            protected RecipeMap<?> getCurrentRecipeMap() {
-                lastRecipeMap = currentRecipeMap;
-                return currentRecipeMap;
-            }
-
-            @NotNull
-            @Override
-            public CheckRecipeResult process() {
-                currentRecipeMap = RecipeMaps.fluidSolidifierRecipes;
-                CheckRecipeResult result = super.process();
-                if (result.wasSuccessful()) return result;
-
-                currentRecipeMap = GGFabRecipeMaps.toolCastRecipes;
-                return super.process();
-            }
-
             @Override
             public boolean tryCachePossibleRecipesFromPattern(IDualInputInventoryWithPattern inv) {
                 if (dualInvWithPatternToRecipeCache.containsKey(inv)) {
@@ -313,6 +291,7 @@ public class MTEMultiSolidifier extends MTEExtendedPowerMultiBlockBase<MTEMultiS
                 setInputFluids(inputs.inputFluid);
                 Set<GTRecipe> recipes = findRecipeMatches(RecipeMaps.fluidSolidifierRecipes)
                     .collect(Collectors.toSet());
+                // this might be able to be safely removed. Ill keep it in. REMOVE IN NEXT MAJOR UPDATE
                 if (recipes.isEmpty())
                     recipes = findRecipeMatches(GGFabRecipeMaps.toolCastRecipes).collect(Collectors.toSet());
                 if (!recipes.isEmpty()) {
@@ -357,11 +336,6 @@ public class MTEMultiSolidifier extends MTEExtendedPowerMultiBlockBase<MTEMultiS
     @Override
     public int getMaxParallelRecipes() {
         return (BASE_PARALLELS + (width * PARALLELS_PER_WIDTH)) * GTUtility.getTier(this.getMaxInputVoltage());
-    }
-
-    @Override
-    public @NotNull Collection<RecipeMap<?>> getAvailableRecipeMaps() {
-        return Arrays.asList(RecipeMaps.fluidSolidifierRecipes, GGFabRecipeMaps.toolCastRecipes);
     }
 
     @Override


### PR DESCRIPTION
Changelist:
Remove Crafting Recipe and add Deprecation info to tooltip of tool casting machines.
Add comments to recipeloader code to say remove in next major update
Add equivalent recipes to current fluid solidifer.
Remove *nearly all mentions of tool casting recipe map in MTEFluidSolidifier.java . 