### PR TITLE
Changes Lava Boiler and Advanced Solar Boiler Recipes

### DIFF
--- a/src/main/java/gregtech/loaders/load/MTERecipeLoader.java
+++ b/src/main/java/gregtech/loaders/load/MTERecipeLoader.java
@@ -2443,7 +2443,7 @@ public class MTERecipeLoader implements Runnable {
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_Steel_Boiler_Lava.get(1L),
             GTModHandler.RecipeBits.BITSD,
-            new Object[] { aTextPlate, "PTP", aTextPlateMotor, 'M', ItemList.Hull_HP, 'P',
+            new Object[] { aTextPlate, "PTP", aTextPlateMotor, 'M', ItemList.Hull_HP_Bricks, 'P',
                 OrePrefixes.plate.get(Materials.Steel), 'T',
                 GTModHandler.getModItem(BuildCraftFactory.ID, "tankBlock", 1L, 0) });
         GTModHandler.addCraftingRecipe(
@@ -2455,8 +2455,9 @@ public class MTERecipeLoader implements Runnable {
         GTModHandler.addCraftingRecipe(
             ItemList.Machine_HP_Solar.get(1L),
             GTModHandler.RecipeBits.BITSD,
-            new Object[] { "GGG", "SSS", aTextPlateMotor, 'M', ItemList.Hull_HP_Bricks, 'P',
-                OrePrefixes.pipeSmall.get(Materials.Steel), 'S', OrePrefixes.plateTriple.get(Materials.Silver), 'G',
+            new Object[] { "GGG", "WSW", aTextPlateMotor, 'M', ItemList.Machine_Bronze_Boiler_Solar, 'P',
+                OrePrefixes.pipeSmall.get(Materials.Steel), 'S', OrePrefixes.plateTriple.get(Materials.Silver), 'W',
+                OrePrefixes.plateDouble.get(Materials.WroughtIron), 'G',
                 GTModHandler.getModItem(IndustrialCraft2.ID, "blockAlloyGlass", 1L) });
 
         GTModHandler.addCraftingRecipe(


### PR DESCRIPTION
## Changes:
- Makes advanced solar boiler dependent on solar boiler to craft. Resource-wise, it's the same silver cost, 1 ingot reduced wrought iron, and of course the 7 bronze ingots for the T1 boiler.
- Switches the Lava boiler to using the wrought iron hull rather than the steel hull. Resource difference of -8 steel, +3 brick +5 wrought iron. 


## Why (Solar)
- Brings actual purpose to the T1 solar boiler, before it was just flat out skipped in crafting because you might as well go for the better one with the expensive silver cost, now it's a direct upgrade so there is no waste. Additionally this follows closely with the scheme of the other steam machines (& quests), the rest of the advanced models upgrade in the exact same way. 
- Also this has support in meta-dev

### Solar Recipe Comparison:
Left Top -) Current T1 (Silver is 2x)
Left Bottom -) Old T2 (Silver is 3x)
Right Bottom -) New T2 (Silver is 3x. WIron is 2x)

<img width="649" height="378" alt="image" src="https://github.com/user-attachments/assets/28879e7b-0065-46a2-b5a5-820241e6ed53" />


## Why (Lava)
- The lava boiler is rarely if ever used. If the impracticality of obtaining and regularly expending lava in the ripe early steam age placed the kindling then the whopping 15 steel cost of one single boiler was the match that blew the feasibility of this machine into oblivion. This provides a discount, making it only 7 steel, w/ the wrought iron hull cost. As an added bonus, having it craft like this also makes it more accurately align with it's brick given texture as well. 

Will people still err toward RC boilers? Yes. But at least this gets a small leg up.

### Lava Recipe Comparison:
Left -) Before
Right -) After

<img width="651" height="170" alt="image" src="https://github.com/user-attachments/assets/27a60aa9-faec-4f96-969b-0450afd6e693" />


