### PR TITLE
Centralize Kubatech UI textures all in one class

### DIFF
--- a/src/main/java/kubatech/api/gui/KubaTechUITextures.java
+++ b/src/main/java/kubatech/api/gui/KubaTechUITextures.java
@@ -9,6 +9,12 @@ import kubatech.Tags;
 
 public class KubaTechUITextures {
 
+    public static final UITexture PICTURE_KUBATECH_LOGO = UITexture.fullImage(Tags.MODID, "gui/logo_13x15_dark");
+
+    public static final UITexture SLOT_EEC_SPAWNER = UITexture.fullImage(Tags.MODID, "gui/slot/gray_spawner");
+
+    public static final UITexture SLOT_EEC_SWORD = UITexture.fullImage(Tags.MODID, "gui/slot/gray_sword");
+
     public static final UITexture OVERLAY_BUTTON_EEC_RITUAL_MODE_ON = UITexture
         .fullImage(Tags.MODID, "gui/overlay_button/machine_mode_eec_ritual_mode_on");
 
@@ -38,4 +44,9 @@ public class KubaTechUITextures {
 
     public static final UITexture OVERLAY_BUTTON_EEC_WEAPON_PRESERVATION_OFF = UITexture
         .fullImage(Tags.MODID, "gui/overlay_button/machine_mode_eec_weapon_preservation_off");
+
+    public static final UITexture SLOT_FUSION_CRAFTER = UITexture.fullImage(Tags.MODID, "gui/slot/fusion_crafter");
+
+    public static final UITexture APIARY_INVENTORY_BACKGROUND = UITexture
+        .fullImage(Tags.MODID, "gui/apiary_inventory_background");
 }

--- a/src/main/java/kubatech/api/implementations/KubaTechGTMultiBlockBase.java
+++ b/src/main/java/kubatech/api/implementations/KubaTechGTMultiBlockBase.java
@@ -22,6 +22,7 @@ package kubatech.api.implementations;
 
 import static gregtech.api.metatileentity.BaseTileEntity.TOOLTIP_DELAY;
 import static kubatech.api.Variables.ln4;
+import static kubatech.api.gui.KubaTechUITextures.PICTURE_KUBATECH_LOGO;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -38,7 +39,6 @@ import org.jetbrains.annotations.Nullable;
 
 import com.gtnewhorizons.modularui.api.drawable.IDrawable;
 import com.gtnewhorizons.modularui.api.drawable.Text;
-import com.gtnewhorizons.modularui.api.drawable.UITexture;
 import com.gtnewhorizons.modularui.api.math.Color;
 import com.gtnewhorizons.modularui.api.math.MainAxisAlignment;
 import com.gtnewhorizons.modularui.api.math.Pos2d;
@@ -233,10 +233,6 @@ public abstract class KubaTechGTMultiBlockBase<T extends MTEExtendedPowerMultiBl
         }
         return wasSomethingRemoved;
     }
