### PR TITLE
[Structure Rework] Boldarnator

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialRockBreaker.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialRockBreaker.java
@@ -1,0 +1,311 @@
+package gregtech.common.tileentities.machines.multi;
+
+import static com.gtnewhorizon.structurelib.structure.StructureUtility.isAir;
+import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofBlockAnyMeta;
+import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofChain;
+import static com.gtnewhorizon.structurelib.structure.StructureUtility.onElementPass;
+import static gregtech.api.enums.HatchElement.Energy;
+import static gregtech.api.enums.HatchElement.InputBus;
+import static gregtech.api.enums.HatchElement.InputHatch;
+import static gregtech.api.enums.HatchElement.Maintenance;
+import static gregtech.api.enums.HatchElement.Muffler;
+import static gregtech.api.enums.HatchElement.OutputBus;
+import static gregtech.api.util.GTStructureUtility.buildHatchAdder;
+import static gregtech.api.util.GTStructureUtility.ofAnyWater;
+import static gregtech.api.util.GTStructureUtility.ofFrame;
+
+import net.minecraft.block.Block;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.init.Blocks;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumChatFormatting;
+import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
+
+import com.gtnewhorizon.structurelib.alignment.constructable.ISurvivalConstructable;
+import com.gtnewhorizon.structurelib.structure.IStructureDefinition;
+import com.gtnewhorizon.structurelib.structure.ISurvivalBuildEnvironment;
+import com.gtnewhorizon.structurelib.structure.StructureDefinition;
+
+import cofh.asmhooks.block.BlockTickingWater;
+import cofh.asmhooks.block.BlockWater;
+import gregtech.api.GregTechAPI;
+import gregtech.api.casing.Casings;
+import gregtech.api.enums.Materials;
+import gregtech.api.enums.Mods;
+import gregtech.api.enums.SoundResource;
+import gregtech.api.interfaces.ITexture;
+import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
+import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
+import gregtech.api.logic.ProcessingLogic;
+import gregtech.api.metatileentity.implementations.MTEExtendedPowerMultiBlockBase;
+import gregtech.api.recipe.RecipeMap;
+import gregtech.api.render.TextureFactory;
+import gregtech.api.util.GTUtility;
+import gregtech.api.util.MultiblockTooltipBuilder;
+import gregtech.common.pollution.PollutionConfig;
+import gtPlusPlus.api.recipe.GTPPRecipeMaps;
+import gtPlusPlus.xmod.gregtech.common.blocks.textures.TexturesGtBlock;
+
+public class MTEIndustrialRockBreaker extends MTEExtendedPowerMultiBlockBase<MTEIndustrialRockBreaker>
+    implements ISurvivalConstructable {
+
+    private static final String STRUCTURE_PIECE_MAIN = "main";
+    private static final int OFFSET_X = 3;
+    private static final int OFFSET_Y = 2;
+    private static final int OFFSET_Z = 1;
+
+    private int casingAmount;
+    private static IStructureDefinition<MTEIndustrialRockBreaker> STRUCTURE_DEFINITION = null;
+    private boolean needsFluidRefill = false;
+
+    private static final String[][] structure = new String[][] {
+        { "  ACA  ", "       ", "       ", "       ", "  ACA  " },
+        { "CACCCAC", "ABACABA", "ABA~ABA", "ABACABA", "CCCCCCC" },
+        { "CCCCCCC", "CEC CDC", "CEC CDC", "CEC CDC", "CCCCCCC" },
+        { "CACCCAC", "ABACABA", "ABACABA", "ABACABA", "CCCCCCC" },
+        { "  ACA  ", "       ", "       ", "       ", "  ACA  " } };
+
+    public MTEIndustrialRockBreaker(final int aID, final String aName, final String aNameRegional) {
+        super(aID, aName, aNameRegional);
+    }
+
+    public MTEIndustrialRockBreaker(final String aName) {
+        super(aName);
+    }
+
+    @Override
+    public IMetaTileEntity newMetaEntity(final IGregTechTileEntity aTileEntity) {
+        return new MTEIndustrialRockBreaker(this.mName);
+    }
+
+    @Override
+    protected MultiblockTooltipBuilder createTooltip() {
+        MultiblockTooltipBuilder tt = new MultiblockTooltipBuilder();
+        tt.addMachineType("Rock Breaker")
+            .addBulkMachineInfo(8, 3f, 0.75f)
+            .addInfo("Use Integrated Circuit to determine recipe")
+            .addInfo("1 = Cobble, 2 = Stone, 3 = Obsidian, 4 = Basalt, 5 = Deepslate, 6 = Netherrack")
+            .addInfo("Needs Soul Sand and Blue Ice in input bus for basalt")
+            .addInfo("Needs Soul Sand and Magma in input bus for deepslate")
+            .addPollutionAmount(getPollutionPerSecond(null))
+            .beginStructureBlock(7, 5, 5, false)
+            .addController("Front center")
+            .addCasingInfoMin("Thermal Processing Casing", 50, false)
+            .addCasingInfoExactly("Tungsten Frame Box", 36, false)
+            .addCasingInfoExactly("Any Tinted Industrial Glass", 12, false)
+            .addInputBus("Any Thermal Processing Casing", 1)
+            .addInputHatch("Any Thermal Processing Casing", 1)
+            .addOutputBus("Any Thermal Processing Casing", 1)
+            .addEnergyHatch("Any Thermal Processing Casing", 1)
+            .addMaintenanceHatch("Any Thermal Processing Casing", 1)
+            .addMufflerHatch("Any Thermal Processing Casing", 1)
+            .addStructureAuthors(EnumChatFormatting.GOLD + "VorTex")
+            .toolTipFinisher();
+        return tt;
+    }
+
+    @Override
+    public IStructureDefinition<MTEIndustrialRockBreaker> getStructureDefinition() {
+        if (STRUCTURE_DEFINITION == null) {
+            STRUCTURE_DEFINITION = StructureDefinition.<MTEIndustrialRockBreaker>builder()
+                .addShape(STRUCTURE_PIECE_MAIN, structure)
+                .addElement('A', ofFrame(Materials.Tungsten))
+                .addElement('B', ofBlockAnyMeta(GregTechAPI.sBlockTintedGlass))
+                .addElement(
+                    'C',
+                    buildHatchAdder(MTEIndustrialRockBreaker.class)
+                        .atLeast(InputBus, InputHatch, OutputBus, Maintenance, Energy, Muffler)
+                        .casingIndex(Casings.ThermalProcessingCasing.textureId)
+                        .hint(1)
+                        .buildAndChain(
+                            onElementPass(x -> ++x.casingAmount, Casings.ThermalProcessingCasing.asElement())))
+                .addElement('D', ofChain(isAir(), ofBlockAnyMeta(Blocks.lava, 1)))
+                .addElement('E', ofChain(isAir(), ofAnyWater(false)))
+                .build();
+        }
+        return STRUCTURE_DEFINITION;
+    }
+
+    @Override
+    public void construct(ItemStack stackSize, boolean hintsOnly) {
+        buildPiece(STRUCTURE_PIECE_MAIN, stackSize, hintsOnly, OFFSET_X, OFFSET_Y, OFFSET_Z);
+    }
+
+    @Override
+    public int survivalConstruct(ItemStack stackSize, int elementBudget, ISurvivalBuildEnvironment env) {
+        if (mMachine) return -1;
+        return survivalBuildPiece(
+            STRUCTURE_PIECE_MAIN,
+            stackSize,
+            OFFSET_X,
+            OFFSET_Y,
+            OFFSET_Z,
+            elementBudget,
+            env,
+            false,
+            true);
+    }
+
+    @Override
+    public boolean checkMachine(IGregTechTileEntity aBaseMetaTileEntity, ItemStack aStack) {
+        casingAmount = 0;
+        boolean valid = checkPiece(STRUCTURE_PIECE_MAIN, OFFSET_X, OFFSET_Y, OFFSET_Z) && casingAmount >= 50
+            && checkHatch();
+        if (valid) needsFluidRefill = true;
+        return valid;
+    }
+
+    public boolean checkHatch() {
+        return mEnergyHatches.size() >= 1 && mMufflerHatches.size() == 1 && mOutputBusses.size() >= 1;
+    }
+
+    @Override
+    protected SoundResource getProcessStartSound() {
+        return SoundResource.IC2_MACHINES_INDUCTION_LOOP;
+    }
+
+    @Override
+    public ITexture[] getTexture(IGregTechTileEntity baseMetaTileEntity, ForgeDirection sideDirection,
+        ForgeDirection facingDirection, int colorIndex, boolean active, boolean redstoneLevel) {
+        if (sideDirection == facingDirection) {
+            if (active) return new ITexture[] { Casings.ThermalProcessingCasing.getCasingTexture(),
+                TextureFactory.builder()
+                    .addIcon(TexturesGtBlock.oMCAIndustrialRockBreakerActive)
+                    .extFacing()
+                    .build(),
+                TextureFactory.builder()
+                    .addIcon(TexturesGtBlock.oMCAIndustrialRockBreakerActiveGlow)
+                    .extFacing()
+                    .glow()
+                    .build() };
+            return new ITexture[] { Casings.ThermalProcessingCasing.getCasingTexture(), TextureFactory.builder()
+                .addIcon(TexturesGtBlock.oMCAIndustrialRockBreaker)
+                .extFacing()
+                .build(),
+                TextureFactory.builder()
+                    .addIcon(TexturesGtBlock.oMCAIndustrialRockBreakerGlow)
+                    .extFacing()
+                    .glow()
+                    .build() };
+        }
+        return new ITexture[] { Casings.ThermalProcessingCasing.getCasingTexture() };
+    }
+
+    @Override
+    public RecipeMap<?> getRecipeMap() {
+        return GTPPRecipeMaps.multiblockRockBreakerRecipes;
+    }
+
+    @Override
+    protected boolean filtersFluid() {
+        return false;
+    }
+
+    @Override
+    protected ProcessingLogic createProcessingLogic() {
+        return new ProcessingLogic().setSpeedBonus(1 / 3.0)
+            .setEuModifier(0.75)
+            .setMaxParallelSupplier(this::getTrueParallel);
+
+    }
+
+    @Override
+    public int getMaxParallelRecipes() {
+        return 8 * GTUtility.getTier(this.getMaxInputVoltage());
+    }
+
+    @Override
+    public int getPollutionPerSecond(final ItemStack aStack) {
+        return PollutionConfig.pollutionPerSecondMultiIndustrialRockBreaker;
+    }
+
+    @Override
+    public void getWailaNBTData(EntityPlayerMP player, TileEntity tile, NBTTagCompound tag, World world, int x, int y,
+        int z) {
+        super.getWailaNBTData(player, tile, tag, world, x, y, z);
+        tag.setInteger("maxParallelRecipes", getMaxParallelRecipes());
+    }
+
+    @Override
+    public boolean supportsInputSeparation() {
+        return true;
+    }
+
+    @Override
+    public boolean supportsSingleRecipeLocking() {
+        return true;
+    }
+
+    @Override
+    public boolean supportsVoidProtection() {
+        return true;
+    }
+
+    @Override
+    public boolean supportsBatchMode() {
+        return true;
+    }
+
+    @Override
+    public void onPostTick(IGregTechTileEntity aBaseMetaTileEntity, long aTick) {
+        super.onPostTick(aBaseMetaTileEntity, aTick);
+        if (aBaseMetaTileEntity.isServerSide() && needsFluidRefill && mMachine && aTick % 20 == 0) {
+            World world = aBaseMetaTileEntity.getWorld();
+            boolean allFilled = true;
+            int controllerX = aBaseMetaTileEntity.getXCoord();
+            int controllerY = aBaseMetaTileEntity.getYCoord();
+            int controllerZ = aBaseMetaTileEntity.getZCoord();
+
+            for (int sliceZ = 0; sliceZ < structure.length; sliceZ++) {
+                String[] layers = structure[sliceZ];
+                for (int layerY = 0; layerY < layers.length; layerY++) {
+                    String row = layers[layerY];
+                    for (int charX = 0; charX < row.length(); charX++) {
+                        char c = row.charAt(charX);
+                        if (c != 'E' && c != 'D') continue;
+
+                        int[] abc = new int[] { charX - OFFSET_X, layerY - OFFSET_Y, sliceZ - OFFSET_Z };
+                        int[] xyz = new int[] { 0, 0, 0 };
+                        this.getExtendedFacing()
+                            .getWorldOffset(abc, xyz);
+                        int wx = controllerX + xyz[0];
+                        int wy = controllerY + xyz[1];
+                        int wz = controllerZ + xyz[2];
+
+                        Block existing = world.getBlock(wx, wy, wz);
+                        boolean isReplaceable;
+
+                        if (c == 'E') {
+                            boolean isCOFHCore = Mods.COFHCore.isModLoaded()
+                                && (existing instanceof BlockWater || existing instanceof BlockTickingWater);
+                            boolean isFlowing = existing == Blocks.flowing_water;
+                            boolean isWater = isFlowing || existing == Blocks.water || isCOFHCore;
+                            isFlowing = isFlowing || (isWater && world.getBlockMetadata(wx, wy, wz) > 0);
+                            isReplaceable = isFlowing || existing == Blocks.air;
+
+                            if (existing != Blocks.water && !isCOFHCore) {
+                                if (isReplaceable) {
+                                    world.setBlock(wx, wy, wz, Blocks.water, 0, 3);
+                                } else allFilled = false;
+                            }
+                        } else {
+                            isReplaceable = existing == Blocks.air || existing == Blocks.flowing_lava
+                                || existing.isReplaceable(world, wx, wy, wz);
+
+                            if (existing != Blocks.lava) {
+                                if (isReplaceable) {
+                                    world.setBlock(wx, wy, wz, Blocks.lava, 0, 3);
+                                } else allFilled = false;
+                            }
+                        }
+                    }
+                }
+            }
+            if (allFilled) needsFluidRefill = false;
+        }
+
+    }
+}

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialRockBreaker.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialRockBreaker.java
@@ -159,7 +159,7 @@ public class MTEIndustrialRockBreaker extends MTEExtendedPowerMultiBlockBase<MTE
     }
 
     public boolean checkHatch() {
-        return mEnergyHatches.size() >= 1 && mMufflerHatches.size() == 1 && mOutputBusses.size() >= 1;
+        return !mEnergyHatches.isEmpty() && !mMufflerHatches.isEmpty() && !mOutputBusses.isEmpty();
     }
 
     @Override

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialRockBreaker.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialRockBreaker.java
@@ -58,7 +58,6 @@ public class MTEIndustrialRockBreaker extends MTEExtendedPowerMultiBlockBase<MTE
     private static final int OFFSET_Z = 1;
 
     private int casingAmount;
