### PR TITLE
Remove Fusion Reactor Min Input Hatch Tier

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEFusionComputer.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEFusionComputer.java
@@ -114,8 +114,9 @@ public abstract class MTEFusionComputer extends MTEEnhancedMultiBlockBase<MTEFus
                     'i',
                     lazy(
                         t -> buildHatchAdder(MTEFusionComputer.class)
-                            .atLeast(ImmutableMap.of(InputHatch.withAdder(MTEFusionComputer::addInjector), 1))
-                            .hatchItemFilterAnd(t2 -> filterByMTETier(t2.tier(), Integer.MAX_VALUE))
+                            .atLeast(
+                                gregtech.api.enums.HatchElement.InputHatch.or(gregtech.api.enums.HatchElement.InputBus),
+                                gregtech.api.enums.HatchElement.OutputHatch)
                             .casingIndex(53)
                             .dot(1)
                             .buildAndChain(t.getCasing(), t.getCasingMeta())))
@@ -236,16 +237,6 @@ public abstract class MTEFusionComputer extends MTEEnhancedMultiBlockBase<MTEFus
         if (tHatch.mTier < tier()) return false;
         tHatch.updateTexture(aBaseCasingIndex);
         return mEnergyHatches.add(tHatch);
-    }
-
-    private boolean addInjector(IGregTechTileEntity aBaseMetaTileEntity, int aBaseCasingIndex) {
-        IMetaTileEntity aMetaTileEntity = aBaseMetaTileEntity.getMetaTileEntity();
-        if (aMetaTileEntity == null) return false;
-        if (!(aMetaTileEntity instanceof MTEHatchInput tHatch)) return false;
-        if (tHatch.getTierForStructure() < tier()) return false;
-        tHatch.updateTexture(aBaseCasingIndex);
-        tHatch.mRecipeMap = getRecipeMap();
-        return mInputHatches.add(tHatch);
     }
 
     private boolean addExtractor(IGregTechTileEntity aBaseMetaTileEntity, int aBaseCasingIndex) {


### PR DESCRIPTION
CURRENT STATE
- Fusion Reactor: Minimum Tier on ALL hatches.
- Compact Fusion Reactor: Minimum Tier on ENERGY hatches.

PROPOSED STATE
- Fusion Reactor: Minimum Tier on ENERGY hatches.
- Compact Fusion Reactor: Minimum Tier on ENERGY hatches.

Not only does it make the behavior consistent between the two machines, but it solves an awkward gap that was recently created from the downtiering of the advanced stocking input hatch. More specifically, the Mk-V Fusion Reactor expects ALL hatches to be UEV+ which prevents the advanced stocking input hatch (UHV) from being used.

There isn't really a balance concern here because Fusion Reactor casings could already be replaced by minimum tier input hatches.  Removing the restriction on non-energy hatches would naturally make it even cheaper to replace casings, but they were never a significant cost to the Fusion Reactor anyway.

Also creating a PR for updated quests.