### PR TITLE
Item VP Refactor Fixes

### DIFF
--- a/src/main/java/ggfab/mte/MTEAdvAssLine.java
+++ b/src/main/java/ggfab/mte/MTEAdvAssLine.java
@@ -1024,11 +1024,17 @@ public class MTEAdvAssLine extends MTEExtendedPowerMultiBlockBase<MTEAdvAssLine>
                 if (id + 1 >= currentInputLength) {
                     // use previously calculated parallel output
                     ItemStack output = mOutputItems[0];
-                    if (addOutputAtomic(output) || !voidingMode.protectItem) reset();
-                    else stuck = true;
+                    if (addOutputAtomic(GTUtility.copy(output)) || !voidingMode.protectItem) {
+                        reset();
+                    } else {
+                        stuck = true;
+                    }
                 } else {
-                    if (slices[id + 1].start()) reset();
-                    else stuck = true;
+                    if (slices[id + 1].start()) {
+                        reset();
+                    } else {
+                        stuck = true;
+                    }
                 }
             }
         }

--- a/src/main/java/gregtech/api/util/ItemEjectionHelper.java
+++ b/src/main/java/gregtech/api/util/ItemEjectionHelper.java
@@ -86,6 +86,8 @@ public class ItemEjectionHelper {
             Comparator.comparingInt(output -> -output.remaining.stackSize));
 
         for (var e : Object2LongMaps.fastIterable(GTUtility.getItemStackHistogram(outputs))) {
+            if (e.getLongValue() <= 0) continue;
+
             GTUtility.ItemId id = e.getKey();
             int amount = GTUtility.longToInt(e.getLongValue());
 


### PR DESCRIPTION
fixes: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/21692

I added some code to prevent div-by-zeroes, but that shouldn't be relied on for future problems like this. I fixed the root cause by copying the ejected stack (AALs don't expect the stack reference to be modified, but addOutputAtomic reduces the stack by however many items were ejected).