### PR TITLE
T4 nano forge adjustments

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTENanoForge.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTENanoForge.java
@@ -902,13 +902,13 @@ public class MTENanoForge extends MTEExtendedPowerMultiBlockBase<MTENanoForge>
                 TextWidget.localised("GT5U.machines.nano_forge.t4_info_text.2")
                     .setDefaultColor(EnumChatFormatting.GOLD)
                     .setTextAlignment(Alignment.CenterLeft)
-                    .setPos(0, 80)
+                    .setPos(0, 75)
                     .setSize(244, 60))
             .widget(
                 TextWidget.localised("GT5U.machines.nano_forge.t4_info_text.3")
                     .setDefaultColor(EnumChatFormatting.GREEN)
                     .setTextAlignment(Alignment.CenterLeft)
-                    .setPos(0, 140)
+                    .setPos(0, 135)
                     .setSize(244, 20))
             .widget(
                 TextWidget.localised("GT5U.machines.nano_forge.t4_info_text.4")
@@ -927,7 +927,13 @@ public class MTENanoForge extends MTEExtendedPowerMultiBlockBase<MTENanoForge>
                     .setDefaultColor(EnumChatFormatting.GREEN)
                     .setTextAlignment(Alignment.CenterLeft)
                     .setPos(0, 230)
-                    .setSize(244, 20));
+                    .setSize(244, 20))
+            .widget(
+                TextWidget.localised("GT5U.machines.nano_forge.t4_info_text.7")
+                    .setDefaultColor(EnumChatFormatting.GOLD)
+                    .setTextAlignment(Alignment.CenterLeft)
+                    .setPos(0, 255)
+                    .setSize(244, 50));
         builder.widget(
             scrollable.setSize(244, 244)
                 .setPos(3, 3))

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTENanoForge.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTENanoForge.java
@@ -509,7 +509,7 @@ public class MTENanoForge extends MTEExtendedPowerMultiBlockBase<MTENanoForge>
                         }
                     }
                 }
-                maxParallel = Math.max((int) (drainedMagmatter / (144 / GTUtility.powInt(2, 4 - mSpecialTier))), 1);
+                maxParallel = Math.max((int) (drainedMagmatter / (288 / GTUtility.powInt(2, 4 - mSpecialTier))), 1);
                 return recipe.mSpecialValue <= mSpecialTier ? CheckRecipeResultRegistry.SUCCESSFUL
                     : CheckRecipeResultRegistry.NO_RECIPE;
             }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTENanoForge.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTENanoForge.java
@@ -524,8 +524,15 @@ public class MTENanoForge extends MTEExtendedPowerMultiBlockBase<MTENanoForge>
             @Nonnull
             @Override
             protected OverclockCalculator createOverclockCalculator(@Nonnull GTRecipe recipe) {
-                return super.createOverclockCalculator(recipe)
-                    .setDurationDecreasePerOC(mSpecialTier > recipe.mSpecialValue ? 4.0 : 2.0)
+                // Perfect OC for recipes for struct tier 1-3 if recipe tier is lower than struct tier
+                // If struct is t4, only apply perfect OC if the parallel mechanic is used
+                double OCFactor = 2.0;
+                if ((mSpecialTier < 4 || recipe.mSpecialValue < 3) && mSpecialTier > recipe.mSpecialValue) {
+                    OCFactor = 4.0;
+                } else if (recipe.mSpecialValue == 3 && maxParallel > 1) {
+                    OCFactor = 4.0;
+                }
+                return super.createOverclockCalculator(recipe).setDurationDecreasePerOC(OCFactor)
                     .setDurationModifier(mSpecialTier >= 4 ? GTUtility.powInt(0.9999, maxParallel) : 1);
             }
         };

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTENanoForge.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTENanoForge.java
@@ -54,6 +54,7 @@ import com.gtnewhorizons.modularui.common.widget.TextWidget;
 import gregtech.api.GregTechAPI;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.MaterialsUEVplus;
+import gregtech.api.enums.OrePrefixes;
 import gregtech.api.enums.Textures.BlockIcons;
 import gregtech.api.interfaces.INEIPreviewModifier;
 import gregtech.api.interfaces.ITexture;
@@ -452,6 +453,7 @@ public class MTENanoForge extends MTEExtendedPowerMultiBlockBase<MTENanoForge>
                 drainedMagmatter = 0;
                 if (mSpecialTier >= 4) {
                     boolean foundNanite = false;
+                    boolean foundOtherNanite = false;
                     ItemStack inputNanite = recipe.mOutputs[0];
 
                     int busWithNaniteIndex = 0;
@@ -473,11 +475,20 @@ public class MTENanoForge extends MTEExtendedPowerMultiBlockBase<MTENanoForge>
                             } else {
                                 inputItem = inputBus.getStackInSlot(j);
                             }
