### PR TITLE
Fix eic tierskip behaviour

### DIFF
--- a/src/main/java/bartworks/common/tileentities/multis/MTEElectricImplosionCompressor.java
+++ b/src/main/java/bartworks/common/tileentities/multis/MTEElectricImplosionCompressor.java
@@ -255,7 +255,7 @@ public class MTEElectricImplosionCompressor extends MTEExtendedPowerMultiBlockBa
 
     @Override
     protected ProcessingLogic createProcessingLogic() {
-        return new ProcessingLogic() {}.setMaxParallelSupplier(this::getTrueParallel);
+        return new ProcessingLogic().setMaxParallelSupplier(this::getTrueParallel);
     }
 
     @Override


### PR DESCRIPTION
The EIC processing logic code still had remnants from the time before the tierskip unification, allowing it to tierskip an unlimited amount of times. This PR fixes that. Overclocks, tierskips and parallel work correctly now.