### PR TITLE
Fix: Center the Slotgroup and give the title a bit more padding ontop

### DIFF
--- a/src/main/java/gtPlusPlus/core/tileentities/general/TileEntityDecayablesChest.java
+++ b/src/main/java/gtPlusPlus/core/tileentities/general/TileEntityDecayablesChest.java
@@ -406,7 +406,7 @@ public class TileEntityDecayablesChest extends TileEntity implements ISidedInven
         final ModularPanel panel = ModularPanel.defaultPanel("decayablesChest");
         panel.bindPlayerInventory();
         panel.child(
-            new TextWidget(IKey.lang("tile.blockDecayablesChest.name")).top(5)
+            new TextWidget(IKey.lang("tile.blockDecayablesChest.name")).top(7)
                 .left(5));
         panel.child(
             SlotGroupWidget.builder()
@@ -419,8 +419,9 @@ public class TileEntityDecayablesChest extends TileEntity implements ISidedInven
                 .build()
                 .flex(
                     flex -> flex.anchor(Alignment.TopCenter)
-                        .marginTop(15)
-                        .leftRelAnchor(0.5f, 0.5f)));
+                        .leftRelAnchor(0.5f, 0.5f)
+                        .topRelAnchor(0.125f, 0f)));
+
         return panel;
     }
 


### PR DESCRIPTION
Before:
<img width="529" height="428" alt="before" src="https://github.com/user-attachments/assets/dd2f7230-8551-48c3-bf56-50355df3f506" />

After:
<img width="529" height="428" alt="after" src="https://github.com/user-attachments/assets/74f0ba0f-ffd0-45b7-b506-2080cc079363" />

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20726
