### PR TITLE
Add Thermic Heating Device Abbreviation

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/MTEIndustrialFluidHeater.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/MTEIndustrialFluidHeater.java
@@ -55,7 +55,7 @@ public class MTEIndustrialFluidHeater extends GTPPMultiBlockBase<MTEIndustrialFl
 
     @Override
     public String getMachineType() {
-        return "Fluid Heater";
+        return "Fluid Heater, THD";
     }
 
     @Override


### PR DESCRIPTION
In my defense the THD wasn't even on the main page of the wiki for a long time which is what I used as my reference in the past. I would save these for a larger PR if 2.8 wasn't so soon.