### PR TITLE
Add pollution output bypass for large essentia smeltery

### DIFF
--- a/src/main/java/goodgenerator/blocks/tileEntity/MTELargeEssentiaSmeltery.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/MTELargeEssentiaSmeltery.java
@@ -3,6 +3,7 @@ package goodgenerator.blocks.tileEntity;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.*;
 import static gregtech.api.enums.Mods.ThaumicBases;
 import static gregtech.api.util.GTStructureUtility.buildHatchAdder;
+import static gregtech.api.util.GTUtility.validMTEList;
 
 import java.util.ArrayList;
 import java.util.Map;
@@ -34,6 +35,7 @@ import com.gtnewhorizons.modularui.common.widget.TextWidget;
 import goodgenerator.blocks.tileEntity.base.MTETooltipMultiBlockBaseEM;
 import goodgenerator.loader.Loaders;
 import goodgenerator.util.DescTextLocalization;
+import gregtech.GTMod;
 import gregtech.api.enums.Textures;
 import gregtech.api.interfaces.IIconContainer;
 import gregtech.api.interfaces.ITexture;
@@ -49,6 +51,7 @@ import gregtech.api.util.GTUtility;
 import gregtech.api.util.MultiblockTooltipBuilder;
 import gregtech.api.util.OverclockCalculator;
 import gregtech.api.util.shutdown.ShutDownReason;
+import gregtech.common.pollution.Pollution;
 import tectech.thing.metaTileEntity.multi.base.TTMultiblockBase;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
@@ -557,6 +560,30 @@ public class MTELargeEssentiaSmeltery extends MTETooltipMultiBlockBaseEM
             }
         }
         return super.onRunningTick(aStack);
+    }
+
+    @Override
+    public boolean polluteEnvironment(int aPollutionLevel) {
+        final int VENT_AMOUNT = 10_000;
+        // Early exit if pollution is disabled
+        if (!GTMod.proxy.mPollution) return true;
+        mPollution += aPollutionLevel;
+        if (mPollution < VENT_AMOUNT) return true;
+        if (mMufflerHatches.size() == 0) {
+            // No muffler present. Fail.
+            return false;
+        }
+
+        int pollutionBatch = mPollution / mMufflerHatches.size();
+        int reducedPollution = 0;
+
+        for (MTEHatchMuffler muffler : validMTEList(mMufflerHatches)) {
+            mPollution -= pollutionBatch;
+            reducedPollution += muffler.calculatePollutionReduction(pollutionBatch);
+        }
+
+        Pollution.addPollution(getBaseMetaTileEntity(), reducedPollution);
+        return true;
     }
 
     @Override

--- a/src/main/java/goodgenerator/blocks/tileEntity/MTELargeEssentiaSmeltery.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/MTELargeEssentiaSmeltery.java
@@ -564,6 +564,11 @@ public class MTELargeEssentiaSmeltery extends MTETooltipMultiBlockBaseEM
 
     @Override
     public boolean polluteEnvironment(int aPollutionLevel) {
+        // Since this multi places gas blocks on top of its mufflers
+        // we need to override default behavior to not fail if there is no air
+
+        // This function is similar to the base method but does no air check
+
         final int VENT_AMOUNT = 10_000;
         // Early exit if pollution is disabled
         if (!GTMod.proxy.mPollution) return true;


### PR DESCRIPTION
At the current moment LES has a lot of issues, but the most critical one is the fact that it cannot be used without powerfailures if pollution is enabled. There is a lot of reports of LES powerfailing on discord and no solution aside from disabling pollution in config.

It is caused because LES places a non-air block on top of the muffler. It does not intend powerfail itself by that - power failure is caused by MTEBase/Muffler rework and LES not being adapted for that.

There is no way to avoid powerfailures. UHV mufflers do not help. And even tick-perfect gas deletion solutions do not save from possible rare race-conditions arising if air check happens just after the block was placed.

It is also not possible to completely eliminate flux gas generation even with infinite nodes. One reason for that Ordo only reduces flux but not eleminates completely it and second issue is that LES unable to correctly buffer ordo and will occasionally emit gas.

While it is possible to have a rework of either muffler system or LES - this is out of the scope of this PR.

This PR provides pollution emission override for LES that only solves the most critical issue of inevitable LES powerfailures with pollution enabled.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/21556
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18214