### PR TITLE
Remove extra % symbol at end of rotor text in needs maintenance cover GUI English localisation

### DIFF
--- a/src/main/resources/assets/gregtech/lang/en_US.lang
+++ b/src/main/resources/assets/gregtech/lang/en_US.lang
@@ -245,8 +245,8 @@ gt.interact.desc.need_maint_rotor_lo=Emit if rotor needs maintenance low accurac
 gt.interact.desc.need_maint_rotor_hi=Emit if rotor needs maintenance high accuracy mod
 gt.interact.desc.issue=1 Issue
 gt.interact.desc.issues=%s Issues
-gt.interact.desc.issue_rotor_low=Rotor < 20%%
-gt.interact.desc.issue_rotor_dead=Rotor ≈ 0%%
+gt.interact.desc.issue_rotor_low=Rotor < 20%
+gt.interact.desc.issue_rotor_dead=Rotor ≈ 0%
 
 # GT++ items
 item.GTPP.air_intake_hatch.name=Air Intake Hatch


### PR DESCRIPTION
Just randomly spotted this when putting down a load of needs maintenance covers but can't unsee it now :).

Only the English localisation had the extra % sign at the end of the turbine rotor lines.