### PR TITLE
Upgrade Input & Output bus inventory

### DIFF
--- a/src/main/java/ggfab/mte/MTELinkedInputBus.java
+++ b/src/main/java/ggfab/mte/MTELinkedInputBus.java
@@ -370,6 +370,16 @@ public class MTELinkedInputBus extends MTEHatchInputBus implements IRecipeProces
     }
 
     @Override
+    public int getGUIHeight() {
+        return 166;
+    }
+
+    @Override
+    public int getGUIWidth() {
+        return 176;
+    }
+
+    @Override
     public NBTTagCompound getCopiedData(EntityPlayer player) {
         if (getChannel() == null) {
             return null;

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEHatch.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEHatch.java
@@ -40,7 +40,7 @@ public abstract class MTEHatch extends MTEBasicTank implements ICraftingIconProv
     }
 
     public static int getSlots(int aTier) {
-        return aTier < 1 ? 1 : aTier == 1 ? 4 : aTier == 2 ? 9 : 16;
+        return (aTier + 1) * (aTier + 1);
     }
 
     @Override

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEHatchInputBus.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEHatchInputBus.java
@@ -11,12 +11,6 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-import com.gtnewhorizons.modularui.api.ModularUITextures;
-import com.gtnewhorizons.modularui.api.forge.ItemStackHandler;
-import com.gtnewhorizons.modularui.common.widget.DrawableWidget;
-import com.gtnewhorizons.modularui.common.widget.FluidSlotWidget;
-import com.gtnewhorizons.modularui.common.widget.SlotWidget;
-import gregtech.api.interfaces.modularui.IAddGregtechLogo;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
@@ -27,11 +21,13 @@ import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import com.gtnewhorizons.modularui.api.ModularUITextures;
 import com.gtnewhorizons.modularui.api.drawable.UITexture;
 import com.gtnewhorizons.modularui.api.screen.ModularWindow;
 import com.gtnewhorizons.modularui.api.screen.UIBuildContext;
 import com.gtnewhorizons.modularui.api.widget.Widget;
 import com.gtnewhorizons.modularui.common.widget.CycleButtonWidget;
+import com.gtnewhorizons.modularui.common.widget.SlotWidget;
 
 import gregtech.GTMod;
 import gregtech.api.enums.Dyes;
@@ -50,7 +46,6 @@ import gregtech.api.util.GTUtility;
 import gregtech.api.util.extensions.ArrayExt;
 import mcp.mobius.waila.api.IWailaConfigHandler;
 import mcp.mobius.waila.api.IWailaDataAccessor;
-import org.jetbrains.annotations.NotNull;
 
 public class MTEHatchInputBus extends MTEHatch implements IConfigurationCircuitSupport, IAddUIWidgets {
 

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEHatchOutputBus.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEHatchOutputBus.java
@@ -6,10 +6,6 @@ import static gregtech.api.util.GTUtility.areStacksEqual;
 import static gregtech.api.util.GTUtility.isStackInvalid;
 import static gregtech.api.util.GTUtility.moveMultipleItemStacks;
 
-import com.gtnewhorizons.modularui.api.ModularUITextures;
-import com.gtnewhorizons.modularui.common.widget.DrawableWidget;
-import com.gtnewhorizons.modularui.common.widget.SlotWidget;
-import gregtech.api.interfaces.modularui.IAddGregtechLogo;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.inventory.IInventory;
@@ -20,9 +16,12 @@ import net.minecraftforge.common.util.ForgeDirection;
 
 import org.jetbrains.annotations.Nullable;
 
+import com.gtnewhorizons.modularui.api.ModularUITextures;
 import com.gtnewhorizons.modularui.api.forge.ItemHandlerHelper;
 import com.gtnewhorizons.modularui.api.screen.ModularWindow;
 import com.gtnewhorizons.modularui.api.screen.UIBuildContext;
+import com.gtnewhorizons.modularui.common.widget.DrawableWidget;
+import com.gtnewhorizons.modularui.common.widget.SlotWidget;
 
 import gregtech.GTMod;
 import gregtech.api.enums.ItemList;
@@ -30,13 +29,15 @@ import gregtech.api.gui.widgets.PhantomItemButton;
 import gregtech.api.interfaces.IDataCopyable;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.metatileentity.IItemLockable;
+import gregtech.api.interfaces.modularui.IAddGregtechLogo;
 import gregtech.api.interfaces.modularui.IAddUIWidgets;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.extensions.ArrayExt;
 
-public class MTEHatchOutputBus extends MTEHatch implements IAddUIWidgets, IItemLockable, IDataCopyable, IAddGregtechLogo {
+public class MTEHatchOutputBus extends MTEHatch
+    implements IAddUIWidgets, IItemLockable, IDataCopyable, IAddGregtechLogo {
 
     private static final String DATA_STICK_DATA_TYPE = "outputBusFilter";
     private static final String LOCKED_ITEM_NBT_KEY = "lockedItem";
@@ -358,7 +359,6 @@ public class MTEHatchOutputBus extends MTEHatch implements IAddUIWidgets, IItemL
                 .setSize(18, 18)
                 .setPos(152 + (mTier < 4 ? 0 : 2 * (mTier - 1)), 60 + (mTier < 4 ? 0 : 16 * (mTier - 1))));
     }
-
 
     @Override
     public int getGUIWidth() {

--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchCraftingInputME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchCraftingInputME.java
@@ -830,7 +830,12 @@ public class MTEHatchCraftingInputME extends MTEHatchInputBus
 
     @Override
     public int getGUIWidth() {
-        return super.getGUIWidth() + 16;
+        return 176 + 16;
+    }
+
+    @Override
+    public int getGUIHeight() {
+        return 166;
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/core/recipe/RecipesMachines.java
+++ b/src/main/java/gtPlusPlus/core/recipe/RecipesMachines.java
@@ -191,7 +191,7 @@ public class RecipesMachines {
         industrialVacuumFurnace();
         fakeMachineCasingCovers();
         overflowValveCovers();
-        superBuses();
+//        superBuses();
         distillus();
         algaeFarm();
         chemPlant();

--- a/src/main/java/gtPlusPlus/core/recipe/RecipesMachines.java
+++ b/src/main/java/gtPlusPlus/core/recipe/RecipesMachines.java
@@ -191,7 +191,7 @@ public class RecipesMachines {
         industrialVacuumFurnace();
         fakeMachineCasingCovers();
         overflowValveCovers();
-//        superBuses();
+        // superBuses();
         distillus();
         algaeFarm();
         chemPlant();

--- a/src/main/java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechCustomHatches.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechCustomHatches.java
@@ -44,6 +44,8 @@ import static gregtech.api.enums.MetaTileEntityIDs.Hatch_SuperBus_Output_UHV;
 import static gregtech.api.enums.MetaTileEntityIDs.Hatch_SuperBus_Output_UV;
 import static gregtech.api.enums.MetaTileEntityIDs.Hatch_SuperBus_Output_ZPM;
 
+import net.minecraft.util.EnumChatFormatting;
+
 import gregtech.GTMod;
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.Materials;
@@ -62,7 +64,6 @@ import gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.MTEHatchTurbi
 import gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.MTESuperBusOutput;
 import gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.base.MTEHatchCustomFluidBase;
 import gtPlusPlus.xmod.thermalfoundation.fluid.TFFluids;
-import net.minecraft.util.EnumChatFormatting;
 
 public class GregtechCustomHatches {
 

--- a/src/main/java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechCustomHatches.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechCustomHatches.java
@@ -62,6 +62,7 @@ import gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.MTEHatchTurbi
 import gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.MTESuperBusOutput;
 import gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.base.MTEHatchCustomFluidBase;
 import gtPlusPlus.xmod.thermalfoundation.fluid.TFFluids;
+import net.minecraft.util.EnumChatFormatting;
 
 public class GregtechCustomHatches {
 
@@ -199,114 +200,115 @@ public class GregtechCustomHatches {
     }
 
     private static void run3() {
+        String DEPRECATED = EnumChatFormatting.RED + "DEPRECATED! " + EnumChatFormatting.RESET;
         GregtechItemList.Hatch_SuperBus_Input_LV.set(
             ((IMetaTileEntity) makeInputBus(
                 Hatch_SuperBus_Input_LV.ID,
                 "hatch.superbus.input.tier.01",
-                "Super Bus (I) (LV)",
+                DEPRECATED + "Super Bus (I) (LV)",
                 1)).getStackForm(1L));
         GregtechItemList.Hatch_SuperBus_Input_MV.set(
             ((IMetaTileEntity) makeInputBus(
                 Hatch_SuperBus_Input_MV.ID,
                 "hatch.superbus.input.tier.02",
-                "Super Bus (I) (MV)",
+                DEPRECATED + "Super Bus (I) (MV)",
                 2)).getStackForm(1L));
         GregtechItemList.Hatch_SuperBus_Input_HV.set(
             ((IMetaTileEntity) makeInputBus(
                 Hatch_SuperBus_Input_HV.ID,
                 "hatch.superbus.input.tier.03",
-                "Super Bus (I) (HV)",
+                DEPRECATED + "Super Bus (I) (HV)",
                 3)).getStackForm(1L));
         GregtechItemList.Hatch_SuperBus_Input_EV.set(
             ((IMetaTileEntity) makeInputBus(
                 Hatch_SuperBus_Input_EV.ID,
                 "hatch.superbus.input.tier.04",
-                "Super Bus (I) (EV)",
+                DEPRECATED + "Super Bus (I) (EV)",
                 4)).getStackForm(1L));
         GregtechItemList.Hatch_SuperBus_Input_IV.set(
             ((IMetaTileEntity) makeInputBus(
                 Hatch_SuperBus_Input_IV.ID,
                 "hatch.superbus.input.tier.05",
-                "Super Bus (I) (IV)",
+                DEPRECATED + "Super Bus (I) (IV)",
                 5)).getStackForm(1L));
         GregtechItemList.Hatch_SuperBus_Input_LuV.set(
             ((IMetaTileEntity) makeInputBus(
                 Hatch_SuperBus_Input_LuV.ID,
                 "hatch.superbus.input.tier.06",
-                "Super Bus (I) (LuV)",
+                DEPRECATED + "Super Bus (I) (LuV)",
                 6)).getStackForm(1L));
         GregtechItemList.Hatch_SuperBus_Input_ZPM.set(
             ((IMetaTileEntity) makeInputBus(
                 Hatch_SuperBus_Input_ZPM.ID,
                 "hatch.superbus.input.tier.07",
-                "Super Bus (I) (ZPM)",
+                DEPRECATED + "Super Bus (I) (ZPM)",
                 7)).getStackForm(1L));
         GregtechItemList.Hatch_SuperBus_Input_UV.set(
             ((IMetaTileEntity) makeInputBus(
                 Hatch_SuperBus_Input_UV.ID,
                 "hatch.superbus.input.tier.08",
-                "Super Bus (I) (UV)",
+                DEPRECATED + "Super Bus (I) (UV)",
                 8)).getStackForm(1L));
         GregtechItemList.Hatch_SuperBus_Input_MAX.set(
             ((IMetaTileEntity) makeInputBus(
                 Hatch_SuperBus_Input_UHV.ID,
                 "hatch.superbus.input.tier.09",
-                "Super Bus (I) (UHV)",
+                DEPRECATED + "Super Bus (I) (UHV)",
                 9)).getStackForm(1L));
 
         GregtechItemList.Hatch_SuperBus_Output_LV.set(
             ((IMetaTileEntity) makeOutputBus(
                 Hatch_SuperBus_Output_LV.ID,
                 "hatch.superbus.output.tier.01",
-                "Super Bus (O) (LV)",
+                DEPRECATED + "Super Bus (O) (LV)",
                 1)).getStackForm(1L));
         GregtechItemList.Hatch_SuperBus_Output_MV.set(
             ((IMetaTileEntity) makeOutputBus(
                 Hatch_SuperBus_Output_MV.ID,
                 "hatch.superbus.output.tier.02",
-                "Super Bus (O) (MV)",
+                DEPRECATED + "Super Bus (O) (MV)",
                 2)).getStackForm(1L));
         GregtechItemList.Hatch_SuperBus_Output_HV.set(
             ((IMetaTileEntity) makeOutputBus(
                 Hatch_SuperBus_Output_HV.ID,
                 "hatch.superbus.output.tier.03",
-                "Super Bus (O) (HV)",
+                DEPRECATED + "Super Bus (O) (HV)",
                 3)).getStackForm(1L));
         GregtechItemList.Hatch_SuperBus_Output_EV.set(
             ((IMetaTileEntity) makeOutputBus(
                 Hatch_SuperBus_Output_EV.ID,
                 "hatch.superbus.output.tier.04",
-                "Super Bus (O) (EV)",
+                DEPRECATED + "Super Bus (O) (EV)",
                 4)).getStackForm(1L));
         GregtechItemList.Hatch_SuperBus_Output_IV.set(
             ((IMetaTileEntity) makeOutputBus(
                 Hatch_SuperBus_Output_IV.ID,
                 "hatch.superbus.output.tier.05",
-                "Super Bus (O) (IV)",
+                DEPRECATED + "Super Bus (O) (IV)",
                 5)).getStackForm(1L));
         GregtechItemList.Hatch_SuperBus_Output_LuV.set(
             ((IMetaTileEntity) makeOutputBus(
                 Hatch_SuperBus_Output_LuV.ID,
                 "hatch.superbus.output.tier.06",
-                "Super Bus (O) (LuV)",
+                DEPRECATED + "Super Bus (O) (LuV)",
                 6)).getStackForm(1L));
         GregtechItemList.Hatch_SuperBus_Output_ZPM.set(
             ((IMetaTileEntity) makeOutputBus(
                 Hatch_SuperBus_Output_ZPM.ID,
                 "hatch.superbus.output.tier.07",
-                "Super Bus (O) (ZPM)",
+                DEPRECATED + "Super Bus (O) (ZPM)",
                 7)).getStackForm(1L));
         GregtechItemList.Hatch_SuperBus_Output_UV.set(
             ((IMetaTileEntity) makeOutputBus(
                 Hatch_SuperBus_Output_UV.ID,
                 "hatch.superbus.output.tier.08",
-                "Super Bus (O) (UV)",
+                DEPRECATED + "Super Bus (O) (UV)",
                 8)).getStackForm(1L));
         GregtechItemList.Hatch_SuperBus_Output_MAX.set(
             ((IMetaTileEntity) makeOutputBus(
                 Hatch_SuperBus_Output_UHV.ID,
                 "hatch.superbus.output.tier.09",
-                "Super Bus (O) (UHV)",
+                DEPRECATED + "Super Bus (O) (UHV)",
                 9)).getStackForm(1L));
     }
 


### PR DESCRIPTION
### **Inventory capacity has been increased for buses above HV tier.**
Crafting for Super Buses has been disabled, and a "DEPRECATED" label has been added, indicating they will be removed in the next update. This is because regular buses now have a standard size, and no other types are needed.
The maximum GUI size is approximately that of a diamond chest, maybe even smaller, so there should be no issues.

<img width="580" height="926" alt="image" src="https://github.com/user-attachments/assets/115185bd-715e-4b41-8ff1-c20f56b16891" />

<img width="578" height="931" alt="image" src="https://github.com/user-attachments/assets/644aba58-ae60-4c8d-ba97-dc18f0e2fac7" />

<img width="681" height="211" alt="image" src="https://github.com/user-attachments/assets/b8ac9e24-3be8-4b08-8cf1-6b7762eab82e" />
