### PR TITLE
Fix Singleblock Distilled Water Recipe

### DIFF
--- a/src/main/java/gregtech/api/recipe/RecipeMaps.java
+++ b/src/main/java/gregtech/api/recipe/RecipeMaps.java
@@ -422,7 +422,7 @@ public final class RecipeMaps {
         .build();
     public static final RecipeMap<RecipeMapBackend> distilleryRecipes = RecipeMapBuilder.of("gt.recipe.distillery")
         .maxIO(1, 1, 1, 1)
-        .minInputs(1, 1)
+        .minInputs(0, 1)
         .slotOverlays((index, isFluid, isOutput, isSpecial) -> {
             if (!isFluid) {
                 return null;


### PR DESCRIPTION
Set minimum items for distillery recipes to 0 to fix the singleblock distilled water recipe failing after its ghost circuit was removed by https://github.com/GTNewHorizons/GT5-Unofficial/pull/4623 (mutliblock recipe was unaffected by that change).

Should some other ghost circuits be removed from SB distillery recipes with no alternative outputs for the fluid in a future PR?

See discussion about this issue down from here: https://discord.com/channels/181078474394566657/522098956491030558/1399234023578009600