### PR TITLE
Fix Ghost machines being shown in the NEI recipes

### DIFF
--- a/src/main/java/gregtech/nei/NEIGTConfig.java
+++ b/src/main/java/gregtech/nei/NEIGTConfig.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 import net.minecraft.item.ItemStack;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ListMultimap;
@@ -65,6 +66,33 @@ public class NEIGTConfig implements IConfigureNEI {
 
     public static boolean sIsAdded = true;
 
+    // ugly initialization where people can add metaid and recipe map
+    // to remove ghost items from catalysts
+    private static final ImmutableMap<Integer, ImmutableList<String>> RECIPE_CATALYST_REMOVAL_LIST_SIMPLE_MAP = ImmutableMap
+        .<Integer, ImmutableList<String>>builder()
+        .put(
+            108, // Bronze Blast Furnace
+            ImmutableList.of(RecipeMaps.primitiveBlastRecipes.unlocalizedName))
+        .put(
+            960, // ghost item in Diesel
+            ImmutableList.of(RecipeMaps.dieselFuels.unlocalizedName))
+        .put(
+            961, // ghost item in Gas
+            ImmutableList.of(RecipeMaps.gasTurbineFuels.unlocalizedName))
+        .put(
+            860, // LPF
+            ImmutableList.of(
+                RecipeMaps.laserEngraverRecipes.unlocalizedName,
+                RecipeMaps.polarizerRecipes.unlocalizedName,
+                RecipeMaps.compressorRecipes.unlocalizedName,
+                RecipeMaps.autoclaveRecipes.unlocalizedName,
+                RecipeMaps.latheRecipes.unlocalizedName,
+                RecipeMaps.fermentingRecipes.unlocalizedName,
+                RecipeMaps.fluidExtractionRecipes.unlocalizedName,
+                RecipeMaps.fluidSolidifierRecipes.unlocalizedName,
+                RecipeMaps.extractorRecipes.unlocalizedName))
+        .build();
+
     private static void addHandler(TemplateRecipeHandler handler) {
         FMLInterModComms.sendRuntimeMessage(
             GTMod.GT,
@@ -114,10 +142,11 @@ public class NEIGTConfig implements IConfigureNEI {
             RecipeMaps.ic2NuclearFakeRecipes.unlocalizedName);
 
         // Remove the ones already registered by NEI assets
-        // Bronze Blast Furnace
-        API.removeRecipeCatalyst(
-            new ItemStack(GregTechAPI.sBlockMachines, 1, 108),
-            RecipeMaps.primitiveBlastRecipes.unlocalizedName);
+        // With the removal of LPF and ghost catalysts in Diesel and Gas fuels
+        // this was changed to iterable map to save up(?) space
+        RECIPE_CATALYST_REMOVAL_LIST_SIMPLE_MAP.forEach(
+            (key, value) -> value
+                .forEach((name) -> API.removeRecipeCatalyst(new ItemStack(GregTechAPI.sBlockMachines, 1, key), name)));
     }
 
     private void registerItemEntries() {


### PR DESCRIPTION
According to this PR https://github.com/GTNewHorizons/GT5-Unofficial/pull/4028 there was added an exclusion for removed Bronze Blast Smelter. 
Following the same logic, i remade it into a single call using a map.

After fix:

https://github.com/user-attachments/assets/312dde31-84ea-408e-9e65-17d85b56dc45



Lengthy discussions here https://discord.com/channels/181078474394566657/603348502637969419/1414230512666677339
and struggles here https://discord.com/channels/181078474394566657/522098956491030558/1414274189677953056 https://discord.com/channels/181078474394566657/522098956491030558/1414286953053950032

TL;DR: We either do something like what i did
or remove the ghost items from catalysts.csv from NEI assets (against it was that we would need to manually remove such machines, but honestly i don't think this .csv autogenerates, so it would be a one time fix after machine removal(?))
<img width="935" height="619" alt="image" src="https://github.com/user-attachments/assets/c615e5d4-9eaa-4dd0-b18a-bf4fd8a3ae8c" />
<img width="769" height="73" alt="image" src="https://github.com/user-attachments/assets/7da2c534-355a-436f-a85f-5a21e6bff7ed" />

or the hard way, we include soft dep in the NEI so it can check if the machine from catalysts.csv is a valid GT one.

I spent too much time on digging into this, so i will just throw it in here and let the council decide it's destiny.

Tomorrow i can make a NEI PR to just remove the machines from .csv if this is not the desired logic (I mainly didn't touch the said file because GTNH NEI fork can be used outside of GTNH, where said removed entries could be useful for some people)