### PR TITLE
Fix IApiary info symbol overlapping mute symbol in UI

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/basic/MTEIndustrialApiary.java
+++ b/src/main/java/gregtech/common/tileentities/machines/basic/MTEIndustrialApiary.java
@@ -1275,7 +1275,7 @@ public class MTEIndustrialApiary extends MTEBasicMachine
                         new FakeSyncWidget.ItemStackSyncer(() -> usedQueen, val -> usedQueen = val),
                         builder,
                         (widget, val) -> widget.notifyTooltipChange())
-                    .setPos(163, 5)
+                    .setPos(163, 19)
                     .setSize(7, 18))
             .widget(new ButtonWidget().setOnClick((clickData, widget) -> {
                 if (clickData.mouseButton == 0) {


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/21280

It now looks like this:

<img width="1453" height="1493" alt="image" src="https://github.com/user-attachments/assets/7ffa1b08-4e9c-4366-9207-bfc90cf59abe" />
