### PR TITLE
Fixes 64A UHV Dynamo Hatch Recipe (S4Stable)

### DIFF
--- a/src/main/java/tectech/loader/recipe/Assembler.java
+++ b/src/main/java/tectech/loader/recipe/Assembler.java
@@ -576,7 +576,7 @@ public class Assembler implements Runnable {
                     .itemOutputs(CustomItemList.eM_dynamoMulti64_UHV.get(1))
                     .fluidInputs(Materials.Tungsten.getMolten(16 * INGOTS))
                     .duration(20 * SECONDS)
-                    .eut(TierEU.RECIPE_UHV)
+                    .eut(TierEU.RECIPE_UV)
                     .addTo(assemblerRecipes);
                 // Dynamo UEV 64A
                 GTValues.RA.stdBuilder()


### PR DESCRIPTION
### Changes:
- 64A UHV Dynamo hatch was tiered at UHV for the recipe which is wrong. I down-tiered it to be UV to match all of the other dynamo hatch recipes.

Shoutout @LewisSaber for being ultra-observant