### PR TITLE
fix(GTPP/BlockBaseOre): now render pass 1

### DIFF
--- a/src/main/java/gtPlusPlus/core/block/base/BlockBaseOre.java
+++ b/src/main/java/gtPlusPlus/core/block/base/BlockBaseOre.java
@@ -79,6 +79,21 @@ public class BlockBaseOre extends BasicBlock implements ITexturedBlock {
         }
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @implNote Can render in both opaque (pass 0) and alpha-blended (pass 1) rendering passes.
+     */
+    @Override
+    public boolean canRenderInPass(int pass) {
+        return pass == 0 || pass == 1;
+    }
+
+    @Override
+    public int getRenderBlockPass() {
+        return 1;
+    }
+
     @Override
     public IIcon getIcon(IBlockAccess aIBlockAccess, int aX, int aY, int aZ, int ordinalSide) {
         return Blocks.stone.getIcon(0, 0);


### PR DESCRIPTION
GT++ ore block also need render pass 1 as it shares the alpha-blended textures with GT now.

Reported by @GDCloudstrike via Discord:
![broken rendering](https://cdn.discordapp.com/attachments/603348502637969419/1399498080579092671/2025-07-28_23.03.24.png?ex=688937a7&is=6887e627&hm=9e2062c4d74090f3f78efca9bdde4409638c5585321b20d932e0d3bbdd97631c&)

Now fixed!
<img width="1920" height="989" alt="2025-07-29_00 15 15" src="https://github.com/user-attachments/assets/be9bde74-f83c-4ba5-ab8c-a888c4019e05" />

