### PR TITLE
Hotfix - Muffler upgrades now work with Steam Boilers

### DIFF
--- a/src/main/java/gregtech/common/tileentities/boilers/MTEBoiler.java
+++ b/src/main/java/gregtech/common/tileentities/boilers/MTEBoiler.java
@@ -76,7 +76,6 @@ public abstract class MTEBoiler extends MTEBasicTank implements IGetTitleColor, 
         this::getSteamCapacity);
     public boolean mHadNoWater = false;
     private int mExcessWater = 0;
-    public boolean playHeating = false;
     public boolean playBoiling = false;
     @SideOnly(Side.CLIENT)
     protected GTSoundLoop mHeatingSound;
@@ -245,7 +244,7 @@ public abstract class MTEBoiler extends MTEBasicTank implements IGetTitleColor, 
     @Override
     public void onPostTick(IGregTechTileEntity aBaseMetaTileEntity, long aTick) {
         if (aBaseMetaTileEntity.isClientSide()) {
-            updateSoundLoops(aBaseMetaTileEntity, playBoiling);
+            updateSoundLoops(playBoiling);
         }
 
         pollute(aTick);
@@ -278,8 +277,8 @@ public abstract class MTEBoiler extends MTEBasicTank implements IGetTitleColor, 
     }
 
     @SideOnly(Side.CLIENT)
-    protected void updateSoundLoops(IGregTechTileEntity aBaseMetaTileEntity, boolean playBoiling) {
-        if (playBoiling) {
+    protected void updateSoundLoops(boolean playBoiling) {
+        if (playBoiling && !getBaseMetaTileEntity().hasMufflerUpgrade()) {
             if (mBoilingSound == null) {
                 mBoilingSound = new GTSoundLoop(
                     SoundResource.GTCEU_LOOP_BOILER.resourceLocation,
@@ -296,7 +295,8 @@ public abstract class MTEBoiler extends MTEBasicTank implements IGetTitleColor, 
                 mBoilingSound = null;
             }
         }
-        if (aBaseMetaTileEntity.isActive()) {
+        if (getBaseMetaTileEntity().isActive()
+            && !getBaseMetaTileEntity().hasMufflerUpgrade()) {
             if (mHeatingSound == null) {
                 mHeatingSound = new GTSoundLoop(
                     SoundResource.GTCEU_LOOP_FURNACE.resourceLocation,

--- a/src/main/java/gregtech/common/tileentities/boilers/MTEBoiler.java
+++ b/src/main/java/gregtech/common/tileentities/boilers/MTEBoiler.java
@@ -295,8 +295,7 @@ public abstract class MTEBoiler extends MTEBasicTank implements IGetTitleColor, 
                 mBoilingSound = null;
             }
         }
-        if (getBaseMetaTileEntity().isActive()
-            && !getBaseMetaTileEntity().hasMufflerUpgrade()) {
+        if (getBaseMetaTileEntity().isActive() && !getBaseMetaTileEntity().hasMufflerUpgrade()) {
             if (mHeatingSound == null) {
                 mHeatingSound = new GTSoundLoop(
                     SoundResource.GTCEU_LOOP_FURNACE.resourceLocation,


### PR DESCRIPTION
Missed this in the other muffler hotfix (https://github.com/GTNewHorizons/GT5-Unofficial/pull/4801). Also did some cleanup with boilers as playHeating was unused (isActive is the actual determination), and the BaseMetaTileEntity didn't really need to get included as a method argument.