### PR TITLE
fix(render): correct inventory lighting

### DIFF
--- a/src/main/java/gregtech/api/render/SBRContext.java
+++ b/src/main/java/gregtech/api/render/SBRContext.java
@@ -207,6 +207,7 @@ public class SBRContext {
         hasBrightnessOverride = false;
         hasColorOverride = false;
         hasLightnessOverride = false;
+        if (renderer.useInventoryTint) setLightnessOverride(1.0F);
         return this;
     }
 

--- a/src/main/java/gregtech/common/render/GTRenderedTexture.java
+++ b/src/main/java/gregtech/common/render/GTRenderedTexture.java
@@ -57,10 +57,7 @@ public class GTRenderedTexture extends GTTextureBase implements ITexture, IColor
             }
             ctx.renderer.enableAO = false;
             ctx.setLightnessOverride(1.0F);
-            if (enableAO) ctx.setBrightnessOverride(MAX_BRIGHTNESS);
-        } else {
-            ctx.clearLightnessOverride()
-                .clearBrightnessOverride();
+            ctx.setBrightnessOverride(MAX_BRIGHTNESS);
         }
         ctx.setupLightingXPos();
         final ExtendedFacing rotation = getExtendedFacing(ctx.x, ctx.y, ctx.z);
@@ -85,11 +82,7 @@ public class GTRenderedTexture extends GTTextureBase implements ITexture, IColor
             if (!GTMod.proxy.mRenderGlowTextures) {
                 draw(ctx.renderer);
                 return;
-            } else {
-                ctx.clearLightnessOverride();
-                ctx.clearBrightnessOverride();
             }
-
             ctx.renderer.enableAO = false;
             ctx.setLightnessOverride(1.0F);
             ctx.setBrightnessOverride(MAX_BRIGHTNESS);
@@ -121,9 +114,6 @@ public class GTRenderedTexture extends GTTextureBase implements ITexture, IColor
             ctx.renderer.enableAO = false;
             ctx.setLightnessOverride(1.0F);
             ctx.setBrightnessOverride(MAX_BRIGHTNESS);
-        } else {
-            ctx.clearLightnessOverride();
-            ctx.clearBrightnessOverride();
         }
         ctx.setupLightingYPos();
         final ExtendedFacing rotation = getExtendedFacing(ctx.x, ctx.y, ctx.z);
@@ -152,9 +142,6 @@ public class GTRenderedTexture extends GTTextureBase implements ITexture, IColor
             ctx.renderer.enableAO = false;
             ctx.setLightnessOverride(1.0F);
             ctx.setBrightnessOverride(MAX_BRIGHTNESS);
-        } else {
-            ctx.clearLightnessOverride();
-            ctx.clearBrightnessOverride();
         }
         ctx.setupLightingYNeg();
         final ExtendedFacing rotation = getExtendedFacing(ctx.x, ctx.y, ctx.z);
@@ -183,9 +170,6 @@ public class GTRenderedTexture extends GTTextureBase implements ITexture, IColor
             ctx.renderer.enableAO = false;
             ctx.setLightnessOverride(1.0F);
             ctx.setBrightnessOverride(MAX_BRIGHTNESS);
-        } else {
-            ctx.clearLightnessOverride();
-            ctx.clearBrightnessOverride();
         }
         ctx.setupLightingZPos();
         final ExtendedFacing rotation = getExtendedFacing(ctx.x, ctx.y, ctx.z);
@@ -214,9 +198,6 @@ public class GTRenderedTexture extends GTTextureBase implements ITexture, IColor
             ctx.renderer.enableAO = false;
             ctx.setLightnessOverride(1.0F);
             ctx.setBrightnessOverride(MAX_BRIGHTNESS);
-        } else {
-            ctx.clearLightnessOverride();
-            ctx.clearBrightnessOverride();
         }
         ctx.setupLightingZNeg();
         final ExtendedFacing rotation = getExtendedFacing(ctx.x, ctx.y, ctx.z);


### PR DESCRIPTION
This correctly restores the lightness of faces when rendering in inventory.

Sharing the same `SBRContext` between world rendering and inventory rendering was a design mistake. But for now it works as is with conditional handling.

For now, this fix is good enough as-is for stable and I need some time to refactor/split the `SBRContext` and some other optimizations with it.

**TODO:**
I need to refactor this `SBRContext` turn it into an abstract class, then extends one varient specific for world and one varient specific for inventory.
