### PR TITLE
Fixes cryogenic freezer structure preview 

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/MTEIndustrialVacuumFreezer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/MTEIndustrialVacuumFreezer.java
@@ -130,6 +130,7 @@ public class MTEIndustrialVacuumFreezer extends GTPPMultiBlockBase<MTEIndustrial
                     ofChain(
                         buildHatchAdder(MTEIndustrialVacuumFreezer.class)
                             .adder(MTEIndustrialVacuumFreezer::addCryotheumHatch)
+                            .shouldReject(x -> !x.mCryotheumHatches.isEmpty())
                             .hatchId(MetaTileEntityIDs.Hatch_Input_Cryotheum.ID)
                             .casingIndex(CASING_TEXTURE_ID)
                             .dot(1)


### PR DESCRIPTION
A PR ~February of this year removed a line of code(on accident?) that would reject more special input hatches from being added in the case that there already was one.

adding this back fixes it (same as volcanus now)

before/after
<img width="520" height="512" alt="image" src="https://github.com/user-attachments/assets/ba13d341-e494-4c53-a5d8-324ff9d928e6" />
<img width="620" height="448" alt="image" src="https://github.com/user-attachments/assets/1ebf4135-8f4f-464d-af14-7b532d00b88b" />

