### PR TITLE
Fix icon deletion for powerfail in journeymap

### DIFF
--- a/src/main/java/gregtech/crossmod/navigator/PowerfailLayerManager.java
+++ b/src/main/java/gregtech/crossmod/navigator/PowerfailLayerManager.java
@@ -70,7 +70,7 @@ public class PowerfailLayerManager extends InteractableLayerManager {
         // Copy the set because java is stupid and doesn't like to allow generic upcasting.
         // We also use a linked collection to prevent what looks like z fighting in the HUD minimap.
         // It isn't actually z fighting, hashed collections just have pseudorandom/arbitrary iteration order.
-        Set<ILocationProvider> locs = new LinkedHashSet<>(wrappers.values());
+        Set<ILocationProvider> locs = new LinkedHashSet<>(getVisibleLocations());
 
         layerRenderer.values()
             .forEach(layer -> layer.refreshVisibleElements(locs));


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/21536

As a note, this *mostly* fixes the issue, as long as there aren't multiple powerfails per chunk. It will still allow the command to clear the icons and also via entering the machine ui, but if you remove the icon via journeymap exclusively when there are 2 or more powerfails in a chunk it will only clear one of them and the other will have to be cleared via either entering the machine UI or running the clear command (In reality there really is only 1 icon on the map due to the way that Navigator handles the ILocationProvider toLong method which is used for getting or creating a new render step).

Overall a full fix for this would need a PR to Navigator aswell to handle a key for a render step that would be the same since its in the same chunk