### PR TITLE
Fixed Drone Remote Interface NPE

### DIFF
--- a/src/main/java/gregtech/common/items/ItemDroneRemoteInterface.java
+++ b/src/main/java/gregtech/common/items/ItemDroneRemoteInterface.java
@@ -45,7 +45,24 @@ public class ItemDroneRemoteInterface extends GTGenericItem implements IGuiHolde
         if (!world.isRemote && stack.hasTagCompound()
             && stack.getTagCompound()
                 .hasKey("droneCentre")) {
-            GuiManager.open(factory, new ItemStackGuiData(player, stack), (EntityPlayerMP) player);
+            // check whether drone centre is still exists
+            NBTTagCompound centreNbt = stack.getTagCompound()
+                .getCompoundTag("droneCentre");
+            int x = centreNbt.getInteger("x");
+            int y = centreNbt.getInteger("y");
+            int z = centreNbt.getInteger("z");
+            int dim = centreNbt.getInteger("dim");
+
+            World targetWorld = MinecraftServer.getServer()
+                .worldServerForDimension(dim);
+            if (targetWorld != null) {
+                TileEntity te = targetWorld.getTileEntity(x, y, z);
+                if (te instanceof IGregTechTileEntity
+                    && ((IGregTechTileEntity) te).getMetaTileEntity() instanceof MTEDroneCentre)
+                    GuiManager.open(factory, new ItemStackGuiData(player, stack), (EntityPlayerMP) player);
+                else player
+                    .addChatMessage(new ChatComponentTranslation("GT5U.tooltip.drone_remote_not_found", x, y, z, dim));
+            }
         }
         return super.onItemRightClick(stack, world, player);
     }

--- a/src/main/resources/assets/gregtech/lang/en_US.lang
+++ b/src/main/resources/assets/gregtech/lang/en_US.lang
@@ -6718,6 +6718,7 @@ GT5U.scanner.chunk_info_3=§f%s: §6%sL
 GT5U.scanner.chunk_info_4=Nothing: §60L
 GT5U.tooltip.drone_remote_disconnected=Shift right click an active drone centre to connect
 GT5U.tooltip.drone_remote_connected=Connected to centre: %s, %s, %s, on dim%s
+GT5U.tooltip.drone_remote_not_found=Drone Centre at x: %s, y: %s, z: %s in dim%s was not found!
 
 # info data
 GT5U.infodata.no_network=No Network


### PR DESCRIPTION
If a Drone Centre that was linked to a Drone Remote Interface was broken and the player tried to use the remote, the game would crash with a NPE. This fixes that.

Now it displays this chat message:
<img width="2880" height="1656" alt="after" src="https://github.com/user-attachments/assets/dd6b6573-86d9-48b8-9733-b6193cc6b6da" />

There is no issue open for this bug, I can open one if needed.