### PR TITLE
Add UCFE to GTPP Rocket Fuel NEI page

### DIFF
--- a/src/main/java/goodgenerator/blocks/tileEntity/MTEUniversalChemicalFuelEngine.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/MTEUniversalChemicalFuelEngine.java
@@ -5,7 +5,11 @@ import static com.gtnewhorizon.structurelib.structure.StructureUtility.transpose
 import static gregtech.api.enums.Textures.BlockIcons.*;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
+
+import javax.annotation.Nonnull;
 
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumChatFormatting;
@@ -378,5 +382,16 @@ public class MTEUniversalChemicalFuelEngine extends MTETooltipMultiBlockBaseEM
     @Override
     public boolean showRecipeTextInGUI() {
         return false;
+    }
+
+    @Nonnull
+    @Override
+    public Collection<RecipeMap<?>> getAvailableRecipeMaps() {
+        return Arrays.asList(GTPPRecipeMaps.rocketFuels, RecipeMaps.dieselFuels, RecipeMaps.gasTurbineFuels);
+    }
+
+    @Override
+    public int getRecipeCatalystPriority() {
+        return -2;
     }
 }


### PR DESCRIPTION
Still on path to catch the most insignificant changes to smooth out the game.
UCFE in code can use GTPP rocket fuels, which is mentioned in the tooltip in terms of "efficiency", but doesn't show up in NEI.
This PR fixes it.
Before:

https://github.com/user-attachments/assets/fd5d0856-5aa3-43d5-9a82-2bdfc9c86fc7


After:


https://github.com/user-attachments/assets/4012b1c4-1c79-48c7-8d18-b8c560244ae2

If it can be done in a better way, i am open for suggestion. I found this was a way other multis did several recipe maps in 1 multi, but couldn't find how UFCE could be inside 2 different maps before (or maybe i am just blind)