### PR TITLE
Removes Duplicate Zirconium

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoaderChemicalSkips.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/recipe/RecipeLoaderChemicalSkips.java
@@ -246,7 +246,7 @@ public class RecipeLoaderChemicalSkips {
                 Materials.Gadolinium.getDust(64),
                 Materials.Samarium.getDust(64),
                 new ItemStack(WerkstoffLoader.items.get(OrePrefixes.dust), 64, 11002),
-                new ItemStack(WerkstoffLoader.items.get(OrePrefixes.dust), 64, 11007),
+                new ItemStack(WerkstoffLoader.items.get(OrePrefixes.dust), 64, 3),
                 ItemList.SuperconductorComposite.get(1))
             .duration(20 * SECONDS)
             .eut(TierEU.RECIPE_UHV)

--- a/src/main/java/gtnhlanth/common/register/WerkstoffMaterialPool.java
+++ b/src/main/java/gtnhlanth/common/register/WerkstoffMaterialPool.java
@@ -113,19 +113,6 @@ public class WerkstoffMaterialPool implements Runnable {
         offsetID + 6,
         TextureSet.SET_DULL);
 
-    public static final Werkstoff Zirconium = new Werkstoff(
-        new short[] { 225, 230, 225 },
-        "Zirconium",
-        subscriptNumbers("Zr"),
-        new Werkstoff.Stats().setBlastFurnace(true),
-        Werkstoff.Types.ELEMENT,
-        new Werkstoff.GenerationFeatures().disable()
-            .onlyDust()
-            .addMetalItems(),
-        // .enforceUnification(),
-        offsetID + 7,
-        TextureSet.SET_METALLIC);
-
     public static final Werkstoff Zirconia = new Werkstoff(
         new short[] { 177, 152, 101 },
         "Zirconia",

--- a/src/main/java/gtnhlanth/common/register/WerkstoffMaterialPool.java
+++ b/src/main/java/gtnhlanth/common/register/WerkstoffMaterialPool.java
@@ -113,6 +113,19 @@ public class WerkstoffMaterialPool implements Runnable {
         offsetID + 6,
         TextureSet.SET_DULL);
 
+    public static final Werkstoff Zirconium = new Werkstoff(
+        new short[] { 225, 230, 225 },
+        "Zirconium",
+        subscriptNumbers("Zr"),
+        new Werkstoff.Stats(),
+        Werkstoff.Types.ELEMENT,
+        new Werkstoff.GenerationFeatures().disable()
+            .onlyDust()
+            .addMetalItems(),
+        // .enforceUnification(),
+        offsetID + 7,
+        TextureSet.SET_METALLIC);
+
     public static final Werkstoff Zirconia = new Werkstoff(
         new short[] { 177, 152, 101 },
         "Zirconia",


### PR DESCRIPTION
### Changes:
- Removes the duplicate zirconium call, there's already a nearly identical one (except more fleshed out) so this is just bloat. 
- Changes QFT recipe to use remaining zirconium (QFT recipe was the only recipe using the weird zirconium)

I was initially just getting rid of the bad EBF recipe but ultimately this entire generated metal can be cutout, all recipes using zirconium functioned on both of them and there is no recipe nor usage I can find that favored using on type over the other because they were both registered the same way (besides QFT, which was assigned to the 11007 ID, switched over to 3).

Tested & compared side-by-side.

This will close https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20630.

