### PR TITLE
Fix solidifier hatch duplication bug

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEMultiSolidifier.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEMultiSolidifier.java
@@ -106,8 +106,7 @@ public class MTEMultiSolidifier extends MTEExtendedPowerMultiBlockBase<MTEMultiS
         .addShape(
             STRUCTURE_PIECE_MAIN,
             (transpose(
-                new String[][] {
-                    { "       ", "BBBBBBB", "BBBBBBB", "BBBBBBB", "       " },
+                new String[][] { { "       ", "BBBBBBB", "BBBBBBB", "BBBBBBB", "       " },
                     { "BBBBBBB", "       ", "D D D D", "       ", "BBBBBBB" },
                     { "AAAAAAA", "       ", "       ", "       ", "AAAAAAA" },
                     { "CCCBCCC", "       ", "F F F F", "       ", "CCCCCCC" },

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEMultiSolidifier.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEMultiSolidifier.java
@@ -106,7 +106,8 @@ public class MTEMultiSolidifier extends MTEExtendedPowerMultiBlockBase<MTEMultiS
         .addShape(
             STRUCTURE_PIECE_MAIN,
             (transpose(
-                new String[][] { { "       ", "BBBBBBB", "BBBBBBB", "BBBBBBB", "       " },
+                new String[][] {
+                    { "       ", "BBBBBBB", "BBBBBBB", "BBBBBBB", "       " },
                     { "BBBBBBB", "       ", "D D D D", "       ", "BBBBBBB" },
                     { "AAAAAAA", "       ", "       ", "       ", "AAAAAAA" },
                     { "CCCBCCC", "       ", "F F F F", "       ", "CCCCCCC" },
@@ -259,7 +260,7 @@ public class MTEMultiSolidifier extends MTEExtendedPowerMultiBlockBase<MTEMultiS
 
         if (checkPiece(STRUCTURE_PIECE_MAIN, 3, 4, 0)) {
             while (width < (6)) {
-                if (checkPiece(MS_RIGHT_MID, -4 - 2 * width, 4, 0) && checkPiece(MS_LEFT_MID, 5 + 2 * width, 4, 0)) {
+                if (checkPiece(MS_LEFT_MID, 5 + 2 * width, 4, 0) && checkPiece(MS_RIGHT_MID, -4 - 2 * width, 4, 0)) {
                     width++;
                 } else break;
             }


### PR DESCRIPTION
tldr this is due to structure checking the same spot twice. 


i changed the order of extension checks from (right / left) to (left / right) as the left structure check is a different position than the end piece structure check, while the right is not.

tested in game and it seemingly works
<img width="1833" height="1179" alt="image" src="https://github.com/user-attachments/assets/5081b934-ec7d-4d1c-9f8d-2fbbf1f796cf" />


closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20826