### PR TITLE
Hotfix - Mufflers now work with Singleblock Machines

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEBasicMachine.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEBasicMachine.java
@@ -658,7 +658,9 @@ public abstract class MTEBasicMachine extends MTEBasicTank implements RecipeMapW
                 }
             }
         } else {
-            doActivitySound(getActivitySoundLoop());
+            if (!aBaseMetaTileEntity.hasMufflerUpgrade()) {
+                doActivitySound(getActivitySoundLoop());
+            }
         }
         // Only using mNeedsSteamVenting right now and assigning it to 64 to space in the range for more single block
         // machine problems.


### PR DESCRIPTION
oops

Somehow missed this implementation from MTEMultiBlockBase when doing the doActivitySound() method call.

I never use mufflers so it literally did not cross my mind to test them, even though I mentioned mufflers in the discord post.

(edit is done via github as I'm not at my home PC rn, as a heads up)