### PR TITLE
Fix dynamism tablet not performing maintenance

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -36,11 +36,11 @@
 dependencies {
     api("com.github.GTNewHorizons:StructureLib:1.4.23:dev")
     api("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev")
-    api("com.github.GTNewHorizons:NotEnoughItems:2.8.2-GTNH:dev")
+    api("com.github.GTNewHorizons:NotEnoughItems:2.8.4-GTNH:dev")
     api("com.github.GTNewHorizons:NotEnoughIds:2.1.10:dev")
     api("com.github.GTNewHorizons:GTNHLib:0.7.0:dev")
     api("com.github.GTNewHorizons:ModularUI:1.2.20:dev")
-    api("com.github.GTNewHorizons:ModularUI2:2.2.18-1.7.10:dev")
+    api("com.github.GTNewHorizons:ModularUI2:2.2.20-1.7.10:dev")
     api("com.github.GTNewHorizons:waila:1.9.0:dev")
     api("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-700-GTNH:dev")
     api("com.github.GTNewHorizons:AE2FluidCraft-Rework:1.5.1-gtnh:dev")

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEHatchMaintenance.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEHatchMaintenance.java
@@ -55,6 +55,7 @@ import gregtech.api.util.GTOreDictUnificator;
 import gregtech.api.util.GTUtility;
 import ic2.core.IHasGui;
 import ic2.core.item.ItemToolbox;
+import thaumic.tinkerer.common.block.tile.tablet.TabletFakePlayer;
 
 public class MTEHatchMaintenance extends MTEHatch implements IAddUIWidgets, IAlignment {
 
@@ -175,10 +176,14 @@ public class MTEHatchMaintenance extends MTEHatch implements IAddUIWidgets, IAli
         float aX, float aY, float aZ) {
         if (side == aBaseMetaTileEntity.getFrontFacing()) {
             if (aBaseMetaTileEntity.isClientSide()) return true;
-            // only allow OC robot fake player
-            if (aPlayer instanceof FakePlayer && !aPlayer.getGameProfile()
-                .getName()
-                .endsWith(".robot")) return false;
+            // only allow OC robot & dynamism tablet fake player
+            if (aPlayer instanceof FakePlayer) {
+                if (!(aPlayer instanceof TabletFakePlayer) && !aPlayer.getGameProfile()
+                    .getName()
+                    .endsWith(".robot")) {
+                    return false;
+                }
+            }
             ItemStack tStack = aPlayer.getCurrentEquippedItem();
             if (tStack != null) {
                 if (tStack.getItem() instanceof ItemToolbox) {


### PR DESCRIPTION
https://discord.com/channels/181078474394566657/234936569360809996/1423103183110279168

This is an artifact from my dynamism tablet rewrite. Old dynamism tablet used FakeThaumcraftPlayer (not instanceof FakePlayer) so this check never happened. This PR just makes it work like it used to.