### PR TITLE
Fixes IV Electric Furnace Name

### DIFF
--- a/src/main/java/gregtech/loaders/preload/LoaderMetaTileEntities.java
+++ b/src/main/java/gregtech/loaders/preload/LoaderMetaTileEntities.java
@@ -4520,7 +4520,7 @@ public class LoaderMetaTileEntities implements Runnable { // TODO CHECK CIRCUIT 
             new MTEBasicMachineWithRecipe(
                 ELECTRIC_FURNACE_IV.ID,
                 "basicmachine.e_furnace.tier.05",
-                "Electron Exitement Processor",
+                "Electron Excitement Processor",
                 5,
                 MachineType.ELECTRIC_FURNACE.tooltipDescription(),
                 RecipeMaps.furnaceRecipes,


### PR DESCRIPTION
### Changes:
- Spells "Excitement" correctly

It's funny that this wasn't noticed in the past year because nobody bothers to use these machines. This also made me realize that we do Basic -> Advanced 1-3 -> quirky IV name -> Elite 1-2, Ultimate -> Epic 1-4. What an interesting pattern we keep.