### PR TITLE
Disable auto-output for steam output hatches

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/MTEHatchSteamBusOutput.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/MTEHatchSteamBusOutput.java
@@ -189,4 +189,9 @@ public class MTEHatchSteamBusOutput extends MTEHatchOutputBus {
     public void addUIWidgets(ModularWindow.Builder builder, UIBuildContext buildContext) {
         getBaseMetaTileEntity().add2by2Slots(builder);
     }
+
+    @Override
+    public boolean pushOutputInventory() {
+        return false;
+    }
 }


### PR DESCRIPTION
Bug that was introduced in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4609.