### PR TITLE
Fix "Heat Formula of GT's Fuel Rod is Wrong"

### DIFF
--- a/src/main/java/gregtech/api/items/ItemRadioactiveCellIC.java
+++ b/src/main/java/gregtech/api/items/ItemRadioactiveCellIC.java
@@ -59,8 +59,8 @@ public class ItemRadioactiveCellIC extends ItemRadioactiveCell implements IReact
                         : StatCollector.translateToLocalFormatted(
                             "GT5U.nei.nuclear.heat.1",
                             (aHeat * MYSTERIOUS_MULTIPLIER_HEAT) * aCellcount / 2f,
-                            aCellcount,
-                            aCellcount + 1),
+                            pulses,
+                            pulses + 1),
                     StatCollector.translateToLocalFormatted(
                         "GT5U.nei.nuclear.energy",
                         aEnergy * aCellcount * pulses * nukePowerMult,


### PR DESCRIPTION
Fixes GTNewHorizons/GT-New-Horizons-Modpack#21039
Right Formula from [here](https://github.com/GTNewHorizons/GT5-Unofficial/blob/d60e981c43dbcb2b320126542b2fbfb0e7cedb14/src/main/java/gregtech/api/items/ItemRadioactiveCellIC.java#L90).