### PR TITLE
Fix ME Input Bus getFirstShadowItemStack

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchInputBusME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchInputBusME.java
@@ -730,7 +730,7 @@ public class MTEHatchInputBusME extends MTEHatchInputBus
         do {
             itemStack = getShadowItemStack(slotToCheck);
             slotToCheck++;
-        } while ((itemStack == null || !(hasToMatchGhost && lockedSlot.getItem() == itemStack.getItem()))
+        } while ((itemStack == null || (hasToMatchGhost && lockedSlot.getItem() != itemStack.getItem()))
             && slotToCheck < getSizeInventory());
         return itemStack;
     }

--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchInputBusME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchInputBusME.java
@@ -723,15 +723,15 @@ public class MTEHatchInputBusME extends MTEHatchInputBus
             do {
                 lockedSlot = mInventory[slotToCheck];
                 slotToCheck++;
-            } while (lockedSlot == null && slotToCheck < getSizeInventory());
+            } while (lockedSlot == null && slotToCheck < SLOT_COUNT);
             if (lockedSlot == null) return null;
         }
         byte slotToCheck = 0;
         do {
+            if (slotToCheck >= getShadowInventorySize()) return null;
             itemStack = getShadowItemStack(slotToCheck);
             slotToCheck++;
-        } while ((itemStack == null || (hasToMatchGhost && lockedSlot.getItem() != itemStack.getItem()))
-            && slotToCheck < getSizeInventory());
+        } while ((itemStack == null || (hasToMatchGhost && lockedSlot.getItem() != itemStack.getItem())));
         return itemStack;
     }
 

--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchInputME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchInputME.java
@@ -541,7 +541,7 @@ public class MTEHatchInputME extends MTEHatchInput implements IPowerChannelState
         do {
             fluidStack = getShadowFluidStack(slotToCheck);
             slotToCheck++;
-        } while ((fluidStack == null || !(hasToMatchGhost && lockedSlot.getFluid() == fluidStack.getFluid()))
+        } while ((fluidStack == null || (hasToMatchGhost && lockedSlot.getFluid() != fluidStack.getFluid()))
             && slotToCheck < getShadowStoredFluidsSize());
         return fluidStack;
     }

--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchInputME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchInputME.java
@@ -539,10 +539,10 @@ public class MTEHatchInputME extends MTEHatchInput implements IPowerChannelState
         }
         byte slotToCheck = 0;
         do {
+            if (slotToCheck >= getShadowStoredFluidsSize()) return null;
             fluidStack = getShadowFluidStack(slotToCheck);
             slotToCheck++;
-        } while ((fluidStack == null || (hasToMatchGhost && lockedSlot.getFluid() != fluidStack.getFluid()))
-            && slotToCheck < getShadowStoredFluidsSize());
+        } while ((fluidStack == null || (hasToMatchGhost && lockedSlot.getFluid() != fluidStack.getFluid())));
         return fluidStack;
     }
 


### PR DESCRIPTION
BUG1:
If arg 'hasToMatchGhost' is false, getFirstShadowItemStack will return the item in the last slot, because the loop condition is always true.
This PR fix it.


Explained:
```
(itemStack == null                               ||           (hasToMatchGhost && lockedSlot.getItem() != itemStack.getItem()))
if item is null, check the next slot        or          hasToMatchGhost but it fails to match, so check the next slot
```

BUG2:
getSizeInventory() returns 34 , use 16(SLOT_COUNT/getShadowInventorySize()) instead 
(as it should check 16 phantom slots, not all 34 slots).
<img width="1905" height="1125" alt="WBDC1B)LTM(8@V6O6(7C$RE" src="https://github.com/user-attachments/assets/941a57db-db81-4268-a920-037ec429173c" />


