### PR TITLE
Fix Drown Downlink module not connecting on certain multiblocks

### DIFF
--- a/src/main/java/goodgenerator/blocks/tileEntity/MTEPreciseAssembler.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/MTEPreciseAssembler.java
@@ -124,31 +124,31 @@ public class MTEPreciseAssembler extends MTEExtendedPowerMultiBlockBase<MTEPreci
                 .addElement(
                     'C',
                     GTStructureChannels.PRASS_UNIT_CASING.use(
-                    buildHatchAdder(MTEPreciseAssembler.class)
-                        .atLeast(
-                            InputBus,
-                            InputHatch,
-                            OutputHatch,
-                            OutputBus,
-                            Maintenance,
-                            Muffler,
-                            ExoticEnergy.or(Energy))
-                        .casingIndex(CASING_INDEX)
-                        .dot(1)
-                        .buildAndChain(
-                            onElementPass(
-                                x -> x.casingAmount++,
-                                StructureUtility.ofBlocksTiered(
-                                    MTEPreciseAssembler::getCasingBlockTier,
-                                    ImmutableList.of(
-                                        Pair.of(Loaders.impreciseUnitCasing, 0),
-                                        Pair.of(Loaders.preciseUnitCasing, 0),
-                                        Pair.of(Loaders.preciseUnitCasing, 1),
-                                        Pair.of(Loaders.preciseUnitCasing, 2),
-                                        Pair.of(Loaders.preciseUnitCasing, 3)),
-                                    -3,
-                                    MTEPreciseAssembler::setCasingTier,
-                                    MTEPreciseAssembler::getCasingTier)))))
+                        buildHatchAdder(MTEPreciseAssembler.class)
+                            .atLeast(
+                                InputBus,
+                                InputHatch,
+                                OutputHatch,
+                                OutputBus,
+                                Maintenance,
+                                Muffler,
+                                ExoticEnergy.or(Energy))
+                            .casingIndex(CASING_INDEX)
+                            .dot(1)
+                            .buildAndChain(
+                                onElementPass(
+                                    x -> x.casingAmount++,
+                                    StructureUtility.ofBlocksTiered(
+                                        MTEPreciseAssembler::getCasingBlockTier,
+                                        ImmutableList.of(
+                                            Pair.of(Loaders.impreciseUnitCasing, 0),
+                                            Pair.of(Loaders.preciseUnitCasing, 0),
+                                            Pair.of(Loaders.preciseUnitCasing, 1),
+                                            Pair.of(Loaders.preciseUnitCasing, 2),
+                                            Pair.of(Loaders.preciseUnitCasing, 3)),
+                                        -3,
+                                        MTEPreciseAssembler::setCasingTier,
+                                        MTEPreciseAssembler::getCasingTier)))))
                 .addElement('F', ofFrame(Materials.TungstenSteel))
                 .addElement('G', chainAllGlasses(-1, (te, t) -> te.glassTier = t, te -> te.glassTier))
                 .addElement(

--- a/src/main/java/goodgenerator/blocks/tileEntity/MTEPreciseAssembler.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/MTEPreciseAssembler.java
@@ -123,6 +123,7 @@ public class MTEPreciseAssembler extends MTEExtendedPowerMultiBlockBase<MTEPreci
                             { "CCCC~CCCC", "CMMMMMMMC", "CMMMMMMMC", "CMMMMMMMC", "CCCCCCCCC" } }))
                 .addElement(
                     'C',
+                    GTStructureChannels.PRASS_UNIT_CASING.use(
                     buildHatchAdder(MTEPreciseAssembler.class)
                         .atLeast(
                             InputBus,
@@ -147,7 +148,7 @@ public class MTEPreciseAssembler extends MTEExtendedPowerMultiBlockBase<MTEPreci
                                         Pair.of(Loaders.preciseUnitCasing, 3)),
                                     -3,
                                     MTEPreciseAssembler::setCasingTier,
-                                    MTEPreciseAssembler::getCasingTier))))
+                                    MTEPreciseAssembler::getCasingTier)))))
                 .addElement('F', ofFrame(Materials.TungstenSteel))
                 .addElement('G', chainAllGlasses(-1, (te, t) -> te.glassTier = t, te -> te.glassTier))
                 .addElement(

--- a/src/main/java/gregtech/common/tileentities/machines/multi/drone/MTEHatchDroneDownLink.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/drone/MTEHatchDroneDownLink.java
@@ -155,7 +155,7 @@ public class MTEHatchDroneDownLink extends MTEHatchMaintenance {
             if (aPlayer instanceof FakePlayer) return false;
             if (!hasConnection()) {
                 aPlayer.addChatComponentMessage(new ChatComponentTranslation("GT5U.machines.dronecentre.noconnection"));
-                return false;
+                return true;
             }
             openGui(aPlayer);
             return true;

--- a/src/main/java/kekztech/common/tileentities/MTELapotronicSuperCapacitor.java
+++ b/src/main/java/kekztech/common/tileentities/MTELapotronicSuperCapacitor.java
@@ -89,6 +89,7 @@ import gregtech.common.gui.modularui.widget.ShutDownReasonSyncer;
 import gregtech.common.misc.GTStructureChannels;
 import gregtech.common.misc.WirelessNetworkManager;
 import gregtech.common.misc.spaceprojects.SpaceProjectManager;
+import gregtech.common.tileentities.machines.multi.drone.MTEHatchDroneDownLink;
 import kekztech.client.gui.KTUITextures;
 import kekztech.common.Blocks;
 import kekztech.common.itemBlocks.ItemBlockLapotronicEnergyUnit;
@@ -287,9 +288,12 @@ public class MTELapotronicSuperCapacitor extends MTEEnhancedMultiBlockBase<MTELa
         if (aTileEntity == null || aTileEntity.isDead()) return false;
         IMetaTileEntity aMetaTileEntity = aTileEntity.getMetaTileEntity();
         if (!(aMetaTileEntity instanceof MTEHatch)) return false;
-        if (aMetaTileEntity instanceof MTEHatchMaintenance) {
+        if (aMetaTileEntity instanceof MTEHatchMaintenance hatch) {
             ((MTEHatch) aMetaTileEntity).updateTexture(aBaseCasingIndex);
-            return MTELapotronicSuperCapacitor.this.mMaintenanceHatches.add((MTEHatchMaintenance) aMetaTileEntity);
+            if (hatch instanceof MTEHatchDroneDownLink droneDownLink) {
+                droneDownLink.registerMachineController(this);
+            }
+            return MTELapotronicSuperCapacitor.this.mMaintenanceHatches.add(hatch);
         } else if (aMetaTileEntity instanceof MTEHatchEnergy) {
             // Add GT hatches
             final MTEHatchEnergy tHatch = ((MTEHatchEnergy) aMetaTileEntity);

--- a/src/main/java/tectech/thing/metaTileEntity/multi/MTETeslaTower.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/MTETeslaTower.java
@@ -775,7 +775,7 @@ public class MTETeslaTower extends TTMultiblockBase implements ISurvivalConstruc
         return getBaseMetaTileEntity().isActive() ? super.getEUVar() : 1;
     }
 
-    private boolean addCapacitorToMachineList(IGregTechTileEntity aTileEntity, int aBaseCasingIndex) {
+    public boolean addCapacitorToMachineList(IGregTechTileEntity aTileEntity, int aBaseCasingIndex) {
         if (aTileEntity == null) {
             return false;
         }
@@ -789,7 +789,7 @@ public class MTETeslaTower extends TTMultiblockBase implements ISurvivalConstruc
         }
         if (aMetaTileEntity instanceof MTEHatchMaintenance) {
             ((MTEHatch) aMetaTileEntity).updateTexture(aBaseCasingIndex);
-            return mMaintenanceHatches.add((MTEHatchMaintenance) aMetaTileEntity);
+            return addMaintenanceToMachineList(aTileEntity, aBaseCasingIndex);
         }
         if (aMetaTileEntity instanceof MTEHatchEnergy) {
             ((MTEHatch) aMetaTileEntity).updateTexture(aBaseCasingIndex);

--- a/src/main/java/tectech/thing/metaTileEntity/multi/base/TTMultiblockBase.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/base/TTMultiblockBase.java
@@ -91,6 +91,7 @@ import gregtech.api.util.shutdown.ShutDownReason;
 import gregtech.api.util.shutdown.ShutDownReasonRegistry;
 import gregtech.api.util.shutdown.SimpleShutDownReason;
 import gregtech.common.tileentities.machines.IDualInputHatch;
+import gregtech.common.tileentities.machines.multi.drone.MTEHatchDroneDownLink;
 import tectech.TecTech;
 import tectech.loader.ConfigHandler;
 import tectech.thing.gui.TecTechUITextures;
@@ -1659,8 +1660,11 @@ public abstract class TTMultiblockBase extends MTEExtendedPowerMultiBlockBase<TT
         if (aMetaTileEntity instanceof MTEHatchDynamo) {
             return mDynamoHatches.add((MTEHatchDynamo) aMetaTileEntity);
         }
-        if (aMetaTileEntity instanceof MTEHatchMaintenance) {
-            return mMaintenanceHatches.add((MTEHatchMaintenance) aMetaTileEntity);
+        if (aMetaTileEntity instanceof MTEHatchMaintenance hatch) {
+            if (hatch instanceof MTEHatchDroneDownLink droneDownLink) {
+                droneDownLink.registerMachineController(this);
+            }
+            return mMaintenanceHatches.add(hatch);
         }
         if (aMetaTileEntity instanceof MTEHatchMuffler) {
             return mMufflerHatches.add((MTEHatchMuffler) aMetaTileEntity);
@@ -1914,6 +1918,9 @@ public abstract class TTMultiblockBase extends MTEExtendedPowerMultiBlockBase<TT
         if (aMetaTileEntity instanceof MTEHatchMaintenance hatch) {
             hatch.updateTexture(aBaseCasingIndex);
             hatch.updateCraftingIcon(this.getMachineCraftingIcon());
+            if (hatch instanceof MTEHatchDroneDownLink droneDownLink) {
+                droneDownLink.registerMachineController(this);
+            }
             return mMaintenanceHatches.add(hatch);
         }
         if (aMetaTileEntity instanceof MTEHatchUncertainty hatch) {


### PR DESCRIPTION
Fixes [#21143](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/21143).

Drone Downlink Hatches now connect when used in good generator and tectech machines.

I also saw that you can place blocks against a not connected drone downlink hatch, which would also print a message noting the invalid connection. That is no longer possible, and only the message is printed. When holding shift and placing a block the message will not print, and the block will be placed.