-                            if (inputItem != null && inputItem.isItemEqual(inputNanite)) {
-                                busWithNaniteIndex = i;
-                                slotWithNaniteIndex = j;
-                                foundNanite = true;
-                                break;
+                            if (inputItem != null) {
+                                ItemData data = GTOreDictUnificator.getAssociation(inputItem);
+                                if (data == null) {
+                                    continue;
+                                }
+                                if (data.mPrefix == OrePrefixes.nanite) {
+                                    if (inputItem.isItemEqual(inputNanite)) {
+                                        busWithNaniteIndex = i;
+                                        slotWithNaniteIndex = j;
+                                        foundNanite = true;
+                                    } else {
+                                        foundOtherNanite = true;
+                                    }
+                                }
                             }
                         }
                     }
@@ -494,7 +505,7 @@ public class MTENanoForge extends MTEExtendedPowerMultiBlockBase<MTENanoForge>
                         }
                     }
 
-                    if (foundNanite) {
+                    if (foundNanite && !foundOtherNanite) {
                         for (MTEHatchInput hatch : filterValidMTEs(mInputHatches)) {
                             FluidStack drained = hatch.drain(
                                 ForgeDirection.UNKNOWN,

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTENanoForge.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTENanoForge.java
@@ -449,6 +449,7 @@ public class MTENanoForge extends MTEExtendedPowerMultiBlockBase<MTENanoForge>
 
             @Override
             protected @Nonnull CheckRecipeResult validateRecipe(@Nonnull GTRecipe recipe) {
+                drainedMagmatter = 0;
                 if (mSpecialTier >= 4) {
                     boolean foundNanite = false;
                     ItemStack inputNanite = recipe.mOutputs[0];
@@ -507,8 +508,6 @@ public class MTENanoForge extends MTEExtendedPowerMultiBlockBase<MTENanoForge>
                                 .decrStackSize(slotWithNaniteIndex, 1);
                         }
                     }
-                } else {
-                    drainedMagmatter = 0;
                 }
                 maxParallel = Math.max((int) (drainedMagmatter / (144 / GTUtility.powInt(2, 4 - mSpecialTier))), 1);
                 return recipe.mSpecialValue <= mSpecialTier ? CheckRecipeResultRegistry.SUCCESSFUL

--- a/src/main/resources/assets/gregtech/lang/en_US.lang
+++ b/src/main/resources/assets/gregtech/lang/en_US.lang
@@ -1303,10 +1303,11 @@ GT5U.machines.nano_forge.t4_info_tooltip=Click for T4 info
 GT5U.machines.nano_forge.t4_info_header=Nano Forge Tier 4
 GT5U.machines.nano_forge.t4_info_text.1=Upgrading the Nano Forge to T4 by placing an eternity nanite into the controller completely transforms the structure and unlocks both a scaling speed boost and parallel for mass nanite creation.
 GT5U.machines.nano_forge.t4_info_text.2=The Nano Forge can be supplied with molten magmatter to increase its maximum parallels. At the start of a recipe cycle ALL supplied magmatter is consumed and converted to parallels via the following formula:
-GT5U.machines.nano_forge.t4_info_text.3=Maximum Parallel = Max((Magmatter Amount / (144 / 2^(4 - Recipe Tier))), 1)
-GT5U.machines.nano_forge.t4_info_text.4=To actually apply the parallels to the recipe, a copy of the output nanite has to be supplied in an input bus and will be consumed.
+GT5U.machines.nano_forge.t4_info_text.3=Maximum Parallel = Max((Magmatter Amount / (288 / 2^(4 - Recipe Tier))), 1)
+GT5U.machines.nano_forge.t4_info_text.4=To actually apply the parallels to the recipe, a copy of the output nanite has to be supplied in an input bus and will be consumed. If other types of nanites are present this wont work.
 GT5U.machines.nano_forge.t4_info_text.5=A recipe time multiplier is also granted based on maximum parallels via the following formula:
 GT5U.machines.nano_forge.t4_info_text.6=Recipe Time Multiplier = 0.9999^(Maximum Parallel)
+GT5U.machines.nano_forge.t4_info_text.7=Additionally, tier 1 & 2 nanites will receive unconditional perfect overclocks, while perfect OCs on tier 3 nanites require parallels to be above 1. Tier 4 nanites do not get perfect overclocks.
 GT5U.machines.antimatter_forge.enableRender=Enable Antimatter Forge Render
 GT5U.machines.antimatter_forge.disableRender=Disable Antimatter Forge Render
 


### PR DESCRIPTION
This PR adjusts a couple things regarding the t4 nano forge's mechanics based on some feedback.
The changes are as follows:

-Currently you can just stock 1 of each nanite you intend to make and it works with the t4 mechanic. This has been changed to be nanite type exclusive, e.g. if you are making gold nanites and have any other nanite types in an input bus, the parallel mechanic wont activate. An exception to this are recipes that require a nanite as a recipe input, like eternity or magmatter, those input nanites wont stop the parallels from working.
-The base magmatter cost for each parallel has been doubled (144L->288L)
-Perfect OCs for t3 nanites are now tied to the usage of the parallel mechanic. T1 & 2 nanites still get unconditional perfect OCs and t4 nanites dont get any (as is the case currently).

