### PR TITLE
Fix Pyrolyse Oven Hint-Dots

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEPyrolyseOven.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEPyrolyseOven.java
@@ -74,7 +74,7 @@ public class MTEPyrolyseOven extends MTEEnhancedMultiBlockBase<MTEPyrolyseOven> 
             't',
             buildHatchAdder(MTEPyrolyseOven.class).atLeast(InputBus, InputHatch, Muffler)
                 .casingIndex(CASING_INDEX)
-                .dot(1)
+                .dot(2)
                 .buildAndChain(onElementPass(MTEPyrolyseOven::onCasingAdded, ofBlock(GregTechAPI.sBlockCasingsNH, 2))))
         .build();
 


### PR DESCRIPTION
It's stated that Input Hatch/Bus and Muffler should be hinted at with 2 Dots. This only makes sense to be able to split them apart from the other Hatches (at the bottom layer).
<img width="597" height="83" alt="image" src="https://github.com/user-attachments/assets/44d405f0-33e5-400a-b80c-9c5bf4178c9a" />

closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/21245
