### PR TITLE
Change both Network Switches machine type and make Static version use lang file.

### DIFF
--- a/src/main/java/tectech/thing/metaTileEntity/multi/MTENetworkSwitch.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/MTENetworkSwitch.java
@@ -137,7 +137,7 @@ public class MTENetworkSwitch extends TTMultiblockBase
     public MultiblockTooltipBuilder createTooltip() {
         StructureWrapperTooltipBuilder<MTENetworkSwitch> tt = new StructureWrapperTooltipBuilder<>(structure);
 
-        tt.addMachineType(translateToLocal("gt.blockmachines.multimachine.em.switch.name"));
+        tt.addMachineType(translateToLocal("gt.blockmachines.multimachine.em.switch.type"));
 
         tt.addInfo(translateToLocal("gt.blockmachines.multimachine.em.switch.desc.0"));
         tt.addInfo(translateToLocal("gt.blockmachines.multimachine.em.switch.desc.1"));

--- a/src/main/java/tectech/thing/metaTileEntity/multi/MTENetworkSwitchAdv.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/MTENetworkSwitchAdv.java
@@ -3,6 +3,8 @@ package tectech.thing.metaTileEntity.multi;
 import static gregtech.api.enums.HatchElement.Dynamo;
 import static gregtech.api.enums.HatchElement.Energy;
 import static gregtech.api.util.GTUtility.validMTEList;
+import static net.minecraft.util.StatCollector.translateToLocal;
+import static net.minecraft.util.StatCollector.translateToLocalFormatted;
 import static tectech.thing.CustomItemList.Machine_Multi_Switch;
 import static tectech.thing.metaTileEntity.multi.base.TTMultiblockBase.HatchElement.DynamoMulti;
 import static tectech.thing.metaTileEntity.multi.base.TTMultiblockBase.HatchElement.EnergyMulti;
@@ -277,17 +279,19 @@ public class MTENetworkSwitchAdv extends TTMultiblockBase
     protected MultiblockTooltipBuilder createTooltip() {
         StructureWrapperTooltipBuilder<MTENetworkSwitchAdv> tt = new StructureWrapperTooltipBuilder<>(structure);
 
-        tt.addMachineType("Static Network Switch With QoS")
-            .addInfo("Variable-length version of the Weighted Network Switch.")
+        tt.addMachineType(translateToLocal("gt.blockmachines.multimachine.em.switch.type"))
+            .addInfo(translateToLocal("gt.blockmachines.multimachine.em.switch.adv.desc.0"))
             .addSeparator()
-            .addInfo("Consumes §b524,288§7 EU/t per middle slice while active.")
+            .addInfo(translateToLocal("gt.blockmachines.multimachine.em.switch.adv.desc.1"))
             .addSeparator()
-            .addInfo("Computation output is configured by right clicking transmission connectors with a screwdriver.")
-            .addInfo("Transmission connectors must be part of the structure for them to be configurable.")
-            .addInfo("Computation output for a hatch is directly controlled by the hatch's setting.")
+            .addInfo(translateToLocal("gt.blockmachines.multimachine.em.switch.adv.desc.2"))
+            .addInfo(translateToLocal("gt.blockmachines.multimachine.em.switch.adv.desc.3"))
+            .addInfo(translateToLocal("gt.blockmachines.multimachine.em.switch.adv.desc.4"))
             .addInfo(
-                "For weighted computation distribution, use the §6" + Machine_Multi_Switch.get(1)
-                    .getDisplayName() + "§r.")
+                translateToLocalFormatted(
+                    "gt.blockmachines.multimachine.em.switch.adv.desc.5",
+                    Machine_Multi_Switch.get(1)
+                        .getDisplayName()))
             .addSeparator();
 
         tt.beginStructureBlock();

--- a/src/main/resources/assets/tectech/lang/en_US.lang
+++ b/src/main/resources/assets/tectech/lang/en_US.lang
@@ -708,12 +708,21 @@ gt.blockmachines.multimachine.tm.teslaCoil.cfgo.7=Energy Fraction display
 gt.blockmachines.multimachine.tm.teslaCoil.cfgo.8=Scan time display
 gt.blockmachines.multimachine.tm.teslaCoil.cfgo.9=Output max display
 
+gt.blockmachines.multimachine.em.switch.type=Computation Network Switch, CNS
+gt.blockmachines.multimachine.em.switch.name=Weighted Network Switch With QoS
 gt.blockmachines.multimachine.em.switch.desc.0=Distributes computation to transmission connectors based on weights.
 gt.blockmachines.multimachine.em.switch.desc.1=Transmission connectors are assigned an ID.
 gt.blockmachines.multimachine.em.switch.desc.2=Scan connectors with a Portable Scanner to determine their ID.
 gt.blockmachines.multimachine.em.switch.desc.3=Computation output is configured via TecTech parameters.
 gt.blockmachines.multimachine.em.switch.desc.4=The first parameter in each group controls the hatch ID.
 gt.blockmachines.multimachine.em.switch.desc.5=The second parameter in each group controls the hatch weight.
+gt.blockmachines.multimachine.em.switch.adv.name=Static Network Switch With QoS
+gt.blockmachines.multimachine.em.switch.adv.desc.0=Variable-length version of the Weighted Network Switch.
+gt.blockmachines.multimachine.em.switch.adv.desc.1=Consumes §b524,288§7 EU/t per middle slice while active.
+gt.blockmachines.multimachine.em.switch.adv.desc.2=Computation output is configured by right clicking transmission connectors with a screwdriver.
+gt.blockmachines.multimachine.em.switch.adv.desc.3=Transmission connectors must be part of the structure for them to be configurable.
+gt.blockmachines.multimachine.em.switch.adv.desc.4=Computation output for a hatch is directly controlled by the hatch's setting.
+gt.blockmachines.multimachine.em.switch.adv.desc.5=For weighted computation distribution, use the §6%s§r.
 
 gt.blockmachines.multimachine.em.computer.name=Quantum Computer
 gt.blockmachines.multimachine.em.computer.machinetype=Quantum Computer, QC


### PR DESCRIPTION
Just having both machines say their name in machine type was illogical, so i made this PR to change it and moved tooltip of Static version into lang file.
Before:
<img width="771" height="300" alt="image" src="https://github.com/user-attachments/assets/d7dffb59-9ef8-4519-beef-159bd5135271" />
<img width="1029" height="343" alt="image" src="https://github.com/user-attachments/assets/171fd5a9-5e55-4cc3-add0-dcececde38b1" />

After:
<img width="1132" height="441" alt="image" src="https://github.com/user-attachments/assets/098c841d-f70e-43af-a275-cb2e585e17c0" />
<img width="1470" height="506" alt="image" src="https://github.com/user-attachments/assets/9a3f357c-e94e-4818-a232-096f2263811f" />
Now both can be found easily with CNS in NEI. Open for other machine type naming suggestions.