### PR TITLE
fixed bug with VM's

### DIFF
--- a/src/main/java/bwcrossmod/galacticgreg/MTEVoidMinerBase.java
+++ b/src/main/java/bwcrossmod/galacticgreg/MTEVoidMinerBase.java
@@ -129,12 +129,16 @@ public abstract class MTEVoidMinerBase<T extends MTEVoidMinerBase<T>> extends MT
 
         if (this.totalWeight != 0.f) {
             this.handleFluidConsumption();
-            this.handleOutputs();
             return true;
         } else {
             this.stopMachine(ShutDownReasonRegistry.NONE);
             return false;
         }
+    }
+
+    @Override
+    protected void outputAfterRecipe() {
+        if (this.totalWeight != 0.f) this.handleOutputs();
     }
 
     @Override


### PR DESCRIPTION
VM's currently output on recipe start, not end. this would allow people to use a machine controller cover and no power supplied to get an ore roll every 2 tick, regardless of if batch mode was/wasn't enabled.

to fix this, i moved it to a method (outputAfterRecipe) that would only run 'after the recipe', thus removing this cheese.

this is ridiculously OP, so it needs to be in before 2.8.