### PR TITLE
Fix power goggle ticking in multiplayer

### DIFF
--- a/src/main/java/gregtech/common/handlers/PowerGogglesEventHandler.java
+++ b/src/main/java/gregtech/common/handlers/PowerGogglesEventHandler.java
@@ -64,8 +64,9 @@ public class PowerGogglesEventHandler {
         EntityPlayerMP player = (EntityPlayerMP) event.player;
         UUID uuid = player.getUniqueID();
 
-        int playerTicks = forceUpdate ? 1 : tickMap.getOrDefault(uuid, 0) + 1;
-        tickMap.put(uuid, playerTicks % PowerGogglesHudHandler.ticksBetweenMeasurements);
+        int playerTicks = forceUpdate ? 1
+            : (tickMap.getOrDefault(uuid, 0) + 1) % PowerGogglesHudHandler.ticksBetweenMeasurements;
+        tickMap.put(uuid, playerTicks);
 
         if (playerTicks != 1) return;
         if (isValidLink(player, lscLinkMap.get(uuid))) {


### PR DESCRIPTION
`PowerGogglesEventHandler#doServerStuff` is called once per tick per player, and it makes the goggles not work properly in a multiplayer setting due to the `ticks` field being incremented multiple times in a single tick. Now ticks are stored per UUID 