### PR TITLE
Fix(render): distinct pass for background and overlay

### DIFF
--- a/src/main/java/bartworks/client/renderer/BWBlockOreRenderer.java
+++ b/src/main/java/bartworks/client/renderer/BWBlockOreRenderer.java
@@ -23,7 +23,9 @@ import static gregtech.common.render.GTRendererBlock.renderPositiveZFacing;
 import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.RenderBlocks;
+import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.world.IBlockAccess;
+import net.minecraftforge.client.ForgeHooksClient;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import org.lwjgl.opengl.GL11;
@@ -35,6 +37,8 @@ import bartworks.system.material.TileEntityMetaGeneratedBlock;
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
 import cpw.mods.fml.client.registry.RenderingRegistry;
 import gregtech.GTMod;
+import gregtech.api.util.LightingHelper;
+import gregtech.mixin.interfaces.accessors.TesselatorAccessor;
 
 @ThreadSafeISBRH(perThread = true)
 public class BWBlockOreRenderer implements ISimpleBlockRenderingHandler {
@@ -52,6 +56,7 @@ public class BWBlockOreRenderer implements ISimpleBlockRenderingHandler {
 
     @Override
     public void renderInventoryBlock(Block aBlock, int aMeta, int modelId, RenderBlocks aRenderer) {
+        LightingHelper lightingHelper = new LightingHelper(aRenderer);
         TileEntityMetaGeneratedBlock tTileEntity = ((BWMetaGeneratedBlocks) aBlock).getProperTileEntityForRendering();
         tTileEntity.mMetaData = (short) aMeta;
         aRenderer.enableAO = false;
@@ -63,57 +68,69 @@ public class BWBlockOreRenderer implements ISimpleBlockRenderingHandler {
         renderNegativeYFacing(
             null,
             aRenderer,
+            lightingHelper,
             aBlock,
             0,
             0,
             0,
             tTileEntity.getTexture(aBlock, ForgeDirection.DOWN),
-            true);
+            true,
+            -1);
         renderPositiveYFacing(
             null,
             aRenderer,
+            lightingHelper,
             aBlock,
             0,
             0,
             0,
             tTileEntity.getTexture(aBlock, ForgeDirection.UP),
-            true);
+            true,
+            -1);
         renderNegativeZFacing(
             null,
             aRenderer,
+            lightingHelper,
             aBlock,
             0,
             0,
             0,
             tTileEntity.getTexture(aBlock, ForgeDirection.NORTH),
-            true);
+            true,
+            -1);
         renderPositiveZFacing(
             null,
             aRenderer,
+            lightingHelper,
             aBlock,
             0,
             0,
             0,
             tTileEntity.getTexture(aBlock, ForgeDirection.SOUTH),
-            true);
+            true,
+            -1);
         renderNegativeXFacing(
             null,
             aRenderer,
+            lightingHelper,
             aBlock,
             0,
             0,
             0,
             tTileEntity.getTexture(aBlock, ForgeDirection.WEST),
-            true);
+            true,
+            -1);
         renderPositiveXFacing(
             null,
             aRenderer,
+            lightingHelper,
             aBlock,
             0,
             0,
             0,
             tTileEntity.getTexture(aBlock, ForgeDirection.EAST),
-            true);
+            true,
+            -1);
         aRenderer.setRenderBoundsFromBlock(aBlock);
         aBlock.setBlockBounds(blockMin, blockMin, blockMin, blockMax, blockMax, blockMax);
         GL11.glTranslatef(0.5F, 0.5F, 0.5F);
@@ -132,18 +149,22 @@ public class BWBlockOreRenderer implements ISimpleBlockRenderingHandler {
         TileEntityMetaGeneratedBlock actualTileEntity = (TileEntityMetaGeneratedBlock) aWorld.getTileEntity(aX, aY, aZ);
         if(actualTileEntity == null) return false;
 
+        final TesselatorAccessor tessAccess = (TesselatorAccessor) Tessellator.instance;
+        final LightingHelper lightingHelper = new LightingHelper(aRenderer);
+        final int worldRenderPass = ForgeHooksClient.getWorldRenderPass();
+
         fakeTileEntity.mMetaData = actualTileEntity.mMetaData;
         aRenderer.useInventoryTint = false;
         aBlock.setBlockBounds(blockMin, blockMin, blockMin, blockMax, blockMax, blockMax);
         aRenderer.enableAO = Minecraft.isAmbientOcclusionEnabled() && GTMod.proxy.mRenderTileAmbientOcclusion;
         aRenderer.setRenderBoundsFromBlock(aBlock);
-        renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, fakeTileEntity.getTexture(aBlock, ForgeDirection.DOWN), true);
-        renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, fakeTileEntity.getTexture(aBlock, ForgeDirection.UP), true);
-        renderNegativeZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, fakeTileEntity.getTexture(aBlock, ForgeDirection.NORTH), true);
-        renderPositiveZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, fakeTileEntity.getTexture(aBlock, ForgeDirection.SOUTH), true);
-        renderNegativeXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, fakeTileEntity.getTexture(aBlock, ForgeDirection.WEST), true);
-        renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, fakeTileEntity.getTexture(aBlock, ForgeDirection.EAST), true);
-        return true;
+        renderNegativeYFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, fakeTileEntity.getTexture(aBlock, ForgeDirection.DOWN), true, worldRenderPass);
+        renderPositiveYFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, fakeTileEntity.getTexture(aBlock, ForgeDirection.UP), true, worldRenderPass);
+        renderNegativeZFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, fakeTileEntity.getTexture(aBlock, ForgeDirection.NORTH), true, worldRenderPass);
+        renderPositiveZFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, fakeTileEntity.getTexture(aBlock, ForgeDirection.SOUTH), true, worldRenderPass);
+        renderNegativeXFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, fakeTileEntity.getTexture(aBlock, ForgeDirection.WEST), true, worldRenderPass);
+        renderPositiveXFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, fakeTileEntity.getTexture(aBlock, ForgeDirection.EAST), true, worldRenderPass);
+        return tessAccess.gt5u$hasVertices();
     }
     // spotless:on
 

--- a/src/main/java/bartworks/system/material/BWMetaGeneratedBlocks.java
+++ b/src/main/java/bartworks/system/material/BWMetaGeneratedBlocks.java
@@ -59,6 +59,16 @@ public abstract class BWMetaGeneratedBlocks extends BWTileEntityContainer {
     }
 
     @Override