-
-    // UI stuff
-
-    public static final UITexture PICTURE_KUBATECH_LOGO = UITexture.fullImage(Tags.MODID, "gui/logo_13x15_dark");
 
     @Override
     public void addGregTechLogo(ModularWindow.@NotNull Builder builder) {

--- a/src/main/java/kubatech/loaders/DEFCRecipes.java
+++ b/src/main/java/kubatech/loaders/DEFCRecipes.java
@@ -12,6 +12,7 @@ import static gregtech.api.util.GTRecipeBuilder.INGOTS;
 import static gregtech.api.util.GTRecipeBuilder.SECONDS;
 import static gregtech.api.util.GTRecipeBuilder.STACKS;
 import static gregtech.api.util.GTRecipeConstants.DEFC_CASING_TIER;
+import static kubatech.api.gui.KubaTechUITextures.SLOT_FUSION_CRAFTER;
 
 import java.util.Arrays;
 
@@ -20,8 +21,6 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
-
-import com.gtnewhorizons.modularui.api.drawable.UITexture;
 
 import cpw.mods.fml.common.registry.GameRegistry;
 import gregtech.api.enums.GTValues;
@@ -40,7 +39,6 @@ import gregtech.api.util.GTRecipe;
 import gregtech.api.util.GTUtility;
 import gregtech.nei.formatter.SimpleSpecialValueFormatter;
 import gtPlusPlus.xmod.forestry.bees.handler.GTPPCombType;
-import kubatech.Tags;
 
 public class DEFCRecipes {
 
@@ -49,9 +47,7 @@ public class DEFCRecipes {
         .maxIO(9, 1, 1, 1)
         .minInputs(1, 0)
         .neiSpecialInfoFormatter(new SimpleSpecialValueFormatter("kubatech.defusioncrafter.tier"))
-        .slotOverlays(
-            (index, isFluid, isOutput,
-                isSpecial) -> !isFluid && !isOutput ? UITexture.fullImage(Tags.MODID, "gui/slot/fusion_crafter") : null)
+        .slotOverlays((index, isFluid, isOutput, isSpecial) -> !isFluid && !isOutput ? SLOT_FUSION_CRAFTER : null)
         .build();
 
     public static void addRecipes() {

--- a/src/main/java/kubatech/tileentity/gregtech/multiblock/MTEExtremeEntityCrusher.java
+++ b/src/main/java/kubatech/tileentity/gregtech/multiblock/MTEExtremeEntityCrusher.java
@@ -50,6 +50,8 @@ import static kubatech.api.gui.KubaTechUITextures.OVERLAY_BUTTON_EEC_WEAPON_CYCL
 import static kubatech.api.gui.KubaTechUITextures.OVERLAY_BUTTON_EEC_WEAPON_CYCLING_ON;
 import static kubatech.api.gui.KubaTechUITextures.OVERLAY_BUTTON_EEC_WEAPON_PRESERVATION_OFF;
 import static kubatech.api.gui.KubaTechUITextures.OVERLAY_BUTTON_EEC_WEAPON_PRESERVATION_ON;
+import static kubatech.api.gui.KubaTechUITextures.SLOT_EEC_SPAWNER;
+import static kubatech.api.gui.KubaTechUITextures.SLOT_EEC_SWORD;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -96,7 +98,6 @@ import com.gtnewhorizon.structurelib.structure.ISurvivalBuildEnvironment;
 import com.gtnewhorizon.structurelib.structure.StructureDefinition;
 import com.gtnewhorizons.modularui.api.drawable.IDrawable;
 import com.gtnewhorizons.modularui.api.drawable.Text;
-import com.gtnewhorizons.modularui.api.drawable.UITexture;
 import com.gtnewhorizons.modularui.api.forge.ItemStackHandler;
 import com.gtnewhorizons.modularui.api.math.Alignment;
 import com.gtnewhorizons.modularui.api.math.Color;
@@ -143,7 +144,6 @@ import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.MultiblockTooltipBuilder;
 import gregtech.common.misc.GTStructureChannels;
-import kubatech.Tags;
 import kubatech.api.implementations.KubaTechGTMultiBlockBase;
 import kubatech.api.tileentity.CustomTileEntityPacketHandler;
 import kubatech.api.utils.ModUtils;
@@ -1110,16 +1110,14 @@ public class MTEExtremeEntityCrusher extends KubaTechGTMultiBlockBase<MTEExtreme
         final SlotWidget spawnerSlot = new SlotWidget(inventoryHandler, 1);
         spawnerSlot.setBackground(
             GTUITextures.SLOT_DARK_GRAY,
-            UITexture.fullImage(Tags.MODID, "gui/slot/gray_spawner")
-                .withFixedSize(16, 16)
+            SLOT_EEC_SPAWNER.withFixedSize(16, 16)
                 .withOffset(1, 1));
         spawnerSlot.setFilter(stack -> stack.getItem() == poweredSpawnerItem);
         slotWidgets.add(spawnerSlot);
         final SlotWidget weaponSlot = new SlotWidget(weaponCache, 0);
         weaponSlot.setBackground(
             GTUITextures.SLOT_DARK_GRAY,
-            UITexture.fullImage(Tags.MODID, "gui/slot/gray_sword")
-                .withFixedSize(16, 16)
+            SLOT_EEC_SWORD.withFixedSize(16, 16)
                 .withOffset(1, 1));
         slotWidgets.add(weaponSlot);
     }

--- a/src/main/java/kubatech/tileentity/gregtech/multiblock/MTEMegaIndustrialApiary.java
+++ b/src/main/java/kubatech/tileentity/gregtech/multiblock/MTEMegaIndustrialApiary.java
@@ -40,6 +40,7 @@ import static gregtech.api.util.GTStructureUtility.chainAllGlasses;
 import static gregtech.api.util.GTStructureUtility.ofAnyWater;
 import static gregtech.api.util.GTUtility.formatShortenedLong;
 import static gregtech.api.util.GTUtility.truncateText;
+import static kubatech.api.gui.KubaTechUITextures.APIARY_INVENTORY_BACKGROUND;
 import static kubatech.api.utils.ItemUtils.readItemStackFromNBT;
 import static kubatech.api.utils.ItemUtils.writeItemStackToNBT;
 
@@ -80,7 +81,6 @@ import com.gtnewhorizon.structurelib.structure.StructureDefinition;
 import com.gtnewhorizons.modularui.api.ModularUITextures;
 import com.gtnewhorizons.modularui.api.drawable.ItemDrawable;
 import com.gtnewhorizons.modularui.api.drawable.Text;
-import com.gtnewhorizons.modularui.api.drawable.UITexture;
 import com.gtnewhorizons.modularui.api.math.Alignment;
 import com.gtnewhorizons.modularui.api.math.Color;
 import com.gtnewhorizons.modularui.api.math.MainAxisAlignment;
@@ -133,7 +133,6 @@ import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.GTUtility.ItemId;
 import gregtech.api.util.MultiblockTooltipBuilder;
-import kubatech.Tags;
 import kubatech.api.DynamicInventory;
 import kubatech.api.implementations.KubaTechGTMultiBlockBase;
 import kubatech.client.effect.MegaApiaryBeesRenderer;
@@ -845,7 +844,7 @@ public class MTEMegaIndustrialApiary extends KubaTechGTMultiBlockBase<MTEMegaInd
 
         final int backgroundPadding = INVENTORY_BORDER_WIDTH * 2;
         builder.widget(
-            new DrawableWidget().setDrawable(UITexture.fullImage(Tags.MODID, "gui/apiary_inventory_background"))
+            new DrawableWidget().setDrawable(APIARY_INVENTORY_BACKGROUND)
                 .setPos(INVENTORY_X - INVENTORY_BORDER_WIDTH, INVENTORY_Y - INVENTORY_BORDER_WIDTH)
                 .setSize(INVENTORY_WIDTH + backgroundPadding, INVENTORY_HEIGHT + backgroundPadding)
                 .setEnabled(w -> isInInventory));


### PR DESCRIPTION
While I was working on https://github.com/GTNewHorizons/GT5-Unofficial/pull/4787 I created a file to group all the new UI textures I made for the EEC. 

This PR aims to improve code organization by moving all the other refs to UI textures for the other machines in Kubatech into this file.