### PR TITLE
Remove CoverLegacyData from the ender fluid link cover

### DIFF
--- a/src/main/java/gregtech/common/gui/mui1/cover/EnderFluidLinkUIFactory.java
+++ b/src/main/java/gregtech/common/gui/mui1/cover/EnderFluidLinkUIFactory.java
@@ -1,8 +1,6 @@
 package gregtech.common.gui.mui1.cover;
 
 import static net.minecraft.util.StatCollector.translateToLocal;
-import static tectech.thing.cover.CoverEnderFluidLink.PUBLIC_PRIVATE_MASK;
-import static tectech.thing.cover.CoverEnderFluidLink.toggleBit;
 
 import java.util.UUID;
 
@@ -32,10 +30,6 @@ public class EnderFluidLinkUIFactory extends CoverUIFactory<CoverEnderFluidLink>
     private static final int START_Y = 25;
     private static final int SPACE_X = 18;
     private static final int SPACE_Y = 18;
-    private static final int PUBLIC_BUTTON_ID = 0;
-    private static final int PRIVATE_BUTTON_ID = 1;
-    private static final int IMPORT_BUTTON_ID = 2;
-    private static final int EXPORT_BUTTON_ID = 3;
 
     public EnderFluidLinkUIFactory(CoverUIBuildContext buildContext) {
         super(buildContext);
@@ -131,25 +125,6 @@ public class EnderFluidLinkUIFactory extends CoverUIFactory<CoverEnderFluidLink>
             .widget(
                 new TextWidget(translateToLocal("gt.interact.desc.set_io"))
                     .setPos(START_X + SPACE_X * 2, 4 + START_Y + SPACE_Y * 3));
-    }
-
-    private int getNewCoverVariable(int id, int coverVariable) {
-        return switch (id) {
-            case PUBLIC_BUTTON_ID, PRIVATE_BUTTON_ID -> toggleBit(coverVariable, PUBLIC_PRIVATE_MASK);
-            case IMPORT_BUTTON_ID, EXPORT_BUTTON_ID -> toggleBit(coverVariable, CoverEnderFluidLink.IMPORT_EXPORT_MASK);
-            default -> coverVariable;
-        };
-    }
-
-    private boolean getClickable(int id, int coverVariable) {
-        return switch (id) {
-            case PUBLIC_BUTTON_ID -> CoverEnderFluidLink.testBit(coverVariable, PUBLIC_PRIVATE_MASK);
-            case PRIVATE_BUTTON_ID -> !CoverEnderFluidLink.testBit(coverVariable, PUBLIC_PRIVATE_MASK);
-            case IMPORT_BUTTON_ID -> !CoverEnderFluidLink
-                .testBit(coverVariable, CoverEnderFluidLink.IMPORT_EXPORT_MASK);
-            case EXPORT_BUTTON_ID -> CoverEnderFluidLink.testBit(coverVariable, CoverEnderFluidLink.IMPORT_EXPORT_MASK);
-            default -> false;
-        };
     }
 
     private UUID getUUID() {

--- a/src/main/java/gregtech/common/gui/mui1/cover/EnderFluidLinkUIFactory.java
+++ b/src/main/java/gregtech/common/gui/mui1/cover/EnderFluidLinkUIFactory.java
@@ -8,6 +8,8 @@ import java.util.UUID;
 
 import net.minecraftforge.fluids.IFluidHandler;
 
+import org.jetbrains.annotations.Nullable;
+
 import com.gtnewhorizons.modularui.api.math.Alignment;
 import com.gtnewhorizons.modularui.api.math.Color;
 import com.gtnewhorizons.modularui.api.screen.ModularWindow;
@@ -17,14 +19,14 @@ import com.gtnewhorizons.modularui.common.widget.textfield.TextFieldWidget;
 import gregtech.api.gui.modularui.CoverUIBuildContext;
 import gregtech.api.gui.modularui.GTUITextures;
 import gregtech.api.interfaces.tileentity.ICoverable;
-import gregtech.common.covers.CoverLegacyData;
+import gregtech.common.covers.Cover;
 import gregtech.common.gui.modularui.widget.CoverDataControllerWidget;
 import gregtech.common.gui.modularui.widget.CoverDataFollowerToggleButtonWidget;
 import tectech.mechanics.enderStorage.EnderLinkTag;
 import tectech.mechanics.enderStorage.EnderWorldSavedData;
 import tectech.thing.cover.CoverEnderFluidLink;
 
-public class EnderFluidLinkUIFactory extends CoverLegacyDataUIFactory {
+public class EnderFluidLinkUIFactory extends CoverUIFactory<CoverEnderFluidLink> {
 
     private static final int START_X = 10;
     private static final int START_Y = 25;
@@ -37,6 +39,14 @@ public class EnderFluidLinkUIFactory extends CoverLegacyDataUIFactory {
 
     public EnderFluidLinkUIFactory(CoverUIBuildContext buildContext) {
         super(buildContext);
+    }
+
+    @Override
+    protected @Nullable CoverEnderFluidLink adaptCover(Cover cover) {
+        if (cover instanceof CoverEnderFluidLink adapterCover) {
+            return adapterCover;
+        }
+        return null;
     }
 
     @Override
@@ -55,8 +65,8 @@ public class EnderFluidLinkUIFactory extends CoverLegacyDataUIFactory {
                 if (!frequencyField.isClient() && getUIBuildContext().getTile() instanceof IFluidHandler tank) {
                     UUID uuid = null;
 
-                    CoverLegacyData cover = getCover();
-                    if (cover != null && CoverEnderFluidLink.testBit(cover.getVariable(), PUBLIC_PRIVATE_MASK)) {
+                    CoverEnderFluidLink cover = getCover();
+                    if (cover != null && cover.isPrivateChannel()) {
                         uuid = getUUID();
                         if (!uuid.equals(CoverEnderFluidLink.getOwner(tank))) return;
                     }
@@ -71,35 +81,47 @@ public class EnderFluidLinkUIFactory extends CoverLegacyDataUIFactory {
             .setPos(START_X + SPACE_X * 0, START_Y + SPACE_Y * 0)
             .setSize(SPACE_X * 5 - 8, 12))
             .widget(
-                new CoverDataControllerWidget.CoverDataIndexedControllerWidget_ToggleButtons<>(
-                    this::getCover,
-                    (id, coverData) -> !getClickable(id, coverData.getVariable()),
-                    (id, coverData) -> coverData.setVariable(getNewCoverVariable(id, coverData.getVariable())),
-                    getUIBuildContext())
-                        .addToggleButton(
-                            PUBLIC_BUTTON_ID,
-                            CoverDataFollowerToggleButtonWidget.ofDisableable(),
-                            widget -> widget.setStaticTexture(GTUITextures.OVERLAY_BUTTON_WHITELIST)
-                                .addTooltip(translateToLocal("gt.interact.desc.public"))
-                                .setPos(START_X + SPACE_X * 0, START_Y + SPACE_Y * 2))
-                        .addToggleButton(
-                            PRIVATE_BUTTON_ID,
-                            CoverDataFollowerToggleButtonWidget.ofDisableable(),
-                            widget -> widget.setStaticTexture(GTUITextures.OVERLAY_BUTTON_BLACKLIST)
-                                .addTooltip(translateToLocal("gt.interact.desc.private"))
-                                .setPos(START_X + SPACE_X * 1, START_Y + SPACE_Y * 2))
-                        .addToggleButton(
-                            IMPORT_BUTTON_ID,
-                            CoverDataFollowerToggleButtonWidget.ofDisableable(),
-                            widget -> widget.setStaticTexture(GTUITextures.OVERLAY_BUTTON_IMPORT)
-                                .addTooltip(translateToLocal("gt.interact.desc.import"))
-                                .setPos(START_X + SPACE_X * 0, START_Y + SPACE_Y * 3))
-                        .addToggleButton(
-                            EXPORT_BUTTON_ID,
-                            CoverDataFollowerToggleButtonWidget.ofDisableable(),
-                            widget -> widget.setStaticTexture(GTUITextures.OVERLAY_BUTTON_EXPORT)
-                                .addTooltip(translateToLocal("gt.interact.desc.export"))
-                                .setPos(START_X + SPACE_X * 1, START_Y + SPACE_Y * 3)))
+                new CoverDataControllerWidget<>(this::getCover, getUIBuildContext()).addFollower(
+                    CoverDataFollowerToggleButtonWidget.ofDisableable(),
+                    cover -> !cover.isPrivateChannel(),
+                    (cover, state) -> {
+                        cover.setPrivateChannel(!state);
+                        return cover;
+                    },
+                    widget -> widget.setStaticTexture(GTUITextures.OVERLAY_BUTTON_WHITELIST)
+                        .addTooltip(translateToLocal("gt.interact.desc.public"))
+                        .setPos(START_X + SPACE_X * 0, START_Y + SPACE_Y * 2))
+
+                    .addFollower(
+                        CoverDataFollowerToggleButtonWidget.ofDisableable(),
+                        CoverEnderFluidLink::isPrivateChannel,
+                        (cover, state) -> {
+                            cover.setPrivateChannel(state);
+                            return cover;
+                        },
+                        widget -> widget.setStaticTexture(GTUITextures.OVERLAY_BUTTON_BLACKLIST)
+                            .addTooltip(translateToLocal("gt.interact.desc.private"))
+                            .setPos(START_X + SPACE_X * 1, START_Y + SPACE_Y * 2))
+                    .addFollower(
+                        CoverDataFollowerToggleButtonWidget.ofDisableable(),
+                        cover -> !cover.isExport(),
+                        (cover, state) -> {
+                            cover.setExport(!state);
+                            return cover;
+                        },
+                        widget -> widget.setStaticTexture(GTUITextures.OVERLAY_BUTTON_IMPORT)
+                            .addTooltip(translateToLocal("gt.interact.desc.import"))
+                            .setPos(START_X + SPACE_X * 0, START_Y + SPACE_Y * 3))
+                    .addFollower(
+                        CoverDataFollowerToggleButtonWidget.ofDisableable(),
+                        CoverEnderFluidLink::isExport,
+                        (cover, state) -> {
+                            cover.setExport(state);
+                            return cover;
+                        },
+                        widget -> widget.setStaticTexture(GTUITextures.OVERLAY_BUTTON_EXPORT)
+                            .addTooltip(translateToLocal("gt.interact.desc.export"))
+                            .setPos(START_X + SPACE_X * 1, START_Y + SPACE_Y * 3)))
             .widget(
                 new TextWidget(translateToLocal("gt.interact.desc.channel"))
                     .setPos(START_X + SPACE_X * 5, 4 + START_Y + SPACE_Y * 0))

--- a/src/main/java/tectech/loader/thing/CoverLoader.java
+++ b/src/main/java/tectech/loader/thing/CoverLoader.java
@@ -38,7 +38,7 @@ public class CoverLoader implements Runnable {
         CoverRegistry.registerCover(
             new ItemStack(ItemEnderFluidLinkCover.INSTANCE, 1, 0),
             TextureFactory.of(ENDERFLUIDLINK_OVERLAY),
-            CoverEnderFluidLink::new);
+            context -> new CoverEnderFluidLink(context, TextureFactory.of(ENDERFLUIDLINK_OVERLAY)));
         CoverRegistry.registerCover(
             new ItemStack(ItemPowerPassUpgradeCover.INSTANCE, 1, 0),
             TextureFactory.of(POWERPASSUPGRADE_OVERLAY),

--- a/src/main/java/tectech/thing/cover/CoverEnderFluidLink.java
+++ b/src/main/java/tectech/thing/cover/CoverEnderFluidLink.java
@@ -56,26 +56,29 @@ public class CoverEnderFluidLink extends CoverLegacyData {
         if (coverable == null) {
             return;
         }
-        if ((coverable instanceof IFluidHandler teTank)) {
-            EnderLinkTag tag = EnderWorldSavedData.getEnderLinkTag(teTank);
+        if (!(coverable instanceof IFluidHandler teTank)) {
+            return;
+        }
 
-            if (tag != null) {
-                boolean shouldBePrivate = testBit(this.coverData, PUBLIC_PRIVATE_MASK);
-                boolean isPrivate = tag.getUUID() != null;
+        EnderLinkTag tag = EnderWorldSavedData.getEnderLinkTag(teTank);
+        if (tag == null) {
+            return;
+        }
 
-                if (shouldBePrivate != isPrivate) {
-                    tag = new EnderLinkTag(tag.getFrequency(), shouldBePrivate ? getOwner(coverable) : null);
-                    EnderWorldSavedData.bindEnderLinkTag(teTank, tag);
-                }
+        boolean shouldBePrivate = testBit(this.coverData, PUBLIC_PRIVATE_MASK);
+        boolean isPrivate = tag.getUUID() != null;
 
-                IFluidHandler enderTank = EnderWorldSavedData.getEnderFluidContainer(tag);
+        if (shouldBePrivate != isPrivate) {
+            tag = new EnderLinkTag(tag.getFrequency(), shouldBePrivate ? getOwner(coverable) : null);
+            EnderWorldSavedData.bindEnderLinkTag(teTank, tag);
+        }
 
-                if (testBit(this.coverData, IMPORT_EXPORT_MASK)) {
-                    transferFluid(enderTank, ForgeDirection.UNKNOWN, teTank, coverSide);
-                } else {
-                    transferFluid(teTank, coverSide, enderTank, ForgeDirection.UNKNOWN);
-                }
-            }
+        IFluidHandler enderTank = EnderWorldSavedData.getEnderFluidContainer(tag);
+
+        if (testBit(this.coverData, IMPORT_EXPORT_MASK)) {
+            transferFluid(enderTank, ForgeDirection.UNKNOWN, teTank, coverSide);
+        } else {
+            transferFluid(teTank, coverSide, enderTank, ForgeDirection.UNKNOWN);
         }
     }
 


### PR DESCRIPTION
Move the Ender Fluid Link Cover away from CoverLegacyData in preparation for the mui2 port.