### PR TITLE
Clamp multi smelter energy usage to safe voltage

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEMultiFurnace.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEMultiFurnace.java
@@ -299,7 +299,7 @@ public class MTEMultiFurnace extends MTEAbstractMultiFurnace<MTEMultiFurnace> im
         this.mEfficiency = 10000 - (getIdealStatus() - getRepairStatus()) * 1000;
         this.mEfficiencyIncrease = 10000;
         this.mMaxProgresstime = (int) (calculator.getDuration() * batchMultiplierMax);
-        this.lEUt = VP[GTUtility.getTier(calculator.getConsumption())];
+        this.lEUt = Math.min(VP[GTUtility.getTier(calculator.getConsumption())], calculator.getConsumption());
         if (this.lEUt > 0) {
             this.lEUt = -this.lEUt;
         }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEMultiFurnace.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEMultiFurnace.java
@@ -299,7 +299,7 @@ public class MTEMultiFurnace extends MTEAbstractMultiFurnace<MTEMultiFurnace> im
         this.mEfficiency = 10000 - (getIdealStatus() - getRepairStatus()) * 1000;
         this.mEfficiencyIncrease = 10000;
         this.mMaxProgresstime = (int) (calculator.getDuration() * batchMultiplierMax);
-        this.lEUt = Math.min(VP[GTUtility.getTier(calculator.getConsumption())], calculator.getConsumption());
+        this.lEUt = Math.min(VP[GTUtility.getTier(getAverageInputVoltage())], calculator.getConsumption());
         if (this.lEUt > 0) {
             this.lEUt = -this.lEUt;
         }


### PR DESCRIPTION
A correction to PR #4805.

My original PR was just "setting" the consumption to be the safe practical voltage for a given tier but that was an oversight on my part as that increased power consumption when not all parallels were used.

I have implemented option 1 in @wlhlm's comment on my previous PR which when tested with an LV multi smelter with cupronickel coils results in the following EU/t usage curve up to 8 parallels:

```
4/7/12/16/20/24/28/30
```

Not sure why the second value comes out as 7eu/t instead of 8eu/t in WAILA but all other values are correct.