### PR TITLE
[Hotfix] Fix soundloop continuing after machine powerloss

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEBasicMachine.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEBasicMachine.java
@@ -785,8 +785,10 @@ public abstract class MTEBasicMachine extends MTEBasicTank implements RecipeMapW
     @Override
     public void doSound(byte aIndex, double aX, double aY, double aZ) {
         super.doSound(aIndex, aX, aY, aZ);
-        if (aIndex == 8) GTUtility.doSoundAtClient(SoundResource.IC2_MACHINES_INTERRUPT_ONE, 100, 1.0F, aX, aY, aZ);
-        mStuttering = true;
+        if (aIndex == 8) {
+            GTUtility.doSoundAtClient(SoundResource.IC2_MACHINES_INTERRUPT_ONE, 100, 1.0F, aX, aY, aZ);
+            mStuttering = true;
+        }
     }
 
     public boolean doesAutoOutput() {

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEBasicMachine.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEBasicMachine.java
@@ -786,6 +786,7 @@ public abstract class MTEBasicMachine extends MTEBasicTank implements RecipeMapW
     public void doSound(byte aIndex, double aX, double aY, double aZ) {
         super.doSound(aIndex, aX, aY, aZ);
         if (aIndex == 8) GTUtility.doSoundAtClient(SoundResource.IC2_MACHINES_INTERRUPT_ONE, 100, 1.0F, aX, aY, aZ);
+        mStuttering = true;
     }
 
     public boolean doesAutoOutput() {
@@ -848,7 +849,7 @@ public abstract class MTEBasicMachine extends MTEBasicTank implements RecipeMapW
     protected void doActivitySound(SoundResource activitySound) {
         if (getBaseMetaTileEntity().isActive() && activitySound != null
             && !getBaseMetaTileEntity().hasMufflerUpgrade()
-            && getBaseMetaTileEntity().isAllowedToWork()) {
+            && !mStuttering) {
             if (activitySoundLoop == null) {
                 activitySoundLoop = new GTSoundLoop(
                     activitySound.resourceLocation,

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEBasicMachine.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEBasicMachine.java
@@ -847,7 +847,7 @@ public abstract class MTEBasicMachine extends MTEBasicTank implements RecipeMapW
     @SideOnly(Side.CLIENT)
     protected void doActivitySound(SoundResource activitySound) {
         if (getBaseMetaTileEntity().isActive() && activitySound != null
-            && !getBaseMetaTileEntity().hasMufflerUpgrade()) {
+            && !getBaseMetaTileEntity().hasMufflerUpgrade() && !mStuttering) {
             if (activitySoundLoop == null) {
                 activitySoundLoop = new GTSoundLoop(
                     activitySound.resourceLocation,

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEBasicMachine.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEBasicMachine.java
@@ -847,7 +847,8 @@ public abstract class MTEBasicMachine extends MTEBasicTank implements RecipeMapW
     @SideOnly(Side.CLIENT)
     protected void doActivitySound(SoundResource activitySound) {
         if (getBaseMetaTileEntity().isActive() && activitySound != null
-            && !getBaseMetaTileEntity().hasMufflerUpgrade() && !mStuttering) {
+            && !getBaseMetaTileEntity().hasMufflerUpgrade()
+            && getBaseMetaTileEntity().isAllowedToWork()) {
             if (activitySoundLoop == null) {
                 activitySoundLoop = new GTSoundLoop(
                     activitySound.resourceLocation,

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEBasicMachine.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEBasicMachine.java
@@ -848,7 +848,7 @@ public abstract class MTEBasicMachine extends MTEBasicTank implements RecipeMapW
     protected void doActivitySound(SoundResource activitySound) {
         if (getBaseMetaTileEntity().isActive() && activitySound != null
             && !getBaseMetaTileEntity().hasMufflerUpgrade()
-            && !getBaseMetaTileEntity().getProgress() < 0) {
+            && !(getBaseMetaTileEntity().getProgress() < 0)) {
             if (activitySoundLoop == null) {
                 activitySoundLoop = new GTSoundLoop(
                     activitySound.resourceLocation,

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEBasicMachine.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEBasicMachine.java
@@ -785,10 +785,7 @@ public abstract class MTEBasicMachine extends MTEBasicTank implements RecipeMapW
     @Override
     public void doSound(byte aIndex, double aX, double aY, double aZ) {
         super.doSound(aIndex, aX, aY, aZ);
-        if (aIndex == 8) {
-            GTUtility.doSoundAtClient(SoundResource.IC2_MACHINES_INTERRUPT_ONE, 100, 1.0F, aX, aY, aZ);
-            mStuttering = true;
-        }
+        if (aIndex == 8) GTUtility.doSoundAtClient(SoundResource.IC2_MACHINES_INTERRUPT_ONE, 100, 1.0F, aX, aY, aZ);
     }
 
     public boolean doesAutoOutput() {
@@ -851,7 +848,7 @@ public abstract class MTEBasicMachine extends MTEBasicTank implements RecipeMapW
     protected void doActivitySound(SoundResource activitySound) {
         if (getBaseMetaTileEntity().isActive() && activitySound != null
             && !getBaseMetaTileEntity().hasMufflerUpgrade()
-            && !mStuttering) {
+            && !getBaseMetaTileEntity().getProgress() < 0) {
             if (activitySoundLoop == null) {
                 activitySoundLoop = new GTSoundLoop(
                     activitySound.resourceLocation,

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEBasicMachineBronze.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEBasicMachineBronze.java
@@ -223,6 +223,7 @@ public abstract class MTEBasicMachineBronze extends MTEBasicMachine {
                             aZ - 0.5 + XSTR_INSTANCE.nextFloat())
                         .run());
         }
+        mStuttering = true;
     }
 
     @Override

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEBasicMachineBronze.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEBasicMachineBronze.java
@@ -222,8 +222,8 @@ public abstract class MTEBasicMachineBronze extends MTEBasicMachine {
                             aY - 0.5 + XSTR_INSTANCE.nextFloat(),
                             aZ - 0.5 + XSTR_INSTANCE.nextFloat())
                         .run());
+            mStuttering = true;
         }
-        mStuttering = true;
     }
 
     @Override

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEBasicMachineBronze.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEBasicMachineBronze.java
@@ -222,7 +222,6 @@ public abstract class MTEBasicMachineBronze extends MTEBasicMachine {
                             aY - 0.5 + XSTR_INSTANCE.nextFloat(),
                             aZ - 0.5 + XSTR_INSTANCE.nextFloat())
                         .run());
-            mStuttering = true;
         }
     }
 


### PR DESCRIPTION
Caught in discord by yoshy1952. If powerloss occurs (Stuttering boolean), then a soundloop won't be created / existing soundloop will fade out.