### PR TITLE
Tweaks Void Hatch Recipe

### DIFF
--- a/src/main/java/gregtech/loaders/postload/recipes/AssemblerRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/AssemblerRecipes.java
@@ -4465,7 +4465,7 @@ public class AssemblerRecipes implements Runnable {
         // Void hatch
         {
             GTValues.RA.stdBuilder()
-                .itemInputs(ItemList.Hatch_Output_LV.get(1), getModItem(ExtraUtilities.ID, "trashcan", 1L, 0))
+                .itemInputs(ItemList.Hatch_Output_LV.get(1), getModItem(ExtraUtilities.ID, "trashcan", 1L, 1))
                 .itemOutputs(ItemList.Hatch_Void.get(1))
                 .duration(20 * SECONDS)
                 .eut(TierEU.RECIPE_LV)


### PR DESCRIPTION
### Changes:
- Just switches the void hatch to use a fluid trash can in it's recipe rather than an item trash can. Regular void bus still uses item trash can

Super easy change for consistency sake.
Good for 2.8.X