### PR TITLE
Use True Manhattan Distance for Long Distance Pipes

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/long_distance/MTELongDistancePipelineBase.java
+++ b/src/main/java/gregtech/common/tileentities/machines/long_distance/MTELongDistancePipelineBase.java
@@ -285,7 +285,7 @@ public abstract class MTELongDistancePipelineBase extends MTEBasicHullNonElectri
 
     protected int getDistanceToSelf(ChunkCoordinates aCoords) {
         return Math.abs(getBaseMetaTileEntity().getXCoord() - aCoords.posX)
-            + Math.abs(getBaseMetaTileEntity().getYCoord() - aCoords.posY) / 2
+            + Math.abs(getBaseMetaTileEntity().getYCoord() - aCoords.posY)
             + Math.abs(getBaseMetaTileEntity().getZCoord() - aCoords.posZ);
     }
 


### PR DESCRIPTION
The height difference gets (seemingly) arbitrarily divided by 2. This is not indicated anywhere in the quests of GT:NH, which just specify a minimum distance of 64 blocks. The change should not break existing setups as it is more lenient.