-    private static IStructureDefinition<MTEIndustrialRockBreaker> STRUCTURE_DEFINITION = null;
     private boolean needsFluidRefill = false;
 
     private static final String[][] structure = new String[][] {
@@ -67,6 +66,22 @@ public class MTEIndustrialRockBreaker extends MTEExtendedPowerMultiBlockBase<MTE
         { "CCCCCCC", "CEC CDC", "CEC CDC", "CEC CDC", "CCCCCCC" },
         { "CACCCAC", "ABACABA", "ABACABA", "ABACABA", "CCCCCCC" },
         { "  ACA  ", "       ", "       ", "       ", "  ACA  " } };
+
+    private static final IStructureDefinition<MTEIndustrialRockBreaker> STRUCTURE_DEFINITION = StructureDefinition
+        .<MTEIndustrialRockBreaker>builder()
+        .addShape(STRUCTURE_PIECE_MAIN, structure)
+        .addElement('A', ofFrame(Materials.Tungsten))
+        .addElement('B', ofBlockAnyMeta(GregTechAPI.sBlockTintedGlass))
+        .addElement(
+            'C',
+            buildHatchAdder(MTEIndustrialRockBreaker.class)
+                .atLeast(InputBus, InputHatch, OutputBus, Maintenance, Energy, Muffler)
+                .casingIndex(Casings.ThermalProcessingCasing.textureId)
+                .hint(1)
+                .buildAndChain(onElementPass(x -> ++x.casingAmount, Casings.ThermalProcessingCasing.asElement())))
+        .addElement('D', ofChain(isAir(), ofBlockAnyMeta(Blocks.lava, 1)))
+        .addElement('E', ofChain(isAir(), ofAnyWater(false)))
+        .build();
 
     public MTEIndustrialRockBreaker(final int aID, final String aName, final String aNameRegional) {
         super(aID, aName, aNameRegional);
@@ -109,23 +124,6 @@ public class MTEIndustrialRockBreaker extends MTEExtendedPowerMultiBlockBase<MTE
 
     @Override
     public IStructureDefinition<MTEIndustrialRockBreaker> getStructureDefinition() {
-        if (STRUCTURE_DEFINITION == null) {
-            STRUCTURE_DEFINITION = StructureDefinition.<MTEIndustrialRockBreaker>builder()
-                .addShape(STRUCTURE_PIECE_MAIN, structure)
-                .addElement('A', ofFrame(Materials.Tungsten))
-                .addElement('B', ofBlockAnyMeta(GregTechAPI.sBlockTintedGlass))
-                .addElement(
-                    'C',
-                    buildHatchAdder(MTEIndustrialRockBreaker.class)
-                        .atLeast(InputBus, InputHatch, OutputBus, Maintenance, Energy, Muffler)
-                        .casingIndex(Casings.ThermalProcessingCasing.textureId)
-                        .hint(1)
-                        .buildAndChain(
-                            onElementPass(x -> ++x.casingAmount, Casings.ThermalProcessingCasing.asElement())))
-                .addElement('D', ofChain(isAir(), ofBlockAnyMeta(Blocks.lava, 1)))
-                .addElement('E', ofChain(isAir(), ofAnyWater(false)))
-                .build();
-        }
         return STRUCTURE_DEFINITION;
     }
 

--- a/src/main/java/gregtech/loaders/load/MTERecipeLoader.java
+++ b/src/main/java/gregtech/loaders/load/MTERecipeLoader.java
@@ -1650,6 +1650,11 @@ public class MTERecipeLoader implements Runnable {
             ItemList.LargeThermalRefinery.get(1),
             new Object[] { GregtechItemList.Industrial_ThermalCentrifuge });
 
+        // Boldarnator Conversion Recipe
+        GTModHandler.addShapelessCraftingRecipe(
+            ItemList.Boldarnator.get(1),
+            new Object[] { GregtechItemList.Controller_IndustrialRockBreaker });
+
         // Amazon Packager Conversion Recipe
         GTModHandler.addShapelessCraftingRecipe(
             ItemList.IndustrialPackager.get(1),

--- a/src/main/java/gregtech/loaders/preload/LoaderMetaTileEntities.java
+++ b/src/main/java/gregtech/loaders/preload/LoaderMetaTileEntities.java
@@ -165,6 +165,7 @@ import gregtech.common.tileentities.machines.multi.MTEIndustrialExtractor;
 import gregtech.common.tileentities.machines.multi.MTEIndustrialLaserEngraver;
 import gregtech.common.tileentities.machines.multi.MTEIndustrialMolecularTransformer;
 import gregtech.common.tileentities.machines.multi.MTEIndustrialPackager;
+import gregtech.common.tileentities.machines.multi.MTEIndustrialRockBreaker;
 import gregtech.common.tileentities.machines.multi.MTEIndustrialThermalCentrifuge;
 import gregtech.common.tileentities.machines.multi.MTEIndustrialWireMill;
 import gregtech.common.tileentities.machines.multi.MTEIntegratedOreFactory;
@@ -844,6 +845,10 @@ public class LoaderMetaTileEntities implements Runnable { // TODO CHECK CIRCUIT 
                 MolecularTransformer.ID,
                 "moleculartransformer.controller.tier.single",
                 "Molecular Transformer").getStackForm(1L));
+
+        ItemList.Boldarnator.set(
+            new MTEIndustrialRockBreaker(Boldarnator.ID, "industrialrockcrusher.controller.tier.single", "Boldarnator")
+                .getStackForm(1L));
 
         ItemList.IntegratedOreFactory.set(
             new MTEIntegratedOreFactory(IntegratedOreFactory.ID, "multimachine.oreprocessor", "Integrated Ore Factory")

--- a/src/main/java/gtPlusPlus/core/recipe/RecipesMachinesMulti.java
+++ b/src/main/java/gtPlusPlus/core/recipe/RecipesMachinesMulti.java
@@ -944,7 +944,7 @@ public class RecipesMachinesMulti {
                 GTOreDictUnificator.get(OrePrefixes.plateDouble, Materials.Aluminium, 8),
                 MaterialsAlloy.EGLIN_STEEL.getScrew(8))
             .circuit(12)
-            .itemOutputs(GregtechItemList.Controller_IndustrialRockBreaker.get(1))
+            .itemOutputs(ItemList.Boldarnator.get(1))
             .fluidInputs(Materials.Aluminium.getMolten(8 * INGOTS))
             .duration(2 * MINUTES)
             .eut(TierEU.RECIPE_EV)

--- a/src/main/java/gtPlusPlus/nei/NEIGTPPConfig.java
+++ b/src/main/java/gtPlusPlus/nei/NEIGTPPConfig.java
@@ -6,6 +6,7 @@ import net.minecraft.item.ItemStack;
 
 import codechicken.nei.api.API;
 import codechicken.nei.api.IConfigureNEI;
+import gregtech.api.enums.ItemList;
 import gregtech.api.recipe.RecipeMaps;
 import gtPlusPlus.api.objects.Logger;
 import gtPlusPlus.api.recipe.GTPPRecipeMaps;
@@ -46,6 +47,8 @@ public class NEIGTPPConfig implements IConfigureNEI {
         API.removeRecipeCatalyst(
             GregtechItemList.Controller_IndustrialRockBreaker.get(1),
             RecipeMaps.rockBreakerFakeRecipes.unlocalizedName);
+
+        API.removeRecipeCatalyst(ItemList.Boldarnator.get(1), RecipeMaps.rockBreakerFakeRecipes.unlocalizedName);
 
         // Hide Flasks
         if (Utils.isClient()) {

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTEIndustrialRockBreakerLegacy.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTEIndustrialRockBreakerLegacy.java
@@ -46,23 +46,23 @@ import gtPlusPlus.core.block.ModBlocks;
 import gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.base.GTPPMultiBlockBase;
 import gtPlusPlus.xmod.gregtech.common.blocks.textures.TexturesGtBlock;
 
-public class MTEIndustrialRockBreaker extends GTPPMultiBlockBase<MTEIndustrialRockBreaker>
+public class MTEIndustrialRockBreakerLegacy extends GTPPMultiBlockBase<MTEIndustrialRockBreakerLegacy>
     implements ISurvivalConstructable {
 
     private int mCasing;
-    private static IStructureDefinition<MTEIndustrialRockBreaker> STRUCTURE_DEFINITION = null;
+    private static IStructureDefinition<MTEIndustrialRockBreakerLegacy> STRUCTURE_DEFINITION = null;
 
-    public MTEIndustrialRockBreaker(final int aID, final String aName, final String aNameRegional) {
+    public MTEIndustrialRockBreakerLegacy(final int aID, final String aName, final String aNameRegional) {
         super(aID, aName, aNameRegional);
     }
 
-    public MTEIndustrialRockBreaker(final String aName) {
+    public MTEIndustrialRockBreakerLegacy(final String aName) {
         super(aName);
     }
 
     @Override
     public IMetaTileEntity newMetaEntity(final IGregTechTileEntity aTileEntity) {
-        return new MTEIndustrialRockBreaker(this.mName);
+        return new MTEIndustrialRockBreakerLegacy(this.mName);
     }
 
     @Override
@@ -78,6 +78,7 @@ public class MTEIndustrialRockBreaker extends GTPPMultiBlockBase<MTEIndustrialRo
     protected MultiblockTooltipBuilder createTooltip() {
         MultiblockTooltipBuilder tt = new MultiblockTooltipBuilder();
         tt.addMachineType(getMachineType())
+            .addStructureDeprecatedLine()
             .addBulkMachineInfo(8, 3f, 0.75f)
             .addInfo("Use Integrated Circuit to determine recipe")
             .addInfo("1 = Cobble, 2 = Stone, 3 = Obsidian, 4 = Basalt, 5 = Deepslate, 6 = Netherrack")
@@ -100,9 +101,9 @@ public class MTEIndustrialRockBreaker extends GTPPMultiBlockBase<MTEIndustrialRo
     }
 
     @Override
-    public IStructureDefinition<MTEIndustrialRockBreaker> getStructureDefinition() {
+    public IStructureDefinition<MTEIndustrialRockBreakerLegacy> getStructureDefinition() {
         if (STRUCTURE_DEFINITION == null) {
-            STRUCTURE_DEFINITION = StructureDefinition.<MTEIndustrialRockBreaker>builder()
+            STRUCTURE_DEFINITION = StructureDefinition.<MTEIndustrialRockBreakerLegacy>builder()
                 .addShape(
                     mName,
                     transpose(
@@ -110,7 +111,7 @@ public class MTEIndustrialRockBreaker extends GTPPMultiBlockBase<MTEIndustrialRo
                             { "C~C", "CCC", "CCC" }, }))
                 .addElement(
                     'C',
-                    buildHatchAdder(MTEIndustrialRockBreaker.class)
+                    buildHatchAdder(MTEIndustrialRockBreakerLegacy.class)
                         .atLeast(InputBus, InputHatch, OutputBus, Maintenance, Energy, Muffler)
                         .casingIndex(TAE.GTPP_INDEX(16))
                         .hint(1)

--- a/src/main/java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechIndustrialRockBreaker.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechIndustrialRockBreaker.java
@@ -3,13 +3,13 @@ package gtPlusPlus.xmod.gregtech.registration.gregtech;
 import static gregtech.api.enums.MetaTileEntityIDs.Controller_IndustrialRockBreaker;
 
 import gtPlusPlus.xmod.gregtech.api.enums.GregtechItemList;
-import gtPlusPlus.xmod.gregtech.common.tileentities.machines.multi.production.MTEIndustrialRockBreaker;
+import gtPlusPlus.xmod.gregtech.common.tileentities.machines.multi.production.MTEIndustrialRockBreakerLegacy;
 
 public class GregtechIndustrialRockBreaker {
 
     public static void run() {
         GregtechItemList.Controller_IndustrialRockBreaker.set(
-            new MTEIndustrialRockBreaker(
+            new MTEIndustrialRockBreakerLegacy(
                 Controller_IndustrialRockBreaker.ID,
                 "industrialrockcrusher.controller.tier.single",
                 "Boldarnator").getStackForm(1L));


### PR DESCRIPTION
# Checklist
- [x] use class Casings everywhere it can be used
- [x] change base class to MTEExtendedPowerMultiBlockBase
- [x] leave old code controller untouched (except class renaming) for easier deprecation
- [x] add new class for new structure
- [x] use new structure from the contest and add author to the tooltip
- [x] deprecate old controller, switch its name to -Legacy suffix
- [x] change recipes from old to new controller, add conversion recipe
- [x] make sure dimensions in tooltip correspond to new dimensions from structure definition
- [x] make sure ISurvivalConstructable is implemented to not make structure unbuildable in survival
- [x] make sure every casing and tiered element is reset to 0 before new checkPiece()
- [x] make sure maintenance hatch requirement is removed
- [x] make sure structure offsets and machine bonuses (eu discount, speed, parallel) are set to variables instead of hardcoding

# Author: VorTex

Currently, the Water and Lava are still shown as "NC" inputs in NEI Recipes. If wanted, i could remove those, due to them being obsolete now:
<img width="341" height="160" alt="image" src="https://github.com/user-attachments/assets/aaa6aecb-933c-4e14-901e-afc123b1213d" />


No mechanics of the multi got changed.
However, as proposed in the Structure rework, you no longer need lava and water in an Input Hatch, because those are built into the structure.

Before:
<img width="377" height="510" alt="image" src="https://github.com/user-attachments/assets/9d409cac-20da-40c1-aae4-97f8f41adbaa" />


After:
<img width="668" height="571" alt="boldnew" src="https://github.com/user-attachments/assets/6309937f-7e6c-4b18-8273-041cac7ec289" />

