### PR TITLE
Account for window resolution when drawing block overlay lines

### DIFF
--- a/src/main/java/gregtech/client/BlockOverlayRenderer.java
+++ b/src/main/java/gregtech/client/BlockOverlayRenderer.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.function.Function;
 
 import net.minecraft.block.Block;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GLAllocation;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.entity.player.EntityPlayer;
@@ -183,7 +184,7 @@ public class BlockOverlayRenderer {
         Rotation.sideRotations[tSideHit].glApply();
         // draw grid
         GL11.glTranslated(0.0D, -0.502D, 0.0D);
-        GL11.glLineWidth(Client.blockoverlay.lineWidth);
+        GL11.glLineWidth(calculateLineWidth());
         final Tessellator tess = Tessellator.instance;
         tess.startDrawing(GL11.GL_LINES);
         int red = Client.blockoverlay.red;
@@ -409,4 +410,13 @@ public class BlockOverlayRenderer {
         GL11.glPopMatrix();
     }
 
+    private static float calculateLineWidth() {
+        // Assume default resolution has the same height as a standard Full HD monitor
+        final float baseHeight = 1080F;
+
+        // Calculate deviation using the actual height of the application window,
+        // higher resolutions result in thicker lines,
+        // lower resolutions result in thinner lines.
+        return Client.blockoverlay.lineWidth * (Minecraft.getMinecraft().displayHeight / baseHeight);
+    }
 }


### PR DESCRIPTION
**The Problem:**
When playing the game in higher definition display, say 2K or 4K, The wrench interaction overlay lines are thinner than they should be when compared to a game running in a 1920x1080 display. This happens because `GL11.glLineWidth()` sets the line thickness to number in absolute pixels, ignoring the actual display resolution.

**The Solution:**
This PR changes that so that the size of the Minecraft window is taken into account during the line width calculation. This ensures that the relative width of each line (that is, its width when compared to the pixels in the block they are drawn over) stays the same no matter the resolution.

An example. The first one is at 1920x1080, the second one is in a small window. Notice that the actual thickness is smaller in the second picture, but it's relative size is the same:
<img width="327" height="328" alt="image" src="https://github.com/user-attachments/assets/405b3c16-058b-414d-be56-6c5383c677e0" /> 
<img width="152" height="150" alt="image" src="https://github.com/user-attachments/assets/54f0326f-f467-4e94-b339-f3b82f7852fd" />

**More Details:**
This is done by calculating the ratio of the window's height with a base value. This prevents monitors with different aspect ratios like 21:9 on 4:3 from having a different line thickness. A side effect of this is that anyone playing the game in a vertical monitor will have thinner lines than expected, and to those people I say: I'm not sure you exist, but I commend your bravery, and I expect you know how to configure the line thickness manually.

This PR makes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/pull/21513 obsolete. Nothing will break if both are merged, but it will make the default line very thick for all resolutions (see @wlhlm's screenshot in that thread).

I'm currently unable to test this at resolutions higher than 1920x1080, so I'd appreciate if anyone could take some time to test this in different resolutions and aspect ratios and report back with a screenshot to this thread.

