### PR TITLE
Remove gem recipes from Block to gem, ingot, and dust

### DIFF
--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingBlock.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingBlock.java
@@ -162,11 +162,6 @@ public class ProcessingBlock implements gregtech.api.interfaces.IOreRecipeRegist
                 .duration(5 * SECONDS)
                 .eut(24)
                 .addTo(hammerRecipes);
-            if (tStack3 != null)
-                GTModHandler.addShapelessCraftingRecipe(tStack3, new Object[] { OrePrefixes.block.get(aMaterial) });
-            GTModHandler.addShapelessCraftingRecipe(tStack2, new Object[] { OrePrefixes.block.get(aMaterial) });
-            if (tStack1 != null)
-                GTModHandler.addShapelessCraftingRecipe(tStack1, new Object[] { OrePrefixes.block.get(aMaterial) });
         }
 
         if (tStack1 != null && !OrePrefixes.block.isIgnored(aMaterial) && aMaterial != Materials.Obsidian) {

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingBlock.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingBlock.java
@@ -125,13 +125,14 @@ public class ProcessingBlock implements gregtech.api.interfaces.IOreRecipeRegist
 
         GTModHandler.removeRecipeDelayed(GTUtility.copyAmount(1, aStack));
 
-        if (tStack1 != null) GTModHandler
-            .removeRecipeDelayed(tStack1, tStack1, tStack1, tStack1, tStack1, tStack1, tStack1, tStack1, tStack1);
-        if (tStack2 != null) GTModHandler
-            .removeRecipeDelayed(tStack2, tStack2, tStack2, tStack2, tStack2, tStack2, tStack2, tStack2, tStack2);
+        if (tStack1 != null) {
+            GTModHandler.removeRecipeDelayed(tStack1, tStack1, tStack1, tStack1, tStack1, tStack1, tStack1, tStack1, tStack1);
+        }
+        if (tStack2 != null) {
+            GTModHandler.removeRecipeDelayed(tStack2, tStack2, tStack2, tStack2, tStack2, tStack2, tStack2, tStack2, tStack2);
+        }
         if (tStack3 != null) {
-            GTModHandler
-                .removeRecipeDelayed(tStack3, tStack3, tStack3, tStack3, tStack3, tStack3, tStack3, tStack3, tStack3);
+            GTModHandler.removeRecipeDelayed(tStack3, tStack3, tStack3, tStack3, tStack3, tStack3, tStack3, tStack3, tStack3);
         }
 
         if (aMaterial.mStandardMoltenFluid != null) {

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingBlock.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingBlock.java
@@ -119,20 +119,20 @@ public class ProcessingBlock implements gregtech.api.interfaces.IOreRecipeRegist
             }
         }
 
-        ItemStack tStack1 = GTOreDictUnificator.get(OrePrefixes.ingot, aMaterial, 1L);
-        ItemStack tStack2 = GTOreDictUnificator.get(OrePrefixes.gem, aMaterial, 1L);
-        ItemStack tStack3 = GTOreDictUnificator.get(OrePrefixes.dust, aMaterial, 1L);
+        ItemStack ingot = GTOreDictUnificator.get(OrePrefixes.ingot, aMaterial, 1L);
+        ItemStack gem = GTOreDictUnificator.get(OrePrefixes.gem, aMaterial, 1L);
+        ItemStack dust = GTOreDictUnificator.get(OrePrefixes.dust, aMaterial, 1L);
 
         GTModHandler.removeRecipeDelayed(GTUtility.copyAmount(1, aStack));
 
