### PR TITLE
Gets Rid of Duplicate Netherrack Compression Recipe

### DIFF
--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingDust.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingDust.java
@@ -113,7 +113,8 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                     if ((!OrePrefixes.block.isIgnored(aMaterial))
                         && (null == GTOreDictUnificator.get(OrePrefixes.gem, aMaterial, 1L))
                         && GTOreDictUnificator.get(OrePrefixes.block, aMaterial, 1L) != null
-                        && (aMaterial != Materials.Clay) && (aMaterial != Materials.Netherrack)) {
+                        && (aMaterial != Materials.Clay)
+                        && (aMaterial != Materials.Netherrack)) {
 
                         GTValues.RA.stdBuilder()
                             .itemInputs(GTUtility.copyAmount(9, aStack))

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingDust.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingDust.java
@@ -113,7 +113,7 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                     if ((!OrePrefixes.block.isIgnored(aMaterial))
                         && (null == GTOreDictUnificator.get(OrePrefixes.gem, aMaterial, 1L))
                         && GTOreDictUnificator.get(OrePrefixes.block, aMaterial, 1L) != null
-                        && (aMaterial != Materials.Clay)) {
+                        && (aMaterial != Materials.Clay) && (aMaterial != Materials.Netherrack)) {
 
                         GTValues.RA.stdBuilder()
                             .itemInputs(GTUtility.copyAmount(9, aStack))

--- a/src/main/java/gregtech/loaders/postload/recipes/CompressorRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/CompressorRecipes.java
@@ -32,7 +32,7 @@ public class CompressorRecipes implements Runnable {
 
         GTValues.RA.stdBuilder()
             .itemInputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.Netherrack, 4))
-            .itemOutputs(GTOreDictUnificator.get(new ItemStack(Blocks.netherrack, 3)))
+            .itemOutputs(GTOreDictUnificator.get(new ItemStack(Blocks.netherrack, 1)))
             .duration(5 * SECONDS)
             .eut(2)
             .addTo(compressorRecipes);


### PR DESCRIPTION
### Changes:
- Gets rid of ProcessingDust 9 -> 1 recipe since it's a 1 -> 1 maceration
- Changes 4 -> 3 recipe to 4 -> 1 to prevent recycling abuse of the 5% special output from the maceration recipe

This will close https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/21097

### New Recipe: 
<img width="338" height="289" alt="image" src="https://github.com/user-attachments/assets/3d4fb625-730b-48db-8fe5-5396773e5a59" />
