### PR TITLE
fix(dependency) make dependency on Blockrenderer6343 optional

### DIFF
--- a/src/main/java/gregtech/common/render/SBRWorldContext.java
+++ b/src/main/java/gregtech/common/render/SBRWorldContext.java
@@ -41,8 +41,6 @@ import gregtech.api.render.SBRContextHolder;
  */
 public final class SBRWorldContext extends SBRContextBase implements ISBRWorldContext {
 
-    private static final float NO_Z_FIGHT_OFFSET = 1.0F / 1024.0F;
-
     /**
      * Used to determine if face is flush with negative neighbour
      */
@@ -321,13 +319,35 @@ public final class SBRWorldContext extends SBRContextBase implements ISBRWorldCo
     }
 
     /**
+     * Optionally loads the {@code blockrenderer6343.client.world.DummyWorld} class
+     */
+    private static final Class<?> BR63430_DUMMY_WORLD_CLASS;
+    static {
+        Class<?> c = null;
+        try {
+            c = Class.forName("blockrenderer6343.client.world.DummyWorld");
+        } catch (ClassNotFoundException ignored) {}
+        BR63430_DUMMY_WORLD_CLASS = c;
+    }
+
+    /**
+     * Performs an optional instanceof check
+     * 
+     * @param blockAccess the world access interface to check
+     * @return {@code true} if {@code blockAccess instanceof blockrenderer6343.client.world.DummyWorld}
+     */
+    private static boolean isBlockRenderer6343DummyWorld(IBlockAccess blockAccess) {
+        return BR63430_DUMMY_WORLD_CLASS != null && BR63430_DUMMY_WORLD_CLASS.isInstance(blockAccess);
+    }
+
+    /**
      * {@inheritDoc}
      *
      * @implNote Check against the world render pass
      */
     @Override
     public boolean canRenderInPass(@NotNull IntPredicate predicate) {
-        return blockAccess instanceof blockrenderer6343.client.world.DummyWorld || predicate.test(worldRenderPass);
+        return predicate.test(worldRenderPass) || isBlockRenderer6343DummyWorld(blockAccess);
     }
 
     /**


### PR DESCRIPTION
This removes the hard dependency on Blockrenderer6343 for the special case check on its DummyWorld implementation.

Tested server side ok
Tested client side ok

@chrombread this should fix your problem with dev on Core mod or any mod not having the Blockrenderer6343 available.