### PR TITLE
Power goggles ux improvements

### DIFF
--- a/src/main/java/gregtech/common/GTClient.java
+++ b/src/main/java/gregtech/common/GTClient.java
@@ -96,6 +96,7 @@ import gregtech.common.entity.EntityPowderBarrelPrimed;
 import gregtech.common.misc.GTPowerfailCommandClient;
 import gregtech.common.pollution.Pollution;
 import gregtech.common.pollution.PollutionRenderer;
+import gregtech.common.powergoggles.PowerGogglesCommand;
 import gregtech.common.render.BaseMetaTileEntityRenderer;
 import gregtech.common.render.BlackholeRenderer;
 import gregtech.common.render.DroneRender;
@@ -287,6 +288,7 @@ public class GTClient extends GTProxy {
         Materials.initClient();
 
         ClientCommandHandler.instance.registerCommand(new GTPowerfailCommandClient());
+        ClientCommandHandler.instance.registerCommand(new PowerGogglesCommand());
 
         if (Mods.Navigator.isModLoaded()) {
             registerMapLayers();

--- a/src/main/java/gregtech/common/powergoggles/DelayedGuiDisplayTicker.java
+++ b/src/main/java/gregtech/common/powergoggles/DelayedGuiDisplayTicker.java
@@ -1,0 +1,39 @@
+package gregtech.common.powergoggles;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiScreen;
+
+import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import cpw.mods.fml.common.gameevent.TickEvent;
+
+// Thanks, InGame-Info :)
+public class DelayedGuiDisplayTicker {
+
+    private final GuiScreen guiScreen;
+    private int ticks;
+
+    private DelayedGuiDisplayTicker(GuiScreen guiScreen, int delay) {
+        this.guiScreen = guiScreen;
+        this.ticks = delay;
+    }
+
+    @SubscribeEvent
+    public void onClientTick(TickEvent.ClientTickEvent event) {
+        this.ticks--;
+
+        if (this.ticks < 0) {
+            Minecraft.getMinecraft()
+                .displayGuiScreen(this.guiScreen);
+            FMLCommonHandler.instance()
+                .bus()
+                .unregister(this);
+        }
+    }
+
+    public static void create(GuiScreen guiScreen, int delay) {
+        FMLCommonHandler.instance()
+            .bus()
+            .register(new DelayedGuiDisplayTicker(guiScreen, delay));
+    }
+}

--- a/src/main/java/gregtech/common/powergoggles/PowerGogglesCommand.java
+++ b/src/main/java/gregtech/common/powergoggles/PowerGogglesCommand.java
@@ -1,0 +1,91 @@
+package gregtech.common.powergoggles;
+
+import static com.gtnewhorizon.gtnhlib.util.AnimatedTooltipHandler.RED;
+
+import java.util.*;
+
+import net.minecraft.command.ICommandSender;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.ChatComponentText;
+import net.minecraft.util.IChatComponent;
+
+import gregtech.commands.GTBaseCommand;
+import gregtech.common.powergoggles.gui.PowerGogglesGuiHudConfig;
+import gregtech.common.powergoggles.handlers.PowerGogglesEventHandler;
+
+public class PowerGogglesCommand extends GTBaseCommand {
+
+    private static final String[] SUBCOMMANDS = { "config", "chart" };
+
+    public PowerGogglesCommand() {
+        super("goggles", "pg");
+    }
+
+    @Override
+    public String getCommandName() {
+        return "powergoggles";
+    }
+
+    @Override
+    public String getCommandUsage(ICommandSender sender) {
+        return "Usage: /powergoggles <subcommand>. Valid subcommands are: " + String.join(", ", SUBCOMMANDS) + ".";
+    }
+
+    @Override
+    public int getRequiredPermissionLevel() {
+        return 0;
+    }
+
+    @Override
+    public boolean canCommandSenderUseCommand(ICommandSender sender) {
+        return sender instanceof EntityPlayer;
+    }
+
+    @Override
+    protected List<IChatComponent> getHelpMessages() {
+
+        List<IChatComponent> messages = new ArrayList<>();
+        messages.add(new ChatComponentText(getCommandUsage(null)));
+        messages.add(new ChatComponentText(" config - Opens power goggles configuration menu"));
+        messages.add(new ChatComponentText(" chart - Toggles the power goggles chart"));
+        messages.add(new ChatComponentText(""));
+        messages.add(new ChatComponentText("Aliases: powergoggles, goggles, pg"));
+        return messages;
+
+    }
+
+    @Override
+    public List<String> addTabCompletionOptions(ICommandSender sender, String[] args) {
+        List<String> l = new ArrayList<>();
+        String first = args.length == 0 ? "" : args[0].trim();
+
+        if (first.isEmpty()) {
+            l.addAll(Arrays.asList(SUBCOMMANDS));
+        } else {
+            if (args.length == 1) {
+                l.addAll(getListOfStringsMatchingLastWord(args, SUBCOMMANDS));
+            }
+        }
+
+        return l;
+    }
+
+    @Override
+    public void processCommand(ICommandSender sender, String[] args) {
+
+        if (args.length < 1) {
+            sendHelpMessage(sender);
+            return;
+        }
+
+        switch (args[0]) {
+            case "config" -> DelayedGuiDisplayTicker.create(new PowerGogglesGuiHudConfig(), 1);
+            case "chart" -> PowerGogglesEventHandler.getInstance()
+                .toggleChart();
+            default -> {
+                sendChatToPlayer(sender, RED + "Illegal subcommand: " + args[0]);
+                sendHelpMessage(sender);
+            }
+        }
+    }
+}

--- a/src/main/java/gregtech/common/powergoggles/PowerGogglesCommand.java
+++ b/src/main/java/gregtech/common/powergoggles/PowerGogglesCommand.java
@@ -2,7 +2,9 @@ package gregtech.common.powergoggles;
 
 import static com.gtnewhorizon.gtnhlib.util.AnimatedTooltipHandler.RED;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import net.minecraft.command.ICommandSender;
 import net.minecraft.entity.player.EntityPlayer;

--- a/src/main/java/gregtech/common/powergoggles/handlers/PowerGogglesConfigHandler.java
+++ b/src/main/java/gregtech/common/powergoggles/handlers/PowerGogglesConfigHandler.java
@@ -44,7 +44,7 @@ public class PowerGogglesConfigHandler {
     public static void syncConfig() {
 
         try {
-            mainOffsetX = config.get(Configuration.CATEGORY_GENERAL, "Render Offset X", 334, "")
+            mainOffsetX = config.get(Configuration.CATEGORY_GENERAL, "Render Offset X", 10, "")
                 .getInt(10);
             mainOffsetY = config.get(Configuration.CATEGORY_GENERAL, "Render Offset Y", 37, "")
                 .getInt(40);
@@ -83,8 +83,8 @@ public class PowerGogglesConfigHandler {
             hudScale = config.get(Configuration.CATEGORY_GENERAL, "HUD Scale", 1.0, "")
                 .getDouble(1.0);
             hideWhenChatOpen = config
-                .get(Configuration.CATEGORY_GENERAL, "Hide HUD", false, "Hide the HUD when the in-game chat is open")
-                .getBoolean(false);
+                .get(Configuration.CATEGORY_GENERAL, "Hide HUD", true, "Hide the HUD when the in-game chat is open")
+                .getBoolean(true);
 
             gradientBadColor = config
                 .get(Configuration.CATEGORY_GENERAL, "Bad Gradient", Color.rgb(255, 50, 50), "", 0, Integer.MAX_VALUE)

--- a/src/main/java/gregtech/common/powergoggles/handlers/PowerGogglesConfigHandler.java
+++ b/src/main/java/gregtech/common/powergoggles/handlers/PowerGogglesConfigHandler.java
@@ -44,9 +44,9 @@ public class PowerGogglesConfigHandler {
     public static void syncConfig() {
 
         try {
-            mainOffsetX = config.get(Configuration.CATEGORY_GENERAL, "Render Offset X", 10, "")
+            mainOffsetX = config.get(Configuration.CATEGORY_GENERAL, "Render Offset X", 334, "")
                 .getInt(10);
-            mainOffsetY = config.get(Configuration.CATEGORY_GENERAL, "Render Offset Y", 40, "")
+            mainOffsetY = config.get(Configuration.CATEGORY_GENERAL, "Render Offset Y", 37, "")
                 .getInt(40);
             rectangleWidth = config.get(Configuration.CATEGORY_GENERAL, "Power Rectangle Width", 120, "")
                 .getInt(120);

--- a/src/main/java/gregtech/common/powergoggles/handlers/PowerGogglesEventHandler.java
+++ b/src/main/java/gregtech/common/powergoggles/handlers/PowerGogglesEventHandler.java
@@ -103,14 +103,14 @@ public class PowerGogglesEventHandler {
     }
 
     @SideOnly(Side.CLIENT)
-    private void openConfig() {
+    public void openConfig() {
         Minecraft screenInfo = Minecraft.getMinecraft();
         Minecraft.getMinecraft()
             .displayGuiScreen(new PowerGogglesGuiHudConfig(screenInfo.displayWidth, screenInfo.displayHeight));
     }
 
     @SideOnly(Side.CLIENT)
-    private void toggleChart() {
+    public void toggleChart() {
         PowerGogglesConfigHandler.showPowerChart = !PowerGogglesConfigHandler.showPowerChart;
         PowerGogglesConfigHandler.config.getCategory(Configuration.CATEGORY_GENERAL)
             .get("Show Power Chart")


### PR DESCRIPTION
closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/21672

Adds a /powergoggles (also /goggles or /pg) command with the `config` and `chart` subcommands, which open the configuration window and toggle the chart respectively.
Instead of toggling the display when opening the chat window i moved it to the right of the player's hotbar.