### PR TITLE
Fix power goggles crash where client map persists between worlds

### DIFF
--- a/src/main/java/gregtech/common/GTProxy.java
+++ b/src/main/java/gregtech/common/GTProxy.java
@@ -1252,6 +1252,9 @@ public class GTProxy implements IFuelHandler {
         PLAYERS_BY_UUID = null;
         UUID_BY_NAME = null;
         // spotless:on
+
+        PowerGogglesEventHandler.getInstance()
+            .onServerStopped(event);
     }
 
     /**

--- a/src/main/java/gregtech/common/powergoggles/PowerGogglesUtil.java
+++ b/src/main/java/gregtech/common/powergoggles/PowerGogglesUtil.java
@@ -40,6 +40,15 @@ public class PowerGogglesUtil {
 
         WorldServer lscDim = MinecraftServer.getServer()
             .worldServerForDimension(lscLink.getDimension());
+
+        // TODO: REMOVE IN 2.9
+        // Should be safe to remove this check in 2.9. This is a safeguard against a situation where in one
+        // Singleplayer world you link goggles to something in a dimension that doesn't normally exist e.g. Personal Dim
+        // And you quit and select another world.
+        if (lscDim == null) {
+            return null;
+        }
+
         TileEntity tileEntity = lscDim.getTileEntity(lscLink.x, lscLink.y, lscLink.z);
 
         if (tileEntity == null) {

--- a/src/main/java/gregtech/common/powergoggles/handlers/PowerGogglesEventHandler.java
+++ b/src/main/java/gregtech/common/powergoggles/handlers/PowerGogglesEventHandler.java
@@ -10,6 +10,7 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.common.config.Configuration;
 
+import cpw.mods.fml.common.event.FMLServerStoppedEvent;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.InputEvent;
 import cpw.mods.fml.common.gameevent.PlayerEvent;
@@ -25,7 +26,7 @@ public class PowerGogglesEventHandler {
 
     private static final PowerGogglesEventHandler INSTANCE = new PowerGogglesEventHandler();
 
-    private final Map<UUID, PowerGogglesClient> clients = new HashMap<>();
+    private Map<UUID, PowerGogglesClient> clients = new HashMap<>();
     private int updateTicker = 0;
 
     private PowerGogglesEventHandler() {}
@@ -120,6 +121,10 @@ public class PowerGogglesEventHandler {
     public void updatePlayerLink(ItemStack itemstack, EntityPlayerMP player) {
         PowerGogglesClient client = clients.computeIfAbsent(player.getUniqueID(), uuid -> new PowerGogglesClient());
         client.updateLscLink(itemstack, player);
+    }
+
+    public void onServerStopped(FMLServerStoppedEvent event) {
+        this.clients = new HashMap<>();
     }
 
     public Map<UUID, PowerGogglesClient> getClients() {


### PR DESCRIPTION
Turns out that the client map persists between worlds. This means that in a situation where you link goggles to an lsc that exists in a dimension normally not there (e.g. Personal Dimension) the getLsc method passes the lscLink null check and crashes with an NPE because the dimension doesn't exist in the other world.

PR Fixes this bug by resetting the client list when a world is stopped (no effect on data persistence); Also adds a safeguard for users already affected by the bug.


Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/21477
