### PR TITLE
Fixes Plutonium Fuel Rod Names

### DIFF
--- a/src/main/java/gregtech/loaders/preload/LoaderGTBlockFluid.java
+++ b/src/main/java/gregtech/loaders/preload/LoaderGTBlockFluid.java
@@ -531,7 +531,7 @@ public class LoaderGTBlockFluid implements Runnable {
         ItemList.RodExcitedPlutonium2.set(
             new ItemRadioactiveCellIC(
                 "rodExcitedPlutonium2",
-                "Fuel Rod (Excited Plutonium)",
+                "Dual Fuel Rod (Excited Plutonium)",
                 2,
                 10_000,
                 64,
@@ -542,7 +542,7 @@ public class LoaderGTBlockFluid implements Runnable {
         ItemList.RodExcitedPlutonium4.set(
             new ItemRadioactiveCellIC(
                 "rodExcitedPlutonium4",
-                "Fuel Rod (Excited Plutonium)",
+                "Quad Fuel Rod (Excited Plutonium)",
                 4,
                 10_000,
                 64,


### PR DESCRIPTION
### Changes:
- Excited Plutonium Dual & Quad fuel rods were missing the "dual" and "quad" in front of their names, I remember seeing this a month ago when I was doing quests I just realized it was never addressed. 

Checked in game so no need to be paranoid.