### PR TITLE
Fix EEC ritual mode exception

### DIFF
--- a/src/main/java/kubatech/tileentity/gregtech/multiblock/MTEExtremeEntityCrusher.java
+++ b/src/main/java/kubatech/tileentity/gregtech/multiblock/MTEExtremeEntityCrusher.java
@@ -885,7 +885,8 @@ public class MTEExtremeEntityCrusher extends KubaTechGTMultiBlockBase<MTEExtreme
                 .getTileEntity(xyz[0], xyz[1], xyz[2]);
         }
 
-        if (masterStoneRitual != null && !masterStoneRitual.isInvalid() && masterStoneRitual instanceof TEMasterStone tRitualTe) {
+        if (masterStoneRitual != null && !masterStoneRitual.isInvalid()
+            && masterStoneRitual instanceof TEMasterStone tRitualTe) {
             if (tRitualTe.getCurrentRitual()
                 .equals(WellOfSufferingRitualName)) return true;
         }

--- a/src/main/java/kubatech/tileentity/gregtech/multiblock/MTEExtremeEntityCrusher.java
+++ b/src/main/java/kubatech/tileentity/gregtech/multiblock/MTEExtremeEntityCrusher.java
@@ -794,10 +794,10 @@ public class MTEExtremeEntityCrusher extends KubaTechGTMultiBlockBase<MTEExtreme
 
         EECPlayer.currentWeapon = tWeaponCopy;
         for (int i = 0; i < aBatchModeMultiplier; i++) {
-            // Force max weapons at max damage to be considered broken,
+            // Force weapons at max damage to be considered broken,
             // even if they would survive a hit by having the Unbreaking enchantment.
-            // This prevents weapons from being effectively unbreakable due to the
-            // removal the chance-based chance of the weapon breaking.
+            // This prevents weapons from being effectively unbreakable due to being
+            // able to perfectly predict when a hit would or would not damage it.
             if (aPreventPerfectUnbreaking && tWeaponCopy.getItemDamage() == tWeaponCopy.getMaxDamage()) {
                 EECPlayer.currentWeapon = null;
                 return null;

--- a/src/main/java/kubatech/tileentity/gregtech/multiblock/MTEExtremeEntityCrusher.java
+++ b/src/main/java/kubatech/tileentity/gregtech/multiblock/MTEExtremeEntityCrusher.java
@@ -885,7 +885,7 @@ public class MTEExtremeEntityCrusher extends KubaTechGTMultiBlockBase<MTEExtreme
                 .getTileEntity(xyz[0], xyz[1], xyz[2]);
         }
 
-        if (!masterStoneRitual.isInvalid() && masterStoneRitual instanceof TEMasterStone tRitualTe) {
+        if (masterStoneRitual != null && !masterStoneRitual.isInvalid() && masterStoneRitual instanceof TEMasterStone tRitualTe) {
             if (tRitualTe.getCurrentRitual()
                 .equals(WellOfSufferingRitualName)) return true;
         }


### PR DESCRIPTION
Added a missing null check when trying to get the Master Ritual Stone TE.

Improved the explanation of a confusingly written comment while I was at it.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/21102