### PR TITLE
impr(render): reuse SBR contexts instead of creating new instances

### DIFF
--- a/src/main/java/bartworks/client/renderer/BWBlockOreRenderer.java
+++ b/src/main/java/bartworks/client/renderer/BWBlockOreRenderer.java
@@ -41,14 +41,13 @@ public class BWBlockOreRenderer implements ISimpleBlockRenderingHandler {
     public static int renderID;
     public static final float blockMin = 0.0F;
     public static final float blockMax = 1.0F;
+    private final SBRContextHolder contextHolder = new SBRContextHolder();
 
     public static void register() {
         renderID = RenderingRegistry.getNextAvailableRenderId();
         INSTANCE = new BWBlockOreRenderer();
         RenderingRegistry.registerBlockHandler(INSTANCE);
     }
-
-    private final SBRContextHolder contextHolder = new SBRContextHolder();
 
     @Override
     public void renderInventoryBlock(Block aBlock, int aMeta, int modelId, RenderBlocks aRenderer) {

--- a/src/main/java/bartworks/client/renderer/BWBlockOreRenderer.java
+++ b/src/main/java/bartworks/client/renderer/BWBlockOreRenderer.java
@@ -29,6 +29,7 @@ import bartworks.system.material.TileEntityMetaGeneratedBlock;
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
 import cpw.mods.fml.client.registry.RenderingRegistry;
 import gregtech.GTMod;
+import gregtech.api.render.SBRContextHolder;
 import gregtech.api.render.SBRInventoryContext;
 import gregtech.api.render.SBRWorldContext;
 import gregtech.mixin.interfaces.accessors.TesselatorAccessor;
@@ -47,9 +48,11 @@ public class BWBlockOreRenderer implements ISimpleBlockRenderingHandler {
         RenderingRegistry.registerBlockHandler(INSTANCE);
     }
 
+    private final SBRContextHolder contextHolder = new SBRContextHolder();
+
     @Override
     public void renderInventoryBlock(Block aBlock, int aMeta, int modelId, RenderBlocks aRenderer) {
-        SBRInventoryContext ctx = new SBRInventoryContext(aBlock, aMeta, modelId, aRenderer);
+        SBRInventoryContext ctx = contextHolder.getSBRInventoryContext(aBlock, aMeta, modelId, aRenderer);
         TileEntityMetaGeneratedBlock tTileEntity = ((BWMetaGeneratedBlocks) aBlock).getProperTileEntityForRendering();
         tTileEntity.mMetaData = (short) aMeta;
         aRenderer.enableAO = false;
@@ -83,7 +86,7 @@ public class BWBlockOreRenderer implements ISimpleBlockRenderingHandler {
         if(actualTileEntity == null) return false;
 
         final TesselatorAccessor tessAccess = (TesselatorAccessor) Tessellator.instance;
-        final SBRWorldContext ctx = new SBRWorldContext(aX, aY, aZ, aBlock, modelId, aRenderer);
+        final SBRWorldContext ctx = contextHolder.getSBRWorldContext(aX, aY, aZ, aBlock, modelId, aRenderer);
         ctx.fullBlock = true;
 
         fakeTileEntity.mMetaData = actualTileEntity.mMetaData;

--- a/src/main/java/bartworks/client/renderer/BWBlockOreRenderer.java
+++ b/src/main/java/bartworks/client/renderer/BWBlockOreRenderer.java
@@ -86,7 +86,7 @@ public class BWBlockOreRenderer implements ISimpleBlockRenderingHandler {
 
         final TesselatorAccessor tessAccess = (TesselatorAccessor) Tessellator.instance;
         final SBRWorldContext ctx = contextHolder.getSBRWorldContext(aX, aY, aZ, aBlock, modelId, aRenderer);
-        ctx.fullBlock = true;
+        ctx.setFullBlock(true);
 
         fakeTileEntity.mMetaData = actualTileEntity.mMetaData;
         aRenderer.useInventoryTint = false;

--- a/src/main/java/gregtech/api/interfaces/ITexture.java
+++ b/src/main/java/gregtech/api/interfaces/ITexture.java
@@ -7,17 +7,17 @@ import gregtech.api.render.SBRContextBase;
 
 public interface ITexture {
 
-    void renderXPos(SBRContextBase<? extends SBRContextBase<?>> ctx);
+    void renderXPos(SBRContextBase ctx);
 
-    void renderXNeg(SBRContextBase<? extends SBRContextBase<?>> ctx);
+    void renderXNeg(SBRContextBase ctx);
 
-    void renderYPos(SBRContextBase<? extends SBRContextBase<?>> ctx);
+    void renderYPos(SBRContextBase ctx);
 
-    void renderYNeg(SBRContextBase<? extends SBRContextBase<?>> ctx);
+    void renderYNeg(SBRContextBase ctx);
 
-    void renderZPos(SBRContextBase<? extends SBRContextBase<?>> ctx);
+    void renderZPos(SBRContextBase ctx);
 
-    void renderZNeg(SBRContextBase<? extends SBRContextBase<?>> ctx);
+    void renderZNeg(SBRContextBase ctx);
 
     boolean isValidTexture();
 

--- a/src/main/java/gregtech/api/interfaces/metatileentity/IMetaTileEntity.java
+++ b/src/main/java/gregtech/api/interfaces/metatileentity/IMetaTileEntity.java
@@ -5,8 +5,6 @@ import java.util.List;
 
 import javax.annotation.Nullable;
 
-import net.minecraft.block.Block;
-import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
@@ -16,7 +14,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.StatCollector;
-import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.IFluidHandler;
@@ -36,6 +33,7 @@ import gregtech.api.interfaces.tileentity.IGregTechDeviceInformation;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.interfaces.tileentity.IGregtechWailaProvider;
 import gregtech.api.interfaces.tileentity.IMachineBlockUpdateable;
+import gregtech.api.render.SBRContextBase;
 
 /**
  * Warning, this Interface has just been made to be able to add multiple kinds of MetaTileEntities (Cables, Pipes,
@@ -355,13 +353,9 @@ public interface IMetaTileEntity extends ISidedInventory, IFluidTank, IFluidHand
      * @return true if you override the Rendering.
      */
     @SideOnly(Side.CLIENT)
-    boolean renderInInventory(Block aBlock, int aMeta, RenderBlocks aRenderer);
-
-    /**
-     * @return true if you override the Rendering.
-     */
-    @SideOnly(Side.CLIENT)
-    boolean renderInWorld(IBlockAccess aWorld, int aX, int aY, int aZ, Block aBlock, RenderBlocks aRenderer);
+    default boolean render(SBRContextBase<? extends SBRContextBase<?>> ctx) {
+        return false;
+    }
 
     /**
      * Gets the Output for the comparator on the given Side

--- a/src/main/java/gregtech/api/interfaces/metatileentity/IMetaTileEntity.java
+++ b/src/main/java/gregtech/api/interfaces/metatileentity/IMetaTileEntity.java
@@ -353,7 +353,7 @@ public interface IMetaTileEntity extends ISidedInventory, IFluidTank, IFluidHand
      * @return true if you override the Rendering.
      */
     @SideOnly(Side.CLIENT)
-    default boolean render(SBRContextBase<? extends SBRContextBase<?>> ctx) {
+    default boolean render(SBRContextBase ctx) {
         return false;
     }
 

--- a/src/main/java/gregtech/api/metatileentity/CommonMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/CommonMetaTileEntity.java
@@ -4,15 +4,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
-import net.minecraft.block.Block;
-import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.AxisAlignedBB;
-import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.Fluid;
@@ -519,18 +516,6 @@ public abstract class CommonMetaTileEntity implements IMetaTileEntity {
 
     @Override
     public boolean hasCustomInventoryName() {
-        return false;
-    }
-
-    @Override
-    @SideOnly(Side.CLIENT)
-    public boolean renderInInventory(Block block, int meta, RenderBlocks renderer) {
-        return false;
-    }
-
-    @Override
-    @SideOnly(Side.CLIENT)
-    public boolean renderInWorld(IBlockAccess world, int x, int y, int z, Block block, RenderBlocks renderer) {
         return false;
     }
 

--- a/src/main/java/gregtech/api/render/SBRContextBase.java
+++ b/src/main/java/gregtech/api/render/SBRContextBase.java
@@ -40,17 +40,20 @@ import gregtech.api.interfaces.ITexture;
  * for critical speed, as it avoids creating an iterator object.</li>
  * </ul>
  */
-@SuppressWarnings({ "UnusedReturnValue", "ClassWithTooManyFields", "ForLoopReplaceableByForEach" })
+@SuppressWarnings({ "UnusedReturnValue", "ClassWithTooManyFields" })
 @SideOnly(Side.CLIENT)
-public abstract class SBRContextBase<T extends SBRContextBase<T>> {
+public abstract class SBRContextBase {
 
     public static final int MAX_BRIGHTNESS = 0xf000f0;
-
-    /** Non-null placeholder RenderBlocks, replaced in {@link #setup}. */
+    protected static final float[] LIGHTNESS = { 0.5F, 1.0F, 0.8F, 0.8F, 0.6F, 0.6F };
+    /**
+     * Non-null placeholder RenderBlocks, replaced in {@link #setup}.
+     */
     @NotNull
     protected RenderBlocks renderBlocks = RenderBlocks.getInstance();
-
-    /** Non-null placeholder block, replaced in {@link #setup}. */
+    /**
+     * Non-null placeholder block, replaced in {@link #setup}.
+     */
     @NotNull
     protected Block block = Blocks.air;
     /**
@@ -60,7 +63,6 @@ public abstract class SBRContextBase<T extends SBRContextBase<T>> {
      */
     protected int x, y, z;
     protected int modelId;
-    protected static final float[] LIGHTNESS = { 0.5F, 1.0F, 0.8F, 0.8F, 0.6F, 0.6F };
     /**
      * Determines if block faces can be culled
      */
@@ -75,71 +77,55 @@ public abstract class SBRContextBase<T extends SBRContextBase<T>> {
     protected int colorOverride;
 
     /**
+     * Gets int color from RGBA array.
+     *
+     * @param rgba the short RGBA color array
+     * @return int color
+     */
+    private static int rgbaToInt(short @NotNull [] rgba) {
+        return (rgba[2] & 0xff) | (rgba[1] & 0xff) << 8 | (rgba[0] & 0xff) << 16;
+    }
+
+    /**
      * Set up the {@link SBRContextBase} used to render a single {@link Block}
      *
      * @param block        the {@link Block} to render
      * @param modelId      the Model ID for the block
      * @param renderBlocks the {@link RenderBlocks} renderer to use
      */
-    public T setup(@NotNull Block block, int modelId, @NotNull RenderBlocks renderBlocks) {
+    public SBRContextBase setup(@NotNull Block block, int modelId, @NotNull RenderBlocks renderBlocks) {
         this.block = block;
         this.modelId = modelId;
         this.renderBlocks = renderBlocks;
-        @SuppressWarnings("unchecked")
-        final T self = (T) this;
-        return self;
+        return this;
     }
 
-    public void setFullBlock(boolean fullBlock) {
+    public final void setFullBlock(boolean fullBlock) {
         this.fullBlock = fullBlock;
     }
 
-    public @NotNull RenderBlocks getRenderBlocks() {
+    public final @NotNull RenderBlocks getRenderBlocks() {
         return renderBlocks;
     }
 
-    public @NotNull Block getBlock() {
+    public final @NotNull Block getBlock() {
         return block;
     }
 
-    public int getModelId() {
+    public final int getModelId() {
         return modelId;
     }
 
-    public int getX() {
+    public final int getX() {
         return x;
     }
 
-    public int getY() {
+    public final int getY() {
         return y;
     }
 
-    public int getZ() {
+    public final int getZ() {
         return z;
-    }
-
-    /**
-     * Gets rgb color from integer.
-     *
-     * @param color the integer color
-     * @return a float array with rgb values
-     */
-    public static float[] getRGB(int color) {
-        final float red = (color >> 16 & 0xff) / 255.0F;
-        final float green = (color >> 8 & 0xff) / 255.0F;
-        final float blue = (color & 0xff) / 255.0F;
-
-        return new float[] { red, green, blue };
-    }
-
-    /**
-     * Gets int color from RGBA array.
-     *
-     * @param rgba the short RGBA color array
-     * @return int color
-     */
-    public static int rgbaToInt(short[] rgba) {
-        return (rgba[2] & 0xff) | (rgba[1] & 0xff) << 8 | (rgba[0] & 0xff) << 16;
     }
 
     /**
@@ -150,7 +136,7 @@ public abstract class SBRContextBase<T extends SBRContextBase<T>> {
      *
      * @return this {@link SBRContextBase} instance for chaining
      */
-    public abstract T reset();
+    public abstract SBRContextBase reset();
 
     /**
      * Sets brightness override.
@@ -158,12 +144,10 @@ public abstract class SBRContextBase<T extends SBRContextBase<T>> {
      * @param brightness the brightness override
      * @return the {@link SBRContextBase}
      */
-    public T setBrightnessOverride(int brightness) {
+    public final SBRContextBase setBrightnessOverride(int brightness) {
         hasBrightnessOverride = true;
         brightnessOverride = brightness;
-        @SuppressWarnings("unchecked")
-        final T self = (T) this;
-        return self;
+        return this;
     }
 
     /**
@@ -172,12 +156,10 @@ public abstract class SBRContextBase<T extends SBRContextBase<T>> {
      * @param lightness the lightness override
      * @return the {@link SBRContextBase}
      */
-    public T setLightnessOverride(float lightness) {
+    public final SBRContextBase setLightnessOverride(float lightness) {
         hasLightnessOverride = true;
         lightnessOverride = lightness;
-        @SuppressWarnings("unchecked")
-        final T self = (T) this;
-        return self;
+        return this;
     }
 
     /**
@@ -186,18 +168,16 @@ public abstract class SBRContextBase<T extends SBRContextBase<T>> {
      * @param side the side
      * @param rgba the primary short[] RGBA color array
      */
-    public T setupColor(ForgeDirection side, short[] rgba) {
+    public final SBRContextBase setupColor(ForgeDirection side, short[] rgba) {
         return setupColor(side, rgbaToInt(rgba));
     }
 
     /**
      * Like setRenderBounds, but automatically pulling the bounds from the context's block.
      */
-    public T setRenderBoundsFromBlock() {
+    public final SBRContextBase setRenderBoundsFromBlock() {
         renderBlocks.setRenderBoundsFromBlock(block);
-        @SuppressWarnings("unchecked")
-        final T self = (T) this;
-        return self;
+        return this;
     }
 
     /**
@@ -215,56 +195,38 @@ public abstract class SBRContextBase<T extends SBRContextBase<T>> {
      * @see #renderPositiveXFacing(ITexture[])
      */
     public void renderNegativeYFacing(ITexture[] tex) {
-        final long length = tex.length;
-        for (int i = 0; i < length; i++) {
-            final ITexture layer = tex[i];
-            if (layer == null) continue;
-            layer.renderYNeg(this);
+        for (final ITexture layer : tex) {
+            if (layer != null) layer.renderYNeg(this);
         }
     }
 
     public void renderPositiveYFacing(ITexture[] tex) {
-        final long length = tex.length;
-        for (int i = 0; i < length; i++) {
-            final ITexture layer = tex[i];
-            if (layer == null) continue;
-            layer.renderYPos(this);
+        for (final ITexture layer : tex) {
+            if (layer != null) layer.renderYPos(this);
         }
     }
 
     public void renderNegativeZFacing(ITexture[] tex) {
-        final long length = tex.length;
-        for (int i = 0; i < length; i++) {
-            final ITexture layer = tex[i];
-            if (layer == null) continue;
-            layer.renderZNeg(this);
+        for (final ITexture layer : tex) {
+            if (layer != null) layer.renderZNeg(this);
         }
     }
 
     public void renderPositiveZFacing(ITexture[] tex) {
-        final long length = tex.length;
-        for (int i = 0; i < length; i++) {
-            final ITexture layer = tex[i];
-            if (layer == null) continue;
-            layer.renderZPos(this);
+        for (final ITexture layer : tex) {
+            if (layer != null) layer.renderZPos(this);
         }
     }
 
     public void renderNegativeXFacing(ITexture[] tex) {
-        final long length = tex.length;
-        for (int i = 0; i < length; i++) {
-            final ITexture layer = tex[i];
-            if (layer == null) continue;
-            layer.renderXNeg(this);
+        for (final ITexture layer : tex) {
+            if (layer != null) layer.renderXNeg(this);
         }
     }
 
     public void renderPositiveXFacing(ITexture[] tex) {
-        final long length = tex.length;
-        for (int i = 0; i < length; i++) {
-            final ITexture layer = tex[i];
-            if (layer == null) continue;
-            layer.renderXPos(this);
+        for (final ITexture layer : tex) {
+            if (layer != null) layer.renderXPos(this);
         }
     }
 
@@ -274,7 +236,7 @@ public abstract class SBRContextBase<T extends SBRContextBase<T>> {
      * @param side     the side
      * @param hexColor the primary color
      */
-    public abstract T setupColor(ForgeDirection side, int hexColor);
+    public abstract SBRContextBase setupColor(ForgeDirection side, int hexColor);
 
     /**
      * Checks if rendering is allowed for the current pass.

--- a/src/main/java/gregtech/api/render/SBRContextBase.java
+++ b/src/main/java/gregtech/api/render/SBRContextBase.java
@@ -14,6 +14,7 @@ import java.util.function.IntPredicate;
 
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
+import net.minecraft.init.Blocks;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import org.jetbrains.annotations.NotNull;
@@ -45,9 +46,16 @@ public abstract class SBRContextBase<T extends SBRContextBase<T>> {
 
     public static final int MAX_BRIGHTNESS = 0xf000f0;
     protected static final float[] LIGHTNESS = { 0.5F, 1.0F, 0.8F, 0.8F, 0.6F, 0.6F };
-    public final RenderBlocks renderer;
-    public final Block block;
-    public final int modelId;
+
+    /** Non-null placeholder RenderBlocks, replaced in {@link #setup}. */
+    @NotNull
+    public RenderBlocks renderBlocks = RenderBlocks.getInstance();
+
+    /** Non-null placeholder block, replaced in {@link #setup}. */
+    @NotNull
+    public Block block = Blocks.air;
+    public int modelId;
+
     /**
      * Determines if block faces can be culled
      */
@@ -68,16 +76,19 @@ public abstract class SBRContextBase<T extends SBRContextBase<T>> {
     protected int colorOverride;
 
     /**
-     * Constructs a new {@link SBRContextBase} used to render a single {@link Block} inside an inventory
+     * Set up the {@link SBRContextBase} used to render a single {@link Block}
      *
-     * @param block    the {@link Block} to render
-     * @param modelId  the Model ID for the block
-     * @param renderer the {@link RenderBlocks} renderer to use
+     * @param block        the {@link Block} to render
+     * @param modelId      the Model ID for the block
+     * @param renderBlocks the {@link RenderBlocks} renderer to use
      */
-    public SBRContextBase(@NotNull Block block, int modelId, @NotNull RenderBlocks renderer) {
+    public T setup(@NotNull Block block, int modelId, @NotNull RenderBlocks renderBlocks) {
         this.block = block;
         this.modelId = modelId;
-        this.renderer = renderer;
+        this.renderBlocks = renderBlocks;
+        @SuppressWarnings("unchecked")
+        final T self = (T) this;
+        return self;
     }
 
     /**

--- a/src/main/java/gregtech/api/render/SBRContextBase.java
+++ b/src/main/java/gregtech/api/render/SBRContextBase.java
@@ -45,30 +45,29 @@ import gregtech.api.interfaces.ITexture;
 public abstract class SBRContextBase<T extends SBRContextBase<T>> {
 
     public static final int MAX_BRIGHTNESS = 0xf000f0;
-    protected static final float[] LIGHTNESS = { 0.5F, 1.0F, 0.8F, 0.8F, 0.6F, 0.6F };
 
     /** Non-null placeholder RenderBlocks, replaced in {@link #setup}. */
     @NotNull
-    public RenderBlocks renderBlocks = RenderBlocks.getInstance();
+    protected RenderBlocks renderBlocks = RenderBlocks.getInstance();
 
     /** Non-null placeholder block, replaced in {@link #setup}. */
     @NotNull
-    public Block block = Blocks.air;
-    public int modelId;
-
-    /**
-     * Determines if block faces can be culled
-     */
-    public boolean fullBlock;
-
+    protected Block block = Blocks.air;
     /**
      * Rendering coordinates for {@link RenderBlocks}; present to sidestep API limitations
      * and keep logic out of rendering.
      * (0, 0, 0) is used in inventory contexts due to Minecraft’s questionable design.
      */
-    public int x, y, z;
+    protected int x, y, z;
+    protected int modelId;
+    protected static final float[] LIGHTNESS = { 0.5F, 1.0F, 0.8F, 0.8F, 0.6F, 0.6F };
+    /**
+     * Determines if block faces can be culled
+     */
+    protected boolean fullBlock;
 
     protected boolean hasLightnessOverride;
+
     protected float lightnessOverride;
     protected boolean hasBrightnessOverride;
     protected int brightnessOverride;
@@ -89,6 +88,34 @@ public abstract class SBRContextBase<T extends SBRContextBase<T>> {
         @SuppressWarnings("unchecked")
         final T self = (T) this;
         return self;
+    }
+
+    public void setFullBlock(boolean fullBlock) {
+        this.fullBlock = fullBlock;
+    }
+
+    public @NotNull RenderBlocks getRenderBlocks() {
+        return renderBlocks;
+    }
+
+    public @NotNull Block getBlock() {
+        return block;
+    }
+
+    public int getModelId() {
+        return modelId;
+    }
+
+    public int getX() {
+        return x;
+    }
+
+    public int getY() {
+        return y;
+    }
+
+    public int getZ() {
+        return z;
     }
 
     /**
@@ -161,6 +188,16 @@ public abstract class SBRContextBase<T extends SBRContextBase<T>> {
      */
     public T setupColor(ForgeDirection side, short[] rgba) {
         return setupColor(side, rgbaToInt(rgba));
+    }
+
+    /**
+     * Like setRenderBounds, but automatically pulling the bounds from the context's block.
+     */
+    public T setRenderBoundsFromBlock() {
+        renderBlocks.setRenderBoundsFromBlock(block);
+        @SuppressWarnings("unchecked")
+        final T self = (T) this;
+        return self;
     }
 
     /**

--- a/src/main/java/gregtech/api/render/SBRContextHolder.java
+++ b/src/main/java/gregtech/api/render/SBRContextHolder.java
@@ -1,0 +1,58 @@
+package gregtech.api.render;
+
+import net.minecraft.block.Block;
+import net.minecraft.client.renderer.RenderBlocks;
+import net.minecraft.item.Item;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Holds and manages single instances of {@link SBRInventoryContext} and {@link SBRWorldContext},
+ * intended to be reused and reconfigured for each rendering operation.
+ * <p>
+ * This holder is expected to be used in a thread-confined context (e.g. via
+ * ThreadLocal management upstream). No internal synchronization is performed.
+ * </p>
+ */
+public class SBRContextHolder {
+
+    private SBRInventoryContext inventoryContext;
+    private SBRWorldContext worldContext;
+
+    /**
+     * Returns this holder's {@link SBRInventoryContext} instance configured to
+     * render a single {@link Block} in an inventory, using the provided parameters.
+     *
+     * @param block        the block to render
+     * @param meta         the block's metadata value (corresponds to the {@link Item} damage value)
+     * @param modelId      the model ID for the block
+     * @param renderBlocks the {@link RenderBlocks} renderer to use
+     * @return the configured {@link SBRInventoryContext} instance unique to this holder
+     */
+    public SBRInventoryContext getSBRInventoryContext(@NotNull Block block, int meta, int modelId,
+        @NotNull RenderBlocks renderBlocks) {
+        if (null == inventoryContext) inventoryContext = new SBRInventoryContext();
+        return inventoryContext.setup(block, meta, modelId, renderBlocks);
+    }
+
+    /**
+     * Returns this holder's {@link SBRWorldContext} instance configured to
+     * render a single {@link Block} in world, using the provided parameters.
+     *
+     * @param x        world X coordinate
+     * @param y        world Y coordinate
+     * @param z        world Z coordinate
+     * @param block    the block to render
+     * @param modelId  the Model ID for the block
+     * @param renderer the {@link RenderBlocks} renderer to use
+     * @return the configured {@link SBRWorldContext} instance unique to this holder
+     */
+    @SuppressWarnings("MethodWithTooManyParameters") // Blame ISimpleBlockRenderingHandler.renderWorldBlock
+    public SBRWorldContext getSBRWorldContext(int x, int y, int z, @NotNull Block block, int modelId,
+        @NotNull RenderBlocks renderer) {
+        if (worldContext == null) {
+            worldContext = new SBRWorldContext();
+        }
+        return worldContext.setup(x, y, z, block, modelId, renderer);
+    }
+}

--- a/src/main/java/gregtech/api/render/SBRContextHolder.java
+++ b/src/main/java/gregtech/api/render/SBRContextHolder.java
@@ -16,8 +16,8 @@ import org.jetbrains.annotations.NotNull;
  */
 public final class SBRContextHolder {
 
-    private SBRInventoryContext inventoryContext;
-    private SBRWorldContext worldContext;
+    private final SBRInventoryContext inventoryContext = new SBRInventoryContext();
+    private final SBRWorldContext worldContext = new SBRWorldContext();
 
     /**
      * Returns this holder's {@link SBRInventoryContext} instance configured to
@@ -31,7 +31,6 @@ public final class SBRContextHolder {
      */
     public SBRInventoryContext getSBRInventoryContext(@NotNull Block block, int meta, int modelId,
         @NotNull RenderBlocks renderBlocks) {
-        if (null == inventoryContext) inventoryContext = new SBRInventoryContext();
         return inventoryContext.setup(block, meta, modelId, renderBlocks);
     }
 
@@ -50,9 +49,6 @@ public final class SBRContextHolder {
     @SuppressWarnings("MethodWithTooManyParameters") // Blame ISimpleBlockRenderingHandler.renderWorldBlock
     public SBRWorldContext getSBRWorldContext(int x, int y, int z, @NotNull Block block, int modelId,
         @NotNull RenderBlocks renderer) {
-        if (worldContext == null) {
-            worldContext = new SBRWorldContext();
-        }
         return worldContext.setup(x, y, z, block, modelId, renderer);
     }
 }

--- a/src/main/java/gregtech/api/render/SBRContextHolder.java
+++ b/src/main/java/gregtech/api/render/SBRContextHolder.java
@@ -14,7 +14,7 @@ import org.jetbrains.annotations.NotNull;
  * ThreadLocal management upstream). No internal synchronization is performed.
  * </p>
  */
-public class SBRContextHolder {
+public final class SBRContextHolder {
 
     private SBRInventoryContext inventoryContext;
     private SBRWorldContext worldContext;

--- a/src/main/java/gregtech/api/render/SBRInventoryContext.java
+++ b/src/main/java/gregtech/api/render/SBRInventoryContext.java
@@ -35,20 +35,30 @@ import cpw.mods.fml.relauncher.SideOnly;
 public class SBRInventoryContext extends SBRContextBase<SBRInventoryContext> {
 
     protected static final float[] LIGHTNESS = { 0.5F, 1.0F, 0.8F, 0.8F, 0.6F, 0.6F };
-    public final int meta;
+    public int meta;
 
     /**
-     * Constructs a new {@link SBRInventoryContext} used to render a single {@link Block} inside an inventory
-     *
-     * @param block    the {@link Block} to render
-     * @param meta     the meta value of the {@link Block}'s {@link Item} meta value
-     * @param modelId  the Model ID for the block
-     * @param renderer the {@link RenderBlocks} renderer to use
+     * Package-private constructor.
+     * <p>
+     * Instances should be obtained via {@link SBRContextHolder#getSBRInventoryContext}.
      */
-    public SBRInventoryContext(@NotNull Block block, int meta, int modelId, @NotNull RenderBlocks renderer) {
-        super(block, modelId, renderer);
+    SBRInventoryContext() {}
+
+    /**
+     * Configures this {@link SBRInventoryContext} to render a single {@link Block}
+     * inside an inventory, using the given parameters.
+     *
+     * @param block    the block to render
+     * @param meta     the block's metadata value (corresponds to the {@link Item} damage value)
+     * @param modelId  the model ID for the block
+     * @param renderer the {@link RenderBlocks} renderer to use
+     * @return this context instance, configured with the given parameters
+     */
+    SBRInventoryContext setup(@NotNull Block block, int meta, int modelId, @NotNull RenderBlocks renderer) {
+        super.setup(block, modelId, renderer);
         this.meta = meta;
         reset();
+        return this;
     }
 
     /**
@@ -109,7 +119,7 @@ public class SBRInventoryContext extends SBRContextBase<SBRInventoryContext> {
     public SBRInventoryContext setupColor(ForgeDirection side, int hexColor) {
         final Tessellator tessellator = Tessellator.instance;
         final float lightness = hasLightnessOverride ? lightnessOverride : LIGHTNESS[side.ordinal()];
-        final float[] rgb = hasColorOverride && !renderer.hasOverrideBlockTexture() ? getRGB(colorOverride)
+        final float[] rgb = hasColorOverride && !renderBlocks.hasOverrideBlockTexture() ? getRGB(colorOverride)
             : getRGB(hexColor);
 
         if (hasBrightnessOverride) tessellator.setBrightness(brightnessOverride);

--- a/src/main/java/gregtech/api/render/SBRInventoryContext.java
+++ b/src/main/java/gregtech/api/render/SBRInventoryContext.java
@@ -32,7 +32,7 @@ import cpw.mods.fml.relauncher.SideOnly;
  * to various rendering methods throughout a block's render cycle.
  */
 @SideOnly(Side.CLIENT)
-public final class SBRInventoryContext extends SBRContextBase<SBRInventoryContext> {
+public final class SBRInventoryContext extends SBRContextBase {
 
     private static final float[] LIGHTNESS = { 0.5F, 1.0F, 0.8F, 0.8F, 0.6F, 0.6F };
     private int meta;
@@ -77,40 +77,6 @@ public final class SBRInventoryContext extends SBRContextBase<SBRInventoryContex
     }
 
     /**
-     * Sets brightness override.
-     *
-     * @param brightness the brightness override
-     * @return the {@link SBRInventoryContext}
-     */
-    public SBRInventoryContext setBrightnessOverride(int brightness) {
-        hasBrightnessOverride = true;
-        brightnessOverride = brightness;
-        return this;
-    }
-
-    /**
-     * Sets lightness override.
-     *
-     * @param lightness the lightness override
-     * @return the {@link SBRInventoryContext}
-     */
-    public SBRInventoryContext setLightnessOverride(float lightness) {
-        hasLightnessOverride = true;
-        lightnessOverride = lightness;
-        return this;
-    }
-
-    /**
-     * Sets up the color using lightness, brightness, and the primary color value (usually the dye color) for the side.
-     *
-     * @param side the side
-     * @param rgba the primary short[] RGBA color array
-     */
-    public SBRInventoryContext setupColor(ForgeDirection side, short[] rgba) {
-        return setupColor(side, rgbaToInt(rgba));
-    }
-
-    /**
      * Sets up the color using lightness, brightness, and the primary color value (usually the dye color) for the side.
      *
      * @param side     the side
@@ -119,16 +85,16 @@ public final class SBRInventoryContext extends SBRContextBase<SBRInventoryContex
     public SBRInventoryContext setupColor(ForgeDirection side, int hexColor) {
         final Tessellator tessellator = Tessellator.instance;
         final float lightness = hasLightnessOverride ? lightnessOverride : LIGHTNESS[side.ordinal()];
-        final float[] rgb = hasColorOverride && !renderBlocks.hasOverrideBlockTexture() ? getRGB(colorOverride)
-            : getRGB(hexColor);
+
+        final int color = hasColorOverride ? colorOverride : hexColor;
+
+        final float red = (color >> 16 & 0xff) / 255.0F;
+        final float green = (color >> 8 & 0xff) / 255.0F;
+        final float blue = (color & 0xff) / 255.0F;
 
         if (hasBrightnessOverride) tessellator.setBrightness(brightnessOverride);
-        tessellator.setColorOpaque_F(rgb[0] * lightness, rgb[1] * lightness, rgb[2] * lightness);
+        tessellator.setColorOpaque_F(red * lightness, green * lightness, blue * lightness);
         return this;
-    }
-
-    public int getMeta() {
-        return meta;
     }
 
     /**
@@ -139,5 +105,9 @@ public final class SBRInventoryContext extends SBRContextBase<SBRInventoryContex
     @Override
     public boolean canRenderInPass(@NotNull IntPredicate predicate) {
         return true;
+    }
+
+    public int getMeta() {
+        return meta;
     }
 }

--- a/src/main/java/gregtech/api/render/SBRInventoryContext.java
+++ b/src/main/java/gregtech/api/render/SBRInventoryContext.java
@@ -32,10 +32,10 @@ import cpw.mods.fml.relauncher.SideOnly;
  * to various rendering methods throughout a block's render cycle.
  */
 @SideOnly(Side.CLIENT)
-public class SBRInventoryContext extends SBRContextBase<SBRInventoryContext> {
+public final class SBRInventoryContext extends SBRContextBase<SBRInventoryContext> {
 
-    protected static final float[] LIGHTNESS = { 0.5F, 1.0F, 0.8F, 0.8F, 0.6F, 0.6F };
-    public int meta;
+    private static final float[] LIGHTNESS = { 0.5F, 1.0F, 0.8F, 0.8F, 0.6F, 0.6F };
+    private int meta;
 
     /**
      * Package-private constructor.
@@ -127,27 +127,17 @@ public class SBRInventoryContext extends SBRContextBase<SBRInventoryContext> {
         return this;
     }
 
+    public int getMeta() {
+        return meta;
+    }
+
     /**
      * {@inheritDoc}
-     * 
+     *
      * @implNote Always true in Inventory Context
      */
     @Override
     public boolean canRenderInPass(@NotNull IntPredicate predicate) {
         return true;
-    }
-
-    /**
-     * Gets rgb color from integer.
-     *
-     * @param color the integer color
-     * @return a float array with rgb values
-     */
-    public static float[] getRGB(int color) {
-        final float red = (color >> 16 & 0xff) / 255.0F;
-        final float green = (color >> 8 & 0xff) / 255.0F;
-        final float blue = (color & 0xff) / 255.0F;
-
-        return new float[] { red, green, blue };
     }
 }

--- a/src/main/java/gregtech/api/render/SBRWorldContext.java
+++ b/src/main/java/gregtech/api/render/SBRWorldContext.java
@@ -250,7 +250,7 @@ public final class SBRWorldContext extends SBRContextBase<SBRWorldContext> {
      */
     @Override
     public boolean canRenderInPass(@NotNull IntPredicate predicate) {
-        return predicate.test(worldRenderPass);
+        return worldRenderPass == -1 || predicate.test(worldRenderPass);
     }
 
     @Override

--- a/src/main/java/gregtech/api/render/SBRWorldContext.java
+++ b/src/main/java/gregtech/api/render/SBRWorldContext.java
@@ -25,6 +25,8 @@ import org.jetbrains.annotations.NotNull;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import gregtech.GTMod;
+import gregtech.api.enums.GTValues;
 import gregtech.api.interfaces.ITexture;
 
 /**
@@ -39,8 +41,11 @@ import gregtech.api.interfaces.ITexture;
 public class SBRWorldContext extends SBRContextBase<SBRWorldContext> {
 
     public static final float NO_Z_FIGHT_OFFSET = 1.0F / 1024.0F;
-    public final int worldRenderPass;
-    public final IBlockAccess world;
+    public int worldRenderPass;
+
+    /** Non-null dummy world, replaced in {@link #setup}. */
+    @NotNull
+    public IBlockAccess blockAccess = GTValues.DW;
 
     /**
      * Mixed Brightness cache
@@ -58,6 +63,12 @@ public class SBRWorldContext extends SBRContextBase<SBRWorldContext> {
      * and its 26 neighbors within a 3×3×3 cube centered on (x, y, z).
      */
     private final float[][][] AOLV = new float[3][3][3];
+
+    /** Used to determine if face is flush with negative neighbour */
+    private static final double FLUSH_MIN = 0.001D;
+    /** Used to determine if face is flush with positive neighbour */
+    private static final double FLUSH_MAX = 0.999D;
+
     /**
      * Brightness for side.
      */
@@ -68,7 +79,14 @@ public class SBRWorldContext extends SBRContextBase<SBRWorldContext> {
     private float aoTopLeft, aoBottomLeft, aoBottomRight, aoTopRight;
 
     /**
-     * Constructs a new {@link SBRWorldContext} used to render a single {@link Block} in world for the
+     * Package-private constructor.
+     * <p>
+     * Instances should be obtained via {@link SBRContextHolder#getSBRWorldContext}.
+     */
+    SBRWorldContext() {}
+
+    /**
+     * Configures this {@link SBRWorldContext} used to render a single {@link Block} in world for the
      * current render pass at the given coordinates
      *
      * @param x            the x coordinate
@@ -77,17 +95,20 @@ public class SBRWorldContext extends SBRContextBase<SBRWorldContext> {
      * @param block        the {@link Block} to render
      * @param modelId      the Model ID for the block
      * @param renderBlocks the {@link RenderBlocks} renderer to use
+     * @return this context instance, configured with the given parameters
      */
-    @SuppressWarnings("ConstructorWithTooManyParameters") // Blame ISimpleBlockRenderingHandler.renderWorldBlock
-    public SBRWorldContext(int x, int y, int z, Block block, int modelId, RenderBlocks renderBlocks) {
-        super(block, modelId, renderBlocks);
-        this.world = renderBlocks.blockAccess;
+    @SuppressWarnings("MethodWithTooManyParameters") // Blame ISimpleBlockRenderingHandler.renderWorldBlock
+    SBRWorldContext setup(int x, int y, int z, Block block, int modelId, RenderBlocks renderBlocks) {
+        super.setup(block, modelId, renderBlocks);
+        this.blockAccess = renderBlocks.blockAccess;
         this.worldRenderPass = ForgeHooksClient.getWorldRenderPass();
-        super.x = x;
-        super.y = y;
-        super.z = z;
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.renderBlocks.useInventoryTint = false;
+        populatesLightingCaches();
         reset();
-        populatesBlockAOCaches();
+        return this;
     }
 
     /**
@@ -128,13 +149,15 @@ public class SBRWorldContext extends SBRContextBase<SBRWorldContext> {
      * <p>
      * This method skips processing if Ambient Occlusion is disabled in the game settings.
      */
-    private void populatesBlockAOCaches() {
-        if (Minecraft.getMinecraft().gameSettings.ambientOcclusion == 0) return;
+    private void populatesLightingCaches() {
+        final boolean aoDisabled = Minecraft.getMinecraft().gameSettings.ambientOcclusion == 0;
         for (int dx = -1; dx <= 1; dx++) {
             for (int dy = -1; dy <= 1; dy++) {
                 for (int dz = -1; dz <= 1; dz++) {
-                    MBFB[dx + 1][dy + 1][dz + 1] = block.getMixedBrightnessForBlock(world, x + dx, y + dy, z + dz);
-                    AOLV[dx + 1][dy + 1][dz + 1] = world.getBlock(x + dx, y + dy, z + dz)
+                    MBFB[dx + 1][dy + 1][dz + 1] = block
+                        .getMixedBrightnessForBlock(blockAccess, x + dx, y + dy, z + dz);
+                    if (aoDisabled) continue;
+                    AOLV[dx + 1][dy + 1][dz + 1] = blockAccess.getBlock(x + dx, y + dy, z + dz)
                         .getAmbientOcclusionLightValue();
                 }
             }
@@ -151,9 +174,10 @@ public class SBRWorldContext extends SBRContextBase<SBRWorldContext> {
      */
     @Override
     public SBRWorldContext reset() {
-        super.hasBrightnessOverride = false;
-        super.hasColorOverride = false;
-        super.hasLightnessOverride = false;
+        this.hasBrightnessOverride = false;
+        this.hasColorOverride = false;
+        this.hasLightnessOverride = false;
+        this.renderBlocks.enableAO = Minecraft.isAmbientOcclusionEnabled() && GTMod.proxy.mRenderTileAmbientOcclusion;
         return this;
     }
 
@@ -165,42 +189,42 @@ public class SBRWorldContext extends SBRContextBase<SBRWorldContext> {
      */
     public SBRWorldContext setupColor(ForgeDirection side, int hexColor) {
         final float lightness = hasLightnessOverride ? lightnessOverride : LIGHTNESS[side.ordinal()];
-        final float[] rgb = hasColorOverride && !renderer.hasOverrideBlockTexture() ? getRGB(colorOverride)
+        final float[] rgb = hasColorOverride && !renderBlocks.hasOverrideBlockTexture() ? getRGB(colorOverride)
             : getRGB(hexColor);
 
         applyAnaglyph(rgb);
 
         final Tessellator tessellator = Tessellator.instance;
-        if (renderer.enableAO) {
+        if (renderBlocks.enableAO) {
             tessellator.setBrightness(hasBrightnessOverride ? brightnessOverride : brightness);
 
-            if (renderer.hasOverrideBlockTexture()) {
+            if (renderBlocks.hasOverrideBlockTexture()) {
 
-                renderer.colorRedTopLeft = renderer.colorRedBottomLeft = renderer.colorRedBottomRight = renderer.colorRedTopRight = rgb[0];
-                renderer.colorGreenTopLeft = renderer.colorGreenBottomLeft = renderer.colorGreenBottomRight = renderer.colorGreenTopRight = rgb[1];
-                renderer.colorBlueTopLeft = renderer.colorBlueBottomLeft = renderer.colorBlueBottomRight = renderer.colorBlueTopRight = rgb[2];
+                renderBlocks.colorRedTopLeft = renderBlocks.colorRedBottomLeft = renderBlocks.colorRedBottomRight = renderBlocks.colorRedTopRight = rgb[0];
+                renderBlocks.colorGreenTopLeft = renderBlocks.colorGreenBottomLeft = renderBlocks.colorGreenBottomRight = renderBlocks.colorGreenTopRight = rgb[1];
+                renderBlocks.colorBlueTopLeft = renderBlocks.colorBlueBottomLeft = renderBlocks.colorBlueBottomRight = renderBlocks.colorBlueTopRight = rgb[2];
 
             } else {
 
-                renderer.colorRedTopLeft = renderer.colorRedBottomLeft = renderer.colorRedBottomRight = renderer.colorRedTopRight = rgb[0]
+                renderBlocks.colorRedTopLeft = renderBlocks.colorRedBottomLeft = renderBlocks.colorRedBottomRight = renderBlocks.colorRedTopRight = rgb[0]
                     * lightness;
-                renderer.colorGreenTopLeft = renderer.colorGreenBottomLeft = renderer.colorGreenBottomRight = renderer.colorGreenTopRight = rgb[1]
+                renderBlocks.colorGreenTopLeft = renderBlocks.colorGreenBottomLeft = renderBlocks.colorGreenBottomRight = renderBlocks.colorGreenTopRight = rgb[1]
                     * lightness;
-                renderer.colorBlueTopLeft = renderer.colorBlueBottomLeft = renderer.colorBlueBottomRight = renderer.colorBlueTopRight = rgb[2]
+                renderBlocks.colorBlueTopLeft = renderBlocks.colorBlueBottomLeft = renderBlocks.colorBlueBottomRight = renderBlocks.colorBlueTopRight = rgb[2]
                     * lightness;
 
-                renderer.colorRedTopLeft *= aoTopLeft;
-                renderer.colorGreenTopLeft *= aoTopLeft;
-                renderer.colorBlueTopLeft *= aoTopLeft;
-                renderer.colorRedBottomLeft *= aoBottomLeft;
-                renderer.colorGreenBottomLeft *= aoBottomLeft;
-                renderer.colorBlueBottomLeft *= aoBottomLeft;
-                renderer.colorRedBottomRight *= aoBottomRight;
-                renderer.colorGreenBottomRight *= aoBottomRight;
-                renderer.colorBlueBottomRight *= aoBottomRight;
-                renderer.colorRedTopRight *= aoTopRight;
-                renderer.colorGreenTopRight *= aoTopRight;
-                renderer.colorBlueTopRight *= aoTopRight;
+                renderBlocks.colorRedTopLeft *= aoTopLeft;
+                renderBlocks.colorGreenTopLeft *= aoTopLeft;
+                renderBlocks.colorBlueTopLeft *= aoTopLeft;
+                renderBlocks.colorRedBottomLeft *= aoBottomLeft;
+                renderBlocks.colorGreenBottomLeft *= aoBottomLeft;
+                renderBlocks.colorBlueBottomLeft *= aoBottomLeft;
+                renderBlocks.colorRedBottomRight *= aoBottomRight;
+                renderBlocks.colorGreenBottomRight *= aoBottomRight;
+                renderBlocks.colorBlueBottomRight *= aoBottomRight;
+                renderBlocks.colorRedTopRight *= aoTopRight;
+                renderBlocks.colorGreenTopRight *= aoTopRight;
+                renderBlocks.colorBlueTopRight *= aoTopRight;
             }
         } else {
             if (hasBrightnessOverride) tessellator.setBrightness(brightnessOverride);
@@ -221,330 +245,70 @@ public class SBRWorldContext extends SBRContextBase<SBRWorldContext> {
 
     @Override
     public void renderNegativeYFacing(ITexture[] tex) {
-        if (fullBlock && !renderer.renderAllFaces && !block.shouldSideBeRendered(world, x, y - 1, z, 0)) return;
-        setupAOYNeg();
+        if (fullBlock && !renderBlocks.renderAllFaces && !block.shouldSideBeRendered(blockAccess, x, y - 1, z, 0))
+            return;
+        setupLightingYNeg();
         super.renderNegativeYFacing(tex);
     }
 
     @Override
     public void renderPositiveYFacing(ITexture[] tex) {
-        if (fullBlock && !renderer.renderAllFaces && !block.shouldSideBeRendered(world, x, y + 1, z, 1)) return;
-        setupAOYPos();
+        if (fullBlock && !renderBlocks.renderAllFaces && !block.shouldSideBeRendered(blockAccess, x, y + 1, z, 1))
+            return;
+        setupLightingYPos();
         super.renderPositiveYFacing(tex);
     }
 
     @Override
     public void renderNegativeZFacing(ITexture[] tex) {
-        if (fullBlock && !renderer.renderAllFaces && !block.shouldSideBeRendered(world, x, y, z - 1, 2)) return;
-        setupAOZNeg();
+        if (fullBlock && !renderBlocks.renderAllFaces && !block.shouldSideBeRendered(blockAccess, x, y, z - 1, 2))
+            return;
+        setupLightingZNeg();
         super.renderNegativeZFacing(tex);
     }
 
     @Override
     public void renderPositiveZFacing(ITexture[] tex) {
-        if (fullBlock && !renderer.renderAllFaces && !block.shouldSideBeRendered(world, x, y, z + 1, 3)) return;
-        setupAOZPos();
+        if (fullBlock && !renderBlocks.renderAllFaces && !block.shouldSideBeRendered(blockAccess, x, y, z + 1, 3))
+            return;
+        setupLightingZPos();
         super.renderPositiveZFacing(tex);
     }
 
     @Override
     public void renderNegativeXFacing(ITexture[] tex) {
-        if (fullBlock && !renderer.renderAllFaces && !block.shouldSideBeRendered(world, x - 1, y, z, 4)) return;
-        setupAOXNeg();
+        if (fullBlock && !renderBlocks.renderAllFaces && !block.shouldSideBeRendered(blockAccess, x - 1, y, z, 4))
+            return;
+        setupLightingXNeg();
         super.renderNegativeXFacing(tex);
     }
 
     @Override
     public void renderPositiveXFacing(ITexture[] tex) {
-        if (fullBlock && !renderer.renderAllFaces && !block.shouldSideBeRendered(world, x + 1, y, z, 5)) return;
-        setupAOXPos();
+        if (fullBlock && !renderBlocks.renderAllFaces && !block.shouldSideBeRendered(blockAccess, x + 1, y, z, 5))
+            return;
+        setupLightingXPos();
         super.renderPositiveXFacing(tex);
     }
 
     /**
-     * @see #setupAOXNeg()
-     * @see #setupAOYNeg()
-     * @see #setupAOZNeg()
-     * @see #setupAOXPos()
-     * @see #setupAOYPos()
-     * @see #setupAOZPos()
+     * @see #setupLightingXNeg()
+     * @see #setupLightingYNeg()
+     * @see #setupLightingZNeg()
+     * @see #setupLightingXPos()
+     * @see #setupLightingYPos()
+     * @see #setupLightingZPos()
      */
-    public SBRWorldContext setupAO(ForgeDirection facing) {
+    public SBRWorldContext setupLighting(ForgeDirection facing) {
         return switch (facing) {
-            case DOWN -> setupAOYNeg();
-            case UP -> setupAOYPos();
-            case NORTH -> setupAOZNeg();
-            case SOUTH -> setupAOZPos();
-            case WEST -> setupAOXNeg();
-            case EAST -> setupAOXPos();
+            case DOWN -> setupLightingYNeg();
+            case UP -> setupLightingYPos();
+            case NORTH -> setupLightingZNeg();
+            case SOUTH -> setupLightingZPos();
+            case WEST -> setupLightingXNeg();
+            case EAST -> setupLightingXPos();
             default -> throw new IllegalArgumentException("Unknown side: " + facing);
         };
-    }
-
-    /**
-     * Sets up lighting for the West face and returns the {@link SBRWorldContext}.
-     * <p>
-     * This is a consolidated <code>method</code> that sets side shading with respect to the following attributes:
-     * <p>
-     * <ul>
-     * <li>{@link RenderBlocks#enableAO}</li>
-     * <li>{@link RenderBlocks#partialRenderBounds}</li>
-     * </ul>
-     *
-     * @return the {@link SBRWorldContext}
-     */
-    public SBRWorldContext setupAOXNeg() {
-
-        if (renderer.enableAO) {
-
-            final int iX = renderer.renderMinX > 0.0F + NO_Z_FIGHT_OFFSET ? 1 : 0;
-
-            final int mixedBrightness = MBFB[iX][1][1];
-            brightness = mixedBrightness;
-
-            final double ratio = 1.0D - renderer.renderMinX;
-            final float aoLightValue = AOLV[0][1][1];
-
-            renderer.aoBrightnessXYNN = MBFB[iX][0][1];
-            renderer.aoBrightnessXZNN = MBFB[iX][1][0];
-            renderer.aoBrightnessXZNP = MBFB[iX][1][2];
-            renderer.aoBrightnessXYNP = MBFB[iX][2][1];
-            renderer.aoBrightnessXYZNNN = MBFB[iX][0][0];
-            renderer.aoBrightnessXYZNNP = MBFB[iX][0][2];
-            renderer.aoBrightnessXYZNPN = MBFB[iX][2][0];
-            renderer.aoBrightnessXYZNPP = MBFB[iX][2][2];
-            renderer.aoLightValueScratchXYNN = getMixedAo(AOLV[0][0][1], AOLV[1][0][1], ratio);
-            renderer.aoLightValueScratchXZNN = getMixedAo(AOLV[0][1][0], AOLV[1][1][0], ratio);
-            renderer.aoLightValueScratchXZNP = getMixedAo(AOLV[0][1][2], AOLV[1][1][2], ratio);
-            renderer.aoLightValueScratchXYNP = getMixedAo(AOLV[0][2][1], AOLV[1][2][1], ratio);
-            renderer.aoLightValueScratchXYZNNN = getMixedAo(AOLV[0][0][0], AOLV[1][0][0], ratio);
-            renderer.aoLightValueScratchXYZNNP = getMixedAo(AOLV[0][0][2], AOLV[1][0][2], ratio);
-            renderer.aoLightValueScratchXYZNPN = getMixedAo(AOLV[0][2][0], AOLV[1][2][0], ratio);
-            renderer.aoLightValueScratchXYZNPP = getMixedAo(AOLV[0][2][2], AOLV[1][2][2], ratio);
-
-            final int brightnessMixedXYZNPN = renderer.getAoBrightness(
-                renderer.aoBrightnessXZNN,
-                renderer.aoBrightnessXYZNPN,
-                renderer.aoBrightnessXYNP,
-                mixedBrightness);
-            final int brightnessMixedXYZNNN = renderer.getAoBrightness(
-                renderer.aoBrightnessXYZNNN,
-                renderer.aoBrightnessXYNN,
-                renderer.aoBrightnessXZNN,
-                mixedBrightness);
-            final int brightnessMixedXYZNNP = renderer.getAoBrightness(
-                renderer.aoBrightnessXYNN,
-                renderer.aoBrightnessXYZNNP,
-                renderer.aoBrightnessXZNP,
-                mixedBrightness);
-            final int brightnessMixedXYZNPP = renderer.getAoBrightness(
-                renderer.aoBrightnessXZNP,
-                renderer.aoBrightnessXYNP,
-                renderer.aoBrightnessXYZNPP,
-                mixedBrightness);
-
-            final float aoMixedXYZNPN = (renderer.aoLightValueScratchXZNN + aoLightValue
-                + renderer.aoLightValueScratchXYZNPN
-                + renderer.aoLightValueScratchXYNP) / 4.0F;
-            final float aoMixedXYZNNN = (renderer.aoLightValueScratchXYZNNN + renderer.aoLightValueScratchXYNN
-                + renderer.aoLightValueScratchXZNN
-                + aoLightValue) / 4.0F;
-            final float aoMixedXYZNNP = (renderer.aoLightValueScratchXYNN + renderer.aoLightValueScratchXYZNNP
-                + aoLightValue
-                + renderer.aoLightValueScratchXZNP) / 4.0F;
-            final float aoMixedXYZNPP = (aoLightValue + renderer.aoLightValueScratchXZNP
-                + renderer.aoLightValueScratchXYNP
-                + renderer.aoLightValueScratchXYZNPP) / 4.0F;
-
-            aoTopLeft = (float) (aoMixedXYZNPP * renderer.renderMaxY * renderer.renderMaxZ
-                + aoMixedXYZNPN * renderer.renderMaxY * (1.0D - renderer.renderMaxZ)
-                + aoMixedXYZNNN * (1.0D - renderer.renderMaxY) * (1.0D - renderer.renderMaxZ)
-                + aoMixedXYZNNP * (1.0D - renderer.renderMaxY) * renderer.renderMaxZ);
-            aoBottomLeft = (float) (aoMixedXYZNPP * renderer.renderMaxY * renderer.renderMinZ
-                + aoMixedXYZNPN * renderer.renderMaxY * (1.0D - renderer.renderMinZ)
-                + aoMixedXYZNNN * (1.0D - renderer.renderMaxY) * (1.0D - renderer.renderMinZ)
-                + aoMixedXYZNNP * (1.0D - renderer.renderMaxY) * renderer.renderMinZ);
-            aoBottomRight = (float) (aoMixedXYZNPP * renderer.renderMinY * renderer.renderMinZ
-                + aoMixedXYZNPN * renderer.renderMinY * (1.0D - renderer.renderMinZ)
-                + aoMixedXYZNNN * (1.0D - renderer.renderMinY) * (1.0D - renderer.renderMinZ)
-                + aoMixedXYZNNP * (1.0D - renderer.renderMinY) * renderer.renderMinZ);
-            aoTopRight = (float) (aoMixedXYZNPP * renderer.renderMinY * renderer.renderMaxZ
-                + aoMixedXYZNPN * renderer.renderMinY * (1.0D - renderer.renderMaxZ)
-                + aoMixedXYZNNN * (1.0D - renderer.renderMinY) * (1.0D - renderer.renderMaxZ)
-                + aoMixedXYZNNP * (1.0D - renderer.renderMinY) * renderer.renderMaxZ);
-
-            renderer.brightnessTopLeft = renderer.mixAoBrightness(
-                brightnessMixedXYZNPP,
-                brightnessMixedXYZNPN,
-                brightnessMixedXYZNNN,
-                brightnessMixedXYZNNP,
-                renderer.renderMaxY * renderer.renderMaxZ,
-                renderer.renderMaxY * (1.0D - renderer.renderMaxZ),
-                (1.0D - renderer.renderMaxY) * (1.0D - renderer.renderMaxZ),
-                (1.0D - renderer.renderMaxY) * renderer.renderMaxZ);
-            renderer.brightnessBottomLeft = renderer.mixAoBrightness(
-                brightnessMixedXYZNPP,
-                brightnessMixedXYZNPN,
-                brightnessMixedXYZNNN,
-                brightnessMixedXYZNNP,
-                renderer.renderMaxY * renderer.renderMinZ,
-                renderer.renderMaxY * (1.0D - renderer.renderMinZ),
-                (1.0D - renderer.renderMaxY) * (1.0D - renderer.renderMinZ),
-                (1.0D - renderer.renderMaxY) * renderer.renderMinZ);
-            renderer.brightnessBottomRight = renderer.mixAoBrightness(
-                brightnessMixedXYZNPP,
-                brightnessMixedXYZNPN,
-                brightnessMixedXYZNNN,
-                brightnessMixedXYZNNP,
-                renderer.renderMinY * renderer.renderMinZ,
-                renderer.renderMinY * (1.0D - renderer.renderMinZ),
-                (1.0D - renderer.renderMinY) * (1.0D - renderer.renderMinZ),
-                (1.0D - renderer.renderMinY) * renderer.renderMinZ);
-            renderer.brightnessTopRight = renderer.mixAoBrightness(
-                brightnessMixedXYZNPP,
-                brightnessMixedXYZNPN,
-                brightnessMixedXYZNNN,
-                brightnessMixedXYZNNP,
-                renderer.renderMinY * renderer.renderMaxZ,
-                renderer.renderMinY * (1.0D - renderer.renderMaxZ),
-                (1.0D - renderer.renderMinY) * (1.0D - renderer.renderMaxZ),
-                (1.0D - renderer.renderMinY) * renderer.renderMaxZ);
-        }
-
-        return this;
-    }
-
-    /**
-     * Sets up lighting for the East face and returns the {@link SBRWorldContext}.
-     * <p>
-     * This is a consolidated <code>method</code> that sets side shading with respect to the following attributes:
-     * <p>
-     * <ul>
-     * <li>{@link RenderBlocks#enableAO}</li>
-     * <li>{@link RenderBlocks#partialRenderBounds}</li>
-     * </ul>
-     *
-     * @return the {@link SBRWorldContext}
-     */
-    public SBRWorldContext setupAOXPos() {
-
-        if (renderer.enableAO) {
-
-            final int iX = renderer.renderMaxX < 1.0F - NO_Z_FIGHT_OFFSET ? 1 : 2;
-
-            final int mixedBrightness = MBFB[iX][1][1];
-            brightness = mixedBrightness;
-
-            final double ratio = renderer.renderMaxX;
-            final float aoLightValue = AOLV[2][1][1];
-
-            renderer.aoBrightnessXYPN = MBFB[iX][0][1];
-            renderer.aoBrightnessXZPN = MBFB[iX][1][0];
-            renderer.aoBrightnessXZPP = MBFB[iX][1][2];
-            renderer.aoBrightnessXYPP = MBFB[iX][2][1];
-            renderer.aoBrightnessXYZPNN = MBFB[iX][0][0];
-            renderer.aoBrightnessXYZPNP = MBFB[iX][0][2];
-            renderer.aoBrightnessXYZPPN = MBFB[iX][2][0];
-            renderer.aoBrightnessXYZPPP = MBFB[iX][2][2];
-            renderer.aoLightValueScratchXYPN = getMixedAo(AOLV[2][0][1], AOLV[1][0][1], ratio);
-            renderer.aoLightValueScratchXZPN = getMixedAo(AOLV[2][1][0], AOLV[1][1][0], ratio);
-            renderer.aoLightValueScratchXZPP = getMixedAo(AOLV[2][1][2], AOLV[1][1][2], ratio);
-            renderer.aoLightValueScratchXYPP = getMixedAo(AOLV[2][2][1], AOLV[1][2][1], ratio);
-            renderer.aoLightValueScratchXYZPNN = getMixedAo(AOLV[2][0][0], AOLV[1][0][0], ratio);
-            renderer.aoLightValueScratchXYZPNP = getMixedAo(AOLV[2][0][2], AOLV[1][0][2], ratio);
-            renderer.aoLightValueScratchXYZPPN = getMixedAo(AOLV[2][2][0], AOLV[1][2][0], ratio);
-            renderer.aoLightValueScratchXYZPPP = getMixedAo(AOLV[2][2][2], AOLV[1][2][2], ratio);
-
-            final int brightnessMixedXYZPPP = renderer.getAoBrightness(
-                renderer.aoBrightnessXZPP,
-                renderer.aoBrightnessXYPP,
-                renderer.aoBrightnessXYZPPP,
-                mixedBrightness);
-            final int brightnessMixedXYZPNP = renderer.getAoBrightness(
-                renderer.aoBrightnessXYPN,
-                renderer.aoBrightnessXYZPNP,
-                renderer.aoBrightnessXZPP,
-                mixedBrightness);
-            final int brightnessMixedXYZPNN = renderer.getAoBrightness(
-                renderer.aoBrightnessXYZPNN,
-                renderer.aoBrightnessXYPN,
-                renderer.aoBrightnessXZPN,
-                mixedBrightness);
-            final int brightnessMixedXYZPPN = renderer.getAoBrightness(
-                renderer.aoBrightnessXZPN,
-                renderer.aoBrightnessXYZPPN,
-                renderer.aoBrightnessXYPP,
-                mixedBrightness);
-
-            final float aoMixedXYZPPP = (aoLightValue + renderer.aoLightValueScratchXZPP
-                + renderer.aoLightValueScratchXYPP
-                + renderer.aoLightValueScratchXYZPPP) / 4.0F;
-            final float aoMixedXYZPNP = (renderer.aoLightValueScratchXYPN + renderer.aoLightValueScratchXYZPNP
-                + aoLightValue
-                + renderer.aoLightValueScratchXZPP) / 4.0F;
-            final float aoMixedXYZPNN = (renderer.aoLightValueScratchXYZPNN + renderer.aoLightValueScratchXYPN
-                + renderer.aoLightValueScratchXZPN
-                + aoLightValue) / 4.0F;
-            final float aoMixedXYZPPN = (renderer.aoLightValueScratchXZPN + aoLightValue
-                + renderer.aoLightValueScratchXYZPPN
-                + renderer.aoLightValueScratchXYPP) / 4.0F;
-
-            aoTopLeft = (float) (aoMixedXYZPNP * (1.0D - renderer.renderMinY) * renderer.renderMaxZ
-                + aoMixedXYZPNN * (1.0D - renderer.renderMinY) * (1.0D - renderer.renderMaxZ)
-                + aoMixedXYZPPN * renderer.renderMinY * (1.0D - renderer.renderMaxZ)
-                + aoMixedXYZPPP * renderer.renderMinY * renderer.renderMaxZ);
-            aoBottomLeft = (float) (aoMixedXYZPNP * (1.0D - renderer.renderMinY) * renderer.renderMinZ
-                + aoMixedXYZPNN * (1.0D - renderer.renderMinY) * (1.0D - renderer.renderMinZ)
-                + aoMixedXYZPPN * renderer.renderMinY * (1.0D - renderer.renderMinZ)
-                + aoMixedXYZPPP * renderer.renderMinY * renderer.renderMinZ);
-            aoBottomRight = (float) (aoMixedXYZPNP * (1.0D - renderer.renderMaxY) * renderer.renderMinZ
-                + aoMixedXYZPNN * (1.0D - renderer.renderMaxY) * (1.0D - renderer.renderMinZ)
-                + aoMixedXYZPPN * renderer.renderMaxY * (1.0D - renderer.renderMinZ)
-                + aoMixedXYZPPP * renderer.renderMaxY * renderer.renderMinZ);
-            aoTopRight = (float) (aoMixedXYZPNP * (1.0D - renderer.renderMaxY) * renderer.renderMaxZ
-                + aoMixedXYZPNN * (1.0D - renderer.renderMaxY) * (1.0D - renderer.renderMaxZ)
-                + aoMixedXYZPPN * renderer.renderMaxY * (1.0D - renderer.renderMaxZ)
-                + aoMixedXYZPPP * renderer.renderMaxY * renderer.renderMaxZ);
-
-            renderer.brightnessTopLeft = renderer.mixAoBrightness(
-                brightnessMixedXYZPNP,
-                brightnessMixedXYZPNN,
-                brightnessMixedXYZPPN,
-                brightnessMixedXYZPPP,
-                (1.0D - renderer.renderMinY) * renderer.renderMaxZ,
-                (1.0D - renderer.renderMinY) * (1.0D - renderer.renderMaxZ),
-                renderer.renderMinY * (1.0D - renderer.renderMaxZ),
-                renderer.renderMinY * renderer.renderMaxZ);
-            renderer.brightnessBottomLeft = renderer.mixAoBrightness(
-                brightnessMixedXYZPNP,
-                brightnessMixedXYZPNN,
-                brightnessMixedXYZPPN,
-                brightnessMixedXYZPPP,
-                (1.0D - renderer.renderMinY) * renderer.renderMinZ,
-                (1.0D - renderer.renderMinY) * (1.0D - renderer.renderMinZ),
-                renderer.renderMinY * (1.0D - renderer.renderMinZ),
-                renderer.renderMinY * renderer.renderMinZ);
-            renderer.brightnessBottomRight = renderer.mixAoBrightness(
-                brightnessMixedXYZPNP,
-                brightnessMixedXYZPNN,
-                brightnessMixedXYZPPN,
-                brightnessMixedXYZPPP,
-                (1.0D - renderer.renderMaxY) * renderer.renderMinZ,
-                (1.0D - renderer.renderMaxY) * (1.0D - renderer.renderMinZ),
-                renderer.renderMaxY * (1.0D - renderer.renderMinZ),
-                renderer.renderMaxY * renderer.renderMinZ);
-            renderer.brightnessTopRight = renderer.mixAoBrightness(
-                brightnessMixedXYZPNP,
-                brightnessMixedXYZPNN,
-                brightnessMixedXYZPPN,
-                brightnessMixedXYZPPP,
-                (1.0D - renderer.renderMaxY) * renderer.renderMaxZ,
-                (1.0D - renderer.renderMaxY) * (1.0D - renderer.renderMaxZ),
-                renderer.renderMaxY * (1.0D - renderer.renderMaxZ),
-                renderer.renderMaxY * renderer.renderMaxZ);
-        }
-
-        return this;
     }
 
     /**
@@ -559,122 +323,126 @@ public class SBRWorldContext extends SBRContextBase<SBRWorldContext> {
      *
      * @return the {@link SBRWorldContext}
      */
-    public SBRWorldContext setupAOYNeg() {
+    public SBRWorldContext setupLightingYNeg() {
 
-        if (renderer.enableAO) {
+        if (renderBlocks.enableAO) {
 
-            final int iY = renderer.renderMinY > 0.0F + NO_Z_FIGHT_OFFSET ? 1 : 0;
+            final int iY = renderBlocks.renderMinY > 0.0F + NO_Z_FIGHT_OFFSET ? 1 : 0;
 
             final int mixedBrightness = MBFB[1][iY][1];
             brightness = mixedBrightness;
 
-            final double ratio = 1.0D - renderer.renderMinY;
+            final double ratio = 1.0D - renderBlocks.renderMinY;
             final float aoLightValue = AOLV[1][0][1];
 
-            renderer.aoBrightnessXYNN = MBFB[0][iY][1];
-            renderer.aoBrightnessYZNN = MBFB[1][iY][0];
-            renderer.aoBrightnessYZNP = MBFB[1][iY][2];
-            renderer.aoBrightnessXYPN = MBFB[2][iY][1];
-            renderer.aoBrightnessXYZNNN = MBFB[0][iY][0];
-            renderer.aoBrightnessXYZNNP = MBFB[0][iY][2];
-            renderer.aoBrightnessXYZPNN = MBFB[2][iY][0];
-            renderer.aoBrightnessXYZPNP = MBFB[2][iY][2];
-            renderer.aoLightValueScratchXYNN = getMixedAo(AOLV[0][0][1], AOLV[0][1][1], ratio);
-            renderer.aoLightValueScratchYZNN = getMixedAo(AOLV[1][0][0], AOLV[1][1][0], ratio);
-            renderer.aoLightValueScratchYZNP = getMixedAo(AOLV[1][0][2], AOLV[1][1][2], ratio);
-            renderer.aoLightValueScratchXYPN = getMixedAo(AOLV[2][0][1], AOLV[2][1][1], ratio);
-            renderer.aoLightValueScratchXYZNNN = getMixedAo(AOLV[0][0][0], AOLV[0][1][0], ratio);
-            renderer.aoLightValueScratchXYZNNP = getMixedAo(AOLV[0][0][2], AOLV[0][1][2], ratio);
-            renderer.aoLightValueScratchXYZPNN = getMixedAo(AOLV[2][0][0], AOLV[2][1][0], ratio);
-            renderer.aoLightValueScratchXYZPNP = getMixedAo(AOLV[2][0][2], AOLV[2][1][2], ratio);
+            renderBlocks.aoBrightnessXYNN = MBFB[0][iY][1];
+            renderBlocks.aoBrightnessYZNN = MBFB[1][iY][0];
+            renderBlocks.aoBrightnessYZNP = MBFB[1][iY][2];
+            renderBlocks.aoBrightnessXYPN = MBFB[2][iY][1];
+            renderBlocks.aoBrightnessXYZNNN = MBFB[0][iY][0];
+            renderBlocks.aoBrightnessXYZNNP = MBFB[0][iY][2];
+            renderBlocks.aoBrightnessXYZPNN = MBFB[2][iY][0];
+            renderBlocks.aoBrightnessXYZPNP = MBFB[2][iY][2];
+            renderBlocks.aoLightValueScratchXYNN = getMixedAo(AOLV[0][0][1], AOLV[0][1][1], ratio);
+            renderBlocks.aoLightValueScratchYZNN = getMixedAo(AOLV[1][0][0], AOLV[1][1][0], ratio);
+            renderBlocks.aoLightValueScratchYZNP = getMixedAo(AOLV[1][0][2], AOLV[1][1][2], ratio);
+            renderBlocks.aoLightValueScratchXYPN = getMixedAo(AOLV[2][0][1], AOLV[2][1][1], ratio);
+            renderBlocks.aoLightValueScratchXYZNNN = getMixedAo(AOLV[0][0][0], AOLV[0][1][0], ratio);
+            renderBlocks.aoLightValueScratchXYZNNP = getMixedAo(AOLV[0][0][2], AOLV[0][1][2], ratio);
+            renderBlocks.aoLightValueScratchXYZPNN = getMixedAo(AOLV[2][0][0], AOLV[2][1][0], ratio);
+            renderBlocks.aoLightValueScratchXYZPNP = getMixedAo(AOLV[2][0][2], AOLV[2][1][2], ratio);
 
-            final int brightnessMixedXYZPNP = renderer.getAoBrightness(
-                renderer.aoBrightnessYZNP,
-                renderer.aoBrightnessXYZPNP,
-                renderer.aoBrightnessXYPN,
+            final int brightnessMixedXYZPNP = renderBlocks.getAoBrightness(
+                renderBlocks.aoBrightnessYZNP,
+                renderBlocks.aoBrightnessXYZPNP,
+                renderBlocks.aoBrightnessXYPN,
                 mixedBrightness);
-            final int brightnessMixedXYZPNN = renderer.getAoBrightness(
-                renderer.aoBrightnessYZNN,
-                renderer.aoBrightnessXYPN,
-                renderer.aoBrightnessXYZPNN,
+            final int brightnessMixedXYZPNN = renderBlocks.getAoBrightness(
+                renderBlocks.aoBrightnessYZNN,
+                renderBlocks.aoBrightnessXYPN,
+                renderBlocks.aoBrightnessXYZPNN,
                 mixedBrightness);
-            final int brightnessMixedXYZNNN = renderer.getAoBrightness(
-                renderer.aoBrightnessXYNN,
-                renderer.aoBrightnessXYZNNN,
-                renderer.aoBrightnessYZNN,
+            final int brightnessMixedXYZNNN = renderBlocks.getAoBrightness(
+                renderBlocks.aoBrightnessXYNN,
+                renderBlocks.aoBrightnessXYZNNN,
+                renderBlocks.aoBrightnessYZNN,
                 mixedBrightness);
-            final int brightnessMixedXYZNNP = renderer.getAoBrightness(
-                renderer.aoBrightnessXYZNNP,
-                renderer.aoBrightnessXYNN,
-                renderer.aoBrightnessYZNP,
+            final int brightnessMixedXYZNNP = renderBlocks.getAoBrightness(
+                renderBlocks.aoBrightnessXYZNNP,
+                renderBlocks.aoBrightnessXYNN,
+                renderBlocks.aoBrightnessYZNP,
                 mixedBrightness);
 
-            final float aoMixedXYZPNP = (renderer.aoLightValueScratchYZNP + aoLightValue
-                + renderer.aoLightValueScratchXYZPNP
-                + renderer.aoLightValueScratchXYPN) / 4.0F;
-            final float aoMixedXYZPNN = (aoLightValue + renderer.aoLightValueScratchYZNN
-                + renderer.aoLightValueScratchXYPN
-                + renderer.aoLightValueScratchXYZPNN) / 4.0F;
-            final float aoMixedXYZNNN = (renderer.aoLightValueScratchXYNN + renderer.aoLightValueScratchXYZNNN
+            final float aoMixedXYZPNP = (renderBlocks.aoLightValueScratchYZNP + aoLightValue
+                + renderBlocks.aoLightValueScratchXYZPNP
+                + renderBlocks.aoLightValueScratchXYPN) / 4.0F;
+            final float aoMixedXYZPNN = (aoLightValue + renderBlocks.aoLightValueScratchYZNN
+                + renderBlocks.aoLightValueScratchXYPN
+                + renderBlocks.aoLightValueScratchXYZPNN) / 4.0F;
+            final float aoMixedXYZNNN = (renderBlocks.aoLightValueScratchXYNN + renderBlocks.aoLightValueScratchXYZNNN
                 + aoLightValue
-                + renderer.aoLightValueScratchYZNN) / 4.0F;
-            final float aoMixedXYZNNP = (renderer.aoLightValueScratchXYZNNP + renderer.aoLightValueScratchXYNN
-                + renderer.aoLightValueScratchYZNP
+                + renderBlocks.aoLightValueScratchYZNN) / 4.0F;
+            final float aoMixedXYZNNP = (renderBlocks.aoLightValueScratchXYZNNP + renderBlocks.aoLightValueScratchXYNN
+                + renderBlocks.aoLightValueScratchYZNP
                 + aoLightValue) / 4.0F;
 
-            aoTopLeft = (float) (aoMixedXYZNNP * renderer.renderMaxZ * (1.0D - renderer.renderMinX)
-                + aoMixedXYZPNP * renderer.renderMaxZ * renderer.renderMinX
-                + aoMixedXYZPNN * (1.0D - renderer.renderMaxZ) * renderer.renderMinX
-                + aoMixedXYZNNN * (1.0D - renderer.renderMaxZ) * (1.0D - renderer.renderMinX));
-            aoBottomLeft = (float) (aoMixedXYZNNP * renderer.renderMinZ * (1.0D - renderer.renderMinX)
-                + aoMixedXYZPNP * renderer.renderMinZ * renderer.renderMinX
-                + aoMixedXYZPNN * (1.0D - renderer.renderMinZ) * renderer.renderMinX
-                + aoMixedXYZNNN * (1.0D - renderer.renderMinZ) * (1.0D - renderer.renderMinX));
-            aoBottomRight = (float) (aoMixedXYZNNP * renderer.renderMinZ * (1.0D - renderer.renderMaxX)
-                + aoMixedXYZPNP * renderer.renderMinZ * renderer.renderMaxX
-                + aoMixedXYZPNN * (1.0D - renderer.renderMinZ) * renderer.renderMaxX
-                + aoMixedXYZNNN * (1.0D - renderer.renderMinZ) * (1.0D - renderer.renderMaxX));
-            aoTopRight = (float) (aoMixedXYZNNP * renderer.renderMaxZ * (1.0D - renderer.renderMaxX)
-                + aoMixedXYZPNP * renderer.renderMaxZ * renderer.renderMaxX
-                + aoMixedXYZPNN * (1.0D - renderer.renderMaxZ) * renderer.renderMaxX
-                + aoMixedXYZNNN * (1.0D - renderer.renderMaxZ) * (1.0D - renderer.renderMaxX));
+            aoTopLeft = (float) (aoMixedXYZNNP * renderBlocks.renderMaxZ * (1.0D - renderBlocks.renderMinX)
+                + aoMixedXYZPNP * renderBlocks.renderMaxZ * renderBlocks.renderMinX
+                + aoMixedXYZPNN * (1.0D - renderBlocks.renderMaxZ) * renderBlocks.renderMinX
+                + aoMixedXYZNNN * (1.0D - renderBlocks.renderMaxZ) * (1.0D - renderBlocks.renderMinX));
+            aoBottomLeft = (float) (aoMixedXYZNNP * renderBlocks.renderMinZ * (1.0D - renderBlocks.renderMinX)
+                + aoMixedXYZPNP * renderBlocks.renderMinZ * renderBlocks.renderMinX
+                + aoMixedXYZPNN * (1.0D - renderBlocks.renderMinZ) * renderBlocks.renderMinX
+                + aoMixedXYZNNN * (1.0D - renderBlocks.renderMinZ) * (1.0D - renderBlocks.renderMinX));
+            aoBottomRight = (float) (aoMixedXYZNNP * renderBlocks.renderMinZ * (1.0D - renderBlocks.renderMaxX)
+                + aoMixedXYZPNP * renderBlocks.renderMinZ * renderBlocks.renderMaxX
+                + aoMixedXYZPNN * (1.0D - renderBlocks.renderMinZ) * renderBlocks.renderMaxX
+                + aoMixedXYZNNN * (1.0D - renderBlocks.renderMinZ) * (1.0D - renderBlocks.renderMaxX));
+            aoTopRight = (float) (aoMixedXYZNNP * renderBlocks.renderMaxZ * (1.0D - renderBlocks.renderMaxX)
+                + aoMixedXYZPNP * renderBlocks.renderMaxZ * renderBlocks.renderMaxX
+                + aoMixedXYZPNN * (1.0D - renderBlocks.renderMaxZ) * renderBlocks.renderMaxX
+                + aoMixedXYZNNN * (1.0D - renderBlocks.renderMaxZ) * (1.0D - renderBlocks.renderMaxX));
 
-            renderer.brightnessTopLeft = renderer.mixAoBrightness(
+            renderBlocks.brightnessTopLeft = renderBlocks.mixAoBrightness(
                 brightnessMixedXYZNNP,
                 brightnessMixedXYZPNP,
                 brightnessMixedXYZPNN,
                 brightnessMixedXYZNNN,
-                renderer.renderMaxZ * (1.0D - renderer.renderMinX),
-                renderer.renderMaxZ * renderer.renderMinX,
-                (1.0D - renderer.renderMaxZ) * renderer.renderMinX,
-                (1.0D - renderer.renderMaxZ) * (1.0D - renderer.renderMinX));
-            renderer.brightnessBottomLeft = renderer.mixAoBrightness(
+                renderBlocks.renderMaxZ * (1.0D - renderBlocks.renderMinX),
+                renderBlocks.renderMaxZ * renderBlocks.renderMinX,
+                (1.0D - renderBlocks.renderMaxZ) * renderBlocks.renderMinX,
+                (1.0D - renderBlocks.renderMaxZ) * (1.0D - renderBlocks.renderMinX));
+            renderBlocks.brightnessBottomLeft = renderBlocks.mixAoBrightness(
                 brightnessMixedXYZNNP,
                 brightnessMixedXYZPNP,
                 brightnessMixedXYZPNN,
                 brightnessMixedXYZNNN,
-                renderer.renderMinZ * (1.0D - renderer.renderMinX),
-                renderer.renderMinZ * renderer.renderMinX,
-                (1.0D - renderer.renderMinZ) * renderer.renderMinX,
-                (1.0D - renderer.renderMinZ) * (1.0D - renderer.renderMinX));
-            renderer.brightnessBottomRight = renderer.mixAoBrightness(
+                renderBlocks.renderMinZ * (1.0D - renderBlocks.renderMinX),
+                renderBlocks.renderMinZ * renderBlocks.renderMinX,
+                (1.0D - renderBlocks.renderMinZ) * renderBlocks.renderMinX,
+                (1.0D - renderBlocks.renderMinZ) * (1.0D - renderBlocks.renderMinX));
+            renderBlocks.brightnessBottomRight = renderBlocks.mixAoBrightness(
                 brightnessMixedXYZNNP,
                 brightnessMixedXYZPNP,
                 brightnessMixedXYZPNN,
                 brightnessMixedXYZNNN,
-                renderer.renderMinZ * (1.0D - renderer.renderMaxX),
-                renderer.renderMinZ * renderer.renderMaxX,
-                (1.0D - renderer.renderMinZ) * renderer.renderMaxX,
-                (1.0D - renderer.renderMinZ) * (1.0D - renderer.renderMaxX));
-            renderer.brightnessTopRight = renderer.mixAoBrightness(
+                renderBlocks.renderMinZ * (1.0D - renderBlocks.renderMaxX),
+                renderBlocks.renderMinZ * renderBlocks.renderMaxX,
+                (1.0D - renderBlocks.renderMinZ) * renderBlocks.renderMaxX,
+                (1.0D - renderBlocks.renderMinZ) * (1.0D - renderBlocks.renderMaxX));
+            renderBlocks.brightnessTopRight = renderBlocks.mixAoBrightness(
                 brightnessMixedXYZNNP,
                 brightnessMixedXYZPNP,
                 brightnessMixedXYZPNN,
                 brightnessMixedXYZNNN,
-                renderer.renderMaxZ * (1.0D - renderer.renderMaxX),
-                renderer.renderMaxZ * renderer.renderMaxX,
-                (1.0D - renderer.renderMaxZ) * renderer.renderMaxX,
-                (1.0D - renderer.renderMaxZ) * (1.0D - renderer.renderMaxX));
+                renderBlocks.renderMaxZ * (1.0D - renderBlocks.renderMaxX),
+                renderBlocks.renderMaxZ * renderBlocks.renderMaxX,
+                (1.0D - renderBlocks.renderMaxZ) * renderBlocks.renderMaxX,
+                (1.0D - renderBlocks.renderMaxZ) * (1.0D - renderBlocks.renderMaxX));
+        } else {
+            final int iY = block.getBlockBoundsMinY() < FLUSH_MIN ? 0 : 1;
+            // Use neighbor brightness if face is flush with neighbor, otherwise current block brightness
+            Tessellator.instance.setBrightness(MBFB[1][iY][1]);
         }
 
         return this;
@@ -692,122 +460,126 @@ public class SBRWorldContext extends SBRContextBase<SBRWorldContext> {
      *
      * @return the {@link SBRWorldContext}
      */
-    public SBRWorldContext setupAOYPos() {
+    public SBRWorldContext setupLightingYPos() {
 
-        if (renderer.enableAO) {
+        if (renderBlocks.enableAO) {
 
-            final int iY = renderer.renderMaxY < 1.0F - NO_Z_FIGHT_OFFSET ? 1 : 2;
+            final int iY = renderBlocks.renderMaxY < 1.0F - NO_Z_FIGHT_OFFSET ? 1 : 2;
 
             final int mixedBrightness = MBFB[1][iY][1];
             brightness = mixedBrightness;
 
-            final double ratio = renderer.renderMaxY;
+            final double ratio = renderBlocks.renderMaxY;
             final float aoLightValue = AOLV[1][2][1];
 
-            renderer.aoBrightnessXYNP = MBFB[0][iY][1];
-            renderer.aoBrightnessXYPP = MBFB[2][iY][1];
-            renderer.aoBrightnessYZPN = MBFB[1][iY][0];
-            renderer.aoBrightnessYZPP = MBFB[1][iY][2];
-            renderer.aoBrightnessXYZNPN = MBFB[0][iY][0];
-            renderer.aoBrightnessXYZPPN = MBFB[2][iY][0];
-            renderer.aoBrightnessXYZNPP = MBFB[0][iY][2];
-            renderer.aoBrightnessXYZPPP = MBFB[2][iY][2];
-            renderer.aoLightValueScratchXYNP = getMixedAo(AOLV[0][2][1], AOLV[0][1][1], ratio);
-            renderer.aoLightValueScratchXYPP = getMixedAo(AOLV[2][2][1], AOLV[2][1][1], ratio);
-            renderer.aoLightValueScratchYZPN = getMixedAo(AOLV[1][2][0], AOLV[1][1][0], ratio);
-            renderer.aoLightValueScratchYZPP = getMixedAo(AOLV[1][2][2], AOLV[1][1][2], ratio);
-            renderer.aoLightValueScratchXYZNPN = getMixedAo(AOLV[0][2][0], AOLV[0][1][0], ratio);
-            renderer.aoLightValueScratchXYZPPN = getMixedAo(AOLV[2][2][0], AOLV[2][1][0], ratio);
-            renderer.aoLightValueScratchXYZNPP = getMixedAo(AOLV[0][2][2], AOLV[0][1][2], ratio);
-            renderer.aoLightValueScratchXYZPPP = getMixedAo(AOLV[2][2][2], AOLV[2][1][2], ratio);
+            renderBlocks.aoBrightnessXYNP = MBFB[0][iY][1];
+            renderBlocks.aoBrightnessXYPP = MBFB[2][iY][1];
+            renderBlocks.aoBrightnessYZPN = MBFB[1][iY][0];
+            renderBlocks.aoBrightnessYZPP = MBFB[1][iY][2];
+            renderBlocks.aoBrightnessXYZNPN = MBFB[0][iY][0];
+            renderBlocks.aoBrightnessXYZPPN = MBFB[2][iY][0];
+            renderBlocks.aoBrightnessXYZNPP = MBFB[0][iY][2];
+            renderBlocks.aoBrightnessXYZPPP = MBFB[2][iY][2];
+            renderBlocks.aoLightValueScratchXYNP = getMixedAo(AOLV[0][2][1], AOLV[0][1][1], ratio);
+            renderBlocks.aoLightValueScratchXYPP = getMixedAo(AOLV[2][2][1], AOLV[2][1][1], ratio);
+            renderBlocks.aoLightValueScratchYZPN = getMixedAo(AOLV[1][2][0], AOLV[1][1][0], ratio);
+            renderBlocks.aoLightValueScratchYZPP = getMixedAo(AOLV[1][2][2], AOLV[1][1][2], ratio);
+            renderBlocks.aoLightValueScratchXYZNPN = getMixedAo(AOLV[0][2][0], AOLV[0][1][0], ratio);
+            renderBlocks.aoLightValueScratchXYZPPN = getMixedAo(AOLV[2][2][0], AOLV[2][1][0], ratio);
+            renderBlocks.aoLightValueScratchXYZNPP = getMixedAo(AOLV[0][2][2], AOLV[0][1][2], ratio);
+            renderBlocks.aoLightValueScratchXYZPPP = getMixedAo(AOLV[2][2][2], AOLV[2][1][2], ratio);
 
-            final int brightnessMixedXYZPPP = renderer.getAoBrightness(
-                renderer.aoBrightnessYZPP,
-                renderer.aoBrightnessXYZPPP,
-                renderer.aoBrightnessXYPP,
+            final int brightnessMixedXYZPPP = renderBlocks.getAoBrightness(
+                renderBlocks.aoBrightnessYZPP,
+                renderBlocks.aoBrightnessXYZPPP,
+                renderBlocks.aoBrightnessXYPP,
                 mixedBrightness);
-            final int brightnessMixedXYZPPN = renderer.getAoBrightness(
-                renderer.aoBrightnessYZPN,
-                renderer.aoBrightnessXYPP,
-                renderer.aoBrightnessXYZPPN,
+            final int brightnessMixedXYZPPN = renderBlocks.getAoBrightness(
+                renderBlocks.aoBrightnessYZPN,
+                renderBlocks.aoBrightnessXYPP,
+                renderBlocks.aoBrightnessXYZPPN,
                 mixedBrightness);
-            final int brightnessMixedXYZNPN = renderer.getAoBrightness(
-                renderer.aoBrightnessXYNP,
-                renderer.aoBrightnessXYZNPN,
-                renderer.aoBrightnessYZPN,
+            final int brightnessMixedXYZNPN = renderBlocks.getAoBrightness(
+                renderBlocks.aoBrightnessXYNP,
+                renderBlocks.aoBrightnessXYZNPN,
+                renderBlocks.aoBrightnessYZPN,
                 mixedBrightness);
-            final int brightnessMixedXYZNPP = renderer.getAoBrightness(
-                renderer.aoBrightnessXYZNPP,
-                renderer.aoBrightnessXYNP,
-                renderer.aoBrightnessYZPP,
+            final int brightnessMixedXYZNPP = renderBlocks.getAoBrightness(
+                renderBlocks.aoBrightnessXYZNPP,
+                renderBlocks.aoBrightnessXYNP,
+                renderBlocks.aoBrightnessYZPP,
                 mixedBrightness);
 
-            final float aoMixedXYZPPP = (renderer.aoLightValueScratchYZPP + aoLightValue
-                + renderer.aoLightValueScratchXYZPPP
-                + renderer.aoLightValueScratchXYPP) / 4.0F;
-            final float aoMixedXYZPPN = (aoLightValue + renderer.aoLightValueScratchYZPN
-                + renderer.aoLightValueScratchXYPP
-                + renderer.aoLightValueScratchXYZPPN) / 4.0F;
-            final float aoMixedXYZNPN = (renderer.aoLightValueScratchXYNP + renderer.aoLightValueScratchXYZNPN
+            final float aoMixedXYZPPP = (renderBlocks.aoLightValueScratchYZPP + aoLightValue
+                + renderBlocks.aoLightValueScratchXYZPPP
+                + renderBlocks.aoLightValueScratchXYPP) / 4.0F;
+            final float aoMixedXYZPPN = (aoLightValue + renderBlocks.aoLightValueScratchYZPN
+                + renderBlocks.aoLightValueScratchXYPP
+                + renderBlocks.aoLightValueScratchXYZPPN) / 4.0F;
+            final float aoMixedXYZNPN = (renderBlocks.aoLightValueScratchXYNP + renderBlocks.aoLightValueScratchXYZNPN
                 + aoLightValue
-                + renderer.aoLightValueScratchYZPN) / 4.0F;
-            final float aoMixedXYZNPP = (renderer.aoLightValueScratchXYZNPP + renderer.aoLightValueScratchXYNP
-                + renderer.aoLightValueScratchYZPP
+                + renderBlocks.aoLightValueScratchYZPN) / 4.0F;
+            final float aoMixedXYZNPP = (renderBlocks.aoLightValueScratchXYZNPP + renderBlocks.aoLightValueScratchXYNP
+                + renderBlocks.aoLightValueScratchYZPP
                 + aoLightValue) / 4.0F;
 
-            aoTopLeft /* SE */ = (float) (aoMixedXYZNPP * renderer.renderMaxZ * (1.0D - renderer.renderMaxX)
-                + aoMixedXYZPPP * renderer.renderMaxZ * renderer.renderMaxX
-                + aoMixedXYZPPN * (1.0D - renderer.renderMaxZ) * renderer.renderMaxX
-                + aoMixedXYZNPN * (1.0D - renderer.renderMaxZ) * (1.0D - renderer.renderMaxX));
-            aoBottomLeft /* NE */ = (float) (aoMixedXYZNPP * renderer.renderMinZ * (1.0D - renderer.renderMaxX)
-                + aoMixedXYZPPP * renderer.renderMinZ * renderer.renderMaxX
-                + aoMixedXYZPPN * (1.0D - renderer.renderMinZ) * renderer.renderMaxX
-                + aoMixedXYZNPN * (1.0D - renderer.renderMinZ) * (1.0D - renderer.renderMaxX));
-            aoBottomRight /* NW */ = (float) (aoMixedXYZNPP * renderer.renderMinZ * (1.0D - renderer.renderMinX)
-                + aoMixedXYZPPP * renderer.renderMinZ * renderer.renderMinX
-                + aoMixedXYZPPN * (1.0D - renderer.renderMinZ) * renderer.renderMinX
-                + aoMixedXYZNPN * (1.0D - renderer.renderMinZ) * (1.0D - renderer.renderMinX));
-            aoTopRight /* SW */ = (float) (aoMixedXYZNPP * renderer.renderMaxZ * (1.0D - renderer.renderMinX)
-                + aoMixedXYZPPP * renderer.renderMaxZ * renderer.renderMinX
-                + aoMixedXYZPPN * (1.0D - renderer.renderMaxZ) * renderer.renderMinX
-                + aoMixedXYZNPN * (1.0D - renderer.renderMaxZ) * (1.0D - renderer.renderMinX));
+            aoTopLeft /* SE */ = (float) (aoMixedXYZNPP * renderBlocks.renderMaxZ * (1.0D - renderBlocks.renderMaxX)
+                + aoMixedXYZPPP * renderBlocks.renderMaxZ * renderBlocks.renderMaxX
+                + aoMixedXYZPPN * (1.0D - renderBlocks.renderMaxZ) * renderBlocks.renderMaxX
+                + aoMixedXYZNPN * (1.0D - renderBlocks.renderMaxZ) * (1.0D - renderBlocks.renderMaxX));
+            aoBottomLeft /* NE */ = (float) (aoMixedXYZNPP * renderBlocks.renderMinZ * (1.0D - renderBlocks.renderMaxX)
+                + aoMixedXYZPPP * renderBlocks.renderMinZ * renderBlocks.renderMaxX
+                + aoMixedXYZPPN * (1.0D - renderBlocks.renderMinZ) * renderBlocks.renderMaxX
+                + aoMixedXYZNPN * (1.0D - renderBlocks.renderMinZ) * (1.0D - renderBlocks.renderMaxX));
+            aoBottomRight /* NW */ = (float) (aoMixedXYZNPP * renderBlocks.renderMinZ * (1.0D - renderBlocks.renderMinX)
+                + aoMixedXYZPPP * renderBlocks.renderMinZ * renderBlocks.renderMinX
+                + aoMixedXYZPPN * (1.0D - renderBlocks.renderMinZ) * renderBlocks.renderMinX
+                + aoMixedXYZNPN * (1.0D - renderBlocks.renderMinZ) * (1.0D - renderBlocks.renderMinX));
+            aoTopRight /* SW */ = (float) (aoMixedXYZNPP * renderBlocks.renderMaxZ * (1.0D - renderBlocks.renderMinX)
+                + aoMixedXYZPPP * renderBlocks.renderMaxZ * renderBlocks.renderMinX
+                + aoMixedXYZPPN * (1.0D - renderBlocks.renderMaxZ) * renderBlocks.renderMinX
+                + aoMixedXYZNPN * (1.0D - renderBlocks.renderMaxZ) * (1.0D - renderBlocks.renderMinX));
 
-            renderer.brightnessTopLeft = renderer.mixAoBrightness(
+            renderBlocks.brightnessTopLeft = renderBlocks.mixAoBrightness(
                 brightnessMixedXYZNPP,
                 brightnessMixedXYZPPP,
                 brightnessMixedXYZPPN,
                 brightnessMixedXYZNPN,
-                renderer.renderMaxZ * (1.0D - renderer.renderMaxX),
-                renderer.renderMaxZ * renderer.renderMaxX,
-                (1.0D - renderer.renderMaxZ) * renderer.renderMaxX,
-                (1.0D - renderer.renderMaxZ) * (1.0D - renderer.renderMaxX));
-            renderer.brightnessBottomLeft = renderer.mixAoBrightness(
+                renderBlocks.renderMaxZ * (1.0D - renderBlocks.renderMaxX),
+                renderBlocks.renderMaxZ * renderBlocks.renderMaxX,
+                (1.0D - renderBlocks.renderMaxZ) * renderBlocks.renderMaxX,
+                (1.0D - renderBlocks.renderMaxZ) * (1.0D - renderBlocks.renderMaxX));
+            renderBlocks.brightnessBottomLeft = renderBlocks.mixAoBrightness(
                 brightnessMixedXYZNPP,
                 brightnessMixedXYZPPP,
                 brightnessMixedXYZPPN,
                 brightnessMixedXYZNPN,
-                renderer.renderMinZ * (1.0D - renderer.renderMaxX),
-                renderer.renderMinZ * renderer.renderMaxX,
-                (1.0D - renderer.renderMinZ) * renderer.renderMaxX,
-                (1.0D - renderer.renderMinZ) * (1.0D - renderer.renderMaxX));
-            renderer.brightnessBottomRight = renderer.mixAoBrightness(
+                renderBlocks.renderMinZ * (1.0D - renderBlocks.renderMaxX),
+                renderBlocks.renderMinZ * renderBlocks.renderMaxX,
+                (1.0D - renderBlocks.renderMinZ) * renderBlocks.renderMaxX,
+                (1.0D - renderBlocks.renderMinZ) * (1.0D - renderBlocks.renderMaxX));
+            renderBlocks.brightnessBottomRight = renderBlocks.mixAoBrightness(
                 brightnessMixedXYZNPP,
                 brightnessMixedXYZPPP,
                 brightnessMixedXYZPPN,
                 brightnessMixedXYZNPN,
-                renderer.renderMinZ * (1.0D - renderer.renderMinX),
-                renderer.renderMinZ * renderer.renderMinX,
-                (1.0D - renderer.renderMinZ) * renderer.renderMinX,
-                (1.0D - renderer.renderMinZ) * (1.0D - renderer.renderMinX));
-            renderer.brightnessTopRight = renderer.mixAoBrightness(
+                renderBlocks.renderMinZ * (1.0D - renderBlocks.renderMinX),
+                renderBlocks.renderMinZ * renderBlocks.renderMinX,
+                (1.0D - renderBlocks.renderMinZ) * renderBlocks.renderMinX,
+                (1.0D - renderBlocks.renderMinZ) * (1.0D - renderBlocks.renderMinX));
+            renderBlocks.brightnessTopRight = renderBlocks.mixAoBrightness(
                 brightnessMixedXYZNPP,
                 brightnessMixedXYZPPP,
                 brightnessMixedXYZPPN,
                 brightnessMixedXYZNPN,
-                renderer.renderMaxZ * (1.0D - renderer.renderMinX),
-                renderer.renderMaxZ * renderer.renderMinX,
-                (1.0D - renderer.renderMaxZ) * renderer.renderMinX,
-                (1.0D - renderer.renderMaxZ) * (1.0D - renderer.renderMinX));
+                renderBlocks.renderMaxZ * (1.0D - renderBlocks.renderMinX),
+                renderBlocks.renderMaxZ * renderBlocks.renderMinX,
+                (1.0D - renderBlocks.renderMaxZ) * renderBlocks.renderMinX,
+                (1.0D - renderBlocks.renderMaxZ) * (1.0D - renderBlocks.renderMinX));
+        } else {
+            final int iY = block.getBlockBoundsMaxY() > FLUSH_MAX ? 2 : 1;
+            // Use neighbor brightness if face is flush with neighbor, otherwise current block brightness
+            Tessellator.instance.setBrightness(MBFB[1][iY][1]);
         }
 
         return this;
@@ -825,122 +597,126 @@ public class SBRWorldContext extends SBRContextBase<SBRWorldContext> {
      *
      * @return the {@link SBRWorldContext}
      */
-    public SBRWorldContext setupAOZNeg() {
+    public SBRWorldContext setupLightingZNeg() {
 
-        if (renderer.enableAO) {
+        if (renderBlocks.enableAO) {
 
-            final int iZ = renderer.renderMinZ > 0.0F + NO_Z_FIGHT_OFFSET ? 1 : 0;
+            final int iZ = renderBlocks.renderMinZ > 0.0F + NO_Z_FIGHT_OFFSET ? 1 : 0;
 
             final int mixedBrightness = MBFB[1][1][iZ];
             brightness = mixedBrightness;
 
-            final double ratio = 1.0D - renderer.renderMinZ;
+            final double ratio = 1.0D - renderBlocks.renderMinZ;
             final float aoLightValue = AOLV[1][1][0];
 
-            renderer.aoBrightnessXZNN = MBFB[0][1][iZ];
-            renderer.aoBrightnessYZNN = MBFB[1][0][iZ];
-            renderer.aoBrightnessYZPN = MBFB[1][2][iZ];
-            renderer.aoBrightnessXZPN = MBFB[2][1][iZ];
-            renderer.aoBrightnessXYZNNN = MBFB[0][0][iZ];
-            renderer.aoBrightnessXYZNPN = MBFB[0][2][iZ];
-            renderer.aoBrightnessXYZPNN = MBFB[2][0][iZ];
-            renderer.aoBrightnessXYZPPN = MBFB[2][2][iZ];
-            renderer.aoLightValueScratchXZNN = getMixedAo(AOLV[0][1][0], AOLV[0][1][1], ratio);
-            renderer.aoLightValueScratchYZNN = getMixedAo(AOLV[1][0][0], AOLV[1][0][1], ratio);
-            renderer.aoLightValueScratchYZPN = getMixedAo(AOLV[1][2][0], AOLV[1][2][1], ratio);
-            renderer.aoLightValueScratchXZPN = getMixedAo(AOLV[2][1][0], AOLV[2][1][1], ratio);
-            renderer.aoLightValueScratchXYZNNN = getMixedAo(AOLV[0][0][0], AOLV[0][0][1], ratio);
-            renderer.aoLightValueScratchXYZNPN = getMixedAo(AOLV[0][2][0], AOLV[0][2][1], ratio);
-            renderer.aoLightValueScratchXYZPNN = getMixedAo(AOLV[2][0][0], AOLV[2][0][1], ratio);
-            renderer.aoLightValueScratchXYZPPN = getMixedAo(AOLV[2][2][0], AOLV[2][2][1], ratio);
+            renderBlocks.aoBrightnessXZNN = MBFB[0][1][iZ];
+            renderBlocks.aoBrightnessYZNN = MBFB[1][0][iZ];
+            renderBlocks.aoBrightnessYZPN = MBFB[1][2][iZ];
+            renderBlocks.aoBrightnessXZPN = MBFB[2][1][iZ];
+            renderBlocks.aoBrightnessXYZNNN = MBFB[0][0][iZ];
+            renderBlocks.aoBrightnessXYZNPN = MBFB[0][2][iZ];
+            renderBlocks.aoBrightnessXYZPNN = MBFB[2][0][iZ];
+            renderBlocks.aoBrightnessXYZPPN = MBFB[2][2][iZ];
+            renderBlocks.aoLightValueScratchXZNN = getMixedAo(AOLV[0][1][0], AOLV[0][1][1], ratio);
+            renderBlocks.aoLightValueScratchYZNN = getMixedAo(AOLV[1][0][0], AOLV[1][0][1], ratio);
+            renderBlocks.aoLightValueScratchYZPN = getMixedAo(AOLV[1][2][0], AOLV[1][2][1], ratio);
+            renderBlocks.aoLightValueScratchXZPN = getMixedAo(AOLV[2][1][0], AOLV[2][1][1], ratio);
+            renderBlocks.aoLightValueScratchXYZNNN = getMixedAo(AOLV[0][0][0], AOLV[0][0][1], ratio);
+            renderBlocks.aoLightValueScratchXYZNPN = getMixedAo(AOLV[0][2][0], AOLV[0][2][1], ratio);
+            renderBlocks.aoLightValueScratchXYZPNN = getMixedAo(AOLV[2][0][0], AOLV[2][0][1], ratio);
+            renderBlocks.aoLightValueScratchXYZPPN = getMixedAo(AOLV[2][2][0], AOLV[2][2][1], ratio);
 
-            final int brightnessMixedXYZPPN = renderer.getAoBrightness(
-                renderer.aoBrightnessYZPN,
-                renderer.aoBrightnessXZPN,
-                renderer.aoBrightnessXYZPPN,
+            final int brightnessMixedXYZPPN = renderBlocks.getAoBrightness(
+                renderBlocks.aoBrightnessYZPN,
+                renderBlocks.aoBrightnessXZPN,
+                renderBlocks.aoBrightnessXYZPPN,
                 mixedBrightness);
-            final int brightnessMixedXYZPNN = renderer.getAoBrightness(
-                renderer.aoBrightnessYZNN,
-                renderer.aoBrightnessXYZPNN,
-                renderer.aoBrightnessXZPN,
+            final int brightnessMixedXYZPNN = renderBlocks.getAoBrightness(
+                renderBlocks.aoBrightnessYZNN,
+                renderBlocks.aoBrightnessXYZPNN,
+                renderBlocks.aoBrightnessXZPN,
                 mixedBrightness);
-            final int brightnessMixedXYZNNN = renderer.getAoBrightness(
-                renderer.aoBrightnessXYZNNN,
-                renderer.aoBrightnessXZNN,
-                renderer.aoBrightnessYZNN,
+            final int brightnessMixedXYZNNN = renderBlocks.getAoBrightness(
+                renderBlocks.aoBrightnessXYZNNN,
+                renderBlocks.aoBrightnessXZNN,
+                renderBlocks.aoBrightnessYZNN,
                 mixedBrightness);
-            final int brightnessMixedXYZNPN = renderer.getAoBrightness(
-                renderer.aoBrightnessXZNN,
-                renderer.aoBrightnessXYZNPN,
-                renderer.aoBrightnessYZPN,
+            final int brightnessMixedXYZNPN = renderBlocks.getAoBrightness(
+                renderBlocks.aoBrightnessXZNN,
+                renderBlocks.aoBrightnessXYZNPN,
+                renderBlocks.aoBrightnessYZPN,
                 mixedBrightness);
 
-            final float aoMixedXYZPPN = (aoLightValue + renderer.aoLightValueScratchYZPN
-                + renderer.aoLightValueScratchXZPN
-                + renderer.aoLightValueScratchXYZPPN) / 4.0F;
-            final float aoMixedXYZPNN = (renderer.aoLightValueScratchYZNN + aoLightValue
-                + renderer.aoLightValueScratchXYZPNN
-                + renderer.aoLightValueScratchXZPN) / 4.0F;
-            final float aoMixedXYZNNN = (renderer.aoLightValueScratchXYZNNN + renderer.aoLightValueScratchXZNN
-                + renderer.aoLightValueScratchYZNN
+            final float aoMixedXYZPPN = (aoLightValue + renderBlocks.aoLightValueScratchYZPN
+                + renderBlocks.aoLightValueScratchXZPN
+                + renderBlocks.aoLightValueScratchXYZPPN) / 4.0F;
+            final float aoMixedXYZPNN = (renderBlocks.aoLightValueScratchYZNN + aoLightValue
+                + renderBlocks.aoLightValueScratchXYZPNN
+                + renderBlocks.aoLightValueScratchXZPN) / 4.0F;
+            final float aoMixedXYZNNN = (renderBlocks.aoLightValueScratchXYZNNN + renderBlocks.aoLightValueScratchXZNN
+                + renderBlocks.aoLightValueScratchYZNN
                 + aoLightValue) / 4.0F;
-            final float aoMixedXYZNPN = (renderer.aoLightValueScratchXZNN + renderer.aoLightValueScratchXYZNPN
+            final float aoMixedXYZNPN = (renderBlocks.aoLightValueScratchXZNN + renderBlocks.aoLightValueScratchXYZNPN
                 + aoLightValue
-                + renderer.aoLightValueScratchYZPN) / 4.0F;
+                + renderBlocks.aoLightValueScratchYZPN) / 4.0F;
 
-            aoTopLeft = (float) (aoMixedXYZNPN * renderer.renderMaxY * (1.0D - renderer.renderMinX)
-                + aoMixedXYZPPN * renderer.renderMaxY * renderer.renderMinX
-                + aoMixedXYZPNN * (1.0D - renderer.renderMaxY) * renderer.renderMinX
-                + aoMixedXYZNNN * (1.0D - renderer.renderMaxY) * (1.0D - renderer.renderMinX));
-            aoBottomLeft = (float) (aoMixedXYZNPN * renderer.renderMaxY * (1.0D - renderer.renderMaxX)
-                + aoMixedXYZPPN * renderer.renderMaxY * renderer.renderMaxX
-                + aoMixedXYZPNN * (1.0D - renderer.renderMaxY) * renderer.renderMaxX
-                + aoMixedXYZNNN * (1.0D - renderer.renderMaxY) * (1.0D - renderer.renderMaxX));
-            aoBottomRight = (float) (aoMixedXYZNPN * renderer.renderMinY * (1.0D - renderer.renderMaxX)
-                + aoMixedXYZPPN * renderer.renderMinY * renderer.renderMaxX
-                + aoMixedXYZPNN * (1.0D - renderer.renderMinY) * renderer.renderMaxX
-                + aoMixedXYZNNN * (1.0D - renderer.renderMinY) * (1.0D - renderer.renderMaxX));
-            aoTopRight = (float) (aoMixedXYZNPN * renderer.renderMinY * (1.0D - renderer.renderMinX)
-                + aoMixedXYZPPN * renderer.renderMinY * renderer.renderMinX
-                + aoMixedXYZPNN * (1.0D - renderer.renderMinY) * renderer.renderMinX
-                + aoMixedXYZNNN * (1.0D - renderer.renderMinY) * (1.0D - renderer.renderMinX));
+            aoTopLeft = (float) (aoMixedXYZNPN * renderBlocks.renderMaxY * (1.0D - renderBlocks.renderMinX)
+                + aoMixedXYZPPN * renderBlocks.renderMaxY * renderBlocks.renderMinX
+                + aoMixedXYZPNN * (1.0D - renderBlocks.renderMaxY) * renderBlocks.renderMinX
+                + aoMixedXYZNNN * (1.0D - renderBlocks.renderMaxY) * (1.0D - renderBlocks.renderMinX));
+            aoBottomLeft = (float) (aoMixedXYZNPN * renderBlocks.renderMaxY * (1.0D - renderBlocks.renderMaxX)
+                + aoMixedXYZPPN * renderBlocks.renderMaxY * renderBlocks.renderMaxX
+                + aoMixedXYZPNN * (1.0D - renderBlocks.renderMaxY) * renderBlocks.renderMaxX
+                + aoMixedXYZNNN * (1.0D - renderBlocks.renderMaxY) * (1.0D - renderBlocks.renderMaxX));
+            aoBottomRight = (float) (aoMixedXYZNPN * renderBlocks.renderMinY * (1.0D - renderBlocks.renderMaxX)
+                + aoMixedXYZPPN * renderBlocks.renderMinY * renderBlocks.renderMaxX
+                + aoMixedXYZPNN * (1.0D - renderBlocks.renderMinY) * renderBlocks.renderMaxX
+                + aoMixedXYZNNN * (1.0D - renderBlocks.renderMinY) * (1.0D - renderBlocks.renderMaxX));
+            aoTopRight = (float) (aoMixedXYZNPN * renderBlocks.renderMinY * (1.0D - renderBlocks.renderMinX)
+                + aoMixedXYZPPN * renderBlocks.renderMinY * renderBlocks.renderMinX
+                + aoMixedXYZPNN * (1.0D - renderBlocks.renderMinY) * renderBlocks.renderMinX
+                + aoMixedXYZNNN * (1.0D - renderBlocks.renderMinY) * (1.0D - renderBlocks.renderMinX));
 
-            renderer.brightnessTopLeft = renderer.mixAoBrightness(
+            renderBlocks.brightnessTopLeft = renderBlocks.mixAoBrightness(
                 brightnessMixedXYZNPN,
                 brightnessMixedXYZPPN,
                 brightnessMixedXYZPNN,
                 brightnessMixedXYZNNN,
-                renderer.renderMaxY * (1.0D - renderer.renderMinX),
-                renderer.renderMaxY * renderer.renderMinX,
-                (1.0D - renderer.renderMaxY) * renderer.renderMinX,
-                (1.0D - renderer.renderMaxY) * (1.0D - renderer.renderMinX));
-            renderer.brightnessBottomLeft = renderer.mixAoBrightness(
+                renderBlocks.renderMaxY * (1.0D - renderBlocks.renderMinX),
+                renderBlocks.renderMaxY * renderBlocks.renderMinX,
+                (1.0D - renderBlocks.renderMaxY) * renderBlocks.renderMinX,
+                (1.0D - renderBlocks.renderMaxY) * (1.0D - renderBlocks.renderMinX));
+            renderBlocks.brightnessBottomLeft = renderBlocks.mixAoBrightness(
                 brightnessMixedXYZNPN,
                 brightnessMixedXYZPPN,
                 brightnessMixedXYZPNN,
                 brightnessMixedXYZNNN,
-                renderer.renderMaxY * (1.0D - renderer.renderMaxX),
-                renderer.renderMaxY * renderer.renderMaxX,
-                (1.0D - renderer.renderMaxY) * renderer.renderMaxX,
-                (1.0D - renderer.renderMaxY) * (1.0D - renderer.renderMaxX));
-            renderer.brightnessBottomRight = renderer.mixAoBrightness(
+                renderBlocks.renderMaxY * (1.0D - renderBlocks.renderMaxX),
+                renderBlocks.renderMaxY * renderBlocks.renderMaxX,
+                (1.0D - renderBlocks.renderMaxY) * renderBlocks.renderMaxX,
+                (1.0D - renderBlocks.renderMaxY) * (1.0D - renderBlocks.renderMaxX));
+            renderBlocks.brightnessBottomRight = renderBlocks.mixAoBrightness(
                 brightnessMixedXYZNPN,
                 brightnessMixedXYZPPN,
                 brightnessMixedXYZPNN,
                 brightnessMixedXYZNNN,
-                renderer.renderMinY * (1.0D - renderer.renderMaxX),
-                renderer.renderMinY * renderer.renderMaxX,
-                (1.0D - renderer.renderMinY) * renderer.renderMaxX,
-                (1.0D - renderer.renderMinY) * (1.0D - renderer.renderMaxX));
-            renderer.brightnessTopRight = renderer.mixAoBrightness(
+                renderBlocks.renderMinY * (1.0D - renderBlocks.renderMaxX),
+                renderBlocks.renderMinY * renderBlocks.renderMaxX,
+                (1.0D - renderBlocks.renderMinY) * renderBlocks.renderMaxX,
+                (1.0D - renderBlocks.renderMinY) * (1.0D - renderBlocks.renderMaxX));
+            renderBlocks.brightnessTopRight = renderBlocks.mixAoBrightness(
                 brightnessMixedXYZNPN,
                 brightnessMixedXYZPPN,
                 brightnessMixedXYZPNN,
                 brightnessMixedXYZNNN,
-                renderer.renderMinY * (1.0D - renderer.renderMinX),
-                renderer.renderMinY * renderer.renderMinX,
-                (1.0D - renderer.renderMinY) * renderer.renderMinX,
-                (1.0D - renderer.renderMinY) * (1.0D - renderer.renderMinX));
+                renderBlocks.renderMinY * (1.0D - renderBlocks.renderMinX),
+                renderBlocks.renderMinY * renderBlocks.renderMinX,
+                (1.0D - renderBlocks.renderMinY) * renderBlocks.renderMinX,
+                (1.0D - renderBlocks.renderMinY) * (1.0D - renderBlocks.renderMinX));
+        } else {
+            final int iZ = block.getBlockBoundsMinZ() < FLUSH_MIN ? 0 : 1;
+            // Use neighbor brightness if face is flush with neighbor, otherwise current block brightness
+            Tessellator.instance.setBrightness(MBFB[1][1][iZ]);
         }
 
         return this;
@@ -958,122 +734,400 @@ public class SBRWorldContext extends SBRContextBase<SBRWorldContext> {
      *
      * @return the {@link SBRWorldContext}
      */
-    public SBRWorldContext setupAOZPos() {
+    public SBRWorldContext setupLightingZPos() {
 
-        if (renderer.enableAO) {
+        if (renderBlocks.enableAO) {
 
-            final int iZ = renderer.renderMaxZ < 1.0F - NO_Z_FIGHT_OFFSET ? 1 : 2;
+            final int iZ = renderBlocks.renderMaxZ < 1.0F - NO_Z_FIGHT_OFFSET ? 1 : 2;
 
             final int mixedBrightness = MBFB[1][1][iZ];
             brightness = mixedBrightness;
 
-            final double ratio = renderer.renderMaxZ;
+            final double ratio = renderBlocks.renderMaxZ;
             final float aoLightValue = AOLV[1][1][2];
 
-            renderer.aoBrightnessXZNP = MBFB[0][1][iZ];
-            renderer.aoBrightnessXZPP = MBFB[2][1][iZ];
-            renderer.aoBrightnessYZNP = MBFB[1][0][iZ];
-            renderer.aoBrightnessYZPP = MBFB[1][2][iZ];
-            renderer.aoBrightnessXYZNNP = MBFB[0][0][iZ];
-            renderer.aoBrightnessXYZNPP = MBFB[0][2][iZ];
-            renderer.aoBrightnessXYZPNP = MBFB[2][0][iZ];
-            renderer.aoBrightnessXYZPPP = MBFB[2][2][iZ];
-            renderer.aoLightValueScratchXZNP = getMixedAo(AOLV[0][1][2], AOLV[0][1][1], ratio);
-            renderer.aoLightValueScratchXZPP = getMixedAo(AOLV[2][1][2], AOLV[2][1][1], ratio);
-            renderer.aoLightValueScratchYZNP = getMixedAo(AOLV[1][0][2], AOLV[1][0][1], ratio);
-            renderer.aoLightValueScratchYZPP = getMixedAo(AOLV[1][2][2], AOLV[1][2][1], ratio);
-            renderer.aoLightValueScratchXYZNNP = getMixedAo(AOLV[0][0][2], AOLV[0][0][1], ratio);
-            renderer.aoLightValueScratchXYZNPP = getMixedAo(AOLV[0][2][2], AOLV[0][2][1], ratio);
-            renderer.aoLightValueScratchXYZPNP = getMixedAo(AOLV[2][0][2], AOLV[2][0][1], ratio);
-            renderer.aoLightValueScratchXYZPPP = getMixedAo(AOLV[2][2][2], AOLV[2][2][1], ratio);
+            renderBlocks.aoBrightnessXZNP = MBFB[0][1][iZ];
+            renderBlocks.aoBrightnessXZPP = MBFB[2][1][iZ];
+            renderBlocks.aoBrightnessYZNP = MBFB[1][0][iZ];
+            renderBlocks.aoBrightnessYZPP = MBFB[1][2][iZ];
+            renderBlocks.aoBrightnessXYZNNP = MBFB[0][0][iZ];
+            renderBlocks.aoBrightnessXYZNPP = MBFB[0][2][iZ];
+            renderBlocks.aoBrightnessXYZPNP = MBFB[2][0][iZ];
+            renderBlocks.aoBrightnessXYZPPP = MBFB[2][2][iZ];
+            renderBlocks.aoLightValueScratchXZNP = getMixedAo(AOLV[0][1][2], AOLV[0][1][1], ratio);
+            renderBlocks.aoLightValueScratchXZPP = getMixedAo(AOLV[2][1][2], AOLV[2][1][1], ratio);
+            renderBlocks.aoLightValueScratchYZNP = getMixedAo(AOLV[1][0][2], AOLV[1][0][1], ratio);
+            renderBlocks.aoLightValueScratchYZPP = getMixedAo(AOLV[1][2][2], AOLV[1][2][1], ratio);
+            renderBlocks.aoLightValueScratchXYZNNP = getMixedAo(AOLV[0][0][2], AOLV[0][0][1], ratio);
+            renderBlocks.aoLightValueScratchXYZNPP = getMixedAo(AOLV[0][2][2], AOLV[0][2][1], ratio);
+            renderBlocks.aoLightValueScratchXYZPNP = getMixedAo(AOLV[2][0][2], AOLV[2][0][1], ratio);
+            renderBlocks.aoLightValueScratchXYZPPP = getMixedAo(AOLV[2][2][2], AOLV[2][2][1], ratio);
 
-            final int brightnessMixedXYZNPP = renderer.getAoBrightness(
-                renderer.aoBrightnessXZNP,
-                renderer.aoBrightnessXYZNPP,
-                renderer.aoBrightnessYZPP,
+            final int brightnessMixedXYZNPP = renderBlocks.getAoBrightness(
+                renderBlocks.aoBrightnessXZNP,
+                renderBlocks.aoBrightnessXYZNPP,
+                renderBlocks.aoBrightnessYZPP,
                 mixedBrightness);
-            final int brightnessMixedXYZNNP = renderer.getAoBrightness(
-                renderer.aoBrightnessXYZNNP,
-                renderer.aoBrightnessXZNP,
-                renderer.aoBrightnessYZNP,
+            final int brightnessMixedXYZNNP = renderBlocks.getAoBrightness(
+                renderBlocks.aoBrightnessXYZNNP,
+                renderBlocks.aoBrightnessXZNP,
+                renderBlocks.aoBrightnessYZNP,
                 mixedBrightness);
-            final int brightnessMixedXYZPNP = renderer.getAoBrightness(
-                renderer.aoBrightnessYZNP,
-                renderer.aoBrightnessXYZPNP,
-                renderer.aoBrightnessXZPP,
+            final int brightnessMixedXYZPNP = renderBlocks.getAoBrightness(
+                renderBlocks.aoBrightnessYZNP,
+                renderBlocks.aoBrightnessXYZPNP,
+                renderBlocks.aoBrightnessXZPP,
                 mixedBrightness);
-            final int brightnessMixedXYZPPP = renderer.getAoBrightness(
-                renderer.aoBrightnessYZPP,
-                renderer.aoBrightnessXZPP,
-                renderer.aoBrightnessXYZPPP,
+            final int brightnessMixedXYZPPP = renderBlocks.getAoBrightness(
+                renderBlocks.aoBrightnessYZPP,
+                renderBlocks.aoBrightnessXZPP,
+                renderBlocks.aoBrightnessXYZPPP,
                 mixedBrightness);
 
-            final float aoMixedXYZNPP = (renderer.aoLightValueScratchXZNP + renderer.aoLightValueScratchXYZNPP
+            final float aoMixedXYZNPP = (renderBlocks.aoLightValueScratchXZNP + renderBlocks.aoLightValueScratchXYZNPP
                 + aoLightValue
-                + renderer.aoLightValueScratchYZPP) / 4.0F;
-            final float aoMixedXYZNNP = (renderer.aoLightValueScratchXYZNNP + renderer.aoLightValueScratchXZNP
-                + renderer.aoLightValueScratchYZNP
+                + renderBlocks.aoLightValueScratchYZPP) / 4.0F;
+            final float aoMixedXYZNNP = (renderBlocks.aoLightValueScratchXYZNNP + renderBlocks.aoLightValueScratchXZNP
+                + renderBlocks.aoLightValueScratchYZNP
                 + aoLightValue) / 4.0F;
-            final float aoMixedXYZPNP = (renderer.aoLightValueScratchYZNP + aoLightValue
-                + renderer.aoLightValueScratchXYZPNP
-                + renderer.aoLightValueScratchXZPP) / 4.0F;
-            final float aoMixedXYZPPP = (aoLightValue + renderer.aoLightValueScratchYZPP
-                + renderer.aoLightValueScratchXZPP
-                + renderer.aoLightValueScratchXYZPPP) / 4.0F;
+            final float aoMixedXYZPNP = (renderBlocks.aoLightValueScratchYZNP + aoLightValue
+                + renderBlocks.aoLightValueScratchXYZPNP
+                + renderBlocks.aoLightValueScratchXZPP) / 4.0F;
+            final float aoMixedXYZPPP = (aoLightValue + renderBlocks.aoLightValueScratchYZPP
+                + renderBlocks.aoLightValueScratchXZPP
+                + renderBlocks.aoLightValueScratchXYZPPP) / 4.0F;
 
-            aoTopLeft = (float) (aoMixedXYZNPP * renderer.renderMaxY * (1.0D - renderer.renderMinX)
-                + aoMixedXYZPPP * renderer.renderMaxY * renderer.renderMinX
-                + aoMixedXYZPNP * (1.0D - renderer.renderMaxY) * renderer.renderMinX
-                + aoMixedXYZNNP * (1.0D - renderer.renderMaxY) * (1.0D - renderer.renderMinX));
-            aoBottomLeft = (float) (aoMixedXYZNPP * renderer.renderMinY * (1.0D - renderer.renderMinX)
-                + aoMixedXYZPPP * renderer.renderMinY * renderer.renderMinX
-                + aoMixedXYZPNP * (1.0D - renderer.renderMinY) * renderer.renderMinX
-                + aoMixedXYZNNP * (1.0D - renderer.renderMinY) * (1.0D - renderer.renderMinX));
-            aoBottomRight = (float) (aoMixedXYZNPP * renderer.renderMinY * (1.0D - renderer.renderMaxX)
-                + aoMixedXYZPPP * renderer.renderMinY * renderer.renderMaxX
-                + aoMixedXYZPNP * (1.0D - renderer.renderMinY) * renderer.renderMaxX
-                + aoMixedXYZNNP * (1.0D - renderer.renderMinY) * (1.0D - renderer.renderMaxX));
-            aoTopRight = (float) (aoMixedXYZNPP * renderer.renderMaxY * (1.0D - renderer.renderMaxX)
-                + aoMixedXYZPPP * renderer.renderMaxY * renderer.renderMaxX
-                + aoMixedXYZPNP * (1.0D - renderer.renderMaxY) * renderer.renderMaxX
-                + aoMixedXYZNNP * (1.0D - renderer.renderMaxY) * (1.0D - renderer.renderMaxX));
+            aoTopLeft = (float) (aoMixedXYZNPP * renderBlocks.renderMaxY * (1.0D - renderBlocks.renderMinX)
+                + aoMixedXYZPPP * renderBlocks.renderMaxY * renderBlocks.renderMinX
+                + aoMixedXYZPNP * (1.0D - renderBlocks.renderMaxY) * renderBlocks.renderMinX
+                + aoMixedXYZNNP * (1.0D - renderBlocks.renderMaxY) * (1.0D - renderBlocks.renderMinX));
+            aoBottomLeft = (float) (aoMixedXYZNPP * renderBlocks.renderMinY * (1.0D - renderBlocks.renderMinX)
+                + aoMixedXYZPPP * renderBlocks.renderMinY * renderBlocks.renderMinX
+                + aoMixedXYZPNP * (1.0D - renderBlocks.renderMinY) * renderBlocks.renderMinX
+                + aoMixedXYZNNP * (1.0D - renderBlocks.renderMinY) * (1.0D - renderBlocks.renderMinX));
+            aoBottomRight = (float) (aoMixedXYZNPP * renderBlocks.renderMinY * (1.0D - renderBlocks.renderMaxX)
+                + aoMixedXYZPPP * renderBlocks.renderMinY * renderBlocks.renderMaxX
+                + aoMixedXYZPNP * (1.0D - renderBlocks.renderMinY) * renderBlocks.renderMaxX
+                + aoMixedXYZNNP * (1.0D - renderBlocks.renderMinY) * (1.0D - renderBlocks.renderMaxX));
+            aoTopRight = (float) (aoMixedXYZNPP * renderBlocks.renderMaxY * (1.0D - renderBlocks.renderMaxX)
+                + aoMixedXYZPPP * renderBlocks.renderMaxY * renderBlocks.renderMaxX
+                + aoMixedXYZPNP * (1.0D - renderBlocks.renderMaxY) * renderBlocks.renderMaxX
+                + aoMixedXYZNNP * (1.0D - renderBlocks.renderMaxY) * (1.0D - renderBlocks.renderMaxX));
 
-            renderer.brightnessTopLeft = renderer.mixAoBrightness(
+            renderBlocks.brightnessTopLeft = renderBlocks.mixAoBrightness(
                 brightnessMixedXYZNPP,
                 brightnessMixedXYZNNP,
                 brightnessMixedXYZPNP,
                 brightnessMixedXYZPPP,
-                renderer.renderMaxY * (1.0D - renderer.renderMinX),
-                (1.0D - renderer.renderMaxY) * (1.0D - renderer.renderMinX),
-                (1.0D - renderer.renderMaxY) * renderer.renderMinX,
-                renderer.renderMaxY * renderer.renderMinX);
-            renderer.brightnessBottomLeft = renderer.mixAoBrightness(
+                renderBlocks.renderMaxY * (1.0D - renderBlocks.renderMinX),
+                (1.0D - renderBlocks.renderMaxY) * (1.0D - renderBlocks.renderMinX),
+                (1.0D - renderBlocks.renderMaxY) * renderBlocks.renderMinX,
+                renderBlocks.renderMaxY * renderBlocks.renderMinX);
+            renderBlocks.brightnessBottomLeft = renderBlocks.mixAoBrightness(
                 brightnessMixedXYZNPP,
                 brightnessMixedXYZNNP,
                 brightnessMixedXYZPNP,
                 brightnessMixedXYZPPP,
-                renderer.renderMinY * (1.0D - renderer.renderMinX),
-                (1.0D - renderer.renderMinY) * (1.0D - renderer.renderMinX),
-                (1.0D - renderer.renderMinY) * renderer.renderMinX,
-                renderer.renderMinY * renderer.renderMinX);
-            renderer.brightnessBottomRight = renderer.mixAoBrightness(
+                renderBlocks.renderMinY * (1.0D - renderBlocks.renderMinX),
+                (1.0D - renderBlocks.renderMinY) * (1.0D - renderBlocks.renderMinX),
+                (1.0D - renderBlocks.renderMinY) * renderBlocks.renderMinX,
+                renderBlocks.renderMinY * renderBlocks.renderMinX);
+            renderBlocks.brightnessBottomRight = renderBlocks.mixAoBrightness(
                 brightnessMixedXYZNPP,
                 brightnessMixedXYZNNP,
                 brightnessMixedXYZPNP,
                 brightnessMixedXYZPPP,
-                renderer.renderMinY * (1.0D - renderer.renderMaxX),
-                (1.0D - renderer.renderMinY) * (1.0D - renderer.renderMaxX),
-                (1.0D - renderer.renderMinY) * renderer.renderMaxX,
-                renderer.renderMinY * renderer.renderMaxX);
-            renderer.brightnessTopRight = renderer.mixAoBrightness(
+                renderBlocks.renderMinY * (1.0D - renderBlocks.renderMaxX),
+                (1.0D - renderBlocks.renderMinY) * (1.0D - renderBlocks.renderMaxX),
+                (1.0D - renderBlocks.renderMinY) * renderBlocks.renderMaxX,
+                renderBlocks.renderMinY * renderBlocks.renderMaxX);
+            renderBlocks.brightnessTopRight = renderBlocks.mixAoBrightness(
                 brightnessMixedXYZNPP,
                 brightnessMixedXYZNNP,
                 brightnessMixedXYZPNP,
                 brightnessMixedXYZPPP,
-                renderer.renderMaxY * (1.0D - renderer.renderMaxX),
-                (1.0D - renderer.renderMaxY) * (1.0D - renderer.renderMaxX),
-                (1.0D - renderer.renderMaxY) * renderer.renderMaxX,
-                renderer.renderMaxY * renderer.renderMaxX);
+                renderBlocks.renderMaxY * (1.0D - renderBlocks.renderMaxX),
+                (1.0D - renderBlocks.renderMaxY) * (1.0D - renderBlocks.renderMaxX),
+                (1.0D - renderBlocks.renderMaxY) * renderBlocks.renderMaxX,
+                renderBlocks.renderMaxY * renderBlocks.renderMaxX);
+        } else {
+            final int iZ = block.getBlockBoundsMaxZ() > FLUSH_MAX ? 2 : 1;
+            // Use neighbor brightness if face is flush with neighbor, otherwise current block brightness
+            Tessellator.instance.setBrightness(MBFB[1][1][iZ]);
+        }
+
+        return this;
+    }
+
+    /**
+     * Sets up lighting for the West face and returns the {@link SBRWorldContext}.
+     * <p>
+     * This is a consolidated <code>method</code> that sets side shading with respect to the following attributes:
+     * <p>
+     * <ul>
+     * <li>{@link RenderBlocks#enableAO}</li>
+     * <li>{@link RenderBlocks#partialRenderBounds}</li>
+     * </ul>
+     *
+     * @return the {@link SBRWorldContext}
+     */
+    public SBRWorldContext setupLightingXNeg() {
+
+        if (renderBlocks.enableAO) {
+
+            final int iX = renderBlocks.renderMinX > 0.0F + NO_Z_FIGHT_OFFSET ? 1 : 0;
+
+            final int mixedBrightness = MBFB[iX][1][1];
+            brightness = mixedBrightness;
+
+            final double ratio = 1.0D - renderBlocks.renderMinX;
+            final float aoLightValue = AOLV[0][1][1];
+
+            renderBlocks.aoBrightnessXYNN = MBFB[iX][0][1];
+            renderBlocks.aoBrightnessXZNN = MBFB[iX][1][0];
+            renderBlocks.aoBrightnessXZNP = MBFB[iX][1][2];
+            renderBlocks.aoBrightnessXYNP = MBFB[iX][2][1];
+            renderBlocks.aoBrightnessXYZNNN = MBFB[iX][0][0];
+            renderBlocks.aoBrightnessXYZNNP = MBFB[iX][0][2];
+            renderBlocks.aoBrightnessXYZNPN = MBFB[iX][2][0];
+            renderBlocks.aoBrightnessXYZNPP = MBFB[iX][2][2];
+            renderBlocks.aoLightValueScratchXYNN = getMixedAo(AOLV[0][0][1], AOLV[1][0][1], ratio);
+            renderBlocks.aoLightValueScratchXZNN = getMixedAo(AOLV[0][1][0], AOLV[1][1][0], ratio);
+            renderBlocks.aoLightValueScratchXZNP = getMixedAo(AOLV[0][1][2], AOLV[1][1][2], ratio);
+            renderBlocks.aoLightValueScratchXYNP = getMixedAo(AOLV[0][2][1], AOLV[1][2][1], ratio);
+            renderBlocks.aoLightValueScratchXYZNNN = getMixedAo(AOLV[0][0][0], AOLV[1][0][0], ratio);
+            renderBlocks.aoLightValueScratchXYZNNP = getMixedAo(AOLV[0][0][2], AOLV[1][0][2], ratio);
+            renderBlocks.aoLightValueScratchXYZNPN = getMixedAo(AOLV[0][2][0], AOLV[1][2][0], ratio);
+            renderBlocks.aoLightValueScratchXYZNPP = getMixedAo(AOLV[0][2][2], AOLV[1][2][2], ratio);
+
+            final int brightnessMixedXYZNPN = renderBlocks.getAoBrightness(
+                renderBlocks.aoBrightnessXZNN,
+                renderBlocks.aoBrightnessXYZNPN,
+                renderBlocks.aoBrightnessXYNP,
+                mixedBrightness);
+            final int brightnessMixedXYZNNN = renderBlocks.getAoBrightness(
+                renderBlocks.aoBrightnessXYZNNN,
+                renderBlocks.aoBrightnessXYNN,
+                renderBlocks.aoBrightnessXZNN,
+                mixedBrightness);
+            final int brightnessMixedXYZNNP = renderBlocks.getAoBrightness(
+                renderBlocks.aoBrightnessXYNN,
+                renderBlocks.aoBrightnessXYZNNP,
+                renderBlocks.aoBrightnessXZNP,
+                mixedBrightness);
+            final int brightnessMixedXYZNPP = renderBlocks.getAoBrightness(
+                renderBlocks.aoBrightnessXZNP,
+                renderBlocks.aoBrightnessXYNP,
+                renderBlocks.aoBrightnessXYZNPP,
+                mixedBrightness);
+
+            final float aoMixedXYZNPN = (renderBlocks.aoLightValueScratchXZNN + aoLightValue
+                + renderBlocks.aoLightValueScratchXYZNPN
+                + renderBlocks.aoLightValueScratchXYNP) / 4.0F;
+            final float aoMixedXYZNNN = (renderBlocks.aoLightValueScratchXYZNNN + renderBlocks.aoLightValueScratchXYNN
+                + renderBlocks.aoLightValueScratchXZNN
+                + aoLightValue) / 4.0F;
+            final float aoMixedXYZNNP = (renderBlocks.aoLightValueScratchXYNN + renderBlocks.aoLightValueScratchXYZNNP
+                + aoLightValue
+                + renderBlocks.aoLightValueScratchXZNP) / 4.0F;
+            final float aoMixedXYZNPP = (aoLightValue + renderBlocks.aoLightValueScratchXZNP
+                + renderBlocks.aoLightValueScratchXYNP
+                + renderBlocks.aoLightValueScratchXYZNPP) / 4.0F;
+
+            aoTopLeft = (float) (aoMixedXYZNPP * renderBlocks.renderMaxY * renderBlocks.renderMaxZ
+                + aoMixedXYZNPN * renderBlocks.renderMaxY * (1.0D - renderBlocks.renderMaxZ)
+                + aoMixedXYZNNN * (1.0D - renderBlocks.renderMaxY) * (1.0D - renderBlocks.renderMaxZ)
+                + aoMixedXYZNNP * (1.0D - renderBlocks.renderMaxY) * renderBlocks.renderMaxZ);
+            aoBottomLeft = (float) (aoMixedXYZNPP * renderBlocks.renderMaxY * renderBlocks.renderMinZ
+                + aoMixedXYZNPN * renderBlocks.renderMaxY * (1.0D - renderBlocks.renderMinZ)
+                + aoMixedXYZNNN * (1.0D - renderBlocks.renderMaxY) * (1.0D - renderBlocks.renderMinZ)
+                + aoMixedXYZNNP * (1.0D - renderBlocks.renderMaxY) * renderBlocks.renderMinZ);
+            aoBottomRight = (float) (aoMixedXYZNPP * renderBlocks.renderMinY * renderBlocks.renderMinZ
+                + aoMixedXYZNPN * renderBlocks.renderMinY * (1.0D - renderBlocks.renderMinZ)
+                + aoMixedXYZNNN * (1.0D - renderBlocks.renderMinY) * (1.0D - renderBlocks.renderMinZ)
+                + aoMixedXYZNNP * (1.0D - renderBlocks.renderMinY) * renderBlocks.renderMinZ);
+            aoTopRight = (float) (aoMixedXYZNPP * renderBlocks.renderMinY * renderBlocks.renderMaxZ
+                + aoMixedXYZNPN * renderBlocks.renderMinY * (1.0D - renderBlocks.renderMaxZ)
+                + aoMixedXYZNNN * (1.0D - renderBlocks.renderMinY) * (1.0D - renderBlocks.renderMaxZ)
+                + aoMixedXYZNNP * (1.0D - renderBlocks.renderMinY) * renderBlocks.renderMaxZ);
+
+            renderBlocks.brightnessTopLeft = renderBlocks.mixAoBrightness(
+                brightnessMixedXYZNPP,
+                brightnessMixedXYZNPN,
+                brightnessMixedXYZNNN,
+                brightnessMixedXYZNNP,
+                renderBlocks.renderMaxY * renderBlocks.renderMaxZ,
+                renderBlocks.renderMaxY * (1.0D - renderBlocks.renderMaxZ),
+                (1.0D - renderBlocks.renderMaxY) * (1.0D - renderBlocks.renderMaxZ),
+                (1.0D - renderBlocks.renderMaxY) * renderBlocks.renderMaxZ);
+            renderBlocks.brightnessBottomLeft = renderBlocks.mixAoBrightness(
+                brightnessMixedXYZNPP,
+                brightnessMixedXYZNPN,
+                brightnessMixedXYZNNN,
+                brightnessMixedXYZNNP,
+                renderBlocks.renderMaxY * renderBlocks.renderMinZ,
+                renderBlocks.renderMaxY * (1.0D - renderBlocks.renderMinZ),
+                (1.0D - renderBlocks.renderMaxY) * (1.0D - renderBlocks.renderMinZ),
+                (1.0D - renderBlocks.renderMaxY) * renderBlocks.renderMinZ);
+            renderBlocks.brightnessBottomRight = renderBlocks.mixAoBrightness(
+                brightnessMixedXYZNPP,
+                brightnessMixedXYZNPN,
+                brightnessMixedXYZNNN,
+                brightnessMixedXYZNNP,
+                renderBlocks.renderMinY * renderBlocks.renderMinZ,
+                renderBlocks.renderMinY * (1.0D - renderBlocks.renderMinZ),
+                (1.0D - renderBlocks.renderMinY) * (1.0D - renderBlocks.renderMinZ),
+                (1.0D - renderBlocks.renderMinY) * renderBlocks.renderMinZ);
+            renderBlocks.brightnessTopRight = renderBlocks.mixAoBrightness(
+                brightnessMixedXYZNPP,
+                brightnessMixedXYZNPN,
+                brightnessMixedXYZNNN,
+                brightnessMixedXYZNNP,
+                renderBlocks.renderMinY * renderBlocks.renderMaxZ,
+                renderBlocks.renderMinY * (1.0D - renderBlocks.renderMaxZ),
+                (1.0D - renderBlocks.renderMinY) * (1.0D - renderBlocks.renderMaxZ),
+                (1.0D - renderBlocks.renderMinY) * renderBlocks.renderMaxZ);
+        } else {
+            final int iX = block.getBlockBoundsMinX() < FLUSH_MIN ? 0 : 1;
+            // Use neighbor brightness if face is flush with neighbor, otherwise current block brightness
+            Tessellator.instance.setBrightness(MBFB[iX][1][1]);
+        }
+
+        return this;
+    }
+
+    /**
+     * Sets up lighting for the East face and returns the {@link SBRWorldContext}.
+     * <p>
+     * This is a consolidated <code>method</code> that sets side shading with respect to the following attributes:
+     * <p>
+     * <ul>
+     * <li>{@link RenderBlocks#enableAO}</li>
+     * <li>{@link RenderBlocks#partialRenderBounds}</li>
+     * </ul>
+     *
+     * @return the {@link SBRWorldContext}
+     */
+    public SBRWorldContext setupLightingXPos() {
+
+        if (renderBlocks.enableAO) {
+
+            final int iX = renderBlocks.renderMaxX < 1.0F - NO_Z_FIGHT_OFFSET ? 1 : 2;
+
+            final int mixedBrightness = MBFB[iX][1][1];
+            brightness = mixedBrightness;
+
+            final double ratio = renderBlocks.renderMaxX;
+            final float aoLightValue = AOLV[2][1][1];
+
+            renderBlocks.aoBrightnessXYPN = MBFB[iX][0][1];
+            renderBlocks.aoBrightnessXZPN = MBFB[iX][1][0];
+            renderBlocks.aoBrightnessXZPP = MBFB[iX][1][2];
+            renderBlocks.aoBrightnessXYPP = MBFB[iX][2][1];
+            renderBlocks.aoBrightnessXYZPNN = MBFB[iX][0][0];
+            renderBlocks.aoBrightnessXYZPNP = MBFB[iX][0][2];
+            renderBlocks.aoBrightnessXYZPPN = MBFB[iX][2][0];
+            renderBlocks.aoBrightnessXYZPPP = MBFB[iX][2][2];
+            renderBlocks.aoLightValueScratchXYPN = getMixedAo(AOLV[2][0][1], AOLV[1][0][1], ratio);
+            renderBlocks.aoLightValueScratchXZPN = getMixedAo(AOLV[2][1][0], AOLV[1][1][0], ratio);
+            renderBlocks.aoLightValueScratchXZPP = getMixedAo(AOLV[2][1][2], AOLV[1][1][2], ratio);
+            renderBlocks.aoLightValueScratchXYPP = getMixedAo(AOLV[2][2][1], AOLV[1][2][1], ratio);
+            renderBlocks.aoLightValueScratchXYZPNN = getMixedAo(AOLV[2][0][0], AOLV[1][0][0], ratio);
+            renderBlocks.aoLightValueScratchXYZPNP = getMixedAo(AOLV[2][0][2], AOLV[1][0][2], ratio);
+            renderBlocks.aoLightValueScratchXYZPPN = getMixedAo(AOLV[2][2][0], AOLV[1][2][0], ratio);
+            renderBlocks.aoLightValueScratchXYZPPP = getMixedAo(AOLV[2][2][2], AOLV[1][2][2], ratio);
+
+            final int brightnessMixedXYZPPP = renderBlocks.getAoBrightness(
+                renderBlocks.aoBrightnessXZPP,
+                renderBlocks.aoBrightnessXYPP,
+                renderBlocks.aoBrightnessXYZPPP,
+                mixedBrightness);
+            final int brightnessMixedXYZPNP = renderBlocks.getAoBrightness(
+                renderBlocks.aoBrightnessXYPN,
+                renderBlocks.aoBrightnessXYZPNP,
+                renderBlocks.aoBrightnessXZPP,
+                mixedBrightness);
+            final int brightnessMixedXYZPNN = renderBlocks.getAoBrightness(
+                renderBlocks.aoBrightnessXYZPNN,
+                renderBlocks.aoBrightnessXYPN,
+                renderBlocks.aoBrightnessXZPN,
+                mixedBrightness);
+            final int brightnessMixedXYZPPN = renderBlocks.getAoBrightness(
+                renderBlocks.aoBrightnessXZPN,
+                renderBlocks.aoBrightnessXYZPPN,
+                renderBlocks.aoBrightnessXYPP,
+                mixedBrightness);
+
+            final float aoMixedXYZPPP = (aoLightValue + renderBlocks.aoLightValueScratchXZPP
+                + renderBlocks.aoLightValueScratchXYPP
+                + renderBlocks.aoLightValueScratchXYZPPP) / 4.0F;
+            final float aoMixedXYZPNP = (renderBlocks.aoLightValueScratchXYPN + renderBlocks.aoLightValueScratchXYZPNP
+                + aoLightValue
+                + renderBlocks.aoLightValueScratchXZPP) / 4.0F;
+            final float aoMixedXYZPNN = (renderBlocks.aoLightValueScratchXYZPNN + renderBlocks.aoLightValueScratchXYPN
+                + renderBlocks.aoLightValueScratchXZPN
+                + aoLightValue) / 4.0F;
+            final float aoMixedXYZPPN = (renderBlocks.aoLightValueScratchXZPN + aoLightValue
+                + renderBlocks.aoLightValueScratchXYZPPN
+                + renderBlocks.aoLightValueScratchXYPP) / 4.0F;
+
+            aoTopLeft = (float) (aoMixedXYZPNP * (1.0D - renderBlocks.renderMinY) * renderBlocks.renderMaxZ
+                + aoMixedXYZPNN * (1.0D - renderBlocks.renderMinY) * (1.0D - renderBlocks.renderMaxZ)
+                + aoMixedXYZPPN * renderBlocks.renderMinY * (1.0D - renderBlocks.renderMaxZ)
+                + aoMixedXYZPPP * renderBlocks.renderMinY * renderBlocks.renderMaxZ);
+            aoBottomLeft = (float) (aoMixedXYZPNP * (1.0D - renderBlocks.renderMinY) * renderBlocks.renderMinZ
+                + aoMixedXYZPNN * (1.0D - renderBlocks.renderMinY) * (1.0D - renderBlocks.renderMinZ)
+                + aoMixedXYZPPN * renderBlocks.renderMinY * (1.0D - renderBlocks.renderMinZ)
+                + aoMixedXYZPPP * renderBlocks.renderMinY * renderBlocks.renderMinZ);
+            aoBottomRight = (float) (aoMixedXYZPNP * (1.0D - renderBlocks.renderMaxY) * renderBlocks.renderMinZ
+                + aoMixedXYZPNN * (1.0D - renderBlocks.renderMaxY) * (1.0D - renderBlocks.renderMinZ)
+                + aoMixedXYZPPN * renderBlocks.renderMaxY * (1.0D - renderBlocks.renderMinZ)
+                + aoMixedXYZPPP * renderBlocks.renderMaxY * renderBlocks.renderMinZ);
+            aoTopRight = (float) (aoMixedXYZPNP * (1.0D - renderBlocks.renderMaxY) * renderBlocks.renderMaxZ
+                + aoMixedXYZPNN * (1.0D - renderBlocks.renderMaxY) * (1.0D - renderBlocks.renderMaxZ)
+                + aoMixedXYZPPN * renderBlocks.renderMaxY * (1.0D - renderBlocks.renderMaxZ)
+                + aoMixedXYZPPP * renderBlocks.renderMaxY * renderBlocks.renderMaxZ);
+
+            renderBlocks.brightnessTopLeft = renderBlocks.mixAoBrightness(
+                brightnessMixedXYZPNP,
+                brightnessMixedXYZPNN,
+                brightnessMixedXYZPPN,
+                brightnessMixedXYZPPP,
+                (1.0D - renderBlocks.renderMinY) * renderBlocks.renderMaxZ,
+                (1.0D - renderBlocks.renderMinY) * (1.0D - renderBlocks.renderMaxZ),
+                renderBlocks.renderMinY * (1.0D - renderBlocks.renderMaxZ),
+                renderBlocks.renderMinY * renderBlocks.renderMaxZ);
+            renderBlocks.brightnessBottomLeft = renderBlocks.mixAoBrightness(
+                brightnessMixedXYZPNP,
+                brightnessMixedXYZPNN,
+                brightnessMixedXYZPPN,
+                brightnessMixedXYZPPP,
+                (1.0D - renderBlocks.renderMinY) * renderBlocks.renderMinZ,
+                (1.0D - renderBlocks.renderMinY) * (1.0D - renderBlocks.renderMinZ),
+                renderBlocks.renderMinY * (1.0D - renderBlocks.renderMinZ),
+                renderBlocks.renderMinY * renderBlocks.renderMinZ);
+            renderBlocks.brightnessBottomRight = renderBlocks.mixAoBrightness(
+                brightnessMixedXYZPNP,
+                brightnessMixedXYZPNN,
+                brightnessMixedXYZPPN,
+                brightnessMixedXYZPPP,
+                (1.0D - renderBlocks.renderMaxY) * renderBlocks.renderMinZ,
+                (1.0D - renderBlocks.renderMaxY) * (1.0D - renderBlocks.renderMinZ),
+                renderBlocks.renderMaxY * (1.0D - renderBlocks.renderMinZ),
+                renderBlocks.renderMaxY * renderBlocks.renderMinZ);
+            renderBlocks.brightnessTopRight = renderBlocks.mixAoBrightness(
+                brightnessMixedXYZPNP,
+                brightnessMixedXYZPNN,
+                brightnessMixedXYZPPN,
+                brightnessMixedXYZPPP,
+                (1.0D - renderBlocks.renderMaxY) * renderBlocks.renderMaxZ,
+                (1.0D - renderBlocks.renderMaxY) * (1.0D - renderBlocks.renderMaxZ),
+                renderBlocks.renderMaxY * (1.0D - renderBlocks.renderMaxZ),
+                renderBlocks.renderMaxY * renderBlocks.renderMaxZ);
+        } else {
+            final int iX = block.getBlockBoundsMaxX() > FLUSH_MAX ? 2 : 1;
+            // Use neighbor brightness if face is flush with neighbor, otherwise current block brightness
+            Tessellator.instance.setBrightness(MBFB[iX][1][1]);
         }
 
         return this;

--- a/src/main/java/gregtech/api/render/SBRWorldContext.java
+++ b/src/main/java/gregtech/api/render/SBRWorldContext.java
@@ -17,6 +17,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.EntityRenderer;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.client.ForgeHooksClient;
 import net.minecraftforge.common.util.ForgeDirection;
@@ -38,14 +39,14 @@ import gregtech.api.interfaces.ITexture;
  * to various rendering methods throughout a block's render cycle.
  */
 @SideOnly(Side.CLIENT)
-public class SBRWorldContext extends SBRContextBase<SBRWorldContext> {
+public final class SBRWorldContext extends SBRContextBase<SBRWorldContext> {
 
-    public static final float NO_Z_FIGHT_OFFSET = 1.0F / 1024.0F;
-    public int worldRenderPass;
+    private static final float NO_Z_FIGHT_OFFSET = 1.0F / 1024.0F;
+    private int worldRenderPass;
 
     /** Non-null dummy world, replaced in {@link #setup}. */
     @NotNull
-    public IBlockAccess blockAccess = GTValues.DW;
+    private IBlockAccess blockAccess = GTValues.DW;
 
     /**
      * Mixed Brightness cache
@@ -55,6 +56,7 @@ public class SBRWorldContext extends SBRContextBase<SBRWorldContext> {
      * and its 26 neighbors within a 3×3×3 cube centered on (x, y, z).
      */
     private final int[][][] MBFB = new int[3][3][3];
+
     /**
      * Ambient Occlusion Light Value cache
      * <p>
@@ -63,16 +65,16 @@ public class SBRWorldContext extends SBRContextBase<SBRWorldContext> {
      * and its 26 neighbors within a 3×3×3 cube centered on (x, y, z).
      */
     private final float[][][] AOLV = new float[3][3][3];
-
     /** Used to determine if face is flush with negative neighbour */
     private static final double FLUSH_MIN = 0.001D;
+
     /** Used to determine if face is flush with positive neighbour */
     private static final double FLUSH_MAX = 0.999D;
-
     /**
      * Brightness for side.
      */
     private int brightness;
+
     /**
      * Ambient occlusion values for all four corners of side.
      */
@@ -109,6 +111,14 @@ public class SBRWorldContext extends SBRContextBase<SBRWorldContext> {
         populatesLightingCaches();
         reset();
         return this;
+    }
+
+    public @NotNull IBlockAccess getBlockAccess() {
+        return blockAccess;
+    }
+
+    public TileEntity getTileEntity() {
+        return blockAccess.getTileEntity(x, y, z);
     }
 
     /**

--- a/src/main/java/gregtech/api/util/GTUtilityClient.java
+++ b/src/main/java/gregtech/api/util/GTUtilityClient.java
@@ -84,7 +84,8 @@ public class GTUtilityClient {
         tExtendedFacing = ExtendedFacing.of(tDirection);
 
         // for some reason +x and -z need this field set to true, but not any other sides
-        if (tDirection == ForgeDirection.NORTH || tDirection == ForgeDirection.EAST) ctx.renderer.field_152631_f = true;
+        if (tDirection == ForgeDirection.NORTH || tDirection == ForgeDirection.EAST)
+            ctx.renderBlocks.field_152631_f = true;
 
         for (int i = 0; i < 9; i++) {
             tExtendedFacing.getWorldOffset(tABCCoord, tXYZOffset);
@@ -94,7 +95,7 @@ public class GTUtilityClient {
             int tZ = tXYZOffset[2] + ctx.z;
             Block tBlock;
             if (tBlockOverride == null) {
-                tBlock = ctx.world
+                tBlock = ctx.blockAccess
                     .getBlock(ctx.x + tDirection.offsetX, tY + tDirection.offsetY, ctx.z + tDirection.offsetZ);
             } else {
                 tBlock = tBlockOverride;
@@ -103,14 +104,14 @@ public class GTUtilityClient {
             // so the front face cannot be occluded whatsoever in the most cases.
             Tessellator.instance.setBrightness(
                 tBlock.getMixedBrightnessForBlock(
-                    ctx.world,
+                    ctx.blockAccess,
                     ctx.x + tDirection.offsetX,
                     tY + tDirection.offsetY,
                     ctx.z + tDirection.offsetZ));
-            ctx.setupAO(tDirection)
+            ctx.setupLighting(tDirection)
                 .setupColor(tDirection, Dyes._NULL.getRGBA());
             GTRenderUtil.renderBlockIcon(
-                ctx.renderer,
+                ctx.renderBlocks,
                 tBlock,
                 tX + tDirection.offsetX * 0.001,
                 tY + tDirection.offsetY * 0.001,
@@ -123,6 +124,6 @@ public class GTUtilityClient {
             }
         }
 
-        ctx.renderer.field_152631_f = false;
+        ctx.renderBlocks.field_152631_f = false;
     }
 }

--- a/src/main/java/gregtech/api/util/GTUtilityClient.java
+++ b/src/main/java/gregtech/api/util/GTUtilityClient.java
@@ -85,18 +85,21 @@ public class GTUtilityClient {
 
         // for some reason +x and -z need this field set to true, but not any other sides
         if (tDirection == ForgeDirection.NORTH || tDirection == ForgeDirection.EAST)
-            ctx.renderBlocks.field_152631_f = true;
+            ctx.getRenderBlocks().field_152631_f = true;
 
         for (int i = 0; i < 9; i++) {
             tExtendedFacing.getWorldOffset(tABCCoord, tXYZOffset);
             // since structure check passed, we can assume it is turbine casing
-            int tX = tXYZOffset[0] + ctx.x;
-            int tY = tXYZOffset[1] + ctx.y;
-            int tZ = tXYZOffset[2] + ctx.z;
+            int tX = tXYZOffset[0] + ctx.getX();
+            int tY = tXYZOffset[1] + ctx.getY();
+            int tZ = tXYZOffset[2] + ctx.getZ();
             Block tBlock;
             if (tBlockOverride == null) {
-                tBlock = ctx.blockAccess
-                    .getBlock(ctx.x + tDirection.offsetX, tY + tDirection.offsetY, ctx.z + tDirection.offsetZ);
+                tBlock = ctx.getBlockAccess()
+                    .getBlock(
+                        ctx.getX() + tDirection.offsetX,
+                        tY + tDirection.offsetY,
+                        ctx.getZ() + tDirection.offsetZ);
             } else {
                 tBlock = tBlockOverride;
             }
@@ -104,14 +107,14 @@ public class GTUtilityClient {
             // so the front face cannot be occluded whatsoever in the most cases.
             Tessellator.instance.setBrightness(
                 tBlock.getMixedBrightnessForBlock(
-                    ctx.blockAccess,
-                    ctx.x + tDirection.offsetX,
+                    ctx.getBlockAccess(),
+                    ctx.getX() + tDirection.offsetX,
                     tY + tDirection.offsetY,
-                    ctx.z + tDirection.offsetZ));
+                    ctx.getZ() + tDirection.offsetZ));
             ctx.setupLighting(tDirection)
                 .setupColor(tDirection, Dyes._NULL.getRGBA());
             GTRenderUtil.renderBlockIcon(
-                ctx.renderBlocks,
+                ctx.getRenderBlocks(),
                 tBlock,
                 tX + tDirection.offsetX * 0.001,
                 tY + tDirection.offsetY * 0.001,
@@ -124,6 +127,6 @@ public class GTUtilityClient {
             }
         }
 
-        ctx.renderBlocks.field_152631_f = false;
+        ctx.getRenderBlocks().field_152631_f = false;
     }
 }

--- a/src/main/java/gregtech/common/render/GTCopiedBlockTextureRender.java
+++ b/src/main/java/gregtech/common/render/GTCopiedBlockTextureRender.java
@@ -27,7 +27,7 @@ public class GTCopiedBlockTextureRender extends GTTextureBase implements ITextur
         mMeta = aMeta;
     }
 
-    private IIcon getIcon(int ordinalSide, SBRContextBase<? extends SBRContextBase<?>> ctx) {
+    private IIcon getIcon(int ordinalSide, SBRContextBase ctx) {
         final IIcon icon;
         if (mSide == 6) icon = mBlock.getIcon(ordinalSide, mMeta);
         else icon = mBlock.getIcon(mSide, mMeta);
@@ -39,7 +39,7 @@ public class GTCopiedBlockTextureRender extends GTTextureBase implements ITextur
     }
 
     @Override
-    public void renderXPos(SBRContextBase<? extends SBRContextBase<?>> ctx) {
+    public void renderXPos(SBRContextBase ctx) {
         if (!ctx.canRenderInPass(mBlock::canRenderInPass)) return;
         final IIcon aIcon = getIcon(ForgeDirection.EAST.ordinal(), ctx);
         ctx.getRenderBlocks().field_152631_f = true;
@@ -53,7 +53,7 @@ public class GTCopiedBlockTextureRender extends GTTextureBase implements ITextur
     }
 
     @Override
-    public void renderXNeg(SBRContextBase<? extends SBRContextBase<?>> ctx) {
+    public void renderXNeg(SBRContextBase ctx) {
         if (!ctx.canRenderInPass(mBlock::canRenderInPass)) return;
         startDrawingQuads(ctx.getRenderBlocks(), -1.0f, 0.0f, 0.0f);
         final IIcon aIcon = getIcon(ForgeDirection.WEST.ordinal(), ctx);
@@ -65,7 +65,7 @@ public class GTCopiedBlockTextureRender extends GTTextureBase implements ITextur
     }
 
     @Override
-    public void renderYPos(SBRContextBase<? extends SBRContextBase<?>> ctx) {
+    public void renderYPos(SBRContextBase ctx) {
         if (!ctx.canRenderInPass(mBlock::canRenderInPass)) return;
         startDrawingQuads(ctx.getRenderBlocks(), 0.0f, 1.0f, 0.0f);
         final IIcon aIcon = getIcon(ForgeDirection.UP.ordinal(), ctx);
@@ -77,7 +77,7 @@ public class GTCopiedBlockTextureRender extends GTTextureBase implements ITextur
     }
 
     @Override
-    public void renderYNeg(SBRContextBase<? extends SBRContextBase<?>> ctx) {
+    public void renderYNeg(SBRContextBase ctx) {
         if (!ctx.canRenderInPass(mBlock::canRenderInPass)) return;
         startDrawingQuads(ctx.getRenderBlocks(), 0.0f, -1.0f, 0.0f);
         final IIcon aIcon = getIcon(ForgeDirection.DOWN.ordinal(), ctx);
@@ -89,7 +89,7 @@ public class GTCopiedBlockTextureRender extends GTTextureBase implements ITextur
     }
 
     @Override
-    public void renderZPos(SBRContextBase<? extends SBRContextBase<?>> ctx) {
+    public void renderZPos(SBRContextBase ctx) {
         if (!ctx.canRenderInPass(mBlock::canRenderInPass)) return;
         startDrawingQuads(ctx.getRenderBlocks(), 0.0f, 0.0f, 1.0f);
         final IIcon aIcon = getIcon(ForgeDirection.SOUTH.ordinal(), ctx);
@@ -101,7 +101,7 @@ public class GTCopiedBlockTextureRender extends GTTextureBase implements ITextur
     }
 
     @Override
-    public void renderZNeg(SBRContextBase<? extends SBRContextBase<?>> ctx) {
+    public void renderZNeg(SBRContextBase ctx) {
         if (!ctx.canRenderInPass(mBlock::canRenderInPass)) return;
         startDrawingQuads(ctx.getRenderBlocks(), 0.0f, 0.0f, -1.0f);
         final IIcon aIcon = getIcon(ForgeDirection.NORTH.ordinal(), ctx);

--- a/src/main/java/gregtech/common/render/GTCopiedBlockTextureRender.java
+++ b/src/main/java/gregtech/common/render/GTCopiedBlockTextureRender.java
@@ -33,7 +33,8 @@ public class GTCopiedBlockTextureRender extends GTTextureBase implements ITextur
         else icon = mBlock.getIcon(mSide, mMeta);
         if (!Angelica.isModLoaded()) return icon;
         else return ctx instanceof SBRWorldContext ctxW
-            ? CTMUtils.getBlockIcon(icon, mBlock, ctxW.blockAccess, ctxW.x, ctxW.y, ctxW.z, ordinalSide)
+            ? CTMUtils
+                .getBlockIcon(icon, mBlock, ctxW.getBlockAccess(), ctxW.getX(), ctxW.getY(), ctxW.getZ(), ordinalSide)
             : CTMUtils.getBlockIcon(icon, mBlock, ordinalSide);
     }
 
@@ -41,70 +42,76 @@ public class GTCopiedBlockTextureRender extends GTTextureBase implements ITextur
     public void renderXPos(SBRContextBase<? extends SBRContextBase<?>> ctx) {
         if (!ctx.canRenderInPass(mBlock::canRenderInPass)) return;
         final IIcon aIcon = getIcon(ForgeDirection.EAST.ordinal(), ctx);
-        ctx.renderBlocks.field_152631_f = true;
-        startDrawingQuads(ctx.renderBlocks, 1.0f, 0.0f, 0.0f);
+        ctx.getRenderBlocks().field_152631_f = true;
+        startDrawingQuads(ctx.getRenderBlocks(), 1.0f, 0.0f, 0.0f);
         ctx.reset()
             .setupColor(ForgeDirection.EAST, 0xffffff);
-        ctx.renderBlocks.renderFaceXPos(ctx.block, ctx.x, ctx.y, ctx.z, aIcon);
-        draw(ctx.renderBlocks);
-        ctx.renderBlocks.field_152631_f = false;
+        ctx.getRenderBlocks()
+            .renderFaceXPos(ctx.getBlock(), ctx.getX(), ctx.getY(), ctx.getZ(), aIcon);
+        draw(ctx.getRenderBlocks());
+        ctx.getRenderBlocks().field_152631_f = false;
     }
 
     @Override
     public void renderXNeg(SBRContextBase<? extends SBRContextBase<?>> ctx) {
         if (!ctx.canRenderInPass(mBlock::canRenderInPass)) return;
-        startDrawingQuads(ctx.renderBlocks, -1.0f, 0.0f, 0.0f);
+        startDrawingQuads(ctx.getRenderBlocks(), -1.0f, 0.0f, 0.0f);
         final IIcon aIcon = getIcon(ForgeDirection.WEST.ordinal(), ctx);
         ctx.reset()
             .setupColor(ForgeDirection.WEST, 0xffffff);
-        ctx.renderBlocks.renderFaceXNeg(ctx.block, ctx.x, ctx.y, ctx.z, aIcon);
-        draw(ctx.renderBlocks);
+        ctx.getRenderBlocks()
+            .renderFaceXNeg(ctx.getBlock(), ctx.getX(), ctx.getY(), ctx.getZ(), aIcon);
+        draw(ctx.getRenderBlocks());
     }
 
     @Override
     public void renderYPos(SBRContextBase<? extends SBRContextBase<?>> ctx) {
         if (!ctx.canRenderInPass(mBlock::canRenderInPass)) return;
-        startDrawingQuads(ctx.renderBlocks, 0.0f, 1.0f, 0.0f);
+        startDrawingQuads(ctx.getRenderBlocks(), 0.0f, 1.0f, 0.0f);
         final IIcon aIcon = getIcon(ForgeDirection.UP.ordinal(), ctx);
         ctx.reset()
             .setupColor(ForgeDirection.UP, 0xffffff);
-        ctx.renderBlocks.renderFaceYPos(ctx.block, ctx.x, ctx.y, ctx.z, aIcon);
-        draw(ctx.renderBlocks);
+        ctx.getRenderBlocks()
+            .renderFaceYPos(ctx.getBlock(), ctx.getX(), ctx.getY(), ctx.getZ(), aIcon);
+        draw(ctx.getRenderBlocks());
     }
 
     @Override
     public void renderYNeg(SBRContextBase<? extends SBRContextBase<?>> ctx) {
         if (!ctx.canRenderInPass(mBlock::canRenderInPass)) return;
-        startDrawingQuads(ctx.renderBlocks, 0.0f, -1.0f, 0.0f);
+        startDrawingQuads(ctx.getRenderBlocks(), 0.0f, -1.0f, 0.0f);
         final IIcon aIcon = getIcon(ForgeDirection.DOWN.ordinal(), ctx);
         ctx.reset()
             .setupColor(ForgeDirection.DOWN, 0xffffff);
-        ctx.renderBlocks.renderFaceYNeg(ctx.block, ctx.x, ctx.y, ctx.z, aIcon);
-        draw(ctx.renderBlocks);
+        ctx.getRenderBlocks()
+            .renderFaceYNeg(ctx.getBlock(), ctx.getX(), ctx.getY(), ctx.getZ(), aIcon);
+        draw(ctx.getRenderBlocks());
     }
 
     @Override
     public void renderZPos(SBRContextBase<? extends SBRContextBase<?>> ctx) {
         if (!ctx.canRenderInPass(mBlock::canRenderInPass)) return;
-        startDrawingQuads(ctx.renderBlocks, 0.0f, 0.0f, 1.0f);
+        startDrawingQuads(ctx.getRenderBlocks(), 0.0f, 0.0f, 1.0f);
         final IIcon aIcon = getIcon(ForgeDirection.SOUTH.ordinal(), ctx);
         ctx.reset()
             .setupColor(ForgeDirection.SOUTH, 0xffffff);
-        ctx.renderBlocks.renderFaceZPos(ctx.block, ctx.x, ctx.y, ctx.z, aIcon);
-        draw(ctx.renderBlocks);
+        ctx.getRenderBlocks()
+            .renderFaceZPos(ctx.getBlock(), ctx.getX(), ctx.getY(), ctx.getZ(), aIcon);
+        draw(ctx.getRenderBlocks());
     }
 
     @Override
     public void renderZNeg(SBRContextBase<? extends SBRContextBase<?>> ctx) {
         if (!ctx.canRenderInPass(mBlock::canRenderInPass)) return;
-        startDrawingQuads(ctx.renderBlocks, 0.0f, 0.0f, -1.0f);
+        startDrawingQuads(ctx.getRenderBlocks(), 0.0f, 0.0f, -1.0f);
         final IIcon aIcon = getIcon(ForgeDirection.NORTH.ordinal(), ctx);
-        ctx.renderBlocks.field_152631_f = true;
+        ctx.getRenderBlocks().field_152631_f = true;
         ctx.reset()
             .setupColor(ForgeDirection.NORTH, 0xffffff);
-        ctx.renderBlocks.renderFaceZNeg(ctx.block, ctx.x, ctx.y, ctx.z, aIcon);
-        draw(ctx.renderBlocks);
-        ctx.renderBlocks.field_152631_f = false;
+        ctx.getRenderBlocks()
+            .renderFaceZNeg(ctx.getBlock(), ctx.getX(), ctx.getY(), ctx.getZ(), aIcon);
+        draw(ctx.getRenderBlocks());
+        ctx.getRenderBlocks().field_152631_f = false;
     }
 
     @Override

--- a/src/main/java/gregtech/common/render/GTCopiedBlockTextureRender.java
+++ b/src/main/java/gregtech/common/render/GTCopiedBlockTextureRender.java
@@ -33,7 +33,7 @@ public class GTCopiedBlockTextureRender extends GTTextureBase implements ITextur
         else icon = mBlock.getIcon(mSide, mMeta);
         if (!Angelica.isModLoaded()) return icon;
         else return ctx instanceof SBRWorldContext ctxW
-            ? CTMUtils.getBlockIcon(icon, mBlock, ctxW.world, ctxW.x, ctxW.y, ctxW.z, ordinalSide)
+            ? CTMUtils.getBlockIcon(icon, mBlock, ctxW.blockAccess, ctxW.x, ctxW.y, ctxW.z, ordinalSide)
             : CTMUtils.getBlockIcon(icon, mBlock, ordinalSide);
     }
 
@@ -41,70 +41,70 @@ public class GTCopiedBlockTextureRender extends GTTextureBase implements ITextur
     public void renderXPos(SBRContextBase<? extends SBRContextBase<?>> ctx) {
         if (!ctx.canRenderInPass(mBlock::canRenderInPass)) return;
         final IIcon aIcon = getIcon(ForgeDirection.EAST.ordinal(), ctx);
-        ctx.renderer.field_152631_f = true;
-        startDrawingQuads(ctx.renderer, 1.0f, 0.0f, 0.0f);
+        ctx.renderBlocks.field_152631_f = true;
+        startDrawingQuads(ctx.renderBlocks, 1.0f, 0.0f, 0.0f);
         ctx.reset()
             .setupColor(ForgeDirection.EAST, 0xffffff);
-        ctx.renderer.renderFaceXPos(ctx.block, ctx.x, ctx.y, ctx.z, aIcon);
-        draw(ctx.renderer);
-        ctx.renderer.field_152631_f = false;
+        ctx.renderBlocks.renderFaceXPos(ctx.block, ctx.x, ctx.y, ctx.z, aIcon);
+        draw(ctx.renderBlocks);
+        ctx.renderBlocks.field_152631_f = false;
     }
 
     @Override
     public void renderXNeg(SBRContextBase<? extends SBRContextBase<?>> ctx) {
         if (!ctx.canRenderInPass(mBlock::canRenderInPass)) return;
-        startDrawingQuads(ctx.renderer, -1.0f, 0.0f, 0.0f);
+        startDrawingQuads(ctx.renderBlocks, -1.0f, 0.0f, 0.0f);
         final IIcon aIcon = getIcon(ForgeDirection.WEST.ordinal(), ctx);
         ctx.reset()
             .setupColor(ForgeDirection.WEST, 0xffffff);
-        ctx.renderer.renderFaceXNeg(ctx.block, ctx.x, ctx.y, ctx.z, aIcon);
-        draw(ctx.renderer);
+        ctx.renderBlocks.renderFaceXNeg(ctx.block, ctx.x, ctx.y, ctx.z, aIcon);
+        draw(ctx.renderBlocks);
     }
 
     @Override
     public void renderYPos(SBRContextBase<? extends SBRContextBase<?>> ctx) {
         if (!ctx.canRenderInPass(mBlock::canRenderInPass)) return;
-        startDrawingQuads(ctx.renderer, 0.0f, 1.0f, 0.0f);
+        startDrawingQuads(ctx.renderBlocks, 0.0f, 1.0f, 0.0f);
         final IIcon aIcon = getIcon(ForgeDirection.UP.ordinal(), ctx);
         ctx.reset()
             .setupColor(ForgeDirection.UP, 0xffffff);
-        ctx.renderer.renderFaceYPos(ctx.block, ctx.x, ctx.y, ctx.z, aIcon);
-        draw(ctx.renderer);
+        ctx.renderBlocks.renderFaceYPos(ctx.block, ctx.x, ctx.y, ctx.z, aIcon);
+        draw(ctx.renderBlocks);
     }
 
     @Override
     public void renderYNeg(SBRContextBase<? extends SBRContextBase<?>> ctx) {
         if (!ctx.canRenderInPass(mBlock::canRenderInPass)) return;
-        startDrawingQuads(ctx.renderer, 0.0f, -1.0f, 0.0f);
+        startDrawingQuads(ctx.renderBlocks, 0.0f, -1.0f, 0.0f);
         final IIcon aIcon = getIcon(ForgeDirection.DOWN.ordinal(), ctx);
         ctx.reset()
             .setupColor(ForgeDirection.DOWN, 0xffffff);
-        ctx.renderer.renderFaceYNeg(ctx.block, ctx.x, ctx.y, ctx.z, aIcon);
-        draw(ctx.renderer);
+        ctx.renderBlocks.renderFaceYNeg(ctx.block, ctx.x, ctx.y, ctx.z, aIcon);
+        draw(ctx.renderBlocks);
     }
 
     @Override
     public void renderZPos(SBRContextBase<? extends SBRContextBase<?>> ctx) {
         if (!ctx.canRenderInPass(mBlock::canRenderInPass)) return;
-        startDrawingQuads(ctx.renderer, 0.0f, 0.0f, 1.0f);
+        startDrawingQuads(ctx.renderBlocks, 0.0f, 0.0f, 1.0f);
         final IIcon aIcon = getIcon(ForgeDirection.SOUTH.ordinal(), ctx);
         ctx.reset()
             .setupColor(ForgeDirection.SOUTH, 0xffffff);
-        ctx.renderer.renderFaceZPos(ctx.block, ctx.x, ctx.y, ctx.z, aIcon);
-        draw(ctx.renderer);
+        ctx.renderBlocks.renderFaceZPos(ctx.block, ctx.x, ctx.y, ctx.z, aIcon);
+        draw(ctx.renderBlocks);
     }
 
     @Override
     public void renderZNeg(SBRContextBase<? extends SBRContextBase<?>> ctx) {
         if (!ctx.canRenderInPass(mBlock::canRenderInPass)) return;
-        startDrawingQuads(ctx.renderer, 0.0f, 0.0f, -1.0f);
+        startDrawingQuads(ctx.renderBlocks, 0.0f, 0.0f, -1.0f);
         final IIcon aIcon = getIcon(ForgeDirection.NORTH.ordinal(), ctx);
-        ctx.renderer.field_152631_f = true;
+        ctx.renderBlocks.field_152631_f = true;
         ctx.reset()
             .setupColor(ForgeDirection.NORTH, 0xffffff);
-        ctx.renderer.renderFaceZNeg(ctx.block, ctx.x, ctx.y, ctx.z, aIcon);
-        draw(ctx.renderer);
-        ctx.renderer.field_152631_f = false;
+        ctx.renderBlocks.renderFaceZNeg(ctx.block, ctx.x, ctx.y, ctx.z, aIcon);
+        draw(ctx.renderBlocks);
+        ctx.renderBlocks.field_152631_f = false;
     }
 
     @Override

--- a/src/main/java/gregtech/common/render/GTCopiedCTMBlockTexture.java
+++ b/src/main/java/gregtech/common/render/GTCopiedCTMBlockTexture.java
@@ -33,123 +33,71 @@ class GTCopiedCTMBlockTexture extends GTTextureBase implements ITexture, IBlockC
         return GTRenderingWorld.getInstance(aRenderer.blockAccess);
     }
 
+    // spotless:off
     @Override
-    public void renderXPos(SBRContextBase<? extends SBRContextBase<?>> ctx) {
-        if (!ctx.canRenderInPass(mBlock::canRenderInPass)) return;
-        final IIcon aIcon = getIcon(
-            ForgeDirection.EAST.ordinal(),
-            ctx.getX(),
-            ctx.getY(),
-            ctx.getZ(),
-            ctx.getRenderBlocks());
-        ctx.getRenderBlocks().field_152631_f = true;
-        startDrawingQuads(ctx.getRenderBlocks(), 1.0f, 0.0f, 0.0f);
-        ctx.reset()
-            .setupColor(
-                ForgeDirection.EAST,
-                mBlock.colorMultiplier(getBlockAccess(ctx.getRenderBlocks()), ctx.getX(), ctx.getY(), ctx.getZ()));
-        ctx.getRenderBlocks()
-            .renderFaceXPos(ctx.getBlock(), ctx.getX(), ctx.getY(), ctx.getZ(), aIcon);
-        draw(ctx.getRenderBlocks());
-        ctx.getRenderBlocks().field_152631_f = false;
-    }
-
-    @Override
-    public void renderXNeg(SBRContextBase<? extends SBRContextBase<?>> ctx) {
-        if (!ctx.canRenderInPass(mBlock::canRenderInPass)) return;
-        startDrawingQuads(ctx.getRenderBlocks(), -1.0f, 0.0f, 0.0f);
-        final IIcon aIcon = getIcon(
-            ForgeDirection.WEST.ordinal(),
-            ctx.getX(),
-            ctx.getY(),
-            ctx.getZ(),
-            ctx.getRenderBlocks());
-        ctx.reset()
-            .setupColor(
-                ForgeDirection.WEST,
-                mBlock.colorMultiplier(getBlockAccess(ctx.getRenderBlocks()), ctx.getX(), ctx.getY(), ctx.getZ()));
-        ctx.getRenderBlocks()
-            .renderFaceXNeg(ctx.getBlock(), ctx.getX(), ctx.getY(), ctx.getZ(), aIcon);
-        draw(ctx.getRenderBlocks());
-    }
-
-    @Override
-    public void renderYPos(SBRContextBase<? extends SBRContextBase<?>> ctx) {
-        if (!ctx.canRenderInPass(mBlock::canRenderInPass)) return;
-        startDrawingQuads(ctx.getRenderBlocks(), 0.0f, 1.0f, 0.0f);
-        final IIcon aIcon = getIcon(
-            ForgeDirection.UP.ordinal(),
-            ctx.getX(),
-            ctx.getY(),
-            ctx.getZ(),
-            ctx.getRenderBlocks());
-        ctx.reset()
-            .setupColor(
-                ForgeDirection.UP,
-                mBlock.colorMultiplier(getBlockAccess(ctx.getRenderBlocks()), ctx.getX(), ctx.getY(), ctx.getZ()));
-        ctx.getRenderBlocks()
-            .renderFaceYPos(ctx.getBlock(), ctx.getX(), ctx.getY(), ctx.getZ(), aIcon);
-        draw(ctx.getRenderBlocks());
-    }
-
-    @Override
-    public void renderYNeg(SBRContextBase<? extends SBRContextBase<?>> ctx) {
+    public void renderYNeg(SBRContextBase ctx) {
         if (!ctx.canRenderInPass(mBlock::canRenderInPass)) return;
         startDrawingQuads(ctx.getRenderBlocks(), 0.0f, -1.0f, 0.0f);
-        final IIcon aIcon = getIcon(
-            ForgeDirection.DOWN.ordinal(),
-            ctx.getX(),
-            ctx.getY(),
-            ctx.getZ(),
-            ctx.getRenderBlocks());
-        ctx.reset()
-            .setupColor(
-                ForgeDirection.DOWN,
-                mBlock.colorMultiplier(getBlockAccess(ctx.getRenderBlocks()), ctx.getX(), ctx.getY(), ctx.getZ()));
-        ctx.getRenderBlocks()
-            .renderFaceYNeg(ctx.getBlock(), ctx.getX(), ctx.getY(), ctx.getZ(), aIcon);
+        final IIcon aIcon = getIcon(ForgeDirection.DOWN.ordinal(), ctx.getX(), ctx.getY(), ctx.getZ(), ctx.getRenderBlocks());
+        ctx.reset().setupColor(ForgeDirection.DOWN, mBlock.colorMultiplier(getBlockAccess(ctx.getRenderBlocks()), ctx.getX(), ctx.getY(), ctx.getZ()));
+        ctx.getRenderBlocks().renderFaceYNeg(ctx.getBlock(), ctx.getX(), ctx.getY(), ctx.getZ(), aIcon);
         draw(ctx.getRenderBlocks());
     }
 
     @Override
-    public void renderZPos(SBRContextBase<? extends SBRContextBase<?>> ctx) {
+    public void renderYPos(SBRContextBase ctx) {
         if (!ctx.canRenderInPass(mBlock::canRenderInPass)) return;
-        startDrawingQuads(ctx.getRenderBlocks(), 0.0f, 0.0f, 1.0f);
-        final IIcon aIcon = getIcon(
-            ForgeDirection.SOUTH.ordinal(),
-            ctx.getX(),
-            ctx.getY(),
-            ctx.getZ(),
-            ctx.getRenderBlocks());
-        ctx.reset()
-            .setupColor(
-                ForgeDirection.SOUTH,
-                mBlock.colorMultiplier(getBlockAccess(ctx.getRenderBlocks()), ctx.getX(), ctx.getY(), ctx.getZ()));
-        ctx.getRenderBlocks()
-            .renderFaceZPos(ctx.getBlock(), ctx.getX(), ctx.getY(), ctx.getZ(), aIcon);
+        startDrawingQuads(ctx.getRenderBlocks(), 0.0f, 1.0f, 0.0f);
+        final IIcon aIcon = getIcon(ForgeDirection.UP.ordinal(), ctx.getX(), ctx.getY(), ctx.getZ(), ctx.getRenderBlocks());
+        ctx.reset().setupColor(ForgeDirection.UP, mBlock.colorMultiplier(getBlockAccess(ctx.getRenderBlocks()), ctx.getX(), ctx.getY(), ctx.getZ()));
+        ctx.getRenderBlocks().renderFaceYPos(ctx.getBlock(), ctx.getX(), ctx.getY(), ctx.getZ(), aIcon);
         draw(ctx.getRenderBlocks());
     }
 
     @Override
-    public void renderZNeg(SBRContextBase<? extends SBRContextBase<?>> ctx) {
+    public void renderZNeg(SBRContextBase ctx) {
         if (!ctx.canRenderInPass(mBlock::canRenderInPass)) return;
         startDrawingQuads(ctx.getRenderBlocks(), 0.0f, 0.0f, -1.0f);
-        final IIcon aIcon = getIcon(
-            ForgeDirection.NORTH.ordinal(),
-            ctx.getX(),
-            ctx.getY(),
-            ctx.getZ(),
-            ctx.getRenderBlocks());
+        final IIcon aIcon = getIcon(ForgeDirection.NORTH.ordinal(), ctx.getX(), ctx.getY(), ctx.getZ(), ctx.getRenderBlocks());
         ctx.getRenderBlocks().field_152631_f = true;
-        ctx.reset()
-            .setupColor(
-                ForgeDirection.NORTH,
-                mBlock.colorMultiplier(getBlockAccess(ctx.getRenderBlocks()), ctx.getX(), ctx.getY(), ctx.getZ()));
-        ctx.getRenderBlocks()
-            .renderFaceZNeg(ctx.getBlock(), ctx.getX(), ctx.getY(), ctx.getZ(), aIcon);
+        ctx.reset().setupColor(ForgeDirection.NORTH, mBlock.colorMultiplier(getBlockAccess(ctx.getRenderBlocks()), ctx.getX(), ctx.getY(), ctx.getZ()));
+        ctx.getRenderBlocks().renderFaceZNeg(ctx.getBlock(), ctx.getX(), ctx.getY(), ctx.getZ(), aIcon);
         draw(ctx.getRenderBlocks());
         ctx.getRenderBlocks().field_152631_f = false;
     }
+
+    @Override
+    public void renderZPos(SBRContextBase ctx) {
+        if (!ctx.canRenderInPass(mBlock::canRenderInPass)) return;
+        startDrawingQuads(ctx.getRenderBlocks(), 0.0f, 0.0f, 1.0f);
+        final IIcon aIcon = getIcon(ForgeDirection.SOUTH.ordinal(), ctx.getX(), ctx.getY(), ctx.getZ(), ctx.getRenderBlocks());
+        ctx.reset().setupColor(ForgeDirection.SOUTH, mBlock.colorMultiplier(getBlockAccess(ctx.getRenderBlocks()), ctx.getX(), ctx.getY(), ctx.getZ()));
+        ctx.getRenderBlocks().renderFaceZPos(ctx.getBlock(), ctx.getX(), ctx.getY(), ctx.getZ(), aIcon);
+        draw(ctx.getRenderBlocks());
+    }
+
+    @Override
+    public void renderXNeg(SBRContextBase ctx) {
+        if (!ctx.canRenderInPass(mBlock::canRenderInPass)) return;
+        startDrawingQuads(ctx.getRenderBlocks(), -1.0f, 0.0f, 0.0f);
+        final IIcon aIcon = getIcon(ForgeDirection.WEST.ordinal(), ctx.getX(), ctx.getY(), ctx.getZ(), ctx.getRenderBlocks());
+        ctx.reset().setupColor(ForgeDirection.WEST, mBlock.colorMultiplier(getBlockAccess(ctx.getRenderBlocks()), ctx.getX(), ctx.getY(), ctx.getZ()));
+        ctx.getRenderBlocks().renderFaceXNeg(ctx.getBlock(), ctx.getX(), ctx.getY(), ctx.getZ(), aIcon);
+        draw(ctx.getRenderBlocks());
+    }
+
+    @Override
+    public void renderXPos(SBRContextBase ctx) {
+        if (!ctx.canRenderInPass(mBlock::canRenderInPass)) return;
+        final IIcon aIcon = getIcon(ForgeDirection.EAST.ordinal(), ctx.getX(), ctx.getY(), ctx.getZ(), ctx.getRenderBlocks());
+        ctx.getRenderBlocks().field_152631_f = true;
+        startDrawingQuads(ctx.getRenderBlocks(), 1.0f, 0.0f, 0.0f);
+        ctx.reset().setupColor(ForgeDirection.EAST, mBlock.colorMultiplier(getBlockAccess(ctx.getRenderBlocks()), ctx.getX(), ctx.getY(), ctx.getZ()));
+        ctx.getRenderBlocks().renderFaceXPos(ctx.getBlock(), ctx.getX(), ctx.getY(), ctx.getZ(), aIcon);
+        draw(ctx.getRenderBlocks());
+        ctx.getRenderBlocks().field_152631_f = false;
+    }
+    //spotless:on
 
     @Override
     public boolean isValidTexture() {

--- a/src/main/java/gregtech/common/render/GTCopiedCTMBlockTexture.java
+++ b/src/main/java/gregtech/common/render/GTCopiedCTMBlockTexture.java
@@ -36,75 +36,83 @@ class GTCopiedCTMBlockTexture extends GTTextureBase implements ITexture, IBlockC
     @Override
     public void renderXPos(SBRContextBase<? extends SBRContextBase<?>> ctx) {
         if (!ctx.canRenderInPass(mBlock::canRenderInPass)) return;
-        final IIcon aIcon = getIcon(ForgeDirection.EAST.ordinal(), ctx.x, ctx.y, ctx.z, ctx.renderer);
-        ctx.renderer.field_152631_f = true;
-        startDrawingQuads(ctx.renderer, 1.0f, 0.0f, 0.0f);
+        final IIcon aIcon = getIcon(ForgeDirection.EAST.ordinal(), ctx.x, ctx.y, ctx.z, ctx.renderBlocks);
+        ctx.renderBlocks.field_152631_f = true;
+        startDrawingQuads(ctx.renderBlocks, 1.0f, 0.0f, 0.0f);
         ctx.reset()
-            .setupColor(ForgeDirection.EAST, mBlock.colorMultiplier(getBlockAccess(ctx.renderer), ctx.x, ctx.y, ctx.z));
-        ctx.renderer.renderFaceXPos(ctx.block, ctx.x, ctx.y, ctx.z, aIcon);
-        draw(ctx.renderer);
-        ctx.renderer.field_152631_f = false;
+            .setupColor(
+                ForgeDirection.EAST,
+                mBlock.colorMultiplier(getBlockAccess(ctx.renderBlocks), ctx.x, ctx.y, ctx.z));
+        ctx.renderBlocks.renderFaceXPos(ctx.block, ctx.x, ctx.y, ctx.z, aIcon);
+        draw(ctx.renderBlocks);
+        ctx.renderBlocks.field_152631_f = false;
     }
 
     @Override
     public void renderXNeg(SBRContextBase<? extends SBRContextBase<?>> ctx) {
         if (!ctx.canRenderInPass(mBlock::canRenderInPass)) return;
-        startDrawingQuads(ctx.renderer, -1.0f, 0.0f, 0.0f);
-        final IIcon aIcon = getIcon(ForgeDirection.WEST.ordinal(), ctx.x, ctx.y, ctx.z, ctx.renderer);
+        startDrawingQuads(ctx.renderBlocks, -1.0f, 0.0f, 0.0f);
+        final IIcon aIcon = getIcon(ForgeDirection.WEST.ordinal(), ctx.x, ctx.y, ctx.z, ctx.renderBlocks);
         ctx.reset()
-            .setupColor(ForgeDirection.WEST, mBlock.colorMultiplier(getBlockAccess(ctx.renderer), ctx.x, ctx.y, ctx.z));
-        ctx.renderer.renderFaceXNeg(ctx.block, ctx.x, ctx.y, ctx.z, aIcon);
-        draw(ctx.renderer);
+            .setupColor(
+                ForgeDirection.WEST,
+                mBlock.colorMultiplier(getBlockAccess(ctx.renderBlocks), ctx.x, ctx.y, ctx.z));
+        ctx.renderBlocks.renderFaceXNeg(ctx.block, ctx.x, ctx.y, ctx.z, aIcon);
+        draw(ctx.renderBlocks);
     }
 
     @Override
     public void renderYPos(SBRContextBase<? extends SBRContextBase<?>> ctx) {
         if (!ctx.canRenderInPass(mBlock::canRenderInPass)) return;
-        startDrawingQuads(ctx.renderer, 0.0f, 1.0f, 0.0f);
-        final IIcon aIcon = getIcon(ForgeDirection.UP.ordinal(), ctx.x, ctx.y, ctx.z, ctx.renderer);
+        startDrawingQuads(ctx.renderBlocks, 0.0f, 1.0f, 0.0f);
+        final IIcon aIcon = getIcon(ForgeDirection.UP.ordinal(), ctx.x, ctx.y, ctx.z, ctx.renderBlocks);
         ctx.reset()
-            .setupColor(ForgeDirection.UP, mBlock.colorMultiplier(getBlockAccess(ctx.renderer), ctx.x, ctx.y, ctx.z));
-        ctx.renderer.renderFaceYPos(ctx.block, ctx.x, ctx.y, ctx.z, aIcon);
-        draw(ctx.renderer);
+            .setupColor(
+                ForgeDirection.UP,
+                mBlock.colorMultiplier(getBlockAccess(ctx.renderBlocks), ctx.x, ctx.y, ctx.z));
+        ctx.renderBlocks.renderFaceYPos(ctx.block, ctx.x, ctx.y, ctx.z, aIcon);
+        draw(ctx.renderBlocks);
     }
 
     @Override
     public void renderYNeg(SBRContextBase<? extends SBRContextBase<?>> ctx) {
         if (!ctx.canRenderInPass(mBlock::canRenderInPass)) return;
-        startDrawingQuads(ctx.renderer, 0.0f, -1.0f, 0.0f);
-        final IIcon aIcon = getIcon(ForgeDirection.DOWN.ordinal(), ctx.x, ctx.y, ctx.z, ctx.renderer);
+        startDrawingQuads(ctx.renderBlocks, 0.0f, -1.0f, 0.0f);
+        final IIcon aIcon = getIcon(ForgeDirection.DOWN.ordinal(), ctx.x, ctx.y, ctx.z, ctx.renderBlocks);
         ctx.reset()
-            .setupColor(ForgeDirection.DOWN, mBlock.colorMultiplier(getBlockAccess(ctx.renderer), ctx.x, ctx.y, ctx.z));
-        ctx.renderer.renderFaceYNeg(ctx.block, ctx.x, ctx.y, ctx.z, aIcon);
-        draw(ctx.renderer);
+            .setupColor(
+                ForgeDirection.DOWN,
+                mBlock.colorMultiplier(getBlockAccess(ctx.renderBlocks), ctx.x, ctx.y, ctx.z));
+        ctx.renderBlocks.renderFaceYNeg(ctx.block, ctx.x, ctx.y, ctx.z, aIcon);
+        draw(ctx.renderBlocks);
     }
 
     @Override
     public void renderZPos(SBRContextBase<? extends SBRContextBase<?>> ctx) {
         if (!ctx.canRenderInPass(mBlock::canRenderInPass)) return;
-        startDrawingQuads(ctx.renderer, 0.0f, 0.0f, 1.0f);
-        final IIcon aIcon = getIcon(ForgeDirection.SOUTH.ordinal(), ctx.x, ctx.y, ctx.z, ctx.renderer);
+        startDrawingQuads(ctx.renderBlocks, 0.0f, 0.0f, 1.0f);
+        final IIcon aIcon = getIcon(ForgeDirection.SOUTH.ordinal(), ctx.x, ctx.y, ctx.z, ctx.renderBlocks);
         ctx.reset()
             .setupColor(
                 ForgeDirection.SOUTH,
-                mBlock.colorMultiplier(getBlockAccess(ctx.renderer), ctx.x, ctx.y, ctx.z));
-        ctx.renderer.renderFaceZPos(ctx.block, ctx.x, ctx.y, ctx.z, aIcon);
-        draw(ctx.renderer);
+                mBlock.colorMultiplier(getBlockAccess(ctx.renderBlocks), ctx.x, ctx.y, ctx.z));
+        ctx.renderBlocks.renderFaceZPos(ctx.block, ctx.x, ctx.y, ctx.z, aIcon);
+        draw(ctx.renderBlocks);
     }
 
     @Override
     public void renderZNeg(SBRContextBase<? extends SBRContextBase<?>> ctx) {
         if (!ctx.canRenderInPass(mBlock::canRenderInPass)) return;
-        startDrawingQuads(ctx.renderer, 0.0f, 0.0f, -1.0f);
-        final IIcon aIcon = getIcon(ForgeDirection.NORTH.ordinal(), ctx.x, ctx.y, ctx.z, ctx.renderer);
-        ctx.renderer.field_152631_f = true;
+        startDrawingQuads(ctx.renderBlocks, 0.0f, 0.0f, -1.0f);
+        final IIcon aIcon = getIcon(ForgeDirection.NORTH.ordinal(), ctx.x, ctx.y, ctx.z, ctx.renderBlocks);
+        ctx.renderBlocks.field_152631_f = true;
         ctx.reset()
             .setupColor(
                 ForgeDirection.NORTH,
-                mBlock.colorMultiplier(getBlockAccess(ctx.renderer), ctx.x, ctx.y, ctx.z));
-        ctx.renderer.renderFaceZNeg(ctx.block, ctx.x, ctx.y, ctx.z, aIcon);
-        draw(ctx.renderer);
-        ctx.renderer.field_152631_f = false;
+                mBlock.colorMultiplier(getBlockAccess(ctx.renderBlocks), ctx.x, ctx.y, ctx.z));
+        ctx.renderBlocks.renderFaceZNeg(ctx.block, ctx.x, ctx.y, ctx.z, aIcon);
+        draw(ctx.renderBlocks);
+        ctx.renderBlocks.field_152631_f = false;
     }
 
     @Override

--- a/src/main/java/gregtech/common/render/GTCopiedCTMBlockTexture.java
+++ b/src/main/java/gregtech/common/render/GTCopiedCTMBlockTexture.java
@@ -36,83 +36,119 @@ class GTCopiedCTMBlockTexture extends GTTextureBase implements ITexture, IBlockC
     @Override
     public void renderXPos(SBRContextBase<? extends SBRContextBase<?>> ctx) {
         if (!ctx.canRenderInPass(mBlock::canRenderInPass)) return;
-        final IIcon aIcon = getIcon(ForgeDirection.EAST.ordinal(), ctx.x, ctx.y, ctx.z, ctx.renderBlocks);
-        ctx.renderBlocks.field_152631_f = true;
-        startDrawingQuads(ctx.renderBlocks, 1.0f, 0.0f, 0.0f);
+        final IIcon aIcon = getIcon(
+            ForgeDirection.EAST.ordinal(),
+            ctx.getX(),
+            ctx.getY(),
+            ctx.getZ(),
+            ctx.getRenderBlocks());
+        ctx.getRenderBlocks().field_152631_f = true;
+        startDrawingQuads(ctx.getRenderBlocks(), 1.0f, 0.0f, 0.0f);
         ctx.reset()
             .setupColor(
                 ForgeDirection.EAST,
-                mBlock.colorMultiplier(getBlockAccess(ctx.renderBlocks), ctx.x, ctx.y, ctx.z));
-        ctx.renderBlocks.renderFaceXPos(ctx.block, ctx.x, ctx.y, ctx.z, aIcon);
-        draw(ctx.renderBlocks);
-        ctx.renderBlocks.field_152631_f = false;
+                mBlock.colorMultiplier(getBlockAccess(ctx.getRenderBlocks()), ctx.getX(), ctx.getY(), ctx.getZ()));
+        ctx.getRenderBlocks()
+            .renderFaceXPos(ctx.getBlock(), ctx.getX(), ctx.getY(), ctx.getZ(), aIcon);
+        draw(ctx.getRenderBlocks());
+        ctx.getRenderBlocks().field_152631_f = false;
     }
 
     @Override
     public void renderXNeg(SBRContextBase<? extends SBRContextBase<?>> ctx) {
         if (!ctx.canRenderInPass(mBlock::canRenderInPass)) return;
-        startDrawingQuads(ctx.renderBlocks, -1.0f, 0.0f, 0.0f);
-        final IIcon aIcon = getIcon(ForgeDirection.WEST.ordinal(), ctx.x, ctx.y, ctx.z, ctx.renderBlocks);
+        startDrawingQuads(ctx.getRenderBlocks(), -1.0f, 0.0f, 0.0f);
+        final IIcon aIcon = getIcon(
+            ForgeDirection.WEST.ordinal(),
+            ctx.getX(),
+            ctx.getY(),
+            ctx.getZ(),
+            ctx.getRenderBlocks());
         ctx.reset()
             .setupColor(
                 ForgeDirection.WEST,
-                mBlock.colorMultiplier(getBlockAccess(ctx.renderBlocks), ctx.x, ctx.y, ctx.z));
-        ctx.renderBlocks.renderFaceXNeg(ctx.block, ctx.x, ctx.y, ctx.z, aIcon);
-        draw(ctx.renderBlocks);
+                mBlock.colorMultiplier(getBlockAccess(ctx.getRenderBlocks()), ctx.getX(), ctx.getY(), ctx.getZ()));
+        ctx.getRenderBlocks()
+            .renderFaceXNeg(ctx.getBlock(), ctx.getX(), ctx.getY(), ctx.getZ(), aIcon);
+        draw(ctx.getRenderBlocks());
     }
 
     @Override
     public void renderYPos(SBRContextBase<? extends SBRContextBase<?>> ctx) {
         if (!ctx.canRenderInPass(mBlock::canRenderInPass)) return;
-        startDrawingQuads(ctx.renderBlocks, 0.0f, 1.0f, 0.0f);
-        final IIcon aIcon = getIcon(ForgeDirection.UP.ordinal(), ctx.x, ctx.y, ctx.z, ctx.renderBlocks);
+        startDrawingQuads(ctx.getRenderBlocks(), 0.0f, 1.0f, 0.0f);
+        final IIcon aIcon = getIcon(
+            ForgeDirection.UP.ordinal(),
+            ctx.getX(),
+            ctx.getY(),
+            ctx.getZ(),
+            ctx.getRenderBlocks());
         ctx.reset()
             .setupColor(
                 ForgeDirection.UP,
-                mBlock.colorMultiplier(getBlockAccess(ctx.renderBlocks), ctx.x, ctx.y, ctx.z));
-        ctx.renderBlocks.renderFaceYPos(ctx.block, ctx.x, ctx.y, ctx.z, aIcon);
-        draw(ctx.renderBlocks);
+                mBlock.colorMultiplier(getBlockAccess(ctx.getRenderBlocks()), ctx.getX(), ctx.getY(), ctx.getZ()));
+        ctx.getRenderBlocks()
+            .renderFaceYPos(ctx.getBlock(), ctx.getX(), ctx.getY(), ctx.getZ(), aIcon);
+        draw(ctx.getRenderBlocks());
     }
 
     @Override
     public void renderYNeg(SBRContextBase<? extends SBRContextBase<?>> ctx) {
         if (!ctx.canRenderInPass(mBlock::canRenderInPass)) return;
-        startDrawingQuads(ctx.renderBlocks, 0.0f, -1.0f, 0.0f);
-        final IIcon aIcon = getIcon(ForgeDirection.DOWN.ordinal(), ctx.x, ctx.y, ctx.z, ctx.renderBlocks);
+        startDrawingQuads(ctx.getRenderBlocks(), 0.0f, -1.0f, 0.0f);
+        final IIcon aIcon = getIcon(
+            ForgeDirection.DOWN.ordinal(),
+            ctx.getX(),
+            ctx.getY(),
+            ctx.getZ(),
+            ctx.getRenderBlocks());
         ctx.reset()
             .setupColor(
                 ForgeDirection.DOWN,
-                mBlock.colorMultiplier(getBlockAccess(ctx.renderBlocks), ctx.x, ctx.y, ctx.z));
-        ctx.renderBlocks.renderFaceYNeg(ctx.block, ctx.x, ctx.y, ctx.z, aIcon);
-        draw(ctx.renderBlocks);
+                mBlock.colorMultiplier(getBlockAccess(ctx.getRenderBlocks()), ctx.getX(), ctx.getY(), ctx.getZ()));
+        ctx.getRenderBlocks()
+            .renderFaceYNeg(ctx.getBlock(), ctx.getX(), ctx.getY(), ctx.getZ(), aIcon);
+        draw(ctx.getRenderBlocks());
     }
 
     @Override
     public void renderZPos(SBRContextBase<? extends SBRContextBase<?>> ctx) {
         if (!ctx.canRenderInPass(mBlock::canRenderInPass)) return;
-        startDrawingQuads(ctx.renderBlocks, 0.0f, 0.0f, 1.0f);
-        final IIcon aIcon = getIcon(ForgeDirection.SOUTH.ordinal(), ctx.x, ctx.y, ctx.z, ctx.renderBlocks);
+        startDrawingQuads(ctx.getRenderBlocks(), 0.0f, 0.0f, 1.0f);
+        final IIcon aIcon = getIcon(
+            ForgeDirection.SOUTH.ordinal(),
+            ctx.getX(),
+            ctx.getY(),
+            ctx.getZ(),
+            ctx.getRenderBlocks());
         ctx.reset()
             .setupColor(
                 ForgeDirection.SOUTH,
-                mBlock.colorMultiplier(getBlockAccess(ctx.renderBlocks), ctx.x, ctx.y, ctx.z));
-        ctx.renderBlocks.renderFaceZPos(ctx.block, ctx.x, ctx.y, ctx.z, aIcon);
-        draw(ctx.renderBlocks);
+                mBlock.colorMultiplier(getBlockAccess(ctx.getRenderBlocks()), ctx.getX(), ctx.getY(), ctx.getZ()));
+        ctx.getRenderBlocks()
+            .renderFaceZPos(ctx.getBlock(), ctx.getX(), ctx.getY(), ctx.getZ(), aIcon);
+        draw(ctx.getRenderBlocks());
     }
 
     @Override
     public void renderZNeg(SBRContextBase<? extends SBRContextBase<?>> ctx) {
         if (!ctx.canRenderInPass(mBlock::canRenderInPass)) return;
-        startDrawingQuads(ctx.renderBlocks, 0.0f, 0.0f, -1.0f);
-        final IIcon aIcon = getIcon(ForgeDirection.NORTH.ordinal(), ctx.x, ctx.y, ctx.z, ctx.renderBlocks);
-        ctx.renderBlocks.field_152631_f = true;
+        startDrawingQuads(ctx.getRenderBlocks(), 0.0f, 0.0f, -1.0f);
+        final IIcon aIcon = getIcon(
+            ForgeDirection.NORTH.ordinal(),
+            ctx.getX(),
+            ctx.getY(),
+            ctx.getZ(),
+            ctx.getRenderBlocks());
+        ctx.getRenderBlocks().field_152631_f = true;
         ctx.reset()
             .setupColor(
                 ForgeDirection.NORTH,
-                mBlock.colorMultiplier(getBlockAccess(ctx.renderBlocks), ctx.x, ctx.y, ctx.z));
-        ctx.renderBlocks.renderFaceZNeg(ctx.block, ctx.x, ctx.y, ctx.z, aIcon);
-        draw(ctx.renderBlocks);
-        ctx.renderBlocks.field_152631_f = false;
+                mBlock.colorMultiplier(getBlockAccess(ctx.getRenderBlocks()), ctx.getX(), ctx.getY(), ctx.getZ()));
+        ctx.getRenderBlocks()
+            .renderFaceZNeg(ctx.getBlock(), ctx.getX(), ctx.getY(), ctx.getZ(), aIcon);
+        draw(ctx.getRenderBlocks());
+        ctx.getRenderBlocks().field_152631_f = false;
     }
 
     @Override

--- a/src/main/java/gregtech/common/render/GTMultiTextureRender.java
+++ b/src/main/java/gregtech/common/render/GTMultiTextureRender.java
@@ -25,32 +25,32 @@ public class GTMultiTextureRender extends GTTextureBase implements ITexture {
     }
 
     @Override
-    public void renderXPos(SBRContextBase<? extends SBRContextBase<?>> ctx) {
+    public void renderXPos(SBRContextBase ctx) {
         for (ITexture tTexture : mTextures) if (tTexture != null && tTexture.isValidTexture()) tTexture.renderXPos(ctx);
     }
 
     @Override
-    public void renderXNeg(SBRContextBase<? extends SBRContextBase<?>> ctx) {
+    public void renderXNeg(SBRContextBase ctx) {
         for (ITexture tTexture : mTextures) if (tTexture != null && tTexture.isValidTexture()) tTexture.renderXNeg(ctx);
     }
 
     @Override
-    public void renderYPos(SBRContextBase<? extends SBRContextBase<?>> ctx) {
+    public void renderYPos(SBRContextBase ctx) {
         for (ITexture tTexture : mTextures) if (tTexture != null && tTexture.isValidTexture()) tTexture.renderYPos(ctx);
     }
 
     @Override
-    public void renderYNeg(SBRContextBase<? extends SBRContextBase<?>> ctx) {
+    public void renderYNeg(SBRContextBase ctx) {
         for (ITexture tTexture : mTextures) if (tTexture != null && tTexture.isValidTexture()) tTexture.renderYNeg(ctx);
     }
 
     @Override
-    public void renderZPos(SBRContextBase<? extends SBRContextBase<?>> ctx) {
+    public void renderZPos(SBRContextBase ctx) {
         for (ITexture tTexture : mTextures) if (tTexture != null && tTexture.isValidTexture()) tTexture.renderZPos(ctx);
     }
 
     @Override
-    public void renderZNeg(SBRContextBase<? extends SBRContextBase<?>> ctx) {
+    public void renderZNeg(SBRContextBase ctx) {
         for (ITexture tTexture : mTextures) if (tTexture != null && tTexture.isValidTexture()) tTexture.renderZNeg(ctx);
     }
 

--- a/src/main/java/gregtech/common/render/GTRenderedTexture.java
+++ b/src/main/java/gregtech/common/render/GTRenderedTexture.java
@@ -42,164 +42,236 @@ public class GTRenderedTexture extends GTTextureBase implements ITexture, IColor
 
     @Override
     public void renderXPos(SBRContextBase<? extends SBRContextBase<?>> ctx) {
-        startDrawingQuads(ctx.renderBlocks, 1.0f, 0.0f, 0.0f);
+        startDrawingQuads(ctx.getRenderBlocks(), 1.0f, 0.0f, 0.0f);
         ctx.reset();
-        final boolean enableAO = ctx.renderBlocks.enableAO;
+        final boolean enableAO = ctx.getRenderBlocks().enableAO;
         if (glow) {
             if (!GTMod.proxy.mRenderGlowTextures) {
-                draw(ctx.renderBlocks);
+                draw(ctx.getRenderBlocks());
                 return;
             }
-            ctx.renderBlocks.enableAO = false;
+            ctx.getRenderBlocks().enableAO = false;
             ctx.setLightnessOverride(1.0F);
             ctx.setBrightnessOverride(MAX_BRIGHTNESS);
         }
-        final ExtendedFacing rotation = getExtendedFacing(ctx.x, ctx.y, ctx.z);
+        final ExtendedFacing rotation = getExtendedFacing(ctx.getX(), ctx.getY(), ctx.getZ());
         if (ctx.canRenderInPass(mIconContainer::canRenderInPass)) {
             ctx.setupColor(ForgeDirection.EAST, mRGBa);
-            renderFaceXPos(ctx.renderBlocks, ctx.x, ctx.y, ctx.z, mIconContainer.getIcon(), rotation);
+            renderFaceXPos(
+                ctx.getRenderBlocks(),
+                ctx.getX(),
+                ctx.getY(),
+                ctx.getZ(),
+                mIconContainer.getIcon(),
+                rotation);
         }
         if (mIconContainer.getOverlayIcon() != null && ctx.canRenderInPass(pass -> pass == 1)) {
             ctx.setupColor(ForgeDirection.EAST, 0xffffff);
-            renderFaceXPos(ctx.renderBlocks, ctx.x, ctx.y, ctx.z, mIconContainer.getOverlayIcon(), rotation);
+            renderFaceXPos(
+                ctx.getRenderBlocks(),
+                ctx.getX(),
+                ctx.getY(),
+                ctx.getZ(),
+                mIconContainer.getOverlayIcon(),
+                rotation);
         }
-        ctx.renderBlocks.enableAO = enableAO;
-        draw(ctx.renderBlocks);
+        ctx.getRenderBlocks().enableAO = enableAO;
+        draw(ctx.getRenderBlocks());
     }
 
     @Override
     public void renderXNeg(SBRContextBase<? extends SBRContextBase<?>> ctx) {
-        startDrawingQuads(ctx.renderBlocks, -1.0f, 0.0f, 0.0f);
+        startDrawingQuads(ctx.getRenderBlocks(), -1.0f, 0.0f, 0.0f);
         ctx.reset();
-        final boolean enableAO = ctx.renderBlocks.enableAO;
+        final boolean enableAO = ctx.getRenderBlocks().enableAO;
         if (glow) {
             if (!GTMod.proxy.mRenderGlowTextures) {
-                draw(ctx.renderBlocks);
+                draw(ctx.getRenderBlocks());
                 return;
             }
-            ctx.renderBlocks.enableAO = false;
+            ctx.getRenderBlocks().enableAO = false;
             ctx.setLightnessOverride(1.0F);
             ctx.setBrightnessOverride(MAX_BRIGHTNESS);
         }
-        final ExtendedFacing rotation = getExtendedFacing(ctx.x, ctx.y, ctx.z);
+        final ExtendedFacing rotation = getExtendedFacing(ctx.getX(), ctx.getY(), ctx.getZ());
         if (ctx.canRenderInPass(mIconContainer::canRenderInPass)) {
             ctx.setupColor(ForgeDirection.WEST, mRGBa);
-            renderFaceXNeg(ctx.renderBlocks, ctx.x, ctx.y, ctx.z, mIconContainer.getIcon(), rotation);
+            renderFaceXNeg(
+                ctx.getRenderBlocks(),
+                ctx.getX(),
+                ctx.getY(),
+                ctx.getZ(),
+                mIconContainer.getIcon(),
+                rotation);
         }
         if (mIconContainer.getOverlayIcon() != null && ctx.canRenderInPass(pass -> pass == 1)) {
             ctx.setupColor(ForgeDirection.WEST, 0xffffff);
-            renderFaceXNeg(ctx.renderBlocks, ctx.x, ctx.y, ctx.z, mIconContainer.getOverlayIcon(), rotation);
+            renderFaceXNeg(
+                ctx.getRenderBlocks(),
+                ctx.getX(),
+                ctx.getY(),
+                ctx.getZ(),
+                mIconContainer.getOverlayIcon(),
+                rotation);
         }
-        ctx.renderBlocks.enableAO = enableAO;
-        draw(ctx.renderBlocks);
+        ctx.getRenderBlocks().enableAO = enableAO;
+        draw(ctx.getRenderBlocks());
     }
 
     @Override
     public void renderYPos(SBRContextBase<? extends SBRContextBase<?>> ctx) {
-        startDrawingQuads(ctx.renderBlocks, 0.0f, 1.0f, 0.0f);
+        startDrawingQuads(ctx.getRenderBlocks(), 0.0f, 1.0f, 0.0f);
         ctx.reset();
-        final boolean enableAO = ctx.renderBlocks.enableAO;
+        final boolean enableAO = ctx.getRenderBlocks().enableAO;
         if (glow) {
             if (!GTMod.proxy.mRenderGlowTextures) {
-                draw(ctx.renderBlocks);
+                draw(ctx.getRenderBlocks());
                 return;
             }
-            ctx.renderBlocks.enableAO = false;
+            ctx.getRenderBlocks().enableAO = false;
             ctx.setLightnessOverride(1.0F);
             ctx.setBrightnessOverride(MAX_BRIGHTNESS);
         }
-        final ExtendedFacing rotation = getExtendedFacing(ctx.x, ctx.y, ctx.z);
+        final ExtendedFacing rotation = getExtendedFacing(ctx.getX(), ctx.getY(), ctx.getZ());
         if (ctx.canRenderInPass(mIconContainer::canRenderInPass)) {
             ctx.setupColor(ForgeDirection.UP, mRGBa);
-            renderFaceYPos(ctx.renderBlocks, ctx.x, ctx.y, ctx.z, mIconContainer.getIcon(), rotation);
+            renderFaceYPos(
+                ctx.getRenderBlocks(),
+                ctx.getX(),
+                ctx.getY(),
+                ctx.getZ(),
+                mIconContainer.getIcon(),
+                rotation);
         }
         if (mIconContainer.getOverlayIcon() != null && ctx.canRenderInPass(pass -> pass == 1)) {
             ctx.setupColor(ForgeDirection.UP, 0xffffff);
-            renderFaceYPos(ctx.renderBlocks, ctx.x, ctx.y, ctx.z, mIconContainer.getOverlayIcon(), rotation);
+            renderFaceYPos(
+                ctx.getRenderBlocks(),
+                ctx.getX(),
+                ctx.getY(),
+                ctx.getZ(),
+                mIconContainer.getOverlayIcon(),
+                rotation);
         }
-        ctx.renderBlocks.enableAO = enableAO;
-        draw(ctx.renderBlocks);
+        ctx.getRenderBlocks().enableAO = enableAO;
+        draw(ctx.getRenderBlocks());
     }
 
     @Override
     public void renderYNeg(SBRContextBase<? extends SBRContextBase<?>> ctx) {
-        startDrawingQuads(ctx.renderBlocks, 0.0f, -1.0f, 0.0f);
+        startDrawingQuads(ctx.getRenderBlocks(), 0.0f, -1.0f, 0.0f);
         ctx.reset();
-        final boolean enableAO = ctx.renderBlocks.enableAO;
+        final boolean enableAO = ctx.getRenderBlocks().enableAO;
         if (glow) {
             if (!GTMod.proxy.mRenderGlowTextures) {
-                draw(ctx.renderBlocks);
+                draw(ctx.getRenderBlocks());
                 return;
             }
-            ctx.renderBlocks.enableAO = false;
+            ctx.getRenderBlocks().enableAO = false;
             ctx.setLightnessOverride(1.0F);
             ctx.setBrightnessOverride(MAX_BRIGHTNESS);
         }
-        final ExtendedFacing rotation = getExtendedFacing(ctx.x, ctx.y, ctx.z);
+        final ExtendedFacing rotation = getExtendedFacing(ctx.getX(), ctx.getY(), ctx.getZ());
         if (ctx.canRenderInPass(mIconContainer::canRenderInPass)) {
             ctx.setupColor(ForgeDirection.DOWN, mRGBa);
-            renderFaceYNeg(ctx.renderBlocks, ctx.x, ctx.y, ctx.z, mIconContainer.getIcon(), rotation);
+            renderFaceYNeg(
+                ctx.getRenderBlocks(),
+                ctx.getX(),
+                ctx.getY(),
+                ctx.getZ(),
+                mIconContainer.getIcon(),
+                rotation);
         }
         if (mIconContainer.getOverlayIcon() != null && ctx.canRenderInPass(pass -> pass == 1)) {
             ctx.setupColor(ForgeDirection.DOWN, 0xffffff);
-            renderFaceYNeg(ctx.renderBlocks, ctx.x, ctx.y, ctx.z, mIconContainer.getOverlayIcon(), rotation);
+            renderFaceYNeg(
+                ctx.getRenderBlocks(),
+                ctx.getX(),
+                ctx.getY(),
+                ctx.getZ(),
+                mIconContainer.getOverlayIcon(),
+                rotation);
         }
-        ctx.renderBlocks.enableAO = enableAO;
-        draw(ctx.renderBlocks);
+        ctx.getRenderBlocks().enableAO = enableAO;
+        draw(ctx.getRenderBlocks());
     }
 
     @Override
     public void renderZPos(SBRContextBase<? extends SBRContextBase<?>> ctx) {
-        startDrawingQuads(ctx.renderBlocks, 0.0f, 0.0f, 1.0f);
+        startDrawingQuads(ctx.getRenderBlocks(), 0.0f, 0.0f, 1.0f);
         ctx.reset();
-        final boolean enableAO = ctx.renderBlocks.enableAO;
+        final boolean enableAO = ctx.getRenderBlocks().enableAO;
         if (glow) {
             if (!GTMod.proxy.mRenderGlowTextures) {
-                draw(ctx.renderBlocks);
+                draw(ctx.getRenderBlocks());
                 return;
             }
-            ctx.renderBlocks.enableAO = false;
+            ctx.getRenderBlocks().enableAO = false;
             ctx.setLightnessOverride(1.0F);
             ctx.setBrightnessOverride(MAX_BRIGHTNESS);
         }
-        final ExtendedFacing rotation = getExtendedFacing(ctx.x, ctx.y, ctx.z);
+        final ExtendedFacing rotation = getExtendedFacing(ctx.getX(), ctx.getY(), ctx.getZ());
         if (ctx.canRenderInPass(mIconContainer::canRenderInPass)) {
             ctx.setupColor(ForgeDirection.SOUTH, mRGBa);
-            renderFaceZPos(ctx.renderBlocks, ctx.x, ctx.y, ctx.z, mIconContainer.getIcon(), rotation);
+            renderFaceZPos(
+                ctx.getRenderBlocks(),
+                ctx.getX(),
+                ctx.getY(),
+                ctx.getZ(),
+                mIconContainer.getIcon(),
+                rotation);
         }
         if (mIconContainer.getOverlayIcon() != null && ctx.canRenderInPass(pass -> pass == 1)) {
             ctx.setupColor(ForgeDirection.SOUTH, 0xffffff);
-            renderFaceZPos(ctx.renderBlocks, ctx.x, ctx.y, ctx.z, mIconContainer.getOverlayIcon(), rotation);
+            renderFaceZPos(
+                ctx.getRenderBlocks(),
+                ctx.getX(),
+                ctx.getY(),
+                ctx.getZ(),
+                mIconContainer.getOverlayIcon(),
+                rotation);
         }
-        ctx.renderBlocks.enableAO = enableAO;
-        draw(ctx.renderBlocks);
+        ctx.getRenderBlocks().enableAO = enableAO;
+        draw(ctx.getRenderBlocks());
     }
 
     @Override
     public void renderZNeg(SBRContextBase<? extends SBRContextBase<?>> ctx) {
-        startDrawingQuads(ctx.renderBlocks, 0.0f, 0.0f, -1.0f);
+        startDrawingQuads(ctx.getRenderBlocks(), 0.0f, 0.0f, -1.0f);
         ctx.reset();
-        final boolean enableAO = ctx.renderBlocks.enableAO;
+        final boolean enableAO = ctx.getRenderBlocks().enableAO;
         if (glow) {
             if (!GTMod.proxy.mRenderGlowTextures) {
-                draw(ctx.renderBlocks);
+                draw(ctx.getRenderBlocks());
                 return;
             }
-            ctx.renderBlocks.enableAO = false;
+            ctx.getRenderBlocks().enableAO = false;
             ctx.setLightnessOverride(1.0F);
             ctx.setBrightnessOverride(MAX_BRIGHTNESS);
         }
-        final ExtendedFacing rotation = getExtendedFacing(ctx.x, ctx.y, ctx.z);
+        final ExtendedFacing rotation = getExtendedFacing(ctx.getX(), ctx.getY(), ctx.getZ());
         if (ctx.canRenderInPass(mIconContainer::canRenderInPass)) {
             ctx.setupColor(ForgeDirection.NORTH, mRGBa);
-            renderFaceZNeg(ctx.renderBlocks, ctx.x, ctx.y, ctx.z, mIconContainer.getIcon(), rotation);
+            renderFaceZNeg(
+                ctx.getRenderBlocks(),
+                ctx.getX(),
+                ctx.getY(),
+                ctx.getZ(),
+                mIconContainer.getIcon(),
+                rotation);
         }
         if (mIconContainer.getOverlayIcon() != null && ctx.canRenderInPass(pass -> pass == 1)) {
             ctx.setupColor(ForgeDirection.NORTH, 0xffffff);
-            renderFaceZNeg(ctx.renderBlocks, ctx.x, ctx.y, ctx.z, mIconContainer.getOverlayIcon(), rotation);
+            renderFaceZNeg(
+                ctx.getRenderBlocks(),
+                ctx.getX(),
+                ctx.getY(),
+                ctx.getZ(),
+                mIconContainer.getOverlayIcon(),
+                rotation);
         }
-        ctx.renderBlocks.enableAO = enableAO;
-        draw(ctx.renderBlocks);
+        ctx.getRenderBlocks().enableAO = enableAO;
+        draw(ctx.getRenderBlocks());
     }
 
     @Override

--- a/src/main/java/gregtech/common/render/GTRenderedTexture.java
+++ b/src/main/java/gregtech/common/render/GTRenderedTexture.java
@@ -42,164 +42,164 @@ public class GTRenderedTexture extends GTTextureBase implements ITexture, IColor
 
     @Override
     public void renderXPos(SBRContextBase<? extends SBRContextBase<?>> ctx) {
-        startDrawingQuads(ctx.renderer, 1.0f, 0.0f, 0.0f);
+        startDrawingQuads(ctx.renderBlocks, 1.0f, 0.0f, 0.0f);
         ctx.reset();
-        final boolean enableAO = ctx.renderer.enableAO;
+        final boolean enableAO = ctx.renderBlocks.enableAO;
         if (glow) {
             if (!GTMod.proxy.mRenderGlowTextures) {
-                draw(ctx.renderer);
+                draw(ctx.renderBlocks);
                 return;
             }
-            ctx.renderer.enableAO = false;
+            ctx.renderBlocks.enableAO = false;
             ctx.setLightnessOverride(1.0F);
             ctx.setBrightnessOverride(MAX_BRIGHTNESS);
         }
         final ExtendedFacing rotation = getExtendedFacing(ctx.x, ctx.y, ctx.z);
         if (ctx.canRenderInPass(mIconContainer::canRenderInPass)) {
             ctx.setupColor(ForgeDirection.EAST, mRGBa);
-            renderFaceXPos(ctx.renderer, ctx.x, ctx.y, ctx.z, mIconContainer.getIcon(), rotation);
+            renderFaceXPos(ctx.renderBlocks, ctx.x, ctx.y, ctx.z, mIconContainer.getIcon(), rotation);
         }
         if (mIconContainer.getOverlayIcon() != null && ctx.canRenderInPass(pass -> pass == 1)) {
             ctx.setupColor(ForgeDirection.EAST, 0xffffff);
-            renderFaceXPos(ctx.renderer, ctx.x, ctx.y, ctx.z, mIconContainer.getOverlayIcon(), rotation);
+            renderFaceXPos(ctx.renderBlocks, ctx.x, ctx.y, ctx.z, mIconContainer.getOverlayIcon(), rotation);
         }
-        ctx.renderer.enableAO = enableAO;
-        draw(ctx.renderer);
+        ctx.renderBlocks.enableAO = enableAO;
+        draw(ctx.renderBlocks);
     }
 
     @Override
     public void renderXNeg(SBRContextBase<? extends SBRContextBase<?>> ctx) {
-        startDrawingQuads(ctx.renderer, -1.0f, 0.0f, 0.0f);
+        startDrawingQuads(ctx.renderBlocks, -1.0f, 0.0f, 0.0f);
         ctx.reset();
-        final boolean enableAO = ctx.renderer.enableAO;
+        final boolean enableAO = ctx.renderBlocks.enableAO;
         if (glow) {
             if (!GTMod.proxy.mRenderGlowTextures) {
-                draw(ctx.renderer);
+                draw(ctx.renderBlocks);
                 return;
             }
-            ctx.renderer.enableAO = false;
+            ctx.renderBlocks.enableAO = false;
             ctx.setLightnessOverride(1.0F);
             ctx.setBrightnessOverride(MAX_BRIGHTNESS);
         }
         final ExtendedFacing rotation = getExtendedFacing(ctx.x, ctx.y, ctx.z);
         if (ctx.canRenderInPass(mIconContainer::canRenderInPass)) {
             ctx.setupColor(ForgeDirection.WEST, mRGBa);
-            renderFaceXNeg(ctx.renderer, ctx.x, ctx.y, ctx.z, mIconContainer.getIcon(), rotation);
+            renderFaceXNeg(ctx.renderBlocks, ctx.x, ctx.y, ctx.z, mIconContainer.getIcon(), rotation);
         }
         if (mIconContainer.getOverlayIcon() != null && ctx.canRenderInPass(pass -> pass == 1)) {
             ctx.setupColor(ForgeDirection.WEST, 0xffffff);
-            renderFaceXNeg(ctx.renderer, ctx.x, ctx.y, ctx.z, mIconContainer.getOverlayIcon(), rotation);
+            renderFaceXNeg(ctx.renderBlocks, ctx.x, ctx.y, ctx.z, mIconContainer.getOverlayIcon(), rotation);
         }
-        ctx.renderer.enableAO = enableAO;
-        draw(ctx.renderer);
+        ctx.renderBlocks.enableAO = enableAO;
+        draw(ctx.renderBlocks);
     }
 
     @Override
     public void renderYPos(SBRContextBase<? extends SBRContextBase<?>> ctx) {
-        startDrawingQuads(ctx.renderer, 0.0f, 1.0f, 0.0f);
+        startDrawingQuads(ctx.renderBlocks, 0.0f, 1.0f, 0.0f);
         ctx.reset();
-        final boolean enableAO = ctx.renderer.enableAO;
+        final boolean enableAO = ctx.renderBlocks.enableAO;
         if (glow) {
             if (!GTMod.proxy.mRenderGlowTextures) {
-                draw(ctx.renderer);
+                draw(ctx.renderBlocks);
                 return;
             }
-            ctx.renderer.enableAO = false;
+            ctx.renderBlocks.enableAO = false;
             ctx.setLightnessOverride(1.0F);
             ctx.setBrightnessOverride(MAX_BRIGHTNESS);
         }
         final ExtendedFacing rotation = getExtendedFacing(ctx.x, ctx.y, ctx.z);
         if (ctx.canRenderInPass(mIconContainer::canRenderInPass)) {
             ctx.setupColor(ForgeDirection.UP, mRGBa);
-            renderFaceYPos(ctx.renderer, ctx.x, ctx.y, ctx.z, mIconContainer.getIcon(), rotation);
+            renderFaceYPos(ctx.renderBlocks, ctx.x, ctx.y, ctx.z, mIconContainer.getIcon(), rotation);
         }
         if (mIconContainer.getOverlayIcon() != null && ctx.canRenderInPass(pass -> pass == 1)) {
             ctx.setupColor(ForgeDirection.UP, 0xffffff);
-            renderFaceYPos(ctx.renderer, ctx.x, ctx.y, ctx.z, mIconContainer.getOverlayIcon(), rotation);
+            renderFaceYPos(ctx.renderBlocks, ctx.x, ctx.y, ctx.z, mIconContainer.getOverlayIcon(), rotation);
         }
-        ctx.renderer.enableAO = enableAO;
-        draw(ctx.renderer);
+        ctx.renderBlocks.enableAO = enableAO;
+        draw(ctx.renderBlocks);
     }
 
     @Override
     public void renderYNeg(SBRContextBase<? extends SBRContextBase<?>> ctx) {
-        startDrawingQuads(ctx.renderer, 0.0f, -1.0f, 0.0f);
+        startDrawingQuads(ctx.renderBlocks, 0.0f, -1.0f, 0.0f);
         ctx.reset();
-        final boolean enableAO = ctx.renderer.enableAO;
+        final boolean enableAO = ctx.renderBlocks.enableAO;
         if (glow) {
             if (!GTMod.proxy.mRenderGlowTextures) {
-                draw(ctx.renderer);
+                draw(ctx.renderBlocks);
                 return;
             }
-            ctx.renderer.enableAO = false;
+            ctx.renderBlocks.enableAO = false;
             ctx.setLightnessOverride(1.0F);
             ctx.setBrightnessOverride(MAX_BRIGHTNESS);
         }
         final ExtendedFacing rotation = getExtendedFacing(ctx.x, ctx.y, ctx.z);
         if (ctx.canRenderInPass(mIconContainer::canRenderInPass)) {
             ctx.setupColor(ForgeDirection.DOWN, mRGBa);
-            renderFaceYNeg(ctx.renderer, ctx.x, ctx.y, ctx.z, mIconContainer.getIcon(), rotation);
+            renderFaceYNeg(ctx.renderBlocks, ctx.x, ctx.y, ctx.z, mIconContainer.getIcon(), rotation);
         }
         if (mIconContainer.getOverlayIcon() != null && ctx.canRenderInPass(pass -> pass == 1)) {
             ctx.setupColor(ForgeDirection.DOWN, 0xffffff);
-            renderFaceYNeg(ctx.renderer, ctx.x, ctx.y, ctx.z, mIconContainer.getOverlayIcon(), rotation);
+            renderFaceYNeg(ctx.renderBlocks, ctx.x, ctx.y, ctx.z, mIconContainer.getOverlayIcon(), rotation);
         }
-        ctx.renderer.enableAO = enableAO;
-        draw(ctx.renderer);
+        ctx.renderBlocks.enableAO = enableAO;
+        draw(ctx.renderBlocks);
     }
 
     @Override
     public void renderZPos(SBRContextBase<? extends SBRContextBase<?>> ctx) {
-        startDrawingQuads(ctx.renderer, 0.0f, 0.0f, 1.0f);
+        startDrawingQuads(ctx.renderBlocks, 0.0f, 0.0f, 1.0f);
         ctx.reset();
-        final boolean enableAO = ctx.renderer.enableAO;
+        final boolean enableAO = ctx.renderBlocks.enableAO;
         if (glow) {
             if (!GTMod.proxy.mRenderGlowTextures) {
-                draw(ctx.renderer);
+                draw(ctx.renderBlocks);
                 return;
             }
-            ctx.renderer.enableAO = false;
+            ctx.renderBlocks.enableAO = false;
             ctx.setLightnessOverride(1.0F);
             ctx.setBrightnessOverride(MAX_BRIGHTNESS);
         }
         final ExtendedFacing rotation = getExtendedFacing(ctx.x, ctx.y, ctx.z);
         if (ctx.canRenderInPass(mIconContainer::canRenderInPass)) {
             ctx.setupColor(ForgeDirection.SOUTH, mRGBa);
-            renderFaceZPos(ctx.renderer, ctx.x, ctx.y, ctx.z, mIconContainer.getIcon(), rotation);
+            renderFaceZPos(ctx.renderBlocks, ctx.x, ctx.y, ctx.z, mIconContainer.getIcon(), rotation);
         }
         if (mIconContainer.getOverlayIcon() != null && ctx.canRenderInPass(pass -> pass == 1)) {
             ctx.setupColor(ForgeDirection.SOUTH, 0xffffff);
-            renderFaceZPos(ctx.renderer, ctx.x, ctx.y, ctx.z, mIconContainer.getOverlayIcon(), rotation);
+            renderFaceZPos(ctx.renderBlocks, ctx.x, ctx.y, ctx.z, mIconContainer.getOverlayIcon(), rotation);
         }
-        ctx.renderer.enableAO = enableAO;
-        draw(ctx.renderer);
+        ctx.renderBlocks.enableAO = enableAO;
+        draw(ctx.renderBlocks);
     }
 
     @Override
     public void renderZNeg(SBRContextBase<? extends SBRContextBase<?>> ctx) {
-        startDrawingQuads(ctx.renderer, 0.0f, 0.0f, -1.0f);
+        startDrawingQuads(ctx.renderBlocks, 0.0f, 0.0f, -1.0f);
         ctx.reset();
-        final boolean enableAO = ctx.renderer.enableAO;
+        final boolean enableAO = ctx.renderBlocks.enableAO;
         if (glow) {
             if (!GTMod.proxy.mRenderGlowTextures) {
-                draw(ctx.renderer);
+                draw(ctx.renderBlocks);
                 return;
             }
-            ctx.renderer.enableAO = false;
+            ctx.renderBlocks.enableAO = false;
             ctx.setLightnessOverride(1.0F);
             ctx.setBrightnessOverride(MAX_BRIGHTNESS);
         }
         final ExtendedFacing rotation = getExtendedFacing(ctx.x, ctx.y, ctx.z);
         if (ctx.canRenderInPass(mIconContainer::canRenderInPass)) {
             ctx.setupColor(ForgeDirection.NORTH, mRGBa);
-            renderFaceZNeg(ctx.renderer, ctx.x, ctx.y, ctx.z, mIconContainer.getIcon(), rotation);
+            renderFaceZNeg(ctx.renderBlocks, ctx.x, ctx.y, ctx.z, mIconContainer.getIcon(), rotation);
         }
         if (mIconContainer.getOverlayIcon() != null && ctx.canRenderInPass(pass -> pass == 1)) {
             ctx.setupColor(ForgeDirection.NORTH, 0xffffff);
-            renderFaceZNeg(ctx.renderer, ctx.x, ctx.y, ctx.z, mIconContainer.getOverlayIcon(), rotation);
+            renderFaceZNeg(ctx.renderBlocks, ctx.x, ctx.y, ctx.z, mIconContainer.getOverlayIcon(), rotation);
         }
-        ctx.renderer.enableAO = enableAO;
-        draw(ctx.renderer);
+        ctx.renderBlocks.enableAO = enableAO;
+        draw(ctx.renderBlocks);
     }
 
     @Override

--- a/src/main/java/gregtech/common/render/GTRenderedTexture.java
+++ b/src/main/java/gregtech/common/render/GTRenderedTexture.java
@@ -41,7 +41,7 @@ public class GTRenderedTexture extends GTTextureBase implements ITexture, IColor
     }
 
     @Override
-    public void renderXPos(SBRContextBase<? extends SBRContextBase<?>> ctx) {
+    public void renderXPos(SBRContextBase ctx) {
         startDrawingQuads(ctx.getRenderBlocks(), 1.0f, 0.0f, 0.0f);
         ctx.reset();
         final boolean enableAO = ctx.getRenderBlocks().enableAO;
@@ -57,30 +57,19 @@ public class GTRenderedTexture extends GTTextureBase implements ITexture, IColor
         final ExtendedFacing rotation = getExtendedFacing(ctx.getX(), ctx.getY(), ctx.getZ());
         if (ctx.canRenderInPass(mIconContainer::canRenderInPass)) {
             ctx.setupColor(ForgeDirection.EAST, mRGBa);
-            renderFaceXPos(
-                ctx.getRenderBlocks(),
-                ctx.getX(),
-                ctx.getY(),
-                ctx.getZ(),
-                mIconContainer.getIcon(),
-                rotation);
+            renderFaceXPos(ctx, mIconContainer.getIcon(), rotation);
         }
-        if (mIconContainer.getOverlayIcon() != null && ctx.canRenderInPass(pass -> pass == 1)) {
+        final IIcon overlayIcon = mIconContainer.getOverlayIcon();
+        if (overlayIcon != null && ctx.canRenderInPass(pass -> pass == 1)) {
             ctx.setupColor(ForgeDirection.EAST, 0xffffff);
-            renderFaceXPos(
-                ctx.getRenderBlocks(),
-                ctx.getX(),
-                ctx.getY(),
-                ctx.getZ(),
-                mIconContainer.getOverlayIcon(),
-                rotation);
+            renderFaceXPos(ctx, overlayIcon, rotation);
         }
         ctx.getRenderBlocks().enableAO = enableAO;
         draw(ctx.getRenderBlocks());
     }
 
     @Override
-    public void renderXNeg(SBRContextBase<? extends SBRContextBase<?>> ctx) {
+    public void renderXNeg(SBRContextBase ctx) {
         startDrawingQuads(ctx.getRenderBlocks(), -1.0f, 0.0f, 0.0f);
         ctx.reset();
         final boolean enableAO = ctx.getRenderBlocks().enableAO;
@@ -96,30 +85,19 @@ public class GTRenderedTexture extends GTTextureBase implements ITexture, IColor
         final ExtendedFacing rotation = getExtendedFacing(ctx.getX(), ctx.getY(), ctx.getZ());
         if (ctx.canRenderInPass(mIconContainer::canRenderInPass)) {
             ctx.setupColor(ForgeDirection.WEST, mRGBa);
-            renderFaceXNeg(
-                ctx.getRenderBlocks(),
-                ctx.getX(),
-                ctx.getY(),
-                ctx.getZ(),
-                mIconContainer.getIcon(),
-                rotation);
+            renderFaceXNeg(ctx, mIconContainer.getIcon(), rotation);
         }
-        if (mIconContainer.getOverlayIcon() != null && ctx.canRenderInPass(pass -> pass == 1)) {
+        final IIcon overlayIcon = mIconContainer.getOverlayIcon();
+        if (overlayIcon != null && ctx.canRenderInPass(pass -> pass == 1)) {
             ctx.setupColor(ForgeDirection.WEST, 0xffffff);
-            renderFaceXNeg(
-                ctx.getRenderBlocks(),
-                ctx.getX(),
-                ctx.getY(),
-                ctx.getZ(),
-                mIconContainer.getOverlayIcon(),
-                rotation);
+            renderFaceXNeg(ctx, overlayIcon, rotation);
         }
         ctx.getRenderBlocks().enableAO = enableAO;
         draw(ctx.getRenderBlocks());
     }
 
     @Override
-    public void renderYPos(SBRContextBase<? extends SBRContextBase<?>> ctx) {
+    public void renderYPos(SBRContextBase ctx) {
         startDrawingQuads(ctx.getRenderBlocks(), 0.0f, 1.0f, 0.0f);
         ctx.reset();
         final boolean enableAO = ctx.getRenderBlocks().enableAO;
@@ -135,30 +113,19 @@ public class GTRenderedTexture extends GTTextureBase implements ITexture, IColor
         final ExtendedFacing rotation = getExtendedFacing(ctx.getX(), ctx.getY(), ctx.getZ());
         if (ctx.canRenderInPass(mIconContainer::canRenderInPass)) {
             ctx.setupColor(ForgeDirection.UP, mRGBa);
-            renderFaceYPos(
-                ctx.getRenderBlocks(),
-                ctx.getX(),
-                ctx.getY(),
-                ctx.getZ(),
-                mIconContainer.getIcon(),
-                rotation);
+            renderFaceYPos(ctx, mIconContainer.getIcon(), rotation);
         }
-        if (mIconContainer.getOverlayIcon() != null && ctx.canRenderInPass(pass -> pass == 1)) {
+        final IIcon overlayIcon = mIconContainer.getOverlayIcon();
+        if (overlayIcon != null && ctx.canRenderInPass(pass -> pass == 1)) {
             ctx.setupColor(ForgeDirection.UP, 0xffffff);
-            renderFaceYPos(
-                ctx.getRenderBlocks(),
-                ctx.getX(),
-                ctx.getY(),
-                ctx.getZ(),
-                mIconContainer.getOverlayIcon(),
-                rotation);
+            renderFaceYPos(ctx, overlayIcon, rotation);
         }
         ctx.getRenderBlocks().enableAO = enableAO;
         draw(ctx.getRenderBlocks());
     }
 
     @Override
-    public void renderYNeg(SBRContextBase<? extends SBRContextBase<?>> ctx) {
+    public void renderYNeg(SBRContextBase ctx) {
         startDrawingQuads(ctx.getRenderBlocks(), 0.0f, -1.0f, 0.0f);
         ctx.reset();
         final boolean enableAO = ctx.getRenderBlocks().enableAO;
@@ -174,30 +141,19 @@ public class GTRenderedTexture extends GTTextureBase implements ITexture, IColor
         final ExtendedFacing rotation = getExtendedFacing(ctx.getX(), ctx.getY(), ctx.getZ());
         if (ctx.canRenderInPass(mIconContainer::canRenderInPass)) {
             ctx.setupColor(ForgeDirection.DOWN, mRGBa);
-            renderFaceYNeg(
-                ctx.getRenderBlocks(),
-                ctx.getX(),
-                ctx.getY(),
-                ctx.getZ(),
-                mIconContainer.getIcon(),
-                rotation);
+            renderFaceYNeg(ctx, mIconContainer.getIcon(), rotation);
         }
-        if (mIconContainer.getOverlayIcon() != null && ctx.canRenderInPass(pass -> pass == 1)) {
+        final IIcon overlayIcon = mIconContainer.getOverlayIcon();
+        if (overlayIcon != null && ctx.canRenderInPass(pass -> pass == 1)) {
             ctx.setupColor(ForgeDirection.DOWN, 0xffffff);
-            renderFaceYNeg(
-                ctx.getRenderBlocks(),
-                ctx.getX(),
-                ctx.getY(),
-                ctx.getZ(),
-                mIconContainer.getOverlayIcon(),
-                rotation);
+            renderFaceYNeg(ctx, overlayIcon, rotation);
         }
         ctx.getRenderBlocks().enableAO = enableAO;
         draw(ctx.getRenderBlocks());
     }
 
     @Override
-    public void renderZPos(SBRContextBase<? extends SBRContextBase<?>> ctx) {
+    public void renderZPos(SBRContextBase ctx) {
         startDrawingQuads(ctx.getRenderBlocks(), 0.0f, 0.0f, 1.0f);
         ctx.reset();
         final boolean enableAO = ctx.getRenderBlocks().enableAO;
@@ -213,30 +169,19 @@ public class GTRenderedTexture extends GTTextureBase implements ITexture, IColor
         final ExtendedFacing rotation = getExtendedFacing(ctx.getX(), ctx.getY(), ctx.getZ());
         if (ctx.canRenderInPass(mIconContainer::canRenderInPass)) {
             ctx.setupColor(ForgeDirection.SOUTH, mRGBa);
-            renderFaceZPos(
-                ctx.getRenderBlocks(),
-                ctx.getX(),
-                ctx.getY(),
-                ctx.getZ(),
-                mIconContainer.getIcon(),
-                rotation);
+            renderFaceZPos(ctx, mIconContainer.getIcon(), rotation);
         }
-        if (mIconContainer.getOverlayIcon() != null && ctx.canRenderInPass(pass -> pass == 1)) {
+        final IIcon overlayIcon = mIconContainer.getOverlayIcon();
+        if (overlayIcon != null && ctx.canRenderInPass(pass -> pass == 1)) {
             ctx.setupColor(ForgeDirection.SOUTH, 0xffffff);
-            renderFaceZPos(
-                ctx.getRenderBlocks(),
-                ctx.getX(),
-                ctx.getY(),
-                ctx.getZ(),
-                mIconContainer.getOverlayIcon(),
-                rotation);
+            renderFaceZPos(ctx, overlayIcon, rotation);
         }
         ctx.getRenderBlocks().enableAO = enableAO;
         draw(ctx.getRenderBlocks());
     }
 
     @Override
-    public void renderZNeg(SBRContextBase<? extends SBRContextBase<?>> ctx) {
+    public void renderZNeg(SBRContextBase ctx) {
         startDrawingQuads(ctx.getRenderBlocks(), 0.0f, 0.0f, -1.0f);
         ctx.reset();
         final boolean enableAO = ctx.getRenderBlocks().enableAO;
@@ -252,23 +197,12 @@ public class GTRenderedTexture extends GTTextureBase implements ITexture, IColor
         final ExtendedFacing rotation = getExtendedFacing(ctx.getX(), ctx.getY(), ctx.getZ());
         if (ctx.canRenderInPass(mIconContainer::canRenderInPass)) {
             ctx.setupColor(ForgeDirection.NORTH, mRGBa);
-            renderFaceZNeg(
-                ctx.getRenderBlocks(),
-                ctx.getX(),
-                ctx.getY(),
-                ctx.getZ(),
-                mIconContainer.getIcon(),
-                rotation);
+            renderFaceZNeg(ctx, mIconContainer.getIcon(), rotation);
         }
-        if (mIconContainer.getOverlayIcon() != null && ctx.canRenderInPass(pass -> pass == 1)) {
+        final IIcon overlayIcon = mIconContainer.getOverlayIcon();
+        if (overlayIcon != null && ctx.canRenderInPass(pass -> pass == 1)) {
             ctx.setupColor(ForgeDirection.NORTH, 0xffffff);
-            renderFaceZNeg(
-                ctx.getRenderBlocks(),
-                ctx.getX(),
-                ctx.getY(),
-                ctx.getZ(),
-                mIconContainer.getOverlayIcon(),
-                rotation);
+            renderFaceZNeg(ctx, overlayIcon, rotation);
         }
         ctx.getRenderBlocks().enableAO = enableAO;
         draw(ctx.getRenderBlocks());
@@ -287,89 +221,88 @@ public class GTRenderedTexture extends GTTextureBase implements ITexture, IColor
     /**
      * Renders the given texture to the bottom face of the block. Args: block, x, y, z, texture
      */
-    protected void renderFaceYNeg(RenderBlocks aRenderer, double x, double y, double z, IIcon icon,
-        ExtendedFacing extendedFacing) {
-
-        aRenderer.uvRotateBottom = getRotation(extendedFacing);
+    protected void renderFaceYNeg(SBRContextBase ctx, IIcon icon, ExtendedFacing extendedFacing) {
+        final RenderBlocks renderBlocks = ctx.getRenderBlocks();
+        renderBlocks.uvRotateBottom = getRotation(extendedFacing);
         icon = getFlipped(ForgeDirection.DOWN, extendedFacing, icon);
 
-        aRenderer.renderFaceYNeg(Blocks.air, x, y, z, icon);
+        renderBlocks.renderFaceYNeg(Blocks.air, ctx.getX(), ctx.getY(), ctx.getZ(), icon);
 
-        aRenderer.uvRotateBottom = 0;
+        renderBlocks.uvRotateBottom = 0;
     }
 
     /**
      * Renders the given texture to the top face of the block. Args: block, x, y, z, texture
      */
-    protected void renderFaceYPos(RenderBlocks aRenderer, double x, double y, double z, IIcon icon,
-        ExtendedFacing extendedFacing) {
+    protected void renderFaceYPos(SBRContextBase ctx, IIcon icon, ExtendedFacing extendedFacing) {
+        final RenderBlocks renderBlocks = ctx.getRenderBlocks();
 
-        aRenderer.uvRotateTop = getRotation(extendedFacing);
+        renderBlocks.uvRotateTop = getRotation(extendedFacing);
         icon = getFlipped(ForgeDirection.UP, extendedFacing, icon);
 
-        aRenderer.renderFaceYPos(Blocks.air, x, y, z, icon);
+        renderBlocks.renderFaceYPos(Blocks.air, ctx.getX(), ctx.getY(), ctx.getZ(), icon);
 
-        aRenderer.uvRotateTop = 0;
+        renderBlocks.uvRotateTop = 0;
     }
 
     /**
      * Renders the given texture to the north (z-negative) face of the block. Args: block, x, y, z, texture
      */
-    protected void renderFaceZNeg(RenderBlocks aRenderer, double x, double y, double z, IIcon icon,
-        ExtendedFacing extendedFacing) {
+    protected void renderFaceZNeg(SBRContextBase ctx, IIcon icon, ExtendedFacing extendedFacing) {
+        final RenderBlocks renderBlocks = ctx.getRenderBlocks();
 
-        aRenderer.uvRotateEast = getRotation(extendedFacing);
-        aRenderer.field_152631_f = true;
+        renderBlocks.uvRotateEast = getRotation(extendedFacing);
+        renderBlocks.field_152631_f = true;
         icon = getFlipped(ForgeDirection.NORTH, extendedFacing, icon);
 
-        aRenderer.renderFaceZNeg(Blocks.air, x, y, z, icon);
+        renderBlocks.renderFaceZNeg(Blocks.air, ctx.getX(), ctx.getY(), ctx.getZ(), icon);
 
-        aRenderer.uvRotateEast = 0;
-        aRenderer.field_152631_f = false;
+        renderBlocks.uvRotateEast = 0;
+        renderBlocks.field_152631_f = false;
     }
 
     /**
      * Renders the given texture to the south (z-positive) face of the block. Args: block, x, y, z, texture
      */
-    protected void renderFaceZPos(RenderBlocks aRenderer, double x, double y, double z, IIcon icon,
-        ExtendedFacing extendedFacing) {
+    protected void renderFaceZPos(SBRContextBase ctx, IIcon icon, ExtendedFacing extendedFacing) {
+        final RenderBlocks renderBlocks = ctx.getRenderBlocks();
 
-        aRenderer.uvRotateWest = getRotation(extendedFacing);
+        renderBlocks.uvRotateWest = getRotation(extendedFacing);
         icon = getFlipped(ForgeDirection.SOUTH, extendedFacing, icon);
 
-        aRenderer.renderFaceZPos(Blocks.air, x, y, z, icon);
+        renderBlocks.renderFaceZPos(Blocks.air, ctx.getX(), ctx.getY(), ctx.getZ(), icon);
 
-        aRenderer.uvRotateWest = 0;
+        renderBlocks.uvRotateWest = 0;
     }
 
     /**
      * Renders the given texture to the west (x-negative) face of the block. Args: block, x, y, z, texture
      */
-    protected void renderFaceXNeg(RenderBlocks aRenderer, double x, double y, double z, IIcon icon,
-        ExtendedFacing extendedFacing) {
+    protected void renderFaceXNeg(SBRContextBase ctx, IIcon icon, ExtendedFacing extendedFacing) {
+        final RenderBlocks renderBlocks = ctx.getRenderBlocks();
 
-        aRenderer.uvRotateNorth = getRotation(extendedFacing);
+        renderBlocks.uvRotateNorth = getRotation(extendedFacing);
         icon = getFlipped(ForgeDirection.WEST, extendedFacing, icon);
 
-        aRenderer.renderFaceXNeg(Blocks.air, x, y, z, icon);
+        renderBlocks.renderFaceXNeg(Blocks.air, ctx.getX(), ctx.getY(), ctx.getZ(), icon);
 
-        aRenderer.uvRotateNorth = 0;
+        renderBlocks.uvRotateNorth = 0;
     }
 
     /**
      * Renders the given texture to the east (x-positive) face of the block. Args: block, x, y, z, texture
      */
-    protected void renderFaceXPos(RenderBlocks aRenderer, double x, double y, double z, IIcon icon,
-        ExtendedFacing extendedFacing) {
+    protected void renderFaceXPos(SBRContextBase ctx, IIcon icon, ExtendedFacing extendedFacing) {
+        final RenderBlocks renderBlocks = ctx.getRenderBlocks();
 
-        aRenderer.uvRotateSouth = getRotation(extendedFacing);
-        aRenderer.field_152631_f = true;
+        renderBlocks.uvRotateSouth = getRotation(extendedFacing);
+        renderBlocks.field_152631_f = true;
         icon = getFlipped(ForgeDirection.EAST, extendedFacing, icon);
 
-        aRenderer.renderFaceXPos(Blocks.air, x, y, z, icon);
+        renderBlocks.renderFaceXPos(Blocks.air, ctx.getX(), ctx.getY(), ctx.getZ(), icon);
 
-        aRenderer.uvRotateSouth = 0;
-        aRenderer.field_152631_f = false;
+        renderBlocks.uvRotateSouth = 0;
+        renderBlocks.field_152631_f = false;
     }
 
     private static final int NORMAL = 0;
@@ -405,8 +338,6 @@ public class GTRenderedTexture extends GTTextureBase implements ITexture, IColor
 
             return new GTIconFlipped(icon, flipU, flipV);
         }
-
-        ForgeDirection dir = extendedFacing.getDirection();
 
         // certain directions need to be flipped horizontally seemingly randomly
         // maybe there's a reason, maybe there isn't, I haven't bothered to dig into the code to figure out why

--- a/src/main/java/gregtech/common/render/GTRendererBlock.java
+++ b/src/main/java/gregtech/common/render/GTRendererBlock.java
@@ -81,10 +81,10 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
     private final ITexture[][] textureArray = new ITexture[6][];
     private final ITexture[] overlayHolder = new ITexture[1];
 
-    private final SBRContextHolder sbrContextHolder = new SBRContextHolder();
+    protected final SBRContextHolder sbrContextHolder = new SBRContextHolder();
 
     public boolean renderStandardBlock(SBRWorldContext ctx) {
-        final TileEntity tTileEntity = ctx.blockAccess.getTileEntity(ctx.x, ctx.y, ctx.z);
+        final TileEntity tTileEntity = ctx.getTileEntity();
         if (tTileEntity instanceof IPipeRenderedTileEntity pipeRenderedTileEntity) {
             textureArray[0] = pipeRenderedTileEntity.getTextureCovered(DOWN);
             textureArray[1] = pipeRenderedTileEntity.getTextureCovered(UP);
@@ -95,7 +95,7 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
             return renderStandardBlock(ctx, textureArray);
         }
         if (tTileEntity instanceof IAllSidedTexturedTileEntity allSidedTexturedTileEntity) {
-            ITexture[] texture = allSidedTexturedTileEntity.getTexture(ctx.block);
+            ITexture[] texture = allSidedTexturedTileEntity.getTexture(ctx.getBlock());
             textureArray[0] = texture;
             textureArray[1] = texture;
             textureArray[2] = texture;
@@ -105,12 +105,12 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
             return renderStandardBlock(ctx, textureArray);
         }
         if (tTileEntity instanceof ITexturedTileEntity texturedTileEntity) {
-            textureArray[0] = texturedTileEntity.getTexture(ctx.block, DOWN);
-            textureArray[1] = texturedTileEntity.getTexture(ctx.block, UP);
-            textureArray[2] = texturedTileEntity.getTexture(ctx.block, NORTH);
-            textureArray[3] = texturedTileEntity.getTexture(ctx.block, SOUTH);
-            textureArray[4] = texturedTileEntity.getTexture(ctx.block, WEST);
-            textureArray[5] = texturedTileEntity.getTexture(ctx.block, EAST);
+            textureArray[0] = texturedTileEntity.getTexture(ctx.getBlock(), DOWN);
+            textureArray[1] = texturedTileEntity.getTexture(ctx.getBlock(), UP);
+            textureArray[2] = texturedTileEntity.getTexture(ctx.getBlock(), NORTH);
+            textureArray[3] = texturedTileEntity.getTexture(ctx.getBlock(), SOUTH);
+            textureArray[4] = texturedTileEntity.getTexture(ctx.getBlock(), WEST);
+            textureArray[5] = texturedTileEntity.getTexture(ctx.getBlock(), EAST);
             return renderStandardBlock(ctx, textureArray);
         }
 
@@ -118,11 +118,12 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
     }
 
     public boolean renderStandardBlock(SBRWorldContext ctx, ITexture[][] aTextures) {
-        ctx.block.setBlockBounds(blockMin, blockMin, blockMin, blockMax, blockMax, blockMax);
-        ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
-        ctx.fullBlock = true;
+        ctx.getBlock()
+            .setBlockBounds(blockMin, blockMin, blockMin, blockMax, blockMax, blockMax);
+        ctx.setRenderBoundsFromBlock();
+        ctx.setFullBlock(true);
 
-        ITexture[] overlays = RenderOverlay.get(ctx.blockAccess, ctx.x, ctx.y, ctx.z);
+        ITexture[] overlays = RenderOverlay.get(ctx.getBlockAccess(), ctx.getX(), ctx.getY(), ctx.getZ());
         if (overlays != null) {
             ctx.renderNegativeYFacing(aTextures[SIDE_DOWN]);
             if (overlays[SIDE_DOWN] != null) {
@@ -182,14 +183,15 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
         for (int i = 0; i < VALID_DIRECTIONS.length; i++) {
             final ForgeDirection iSide = VALID_DIRECTIONS[i];
             tIsCovered[i] = aTileEntity.hasCoverAtSide(iSide);
-            tCovers[i] = aTileEntity.getTexture(ctx.block, iSide);
+            tCovers[i] = aTileEntity.getTexture(ctx.getBlock(), iSide);
             tIcons[i] = aTileEntity.getTextureUncovered(iSide);
         }
 
         switch (aConnections) {
             case NO_CONNECTION -> {
-                ctx.block.setBlockBounds(pipeMin, pipeMin, pipeMin, pipeMax, pipeMax, pipeMax);
-                ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+                ctx.getBlock()
+                    .setBlockBounds(pipeMin, pipeMin, pipeMin, pipeMax, pipeMax, pipeMax);
+                ctx.setRenderBoundsFromBlock();
                 ctx.renderNegativeYFacing(tIcons[SIDE_DOWN]);
                 ctx.renderPositiveYFacing(tIcons[SIDE_UP]);
                 ctx.renderNegativeZFacing(tIcons[SIDE_NORTH]);
@@ -199,8 +201,9 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
             }
             case CONNECTED_EAST | CONNECTED_WEST -> {
                 // EAST - WEST Pipe Sides
-                ctx.block.setBlockBounds(blockMin, pipeMin, pipeMin, blockMax, pipeMax, pipeMax);
-                ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+                ctx.getBlock()
+                    .setBlockBounds(blockMin, pipeMin, pipeMin, blockMax, pipeMax, pipeMax);
+                ctx.setRenderBoundsFromBlock();
                 ctx.renderNegativeYFacing(tIcons[SIDE_DOWN]);
                 ctx.renderPositiveYFacing(tIcons[SIDE_UP]);
                 ctx.renderNegativeZFacing(tIcons[SIDE_NORTH]);
@@ -212,8 +215,9 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
             }
             case CONNECTED_DOWN | CONNECTED_UP -> {
                 // UP - DOWN Pipe Sides
-                ctx.block.setBlockBounds(pipeMin, blockMin, pipeMin, pipeMax, blockMax, pipeMax);
-                ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+                ctx.getBlock()
+                    .setBlockBounds(pipeMin, blockMin, pipeMin, pipeMax, blockMax, pipeMax);
+                ctx.setRenderBoundsFromBlock();
                 ctx.renderNegativeZFacing(tIcons[SIDE_NORTH]);
                 ctx.renderPositiveZFacing(tIcons[SIDE_SOUTH]);
                 ctx.renderNegativeXFacing(tIcons[SIDE_WEST]);
@@ -225,8 +229,9 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
             }
             case CONNECTED_NORTH | CONNECTED_SOUTH -> {
                 // NORTH - SOUTH Pipe Sides
-                ctx.block.setBlockBounds(pipeMin, pipeMin, blockMin, pipeMax, pipeMax, blockMax);
-                ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+                ctx.getBlock()
+                    .setBlockBounds(pipeMin, pipeMin, blockMin, pipeMax, pipeMax, blockMax);
+                ctx.setRenderBoundsFromBlock();
                 ctx.renderNegativeYFacing(tIcons[SIDE_DOWN]);
                 ctx.renderPositiveYFacing(tIcons[SIDE_UP]);
                 ctx.renderNegativeXFacing(tIcons[SIDE_WEST]);
@@ -238,11 +243,13 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
             }
             default -> {
                 if ((aConnections & CONNECTED_WEST) == 0) {
-                    ctx.block.setBlockBounds(pipeMin, pipeMin, pipeMin, pipeMax, pipeMax, pipeMax);
-                    ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+                    ctx.getBlock()
+                        .setBlockBounds(pipeMin, pipeMin, pipeMin, pipeMax, pipeMax, pipeMax);
+                    ctx.setRenderBoundsFromBlock();
                 } else {
-                    ctx.block.setBlockBounds(blockMin, pipeMin, pipeMin, pipeMin, pipeMax, pipeMax);
-                    ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+                    ctx.getBlock()
+                        .setBlockBounds(blockMin, pipeMin, pipeMin, pipeMin, pipeMax, pipeMax);
+                    ctx.setRenderBoundsFromBlock();
                     ctx.renderNegativeYFacing(tIcons[SIDE_DOWN]);
                     ctx.renderPositiveYFacing(tIcons[SIDE_UP]);
                     ctx.renderNegativeZFacing(tIcons[SIDE_NORTH]);
@@ -250,11 +257,13 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
                 }
                 ctx.renderNegativeXFacing(tIcons[SIDE_WEST]);
                 if ((aConnections & CONNECTED_EAST) == 0) {
-                    ctx.block.setBlockBounds(pipeMin, pipeMin, pipeMin, pipeMax, pipeMax, pipeMax);
-                    ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+                    ctx.getBlock()
+                        .setBlockBounds(pipeMin, pipeMin, pipeMin, pipeMax, pipeMax, pipeMax);
+                    ctx.setRenderBoundsFromBlock();
                 } else {
-                    ctx.block.setBlockBounds(pipeMax, pipeMin, pipeMin, blockMax, pipeMax, pipeMax);
-                    ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+                    ctx.getBlock()
+                        .setBlockBounds(pipeMax, pipeMin, pipeMin, blockMax, pipeMax, pipeMax);
+                    ctx.setRenderBoundsFromBlock();
                     ctx.renderNegativeYFacing(tIcons[SIDE_DOWN]);
                     ctx.renderPositiveYFacing(tIcons[SIDE_UP]);
                     ctx.renderNegativeZFacing(tIcons[SIDE_NORTH]);
@@ -262,11 +271,13 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
                 }
                 ctx.renderPositiveXFacing(tIcons[SIDE_EAST]);
                 if ((aConnections & CONNECTED_DOWN) == 0) {
-                    ctx.block.setBlockBounds(pipeMin, pipeMin, pipeMin, pipeMax, pipeMax, pipeMax);
-                    ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+                    ctx.getBlock()
+                        .setBlockBounds(pipeMin, pipeMin, pipeMin, pipeMax, pipeMax, pipeMax);
+                    ctx.setRenderBoundsFromBlock();
                 } else {
-                    ctx.block.setBlockBounds(pipeMin, blockMin, pipeMin, pipeMax, pipeMin, pipeMax);
-                    ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+                    ctx.getBlock()
+                        .setBlockBounds(pipeMin, blockMin, pipeMin, pipeMax, pipeMin, pipeMax);
+                    ctx.setRenderBoundsFromBlock();
                     ctx.renderNegativeZFacing(tIcons[SIDE_NORTH]);
                     ctx.renderPositiveZFacing(tIcons[SIDE_SOUTH]);
                     ctx.renderNegativeXFacing(tIcons[SIDE_WEST]);
@@ -274,11 +285,13 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
                 }
                 ctx.renderNegativeYFacing(tIcons[SIDE_DOWN]);
                 if ((aConnections & CONNECTED_UP) == 0) {
-                    ctx.block.setBlockBounds(pipeMin, pipeMin, pipeMin, pipeMax, pipeMax, pipeMax);
-                    ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+                    ctx.getBlock()
+                        .setBlockBounds(pipeMin, pipeMin, pipeMin, pipeMax, pipeMax, pipeMax);
+                    ctx.setRenderBoundsFromBlock();
                 } else {
-                    ctx.block.setBlockBounds(pipeMin, pipeMax, pipeMin, pipeMax, blockMax, pipeMax);
-                    ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+                    ctx.getBlock()
+                        .setBlockBounds(pipeMin, pipeMax, pipeMin, pipeMax, blockMax, pipeMax);
+                    ctx.setRenderBoundsFromBlock();
                     ctx.renderNegativeZFacing(tIcons[SIDE_NORTH]);
                     ctx.renderPositiveZFacing(tIcons[SIDE_SOUTH]);
                     ctx.renderNegativeXFacing(tIcons[SIDE_WEST]);
@@ -286,11 +299,13 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
                 }
                 ctx.renderPositiveYFacing(tIcons[SIDE_UP]);
                 if ((aConnections & CONNECTED_NORTH) == 0) {
-                    ctx.block.setBlockBounds(pipeMin, pipeMin, pipeMin, pipeMax, pipeMax, pipeMax);
-                    ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+                    ctx.getBlock()
+                        .setBlockBounds(pipeMin, pipeMin, pipeMin, pipeMax, pipeMax, pipeMax);
+                    ctx.setRenderBoundsFromBlock();
                 } else {
-                    ctx.block.setBlockBounds(pipeMin, pipeMin, blockMin, pipeMax, pipeMax, pipeMin);
-                    ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+                    ctx.getBlock()
+                        .setBlockBounds(pipeMin, pipeMin, blockMin, pipeMax, pipeMax, pipeMin);
+                    ctx.setRenderBoundsFromBlock();
                     ctx.renderNegativeYFacing(tIcons[SIDE_DOWN]);
                     ctx.renderPositiveYFacing(tIcons[SIDE_UP]);
                     ctx.renderNegativeXFacing(tIcons[SIDE_WEST]);
@@ -298,11 +313,13 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
                 }
                 ctx.renderNegativeZFacing(tIcons[SIDE_NORTH]);
                 if ((aConnections & CONNECTED_SOUTH) == 0) {
-                    ctx.block.setBlockBounds(pipeMin, pipeMin, pipeMin, pipeMax, pipeMax, pipeMax);
-                    ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+                    ctx.getBlock()
+                        .setBlockBounds(pipeMin, pipeMin, pipeMin, pipeMax, pipeMax, pipeMax);
+                    ctx.setRenderBoundsFromBlock();
                 } else {
-                    ctx.block.setBlockBounds(pipeMin, pipeMin, pipeMax, pipeMax, pipeMax, blockMax);
-                    ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+                    ctx.getBlock()
+                        .setBlockBounds(pipeMin, pipeMin, pipeMax, pipeMax, pipeMax, blockMax);
+                    ctx.setRenderBoundsFromBlock();
                     ctx.renderNegativeYFacing(tIcons[SIDE_DOWN]);
                     ctx.renderPositiveYFacing(tIcons[SIDE_UP]);
                     ctx.renderNegativeXFacing(tIcons[SIDE_WEST]);
@@ -314,8 +331,9 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
 
         // Render covers on pipes
         if (tIsCovered[SIDE_DOWN]) {
-            ctx.block.setBlockBounds(blockMin, blockMin, blockMin, blockMax, coverInnerMin, blockMax);
-            ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+            ctx.getBlock()
+                .setBlockBounds(blockMin, blockMin, blockMin, blockMax, coverInnerMin, blockMax);
+            ctx.setRenderBoundsFromBlock();
             if (!tIsCovered[SIDE_NORTH]) {
                 ctx.renderNegativeZFacing(tCovers[SIDE_DOWN]);
             }
@@ -332,23 +350,28 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
             if ((aConnections & CONNECTED_DOWN) != 0) {
                 // Split outer face to leave hole for pipe
                 // Lower panel
-                ctx.renderBlocks.setRenderBounds(blockMin, blockMin, blockMin, blockMax, blockMin, pipeMin);
+                ctx.getRenderBlocks()
+                    .setRenderBounds(blockMin, blockMin, blockMin, blockMax, blockMin, pipeMin);
                 ctx.renderNegativeYFacing(tCovers[SIDE_DOWN]);
                 // Upper panel
-                ctx.renderBlocks.setRenderBounds(blockMin, blockMin, pipeMax, blockMax, blockMin, blockMax);
+                ctx.getRenderBlocks()
+                    .setRenderBounds(blockMin, blockMin, pipeMax, blockMax, blockMin, blockMax);
                 ctx.renderNegativeYFacing(tCovers[SIDE_DOWN]);
                 // Middle left panel
-                ctx.renderBlocks.setRenderBounds(blockMin, blockMin, pipeMin, pipeMin, blockMin, pipeMax);
+                ctx.getRenderBlocks()
+                    .setRenderBounds(blockMin, blockMin, pipeMin, pipeMin, blockMin, pipeMax);
                 ctx.renderNegativeYFacing(tCovers[SIDE_DOWN]);
                 // Middle right panel
-                ctx.renderBlocks.setRenderBounds(pipeMax, blockMin, pipeMin, blockMax, blockMin, pipeMax);
+                ctx.getRenderBlocks()
+                    .setRenderBounds(pipeMax, blockMin, pipeMin, blockMax, blockMin, pipeMax);
             }
             ctx.renderNegativeYFacing(tCovers[SIDE_DOWN]);
         }
 
         if (tIsCovered[SIDE_UP]) {
-            ctx.block.setBlockBounds(blockMin, coverInnerMax, blockMin, blockMax, blockMax, blockMax);
-            ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+            ctx.getBlock()
+                .setBlockBounds(blockMin, coverInnerMax, blockMin, blockMax, blockMax, blockMax);
+            ctx.setRenderBoundsFromBlock();
             if (!tIsCovered[SIDE_NORTH]) ctx.renderNegativeZFacing(tCovers[SIDE_UP]);
             if (!tIsCovered[SIDE_SOUTH]) ctx.renderPositiveZFacing(tCovers[SIDE_UP]);
             if (!tIsCovered[SIDE_WEST]) ctx.renderNegativeXFacing(tCovers[SIDE_UP]);
@@ -357,23 +380,28 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
             if ((aConnections & CONNECTED_UP) != 0) {
                 // Split outer face to leave hole for pipe
                 // Lower panel
-                ctx.renderBlocks.setRenderBounds(blockMin, blockMax, blockMin, blockMax, blockMax, pipeMin);
+                ctx.getRenderBlocks()
+                    .setRenderBounds(blockMin, blockMax, blockMin, blockMax, blockMax, pipeMin);
                 ctx.renderPositiveYFacing(tCovers[SIDE_UP]);
                 // Upper panel
-                ctx.renderBlocks.setRenderBounds(blockMin, blockMax, pipeMax, blockMax, blockMax, blockMax);
+                ctx.getRenderBlocks()
+                    .setRenderBounds(blockMin, blockMax, pipeMax, blockMax, blockMax, blockMax);
                 ctx.renderPositiveYFacing(tCovers[SIDE_UP]);
                 // Middle left panel
-                ctx.renderBlocks.setRenderBounds(blockMin, blockMax, pipeMin, pipeMin, blockMax, pipeMax);
+                ctx.getRenderBlocks()
+                    .setRenderBounds(blockMin, blockMax, pipeMin, pipeMin, blockMax, pipeMax);
                 ctx.renderPositiveYFacing(tCovers[SIDE_UP]);
                 // Middle right panel
-                ctx.renderBlocks.setRenderBounds(pipeMax, blockMax, pipeMin, blockMax, blockMax, pipeMax);
+                ctx.getRenderBlocks()
+                    .setRenderBounds(pipeMax, blockMax, pipeMin, blockMax, blockMax, pipeMax);
             }
             ctx.renderPositiveYFacing(tCovers[SIDE_UP]);
         }
 
         if (tIsCovered[SIDE_NORTH]) {
-            ctx.block.setBlockBounds(blockMin, blockMin, blockMin, blockMax, blockMax, coverInnerMin);
-            ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+            ctx.getBlock()
+                .setBlockBounds(blockMin, blockMin, blockMin, blockMax, blockMax, coverInnerMin);
+            ctx.setRenderBoundsFromBlock();
             if (!tIsCovered[SIDE_DOWN]) ctx.renderNegativeYFacing(tCovers[SIDE_NORTH]);
             if (!tIsCovered[SIDE_UP]) ctx.renderPositiveYFacing(tCovers[SIDE_NORTH]);
             if (!tIsCovered[SIDE_WEST]) ctx.renderNegativeXFacing(tCovers[SIDE_NORTH]);
@@ -382,23 +410,28 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
             if ((aConnections & CONNECTED_NORTH) != 0) {
                 // Split outer face to leave hole for pipe
                 // Lower panel
-                ctx.renderBlocks.setRenderBounds(blockMin, blockMin, blockMin, blockMax, pipeMin, blockMin);
+                ctx.getRenderBlocks()
+                    .setRenderBounds(blockMin, blockMin, blockMin, blockMax, pipeMin, blockMin);
                 ctx.renderNegativeZFacing(tCovers[SIDE_NORTH]);
                 // Upper panel
-                ctx.renderBlocks.setRenderBounds(blockMin, pipeMax, blockMin, blockMax, blockMax, blockMin);
+                ctx.getRenderBlocks()
+                    .setRenderBounds(blockMin, pipeMax, blockMin, blockMax, blockMax, blockMin);
                 ctx.renderNegativeZFacing(tCovers[SIDE_NORTH]);
                 // Middle left panel
-                ctx.renderBlocks.setRenderBounds(blockMin, pipeMin, blockMin, pipeMin, pipeMax, blockMin);
+                ctx.getRenderBlocks()
+                    .setRenderBounds(blockMin, pipeMin, blockMin, pipeMin, pipeMax, blockMin);
                 ctx.renderNegativeZFacing(tCovers[SIDE_NORTH]);
                 // Middle right panel
-                ctx.renderBlocks.setRenderBounds(pipeMax, pipeMin, blockMin, blockMax, pipeMax, blockMin);
+                ctx.getRenderBlocks()
+                    .setRenderBounds(pipeMax, pipeMin, blockMin, blockMax, pipeMax, blockMin);
             }
             ctx.renderNegativeZFacing(tCovers[SIDE_NORTH]);
         }
 
         if (tIsCovered[SIDE_SOUTH]) {
-            ctx.block.setBlockBounds(blockMin, blockMin, coverInnerMax, blockMax, blockMax, blockMax);
-            ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+            ctx.getBlock()
+                .setBlockBounds(blockMin, blockMin, coverInnerMax, blockMax, blockMax, blockMax);
+            ctx.setRenderBoundsFromBlock();
             if (!tIsCovered[SIDE_DOWN]) ctx.renderNegativeYFacing(tCovers[SIDE_SOUTH]);
             if (!tIsCovered[SIDE_UP]) ctx.renderPositiveYFacing(tCovers[SIDE_SOUTH]);
             if (!tIsCovered[SIDE_WEST]) ctx.renderNegativeXFacing(tCovers[SIDE_SOUTH]);
@@ -407,23 +440,28 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
             if ((aConnections & CONNECTED_SOUTH) != 0) {
                 // Split outer face to leave hole for pipe
                 // Lower panel
-                ctx.renderBlocks.setRenderBounds(blockMin, blockMin, blockMax, blockMax, pipeMin, blockMax);
+                ctx.getRenderBlocks()
+                    .setRenderBounds(blockMin, blockMin, blockMax, blockMax, pipeMin, blockMax);
                 ctx.renderPositiveZFacing(tCovers[SIDE_SOUTH]);
                 // Upper panel
-                ctx.renderBlocks.setRenderBounds(blockMin, pipeMax, blockMax, blockMax, blockMax, blockMax);
+                ctx.getRenderBlocks()
+                    .setRenderBounds(blockMin, pipeMax, blockMax, blockMax, blockMax, blockMax);
                 ctx.renderPositiveZFacing(tCovers[SIDE_SOUTH]);
                 // Middle left panel
-                ctx.renderBlocks.setRenderBounds(blockMin, pipeMin, blockMax, pipeMin, pipeMax, blockMax);
+                ctx.getRenderBlocks()
+                    .setRenderBounds(blockMin, pipeMin, blockMax, pipeMin, pipeMax, blockMax);
                 ctx.renderPositiveZFacing(tCovers[SIDE_SOUTH]);
                 // Middle right panel
-                ctx.renderBlocks.setRenderBounds(pipeMax, pipeMin, blockMax, blockMax, pipeMax, blockMax);
+                ctx.getRenderBlocks()
+                    .setRenderBounds(pipeMax, pipeMin, blockMax, blockMax, pipeMax, blockMax);
             }
             ctx.renderPositiveZFacing(tCovers[SIDE_SOUTH]);
         }
 
         if (tIsCovered[SIDE_WEST]) {
-            ctx.block.setBlockBounds(blockMin, blockMin, blockMin, coverInnerMin, blockMax, blockMax);
-            ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+            ctx.getBlock()
+                .setBlockBounds(blockMin, blockMin, blockMin, coverInnerMin, blockMax, blockMax);
+            ctx.setRenderBoundsFromBlock();
             if (!tIsCovered[SIDE_DOWN]) ctx.renderNegativeYFacing(tCovers[SIDE_WEST]);
             if (!tIsCovered[SIDE_UP]) ctx.renderPositiveYFacing(tCovers[SIDE_WEST]);
             if (!tIsCovered[SIDE_NORTH]) ctx.renderNegativeZFacing(tCovers[SIDE_WEST]);
@@ -432,23 +470,28 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
             if ((aConnections & CONNECTED_WEST) != 0) {
                 // Split outer face to leave hole for pipe
                 // Lower panel
-                ctx.renderBlocks.setRenderBounds(blockMin, blockMin, blockMin, blockMin, pipeMin, blockMax);
+                ctx.getRenderBlocks()
+                    .setRenderBounds(blockMin, blockMin, blockMin, blockMin, pipeMin, blockMax);
                 ctx.renderNegativeXFacing(tCovers[SIDE_WEST]);
                 // Upper panel
-                ctx.renderBlocks.setRenderBounds(blockMin, pipeMax, blockMin, blockMin, blockMax, blockMax);
+                ctx.getRenderBlocks()
+                    .setRenderBounds(blockMin, pipeMax, blockMin, blockMin, blockMax, blockMax);
                 ctx.renderNegativeXFacing(tCovers[SIDE_WEST]);
                 // Middle left panel
-                ctx.renderBlocks.setRenderBounds(blockMin, pipeMin, blockMin, blockMin, pipeMax, pipeMin);
+                ctx.getRenderBlocks()
+                    .setRenderBounds(blockMin, pipeMin, blockMin, blockMin, pipeMax, pipeMin);
                 ctx.renderNegativeXFacing(tCovers[SIDE_WEST]);
                 // Middle right panel
-                ctx.renderBlocks.setRenderBounds(blockMin, pipeMin, pipeMax, blockMin, pipeMax, blockMax);
+                ctx.getRenderBlocks()
+                    .setRenderBounds(blockMin, pipeMin, pipeMax, blockMin, pipeMax, blockMax);
             }
             ctx.renderNegativeXFacing(tCovers[SIDE_WEST]);
         }
 
         if (tIsCovered[SIDE_EAST]) {
-            ctx.block.setBlockBounds(coverInnerMax, blockMin, blockMin, blockMax, blockMax, blockMax);
-            ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+            ctx.getBlock()
+                .setBlockBounds(coverInnerMax, blockMin, blockMin, blockMax, blockMax, blockMax);
+            ctx.setRenderBoundsFromBlock();
             if (!tIsCovered[SIDE_DOWN]) ctx.renderNegativeYFacing(tCovers[SIDE_EAST]);
             if (!tIsCovered[SIDE_UP]) ctx.renderPositiveYFacing(tCovers[SIDE_EAST]);
             if (!tIsCovered[SIDE_NORTH]) ctx.renderNegativeZFacing(tCovers[SIDE_EAST]);
@@ -458,21 +501,26 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
             if ((aConnections & CONNECTED_EAST) != 0) {
                 // Split outer face to leave hole for pipe
                 // Lower panel
-                ctx.renderBlocks.setRenderBounds(blockMax, blockMin, blockMin, blockMax, pipeMin, blockMax);
+                ctx.getRenderBlocks()
+                    .setRenderBounds(blockMax, blockMin, blockMin, blockMax, pipeMin, blockMax);
                 ctx.renderPositiveXFacing(tCovers[SIDE_EAST]);
                 // Upper panel
-                ctx.renderBlocks.setRenderBounds(blockMax, pipeMax, blockMin, blockMax, blockMax, blockMax);
+                ctx.getRenderBlocks()
+                    .setRenderBounds(blockMax, pipeMax, blockMin, blockMax, blockMax, blockMax);
                 ctx.renderPositiveXFacing(tCovers[SIDE_EAST]);
                 // Middle left panel
-                ctx.renderBlocks.setRenderBounds(blockMax, pipeMin, blockMin, blockMax, pipeMax, pipeMin);
+                ctx.getRenderBlocks()
+                    .setRenderBounds(blockMax, pipeMin, blockMin, blockMax, pipeMax, pipeMin);
                 ctx.renderPositiveXFacing(tCovers[SIDE_EAST]);
                 // Middle right panel
-                ctx.renderBlocks.setRenderBounds(blockMax, pipeMin, pipeMax, blockMax, pipeMax, blockMax);
+                ctx.getRenderBlocks()
+                    .setRenderBounds(blockMax, pipeMin, pipeMax, blockMax, pipeMax, blockMax);
             }
             ctx.renderPositiveXFacing(tCovers[SIDE_EAST]);
         }
-        ctx.block.setBlockBounds(blockMin, blockMin, blockMin, blockMax, blockMax, blockMax);
-        ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+        ctx.getBlock()
+            .setBlockBounds(blockMin, blockMin, blockMin, blockMax, blockMax, blockMax);
+        ctx.setRenderBoundsFromBlock();
 
         return true;
     }
@@ -603,15 +651,16 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
     }
 
     private static void renderNormalInventoryMetaTileEntity(SBRInventoryContext ctx) {
-        if ((ctx.meta <= 0) || (ctx.meta >= GregTechAPI.METATILEENTITIES.length)) {
+        if ((ctx.getMeta() <= 0) || (ctx.getMeta() >= GregTechAPI.METATILEENTITIES.length)) {
             return;
         }
-        final IMetaTileEntity tMetaTileEntity = GregTechAPI.METATILEENTITIES[ctx.meta];
+        final IMetaTileEntity tMetaTileEntity = GregTechAPI.METATILEENTITIES[ctx.getMeta()];
         if (tMetaTileEntity == null) {
             return;
         }
-        ctx.block.setBlockBoundsForItemRender();
-        ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+        ctx.getBlock()
+            .setBlockBoundsForItemRender();
+        ctx.setRenderBoundsFromBlock();
 
         final IGregTechTileEntity iGregTechTileEntity = tMetaTileEntity.getBaseMetaTileEntity();
         // spotless:off
@@ -621,8 +670,8 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
             final float pipeMin = (blockMax - tThickness) / 2.0F;
             final float pipeMax = blockMax - pipeMin;
 
-            ctx.block.setBlockBounds(blockMin, pipeMin, pipeMin, blockMax, pipeMax, pipeMax);
-            ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+            ctx.getBlock().setBlockBounds(blockMin, pipeMin, pipeMin, blockMax, pipeMax, pipeMax);
+            ctx.setRenderBoundsFromBlock();
             ctx.renderNegativeYFacing(pipeEntity.getTexture(iGregTechTileEntity, DOWN, (CONNECTED_WEST | CONNECTED_EAST), -1, false, false));
             ctx.renderPositiveYFacing(pipeEntity.getTexture(iGregTechTileEntity, UP, (CONNECTED_WEST | CONNECTED_EAST), -1, false, false));
             ctx.renderNegativeZFacing(pipeEntity.getTexture(iGregTechTileEntity, NORTH, (CONNECTED_WEST | CONNECTED_EAST), -1, false, false));
@@ -645,13 +694,13 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
         RenderBlocks aRenderer) {
         final SBRWorldContext ctx = sbrContextHolder.getSBRWorldContext(aX, aY, aZ, aBlock, aModelID, aRenderer);
 
-        final TileEntity tileEntity = aWorld.getTileEntity(ctx.x, ctx.y, ctx.z);
+        final TileEntity tileEntity = ctx.getTileEntity();
         final TesselatorAccessor tessAccess = (TesselatorAccessor) Tessellator.instance;
 
         // If this block does not have a TE, render it as a normal block.
         // Otherwise, render the TE instead.
-        if (tileEntity == null && ctx.block instanceof BlockFrameBox frameBlock) {
-            int meta = aWorld.getBlockMetadata(ctx.x, ctx.y, ctx.z);
+        if (tileEntity == null && ctx.getBlock() instanceof BlockFrameBox frameBlock) {
+            int meta = aWorld.getBlockMetadata(ctx.getX(), ctx.getY(), ctx.getZ());
             ITexture[] texture = frameBlock.getTexture(meta);
             if (texture == null) return false;
             textureArray[0] = texture;
@@ -664,8 +713,8 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
             return tessAccess.gt5u$hasVertices();
         }
 
-        if (ctx.block instanceof IBlockWithTextures texturedBlock) {
-            int meta = aWorld.getBlockMetadata(ctx.x, ctx.y, ctx.z);
+        if (ctx.getBlock() instanceof IBlockWithTextures texturedBlock) {
+            int meta = aWorld.getBlockMetadata(ctx.getX(), ctx.getY(), ctx.getZ());
             ITexture[][] texture = texturedBlock.getTextures(meta);
             if (texture == null) return false;
             renderStandardBlock(ctx, texture);

--- a/src/main/java/gregtech/common/render/GTRendererBlock.java
+++ b/src/main/java/gregtech/common/render/GTRendererBlock.java
@@ -22,7 +22,6 @@ import static net.minecraftforge.common.util.ForgeDirection.VALID_DIRECTIONS;
 import static net.minecraftforge.common.util.ForgeDirection.WEST;
 
 import net.minecraft.block.Block;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.particle.EffectRenderer;
 import net.minecraft.client.particle.EntityDiggingFX;
 import net.minecraft.client.renderer.RenderBlocks;
@@ -40,7 +39,6 @@ import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
 import cpw.mods.fml.client.registry.RenderingRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
-import gregtech.GTMod;
 import gregtech.api.GregTechAPI;
 import gregtech.api.interfaces.IBlockWithTextures;
 import gregtech.api.interfaces.ITexture;
@@ -52,6 +50,7 @@ import gregtech.api.interfaces.tileentity.ITexturedTileEntity;
 import gregtech.api.metatileentity.MetaPipeEntity;
 import gregtech.api.objects.XSTR;
 import gregtech.api.render.RenderOverlay;
+import gregtech.api.render.SBRContextHolder;
 import gregtech.api.render.SBRInventoryContext;
 import gregtech.api.render.SBRWorldContext;
 import gregtech.common.blocks.BlockFrameBox;
@@ -82,8 +81,10 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
     private final ITexture[][] textureArray = new ITexture[6][];
     private final ITexture[] overlayHolder = new ITexture[1];
 
+    private final SBRContextHolder sbrContextHolder = new SBRContextHolder();
+
     public boolean renderStandardBlock(SBRWorldContext ctx) {
-        final TileEntity tTileEntity = ctx.world.getTileEntity(ctx.x, ctx.y, ctx.z);
+        final TileEntity tTileEntity = ctx.blockAccess.getTileEntity(ctx.x, ctx.y, ctx.z);
         if (tTileEntity instanceof IPipeRenderedTileEntity pipeRenderedTileEntity) {
             textureArray[0] = pipeRenderedTileEntity.getTextureCovered(DOWN);
             textureArray[1] = pipeRenderedTileEntity.getTextureCovered(UP);
@@ -118,10 +119,10 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
 
     public boolean renderStandardBlock(SBRWorldContext ctx, ITexture[][] aTextures) {
         ctx.block.setBlockBounds(blockMin, blockMin, blockMin, blockMax, blockMax, blockMax);
-        ctx.renderer.setRenderBoundsFromBlock(ctx.block);
+        ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
         ctx.fullBlock = true;
 
-        ITexture[] overlays = RenderOverlay.get(ctx.world, ctx.x, ctx.y, ctx.z);
+        ITexture[] overlays = RenderOverlay.get(ctx.blockAccess, ctx.x, ctx.y, ctx.z);
         if (overlays != null) {
             ctx.renderNegativeYFacing(aTextures[SIDE_DOWN]);
             if (overlays[SIDE_DOWN] != null) {
@@ -188,7 +189,7 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
         switch (aConnections) {
             case NO_CONNECTION -> {
                 ctx.block.setBlockBounds(pipeMin, pipeMin, pipeMin, pipeMax, pipeMax, pipeMax);
-                ctx.renderer.setRenderBoundsFromBlock(ctx.block);
+                ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
                 ctx.renderNegativeYFacing(tIcons[SIDE_DOWN]);
                 ctx.renderPositiveYFacing(tIcons[SIDE_UP]);
                 ctx.renderNegativeZFacing(tIcons[SIDE_NORTH]);
@@ -199,7 +200,7 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
             case CONNECTED_EAST | CONNECTED_WEST -> {
                 // EAST - WEST Pipe Sides
                 ctx.block.setBlockBounds(blockMin, pipeMin, pipeMin, blockMax, pipeMax, pipeMax);
-                ctx.renderer.setRenderBoundsFromBlock(ctx.block);
+                ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
                 ctx.renderNegativeYFacing(tIcons[SIDE_DOWN]);
                 ctx.renderPositiveYFacing(tIcons[SIDE_UP]);
                 ctx.renderNegativeZFacing(tIcons[SIDE_NORTH]);
@@ -212,7 +213,7 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
             case CONNECTED_DOWN | CONNECTED_UP -> {
                 // UP - DOWN Pipe Sides
                 ctx.block.setBlockBounds(pipeMin, blockMin, pipeMin, pipeMax, blockMax, pipeMax);
-                ctx.renderer.setRenderBoundsFromBlock(ctx.block);
+                ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
                 ctx.renderNegativeZFacing(tIcons[SIDE_NORTH]);
                 ctx.renderPositiveZFacing(tIcons[SIDE_SOUTH]);
                 ctx.renderNegativeXFacing(tIcons[SIDE_WEST]);
@@ -225,7 +226,7 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
             case CONNECTED_NORTH | CONNECTED_SOUTH -> {
                 // NORTH - SOUTH Pipe Sides
                 ctx.block.setBlockBounds(pipeMin, pipeMin, blockMin, pipeMax, pipeMax, blockMax);
-                ctx.renderer.setRenderBoundsFromBlock(ctx.block);
+                ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
                 ctx.renderNegativeYFacing(tIcons[SIDE_DOWN]);
                 ctx.renderPositiveYFacing(tIcons[SIDE_UP]);
                 ctx.renderNegativeXFacing(tIcons[SIDE_WEST]);
@@ -238,10 +239,10 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
             default -> {
                 if ((aConnections & CONNECTED_WEST) == 0) {
                     ctx.block.setBlockBounds(pipeMin, pipeMin, pipeMin, pipeMax, pipeMax, pipeMax);
-                    ctx.renderer.setRenderBoundsFromBlock(ctx.block);
+                    ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
                 } else {
                     ctx.block.setBlockBounds(blockMin, pipeMin, pipeMin, pipeMin, pipeMax, pipeMax);
-                    ctx.renderer.setRenderBoundsFromBlock(ctx.block);
+                    ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
                     ctx.renderNegativeYFacing(tIcons[SIDE_DOWN]);
                     ctx.renderPositiveYFacing(tIcons[SIDE_UP]);
                     ctx.renderNegativeZFacing(tIcons[SIDE_NORTH]);
@@ -250,10 +251,10 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
                 ctx.renderNegativeXFacing(tIcons[SIDE_WEST]);
                 if ((aConnections & CONNECTED_EAST) == 0) {
                     ctx.block.setBlockBounds(pipeMin, pipeMin, pipeMin, pipeMax, pipeMax, pipeMax);
-                    ctx.renderer.setRenderBoundsFromBlock(ctx.block);
+                    ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
                 } else {
                     ctx.block.setBlockBounds(pipeMax, pipeMin, pipeMin, blockMax, pipeMax, pipeMax);
-                    ctx.renderer.setRenderBoundsFromBlock(ctx.block);
+                    ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
                     ctx.renderNegativeYFacing(tIcons[SIDE_DOWN]);
                     ctx.renderPositiveYFacing(tIcons[SIDE_UP]);
                     ctx.renderNegativeZFacing(tIcons[SIDE_NORTH]);
@@ -262,10 +263,10 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
                 ctx.renderPositiveXFacing(tIcons[SIDE_EAST]);
                 if ((aConnections & CONNECTED_DOWN) == 0) {
                     ctx.block.setBlockBounds(pipeMin, pipeMin, pipeMin, pipeMax, pipeMax, pipeMax);
-                    ctx.renderer.setRenderBoundsFromBlock(ctx.block);
+                    ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
                 } else {
                     ctx.block.setBlockBounds(pipeMin, blockMin, pipeMin, pipeMax, pipeMin, pipeMax);
-                    ctx.renderer.setRenderBoundsFromBlock(ctx.block);
+                    ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
                     ctx.renderNegativeZFacing(tIcons[SIDE_NORTH]);
                     ctx.renderPositiveZFacing(tIcons[SIDE_SOUTH]);
                     ctx.renderNegativeXFacing(tIcons[SIDE_WEST]);
@@ -274,10 +275,10 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
                 ctx.renderNegativeYFacing(tIcons[SIDE_DOWN]);
                 if ((aConnections & CONNECTED_UP) == 0) {
                     ctx.block.setBlockBounds(pipeMin, pipeMin, pipeMin, pipeMax, pipeMax, pipeMax);
-                    ctx.renderer.setRenderBoundsFromBlock(ctx.block);
+                    ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
                 } else {
                     ctx.block.setBlockBounds(pipeMin, pipeMax, pipeMin, pipeMax, blockMax, pipeMax);
-                    ctx.renderer.setRenderBoundsFromBlock(ctx.block);
+                    ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
                     ctx.renderNegativeZFacing(tIcons[SIDE_NORTH]);
                     ctx.renderPositiveZFacing(tIcons[SIDE_SOUTH]);
                     ctx.renderNegativeXFacing(tIcons[SIDE_WEST]);
@@ -286,10 +287,10 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
                 ctx.renderPositiveYFacing(tIcons[SIDE_UP]);
                 if ((aConnections & CONNECTED_NORTH) == 0) {
                     ctx.block.setBlockBounds(pipeMin, pipeMin, pipeMin, pipeMax, pipeMax, pipeMax);
-                    ctx.renderer.setRenderBoundsFromBlock(ctx.block);
+                    ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
                 } else {
                     ctx.block.setBlockBounds(pipeMin, pipeMin, blockMin, pipeMax, pipeMax, pipeMin);
-                    ctx.renderer.setRenderBoundsFromBlock(ctx.block);
+                    ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
                     ctx.renderNegativeYFacing(tIcons[SIDE_DOWN]);
                     ctx.renderPositiveYFacing(tIcons[SIDE_UP]);
                     ctx.renderNegativeXFacing(tIcons[SIDE_WEST]);
@@ -298,10 +299,10 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
                 ctx.renderNegativeZFacing(tIcons[SIDE_NORTH]);
                 if ((aConnections & CONNECTED_SOUTH) == 0) {
                     ctx.block.setBlockBounds(pipeMin, pipeMin, pipeMin, pipeMax, pipeMax, pipeMax);
-                    ctx.renderer.setRenderBoundsFromBlock(ctx.block);
+                    ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
                 } else {
                     ctx.block.setBlockBounds(pipeMin, pipeMin, pipeMax, pipeMax, pipeMax, blockMax);
-                    ctx.renderer.setRenderBoundsFromBlock(ctx.block);
+                    ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
                     ctx.renderNegativeYFacing(tIcons[SIDE_DOWN]);
                     ctx.renderPositiveYFacing(tIcons[SIDE_UP]);
                     ctx.renderNegativeXFacing(tIcons[SIDE_WEST]);
@@ -314,7 +315,7 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
         // Render covers on pipes
         if (tIsCovered[SIDE_DOWN]) {
             ctx.block.setBlockBounds(blockMin, blockMin, blockMin, blockMax, coverInnerMin, blockMax);
-            ctx.renderer.setRenderBoundsFromBlock(ctx.block);
+            ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
             if (!tIsCovered[SIDE_NORTH]) {
                 ctx.renderNegativeZFacing(tCovers[SIDE_DOWN]);
             }
@@ -331,187 +332,147 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
             if ((aConnections & CONNECTED_DOWN) != 0) {
                 // Split outer face to leave hole for pipe
                 // Lower panel
-                ctx.renderer.setRenderBounds(blockMin, blockMin, blockMin, blockMax, blockMin, pipeMin);
+                ctx.renderBlocks.setRenderBounds(blockMin, blockMin, blockMin, blockMax, blockMin, pipeMin);
                 ctx.renderNegativeYFacing(tCovers[SIDE_DOWN]);
                 // Upper panel
-                ctx.renderer.setRenderBounds(blockMin, blockMin, pipeMax, blockMax, blockMin, blockMax);
+                ctx.renderBlocks.setRenderBounds(blockMin, blockMin, pipeMax, blockMax, blockMin, blockMax);
                 ctx.renderNegativeYFacing(tCovers[SIDE_DOWN]);
                 // Middle left panel
-                ctx.renderer.setRenderBounds(blockMin, blockMin, pipeMin, pipeMin, blockMin, pipeMax);
+                ctx.renderBlocks.setRenderBounds(blockMin, blockMin, pipeMin, pipeMin, blockMin, pipeMax);
                 ctx.renderNegativeYFacing(tCovers[SIDE_DOWN]);
                 // Middle right panel
-                ctx.renderer.setRenderBounds(pipeMax, blockMin, pipeMin, blockMax, blockMin, pipeMax);
+                ctx.renderBlocks.setRenderBounds(pipeMax, blockMin, pipeMin, blockMax, blockMin, pipeMax);
             }
             ctx.renderNegativeYFacing(tCovers[SIDE_DOWN]);
         }
 
         if (tIsCovered[SIDE_UP]) {
             ctx.block.setBlockBounds(blockMin, coverInnerMax, blockMin, blockMax, blockMax, blockMax);
-            ctx.renderer.setRenderBoundsFromBlock(ctx.block);
-            if (!tIsCovered[SIDE_NORTH]) {
-                ctx.renderNegativeZFacing(tCovers[SIDE_UP]);
-            }
-            if (!tIsCovered[SIDE_SOUTH]) {
-                ctx.renderPositiveZFacing(tCovers[SIDE_UP]);
-            }
-            if (!tIsCovered[SIDE_WEST]) {
-                ctx.renderNegativeXFacing(tCovers[SIDE_UP]);
-            }
-            if (!tIsCovered[SIDE_EAST]) {
-                ctx.renderPositiveXFacing(tCovers[SIDE_UP]);
-            }
+            ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+            if (!tIsCovered[SIDE_NORTH]) ctx.renderNegativeZFacing(tCovers[SIDE_UP]);
+            if (!tIsCovered[SIDE_SOUTH]) ctx.renderPositiveZFacing(tCovers[SIDE_UP]);
+            if (!tIsCovered[SIDE_WEST]) ctx.renderNegativeXFacing(tCovers[SIDE_UP]);
+            if (!tIsCovered[SIDE_EAST]) ctx.renderPositiveXFacing(tCovers[SIDE_UP]);
             ctx.renderNegativeYFacing(tCovers[SIDE_UP]);
             if ((aConnections & CONNECTED_UP) != 0) {
                 // Split outer face to leave hole for pipe
                 // Lower panel
-                ctx.renderer.setRenderBounds(blockMin, blockMax, blockMin, blockMax, blockMax, pipeMin);
+                ctx.renderBlocks.setRenderBounds(blockMin, blockMax, blockMin, blockMax, blockMax, pipeMin);
                 ctx.renderPositiveYFacing(tCovers[SIDE_UP]);
                 // Upper panel
-                ctx.renderer.setRenderBounds(blockMin, blockMax, pipeMax, blockMax, blockMax, blockMax);
+                ctx.renderBlocks.setRenderBounds(blockMin, blockMax, pipeMax, blockMax, blockMax, blockMax);
                 ctx.renderPositiveYFacing(tCovers[SIDE_UP]);
                 // Middle left panel
-                ctx.renderer.setRenderBounds(blockMin, blockMax, pipeMin, pipeMin, blockMax, pipeMax);
+                ctx.renderBlocks.setRenderBounds(blockMin, blockMax, pipeMin, pipeMin, blockMax, pipeMax);
                 ctx.renderPositiveYFacing(tCovers[SIDE_UP]);
                 // Middle right panel
-                ctx.renderer.setRenderBounds(pipeMax, blockMax, pipeMin, blockMax, blockMax, pipeMax);
+                ctx.renderBlocks.setRenderBounds(pipeMax, blockMax, pipeMin, blockMax, blockMax, pipeMax);
             }
             ctx.renderPositiveYFacing(tCovers[SIDE_UP]);
         }
 
         if (tIsCovered[SIDE_NORTH]) {
             ctx.block.setBlockBounds(blockMin, blockMin, blockMin, blockMax, blockMax, coverInnerMin);
-            ctx.renderer.setRenderBoundsFromBlock(ctx.block);
-            if (!tIsCovered[SIDE_DOWN]) {
-                ctx.renderNegativeYFacing(tCovers[SIDE_NORTH]);
-            }
-            if (!tIsCovered[SIDE_UP]) {
-                ctx.renderPositiveYFacing(tCovers[SIDE_NORTH]);
-            }
-            if (!tIsCovered[SIDE_WEST]) {
-                ctx.renderNegativeXFacing(tCovers[SIDE_NORTH]);
-            }
-            if (!tIsCovered[SIDE_EAST]) {
-                ctx.renderPositiveXFacing(tCovers[SIDE_NORTH]);
-            }
+            ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+            if (!tIsCovered[SIDE_DOWN]) ctx.renderNegativeYFacing(tCovers[SIDE_NORTH]);
+            if (!tIsCovered[SIDE_UP]) ctx.renderPositiveYFacing(tCovers[SIDE_NORTH]);
+            if (!tIsCovered[SIDE_WEST]) ctx.renderNegativeXFacing(tCovers[SIDE_NORTH]);
+            if (!tIsCovered[SIDE_EAST]) ctx.renderPositiveXFacing(tCovers[SIDE_NORTH]);
             ctx.renderPositiveZFacing(tCovers[SIDE_NORTH]);
             if ((aConnections & CONNECTED_NORTH) != 0) {
                 // Split outer face to leave hole for pipe
                 // Lower panel
-                ctx.renderer.setRenderBounds(blockMin, blockMin, blockMin, blockMax, pipeMin, blockMin);
+                ctx.renderBlocks.setRenderBounds(blockMin, blockMin, blockMin, blockMax, pipeMin, blockMin);
                 ctx.renderNegativeZFacing(tCovers[SIDE_NORTH]);
                 // Upper panel
-                ctx.renderer.setRenderBounds(blockMin, pipeMax, blockMin, blockMax, blockMax, blockMin);
+                ctx.renderBlocks.setRenderBounds(blockMin, pipeMax, blockMin, blockMax, blockMax, blockMin);
                 ctx.renderNegativeZFacing(tCovers[SIDE_NORTH]);
                 // Middle left panel
-                ctx.renderer.setRenderBounds(blockMin, pipeMin, blockMin, pipeMin, pipeMax, blockMin);
+                ctx.renderBlocks.setRenderBounds(blockMin, pipeMin, blockMin, pipeMin, pipeMax, blockMin);
                 ctx.renderNegativeZFacing(tCovers[SIDE_NORTH]);
                 // Middle right panel
-                ctx.renderer.setRenderBounds(pipeMax, pipeMin, blockMin, blockMax, pipeMax, blockMin);
+                ctx.renderBlocks.setRenderBounds(pipeMax, pipeMin, blockMin, blockMax, pipeMax, blockMin);
             }
             ctx.renderNegativeZFacing(tCovers[SIDE_NORTH]);
         }
 
         if (tIsCovered[SIDE_SOUTH]) {
             ctx.block.setBlockBounds(blockMin, blockMin, coverInnerMax, blockMax, blockMax, blockMax);
-            ctx.renderer.setRenderBoundsFromBlock(ctx.block);
-            if (!tIsCovered[SIDE_DOWN]) {
-                ctx.renderNegativeYFacing(tCovers[SIDE_SOUTH]);
-            }
-            if (!tIsCovered[SIDE_UP]) {
-                ctx.renderPositiveYFacing(tCovers[SIDE_SOUTH]);
-            }
-            if (!tIsCovered[SIDE_WEST]) {
-                ctx.renderNegativeXFacing(tCovers[SIDE_SOUTH]);
-            }
-            if (!tIsCovered[SIDE_EAST]) {
-                ctx.renderPositiveXFacing(tCovers[SIDE_SOUTH]);
-            }
+            ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+            if (!tIsCovered[SIDE_DOWN]) ctx.renderNegativeYFacing(tCovers[SIDE_SOUTH]);
+            if (!tIsCovered[SIDE_UP]) ctx.renderPositiveYFacing(tCovers[SIDE_SOUTH]);
+            if (!tIsCovered[SIDE_WEST]) ctx.renderNegativeXFacing(tCovers[SIDE_SOUTH]);
+            if (!tIsCovered[SIDE_EAST]) ctx.renderPositiveXFacing(tCovers[SIDE_SOUTH]);
             ctx.renderNegativeZFacing(tCovers[SIDE_SOUTH]);
             if ((aConnections & CONNECTED_SOUTH) != 0) {
                 // Split outer face to leave hole for pipe
                 // Lower panel
-                ctx.renderer.setRenderBounds(blockMin, blockMin, blockMax, blockMax, pipeMin, blockMax);
+                ctx.renderBlocks.setRenderBounds(blockMin, blockMin, blockMax, blockMax, pipeMin, blockMax);
                 ctx.renderPositiveZFacing(tCovers[SIDE_SOUTH]);
                 // Upper panel
-                ctx.renderer.setRenderBounds(blockMin, pipeMax, blockMax, blockMax, blockMax, blockMax);
+                ctx.renderBlocks.setRenderBounds(blockMin, pipeMax, blockMax, blockMax, blockMax, blockMax);
                 ctx.renderPositiveZFacing(tCovers[SIDE_SOUTH]);
                 // Middle left panel
-                ctx.renderer.setRenderBounds(blockMin, pipeMin, blockMax, pipeMin, pipeMax, blockMax);
+                ctx.renderBlocks.setRenderBounds(blockMin, pipeMin, blockMax, pipeMin, pipeMax, blockMax);
                 ctx.renderPositiveZFacing(tCovers[SIDE_SOUTH]);
                 // Middle right panel
-                ctx.renderer.setRenderBounds(pipeMax, pipeMin, blockMax, blockMax, pipeMax, blockMax);
+                ctx.renderBlocks.setRenderBounds(pipeMax, pipeMin, blockMax, blockMax, pipeMax, blockMax);
             }
             ctx.renderPositiveZFacing(tCovers[SIDE_SOUTH]);
         }
 
         if (tIsCovered[SIDE_WEST]) {
             ctx.block.setBlockBounds(blockMin, blockMin, blockMin, coverInnerMin, blockMax, blockMax);
-            ctx.renderer.setRenderBoundsFromBlock(ctx.block);
-            if (!tIsCovered[SIDE_DOWN]) {
-                ctx.renderNegativeYFacing(tCovers[SIDE_WEST]);
-            }
-            if (!tIsCovered[SIDE_UP]) {
-                ctx.renderPositiveYFacing(tCovers[SIDE_WEST]);
-            }
-            if (!tIsCovered[SIDE_NORTH]) {
-                ctx.renderNegativeZFacing(tCovers[SIDE_WEST]);
-            }
-            if (!tIsCovered[SIDE_SOUTH]) {
-                ctx.renderPositiveZFacing(tCovers[SIDE_WEST]);
-            }
+            ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+            if (!tIsCovered[SIDE_DOWN]) ctx.renderNegativeYFacing(tCovers[SIDE_WEST]);
+            if (!tIsCovered[SIDE_UP]) ctx.renderPositiveYFacing(tCovers[SIDE_WEST]);
+            if (!tIsCovered[SIDE_NORTH]) ctx.renderNegativeZFacing(tCovers[SIDE_WEST]);
+            if (!tIsCovered[SIDE_SOUTH]) ctx.renderPositiveZFacing(tCovers[SIDE_WEST]);
             ctx.renderPositiveXFacing(tCovers[SIDE_WEST]);
             if ((aConnections & CONNECTED_WEST) != 0) {
                 // Split outer face to leave hole for pipe
                 // Lower panel
-                ctx.renderer.setRenderBounds(blockMin, blockMin, blockMin, blockMin, pipeMin, blockMax);
+                ctx.renderBlocks.setRenderBounds(blockMin, blockMin, blockMin, blockMin, pipeMin, blockMax);
                 ctx.renderNegativeXFacing(tCovers[SIDE_WEST]);
                 // Upper panel
-                ctx.renderer.setRenderBounds(blockMin, pipeMax, blockMin, blockMin, blockMax, blockMax);
+                ctx.renderBlocks.setRenderBounds(blockMin, pipeMax, blockMin, blockMin, blockMax, blockMax);
                 ctx.renderNegativeXFacing(tCovers[SIDE_WEST]);
                 // Middle left panel
-                ctx.renderer.setRenderBounds(blockMin, pipeMin, blockMin, blockMin, pipeMax, pipeMin);
+                ctx.renderBlocks.setRenderBounds(blockMin, pipeMin, blockMin, blockMin, pipeMax, pipeMin);
                 ctx.renderNegativeXFacing(tCovers[SIDE_WEST]);
                 // Middle right panel
-                ctx.renderer.setRenderBounds(blockMin, pipeMin, pipeMax, blockMin, pipeMax, blockMax);
+                ctx.renderBlocks.setRenderBounds(blockMin, pipeMin, pipeMax, blockMin, pipeMax, blockMax);
             }
             ctx.renderNegativeXFacing(tCovers[SIDE_WEST]);
         }
 
         if (tIsCovered[SIDE_EAST]) {
             ctx.block.setBlockBounds(coverInnerMax, blockMin, blockMin, blockMax, blockMax, blockMax);
-            ctx.renderer.setRenderBoundsFromBlock(ctx.block);
-            if (!tIsCovered[SIDE_DOWN]) {
-                ctx.renderNegativeYFacing(tCovers[SIDE_EAST]);
-            }
-            if (!tIsCovered[SIDE_UP]) {
-                ctx.renderPositiveYFacing(tCovers[SIDE_EAST]);
-            }
-            if (!tIsCovered[SIDE_NORTH]) {
-                ctx.renderNegativeZFacing(tCovers[SIDE_EAST]);
-            }
-            if (!tIsCovered[SIDE_SOUTH]) {
-                ctx.renderPositiveZFacing(tCovers[SIDE_EAST]);
-            }
+            ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+            if (!tIsCovered[SIDE_DOWN]) ctx.renderNegativeYFacing(tCovers[SIDE_EAST]);
+            if (!tIsCovered[SIDE_UP]) ctx.renderPositiveYFacing(tCovers[SIDE_EAST]);
+            if (!tIsCovered[SIDE_NORTH]) ctx.renderNegativeZFacing(tCovers[SIDE_EAST]);
+            if (!tIsCovered[SIDE_SOUTH]) ctx.renderPositiveZFacing(tCovers[SIDE_EAST]);
             ctx.renderNegativeXFacing(tCovers[SIDE_EAST]);
 
             if ((aConnections & CONNECTED_EAST) != 0) {
                 // Split outer face to leave hole for pipe
                 // Lower panel
-                ctx.renderer.setRenderBounds(blockMax, blockMin, blockMin, blockMax, pipeMin, blockMax);
+                ctx.renderBlocks.setRenderBounds(blockMax, blockMin, blockMin, blockMax, pipeMin, blockMax);
                 ctx.renderPositiveXFacing(tCovers[SIDE_EAST]);
                 // Upper panel
-                ctx.renderer.setRenderBounds(blockMax, pipeMax, blockMin, blockMax, blockMax, blockMax);
+                ctx.renderBlocks.setRenderBounds(blockMax, pipeMax, blockMin, blockMax, blockMax, blockMax);
                 ctx.renderPositiveXFacing(tCovers[SIDE_EAST]);
                 // Middle left panel
-                ctx.renderer.setRenderBounds(blockMax, pipeMin, blockMin, blockMax, pipeMax, pipeMin);
+                ctx.renderBlocks.setRenderBounds(blockMax, pipeMin, blockMin, blockMax, pipeMax, pipeMin);
                 ctx.renderPositiveXFacing(tCovers[SIDE_EAST]);
                 // Middle right panel
-                ctx.renderer.setRenderBounds(blockMax, pipeMin, pipeMax, blockMax, pipeMax, blockMax);
+                ctx.renderBlocks.setRenderBounds(blockMax, pipeMin, pipeMax, blockMax, pipeMax, blockMax);
             }
             ctx.renderPositiveXFacing(tCovers[SIDE_EAST]);
         }
         ctx.block.setBlockBounds(blockMin, blockMin, blockMin, blockMax, blockMax, blockMax);
-        ctx.renderer.setRenderBoundsFromBlock(ctx.block);
+        ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
 
         return true;
     }
@@ -581,7 +542,7 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
 
     @Override
     public void renderInventoryBlock(Block aBlock, int aMeta, int aModelID, RenderBlocks aRenderer) {
-        final SBRInventoryContext ctx = new SBRInventoryContext(aBlock, aMeta, aModelID, aRenderer);
+        final SBRInventoryContext ctx = sbrContextHolder.getSBRInventoryContext(aBlock, aMeta, aModelID, aRenderer);
         aRenderer.enableAO = false;
         aRenderer.useInventoryTint = true;
 
@@ -604,7 +565,7 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
         } else if (aMeta > 0 && (aMeta < GregTechAPI.METATILEENTITIES.length)
             && aBlock instanceof BlockMachines
             && (GregTechAPI.METATILEENTITIES[aMeta] != null)
-            && (!GregTechAPI.METATILEENTITIES[aMeta].renderInInventory(aBlock, aMeta, aRenderer))) {
+            && (!GregTechAPI.METATILEENTITIES[aMeta].render(ctx))) {
                 renderNormalInventoryMetaTileEntity(ctx);
             } else if (aBlock instanceof BlockFrameBox) {
                 ITexture[] texture = ((BlockFrameBox) aBlock).getTexture(aMeta);
@@ -650,7 +611,7 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
             return;
         }
         ctx.block.setBlockBoundsForItemRender();
-        ctx.renderer.setRenderBoundsFromBlock(ctx.block);
+        ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
 
         final IGregTechTileEntity iGregTechTileEntity = tMetaTileEntity.getBaseMetaTileEntity();
         // spotless:off
@@ -661,7 +622,7 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
             final float pipeMax = blockMax - pipeMin;
 
             ctx.block.setBlockBounds(blockMin, pipeMin, pipeMin, blockMax, pipeMax, pipeMax);
-            ctx.renderer.setRenderBoundsFromBlock(ctx.block);
+            ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
             ctx.renderNegativeYFacing(pipeEntity.getTexture(iGregTechTileEntity, DOWN, (CONNECTED_WEST | CONNECTED_EAST), -1, false, false));
             ctx.renderPositiveYFacing(pipeEntity.getTexture(iGregTechTileEntity, UP, (CONNECTED_WEST | CONNECTED_EAST), -1, false, false));
             ctx.renderNegativeZFacing(pipeEntity.getTexture(iGregTechTileEntity, NORTH, (CONNECTED_WEST | CONNECTED_EAST), -1, false, false));
@@ -682,9 +643,7 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
     @Override
     public boolean renderWorldBlock(IBlockAccess aWorld, int aX, int aY, int aZ, Block aBlock, int aModelID,
         RenderBlocks aRenderer) {
-        final SBRWorldContext ctx = new SBRWorldContext(aX, aY, aZ, aBlock, aModelID, aRenderer);
-        aRenderer.enableAO = Minecraft.isAmbientOcclusionEnabled() && GTMod.proxy.mRenderTileAmbientOcclusion;
-        aRenderer.useInventoryTint = false;
+        final SBRWorldContext ctx = sbrContextHolder.getSBRWorldContext(aX, aY, aZ, aBlock, aModelID, aRenderer);
 
         final TileEntity tileEntity = aWorld.getTileEntity(ctx.x, ctx.y, ctx.z);
         final TesselatorAccessor tessAccess = (TesselatorAccessor) Tessellator.instance;
@@ -718,18 +677,15 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
         if (tileEntity instanceof IGregTechTileEntity) {
             final IMetaTileEntity metaTileEntity;
             if ((metaTileEntity = ((IGregTechTileEntity) tileEntity).getMetaTileEntity()) != null
-                && metaTileEntity.renderInWorld(aWorld, ctx.x, ctx.y, ctx.z, ctx.block, aRenderer)) {
-                aRenderer.enableAO = false;
+                && metaTileEntity.render(ctx)) {
                 return tessAccess.gt5u$hasVertices();
             }
         }
         if (tileEntity instanceof IPipeRenderedTileEntity
             && renderPipeBlock(ctx, (IPipeRenderedTileEntity) tileEntity)) {
-            aRenderer.enableAO = false;
             return tessAccess.gt5u$hasVertices();
         }
         if (renderStandardBlock(ctx)) {
-            aRenderer.enableAO = false;
             return tessAccess.gt5u$hasVertices();
         }
         return false;

--- a/src/main/java/gregtech/common/render/GTRendererCasing.java
+++ b/src/main/java/gregtech/common/render/GTRendererCasing.java
@@ -19,6 +19,7 @@ import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
 import cpw.mods.fml.client.registry.RenderingRegistry;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.render.RenderOverlay;
+import gregtech.api.render.SBRContextHolder;
 import gregtech.api.render.SBRInventoryContext;
 import gregtech.api.render.SBRWorldContext;
 import gregtech.api.render.TextureFactory;
@@ -40,12 +41,13 @@ public class GTRendererCasing implements ISimpleBlockRenderingHandler {
     }
 
     private final ITexture[][] textureArray = new ITexture[6][2];
+    private final SBRContextHolder sbrContextHolder = new SBRContextHolder();
 
     @Override
     public void renderInventoryBlock(Block aBlock, int aMeta, int aModelID, RenderBlocks aRenderer) {
         aRenderer.enableAO = false;
         aRenderer.useInventoryTint = true;
-        final SBRInventoryContext ctx = new SBRInventoryContext(aBlock, aMeta, aModelID, aRenderer);
+        final SBRInventoryContext ctx = sbrContextHolder.getSBRInventoryContext(aBlock, aMeta, aModelID, aRenderer);
 
         setupBlockTexturesOnly(aBlock, aMeta, true);
 
@@ -94,7 +96,7 @@ public class GTRendererCasing implements ISimpleBlockRenderingHandler {
         aRenderer.useInventoryTint = false;
 
         final TesselatorAccessor tessAccess = (TesselatorAccessor) Tessellator.instance;
-        final SBRWorldContext ctx = new SBRWorldContext(aX, aY, aZ, aBlock, aModelID, aRenderer);
+        final SBRWorldContext ctx = sbrContextHolder.getSBRWorldContext(aX, aY, aZ, aBlock, aModelID, aRenderer);
 
         int tMeta = aWorld.getBlockMetadata(aX, aY, aZ);
 

--- a/src/main/java/gregtech/common/render/GTSidedTextureRender.java
+++ b/src/main/java/gregtech/common/render/GTSidedTextureRender.java
@@ -27,32 +27,32 @@ public class GTSidedTextureRender extends GTTextureBase implements ITexture, ICo
     }
 
     @Override
-    public void renderXPos(SBRContextBase<? extends SBRContextBase<?>> ctx) {
+    public void renderXPos(SBRContextBase ctx) {
         mTextures[5].renderXPos(ctx);
     }
 
     @Override
-    public void renderXNeg(SBRContextBase<? extends SBRContextBase<?>> ctx) {
+    public void renderXNeg(SBRContextBase ctx) {
         mTextures[4].renderXNeg(ctx);
     }
 
     @Override
-    public void renderYPos(SBRContextBase<? extends SBRContextBase<?>> ctx) {
+    public void renderYPos(SBRContextBase ctx) {
         mTextures[1].renderYPos(ctx);
     }
 
     @Override
-    public void renderYNeg(SBRContextBase<? extends SBRContextBase<?>> ctx) {
+    public void renderYNeg(SBRContextBase ctx) {
         mTextures[0].renderYNeg(ctx);
     }
 
     @Override
-    public void renderZPos(SBRContextBase<? extends SBRContextBase<?>> ctx) {
+    public void renderZPos(SBRContextBase ctx) {
         mTextures[3].renderZPos(ctx);
     }
 
     @Override
-    public void renderZNeg(SBRContextBase<? extends SBRContextBase<?>> ctx) {
+    public void renderZNeg(SBRContextBase ctx) {
         mTextures[2].renderZNeg(ctx);
     }
 

--- a/src/main/java/gregtech/common/render/IRenderedBlock.java
+++ b/src/main/java/gregtech/common/render/IRenderedBlock.java
@@ -10,6 +10,7 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import gregtech.api.enums.Textures;
 import gregtech.api.interfaces.ITexture;
+import gregtech.api.render.SBRContextHolder;
 import gregtech.api.render.SBRWorldContext;
 
 public interface IRenderedBlock {
@@ -57,6 +58,7 @@ public interface IRenderedBlock {
 
         public static final ErrorRenderer INSTANCE = new ErrorRenderer();
         public ITexture[] mErrorTexture = Textures.BlockIcons.ERROR_RENDERING;
+        private final SBRContextHolder contextHolder = new SBRContextHolder();
 
         @Override
         public ITexture[] getTexture(Block aBlock, ForgeDirection side, int aRenderPass,
@@ -102,7 +104,7 @@ public interface IRenderedBlock {
 
         @Override
         public boolean renderBlock(Block aBlock, RenderBlocks aRenderer, IBlockAccess aWorld, int aX, int aY, int aZ) {
-            final SBRWorldContext ctx = new SBRWorldContext(aX, aY, aZ, aBlock, 0, aRenderer);
+            final SBRWorldContext ctx = contextHolder.getSBRWorldContext(aX, aY, aZ, aBlock, 0, aRenderer);
             aBlock.setBlockBounds(-0.25F, -0.25F, -0.25F, 1.25F, 1.25F, 1.25F);
             ctx.renderNegativeYFacing(mErrorTexture);
             ctx.renderPositiveYFacing(mErrorTexture);

--- a/src/main/java/gtPlusPlus/core/client/renderer/CustomOreBlockRenderer.java
+++ b/src/main/java/gtPlusPlus/core/client/renderer/CustomOreBlockRenderer.java
@@ -70,7 +70,7 @@ public class CustomOreBlockRenderer implements ISimpleBlockRenderingHandler {
 
         final TesselatorAccessor tessAccess = (TesselatorAccessor) Tessellator.instance;
         final SBRWorldContext ctx = contextHolder.getSBRWorldContext(aX, aY, aZ, aBlock, aModelID, aRenderer);
-        ctx.fullBlock = true;
+        ctx.setFullBlock(true);
 
         aRenderer.enableAO = Minecraft.isAmbientOcclusionEnabled() && GTMod.proxy.mRenderTileAmbientOcclusion;
         aRenderer.useInventoryTint = false;

--- a/src/main/java/gtPlusPlus/core/client/renderer/CustomOreBlockRenderer.java
+++ b/src/main/java/gtPlusPlus/core/client/renderer/CustomOreBlockRenderer.java
@@ -14,6 +14,7 @@ import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
 import cpw.mods.fml.client.registry.RenderingRegistry;
 import gregtech.GTMod;
+import gregtech.api.render.SBRContextHolder;
 import gregtech.api.render.SBRInventoryContext;
 import gregtech.api.render.SBRWorldContext;
 import gregtech.mixin.interfaces.accessors.TesselatorAccessor;
@@ -25,6 +26,7 @@ public class CustomOreBlockRenderer implements ISimpleBlockRenderingHandler {
 
     public static CustomOreBlockRenderer INSTANCE;
     public final int mRenderID;
+    private final SBRContextHolder contextHolder = new SBRContextHolder();
 
     public CustomOreBlockRenderer() {
         INSTANCE = this;
@@ -35,7 +37,7 @@ public class CustomOreBlockRenderer implements ISimpleBlockRenderingHandler {
 
     @Override
     public void renderInventoryBlock(Block aBlock, int aMeta, int aModelID, RenderBlocks aRenderer) {
-        final SBRInventoryContext ctx = new SBRInventoryContext(aBlock, aMeta, aModelID, aRenderer);
+        final SBRInventoryContext ctx = contextHolder.getSBRInventoryContext(aBlock, aMeta, aModelID, aRenderer);
         aRenderer.enableAO = false;
         aRenderer.useInventoryTint = true;
         GL11.glRotatef(90.0F, 0.0F, 1.0F, 0.0F);
@@ -67,7 +69,7 @@ public class CustomOreBlockRenderer implements ISimpleBlockRenderingHandler {
         }
 
         final TesselatorAccessor tessAccess = (TesselatorAccessor) Tessellator.instance;
-        final SBRWorldContext ctx = new SBRWorldContext(aX, aY, aZ, aBlock, aModelID, aRenderer);
+        final SBRWorldContext ctx = contextHolder.getSBRWorldContext(aX, aY, aZ, aBlock, aModelID, aRenderer);
         ctx.fullBlock = true;
 
         aRenderer.enableAO = Minecraft.isAmbientOcclusionEnabled() && GTMod.proxy.mRenderTileAmbientOcclusion;

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/render/MachineBlockRenderer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/render/MachineBlockRenderer.java
@@ -34,6 +34,7 @@ import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.interfaces.tileentity.IPipeRenderedTileEntity;
 import gregtech.api.interfaces.tileentity.ITexturedTileEntity;
 import gregtech.api.metatileentity.MetaPipeEntity;
+import gregtech.api.render.SBRContextHolder;
 import gregtech.api.render.SBRInventoryContext;
 import gregtech.api.render.SBRWorldContext;
 import gregtech.common.blocks.BlockMachines;
@@ -45,6 +46,7 @@ public class MachineBlockRenderer extends GTRendererBlock {
 
     public static MachineBlockRenderer INSTANCE;
     public final int mRenderID = RenderingRegistry.getNextAvailableRenderId();
+    private final SBRContextHolder contextHolder = new SBRContextHolder();
 
     public MachineBlockRenderer() {
         INSTANCE = this;
@@ -69,7 +71,7 @@ public class MachineBlockRenderer extends GTRendererBlock {
             IMetaTileEntity tMetaTileEntity = GregTechAPI.METATILEENTITIES[ctx.meta];
             if (tMetaTileEntity != null) {
                 ctx.block.setBlockBoundsForItemRender();
-                ctx.renderer.setRenderBoundsFromBlock(ctx.block);
+                ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
                 GL11.glRotatef(90.0F, 0.0F, 1.0F, 0.0F);
                 GL11.glTranslatef(-0.5F, -0.5F, -0.5F);
                 final Tessellator tess = Tessellator.instance;
@@ -77,7 +79,7 @@ public class MachineBlockRenderer extends GTRendererBlock {
                     float tThickness = pipeRenderedTile.getThickNess();
                     float sp = (1.0F - tThickness) / 2.0F;
                     ctx.block.setBlockBounds(0.0F, sp, sp, 1.0F, sp + tThickness, sp + tThickness);
-                    ctx.renderer.setRenderBoundsFromBlock(ctx.block);
+                    ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
                     tess.startDrawingQuads();
                     tess.setNormal(0.0F, -1.0F, 0.0F);
                     ctx.renderNegativeYFacing(getTexture(tMetaTileEntity, DOWN, 0b001001, -1, false, false));
@@ -130,7 +132,7 @@ public class MachineBlockRenderer extends GTRendererBlock {
                 }
 
                 ctx.block.setBlockBounds(0.0F, 0.0F, 0.0F, 1.0F, 1.0F, 1.0F);
-                ctx.renderer.setRenderBoundsFromBlock(ctx.block);
+                ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
                 GL11.glTranslatef(0.5F, 0.5F, 0.5F);
             }
         }
@@ -138,7 +140,7 @@ public class MachineBlockRenderer extends GTRendererBlock {
     // spotless:on
 
     public boolean renderStandardBlock(SBRWorldContext ctx) {
-        final TileEntity te = ctx.world.getTileEntity(ctx.x, ctx.y, ctx.z);
+        final TileEntity te = ctx.blockAccess.getTileEntity(ctx.x, ctx.y, ctx.z);
         return te instanceof ITexturedTileEntity && renderStandardBlock(
             ctx,
             new ITexture[][] { GTMethodHelper.getTexture(te, ctx.block, DOWN),
@@ -151,7 +153,7 @@ public class MachineBlockRenderer extends GTRendererBlock {
 
     public boolean renderStandardBlock(SBRWorldContext ctx, ITexture[][] aTextures) {
         ctx.block.setBlockBounds(0.0F, 0.0F, 0.0F, 1.0F, 1.0F, 1.0F);
-        ctx.renderer.setRenderBoundsFromBlock(ctx.block);
+        ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
         ctx.fullBlock = true;
         ctx.renderNegativeYFacing(aTextures[DOWN.ordinal()]);
         ctx.renderPositiveYFacing(aTextures[UP.ordinal()]);
@@ -198,7 +200,7 @@ public class MachineBlockRenderer extends GTRendererBlock {
                 switch (connexionSidesBits) {
                     case NO_CONNECTION -> {
                         ctx.block.setBlockBounds(sp, sp, sp, sp + tThickness, sp + tThickness, sp + tThickness);
-                        ctx.renderer.setRenderBoundsFromBlock(ctx.block);
+                        ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
                         ctx.renderNegativeYFacing(textureUncovered.get(DOWN));
                         ctx.renderPositiveYFacing(textureUncovered.get(UP));
                         ctx.renderNegativeZFacing(textureUncovered.get(NORTH));
@@ -208,7 +210,7 @@ public class MachineBlockRenderer extends GTRendererBlock {
                     }
                     case (CONNECTED_DOWN | CONNECTED_UP) -> {
                         ctx.block.setBlockBounds(0.0F, sp, sp, 1.0F, sp + tThickness, sp + tThickness);
-                        ctx.renderer.setRenderBoundsFromBlock(ctx.block);
+                        ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
                         ctx.renderNegativeYFacing(textureUncovered.get(DOWN));
                         ctx.renderPositiveYFacing(textureUncovered.get(UP));
                         ctx.renderNegativeZFacing(textureUncovered.get(NORTH));
@@ -222,7 +224,7 @@ public class MachineBlockRenderer extends GTRendererBlock {
                     }
                     case (CONNECTED_NORTH | CONNECTED_SOUTH) -> {
                         ctx.block.setBlockBounds(sp, 0.0F, sp, sp + tThickness, 1.0F, sp + tThickness);
-                        ctx.renderer.setRenderBoundsFromBlock(ctx.block);
+                        ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
                         ctx.renderNegativeZFacing(textureUncovered.get(NORTH));
                         ctx.renderPositiveZFacing(textureUncovered.get(SOUTH));
                         ctx.renderNegativeXFacing(textureUncovered.get(WEST));
@@ -236,7 +238,7 @@ public class MachineBlockRenderer extends GTRendererBlock {
                     }
                     case (CONNECTED_WEST | CONNECTED_EAST) -> {
                         ctx.block.setBlockBounds(sp, sp, 0.0F, sp + tThickness, sp + tThickness, 1.0F);
-                        ctx.renderer.setRenderBoundsFromBlock(ctx.block);
+                        ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
                         ctx.renderNegativeYFacing(textureUncovered.get(DOWN));
                         ctx.renderPositiveYFacing(textureUncovered.get(UP));
                         ctx.renderNegativeXFacing(textureUncovered.get(WEST));
@@ -251,11 +253,11 @@ public class MachineBlockRenderer extends GTRendererBlock {
                     default -> {
                         if ((connexionSidesBits & CONNECTED_DOWN) == 0) {
                             ctx.block.setBlockBounds(sp, sp, sp, sp + tThickness, sp + tThickness, sp + tThickness);
-                            ctx.renderer.setRenderBoundsFromBlock(ctx.block);
+                            ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
                             ctx.renderNegativeXFacing(textureUncovered.get(WEST));
                         } else {
                             ctx.block.setBlockBounds(0.0F, sp, sp, sp, sp + tThickness, sp + tThickness);
-                            ctx.renderer.setRenderBoundsFromBlock(ctx.block);
+                            ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
                             ctx.renderNegativeYFacing(textureUncovered.get(DOWN));
                             ctx.renderPositiveYFacing(textureUncovered.get(UP));
                             ctx.renderNegativeZFacing(textureUncovered.get(NORTH));
@@ -266,11 +268,11 @@ public class MachineBlockRenderer extends GTRendererBlock {
                         }
                         if ((connexionSidesBits & CONNECTED_UP) == 0) {
                             ctx.block.setBlockBounds(sp, sp, sp, sp + tThickness, sp + tThickness, sp + tThickness);
-                            ctx.renderer.setRenderBoundsFromBlock(ctx.block);
+                            ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
                             ctx.renderPositiveXFacing(textureUncovered.get(EAST));
                         } else {
                             ctx.block.setBlockBounds(sp + tThickness, sp, sp, 1.0F, sp + tThickness, sp + tThickness);
-                            ctx.renderer.setRenderBoundsFromBlock(ctx.block);
+                            ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
                             ctx.renderNegativeYFacing(textureUncovered.get(DOWN));
                             ctx.renderPositiveYFacing(textureUncovered.get(UP));
                             ctx.renderNegativeZFacing(textureUncovered.get(NORTH));
@@ -281,11 +283,11 @@ public class MachineBlockRenderer extends GTRendererBlock {
                         }
                         if ((connexionSidesBits & CONNECTED_NORTH) == 0) {
                             ctx.block.setBlockBounds(sp, sp, sp, sp + tThickness, sp + tThickness, sp + tThickness);
-                            ctx.renderer.setRenderBoundsFromBlock(ctx.block);
+                            ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
                             ctx.renderNegativeYFacing(textureUncovered.get(DOWN));
                         } else {
                             ctx.block.setBlockBounds(sp, 0.0F, sp, sp + tThickness, sp, sp + tThickness);
-                            ctx.renderer.setRenderBoundsFromBlock(ctx.block);
+                            ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
                             ctx.renderNegativeZFacing(textureUncovered.get(NORTH));
                             ctx.renderPositiveZFacing(textureUncovered.get(SOUTH));
                             ctx.renderNegativeXFacing(textureUncovered.get(WEST));
@@ -296,11 +298,11 @@ public class MachineBlockRenderer extends GTRendererBlock {
                         }
                         if ((connexionSidesBits & CONNECTED_SOUTH) == 0) {
                             ctx.block.setBlockBounds(sp, sp, sp, sp + tThickness, sp + tThickness, sp + tThickness);
-                            ctx.renderer.setRenderBoundsFromBlock(ctx.block);
+                            ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
                             ctx.renderPositiveYFacing(textureUncovered.get(UP));
                         } else {
                             ctx.block.setBlockBounds(sp, sp + tThickness, sp, sp + tThickness, 1.0F, sp + tThickness);
-                            ctx.renderer.setRenderBoundsFromBlock(ctx.block);
+                            ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
                             ctx.renderNegativeZFacing(textureUncovered.get(NORTH));
                             ctx.renderPositiveZFacing(textureUncovered.get(SOUTH));
                             ctx.renderNegativeXFacing(textureUncovered.get(WEST));
@@ -311,11 +313,11 @@ public class MachineBlockRenderer extends GTRendererBlock {
                         }
                         if ((connexionSidesBits & CONNECTED_WEST) == 0) {
                             ctx.block.setBlockBounds(sp, sp, sp, sp + tThickness, sp + tThickness, sp + tThickness);
-                            ctx.renderer.setRenderBoundsFromBlock(ctx.block);
+                            ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
                             ctx.renderNegativeZFacing(textureUncovered.get(NORTH));
                         } else {
                             ctx.block.setBlockBounds(sp, sp, 0.0F, sp + tThickness, sp + tThickness, sp);
-                            ctx.renderer.setRenderBoundsFromBlock(ctx.block);
+                            ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
                             ctx.renderNegativeYFacing(textureUncovered.get(DOWN));
                             ctx.renderPositiveYFacing(textureUncovered.get(UP));
                             ctx.renderNegativeXFacing(textureUncovered.get(WEST));
@@ -326,11 +328,11 @@ public class MachineBlockRenderer extends GTRendererBlock {
                         }
                         if ((connexionSidesBits & CONNECTED_EAST) == 0) {
                             ctx.block.setBlockBounds(sp, sp, sp, sp + tThickness, sp + tThickness, sp + tThickness);
-                            ctx.renderer.setRenderBoundsFromBlock(ctx.block);
+                            ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
                             ctx.renderPositiveZFacing(textureUncovered.get(SOUTH));
                         } else {
                             ctx.block.setBlockBounds(sp, sp, sp + tThickness, sp + tThickness, sp + tThickness, 1.0F);
-                            ctx.renderer.setRenderBoundsFromBlock(ctx.block);
+                            ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
                             ctx.renderNegativeYFacing(textureUncovered.get(DOWN));
                             ctx.renderPositiveYFacing(textureUncovered.get(UP));
                             ctx.renderNegativeXFacing(textureUncovered.get(WEST));
@@ -344,7 +346,7 @@ public class MachineBlockRenderer extends GTRendererBlock {
 
                 if (coveredSides.contains(DOWN)) {
                     ctx.block.setBlockBounds(0.0F, 0.0F, 0.0F, 1.0F, 0.125F, 1.0F);
-                    ctx.renderer.setRenderBoundsFromBlock(ctx.block);
+                    ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
                     ctx.renderNegativeYFacing(texture.get(DOWN));
                     ctx.renderPositiveYFacing(texture.get(DOWN));
                     if (!coveredSides.contains(NORTH)) {
@@ -366,7 +368,7 @@ public class MachineBlockRenderer extends GTRendererBlock {
 
                 if (coveredSides.contains(UP)) {
                     ctx.block.setBlockBounds(0.0F, 0.875F, 0.0F, 1.0F, 1.0F, 1.0F);
-                    ctx.renderer.setRenderBoundsFromBlock(ctx.block);
+                    ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
                     ctx.renderNegativeYFacing(texture.get(UP));
                     ctx.renderPositiveYFacing(texture.get(UP));
                     if (!coveredSides.contains(NORTH)) {
@@ -388,7 +390,7 @@ public class MachineBlockRenderer extends GTRendererBlock {
 
                 if (coveredSides.contains(NORTH)) {
                     ctx.block.setBlockBounds(0.0F, 0.0F, 0.0F, 1.0F, 1.0F, 0.125F);
-                    ctx.renderer.setRenderBoundsFromBlock(ctx.block);
+                    ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
                     if (!coveredSides.contains(DOWN)) {
                         ctx.renderNegativeYFacing(texture.get(NORTH));
                     }
@@ -410,7 +412,7 @@ public class MachineBlockRenderer extends GTRendererBlock {
 
                 if (coveredSides.contains(SOUTH)) {
                     ctx.block.setBlockBounds(0.0F, 0.0F, 0.875F, 1.0F, 1.0F, 1.0F);
-                    ctx.renderer.setRenderBoundsFromBlock(ctx.block);
+                    ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
                     if (!coveredSides.contains(DOWN)) {
                         ctx.renderNegativeYFacing(texture.get(SOUTH));
                     }
@@ -432,7 +434,7 @@ public class MachineBlockRenderer extends GTRendererBlock {
 
                 if (coveredSides.contains(WEST)) {
                     ctx.block.setBlockBounds(0.0F, 0.0F, 0.0F, 0.125F, 1.0F, 1.0F);
-                    ctx.renderer.setRenderBoundsFromBlock(ctx.block);
+                    ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
                     if (!coveredSides.contains(DOWN)) {
                         ctx.renderNegativeYFacing(texture.get(WEST));
                     }
@@ -455,7 +457,7 @@ public class MachineBlockRenderer extends GTRendererBlock {
 
                 if (coveredSides.contains(EAST)) {
                     ctx.block.setBlockBounds(0.875F, 0.0F, 0.0F, 1.0F, 1.0F, 1.0F);
-                    ctx.renderer.setRenderBoundsFromBlock(ctx.block);
+                    ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
                     if (!coveredSides.contains(DOWN)) {
                         ctx.renderNegativeYFacing(texture.get(EAST));
                     }
@@ -477,7 +479,7 @@ public class MachineBlockRenderer extends GTRendererBlock {
                 }
 
                 ctx.block.setBlockBounds(0.0F, 0.0F, 0.0F, 1.0F, 1.0F, 1.0F);
-                ctx.renderer.setRenderBoundsFromBlock(ctx.block);
+                ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
                 return true;
             }
         }
@@ -485,13 +487,13 @@ public class MachineBlockRenderer extends GTRendererBlock {
     // spotless:on
 
     public static void renderNegativeYFacing(SBRWorldContext ctx, ITexture[] aIcon, boolean aFullBlock) {
-        if (ctx.world != null) {
-            if (aFullBlock && !ctx.renderer.renderAllFaces
-                && !ctx.block.shouldSideBeRendered(ctx.world, ctx.x, ctx.y - 1, ctx.z, 0)) {
+        if (ctx.blockAccess != null) {
+            if (aFullBlock && !ctx.renderBlocks.renderAllFaces
+                && !ctx.block.shouldSideBeRendered(ctx.blockAccess, ctx.x, ctx.y - 1, ctx.z, 0)) {
                 return;
             }
             Tessellator.instance.setBrightness(
-                ctx.block.getMixedBrightnessForBlock(ctx.world, ctx.x, aFullBlock ? ctx.y - 1 : ctx.y, ctx.z));
+                ctx.block.getMixedBrightnessForBlock(ctx.blockAccess, ctx.x, aFullBlock ? ctx.y - 1 : ctx.y, ctx.z));
         }
 
         if (aIcon != null) {
@@ -502,19 +504,19 @@ public class MachineBlockRenderer extends GTRendererBlock {
             }
         }
 
-        ctx.renderer.flipTexture = false;
+        ctx.renderBlocks.flipTexture = false;
     }
 
     @SuppressWarnings("MethodWithTooManyParameters")
     public static void renderPositiveYFacing(SBRWorldContext ctx, ITexture[] aIcon, boolean aFullBlock) {
-        if (ctx.world != null) {
-            if (aFullBlock && !ctx.renderer.renderAllFaces
-                && !ctx.block.shouldSideBeRendered(ctx.world, ctx.x, ctx.y + 1, ctx.z, 1)) {
+        if (ctx.blockAccess != null) {
+            if (aFullBlock && !ctx.renderBlocks.renderAllFaces
+                && !ctx.block.shouldSideBeRendered(ctx.blockAccess, ctx.x, ctx.y + 1, ctx.z, 1)) {
                 return;
             }
 
             Tessellator.instance.setBrightness(
-                ctx.block.getMixedBrightnessForBlock(ctx.world, ctx.x, aFullBlock ? ctx.y + 1 : ctx.y, ctx.z));
+                ctx.block.getMixedBrightnessForBlock(ctx.blockAccess, ctx.x, aFullBlock ? ctx.y + 1 : ctx.y, ctx.z));
         }
 
         if (aIcon != null) {
@@ -525,22 +527,22 @@ public class MachineBlockRenderer extends GTRendererBlock {
             }
         }
 
-        ctx.renderer.flipTexture = false;
+        ctx.renderBlocks.flipTexture = false;
     }
 
     @SuppressWarnings("MethodWithTooManyParameters")
     public static void renderNegativeZFacing(SBRWorldContext ctx, ITexture[] aIcon, boolean aFullBlock) {
-        if (ctx.world != null) {
-            if (aFullBlock && !ctx.renderer.renderAllFaces
-                && !ctx.block.shouldSideBeRendered(ctx.world, ctx.x, ctx.y, ctx.z - 1, 2)) {
+        if (ctx.blockAccess != null) {
+            if (aFullBlock && !ctx.renderBlocks.renderAllFaces
+                && !ctx.block.shouldSideBeRendered(ctx.blockAccess, ctx.x, ctx.y, ctx.z - 1, 2)) {
                 return;
             }
 
             Tessellator.instance.setBrightness(
-                ctx.block.getMixedBrightnessForBlock(ctx.world, ctx.x, ctx.y, aFullBlock ? ctx.z - 1 : ctx.z));
+                ctx.block.getMixedBrightnessForBlock(ctx.blockAccess, ctx.x, ctx.y, aFullBlock ? ctx.z - 1 : ctx.z));
         }
 
-        ctx.renderer.flipTexture = !aFullBlock;
+        ctx.renderBlocks.flipTexture = !aFullBlock;
         if (aIcon != null) {
             for (ITexture iTexture : aIcon) {
                 if (iTexture != null) {
@@ -549,19 +551,19 @@ public class MachineBlockRenderer extends GTRendererBlock {
             }
         }
 
-        ctx.renderer.flipTexture = false;
+        ctx.renderBlocks.flipTexture = false;
     }
 
     @SuppressWarnings("MethodWithTooManyParameters")
     public static void renderPositiveZFacing(SBRWorldContext ctx, ITexture[] aIcon, boolean aFullBlock) {
-        if (ctx.world != null) {
-            if (aFullBlock && !ctx.renderer.renderAllFaces
-                && !ctx.block.shouldSideBeRendered(ctx.world, ctx.x, ctx.y, ctx.z + 1, 3)) {
+        if (ctx.blockAccess != null) {
+            if (aFullBlock && !ctx.renderBlocks.renderAllFaces
+                && !ctx.block.shouldSideBeRendered(ctx.blockAccess, ctx.x, ctx.y, ctx.z + 1, 3)) {
                 return;
             }
 
             Tessellator.instance.setBrightness(
-                ctx.block.getMixedBrightnessForBlock(ctx.world, ctx.x, ctx.y, aFullBlock ? ctx.z + 1 : ctx.z));
+                ctx.block.getMixedBrightnessForBlock(ctx.blockAccess, ctx.x, ctx.y, aFullBlock ? ctx.z + 1 : ctx.z));
         }
 
         if (aIcon != null) {
@@ -572,19 +574,19 @@ public class MachineBlockRenderer extends GTRendererBlock {
             }
         }
 
-        ctx.renderer.flipTexture = false;
+        ctx.renderBlocks.flipTexture = false;
     }
 
     @SuppressWarnings("MethodWithTooManyParameters")
     public static void renderNegativeXFacing(SBRWorldContext ctx, ITexture[] aIcon, boolean aFullBlock) {
-        if (ctx.world != null) {
-            if (aFullBlock && !ctx.renderer.renderAllFaces
-                && !ctx.block.shouldSideBeRendered(ctx.world, ctx.x - 1, ctx.y, ctx.z, 4)) {
+        if (ctx.blockAccess != null) {
+            if (aFullBlock && !ctx.renderBlocks.renderAllFaces
+                && !ctx.block.shouldSideBeRendered(ctx.blockAccess, ctx.x - 1, ctx.y, ctx.z, 4)) {
                 return;
             }
 
             Tessellator.instance.setBrightness(
-                ctx.block.getMixedBrightnessForBlock(ctx.world, aFullBlock ? ctx.x - 1 : ctx.x, ctx.y, ctx.z));
+                ctx.block.getMixedBrightnessForBlock(ctx.blockAccess, aFullBlock ? ctx.x - 1 : ctx.x, ctx.y, ctx.z));
         }
 
         if (aIcon != null) {
@@ -595,22 +597,22 @@ public class MachineBlockRenderer extends GTRendererBlock {
             }
         }
 
-        ctx.renderer.flipTexture = false;
+        ctx.renderBlocks.flipTexture = false;
     }
 
     @SuppressWarnings("MethodWithTooManyParameters")
     public static void renderPositiveXFacing(SBRWorldContext ctx, ITexture[] aIcon, boolean aFullBlock) {
-        if (ctx.world != null) {
-            if (aFullBlock && !ctx.renderer.renderAllFaces
-                && !ctx.block.shouldSideBeRendered(ctx.world, ctx.x + 1, ctx.y, ctx.z, 5)) {
+        if (ctx.blockAccess != null) {
+            if (aFullBlock && !ctx.renderBlocks.renderAllFaces
+                && !ctx.block.shouldSideBeRendered(ctx.blockAccess, ctx.x + 1, ctx.y, ctx.z, 5)) {
                 return;
             }
 
             Tessellator.instance.setBrightness(
-                ctx.block.getMixedBrightnessForBlock(ctx.world, aFullBlock ? ctx.x + 1 : ctx.x, ctx.y, ctx.z));
+                ctx.block.getMixedBrightnessForBlock(ctx.blockAccess, aFullBlock ? ctx.x + 1 : ctx.x, ctx.y, ctx.z));
         }
 
-        ctx.renderer.flipTexture = !aFullBlock;
+        ctx.renderBlocks.flipTexture = !aFullBlock;
         if (aIcon != null) {
             for (ITexture iTexture : aIcon) {
                 if (iTexture != null) {
@@ -619,17 +621,17 @@ public class MachineBlockRenderer extends GTRendererBlock {
             }
         }
 
-        ctx.renderer.flipTexture = false;
+        ctx.renderBlocks.flipTexture = false;
     }
 
     @Override
     public void renderInventoryBlock(Block aBlock, int aMeta, int aModelID, RenderBlocks aRenderer) {
-        final SBRInventoryContext ctx = new SBRInventoryContext(aBlock, aMeta, aModelID, aRenderer);
+        final SBRInventoryContext ctx = contextHolder.getSBRInventoryContext(aBlock, aMeta, aModelID, aRenderer);
         aMeta += 30400;
         if (aBlock instanceof BlockMachines) {
             if (aMeta > 0 && aMeta < GregTechAPI.METATILEENTITIES.length
                 && GregTechAPI.METATILEENTITIES[aMeta] != null
-                && !GregTechAPI.METATILEENTITIES[aMeta].renderInInventory(aBlock, aMeta, aRenderer)) {
+                && !GregTechAPI.METATILEENTITIES[aMeta].render(ctx)) {
                 renderNormalInventoryMetaTileEntity(ctx);
             }
         }
@@ -642,14 +644,14 @@ public class MachineBlockRenderer extends GTRendererBlock {
     public boolean renderWorldBlock(IBlockAccess aWorld, int aX, int aY, int aZ, Block aBlock, int aModelID,
         RenderBlocks aRenderer) {
         final TesselatorAccessor tessAccess = (TesselatorAccessor) Tessellator.instance;
-        final SBRWorldContext ctx = new SBRWorldContext(aX, aY, aZ, aBlock, aModelID, aRenderer);
+        final SBRWorldContext ctx = contextHolder.getSBRWorldContext(aX, aY, aZ, aBlock, aModelID, aRenderer);
 
         TileEntity aTileEntity = aWorld.getTileEntity(aX, aY, aZ);
         return aTileEntity != null && (aTileEntity instanceof IGregTechTileEntity
             && ((IGregTechTileEntity) aTileEntity).getMetaTileEntity() != null
             && tessAccess.gt5u$hasVertices()
             && ((IGregTechTileEntity) aTileEntity).getMetaTileEntity()
-                .renderInWorld(aWorld, aX, aY, aZ, aBlock, aRenderer)
+                .render(ctx)
             || (aTileEntity instanceof IPipeRenderedTileEntity
                 ? renderPipeBlock(ctx, (IPipeRenderedTileEntity) aTileEntity)
                 : renderStandardBlock(ctx)));

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/render/MachineBlockRenderer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/render/MachineBlockRenderer.java
@@ -34,7 +34,6 @@ import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.interfaces.tileentity.IPipeRenderedTileEntity;
 import gregtech.api.interfaces.tileentity.ITexturedTileEntity;
 import gregtech.api.metatileentity.MetaPipeEntity;
-import gregtech.api.render.SBRContextHolder;
 import gregtech.api.render.SBRInventoryContext;
 import gregtech.api.render.SBRWorldContext;
 import gregtech.common.blocks.BlockMachines;
@@ -46,7 +45,6 @@ public class MachineBlockRenderer extends GTRendererBlock {
 
     public static MachineBlockRenderer INSTANCE;
     public final int mRenderID = RenderingRegistry.getNextAvailableRenderId();
-    private final SBRContextHolder contextHolder = new SBRContextHolder();
 
     public MachineBlockRenderer() {
         INSTANCE = this;
@@ -67,19 +65,19 @@ public class MachineBlockRenderer extends GTRendererBlock {
 
     // spotless:off
     private static void renderNormalInventoryMetaTileEntity(SBRInventoryContext ctx) {
-        if (ctx.meta > 0 && ctx.meta < GregTechAPI.METATILEENTITIES.length) {
-            IMetaTileEntity tMetaTileEntity = GregTechAPI.METATILEENTITIES[ctx.meta];
+        if (ctx.getMeta() > 0 && ctx.getMeta() < GregTechAPI.METATILEENTITIES.length) {
+            IMetaTileEntity tMetaTileEntity = GregTechAPI.METATILEENTITIES[ctx.getMeta()];
             if (tMetaTileEntity != null) {
-                ctx.block.setBlockBoundsForItemRender();
-                ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+                ctx.getBlock().setBlockBoundsForItemRender();
+                ctx.setRenderBoundsFromBlock();
                 GL11.glRotatef(90.0F, 0.0F, 1.0F, 0.0F);
                 GL11.glTranslatef(-0.5F, -0.5F, -0.5F);
                 final Tessellator tess = Tessellator.instance;
                 if (tMetaTileEntity.getBaseMetaTileEntity() instanceof IPipeRenderedTileEntity pipeRenderedTile) {
                     float tThickness = pipeRenderedTile.getThickNess();
                     float sp = (1.0F - tThickness) / 2.0F;
-                    ctx.block.setBlockBounds(0.0F, sp, sp, 1.0F, sp + tThickness, sp + tThickness);
-                    ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+                    ctx.getBlock().setBlockBounds(0.0F, sp, sp, 1.0F, sp + tThickness, sp + tThickness);
+                    ctx.setRenderBoundsFromBlock();
                     tess.startDrawingQuads();
                     tess.setNormal(0.0F, -1.0F, 0.0F);
                     ctx.renderNegativeYFacing(getTexture(tMetaTileEntity, DOWN, 0b001001, -1, false, false));
@@ -131,8 +129,8 @@ public class MachineBlockRenderer extends GTRendererBlock {
                     tess.draw();
                 }
 
-                ctx.block.setBlockBounds(0.0F, 0.0F, 0.0F, 1.0F, 1.0F, 1.0F);
-                ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+                ctx.getBlock().setBlockBounds(0.0F, 0.0F, 0.0F, 1.0F, 1.0F, 1.0F);
+                ctx.setRenderBoundsFromBlock();
                 GL11.glTranslatef(0.5F, 0.5F, 0.5F);
             }
         }
@@ -140,21 +138,23 @@ public class MachineBlockRenderer extends GTRendererBlock {
     // spotless:on
 
     public boolean renderStandardBlock(SBRWorldContext ctx) {
-        final TileEntity te = ctx.blockAccess.getTileEntity(ctx.x, ctx.y, ctx.z);
+        final TileEntity te = ctx.getBlockAccess()
+            .getTileEntity(ctx.getX(), ctx.getY(), ctx.getZ());
         return te instanceof ITexturedTileEntity && renderStandardBlock(
             ctx,
-            new ITexture[][] { GTMethodHelper.getTexture(te, ctx.block, DOWN),
-                GTMethodHelper.getTexture(te, ctx.block, UP),
-                GTMethodHelper.getTexture(te, ctx.block, ForgeDirection.NORTH),
-                GTMethodHelper.getTexture(te, ctx.block, ForgeDirection.SOUTH),
-                GTMethodHelper.getTexture(te, ctx.block, ForgeDirection.WEST),
-                GTMethodHelper.getTexture(te, ctx.block, ForgeDirection.EAST) });
+            new ITexture[][] { GTMethodHelper.getTexture(te, ctx.getBlock(), DOWN),
+                GTMethodHelper.getTexture(te, ctx.getBlock(), UP),
+                GTMethodHelper.getTexture(te, ctx.getBlock(), ForgeDirection.NORTH),
+                GTMethodHelper.getTexture(te, ctx.getBlock(), ForgeDirection.SOUTH),
+                GTMethodHelper.getTexture(te, ctx.getBlock(), ForgeDirection.WEST),
+                GTMethodHelper.getTexture(te, ctx.getBlock(), ForgeDirection.EAST) });
     }
 
     public boolean renderStandardBlock(SBRWorldContext ctx, ITexture[][] aTextures) {
-        ctx.block.setBlockBounds(0.0F, 0.0F, 0.0F, 1.0F, 1.0F, 1.0F);
-        ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
-        ctx.fullBlock = true;
+        ctx.getBlock()
+            .setBlockBounds(0.0F, 0.0F, 0.0F, 1.0F, 1.0F, 1.0F);
+        ctx.setRenderBoundsFromBlock();
+        ctx.setFullBlock(true);
         ctx.renderNegativeYFacing(aTextures[DOWN.ordinal()]);
         ctx.renderPositiveYFacing(aTextures[UP.ordinal()]);
         ctx.renderNegativeZFacing(aTextures[ForgeDirection.NORTH.ordinal()]);
@@ -193,14 +193,14 @@ public class MachineBlockRenderer extends GTRendererBlock {
                 final EnumMap<ForgeDirection, ITexture[]> textureUncovered = new EnumMap<>(ForgeDirection.class);
 
                 for (final ForgeDirection side : ForgeDirection.VALID_DIRECTIONS) {
-                    texture.put(side, GTMethodHelper.getTexture((TileEntity) aTileEntity, ctx.block, side));
+                    texture.put(side, GTMethodHelper.getTexture((TileEntity) aTileEntity, ctx.getBlock(), side));
                     textureUncovered.put(side, aTileEntity.getTextureUncovered(side));
                 }
 
                 switch (connexionSidesBits) {
                     case NO_CONNECTION -> {
-                        ctx.block.setBlockBounds(sp, sp, sp, sp + tThickness, sp + tThickness, sp + tThickness);
-                        ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+                        ctx.getBlock().setBlockBounds(sp, sp, sp, sp + tThickness, sp + tThickness, sp + tThickness);
+                        ctx.setRenderBoundsFromBlock();
                         ctx.renderNegativeYFacing(textureUncovered.get(DOWN));
                         ctx.renderPositiveYFacing(textureUncovered.get(UP));
                         ctx.renderNegativeZFacing(textureUncovered.get(NORTH));
@@ -209,8 +209,8 @@ public class MachineBlockRenderer extends GTRendererBlock {
                         ctx.renderPositiveXFacing(textureUncovered.get(EAST));
                     }
                     case (CONNECTED_DOWN | CONNECTED_UP) -> {
-                        ctx.block.setBlockBounds(0.0F, sp, sp, 1.0F, sp + tThickness, sp + tThickness);
-                        ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+                        ctx.getBlock().setBlockBounds(0.0F, sp, sp, 1.0F, sp + tThickness, sp + tThickness);
+                        ctx.setRenderBoundsFromBlock();
                         ctx.renderNegativeYFacing(textureUncovered.get(DOWN));
                         ctx.renderPositiveYFacing(textureUncovered.get(UP));
                         ctx.renderNegativeZFacing(textureUncovered.get(NORTH));
@@ -223,8 +223,8 @@ public class MachineBlockRenderer extends GTRendererBlock {
                         }
                     }
                     case (CONNECTED_NORTH | CONNECTED_SOUTH) -> {
-                        ctx.block.setBlockBounds(sp, 0.0F, sp, sp + tThickness, 1.0F, sp + tThickness);
-                        ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+                        ctx.getBlock().setBlockBounds(sp, 0.0F, sp, sp + tThickness, 1.0F, sp + tThickness);
+                        ctx.setRenderBoundsFromBlock();
                         ctx.renderNegativeZFacing(textureUncovered.get(NORTH));
                         ctx.renderPositiveZFacing(textureUncovered.get(SOUTH));
                         ctx.renderNegativeXFacing(textureUncovered.get(WEST));
@@ -237,8 +237,8 @@ public class MachineBlockRenderer extends GTRendererBlock {
                         }
                     }
                     case (CONNECTED_WEST | CONNECTED_EAST) -> {
-                        ctx.block.setBlockBounds(sp, sp, 0.0F, sp + tThickness, sp + tThickness, 1.0F);
-                        ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+                        ctx.getBlock().setBlockBounds(sp, sp, 0.0F, sp + tThickness, sp + tThickness, 1.0F);
+                        ctx.setRenderBoundsFromBlock();
                         ctx.renderNegativeYFacing(textureUncovered.get(DOWN));
                         ctx.renderPositiveYFacing(textureUncovered.get(UP));
                         ctx.renderNegativeXFacing(textureUncovered.get(WEST));
@@ -252,12 +252,12 @@ public class MachineBlockRenderer extends GTRendererBlock {
                     }
                     default -> {
                         if ((connexionSidesBits & CONNECTED_DOWN) == 0) {
-                            ctx.block.setBlockBounds(sp, sp, sp, sp + tThickness, sp + tThickness, sp + tThickness);
-                            ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+                            ctx.getBlock().setBlockBounds(sp, sp, sp, sp + tThickness, sp + tThickness, sp + tThickness);
+                            ctx.setRenderBoundsFromBlock();
                             ctx.renderNegativeXFacing(textureUncovered.get(WEST));
                         } else {
-                            ctx.block.setBlockBounds(0.0F, sp, sp, sp, sp + tThickness, sp + tThickness);
-                            ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+                            ctx.getBlock().setBlockBounds(0.0F, sp, sp, sp, sp + tThickness, sp + tThickness);
+                            ctx.setRenderBoundsFromBlock();
                             ctx.renderNegativeYFacing(textureUncovered.get(DOWN));
                             ctx.renderPositiveYFacing(textureUncovered.get(UP));
                             ctx.renderNegativeZFacing(textureUncovered.get(NORTH));
@@ -267,12 +267,12 @@ public class MachineBlockRenderer extends GTRendererBlock {
                             }
                         }
                         if ((connexionSidesBits & CONNECTED_UP) == 0) {
-                            ctx.block.setBlockBounds(sp, sp, sp, sp + tThickness, sp + tThickness, sp + tThickness);
-                            ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+                            ctx.getBlock().setBlockBounds(sp, sp, sp, sp + tThickness, sp + tThickness, sp + tThickness);
+                            ctx.setRenderBoundsFromBlock();
                             ctx.renderPositiveXFacing(textureUncovered.get(EAST));
                         } else {
-                            ctx.block.setBlockBounds(sp + tThickness, sp, sp, 1.0F, sp + tThickness, sp + tThickness);
-                            ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+                            ctx.getBlock().setBlockBounds(sp + tThickness, sp, sp, 1.0F, sp + tThickness, sp + tThickness);
+                            ctx.setRenderBoundsFromBlock();
                             ctx.renderNegativeYFacing(textureUncovered.get(DOWN));
                             ctx.renderPositiveYFacing(textureUncovered.get(UP));
                             ctx.renderNegativeZFacing(textureUncovered.get(NORTH));
@@ -282,12 +282,12 @@ public class MachineBlockRenderer extends GTRendererBlock {
                             }
                         }
                         if ((connexionSidesBits & CONNECTED_NORTH) == 0) {
-                            ctx.block.setBlockBounds(sp, sp, sp, sp + tThickness, sp + tThickness, sp + tThickness);
-                            ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+                            ctx.getBlock().setBlockBounds(sp, sp, sp, sp + tThickness, sp + tThickness, sp + tThickness);
+                            ctx.setRenderBoundsFromBlock();
                             ctx.renderNegativeYFacing(textureUncovered.get(DOWN));
                         } else {
-                            ctx.block.setBlockBounds(sp, 0.0F, sp, sp + tThickness, sp, sp + tThickness);
-                            ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+                            ctx.getBlock().setBlockBounds(sp, 0.0F, sp, sp + tThickness, sp, sp + tThickness);
+                            ctx.setRenderBoundsFromBlock();
                             ctx.renderNegativeZFacing(textureUncovered.get(NORTH));
                             ctx.renderPositiveZFacing(textureUncovered.get(SOUTH));
                             ctx.renderNegativeXFacing(textureUncovered.get(WEST));
@@ -297,12 +297,12 @@ public class MachineBlockRenderer extends GTRendererBlock {
                             }
                         }
                         if ((connexionSidesBits & CONNECTED_SOUTH) == 0) {
-                            ctx.block.setBlockBounds(sp, sp, sp, sp + tThickness, sp + tThickness, sp + tThickness);
-                            ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+                            ctx.getBlock().setBlockBounds(sp, sp, sp, sp + tThickness, sp + tThickness, sp + tThickness);
+                            ctx.setRenderBoundsFromBlock();
                             ctx.renderPositiveYFacing(textureUncovered.get(UP));
                         } else {
-                            ctx.block.setBlockBounds(sp, sp + tThickness, sp, sp + tThickness, 1.0F, sp + tThickness);
-                            ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+                            ctx.getBlock().setBlockBounds(sp, sp + tThickness, sp, sp + tThickness, 1.0F, sp + tThickness);
+                            ctx.setRenderBoundsFromBlock();
                             ctx.renderNegativeZFacing(textureUncovered.get(NORTH));
                             ctx.renderPositiveZFacing(textureUncovered.get(SOUTH));
                             ctx.renderNegativeXFacing(textureUncovered.get(WEST));
@@ -312,12 +312,12 @@ public class MachineBlockRenderer extends GTRendererBlock {
                             }
                         }
                         if ((connexionSidesBits & CONNECTED_WEST) == 0) {
-                            ctx.block.setBlockBounds(sp, sp, sp, sp + tThickness, sp + tThickness, sp + tThickness);
-                            ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+                            ctx.getBlock().setBlockBounds(sp, sp, sp, sp + tThickness, sp + tThickness, sp + tThickness);
+                            ctx.setRenderBoundsFromBlock();
                             ctx.renderNegativeZFacing(textureUncovered.get(NORTH));
                         } else {
-                            ctx.block.setBlockBounds(sp, sp, 0.0F, sp + tThickness, sp + tThickness, sp);
-                            ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+                            ctx.getBlock().setBlockBounds(sp, sp, 0.0F, sp + tThickness, sp + tThickness, sp);
+                            ctx.setRenderBoundsFromBlock();
                             ctx.renderNegativeYFacing(textureUncovered.get(DOWN));
                             ctx.renderPositiveYFacing(textureUncovered.get(UP));
                             ctx.renderNegativeXFacing(textureUncovered.get(WEST));
@@ -327,12 +327,12 @@ public class MachineBlockRenderer extends GTRendererBlock {
                             }
                         }
                         if ((connexionSidesBits & CONNECTED_EAST) == 0) {
-                            ctx.block.setBlockBounds(sp, sp, sp, sp + tThickness, sp + tThickness, sp + tThickness);
-                            ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+                            ctx.getBlock().setBlockBounds(sp, sp, sp, sp + tThickness, sp + tThickness, sp + tThickness);
+                            ctx.setRenderBoundsFromBlock();
                             ctx.renderPositiveZFacing(textureUncovered.get(SOUTH));
                         } else {
-                            ctx.block.setBlockBounds(sp, sp, sp + tThickness, sp + tThickness, sp + tThickness, 1.0F);
-                            ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+                            ctx.getBlock().setBlockBounds(sp, sp, sp + tThickness, sp + tThickness, sp + tThickness, 1.0F);
+                            ctx.setRenderBoundsFromBlock();
                             ctx.renderNegativeYFacing(textureUncovered.get(DOWN));
                             ctx.renderPositiveYFacing(textureUncovered.get(UP));
                             ctx.renderNegativeXFacing(textureUncovered.get(WEST));
@@ -345,8 +345,8 @@ public class MachineBlockRenderer extends GTRendererBlock {
                 }
 
                 if (coveredSides.contains(DOWN)) {
-                    ctx.block.setBlockBounds(0.0F, 0.0F, 0.0F, 1.0F, 0.125F, 1.0F);
-                    ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+                    ctx.getBlock().setBlockBounds(0.0F, 0.0F, 0.0F, 1.0F, 0.125F, 1.0F);
+                    ctx.setRenderBoundsFromBlock();
                     ctx.renderNegativeYFacing(texture.get(DOWN));
                     ctx.renderPositiveYFacing(texture.get(DOWN));
                     if (!coveredSides.contains(NORTH)) {
@@ -367,8 +367,8 @@ public class MachineBlockRenderer extends GTRendererBlock {
                 }
 
                 if (coveredSides.contains(UP)) {
-                    ctx.block.setBlockBounds(0.0F, 0.875F, 0.0F, 1.0F, 1.0F, 1.0F);
-                    ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+                    ctx.getBlock().setBlockBounds(0.0F, 0.875F, 0.0F, 1.0F, 1.0F, 1.0F);
+                    ctx.setRenderBoundsFromBlock();
                     ctx.renderNegativeYFacing(texture.get(UP));
                     ctx.renderPositiveYFacing(texture.get(UP));
                     if (!coveredSides.contains(NORTH)) {
@@ -389,8 +389,8 @@ public class MachineBlockRenderer extends GTRendererBlock {
                 }
 
                 if (coveredSides.contains(NORTH)) {
-                    ctx.block.setBlockBounds(0.0F, 0.0F, 0.0F, 1.0F, 1.0F, 0.125F);
-                    ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+                    ctx.getBlock().setBlockBounds(0.0F, 0.0F, 0.0F, 1.0F, 1.0F, 0.125F);
+                    ctx.setRenderBoundsFromBlock();
                     if (!coveredSides.contains(DOWN)) {
                         ctx.renderNegativeYFacing(texture.get(NORTH));
                     }
@@ -411,8 +411,8 @@ public class MachineBlockRenderer extends GTRendererBlock {
                 }
 
                 if (coveredSides.contains(SOUTH)) {
-                    ctx.block.setBlockBounds(0.0F, 0.0F, 0.875F, 1.0F, 1.0F, 1.0F);
-                    ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+                    ctx.getBlock().setBlockBounds(0.0F, 0.0F, 0.875F, 1.0F, 1.0F, 1.0F);
+                    ctx.setRenderBoundsFromBlock();
                     if (!coveredSides.contains(DOWN)) {
                         ctx.renderNegativeYFacing(texture.get(SOUTH));
                     }
@@ -433,8 +433,8 @@ public class MachineBlockRenderer extends GTRendererBlock {
                 }
 
                 if (coveredSides.contains(WEST)) {
-                    ctx.block.setBlockBounds(0.0F, 0.0F, 0.0F, 0.125F, 1.0F, 1.0F);
-                    ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+                    ctx.getBlock().setBlockBounds(0.0F, 0.0F, 0.0F, 0.125F, 1.0F, 1.0F);
+                    ctx.setRenderBoundsFromBlock();
                     if (!coveredSides.contains(DOWN)) {
                         ctx.renderNegativeYFacing(texture.get(WEST));
                     }
@@ -456,8 +456,8 @@ public class MachineBlockRenderer extends GTRendererBlock {
                 }
 
                 if (coveredSides.contains(EAST)) {
-                    ctx.block.setBlockBounds(0.875F, 0.0F, 0.0F, 1.0F, 1.0F, 1.0F);
-                    ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+                    ctx.getBlock().setBlockBounds(0.875F, 0.0F, 0.0F, 1.0F, 1.0F, 1.0F);
+                    ctx.setRenderBoundsFromBlock();
                     if (!coveredSides.contains(DOWN)) {
                         ctx.renderNegativeYFacing(texture.get(EAST));
                     }
@@ -478,8 +478,8 @@ public class MachineBlockRenderer extends GTRendererBlock {
                     ctx.renderPositiveXFacing(texture.get(EAST));
                 }
 
-                ctx.block.setBlockBounds(0.0F, 0.0F, 0.0F, 1.0F, 1.0F, 1.0F);
-                ctx.renderBlocks.setRenderBoundsFromBlock(ctx.block);
+                ctx.getBlock().setBlockBounds(0.0F, 0.0F, 0.0F, 1.0F, 1.0F, 1.0F);
+                ctx.setRenderBoundsFromBlock();
                 return true;
             }
         }
@@ -487,13 +487,19 @@ public class MachineBlockRenderer extends GTRendererBlock {
     // spotless:on
 
     public static void renderNegativeYFacing(SBRWorldContext ctx, ITexture[] aIcon, boolean aFullBlock) {
-        if (ctx.blockAccess != null) {
-            if (aFullBlock && !ctx.renderBlocks.renderAllFaces
-                && !ctx.block.shouldSideBeRendered(ctx.blockAccess, ctx.x, ctx.y - 1, ctx.z, 0)) {
+        if (ctx.getBlockAccess() != null) {
+            if (aFullBlock && !ctx.getRenderBlocks().renderAllFaces
+                && !ctx.getBlock()
+                    .shouldSideBeRendered(ctx.getBlockAccess(), ctx.getX(), ctx.getY() - 1, ctx.getZ(), 0)) {
                 return;
             }
             Tessellator.instance.setBrightness(
-                ctx.block.getMixedBrightnessForBlock(ctx.blockAccess, ctx.x, aFullBlock ? ctx.y - 1 : ctx.y, ctx.z));
+                ctx.getBlock()
+                    .getMixedBrightnessForBlock(
+                        ctx.getBlockAccess(),
+                        ctx.getX(),
+                        aFullBlock ? ctx.getY() - 1 : ctx.getY(),
+                        ctx.getZ()));
         }
 
         if (aIcon != null) {
@@ -504,19 +510,25 @@ public class MachineBlockRenderer extends GTRendererBlock {
             }
         }
 
-        ctx.renderBlocks.flipTexture = false;
+        ctx.getRenderBlocks().flipTexture = false;
     }
 
     @SuppressWarnings("MethodWithTooManyParameters")
     public static void renderPositiveYFacing(SBRWorldContext ctx, ITexture[] aIcon, boolean aFullBlock) {
-        if (ctx.blockAccess != null) {
-            if (aFullBlock && !ctx.renderBlocks.renderAllFaces
-                && !ctx.block.shouldSideBeRendered(ctx.blockAccess, ctx.x, ctx.y + 1, ctx.z, 1)) {
+        if (ctx.getBlockAccess() != null) {
+            if (aFullBlock && !ctx.getRenderBlocks().renderAllFaces
+                && !ctx.getBlock()
+                    .shouldSideBeRendered(ctx.getBlockAccess(), ctx.getX(), ctx.getY() + 1, ctx.getZ(), 1)) {
                 return;
             }
 
             Tessellator.instance.setBrightness(
-                ctx.block.getMixedBrightnessForBlock(ctx.blockAccess, ctx.x, aFullBlock ? ctx.y + 1 : ctx.y, ctx.z));
+                ctx.getBlock()
+                    .getMixedBrightnessForBlock(
+                        ctx.getBlockAccess(),
+                        ctx.getX(),
+                        aFullBlock ? ctx.getY() + 1 : ctx.getY(),
+                        ctx.getZ()));
         }
 
         if (aIcon != null) {
@@ -527,22 +539,28 @@ public class MachineBlockRenderer extends GTRendererBlock {
             }
         }
 
-        ctx.renderBlocks.flipTexture = false;
+        ctx.getRenderBlocks().flipTexture = false;
     }
 
     @SuppressWarnings("MethodWithTooManyParameters")
     public static void renderNegativeZFacing(SBRWorldContext ctx, ITexture[] aIcon, boolean aFullBlock) {
-        if (ctx.blockAccess != null) {
-            if (aFullBlock && !ctx.renderBlocks.renderAllFaces
-                && !ctx.block.shouldSideBeRendered(ctx.blockAccess, ctx.x, ctx.y, ctx.z - 1, 2)) {
+        if (ctx.getBlockAccess() != null) {
+            if (aFullBlock && !ctx.getRenderBlocks().renderAllFaces
+                && !ctx.getBlock()
+                    .shouldSideBeRendered(ctx.getBlockAccess(), ctx.getX(), ctx.getY(), ctx.getZ() - 1, 2)) {
                 return;
             }
 
             Tessellator.instance.setBrightness(
-                ctx.block.getMixedBrightnessForBlock(ctx.blockAccess, ctx.x, ctx.y, aFullBlock ? ctx.z - 1 : ctx.z));
+                ctx.getBlock()
+                    .getMixedBrightnessForBlock(
+                        ctx.getBlockAccess(),
+                        ctx.getX(),
+                        ctx.getY(),
+                        aFullBlock ? ctx.getZ() - 1 : ctx.getZ()));
         }
 
-        ctx.renderBlocks.flipTexture = !aFullBlock;
+        ctx.getRenderBlocks().flipTexture = !aFullBlock;
         if (aIcon != null) {
             for (ITexture iTexture : aIcon) {
                 if (iTexture != null) {
@@ -551,19 +569,25 @@ public class MachineBlockRenderer extends GTRendererBlock {
             }
         }
 
-        ctx.renderBlocks.flipTexture = false;
+        ctx.getRenderBlocks().flipTexture = false;
     }
 
     @SuppressWarnings("MethodWithTooManyParameters")
     public static void renderPositiveZFacing(SBRWorldContext ctx, ITexture[] aIcon, boolean aFullBlock) {
-        if (ctx.blockAccess != null) {
-            if (aFullBlock && !ctx.renderBlocks.renderAllFaces
-                && !ctx.block.shouldSideBeRendered(ctx.blockAccess, ctx.x, ctx.y, ctx.z + 1, 3)) {
+        if (ctx.getBlockAccess() != null) {
+            if (aFullBlock && !ctx.getRenderBlocks().renderAllFaces
+                && !ctx.getBlock()
+                    .shouldSideBeRendered(ctx.getBlockAccess(), ctx.getX(), ctx.getY(), ctx.getZ() + 1, 3)) {
                 return;
             }
 
             Tessellator.instance.setBrightness(
-                ctx.block.getMixedBrightnessForBlock(ctx.blockAccess, ctx.x, ctx.y, aFullBlock ? ctx.z + 1 : ctx.z));
+                ctx.getBlock()
+                    .getMixedBrightnessForBlock(
+                        ctx.getBlockAccess(),
+                        ctx.getX(),
+                        ctx.getY(),
+                        aFullBlock ? ctx.getZ() + 1 : ctx.getZ()));
         }
 
         if (aIcon != null) {
@@ -574,19 +598,25 @@ public class MachineBlockRenderer extends GTRendererBlock {
             }
         }
 
-        ctx.renderBlocks.flipTexture = false;
+        ctx.getRenderBlocks().flipTexture = false;
     }
 
     @SuppressWarnings("MethodWithTooManyParameters")
     public static void renderNegativeXFacing(SBRWorldContext ctx, ITexture[] aIcon, boolean aFullBlock) {
-        if (ctx.blockAccess != null) {
-            if (aFullBlock && !ctx.renderBlocks.renderAllFaces
-                && !ctx.block.shouldSideBeRendered(ctx.blockAccess, ctx.x - 1, ctx.y, ctx.z, 4)) {
+        if (ctx.getBlockAccess() != null) {
+            if (aFullBlock && !ctx.getRenderBlocks().renderAllFaces
+                && !ctx.getBlock()
+                    .shouldSideBeRendered(ctx.getBlockAccess(), ctx.getX() - 1, ctx.getY(), ctx.getZ(), 4)) {
                 return;
             }
 
             Tessellator.instance.setBrightness(
-                ctx.block.getMixedBrightnessForBlock(ctx.blockAccess, aFullBlock ? ctx.x - 1 : ctx.x, ctx.y, ctx.z));
+                ctx.getBlock()
+                    .getMixedBrightnessForBlock(
+                        ctx.getBlockAccess(),
+                        aFullBlock ? ctx.getX() - 1 : ctx.getX(),
+                        ctx.getY(),
+                        ctx.getZ()));
         }
 
         if (aIcon != null) {
@@ -597,36 +627,12 @@ public class MachineBlockRenderer extends GTRendererBlock {
             }
         }
 
-        ctx.renderBlocks.flipTexture = false;
-    }
-
-    @SuppressWarnings("MethodWithTooManyParameters")
-    public static void renderPositiveXFacing(SBRWorldContext ctx, ITexture[] aIcon, boolean aFullBlock) {
-        if (ctx.blockAccess != null) {
-            if (aFullBlock && !ctx.renderBlocks.renderAllFaces
-                && !ctx.block.shouldSideBeRendered(ctx.blockAccess, ctx.x + 1, ctx.y, ctx.z, 5)) {
-                return;
-            }
-
-            Tessellator.instance.setBrightness(
-                ctx.block.getMixedBrightnessForBlock(ctx.blockAccess, aFullBlock ? ctx.x + 1 : ctx.x, ctx.y, ctx.z));
-        }
-
-        ctx.renderBlocks.flipTexture = !aFullBlock;
-        if (aIcon != null) {
-            for (ITexture iTexture : aIcon) {
-                if (iTexture != null) {
-                    iTexture.renderXPos(ctx);
-                }
-            }
-        }
-
-        ctx.renderBlocks.flipTexture = false;
+        ctx.getRenderBlocks().flipTexture = false;
     }
 
     @Override
     public void renderInventoryBlock(Block aBlock, int aMeta, int aModelID, RenderBlocks aRenderer) {
-        final SBRInventoryContext ctx = contextHolder.getSBRInventoryContext(aBlock, aMeta, aModelID, aRenderer);
+        final SBRInventoryContext ctx = sbrContextHolder.getSBRInventoryContext(aBlock, aMeta, aModelID, aRenderer);
         aMeta += 30400;
         if (aBlock instanceof BlockMachines) {
             if (aMeta > 0 && aMeta < GregTechAPI.METATILEENTITIES.length
@@ -644,7 +650,7 @@ public class MachineBlockRenderer extends GTRendererBlock {
     public boolean renderWorldBlock(IBlockAccess aWorld, int aX, int aY, int aZ, Block aBlock, int aModelID,
         RenderBlocks aRenderer) {
         final TesselatorAccessor tessAccess = (TesselatorAccessor) Tessellator.instance;
-        final SBRWorldContext ctx = contextHolder.getSBRWorldContext(aX, aY, aZ, aBlock, aModelID, aRenderer);
+        final SBRWorldContext ctx = sbrContextHolder.getSBRWorldContext(aX, aY, aZ, aBlock, aModelID, aRenderer);
 
         TileEntity aTileEntity = aWorld.getTileEntity(aX, aY, aZ);
         return aTileEntity != null && (aTileEntity instanceof IGregTechTileEntity

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTEQuantumForceTransformer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTEQuantumForceTransformer.java
@@ -851,14 +851,14 @@ public class MTEQuantumForceTransformer extends MTEExtendedPowerMultiBlockBase<M
             //Corner 6: -2,  7     3 \             / 6
             //Corner 7:  3,  7        \           /
             //Corner 8:  7,  3         4 ------- 5
-            renderForceField(ctx.x + xBaseOffset + 0.5, ctx.y, ctx.z + zBaseOffset + 0.5, 0, minU, maxU, minV, maxV);
-            renderForceField(ctx.x + xBaseOffset + 0.5, ctx.y, ctx.z + zBaseOffset + 0.5, 1, minU, maxU, minV, maxV);
-            renderForceField(ctx.x + xBaseOffset + 0.5, ctx.y, ctx.z + zBaseOffset + 0.5, 2, minU, maxU, minV, maxV);
-            renderForceField(ctx.x + xBaseOffset + 0.5, ctx.y, ctx.z + zBaseOffset + 0.5, 3, minU, maxU, minV, maxV);
-            renderForceField(ctx.x + xBaseOffset + 0.5, ctx.y, ctx.z + zBaseOffset + 0.5, 4, minU, maxU, minV, maxV);
-            renderForceField(ctx.x + xBaseOffset + 0.5, ctx.y, ctx.z + zBaseOffset + 0.5, 5, minU, maxU, minV, maxV);
-            renderForceField(ctx.x + xBaseOffset + 0.5, ctx.y, ctx.z + zBaseOffset + 0.5, 6, minU, maxU, minV, maxV);
-            renderForceField(ctx.x + xBaseOffset + 0.5, ctx.y, ctx.z + zBaseOffset + 0.5, 7, minU, maxU, minV, maxV);
+            renderForceField(ctx.getX() + xBaseOffset + 0.5, ctx.getY(), ctx.getZ() + zBaseOffset + 0.5, 0, minU, maxU, minV, maxV);
+            renderForceField(ctx.getX() + xBaseOffset + 0.5, ctx.getY(), ctx.getZ() + zBaseOffset + 0.5, 1, minU, maxU, minV, maxV);
+            renderForceField(ctx.getX() + xBaseOffset + 0.5, ctx.getY(), ctx.getZ() + zBaseOffset + 0.5, 2, minU, maxU, minV, maxV);
+            renderForceField(ctx.getX() + xBaseOffset + 0.5, ctx.getY(), ctx.getZ() + zBaseOffset + 0.5, 3, minU, maxU, minV, maxV);
+            renderForceField(ctx.getX() + xBaseOffset + 0.5, ctx.getY(), ctx.getZ() + zBaseOffset + 0.5, 4, minU, maxU, minV, maxV);
+            renderForceField(ctx.getX() + xBaseOffset + 0.5, ctx.getY(), ctx.getZ() + zBaseOffset + 0.5, 5, minU, maxU, minV, maxV);
+            renderForceField(ctx.getX() + xBaseOffset + 0.5, ctx.getY(), ctx.getZ() + zBaseOffset + 0.5, 6, minU, maxU, minV, maxV);
+            renderForceField(ctx.getX() + xBaseOffset + 0.5, ctx.getY(), ctx.getZ() + zBaseOffset + 0.5, 7, minU, maxU, minV, maxV);
         }
         // Needs to be false to render the controller
         return false;

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTEQuantumForceTransformer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTEQuantumForceTransformer.java
@@ -25,7 +25,6 @@ import java.util.List;
 import javax.annotation.Nonnull;
 
 import net.minecraft.block.Block;
-import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
@@ -33,7 +32,6 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.IIcon;
 import net.minecraft.util.StatCollector;
-import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
@@ -67,6 +65,7 @@ import gregtech.api.recipe.RecipeMap;
 import gregtech.api.recipe.check.CheckRecipeResult;
 import gregtech.api.recipe.check.CheckRecipeResultRegistry;
 import gregtech.api.recipe.check.SimpleCheckRecipeResult;
+import gregtech.api.render.SBRContextBase;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GTRecipe;
 import gregtech.api.util.GTRecipeConstants;
@@ -831,7 +830,7 @@ public class MTEQuantumForceTransformer extends MTEExtendedPowerMultiBlockBase<M
 
     @SideOnly(Side.CLIENT)
     @Override
-    public boolean renderInWorld(IBlockAccess aWorld, int x, int y, int z, Block block, RenderBlocks renderer) {
+    public boolean render(SBRContextBase<? extends SBRContextBase<?>> ctx) {
         Tessellator tes = Tessellator.instance;
         IIcon forceField = TexturesGtBlock.ForceField.getIcon();
         if (getBaseMetaTileEntity().isActive()) {
@@ -852,14 +851,14 @@ public class MTEQuantumForceTransformer extends MTEExtendedPowerMultiBlockBase<M
             //Corner 6: -2,  7     3 \             / 6
             //Corner 7:  3,  7        \           /
             //Corner 8:  7,  3         4 ------- 5
-            renderForceField(x + xBaseOffset + 0.5, y, z + zBaseOffset + 0.5, 0, minU, maxU, minV, maxV);
-            renderForceField(x + xBaseOffset + 0.5, y, z + zBaseOffset + 0.5, 1, minU, maxU, minV, maxV);
-            renderForceField(x + xBaseOffset + 0.5, y, z + zBaseOffset + 0.5, 2, minU, maxU, minV, maxV);
-            renderForceField(x + xBaseOffset + 0.5, y, z + zBaseOffset + 0.5, 3, minU, maxU, minV, maxV);
-            renderForceField(x + xBaseOffset + 0.5, y, z + zBaseOffset + 0.5, 4, minU, maxU, minV, maxV);
-            renderForceField(x + xBaseOffset + 0.5, y, z + zBaseOffset + 0.5, 5, minU, maxU, minV, maxV);
-            renderForceField(x + xBaseOffset + 0.5, y, z + zBaseOffset + 0.5, 6, minU, maxU, minV, maxV);
-            renderForceField(x + xBaseOffset + 0.5, y, z + zBaseOffset + 0.5, 7, minU, maxU, minV, maxV);
+            renderForceField(ctx.x + xBaseOffset + 0.5, ctx.y, ctx.z + zBaseOffset + 0.5, 0, minU, maxU, minV, maxV);
+            renderForceField(ctx.x + xBaseOffset + 0.5, ctx.y, ctx.z + zBaseOffset + 0.5, 1, minU, maxU, minV, maxV);
+            renderForceField(ctx.x + xBaseOffset + 0.5, ctx.y, ctx.z + zBaseOffset + 0.5, 2, minU, maxU, minV, maxV);
+            renderForceField(ctx.x + xBaseOffset + 0.5, ctx.y, ctx.z + zBaseOffset + 0.5, 3, minU, maxU, minV, maxV);
+            renderForceField(ctx.x + xBaseOffset + 0.5, ctx.y, ctx.z + zBaseOffset + 0.5, 4, minU, maxU, minV, maxV);
+            renderForceField(ctx.x + xBaseOffset + 0.5, ctx.y, ctx.z + zBaseOffset + 0.5, 5, minU, maxU, minV, maxV);
+            renderForceField(ctx.x + xBaseOffset + 0.5, ctx.y, ctx.z + zBaseOffset + 0.5, 6, minU, maxU, minV, maxV);
+            renderForceField(ctx.x + xBaseOffset + 0.5, ctx.y, ctx.z + zBaseOffset + 0.5, 7, minU, maxU, minV, maxV);
         }
         // Needs to be false to render the controller
         return false;

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTEQuantumForceTransformer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTEQuantumForceTransformer.java
@@ -830,7 +830,7 @@ public class MTEQuantumForceTransformer extends MTEExtendedPowerMultiBlockBase<M
 
     @SideOnly(Side.CLIENT)
     @Override
-    public boolean render(SBRContextBase<? extends SBRContextBase<?>> ctx) {
+    public boolean render(SBRContextBase ctx) {
         Tessellator tes = Tessellator.instance;
         IIcon forceField = TexturesGtBlock.ForceField.getIcon();
         if (getBaseMetaTileEntity().isActive()) {


### PR DESCRIPTION
- Improves: Inventory and World contexts are now provided by the `SBRContextHolder`.
  They are lazily instantiated once and configured each time they need to be used.

- Fixes: A lighting bug in non-smooth lighting mode (no AO) introduced in a previous PR has been fixed.
  The bug was caused by a refactor of responsibilities:
  - When lighting configuration responsibility was removed from the caller, it was inadvertently omitted from the context's lighting setup.