### PR TITLE
Add null check for worldObj in markDirty to prevent crashes

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/BaseTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseTileEntity.java
@@ -556,10 +556,13 @@ public abstract class BaseTileEntity extends TileEntity implements IHasWorldObje
 
     @Override
     public void markDirty() {
-        // Avoid sending neighbor updates, just mark the chunk as dirty to make sure it gets saved
-        final Chunk chunk = worldObj.getChunkFromBlockCoords(xCoord, zCoord);
-        if (chunk != null) {
-            chunk.setChunkModified();
+        // If some code calls markDirty before worldObj is assigned, e.g., in loadNBTData we will crash
+        if (worldObj != null) {
+            // Avoid sending neighbor updates, just mark the chunk as dirty to make sure it gets saved
+            final Chunk chunk = worldObj.getChunkFromBlockCoords(xCoord, zCoord);
+            if (chunk != null) {
+                chunk.setChunkModified();
+            }
         }
     }
 


### PR DESCRIPTION
in a chunk was market dirty in loadNBTData

Should fix bug in https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/21704 introduced via https://github.com/GTNewHorizons/GT5-Unofficial/commit/f83e0aadd1bbf83e58c4ec6ac149388a374489be