### PR TITLE
Fix(#4670) Reset shared LightingHelper state

### DIFF
--- a/src/main/java/gregtech/api/util/LightingHelper.java
+++ b/src/main/java/gregtech/api/util/LightingHelper.java
@@ -92,6 +92,21 @@ public class LightingHelper {
     }
 
     /**
+     * Resets override flags to their default values.
+     * <p>
+     * This ensures deterministic rendering by clearing any leftover state
+     * from previous use of this LightingHelper instance.
+     *
+     * @return the {@link LightingHelper}
+     */
+    public LightingHelper reset() {
+        hasBrightnessOverride = false;
+        hasColorOverride = false;
+        hasLightnessOverride = false;
+        return this;
+    }
+
+    /**
      * Clears brightness override.
      */
     public void clearBrightnessOverride() {

--- a/src/main/java/gregtech/common/render/GTCopiedBlockTextureRender.java
+++ b/src/main/java/gregtech/common/render/GTCopiedBlockTextureRender.java
@@ -50,7 +50,8 @@ public class GTCopiedBlockTextureRender extends GTTextureBase implements ITextur
         final IIcon aIcon = getIcon(ForgeDirection.EAST.ordinal(), aRenderer.blockAccess, aX, aY, aZ);
         aRenderer.field_152631_f = true;
         startDrawingQuads(aRenderer, 1.0f, 0.0f, 0.0f);
-        lightingHelper.setupLightingXPos(aBlock, aX, aY, aZ)
+        lightingHelper.reset()
+            .setupLightingXPos(aBlock, aX, aY, aZ)
             .setupColor(ForgeDirection.EAST, 0xffffff);
         aRenderer.renderFaceXPos(aBlock, aX, aY, aZ, aIcon);
         draw(aRenderer);
@@ -63,7 +64,8 @@ public class GTCopiedBlockTextureRender extends GTTextureBase implements ITextur
         if (worldRenderPass != -1 && !mBlock.canRenderInPass(worldRenderPass)) return;
         startDrawingQuads(aRenderer, -1.0f, 0.0f, 0.0f);
         final IIcon aIcon = getIcon(ForgeDirection.WEST.ordinal(), aRenderer.blockAccess, aX, aY, aZ);
-        lightingHelper.setupLightingXNeg(aBlock, aX, aY, aZ)
+        lightingHelper.reset()
+            .setupLightingXNeg(aBlock, aX, aY, aZ)
             .setupColor(ForgeDirection.WEST, 0xffffff);
         aRenderer.renderFaceXNeg(aBlock, aX, aY, aZ, aIcon);
         draw(aRenderer);
@@ -75,7 +77,8 @@ public class GTCopiedBlockTextureRender extends GTTextureBase implements ITextur
         if (worldRenderPass != -1 && !mBlock.canRenderInPass(worldRenderPass)) return;
         startDrawingQuads(aRenderer, 0.0f, 1.0f, 0.0f);
         final IIcon aIcon = getIcon(ForgeDirection.UP.ordinal(), aRenderer.blockAccess, aX, aY, aZ);
-        lightingHelper.setupLightingYPos(aBlock, aX, aY, aZ)
+        lightingHelper.reset()
+            .setupLightingYPos(aBlock, aX, aY, aZ)
             .setupColor(ForgeDirection.UP, 0xffffff);
         aRenderer.renderFaceYPos(aBlock, aX, aY, aZ, aIcon);
         draw(aRenderer);
@@ -87,7 +90,8 @@ public class GTCopiedBlockTextureRender extends GTTextureBase implements ITextur
         if (worldRenderPass != -1 && !mBlock.canRenderInPass(worldRenderPass)) return;
         startDrawingQuads(aRenderer, 0.0f, -1.0f, 0.0f);
         final IIcon aIcon = getIcon(ForgeDirection.DOWN.ordinal(), aRenderer.blockAccess, aX, aY, aZ);
-        lightingHelper.setupLightingYNeg(aBlock, aX, aY, aZ)
+        lightingHelper.reset()
+            .setupLightingYNeg(aBlock, aX, aY, aZ)
             .setupColor(ForgeDirection.DOWN, 0xffffff);
         aRenderer.renderFaceYNeg(aBlock, aX, aY, aZ, aIcon);
         draw(aRenderer);
@@ -99,7 +103,8 @@ public class GTCopiedBlockTextureRender extends GTTextureBase implements ITextur
         if (worldRenderPass != -1 && !mBlock.canRenderInPass(worldRenderPass)) return;
         startDrawingQuads(aRenderer, 0.0f, 0.0f, 1.0f);
         final IIcon aIcon = getIcon(ForgeDirection.SOUTH.ordinal(), aRenderer.blockAccess, aX, aY, aZ);
-        lightingHelper.setupLightingZPos(aBlock, aX, aY, aZ)
+        lightingHelper.reset()
+            .setupLightingZPos(aBlock, aX, aY, aZ)
             .setupColor(ForgeDirection.SOUTH, 0xffffff);
         aRenderer.renderFaceZPos(aBlock, aX, aY, aZ, aIcon);
         draw(aRenderer);
@@ -112,7 +117,8 @@ public class GTCopiedBlockTextureRender extends GTTextureBase implements ITextur
         startDrawingQuads(aRenderer, 0.0f, 0.0f, -1.0f);
         final IIcon aIcon = getIcon(ForgeDirection.NORTH.ordinal(), aRenderer.blockAccess, aX, aY, aZ);
         aRenderer.field_152631_f = true;
-        lightingHelper.setupLightingZNeg(aBlock, aX, aY, aZ)
+        lightingHelper.reset()
+            .setupLightingZNeg(aBlock, aX, aY, aZ)
             .setupColor(ForgeDirection.NORTH, 0xffffff);
         aRenderer.renderFaceZNeg(aBlock, aX, aY, aZ, aIcon);
         draw(aRenderer);

--- a/src/main/java/gregtech/common/render/GTCopiedCTMBlockTexture.java
+++ b/src/main/java/gregtech/common/render/GTCopiedCTMBlockTexture.java
@@ -45,7 +45,8 @@ class GTCopiedCTMBlockTexture extends GTTextureBase implements ITexture, IBlockC
         if (worldRenderPass != -1 && !mBlock.canRenderInPass(worldRenderPass)) return;
         aRenderer.field_152631_f = true;
         startDrawingQuads(aRenderer, 1.0f, 0.0f, 0.0f);
-        lightingHelper.setupLightingXPos(aBlock, aX, aY, aZ)
+        lightingHelper.reset()
+            .setupLightingXPos(aBlock, aX, aY, aZ)
             .setupColor(ForgeDirection.EAST, mBlock.colorMultiplier(getBlockAccess(aRenderer), aX, aY, aZ));
         aRenderer.renderFaceXPos(aBlock, aX, aY, aZ, aIcon);
         draw(aRenderer);
@@ -58,7 +59,8 @@ class GTCopiedCTMBlockTexture extends GTTextureBase implements ITexture, IBlockC
         startDrawingQuads(aRenderer, -1.0f, 0.0f, 0.0f);
         if (worldRenderPass != -1 && !mBlock.canRenderInPass(worldRenderPass)) return;
         final IIcon aIcon = getIcon(ForgeDirection.WEST.ordinal(), aX, aY, aZ, aRenderer);
-        lightingHelper.setupLightingXNeg(aBlock, aX, aY, aZ)
+        lightingHelper.reset()
+            .setupLightingXNeg(aBlock, aX, aY, aZ)
             .setupColor(ForgeDirection.WEST, mBlock.colorMultiplier(getBlockAccess(aRenderer), aX, aY, aZ));
         aRenderer.renderFaceXNeg(aBlock, aX, aY, aZ, aIcon);
         draw(aRenderer);
@@ -70,7 +72,8 @@ class GTCopiedCTMBlockTexture extends GTTextureBase implements ITexture, IBlockC
         startDrawingQuads(aRenderer, 0.0f, 1.0f, 0.0f);
         if (worldRenderPass != -1 && !mBlock.canRenderInPass(worldRenderPass)) return;
         final IIcon aIcon = getIcon(ForgeDirection.UP.ordinal(), aX, aY, aZ, aRenderer);
-        lightingHelper.setupLightingYPos(aBlock, aX, aY, aZ)
+        lightingHelper.reset()
+            .setupLightingYPos(aBlock, aX, aY, aZ)
             .setupColor(ForgeDirection.UP, mBlock.colorMultiplier(getBlockAccess(aRenderer), aX, aY, aZ));
         aRenderer.renderFaceYPos(aBlock, aX, aY, aZ, aIcon);
         draw(aRenderer);
@@ -82,7 +85,8 @@ class GTCopiedCTMBlockTexture extends GTTextureBase implements ITexture, IBlockC
         startDrawingQuads(aRenderer, 0.0f, -1.0f, 0.0f);
         if (worldRenderPass != -1 && !mBlock.canRenderInPass(worldRenderPass)) return;
         final IIcon aIcon = getIcon(ForgeDirection.DOWN.ordinal(), aX, aY, aZ, aRenderer);
-        lightingHelper.setupLightingYNeg(aBlock, aX, aY, aZ)
+        lightingHelper.reset()
+            .setupLightingYNeg(aBlock, aX, aY, aZ)
             .setupColor(ForgeDirection.DOWN, mBlock.colorMultiplier(getBlockAccess(aRenderer), aX, aY, aZ));
         aRenderer.renderFaceYNeg(aBlock, aX, aY, aZ, aIcon);
         draw(aRenderer);
@@ -94,7 +98,8 @@ class GTCopiedCTMBlockTexture extends GTTextureBase implements ITexture, IBlockC
         startDrawingQuads(aRenderer, 0.0f, 0.0f, 1.0f);
         if (worldRenderPass != -1 && !mBlock.canRenderInPass(worldRenderPass)) return;
         final IIcon aIcon = getIcon(ForgeDirection.SOUTH.ordinal(), aX, aY, aZ, aRenderer);
-        lightingHelper.setupLightingZPos(aBlock, aX, aY, aZ)
+        lightingHelper.reset()
+            .setupLightingZPos(aBlock, aX, aY, aZ)
             .setupColor(ForgeDirection.SOUTH, mBlock.colorMultiplier(getBlockAccess(aRenderer), aX, aY, aZ));
         aRenderer.renderFaceZPos(aBlock, aX, aY, aZ, aIcon);
         draw(aRenderer);
@@ -107,7 +112,8 @@ class GTCopiedCTMBlockTexture extends GTTextureBase implements ITexture, IBlockC
         if (worldRenderPass != -1 && !mBlock.canRenderInPass(worldRenderPass)) return;
         final IIcon aIcon = getIcon(ForgeDirection.NORTH.ordinal(), aX, aY, aZ, aRenderer);
         aRenderer.field_152631_f = true;
-        lightingHelper.setupLightingZNeg(aBlock, aX, aY, aZ)
+        lightingHelper.reset()
+            .setupLightingZNeg(aBlock, aX, aY, aZ)
             .setupColor(ForgeDirection.NORTH, mBlock.colorMultiplier(getBlockAccess(aRenderer), aX, aY, aZ));
         aRenderer.renderFaceZNeg(aBlock, aX, aY, aZ, aIcon);
         draw(aRenderer);

--- a/src/main/java/gregtech/common/render/GTRenderedTexture.java
+++ b/src/main/java/gregtech/common/render/GTRenderedTexture.java
@@ -50,6 +50,7 @@ public class GTRenderedTexture extends GTTextureBase implements ITexture, IColor
     public void renderXPos(RenderBlocks aRenderer, LightingHelper lightingHelper, Block aBlock, int aX, int aY, int aZ,
         int worldRenderPass) {
         startDrawingQuads(aRenderer, 1.0f, 0.0f, 0.0f);
+        lightingHelper.reset();
         final boolean enableAO = aRenderer.enableAO;
         if (glow) {
             if (!GTMod.proxy.mRenderGlowTextures) {


### PR DESCRIPTION
Now that the LightingHelper instance is shared across render operations, it must be explicitly reset before each use. Without this, lighting and color state leaks between renders, causing abnormal lightness, brightness, or tint in subsequent rendering operations.

Fixes a bug introduced by PR #4670