### PR TITLE
Speedup getBaseMetaTileEntity()

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -138,7 +138,8 @@ public abstract class MetaTileEntity extends CommonMetaTileEntity implements ICr
 
     @Nullable
     @Override
-    public IGregTechTileEntity getBaseMetaTileEntity() {
+    // making this method final allows it to be inlined by the JIT compiler
+    public final IGregTechTileEntity getBaseMetaTileEntity() {
         return mBaseMetaTileEntity;
     }
 


### PR DESCRIPTION
This method is called everywhere, so much that it shows up on profilers despite being just a getter. By making it final we allow the JIT compiler to inline it which should remove the overhead and make the method call free.