### PR TITLE
Tooltip cleanup for some TEs

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/MTECable.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTECable.java
@@ -1,6 +1,7 @@
 package gregtech.api.metatileentity.implementations;
 
 import static gregtech.api.enums.Mods.GalacticraftCore;
+import static gregtech.api.util.GTUtility.translate;
 import static net.minecraftforge.common.util.ForgeDirection.DOWN;
 
 import java.util.ArrayList;
@@ -505,24 +506,12 @@ public class MTECable extends MetaPipeEntity implements IMetaTileEntityCable {
     @Override
     public String[] getDescription() {
         return new String[] {
-            StatCollector.translateToLocal("GT5U.item.cable.max_voltage") + ": %%%"
-                + EnumChatFormatting.GREEN
-                + GTUtility.formatNumbers(mVoltage)
-                + " ("
-                + GTUtility.getColoredTierNameFromVoltage(mVoltage)
-                + EnumChatFormatting.GREEN
-                + ")"
-                + EnumChatFormatting.GRAY,
-            StatCollector.translateToLocal("GT5U.item.cable.max_amperage") + ": %%%"
-                + EnumChatFormatting.YELLOW
-                + GTUtility.formatNumbers(mAmperage)
-                + EnumChatFormatting.GRAY,
-            StatCollector.translateToLocal("GT5U.item.cable.loss") + ": %%%"
-                + EnumChatFormatting.RED
-                + GTUtility.formatNumbers(mCableLossPerMeter)
-                + EnumChatFormatting.GRAY
-                + "%%% "
-                + StatCollector.translateToLocal("GT5U.item.cable.eu_volt") };
+            translate(
+                "GT5U.item.cable.max_voltage",
+                GTUtility.formatNumbers(mVoltage),
+                GTUtility.getColoredTierNameFromVoltage(mVoltage)),
+            translate("GT5U.item.cable.max_amperage", GTUtility.formatNumbers(mAmperage)),
+            translate("GT5U.item.cable.loss", GTUtility.formatNumbers(mCableLossPerMeter)) };
     }
 
     @Override
@@ -567,18 +556,18 @@ public class MTECable extends MetaPipeEntity implements IMetaTileEntityCable {
         final long maxVoltageOut = (mVoltage - mCableLossPerMeter) * mAmperage;
 
         return new String[] {
-            StatCollector.translateToLocalFormatted(
+            translate(
                 "GT5U.infodata.cable.amperage",
                 EnumChatFormatting.GREEN + GTUtility.formatNumbers(currAmp) + EnumChatFormatting.RESET,
                 EnumChatFormatting.YELLOW + GTUtility.formatNumbers(mAmperage) + EnumChatFormatting.RESET),
-            StatCollector.translateToLocalFormatted(
+            translate(
                 "GT5U.infodata.cable.voltage_out",
                 EnumChatFormatting.GREEN + GTUtility.formatNumbers(currVoltage) + EnumChatFormatting.RESET,
                 EnumChatFormatting.YELLOW + GTUtility.formatNumbers(maxVoltageOut) + EnumChatFormatting.RESET),
-            StatCollector.translateToLocalFormatted(
+            translate(
                 "GT5U.infodata.cable.avg_amperage",
                 EnumChatFormatting.YELLOW + GTUtility.formatNumbers(avgAmp) + EnumChatFormatting.RESET),
-            StatCollector.translateToLocalFormatted(
+            translate(
                 "GT5U.infodata.cable.avg_output",
                 EnumChatFormatting.YELLOW + GTUtility.formatNumbers(avgVoltage) + EnumChatFormatting.RESET) };
     }
@@ -648,23 +637,11 @@ public class MTECable extends MetaPipeEntity implements IMetaTileEntityCable {
         IWailaConfigHandler config) {
 
         currenttip.add(
-            StatCollector.translateToLocal("GT5U.item.cable.max_voltage") + ": "
-                + EnumChatFormatting.GREEN
-                + GTUtility.formatNumbers(mVoltage)
-                + " ("
-                + GTUtility.getColoredTierNameFromVoltage(mVoltage)
-                + EnumChatFormatting.GREEN
-                + ")");
-        currenttip.add(
-            StatCollector.translateToLocal("GT5U.item.cable.max_amperage") + ": "
-                + EnumChatFormatting.YELLOW
-                + GTUtility.formatNumbers(mAmperage));
-        currenttip.add(
-            StatCollector.translateToLocal("GT5U.item.cable.loss") + ": "
-                + EnumChatFormatting.RED
-                + GTUtility.formatNumbers(mCableLossPerMeter)
-                + EnumChatFormatting.RESET
-                + " "
-                + StatCollector.translateToLocal("GT5U.item.cable.eu_volt"));
+            translate(
+                "GT5U.item.cable.max_voltage",
+                GTUtility.formatNumbers(mVoltage),
+                GTUtility.getColoredTierNameFromVoltage(mVoltage)));
+        currenttip.add(translate("GT5U.item.cable.max_amperage", GTUtility.formatNumbers(mAmperage)));
+        currenttip.add(translate("GT5U.item.cable.loss", GTUtility.formatNumbers(mCableLossPerMeter)));
     }
 }

--- a/src/main/resources/assets/gregtech/lang/en_US.lang
+++ b/src/main/resources/assets/gregtech/lang/en_US.lang
@@ -1724,10 +1724,9 @@ GT5U.item.programmed_circuit.tooltip.0=Configuration %s
 GT5U.item.programmed_circuit.tooltip.1=Right click to reconfigure
 GT5U.item.programmed_circuit.tooltip.2=Needs a screwdriver or programming tool
 
-GT5U.item.cable.max_voltage=Max Voltage
-GT5U.item.cable.max_amperage=Max Amperage
-GT5U.item.cable.loss=Loss/Meter/Ampere
-GT5U.item.cable.eu_volt=EU-Volt
+GT5U.item.cable.max_voltage=Max Voltage: §a%s (%s§a)
+GT5U.item.cable.max_amperage=Max Amperage: §e%s
+GT5U.item.cable.loss=Loss/Meter/Ampere: §c%s §7EU-Volt
 GT5U.item.cable.swapped=Cable swapped:
 GT5U.item.tank.locked_to=Content locked to %s
 


### PR DESCRIPTION
Don't get scared by the title. Just some minor fixes.

This PR is to get rid of all `%%%` as split mark for some goofy GTLanguageManager usage in certain types of TEs like cables, singleblock machines and so on. Love me some shorter, neater and more readable code lines.

Might detonate some TNTs so needs a double check when it's done.