### PR TITLE
Fix DC deleting any block behind it

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/drone/MTEDroneCentre.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/drone/MTEDroneCentre.java
@@ -447,36 +447,28 @@ public class MTEDroneCentre extends MTEExtendedPowerMultiBlockBase<MTEDroneCentr
 
     private void createRenderBlock() {
         if (!useRender) return;
-        int x = getBaseMetaTileEntity().getXCoord();
-        int y = getBaseMetaTileEntity().getYCoord();
-        int z = getBaseMetaTileEntity().getZCoord();
-
-        double xOffset = 2 * getExtendedFacing().getRelativeBackInWorld().offsetX;
-        double zOffset = 2 * getExtendedFacing().getRelativeBackInWorld().offsetZ;
-        double yOffset = 2 * getExtendedFacing().getRelativeBackInWorld().offsetY;
+        int x = getBaseMetaTileEntity().getXCoord() + 2 * getExtendedFacing().getRelativeBackInWorld().offsetX;
+        int y = getBaseMetaTileEntity().getYCoord() + 2 * getExtendedFacing().getRelativeBackInWorld().offsetZ;
+        int z = getBaseMetaTileEntity().getZCoord() + 2 * getExtendedFacing().getRelativeBackInWorld().offsetY;
 
         World world = this.getBaseMetaTileEntity()
             .getWorld();
-        if (world.getBlock((int) (x + xOffset), (int) (y + yOffset), (int) (z + zOffset))
+        if (world.getBlock(x, y, z)
             .equals(Blocks.air)) {
-            world.setBlock((int) (x + xOffset), (int) (y + yOffset), (int) (z + zOffset), GregTechAPI.sDroneRender);
+            world.setBlock(x, y, z, GregTechAPI.sDroneRender);
         }
     }
 
     private void destroyRenderBlock() {
-        int x = getBaseMetaTileEntity().getXCoord();
-        int y = getBaseMetaTileEntity().getYCoord();
-        int z = getBaseMetaTileEntity().getZCoord();
-
-        double xOffset = 2 * getExtendedFacing().getRelativeBackInWorld().offsetX;
-        double zOffset = 2 * getExtendedFacing().getRelativeBackInWorld().offsetZ;
-        double yOffset = 2 * getExtendedFacing().getRelativeBackInWorld().offsetY;
+        int x = getBaseMetaTileEntity().getXCoord() + 2 * getExtendedFacing().getRelativeBackInWorld().offsetX;
+        int y = getBaseMetaTileEntity().getYCoord() + 2 * getExtendedFacing().getRelativeBackInWorld().offsetZ;
+        int z = getBaseMetaTileEntity().getZCoord() + 2 * getExtendedFacing().getRelativeBackInWorld().offsetY;
 
         World world = this.getBaseMetaTileEntity()
             .getWorld();
-        if (world.getBlock((int) (x + xOffset), (int) (y + yOffset), (int) (z + zOffset))
+        if (world.getBlock(x, y, z)
             .equals(GregTechAPI.sDroneRender)) {
-            world.setBlock((int) (x + xOffset), (int) (y + yOffset), (int) (z + zOffset), Blocks.air);
+            world.setBlock(x, y, z, Blocks.air);
         }
     }
 

--- a/src/main/java/gregtech/common/tileentities/machines/multi/drone/MTEDroneCentre.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/drone/MTEDroneCentre.java
@@ -455,12 +455,12 @@ public class MTEDroneCentre extends MTEExtendedPowerMultiBlockBase<MTEDroneCentr
         double zOffset = 2 * getExtendedFacing().getRelativeBackInWorld().offsetZ;
         double yOffset = 2 * getExtendedFacing().getRelativeBackInWorld().offsetY;
 
-        this.getBaseMetaTileEntity()
-            .getWorld()
-            .setBlock((int) (x + xOffset), (int) (y + yOffset), (int) (z + zOffset), Blocks.air);
-        this.getBaseMetaTileEntity()
-            .getWorld()
-            .setBlock((int) (x + xOffset), (int) (y + yOffset), (int) (z + zOffset), GregTechAPI.sDroneRender);
+        World world = this.getBaseMetaTileEntity()
+            .getWorld();
+        if (world.getBlock((int) (x + xOffset), (int) (y + yOffset), (int) (z + zOffset))
+            .equals(Blocks.air)) {
+            world.setBlock((int) (x + xOffset), (int) (y + yOffset), (int) (z + zOffset), GregTechAPI.sDroneRender);
+        }
     }
 
     private void destroyRenderBlock() {
@@ -472,9 +472,12 @@ public class MTEDroneCentre extends MTEExtendedPowerMultiBlockBase<MTEDroneCentr
         double zOffset = 2 * getExtendedFacing().getRelativeBackInWorld().offsetZ;
         double yOffset = 2 * getExtendedFacing().getRelativeBackInWorld().offsetY;
 
-        this.getBaseMetaTileEntity()
-            .getWorld()
-            .setBlock((int) (x + xOffset), (int) (y + yOffset), (int) (z + zOffset), Blocks.air);
+        World world = this.getBaseMetaTileEntity()
+            .getWorld();
+        if (world.getBlock((int) (x + xOffset), (int) (y + yOffset), (int) (z + zOffset))
+            .equals(GregTechAPI.sDroneRender)) {
+            world.setBlock((int) (x + xOffset), (int) (y + yOffset), (int) (z + zOffset), Blocks.air);
+        }
     }
 
     @Override


### PR DESCRIPTION
It used to delete/replace any block behind itself. It now checks for air before placing the drone renderer and checks for the drone renderer before removing the block.