### PR TITLE
Hotfix(BlockFrameBox); getRenderBlockPass must return 0

### DIFF
--- a/src/main/java/gregtech/common/blocks/BlockFrameBox.java
+++ b/src/main/java/gregtech/common/blocks/BlockFrameBox.java
@@ -164,7 +164,7 @@ public class BlockFrameBox extends BlockContainer {
 
     @Override
     public int getRenderBlockPass() {
-        return 1;
+        return 0;
     }
 
     @Override


### PR DESCRIPTION
Fix framebox invisible in-world because it had nothing to render in pass 1.