### PR TITLE
Removes Duplicate Macerator Recipes for Netherrrack & Endstone

### DIFF
--- a/src/main/java/gregtech/api/util/GTRecipeRegistrator.java
+++ b/src/main/java/gregtech/api/util/GTRecipeRegistrator.java
@@ -180,7 +180,9 @@ public class GTRecipeRegistrator {
             || aData.mMaterial.mAmount <= 0
             || GTUtility.getFluidForFilledItem(aStack, false) != null) return;
         // Prevents registering a quartz block -> 9x quartz dust recipe
-        if (!GTUtility.areStacksEqual(new ItemStack(Blocks.quartz_block, 1), aStack)) {
+        if (!GTUtility.areStacksEqual(new ItemStack(Blocks.quartz_block, 1), aStack)
+            && (!GTUtility.areStacksEqual(new ItemStack(Blocks.netherrack, 1), aStack))
+            && (!GTUtility.areStacksEqual(new ItemStack(Blocks.end_stone, 1), aStack))) {
             registerReverseMacerating(GTUtility.copyAmount(1, aStack), aData, aData.mPrefix == null, true);
         }
         if (!GTUtility.areStacksEqual(GTModHandler.getIC2Item("iridiumOre", 1L), aStack)) {


### PR DESCRIPTION
### Changes:
- Removes duplicate generated recipes that were conflicting with the intended way stoneProcessing has their usual maceration being performed. Consequentially the maceration recipes are 1 -) 1 again with byproduct instead of the inconsistent 1 -) 9 duplicate being suffered by netherrack and endstone.

This will close https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20616