### PR TITLE
Fix Prismatic Bee Mutation Block

### DIFF
--- a/src/main/java/gregtech/loaders/misc/GTBeeDefinition.java
+++ b/src/main/java/gregtech/loaders/misc/GTBeeDefinition.java
@@ -33,6 +33,7 @@ import static gregtech.api.enums.Mods.AppliedEnergistics2;
 import static gregtech.api.enums.Mods.Avaritia;
 import static gregtech.api.enums.Mods.AvaritiaAddons;
 import static gregtech.api.enums.Mods.BiomesOPlenty;
+import static gregtech.api.enums.Mods.Botania;
 import static gregtech.api.enums.Mods.CropsPlusPlus;
 import static gregtech.api.enums.Mods.EnderStorage;
 import static gregtech.api.enums.Mods.ExtraBees;
@@ -465,7 +466,11 @@ public enum GTBeeDefinition implements IBeeDefinition {
     }, dis -> {
         IBeeMutationCustom tMutation = dis.registerMutation(CERTUS, getSpecies(EXTRABEES, "ocean"), 10);
         tMutation.restrictHumidity(DAMP);
-        tMutation.requireResource("blockPrismarine");
+        tMutation.requireResource(
+            Block.getBlockFromItem(
+                GTModHandler.getModItem(Botania.ID, "prismarine", 1)
+                    .getItem()),
+            0);
     }),
     // Metal Line
     COPPER(GTBranchDefinition.METAL, "Copper", true, new Color(0xFF6600), new Color(0xE65C00), beeSpecies -> {


### PR DESCRIPTION
closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20722
Hardcodes the necessary Block to "Prismarine" , not just one of "Prismarine", "Prismarine Bricks" or "Dark Prismarine" due to the 3 different blocks having the same oreDict but different names, the name couldnt show properly. 
Now using the Standard prismarine Block.
( Disclaimer: I didnt test if the mutation actually works, but i would assume so)
before:
<img width="1709" height="230" alt="image" src="https://github.com/user-attachments/assets/0e054ece-4340-4a92-b785-29f64808e2a3" />

after:
<img width="608" height="115" alt="image" src="https://github.com/user-attachments/assets/bd11b416-cc7f-4a6d-bd13-8cac38c72561" />
