### PR TITLE
Actually replicate vanilla record logic properly

### DIFF
--- a/src/main/java/gregtech/api/util/GTMusicSystem.java
+++ b/src/main/java/gregtech/api/util/GTMusicSystem.java
@@ -457,7 +457,7 @@ public final class GTMusicSystem {
                             .forEach(resources::add);
                     } else {
                         final ResourceLocation res = record.getRecordResource("records." + record.recordName);
-                        resources.add(new ResourceLocation(res.getResourceDomain(), res.getResourcePath()));
+                        resources.add(res);
                     }
                     for (final ResourceLocation res : resources) {
                         try {

--- a/src/main/java/gregtech/api/util/GTMusicSystem.java
+++ b/src/main/java/gregtech/api/util/GTMusicSystem.java
@@ -456,9 +456,8 @@ public final class GTMusicSystem {
                             .filter(Objects::nonNull)
                             .forEach(resources::add);
                     } else {
-                        final ResourceLocation res = record.getRecordResource(record.recordName);
-                        resources
-                            .add(new ResourceLocation(res.getResourceDomain(), "records." + res.getResourcePath()));
+                        final ResourceLocation res = record.getRecordResource("records." + record.recordName);
+                        resources.add(new ResourceLocation(res.getResourceDomain(), res.getResourcePath()));
                     }
                     for (final ResourceLocation res : resources) {
                         try {

--- a/src/main/java/gregtech/common/tileentities/machines/basic/MTEBetterJukebox.java
+++ b/src/main/java/gregtech/common/tileentities/machines/basic/MTEBetterJukebox.java
@@ -249,7 +249,7 @@ public class MTEBetterJukebox extends MTEBasicMachine implements IAddUIWidgets, 
                 resource = mrmp.getMusicRecordResource(mInventory[getInputSlot() + playbackSlot]);
                 playPath = resource;
             } else {
-                resource = record.getRecordResource(record.recordName);
+                resource = record.getRecordResource("records." + record.recordName);
                 playPath = resource;
             }
             currentlyPlaying = record;
@@ -341,10 +341,8 @@ public class MTEBetterJukebox extends MTEBasicMachine implements IAddUIWidgets, 
                         resource = mrmp.getMusicRecordResource(mInventory[getInputSlot() + playbackSlot]);
                         playPath = resource;
                     } else {
-                        resource = record.getRecordResource(record.recordName);
-                        playPath = new ResourceLocation(
-                            resource.getResourceDomain(),
-                            "records." + resource.getResourcePath());
+                        resource = record.getRecordResource("records." + record.recordName);
+                        playPath = new ResourceLocation(resource.getResourceDomain(), resource.getResourcePath());
                     }
                     currentlyPlaying = record;
                     musicSource.setRecord(playPath);

--- a/src/main/java/gregtech/common/tileentities/machines/basic/MTEBetterJukebox.java
+++ b/src/main/java/gregtech/common/tileentities/machines/basic/MTEBetterJukebox.java
@@ -342,7 +342,7 @@ public class MTEBetterJukebox extends MTEBasicMachine implements IAddUIWidgets, 
                         playPath = resource;
                     } else {
                         resource = record.getRecordResource("records." + record.recordName);
-                        playPath = new ResourceLocation(resource.getResourceDomain(), resource.getResourcePath());
+                        playPath = resource;
                     }
                     currentlyPlaying = record;
                     musicSource.setRecord(playPath);


### PR DESCRIPTION
Now I'm more awake and saw the logic bug. The records. string is prepended to the record name, which is then passed as an argument to getRecordResource. Vanilla discs return the parameter unchanged in that function, hence the confusion.


Fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19698 Fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19955