### PR TITLE
Fix dedicated server crash due to trying to load SBRContextBase

### DIFF
--- a/src/main/java/gregtech/common/blocks/BlockCasings5.java
+++ b/src/main/java/gregtech/common/blocks/BlockCasings5.java
@@ -27,6 +27,8 @@ import net.minecraft.world.World;
 
 import org.jetbrains.annotations.Nullable;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import gregtech.api.enums.HeatingCoilLevel;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Textures;
@@ -176,6 +178,7 @@ public class BlockCasings5 extends BlockCasingsAbstract
     }
 
     @Override
+    @SideOnly(Side.CLIENT)
     public int getRenderType() {
         return GTRendererBlock.mRenderID;
     }

--- a/src/main/java/gregtech/common/blocks/BlockFrameBox.java
+++ b/src/main/java/gregtech/common/blocks/BlockFrameBox.java
@@ -150,6 +150,7 @@ public class BlockFrameBox extends BlockContainer {
     }
 
     @Override
+    @SideOnly(Side.CLIENT)
     public int getRenderType() {
         return GTRendererBlock.mRenderID;
     }

--- a/src/main/java/gregtech/common/blocks/BlockMachines.java
+++ b/src/main/java/gregtech/common/blocks/BlockMachines.java
@@ -145,6 +145,7 @@ public class BlockMachines extends GTGenericBlock implements IDebugableBlock, IT
     }
 
     @Override
+    @SideOnly(Side.CLIENT)
     public int getRenderType() {
         return GTRendererBlock.mRenderID;
     }

--- a/src/main/java/gregtech/common/blocks/BlockOresAbstract.java
+++ b/src/main/java/gregtech/common/blocks/BlockOresAbstract.java
@@ -207,6 +207,7 @@ public abstract class BlockOresAbstract extends GTGenericBlock implements ITileE
     }
 
     @Override
+    @SideOnly(Side.CLIENT)
     public int getRenderType() {
         return GTRendererBlock.mRenderID;
     }


### PR DESCRIPTION
Current master branch works fine on client but crashes on dedicated servers due to attempting to load a client side class.

```
Caused by: java.lang.RuntimeException: Attempted to load class gregtech/api/render/SBRContextBase for invalid side SERVER
```

I am still getting familiar with MC modding in general but marking marking 4 instances of `getRenderType()` as client only stops the server from crashing and I have tested this by joining a server with a client that was also running the fixed JAR that runs my IV tier world.

For some reason the error only occurs on real servers and not the server that is started by the Gradle runServer task but I'm not sure what the difference between the two environments is.