### PR TITLE
Add mte-centered rendering

### DIFF
--- a/src/main/java/gregtech/common/GTClient.java
+++ b/src/main/java/gregtech/common/GTClient.java
@@ -69,6 +69,7 @@ import gregtech.api.interfaces.IBlockOnWalkOver;
 import gregtech.api.interfaces.IToolStats;
 import gregtech.api.items.MetaGeneratedItem;
 import gregtech.api.items.MetaGeneratedTool;
+import gregtech.api.metatileentity.BaseMetaTileEntity;
 import gregtech.api.metatileentity.MetaPipeEntity;
 import gregtech.api.net.GTPacketClientPreference;
 import gregtech.api.recipe.RecipeCategory;
@@ -89,6 +90,7 @@ import gregtech.common.config.Client;
 import gregtech.common.entity.EntityPowderBarrelPrimed;
 import gregtech.common.pollution.Pollution;
 import gregtech.common.pollution.PollutionRenderer;
+import gregtech.common.render.BaseMetaTileEntityRenderer;
 import gregtech.common.render.BlackholeRenderer;
 import gregtech.common.render.DroneRender;
 import gregtech.common.render.FlaskRenderer;
@@ -288,7 +290,8 @@ public class GTClient extends GTProxy {
         ClientRegistry.bindTileEntitySpecialRenderer(TileEntityLaser.class, new LaserRenderer());
         ClientRegistry.bindTileEntitySpecialRenderer(TileEntityWormhole.class, new WormholeRenderer());
         ClientRegistry.bindTileEntitySpecialRenderer(TileEntityBlackhole.class, new BlackholeRenderer());
-        ClientRegistry.bindTileEntitySpecialRenderer(TileEntityNanoForgeRenderer.class,  new NanoForgeRenderer());
+        ClientRegistry.bindTileEntitySpecialRenderer(TileEntityNanoForgeRenderer.class, new NanoForgeRenderer());
+        ClientRegistry.bindTileEntitySpecialRenderer(BaseMetaTileEntity.class, new BaseMetaTileEntityRenderer());
 
         MetaGeneratedItemRenderer metaItemRenderer = new MetaGeneratedItemRenderer();
         for (MetaGeneratedItem item : MetaGeneratedItem.sInstances.values()) {

--- a/src/main/java/gregtech/common/render/BaseMetaTileEntityRenderer.java
+++ b/src/main/java/gregtech/common/render/BaseMetaTileEntityRenderer.java
@@ -1,0 +1,17 @@
+package gregtech.common.render;
+
+import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
+import net.minecraft.tileentity.TileEntity;
+
+import gregtech.api.metatileentity.BaseMetaTileEntity;
+
+public class BaseMetaTileEntityRenderer extends TileEntitySpecialRenderer {
+
+    @Override
+    public void renderTileEntityAt(TileEntity te, double x, double y, double z, float timeSinceLastTick) {
+        if (!(te instanceof BaseMetaTileEntity baseTE)) return;
+        if (baseTE.getMetaTileEntity() instanceof IMTERenderer renderer) {
+            renderer.renderTESR(x, y, z, timeSinceLastTick);
+        }
+    }
+}

--- a/src/main/java/gregtech/common/render/IMTERenderer.java
+++ b/src/main/java/gregtech/common/render/IMTERenderer.java
@@ -1,0 +1,6 @@
+package gregtech.common.render;
+
+public interface IMTERenderer {
+
+    void renderTESR(double x, double y, double z, float timeSinceLastTick);
+}


### PR DESCRIPTION
Binds a TESR to the BaseMetaTileEntity that redirects its rendering to MetaTileEntities that implement IMTERenderer.

This allows MTEs to add rendering effects without summoning invisible blocks and other ugly hacks that lead to weird behavior and bugs.

This does mean that _all MTEs_ now have a bound TESR which renders nothing by default. I profiled this on a large base and it does not appear on the profile:
<img width="897" height="821" alt="image" src="https://github.com/user-attachments/assets/f1595e3b-4401-489b-8324-43109edf6fa8" />

Only if you actually override renderTESR for a specific placed MTE will you see normal rendering impact on the profile:
<img width="803" height="65" alt="image" src="https://github.com/user-attachments/assets/10771357-dcaa-418f-8045-f087e2418aa5" />
