### PR TITLE
Fix quadrupled heat on good generator fuel rods

### DIFF
--- a/src/main/java/gregtech/api/items/ItemRadioactiveCellIC.java
+++ b/src/main/java/gregtech/api/items/ItemRadioactiveCellIC.java
@@ -19,7 +19,6 @@ import ic2.core.util.ConfigUtil;
 
 public class ItemRadioactiveCellIC extends ItemRadioactiveCell implements IReactorComponent {
 
-    private static final int MYSTERIOUS_MULTIPLIER_HEAT = 4;
     public final int numberOfCells;
     public final float sEnergy;
     public final int sRadiation;
@@ -55,10 +54,10 @@ public class ItemRadioactiveCellIC extends ItemRadioactiveCell implements IReact
                         .translateToLocal(aMox ? "GT5U.nei.nuclear.model.mox" : "GT5U.nei.nuclear.model.uranium"),
                     StatCollector.translateToLocalFormatted("GT5U.nei.nuclear.neutron_pulse", aCellcount),
                     aCellcount == 1 ? StatCollector
-                        .translateToLocalFormatted("GT5U.nei.nuclear.heat.0", (aHeat * MYSTERIOUS_MULTIPLIER_HEAT) / 2f)
+                        .translateToLocalFormatted("GT5U.nei.nuclear.heat.0", aHeat / 2f)
                         : StatCollector.translateToLocalFormatted(
                             "GT5U.nei.nuclear.heat.1",
-                            (aHeat * MYSTERIOUS_MULTIPLIER_HEAT) * aCellcount / 2f,
+                            aHeat * aCellcount / 2f,
                             pulses,
                             pulses + 1),
                     StatCollector.translateToLocalFormatted(
@@ -104,7 +103,7 @@ public class ItemRadioactiveCellIC extends ItemRadioactiveCell implements IReact
 
                 // int heat = sumUp(pulses) * 4;
 
-                int heat = triangularNumber(pulses) * MYSTERIOUS_MULTIPLIER_HEAT;
+                int heat = triangularNumber(pulses);
 
                 heat = getFinalHeat(reactor, yourStack, x, y, heat);
 

--- a/src/main/java/gregtech/loaders/preload/LoaderGTBlockFluid.java
+++ b/src/main/java/gregtech/loaders/preload/LoaderGTBlockFluid.java
@@ -265,7 +265,7 @@ public class LoaderGTBlockFluid implements Runnable {
                 50_000,
                 0.4F,
                 0,
-                0.25F,
+                1F,
                 ItemList.DepletedRodThorium.get(1),
                 false));
         ItemList.RodThorium2.set(
@@ -276,7 +276,7 @@ public class LoaderGTBlockFluid implements Runnable {
                 50_000,
                 0.4F,
                 0,
-                0.25F,
+                1F,
                 ItemList.DepletedRodThorium2.get(1),
                 false));
         ItemList.RodThorium4.set(
@@ -287,7 +287,7 @@ public class LoaderGTBlockFluid implements Runnable {
                 50_000,
                 0.4F,
                 0,
-                0.25F,
+                1F,
                 ItemList.DepletedRodThorium4.get(1),
                 false));
 
@@ -306,7 +306,7 @@ public class LoaderGTBlockFluid implements Runnable {
                 20_000,
                 2F,
                 1,
-                1F,
+                4F,
                 ItemList.DepletedRodUranium.get(1),
                 false));
         ItemList.RodUranium2.set(
@@ -317,7 +317,7 @@ public class LoaderGTBlockFluid implements Runnable {
                 20_000,
                 2F,
                 1,
-                1F,
+                4F,
                 ItemList.DepletedRodUranium2.get(1),
                 false));
         ItemList.RodUranium4.set(
@@ -328,7 +328,7 @@ public class LoaderGTBlockFluid implements Runnable {
                 20_000,
                 2F,
                 1,
-                1F,
+                4F,
                 ItemList.DepletedRodUranium4.get(1),
                 false));
 
@@ -345,7 +345,7 @@ public class LoaderGTBlockFluid implements Runnable {
                 10_000,
                 2F,
                 1,
-                1F,
+                4F,
                 ItemList.DepletedRodMOX.get(1),
                 true));
         ItemList.RodMOX2.set(
@@ -356,7 +356,7 @@ public class LoaderGTBlockFluid implements Runnable {
                 10_000,
                 2F,
                 1,
-                1F,
+                4F,
                 ItemList.DepletedRodMOX2.get(1),
                 true));
         ItemList.RodMOX4.set(
@@ -367,7 +367,7 @@ public class LoaderGTBlockFluid implements Runnable {
                 10_000,
                 2F,
                 1,
-                1F,
+                4F,
                 ItemList.DepletedRodMOX4.get(1),
                 true));
 
@@ -568,7 +568,7 @@ public class LoaderGTBlockFluid implements Runnable {
                 100_000,
                 4F,
                 1,
-                1F,
+                4F,
                 ItemList.DepletedRodNaquadah.get(1),
                 false));
         ItemList.RodNaquadah2.set(
@@ -579,7 +579,7 @@ public class LoaderGTBlockFluid implements Runnable {
                 100_000,
                 4F,
                 1,
-                1F,
+                4F,
                 ItemList.DepletedRodNaquadah2.get(1),
                 false));
         ItemList.RodNaquadah4.set(
@@ -601,7 +601,7 @@ public class LoaderGTBlockFluid implements Runnable {
                 100_000,
                 8F,
                 32,
-                1F,
+                4F,
                 ItemList.DepletedRodNaquadah32.get(1),
                 false));
 
@@ -621,7 +621,7 @@ public class LoaderGTBlockFluid implements Runnable {
                 100_000,
                 4F,
                 1,
-                1F,
+                4F,
                 ItemList.DepletedRodNaquadria.get(1),
                 true));
         ItemList.RodNaquadria2.set(
@@ -632,7 +632,7 @@ public class LoaderGTBlockFluid implements Runnable {
                 100_000,
                 4F,
                 1,
-                1F,
+                4F,
                 ItemList.DepletedRodNaquadria2.get(1),
                 true));
         ItemList.RodNaquadria4.set(
@@ -643,7 +643,7 @@ public class LoaderGTBlockFluid implements Runnable {
                 100_000,
                 4F,
                 1,
-                1F,
+                4F,
                 ItemList.DepletedRodNaquadria4.get(1),
                 true));
 
@@ -663,7 +663,7 @@ public class LoaderGTBlockFluid implements Runnable {
                 50_000,
                 2F,
                 1,
-                0.5F,
+                2F,
                 ItemList.DepletedRodTiberium.get(1),
                 false));
         ItemList.RodTiberium2.set(
@@ -674,7 +674,7 @@ public class LoaderGTBlockFluid implements Runnable {
                 50_000,
                 2F,
                 1,
-                0.5F,
+                2F,
                 ItemList.DepletedRodTiberium2.get(1),
                 false));
         ItemList.RodTiberium4.set(
@@ -685,7 +685,7 @@ public class LoaderGTBlockFluid implements Runnable {
                 50_000,
                 2F,
                 1,
-                0.5F,
+                2F,
                 ItemList.DepletedRodTiberium4.get(1),
                 false));
 


### PR DESCRIPTION
Also remove mysterious heat multiplier, and have heat be explicitly declared.