### PR TITLE
Made iron furnace recipes using oredict allow  EFR blast furnace

### DIFF
--- a/src/main/java/gregtech/loaders/preload/LoaderGTOreDictionary.java
+++ b/src/main/java/gregtech/loaders/preload/LoaderGTOreDictionary.java
@@ -2,6 +2,7 @@ package gregtech.loaders.preload;
 
 import static gregtech.api.enums.Mods.AppliedEnergistics2;
 import static gregtech.api.enums.Mods.Botania;
+import static gregtech.api.enums.Mods.EtFuturumRequiem;
 import static gregtech.api.enums.Mods.GalacticraftMars;
 import static gregtech.api.enums.Mods.IndustrialCraft2;
 import static gregtech.api.enums.Mods.NewHorizonsCoreMod;
@@ -237,6 +238,9 @@ public class LoaderGTOreDictionary implements Runnable {
             .registerOre(OreDictNames.craftingRecycler, new ItemStack(GregTechAPI.sBlockMachines, 1, 53));
 
         GTOreDictUnificator.registerOre(OreDictNames.craftingIronFurnace, GTModHandler.getIC2Item("ironFurnace", 1L));
+        GTOreDictUnificator.registerOre(
+            OreDictNames.craftingIronFurnace,
+            GTModHandler.getModItem(EtFuturumRequiem.ID, "blast_furnace", 1L, 32767));
 
         GTOreDictUnificator
             .registerOre(OreDictNames.craftingCentrifuge, new ItemStack(GregTechAPI.sBlockMachines, 1, 62));


### PR DESCRIPTION
This addresses https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20717

It looks like a bunch of work was done in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1260 but many of the GT5 integration stuff was missed. There was some discussion in the discord about if we should just do a hard replace rather than add to the oredict, but this feels like a smoother transition. I can rework if needed, this just seemed like the simplest fix for now. In draft for now because I have not tested or made a PR to change the quests.