### PR TITLE
add Vending Machine Mod ID

### DIFF
--- a/src/main/java/gregtech/api/enums/Mods.java
+++ b/src/main/java/gregtech/api/enums/Mods.java
@@ -215,6 +215,7 @@ public enum Mods implements IMod {
     ToroHealth(ModIDs.TORO_HEALTH),
     Translocator(ModIDs.TRANSLOCATOR),
     UniversalSingularities(ModIDs.UNIVERSAL_SINGULARITIES),
+    VendingMachine(ModIDs.VENDING_MACHINE),
     VisualProspecting(ModIDs.VISUAL_PROSPECTING),
     WailaPlugins(ModIDs.WAILA_PLUGINS),
     WailaHarvestability(ModIDs.WAILA_HARVESTABILITY),
@@ -544,6 +545,7 @@ public enum Mods implements IMod {
         public static final String TORO_HEALTH = "torohealthmod";
         public static final String TRANSLOCATOR = "Translocator";
         public static final String UNIVERSAL_SINGULARITIES = "universalsingularities";
+        public static final String VENDING_MACHINE = "vendingmachine";
         public static final String VISUAL_PROSPECTING = "visualprospecting";
         public static final String WAILA_PLUGINS = "wailaplugins";
         public static final String WAILA_HARVESTABILITY = "WailaHarvestability";


### PR DESCRIPTION
Steps:
1. Publish VM 0.4.0 to maven repo https://nexus.gtnewhorizons.com/#browse/browse:releases:com%2Fcubefury%2Fvendingmachine%2FVendingMachine
2. **Add VM to GT5U modlist (This PR)**
3. Update BetterQuesting with VM integration
4. Add Default Trade list to config in main modpack repo https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/pull/21829
5. Update Coremod with recipes https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1398