### PR TITLE
 fix circuit imprint registration

### DIFF
--- a/src/main/java/bartworks/system/material/CircuitGeneration/CircuitImprintLoader.java
+++ b/src/main/java/bartworks/system/material/CircuitGeneration/CircuitImprintLoader.java
@@ -248,7 +248,7 @@ public class CircuitImprintLoader {
         removeOldRecipesFromRegistries();
         CircuitImprintLoader.recipeTagMap.keySet()
             .forEach(e -> {
-                makeAndAddSlicingRecipe(e);
+                makeAndAddCutterRecipe(e);
                 makeAndAddCraftingRecipes(e);
             });
     }
@@ -273,7 +273,7 @@ public class CircuitImprintLoader {
         gtrecipeWorldCache.clear();
     }
 
-    private static void makeAndAddSlicingRecipe(NBTTagCompound tag) {
+    private static void makeAndAddCutterRecipe(NBTTagCompound tag) {
         ItemStack stack = CircuitImprintLoader.getStackFromTag(tag);
         int eut = Integer.MAX_VALUE;
 
@@ -289,7 +289,7 @@ public class CircuitImprintLoader {
                         OreDictionary.getOreIDs(stack) != null && OreDictionary.getOreIDs(stack).length > 0
                             ? OreDictionary.getOreIDs(stack)[0]
                             : -1))));
-        GTRecipe slicingRecipe = new GTRecipe(
+        GTRecipe cutterRecipe = new GTRecipe(
             true,
             new ItemStack[] { stack, ItemList.Shape_Slicer_Flat.get(0) },
             new ItemStack[] { BWMetaItems.getCircuitParts()
@@ -301,8 +301,8 @@ public class CircuitImprintLoader {
             300,
             eut,
             BWUtil.CLEANROOM);
-        gtrecipeWorldCache.add(slicingRecipe);
-        RecipeMaps.slicerRecipes.add(slicingRecipe);
+        gtrecipeWorldCache.add(cutterRecipe);
+        RecipeMaps.cutterRecipes.add(cutterRecipe);
     }
 
     private static void makeAndAddCraftingRecipes(NBTTagCompound tag) {


### PR DESCRIPTION
this pr should fix recipe registration for circuit imprints, which wasn't moved from slicer recipemap to the cutter recipemap in the pr that deprecated slicers (can't test if it does it properly, it doesn't show the recipes in-game)