### PR TITLE
Fix Large Boilers using fluid fuels

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTELargeBoiler.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTELargeBoiler.java
@@ -278,8 +278,8 @@ public abstract class MTELargeBoiler extends MTEEnhancedMultiBlockBase<MTELargeB
                 if (tFluid != null && tRecipe.mSpecialValue > 1) {
                     tFluid.amount = 1000;
                     if (depleteInput(tFluid)) {
-                        this.mEfficiencyIncrease = this.mMaxProgresstime * getEfficiencyIncrease() * 4;
                         this.mMaxProgresstime = adjustBurnTimeForConfig(runtimeBoost(tRecipe.mSpecialValue / 2));
+                        this.mEfficiencyIncrease = this.mMaxProgresstime * getEfficiencyIncrease() * 4;
                         this.mEUt = adjustEUtForConfig(getEUt());
                         return CheckRecipeResultRegistry.SUCCESSFUL;
                     }
@@ -290,9 +290,9 @@ public abstract class MTELargeBoiler extends MTEEnhancedMultiBlockBase<MTELargeB
                 if (tFluid != null) {
                     tFluid.amount = 1000;
                     if (depleteInput(tFluid)) {
-                        this.mEfficiencyIncrease = this.mMaxProgresstime * getEfficiencyIncrease();
                         this.mMaxProgresstime = adjustBurnTimeForConfig(
                             Math.max(1, runtimeBoost(tRecipe.mSpecialValue * 2)));
+                        this.mEfficiencyIncrease = this.mMaxProgresstime * getEfficiencyIncrease();
                         this.mEUt = adjustEUtForConfig(getEUt());
                         return CheckRecipeResultRegistry.SUCCESSFUL;
                     }
@@ -374,8 +374,6 @@ public abstract class MTELargeBoiler extends MTEEnhancedMultiBlockBase<MTELargeB
             int maxEff = getCorrectedMaxEfficiency(mInventory[1]);
             if (this.mSuperEfficencyIncrease > 0 && mEfficiency < maxEff) {
                 mEfficiency = Math.max(0, Math.min(mEfficiency + mSuperEfficencyIncrease, maxEff));
-            } else if (getEfficiencyIncrease() > 0 && mEfficiency < maxEff) {
-                mEfficiency = Math.max(0, Math.min(mEfficiency + getEfficiencyIncrease(), maxEff));
             }
             int tGeneratedEU = (int) (this.mEUt * 2L * this.mEfficiency / 10000L);
             if (tGeneratedEU > 0) {

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTELargeBoiler.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTELargeBoiler.java
@@ -374,6 +374,8 @@ public abstract class MTELargeBoiler extends MTEEnhancedMultiBlockBase<MTELargeB
             int maxEff = getCorrectedMaxEfficiency(mInventory[1]);
             if (this.mSuperEfficencyIncrease > 0 && mEfficiency < maxEff) {
                 mEfficiency = Math.max(0, Math.min(mEfficiency + mSuperEfficencyIncrease, maxEff));
+            } else if (getEfficiencyIncrease() > 0 && mEfficiency < maxEff) {
+                mEfficiency = Math.max(0, Math.min(mEfficiency + getEfficiencyIncrease(), maxEff));
             }
             int tGeneratedEU = (int) (this.mEUt * 2L * this.mEfficiency / 10000L);
             if (tGeneratedEU > 0) {

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTELargeBoiler.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTELargeBoiler.java
@@ -281,6 +281,10 @@ public abstract class MTELargeBoiler extends MTEEnhancedMultiBlockBase<MTELargeB
                         this.mMaxProgresstime = adjustBurnTimeForConfig(runtimeBoost(tRecipe.mSpecialValue / 2));
                         this.mEfficiencyIncrease = this.mMaxProgresstime * getEfficiencyIncrease() * 4;
                         this.mEUt = adjustEUtForConfig(getEUt());
+                        if (this.mEfficiencyIncrease > 5000) {
+                            this.mEfficiencyIncrease = 0;
+                            this.mSuperEfficencyIncrease = 20;
+                        }
                         return CheckRecipeResultRegistry.SUCCESSFUL;
                     }
                 }
@@ -294,6 +298,10 @@ public abstract class MTELargeBoiler extends MTEEnhancedMultiBlockBase<MTELargeB
                             Math.max(1, runtimeBoost(tRecipe.mSpecialValue * 2)));
                         this.mEfficiencyIncrease = this.mMaxProgresstime * getEfficiencyIncrease();
                         this.mEUt = adjustEUtForConfig(getEUt());
+                        if (this.mEfficiencyIncrease > 5000) {
+                            this.mEfficiencyIncrease = 0;
+                            this.mSuperEfficencyIncrease = 20;
+                        }
                         return CheckRecipeResultRegistry.SUCCESSFUL;
                     }
                 }


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/21550
onRunningTick only checks for mSuperEfficencyIncrease, which is only assigned when using solid fuels, which is why i added extra else-if after it.

Would like to hear which way is a better fix for this since there is 3 angles to it 

- We assign mSuperEfficencyIncrease in liquid fuels recipe check
- We yeet mSuperEfficencyIncrease in the onRunningTick and replace with getEfficiencyIncrease() with optional values adjustments in classes to keep current time to reach max eff.
- The current solution i made in this ticket (least ideal?)

The current implementation in this PR makes it work, but max efficiency is reached slower when using fluid fuels than when using solid fuels, by roughly 30 seconds (60s with liquid and 30s with solid)


