### PR TITLE
remove forceful garnierite ore and banded iron ore conversion to roasted variant

### DIFF
--- a/src/main/java/gregtech/api/enums/Materials.java
+++ b/src/main/java/gregtech/api/enums/Materials.java
@@ -1491,8 +1491,6 @@ public class Materials implements IColorModulationContainer, ISubTagContainer {
 
     private static void setOthers() {
         Mercury.add(SubTag.SMELTING_TO_GEM);
-        BandedIron.setOreReplacement(RoastedIron);
-        Garnierite.setOreReplacement(RoastedNickel);
     }
 
     private static void setDirectSmelting() {


### PR DESCRIPTION
<img width="488" height="372" alt="image" src="https://github.com/user-attachments/assets/32b19f5c-183a-4e19-ad8e-888f82eec006" />
<img width="562" height="338" alt="image" src="https://github.com/user-attachments/assets/e27d798a-ab5e-4d17-a7bc-da30db908c49" />
<img width="473" height="338" alt="image" src="https://github.com/user-attachments/assets/a465d1da-45f0-4466-b085-d5dba7a20911" />
<img width="591" height="356" alt="image" src="https://github.com/user-attachments/assets/8d246724-ef79-49d5-8467-23d986565882" />

1) it was wrong advertising on the ore (couldn't get oxygen)
2) roasted straight from the ore doesn't make sense (when was it roasted?)

The rest of the "roasted" variants stay as is because they are properly made in an EBF