### PR TITLE
add recipe to allow titanium dust back into the titaniumline

### DIFF
--- a/src/main/java/gregtech/loaders/postload/recipes/ChemicalRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/ChemicalRecipes.java
@@ -719,6 +719,14 @@ public class ChemicalRecipes implements Runnable {
             .eut(TierEU.RECIPE_HV)
             .addTo(multiblockChemicalReactorRecipes);
 
+        GTValues.RA.stdBuilder()
+            .itemInputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.Titanium, 1))
+            .fluidInputs(Materials.Chlorine.getGas(4_000))
+            .fluidOutputs(Materials.Titaniumtetrachloride.getFluid(1_000))
+            .duration(10 * SECONDS)
+            .eut(TierEU.RECIPE_HV)
+            .addTo(UniversalChemical);
+
         // 4Na + 2MgCl2 = 2Mg + 4NaCl
 
         GTValues.RA.stdBuilder()


### PR DESCRIPTION
<img width="720" height="353" alt="image" src="https://github.com/user-attachments/assets/30a12a84-0937-4ba3-9cb6-3c3c9022fd3d" />
will allow players to recycle titanium dust for cheaper smelting at the cost of running the line