### PR TITLE
Changed Simple Sterling Water Pump to use oredict

### DIFF
--- a/src/main/java/bartworks/common/loaders/recipes/CraftingRecipes.java
+++ b/src/main/java/bartworks/common/loaders/recipes/CraftingRecipes.java
@@ -49,7 +49,6 @@ import gregtech.api.util.GTModHandler;
 import gregtech.api.util.GTOreDictUnificator;
 import gtPlusPlus.core.util.minecraft.RecipeUtils;
 import gtPlusPlus.xmod.gregtech.api.enums.GregtechItemList;
-import ic2.core.Ic2Items;
 
 public class CraftingRecipes implements Runnable {
 
@@ -142,7 +141,7 @@ public class CraftingRecipes implements Runnable {
             GTModHandler.RecipeBits.NOT_REMOVABLE,
             new Object[] { "IPI", "PMP", "ISI", 'I', GTOreDictUnificator.get(OrePrefixes.plate, Materials.Iron, 1L),
                 'P', GTOreDictUnificator.get(OrePrefixes.pipeLarge, Materials.Wood, 1L), 'M',
-                new ItemStack(ItemRegistry.PUMPPARTS, 1, 1), 'S', Ic2Items.ironFurnace });
+                new ItemStack(ItemRegistry.PUMPPARTS, 1, 1), 'S', "craftingIronFurnace" });
 
         GTModHandler.addCraftingRecipe(
             new ItemStack(ItemRegistry.WINDMETER),


### PR DESCRIPTION
This is part of the iron furnace fix for https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20717

It was hardcoded to the iron  furnace before, but now it uses the oredict "craftingIronFurnace" to match most other places in the pack. EFR Blast Furnace will be added to this dict in the coremod, but it's safe to apply as is, as currently the IC2 Iron furnace is the only member of that ore dict. This has been tested on the most recent nightly.