### PR TITLE
Fix crash when there is a duplicate mod

### DIFF
--- a/src/mixin/java/gregtech/mixin/mixins/early/minecraft/MinecraftMixin_MouseOver.java
+++ b/src/mixin/java/gregtech/mixin/mixins/early/minecraft/MinecraftMixin_MouseOver.java
@@ -19,7 +19,7 @@ public class MinecraftMixin_MouseOver {
             shift = At.Shift.BEFORE,
             target = "Lnet/minecraft/client/renderer/EntityRenderer;getMouseOver(F)V"))
     private void gt5u$before$getMouseOver(CallbackInfo ci) {
-        GTMod.clientProxy()
+        if (GTMod.proxy != null) GTMod.clientProxy()
             .setComputingPickBlock(true);
     }
 
@@ -30,7 +30,7 @@ public class MinecraftMixin_MouseOver {
             shift = At.Shift.AFTER,
             target = "Lnet/minecraft/client/renderer/EntityRenderer;getMouseOver(F)V"))
     private void gt5u$after$getMouseOver(CallbackInfo ci) {
-        GTMod.clientProxy()
+        if (GTMod.proxy != null) GTMod.clientProxy()
             .setComputingPickBlock(false);
     }
 }


### PR DESCRIPTION
A GT5u mixin accesses GTMod.proxy, normally GTMod.proxy is set when it's called.
But when there's a duplicate mod found, forge will not load mods and show a window of the duplicate mod.
In this case GTMod.proxy is not set and the game crashes, and get those in log:
```

[02:13:44] [Client thread/ERROR] [FML]: Found a duplicate mod Baubles at [C:\Users\User\.gradle\caches\modules-2\files-2.1\com.github.GTNewHorizons\Baubles-Expanded\2.1.9-GTNH\1ae24e29c590c49821bd6cc14ab5a4a762c9b834\Baubles-Expanded-2.1.9-GTNH-dev.jar, C:\Users\User\.gradle\caches\modules-2\files-2.1\com.github.GTNewHorizons\Baubles\1.0.4\9a5c7248669fb1468bc19aebfcb91a7a77f485e\Baubles-1.0.4-dev.jar]

......


[02:13:46] [Client thread/FATAL]: Unreported exception thrown!
java.lang.NullPointerException
        at gregtech.GTMod.clientProxy(GTMod.java:238) ~[GTMod.class:?]
        at net.minecraft.client.Minecraft.handler$zea000$gregtech$gt5u$before$getMouseOver(Minecraft.java:4596) ~[Minecraft.class:?]
        at net.minecraft.client.Minecraft.runTick(Minecraft.java:1688) ~[Minecraft.class:?]
        at net.minecraft.client.Minecraft.runGameLoop(Minecraft.java:1039) ~[Minecraft.class:?]
        at net.minecraft.client.Minecraft.run(Minecraft.java:962) [Minecraft.class:?]
        at net.minecraft.client.main.Main.main(Main.java:164) [Main.class:?]
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_392]
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_392]
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_392]
        at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_392]
        at net.minecraft.launchwrapper.Launch.launch(Launch.java:135) [launchwrapper-1.12.jar:?]
        at net.minecraft.launchwrapper.Launch.main(Launch.java:28) [launchwrapper-1.12.jar:?]
        at net.minecraftforge.gradle.GradleStartCommon.launch(GradleStartCommon.java:97) [mclauncher-1.7.10.jar:?]
        at GradleStart.main(GradleStart.java:40) [mclauncher-1.7.10.jar:?]
```

This PR adds check to fix it.