### PR TITLE
Fix Wrenching Inconsistencies

### DIFF
--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -3604,50 +3604,52 @@ public class GTUtility {
         float modY = (aY % 1.0f + 1.0f) % 1.0f;
         float modZ = (aZ % 1.0f + 1.0f) % 1.0f;
         ForgeDirection tBack = side.getOpposite();
+        // The = here is necessary; Since the hitVec only has a precision of 1/16th on MP and gets rounded down,
+        // a value of 0.8 would be 0.75 on MP, which is not > 0.75, returning false.
         switch (side) {
             case DOWN, UP -> {
                 if (modX < 0.25) {
                     if (modZ < 0.25) return tBack;
-                    if (modZ > 0.75) return tBack;
+                    if (modZ >= 0.75) return tBack;
                     return WEST;
                 }
-                if (modX > 0.75) {
+                if (modX >= 0.75) {
                     if (modZ < 0.25) return tBack;
-                    if (modZ > 0.75) return tBack;
+                    if (modZ >= 0.75) return tBack;
                     return EAST;
                 }
                 if (modZ < 0.25) return NORTH;
-                if (modZ > 0.75) return SOUTH;
+                if (modZ >= 0.75) return SOUTH;
                 return side;
             }
             case NORTH, SOUTH -> {
                 if (modX < 0.25) {
                     if (modY < 0.25) return tBack;
-                    if (modY > 0.75) return tBack;
+                    if (modY >= 0.75) return tBack;
                     return WEST;
                 }
-                if (modX > 0.75) {
+                if (modX >= 0.75) {
                     if (modY < 0.25) return tBack;
-                    if (modY > 0.75) return tBack;
+                    if (modY >= 0.75) return tBack;
                     return EAST;
                 }
                 if (modY < 0.25) return DOWN;
-                if (modY > 0.75) return UP;
+                if (modY >= 0.75) return UP;
                 return side;
             }
             case WEST, EAST -> {
                 if (modZ < 0.25) {
                     if (modY < 0.25) return tBack;
-                    if (modY > 0.75) return tBack;
+                    if (modY >= 0.75) return tBack;
                     return NORTH;
                 }
-                if (modZ > 0.75) {
+                if (modZ >= 0.75) {
                     if (modY < 0.25) return tBack;
-                    if (modY > 0.75) return tBack;
+                    if (modY >= 0.75) return tBack;
                     return SOUTH;
                 }
                 if (modY < 0.25) return DOWN;
-                if (modY > 0.75) return UP;
+                if (modY >= 0.75) return UP;
                 return side;
             }
         }


### PR DESCRIPTION
Fixes a bug where wrenching a machine/pipe/cable would sometimes rotate it in the wrong direction. How it works is documented in the code.

This only happened in MP.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/21053

Old bounding box: (credits KleinGrrmpf)
<img width="3840" height="2126" alt="image" src="https://github.com/user-attachments/assets/4f25a690-9d50-4d4d-8939-b5650f15bb70" />

