### PR TITLE
Add extra slots to digester

### DIFF
--- a/src/main/java/gtnhlanth/api/recipe/LanthanidesRecipeMaps.java
+++ b/src/main/java/gtnhlanth/api/recipe/LanthanidesRecipeMaps.java
@@ -34,7 +34,7 @@ public class LanthanidesRecipeMaps {
         .create(SourceChamberMetadata.class, "source_chamber_metadata");
 
     public static final RecipeMap<RecipeMapBackend> digesterRecipes = RecipeMapBuilder.of("gtnhlanth.recipe.digester")
-        .maxIO(1, 1, 1, 1)
+        .maxIO(3, 1, 1, 1)
         .minInputs(1, 1)
         .progressBar(GTUITextures.PROGRESSBAR_ARROW_MULTIPLE)
         .neiSpecialInfoFormatter(HeatingCoilSpecialValueFormatter.INSTANCE)


### PR DESCRIPTION
This pr adds 2 more extra slots to the NEI page for the digester. I intend to make use of the digester more for crops NH and the first recipe i will be adding requires 3 item slots.

<img width="661" height="614" alt="image" src="https://github.com/user-attachments/assets/5216bf0c-3090-4a54-bd4d-c6395fb12989" />

The merger of this PR should be dependent on https://github.com/GTNewHorizons/CropsNH/pull/99 passing