### PR TITLE
Arm cover legacy removal

### DIFF
--- a/src/main/java/gregtech/common/covers/CoverArm.java
+++ b/src/main/java/gregtech/common/covers/CoverArm.java
@@ -27,11 +27,11 @@ import io.netty.buffer.ByteBuf;
 
 public class CoverArm extends Cover {
 
-    private boolean export = false;
-    private int internalSlotId = 1;
-    private int externalSlotId = 1;
+    private boolean export;
+    private int internalSlotId;
+    private int externalSlotId;
     public final int mTickRate;
-    // TODO: REMOVE
+    // TODO: REMOVE AFTER 2.9
     // msb converted, 2nd : direction (1=export)
     // right 14 bits: internalSlot, next 14 bits adjSlot, 0 = all, slot = -1
     public static final int EXPORT_MASK = 0x40000000;
@@ -257,27 +257,6 @@ public class CoverArm extends Cover {
 
     public void setExternalSlotId(int externalSlotId) {
         this.externalSlotId = externalSlotId;
-    }
-
-    // LEGACY BACKWARDS COMPAT
-    private int getNewVar(int var, int step) {
-        int intSlot = (var & SLOT_ID_MASK);
-        int adjSlot = (var >> 14) & SLOT_ID_MASK;
-        if ((var & EXPORT_MASK) == 0) {
-            int x = (intSlot + step);
-            if (x > SLOT_ID_MASK) return createVar(0, SLOT_ID_MASK, 0);
-            else if (x < 1) return createVar(-step - intSlot + 1, 0, EXPORT_MASK);
-            else return createVar(0, x, 0);
-        } else {
-            int x = (adjSlot - step);
-            if (x > SLOT_ID_MASK) return createVar(SLOT_ID_MASK, 0, EXPORT_MASK);
-            else if (x < 1) return createVar(0, step - adjSlot + 1, 0);
-            else return createVar(x, 0, EXPORT_MASK);
-        }
-    }
-
-    private int createVar(int adjSlot, int intSlot, int export) {
-        return CONVERTED_BIT | export | ((adjSlot & SLOT_ID_MASK) << 14) | (intSlot & SLOT_ID_MASK);
     }
 
     private boolean getFlagExport(int coverVariable) {

--- a/src/main/java/gregtech/common/gui/mui1/cover/ArmUIFactory.java
+++ b/src/main/java/gregtech/common/gui/mui1/cover/ArmUIFactory.java
@@ -7,6 +7,8 @@ import java.text.FieldPosition;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.tileentity.TileEntity;
 
+import org.jetbrains.annotations.Nullable;
+
 import com.gtnewhorizons.modularui.api.NumberFormatMUI;
 import com.gtnewhorizons.modularui.api.screen.ModularWindow;
 import com.gtnewhorizons.modularui.common.widget.TextWidget;
@@ -14,12 +16,13 @@ import com.gtnewhorizons.modularui.common.widget.TextWidget;
 import gregtech.api.gui.modularui.CoverUIBuildContext;
 import gregtech.api.gui.modularui.GTUITextures;
 import gregtech.api.interfaces.tileentity.ICoverable;
+import gregtech.common.covers.Cover;
 import gregtech.common.covers.CoverArm;
 import gregtech.common.gui.modularui.widget.CoverDataControllerWidget;
 import gregtech.common.gui.modularui.widget.CoverDataFollowerNumericWidget;
 import gregtech.common.gui.modularui.widget.CoverDataFollowerToggleButtonWidget;
 
-public class ArmUIFactory extends CoverLegacyDataUIFactory {
+public class ArmUIFactory extends CoverUIFactory<CoverArm> {
 
     private static final int startX = 10;
     private static final int startY = 25;
@@ -27,6 +30,14 @@ public class ArmUIFactory extends CoverLegacyDataUIFactory {
     private static final int spaceY = 18;
 
     private int maxSlot;
+
+    @Override
+    protected @Nullable CoverArm adaptCover(Cover cover) {
+        if (cover instanceof CoverArm armCover) {
+            return armCover;
+        }
+        return null;
+    }
 
     /**
      * Display the text "Any" instead of a number when the slot is set to -1.
@@ -54,41 +65,30 @@ public class ArmUIFactory extends CoverLegacyDataUIFactory {
         builder.widget(
             new CoverDataControllerWidget<>(this::getCover, getUIBuildContext()).addFollower(
                 CoverDataFollowerToggleButtonWidget.ofDisableable(),
-                cover -> getFlagExport(cover.getVariable()) > 0,
+                CoverArm::isExport,
                 (cover, state) -> {
-                    if (state) {
-                        return cover.setVariable(cover.getVariable() | CoverArm.EXPORT_MASK | CoverArm.CONVERTED_BIT);
-                    } else {
-                        return cover.setVariable(cover.getVariable() & ~CoverArm.EXPORT_MASK | CoverArm.CONVERTED_BIT);
-                    }
+                    cover.setExport(state);
+                    return cover;
                 },
                 widget -> widget.setStaticTexture(GTUITextures.OVERLAY_BUTTON_EXPORT)
                     .addTooltip(translateToLocal("gt.interact.desc.export"))
                     .setPos(spaceX * 0, spaceY * 0))
                 .addFollower(
                     CoverDataFollowerToggleButtonWidget.ofDisableable(),
-                    cover -> getFlagExport(cover.getVariable()) == 0,
+                    cover -> !cover.isExport(),
                     (cover, state) -> {
-                        if (state) {
-                            return cover
-                                .setVariable(cover.getVariable() & ~CoverArm.EXPORT_MASK | CoverArm.CONVERTED_BIT);
-                        } else {
-                            return cover
-                                .setVariable(cover.getVariable() | CoverArm.EXPORT_MASK | CoverArm.CONVERTED_BIT);
-                        }
+                        cover.setExport(!state);
+                        return cover;
                     },
                     widget -> widget.setStaticTexture(GTUITextures.OVERLAY_BUTTON_IMPORT)
                         .addTooltip(translateToLocal("gt.interact.desc.import"))
                         .setPos(spaceX * 1, spaceY * 0))
                 .addFollower(
                     new CoverDataFollowerNumericWidget<>(),
-                    cover -> (double) (getFlagInternalSlot(cover.getVariable()) - 1),
+                    cover -> (double) (cover.getInternalSlotId() - 1),
                     (cover, state) -> {
-                        final int coverVariable = cover.getVariable();
-                        return cover.setVariable(
-                            getFlagExport(coverVariable) | ((state.intValue() + 1) & CoverArm.SLOT_ID_MASK)
-                                | (getFlagAdjacentSlot(coverVariable) << 14)
-                                | CoverArm.CONVERTED_BIT);
+                        cover.setInternalSlotId((int) (state + 1));
+                        return cover;
                     },
                     widget -> widget.setBounds(-1, maxSlot)
                         .setDefaultValue(-1)
@@ -98,13 +98,10 @@ public class ArmUIFactory extends CoverLegacyDataUIFactory {
                         .setSize(spaceX * 2 + 5, 12))
                 .addFollower(
                     new CoverDataFollowerNumericWidget<>(),
-                    cover -> (double) (getFlagAdjacentSlot(cover.getVariable()) - 1),
+                    cover -> (double) cover.getExternalSlotId() - 1,
                     (cover, state) -> {
-                        final int coverVariable = cover.getVariable();
-                        return cover.setVariable(
-                            getFlagExport(coverVariable) | getFlagInternalSlot(coverVariable)
-                                | (((state.intValue() + 1) & CoverArm.SLOT_ID_MASK) << 14)
-                                | CoverArm.CONVERTED_BIT);
+                        cover.setExternalSlotId((int) (state + 1));
+                        return cover;
                     },
                     widget -> widget.setValidator(val -> {
                         // We need to check the adjacent inventory
@@ -133,8 +130,7 @@ public class ArmUIFactory extends CoverLegacyDataUIFactory {
                 new TextWidget()
                     .setStringSupplier(
                         getCoverString(
-                            c -> (c.getVariable() & CoverArm.EXPORT_MASK) > 0
-                                ? translateToLocal("gt.interact.desc.export")
+                            c -> c.isExport() ? translateToLocal("gt.interact.desc.export")
                                 : translateToLocal("gt.interact.desc.import")))
                     .setDefaultColor(COLOR_TEXT_GRAY.get())
                     .setPos(startX + spaceX * 3, 4 + startY + spaceY * 0))
@@ -153,17 +149,5 @@ public class ArmUIFactory extends CoverLegacyDataUIFactory {
         } else {
             return -1;
         }
-    }
-
-    private int getFlagExport(int coverVariable) {
-        return coverVariable & CoverArm.EXPORT_MASK;
-    }
-
-    private int getFlagInternalSlot(int coverVariable) {
-        return coverVariable & CoverArm.SLOT_ID_MASK;
-    }
-
-    private int getFlagAdjacentSlot(int coverVariable) {
-        return (coverVariable >> 14) & CoverArm.SLOT_ID_MASK;
     }
 }


### PR DESCRIPTION
Moves the robot arm cover away from CoverLegacyData in preparation for the mui2 port. Should be backwards compatible with old data