### PR TITLE
Netherrack Recipe Revert

### DIFF
--- a/src/main/java/gregtech/loaders/postload/recipes/CompressorRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/CompressorRecipes.java
@@ -32,7 +32,7 @@ public class CompressorRecipes implements Runnable {
 
         GTValues.RA.stdBuilder()
             .itemInputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.Netherrack, 4))
-            .itemOutputs(GTOreDictUnificator.get(new ItemStack(Blocks.netherrack, 1)))
+            .itemOutputs(GTOreDictUnificator.get(new ItemStack(Blocks.netherrack, 3)))
             .duration(5 * SECONDS)
             .eut(2)
             .addTo(compressorRecipes);


### PR DESCRIPTION
### Changes: 
- I changed the 4 -> 3 recipe to 4 -> 1 when fixing this bug https://github.com/GTNewHorizons/GT5-Unofficial/pull/4836 without considering the implications for the netherrite line, my fault. This is reverting that.

Mb @Nockyx 🐙 