### PR TITLE
#21408 Machine update propagation fix

### DIFF
--- a/src/main/java/gregtech/api/threads/RunnableMachineUpdate.java
+++ b/src/main/java/gregtech/api/threads/RunnableMachineUpdate.java
@@ -1,5 +1,7 @@
 package gregtech.api.threads;
 
+import java.util.LinkedList;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -8,6 +10,9 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
+import gregtech.api.metatileentity.MetaPipeEntity;
+import gregtech.api.metatileentity.implementations.MTEFrame;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
@@ -149,6 +154,8 @@ public class RunnableMachineUpdate implements Runnable {
     @Override
     public void run() {
         int posX, posY, posZ;
+        List<BMPEdata> adjacentCableList = new LinkedList<>();
+        LongSet adjacentCableKeys = new LongOpenHashSet();
         try {
             while (!tQueue.isEmpty()) {
                 final long packedCoords = tQueue.dequeueLong();
@@ -176,9 +183,16 @@ public class RunnableMachineUpdate implements Runnable {
                 if (tTileEntity instanceof IMachineBlockUpdateable)
                     ((IMachineBlockUpdateable) tTileEntity).onMachineBlockUpdate();
 
-                // Skip propagation through pipes\cables\etc as they have their own RunnableCableUpdate
-                if (Gregtech.features.speedupMachineUpdateThread && (tTileEntity instanceof BaseMetaPipeEntity))
-                    continue;
+                // Skip propagation through pipes\cables\etc, but save some BaseMetaPipeEntity data for later
+                if (Gregtech.features.speedupMachineUpdateThread) {
+                    final boolean isBaseMetaPipeEntity = tTileEntity instanceof BaseMetaPipeEntity;
+                    final BMPEdata bmpeData = isBaseMetaPipeEntity ? new BMPEdata((BaseMetaPipeEntity) tTileEntity, posX, posY, posZ) : null;
+                    if (isBaseMetaPipeEntity) {
+                        adjacentCableKeys.add(packedCoords);
+                        adjacentCableList.add(bmpeData);
+                        if (!bmpeData.isPotentialStructureBlock) continue;
+                    }
+                }
 
                 // Now see if we should add the nearby blocks to the queue:
                 // 1) If we've visited less than 5 blocks, then yes
@@ -198,6 +212,24 @@ public class RunnableMachineUpdate implements Runnable {
                     }
                 }
             }
+
+            // Check for connected cables-likes and create RunnableCableUpdate for them.
+            // Requires a full list of visited machines to avoid missing not-yet-visited connections
+            // and a full list of BMPEs to avoid false-positives (e.g. cable runs)
+            for (var cable : adjacentCableList) {
+                if (!cable.isMetaPipe) continue;
+                for (int i = 0; i < ForgeDirection.VALID_DIRECTIONS.length; i++) {
+                    final ForgeDirection side = ForgeDirection.VALID_DIRECTIONS[i];
+                    if (!cable.metaPipe.isConnectedAtSide(side)) continue;
+                    final long targetCoords = CoordinatePacker
+                        .pack(cable.x + side.offsetX, cable.y + side.offsetY, cable.z + side.offsetZ);
+                    if (adjacentCableKeys.contains(targetCoords)) continue;
+                    if (visited.contains(targetCoords)) {
+                        RunnableCableUpdate.setCableUpdateValues(world, cable.x, cable.y, cable.z);
+                    }
+                }
+            }
+
         } catch (Exception e) {
             GTMod.GT_FML_LOGGER.error(
                 "Well this update was broken... " + initialX
@@ -211,6 +243,24 @@ public class RunnableMachineUpdate implements Runnable {
                     + world.provider.dimensionId
                     + "}",
                 e);
+        }
+    }
+
+    private static class BMPEdata {
+        final int x,y,z;
+        final BaseMetaPipeEntity baseMetaPipe;
+        final IMetaTileEntity metaTile;
+        final MetaPipeEntity metaPipe;
+        final boolean isMetaPipe;
+        final boolean isPotentialStructureBlock;
+
+        BMPEdata(BaseMetaPipeEntity bmpe, int x, int y, int z) {
+            this.x = x; this.y = y; this.z = z;
+            baseMetaPipe = bmpe;
+            metaTile = baseMetaPipe.getMetaTileEntity();
+            isMetaPipe = metaTile instanceof MetaPipeEntity;
+            metaPipe = isMetaPipe ? (MetaPipeEntity)metaTile : null;
+            isPotentialStructureBlock = metaPipe instanceof MTEFrame;
         }
     }
 }

--- a/src/main/java/gregtech/api/threads/RunnableMachineUpdate.java
+++ b/src/main/java/gregtech/api/threads/RunnableMachineUpdate.java
@@ -10,9 +10,6 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
-import gregtech.api.metatileentity.MetaPipeEntity;
-import gregtech.api.metatileentity.implementations.MTEFrame;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
@@ -21,8 +18,11 @@ import com.gtnewhorizon.gtnhlib.util.CoordinatePacker;
 
 import gregtech.GTMod;
 import gregtech.api.GregTechAPI;
+import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.IMachineBlockUpdateable;
 import gregtech.api.metatileentity.BaseMetaPipeEntity;
+import gregtech.api.metatileentity.MetaPipeEntity;
+import gregtech.api.metatileentity.implementations.MTEFrame;
 import gregtech.common.config.Gregtech;
 import it.unimi.dsi.fastutil.longs.LongArrayFIFOQueue;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
@@ -186,8 +186,8 @@ public class RunnableMachineUpdate implements Runnable {
                 // Skip propagation through pipes\cables\etc, but save some BaseMetaPipeEntity data for later
                 if (Gregtech.features.speedupMachineUpdateThread) {
                     final boolean isBaseMetaPipeEntity = tTileEntity instanceof BaseMetaPipeEntity;
-                    final BMPEdata bmpeData = isBaseMetaPipeEntity ? new BMPEdata((BaseMetaPipeEntity) tTileEntity, posX, posY, posZ) : null;
                     if (isBaseMetaPipeEntity) {
+                        final BMPEdata bmpeData = new BMPEdata((BaseMetaPipeEntity) tTileEntity, posX, posY, posZ);
                         adjacentCableKeys.add(packedCoords);
                         adjacentCableList.add(bmpeData);
                         if (!bmpeData.isPotentialStructureBlock) continue;
@@ -247,7 +247,8 @@ public class RunnableMachineUpdate implements Runnable {
     }
 
     private static class BMPEdata {
-        final int x,y,z;
+
+        final int x, y, z;
         final BaseMetaPipeEntity baseMetaPipe;
         final IMetaTileEntity metaTile;
         final MetaPipeEntity metaPipe;
@@ -255,11 +256,13 @@ public class RunnableMachineUpdate implements Runnable {
         final boolean isPotentialStructureBlock;
 
         BMPEdata(BaseMetaPipeEntity bmpe, int x, int y, int z) {
-            this.x = x; this.y = y; this.z = z;
+            this.x = x;
+            this.y = y;
+            this.z = z;
             baseMetaPipe = bmpe;
             metaTile = baseMetaPipe.getMetaTileEntity();
             isMetaPipe = metaTile instanceof MetaPipeEntity;
-            metaPipe = isMetaPipe ? (MetaPipeEntity)metaTile : null;
+            metaPipe = isMetaPipe ? (MetaPipeEntity) metaTile : null;
             isPotentialStructureBlock = metaPipe instanceof MTEFrame;
         }
     }


### PR DESCRIPTION
Added more logic to `BaseMetaPipeEntity` exclusion in `RunnableMachineUpdate` introduced in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4865. Now it calls a `RunnableCableUpdate` for every `IConnectable`* that is connected to one of the visited machine blocks.
<sub>* technically only for `MetaPipeEntity`</sub>
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/21408. I have not actually looked at energy distribution code, but during testing the issue only resolved after causing an update for the energy source (aka my Dynamo Hatch), which is weird and of course it would break without cascading updates.
Also added MTEFrame exclusion-exclusion discussed at the end of the first pull request.

[Vid 1](https://youtu.be/NDwmxWnK2hE) of me messing around with debug visualizer with these changes. 
[Vid 2](https://youtu.be/Yd_fVgWi4_g) of debug visualizer with all exclusion changes reverted (aka current release and without #4865).