-        if (tStack1 != null) {
-            GTModHandler.removeRecipeDelayed(tStack1, tStack1, tStack1, tStack1, tStack1, tStack1, tStack1, tStack1, tStack1);
+        if (ingot != null) {
+            GTModHandler.removeRecipeDelayed(ingot, ingot, ingot, ingot, ingot, ingot, ingot, ingot, ingot);
         }
-        if (tStack2 != null) {
-            GTModHandler.removeRecipeDelayed(tStack2, tStack2, tStack2, tStack2, tStack2, tStack2, tStack2, tStack2, tStack2);
+        if (gem != null) {
+            GTModHandler.removeRecipeDelayed(gem, gem, gem, gem, gem, gem, gem, gem, gem);
         }
-        if (tStack3 != null) {
-            GTModHandler.removeRecipeDelayed(tStack3, tStack3, tStack3, tStack3, tStack3, tStack3, tStack3, tStack3, tStack3);
+        if (dust != null) {
+            GTModHandler.removeRecipeDelayed(dust, dust, dust, dust, dust, dust, dust, dust, dust);
         }
 
         if (aMaterial.mStandardMoltenFluid != null) {
@@ -151,20 +151,20 @@ public class ProcessingBlock implements gregtech.api.interfaces.IOreRecipeRegist
             }
         }
 
-        if (tStack1 != null) tStack1.stackSize = 9;
-        if (tStack2 != null) tStack2.stackSize = 9;
-        if (tStack3 != null) tStack3.stackSize = 9;
+        if (ingot != null) ingot.stackSize = 9;
+        if (gem != null) gem.stackSize = 9;
+        if (dust != null) dust.stackSize = 9;
 
-        if (tStack2 != null) {
+        if (gem != null) {
             GTValues.RA.stdBuilder()
                 .itemInputs(aStack)
-                .itemOutputs(tStack2)
+                .itemOutputs(gem)
                 .duration(5 * SECONDS)
                 .eut(24)
                 .addTo(hammerRecipes);
         }
 
-        if (tStack1 != null && !OrePrefixes.block.isIgnored(aMaterial) && aMaterial != Materials.Obsidian) {
+        if (ingot != null && !OrePrefixes.block.isIgnored(aMaterial) && aMaterial != Materials.Obsidian) {
             // 9 ingots -> 1 block
             GTValues.RA.stdBuilder()
                 .itemInputs(GTOreDictUnificator.get(OrePrefixes.ingot, aMaterial, 9L))

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingBlock.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingBlock.java
@@ -169,7 +169,7 @@ public class ProcessingBlock implements gregtech.api.interfaces.IOreRecipeRegist
                 GTModHandler.addShapelessCraftingRecipe(tStack1, new Object[] { OrePrefixes.block.get(aMaterial) });
         }
 
-        if (!OrePrefixes.block.isIgnored(aMaterial) && tStack1 != null && aMaterial != Materials.Obsidian) {
+        if (tStack1 != null && !OrePrefixes.block.isIgnored(aMaterial) && aMaterial != Materials.Obsidian) {
             // 9 ingots -> 1 block
             GTValues.RA.stdBuilder()
                 .itemInputs(GTOreDictUnificator.get(OrePrefixes.ingot, aMaterial, 9L))

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingDust.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingDust.java
@@ -321,6 +321,19 @@ public class ProcessingDust implements gregtech.api.interfaces.IOreRecipeRegistr
                             .addTo(implosionRecipes);
                     }
                         break;
+                    case "ManaDiamond":
+                    case "BotaniaDragonstone": {
+                        GTValues.RA.stdBuilder()
+                            .itemInputs(GTUtility.copyAmount(4, aStack))
+                            .itemOutputs(
+                                GTOreDictUnificator.get(OrePrefixes.gem, aMaterial, 3L),
+                                GTOreDictUnificator.get(OrePrefixes.dustTiny, Materials.DarkAsh, 16L))
+                            .duration(1 * SECONDS)
+                            .eut(TierEU.RECIPE_LV)
+                            .metadata(ADDITIVE_AMOUNT, 32)
+                            .addTo(implosionRecipes);
+                    }
+                        break;
                     case "Opal":
                     case "Olivine":
                     case "Emerald":

--- a/src/main/java/gregtech/loaders/postload/recipes/ForgeHammerRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/ForgeHammerRecipes.java
@@ -1,6 +1,8 @@
 package gregtech.loaders.postload.recipes;
 
+import static gregtech.api.enums.Mods.BiomesOPlenty;
 import static gregtech.api.enums.Mods.HardcoreEnderExpansion;
+import static gregtech.api.enums.Mods.ProjectRedExploration;
 import static gregtech.api.recipe.RecipeMaps.hammerRecipes;
 import static gregtech.api.util.GTModHandler.getModItem;
 import static gregtech.api.util.GTRecipeBuilder.INGOTS;
@@ -151,6 +153,24 @@ public class ForgeHammerRecipes implements Runnable {
                 .itemOutputs(GTOreDictUnificator.get(OrePrefixes.crushed, Materials.HeeEndium, 1))
                 .duration(16)
                 .eut(10)
+                .addTo(hammerRecipes);
+        }
+
+        if (BiomesOPlenty.isModLoaded()) {
+            GTValues.RA.stdBuilder()
+                .itemInputs(getModItem(BiomesOPlenty.ID, "gemOre", 1, 5))
+                .itemOutputs(GTOreDictUnificator.get(OrePrefixes.gem, Materials.Olivine, 9))
+                .duration(5 * SECONDS)
+                .eut(24)
+                .addTo(hammerRecipes);
+        }
+
+        if (ProjectRedExploration.isModLoaded()) {
+            GTValues.RA.stdBuilder()
+                .itemInputs(getModItem(ProjectRedExploration.ID, "projectred.exploration.stone", 1, 7))
+                .itemOutputs(GTOreDictUnificator.get(OrePrefixes.gem, Materials.Olivine, 9))
+                .duration(5 * SECONDS)
+                .eut(24)
                 .addTo(hammerRecipes);
         }
     }

--- a/src/main/java/gregtech/loaders/postload/recipes/Pulverizer.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/Pulverizer.java
@@ -1,7 +1,9 @@
 package gregtech.loaders.postload.recipes;
 
 import static gregtech.api.enums.Mods.AppliedEnergistics2;
+import static gregtech.api.enums.Mods.BiomesOPlenty;
 import static gregtech.api.enums.Mods.HardcoreEnderExpansion;
+import static gregtech.api.enums.Mods.ProjectRedExploration;
 import static gregtech.api.enums.Mods.Railcraft;
 import static gregtech.api.enums.Mods.Thaumcraft;
 import static gregtech.api.recipe.RecipeMaps.maceratorRecipes;
@@ -722,6 +724,24 @@ public class Pulverizer implements Runnable {
                 .outputChances(10000, 5000)
                 .duration(20 * SECONDS)
                 .eut(2)
+                .addTo(maceratorRecipes);
+        }
+
+        if (BiomesOPlenty.isModLoaded()) {
+            GTValues.RA.stdBuilder()
+                .itemInputs(getModItem(BiomesOPlenty.ID, "gemOre", 1, 5))
+                .itemOutputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.Olivine, 9))
+                .duration(Materials.Olivine.getMass() * 9 * TICKS)
+                .eut(4)
+                .addTo(maceratorRecipes);
+        }
+
+        if (ProjectRedExploration.isModLoaded()) {
+            GTValues.RA.stdBuilder()
+                .itemInputs(getModItem(ProjectRedExploration.ID, "projectred.exploration.stone", 1, 7))
+                .itemOutputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.Olivine, 9))
+                .duration(Materials.Olivine.getMass() * 9 * TICKS)
+                .eut(4)
                 .addTo(maceratorRecipes);
         }
 


### PR DESCRIPTION
Removes conflicting shapeless recipes that converted gem blocks to their respective item forms. These conversions can still be done using the intended Forge Hammer, Macerator and, in the case of ingots, Smelting and Liquid Extraction recipes.

This PR also adds implosion compression recipes for Mana Diamond and Dragonstone.

Example using BArTiMaEuSNeK _(which managed to have the full conflicting set!)_:
<img width="509" height="664" alt="image" src="https://github.com/user-attachments/assets/13e26750-2257-494b-a63e-465a68f0f4f2" />

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20928