### PR TITLE
Fixed missing translation for the "EU" string

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/MTECable.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTECable.java
@@ -5,6 +5,7 @@ import static gregtech.api.enums.Mods.GalacticraftCore;
 import static net.minecraftforge.common.util.ForgeDirection.DOWN;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 
@@ -640,25 +641,13 @@ public class MTECable extends MetaPipeEntity implements IMetaTileEntityCable, IL
     public void getWailaBody(ItemStack itemStack, List<String> currenttip, IWailaDataAccessor accessor,
         IWailaConfigHandler config) {
 
-        currenttip.add(
-            StatCollector.translateToLocal("GT5U.item.cable.max_voltage") + ": "
-                + EnumChatFormatting.GREEN
-                + formatNumber(mVoltage)
-                + " ("
-                + GTUtility.getColoredTierNameFromVoltage(mVoltage)
-                + EnumChatFormatting.GREEN
-                + ")");
-        currenttip.add(
-            StatCollector.translateToLocal("GT5U.item.cable.max_amperage") + ": "
-                + EnumChatFormatting.YELLOW
-                + formatNumber(mAmperage));
-        currenttip.add(
-            StatCollector.translateToLocal("GT5U.item.cable.loss") + ": "
-                + EnumChatFormatting.RED
-                + formatNumber(mCableLossPerMeter)
-                + EnumChatFormatting.RESET
-                + " "
-                + StatCollector.translateToLocal("GT5U.item.cable.eu_volt"));
+        Collections.addAll(
+            currenttip,
+            GTSplit.splitLocalizedFormatted(
+                "gt.blockmachines.cable.desc",
+                TooltipHelper.voltageText(mVoltage),
+                TooltipHelper.ampText(mAmperage),
+                TooltipHelper.cableLossText(mCableLossPerMeter)));
     }
 
     @Override


### PR DESCRIPTION
close https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24239
<img width="381" height="125" alt="image" src="https://github.com/user-attachments/assets/2aab9ac2-0989-4d74-82a5-f7a8d6364bb8" />
in addition, Waila is now using the new colors used in the Tooltip