### PR TITLE
Fix Strontium dupe

### DIFF
--- a/src/main/java/gregtech/loaders/postload/chains/NetheriteRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/chains/NetheriteRecipes.java
@@ -131,7 +131,7 @@ public class NetheriteRecipes {
                 .addTo(multiblockChemicalReactorRecipes);
 
             GTValues.RA.stdBuilder() // Precipitation
-                .itemInputs(MaterialMisc.STRONTIUM_HYDROXIDE.getDust(42))
+                .itemInputs(MaterialMisc.STRONTIUM_HYDROXIDE.getDust(48))
                 .itemOutputs(ItemList.Prismarine_Precipitate.get(8))
                 .fluidInputs(Materials.PrismarineRichNitrobenzeneSolution.getFluid(16000))
                 .fluidOutputs(


### PR DESCRIPTION
Strontium is supposed to by catalyst that is cycled nack and forth, currently because of some miscalcultion u get more strontium than u input
14 strontium - > 42 strontium hydroxige -> 8 prismatic precipitate -> 288*8 molten strontium -> 16 strontium
with a fix u get 
16 strontium -> 48 strontium hydroxide -> -//-