### PR TITLE
Make ISBRH render ID static final and make registration explicit

### DIFF
--- a/src/main/java/bartworks/client/renderer/BWBlockOreRenderer.java
+++ b/src/main/java/bartworks/client/renderer/BWBlockOreRenderer.java
@@ -36,16 +36,9 @@ import gregtech.mixin.interfaces.accessors.TesselatorAccessor;
 @ThreadSafeISBRH(perThread = true)
 public class BWBlockOreRenderer implements ISimpleBlockRenderingHandler {
 
-    public static BWBlockOreRenderer INSTANCE;
-    public static int renderID;
+    public static final int renderID = RenderingRegistry.getNextAvailableRenderId();
     public static final float blockMin = 0.0F;
     public static final float blockMax = 1.0F;
-
-    public static void register() {
-        renderID = RenderingRegistry.getNextAvailableRenderId();
-        INSTANCE = new BWBlockOreRenderer();
-        RenderingRegistry.registerBlockHandler(INSTANCE);
-    }
 
     @Override
     public void renderInventoryBlock(Block aBlock, int aMeta, int modelId, RenderBlocks aRenderer) {

--- a/src/main/java/bartworks/client/renderer/RendererGlassBlock.java
+++ b/src/main/java/bartworks/client/renderer/RendererGlassBlock.java
@@ -34,14 +34,8 @@ import cpw.mods.fml.relauncher.SideOnly;
 @ThreadSafeISBRH(perThread = false)
 public class RendererGlassBlock implements ISimpleBlockRenderingHandler {
 
-    public static int renderID;
+    public static final int renderID = RenderingRegistry.getNextAvailableRenderId();
     public static RendererGlassBlock INSTANCE;
-
-    public static void register() {
-        renderID = RenderingRegistry.getNextAvailableRenderId();
-        INSTANCE = new RendererGlassBlock();
-        RenderingRegistry.registerBlockHandler(INSTANCE);
-    }
 
     @Override
     public void renderInventoryBlock(Block block, int metadata, int modelId, RenderBlocks renderer) {

--- a/src/main/java/bartworks/common/loaders/FluidLoader.java
+++ b/src/main/java/bartworks/common/loaders/FluidLoader.java
@@ -48,7 +48,7 @@ public class FluidLoader {
 
     public static IIcon autogenIIcon;
     public static Fluid ff;
-    public static int renderID;
+    public static final int renderID = RenderingRegistry.getNextAvailableRenderId();
     public static Block bioFluidBlock;
     public static Fluid[] BioLabFluidMaterials;
     public static ItemStack[] BioLabFluidCells;
@@ -57,7 +57,6 @@ public class FluidLoader {
     public static Fluid fulvicAcid, heatedfulvicAcid, Kerogen;
 
     public static void run(FMLInitializationEvent event) {
-        renderID = RenderingRegistry.getNextAvailableRenderId();
         ff = new Fluid("BWfakeFluid");
         GregTechAPI.sGTBlockIconload.add(
             () -> ff.setIcons(
@@ -117,7 +116,7 @@ public class FluidLoader {
         if (event.getSide()
             .isClient()) {
             RendererSwitchingColorFluid.register();
-            RendererGlassBlock.register();
+            RenderingRegistry.registerBlockHandler(new RendererGlassBlock());
         }
     }
 

--- a/src/main/java/bartworks/system/material/BWMetaGeneratedBlocks.java
+++ b/src/main/java/bartworks/system/material/BWMetaGeneratedBlocks.java
@@ -95,7 +95,6 @@ public abstract class BWMetaGeneratedBlocks extends BWTileEntityContainer {
 
     @Override
     public int getRenderType() {
-        if (BWBlockOreRenderer.INSTANCE == null) return super.getRenderType();
         return BWBlockOreRenderer.renderID;
     }
 

--- a/src/main/java/bartworks/system/material/WerkstoffLoader.java
+++ b/src/main/java/bartworks/system/material/WerkstoffLoader.java
@@ -119,6 +119,7 @@ import bartworks.util.EnumUtils;
 import bartworks.util.log.DebugLog;
 import bwcrossmod.cls.CLSCompat;
 import codechicken.nei.api.API;
+import cpw.mods.fml.client.registry.RenderingRegistry;
 import cpw.mods.fml.common.ProgressManager;
 import cpw.mods.fml.common.registry.GameRegistry;
 import gregtech.api.enums.Element;
@@ -2003,7 +2004,7 @@ public class WerkstoffLoader {
 
     static void gameRegistryHandler() {
         if (SideReference.Side.Client) {
-            BWBlockOreRenderer.register();
+            RenderingRegistry.registerBlockHandler(new BWBlockOreRenderer());
         }
 
         GameRegistry.registerTileEntity(BWTileEntityMetaGeneratedOre.class, "bw.blockoresTE");

--- a/src/main/java/gregtech/common/GTClient.java
+++ b/src/main/java/gregtech/common/GTClient.java
@@ -43,6 +43,7 @@ import com.glodblock.github.nei.recipes.extractor.GregTech5RecipeExtractor;
 
 import cpw.mods.fml.client.event.ConfigChangedEvent;
 import cpw.mods.fml.client.registry.ClientRegistry;
+import cpw.mods.fml.client.registry.RenderingRegistry;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLLoadCompleteEvent;
@@ -277,8 +278,8 @@ public class GTClient extends GTProxy {
     public void onInitialization(FMLInitializationEvent event) {
         // spotless:off
         super.onInitialization(event);
-        GTRendererBlock.register();
-        GTRendererCasing.register();
+        RenderingRegistry.registerBlockHandler(new GTRendererBlock());
+        RenderingRegistry.registerBlockHandler(new GTRendererCasing());
 
         ClientRegistry.bindTileEntitySpecialRenderer(TileEntityDrone.class, new DroneRender());
         ClientRegistry.bindTileEntitySpecialRenderer(TileEntityLaser.class, new LaserRenderer());

--- a/src/main/java/gregtech/common/blocks/BlockFrameBox.java
+++ b/src/main/java/gregtech/common/blocks/BlockFrameBox.java
@@ -151,9 +151,6 @@ public class BlockFrameBox extends BlockContainer {
 
     @Override
     public int getRenderType() {
-        if (GTRendererBlock.INSTANCE == null) {
-            return super.getRenderType();
-        }
         return GTRendererBlock.mRenderID;
     }
 

--- a/src/main/java/gregtech/common/blocks/BlockMachines.java
+++ b/src/main/java/gregtech/common/blocks/BlockMachines.java
@@ -146,9 +146,6 @@ public class BlockMachines extends GTGenericBlock implements IDebugableBlock, IT
 
     @Override
     public int getRenderType() {
-        if (GTRendererBlock.INSTANCE == null) {
-            return super.getRenderType();
-        }
         return GTRendererBlock.mRenderID;
     }
 

--- a/src/main/java/gregtech/common/blocks/BlockOresAbstract.java
+++ b/src/main/java/gregtech/common/blocks/BlockOresAbstract.java
@@ -208,9 +208,6 @@ public abstract class BlockOresAbstract extends GTGenericBlock implements ITileE
 
     @Override
     public int getRenderType() {
-        if (GTRendererBlock.INSTANCE == null) {
-            return super.getRenderType();
-        }
         return GTRendererBlock.mRenderID;
     }
 

--- a/src/main/java/gregtech/common/render/GTRendererBlock.java
+++ b/src/main/java/gregtech/common/render/GTRendererBlock.java
@@ -63,22 +63,12 @@ import gregtech.mixin.interfaces.accessors.TesselatorAccessor;
 @ThreadSafeISBRH(perThread = true)
 public class GTRendererBlock implements ISimpleBlockRenderingHandler {
 
+    public static final int mRenderID = RenderingRegistry.getNextAvailableRenderId();
     public static final float blockMin = 0.0F;
     public static final float blockMax = 1.0F;
     private static final float coverThickness = blockMax / 8.0F;
     private static final float coverInnerMin = blockMin + coverThickness;
     private static final float coverInnerMax = blockMax - coverThickness;
-
-    @Deprecated
-    public static GTRendererBlock INSTANCE;
-    public static int mRenderID;
-
-    public static void register() {
-        mRenderID = RenderingRegistry.getNextAvailableRenderId();
-        INSTANCE = new GTRendererBlock();
-        RenderingRegistry.registerBlockHandler(INSTANCE);
-    }
-
     private final ITexture[][] textureArray = new ITexture[6][];
     private final ITexture[] overlayHolder = new ITexture[1];
 

--- a/src/main/java/gregtech/common/render/GTRendererCasing.java
+++ b/src/main/java/gregtech/common/render/GTRendererCasing.java
@@ -31,14 +31,7 @@ import gregtech.mixin.interfaces.accessors.TesselatorAccessor;
 @ThreadSafeISBRH(perThread = true)
 public class GTRendererCasing implements ISimpleBlockRenderingHandler {
 
-    private static final GTRendererCasing INSTANCE = new GTRendererCasing();
-    public static int mRenderID;
-
-    public static void register() {
-        mRenderID = RenderingRegistry.getNextAvailableRenderId();
-        RenderingRegistry.registerBlockHandler(INSTANCE);
-    }
-
+    public static final int mRenderID = RenderingRegistry.getNextAvailableRenderId();
     private final ITexture[][] textureArray = new ITexture[6][2];
 
     @Override

--- a/src/main/java/gtPlusPlus/core/block/base/BlockBaseOre.java
+++ b/src/main/java/gtPlusPlus/core/block/base/BlockBaseOre.java
@@ -69,14 +69,7 @@ public class BlockBaseOre extends BasicBlock implements ITexturedBlock {
 
     @Override
     public int getRenderType() {
-        try {
-            if (CustomOreBlockRenderer.INSTANCE != null) {
-                return CustomOreBlockRenderer.INSTANCE.mRenderID;
-            }
-            return super.getRenderType();
-        } catch (NullPointerException n) {
-            return 0;
-        }
+        return CustomOreBlockRenderer.mRenderID;
     }
 
     /**

--- a/src/main/java/gtPlusPlus/core/client/renderer/CustomOreBlockRenderer.java
+++ b/src/main/java/gtPlusPlus/core/client/renderer/CustomOreBlockRenderer.java
@@ -18,20 +18,11 @@ import gregtech.api.render.SBRInventoryContext;
 import gregtech.api.render.SBRWorldContext;
 import gregtech.mixin.interfaces.accessors.TesselatorAccessor;
 import gtPlusPlus.api.interfaces.ITexturedBlock;
-import gtPlusPlus.api.objects.Logger;
 
 @ThreadSafeISBRH(perThread = true)
 public class CustomOreBlockRenderer implements ISimpleBlockRenderingHandler {
 
-    public static CustomOreBlockRenderer INSTANCE;
-    public final int mRenderID;
-
-    public CustomOreBlockRenderer() {
-        INSTANCE = this;
-        this.mRenderID = RenderingRegistry.getNextAvailableRenderId();
-        RenderingRegistry.registerBlockHandler(this);
-        Logger.INFO("Registered Custom Ore Block Renderer.");
-    }
+    public static final int mRenderID = RenderingRegistry.getNextAvailableRenderId();
 
     @Override
     public void renderInventoryBlock(Block aBlock, int aMeta, int aModelID, RenderBlocks aRenderer) {
@@ -93,6 +84,6 @@ public class CustomOreBlockRenderer implements ISimpleBlockRenderingHandler {
 
     @Override
     public int getRenderId() {
-        return this.mRenderID;
+        return mRenderID;
     }
 }

--- a/src/main/java/gtPlusPlus/core/proxy/ClientProxy.java
+++ b/src/main/java/gtPlusPlus/core/proxy/ClientProxy.java
@@ -25,7 +25,6 @@ import gregtech.common.handlers.PowerGogglesHudHandler;
 import gregtech.common.handlers.PowerGogglesKeybindHandler;
 import gregtech.common.items.gui.PowerGogglesGuiOverlay;
 import gtPlusPlus.GTplusplus;
-import gtPlusPlus.api.objects.Logger;
 import gtPlusPlus.core.client.renderer.CustomItemBlockRenderer;
 import gtPlusPlus.core.client.renderer.CustomOreBlockRenderer;
 import gtPlusPlus.core.client.renderer.RenderDecayChest;
@@ -57,9 +56,9 @@ public class ClientProxy extends CommonProxy {
 
     @Override
     public void init(final FMLInitializationEvent e) {
-        new CustomOreBlockRenderer();
+        RenderingRegistry.registerBlockHandler(new CustomOreBlockRenderer());
         new CustomItemBlockRenderer();
-        new MachineBlockRenderer();
+        RenderingRegistry.registerBlockHandler(new MachineBlockRenderer());
         new FlaskRenderer();
         MinecraftForge.EVENT_BUS.register(new PowerGogglesHudHandler());
         PowerGogglesKeybindHandler.init();
@@ -81,8 +80,6 @@ public class ClientProxy extends CommonProxy {
             .registerEntityRenderingHandler(EntityStaballoyConstruct.class, new RenderStaballoyConstruct());
         RenderingRegistry.registerEntityRenderingHandler(EntityToxinballSmall.class, new RenderToxinball(1F));
         RenderingRegistry.registerEntityRenderingHandler(EntityLightningAttack.class, new RenderFireball(1F));
-        // Tiles
-        Logger.INFO("Registering Custom Renderer for the Lead Lined Chest.");
         ClientRegistry.bindTileEntitySpecialRenderer(TileEntityDecayablesChest.class, new RenderDecayChest());
     }
 

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/render/MachineBlockRenderer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/render/MachineBlockRenderer.java
@@ -43,13 +43,7 @@ import gtPlusPlus.xmod.gregtech.common.helpers.GTMethodHelper;
 
 public class MachineBlockRenderer extends GTRendererBlock {
 
-    public static MachineBlockRenderer INSTANCE;
-    public final int mRenderID = RenderingRegistry.getNextAvailableRenderId();
-
-    public MachineBlockRenderer() {
-        INSTANCE = this;
-        RenderingRegistry.registerBlockHandler(this);
-    }
+    private static final int mRenderID = RenderingRegistry.getNextAvailableRenderId();
 
     private static ITexture[] getTexture(IMetaTileEntity tile, ForgeDirection side, ForgeDirection facing,
         int colorIndex, boolean active, boolean arg5) {
@@ -657,6 +651,6 @@ public class MachineBlockRenderer extends GTRendererBlock {
 
     @Override
     public int getRenderId() {
-        return this.mRenderID;
+        return mRenderID;
     }
 }

--- a/src/main/java/gtnhintergalactic/block/BlockSpaceElevatorCable.java
+++ b/src/main/java/gtnhintergalactic/block/BlockSpaceElevatorCable.java
@@ -10,6 +10,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.World;
 
+import cpw.mods.fml.client.registry.RenderingRegistry;
 import cpw.mods.fml.common.registry.GameRegistry;
 import gregtech.api.enums.ItemList;
 import gtnhintergalactic.GTNHIntergalactic;
@@ -28,7 +29,7 @@ public class BlockSpaceElevatorCable extends Block implements ITileEntityProvide
     /** Texture for the motor glow */
     public static IIcon motorGlow;
     /** Render ID of this block type */
-    private static int renderID;
+    public static final int renderID = RenderingRegistry.getNextAvailableRenderId();
     /** Number of steps which the cable light has */
     public static final int LIGHT_STEPS = 80;
 
@@ -73,22 +74,6 @@ public class BlockSpaceElevatorCable extends Block implements ITileEntityProvide
     @Override
     public IIcon getIcon(int side, int meta) {
         return textures[0];
-    }
-
-    /**
-     * Set the render ID of this block type
-     *
-     * @param id New ID
-     */
-    public static void setRenderID(int id) {
-        renderID = id;
-    }
-
-    /**
-     * @return render ID of this block type
-     */
-    public static int getRenderID() {
-        return renderID;
     }
 
     /**

--- a/src/main/java/gtnhintergalactic/proxy/ClientProxy.java
+++ b/src/main/java/gtnhintergalactic/proxy/ClientProxy.java
@@ -7,7 +7,6 @@ import cpw.mods.fml.client.registry.RenderingRegistry;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import gregtech.api.enums.Mods;
-import gtnhintergalactic.block.BlockSpaceElevatorCable;
 import gtnhintergalactic.client.IGTextures;
 import gtnhintergalactic.client.TooltipUtil;
 import gtnhintergalactic.nei.NEI_IG_Config;
@@ -31,9 +30,7 @@ public class ClientProxy extends CommonProxy {
     public void init(FMLInitializationEvent event) {
         super.init(event);
         if (Mods.GalacticraftCore.isModLoaded()) {
-            BlockSpaceElevatorCable.setRenderID(RenderingRegistry.getNextAvailableRenderId());
-            RenderingRegistry
-                .registerBlockHandler(BlockSpaceElevatorCable.getRenderID(), new RenderSpaceElevatorCable());
+            RenderingRegistry.registerBlockHandler(new RenderSpaceElevatorCable());
             ClientRegistry
                 .bindTileEntitySpecialRenderer(TileEntitySpaceElevatorCable.class, new RenderSpaceElevatorCable());
         }

--- a/src/main/java/gtnhintergalactic/render/RenderSpaceElevatorCable.java
+++ b/src/main/java/gtnhintergalactic/render/RenderSpaceElevatorCable.java
@@ -375,6 +375,6 @@ public class RenderSpaceElevatorCable extends TileEntitySpecialRenderer implemen
      */
     @Override
     public int getRenderId() {
-        return BlockSpaceElevatorCable.getRenderID();
+        return BlockSpaceElevatorCable.renderID;
     }
 }

--- a/src/main/java/tectech/proxy/ClientProxy.java
+++ b/src/main/java/tectech/proxy/ClientProxy.java
@@ -23,8 +23,6 @@ import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import tectech.Reference;
 import tectech.rendering.EOH.EOHItemRenderer;
 import tectech.rendering.EOH.EOHTileEntitySR;
-import tectech.thing.block.BlockGodforgeGlass;
-import tectech.thing.block.BlockQuantumGlass;
 import tectech.thing.block.RenderForgeOfGods;
 import tectech.thing.block.RenderGodforgeGlass;
 import tectech.thing.block.RenderQuantumGlass;
@@ -36,15 +34,13 @@ public class ClientProxy extends CommonProxy {
 
     @Override
     public void registerRenderInfo() {
-        BlockQuantumGlass.renderID = RenderingRegistry.getNextAvailableRenderId();
-        RenderingRegistry.registerBlockHandler(BlockQuantumGlass.renderID, new RenderQuantumGlass());
+        RenderingRegistry.registerBlockHandler(new RenderQuantumGlass());
 
         MinecraftForgeClient
             .registerItemRenderer(Item.getItemFromBlock(eyeOfHarmonyRenderBlock), new EOHItemRenderer());
         ClientRegistry.bindTileEntitySpecialRenderer(TileEntityEyeOfHarmony.class, new EOHTileEntitySR());
 
-        BlockGodforgeGlass.renderID = RenderingRegistry.getNextAvailableRenderId();
-        RenderingRegistry.registerBlockHandler(BlockGodforgeGlass.renderID, new RenderGodforgeGlass());
+        RenderingRegistry.registerBlockHandler(new RenderGodforgeGlass());
 
         MinecraftForgeClient
             .registerItemRenderer(Item.getItemFromBlock(forgeOfGodsRenderBlock), new ItemRenderForgeOfGods());

--- a/src/main/java/tectech/thing/block/BlockGodforgeGlass.java
+++ b/src/main/java/tectech/thing/block/BlockGodforgeGlass.java
@@ -7,6 +7,7 @@ import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
+import cpw.mods.fml.client.registry.RenderingRegistry;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
@@ -18,7 +19,7 @@ import tectech.TecTech;
 public class BlockGodforgeGlass extends BlockBase {
 
     public static IIcon Icon;
-    public static int renderID;
+    public static final int renderID = RenderingRegistry.getNextAvailableRenderId();
     public static BlockGodforgeGlass INSTANCE;
 
     public BlockGodforgeGlass() {

--- a/src/main/java/tectech/thing/block/BlockQuantumGlass.java
+++ b/src/main/java/tectech/thing/block/BlockQuantumGlass.java
@@ -7,6 +7,7 @@ import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
+import cpw.mods.fml.client.registry.RenderingRegistry;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
@@ -21,7 +22,7 @@ import tectech.TecTech;
 public final class BlockQuantumGlass extends BlockBase {
 
     public static IIcon stuff;
-    public static int renderID;
+    public static final int renderID = RenderingRegistry.getNextAvailableRenderId();
     public static BlockQuantumGlass INSTANCE;
 
     public BlockQuantumGlass() {


### PR DESCRIPTION
Object constructors should be only setting up fields.
They should not be assigning static fields.
They should not be registering `this` to something.
`new Objects` shouldn't be dangling in the code without anything using them because it turns out the constructor is actually running code that is doing doing somthing other than just constructing the object.

This PR removes the above and replaces it with explicit registration in the form `Something.register(new SomeISBRH()` for ISimpleBlockRenderingHandler.
It also makes the render static final to clearly indicate that it should never change.