### PR TITLE
Lower minimum casings on IndustrialMixer

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/MTEIndustrialMixer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/MTEIndustrialMixer.java
@@ -90,7 +90,7 @@ public class MTEIndustrialMixer extends GTPPMultiBlockBase<MTEIndustrialMixer> i
             .addPollutionAmount(getPollutionPerSecond(null))
             .beginStructureBlock(3, 4, 3, false)
             .addController("Second Layer Center")
-            .addCasingInfoMin(mCasingName, 6, false)
+            .addCasingInfoMin(mCasingName, 5, false)
             .addCasingInfoMin(mCasingName2, 2, false)
             .addInputBus("Any Casing", 1)
             .addOutputBus("Any Casing", 1)


### PR DESCRIPTION
Allows player to automate all recipes on one machine instead of needing a second machine for one circuit :p