### PR TITLE
add assembler recipe for Forming Core

### DIFF
--- a/src/main/java/gregtech/loaders/postload/recipes/AssemblerRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/AssemblerRecipes.java
@@ -2757,6 +2757,17 @@ public class AssemblerRecipes implements Runnable {
 
         GTValues.RA.stdBuilder()
             .itemInputs(
+                GTOreDictUnificator.get(OrePrefixes.plate, Materials.StainlessSteel, 4),
+                GTOreDictUnificator.get(OrePrefixes.plate, Materials.Steel, 2),
+                GTOreDictUnificator.get(OrePrefixes.frameGt, Materials.StainlessSteel, 1))
+            .circuit(1)
+            .itemOutputs(ItemList.FormingCore.get(1))
+            .duration(2 * SECONDS + 10 * TICKS)
+            .eut(TierEU.RECIPE_LV / 2)
+            .addTo(assemblerRecipes);
+
+        GTValues.RA.stdBuilder()
+            .itemInputs(
                 GTOreDictUnificator.get(OrePrefixes.plate, Materials.Titanium, 6),
                 GTOreDictUnificator.get(OrePrefixes.frameGt, Materials.Titanium, 1))
             .circuit(1)


### PR DESCRIPTION
Yoshy didn't add one. Has to be Circuit 1 to avoid Clean Stainless Steel Casing conflict. If you happen to find any other conflicts, lmk, but I went through all the assembler recipes of the three items and it should be fine.