### PR TITLE
Add EFR Mushroom Blocks to TGS

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoaderTreeFarm.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoaderTreeFarm.java
@@ -83,13 +83,13 @@ public class RecipeLoaderTreeFarm {
         MTETreeFarm.registerTreeProducts( // Brown Mushroom
             new ItemStack(Blocks.brown_mushroom, 1, 0),
             new ItemStack(Blocks.brown_mushroom_block, 1, 0),
-            null,
+            GTModHandler.getModItem(Mods.EtFuturumRequiem.ID, "brown_mushroom", 1, 0),
             null);
 
         MTETreeFarm.registerTreeProducts( // Red Mushroom
             new ItemStack(Blocks.red_mushroom, 1, 0),
             new ItemStack(Blocks.red_mushroom_block, 1, 0),
-            null,
+            GTModHandler.getModItem(Mods.EtFuturumRequiem.ID, "red_mushroom", 1, 0),
             null);
     }
 


### PR DESCRIPTION
### Changes:
- As described by title, adds the EFR mushroom blocks as the "leaves" in the TGS recipes. This makes sense because those blocks are essentially the leaves, and it gives a machine-based method to obtain them.

### In-Game-Photos:
<img width="509" height="332" alt="image" src="https://github.com/user-attachments/assets/56e5214f-1b39-4dcc-a3a7-d36c48de1152" />
<img width="510" height="334" alt="image" src="https://github.com/user-attachments/assets/2bc21a8f-306c-4113-8f77-388ce03cda32" />
