### PR TITLE
Cache TE sides

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/BaseTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseTileEntity.java
@@ -43,8 +43,6 @@ import com.gtnewhorizons.modularui.common.widget.SlotGroup;
 import com.gtnewhorizons.modularui.common.widget.SlotWidget;
 import com.gtnewhorizons.modularui.common.widget.TextWidget;
 
-import cpw.mods.fml.common.FMLCommonHandler;
-import cpw.mods.fml.relauncher.Side;
 import gregtech.GTMod;
 import gregtech.api.enums.Dyes;
 import gregtech.api.enums.GTValues;
@@ -96,6 +94,8 @@ public abstract class BaseTileEntity extends TileEntity implements IHasWorldObje
     public boolean isDead = false;
 
     private final ChunkCoordinates mReturnedCoordinates = new ChunkCoordinates();
+
+    private boolean hasSide, isRemote;
 
     public static ForgeDirection getSideForPlayerPlacing(Entity player, ForgeDirection defaultFacing,
         boolean[] aAllowedFacings) {
@@ -164,21 +164,23 @@ public abstract class BaseTileEntity extends TileEntity implements IHasWorldObje
     }
 
     @Override
-    public final boolean isServerSide() {
-        if (worldObj == null) {
-            return FMLCommonHandler.instance()
-                .getEffectiveSide() == Side.SERVER;
+    public void setWorldObj(World worldIn) {
+        super.setWorldObj(worldIn);
+
+        if (worldIn != null) {
+            isRemote = worldIn.isRemote;
+            hasSide = true;
         }
-        return !worldObj.isRemote;
+    }
+
+    @Override
+    public final boolean isServerSide() {
+        return hasSide && !isRemote;
     }
 
     @Override
     public final boolean isClientSide() {
-        if (worldObj == null) {
-            return FMLCommonHandler.instance()
-                .getEffectiveSide() == Side.CLIENT;
-        }
-        return worldObj.isRemote;
+        return hasSide && isRemote;
     }
 
     @Override


### PR DESCRIPTION
I'm not sure why this shows up in a profile (since it means that something is calling methods on an invalid GT TE) but it does and it's easy to fix. Hopefully this change fixes the problem since I can't reproduce it - the method may just be getting called a ridiculous amount in some pathological path. The JIT should be able to inline this easier, at least.

https://spark.lucko.me/obzI1nPxNu
<img width="1848" height="263" alt="image" src="https://github.com/user-attachments/assets/e6f96c51-28c0-48d5-b7af-6de81720d440" />
