### PR TITLE
Consistent Dissolution Tank Recipes

### DIFF
--- a/src/main/java/gregtech/loaders/postload/chains/NetheriteRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/chains/NetheriteRecipes.java
@@ -77,8 +77,8 @@ public class NetheriteRecipes {
             GTValues.RA.stdBuilder() // Leaching
                 .itemInputs(GTOreDictUnificator.get(OrePrefixes.shard, MaterialsGTNH.Prismarine, 24))
                 .fluidInputs(
-                    FluidRegistry.getFluidStack("fluid.hydrogenperoxide", 4000), // Hydrogen Peroxide
-                    FluidUtils.getHydrofluoricAcid(4000)) // Industrial Strength Hydrofluoric Acid
+                    FluidUtils.getHydrofluoricAcid(4000), // Industrial Strength Hydrofluoric Acid
+                    FluidRegistry.getFluidStack("fluid.hydrogenperoxide", 4000)) // Hydrogen Peroxide
                 .itemOutputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.CertusQuartz, 4))
                 .fluidOutputs(Materials.PrismarineSolution.getFluid(8000))
                 .duration(20 * SECONDS)


### PR DESCRIPTION
Keeps Hydrogen Peroxide on the right-side of the NEI Prismarine Dissolution Tank recipes, for better visual consistency. Does not change the recipe itself.