### PR TITLE
Add padding when rendering recipe percentage in GT MTE GUIs

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
@@ -3286,7 +3286,9 @@ public abstract class MTEMultiBlockBase extends MetaTileEntity implements IContr
 
         numberFormat.setMinimumFractionDigits(1);
         numberFormat.setMaximumFractionDigits(1);
+        numberFormat.setMinimumIntegerDigits(2);
         numberFormat.format((double) mProgresstime / mMaxProgresstime * 100, ret);
+        numberFormat.setMinimumIntegerDigits(1);
         ret.append("% ");
         ret.append(EnumChatFormatting.GRAY);
         ret.append("(");


### PR DESCRIPTION
To reduce text jumping on fast recipes.

Before:

https://github.com/user-attachments/assets/02e9aaa8-3f8a-4a95-961c-7cf6ae8fa271

After:

https://github.com/user-attachments/assets/0c6ee330-226d-49be-bb3f-f0fc5c33bbf9

