### PR TITLE
Clamp purification unit fluid stack outputs to max int to avoid overflow at high parallels

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/purification/MTEPurificationUnitBase.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/purification/MTEPurificationUnitBase.java
@@ -244,6 +244,13 @@ public abstract class MTEPurificationUnitBase<T extends MTEExtendedPowerMultiBlo
                     amountAvailable += fluid.amount;
                 }
             }
+
+            /*
+             * Clamp the amount of available input water to Int.MAX_VALUE so that the number of parallels can't cause
+             * an overflow when outputting
+             */
+            amountAvailable = Math.min(amountAvailable, Integer.MAX_VALUE);
+
             // Determine effective parallel
             effectiveParallel = (int) Math.min(maxParallel, Math.floorDiv(amountAvailable, waterInput.amount));
             // This should not happen, throw an error

--- a/src/main/java/gregtech/common/tileentities/machines/multi/purification/MTEPurificationUnitBase.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/purification/MTEPurificationUnitBase.java
@@ -245,12 +245,6 @@ public abstract class MTEPurificationUnitBase<T extends MTEExtendedPowerMultiBlo
                 }
             }
 
-            /*
-             * Clamp the amount of available input water to Int.MAX_VALUE so that the number of parallels can't cause
-             * an overflow when outputting
-             */
-            amountAvailable = Math.min(amountAvailable, Integer.MAX_VALUE);
-
             // Determine effective parallel
             effectiveParallel = (int) Math.min(maxParallel, Math.floorDiv(amountAvailable, waterInput.amount));
             // This should not happen, throw an error
@@ -377,7 +371,9 @@ public abstract class MTEPurificationUnitBase<T extends MTEExtendedPowerMultiBlo
         FluidStack[] fluidOutputs = new FluidStack[this.currentRecipe.mFluidOutputs.length];
         for (int i = 0; i < this.currentRecipe.mFluidOutputs.length; ++i) {
             fluidOutputs[i] = this.currentRecipe.mFluidOutputs[i].copy();
-            fluidOutputs[i].amount *= effectiveParallel;
+            // Clamp the fluid output to max int to avoid overflow at extreme parallels
+            fluidOutputs[i].amount = (int) Math
+                .min((long) effectiveParallel * fluidOutputs[i].amount, Integer.MAX_VALUE);
         }
 
         ItemStack[] recipeOutputs = this.currentRecipe.mOutputs;


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20444

The calculated water input amount for the purification units is stored as a long and when calculating parallels it can use enough parallels to output more purified water than a fluid stack can hold due to fluid stack amount being an `Int`.

This PR clamps the output amounts of fluid stacks produced by purification units to `Integer.MAX_VALUE` to prevent overflow.

I did toy with the idea of clamping the water input so that you couldn't "waste" inputs by feeding in too much but that reduced the theoretical maximum output because with `2,386,092` parallels you can get just under `Integer.MAX_VALUE` of grade 1 water but if I clamp input water to max int then the maximum you could get from the grade 1 recipe for example is just over 1.9 billion with `2,147,483` parallels.

I tested with both 3 million parallels and 1 parallel to ensure everything worked as expected.