+    public boolean canRenderInPass(int pass) {
+        return pass == 0 || pass == 1;
+    }
+
+    @Override
+    public int getRenderBlockPass() {
+        return 1;
+    }
+
+    @Override
     public void onBlockAdded(World aWorld, int aX, int aY, int aZ) {
         super.onBlockAdded(aWorld, aX, aY, aZ);
         // Waste some time to allow the TE to be set, do not use thread sleep here, it doesnt allow for nanoseconds.

--- a/src/main/java/gregtech/api/interfaces/ITexture.java
+++ b/src/main/java/gregtech/api/interfaces/ITexture.java
@@ -4,19 +4,33 @@ import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.client.renderer.Tessellator;
 
+import gregtech.api.util.LightingHelper;
+
 public interface ITexture {
 
-    void renderXPos(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ);
+    @SuppressWarnings("MethodWithTooManyParameters")
+    void renderXPos(RenderBlocks aRenderer, LightingHelper lightingHelper, Block aBlock, int aX, int aY, int aZ,
+        int renderWorldPass);
 
-    void renderXNeg(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ);
+    @SuppressWarnings("MethodWithTooManyParameters")
+    void renderXNeg(RenderBlocks aRenderer, LightingHelper lightingHelper, Block aBlock, int aX, int aY, int aZ,
+        int renderWorldPass);
 
-    void renderYPos(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ);
+    @SuppressWarnings("MethodWithTooManyParameters")
+    void renderYPos(RenderBlocks aRenderer, LightingHelper lightingHelper, Block aBlock, int aX, int aY, int aZ,
+        int renderWorldPass);
 
-    void renderYNeg(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ);
+    @SuppressWarnings("MethodWithTooManyParameters")
+    void renderYNeg(RenderBlocks aRenderer, LightingHelper lightingHelper, Block aBlock, int aX, int aY, int aZ,
+        int renderWorldPass);
 
-    void renderZPos(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ);
+    @SuppressWarnings("MethodWithTooManyParameters")
+    void renderZPos(RenderBlocks aRenderer, LightingHelper lightingHelper, Block aBlock, int aX, int aY, int aZ,
+        int renderWorldPass);
 
-    void renderZNeg(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ);
+    @SuppressWarnings("MethodWithTooManyParameters")
+    void renderZNeg(RenderBlocks aRenderer, LightingHelper lightingHelper, Block aBlock, int aX, int aY, int aZ,
+        int renderWorldPass);
 
     boolean isValidTexture();
 

--- a/src/main/java/gregtech/common/render/GTCopiedBlockTextureRender.java
+++ b/src/main/java/gregtech/common/render/GTCopiedBlockTextureRender.java
@@ -6,7 +6,6 @@ import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
-import net.minecraftforge.client.ForgeHooksClient;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import com.prupe.mcpatcher.ctm.CTMUtils;
@@ -45,13 +44,13 @@ public class GTCopiedBlockTextureRender extends GTTextureBase implements ITextur
     }
 
     @Override
-    public void renderXPos(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
-        final int worldRenderPass = ForgeHooksClient.getWorldRenderPass();
+    public void renderXPos(RenderBlocks aRenderer, LightingHelper lightingHelper, Block aBlock, int aX, int aY, int aZ,
+        int worldRenderPass) {
         if (worldRenderPass != -1 && !mBlock.canRenderInPass(worldRenderPass)) return;
         final IIcon aIcon = getIcon(ForgeDirection.EAST.ordinal(), aRenderer.blockAccess, aX, aY, aZ);
         aRenderer.field_152631_f = true;
         startDrawingQuads(aRenderer, 1.0f, 0.0f, 0.0f);
-        new LightingHelper(aRenderer).setupLightingXPos(aBlock, aX, aY, aZ)
+        lightingHelper.setupLightingXPos(aBlock, aX, aY, aZ)
             .setupColor(ForgeDirection.EAST, 0xffffff);
         aRenderer.renderFaceXPos(aBlock, aX, aY, aZ, aIcon);
         draw(aRenderer);
@@ -59,61 +58,61 @@ public class GTCopiedBlockTextureRender extends GTTextureBase implements ITextur
     }
 
     @Override
-    public void renderXNeg(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
-        final int worldRenderPass = ForgeHooksClient.getWorldRenderPass();
+    public void renderXNeg(RenderBlocks aRenderer, LightingHelper lightingHelper, Block aBlock, int aX, int aY, int aZ,
+        int worldRenderPass) {
         if (worldRenderPass != -1 && !mBlock.canRenderInPass(worldRenderPass)) return;
         startDrawingQuads(aRenderer, -1.0f, 0.0f, 0.0f);
         final IIcon aIcon = getIcon(ForgeDirection.WEST.ordinal(), aRenderer.blockAccess, aX, aY, aZ);
-        new LightingHelper(aRenderer).setupLightingXNeg(aBlock, aX, aY, aZ)
+        lightingHelper.setupLightingXNeg(aBlock, aX, aY, aZ)
             .setupColor(ForgeDirection.WEST, 0xffffff);
         aRenderer.renderFaceXNeg(aBlock, aX, aY, aZ, aIcon);
         draw(aRenderer);
     }
 
     @Override
-    public void renderYPos(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
-        final int worldRenderPass = ForgeHooksClient.getWorldRenderPass();
+    public void renderYPos(RenderBlocks aRenderer, LightingHelper lightingHelper, Block aBlock, int aX, int aY, int aZ,
+        int worldRenderPass) {
         if (worldRenderPass != -1 && !mBlock.canRenderInPass(worldRenderPass)) return;
         startDrawingQuads(aRenderer, 0.0f, 1.0f, 0.0f);
         final IIcon aIcon = getIcon(ForgeDirection.UP.ordinal(), aRenderer.blockAccess, aX, aY, aZ);
-        new LightingHelper(aRenderer).setupLightingYPos(aBlock, aX, aY, aZ)
+        lightingHelper.setupLightingYPos(aBlock, aX, aY, aZ)
             .setupColor(ForgeDirection.UP, 0xffffff);
         aRenderer.renderFaceYPos(aBlock, aX, aY, aZ, aIcon);
         draw(aRenderer);
     }
 
     @Override
-    public void renderYNeg(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
-        final int worldRenderPass = ForgeHooksClient.getWorldRenderPass();
+    public void renderYNeg(RenderBlocks aRenderer, LightingHelper lightingHelper, Block aBlock, int aX, int aY, int aZ,
+        int worldRenderPass) {
         if (worldRenderPass != -1 && !mBlock.canRenderInPass(worldRenderPass)) return;
         startDrawingQuads(aRenderer, 0.0f, -1.0f, 0.0f);
         final IIcon aIcon = getIcon(ForgeDirection.DOWN.ordinal(), aRenderer.blockAccess, aX, aY, aZ);
-        new LightingHelper(aRenderer).setupLightingYNeg(aBlock, aX, aY, aZ)
+        lightingHelper.setupLightingYNeg(aBlock, aX, aY, aZ)
             .setupColor(ForgeDirection.DOWN, 0xffffff);
         aRenderer.renderFaceYNeg(aBlock, aX, aY, aZ, aIcon);
         draw(aRenderer);
     }
 
     @Override
-    public void renderZPos(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
-        final int worldRenderPass = ForgeHooksClient.getWorldRenderPass();
+    public void renderZPos(RenderBlocks aRenderer, LightingHelper lightingHelper, Block aBlock, int aX, int aY, int aZ,
+        int worldRenderPass) {
         if (worldRenderPass != -1 && !mBlock.canRenderInPass(worldRenderPass)) return;
         startDrawingQuads(aRenderer, 0.0f, 0.0f, 1.0f);
         final IIcon aIcon = getIcon(ForgeDirection.SOUTH.ordinal(), aRenderer.blockAccess, aX, aY, aZ);
-        new LightingHelper(aRenderer).setupLightingZPos(aBlock, aX, aY, aZ)
+        lightingHelper.setupLightingZPos(aBlock, aX, aY, aZ)
             .setupColor(ForgeDirection.SOUTH, 0xffffff);
         aRenderer.renderFaceZPos(aBlock, aX, aY, aZ, aIcon);
         draw(aRenderer);
     }
 
     @Override
-    public void renderZNeg(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
-        final int worldRenderPass = ForgeHooksClient.getWorldRenderPass();
+    public void renderZNeg(RenderBlocks aRenderer, LightingHelper lightingHelper, Block aBlock, int aX, int aY, int aZ,
+        int worldRenderPass) {
         if (worldRenderPass != -1 && !mBlock.canRenderInPass(worldRenderPass)) return;
         startDrawingQuads(aRenderer, 0.0f, 0.0f, -1.0f);
         final IIcon aIcon = getIcon(ForgeDirection.NORTH.ordinal(), aRenderer.blockAccess, aX, aY, aZ);
         aRenderer.field_152631_f = true;
-        new LightingHelper(aRenderer).setupLightingZNeg(aBlock, aX, aY, aZ)
+        lightingHelper.setupLightingZNeg(aBlock, aX, aY, aZ)
             .setupColor(ForgeDirection.NORTH, 0xffffff);
         aRenderer.renderFaceZNeg(aBlock, aX, aY, aZ, aIcon);
         draw(aRenderer);

--- a/src/main/java/gregtech/common/render/GTCopiedBlockTextureRender.java
+++ b/src/main/java/gregtech/common/render/GTCopiedBlockTextureRender.java
@@ -6,6 +6,7 @@ import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
+import net.minecraftforge.client.ForgeHooksClient;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import com.prupe.mcpatcher.ctm.CTMUtils;
@@ -45,6 +46,8 @@ public class GTCopiedBlockTextureRender extends GTTextureBase implements ITextur
 
     @Override
     public void renderXPos(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
+        final int worldRenderPass = ForgeHooksClient.getWorldRenderPass();
+        if (worldRenderPass != -1 && !mBlock.canRenderInPass(worldRenderPass)) return;
         final IIcon aIcon = getIcon(ForgeDirection.EAST.ordinal(), aRenderer.blockAccess, aX, aY, aZ);
         aRenderer.field_152631_f = true;
         startDrawingQuads(aRenderer, 1.0f, 0.0f, 0.0f);
@@ -57,6 +60,8 @@ public class GTCopiedBlockTextureRender extends GTTextureBase implements ITextur
 
     @Override
     public void renderXNeg(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
+        final int worldRenderPass = ForgeHooksClient.getWorldRenderPass();
+        if (worldRenderPass != -1 && !mBlock.canRenderInPass(worldRenderPass)) return;
         startDrawingQuads(aRenderer, -1.0f, 0.0f, 0.0f);
         final IIcon aIcon = getIcon(ForgeDirection.WEST.ordinal(), aRenderer.blockAccess, aX, aY, aZ);
         new LightingHelper(aRenderer).setupLightingXNeg(aBlock, aX, aY, aZ)
@@ -67,6 +72,8 @@ public class GTCopiedBlockTextureRender extends GTTextureBase implements ITextur
 
     @Override
     public void renderYPos(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
+        final int worldRenderPass = ForgeHooksClient.getWorldRenderPass();
+        if (worldRenderPass != -1 && !mBlock.canRenderInPass(worldRenderPass)) return;
         startDrawingQuads(aRenderer, 0.0f, 1.0f, 0.0f);
         final IIcon aIcon = getIcon(ForgeDirection.UP.ordinal(), aRenderer.blockAccess, aX, aY, aZ);
         new LightingHelper(aRenderer).setupLightingYPos(aBlock, aX, aY, aZ)
@@ -77,6 +84,8 @@ public class GTCopiedBlockTextureRender extends GTTextureBase implements ITextur
 
     @Override
     public void renderYNeg(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
+        final int worldRenderPass = ForgeHooksClient.getWorldRenderPass();
+        if (worldRenderPass != -1 && !mBlock.canRenderInPass(worldRenderPass)) return;
         startDrawingQuads(aRenderer, 0.0f, -1.0f, 0.0f);
         final IIcon aIcon = getIcon(ForgeDirection.DOWN.ordinal(), aRenderer.blockAccess, aX, aY, aZ);
         new LightingHelper(aRenderer).setupLightingYNeg(aBlock, aX, aY, aZ)
@@ -87,6 +96,8 @@ public class GTCopiedBlockTextureRender extends GTTextureBase implements ITextur
 
     @Override
     public void renderZPos(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
+        final int worldRenderPass = ForgeHooksClient.getWorldRenderPass();
+        if (worldRenderPass != -1 && !mBlock.canRenderInPass(worldRenderPass)) return;
         startDrawingQuads(aRenderer, 0.0f, 0.0f, 1.0f);
         final IIcon aIcon = getIcon(ForgeDirection.SOUTH.ordinal(), aRenderer.blockAccess, aX, aY, aZ);
         new LightingHelper(aRenderer).setupLightingZPos(aBlock, aX, aY, aZ)
@@ -97,6 +108,8 @@ public class GTCopiedBlockTextureRender extends GTTextureBase implements ITextur
 
     @Override
     public void renderZNeg(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
+        final int worldRenderPass = ForgeHooksClient.getWorldRenderPass();
+        if (worldRenderPass != -1 && !mBlock.canRenderInPass(worldRenderPass)) return;
         startDrawingQuads(aRenderer, 0.0f, 0.0f, -1.0f);
         final IIcon aIcon = getIcon(ForgeDirection.NORTH.ordinal(), aRenderer.blockAccess, aX, aY, aZ);
         aRenderer.field_152631_f = true;

--- a/src/main/java/gregtech/common/render/GTCopiedCTMBlockTexture.java
+++ b/src/main/java/gregtech/common/render/GTCopiedCTMBlockTexture.java
@@ -39,11 +39,13 @@ class GTCopiedCTMBlockTexture extends GTTextureBase implements ITexture, IBlockC
     }
 
     @Override
-    public void renderXPos(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
+    public void renderXPos(RenderBlocks aRenderer, LightingHelper lightingHelper, Block aBlock, int aX, int aY, int aZ,
+        int worldRenderPass) {
         final IIcon aIcon = getIcon(ForgeDirection.EAST.ordinal(), aX, aY, aZ, aRenderer);
+        if (worldRenderPass != -1 && !mBlock.canRenderInPass(worldRenderPass)) return;
         aRenderer.field_152631_f = true;
         startDrawingQuads(aRenderer, 1.0f, 0.0f, 0.0f);
-        new LightingHelper(aRenderer).setupLightingXPos(aBlock, aX, aY, aZ)
+        lightingHelper.setupLightingXPos(aBlock, aX, aY, aZ)
             .setupColor(ForgeDirection.EAST, mBlock.colorMultiplier(getBlockAccess(aRenderer), aX, aY, aZ));
         aRenderer.renderFaceXPos(aBlock, aX, aY, aZ, aIcon);
         draw(aRenderer);
@@ -51,51 +53,61 @@ class GTCopiedCTMBlockTexture extends GTTextureBase implements ITexture, IBlockC
     }
 
     @Override
-    public void renderXNeg(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
+    public void renderXNeg(RenderBlocks aRenderer, LightingHelper lightingHelper, Block aBlock, int aX, int aY, int aZ,
+        int worldRenderPass) {
         startDrawingQuads(aRenderer, -1.0f, 0.0f, 0.0f);
+        if (worldRenderPass != -1 && !mBlock.canRenderInPass(worldRenderPass)) return;
         final IIcon aIcon = getIcon(ForgeDirection.WEST.ordinal(), aX, aY, aZ, aRenderer);
-        new LightingHelper(aRenderer).setupLightingXNeg(aBlock, aX, aY, aZ)
+        lightingHelper.setupLightingXNeg(aBlock, aX, aY, aZ)
             .setupColor(ForgeDirection.WEST, mBlock.colorMultiplier(getBlockAccess(aRenderer), aX, aY, aZ));
         aRenderer.renderFaceXNeg(aBlock, aX, aY, aZ, aIcon);
         draw(aRenderer);
     }
 
     @Override
-    public void renderYPos(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
+    public void renderYPos(RenderBlocks aRenderer, LightingHelper lightingHelper, Block aBlock, int aX, int aY, int aZ,
+        int worldRenderPass) {
         startDrawingQuads(aRenderer, 0.0f, 1.0f, 0.0f);
+        if (worldRenderPass != -1 && !mBlock.canRenderInPass(worldRenderPass)) return;
         final IIcon aIcon = getIcon(ForgeDirection.UP.ordinal(), aX, aY, aZ, aRenderer);
-        new LightingHelper(aRenderer).setupLightingYPos(aBlock, aX, aY, aZ)
+        lightingHelper.setupLightingYPos(aBlock, aX, aY, aZ)
             .setupColor(ForgeDirection.UP, mBlock.colorMultiplier(getBlockAccess(aRenderer), aX, aY, aZ));
         aRenderer.renderFaceYPos(aBlock, aX, aY, aZ, aIcon);
         draw(aRenderer);
     }
 
     @Override
-    public void renderYNeg(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
+    public void renderYNeg(RenderBlocks aRenderer, LightingHelper lightingHelper, Block aBlock, int aX, int aY, int aZ,
+        int worldRenderPass) {
         startDrawingQuads(aRenderer, 0.0f, -1.0f, 0.0f);
+        if (worldRenderPass != -1 && !mBlock.canRenderInPass(worldRenderPass)) return;
         final IIcon aIcon = getIcon(ForgeDirection.DOWN.ordinal(), aX, aY, aZ, aRenderer);
-        new LightingHelper(aRenderer).setupLightingYNeg(aBlock, aX, aY, aZ)
+        lightingHelper.setupLightingYNeg(aBlock, aX, aY, aZ)
             .setupColor(ForgeDirection.DOWN, mBlock.colorMultiplier(getBlockAccess(aRenderer), aX, aY, aZ));
         aRenderer.renderFaceYNeg(aBlock, aX, aY, aZ, aIcon);
         draw(aRenderer);
     }
 
     @Override
-    public void renderZPos(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
+    public void renderZPos(RenderBlocks aRenderer, LightingHelper lightingHelper, Block aBlock, int aX, int aY, int aZ,
+        int worldRenderPass) {
         startDrawingQuads(aRenderer, 0.0f, 0.0f, 1.0f);
+        if (worldRenderPass != -1 && !mBlock.canRenderInPass(worldRenderPass)) return;
         final IIcon aIcon = getIcon(ForgeDirection.SOUTH.ordinal(), aX, aY, aZ, aRenderer);
-        new LightingHelper(aRenderer).setupLightingZPos(aBlock, aX, aY, aZ)
+        lightingHelper.setupLightingZPos(aBlock, aX, aY, aZ)
             .setupColor(ForgeDirection.SOUTH, mBlock.colorMultiplier(getBlockAccess(aRenderer), aX, aY, aZ));
         aRenderer.renderFaceZPos(aBlock, aX, aY, aZ, aIcon);
         draw(aRenderer);
     }
 
     @Override
-    public void renderZNeg(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
+    public void renderZNeg(RenderBlocks aRenderer, LightingHelper lightingHelper, Block aBlock, int aX, int aY, int aZ,
+        int worldRenderPass) {
         startDrawingQuads(aRenderer, 0.0f, 0.0f, -1.0f);
+        if (worldRenderPass != -1 && !mBlock.canRenderInPass(worldRenderPass)) return;
         final IIcon aIcon = getIcon(ForgeDirection.NORTH.ordinal(), aX, aY, aZ, aRenderer);
         aRenderer.field_152631_f = true;
-        new LightingHelper(aRenderer).setupLightingZNeg(aBlock, aX, aY, aZ)
+        lightingHelper.setupLightingZNeg(aBlock, aX, aY, aZ)
             .setupColor(ForgeDirection.NORTH, mBlock.colorMultiplier(getBlockAccess(aRenderer), aX, aY, aZ));
         aRenderer.renderFaceZNeg(aBlock, aX, aY, aZ, aIcon);
         draw(aRenderer);

--- a/src/main/java/gregtech/common/render/GTMultiTextureRender.java
+++ b/src/main/java/gregtech/common/render/GTMultiTextureRender.java
@@ -5,6 +5,7 @@ import net.minecraft.client.renderer.RenderBlocks;
 
 import gregtech.GTMod;
 import gregtech.api.interfaces.ITexture;
+import gregtech.api.util.LightingHelper;
 
 /**
  * <p>
@@ -27,39 +28,45 @@ public class GTMultiTextureRender extends GTTextureBase implements ITexture {
     }
 
     @Override
-    public void renderXPos(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
-        for (ITexture tTexture : mTextures)
-            if (tTexture != null && tTexture.isValidTexture()) tTexture.renderXPos(aRenderer, aBlock, aX, aY, aZ);
+    public void renderXPos(RenderBlocks aRenderer, LightingHelper lightingHelper, Block aBlock, int aX, int aY, int aZ,
+        int renderWorldPass) {
+        for (ITexture tTexture : mTextures) if (tTexture != null && tTexture.isValidTexture())
+            tTexture.renderXPos(aRenderer, lightingHelper, aBlock, aX, aY, aZ, renderWorldPass);
     }
 
     @Override
-    public void renderXNeg(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
-        for (ITexture tTexture : mTextures)
-            if (tTexture != null && tTexture.isValidTexture()) tTexture.renderXNeg(aRenderer, aBlock, aX, aY, aZ);
+    public void renderXNeg(RenderBlocks aRenderer, LightingHelper lightingHelper, Block aBlock, int aX, int aY, int aZ,
+        int renderWorldPass) {
+        for (ITexture tTexture : mTextures) if (tTexture != null && tTexture.isValidTexture())
+            tTexture.renderXNeg(aRenderer, lightingHelper, aBlock, aX, aY, aZ, renderWorldPass);
     }
 
     @Override
-    public void renderYPos(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
-        for (ITexture tTexture : mTextures)
-            if (tTexture != null && tTexture.isValidTexture()) tTexture.renderYPos(aRenderer, aBlock, aX, aY, aZ);
+    public void renderYPos(RenderBlocks aRenderer, LightingHelper lightingHelper, Block aBlock, int aX, int aY, int aZ,
+        int renderWorldPass) {
+        for (ITexture tTexture : mTextures) if (tTexture != null && tTexture.isValidTexture())
+            tTexture.renderYPos(aRenderer, lightingHelper, aBlock, aX, aY, aZ, renderWorldPass);
     }
 
     @Override
-    public void renderYNeg(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
-        for (ITexture tTexture : mTextures)
-            if (tTexture != null && tTexture.isValidTexture()) tTexture.renderYNeg(aRenderer, aBlock, aX, aY, aZ);
+    public void renderYNeg(RenderBlocks aRenderer, LightingHelper lightingHelper, Block aBlock, int aX, int aY, int aZ,
+        int renderWorldPass) {
+        for (ITexture tTexture : mTextures) if (tTexture != null && tTexture.isValidTexture())
+            tTexture.renderYNeg(aRenderer, lightingHelper, aBlock, aX, aY, aZ, renderWorldPass);
     }
 
     @Override
-    public void renderZPos(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
-        for (ITexture tTexture : mTextures)
-            if (tTexture != null && tTexture.isValidTexture()) tTexture.renderZPos(aRenderer, aBlock, aX, aY, aZ);
+    public void renderZPos(RenderBlocks aRenderer, LightingHelper lightingHelper, Block aBlock, int aX, int aY, int aZ,
+        int renderWorldPass) {
+        for (ITexture tTexture : mTextures) if (tTexture != null && tTexture.isValidTexture())
+            tTexture.renderZPos(aRenderer, lightingHelper, aBlock, aX, aY, aZ, renderWorldPass);
     }
 
     @Override
-    public void renderZNeg(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
-        for (ITexture tTexture : mTextures)
-            if (tTexture != null && tTexture.isValidTexture()) tTexture.renderZNeg(aRenderer, aBlock, aX, aY, aZ);
+    public void renderZNeg(RenderBlocks aRenderer, LightingHelper lightingHelper, Block aBlock, int aX, int aY, int aZ,
+        int renderWorldPass) {
+        for (ITexture tTexture : mTextures) if (tTexture != null && tTexture.isValidTexture())
+            tTexture.renderZNeg(aRenderer, lightingHelper, aBlock, aX, aY, aZ, renderWorldPass);
     }
 
     @Override

--- a/src/main/java/gregtech/common/render/GTRenderedTexture.java
+++ b/src/main/java/gregtech/common/render/GTRenderedTexture.java
@@ -9,7 +9,6 @@ import net.minecraft.init.Blocks;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.World;
-import net.minecraftforge.client.ForgeHooksClient;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import com.gtnewhorizon.structurelib.alignment.IAlignment;
@@ -48,28 +47,27 @@ public class GTRenderedTexture extends GTTextureBase implements ITexture, IColor
     }
 
     @Override
-    public void renderXPos(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
+    public void renderXPos(RenderBlocks aRenderer, LightingHelper lightingHelper, Block aBlock, int aX, int aY, int aZ,
+        int worldRenderPass) {
         startDrawingQuads(aRenderer, 1.0f, 0.0f, 0.0f);
         final boolean enableAO = aRenderer.enableAO;
-        final LightingHelper lighting = new LightingHelper(aRenderer);
         if (glow) {
             if (!GTMod.proxy.mRenderGlowTextures) {
                 draw(aRenderer);
                 return;
             }
             aRenderer.enableAO = false;
-            lighting.setLightnessOverride(1.0F);
-            if (enableAO) lighting.setBrightnessOverride(MAX_BRIGHTNESS);
+            lightingHelper.setLightnessOverride(1.0F);
+            if (enableAO) lightingHelper.setBrightnessOverride(MAX_BRIGHTNESS);
         }
-        lighting.setupLightingXPos(aBlock, aX, aY, aZ);
+        lightingHelper.setupLightingXPos(aBlock, aX, aY, aZ);
         final ExtendedFacing rotation = getExtendedFacing(aX, aY, aZ);
-        final int worldRenderPass = ForgeHooksClient.getWorldRenderPass();
         if (worldRenderPass == -1 || worldRenderPass == 0) {
-            lighting.setupColor(ForgeDirection.EAST, mRGBa);
+            lightingHelper.setupColor(ForgeDirection.EAST, mRGBa);
             renderFaceXPos(aRenderer, aX, aY, aZ, mIconContainer.getIcon(), rotation);
         }
         if (mIconContainer.getOverlayIcon() != null && (worldRenderPass == -1 || worldRenderPass == 1)) {
-            lighting.setupColor(ForgeDirection.EAST, 0xffffff);
+            lightingHelper.setupColor(ForgeDirection.EAST, 0xffffff);
             renderFaceXPos(aRenderer, aX, aY, aZ, mIconContainer.getOverlayIcon(), rotation);
         }
         aRenderer.enableAO = enableAO;
@@ -77,28 +75,27 @@ public class GTRenderedTexture extends GTTextureBase implements ITexture, IColor
     }
 
     @Override
-    public void renderXNeg(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
+    public void renderXNeg(RenderBlocks aRenderer, LightingHelper lightingHelper, Block aBlock, int aX, int aY, int aZ,
+        int worldRenderPass) {
         startDrawingQuads(aRenderer, -1.0f, 0.0f, 0.0f);
         final boolean enableAO = aRenderer.enableAO;
-        final LightingHelper lighting = new LightingHelper(aRenderer);
         if (glow) {
             if (!GTMod.proxy.mRenderGlowTextures) {
                 draw(aRenderer);
                 return;
             }
             aRenderer.enableAO = false;
-            lighting.setLightnessOverride(1.0F);
-            lighting.setBrightnessOverride(MAX_BRIGHTNESS);
+            lightingHelper.setLightnessOverride(1.0F);
+            lightingHelper.setBrightnessOverride(MAX_BRIGHTNESS);
         }
-        lighting.setupLightingXNeg(aBlock, aX, aY, aZ);
+        lightingHelper.setupLightingXNeg(aBlock, aX, aY, aZ);
         final ExtendedFacing rotation = getExtendedFacing(aX, aY, aZ);
-        final int worldRenderPass = ForgeHooksClient.getWorldRenderPass();
         if (worldRenderPass == -1 || worldRenderPass == 0) {
-            lighting.setupColor(ForgeDirection.WEST, mRGBa);
+            lightingHelper.setupColor(ForgeDirection.WEST, mRGBa);
             renderFaceXNeg(aRenderer, aX, aY, aZ, mIconContainer.getIcon(), rotation);
         }
         if (mIconContainer.getOverlayIcon() != null && (worldRenderPass == -1 || worldRenderPass == 1)) {
-            lighting.setupColor(ForgeDirection.WEST, 0xffffff);
+            lightingHelper.setupColor(ForgeDirection.WEST, 0xffffff);
             renderFaceXNeg(aRenderer, aX, aY, aZ, mIconContainer.getOverlayIcon(), rotation);
         }
         aRenderer.enableAO = enableAO;
@@ -106,28 +103,27 @@ public class GTRenderedTexture extends GTTextureBase implements ITexture, IColor
     }
 
     @Override
-    public void renderYPos(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
+    public void renderYPos(RenderBlocks aRenderer, LightingHelper lightingHelper, Block aBlock, int aX, int aY, int aZ,
+        int worldRenderPass) {
         startDrawingQuads(aRenderer, 0.0f, 1.0f, 0.0f);
         final boolean enableAO = aRenderer.enableAO;
-        final LightingHelper lighting = new LightingHelper(aRenderer);
         if (glow) {
             if (!GTMod.proxy.mRenderGlowTextures) {
                 draw(aRenderer);
                 return;
             }
             aRenderer.enableAO = false;
-            lighting.setLightnessOverride(1.0F);
-            lighting.setBrightnessOverride(MAX_BRIGHTNESS);
+            lightingHelper.setLightnessOverride(1.0F);
+            lightingHelper.setBrightnessOverride(MAX_BRIGHTNESS);
         }
-        lighting.setupLightingYPos(aBlock, aX, aY, aZ);
+        lightingHelper.setupLightingYPos(aBlock, aX, aY, aZ);
         final ExtendedFacing rotation = getExtendedFacing(aX, aY, aZ);
-        final int worldRenderPass = ForgeHooksClient.getWorldRenderPass();
         if (worldRenderPass == -1 || worldRenderPass == 0) {
-            lighting.setupColor(ForgeDirection.UP, mRGBa);
+            lightingHelper.setupColor(ForgeDirection.UP, mRGBa);
             renderFaceYPos(aRenderer, aX, aY, aZ, mIconContainer.getIcon(), rotation);
         }
         if (mIconContainer.getOverlayIcon() != null && (worldRenderPass == -1 || worldRenderPass == 1)) {
-            lighting.setupColor(ForgeDirection.UP, 0xffffff);
+            lightingHelper.setupColor(ForgeDirection.UP, 0xffffff);
             renderFaceYPos(aRenderer, aX, aY, aZ, mIconContainer.getOverlayIcon(), rotation);
         }
         aRenderer.enableAO = enableAO;
@@ -135,28 +131,27 @@ public class GTRenderedTexture extends GTTextureBase implements ITexture, IColor
     }
 
     @Override
-    public void renderYNeg(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
+    public void renderYNeg(RenderBlocks aRenderer, LightingHelper lightingHelper, Block aBlock, int aX, int aY, int aZ,
+        int worldRenderPass) {
         startDrawingQuads(aRenderer, 0.0f, -1.0f, 0.0f);
         final boolean enableAO = aRenderer.enableAO;
-        final LightingHelper lighting = new LightingHelper(aRenderer);
         if (glow) {
             if (!GTMod.proxy.mRenderGlowTextures) {
                 draw(aRenderer);
                 return;
             }
             aRenderer.enableAO = false;
-            lighting.setLightnessOverride(1.0F);
-            lighting.setBrightnessOverride(MAX_BRIGHTNESS);
+            lightingHelper.setLightnessOverride(1.0F);
+            lightingHelper.setBrightnessOverride(MAX_BRIGHTNESS);
         }
-        lighting.setupLightingYNeg(aBlock, aX, aY, aZ);
+        lightingHelper.setupLightingYNeg(aBlock, aX, aY, aZ);
         final ExtendedFacing rotation = getExtendedFacing(aX, aY, aZ);
-        final int worldRenderPass = ForgeHooksClient.getWorldRenderPass();
         if (worldRenderPass == -1 || worldRenderPass == 0) {
-            lighting.setupColor(ForgeDirection.DOWN, mRGBa);
+            lightingHelper.setupColor(ForgeDirection.DOWN, mRGBa);
             renderFaceYNeg(aRenderer, aX, aY, aZ, mIconContainer.getIcon(), rotation);
         }
         if (mIconContainer.getOverlayIcon() != null && (worldRenderPass == -1 || worldRenderPass == 1)) {
-            lighting.setupColor(ForgeDirection.DOWN, 0xffffff);
+            lightingHelper.setupColor(ForgeDirection.DOWN, 0xffffff);
             renderFaceYNeg(aRenderer, aX, aY, aZ, mIconContainer.getOverlayIcon(), rotation);
         }
         aRenderer.enableAO = enableAO;
@@ -164,28 +159,27 @@ public class GTRenderedTexture extends GTTextureBase implements ITexture, IColor
     }
 
     @Override
-    public void renderZPos(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
+    public void renderZPos(RenderBlocks aRenderer, LightingHelper lightingHelper, Block aBlock, int aX, int aY, int aZ,
+        int worldRenderPass) {
         startDrawingQuads(aRenderer, 0.0f, 0.0f, 1.0f);
         final boolean enableAO = aRenderer.enableAO;
-        final LightingHelper lighting = new LightingHelper(aRenderer);
         if (glow) {
             if (!GTMod.proxy.mRenderGlowTextures) {
                 draw(aRenderer);
                 return;
             }
             aRenderer.enableAO = false;
-            lighting.setLightnessOverride(1.0F);
-            lighting.setBrightnessOverride(MAX_BRIGHTNESS);
+            lightingHelper.setLightnessOverride(1.0F);
+            lightingHelper.setBrightnessOverride(MAX_BRIGHTNESS);
         }
-        lighting.setupLightingZPos(aBlock, aX, aY, aZ);
+        lightingHelper.setupLightingZPos(aBlock, aX, aY, aZ);
         final ExtendedFacing rotation = getExtendedFacing(aX, aY, aZ);
-        final int worldRenderPass = ForgeHooksClient.getWorldRenderPass();
         if (worldRenderPass == -1 || worldRenderPass == 0) {
-            lighting.setupColor(ForgeDirection.SOUTH, mRGBa);
+            lightingHelper.setupColor(ForgeDirection.SOUTH, mRGBa);
             renderFaceZPos(aRenderer, aX, aY, aZ, mIconContainer.getIcon(), rotation);
         }
         if (mIconContainer.getOverlayIcon() != null && (worldRenderPass == -1 || worldRenderPass == 1)) {
-            lighting.setupColor(ForgeDirection.SOUTH, 0xffffff);
+            lightingHelper.setupColor(ForgeDirection.SOUTH, 0xffffff);
             renderFaceZPos(aRenderer, aX, aY, aZ, mIconContainer.getOverlayIcon(), rotation);
         }
         aRenderer.enableAO = enableAO;
@@ -193,28 +187,27 @@ public class GTRenderedTexture extends GTTextureBase implements ITexture, IColor
     }
 
     @Override
-    public void renderZNeg(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
+    public void renderZNeg(RenderBlocks aRenderer, LightingHelper lightingHelper, Block aBlock, int aX, int aY, int aZ,
+        int worldRenderPass) {
         startDrawingQuads(aRenderer, 0.0f, 0.0f, -1.0f);
         final boolean enableAO = aRenderer.enableAO;
-        final LightingHelper lighting = new LightingHelper(aRenderer);
         if (glow) {
             if (!GTMod.proxy.mRenderGlowTextures) {
                 draw(aRenderer);
                 return;
             }
             aRenderer.enableAO = false;
-            lighting.setLightnessOverride(1.0F);
-            lighting.setBrightnessOverride(MAX_BRIGHTNESS);
+            lightingHelper.setLightnessOverride(1.0F);
+            lightingHelper.setBrightnessOverride(MAX_BRIGHTNESS);
         }
-        lighting.setupLightingZNeg(aBlock, aX, aY, aZ);
+        lightingHelper.setupLightingZNeg(aBlock, aX, aY, aZ);
         final ExtendedFacing rotation = getExtendedFacing(aX, aY, aZ);
-        final int worldRenderPass = ForgeHooksClient.getWorldRenderPass();
         if (worldRenderPass == -1 || worldRenderPass == 0) {
-            lighting.setupColor(ForgeDirection.NORTH, mRGBa);
+            lightingHelper.setupColor(ForgeDirection.NORTH, mRGBa);
             renderFaceZNeg(aRenderer, aX, aY, aZ, mIconContainer.getIcon(), rotation);
         }
         if (mIconContainer.getOverlayIcon() != null && (worldRenderPass == -1 || worldRenderPass == 1)) {
-            lighting.setupColor(ForgeDirection.NORTH, 0xffffff);
+            lightingHelper.setupColor(ForgeDirection.NORTH, 0xffffff);
             renderFaceZNeg(aRenderer, aX, aY, aZ, mIconContainer.getOverlayIcon(), rotation);
         }
         aRenderer.enableAO = enableAO;

--- a/src/main/java/gregtech/common/render/GTRenderedTexture.java
+++ b/src/main/java/gregtech/common/render/GTRenderedTexture.java
@@ -9,6 +9,7 @@ import net.minecraft.init.Blocks;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.World;
+import net.minecraftforge.client.ForgeHooksClient;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import com.gtnewhorizon.structurelib.alignment.IAlignment;
@@ -60,11 +61,14 @@ public class GTRenderedTexture extends GTTextureBase implements ITexture, IColor
             lighting.setLightnessOverride(1.0F);
             if (enableAO) lighting.setBrightnessOverride(MAX_BRIGHTNESS);
         }
-        lighting.setupLightingXPos(aBlock, aX, aY, aZ)
-            .setupColor(ForgeDirection.EAST, mRGBa);
+        lighting.setupLightingXPos(aBlock, aX, aY, aZ);
         final ExtendedFacing rotation = getExtendedFacing(aX, aY, aZ);
-        renderFaceXPos(aRenderer, aX, aY, aZ, mIconContainer.getIcon(), rotation);
-        if (mIconContainer.getOverlayIcon() != null) {
+        final int worldRenderPass = ForgeHooksClient.getWorldRenderPass();
+        if (worldRenderPass == -1 || worldRenderPass == 0) {
+            lighting.setupColor(ForgeDirection.EAST, mRGBa);
+            renderFaceXPos(aRenderer, aX, aY, aZ, mIconContainer.getIcon(), rotation);
+        }
+        if (mIconContainer.getOverlayIcon() != null && (worldRenderPass == -1 || worldRenderPass == 1)) {
             lighting.setupColor(ForgeDirection.EAST, 0xffffff);
             renderFaceXPos(aRenderer, aX, aY, aZ, mIconContainer.getOverlayIcon(), rotation);
         }
@@ -86,11 +90,14 @@ public class GTRenderedTexture extends GTTextureBase implements ITexture, IColor
             lighting.setLightnessOverride(1.0F);
             lighting.setBrightnessOverride(MAX_BRIGHTNESS);
         }
-        lighting.setupLightingXNeg(aBlock, aX, aY, aZ)
-            .setupColor(ForgeDirection.WEST, mRGBa);
+        lighting.setupLightingXNeg(aBlock, aX, aY, aZ);
         final ExtendedFacing rotation = getExtendedFacing(aX, aY, aZ);
-        renderFaceXNeg(aRenderer, aX, aY, aZ, mIconContainer.getIcon(), rotation);
-        if (mIconContainer.getOverlayIcon() != null) {
+        final int worldRenderPass = ForgeHooksClient.getWorldRenderPass();
+        if (worldRenderPass == -1 || worldRenderPass == 0) {
+            lighting.setupColor(ForgeDirection.WEST, mRGBa);
+            renderFaceXNeg(aRenderer, aX, aY, aZ, mIconContainer.getIcon(), rotation);
+        }
+        if (mIconContainer.getOverlayIcon() != null && (worldRenderPass == -1 || worldRenderPass == 1)) {
             lighting.setupColor(ForgeDirection.WEST, 0xffffff);
             renderFaceXNeg(aRenderer, aX, aY, aZ, mIconContainer.getOverlayIcon(), rotation);
         }
@@ -112,11 +119,14 @@ public class GTRenderedTexture extends GTTextureBase implements ITexture, IColor
             lighting.setLightnessOverride(1.0F);
             lighting.setBrightnessOverride(MAX_BRIGHTNESS);
         }
-        lighting.setupLightingYPos(aBlock, aX, aY, aZ)
-            .setupColor(ForgeDirection.UP, mRGBa);
+        lighting.setupLightingYPos(aBlock, aX, aY, aZ);
         final ExtendedFacing rotation = getExtendedFacing(aX, aY, aZ);
-        renderFaceYPos(aRenderer, aX, aY, aZ, mIconContainer.getIcon(), rotation);
-        if (mIconContainer.getOverlayIcon() != null) {
+        final int worldRenderPass = ForgeHooksClient.getWorldRenderPass();
+        if (worldRenderPass == -1 || worldRenderPass == 0) {
+            lighting.setupColor(ForgeDirection.UP, mRGBa);
+            renderFaceYPos(aRenderer, aX, aY, aZ, mIconContainer.getIcon(), rotation);
+        }
+        if (mIconContainer.getOverlayIcon() != null && (worldRenderPass == -1 || worldRenderPass == 1)) {
             lighting.setupColor(ForgeDirection.UP, 0xffffff);
             renderFaceYPos(aRenderer, aX, aY, aZ, mIconContainer.getOverlayIcon(), rotation);
         }
@@ -138,11 +148,14 @@ public class GTRenderedTexture extends GTTextureBase implements ITexture, IColor
             lighting.setLightnessOverride(1.0F);
             lighting.setBrightnessOverride(MAX_BRIGHTNESS);
         }
-        lighting.setupLightingYNeg(aBlock, aX, aY, aZ)
-            .setupColor(ForgeDirection.DOWN, mRGBa);
+        lighting.setupLightingYNeg(aBlock, aX, aY, aZ);
         final ExtendedFacing rotation = getExtendedFacing(aX, aY, aZ);
-        renderFaceYNeg(aRenderer, aX, aY, aZ, mIconContainer.getIcon(), rotation);
-        if (mIconContainer.getOverlayIcon() != null) {
+        final int worldRenderPass = ForgeHooksClient.getWorldRenderPass();
+        if (worldRenderPass == -1 || worldRenderPass == 0) {
+            lighting.setupColor(ForgeDirection.DOWN, mRGBa);
+            renderFaceYNeg(aRenderer, aX, aY, aZ, mIconContainer.getIcon(), rotation);
+        }
+        if (mIconContainer.getOverlayIcon() != null && (worldRenderPass == -1 || worldRenderPass == 1)) {
             lighting.setupColor(ForgeDirection.DOWN, 0xffffff);
             renderFaceYNeg(aRenderer, aX, aY, aZ, mIconContainer.getOverlayIcon(), rotation);
         }
@@ -164,11 +177,14 @@ public class GTRenderedTexture extends GTTextureBase implements ITexture, IColor
             lighting.setLightnessOverride(1.0F);
             lighting.setBrightnessOverride(MAX_BRIGHTNESS);
         }
-        lighting.setupLightingZPos(aBlock, aX, aY, aZ)
-            .setupColor(ForgeDirection.SOUTH, mRGBa);
+        lighting.setupLightingZPos(aBlock, aX, aY, aZ);
         final ExtendedFacing rotation = getExtendedFacing(aX, aY, aZ);
-        renderFaceZPos(aRenderer, aX, aY, aZ, mIconContainer.getIcon(), rotation);
-        if (mIconContainer.getOverlayIcon() != null) {
+        final int worldRenderPass = ForgeHooksClient.getWorldRenderPass();
+        if (worldRenderPass == -1 || worldRenderPass == 0) {
+            lighting.setupColor(ForgeDirection.SOUTH, mRGBa);
+            renderFaceZPos(aRenderer, aX, aY, aZ, mIconContainer.getIcon(), rotation);
+        }
+        if (mIconContainer.getOverlayIcon() != null && (worldRenderPass == -1 || worldRenderPass == 1)) {
             lighting.setupColor(ForgeDirection.SOUTH, 0xffffff);
             renderFaceZPos(aRenderer, aX, aY, aZ, mIconContainer.getOverlayIcon(), rotation);
         }
@@ -190,11 +206,14 @@ public class GTRenderedTexture extends GTTextureBase implements ITexture, IColor
             lighting.setLightnessOverride(1.0F);
             lighting.setBrightnessOverride(MAX_BRIGHTNESS);
         }
-        lighting.setupLightingZNeg(aBlock, aX, aY, aZ)
-            .setupColor(ForgeDirection.NORTH, mRGBa);
+        lighting.setupLightingZNeg(aBlock, aX, aY, aZ);
         final ExtendedFacing rotation = getExtendedFacing(aX, aY, aZ);
-        renderFaceZNeg(aRenderer, aX, aY, aZ, mIconContainer.getIcon(), rotation);
-        if (mIconContainer.getOverlayIcon() != null) {
+        final int worldRenderPass = ForgeHooksClient.getWorldRenderPass();
+        if (worldRenderPass == -1 || worldRenderPass == 0) {
+            lighting.setupColor(ForgeDirection.NORTH, mRGBa);
+            renderFaceZNeg(aRenderer, aX, aY, aZ, mIconContainer.getIcon(), rotation);
+        }
+        if (mIconContainer.getOverlayIcon() != null && (worldRenderPass == -1 || worldRenderPass == 1)) {
             lighting.setupColor(ForgeDirection.NORTH, 0xffffff);
             renderFaceZNeg(aRenderer, aX, aY, aZ, mIconContainer.getOverlayIcon(), rotation);
         }

--- a/src/main/java/gregtech/common/render/GTRendererBlock.java
+++ b/src/main/java/gregtech/common/render/GTRendererBlock.java
@@ -30,6 +30,7 @@ import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
+import net.minecraftforge.client.ForgeHooksClient;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import org.lwjgl.opengl.GL11;
@@ -52,6 +53,7 @@ import gregtech.api.interfaces.tileentity.ITexturedTileEntity;
 import gregtech.api.metatileentity.MetaPipeEntity;
 import gregtech.api.objects.XSTR;
 import gregtech.api.render.RenderOverlay;
+import gregtech.api.util.LightingHelper;
 import gregtech.common.blocks.BlockFrameBox;
 import gregtech.common.blocks.BlockMachines;
 import gregtech.common.blocks.BlockOresAbstract;
@@ -80,8 +82,9 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
     private final ITexture[][] textureArray = new ITexture[6][];
     private final ITexture[] overlayHolder = new ITexture[1];
 
+    @SuppressWarnings("MethodWithTooManyParameters")
     public boolean renderStandardBlock(IBlockAccess aWorld, int aX, int aY, int aZ, Block aBlock,
-        RenderBlocks aRenderer) {
+        RenderBlocks aRenderer, LightingHelper lightingHelper, int worldRenderPass) {
         final TileEntity tTileEntity = aWorld.getTileEntity(aX, aY, aZ);
         if (tTileEntity instanceof IPipeRenderedTileEntity pipeRenderedTileEntity) {
             textureArray[0] = pipeRenderedTileEntity.getTextureCovered(DOWN);
@@ -90,7 +93,16 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
             textureArray[3] = pipeRenderedTileEntity.getTextureCovered(SOUTH);
             textureArray[4] = pipeRenderedTileEntity.getTextureCovered(WEST);
             textureArray[5] = pipeRenderedTileEntity.getTextureCovered(EAST);
-            return renderStandardBlock(aWorld, aX, aY, aZ, aBlock, aRenderer, textureArray);
+            return renderStandardBlock(
+                aWorld,
+                aX,
+                aY,
+                aZ,
+                aBlock,
+                aRenderer,
+                textureArray,
+                lightingHelper,
+                worldRenderPass);
         }
         if (tTileEntity instanceof IAllSidedTexturedTileEntity allSidedTexturedTileEntity) {
             ITexture[] texture = allSidedTexturedTileEntity.getTexture(aBlock);
@@ -100,7 +112,16 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
             textureArray[3] = texture;
             textureArray[4] = texture;
             textureArray[5] = texture;
-            return renderStandardBlock(aWorld, aX, aY, aZ, aBlock, aRenderer, textureArray);
+            return renderStandardBlock(
+                aWorld,
+                aX,
+                aY,
+                aZ,
+                aBlock,
+                aRenderer,
+                textureArray,
+                lightingHelper,
+                worldRenderPass);
         }
         if (tTileEntity instanceof ITexturedTileEntity texturedTileEntity) {
             textureArray[0] = texturedTileEntity.getTexture(aBlock, DOWN);
@@ -109,56 +130,246 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
             textureArray[3] = texturedTileEntity.getTexture(aBlock, SOUTH);
             textureArray[4] = texturedTileEntity.getTexture(aBlock, WEST);
             textureArray[5] = texturedTileEntity.getTexture(aBlock, EAST);
-            return renderStandardBlock(aWorld, aX, aY, aZ, aBlock, aRenderer, textureArray);
+            return renderStandardBlock(
+                aWorld,
+                aX,
+                aY,
+                aZ,
+                aBlock,
+                aRenderer,
+                textureArray,
+                lightingHelper,
+                worldRenderPass);
         }
 
         return false;
     }
 
+    @SuppressWarnings("MethodWithTooManyParameters")
     public boolean renderStandardBlock(IBlockAccess aWorld, int aX, int aY, int aZ, Block aBlock,
-        RenderBlocks aRenderer, ITexture[][] aTextures) {
+        RenderBlocks aRenderer, ITexture[][] aTextures, LightingHelper lightingHelper, int worldRenderPass) {
         aBlock.setBlockBounds(blockMin, blockMin, blockMin, blockMax, blockMax, blockMax);
         aRenderer.setRenderBoundsFromBlock(aBlock);
 
         ITexture[] overlays = RenderOverlay.get(aWorld, aX, aY, aZ);
         if (overlays != null) {
-            renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, aTextures[SIDE_DOWN], true);
+            renderNegativeYFacing(
+                aWorld,
+                aRenderer,
+                lightingHelper,
+                aBlock,
+                aX,
+                aY,
+                aZ,
+                aTextures[SIDE_DOWN],
+                true,
+                worldRenderPass);
             if (overlays[SIDE_DOWN] != null) {
                 overlayHolder[0] = overlays[SIDE_DOWN];
-                renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, overlayHolder, true);
+                renderNegativeYFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    overlayHolder,
+                    true,
+                    worldRenderPass);
             }
-            renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, aTextures[SIDE_UP], true);
+            renderPositiveYFacing(
+                aWorld,
+                aRenderer,
+                lightingHelper,
+                aBlock,
+                aX,
+                aY,
+                aZ,
+                aTextures[SIDE_UP],
+                true,
+                worldRenderPass);
             if (overlays[SIDE_UP] != null) {
                 overlayHolder[0] = overlays[SIDE_UP];
-                renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, overlayHolder, true);
+                renderPositiveYFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    overlayHolder,
+                    true,
+                    worldRenderPass);
             }
-            renderNegativeZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, aTextures[SIDE_NORTH], true);
+            renderNegativeZFacing(
+                aWorld,
+                aRenderer,
+                lightingHelper,
+                aBlock,
+                aX,
+                aY,
+                aZ,
+                aTextures[SIDE_NORTH],
+                true,
+                worldRenderPass);
             if (overlays[SIDE_NORTH] != null) {
                 overlayHolder[0] = overlays[SIDE_NORTH];
-                renderNegativeZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, overlayHolder, true);
+                renderNegativeZFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    overlayHolder,
+                    true,
+                    worldRenderPass);
             }
-            renderPositiveZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, aTextures[SIDE_SOUTH], true);
+            renderPositiveZFacing(
+                aWorld,
+                aRenderer,
+                lightingHelper,
+                aBlock,
+                aX,
+                aY,
+                aZ,
+                aTextures[SIDE_SOUTH],
+                true,
+                worldRenderPass);
             if (overlays[SIDE_SOUTH] != null) {
                 overlayHolder[0] = overlays[SIDE_SOUTH];
-                renderPositiveZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, overlayHolder, true);
+                renderPositiveZFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    overlayHolder,
+                    true,
+                    worldRenderPass);
             }
-            renderNegativeXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, aTextures[SIDE_WEST], true);
+            renderNegativeXFacing(
+                aWorld,
+                aRenderer,
+                lightingHelper,
+                aBlock,
+                aX,
+                aY,
+                aZ,
+                aTextures[SIDE_WEST],
+                true,
+                worldRenderPass);
             if (overlays[SIDE_WEST] != null) {
                 overlayHolder[0] = overlays[SIDE_WEST];
-                renderNegativeXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, overlayHolder, true);
+                renderNegativeXFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    overlayHolder,
+                    true,
+                    worldRenderPass);
             }
-            renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, aTextures[SIDE_EAST], true);
+            renderPositiveXFacing(
+                aWorld,
+                aRenderer,
+                lightingHelper,
+                aBlock,
+                aX,
+                aY,
+                aZ,
+                aTextures[SIDE_EAST],
+                true,
+                worldRenderPass);
             if (overlays[SIDE_EAST] != null) {
                 overlayHolder[0] = overlays[SIDE_EAST];
-                renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, overlayHolder, true);
+                renderPositiveXFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    overlayHolder,
+                    true,
+                    worldRenderPass);
             }
         } else {
-            renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, aTextures[SIDE_DOWN], true);
-            renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, aTextures[SIDE_UP], true);
-            renderNegativeZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, aTextures[SIDE_NORTH], true);
-            renderPositiveZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, aTextures[SIDE_SOUTH], true);
-            renderNegativeXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, aTextures[SIDE_WEST], true);
-            renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, aTextures[SIDE_EAST], true);
+            renderNegativeYFacing(
+                aWorld,
+                aRenderer,
+                lightingHelper,
+                aBlock,
+                aX,
+                aY,
+                aZ,
+                aTextures[SIDE_DOWN],
+                true,
+                worldRenderPass);
+            renderPositiveYFacing(
+                aWorld,
+                aRenderer,
+                lightingHelper,
+                aBlock,
+                aX,
+                aY,
+                aZ,
+                aTextures[SIDE_UP],
+                true,
+                worldRenderPass);
+            renderNegativeZFacing(
+                aWorld,
+                aRenderer,
+                lightingHelper,
+                aBlock,
+                aX,
+                aY,
+                aZ,
+                aTextures[SIDE_NORTH],
+                true,
+                worldRenderPass);
+            renderPositiveZFacing(
+                aWorld,
+                aRenderer,
+                lightingHelper,
+                aBlock,
+                aX,
+                aY,
+                aZ,
+                aTextures[SIDE_SOUTH],
+                true,
+                worldRenderPass);
+            renderNegativeXFacing(
+                aWorld,
+                aRenderer,
+                lightingHelper,
+                aBlock,
+                aX,
+                aY,
+                aZ,
+                aTextures[SIDE_WEST],
+                true,
+                worldRenderPass);
+            renderPositiveXFacing(
+                aWorld,
+                aRenderer,
+                lightingHelper,
+                aBlock,
+                aX,
+                aY,
+                aZ,
+                aTextures[SIDE_EAST],
+                true,
+                worldRenderPass);
         }
         return true;
     }
@@ -167,12 +378,14 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
     final ITexture[][] tCovers = new ITexture[VALID_DIRECTIONS.length][];
     final boolean[] tIsCovered = new boolean[VALID_DIRECTIONS.length];
 
+    @SuppressWarnings("MethodWithTooManyParameters")
     public boolean renderPipeBlock(IBlockAccess aWorld, int aX, int aY, int aZ, Block aBlock,
-        IPipeRenderedTileEntity aTileEntity, RenderBlocks aRenderer) {
+        IPipeRenderedTileEntity aTileEntity, RenderBlocks aRenderer, LightingHelper lightingHelper,
+        int worldRenderPass) {
         final byte aConnections = aTileEntity.getConnections();
         final float thickness = aTileEntity.getThickNess();
         if (thickness >= 0.99F) {
-            return renderStandardBlock(aWorld, aX, aY, aZ, aBlock, aRenderer);
+            return renderStandardBlock(aWorld, aX, aY, aZ, aBlock, aRenderer, lightingHelper, worldRenderPass);
         }
         // Range of block occupied by pipe
         final float pipeMin = (blockMax - thickness) / 2.0F;
@@ -189,51 +402,291 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
             case NO_CONNECTION -> {
                 aBlock.setBlockBounds(pipeMin, pipeMin, pipeMin, pipeMax, pipeMax, pipeMax);
                 aRenderer.setRenderBoundsFromBlock(aBlock);
-                renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_DOWN], false);
-                renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_UP], false);
-                renderNegativeZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_NORTH], false);
-                renderPositiveZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_SOUTH], false);
-                renderNegativeXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_WEST], false);
-                renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_EAST], false);
+                renderNegativeYFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tIcons[SIDE_DOWN],
+                    false,
+                    worldRenderPass);
+                renderPositiveYFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tIcons[SIDE_UP],
+                    false,
+                    worldRenderPass);
+                renderNegativeZFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tIcons[SIDE_NORTH],
+                    false,
+                    worldRenderPass);
+                renderPositiveZFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tIcons[SIDE_SOUTH],
+                    false,
+                    worldRenderPass);
+                renderNegativeXFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tIcons[SIDE_WEST],
+                    false,
+                    worldRenderPass);
+                renderPositiveXFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tIcons[SIDE_EAST],
+                    false,
+                    worldRenderPass);
             }
             case CONNECTED_EAST | CONNECTED_WEST -> {
                 // EAST - WEST Pipe Sides
                 aBlock.setBlockBounds(blockMin, pipeMin, pipeMin, blockMax, pipeMax, pipeMax);
                 aRenderer.setRenderBoundsFromBlock(aBlock);
-                renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_DOWN], false);
-                renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_UP], false);
-                renderNegativeZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_NORTH], false);
-                renderPositiveZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_SOUTH], false);
+                renderNegativeYFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tIcons[SIDE_DOWN],
+                    false,
+                    worldRenderPass);
+                renderPositiveYFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tIcons[SIDE_UP],
+                    false,
+                    worldRenderPass);
+                renderNegativeZFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tIcons[SIDE_NORTH],
+                    false,
+                    worldRenderPass);
+                renderPositiveZFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tIcons[SIDE_SOUTH],
+                    false,
+                    worldRenderPass);
 
                 // EAST - WEST Pipe Ends
-                renderNegativeXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_WEST], false);
-                renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_EAST], false);
+                renderNegativeXFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tIcons[SIDE_WEST],
+                    false,
+                    worldRenderPass);
+                renderPositiveXFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tIcons[SIDE_EAST],
+                    false,
+                    worldRenderPass);
             }
             case CONNECTED_DOWN | CONNECTED_UP -> {
                 // UP - DOWN Pipe Sides
                 aBlock.setBlockBounds(pipeMin, blockMin, pipeMin, pipeMax, blockMax, pipeMax);
                 aRenderer.setRenderBoundsFromBlock(aBlock);
-                renderNegativeZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_NORTH], false);
-                renderPositiveZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_SOUTH], false);
-                renderNegativeXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_WEST], false);
-                renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_EAST], false);
+                renderNegativeZFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tIcons[SIDE_NORTH],
+                    false,
+                    worldRenderPass);
+                renderPositiveZFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tIcons[SIDE_SOUTH],
+                    false,
+                    worldRenderPass);
+                renderNegativeXFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tIcons[SIDE_WEST],
+                    false,
+                    worldRenderPass);
+                renderPositiveXFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tIcons[SIDE_EAST],
+                    false,
+                    worldRenderPass);
 
                 // UP - DOWN Pipe Ends
-                renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_DOWN], false);
-                renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_UP], false);
+                renderNegativeYFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tIcons[SIDE_DOWN],
+                    false,
+                    worldRenderPass);
+                renderPositiveYFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tIcons[SIDE_UP],
+                    false,
+                    worldRenderPass);
             }
             case CONNECTED_NORTH | CONNECTED_SOUTH -> {
                 // NORTH - SOUTH Pipe Sides
                 aBlock.setBlockBounds(pipeMin, pipeMin, blockMin, pipeMax, pipeMax, blockMax);
                 aRenderer.setRenderBoundsFromBlock(aBlock);
-                renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_DOWN], false);
-                renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_UP], false);
-                renderNegativeXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_WEST], false);
-                renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_EAST], false);
+                renderNegativeYFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tIcons[SIDE_DOWN],
+                    false,
+                    worldRenderPass);
+                renderPositiveYFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tIcons[SIDE_UP],
+                    false,
+                    worldRenderPass);
+                renderNegativeXFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tIcons[SIDE_WEST],
+                    false,
+                    worldRenderPass);
+                renderPositiveXFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tIcons[SIDE_EAST],
+                    false,
+                    worldRenderPass);
 
                 // NORTH - SOUTH Pipe Ends
-                renderNegativeZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_NORTH], false);
-                renderPositiveZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_SOUTH], false);
+                renderNegativeZFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tIcons[SIDE_NORTH],
+                    false,
+                    worldRenderPass);
+                renderPositiveZFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tIcons[SIDE_SOUTH],
+                    false,
+                    worldRenderPass);
             }
             default -> {
                 if ((aConnections & CONNECTED_WEST) == 0) {
@@ -242,72 +695,372 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
                 } else {
                     aBlock.setBlockBounds(blockMin, pipeMin, pipeMin, pipeMin, pipeMax, pipeMax);
                     aRenderer.setRenderBoundsFromBlock(aBlock);
-                    renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_DOWN], false);
-                    renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_UP], false);
-                    renderNegativeZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_NORTH], false);
-                    renderPositiveZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_SOUTH], false);
+                    renderNegativeYFacing(
+                        aWorld,
+                        aRenderer,
+                        lightingHelper,
+                        aBlock,
+                        aX,
+                        aY,
+                        aZ,
+                        tIcons[SIDE_DOWN],
+                        false,
+                        worldRenderPass);
+                    renderPositiveYFacing(
+                        aWorld,
+                        aRenderer,
+                        lightingHelper,
+                        aBlock,
+                        aX,
+                        aY,
+                        aZ,
+                        tIcons[SIDE_UP],
+                        false,
+                        worldRenderPass);
+                    renderNegativeZFacing(
+                        aWorld,
+                        aRenderer,
+                        lightingHelper,
+                        aBlock,
+                        aX,
+                        aY,
+                        aZ,
+                        tIcons[SIDE_NORTH],
+                        false,
+                        worldRenderPass);
+                    renderPositiveZFacing(
+                        aWorld,
+                        aRenderer,
+                        lightingHelper,
+                        aBlock,
+                        aX,
+                        aY,
+                        aZ,
+                        tIcons[SIDE_SOUTH],
+                        false,
+                        worldRenderPass);
                 }
-                renderNegativeXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_WEST], false);
+                renderNegativeXFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tIcons[SIDE_WEST],
+                    false,
+                    worldRenderPass);
                 if ((aConnections & CONNECTED_EAST) == 0) {
                     aBlock.setBlockBounds(pipeMin, pipeMin, pipeMin, pipeMax, pipeMax, pipeMax);
                     aRenderer.setRenderBoundsFromBlock(aBlock);
                 } else {
                     aBlock.setBlockBounds(pipeMax, pipeMin, pipeMin, blockMax, pipeMax, pipeMax);
                     aRenderer.setRenderBoundsFromBlock(aBlock);
-                    renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_DOWN], false);
-                    renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_UP], false);
-                    renderNegativeZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_NORTH], false);
-                    renderPositiveZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_SOUTH], false);
+                    renderNegativeYFacing(
+                        aWorld,
+                        aRenderer,
+                        lightingHelper,
+                        aBlock,
+                        aX,
+                        aY,
+                        aZ,
+                        tIcons[SIDE_DOWN],
+                        false,
+                        worldRenderPass);
+                    renderPositiveYFacing(
+                        aWorld,
+                        aRenderer,
+                        lightingHelper,
+                        aBlock,
+                        aX,
+                        aY,
+                        aZ,
+                        tIcons[SIDE_UP],
+                        false,
+                        worldRenderPass);
+                    renderNegativeZFacing(
+                        aWorld,
+                        aRenderer,
+                        lightingHelper,
+                        aBlock,
+                        aX,
+                        aY,
+                        aZ,
+                        tIcons[SIDE_NORTH],
+                        false,
+                        worldRenderPass);
+                    renderPositiveZFacing(
+                        aWorld,
+                        aRenderer,
+                        lightingHelper,
+                        aBlock,
+                        aX,
+                        aY,
+                        aZ,
+                        tIcons[SIDE_SOUTH],
+                        false,
+                        worldRenderPass);
                 }
-                renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_EAST], false);
+                renderPositiveXFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tIcons[SIDE_EAST],
+                    false,
+                    worldRenderPass);
                 if ((aConnections & CONNECTED_DOWN) == 0) {
                     aBlock.setBlockBounds(pipeMin, pipeMin, pipeMin, pipeMax, pipeMax, pipeMax);
                     aRenderer.setRenderBoundsFromBlock(aBlock);
                 } else {
                     aBlock.setBlockBounds(pipeMin, blockMin, pipeMin, pipeMax, pipeMin, pipeMax);
                     aRenderer.setRenderBoundsFromBlock(aBlock);
-                    renderNegativeZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_NORTH], false);
-                    renderPositiveZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_SOUTH], false);
-                    renderNegativeXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_WEST], false);
-                    renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_EAST], false);
+                    renderNegativeZFacing(
+                        aWorld,
+                        aRenderer,
+                        lightingHelper,
+                        aBlock,
+                        aX,
+                        aY,
+                        aZ,
+                        tIcons[SIDE_NORTH],
+                        false,
+                        worldRenderPass);
+                    renderPositiveZFacing(
+                        aWorld,
+                        aRenderer,
+                        lightingHelper,
+                        aBlock,
+                        aX,
+                        aY,
+                        aZ,
+                        tIcons[SIDE_SOUTH],
+                        false,
+                        worldRenderPass);
+                    renderNegativeXFacing(
+                        aWorld,
+                        aRenderer,
+                        lightingHelper,
+                        aBlock,
+                        aX,
+                        aY,
+                        aZ,
+                        tIcons[SIDE_WEST],
+                        false,
+                        worldRenderPass);
+                    renderPositiveXFacing(
+                        aWorld,
+                        aRenderer,
+                        lightingHelper,
+                        aBlock,
+                        aX,
+                        aY,
+                        aZ,
+                        tIcons[SIDE_EAST],
+                        false,
+                        worldRenderPass);
                 }
-                renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_DOWN], false);
+                renderNegativeYFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tIcons[SIDE_DOWN],
+                    false,
+                    worldRenderPass);
                 if ((aConnections & CONNECTED_UP) == 0) {
                     aBlock.setBlockBounds(pipeMin, pipeMin, pipeMin, pipeMax, pipeMax, pipeMax);
                     aRenderer.setRenderBoundsFromBlock(aBlock);
                 } else {
                     aBlock.setBlockBounds(pipeMin, pipeMax, pipeMin, pipeMax, blockMax, pipeMax);
                     aRenderer.setRenderBoundsFromBlock(aBlock);
-                    renderNegativeZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_NORTH], false);
-                    renderPositiveZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_SOUTH], false);
-                    renderNegativeXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_WEST], false);
-                    renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_EAST], false);
+                    renderNegativeZFacing(
+                        aWorld,
+                        aRenderer,
+                        lightingHelper,
+                        aBlock,
+                        aX,
+                        aY,
+                        aZ,
+                        tIcons[SIDE_NORTH],
+                        false,
+                        worldRenderPass);
+                    renderPositiveZFacing(
+                        aWorld,
+                        aRenderer,
+                        lightingHelper,
+                        aBlock,
+                        aX,
+                        aY,
+                        aZ,
+                        tIcons[SIDE_SOUTH],
+                        false,
+                        worldRenderPass);
+                    renderNegativeXFacing(
+                        aWorld,
+                        aRenderer,
+                        lightingHelper,
+                        aBlock,
+                        aX,
+                        aY,
+                        aZ,
+                        tIcons[SIDE_WEST],
+                        false,
+                        worldRenderPass);
+                    renderPositiveXFacing(
+                        aWorld,
+                        aRenderer,
+                        lightingHelper,
+                        aBlock,
+                        aX,
+                        aY,
+                        aZ,
+                        tIcons[SIDE_EAST],
+                        false,
+                        worldRenderPass);
                 }
-                renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_UP], false);
+                renderPositiveYFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tIcons[SIDE_UP],
+                    false,
+                    worldRenderPass);
                 if ((aConnections & CONNECTED_NORTH) == 0) {
                     aBlock.setBlockBounds(pipeMin, pipeMin, pipeMin, pipeMax, pipeMax, pipeMax);
                     aRenderer.setRenderBoundsFromBlock(aBlock);
                 } else {
                     aBlock.setBlockBounds(pipeMin, pipeMin, blockMin, pipeMax, pipeMax, pipeMin);
                     aRenderer.setRenderBoundsFromBlock(aBlock);
-                    renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_DOWN], false);
-                    renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_UP], false);
-                    renderNegativeXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_WEST], false);
-                    renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_EAST], false);
+                    renderNegativeYFacing(
+                        aWorld,
+                        aRenderer,
+                        lightingHelper,
+                        aBlock,
+                        aX,
+                        aY,
+                        aZ,
+                        tIcons[SIDE_DOWN],
+                        false,
+                        worldRenderPass);
+                    renderPositiveYFacing(
+                        aWorld,
+                        aRenderer,
+                        lightingHelper,
+                        aBlock,
+                        aX,
+                        aY,
+                        aZ,
+                        tIcons[SIDE_UP],
+                        false,
+                        worldRenderPass);
+                    renderNegativeXFacing(
+                        aWorld,
+                        aRenderer,
+                        lightingHelper,
+                        aBlock,
+                        aX,
+                        aY,
+                        aZ,
+                        tIcons[SIDE_WEST],
+                        false,
+                        worldRenderPass);
+                    renderPositiveXFacing(
+                        aWorld,
+                        aRenderer,
+                        lightingHelper,
+                        aBlock,
+                        aX,
+                        aY,
+                        aZ,
+                        tIcons[SIDE_EAST],
+                        false,
+                        worldRenderPass);
                 }
-                renderNegativeZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_NORTH], false);
+                renderNegativeZFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tIcons[SIDE_NORTH],
+                    false,
+                    worldRenderPass);
                 if ((aConnections & CONNECTED_SOUTH) == 0) {
                     aBlock.setBlockBounds(pipeMin, pipeMin, pipeMin, pipeMax, pipeMax, pipeMax);
                     aRenderer.setRenderBoundsFromBlock(aBlock);
                 } else {
                     aBlock.setBlockBounds(pipeMin, pipeMin, pipeMax, pipeMax, pipeMax, blockMax);
                     aRenderer.setRenderBoundsFromBlock(aBlock);
-                    renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_DOWN], false);
-                    renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_UP], false);
-                    renderNegativeXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_WEST], false);
-                    renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_EAST], false);
+                    renderNegativeYFacing(
+                        aWorld,
+                        aRenderer,
+                        lightingHelper,
+                        aBlock,
+                        aX,
+                        aY,
+                        aZ,
+                        tIcons[SIDE_DOWN],
+                        false,
+                        worldRenderPass);
+                    renderPositiveYFacing(
+                        aWorld,
+                        aRenderer,
+                        lightingHelper,
+                        aBlock,
+                        aX,
+                        aY,
+                        aZ,
+                        tIcons[SIDE_UP],
+                        false,
+                        worldRenderPass);
+                    renderNegativeXFacing(
+                        aWorld,
+                        aRenderer,
+                        lightingHelper,
+                        aBlock,
+                        aX,
+                        aY,
+                        aZ,
+                        tIcons[SIDE_WEST],
+                        false,
+                        worldRenderPass);
+                    renderPositiveXFacing(
+                        aWorld,
+                        aRenderer,
+                        lightingHelper,
+                        aBlock,
+                        aX,
+                        aY,
+                        aZ,
+                        tIcons[SIDE_EAST],
+                        false,
+                        worldRenderPass);
                 }
-                renderPositiveZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tIcons[SIDE_SOUTH], false);
+                renderPositiveZFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tIcons[SIDE_SOUTH],
+                    false,
+                    worldRenderPass);
             }
         }
 
@@ -316,199 +1069,739 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
             aBlock.setBlockBounds(blockMin, blockMin, blockMin, blockMax, coverInnerMin, blockMax);
             aRenderer.setRenderBoundsFromBlock(aBlock);
             if (!tIsCovered[SIDE_NORTH]) {
-                renderNegativeZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_DOWN], false);
+                renderNegativeZFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tCovers[SIDE_DOWN],
+                    false,
+                    worldRenderPass);
             }
             if (!tIsCovered[SIDE_SOUTH]) {
-                renderPositiveZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_DOWN], false);
+                renderPositiveZFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tCovers[SIDE_DOWN],
+                    false,
+                    worldRenderPass);
             }
             if (!tIsCovered[SIDE_WEST]) {
-                renderNegativeXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_DOWN], false);
+                renderNegativeXFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tCovers[SIDE_DOWN],
+                    false,
+                    worldRenderPass);
             }
             if (!tIsCovered[SIDE_EAST]) {
-                renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_DOWN], false);
+                renderPositiveXFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tCovers[SIDE_DOWN],
+                    false,
+                    worldRenderPass);
             }
-            renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_DOWN], false);
+            renderPositiveYFacing(
+                aWorld,
+                aRenderer,
+                lightingHelper,
+                aBlock,
+                aX,
+                aY,
+                aZ,
+                tCovers[SIDE_DOWN],
+                false,
+                worldRenderPass);
             if ((aConnections & CONNECTED_DOWN) != 0) {
                 // Split outer face to leave hole for pipe
                 // Lower panel
                 aRenderer.setRenderBounds(blockMin, blockMin, blockMin, blockMax, blockMin, pipeMin);
-                renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_DOWN], false);
+                renderNegativeYFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tCovers[SIDE_DOWN],
+                    false,
+                    worldRenderPass);
                 // Upper panel
                 aRenderer.setRenderBounds(blockMin, blockMin, pipeMax, blockMax, blockMin, blockMax);
-                renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_DOWN], false);
+                renderNegativeYFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tCovers[SIDE_DOWN],
+                    false,
+                    worldRenderPass);
                 // Middle left panel
                 aRenderer.setRenderBounds(blockMin, blockMin, pipeMin, pipeMin, blockMin, pipeMax);
-                renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_DOWN], false);
+                renderNegativeYFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tCovers[SIDE_DOWN],
+                    false,
+                    worldRenderPass);
                 // Middle right panel
                 aRenderer.setRenderBounds(pipeMax, blockMin, pipeMin, blockMax, blockMin, pipeMax);
             }
-            renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_DOWN], false);
+            renderNegativeYFacing(
+                aWorld,
+                aRenderer,
+                lightingHelper,
+                aBlock,
+                aX,
+                aY,
+                aZ,
+                tCovers[SIDE_DOWN],
+                false,
+                worldRenderPass);
         }
 
         if (tIsCovered[SIDE_UP]) {
             aBlock.setBlockBounds(blockMin, coverInnerMax, blockMin, blockMax, blockMax, blockMax);
             aRenderer.setRenderBoundsFromBlock(aBlock);
             if (!tIsCovered[SIDE_NORTH]) {
-                renderNegativeZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_UP], false);
+                renderNegativeZFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tCovers[SIDE_UP],
+                    false,
+                    worldRenderPass);
             }
             if (!tIsCovered[SIDE_SOUTH]) {
-                renderPositiveZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_UP], false);
+                renderPositiveZFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tCovers[SIDE_UP],
+                    false,
+                    worldRenderPass);
             }
             if (!tIsCovered[SIDE_WEST]) {
-                renderNegativeXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_UP], false);
+                renderNegativeXFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tCovers[SIDE_UP],
+                    false,
+                    worldRenderPass);
             }
             if (!tIsCovered[SIDE_EAST]) {
-                renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_UP], false);
+                renderPositiveXFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tCovers[SIDE_UP],
+                    false,
+                    worldRenderPass);
             }
-            renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_UP], false);
+            renderNegativeYFacing(
+                aWorld,
+                aRenderer,
+                lightingHelper,
+                aBlock,
+                aX,
+                aY,
+                aZ,
+                tCovers[SIDE_UP],
+                false,
+                worldRenderPass);
             if ((aConnections & CONNECTED_UP) != 0) {
                 // Split outer face to leave hole for pipe
                 // Lower panel
                 aRenderer.setRenderBounds(blockMin, blockMax, blockMin, blockMax, blockMax, pipeMin);
-                renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_UP], false);
+                renderPositiveYFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tCovers[SIDE_UP],
+                    false,
+                    worldRenderPass);
                 // Upper panel
                 aRenderer.setRenderBounds(blockMin, blockMax, pipeMax, blockMax, blockMax, blockMax);
-                renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_UP], false);
+                renderPositiveYFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tCovers[SIDE_UP],
+                    false,
+                    worldRenderPass);
                 // Middle left panel
                 aRenderer.setRenderBounds(blockMin, blockMax, pipeMin, pipeMin, blockMax, pipeMax);
-                renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_UP], false);
+                renderPositiveYFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tCovers[SIDE_UP],
+                    false,
+                    worldRenderPass);
                 // Middle right panel
                 aRenderer.setRenderBounds(pipeMax, blockMax, pipeMin, blockMax, blockMax, pipeMax);
             }
-            renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_UP], false);
+            renderPositiveYFacing(
+                aWorld,
+                aRenderer,
+                lightingHelper,
+                aBlock,
+                aX,
+                aY,
+                aZ,
+                tCovers[SIDE_UP],
+                false,
+                worldRenderPass);
         }
 
         if (tIsCovered[SIDE_NORTH]) {
             aBlock.setBlockBounds(blockMin, blockMin, blockMin, blockMax, blockMax, coverInnerMin);
             aRenderer.setRenderBoundsFromBlock(aBlock);
             if (!tIsCovered[SIDE_DOWN]) {
-                renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_NORTH], false);
+                renderNegativeYFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tCovers[SIDE_NORTH],
+                    false,
+                    worldRenderPass);
             }
             if (!tIsCovered[SIDE_UP]) {
-                renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_NORTH], false);
+                renderPositiveYFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tCovers[SIDE_NORTH],
+                    false,
+                    worldRenderPass);
             }
             if (!tIsCovered[SIDE_WEST]) {
-                renderNegativeXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_NORTH], false);
+                renderNegativeXFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tCovers[SIDE_NORTH],
+                    false,
+                    worldRenderPass);
             }
             if (!tIsCovered[SIDE_EAST]) {
-                renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_NORTH], false);
+                renderPositiveXFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tCovers[SIDE_NORTH],
+                    false,
+                    worldRenderPass);
             }
-            renderPositiveZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_NORTH], false);
+            renderPositiveZFacing(
+                aWorld,
+                aRenderer,
+                lightingHelper,
+                aBlock,
+                aX,
+                aY,
+                aZ,
+                tCovers[SIDE_NORTH],
+                false,
+                worldRenderPass);
             if ((aConnections & CONNECTED_NORTH) != 0) {
                 // Split outer face to leave hole for pipe
                 // Lower panel
                 aRenderer.setRenderBounds(blockMin, blockMin, blockMin, blockMax, pipeMin, blockMin);
-                renderNegativeZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_NORTH], false);
+                renderNegativeZFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tCovers[SIDE_NORTH],
+                    false,
+                    worldRenderPass);
                 // Upper panel
                 aRenderer.setRenderBounds(blockMin, pipeMax, blockMin, blockMax, blockMax, blockMin);
-                renderNegativeZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_NORTH], false);
+                renderNegativeZFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tCovers[SIDE_NORTH],
+                    false,
+                    worldRenderPass);
                 // Middle left panel
                 aRenderer.setRenderBounds(blockMin, pipeMin, blockMin, pipeMin, pipeMax, blockMin);
-                renderNegativeZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_NORTH], false);
+                renderNegativeZFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tCovers[SIDE_NORTH],
+                    false,
+                    worldRenderPass);
                 // Middle right panel
                 aRenderer.setRenderBounds(pipeMax, pipeMin, blockMin, blockMax, pipeMax, blockMin);
             }
-            renderNegativeZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_NORTH], false);
+            renderNegativeZFacing(
+                aWorld,
+                aRenderer,
+                lightingHelper,
+                aBlock,
+                aX,
+                aY,
+                aZ,
+                tCovers[SIDE_NORTH],
+                false,
+                worldRenderPass);
         }
 
         if (tIsCovered[SIDE_SOUTH]) {
             aBlock.setBlockBounds(blockMin, blockMin, coverInnerMax, blockMax, blockMax, blockMax);
             aRenderer.setRenderBoundsFromBlock(aBlock);
             if (!tIsCovered[SIDE_DOWN]) {
-                renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_SOUTH], false);
+                renderNegativeYFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tCovers[SIDE_SOUTH],
+                    false,
+                    worldRenderPass);
             }
             if (!tIsCovered[SIDE_UP]) {
-                renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_SOUTH], false);
+                renderPositiveYFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tCovers[SIDE_SOUTH],
+                    false,
+                    worldRenderPass);
             }
             if (!tIsCovered[SIDE_WEST]) {
-                renderNegativeXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_SOUTH], false);
+                renderNegativeXFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tCovers[SIDE_SOUTH],
+                    false,
+                    worldRenderPass);
             }
             if (!tIsCovered[SIDE_EAST]) {
-                renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_SOUTH], false);
+                renderPositiveXFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tCovers[SIDE_SOUTH],
+                    false,
+                    worldRenderPass);
             }
-            renderNegativeZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_SOUTH], false);
+            renderNegativeZFacing(
+                aWorld,
+                aRenderer,
+                lightingHelper,
+                aBlock,
+                aX,
+                aY,
+                aZ,
+                tCovers[SIDE_SOUTH],
+                false,
+                worldRenderPass);
             if ((aConnections & CONNECTED_SOUTH) != 0) {
                 // Split outer face to leave hole for pipe
                 // Lower panel
                 aRenderer.setRenderBounds(blockMin, blockMin, blockMax, blockMax, pipeMin, blockMax);
-                renderPositiveZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_SOUTH], false);
+                renderPositiveZFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tCovers[SIDE_SOUTH],
+                    false,
+                    worldRenderPass);
                 // Upper panel
                 aRenderer.setRenderBounds(blockMin, pipeMax, blockMax, blockMax, blockMax, blockMax);
-                renderPositiveZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_SOUTH], false);
+                renderPositiveZFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tCovers[SIDE_SOUTH],
+                    false,
+                    worldRenderPass);
                 // Middle left panel
                 aRenderer.setRenderBounds(blockMin, pipeMin, blockMax, pipeMin, pipeMax, blockMax);
-                renderPositiveZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_SOUTH], false);
+                renderPositiveZFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tCovers[SIDE_SOUTH],
+                    false,
+                    worldRenderPass);
                 // Middle right panel
                 aRenderer.setRenderBounds(pipeMax, pipeMin, blockMax, blockMax, pipeMax, blockMax);
             }
-            renderPositiveZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_SOUTH], false);
+            renderPositiveZFacing(
+                aWorld,
+                aRenderer,
+                lightingHelper,
+                aBlock,
+                aX,
+                aY,
+                aZ,
+                tCovers[SIDE_SOUTH],
+                false,
+                worldRenderPass);
         }
 
         if (tIsCovered[SIDE_WEST]) {
             aBlock.setBlockBounds(blockMin, blockMin, blockMin, coverInnerMin, blockMax, blockMax);
             aRenderer.setRenderBoundsFromBlock(aBlock);
             if (!tIsCovered[SIDE_DOWN]) {
-                renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_WEST], false);
+                renderNegativeYFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tCovers[SIDE_WEST],
+                    false,
+                    worldRenderPass);
             }
             if (!tIsCovered[SIDE_UP]) {
-                renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_WEST], false);
+                renderPositiveYFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tCovers[SIDE_WEST],
+                    false,
+                    worldRenderPass);
             }
             if (!tIsCovered[SIDE_NORTH]) {
-                renderNegativeZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_WEST], false);
+                renderNegativeZFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tCovers[SIDE_WEST],
+                    false,
+                    worldRenderPass);
             }
             if (!tIsCovered[SIDE_SOUTH]) {
-                renderPositiveZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_WEST], false);
+                renderPositiveZFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tCovers[SIDE_WEST],
+                    false,
+                    worldRenderPass);
             }
-            renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_WEST], false);
+            renderPositiveXFacing(
+                aWorld,
+                aRenderer,
+                lightingHelper,
+                aBlock,
+                aX,
+                aY,
+                aZ,
+                tCovers[SIDE_WEST],
+                false,
+                worldRenderPass);
             if ((aConnections & CONNECTED_WEST) != 0) {
                 // Split outer face to leave hole for pipe
                 // Lower panel
                 aRenderer.setRenderBounds(blockMin, blockMin, blockMin, blockMin, pipeMin, blockMax);
-                renderNegativeXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_WEST], false);
+                renderNegativeXFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tCovers[SIDE_WEST],
+                    false,
+                    worldRenderPass);
                 // Upper panel
                 aRenderer.setRenderBounds(blockMin, pipeMax, blockMin, blockMin, blockMax, blockMax);
-                renderNegativeXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_WEST], false);
+                renderNegativeXFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tCovers[SIDE_WEST],
+                    false,
+                    worldRenderPass);
                 // Middle left panel
                 aRenderer.setRenderBounds(blockMin, pipeMin, blockMin, blockMin, pipeMax, pipeMin);
-                renderNegativeXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_WEST], false);
+                renderNegativeXFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tCovers[SIDE_WEST],
+                    false,
+                    worldRenderPass);
                 // Middle right panel
                 aRenderer.setRenderBounds(blockMin, pipeMin, pipeMax, blockMin, pipeMax, blockMax);
             }
-            renderNegativeXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_WEST], false);
+            renderNegativeXFacing(
+                aWorld,
+                aRenderer,
+                lightingHelper,
+                aBlock,
+                aX,
+                aY,
+                aZ,
+                tCovers[SIDE_WEST],
+                false,
+                worldRenderPass);
         }
 
         if (tIsCovered[SIDE_EAST]) {
             aBlock.setBlockBounds(coverInnerMax, blockMin, blockMin, blockMax, blockMax, blockMax);
             aRenderer.setRenderBoundsFromBlock(aBlock);
             if (!tIsCovered[SIDE_DOWN]) {
-                renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_EAST], false);
+                renderNegativeYFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tCovers[SIDE_EAST],
+                    false,
+                    worldRenderPass);
             }
             if (!tIsCovered[SIDE_UP]) {
-                renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_EAST], false);
+                renderPositiveYFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tCovers[SIDE_EAST],
+                    false,
+                    worldRenderPass);
             }
             if (!tIsCovered[SIDE_NORTH]) {
-                renderNegativeZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_EAST], false);
+                renderNegativeZFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tCovers[SIDE_EAST],
+                    false,
+                    worldRenderPass);
             }
             if (!tIsCovered[SIDE_SOUTH]) {
-                renderPositiveZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_EAST], false);
+                renderPositiveZFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tCovers[SIDE_EAST],
+                    false,
+                    worldRenderPass);
             }
-            renderNegativeXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_EAST], false);
+            renderNegativeXFacing(
+                aWorld,
+                aRenderer,
+                lightingHelper,
+                aBlock,
+                aX,
+                aY,
+                aZ,
+                tCovers[SIDE_EAST],
+                false,
+                worldRenderPass);
 
             if ((aConnections & CONNECTED_EAST) != 0) {
                 // Split outer face to leave hole for pipe
                 // Lower panel
                 aRenderer.setRenderBounds(blockMax, blockMin, blockMin, blockMax, pipeMin, blockMax);
-                renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_EAST], false);
+                renderPositiveXFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tCovers[SIDE_EAST],
+                    false,
+                    worldRenderPass);
                 // Upper panel
                 aRenderer.setRenderBounds(blockMax, pipeMax, blockMin, blockMax, blockMax, blockMax);
-                renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_EAST], false);
+                renderPositiveXFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tCovers[SIDE_EAST],
+                    false,
+                    worldRenderPass);
                 // Middle left panel
                 aRenderer.setRenderBounds(blockMax, pipeMin, blockMin, blockMax, pipeMax, pipeMin);
-                renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_EAST], false);
+                renderPositiveXFacing(
+                    aWorld,
+                    aRenderer,
+                    lightingHelper,
+                    aBlock,
+                    aX,
+                    aY,
+                    aZ,
+                    tCovers[SIDE_EAST],
+                    false,
+                    worldRenderPass);
                 // Middle right panel
                 aRenderer.setRenderBounds(blockMax, pipeMin, pipeMax, blockMax, pipeMax, blockMax);
             }
-            renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, tCovers[SIDE_EAST], false);
+            renderPositiveXFacing(
+                aWorld,
+                aRenderer,
+                lightingHelper,
+                aBlock,
+                aX,
+                aY,
+                aZ,
+                tCovers[SIDE_EAST],
+                false,
+                worldRenderPass);
         }
         aBlock.setBlockBounds(blockMin, blockMin, blockMin, blockMax, blockMax, blockMax);
         aRenderer.setRenderBoundsFromBlock(aBlock);
@@ -517,6 +1810,7 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
     }
 
     @SideOnly(Side.CLIENT)
+    @SuppressWarnings("MethodWithTooManyParameters")
     public static void addHitEffects(EffectRenderer effectRenderer, Block block, World world, int x, int y, int z,
         int ordinalSide) {
         double rX = x + XSTR.XSTR_INSTANCE.nextDouble() * 0.8 + 0.1;
@@ -552,6 +1846,7 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
     }
 
     @SideOnly(Side.CLIENT)
+    @SuppressWarnings("MethodWithTooManyParameters")
     public static void addDestroyEffects(EffectRenderer effectRenderer, Block block, World world, int x, int y, int z) {
         for (int iX = 0; iX < 4; ++iX) {
             for (int iY = 0; iY < 4; ++iY) {
@@ -579,6 +1874,8 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
 
     @Override
     public void renderInventoryBlock(Block aBlock, int aMeta, int aModelID, RenderBlocks aRenderer) {
+        final LightingHelper lightingHelper = new LightingHelper(aRenderer);
+        final int worldRenderPass = -1;
         aRenderer.enableAO = false;
         aRenderer.useInventoryTint = true;
 
@@ -591,29 +1888,29 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
             aRenderer.setRenderBoundsFromBlock(aBlock);
             // spotless:off
             ITexture[] texture = tTileEntity.getTexture(aBlock);
-            renderNegativeYFacing(null, aRenderer, aBlock, 0, 0, 0, texture, true);
-            renderPositiveYFacing(null, aRenderer, aBlock, 0, 0, 0, texture, true);
-            renderNegativeZFacing(null, aRenderer, aBlock, 0, 0, 0, texture, true);
-            renderPositiveZFacing(null, aRenderer, aBlock, 0, 0, 0, texture, true);
-            renderNegativeXFacing(null, aRenderer, aBlock, 0, 0, 0, texture, true);
-            renderPositiveXFacing(null, aRenderer, aBlock, 0, 0, 0, texture, true);
+            renderNegativeYFacing(null, aRenderer, lightingHelper, aBlock, 0, 0, 0, texture, true, worldRenderPass);
+            renderPositiveYFacing(null, aRenderer, lightingHelper, aBlock, 0, 0, 0, texture, true, worldRenderPass);
+            renderNegativeZFacing(null, aRenderer, lightingHelper, aBlock, 0, 0, 0, texture, true, worldRenderPass);
+            renderPositiveZFacing(null, aRenderer, lightingHelper, aBlock, 0, 0, 0, texture, true, worldRenderPass);
+            renderNegativeXFacing(null, aRenderer, lightingHelper, aBlock, 0, 0, 0, texture, true, worldRenderPass);
+            renderPositiveXFacing(null, aRenderer, lightingHelper, aBlock, 0, 0, 0, texture, true, worldRenderPass);
             // spotless:on
         } else if (aMeta > 0 && (aMeta < GregTechAPI.METATILEENTITIES.length)
             && aBlock instanceof BlockMachines
             && (GregTechAPI.METATILEENTITIES[aMeta] != null)
             && (!GregTechAPI.METATILEENTITIES[aMeta].renderInInventory(aBlock, aMeta, aRenderer))) {
-                renderNormalInventoryMetaTileEntity(aBlock, aMeta, aRenderer);
+                renderNormalInventoryMetaTileEntity(aBlock, aMeta, aRenderer, lightingHelper);
             } else if (aBlock instanceof BlockFrameBox) {
                 ITexture[] texture = ((BlockFrameBox) aBlock).getTexture(aMeta);
                 aBlock.setBlockBoundsForItemRender();
                 aRenderer.setRenderBoundsFromBlock(aBlock);
                 // spotless:off
-            renderNegativeYFacing(null, aRenderer, aBlock, 0, 0, 0, texture, true);
-            renderPositiveYFacing(null, aRenderer, aBlock, 0, 0, 0, texture, true);
-            renderNegativeZFacing(null, aRenderer, aBlock, 0, 0, 0, texture, true);
-            renderPositiveZFacing(null, aRenderer, aBlock, 0, 0, 0, texture, true);
-            renderNegativeXFacing(null, aRenderer, aBlock, 0, 0, 0, texture, true);
-            renderPositiveXFacing(null, aRenderer, aBlock, 0, 0, 0, texture, true);
+            renderNegativeYFacing(null, aRenderer, lightingHelper, aBlock, 0, 0, 0, texture, true, worldRenderPass);
+            renderPositiveYFacing(null, aRenderer, lightingHelper, aBlock, 0, 0, 0, texture, true, worldRenderPass);
+            renderNegativeZFacing(null, aRenderer, lightingHelper, aBlock, 0, 0, 0, texture, true, worldRenderPass);
+            renderPositiveZFacing(null, aRenderer, lightingHelper, aBlock, 0, 0, 0, texture, true, worldRenderPass);
+            renderNegativeXFacing(null, aRenderer, lightingHelper, aBlock, 0, 0, 0, texture, true, worldRenderPass);
+            renderPositiveXFacing(null, aRenderer, lightingHelper, aBlock, 0, 0, 0, texture, true, worldRenderPass);
             // spotless:on
             } else if (aBlock instanceof IBlockWithTextures texturedBlock) {
                 ITexture[][] texture = texturedBlock.getTextures(aMeta);
@@ -621,12 +1918,12 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
                     // spotless:off
                 aBlock.setBlockBoundsForItemRender();
                 aRenderer.setRenderBoundsFromBlock(aBlock);
-                renderNegativeYFacing(null, aRenderer, aBlock, 0, 0, 0, texture[ForgeDirection.DOWN.ordinal()], true);
-                renderPositiveYFacing(null, aRenderer, aBlock, 0, 0, 0, texture[ForgeDirection.UP.ordinal()], true);
-                renderNegativeZFacing(null, aRenderer, aBlock, 0, 0, 0, texture[ForgeDirection.NORTH.ordinal()], true);
-                renderPositiveZFacing(null, aRenderer, aBlock, 0, 0, 0, texture[ForgeDirection.SOUTH.ordinal()], true);
-                renderNegativeXFacing(null, aRenderer, aBlock, 0, 0, 0, texture[ForgeDirection.WEST.ordinal()], true);
-                renderPositiveXFacing(null, aRenderer, aBlock, 0, 0, 0, texture[ForgeDirection.EAST.ordinal()], true);
+                renderNegativeYFacing(null, aRenderer, lightingHelper, aBlock, 0, 0, 0, texture[ForgeDirection.DOWN.ordinal()], true, worldRenderPass);
+                renderPositiveYFacing(null, aRenderer, lightingHelper, aBlock, 0, 0, 0, texture[ForgeDirection.UP.ordinal()], true, worldRenderPass);
+                renderNegativeZFacing(null, aRenderer, lightingHelper, aBlock, 0, 0, 0, texture[ForgeDirection.NORTH.ordinal()], true, worldRenderPass);
+                renderPositiveZFacing(null, aRenderer, lightingHelper, aBlock, 0, 0, 0, texture[ForgeDirection.SOUTH.ordinal()], true, worldRenderPass);
+                renderNegativeXFacing(null, aRenderer, lightingHelper, aBlock, 0, 0, 0, texture[ForgeDirection.WEST.ordinal()], true, worldRenderPass);
+                renderPositiveXFacing(null, aRenderer, lightingHelper, aBlock, 0, 0, 0, texture[ForgeDirection.EAST.ordinal()], true, worldRenderPass);
                 // spotless:on
                 }
             }
@@ -638,7 +1935,8 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
         aRenderer.useInventoryTint = false;
     }
 
-    private static void renderNormalInventoryMetaTileEntity(Block aBlock, int aMeta, RenderBlocks aRenderer) {
+    private static void renderNormalInventoryMetaTileEntity(Block aBlock, int aMeta, RenderBlocks aRenderer,
+        LightingHelper lightingHelper) {
         if ((aMeta <= 0) || (aMeta >= GregTechAPI.METATILEENTITIES.length)) {
             return;
         }
@@ -650,7 +1948,6 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
         aRenderer.setRenderBoundsFromBlock(aBlock);
 
         final IGregTechTileEntity iGregTechTileEntity = tMetaTileEntity.getBaseMetaTileEntity();
-
         // spotless:off
         if ((iGregTechTileEntity instanceof IPipeRenderedTileEntity renderedPipe)
             && (tMetaTileEntity instanceof MetaPipeEntity pipeEntity)) {
@@ -660,25 +1957,26 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
 
             aBlock.setBlockBounds(blockMin, pipeMin, pipeMin, blockMax, pipeMax, pipeMax);
             aRenderer.setRenderBoundsFromBlock(aBlock);
-            renderNegativeYFacing(null, aRenderer, aBlock, 0, 0, 0, pipeEntity.getTexture(iGregTechTileEntity, DOWN, (CONNECTED_WEST | CONNECTED_EAST), -1, false, false), true);
-            renderPositiveYFacing(null, aRenderer, aBlock, 0, 0, 0, pipeEntity.getTexture(iGregTechTileEntity, UP, (CONNECTED_WEST | CONNECTED_EAST), -1, false, false), true);
-            renderNegativeZFacing(null, aRenderer, aBlock, 0, 0, 0, pipeEntity.getTexture(iGregTechTileEntity, NORTH, (CONNECTED_WEST | CONNECTED_EAST), -1, false, false), true);
-            renderPositiveZFacing(null, aRenderer, aBlock, 0, 0, 0, pipeEntity.getTexture(iGregTechTileEntity, SOUTH, (CONNECTED_WEST | CONNECTED_EAST), -1, false, false), true);
-            renderNegativeXFacing(null, aRenderer, aBlock, 0, 0, 0, pipeEntity.getTexture(iGregTechTileEntity, WEST, (CONNECTED_WEST | CONNECTED_EAST), -1, true, false), true);
-            renderPositiveXFacing(null, aRenderer, aBlock, 0, 0, 0, pipeEntity.getTexture(iGregTechTileEntity, EAST, (CONNECTED_WEST | CONNECTED_EAST), -1, true, false), true);
+            renderNegativeYFacing(null, aRenderer, lightingHelper, aBlock, 0, 0, 0, pipeEntity.getTexture(iGregTechTileEntity, DOWN, (CONNECTED_WEST | CONNECTED_EAST), -1, false, false), true, -1);
+            renderPositiveYFacing(null, aRenderer, lightingHelper, aBlock, 0, 0, 0, pipeEntity.getTexture(iGregTechTileEntity, UP, (CONNECTED_WEST | CONNECTED_EAST), -1, false, false), true, -1);
+            renderNegativeZFacing(null, aRenderer, lightingHelper, aBlock, 0, 0, 0, pipeEntity.getTexture(iGregTechTileEntity, NORTH, (CONNECTED_WEST | CONNECTED_EAST), -1, false, false), true, -1);
+            renderPositiveZFacing(null, aRenderer, lightingHelper, aBlock, 0, 0, 0, pipeEntity.getTexture(iGregTechTileEntity, SOUTH, (CONNECTED_WEST | CONNECTED_EAST), -1, false, false), true, -1);
+            renderNegativeXFacing(null, aRenderer, lightingHelper, aBlock, 0, 0, 0, pipeEntity.getTexture(iGregTechTileEntity, WEST, (CONNECTED_WEST | CONNECTED_EAST), -1, true, false), true, -1);
+            renderPositiveXFacing(null, aRenderer, lightingHelper, aBlock, 0, 0, 0, pipeEntity.getTexture(iGregTechTileEntity, EAST, (CONNECTED_WEST | CONNECTED_EAST), -1, true, false), true, -1);
         } else {
-            renderNegativeYFacing(null, aRenderer, aBlock, 0, 0, 0, tMetaTileEntity.getTexture(iGregTechTileEntity, DOWN, WEST, -1, true, false), true);
-            renderPositiveYFacing(null, aRenderer, aBlock, 0, 0, 0, tMetaTileEntity.getTexture(iGregTechTileEntity, UP, WEST, -1, true, false), true);
-            renderNegativeZFacing(null, aRenderer, aBlock, 0, 0, 0, tMetaTileEntity.getTexture(iGregTechTileEntity, NORTH, WEST, -1, true, false), true);
-            renderPositiveZFacing(null, aRenderer, aBlock, 0, 0, 0, tMetaTileEntity.getTexture(iGregTechTileEntity, SOUTH, WEST, -1, true, false), true);
-            renderNegativeXFacing(null, aRenderer, aBlock, 0, 0, 0, tMetaTileEntity.getTexture(iGregTechTileEntity, WEST, WEST, -1, true, false), true);
-            renderPositiveXFacing(null, aRenderer, aBlock, 0, 0, 0, tMetaTileEntity.getTexture(iGregTechTileEntity, EAST, WEST, -1, true, false), true);
+            renderNegativeYFacing(null, aRenderer, lightingHelper, aBlock, 0, 0, 0, tMetaTileEntity.getTexture(iGregTechTileEntity, DOWN, WEST, -1, true, false), true, -1);
+            renderPositiveYFacing(null, aRenderer, lightingHelper, aBlock, 0, 0, 0, tMetaTileEntity.getTexture(iGregTechTileEntity, UP, WEST, -1, true, false), true, -1);
+            renderNegativeZFacing(null, aRenderer, lightingHelper, aBlock, 0, 0, 0, tMetaTileEntity.getTexture(iGregTechTileEntity, NORTH, WEST, -1, true, false), true, -1);
+            renderPositiveZFacing(null, aRenderer, lightingHelper, aBlock, 0, 0, 0, tMetaTileEntity.getTexture(iGregTechTileEntity, SOUTH, WEST, -1, true, false), true, -1);
+            renderNegativeXFacing(null, aRenderer, lightingHelper, aBlock, 0, 0, 0, tMetaTileEntity.getTexture(iGregTechTileEntity, WEST, WEST, -1, true, false), true, -1);
+            renderPositiveXFacing(null, aRenderer, lightingHelper, aBlock, 0, 0, 0, tMetaTileEntity.getTexture(iGregTechTileEntity, EAST, WEST, -1, true, false), true, -1);
         }
         // spotless:on
     }
 
-    public static void renderNegativeYFacing(IBlockAccess aWorld, RenderBlocks aRenderer, Block aBlock, int aX, int aY,
-        int aZ, ITexture[] aIcon, boolean aFullBlock) {
+    @SuppressWarnings("MethodWithTooManyParameters")
+    public static void renderNegativeYFacing(IBlockAccess aWorld, RenderBlocks aRenderer, LightingHelper lightingHelper,
+        Block aBlock, int aX, int aY, int aZ, ITexture[] aIcon, boolean aFullBlock, int worldRenderPass) {
         if (aWorld != null) {
             if (aFullBlock && !aRenderer.renderAllFaces && !aBlock.shouldSideBeRendered(aWorld, aX, aY - 1, aZ, 0)) {
                 return;
@@ -689,13 +1987,14 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
         if (aIcon == null) return;
         for (final ITexture iTexture : aIcon) {
             if (iTexture != null) {
-                iTexture.renderYNeg(aRenderer, aBlock, aX, aY, aZ);
+                iTexture.renderYNeg(aRenderer, lightingHelper, aBlock, aX, aY, aZ, worldRenderPass);
             }
         }
     }
 
-    public static void renderPositiveYFacing(IBlockAccess aWorld, RenderBlocks aRenderer, Block aBlock, int aX, int aY,
-        int aZ, ITexture[] aIcon, boolean aFullBlock) {
+    @SuppressWarnings("MethodWithTooManyParameters")
+    public static void renderPositiveYFacing(IBlockAccess aWorld, RenderBlocks aRenderer, LightingHelper lightingHelper,
+        Block aBlock, int aX, int aY, int aZ, ITexture[] aIcon, boolean aFullBlock, int worldRenderPass) {
         if (aWorld != null) {
             if (aFullBlock && !aRenderer.renderAllFaces && !aBlock.shouldSideBeRendered(aWorld, aX, aY + 1, aZ, 1)) {
                 return;
@@ -706,13 +2005,14 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
         if (aIcon == null) return;
         for (final ITexture iTexture : aIcon) {
             if (iTexture != null) {
-                iTexture.renderYPos(aRenderer, aBlock, aX, aY, aZ);
+                iTexture.renderYPos(aRenderer, lightingHelper, aBlock, aX, aY, aZ, worldRenderPass);
             }
         }
     }
 
-    public static void renderNegativeZFacing(IBlockAccess aWorld, RenderBlocks aRenderer, Block aBlock, int aX, int aY,
-        int aZ, ITexture[] aIcon, boolean aFullBlock) {
+    @SuppressWarnings("MethodWithTooManyParameters")
+    public static void renderNegativeZFacing(IBlockAccess aWorld, RenderBlocks aRenderer, LightingHelper lightingHelper,
+        Block aBlock, int aX, int aY, int aZ, ITexture[] aIcon, boolean aFullBlock, int worldRenderPass) {
         if (aWorld != null) {
             if (aFullBlock && !aRenderer.renderAllFaces && !aBlock.shouldSideBeRendered(aWorld, aX, aY, aZ - 1, 2)) {
                 return;
@@ -723,13 +2023,14 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
         if (aIcon == null) return;
         for (final ITexture iTexture : aIcon) {
             if (iTexture != null) {
-                iTexture.renderZNeg(aRenderer, aBlock, aX, aY, aZ);
+                iTexture.renderZNeg(aRenderer, lightingHelper, aBlock, aX, aY, aZ, worldRenderPass);
             }
         }
     }
 
-    public static void renderPositiveZFacing(IBlockAccess aWorld, RenderBlocks aRenderer, Block aBlock, int aX, int aY,
-        int aZ, ITexture[] aIcon, boolean aFullBlock) {
+    @SuppressWarnings("MethodWithTooManyParameters")
+    public static void renderPositiveZFacing(IBlockAccess aWorld, RenderBlocks aRenderer, LightingHelper lightingHelper,
+        Block aBlock, int aX, int aY, int aZ, ITexture[] aIcon, boolean aFullBlock, int worldRenderPass) {
         if (aWorld != null) {
             if (aFullBlock && !aRenderer.renderAllFaces && !aBlock.shouldSideBeRendered(aWorld, aX, aY, aZ + 1, 3)) {
                 return;
@@ -740,13 +2041,14 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
         if (aIcon == null) return;
         for (final ITexture iTexture : aIcon) {
             if (iTexture != null) {
-                iTexture.renderZPos(aRenderer, aBlock, aX, aY, aZ);
+                iTexture.renderZPos(aRenderer, lightingHelper, aBlock, aX, aY, aZ, worldRenderPass);
             }
         }
     }
 
-    public static void renderNegativeXFacing(IBlockAccess aWorld, RenderBlocks aRenderer, Block aBlock, int aX, int aY,
-        int aZ, ITexture[] aIcon, boolean aFullBlock) {
+    @SuppressWarnings("MethodWithTooManyParameters")
+    public static void renderNegativeXFacing(IBlockAccess aWorld, RenderBlocks aRenderer, LightingHelper lightingHelper,
+        Block aBlock, int aX, int aY, int aZ, ITexture[] aIcon, boolean aFullBlock, int worldRenderPass) {
         if (aWorld != null) {
             if (aFullBlock && !aRenderer.renderAllFaces && !aBlock.shouldSideBeRendered(aWorld, aX - 1, aY, aZ, 4)) {
                 return;
@@ -757,13 +2059,14 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
         if (aIcon == null) return;
         for (final ITexture iTexture : aIcon) {
             if (iTexture != null) {
-                iTexture.renderXNeg(aRenderer, aBlock, aX, aY, aZ);
+                iTexture.renderXNeg(aRenderer, lightingHelper, aBlock, aX, aY, aZ, worldRenderPass);
             }
         }
     }
 
-    public static void renderPositiveXFacing(IBlockAccess aWorld, RenderBlocks aRenderer, Block aBlock, int aX, int aY,
-        int aZ, ITexture[] aIcon, boolean aFullBlock) {
+    @SuppressWarnings("MethodWithTooManyParameters")
+    public static void renderPositiveXFacing(IBlockAccess aWorld, RenderBlocks aRenderer, LightingHelper lightingHelper,
+        Block aBlock, int aX, int aY, int aZ, ITexture[] aIcon, boolean aFullBlock, int worldRenderPass) {
         if (aWorld != null) {
             if (aFullBlock && !aRenderer.renderAllFaces && !aBlock.shouldSideBeRendered(aWorld, aX + 1, aY, aZ, 5)) {
                 return;
@@ -774,7 +2077,7 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
         if (aIcon == null) return;
         for (final ITexture iTexture : aIcon) {
             if (iTexture != null) {
-                iTexture.renderXPos(aRenderer, aBlock, aX, aY, aZ);
+                iTexture.renderXPos(aRenderer, lightingHelper, aBlock, aX, aY, aZ, worldRenderPass);
             }
         }
     }
@@ -782,6 +2085,8 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
     @Override
     public boolean renderWorldBlock(IBlockAccess aWorld, int aX, int aY, int aZ, Block aBlock, int aModelID,
         RenderBlocks aRenderer) {
+        final LightingHelper lightingHelper = new LightingHelper(aRenderer);
+        final int worldRenderPass = ForgeHooksClient.getWorldRenderPass();
         aRenderer.enableAO = Minecraft.isAmbientOcclusionEnabled() && GTMod.proxy.mRenderTileAmbientOcclusion;
         aRenderer.useInventoryTint = false;
 
@@ -800,7 +2105,7 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
             textureArray[3] = texture;
             textureArray[4] = texture;
             textureArray[5] = texture;
-            renderStandardBlock(aWorld, aX, aY, aZ, aBlock, aRenderer, textureArray);
+            renderStandardBlock(aWorld, aX, aY, aZ, aBlock, aRenderer, textureArray, lightingHelper, worldRenderPass);
             return tessAccess.gt5u$hasVertices();
         }
 
@@ -808,7 +2113,7 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
             int meta = aWorld.getBlockMetadata(aX, aY, aZ);
             ITexture[][] texture = texturedBlock.getTextures(meta);
             if (texture == null) return false;
-            renderStandardBlock(aWorld, aX, aY, aZ, aBlock, aRenderer, texture);
+            renderStandardBlock(aWorld, aX, aY, aZ, aBlock, aRenderer, texture, lightingHelper, worldRenderPass);
             return tessAccess.gt5u$hasVertices();
         }
 
@@ -822,12 +2127,20 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
                 return tessAccess.gt5u$hasVertices();
             }
         }
-        if (tileEntity instanceof IPipeRenderedTileEntity
-            && renderPipeBlock(aWorld, aX, aY, aZ, aBlock, (IPipeRenderedTileEntity) tileEntity, aRenderer)) {
+        if (tileEntity instanceof IPipeRenderedTileEntity && renderPipeBlock(
+            aWorld,
+            aX,
+            aY,
+            aZ,
+            aBlock,
+            (IPipeRenderedTileEntity) tileEntity,
+            aRenderer,
+            lightingHelper,
+            worldRenderPass)) {
             aRenderer.enableAO = false;
             return tessAccess.gt5u$hasVertices();
         }
-        if (renderStandardBlock(aWorld, aX, aY, aZ, aBlock, aRenderer)) {
+        if (renderStandardBlock(aWorld, aX, aY, aZ, aBlock, aRenderer, lightingHelper, worldRenderPass)) {
             aRenderer.enableAO = false;
             return tessAccess.gt5u$hasVertices();
         }

--- a/src/main/java/gregtech/common/render/GTSidedTextureRender.java
+++ b/src/main/java/gregtech/common/render/GTSidedTextureRender.java
@@ -7,6 +7,7 @@ import gregtech.api.interfaces.IColorModulationContainer;
 import gregtech.api.interfaces.IIconContainer;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.render.TextureFactory;
+import gregtech.api.util.LightingHelper;
 
 public class GTSidedTextureRender extends GTTextureBase implements ITexture, IColorModulationContainer {
 
@@ -34,33 +35,39 @@ public class GTSidedTextureRender extends GTTextureBase implements ITexture, ICo
     }
 
     @Override
-    public void renderXPos(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
-        mTextures[5].renderXPos(aRenderer, aBlock, aX, aY, aZ);
+    public void renderXPos(RenderBlocks aRenderer, LightingHelper lightingHelper, Block aBlock, int aX, int aY, int aZ,
+        int worldRenderPass) {
+        mTextures[5].renderXPos(aRenderer, lightingHelper, aBlock, aX, aY, aZ, worldRenderPass);
     }
 
     @Override
-    public void renderXNeg(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
-        mTextures[4].renderXNeg(aRenderer, aBlock, aX, aY, aZ);
+    public void renderXNeg(RenderBlocks aRenderer, LightingHelper lightingHelper, Block aBlock, int aX, int aY, int aZ,
+        int worldRenderPass) {
+        mTextures[4].renderXNeg(aRenderer, lightingHelper, aBlock, aX, aY, aZ, worldRenderPass);
     }
 
     @Override
-    public void renderYPos(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
-        mTextures[1].renderYPos(aRenderer, aBlock, aX, aY, aZ);
+    public void renderYPos(RenderBlocks aRenderer, LightingHelper lightingHelper, Block aBlock, int aX, int aY, int aZ,
+        int worldRenderPass) {
+        mTextures[1].renderYPos(aRenderer, lightingHelper, aBlock, aX, aY, aZ, worldRenderPass);
     }
 
     @Override
-    public void renderYNeg(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
-        mTextures[0].renderYNeg(aRenderer, aBlock, aX, aY, aZ);
+    public void renderYNeg(RenderBlocks aRenderer, LightingHelper lightingHelper, Block aBlock, int aX, int aY, int aZ,
+        int worldRenderPass) {
+        mTextures[0].renderYNeg(aRenderer, lightingHelper, aBlock, aX, aY, aZ, worldRenderPass);
     }
 
     @Override
-    public void renderZPos(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
-        mTextures[3].renderZPos(aRenderer, aBlock, aX, aY, aZ);
+    public void renderZPos(RenderBlocks aRenderer, LightingHelper lightingHelper, Block aBlock, int aX, int aY, int aZ,
+        int worldRenderPass) {
+        mTextures[3].renderZPos(aRenderer, lightingHelper, aBlock, aX, aY, aZ, worldRenderPass);
     }
 
     @Override
-    public void renderZNeg(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
-        mTextures[2].renderZNeg(aRenderer, aBlock, aX, aY, aZ);
+    public void renderZNeg(RenderBlocks aRenderer, LightingHelper lightingHelper, Block aBlock, int aX, int aY, int aZ,
+        int worldRenderPass) {
+        mTextures[2].renderZNeg(aRenderer, lightingHelper, aBlock, aX, aY, aZ, worldRenderPass);
     }
 
     @Override

--- a/src/main/java/gregtech/common/render/IRenderedBlock.java
+++ b/src/main/java/gregtech/common/render/IRenderedBlock.java
@@ -4,12 +4,14 @@ import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.IBlockAccess;
+import net.minecraftforge.client.ForgeHooksClient;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import gregtech.api.enums.Textures;
 import gregtech.api.interfaces.ITexture;
+import gregtech.api.util.LightingHelper;
 
 public interface IRenderedBlock {
 
@@ -101,13 +103,75 @@ public interface IRenderedBlock {
 
         @Override
         public boolean renderBlock(Block aBlock, RenderBlocks aRenderer, IBlockAccess aWorld, int aX, int aY, int aZ) {
+            final LightingHelper lightingHelper = new LightingHelper(aRenderer);
+            final int worldRenderPass = ForgeHooksClient.getWorldRenderPass();
             aBlock.setBlockBounds(-0.25F, -0.25F, -0.25F, 1.25F, 1.25F, 1.25F);
-            GTRendererBlock.renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, mErrorTexture, false);
-            GTRendererBlock.renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, mErrorTexture, false);
-            GTRendererBlock.renderNegativeZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, mErrorTexture, false);
-            GTRendererBlock.renderPositiveZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, mErrorTexture, false);
-            GTRendererBlock.renderNegativeXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, mErrorTexture, false);
-            GTRendererBlock.renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, mErrorTexture, false);
+            GTRendererBlock.renderNegativeYFacing(
+                aWorld,
+                aRenderer,
+                lightingHelper,
+                aBlock,
+                aX,
+                aY,
+                aZ,
+                mErrorTexture,
+                false,
+                worldRenderPass);
+            GTRendererBlock.renderPositiveYFacing(
+                aWorld,
+                aRenderer,
+                lightingHelper,
+                aBlock,
+                aX,
+                aY,
+                aZ,
+                mErrorTexture,
+                false,
+                worldRenderPass);
+            GTRendererBlock.renderNegativeZFacing(
+                aWorld,
+                aRenderer,
+                lightingHelper,
+                aBlock,
+                aX,
+                aY,
+                aZ,
+                mErrorTexture,
+                false,
+                worldRenderPass);
+            GTRendererBlock.renderPositiveZFacing(
+                aWorld,
+                aRenderer,
+                lightingHelper,
+                aBlock,
+                aX,
+                aY,
+                aZ,
+                mErrorTexture,
+                false,
+                worldRenderPass);
+            GTRendererBlock.renderNegativeXFacing(
+                aWorld,
+                aRenderer,
+                lightingHelper,
+                aBlock,
+                aX,
+                aY,
+                aZ,
+                mErrorTexture,
+                false,
+                worldRenderPass);
+            GTRendererBlock.renderPositiveXFacing(
+                aWorld,
+                aRenderer,
+                lightingHelper,
+                aBlock,
+                aX,
+                aY,
+                aZ,
+                mErrorTexture,
+                false,
+                worldRenderPass);
             return true;
         }
     }

--- a/src/main/java/gtPlusPlus/core/client/renderer/CustomOreBlockRenderer.java
+++ b/src/main/java/gtPlusPlus/core/client/renderer/CustomOreBlockRenderer.java
@@ -10,7 +10,9 @@ import static gregtech.common.render.GTRendererBlock.renderPositiveZFacing;
 import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.RenderBlocks;
+import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.world.IBlockAccess;
+import net.minecraftforge.client.ForgeHooksClient;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import org.lwjgl.opengl.GL11;
@@ -20,6 +22,8 @@ import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
 import cpw.mods.fml.client.registry.RenderingRegistry;
 import gregtech.GTMod;
+import gregtech.api.util.LightingHelper;
+import gregtech.mixin.interfaces.accessors.TesselatorAccessor;
 import gtPlusPlus.api.interfaces.ITexturedBlock;
 import gtPlusPlus.api.objects.Logger;
 
@@ -38,6 +42,7 @@ public class CustomOreBlockRenderer implements ISimpleBlockRenderingHandler {
 
     @Override
     public void renderInventoryBlock(Block aBlock, int aMeta, int aModelID, RenderBlocks aRenderer) {
+        final LightingHelper lightingHelper = new LightingHelper(aRenderer);
         aRenderer.enableAO = false;
         aRenderer.useInventoryTint = true;
         GL11.glRotatef(90.0F, 0.0F, 1.0F, 0.0F);
@@ -47,13 +52,14 @@ public class CustomOreBlockRenderer implements ISimpleBlockRenderingHandler {
 
         ITexturedBlock textures = (ITexturedBlock) aBlock;
 
-        renderNegativeYFacing(null, aRenderer, aBlock, 0, 0, 0, textures.getTexture(ForgeDirection.DOWN), true);
-        renderPositiveYFacing(null, aRenderer, aBlock, 0, 0, 0, textures.getTexture(ForgeDirection.UP), true);
-        renderNegativeZFacing(null, aRenderer, aBlock, 0, 0, 0, textures.getTexture(ForgeDirection.NORTH), true);
-        renderPositiveZFacing(null, aRenderer, aBlock, 0, 0, 0, textures.getTexture(ForgeDirection.SOUTH), true);
-        renderNegativeXFacing(null, aRenderer, aBlock, 0, 0, 0, textures.getTexture(ForgeDirection.WEST), true);
-        renderPositiveXFacing(null, aRenderer, aBlock, 0, 0, 0, textures.getTexture(ForgeDirection.EAST), true);
-
+        // spotless:off
+        renderNegativeYFacing(null, aRenderer, lightingHelper, aBlock, 0, 0, 0, textures.getTexture(ForgeDirection.DOWN), true, -1);
+        renderPositiveYFacing(null, aRenderer, lightingHelper, aBlock, 0, 0, 0, textures.getTexture(ForgeDirection.UP), true, -1);
+        renderNegativeZFacing(null, aRenderer, lightingHelper, aBlock, 0, 0, 0, textures.getTexture(ForgeDirection.NORTH), true, -1);
+        renderPositiveZFacing(null, aRenderer, lightingHelper, aBlock, 0, 0, 0, textures.getTexture(ForgeDirection.SOUTH), true, -1);
+        renderNegativeXFacing(null, aRenderer, lightingHelper, aBlock, 0, 0, 0, textures.getTexture(ForgeDirection.WEST), true, -1);
+        renderPositiveXFacing(null, aRenderer, lightingHelper, aBlock, 0, 0, 0, textures.getTexture(ForgeDirection.EAST), true, -1);
+        // spotless:on
         aBlock.setBlockBounds(0.0F, 0.0F, 0.0F, 1.0F, 1.0F, 1.0F);
         aRenderer.setRenderBoundsFromBlock(aBlock);
         GL11.glTranslatef(0.5F, 0.5F, 0.5F);
@@ -67,20 +73,26 @@ public class CustomOreBlockRenderer implements ISimpleBlockRenderingHandler {
             return false;
         }
 
+        final TesselatorAccessor tessAccess = (TesselatorAccessor) Tessellator.instance;
+        final LightingHelper lightingHelper = new LightingHelper(aRenderer);
+        final int worldRenderPass = ForgeHooksClient.getWorldRenderPass();
+
         aRenderer.enableAO = Minecraft.isAmbientOcclusionEnabled() && GTMod.proxy.mRenderTileAmbientOcclusion;
         aRenderer.useInventoryTint = false;
         aBlock.setBlockBounds(0.0F, 0.0F, 0.0F, 1.0F, 1.0F, 1.0F);
         aRenderer.setRenderBoundsFromBlock(aBlock);
 
-        renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textures.getTexture(ForgeDirection.DOWN), true);
-        renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textures.getTexture(ForgeDirection.UP), true);
-        renderNegativeZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textures.getTexture(ForgeDirection.NORTH), true);
-        renderPositiveZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textures.getTexture(ForgeDirection.SOUTH), true);
-        renderNegativeXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textures.getTexture(ForgeDirection.WEST), true);
-        renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textures.getTexture(ForgeDirection.EAST), true);
+        // spotless:off
+        renderNegativeYFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textures.getTexture(ForgeDirection.DOWN), true, worldRenderPass);
+        renderPositiveYFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textures.getTexture(ForgeDirection.UP), true, worldRenderPass);
+        renderNegativeZFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textures.getTexture(ForgeDirection.NORTH), true, worldRenderPass);
+        renderPositiveZFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textures.getTexture(ForgeDirection.SOUTH), true, worldRenderPass);
+        renderNegativeXFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textures.getTexture(ForgeDirection.WEST), true, worldRenderPass);
+        renderPositiveXFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textures.getTexture(ForgeDirection.EAST), true, worldRenderPass);
+        // spotless:on
 
         aRenderer.enableAO = false;
-        return true;
+        return tessAccess.gt5u$hasVertices();
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/render/MachineBlockRenderer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/render/MachineBlockRenderer.java
@@ -22,6 +22,7 @@ import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.IBlockAccess;
+import net.minecraftforge.client.ForgeHooksClient;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import org.lwjgl.opengl.GL11;
@@ -34,8 +35,10 @@ import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.interfaces.tileentity.IPipeRenderedTileEntity;
 import gregtech.api.interfaces.tileentity.ITexturedTileEntity;
 import gregtech.api.metatileentity.MetaPipeEntity;
+import gregtech.api.util.LightingHelper;
 import gregtech.common.blocks.BlockMachines;
 import gregtech.common.render.GTRendererBlock;
+import gregtech.mixin.interfaces.accessors.TesselatorAccessor;
 import gtPlusPlus.xmod.gregtech.common.helpers.GTMethodHelper;
 
 public class MachineBlockRenderer extends GTRendererBlock {
@@ -61,7 +64,7 @@ public class MachineBlockRenderer extends GTRendererBlock {
     }
 
     // spotless:off
-    private static void renderNormalInventoryMetaTileEntity(Block aBlock, int aMeta, RenderBlocks aRenderer) {
+    private static void renderNormalInventoryMetaTileEntity(Block aBlock, int aMeta, RenderBlocks aRenderer, LightingHelper lightingHelper) {
         if (aMeta > 0 && aMeta < GregTechAPI.METATILEENTITIES.length) {
             IMetaTileEntity tMetaTileEntity = GregTechAPI.METATILEENTITIES[aMeta];
             if (tMetaTileEntity != null) {
@@ -77,52 +80,52 @@ public class MachineBlockRenderer extends GTRendererBlock {
                     aRenderer.setRenderBoundsFromBlock(aBlock);
                     tess.startDrawingQuads();
                     tess.setNormal(0.0F, -1.0F, 0.0F);
-                    renderNegativeYFacing(null, aRenderer, aBlock, 0, 0, 0, getTexture(tMetaTileEntity, DOWN, 0b001001, -1, false, false), true);
+                    renderNegativeYFacing(null, aRenderer, lightingHelper, aBlock, 0, 0, 0, getTexture(tMetaTileEntity, DOWN, 0b001001, -1, false, false), true, -1);
                     tess.draw();
                     tess.startDrawingQuads();
                     tess.setNormal(0.0F, 1.0F, 0.0F);
-                    renderPositiveYFacing(null, aRenderer, aBlock, 0, 0, 0, getTexture(tMetaTileEntity, UP, 0b001001, -1, false, false), true);
+                    renderPositiveYFacing(null, aRenderer, lightingHelper, aBlock, 0, 0, 0, getTexture(tMetaTileEntity, UP, 0b001001, -1, false, false), true, -1);
                     tess.draw();
                     tess.startDrawingQuads();
                     tess.setNormal(0.0F, 0.0F, -1.0F);
-                    renderNegativeZFacing(null, aRenderer, aBlock, 0, 0, 0, getTexture(tMetaTileEntity, ForgeDirection.NORTH, 0b001001, -1, false, false), true);
+                    renderNegativeZFacing(null, aRenderer, lightingHelper, aBlock, 0, 0, 0, getTexture(tMetaTileEntity, ForgeDirection.NORTH, 0b001001, -1, false, false), true, -1);
                     tess.draw();
                     tess.startDrawingQuads();
                     tess.setNormal(0.0F, 0.0F, 1.0F);
-                    renderPositiveZFacing(null, aRenderer, aBlock, 0, 0, 0, getTexture(tMetaTileEntity, ForgeDirection.SOUTH, 0b001001, -1, false, false), true);
+                    renderPositiveZFacing(null, aRenderer, lightingHelper, aBlock, 0, 0, 0, getTexture(tMetaTileEntity, ForgeDirection.SOUTH, 0b001001, -1, false, false), true, -1);
                     tess.draw();
                     tess.startDrawingQuads();
                     tess.setNormal(-1.0F, 0.0F, 0.0F);
-                    renderNegativeXFacing(null, aRenderer, aBlock, 0, 0, 0, getTexture(tMetaTileEntity, ForgeDirection.WEST, 0b001001, -1, true, false), true);
+                    renderNegativeXFacing(null, aRenderer, lightingHelper, aBlock, 0, 0, 0, getTexture(tMetaTileEntity, ForgeDirection.WEST, 0b001001, -1, true, false), true, -1);
                     tess.draw();
                     tess.startDrawingQuads();
                     tess.setNormal(1.0F, 0.0F, 0.0F);
-                    renderPositiveXFacing(null, aRenderer, aBlock, 0, 0, 0, getTexture(tMetaTileEntity, ForgeDirection.EAST, 0b001001, -1, true, false), true);
+                    renderPositiveXFacing(null, aRenderer, lightingHelper, aBlock, 0, 0, 0, getTexture(tMetaTileEntity, ForgeDirection.EAST, 0b001001, -1, true, false), true, -1);
                     tess.draw();
                 } else {
                     tess.startDrawingQuads();
                     tess.setNormal(0.0F, -1.0F, 0.0F);
-                    renderNegativeYFacing(null, aRenderer, aBlock, 0, 0, 0, getTexture(tMetaTileEntity, DOWN, ForgeDirection.WEST, -1, true, false), true);
+                    renderNegativeYFacing(null, aRenderer, lightingHelper, aBlock, 0, 0, 0, getTexture(tMetaTileEntity, DOWN, ForgeDirection.WEST, -1, true, false), true, -1);
                     tess.draw();
                     tess.startDrawingQuads();
                     tess.setNormal(0.0F, 1.0F, 0.0F);
-                    renderPositiveYFacing(null, aRenderer, aBlock, 0, 0, 0, getTexture(tMetaTileEntity, UP, ForgeDirection.WEST, -1, true, false), true);
+                    renderPositiveYFacing(null, aRenderer, lightingHelper, aBlock, 0, 0, 0, getTexture(tMetaTileEntity, UP, ForgeDirection.WEST, -1, true, false), true, -1);
                     tess.draw();
                     tess.startDrawingQuads();
                     tess.setNormal(0.0F, 0.0F, -1.0F);
-                    renderNegativeZFacing(null, aRenderer, aBlock, 0, 0, 0, getTexture(tMetaTileEntity, ForgeDirection.NORTH, ForgeDirection.WEST, -1, true, false), true);
+                    renderNegativeZFacing(null, aRenderer, lightingHelper, aBlock, 0, 0, 0, getTexture(tMetaTileEntity, ForgeDirection.NORTH, ForgeDirection.WEST, -1, true, false), true, -1);
                     tess.draw();
                     tess.startDrawingQuads();
                     tess.setNormal(0.0F, 0.0F, 1.0F);
-                    renderPositiveZFacing(null, aRenderer, aBlock, 0, 0, 0, getTexture(tMetaTileEntity, ForgeDirection.SOUTH, ForgeDirection.WEST, -1, true, false), true);
+                    renderPositiveZFacing(null, aRenderer, lightingHelper, aBlock, 0, 0, 0, getTexture(tMetaTileEntity, ForgeDirection.SOUTH, ForgeDirection.WEST, -1, true, false), true, -1);
                     tess.draw();
                     tess.startDrawingQuads();
                     tess.setNormal(-1.0F, 0.0F, 0.0F);
-                    renderNegativeXFacing(null, aRenderer, aBlock, 0, 0, 0, getTexture(tMetaTileEntity, ForgeDirection.WEST, ForgeDirection.WEST, -1, true, false), true);
+                    renderNegativeXFacing(null, aRenderer, lightingHelper, aBlock, 0, 0, 0, getTexture(tMetaTileEntity, ForgeDirection.WEST, ForgeDirection.WEST, -1, true, false), true, -1);
                     tess.draw();
                     tess.startDrawingQuads();
                     tess.setNormal(1.0F, 0.0F, 0.0F);
-                    renderPositiveXFacing(null, aRenderer, aBlock, 0, 0, 0, getTexture(tMetaTileEntity, ForgeDirection.EAST, ForgeDirection.WEST, -1, true, false), true);
+                    renderPositiveXFacing(null, aRenderer, lightingHelper, aBlock, 0, 0, 0, getTexture(tMetaTileEntity, ForgeDirection.EAST, ForgeDirection.WEST, -1, true, false), true, -1);
                     tess.draw();
                 }
 
@@ -155,17 +158,79 @@ public class MachineBlockRenderer extends GTRendererBlock {
         RenderBlocks aRenderer, ITexture[][] aTextures) {
         aBlock.setBlockBounds(0.0F, 0.0F, 0.0F, 1.0F, 1.0F, 1.0F);
         aRenderer.setRenderBoundsFromBlock(aBlock);
-        renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, aTextures[DOWN.ordinal()], true);
-        renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, aTextures[UP.ordinal()], true);
-        renderNegativeZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, aTextures[ForgeDirection.NORTH.ordinal()], true);
-        renderPositiveZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, aTextures[ForgeDirection.SOUTH.ordinal()], true);
-        renderNegativeXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, aTextures[ForgeDirection.WEST.ordinal()], true);
-        renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, aTextures[ForgeDirection.EAST.ordinal()], true);
+        final LightingHelper lightingHelper = new LightingHelper(aRenderer);
+        final int worldRenderPass = ForgeHooksClient.getWorldRenderPass();
+        renderNegativeYFacing(
+            aWorld,
+            aRenderer,
+            lightingHelper,
+            aBlock,
+            aX,
+            aY,
+            aZ,
+            aTextures[DOWN.ordinal()],
+            true,
+            worldRenderPass);
+        renderPositiveYFacing(
+            aWorld,
+            aRenderer,
+            lightingHelper,
+            aBlock,
+            aX,
+            aY,
+            aZ,
+            aTextures[UP.ordinal()],
+            true,
+            worldRenderPass);
+        renderNegativeZFacing(
+            aWorld,
+            aRenderer,
+            lightingHelper,
+            aBlock,
+            aX,
+            aY,
+            aZ,
+            aTextures[ForgeDirection.NORTH.ordinal()],
+            true,
+            worldRenderPass);
+        renderPositiveZFacing(
+            aWorld,
+            aRenderer,
+            lightingHelper,
+            aBlock,
+            aX,
+            aY,
+            aZ,
+            aTextures[ForgeDirection.SOUTH.ordinal()],
+            true,
+            worldRenderPass);
+        renderNegativeXFacing(
+            aWorld,
+            aRenderer,
+            lightingHelper,
+            aBlock,
+            aX,
+            aY,
+            aZ,
+            aTextures[ForgeDirection.WEST.ordinal()],
+            true,
+            worldRenderPass);
+        renderPositiveXFacing(
+            aWorld,
+            aRenderer,
+            lightingHelper,
+            aBlock,
+            aX,
+            aY,
+            aZ,
+            aTextures[ForgeDirection.EAST.ordinal()],
+            true,
+            worldRenderPass);
         return true;
     }
 
     // spotless:off
-    public boolean renderPipeBlock(IBlockAccess aWorld, int aX, int aY, int aZ, Block aBlock, IPipeRenderedTileEntity aTileEntity, RenderBlocks aRenderer) {
+    public boolean renderPipeBlock(IBlockAccess aWorld, int aX, int aY, int aZ, Block aBlock, IPipeRenderedTileEntity aTileEntity, RenderBlocks aRenderer, LightingHelper lightingHelper, int worldRenderPass) {
         final int aConnections = aTileEntity.getConnections();
         float tThickness = aTileEntity.getThickNess();
         if (tThickness >= 0.99F) {
@@ -201,144 +266,144 @@ public class MachineBlockRenderer extends GTRendererBlock {
                     case NO_CONNECTION -> {
                         aBlock.setBlockBounds(sp, sp, sp, sp + tThickness, sp + tThickness, sp + tThickness);
                         aRenderer.setRenderBoundsFromBlock(aBlock);
-                        renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(DOWN), false);
-                        renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(UP), false);
-                        renderNegativeZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(NORTH), false);
-                        renderPositiveZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(SOUTH), false);
-                        renderNegativeXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(WEST), false);
-                        renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(EAST), false);
+                        renderNegativeYFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(DOWN), false, worldRenderPass);
+                        renderPositiveYFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(UP), false, worldRenderPass);
+                        renderNegativeZFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(NORTH), false, worldRenderPass);
+                        renderPositiveZFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(SOUTH), false, worldRenderPass);
+                        renderNegativeXFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(WEST), false, worldRenderPass);
+                        renderPositiveXFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(EAST), false, worldRenderPass);
                     }
                     case (CONNECTED_DOWN | CONNECTED_UP) -> {
                         aBlock.setBlockBounds(0.0F, sp, sp, 1.0F, sp + tThickness, sp + tThickness);
                         aRenderer.setRenderBoundsFromBlock(aBlock);
-                        renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(DOWN), false);
-                        renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(UP), false);
-                        renderNegativeZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(NORTH), false);
-                        renderPositiveZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(SOUTH), false);
+                        renderNegativeYFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(DOWN), false, worldRenderPass);
+                        renderPositiveYFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(UP), false, worldRenderPass);
+                        renderNegativeZFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(NORTH), false, worldRenderPass);
+                        renderPositiveZFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(SOUTH), false, worldRenderPass);
                         if (!coveredSides.contains(WEST)) {
-                            renderNegativeXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(WEST), false);
+                            renderNegativeXFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(WEST), false, worldRenderPass);
                         }
                         if (!coveredSides.contains(EAST)) {
-                            renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(EAST), false);
+                            renderPositiveXFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(EAST), false, worldRenderPass);
                         }
                     }
                     case (CONNECTED_NORTH | CONNECTED_SOUTH) -> {
                         aBlock.setBlockBounds(sp, 0.0F, sp, sp + tThickness, 1.0F, sp + tThickness);
                         aRenderer.setRenderBoundsFromBlock(aBlock);
-                        renderNegativeZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(NORTH), false);
-                        renderPositiveZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(SOUTH), false);
-                        renderNegativeXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(WEST), false);
-                        renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(EAST), false);
+                        renderNegativeZFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(NORTH), false, worldRenderPass);
+                        renderPositiveZFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(SOUTH), false, worldRenderPass);
+                        renderNegativeXFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(WEST), false, worldRenderPass);
+                        renderPositiveXFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(EAST), false, worldRenderPass);
                         if (!coveredSides.contains(DOWN)) {
-                            renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(DOWN), false);
+                            renderNegativeYFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(DOWN), false, worldRenderPass);
                         }
                         if (!coveredSides.contains(UP)) {
-                            renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(UP), false);
+                            renderPositiveYFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(UP), false, worldRenderPass);
                         }
                     }
                     case (CONNECTED_WEST | CONNECTED_EAST) -> {
                         aBlock.setBlockBounds(sp, sp, 0.0F, sp + tThickness, sp + tThickness, 1.0F);
                         aRenderer.setRenderBoundsFromBlock(aBlock);
-                        renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(DOWN), false);
-                        renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(UP), false);
-                        renderNegativeXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(WEST), false);
-                        renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(EAST), false);
+                        renderNegativeYFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(DOWN), false, worldRenderPass);
+                        renderPositiveYFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(UP), false, worldRenderPass);
+                        renderNegativeXFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(WEST), false, worldRenderPass);
+                        renderPositiveXFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(EAST), false, worldRenderPass);
                         if (!coveredSides.contains(NORTH)) {
-                            renderNegativeZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(NORTH), false);
+                            renderNegativeZFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(NORTH), false, worldRenderPass);
                         }
                         if (!coveredSides.contains(SOUTH)) {
-                            renderPositiveZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(SOUTH), false);
+                            renderPositiveZFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(SOUTH), false, worldRenderPass);
                         }
                     }
                     default -> {
                         if ((connexionSidesBits & CONNECTED_DOWN) == 0) {
                             aBlock.setBlockBounds(sp, sp, sp, sp + tThickness, sp + tThickness, sp + tThickness);
                             aRenderer.setRenderBoundsFromBlock(aBlock);
-                            renderNegativeXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(WEST), false);
+                            renderNegativeXFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(WEST), false, worldRenderPass);
                         } else {
                             aBlock.setBlockBounds(0.0F, sp, sp, sp, sp + tThickness, sp + tThickness);
                             aRenderer.setRenderBoundsFromBlock(aBlock);
-                            renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(DOWN), false);
-                            renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(UP), false);
-                            renderNegativeZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(NORTH), false);
-                            renderPositiveZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(SOUTH), false);
+                            renderNegativeYFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(DOWN), false, worldRenderPass);
+                            renderPositiveYFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(UP), false, worldRenderPass);
+                            renderNegativeZFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(NORTH), false, worldRenderPass);
+                            renderPositiveZFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(SOUTH), false, worldRenderPass);
                             if (!coveredSides.contains(WEST)) {
-                                renderNegativeXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(WEST), false);
+                                renderNegativeXFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(WEST), false, worldRenderPass);
                             }
                         }
                         if ((connexionSidesBits & CONNECTED_UP) == 0) {
                             aBlock.setBlockBounds(sp, sp, sp, sp + tThickness, sp + tThickness, sp + tThickness);
                             aRenderer.setRenderBoundsFromBlock(aBlock);
-                            renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(EAST), false);
+                            renderPositiveXFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(EAST), false, worldRenderPass);
                         } else {
                             aBlock.setBlockBounds(sp + tThickness, sp, sp, 1.0F, sp + tThickness, sp + tThickness);
                             aRenderer.setRenderBoundsFromBlock(aBlock);
-                            renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(DOWN), false);
-                            renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(UP), false);
-                            renderNegativeZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(NORTH), false);
-                            renderPositiveZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(SOUTH), false);
+                            renderNegativeYFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(DOWN), false, worldRenderPass);
+                            renderPositiveYFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(UP), false, worldRenderPass);
+                            renderNegativeZFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(NORTH), false, worldRenderPass);
+                            renderPositiveZFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(SOUTH), false, worldRenderPass);
                             if (!coveredSides.contains(EAST)) {
-                                renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(EAST), false);
+                                renderPositiveXFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(EAST), false, worldRenderPass);
                             }
                         }
                         if ((connexionSidesBits & CONNECTED_NORTH) == 0) {
                             aBlock.setBlockBounds(sp, sp, sp, sp + tThickness, sp + tThickness, sp + tThickness);
                             aRenderer.setRenderBoundsFromBlock(aBlock);
-                            renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(DOWN), false);
+                            renderNegativeYFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(DOWN), false, worldRenderPass);
                         } else {
                             aBlock.setBlockBounds(sp, 0.0F, sp, sp + tThickness, sp, sp + tThickness);
                             aRenderer.setRenderBoundsFromBlock(aBlock);
-                            renderNegativeZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(NORTH), false);
-                            renderPositiveZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(SOUTH), false);
-                            renderNegativeXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(WEST), false);
-                            renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(EAST), false);
+                            renderNegativeZFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(NORTH), false, worldRenderPass);
+                            renderPositiveZFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(SOUTH), false, worldRenderPass);
+                            renderNegativeXFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(WEST), false, worldRenderPass);
+                            renderPositiveXFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(EAST), false, worldRenderPass);
                             if (!coveredSides.contains(DOWN)) {
-                                renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(DOWN), false);
+                                renderNegativeYFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(DOWN), false, worldRenderPass);
                             }
                         }
                         if ((connexionSidesBits & CONNECTED_SOUTH) == 0) {
                             aBlock.setBlockBounds(sp, sp, sp, sp + tThickness, sp + tThickness, sp + tThickness);
                             aRenderer.setRenderBoundsFromBlock(aBlock);
-                            renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(UP), false);
+                            renderPositiveYFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(UP), false, worldRenderPass);
                         } else {
                             aBlock.setBlockBounds(sp, sp + tThickness, sp, sp + tThickness, 1.0F, sp + tThickness);
                             aRenderer.setRenderBoundsFromBlock(aBlock);
-                            renderNegativeZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(NORTH), false);
-                            renderPositiveZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(SOUTH), false);
-                            renderNegativeXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(WEST), false);
-                            renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(EAST), false);
+                            renderNegativeZFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(NORTH), false, worldRenderPass);
+                            renderPositiveZFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(SOUTH), false, worldRenderPass);
+                            renderNegativeXFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(WEST), false, worldRenderPass);
+                            renderPositiveXFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(EAST), false, worldRenderPass);
                             if (!coveredSides.contains(UP)) {
-                                renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(UP), false);
+                                renderPositiveYFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(UP), false, worldRenderPass);
                             }
                         }
                         if ((connexionSidesBits & CONNECTED_WEST) == 0) {
                             aBlock.setBlockBounds(sp, sp, sp, sp + tThickness, sp + tThickness, sp + tThickness);
                             aRenderer.setRenderBoundsFromBlock(aBlock);
-                            renderNegativeZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(NORTH), false);
+                            renderNegativeZFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(NORTH), false, worldRenderPass);
                         } else {
                             aBlock.setBlockBounds(sp, sp, 0.0F, sp + tThickness, sp + tThickness, sp);
                             aRenderer.setRenderBoundsFromBlock(aBlock);
-                            renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(DOWN), false);
-                            renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(UP), false);
-                            renderNegativeXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(WEST), false);
-                            renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(EAST), false);
+                            renderNegativeYFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(DOWN), false, worldRenderPass);
+                            renderPositiveYFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(UP), false, worldRenderPass);
+                            renderNegativeXFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(WEST), false, worldRenderPass);
+                            renderPositiveXFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(EAST), false, worldRenderPass);
                             if (!coveredSides.contains(NORTH)) {
-                                renderNegativeZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(NORTH), false);
+                                renderNegativeZFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(NORTH), false, worldRenderPass);
                             }
                         }
                         if ((connexionSidesBits & CONNECTED_EAST) == 0) {
                             aBlock.setBlockBounds(sp, sp, sp, sp + tThickness, sp + tThickness, sp + tThickness);
                             aRenderer.setRenderBoundsFromBlock(aBlock);
-                            renderPositiveZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(SOUTH), false);
+                            renderPositiveZFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(SOUTH), false, worldRenderPass);
                         } else {
                             aBlock.setBlockBounds(sp, sp, sp + tThickness, sp + tThickness, sp + tThickness, 1.0F);
                             aRenderer.setRenderBoundsFromBlock(aBlock);
-                            renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(DOWN), false);
-                            renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(UP), false);
-                            renderNegativeXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(WEST), false);
-                            renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(EAST), false);
+                            renderNegativeYFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(DOWN), false, worldRenderPass);
+                            renderPositiveYFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(UP), false, worldRenderPass);
+                            renderNegativeXFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(WEST), false, worldRenderPass);
+                            renderPositiveXFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(EAST), false, worldRenderPass);
                             if (!coveredSides.contains(SOUTH)) {
-                                renderPositiveZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, textureUncovered.get(SOUTH), false);
+                                renderPositiveZFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, textureUncovered.get(SOUTH), false, worldRenderPass);
                             }
                         }
                     }
@@ -347,44 +412,44 @@ public class MachineBlockRenderer extends GTRendererBlock {
                 if (coveredSides.contains(DOWN)) {
                     aBlock.setBlockBounds(0.0F, 0.0F, 0.0F, 1.0F, 0.125F, 1.0F);
                     aRenderer.setRenderBoundsFromBlock(aBlock);
-                    renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, texture.get(DOWN), false);
-                    renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, texture.get(DOWN), false);
+                    renderNegativeYFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, texture.get(DOWN), false, worldRenderPass);
+                    renderPositiveYFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, texture.get(DOWN), false, worldRenderPass);
                     if (!coveredSides.contains(NORTH)) {
-                        renderNegativeZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, texture.get(DOWN), false);
+                        renderNegativeZFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, texture.get(DOWN), false, worldRenderPass);
                     }
 
                     if (!coveredSides.contains(SOUTH)) {
-                        renderPositiveZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, texture.get(DOWN), false);
+                        renderPositiveZFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, texture.get(DOWN), false, worldRenderPass);
                     }
 
                     if (!coveredSides.contains(WEST)) {
-                        renderNegativeXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, texture.get(DOWN), false);
+                        renderNegativeXFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, texture.get(DOWN), false, worldRenderPass);
                     }
 
                     if (!coveredSides.contains(EAST)) {
-                        renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, texture.get(DOWN), false);
+                        renderPositiveXFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, texture.get(DOWN), false, worldRenderPass);
                     }
                 }
 
                 if (coveredSides.contains(UP)) {
                     aBlock.setBlockBounds(0.0F, 0.875F, 0.0F, 1.0F, 1.0F, 1.0F);
                     aRenderer.setRenderBoundsFromBlock(aBlock);
-                    renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, texture.get(UP), false);
-                    renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, texture.get(UP), false);
+                    renderNegativeYFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, texture.get(UP), false, worldRenderPass);
+                    renderPositiveYFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, texture.get(UP), false, worldRenderPass);
                     if (!coveredSides.contains(NORTH)) {
-                        renderNegativeZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, texture.get(UP), false);
+                        renderNegativeZFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, texture.get(UP), false, worldRenderPass);
                     }
 
                     if (!coveredSides.contains(SOUTH)) {
-                        renderPositiveZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, texture.get(UP), false);
+                        renderPositiveZFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, texture.get(UP), false, worldRenderPass);
                     }
 
                     if (!coveredSides.contains(WEST)) {
-                        renderNegativeXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, texture.get(UP), false);
+                        renderNegativeXFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, texture.get(UP), false, worldRenderPass);
                     }
 
                     if (!coveredSides.contains(EAST)) {
-                        renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, texture.get(UP), false);
+                        renderPositiveXFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, texture.get(UP), false, worldRenderPass);
                     }
                 }
 
@@ -392,21 +457,21 @@ public class MachineBlockRenderer extends GTRendererBlock {
                     aBlock.setBlockBounds(0.0F, 0.0F, 0.0F, 1.0F, 1.0F, 0.125F);
                     aRenderer.setRenderBoundsFromBlock(aBlock);
                     if (!coveredSides.contains(DOWN)) {
-                        renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, texture.get(NORTH), false);
+                        renderNegativeYFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, texture.get(NORTH), false, worldRenderPass);
                     }
 
                     if (!coveredSides.contains(UP)) {
-                        renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, texture.get(NORTH), false);
+                        renderPositiveYFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, texture.get(NORTH), false, worldRenderPass);
                     }
 
-                    renderNegativeZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, texture.get(NORTH), false);
-                    renderPositiveZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, texture.get(NORTH), false);
+                    renderNegativeZFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, texture.get(NORTH), false, worldRenderPass);
+                    renderPositiveZFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, texture.get(NORTH), false, worldRenderPass);
                     if (!coveredSides.contains(WEST)) {
-                        renderNegativeXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, texture.get(NORTH), false);
+                        renderNegativeXFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, texture.get(NORTH), false, worldRenderPass);
                     }
 
                     if (!coveredSides.contains(EAST)) {
-                        renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, texture.get(NORTH), false);
+                        renderPositiveXFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, texture.get(NORTH), false, worldRenderPass);
                     }
                 }
 
@@ -414,21 +479,21 @@ public class MachineBlockRenderer extends GTRendererBlock {
                     aBlock.setBlockBounds(0.0F, 0.0F, 0.875F, 1.0F, 1.0F, 1.0F);
                     aRenderer.setRenderBoundsFromBlock(aBlock);
                     if (!coveredSides.contains(DOWN)) {
-                        renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, texture.get(SOUTH), false);
+                        renderNegativeYFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, texture.get(SOUTH), false, worldRenderPass);
                     }
 
                     if (!coveredSides.contains(UP)) {
-                        renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, texture.get(SOUTH), false);
+                        renderPositiveYFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, texture.get(SOUTH), false, worldRenderPass);
                     }
 
-                    renderNegativeZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, texture.get(SOUTH), false);
-                    renderPositiveZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, texture.get(SOUTH), false);
+                    renderNegativeZFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, texture.get(SOUTH), false, worldRenderPass);
+                    renderPositiveZFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, texture.get(SOUTH), false, worldRenderPass);
                     if (!coveredSides.contains(WEST)) {
-                        renderNegativeXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, texture.get(SOUTH), false);
+                        renderNegativeXFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, texture.get(SOUTH), false, worldRenderPass);
                     }
 
                     if (!coveredSides.contains(EAST)) {
-                        renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, texture.get(SOUTH), false);
+                        renderPositiveXFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, texture.get(SOUTH), false, worldRenderPass);
                     }
                 }
 
@@ -436,46 +501,46 @@ public class MachineBlockRenderer extends GTRendererBlock {
                     aBlock.setBlockBounds(0.0F, 0.0F, 0.0F, 0.125F, 1.0F, 1.0F);
                     aRenderer.setRenderBoundsFromBlock(aBlock);
                     if (!coveredSides.contains(DOWN)) {
-                        renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, texture.get(WEST), false);
+                        renderNegativeYFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, texture.get(WEST), false, worldRenderPass);
                     }
 
                     if (!coveredSides.contains(UP)) {
-                        renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, texture.get(WEST), false);
+                        renderPositiveYFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, texture.get(WEST), false, worldRenderPass);
                     }
 
                     if (!coveredSides.contains(NORTH)) {
-                        renderNegativeZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, texture.get(WEST), false);
+                        renderNegativeZFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, texture.get(WEST), false, worldRenderPass);
                     }
 
                     if (!coveredSides.contains(SOUTH)) {
-                        renderPositiveZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, texture.get(WEST), false);
+                        renderPositiveZFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, texture.get(WEST), false, worldRenderPass);
                     }
 
-                    renderNegativeXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, texture.get(WEST), false);
-                    renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, texture.get(WEST), false);
+                    renderNegativeXFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, texture.get(WEST), false, worldRenderPass);
+                    renderPositiveXFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, texture.get(WEST), false, worldRenderPass);
                 }
 
                 if (coveredSides.contains(EAST)) {
                     aBlock.setBlockBounds(0.875F, 0.0F, 0.0F, 1.0F, 1.0F, 1.0F);
                     aRenderer.setRenderBoundsFromBlock(aBlock);
                     if (!coveredSides.contains(DOWN)) {
-                        renderNegativeYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, texture.get(EAST), false);
+                        renderNegativeYFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, texture.get(EAST), false, worldRenderPass);
                     }
 
                     if (!coveredSides.contains(UP)) {
-                        renderPositiveYFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, texture.get(EAST), false);
+                        renderPositiveYFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, texture.get(EAST), false, worldRenderPass);
                     }
 
                     if (!coveredSides.contains(NORTH)) {
-                        renderNegativeZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, texture.get(EAST), false);
+                        renderNegativeZFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, texture.get(EAST), false, worldRenderPass);
                     }
 
                     if (!coveredSides.contains(SOUTH)) {
-                        renderPositiveZFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, texture.get(EAST), false);
+                        renderPositiveZFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, texture.get(EAST), false, worldRenderPass);
                     }
 
-                    renderNegativeXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, texture.get(EAST), false);
-                    renderPositiveXFacing(aWorld, aRenderer, aBlock, aX, aY, aZ, texture.get(EAST), false);
+                    renderNegativeXFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, texture.get(EAST), false, worldRenderPass);
+                    renderPositiveXFacing(aWorld, aRenderer, lightingHelper, aBlock, aX, aY, aZ, texture.get(EAST), false, worldRenderPass);
                 }
 
                 aBlock.setBlockBounds(0.0F, 0.0F, 0.0F, 1.0F, 1.0F, 1.0F);
@@ -486,8 +551,9 @@ public class MachineBlockRenderer extends GTRendererBlock {
     }
     // spotless:on
 
-    public static void renderNegativeYFacing(IBlockAccess aWorld, RenderBlocks aRenderer, Block aBlock, int aX, int aY,
-        int aZ, ITexture[] aIcon, boolean aFullBlock) {
+    @SuppressWarnings("MethodWithTooManyParameters")
+    public static void renderNegativeYFacing(IBlockAccess aWorld, RenderBlocks aRenderer, LightingHelper lightingHelper,
+        Block aBlock, int aX, int aY, int aZ, ITexture[] aIcon, boolean aFullBlock, int worldRenderPass) {
         if (aWorld != null) {
             if (aFullBlock && !aRenderer.renderAllFaces && !aBlock.shouldSideBeRendered(aWorld, aX, aY - 1, aZ, 0)) {
                 return;
@@ -499,7 +565,7 @@ public class MachineBlockRenderer extends GTRendererBlock {
         if (aIcon != null) {
             for (ITexture iTexture : aIcon) {
                 if (iTexture != null) {
-                    iTexture.renderYNeg(aRenderer, aBlock, aX, aY, aZ);
+                    iTexture.renderYNeg(aRenderer, lightingHelper, aBlock, aX, aY, aZ, worldRenderPass);
                 }
             }
         }
@@ -507,8 +573,9 @@ public class MachineBlockRenderer extends GTRendererBlock {
         aRenderer.flipTexture = false;
     }
 
-    public static void renderPositiveYFacing(IBlockAccess aWorld, RenderBlocks aRenderer, Block aBlock, int aX, int aY,
-        int aZ, ITexture[] aIcon, boolean aFullBlock) {
+    @SuppressWarnings("MethodWithTooManyParameters")
+    public static void renderPositiveYFacing(IBlockAccess aWorld, RenderBlocks aRenderer, LightingHelper lightingHelper,
+        Block aBlock, int aX, int aY, int aZ, ITexture[] aIcon, boolean aFullBlock, int worldRenderPass) {
         if (aWorld != null) {
             if (aFullBlock && !aRenderer.renderAllFaces && !aBlock.shouldSideBeRendered(aWorld, aX, aY + 1, aZ, 1)) {
                 return;
@@ -521,7 +588,7 @@ public class MachineBlockRenderer extends GTRendererBlock {
         if (aIcon != null) {
             for (ITexture iTexture : aIcon) {
                 if (iTexture != null) {
-                    iTexture.renderYPos(aRenderer, aBlock, aX, aY, aZ);
+                    iTexture.renderYPos(aRenderer, lightingHelper, aBlock, aX, aY, aZ, worldRenderPass);
                 }
             }
         }
@@ -529,8 +596,9 @@ public class MachineBlockRenderer extends GTRendererBlock {
         aRenderer.flipTexture = false;
     }
 
-    public static void renderNegativeZFacing(IBlockAccess aWorld, RenderBlocks aRenderer, Block aBlock, int aX, int aY,
-        int aZ, ITexture[] aIcon, boolean aFullBlock) {
+    @SuppressWarnings("MethodWithTooManyParameters")
+    public static void renderNegativeZFacing(IBlockAccess aWorld, RenderBlocks aRenderer, LightingHelper lightingHelper,
+        Block aBlock, int aX, int aY, int aZ, ITexture[] aIcon, boolean aFullBlock, int worldRenderPass) {
         if (aWorld != null) {
             if (aFullBlock && !aRenderer.renderAllFaces && !aBlock.shouldSideBeRendered(aWorld, aX, aY, aZ - 1, 2)) {
                 return;
@@ -544,7 +612,7 @@ public class MachineBlockRenderer extends GTRendererBlock {
         if (aIcon != null) {
             for (ITexture iTexture : aIcon) {
                 if (iTexture != null) {
-                    iTexture.renderZNeg(aRenderer, aBlock, aX, aY, aZ);
+                    iTexture.renderZNeg(aRenderer, lightingHelper, aBlock, aX, aY, aZ, worldRenderPass);
                 }
             }
         }
@@ -552,8 +620,9 @@ public class MachineBlockRenderer extends GTRendererBlock {
         aRenderer.flipTexture = false;
     }
 
-    public static void renderPositiveZFacing(IBlockAccess aWorld, RenderBlocks aRenderer, Block aBlock, int aX, int aY,
-        int aZ, ITexture[] aIcon, boolean aFullBlock) {
+    @SuppressWarnings("MethodWithTooManyParameters")
+    public static void renderPositiveZFacing(IBlockAccess aWorld, RenderBlocks aRenderer, LightingHelper lightingHelper,
+        Block aBlock, int aX, int aY, int aZ, ITexture[] aIcon, boolean aFullBlock, int worldRenderPass) {
         if (aWorld != null) {
             if (aFullBlock && !aRenderer.renderAllFaces && !aBlock.shouldSideBeRendered(aWorld, aX, aY, aZ + 1, 3)) {
                 return;
@@ -566,7 +635,7 @@ public class MachineBlockRenderer extends GTRendererBlock {
         if (aIcon != null) {
             for (ITexture iTexture : aIcon) {
                 if (iTexture != null) {
-                    iTexture.renderZPos(aRenderer, aBlock, aX, aY, aZ);
+                    iTexture.renderZPos(aRenderer, lightingHelper, aBlock, aX, aY, aZ, worldRenderPass);
                 }
             }
         }
@@ -574,8 +643,9 @@ public class MachineBlockRenderer extends GTRendererBlock {
         aRenderer.flipTexture = false;
     }
 
-    public static void renderNegativeXFacing(IBlockAccess aWorld, RenderBlocks aRenderer, Block aBlock, int aX, int aY,
-        int aZ, ITexture[] aIcon, boolean aFullBlock) {
+    @SuppressWarnings("MethodWithTooManyParameters")
+    public static void renderNegativeXFacing(IBlockAccess aWorld, RenderBlocks aRenderer, LightingHelper lightingHelper,
+        Block aBlock, int aX, int aY, int aZ, ITexture[] aIcon, boolean aFullBlock, int worldRenderPass) {
         if (aWorld != null) {
             if (aFullBlock && !aRenderer.renderAllFaces && !aBlock.shouldSideBeRendered(aWorld, aX - 1, aY, aZ, 4)) {
                 return;
@@ -588,7 +658,7 @@ public class MachineBlockRenderer extends GTRendererBlock {
         if (aIcon != null) {
             for (ITexture iTexture : aIcon) {
                 if (iTexture != null) {
-                    iTexture.renderXNeg(aRenderer, aBlock, aX, aY, aZ);
+                    iTexture.renderXNeg(aRenderer, lightingHelper, aBlock, aX, aY, aZ, worldRenderPass);
                 }
             }
         }
@@ -596,8 +666,9 @@ public class MachineBlockRenderer extends GTRendererBlock {
         aRenderer.flipTexture = false;
     }
 
-    public static void renderPositiveXFacing(IBlockAccess aWorld, RenderBlocks aRenderer, Block aBlock, int aX, int aY,
-        int aZ, ITexture[] aIcon, boolean aFullBlock) {
+    @SuppressWarnings("MethodWithTooManyParameters")
+    public static void renderPositiveXFacing(IBlockAccess aWorld, RenderBlocks aRenderer, LightingHelper lightingHelper,
+        Block aBlock, int aX, int aY, int aZ, ITexture[] aIcon, boolean aFullBlock, int worldRenderPass) {
         if (aWorld != null) {
             if (aFullBlock && !aRenderer.renderAllFaces && !aBlock.shouldSideBeRendered(aWorld, aX + 1, aY, aZ, 5)) {
                 return;
@@ -611,7 +682,7 @@ public class MachineBlockRenderer extends GTRendererBlock {
         if (aIcon != null) {
             for (ITexture iTexture : aIcon) {
                 if (iTexture != null) {
-                    iTexture.renderXPos(aRenderer, aBlock, aX, aY, aZ);
+                    iTexture.renderXPos(aRenderer, lightingHelper, aBlock, aX, aY, aZ, worldRenderPass);
                 }
             }
         }
@@ -621,12 +692,13 @@ public class MachineBlockRenderer extends GTRendererBlock {
 
     @Override
     public void renderInventoryBlock(Block aBlock, int aMeta, int aModelID, RenderBlocks aRenderer) {
+        LightingHelper lightingHelper = new LightingHelper(aRenderer);
         aMeta += 30400;
         if (aBlock instanceof BlockMachines) {
             if (aMeta > 0 && aMeta < GregTechAPI.METATILEENTITIES.length
                 && GregTechAPI.METATILEENTITIES[aMeta] != null
                 && !GregTechAPI.METATILEENTITIES[aMeta].renderInInventory(aBlock, aMeta, aRenderer)) {
-                renderNormalInventoryMetaTileEntity(aBlock, aMeta, aRenderer);
+                renderNormalInventoryMetaTileEntity(aBlock, aMeta, aRenderer, lightingHelper);
             }
         }
         aBlock.setBlockBounds(0.0F, 0.0F, 0.0F, 1.0F, 1.0F, 1.0F);
@@ -637,14 +709,28 @@ public class MachineBlockRenderer extends GTRendererBlock {
     @Override
     public boolean renderWorldBlock(IBlockAccess aWorld, int aX, int aY, int aZ, Block aBlock, int aModelID,
         RenderBlocks aRenderer) {
+        final TesselatorAccessor tessAccess = (TesselatorAccessor) Tessellator.instance;
+        final LightingHelper lightingHelper = new LightingHelper(aRenderer);
+        final int renderWorldPass = ForgeHooksClient.getWorldRenderPass();
+
         TileEntity aTileEntity = aWorld.getTileEntity(aX, aY, aZ);
         return aTileEntity != null && (aTileEntity instanceof IGregTechTileEntity
             && ((IGregTechTileEntity) aTileEntity).getMetaTileEntity() != null
+            && tessAccess.gt5u$hasVertices()
             && ((IGregTechTileEntity) aTileEntity).getMetaTileEntity()
                 .renderInWorld(aWorld, aX, aY, aZ, aBlock, aRenderer)
             || (aTileEntity instanceof IPipeRenderedTileEntity
-                ? renderPipeBlock(aWorld, aX, aY, aZ, aBlock, (IPipeRenderedTileEntity) aTileEntity, aRenderer)
-                : renderStandardBlock(aWorld, aX, aY, aZ, aBlock, aRenderer)));
+                ? renderPipeBlock(
+                    aWorld,
+                    aX,
+                    aY,
+                    aZ,
+                    aBlock,
+                    (IPipeRenderedTileEntity) aTileEntity,
+                    aRenderer,
+                    lightingHelper,
+                    renderWorldPass)
+                : renderStandardBlock(aWorld, aX, aY, aZ, aBlock, aRenderer, lightingHelper, renderWorldPass)));
     }
 
     @Override


### PR DESCRIPTION
Improve world rendering performance by rendering block background only in cut-out pass 0 and overlay only in alpha-blended pass 1.
This also fixes the rendering of particles in front of blocks using alpha-blended overlay textures.

Before:
<img width="1920" height="989" alt="2025-07-29_00 47 53" src="https://github.com/user-attachments/assets/f1959d02-5529-44bd-a14c-5e1427a4d1ae" />

After:
<img width="1920" height="989" alt="2025-07-29_14 13 00" src="https://github.com/user-attachments/assets/eb7a9255-ef71-4cbc-b7d6-235badcb9503" />
