### PR TITLE
Adds Integrated Circuit to Prismatic Naq. ABS Recipe

### DIFF
--- a/src/main/java/gregtech/loaders/postload/chains/NetheriteRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/chains/NetheriteRecipes.java
@@ -172,7 +172,9 @@ public class NetheriteRecipes {
         // Naquarite
         {
             GTValues.RA.stdBuilder()
-                .itemInputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.NaquadahEnriched, 32))
+                .itemInputs(
+                    GTUtility.getIntegratedCircuit(2),
+                    GTOreDictUnificator.get(OrePrefixes.dust, Materials.NaquadahEnriched, 32))
                 .fluidInputs(Materials.PrismaticAcid.getFluid(8000))
                 .fluidOutputs(Materials.PrismaticNaquadah.getMolten(2304))
                 .duration(20 * SECONDS)


### PR DESCRIPTION
### Changes:
- As title states, integrated circuit added in order to not conflict with any Piko [8] recipes on the ABS. Groups well with [2] and doesn't overbear the recipe count either.

Suggested by @LewisSaber and a couple others.
Should be good for 2.8.1 but noted in the changelog so people aren't confused if they have it loaded into a [0] right now.