### PR TITLE
Buff MHDCSM v2 Recipe for new EIC

### DIFF
--- a/src/main/java/bartworks/common/loaders/ElectricImplosionCompressorRecipes.java
+++ b/src/main/java/bartworks/common/loaders/ElectricImplosionCompressorRecipes.java
@@ -112,7 +112,7 @@ public class ElectricImplosionCompressorRecipes implements Runnable {
             .itemInputs(Materials.Eternity.getNanite(1), Materials.Universium.getNanite(1))
             .fluidInputs(Materials.RawStarMatter.getFluid(2 * STACKS))
             .fluidOutputs(Materials.MHDCSM.getMolten(32 * INGOTS))
-            .duration(4 * SECONDS)
+            .duration(1 * SECONDS)
             .eut(TierEU.RECIPE_MAX)
             .addTo(electricImplosionCompressorRecipes);
 


### PR DESCRIPTION
Discussed: https://discord.com/channels/181078474394566657/939305179524792340/1493049394671653055

New EIC (https://github.com/GTNewHorizons/GT5-Unofficial/pull/6339) will be much larger, this targets the anticipated future pain point of MHDCSM end-game spam by just quartering the recipe time.