### PR TITLE
Remove hard dep on Galacticraft

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -46,7 +46,6 @@ dependencies {
     api("com.github.GTNewHorizons:AE2FluidCraft-Rework:1.4.108-gtnh:dev")
     api('com.github.GTNewHorizons:Yamcl:0.7.1:dev')
     api("com.github.GTNewHorizons:Postea:1.1.3:dev")
-    api("com.github.GTNewHorizons:Galacticraft:3.3.10-GTNH:dev") { transitive = false }
 
     compileOnlyApi('com.github.GTNewHorizons:ThaumicTinkerer:2.11.20:dev')
     compileOnlyApi("com.github.GTNewHorizons:Mobs-Info:0.5.4-GTNH:dev")
@@ -64,6 +63,7 @@ dependencies {
     compileOnlyApi("com.github.GTNewHorizons:BuildCraft:7.1.44:dev") { transitive = false }
     compileOnlyApi("com.github.GTNewHorizons:EnderIO:2.9.22:dev") { transitive = false }
     compileOnlyApi("com.github.GTNewHorizons:ForestryMC:4.10.17:dev") { transitive = false }
+    compileOnlyApi("com.github.GTNewHorizons:Galacticraft:3.3.10-GTNH:dev") { transitive = false }
     compileOnlyApi("com.github.GTNewHorizons:ProjectRed:4.11.9-GTNH:dev") { transitive = false }
     compileOnlyApi("com.github.GTNewHorizons:Railcraft:9.16.32:dev") { transitive = false }
 
@@ -107,6 +107,9 @@ dependencies {
     // runtimeOnlyNonPublishable('com.github.GTNewHorizons:neiaddons:1.16.0:dev')
     // runtimeOnlyNonPublishable('com.github.GTNewHorizons:MagicBees:2.9.4-GTNH:dev')
     // runtimeOnlyNonPublishable('com.github.GTNewHorizons:Binnie:2.5.16:dev')
+
+    // For testing Galacticraft integration (GTNH intergalactic, Ross, etc)
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Galacticraft:3.3.10-GTNH:dev")
 
     testImplementation(platform('org.junit:junit-bom:5.9.2'))
     testImplementation('org.junit.jupiter:junit-jupiter')

--- a/src/main/java/gtnhintergalactic/GTNHIntergalactic.java
+++ b/src/main/java/gtnhintergalactic/GTNHIntergalactic.java
@@ -24,7 +24,7 @@ import gtnhintergalactic.proxy.CommonProxy;
     version = GT_Version.VERSION,
     name = GTNHIntergalactic.MODNAME,
     acceptedMinecraftVersions = "[1.7.10]",
-    dependencies = "required-after:GalacticraftCore@[3.0.36,);" + "required-after:GalacticraftMars;"
+    dependencies = "after:GalacticraftCore@[3.0.36,);" + "after:GalacticraftMars;"
         + "required-after:gregtech;"
         + "required-after:gtnhlib@[0.5.21,);"
         + "required-after:tectech;"

--- a/src/main/java/gtnhintergalactic/block/BlockCasingGasSiphon.java
+++ b/src/main/java/gtnhintergalactic/block/BlockCasingGasSiphon.java
@@ -5,12 +5,15 @@ import net.minecraft.block.material.Material;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 
+import cpw.mods.fml.common.Optional;
 import cpw.mods.fml.common.registry.GameRegistry;
 import gregtech.api.GregTechAPI;
 import gregtech.api.enums.ItemList;
+import gregtech.api.enums.Mods;
 import gtnhintergalactic.GTNHIntergalactic;
 import micdoodle8.mods.galacticraft.api.block.ITerraformableBlock;
 
+@Optional.Interface(iface = "micdoodle8.mods.galacticraft.api.block.ITerraformableBlock", modid = Mods.ModIDs.GALACTICRAFT_CORE)
 public class BlockCasingGasSiphon extends Block implements ITerraformableBlock {
 
     public BlockCasingGasSiphon() {

--- a/src/main/java/gtnhintergalactic/block/BlockCasingGasSiphon.java
+++ b/src/main/java/gtnhintergalactic/block/BlockCasingGasSiphon.java
@@ -13,7 +13,9 @@ import gregtech.api.enums.Mods;
 import gtnhintergalactic.GTNHIntergalactic;
 import micdoodle8.mods.galacticraft.api.block.ITerraformableBlock;
 
-@Optional.Interface(iface = "micdoodle8.mods.galacticraft.api.block.ITerraformableBlock", modid = Mods.ModIDs.GALACTICRAFT_CORE)
+@Optional.Interface(
+    iface = "micdoodle8.mods.galacticraft.api.block.ITerraformableBlock",
+    modid = Mods.ModIDs.GALACTICRAFT_CORE)
 public class BlockCasingGasSiphon extends Block implements ITerraformableBlock {
 
     public BlockCasingGasSiphon() {

--- a/src/main/java/gtnhintergalactic/item/ItemBlockSpaceElevatorCable.java
+++ b/src/main/java/gtnhintergalactic/item/ItemBlockSpaceElevatorCable.java
@@ -8,7 +8,7 @@ import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumChatFormatting;
 
-import micdoodle8.mods.galacticraft.core.util.GCCoreUtil;
+import gregtech.api.util.GTUtility;
 
 /**
  * Items of the space elevator cable
@@ -48,9 +48,9 @@ public class ItemBlockSpaceElevatorCable extends ItemBlock {
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
     public void addInformation(ItemStack stack, EntityPlayer player, List tooltip, boolean f3_h) {
-        tooltip.add(GCCoreUtil.translate("gt.blockcasings.ig.cable.desc0"));
+        tooltip.add(GTUtility.translate("gt.blockcasings.ig.cable.desc0"));
         tooltip.add(
             EnumChatFormatting.LIGHT_PURPLE.toString() + EnumChatFormatting.BOLD
-                + GCCoreUtil.translate("gt.blockcasings.ig.cable.desc1"));
+                + GTUtility.translate("gt.blockcasings.ig.cable.desc1"));
     }
 }

--- a/src/main/java/gtnhintergalactic/item/ItemCasingSpaceElevator.java
+++ b/src/main/java/gtnhintergalactic/item/ItemCasingSpaceElevator.java
@@ -7,8 +7,8 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumChatFormatting;
 
+import gregtech.api.util.GTUtility;
 import gregtech.common.blocks.ItemCasings;
-import micdoodle8.mods.galacticraft.core.util.GCCoreUtil;
 
 /**
  * Items of the space elevator casings
@@ -38,9 +38,9 @@ public class ItemCasingSpaceElevator extends ItemCasings {
     @Override
     public void addInformation(ItemStack stack, EntityPlayer player, @SuppressWarnings("rawtypes") List tooltip,
         boolean f3_h) {
-        tooltip.add(GCCoreUtil.translate("gt.blockcasings.ig." + stack.getItemDamage() + ".desc0"));
+        tooltip.add(GTUtility.translate("gt.blockcasings.ig." + stack.getItemDamage() + ".desc0"));
         tooltip.add(
             EnumChatFormatting.LIGHT_PURPLE.toString() + EnumChatFormatting.BOLD
-                + GCCoreUtil.translate("gt.blockcasings.ig." + stack.getItemDamage() + ".desc1"));
+                + GTUtility.translate("gt.blockcasings.ig." + stack.getItemDamage() + ".desc1"));
     }
 }

--- a/src/main/java/gtnhintergalactic/item/ItemCasingSpaceElevatorMotor.java
+++ b/src/main/java/gtnhintergalactic/item/ItemCasingSpaceElevatorMotor.java
@@ -7,9 +7,9 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumChatFormatting;
 
+import gregtech.api.util.GTUtility;
 import gregtech.common.blocks.ItemCasings;
 import gtnhintergalactic.tile.multi.elevator.ElevatorUtil;
-import micdoodle8.mods.galacticraft.core.util.GCCoreUtil;
 
 /**
  * Items of the space elevator motors
@@ -39,13 +39,13 @@ public class ItemCasingSpaceElevatorMotor extends ItemCasings {
     @Override
     public void addInformation(ItemStack stack, EntityPlayer player, @SuppressWarnings("rawtypes") List tooltip,
         boolean f3_h) {
-        tooltip.add(GCCoreUtil.translate("gt.blockcasings.ig.motor.desc0"));
+        tooltip.add(GTUtility.translate("gt.blockcasings.ig.motor.desc0"));
         tooltip.add(
             EnumChatFormatting.LIGHT_PURPLE.toString() + EnumChatFormatting.BOLD
-                + GCCoreUtil.translate("gt.blockcasings.ig.motor.t" + (stack.getItemDamage() + 1) + ".desc1"));
+                + GTUtility.translate("gt.blockcasings.ig.motor.t" + (stack.getItemDamage() + 1) + ".desc1"));
         tooltip.add(
             String.format(
-                GCCoreUtil.translate("gt.blockcasings.ig.motor.desc2"),
+                GTUtility.translate("gt.blockcasings.ig.motor.desc2"),
                 ElevatorUtil.getModuleSlotsUnlocked(stack.getItemDamage() + 1)));
     }
 }

--- a/src/main/java/gtnhintergalactic/loader/MachineLoader.java
+++ b/src/main/java/gtnhintergalactic/loader/MachineLoader.java
@@ -18,6 +18,7 @@ import static gregtech.api.enums.MetaTileEntityIDs.SpaceElevatorModuleResearch;
 import net.minecraft.item.ItemStack;
 
 import gregtech.api.enums.ItemList;
+import gregtech.api.util.GTUtility;
 import gtnhintergalactic.tile.multi.TileEntityDysonSwarm;
 import gtnhintergalactic.tile.multi.TileEntityPlanetaryGasSiphon;
 import gtnhintergalactic.tile.multi.elevator.TileEntitySpaceElevator;
@@ -26,7 +27,6 @@ import gtnhintergalactic.tile.multi.elevatormodules.TileEntityModuleManager;
 import gtnhintergalactic.tile.multi.elevatormodules.TileEntityModuleMiner;
 import gtnhintergalactic.tile.multi.elevatormodules.TileEntityModulePump;
 import gtnhintergalactic.tile.multi.elevatormodules.TileEntityModuleResearch;
-import micdoodle8.mods.galacticraft.core.util.GCCoreUtil;
 
 /**
  * Loader for all machines
@@ -46,85 +46,85 @@ public class MachineLoader implements Runnable {
         stack = new TileEntityPlanetaryGasSiphon(
             PlanetaryGasSiphonController.ID,
             "PlanetaryGasSiphon",
-            GCCoreUtil.translate("gt.blockmachines.multimachine.ig.siphon.name")).getStackForm(1);
+            GTUtility.translate("gt.blockmachines.multimachine.ig.siphon.name")).getStackForm(1);
         ItemList.PlanetaryGasSiphonController.set(stack);
 
         stack = new TileEntityDysonSwarm(
             DysonSwarmController.ID,
             "DysonSwarm",
-            GCCoreUtil.translate("gt.blockmachines.multimachine.ig.dyson.name")).getStackForm(1);
+            GTUtility.translate("gt.blockmachines.multimachine.ig.dyson.name")).getStackForm(1);
         ItemList.DysonSwarmController.set(stack);
 
         stack = new TileEntitySpaceElevator(
             SpaceElevatorController.ID,
             "SpaceElevator",
-            GCCoreUtil.translate("gt.blockmachines.multimachine.ig.elevator.name")).getStackForm(1);
+            GTUtility.translate("gt.blockmachines.multimachine.ig.elevator.name")).getStackForm(1);
         ItemList.SpaceElevatorController.set(stack);
 
         stack = new TileEntityModuleAssembler.TileEntityModuleAssemblerT1(
             SpaceElevatorModuleAssemblerT1.ID,
             "ProjectModuleAssemblerT1",
-            GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.assembler.t1.name")).getStackForm(1);
+            GTUtility.translate("gt.blockmachines.multimachine.project.ig.assembler.t1.name")).getStackForm(1);
         ItemList.SpaceElevatorModuleAssemblerT1.set(stack);
 
         stack = new TileEntityModuleAssembler.TileEntityModuleAssemblerT2(
             SpaceElevatorModuleAssemblerT2.ID,
             "ProjectModuleAssemblerT2",
-            GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.assembler.t2.name")).getStackForm(1);
+            GTUtility.translate("gt.blockmachines.multimachine.project.ig.assembler.t2.name")).getStackForm(1);
         ItemList.SpaceElevatorModuleAssemblerT2.set(stack);
 
         stack = new TileEntityModuleAssembler.TileEntityModuleAssemblerT3(
             SpaceElevatorModuleAssemblerT3.ID,
             "ProjectModuleAssemblerT3",
-            GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.assembler.t3.name")).getStackForm(1);
+            GTUtility.translate("gt.blockmachines.multimachine.project.ig.assembler.t3.name")).getStackForm(1);
         ItemList.SpaceElevatorModuleAssemblerT3.set(stack);
 
         stack = new TileEntityModuleMiner.TileEntityModuleMinerT1(
             SpaceElevatorModuleMinerT1.ID,
             "ProjectModuleMinerT1",
-            GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.miner.t1.name")).getStackForm(1);
+            GTUtility.translate("gt.blockmachines.multimachine.project.ig.miner.t1.name")).getStackForm(1);
         ItemList.SpaceElevatorModuleMinerT1.set(stack);
 
         stack = new TileEntityModuleMiner.TileEntityModuleMinerT2(
             SpaceElevatorModuleMinerT2.ID,
             "ProjectModuleMinerT2",
-            GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.miner.t2.name")).getStackForm(1);
+            GTUtility.translate("gt.blockmachines.multimachine.project.ig.miner.t2.name")).getStackForm(1);
         ItemList.SpaceElevatorModuleMinerT2.set(stack);
 
         stack = new TileEntityModuleMiner.TileEntityModuleMinerT3(
             SpaceElevatorModuleMinerT3.ID,
             "ProjectModuleMinerT3",
-            GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.miner.t3.name")).getStackForm(1);
+            GTUtility.translate("gt.blockmachines.multimachine.project.ig.miner.t3.name")).getStackForm(1);
         ItemList.SpaceElevatorModuleMinerT3.set(stack);
 
         stack = new TileEntityModulePump.TileEntityModulePumpT1(
             SpaceElevatorModulePumpT1.ID,
             "ProjectModulePumpT1",
-            GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.pump.t1.name")).getStackForm(1);
+            GTUtility.translate("gt.blockmachines.multimachine.project.ig.pump.t1.name")).getStackForm(1);
         ItemList.SpaceElevatorModulePumpT1.set(stack);
 
         stack = new TileEntityModulePump.TileEntityModulePumpT2(
             SpaceElevatorModulePumpT2.ID,
             "ProjectModulePumpT2",
-            GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.pump.t2.name")).getStackForm(1);
+            GTUtility.translate("gt.blockmachines.multimachine.project.ig.pump.t2.name")).getStackForm(1);
         ItemList.SpaceElevatorModulePumpT2.set(stack);
 
         stack = new TileEntityModulePump.TileEntityModulePumpT3(
             SpaceElevatorModulePumpT3.ID,
             "ProjectModulePumpT3",
-            GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.pump.t3.name")).getStackForm(1);
+            GTUtility.translate("gt.blockmachines.multimachine.project.ig.pump.t3.name")).getStackForm(1);
         ItemList.SpaceElevatorModulePumpT3.set(stack);
 
         stack = new TileEntityModuleManager(
             SpaceElevatorModuleManager.ID,
             "ProjectModuleManager",
-            GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.manager.t1.name")).getStackForm(1);
+            GTUtility.translate("gt.blockmachines.multimachine.project.ig.manager.t1.name")).getStackForm(1);
         ItemList.SpaceElevatorModuleManager.set(stack);
 
         stack = new TileEntityModuleResearch(
             SpaceElevatorModuleResearch.ID,
             "ProjectModuleResearch",
-            GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.research.t1.name")).getStackForm(1);
+            GTUtility.translate("gt.blockmachines.multimachine.project.ig.research.t1.name")).getStackForm(1);
         ItemList.SpaceElevatorModuleResearch.set(stack);
     }
 }

--- a/src/main/java/gtnhintergalactic/nei/GasSiphonRecipeHandler.java
+++ b/src/main/java/gtnhintergalactic/nei/GasSiphonRecipeHandler.java
@@ -216,7 +216,7 @@ public class GasSiphonRecipeHandler extends TemplateRecipeHandler {
             false);
 
         CachedSiphonRecipe recipe = (CachedSiphonRecipe) this.arecipes.get(recipeIndex);
-        GuiDraw.drawStringC(GCCoreUtil.translate(recipe.planet), CATEGORY_VALUE_X, PLANET_TYPE_Y, TEXT_COLOR, false);
+        GuiDraw.drawStringC(GTUtility.translate(recipe.planet), CATEGORY_VALUE_X, PLANET_TYPE_Y, TEXT_COLOR, false);
         GuiDraw.drawStringC(Integer.toString(recipe.depth), CATEGORY_VALUE_X, GAS_TYPE_Y, TEXT_COLOR, false);
         GuiDraw.drawStringC(GTUtility.formatNumbers(recipe.amount), CATEGORY_VALUE_X, OUT_AMOUNT_Y, TEXT_COLOR, false);
 

--- a/src/main/java/gtnhintergalactic/nei/GasSiphonRecipeHandler.java
+++ b/src/main/java/gtnhintergalactic/nei/GasSiphonRecipeHandler.java
@@ -25,7 +25,6 @@ import gregtech.api.gui.modularui.GTUITextures;
 import gregtech.api.util.GTUtility;
 import gtnhintergalactic.gui.IG_UITextures;
 import gtnhintergalactic.recipe.GasSiphonRecipes;
-import micdoodle8.mods.galacticraft.core.util.GCCoreUtil;
 
 /**
  * Recipe handler for the gas siphon recipes

--- a/src/main/java/gtnhintergalactic/proxy/ClientProxy.java
+++ b/src/main/java/gtnhintergalactic/proxy/ClientProxy.java
@@ -6,6 +6,7 @@ import cpw.mods.fml.client.registry.ClientRegistry;
 import cpw.mods.fml.client.registry.RenderingRegistry;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
+import gregtech.api.enums.Mods;
 import gtnhintergalactic.block.BlockSpaceElevatorCable;
 import gtnhintergalactic.client.IGTextures;
 import gtnhintergalactic.client.TooltipUtil;
@@ -29,10 +30,12 @@ public class ClientProxy extends CommonProxy {
     @Override
     public void init(FMLInitializationEvent event) {
         super.init(event);
-        BlockSpaceElevatorCable.setRenderID(RenderingRegistry.getNextAvailableRenderId());
-        RenderingRegistry.registerBlockHandler(BlockSpaceElevatorCable.getRenderID(), new RenderSpaceElevatorCable());
-        ClientRegistry
-            .bindTileEntitySpecialRenderer(TileEntitySpaceElevatorCable.class, new RenderSpaceElevatorCable());
+        if (Mods.GalacticraftCore.isModLoaded()) {
+            BlockSpaceElevatorCable.setRenderID(RenderingRegistry.getNextAvailableRenderId());
+            RenderingRegistry.registerBlockHandler(BlockSpaceElevatorCable.getRenderID(), new RenderSpaceElevatorCable());
+            ClientRegistry
+                .bindTileEntitySpecialRenderer(TileEntitySpaceElevatorCable.class, new RenderSpaceElevatorCable());
+        }
         new IGTextures().run();
         MinecraftForge.EVENT_BUS.register(new NEI_IG_Config());
     }

--- a/src/main/java/gtnhintergalactic/proxy/ClientProxy.java
+++ b/src/main/java/gtnhintergalactic/proxy/ClientProxy.java
@@ -32,7 +32,8 @@ public class ClientProxy extends CommonProxy {
         super.init(event);
         if (Mods.GalacticraftCore.isModLoaded()) {
             BlockSpaceElevatorCable.setRenderID(RenderingRegistry.getNextAvailableRenderId());
-            RenderingRegistry.registerBlockHandler(BlockSpaceElevatorCable.getRenderID(), new RenderSpaceElevatorCable());
+            RenderingRegistry
+                .registerBlockHandler(BlockSpaceElevatorCable.getRenderID(), new RenderSpaceElevatorCable());
             ClientRegistry
                 .bindTileEntitySpecialRenderer(TileEntitySpaceElevatorCable.class, new RenderSpaceElevatorCable());
         }

--- a/src/main/java/gtnhintergalactic/proxy/CommonProxy.java
+++ b/src/main/java/gtnhintergalactic/proxy/CommonProxy.java
@@ -80,7 +80,8 @@ public class CommonProxy {
     }
 
     // This is only used when GC isn't present.
-    // GTNHIntergalactic effectively has a hard dep on GC, but it's easier to just no-op its integration than disable the mod in the dev env somehow.
+    // GTNHIntergalactic effectively has a hard dep on GC, but it's easier to just no-op its integration than disable
+    // the mod in the dev env somehow.
     private static class BlockFakeSECable extends Block {
 
         public BlockFakeSECable() {

--- a/src/main/java/gtnhintergalactic/proxy/CommonProxy.java
+++ b/src/main/java/gtnhintergalactic/proxy/CommonProxy.java
@@ -1,19 +1,26 @@
 package gtnhintergalactic.proxy;
 
+import net.minecraft.block.Block;
+import net.minecraft.block.material.Material;
 import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.registry.GameRegistry;
 import gregtech.api.GregTechAPI;
+import gregtech.api.enums.ItemList;
+import gregtech.api.enums.Mods;
 import gregtech.api.enums.Textures;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.recipe.check.CheckRecipeResultRegistry;
+import gtnhintergalactic.GTNHIntergalactic;
 import gtnhintergalactic.block.BlockCasingDysonSwarm;
 import gtnhintergalactic.block.BlockCasingGasSiphon;
 import gtnhintergalactic.block.BlockCasingSpaceElevator;
 import gtnhintergalactic.block.BlockCasingSpaceElevatorMotor;
 import gtnhintergalactic.block.BlockSpaceElevatorCable;
+import gtnhintergalactic.item.ItemBlockSpaceElevatorCable;
 import gtnhintergalactic.item.ItemDysonSwarmParts;
 import gtnhintergalactic.item.ItemMiningDrones;
 import gtnhintergalactic.item.ItemSpaceElevatorParts;
@@ -43,7 +50,11 @@ public class CommonProxy {
         registerItem(new ItemDysonSwarmParts());
 
         // Blocks
-        GregTechAPI.sSpaceElevatorCable = new BlockSpaceElevatorCable();
+        if (Mods.GalacticraftCore.isModLoaded()) {
+            GregTechAPI.sSpaceElevatorCable = new BlockSpaceElevatorCable();
+        } else {
+            GregTechAPI.sSpaceElevatorCable = new BlockFakeSECable();
+        }
         GregTechAPI.sBlockCasingsSE = new BlockCasingSpaceElevator();
         GregTechAPI.sBlockCasingsSEMotor = new BlockCasingSpaceElevatorMotor();
         GregTechAPI.sBlockCasingsDyson = new BlockCasingDysonSwarm();
@@ -51,7 +62,9 @@ public class CommonProxy {
 
         new MachineLoader().run();
         IG_RecipeAdder.init();
-        GameRegistry.registerTileEntity(TileEntitySpaceElevatorCable.class, "Space Elevator Cable");
+        if (Mods.GalacticraftCore.isModLoaded()) {
+            GameRegistry.registerTileEntity(TileEntitySpaceElevatorCable.class, "Space Elevator Cable");
+        }
         CheckRecipeResultRegistry.register(new ResultNoSpaceProject("", ""));
     }
 
@@ -64,5 +77,21 @@ public class CommonProxy {
 
     private static void registerItem(final Item item) {
         GameRegistry.registerItem(item, item.getUnlocalizedName());
+    }
+
+    // This is only used when GC isn't present.
+    // GTNHIntergalactic effectively has a hard dep on GC, but it's easier to just no-op its integration than disable the mod in the dev env somehow.
+    private static class BlockFakeSECable extends Block {
+
+        public BlockFakeSECable() {
+            super(Material.iron);
+            setBlockName("SpaceElevatorCable");
+            setCreativeTab(GTNHIntergalactic.tab);
+            setHarvestLevel("pickaxe", 2);
+
+            GameRegistry.registerBlock(this, ItemBlockSpaceElevatorCable.class, "spaceelevatorcable");
+
+            ItemList.SpaceElevatorCable.set(new ItemStack(this));
+        }
     }
 }

--- a/src/main/java/gtnhintergalactic/recipe/maps/SpaceAssemblerFrontend.java
+++ b/src/main/java/gtnhintergalactic/recipe/maps/SpaceAssemblerFrontend.java
@@ -10,6 +10,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import com.gtnewhorizons.modularui.api.math.Pos2d;
 import com.gtnewhorizons.modularui.api.screen.ModularWindow;
 import com.gtnewhorizons.modularui.common.widget.ProgressBar;
+
 import gregtech.api.gui.modularui.GTUITextures;
 import gregtech.api.recipe.BasicUIPropertiesBuilder;
 import gregtech.api.recipe.NEIRecipePropertiesBuilder;

--- a/src/main/java/gtnhintergalactic/recipe/maps/SpaceAssemblerFrontend.java
+++ b/src/main/java/gtnhintergalactic/recipe/maps/SpaceAssemblerFrontend.java
@@ -10,18 +10,17 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import com.gtnewhorizons.modularui.api.math.Pos2d;
 import com.gtnewhorizons.modularui.api.screen.ModularWindow;
 import com.gtnewhorizons.modularui.common.widget.ProgressBar;
-
 import gregtech.api.gui.modularui.GTUITextures;
 import gregtech.api.recipe.BasicUIPropertiesBuilder;
 import gregtech.api.recipe.NEIRecipePropertiesBuilder;
 import gregtech.api.recipe.RecipeMapFrontend;
+import gregtech.api.util.GTUtility;
 import gregtech.api.util.MethodsReturnNonnullByDefault;
 import gregtech.common.gui.modularui.UIHelper;
 import gregtech.common.misc.spaceprojects.SpaceProjectManager;
 import gregtech.nei.RecipeDisplayInfo;
 import gregtech.nei.formatter.INEISpecialInfoFormatter;
 import gtnhintergalactic.recipe.IGRecipeMaps;
-import micdoodle8.mods.galacticraft.core.util.GCCoreUtil;
 
 @ParametersAreNonnullByDefault
 @MethodsReturnNonnullByDefault
@@ -76,22 +75,22 @@ public class SpaceAssemblerFrontend extends RecipeMapFrontend {
         public List<String> format(RecipeDisplayInfo recipeInfo) {
             List<String> specialInfo = new ArrayList<>();
             int recipeTier = recipeInfo.recipe.getMetadataOrDefault(IGRecipeMaps.MODULE_TIER, 1);
-            specialInfo.add(GCCoreUtil.translateWithFormat("ig.nei.module", recipeTier));
+            specialInfo.add(GTUtility.translate("ig.nei.module", recipeTier));
 
             String neededProject = recipeInfo.recipe.getMetadata(IGRecipeMaps.SPACE_PROJECT);
             String neededProjectLocation = recipeInfo.recipe.getMetadata(IGRecipeMaps.SPACE_LOCATION);
             if (neededProject != null && !neededProject.isEmpty()) {
                 specialInfo.add(
                     String.format(
-                        GCCoreUtil.translate("ig.nei.spaceassembler.project"),
+                        GTUtility.translate("ig.nei.spaceassembler.project"),
                         SpaceProjectManager.getProject(neededProject)
                             .getLocalizedName()));
                 specialInfo.add(
                     String.format(
-                        GCCoreUtil.translate("ig.nei.spaceassembler.projectAt"),
+                        GTUtility.translate("ig.nei.spaceassembler.projectAt"),
                         neededProjectLocation == null || neededProjectLocation.isEmpty()
-                            ? GCCoreUtil.translate("ig.nei.spaceassembler.projectAnyLocation")
-                            : GCCoreUtil.translate(
+                            ? GTUtility.translate("ig.nei.spaceassembler.projectAnyLocation")
+                            : GTUtility.translate(
                                 SpaceProjectManager.getLocation(neededProjectLocation)
                                     .getUnlocalizedName())));
             }

--- a/src/main/java/gtnhintergalactic/recipe/maps/SpaceMiningFrontend.java
+++ b/src/main/java/gtnhintergalactic/recipe/maps/SpaceMiningFrontend.java
@@ -17,7 +17,6 @@ import gregtech.nei.RecipeDisplayInfo;
 import gregtech.nei.formatter.INEISpecialInfoFormatter;
 import gtnhintergalactic.recipe.IGRecipeMaps;
 import gtnhintergalactic.recipe.SpaceMiningData;
-import micdoodle8.mods.galacticraft.core.util.GCCoreUtil;
 
 @ParametersAreNonnullByDefault
 @MethodsReturnNonnullByDefault
@@ -66,9 +65,7 @@ public class SpaceMiningFrontend extends RecipeMapFrontend {
                         + data.maxDistance);
                 result.add(GTUtility.translate("ig.nei.spacemining.size") + " " + data.minSize + "-" + data.maxSize);
                 result.add(
-                    GTUtility.translate(
-                        "tt.nei.research.min_computation",
-                        GTUtility.formatNumbers(data.computation)));
+                    GTUtility.translate("tt.nei.research.min_computation", GTUtility.formatNumbers(data.computation)));
                 result.add(GTUtility.translate("ig.nei.spacemining.weight") + " " + data.recipeWeight);
             }
             return result;

--- a/src/main/java/gtnhintergalactic/recipe/maps/SpaceMiningFrontend.java
+++ b/src/main/java/gtnhintergalactic/recipe/maps/SpaceMiningFrontend.java
@@ -55,21 +55,21 @@ public class SpaceMiningFrontend extends RecipeMapFrontend {
         public List<String> format(RecipeDisplayInfo recipeInfo) {
             List<String> result = new ArrayList<>();
             int recipeTier = recipeInfo.recipe.getMetadataOrDefault(IGRecipeMaps.MODULE_TIER, 1);
-            result.add(GCCoreUtil.translateWithFormat("ig.nei.module", recipeTier));
+            result.add(GTUtility.translate("ig.nei.module", recipeTier));
 
             SpaceMiningData data = recipeInfo.recipe.getMetadata(IGRecipeMaps.SPACE_MINING_DATA);
             if (data != null) {
                 result.add(
-                    GCCoreUtil.translate("ig.nei.spacemining.distance") + " "
+                    GTUtility.translate("ig.nei.spacemining.distance") + " "
                         + data.minDistance
                         + "-"
                         + data.maxDistance);
-                result.add(GCCoreUtil.translate("ig.nei.spacemining.size") + " " + data.minSize + "-" + data.maxSize);
+                result.add(GTUtility.translate("ig.nei.spacemining.size") + " " + data.minSize + "-" + data.maxSize);
                 result.add(
-                    GCCoreUtil.translateWithFormat(
+                    GTUtility.translate(
                         "tt.nei.research.min_computation",
                         GTUtility.formatNumbers(data.computation)));
-                result.add(GCCoreUtil.translate("ig.nei.spacemining.weight") + " " + data.recipeWeight);
+                result.add(GTUtility.translate("ig.nei.spacemining.weight") + " " + data.recipeWeight);
             }
             return result;
         }

--- a/src/main/java/gtnhintergalactic/recipe/maps/SpaceResearchFrontend.java
+++ b/src/main/java/gtnhintergalactic/recipe/maps/SpaceResearchFrontend.java
@@ -7,17 +7,16 @@ import java.util.List;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 import com.gtnewhorizons.modularui.api.math.Pos2d;
-
 import gregtech.api.recipe.BasicUIPropertiesBuilder;
 import gregtech.api.recipe.NEIRecipePropertiesBuilder;
 import gregtech.api.recipe.RecipeMapFrontend;
+import gregtech.api.util.GTUtility;
 import gregtech.api.util.MethodsReturnNonnullByDefault;
 import gregtech.common.gui.modularui.UIHelper;
 import gregtech.common.misc.spaceprojects.SpaceProjectManager;
 import gregtech.nei.RecipeDisplayInfo;
 import gregtech.nei.formatter.INEISpecialInfoFormatter;
 import gtnhintergalactic.recipe.IGRecipeMaps;
-import micdoodle8.mods.galacticraft.core.util.GCCoreUtil;
 
 @ParametersAreNonnullByDefault
 @MethodsReturnNonnullByDefault
@@ -59,22 +58,22 @@ public class SpaceResearchFrontend extends RecipeMapFrontend {
         public List<String> format(RecipeDisplayInfo recipeInfo) {
             List<String> specialInfo = new ArrayList<>();
             specialInfo.add(
-                GCCoreUtil.translateWithFormat("tt.nei.research.min_computation", recipeInfo.recipe.mSpecialValue));
+                GTUtility.translate("tt.nei.research.min_computation", recipeInfo.recipe.mSpecialValue));
 
             String neededProject = recipeInfo.recipe.getMetadata(IGRecipeMaps.SPACE_PROJECT);
             String neededProjectLocation = recipeInfo.recipe.getMetadata(IGRecipeMaps.SPACE_LOCATION);
             if (neededProject != null && !neededProject.isEmpty()) {
                 specialInfo.add(
                     String.format(
-                        GCCoreUtil.translate("ig.nei.spaceassembler.project"),
+                        GTUtility.translate("ig.nei.spaceassembler.project"),
                         SpaceProjectManager.getProject(neededProject)
                             .getLocalizedName()));
                 specialInfo.add(
                     String.format(
-                        GCCoreUtil.translate("ig.nei.spaceassembler.projectAt"),
+                        GTUtility.translate("ig.nei.spaceassembler.projectAt"),
                         neededProjectLocation == null || neededProjectLocation.isEmpty()
-                            ? GCCoreUtil.translate("ig.nei.spaceassembler.projectAnyLocation")
-                            : GCCoreUtil.translate(
+                            ? GTUtility.translate("ig.nei.spaceassembler.projectAnyLocation")
+                            : GTUtility.translate(
                                 SpaceProjectManager.getLocation(neededProjectLocation)
                                     .getUnlocalizedName())));
             }

--- a/src/main/java/gtnhintergalactic/recipe/maps/SpaceResearchFrontend.java
+++ b/src/main/java/gtnhintergalactic/recipe/maps/SpaceResearchFrontend.java
@@ -7,6 +7,7 @@ import java.util.List;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 import com.gtnewhorizons.modularui.api.math.Pos2d;
+
 import gregtech.api.recipe.BasicUIPropertiesBuilder;
 import gregtech.api.recipe.NEIRecipePropertiesBuilder;
 import gregtech.api.recipe.RecipeMapFrontend;
@@ -57,8 +58,7 @@ public class SpaceResearchFrontend extends RecipeMapFrontend {
         @Override
         public List<String> format(RecipeDisplayInfo recipeInfo) {
             List<String> specialInfo = new ArrayList<>();
-            specialInfo.add(
-                GTUtility.translate("tt.nei.research.min_computation", recipeInfo.recipe.mSpecialValue));
+            specialInfo.add(GTUtility.translate("tt.nei.research.min_computation", recipeInfo.recipe.mSpecialValue));
 
             String neededProject = recipeInfo.recipe.getMetadata(IGRecipeMaps.SPACE_PROJECT);
             String neededProjectLocation = recipeInfo.recipe.getMetadata(IGRecipeMaps.SPACE_LOCATION);

--- a/src/main/java/gtnhintergalactic/tile/multi/TileEntityPlanetaryGasSiphon.java
+++ b/src/main/java/gtnhintergalactic/tile/multi/TileEntityPlanetaryGasSiphon.java
@@ -57,7 +57,6 @@ import gtnhintergalactic.client.IGTextures;
 import gtnhintergalactic.client.TooltipUtil;
 import gtnhintergalactic.recipe.GasSiphonRecipes;
 import micdoodle8.mods.galacticraft.api.world.IOrbitDimension;
-import micdoodle8.mods.galacticraft.core.util.GCCoreUtil;
 
 /**
  * Gas Siphon, used to extract gas from gas planets, when placed on a space station in their orbit

--- a/src/main/java/gtnhintergalactic/tile/multi/TileEntityPlanetaryGasSiphon.java
+++ b/src/main/java/gtnhintergalactic/tile/multi/TileEntityPlanetaryGasSiphon.java
@@ -163,28 +163,28 @@ public class TileEntityPlanetaryGasSiphon extends MTEEnhancedMultiBlockBase<Tile
     @Override
     protected MultiblockTooltipBuilder createTooltip() {
         final MultiblockTooltipBuilder tt = new MultiblockTooltipBuilder();
-        tt.addMachineType(GCCoreUtil.translate("gt.blockmachines.multimachine.ig.siphon.type"));
+        tt.addMachineType(GTUtility.translate("gt.blockmachines.multimachine.ig.siphon.type"));
         if (TooltipUtil.siphonLoreText != null) tt.addInfo(ITALIC + TooltipUtil.siphonLoreText);
-        tt.addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.ig.siphon.desc1"))
-            .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.ig.siphon.desc2"))
-            .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.ig.siphon.desc3"))
-            .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.ig.siphon.desc4"))
-            .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.ig.siphon.desc5"))
+        tt.addInfo(GTUtility.translate("gt.blockmachines.multimachine.ig.siphon.desc1"))
+            .addInfo(GTUtility.translate("gt.blockmachines.multimachine.ig.siphon.desc2"))
+            .addInfo(GTUtility.translate("gt.blockmachines.multimachine.ig.siphon.desc3"))
+            .addInfo(GTUtility.translate("gt.blockmachines.multimachine.ig.siphon.desc4"))
+            .addInfo(GTUtility.translate("gt.blockmachines.multimachine.ig.siphon.desc5"))
             .beginStructureBlock(3, 7, 3, false)
-            .addController(GCCoreUtil.translate("ig.siphon.structure.ControllerPos"))
+            .addController(GTUtility.translate("ig.siphon.structure.ControllerPos"))
             .addOtherStructurePart(
-                GCCoreUtil.translate("ig.siphon.structure.SiphonCasing"),
-                GCCoreUtil.translate("ig.siphon.structure.Base"))
+                GTUtility.translate("ig.siphon.structure.SiphonCasing"),
+                GTUtility.translate("ig.siphon.structure.Base"))
             .addOtherStructurePart(
-                GCCoreUtil.translate("ig.siphon.structure.ReboltedRhodiumPalladiumCasing"),
-                GCCoreUtil.translate("ig.siphon.structure.PillarMiddle"))
+                GTUtility.translate("ig.siphon.structure.ReboltedRhodiumPalladiumCasing"),
+                GTUtility.translate("ig.siphon.structure.PillarMiddle"))
             .addOtherStructurePart(
-                GCCoreUtil.translate("ig.siphon.structure.FrameTungstensteel"),
-                GCCoreUtil.translate("ig.siphon.structure.Sides"))
-            .addEnergyHatch(GCCoreUtil.translate("ig.siphon.structure.AnySiphonCasing"), 1)
-            .addMaintenanceHatch(GCCoreUtil.translate("ig.siphon.structure.AnySiphonCasing"), 1)
-            .addInputBus(GCCoreUtil.translate("ig.siphon.structure.AnySiphonCasing"), 1)
-            .addOutputHatch(GCCoreUtil.translate("ig.siphon.structure.AnySiphonCasing"), 1)
+                GTUtility.translate("ig.siphon.structure.FrameTungstensteel"),
+                GTUtility.translate("ig.siphon.structure.Sides"))
+            .addEnergyHatch(GTUtility.translate("ig.siphon.structure.AnySiphonCasing"), 1)
+            .addMaintenanceHatch(GTUtility.translate("ig.siphon.structure.AnySiphonCasing"), 1)
+            .addInputBus(GTUtility.translate("ig.siphon.structure.AnySiphonCasing"), 1)
+            .addOutputHatch(GTUtility.translate("ig.siphon.structure.AnySiphonCasing"), 1)
             .toolTipFinisher();
         return tt;
     }

--- a/src/main/java/gtnhintergalactic/tile/multi/elevator/TileEntitySpaceElevator.java
+++ b/src/main/java/gtnhintergalactic/tile/multi/elevator/TileEntitySpaceElevator.java
@@ -43,6 +43,7 @@ import com.gtnewhorizons.modularui.common.widget.DynamicPositionedColumn;
 import com.gtnewhorizons.modularui.common.widget.FakeSyncWidget;
 import com.gtnewhorizons.modularui.common.widget.SlotWidget;
 import com.gtnewhorizons.modularui.common.widget.TextWidget;
+
 import cpw.mods.fml.common.Optional;
 import gregtech.api.GregTechAPI;
 import gregtech.api.enums.GTValues;

--- a/src/main/java/gtnhintergalactic/tile/multi/elevator/TileEntitySpaceElevator.java
+++ b/src/main/java/gtnhintergalactic/tile/multi/elevator/TileEntitySpaceElevator.java
@@ -792,7 +792,7 @@ public class TileEntitySpaceElevator extends TTMultiblockBase implements ISurviv
                 .setTooltipShowUpDelay(TOOLTIP_DELAY));
 
         if (Mods.GalacticraftCore.isModLoaded()) {
-            addTeleportationMethod(builder);
+            addTeleportationButton(builder);
         }
 
         // Open contributor window button
@@ -847,7 +847,7 @@ public class TileEntitySpaceElevator extends TTMultiblockBase implements ISurviv
     }
 
     @Optional.Method(modid = Mods.ModIDs.GALACTICRAFT_CORE)
-    private void addTeleportationMethod(ModularWindow.Builder builder) {
+    private void addTeleportationButton(ModularWindow.Builder builder) {
         // Teleportation button
         builder.widget(new ButtonWidget().setOnClick((clickData, widget) -> {
             if (!widget.getContext()

--- a/src/main/java/gtnhintergalactic/tile/multi/elevator/TileEntitySpaceElevator.java
+++ b/src/main/java/gtnhintergalactic/tile/multi/elevator/TileEntitySpaceElevator.java
@@ -67,7 +67,6 @@ import gtnhintergalactic.tile.TileEntitySpaceElevatorCable;
 import gtnhintergalactic.tile.multi.elevatormodules.TileEntityModuleBase;
 import micdoodle8.mods.galacticraft.core.client.gui.screen.GuiCelestialSelection;
 import micdoodle8.mods.galacticraft.core.entities.player.GCPlayerStats;
-import micdoodle8.mods.galacticraft.core.util.GCCoreUtil;
 import micdoodle8.mods.galacticraft.core.util.WorldUtil;
 import tectech.thing.gui.TecTechUITextures;
 import tectech.thing.metaTileEntity.multi.base.TTMultiblockBase;
@@ -643,29 +642,29 @@ public class TileEntitySpaceElevator extends TTMultiblockBase implements ISurviv
     @Override
     protected MultiblockTooltipBuilder createTooltip() {
         final MultiblockTooltipBuilder tt = new MultiblockTooltipBuilder();
-        tt.addMachineType(GCCoreUtil.translate("gt.blockmachines.multimachine.ig.elevator.name"));
+        tt.addMachineType(GTUtility.translate("gt.blockmachines.multimachine.ig.elevator.name"));
         if (TooltipUtil.elevatorLoreText != null) tt.addInfo(ITALIC + TooltipUtil.elevatorLoreText);
-        tt.addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.ig.elevator.desc2"))
-            .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.ig.elevator.desc3"))
-            .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.ig.elevator.desc4"))
-            .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.ig.elevator.desc5"))
-            .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.ig.elevator.desc6"))
-            .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.ig.elevator.desc7"))
-            .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.ig.elevator.desc8"))
+        tt.addInfo(GTUtility.translate("gt.blockmachines.multimachine.ig.elevator.desc2"))
+            .addInfo(GTUtility.translate("gt.blockmachines.multimachine.ig.elevator.desc3"))
+            .addInfo(GTUtility.translate("gt.blockmachines.multimachine.ig.elevator.desc4"))
+            .addInfo(GTUtility.translate("gt.blockmachines.multimachine.ig.elevator.desc5"))
+            .addInfo(GTUtility.translate("gt.blockmachines.multimachine.ig.elevator.desc6"))
+            .addInfo(GTUtility.translate("gt.blockmachines.multimachine.ig.elevator.desc7"))
+            .addInfo(GTUtility.translate("gt.blockmachines.multimachine.ig.elevator.desc8"))
             .addTecTechHatchInfo()
             .beginStructureBlock(35, 43, 35, false)
             .addOtherStructurePart(
-                GCCoreUtil.translate("ig.elevator.structure.ProjectModule"),
-                GCCoreUtil.translate("ig.elevator.structure.AnyBaseCasingWith2Dot"),
+                GTUtility.translate("ig.elevator.structure.ProjectModule"),
+                GTUtility.translate("ig.elevator.structure.AnyBaseCasingWith2Dot"),
                 2)
-            .addCasingInfoExactly(GCCoreUtil.translate("tile.DysonSwarmFloor.name"), 800, false)
-            .addCasingInfoRange(GCCoreUtil.translate("gt.blockcasings.ig.0.name"), 593, 785, false)
-            .addCasingInfoExactly(GCCoreUtil.translate("gt.blockcasings.ig.1.name"), 620, false)
-            .addCasingInfoExactly(GCCoreUtil.translate("gt.blockcasings.ig.2.name"), 360, false)
-            .addCasingInfoExactly(GCCoreUtil.translate("gt.blockcasings.ig.cable.name"), 1, false)
-            .addCasingInfoExactly(GCCoreUtil.translate("ig.elevator.structure.FrameNeutronium"), 56, false)
-            .addCasingInfoExactly(GCCoreUtil.translate("ig.elevator.structure.Motor"), 88, true)
-            .addEnergyHatch(GCCoreUtil.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
+            .addCasingInfoExactly(GTUtility.translate("tile.DysonSwarmFloor.name"), 800, false)
+            .addCasingInfoRange(GTUtility.translate("gt.blockcasings.ig.0.name"), 593, 785, false)
+            .addCasingInfoExactly(GTUtility.translate("gt.blockcasings.ig.1.name"), 620, false)
+            .addCasingInfoExactly(GTUtility.translate("gt.blockcasings.ig.2.name"), 360, false)
+            .addCasingInfoExactly(GTUtility.translate("gt.blockcasings.ig.cable.name"), 1, false)
+            .addCasingInfoExactly(GTUtility.translate("ig.elevator.structure.FrameNeutronium"), 56, false)
+            .addCasingInfoExactly(GTUtility.translate("ig.elevator.structure.Motor"), 88, true)
+            .addEnergyHatch(GTUtility.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
             .toolTipFinisher(GTValues.Authorminecraft7771);
         return tt;
     }

--- a/src/main/java/gtnhintergalactic/tile/multi/elevator/TileEntitySpaceElevator.java
+++ b/src/main/java/gtnhintergalactic/tile/multi/elevator/TileEntitySpaceElevator.java
@@ -43,10 +43,11 @@ import com.gtnewhorizons.modularui.common.widget.DynamicPositionedColumn;
 import com.gtnewhorizons.modularui.common.widget.FakeSyncWidget;
 import com.gtnewhorizons.modularui.common.widget.SlotWidget;
 import com.gtnewhorizons.modularui.common.widget.TextWidget;
-
+import cpw.mods.fml.common.Optional;
 import gregtech.api.GregTechAPI;
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.Materials;
+import gregtech.api.enums.Mods;
 import gregtech.api.enums.SoundResource;
 import gregtech.api.enums.Textures;
 import gregtech.api.interfaces.INEIPreviewModifier;
@@ -789,41 +790,9 @@ public class TileEntitySpaceElevator extends TTMultiblockBase implements ISurviv
                 .addTooltip(StatCollector.translateToLocal("ig.button.extension"))
                 .setTooltipShowUpDelay(TOOLTIP_DELAY));
 
-        // Teleportation button
-        builder.widget(new ButtonWidget().setOnClick((clickData, widget) -> {
-            if (!widget.getContext()
-                .isClient()) {
-                if (getBaseMetaTileEntity().isAllowedToWork() && motorTier > 0) {
-                    EntityPlayer player = widget.getContext()
-                        .getPlayer();
-                    if (player instanceof EntityPlayerMP playerBase) {
-                        final GCPlayerStats stats = GCPlayerStats.get(playerBase);
-                        stats.coordsTeleportedFromX = playerBase.posX;
-                        stats.coordsTeleportedFromZ = playerBase.posZ;
-                        try {
-                            WorldUtil.toCelestialSelection(
-                                playerBase,
-                                stats,
-                                ElevatorUtil.getPlanetaryTravelTier(motorTier),
-                                GuiCelestialSelection.MapMode.TELEPORTATION);
-                        } catch (final Exception e) {
-                            e.printStackTrace();
-                        }
-                    }
-                }
-            }
-        })
-            .setPlayClickSound(false)
-            .setBackground(() -> {
-                List<UITexture> ret = new ArrayList<>();
-                ret.add(TecTechUITextures.BUTTON_STANDARD_16x16);
-                ret.add(IG_UITextures.OVERLAY_BUTTON_PLANET_TELEPORT);
-                return ret.toArray(new IDrawable[0]);
-            })
-            .setPos(174, doesBindPlayerInventory() ? 132 : 156)
-            .setSize(16, 16)
-            .addTooltip(GCCoreUtil.translate("ig.button.travel"))
-            .setTooltipShowUpDelay(TOOLTIP_DELAY));
+        if (Mods.GalacticraftCore.isModLoaded()) {
+            addTeleportationMethod(builder);
+        }
 
         // Open contributor window button
         builder.widget(new ButtonWidget().setOnClick((clickData, widget) -> {
@@ -874,6 +843,45 @@ public class TileEntitySpaceElevator extends TTMultiblockBase implements ISurviv
                 .widget(texts)
                 .build();
         });
+    }
+
+    @Optional.Method(modid = Mods.ModIDs.GALACTICRAFT_CORE)
+    private void addTeleportationMethod(ModularWindow.Builder builder) {
+        // Teleportation button
+        builder.widget(new ButtonWidget().setOnClick((clickData, widget) -> {
+            if (!widget.getContext()
+                .isClient()) {
+                if (getBaseMetaTileEntity().isAllowedToWork() && motorTier > 0) {
+                    EntityPlayer player = widget.getContext()
+                        .getPlayer();
+                    if (player instanceof EntityPlayerMP playerBase) {
+                        final GCPlayerStats stats = GCPlayerStats.get(playerBase);
+                        stats.coordsTeleportedFromX = playerBase.posX;
+                        stats.coordsTeleportedFromZ = playerBase.posZ;
+                        try {
+                            WorldUtil.toCelestialSelection(
+                                playerBase,
+                                stats,
+                                ElevatorUtil.getPlanetaryTravelTier(motorTier),
+                                GuiCelestialSelection.MapMode.TELEPORTATION);
+                        } catch (final Exception e) {
+                            e.printStackTrace();
+                        }
+                    }
+                }
+            }
+        })
+            .setPlayClickSound(false)
+            .setBackground(() -> {
+                List<UITexture> ret = new ArrayList<>();
+                ret.add(TecTechUITextures.BUTTON_STANDARD_16x16);
+                ret.add(IG_UITextures.OVERLAY_BUTTON_PLANET_TELEPORT);
+                return ret.toArray(new IDrawable[0]);
+            })
+            .setPos(174, doesBindPlayerInventory() ? 132 : 156)
+            .setSize(16, 16)
+            .addTooltip(GTUtility.translate("ig.button.travel"))
+            .setTooltipShowUpDelay(TOOLTIP_DELAY));
     }
 
     /**

--- a/src/main/java/gtnhintergalactic/tile/multi/elevatormodules/TileEntityModuleAssembler.java
+++ b/src/main/java/gtnhintergalactic/tile/multi/elevatormodules/TileEntityModuleAssembler.java
@@ -21,6 +21,7 @@ import gregtech.api.recipe.RecipeMap;
 import gregtech.api.recipe.check.CheckRecipeResult;
 import gregtech.api.recipe.check.CheckRecipeResultRegistry;
 import gregtech.api.util.GTRecipe;
+import gregtech.api.util.GTUtility;
 import gregtech.api.util.MultiblockTooltipBuilder;
 import gtnhintergalactic.recipe.IGRecipeMaps;
 import gtnhintergalactic.recipe.ResultNoSpaceProject;
@@ -262,18 +263,18 @@ public abstract class TileEntityModuleAssembler extends TileEntityModuleBase imp
         @Override
         protected MultiblockTooltipBuilder createTooltip() {
             final MultiblockTooltipBuilder tt = new MultiblockTooltipBuilder();
-            tt.addMachineType(GCCoreUtil.translate("gt.blockmachines.module.name"))
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.assembler.desc0"))
+            tt.addMachineType(GTUtility.translate("gt.blockmachines.module.name"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.assembler.desc0"))
                 .addInfo(
                     EnumChatFormatting.LIGHT_PURPLE.toString() + EnumChatFormatting.BOLD
-                        + GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.assembler.t1.desc1"))
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.assembler.t1.desc2"))
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.motorT1"))
+                        + GTUtility.translate("gt.blockmachines.multimachine.project.ig.assembler.t1.desc1"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.assembler.t1.desc2"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.motorT1"))
                 .beginStructureBlock(1, 5, 2, false)
-                .addCasingInfoMin(GCCoreUtil.translate("gt.blockcasings.ig.0.name"), 0, false)
-                .addInputBus(GCCoreUtil.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
-                .addOutputBus(GCCoreUtil.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
-                .addInputHatch(GCCoreUtil.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
+                .addCasingInfoMin(GTUtility.translate("gt.blockcasings.ig.0.name"), 0, false)
+                .addInputBus(GTUtility.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
+                .addOutputBus(GTUtility.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
+                .addInputHatch(GTUtility.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
                 .toolTipFinisher();
             return tt;
         }
@@ -339,18 +340,18 @@ public abstract class TileEntityModuleAssembler extends TileEntityModuleBase imp
         @Override
         protected MultiblockTooltipBuilder createTooltip() {
             final MultiblockTooltipBuilder tt = new MultiblockTooltipBuilder();
-            tt.addMachineType(GCCoreUtil.translate("gt.blockmachines.module.name"))
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.assembler.desc0"))
+            tt.addMachineType(GTUtility.translate("gt.blockmachines.module.name"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.assembler.desc0"))
                 .addInfo(
                     EnumChatFormatting.LIGHT_PURPLE.toString() + EnumChatFormatting.BOLD
-                        + GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.assembler.t2.desc1"))
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.assembler.t2.desc2"))
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.motorT3"))
+                        + GTUtility.translate("gt.blockmachines.multimachine.project.ig.assembler.t2.desc1"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.assembler.t2.desc2"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.motorT3"))
                 .beginStructureBlock(1, 5, 2, false)
-                .addCasingInfoRange(GCCoreUtil.translate("gt.blockcasings.ig.0.name"), 0, 9, false)
-                .addInputBus(GCCoreUtil.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
-                .addOutputBus(GCCoreUtil.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
-                .addInputHatch(GCCoreUtil.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
+                .addCasingInfoRange(GTUtility.translate("gt.blockcasings.ig.0.name"), 0, 9, false)
+                .addInputBus(GTUtility.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
+                .addOutputBus(GTUtility.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
+                .addInputHatch(GTUtility.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
                 .toolTipFinisher();
             return tt;
         }
@@ -416,18 +417,18 @@ public abstract class TileEntityModuleAssembler extends TileEntityModuleBase imp
         @Override
         protected MultiblockTooltipBuilder createTooltip() {
             final MultiblockTooltipBuilder tt = new MultiblockTooltipBuilder();
-            tt.addMachineType(GCCoreUtil.translate("gt.blockmachines.module.name"))
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.assembler.desc0"))
+            tt.addMachineType(GTUtility.translate("gt.blockmachines.module.name"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.assembler.desc0"))
                 .addInfo(
                     EnumChatFormatting.LIGHT_PURPLE.toString() + EnumChatFormatting.BOLD
-                        + GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.assembler.t3.desc1"))
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.assembler.t3.desc2"))
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.motorT5"))
+                        + GTUtility.translate("gt.blockmachines.multimachine.project.ig.assembler.t3.desc1"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.assembler.t3.desc2"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.motorT5"))
                 .beginStructureBlock(1, 5, 2, false)
-                .addCasingInfoMin(GCCoreUtil.translate("gt.blockcasings.ig.0.name"), 0, false)
-                .addInputBus(GCCoreUtil.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
-                .addOutputBus(GCCoreUtil.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
-                .addInputHatch(GCCoreUtil.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
+                .addCasingInfoMin(GTUtility.translate("gt.blockcasings.ig.0.name"), 0, false)
+                .addInputBus(GTUtility.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
+                .addOutputBus(GTUtility.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
+                .addInputHatch(GTUtility.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
                 .toolTipFinisher();
             return tt;
         }

--- a/src/main/java/gtnhintergalactic/tile/multi/elevatormodules/TileEntityModuleManager.java
+++ b/src/main/java/gtnhintergalactic/tile/multi/elevatormodules/TileEntityModuleManager.java
@@ -36,7 +36,6 @@ import com.gtnewhorizons.modularui.common.widget.FakeSyncWidget;
 import com.gtnewhorizons.modularui.common.widget.MultiChildWidget;
 import com.gtnewhorizons.modularui.common.widget.Scrollable;
 import com.gtnewhorizons.modularui.common.widget.TextWidget;
-
 import gregtech.api.enums.GTValues;
 import gregtech.api.gui.modularui.GTUITextures;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
@@ -47,13 +46,13 @@ import gregtech.api.recipe.check.CheckRecipeResult;
 import gregtech.api.recipe.check.CheckRecipeResultRegistry;
 import gregtech.api.recipe.check.SimpleCheckRecipeResult;
 import gregtech.api.util.GTRecipe;
+import gregtech.api.util.GTUtility;
 import gregtech.api.util.MultiblockTooltipBuilder;
 import gregtech.common.misc.spaceprojects.SpaceProjectManager;
 import gregtech.common.misc.spaceprojects.SpaceProjectWorldSavedData;
 import gregtech.common.misc.spaceprojects.interfaces.ISpaceBody;
 import gregtech.common.misc.spaceprojects.interfaces.ISpaceProject;
 import gtnhintergalactic.gui.IG_UITextures;
-import micdoodle8.mods.galacticraft.core.util.GCCoreUtil;
 import tectech.thing.gui.TecTechUITextures;
 
 /**
@@ -120,19 +119,19 @@ public class TileEntityModuleManager extends TileEntityModuleBase {
     @Override
     protected MultiblockTooltipBuilder createTooltip() {
         final MultiblockTooltipBuilder tt = new MultiblockTooltipBuilder();
-        tt.addMachineType(GCCoreUtil.translate("gt.blockmachines.module.name"))
-            .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.manager.desc0"))
+        tt.addMachineType(GTUtility.translate("gt.blockmachines.module.name"))
+            .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.manager.desc0"))
             .addInfo(
                 EnumChatFormatting.LIGHT_PURPLE.toString() + EnumChatFormatting.BOLD
-                    + GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.manager.desc1"))
-            .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.desc2"))
-            .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.motorT1"))
+                    + GTUtility.translate("gt.blockmachines.multimachine.project.ig.manager.desc1"))
+            .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.desc2"))
+            .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.motorT1"))
             .beginStructureBlock(1, 5, 2, false)
-            .addCasingInfoRange(GCCoreUtil.translate("gt.blockcasings.ig.0.name"), 0, 9, false)
-            .addInputBus(GCCoreUtil.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
-            .addOutputBus(GCCoreUtil.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
-            .addInputHatch(GCCoreUtil.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
-            .addOutputHatch(GCCoreUtil.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
+            .addCasingInfoRange(GTUtility.translate("gt.blockcasings.ig.0.name"), 0, 9, false)
+            .addInputBus(GTUtility.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
+            .addOutputBus(GTUtility.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
+            .addInputHatch(GTUtility.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
+            .addOutputHatch(GTUtility.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
             .toolTipFinisher();
         return tt;
     }
@@ -345,7 +344,7 @@ public class TileEntityModuleManager extends TileEntityModuleBase {
             })
             .setPos(174, doesBindPlayerInventory() ? 132 : 156)
             .setSize(16, 16);
-        button.addTooltip(GCCoreUtil.translate("ig.button.projects"))
+        button.addTooltip(GTUtility.translate("ig.button.projects"))
             .setTooltipShowUpDelay(TOOLTIP_DELAY);
         return (ButtonWidget) button;
     }

--- a/src/main/java/gtnhintergalactic/tile/multi/elevatormodules/TileEntityModuleManager.java
+++ b/src/main/java/gtnhintergalactic/tile/multi/elevatormodules/TileEntityModuleManager.java
@@ -36,6 +36,7 @@ import com.gtnewhorizons.modularui.common.widget.FakeSyncWidget;
 import com.gtnewhorizons.modularui.common.widget.MultiChildWidget;
 import com.gtnewhorizons.modularui.common.widget.Scrollable;
 import com.gtnewhorizons.modularui.common.widget.TextWidget;
+
 import gregtech.api.enums.GTValues;
 import gregtech.api.gui.modularui.GTUITextures;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;

--- a/src/main/java/gtnhintergalactic/tile/multi/elevatormodules/TileEntityModuleMiner.java
+++ b/src/main/java/gtnhintergalactic/tile/multi/elevatormodules/TileEntityModuleMiner.java
@@ -1075,35 +1075,35 @@ public abstract class TileEntityModuleMiner extends TileEntityModuleBase impleme
         @Override
         protected MultiblockTooltipBuilder createTooltip() {
             final MultiblockTooltipBuilder tt = new MultiblockTooltipBuilder();
-            tt.addMachineType(GCCoreUtil.translate("gt.blockmachines.module.name"))
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.miner.desc0")) // Module
+            tt.addMachineType(GTUtility.translate("gt.blockmachines.module.name"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.miner.desc0")) // Module
                                                                                                        // that
                 // adds Space
                 // Mining
                 // Operations to the
                 .addInfo(
                     EnumChatFormatting.LIGHT_PURPLE.toString() + EnumChatFormatting.BOLD
-                        + GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.miner.t1.desc1")) // Does
+                        + GTUtility.translate("gt.blockmachines.multimachine.project.ig.miner.t1.desc1")) // Does
                 // this
                 // violate
                 // drone rights?
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.desc2"))
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.miner.desc3"))
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.miner.desc4"))
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.miner.desc5"))
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.miner.desc5.1"))
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.miner.desc5.2"))
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.miner.t1.desc5"))
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.motorT1"))
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.miner.desc6"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.desc2"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.miner.desc3"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.miner.desc4"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.miner.desc5"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.miner.desc5.1"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.miner.desc5.2"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.miner.t1.desc5"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.motorT1"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.miner.desc6"))
                 .beginStructureBlock(1, 5, 2, false)
-                .addCasingInfoRange(GCCoreUtil.translate("gt.blockcasings.ig.0.name"), 0, 9, false)
-                .addInputBus(GCCoreUtil.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
-                .addOutputBus(GCCoreUtil.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
-                .addInputHatch(GCCoreUtil.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
+                .addCasingInfoRange(GTUtility.translate("gt.blockcasings.ig.0.name"), 0, 9, false)
+                .addInputBus(GTUtility.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
+                .addOutputBus(GTUtility.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
+                .addInputHatch(GTUtility.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
                 .addOtherStructurePart(
-                    GCCoreUtil.translate("ig.elevator.structure.OpticalConnector"),
-                    GCCoreUtil.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"),
+                    GTUtility.translate("ig.elevator.structure.OpticalConnector"),
+                    GTUtility.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"),
                     1)
                 .toolTipFinisher();
             return tt;
@@ -1174,35 +1174,35 @@ public abstract class TileEntityModuleMiner extends TileEntityModuleBase impleme
         @Override
         protected MultiblockTooltipBuilder createTooltip() {
             final MultiblockTooltipBuilder tt = new MultiblockTooltipBuilder();
-            tt.addMachineType(GCCoreUtil.translate("gt.blockmachines.module.name"))
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.miner.desc0")) // Module
+            tt.addMachineType(GTUtility.translate("gt.blockmachines.module.name"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.miner.desc0")) // Module
                                                                                                        // that
                 // adds Space
                 // Mining
                 // Operations to the
                 .addInfo(
                     EnumChatFormatting.LIGHT_PURPLE.toString() + EnumChatFormatting.BOLD
-                        + GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.miner.t2.desc1")) // This
+                        + GTUtility.translate("gt.blockmachines.multimachine.project.ig.miner.t2.desc1")) // This
                 // definitely
                 // violates
                 // drone rights.
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.desc2"))
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.miner.desc3"))
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.miner.desc4"))
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.miner.desc5"))
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.miner.desc5.1"))
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.miner.desc5.2"))
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.miner.t2.desc5"))
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.motorT2"))
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.miner.desc6"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.desc2"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.miner.desc3"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.miner.desc4"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.miner.desc5"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.miner.desc5.1"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.miner.desc5.2"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.miner.t2.desc5"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.motorT2"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.miner.desc6"))
                 .beginStructureBlock(1, 5, 2, false)
-                .addCasingInfoRange(GCCoreUtil.translate("gt.blockcasings.ig.0.name"), 0, 9, false)
-                .addInputBus(GCCoreUtil.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
-                .addOutputBus(GCCoreUtil.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
-                .addInputHatch(GCCoreUtil.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
+                .addCasingInfoRange(GTUtility.translate("gt.blockcasings.ig.0.name"), 0, 9, false)
+                .addInputBus(GTUtility.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
+                .addOutputBus(GTUtility.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
+                .addInputHatch(GTUtility.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
                 .addOtherStructurePart(
-                    GCCoreUtil.translate("ig.elevator.structure.OpticalConnector"),
-                    GCCoreUtil.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"),
+                    GTUtility.translate("ig.elevator.structure.OpticalConnector"),
+                    GTUtility.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"),
                     1)
                 .toolTipFinisher();
             return tt;
@@ -1273,35 +1273,35 @@ public abstract class TileEntityModuleMiner extends TileEntityModuleBase impleme
         @Override
         protected MultiblockTooltipBuilder createTooltip() {
             final MultiblockTooltipBuilder tt = new MultiblockTooltipBuilder();
-            tt.addMachineType(GCCoreUtil.translate("gt.blockmachines.module.name"))
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.miner.desc0")) // Module
+            tt.addMachineType(GTUtility.translate("gt.blockmachines.module.name"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.miner.desc0")) // Module
                                                                                                        // that
                 // adds Space
                 // Mining
                 // Operations to the
                 .addInfo(
                     EnumChatFormatting.LIGHT_PURPLE.toString() + EnumChatFormatting.BOLD
-                        + GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.miner.t3.desc1")) // Great
+                        + GTUtility.translate("gt.blockmachines.multimachine.project.ig.miner.t3.desc1")) // Great
                 // treasures
                 // beyond
                 // your imagination await!
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.desc2"))
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.miner.desc3"))
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.miner.desc4"))
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.miner.desc5"))
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.miner.desc5.1"))
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.miner.desc5.2"))
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.miner.t3.desc5"))
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.motorT3"))
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.miner.desc6"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.desc2"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.miner.desc3"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.miner.desc4"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.miner.desc5"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.miner.desc5.1"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.miner.desc5.2"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.miner.t3.desc5"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.motorT3"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.miner.desc6"))
                 .beginStructureBlock(1, 5, 2, false)
-                .addCasingInfoRange(GCCoreUtil.translate("gt.blockcasings.ig.0.name"), 0, 9, false)
-                .addInputBus(GCCoreUtil.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
-                .addOutputBus(GCCoreUtil.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
-                .addInputHatch(GCCoreUtil.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
+                .addCasingInfoRange(GTUtility.translate("gt.blockcasings.ig.0.name"), 0, 9, false)
+                .addInputBus(GTUtility.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
+                .addOutputBus(GTUtility.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
+                .addInputHatch(GTUtility.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
                 .addOtherStructurePart(
-                    GCCoreUtil.translate("ig.elevator.structure.OpticalConnector"),
-                    GCCoreUtil.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"),
+                    GTUtility.translate("ig.elevator.structure.OpticalConnector"),
+                    GTUtility.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"),
                     1)
                 .toolTipFinisher();
             return tt;

--- a/src/main/java/gtnhintergalactic/tile/multi/elevatormodules/TileEntityModuleMiner.java
+++ b/src/main/java/gtnhintergalactic/tile/multi/elevatormodules/TileEntityModuleMiner.java
@@ -1077,7 +1077,7 @@ public abstract class TileEntityModuleMiner extends TileEntityModuleBase impleme
             final MultiblockTooltipBuilder tt = new MultiblockTooltipBuilder();
             tt.addMachineType(GTUtility.translate("gt.blockmachines.module.name"))
                 .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.miner.desc0")) // Module
-                                                                                                       // that
+                                                                                                      // that
                 // adds Space
                 // Mining
                 // Operations to the
@@ -1176,7 +1176,7 @@ public abstract class TileEntityModuleMiner extends TileEntityModuleBase impleme
             final MultiblockTooltipBuilder tt = new MultiblockTooltipBuilder();
             tt.addMachineType(GTUtility.translate("gt.blockmachines.module.name"))
                 .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.miner.desc0")) // Module
-                                                                                                       // that
+                                                                                                      // that
                 // adds Space
                 // Mining
                 // Operations to the
@@ -1275,7 +1275,7 @@ public abstract class TileEntityModuleMiner extends TileEntityModuleBase impleme
             final MultiblockTooltipBuilder tt = new MultiblockTooltipBuilder();
             tt.addMachineType(GTUtility.translate("gt.blockmachines.module.name"))
                 .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.miner.desc0")) // Module
-                                                                                                       // that
+                                                                                                      // that
                 // adds Space
                 // Mining
                 // Operations to the

--- a/src/main/java/gtnhintergalactic/tile/multi/elevatormodules/TileEntityModulePump.java
+++ b/src/main/java/gtnhintergalactic/tile/multi/elevatormodules/TileEntityModulePump.java
@@ -16,6 +16,7 @@ import com.gtnewhorizons.modularui.common.widget.DynamicPositionedColumn;
 import com.gtnewhorizons.modularui.common.widget.FakeSyncWidget;
 import com.gtnewhorizons.modularui.common.widget.SlotWidget;
 import com.gtnewhorizons.modularui.common.widget.TextWidget;
+
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import gregtech.api.enums.GTValues;
@@ -58,22 +59,21 @@ public abstract class TileEntityModulePump extends TileEntityModuleBase {
 
     /** Name of the planet type setting */
     private static final INameFunction<TileEntityModulePump> PLANET_TYPE_SETTING_NAME = (base,
-        p) -> GTUtility.translate("gt.blockmachines.multimachine.project.ig.pump.cfgi.0") + " "
-            + (p.hatchId() / 2 + 1); // Planet Type
+        p) -> GTUtility.translate("gt.blockmachines.multimachine.project.ig.pump.cfgi.0") + " " + (p.hatchId() / 2 + 1); // Planet
+                                                                                                                         // Type
     /** Status of the planet type setting */
     private static final IStatusFunction<TileEntityModulePump> PLANET_TYPE_STATUS = (base, p) -> LedStatus
         .fromLimitsInclusiveOuterBoundary(p.get(), 1, 0, 100, 100);
     /** Name of the gas type setting */
     private static final INameFunction<TileEntityModulePump> GAS_TYPE_SETTING_NAME = (base,
-        p) -> GTUtility.translate("gt.blockmachines.multimachine.project.ig.pump.cfgi.1") + " "
-            + (p.hatchId() / 2 + 1); // Gas Type
+        p) -> GTUtility.translate("gt.blockmachines.multimachine.project.ig.pump.cfgi.1") + " " + (p.hatchId() / 2 + 1); // Gas
+                                                                                                                         // Type
     /** Status of the gas type setting */
     private static final IStatusFunction<TileEntityModulePump> GAS_TYPE_STATUS = (base, p) -> LedStatus
         .fromLimitsInclusiveOuterBoundary(p.get(), 1, 0, 100, 100);
     /** Name of the parallel setting */
     private static final INameFunction<TileEntityModulePump> PARALLEL_SETTING_NAME = (base,
-        p) -> GTUtility.translate("gt.blockmachines.multimachine.project.ig.pump.cfgi.2") + " "
-            + (p.hatchId() / 2 + 1); // Parallels
+        p) -> GTUtility.translate("gt.blockmachines.multimachine.project.ig.pump.cfgi.2") + " " + (p.hatchId() / 2 + 1); // Parallels
     /** Status of the parallel setting */
     private static final IStatusFunction<TileEntityModulePump> PARALLEL_STATUS = (base, p) -> LedStatus
         .fromLimitsInclusiveOuterBoundary(p.get(), 0, 1, 100, base.getParallels());

--- a/src/main/java/gtnhintergalactic/tile/multi/elevatormodules/TileEntityModulePump.java
+++ b/src/main/java/gtnhintergalactic/tile/multi/elevatormodules/TileEntityModulePump.java
@@ -16,7 +16,6 @@ import com.gtnewhorizons.modularui.common.widget.DynamicPositionedColumn;
 import com.gtnewhorizons.modularui.common.widget.FakeSyncWidget;
 import com.gtnewhorizons.modularui.common.widget.SlotWidget;
 import com.gtnewhorizons.modularui.common.widget.TextWidget;
-
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import gregtech.api.enums.GTValues;
@@ -27,6 +26,7 @@ import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.implementations.MTEHatchOutput;
 import gregtech.api.recipe.check.CheckRecipeResult;
 import gregtech.api.recipe.check.CheckRecipeResultRegistry;
+import gregtech.api.util.GTUtility;
 import gregtech.api.util.MultiblockTooltipBuilder;
 import gregtech.api.util.ParallelHelper;
 import gregtech.common.tileentities.machines.MTEHatchOutputME;
@@ -58,21 +58,21 @@ public abstract class TileEntityModulePump extends TileEntityModuleBase {
 
     /** Name of the planet type setting */
     private static final INameFunction<TileEntityModulePump> PLANET_TYPE_SETTING_NAME = (base,
-        p) -> GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.pump.cfgi.0") + " "
+        p) -> GTUtility.translate("gt.blockmachines.multimachine.project.ig.pump.cfgi.0") + " "
             + (p.hatchId() / 2 + 1); // Planet Type
     /** Status of the planet type setting */
     private static final IStatusFunction<TileEntityModulePump> PLANET_TYPE_STATUS = (base, p) -> LedStatus
         .fromLimitsInclusiveOuterBoundary(p.get(), 1, 0, 100, 100);
     /** Name of the gas type setting */
     private static final INameFunction<TileEntityModulePump> GAS_TYPE_SETTING_NAME = (base,
-        p) -> GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.pump.cfgi.1") + " "
+        p) -> GTUtility.translate("gt.blockmachines.multimachine.project.ig.pump.cfgi.1") + " "
             + (p.hatchId() / 2 + 1); // Gas Type
     /** Status of the gas type setting */
     private static final IStatusFunction<TileEntityModulePump> GAS_TYPE_STATUS = (base, p) -> LedStatus
         .fromLimitsInclusiveOuterBoundary(p.get(), 1, 0, 100, 100);
     /** Name of the parallel setting */
     private static final INameFunction<TileEntityModulePump> PARALLEL_SETTING_NAME = (base,
-        p) -> GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.pump.cfgi.2") + " "
+        p) -> GTUtility.translate("gt.blockmachines.multimachine.project.ig.pump.cfgi.2") + " "
             + (p.hatchId() / 2 + 1); // Parallels
     /** Status of the parallel setting */
     private static final IStatusFunction<TileEntityModulePump> PARALLEL_STATUS = (base, p) -> LedStatus
@@ -405,20 +405,20 @@ public abstract class TileEntityModulePump extends TileEntityModuleBase {
         @Override
         protected MultiblockTooltipBuilder createTooltip() {
             final MultiblockTooltipBuilder tt = new MultiblockTooltipBuilder();
-            tt.addMachineType(GCCoreUtil.translate("gt.blockmachines.module.name"))
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.pump.desc0"))
+            tt.addMachineType(GTUtility.translate("gt.blockmachines.module.name"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.pump.desc0"))
                 .addInfo(
                     EnumChatFormatting.LIGHT_PURPLE.toString() + EnumChatFormatting.BOLD
-                        + GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.pump.t1.desc1"))
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.desc2"))
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.pump.desc3"))
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.pump.desc4"))
+                        + GTUtility.translate("gt.blockmachines.multimachine.project.ig.pump.t1.desc1"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.desc2"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.pump.desc3"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.pump.desc4"))
 
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.pump.t1.desc5"))
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.motorT2"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.pump.t1.desc5"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.motorT2"))
                 .beginStructureBlock(1, 5, 2, false)
-                .addCasingInfoRange(GCCoreUtil.translate("gt.blockcasings.ig.0.name"), 0, 9, false)
-                .addOutputHatch(GCCoreUtil.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
+                .addCasingInfoRange(GTUtility.translate("gt.blockcasings.ig.0.name"), 0, 9, false)
+                .addOutputHatch(GTUtility.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
                 .toolTipFinisher();
             return tt;
         }
@@ -494,21 +494,21 @@ public abstract class TileEntityModulePump extends TileEntityModuleBase {
         @Override
         protected MultiblockTooltipBuilder createTooltip() {
             final MultiblockTooltipBuilder tt = new MultiblockTooltipBuilder();
-            tt.addMachineType(GCCoreUtil.translate("gt.blockmachines.module.name"))
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.pump.desc0"))
+            tt.addMachineType(GTUtility.translate("gt.blockmachines.module.name"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.pump.desc0"))
                 .addInfo(
                     EnumChatFormatting.LIGHT_PURPLE.toString() + EnumChatFormatting.BOLD
-                        + GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.pump.t2.desc1"))
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.desc2"))
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.pump.desc3"))
+                        + GTUtility.translate("gt.blockmachines.multimachine.project.ig.pump.t2.desc1"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.desc2"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.pump.desc3"))
 
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.pump.desc4"))
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.pump.t2.desc5"))
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.pump.t2.desc6"))
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.motorT3"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.pump.desc4"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.pump.t2.desc5"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.pump.t2.desc6"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.motorT3"))
                 .beginStructureBlock(1, 5, 2, false)
-                .addCasingInfoRange(GCCoreUtil.translate("gt.blockcasings.ig.0.name"), 0, 9, false)
-                .addOutputHatch(GCCoreUtil.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
+                .addCasingInfoRange(GTUtility.translate("gt.blockcasings.ig.0.name"), 0, 9, false)
+                .addOutputHatch(GTUtility.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
                 .toolTipFinisher();
             return tt;
         }
@@ -584,21 +584,21 @@ public abstract class TileEntityModulePump extends TileEntityModuleBase {
         @Override
         protected MultiblockTooltipBuilder createTooltip() {
             final MultiblockTooltipBuilder tt = new MultiblockTooltipBuilder();
-            tt.addMachineType(GCCoreUtil.translate("gt.blockmachines.module.name"))
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.pump.desc0"))
+            tt.addMachineType(GTUtility.translate("gt.blockmachines.module.name"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.pump.desc0"))
                 .addInfo(
                     EnumChatFormatting.LIGHT_PURPLE.toString() + EnumChatFormatting.BOLD
-                        + GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.pump.t3.desc1"))
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.desc2"))
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.pump.desc3"))
+                        + GTUtility.translate("gt.blockmachines.multimachine.project.ig.pump.t3.desc1"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.desc2"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.pump.desc3"))
 
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.pump.desc4"))
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.pump.t3.desc5"))
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.pump.t2.desc6"))
-                .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.motorT4"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.pump.desc4"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.pump.t3.desc5"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.pump.t2.desc6"))
+                .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.motorT4"))
                 .beginStructureBlock(1, 5, 2, false)
-                .addCasingInfoRange(GCCoreUtil.translate("gt.blockcasings.ig.0.name"), 0, 9, false)
-                .addOutputHatch(GCCoreUtil.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
+                .addCasingInfoRange(GTUtility.translate("gt.blockcasings.ig.0.name"), 0, 9, false)
+                .addOutputHatch(GTUtility.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
                 .toolTipFinisher();
             return tt;
         }

--- a/src/main/java/gtnhintergalactic/tile/multi/elevatormodules/TileEntityModuleResearch.java
+++ b/src/main/java/gtnhintergalactic/tile/multi/elevatormodules/TileEntityModuleResearch.java
@@ -13,11 +13,11 @@ import gregtech.api.recipe.RecipeMap;
 import gregtech.api.recipe.check.CheckRecipeResult;
 import gregtech.api.recipe.check.CheckRecipeResultRegistry;
 import gregtech.api.util.GTRecipe;
+import gregtech.api.util.GTUtility;
 import gregtech.api.util.MultiblockTooltipBuilder;
 import gtnhintergalactic.recipe.IGRecipeMaps;
 import gtnhintergalactic.recipe.ResultNoSpaceProject;
 import gtnhintergalactic.tile.multi.elevator.ElevatorUtil;
-import micdoodle8.mods.galacticraft.core.util.GCCoreUtil;
 
 /**
  * Space Research project module of the Space Elevator
@@ -61,19 +61,19 @@ public class TileEntityModuleResearch extends TileEntityModuleBase {
     @Override
     protected MultiblockTooltipBuilder createTooltip() {
         final MultiblockTooltipBuilder tt = new MultiblockTooltipBuilder();
-        tt.addMachineType(GCCoreUtil.translate("gt.blockmachines.module.name"))
-            .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.research.desc0"))
+        tt.addMachineType(GTUtility.translate("gt.blockmachines.module.name"))
+            .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.research.desc0"))
             .addInfo(
                 EnumChatFormatting.LIGHT_PURPLE.toString() + EnumChatFormatting.BOLD
-                    + GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.research.desc1"))
-            .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.desc2"))
-            .addInfo(GCCoreUtil.translate("gt.blockmachines.multimachine.project.ig.motorT2"))
+                    + GTUtility.translate("gt.blockmachines.multimachine.project.ig.research.desc1"))
+            .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.desc2"))
+            .addInfo(GTUtility.translate("gt.blockmachines.multimachine.project.ig.motorT2"))
             .beginStructureBlock(1, 5, 2, false)
-            .addCasingInfoRange(GCCoreUtil.translate("gt.blockcasings.ig.0.name"), 0, 9, false)
-            .addInputBus(GCCoreUtil.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
-            .addOutputBus(GCCoreUtil.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
-            .addInputHatch(GCCoreUtil.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
-            .addOutputHatch(GCCoreUtil.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
+            .addCasingInfoRange(GTUtility.translate("gt.blockcasings.ig.0.name"), 0, 9, false)
+            .addInputBus(GTUtility.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
+            .addOutputBus(GTUtility.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
+            .addInputHatch(GTUtility.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
+            .addOutputHatch(GTUtility.translate("ig.elevator.structure.AnyBaseCasingWith1Dot"), 1)
             .toolTipFinisher();
         return tt;
     }


### PR DESCRIPTION
This shouldn't break anything in the full pack since I only gated things behind mod presence checks and swapped the GC translate method to the GT translate, which are essentially identical (GC has some special comment logic that I don't think is used anywhere). Other dev envs might break though (like the coremod when I removed forestry, though hopefully not).