### PR TITLE
Fix Energy Infuser charge items without using power

### DIFF
--- a/src/main/java/tectech/thing/metaTileEntity/multi/MTEEnergyInfuser.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/MTEEnergyInfuser.java
@@ -107,14 +107,12 @@ public class MTEEnergyInfuser extends TTMultiblockBase implements ISurvivalConst
 
     private long doChargeItemStack(IElectricItem item, ItemStack stack) {
         try {
-            double euDiff = item.getMaxCharge(stack) - ElectricItem.manager.getCharge(stack);
-            long remove = (long) Math.ceil(
-                ElectricItem.manager.charge(
-                    stack,
-                    Math.min(euDiff, getAverageInputVoltage() * getMaxInputAmps()),
-                    item.getTier(stack),
-                    true,
-                    false));
+            final double missingItemCharge = item.getMaxCharge(stack) - ElectricItem.manager.getCharge(stack);
+            final double availablePower = getAverageInputVoltage() * getMaxInputAmps();
+            final double availableEnergy = getEUVar();
+            final double charge = Math.min(Math.min(missingItemCharge, availablePower), availableEnergy);
+            long remove = (long) Math
+                .ceil(ElectricItem.manager.charge(stack, charge, item.getTier(stack), true, false));
             setEUVar(getEUVar() - remove);
             if (getEUVar() < 0) {
                 setEUVar(0);

--- a/src/main/java/tectech/thing/metaTileEntity/multi/MTEEnergyInfuser.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/MTEEnergyInfuser.java
@@ -109,7 +109,12 @@ public class MTEEnergyInfuser extends TTMultiblockBase implements ISurvivalConst
         try {
             double euDiff = item.getMaxCharge(stack) - ElectricItem.manager.getCharge(stack);
             long remove = (long) Math.ceil(
-                ElectricItem.manager.charge(stack, Math.min(euDiff, getEUVar()), item.getTier(stack), true, false));
+                ElectricItem.manager.charge(
+                    stack,
+                    Math.min(euDiff, getAverageInputVoltage() * getMaxInputAmps()),
+                    item.getTier(stack),
+                    true,
+                    false));
             setEUVar(getEUVar() - remove);
             if (getEUVar() < 0) {
                 setEUVar(0);
@@ -215,13 +220,6 @@ public class MTEEnergyInfuser extends TTMultiblockBase implements ISurvivalConst
                             }
                         }
                     }
-                    if (item instanceof IElectricItem) {
-                        doChargeItemStack((IElectricItem) item, itemStackInBus);
-                        return;
-                    } else if (Mods.COFHCore.isModLoaded() && item instanceof IEnergyContainerItem) {
-                        doChargeItemStackRF((IEnergyContainerItem) item, itemStackInBus);
-                        return;
-                    }
                 }
             }
         }
@@ -276,6 +274,29 @@ public class MTEEnergyInfuser extends TTMultiblockBase implements ISurvivalConst
     @Override
     protected SoundResource getActivitySoundLoop() {
         return SoundResource.TECTECH_MACHINES_FX_WHOOUM;
+    }
+
+    @Override
+    public void onPostTick(IGregTechTileEntity aBaseMetaTileEntity, long aTick) {
+        super.onPostTick(aBaseMetaTileEntity, aTick);
+        if (!this.isAllowedToWork()) return;
+        for (MTEHatchInputBus inputBus : mInputBusses) {
+            if (inputBus instanceof MTEHatchInputBusME) continue;
+            for (ItemStack stack : inputBus.mInventory) {
+                if (stack == null || stack.stackSize != 1 || isItemStackFullyCharged(stack)) continue;
+
+                Item item = stack.getItem();
+                if (item == null) continue;
+
+                if (item instanceof IElectricItem) {
+                    doChargeItemStack((IElectricItem) item, stack);
+                    return;
+                } else if (Mods.COFHCore.isModLoaded() && item instanceof IEnergyContainerItem) {
+                    doChargeItemStackRF((IEnergyContainerItem) item, stack);
+                    return;
+                }
+            }
+        }
     }
 
     @Override

--- a/src/main/java/tectech/thing/metaTileEntity/multi/MTEEnergyInfuser.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/MTEEnergyInfuser.java
@@ -172,6 +172,7 @@ public class MTEEnergyInfuser extends TTMultiblockBase implements ISurvivalConst
                         return SimpleCheckRecipeResult.ofFailure("insufficient_power_no_val");
                     }
                     mEfficiencyIncrease = 10000;
+                    mMaxProgresstime = 20;
                     return SimpleCheckRecipeResult.ofSuccess("charging");
                 }
             }

--- a/src/main/java/tectech/thing/metaTileEntity/multi/MTEEnergyInfuser.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/MTEEnergyInfuser.java
@@ -172,7 +172,6 @@ public class MTEEnergyInfuser extends TTMultiblockBase implements ISurvivalConst
                         return SimpleCheckRecipeResult.ofFailure("insufficient_power_no_val");
                     }
                     mEfficiencyIncrease = 10000;
-                    mMaxProgresstime = 20;
                     return SimpleCheckRecipeResult.ofSuccess("charging");
                 }
             }

