### PR TITLE
Fix Energy Infuser, Improve Tooltip

### DIFF
--- a/src/main/java/tectech/thing/metaTileEntity/multi/MTEEnergyInfuser.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/MTEEnergyInfuser.java
@@ -5,6 +5,7 @@ import static com.gtnewhorizon.structurelib.structure.StructureUtility.transpose
 import static gregtech.api.GregTechAPI.mEUtoRF;
 import static gregtech.api.enums.HatchElement.Energy;
 import static gregtech.api.enums.HatchElement.InputBus;
+import static gregtech.api.enums.HatchElement.InputHatch;
 import static gregtech.api.enums.HatchElement.Maintenance;
 import static gregtech.api.enums.HatchElement.OutputBus;
 import static gregtech.api.util.GTStructureUtility.buildHatchAdder;
@@ -67,7 +68,7 @@ public class MTEEnergyInfuser extends TTMultiblockBase implements ISurvivalConst
         .addElement(
             'C',
             buildHatchAdder(MTEEnergyInfuser.class)
-                .atLeast(Energy.or(HatchElement.EnergyMulti), Maintenance, InputBus, OutputBus)
+                .atLeast(Energy.or(HatchElement.EnergyMulti), Maintenance, InputBus, InputHatch, OutputBus)
                 .casingIndex(Casings.HighPowerCasing.getTextureId())
                 .dot(1)
                 .buildAndChain(Casings.HighPowerCasing.asElement()))
@@ -179,6 +180,7 @@ public class MTEEnergyInfuser extends TTMultiblockBase implements ISurvivalConst
                         return SimpleCheckRecipeResult.ofFailure("insufficient_power_no_val");
                     }
                     mEfficiencyIncrease = 10000;
+                    mMaxProgresstime = 1;
                     return SimpleCheckRecipeResult.ofSuccess("charging");
                 }
             }
@@ -235,16 +237,14 @@ public class MTEEnergyInfuser extends TTMultiblockBase implements ISurvivalConst
     @Override
     public MultiblockTooltipBuilder createTooltip() {
         final MultiblockTooltipBuilder tt = new MultiblockTooltipBuilder();
-        // Machine Type: Energy Infuser
-        tt.addMachineType(translateToLocal("gt.blockmachines.multimachine.em.infuser.name"))
-            // Controller block of the Energy Infuser
-            .addInfo(translateToLocal("gt.blockmachines.multimachine.em.infuser.desc.0"))
-            // Can be used to charge items (lossless)
-            .addInfo(translateToLocal("gt.blockmachines.multimachine.em.infuser.desc.1"))
-            // Can be fed with UU-Matter to repair items
-            .addInfo(translateToLocal("gt.blockmachines.multimachine.em.infuser.desc.2"))
-            // Stocking Bus is not supported
-            .addInfo(translateToLocal("gt.blockmachines.multimachine.em.infuser.desc.3"))
+        tt.addMachineType("Restorer")
+            .addInfo("Simultaneously recharges and repairs equipment")
+            .addInfo("Stocking input buses are not supported")
+            .addInfo(EnumChatFormatting.GOLD + "Recharging" + EnumChatFormatting.GRAY + ": No max speed or energy loss")
+            .addInfo(
+                EnumChatFormatting.GOLD + "Repairing"
+                    + EnumChatFormatting.GRAY
+                    + ": Max 1k durability/t, consumes 1k EU + 1L UUM per point")
             .addTecTechHatchInfo()
             .beginStructureBlock(3, 5, 3, false)
             // Controller: Front 3rd layer center


### PR DESCRIPTION
As title suggests. I discovered that the Energy Infuser could not take input hatches or even repair items on 2.8.RC2. This fixes those issues and adds some information to the tooltip.

<img width="1011" height="320" alt="2025-09-27_12 33 49" src="https://github.com/user-attachments/assets/b97da1f9-a940-44e7-86fd-6e47e8d3c452" />