### PR TITLE
hotfix(render): pipe item end texture

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/MetaPipeEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaPipeEntity.java
@@ -123,7 +123,7 @@ public abstract class MetaPipeEntity extends CommonMetaTileEntity implements ICo
 
         final IGregTechTileEntity mte = getBaseMetaTileEntity();
         final ITexture[] sideTexture = getTexture(mte, DOWN, (CONNECTED_WEST | CONNECTED_EAST), -1, false, false);
-        final ITexture[] endTexture = getTexture(mte, WEST, (CONNECTED_WEST | CONNECTED_EAST), -1, false, false);
+        final ITexture[] endTexture = getTexture(mte, WEST, (CONNECTED_WEST | CONNECTED_EAST), -1, true, false);
         ctx.renderNegativeYFacing(sideTexture);
         ctx.renderPositiveYFacing(sideTexture);
         ctx.renderNegativeZFacing(sideTexture);


### PR DESCRIPTION
typo prevented pipe item to not have connected texture at end.