### PR TITLE
Code cleanup for Materials.java

### DIFF
--- a/src/main/java/gregtech/api/enums/Materials.java
+++ b/src/main/java/gregtech/api/enums/Materials.java
@@ -1757,8 +1757,8 @@ public class Materials implements IColorModulationContainer, ISubTagContainer {
     }
 
     private static void setByProducts() {
-        Mytryl.addOreByProducts(Samarium, Samarium, Zinc, Zinc);
-        Rubracium.addOreByProducts(Samarium, Samarium, Samarium, Samarium);
+        Mytryl.addOreByProducts(Samarium, Zinc);
+        Rubracium.addOreByProducts(Samarium);
         Chalcopyrite.addOreByProducts(Pyrite, Cobalt, Cadmium, Gold);
         Sphalerite.addOreByProducts(GarnetYellow, Cadmium, Gallium, Zinc);
         MeteoricIron.addOreByProducts(Iron, Nickel, Iridium, Platinum);


### PR DESCRIPTION
does not affect balance, just cleanup code
if you see the define of .addOreByProducts(...) you will find that actually it doesn't support duplicate materials. (you can also check it in-game.)