--- a/src/main/java/tectech/thing/metaTileEntity/multi/MTEEnergyInfuser.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/MTEEnergyInfuser.java
@@ -109,12 +109,7 @@ public class MTEEnergyInfuser extends TTMultiblockBase implements ISurvivalConst
         try {
             double euDiff = item.getMaxCharge(stack) - ElectricItem.manager.getCharge(stack);
             long remove = (long) Math.ceil(
-                ElectricItem.manager.charge(
-                    stack,
-                    Math.min(euDiff, getAverageInputVoltage() * getMaxInputAmps()),
-                    item.getTier(stack),
-                    true,
-                    false));
+                ElectricItem.manager.charge(stack, Math.min(euDiff, getEUVar()), item.getTier(stack), true, false));
             setEUVar(getEUVar() - remove);
             if (getEUVar() < 0) {
                 setEUVar(0);
@@ -220,6 +215,13 @@ public class MTEEnergyInfuser extends TTMultiblockBase implements ISurvivalConst
                             }
                         }
                     }
+                    if (item instanceof IElectricItem) {
+                        doChargeItemStack((IElectricItem) item, itemStackInBus);
+                        return;
+                    } else if (Mods.COFHCore.isModLoaded() && item instanceof IEnergyContainerItem) {
+                        doChargeItemStackRF((IEnergyContainerItem) item, itemStackInBus);
+                        return;
+                    }
                 }
             }
         }
@@ -274,29 +276,6 @@ public class MTEEnergyInfuser extends TTMultiblockBase implements ISurvivalConst
     @Override
     protected SoundResource getActivitySoundLoop() {
         return SoundResource.TECTECH_MACHINES_FX_WHOOUM;
-    }
-
-    @Override
-    public void onPostTick(IGregTechTileEntity aBaseMetaTileEntity, long aTick) {
-        super.onPostTick(aBaseMetaTileEntity, aTick);
-        if (!this.isAllowedToWork()) return;
-        for (MTEHatchInputBus inputBus : mInputBusses) {
-            if (inputBus instanceof MTEHatchInputBusME) continue;
-            for (ItemStack stack : inputBus.mInventory) {
-                if (stack == null || stack.stackSize != 1 || isItemStackFullyCharged(stack)) continue;
-
-                Item item = stack.getItem();
-                if (item == null) continue;
-
-                if (item instanceof IElectricItem) {
-                    doChargeItemStack((IElectricItem) item, stack);
-                    return;
-                } else if (Mods.COFHCore.isModLoaded() && item instanceof IEnergyContainerItem) {
-                    doChargeItemStackRF((IEnergyContainerItem) item, stack);
-                    return;
-                }
-            }
-        }
     }
 
     @Override

--- a/src/main/java/tectech/thing/metaTileEntity/multi/MTEEnergyInfuser.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/MTEEnergyInfuser.java
@@ -108,8 +108,9 @@ public class MTEEnergyInfuser extends TTMultiblockBase implements ISurvivalConst
     private long doChargeItemStack(IElectricItem item, ItemStack stack) {
         try {
             double euDiff = item.getMaxCharge(stack) - ElectricItem.manager.getCharge(stack);
-            long remove = (long) Math.ceil(
-                ElectricItem.manager.charge(stack, Math.min(euDiff, getEUVar()), item.getTier(stack), true, false));
+            euDiff = Math.min(euDiff, Math.min(getEUVar(), getAverageInputVoltage() * getMaxInputAmps()));
+            long remove = (long) Math
+                .ceil(ElectricItem.manager.charge(stack, euDiff, item.getTier(stack), true, false));
             setEUVar(getEUVar() - remove);
             if (getEUVar() < 0) {
                 setEUVar(0);

--- a/src/main/java/tectech/thing/metaTileEntity/multi/MTEEnergyInfuser.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/MTEEnergyInfuser.java
@@ -108,9 +108,8 @@ public class MTEEnergyInfuser extends TTMultiblockBase implements ISurvivalConst
     private long doChargeItemStack(IElectricItem item, ItemStack stack) {
         try {
             double euDiff = item.getMaxCharge(stack) - ElectricItem.manager.getCharge(stack);
-            euDiff = Math.min(euDiff, Math.min(getEUVar(), getAverageInputVoltage() * getMaxInputAmps()));
-            long remove = (long) Math
-                .ceil(ElectricItem.manager.charge(stack, euDiff, item.getTier(stack), true, false));
+            long remove = (long) Math.ceil(
+                ElectricItem.manager.charge(stack, Math.min(euDiff, getEUVar()), item.getTier(stack), true, false));
             setEUVar(getEUVar() - remove);
             if (getEUVar() < 0) {
                 setEUVar(0);


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20662

This is a regression from https://github.com/GTNewHorizons/GT5-Unofficial/pull/4409 (7bebf70449e1ba0a69bac14fea9545f598c41157).

It changed the code from
```
ElectricItem.manager.charge(stack, Math.min(euDiff, getEUVar()), item.getTier(stack), true, false));
```
```
ElectricItem.manager.charge(
    stack,
    Math.min(euDiff, getAverageInputVoltage() * getMaxInputAmps()),
    item.getTier(stack),
    true,
    false));
```

I don't fully understand what the original issue was, but we clearly can only charge at maximum with the energy we have. If there is still an issue, it needs to be addressed differently, probably by charging the internal buffer faster.