### PR TITLE
Reduce Magic Feather from EV -> HV Voltage

### DIFF
--- a/src/main/java/gtPlusPlus/core/recipe/RecipesGeneral.java
+++ b/src/main/java/gtPlusPlus/core/recipe/RecipesGeneral.java
@@ -171,7 +171,7 @@ public class RecipesGeneral {
             .itemOutputs(GregtechItemList.MagicFeather.get(1))
             .fluidInputs(Materials.Silver.getMolten(32 * INGOTS))
             .duration(2 * MINUTES)
-            .eut(TierEU.RECIPE_EV)
+            .eut(TierEU.RECIPE_HV)
             .addTo(assemblerRecipes);
 
         addCompressedCactusCharcoal();


### PR DESCRIPTION
Will only affect when the Elytra can be crafted, which will now be HV tier instead of EV.... for anyone insane enough to craft it in the first place.