### PR TITLE
Add Endstone Compression Recipe

### DIFF
--- a/src/main/java/gregtech/loaders/postload/recipes/CompressorRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/CompressorRecipes.java
@@ -52,6 +52,13 @@ public class CompressorRecipes implements Runnable {
             .addTo(compressorRecipes);
 
         GTValues.RA.stdBuilder()
+            .itemInputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.Endstone, 4))
+            .itemOutputs(GTOreDictUnificator.get(new ItemStack(Blocks.end_stone, 3)))
+            .duration(5 * SECONDS)
+            .eut(2)
+            .addTo(compressorRecipes);
+
+        GTValues.RA.stdBuilder()
             .itemInputs(ItemList.IC2_Mixed_Metal_Ingot.get(1L))
             .itemOutputs(GTOreDictUnificator.get(OrePrefixes.plateAlloy, Materials.Advanced, 1L))
             .duration(15 * SECONDS)


### PR DESCRIPTION
### Changes:
- Adds Endstone compression recipe for 4 Dust -> 3 Endstone. This is consistent with netherrack and is not done in perfect ratio to prevent any possibly resource duping from the maceration percentage. 
- This will (please, please, release me) be the final change in this NEI pruning sidequest. All is right with the world once more.

Tested in game ofc can't leave anything to chance 