### PR TITLE
Glowstone Recycling Fix

### DIFF
--- a/src/main/java/gregtech/api/util/GTRecipeRegistrator.java
+++ b/src/main/java/gregtech/api/util/GTRecipeRegistrator.java
@@ -182,7 +182,8 @@ public class GTRecipeRegistrator {
         // Prevents registering a quartz block -> 9x quartz dust recipe
         if (!GTUtility.areStacksEqual(new ItemStack(Blocks.quartz_block, 1), aStack)
             && (!GTUtility.areStacksEqual(new ItemStack(Blocks.netherrack, 1), aStack))
-            && (!GTUtility.areStacksEqual(new ItemStack(Blocks.end_stone, 1), aStack))) {
+            && (!GTUtility.areStacksEqual(new ItemStack(Blocks.end_stone, 1), aStack))
+            && (!GTUtility.areStacksEqual(new ItemStack(Blocks.glowstone, 1), aStack))) {
             registerReverseMacerating(GTUtility.copyAmount(1, aStack), aData, aData.mPrefix == null, true);
         }
         if (!GTUtility.areStacksEqual(GTModHandler.getIC2Item("iridiumOre", 1L), aStack)) {


### PR DESCRIPTION
### Changes:
- Removes bad macerator recycling recipe for glowstone. This is an extension of https://github.com/GTNewHorizons/GT5-Unofficial/pull/4729