### PR TITLE
Allows Only Water Into Crop Manager

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/basic/MTECropHarvestor.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/basic/MTECropHarvestor.java
@@ -11,6 +11,8 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.StatCollector;
 import net.minecraftforge.common.util.ForgeDirection;
+import net.minecraftforge.fluids.FluidRegistry;
+import net.minecraftforge.fluids.FluidStack;
 
 import org.apache.commons.lang3.ArrayUtils;
 
@@ -535,6 +537,11 @@ public class MTECropHarvestor extends MTEBasicTank {
     public ITexture[] getSides(final byte aColor) {
         return new ITexture[] { Textures.BlockIcons.MACHINE_CASINGS[this.mTier][aColor + 1],
             TextureFactory.of(TexturesGtBlock.Casing_CropHarvester_Cutter) };
+    }
+
+    @Override
+    public boolean isFluidInputAllowed(FluidStack aFluid) {
+        return aFluid != null && aFluid.getFluid() == FluidRegistry.WATER;
     }
 
     @Override


### PR DESCRIPTION
### Changes:
- As stated in title, crop manager was allowing any type of fluid into it and treating it as water-- which is honestly relatively inconsequential but it's sloppy nonetheless so it's fixed now. 

This will close https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20806