### PR TITLE
Fix Sweed generation in EIG

### DIFF
--- a/src/main/java/kubatech/tileentity/gregtech/multiblock/eigbuckets/EIGSeedBucket.java
+++ b/src/main/java/kubatech/tileentity/gregtech/multiblock/eigbuckets/EIGSeedBucket.java
@@ -251,7 +251,7 @@ public class EIGSeedBucket extends EIGBucket {
             this.x = x;
             this.y = y;
             this.z = z;
-            this.rand = new EIGSeedBucket.GreenHouseRandom();
+            this.rand = new Random();
         }
 
         @Override
@@ -302,15 +302,4 @@ public class EIGSeedBucket extends EIGBucket {
             return true;
         }
     }
-
-    private static class GreenHouseRandom extends Random {
-
-        private static final long serialVersionUID = -387271808935248890L;
-
-        @Override
-        public int nextInt(int bound) {
-            return 0;
-        }
-    }
-
 }


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/21304
After recent mandrake fix, drops were using fakeworld variable, which had Random.nextInt() override, where it just returned 0.
nextInt() was used by Sweed code to calculate the sugar drops as seen here: https://discord.com/channels/181078474394566657/603348502637969419/1418218947882389567, but since it got 0, it dropped nothing
Didn't notice any changes when removing the special override and using normal Random()
Below is beta3, above is with fix (can't insert mandrake in beta3, only displayed in the fixed version as to show that it doesn't lag the game into the ground as it was before the fix)
https://github.com/user-attachments/assets/890478a5-226f-4024-953d-2f8c7956eef4


IC2 crops seem unaffected too
https://github.com/user-attachments/assets/9bfca50c-d2e0-4bc0-9c39-8ae69215eb27

If GreenHouseRandom had some special usage behind it, i would love to hear it (honestly, for knowledge expansion)