### PR TITLE
Add EU and Speed Modifier Suppliers

### DIFF
--- a/src/main/java/bartworks/common/tileentities/multis/mega/MTEMegaOilCracker.java
+++ b/src/main/java/bartworks/common/tileentities/multis/mega/MTEMegaOilCracker.java
@@ -30,8 +30,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import javax.annotation.Nonnull;
-
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraftforge.common.util.ForgeDirection;
@@ -58,7 +56,6 @@ import gregtech.api.metatileentity.implementations.MTEHatchMultiInput;
 import gregtech.api.metatileentity.implementations.MTEHatchOutput;
 import gregtech.api.recipe.RecipeMap;
 import gregtech.api.recipe.RecipeMaps;
-import gregtech.api.recipe.check.CheckRecipeResult;
 import gregtech.api.recipe.maps.OilCrackerBackend;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.MultiblockTooltipBuilder;

--- a/src/main/java/bartworks/common/tileentities/multis/mega/MTEMegaOilCracker.java
+++ b/src/main/java/bartworks/common/tileentities/multis/mega/MTEMegaOilCracker.java
@@ -224,20 +224,17 @@ public class MTEMegaOilCracker extends MegaMultiBlockBase<MTEMegaOilCracker> imp
 
     @Override
     protected ProcessingLogic createProcessingLogic() {
-        return new ProcessingLogic() {
-
-            @Override
-            @Nonnull
-            public CheckRecipeResult process() {
-                this.setEuModifier(1.0F - Math.min(0.1F * (MTEMegaOilCracker.this.heatLevel.getTier() + 1), 0.5F));
-                return super.process();
-            }
-        }.setMaxParallelSupplier(this::getTrueParallel);
+        return new ProcessingLogic().setMaxParallelSupplier(this::getTrueParallel)
+            .setEuModifierSupplier(this::getEuModifier);
     }
 
     @Override
     public int getMaxParallelRecipes() {
         return Configuration.Multiblocks.megaMachinesMax;
+    }
+
+    public double getEuModifier() {
+        return 1.0F - Math.min(0.1F * (MTEMegaOilCracker.this.heatLevel.getTier() + 1), 0.5F);
     }
 
     public HeatingCoilLevel getCoilLevel() {

--- a/src/main/java/gregtech/api/logic/ProcessingLogic.java
+++ b/src/main/java/gregtech/api/logic/ProcessingLogic.java
@@ -42,6 +42,8 @@ public class ProcessingLogic {
     protected ItemStack specialSlotItem;
     protected int maxParallel = 1;
     protected Supplier<Integer> maxParallelSupplier;
+    protected Supplier<Double> euModSupplier;
+    protected Supplier<Double> speedBoostSupplier;
     protected int batchSize = 1;
     protected Supplier<RecipeMap<?>> recipeMapSupplier;
     protected double euModifier = 1.0;
@@ -215,8 +217,18 @@ public class ProcessingLogic {
         return this;
     }
 
+    public ProcessingLogic setEuModifierSupplier(Supplier<Double> supplier) {
+        this.euModSupplier = supplier;
+        return this;
+    }
+
     public ProcessingLogic setSpeedBonus(double speedModifier) {
         this.speedBoost = speedModifier;
+        return this;
+    }
+
+    public ProcessingLogic setSpeedBonusSupplier(Supplier<Double> supplier) {
+        this.speedBoostSupplier = supplier;
         return this;
     }
 
@@ -375,6 +387,14 @@ public class ProcessingLogic {
 
         if (maxParallelSupplier != null) {
             maxParallel = maxParallelSupplier.get();
+        }
+
+        if (euModSupplier != null) {
+            euModifier = euModSupplier.get();
+        }
+
+        if (speedBoostSupplier != null) {
+            speedBoost = speedBoostSupplier.get();
         }
 
         if (inputItems == null) {

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEFluidShaper.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEFluidShaper.java
@@ -32,8 +32,6 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.FluidStack;
 
-import org.jetbrains.annotations.NotNull;
-
 import com.gtnewhorizon.structurelib.alignment.constructable.ISurvivalConstructable;
 import com.gtnewhorizon.structurelib.structure.IStructureDefinition;
 import com.gtnewhorizon.structurelib.structure.ISurvivalBuildEnvironment;

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEFluidShaper.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEFluidShaper.java
@@ -310,15 +310,13 @@ public class MTEFluidShaper extends MTEExtendedPowerMultiBlockBase<MTEFluidShape
                 }
                 return false;
             }
-
-            @NotNull
-            @Override
-            protected CheckRecipeResult validateRecipe(@NotNull GTRecipe recipe) {
-                setSpeedBonus(1F / speedup);
-                return super.validateRecipe(recipe);
-            }
         }.setMaxParallelSupplier(this::getTrueParallel)
-            .setEuModifier(0.8F);
+            .setEuModifier(0.8F)
+            .setSpeedBonusSupplier(this::getSpeedBonus);
+    }
+
+    public double getSpeedBonus() {
+        return (1F / speedup);
     }
 
     @Override

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialMixer.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialMixer.java
@@ -20,8 +20,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import org.jetbrains.annotations.NotNull;
-
 import com.gtnewhorizon.structurelib.alignment.constructable.ISurvivalConstructable;
 import com.gtnewhorizon.structurelib.structure.IStructureDefinition;
 import com.gtnewhorizon.structurelib.structure.ISurvivalBuildEnvironment;
@@ -37,7 +35,6 @@ import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.logic.ProcessingLogic;
 import gregtech.api.metatileentity.implementations.MTEExtendedPowerMultiBlockBase;
 import gregtech.api.recipe.RecipeMap;
-import gregtech.api.recipe.check.CheckRecipeResult;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.MultiblockTooltipBuilder;

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialMixer.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialMixer.java
@@ -59,7 +59,6 @@ public class MTEIndustrialMixer extends MTEExtendedPowerMultiBlockBase<MTEIndust
     private static final int PARALLEL_PER_TIER = 8;
     private static final float SPEED_INCREASE_TIER = 1f;
     private static final float SPEED_BASIC = 1f;
-    private static final float EU_EFFICIENCY = 1f;
 
     private int glassTier = -1;
 
@@ -212,21 +211,17 @@ public class MTEIndustrialMixer extends MTEExtendedPowerMultiBlockBase<MTEIndust
 
     @Override
     protected ProcessingLogic createProcessingLogic() {
-        return new ProcessingLogic() {
-
-            @NotNull
-            @Override
-            public CheckRecipeResult process() {
-                setEuModifier(EU_EFFICIENCY);
-                setSpeedBonus(1F / SPEED_BASIC / (SPEED_INCREASE_TIER + (itemPipeTier + 1)));
-                return super.process();
-            }
-        }.setMaxParallelSupplier(this::getTrueParallel);
+        return new ProcessingLogic().setMaxParallelSupplier(this::getTrueParallel)
+            .setSpeedBonusSupplier(this::getSpeedBonus);
     }
 
     @Override
     public int getMaxParallelRecipes() {
         return (PARALLEL_PER_TIER * GTUtility.getTier(this.getMaxInputVoltage()));
+    }
+
+    public double getSpeedBonus() {
+        return 1F / (SPEED_INCREASE_TIER + (itemPipeTier + 1));
     }
 
     private int casingAmount;

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialPackager.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialPackager.java
@@ -44,7 +44,6 @@ import gregtech.api.metatileentity.implementations.MTEExtendedPowerMultiBlockBas
 import gregtech.api.modularui2.GTGuiTextures;
 import gregtech.api.recipe.RecipeMap;
 import gregtech.api.recipe.RecipeMaps;
-import gregtech.api.recipe.check.CheckRecipeResult;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.MultiblockTooltipBuilder;

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialPackager.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialPackager.java
@@ -181,21 +181,18 @@ public class MTEIndustrialPackager extends MTEExtendedPowerMultiBlockBase<MTEInd
 
     @Override
     protected ProcessingLogic createProcessingLogic() {
-        return new ProcessingLogic() {
-
-            @NotNull
-            @Override
-            public CheckRecipeResult process() {
-                setEuModifier(EU_EFFICIENCY);
-                setSpeedBonus(1F / (SPEED_INCREASE_TIER * (itemPipeTier + 1)));
-                return super.process();
-            }
-        }.setMaxParallelSupplier(this::getTrueParallel);
+        return new ProcessingLogic().setMaxParallelSupplier(this::getTrueParallel)
+            .setEuModifier(EU_EFFICIENCY)
+            .setSpeedBonusSupplier(this::getSpeedBonus);
     }
 
     @Override
     public int getMaxParallelRecipes() {
         return (PARALLEL_PER_TIER * GTUtility.getTier(this.getMaxInputVoltage()));
+    }
+
+    public double getSpeedBonus() {
+        return 1F / (SPEED_INCREASE_TIER * (itemPipeTier + 1));
     }
 
     private int casingAmount;

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialThermalCentrifuge.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialThermalCentrifuge.java
@@ -227,9 +227,9 @@ public class MTEIndustrialThermalCentrifuge extends MTEExtendedPowerMultiBlockBa
 
     @Override
     protected ProcessingLogic createProcessingLogic() {
-        return new ProcessingLogic().setSpeedBonus(1.0f / getSpeedBonus())
-            .setEuModifier(getEUMultiplier())
-            .setMaxParallelSupplier(this::getTrueParallel);
+        return new ProcessingLogic().setMaxParallelSupplier(this::getTrueParallel)
+            .setEuModifierSupplier(this::getEUMultiplier)
+            .setSpeedBonusSupplier(this::getSpeedBonus);
     }
 
     @Override
@@ -265,19 +265,19 @@ public class MTEIndustrialThermalCentrifuge extends MTEExtendedPowerMultiBlockBa
         solenoidLevel = level;
     }
 
-    public float getCoilSpeedBonus() {
-        return (float) ((coilLevel == null ? 0 : SPEED_PER_COIL * coilLevel.getTier()));
+    public double getCoilSpeedBonus() {
+        return (coilLevel == null ? 0 : SPEED_PER_COIL * coilLevel.getTier());
     }
 
-    public float getSpeedBonus() {
-        return (float) (BASE_SPEED_BONUS + getCoilSpeedBonus());
+    public double getSpeedBonus() {
+        return 1F / (BASE_SPEED_BONUS + getCoilSpeedBonus());
     }
 
-    public float getEUMultiplier() {
+    public double getEUMultiplier() {
         double heatingBonus = (coilLevel == null ? 0
             : GTUtility.powInt(HEATING_COIL_EU_MULTIPLIER, coilLevel.getTier()));
 
-        return (float) (BASE_EU_MULTIPLIER * heatingBonus);
+        return BASE_EU_MULTIPLIER * heatingBonus;
     }
 
     @Override

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialWireMill.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialWireMill.java
@@ -153,21 +153,18 @@ public class MTEIndustrialWireMill extends MTEExtendedPowerMultiBlockBase<MTEInd
 
     @Override
     protected ProcessingLogic createProcessingLogic() {
-        return new ProcessingLogic() {
-
-            @NotNull
-            @Override
-            public CheckRecipeResult process() {
-                setEuModifier(EU_EFFICIENCY);
-                setSpeedBonus(1F / (SPEED_INCREASE_TIER * itemPipeTier));
-                return super.process();
-            }
-        }.setMaxParallelSupplier(this::getTrueParallel);
+        return new ProcessingLogic().setMaxParallelSupplier(this::getTrueParallel)
+            .setEuModifier(EU_EFFICIENCY)
+            .setSpeedBonusSupplier(this::getSpeedBonus);
     }
 
     @Override
     public int getMaxParallelRecipes() {
         return (PARALLEL_PER_TIER * GTUtility.getTier(this.getMaxInputVoltage()));
+    }
+
+    public double getSpeedBonus() {
+        return 1F / (SPEED_INCREASE_TIER * itemPipeTier);
     }
 
     private int mCasingAmount;

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialWireMill.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialWireMill.java
@@ -13,8 +13,6 @@ import static gregtech.api.util.GTStructureUtility.chainItemPipeCasings;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import org.jetbrains.annotations.NotNull;
-
 import com.gtnewhorizon.structurelib.alignment.constructable.ISurvivalConstructable;
 import com.gtnewhorizon.structurelib.structure.IStructureDefinition;
 import com.gtnewhorizon.structurelib.structure.ISurvivalBuildEnvironment;
@@ -29,7 +27,6 @@ import gregtech.api.logic.ProcessingLogic;
 import gregtech.api.metatileentity.implementations.MTEExtendedPowerMultiBlockBase;
 import gregtech.api.recipe.RecipeMap;
 import gregtech.api.recipe.RecipeMaps;
-import gregtech.api.recipe.check.CheckRecipeResult;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.MultiblockTooltipBuilder;

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTELargeFluidExtractor.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTELargeFluidExtractor.java
@@ -46,7 +46,6 @@ import gregtech.api.logic.ProcessingLogic;
 import gregtech.api.metatileentity.implementations.MTEExtendedPowerMultiBlockBase;
 import gregtech.api.recipe.RecipeMap;
 import gregtech.api.recipe.RecipeMaps;
-import gregtech.api.recipe.check.CheckRecipeResult;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.MultiblockTooltipBuilder;

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTELargeFluidExtractor.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTELargeFluidExtractor.java
@@ -210,17 +210,10 @@ public class MTELargeFluidExtractor extends MTEExtendedPowerMultiBlockBase<MTELa
 
     @Override
     protected ProcessingLogic createProcessingLogic() {
-        return new ProcessingLogic() {
-
-            @NotNull
-            @Override
-            public CheckRecipeResult process() {
-                setEuModifier(getEUMultiplier());
-                setSpeedBonus(1.0f / getSpeedBonus());
-                return super.process();
-            }
-        }.noRecipeCaching()
-            .setMaxParallelSupplier(this::getTrueParallel);
+        return new ProcessingLogic().noRecipeCaching()
+            .setMaxParallelSupplier(this::getTrueParallel)
+            .setEuModifierSupplier(this::getEUMultiplier)
+            .setSpeedBonusSupplier(this::getSpeedBonus);
     }
 
     @Override
@@ -392,14 +385,14 @@ public class MTELargeFluidExtractor extends MTEExtendedPowerMultiBlockBase<MTELa
         return (float) ((coilLevel == null ? 0 : SPEED_PER_COIL * coilLevel.getTier()));
     }
 
-    public float getSpeedBonus() {
-        return (float) (BASE_SPEED_BONUS + getCoilSpeedBonus());
+    public double getSpeedBonus() {
+        return (BASE_SPEED_BONUS + getCoilSpeedBonus());
     }
 
-    public float getEUMultiplier() {
+    public double getEUMultiplier() {
         double heatingBonus = (coilLevel == null ? 0
             : GTUtility.powInt(HEATING_COIL_EU_MULTIPLIER, coilLevel.getTier()));
 
-        return (float) (BASE_EU_MULTIPLIER * heatingBonus);
+        return (BASE_EU_MULTIPLIER * heatingBonus);
     }
 }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTELargeFluidExtractor.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTELargeFluidExtractor.java
@@ -363,7 +363,7 @@ public class MTELargeFluidExtractor extends MTEExtendedPowerMultiBlockBase<MTELa
             StatCollector.translateToLocalFormatted(
                 "Total Speed Multiplier: %s%.0f%s %%",
                 YELLOW,
-                getSpeedBonus() * 100,
+                (BASE_SPEED_BONUS + getCoilSpeedBonus()) * 100,
                 RESET));
         data.add(
             StatCollector.translateToLocalFormatted(
@@ -385,7 +385,7 @@ public class MTELargeFluidExtractor extends MTEExtendedPowerMultiBlockBase<MTELa
     }
 
     public double getSpeedBonus() {
-        return (BASE_SPEED_BONUS + getCoilSpeedBonus());
+        return 1F / (BASE_SPEED_BONUS + getCoilSpeedBonus());
     }
 
     public double getEUMultiplier() {

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEMassSolidifier.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEMassSolidifier.java
@@ -32,8 +32,6 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.FluidStack;
 
-import org.jetbrains.annotations.NotNull;
-
 import com.gtnewhorizon.structurelib.alignment.constructable.ISurvivalConstructable;
 import com.gtnewhorizon.structurelib.structure.IStructureDefinition;
 import com.gtnewhorizon.structurelib.structure.ISurvivalBuildEnvironment;

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEMassSolidifier.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEMassSolidifier.java
@@ -300,14 +300,8 @@ public class MTEMassSolidifier extends MTEExtendedPowerMultiBlockBase<MTEMassSol
                 }
                 return false;
             }
-
-            @NotNull
-            @Override
-            protected CheckRecipeResult validateRecipe(@NotNull GTRecipe recipe) {
-                setSpeedBonus(1F / speedup);
-                return super.validateRecipe(recipe);
-            }
-        }.setMaxParallelSupplier(this::getTrueParallel);
+        }.setMaxParallelSupplier(this::getTrueParallel)
+            .setSpeedBonusSupplier(this::getSpeedBonus);
     }
 
     @Nonnull
@@ -340,6 +334,10 @@ public class MTEMassSolidifier extends MTEExtendedPowerMultiBlockBase<MTEMassSol
     @Override
     public int getMaxParallelRecipes() {
         return 10 * GTUtility.getTier(this.getMaxInputVoltage());
+    }
+
+    public double getSpeedBonus() {
+        return 1F / speedup;
     }
 
     @Override

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEOilCracker.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEOilCracker.java
@@ -19,8 +19,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import javax.annotation.Nonnull;
-
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.Fluid;
@@ -47,7 +45,6 @@ import gregtech.api.metatileentity.implementations.MTEHatchMultiInput;
 import gregtech.api.metatileentity.implementations.MTEHatchOutput;
 import gregtech.api.recipe.RecipeMap;
 import gregtech.api.recipe.RecipeMaps;
-import gregtech.api.recipe.check.CheckRecipeResult;
 import gregtech.api.recipe.maps.OilCrackerBackend;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.MultiblockTooltipBuilder;

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEOilCracker.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEOilCracker.java
@@ -183,15 +183,7 @@ public class MTEOilCracker extends MTEEnhancedMultiBlockBase<MTEOilCracker> impl
 
     @Override
     protected ProcessingLogic createProcessingLogic() {
-        return new ProcessingLogic() {
-
-            @Nonnull
-            @Override
-            public CheckRecipeResult process() {
-                setEuModifier(1.0F - Math.min(0.1F * (heatLevel.getTier() + 1), 0.5F));
-                return super.process();
-            }
-        };
+        return new ProcessingLogic().setEuModifierSupplier(this::getEuModifier);
     }
 
     @Override
@@ -205,6 +197,10 @@ public class MTEOilCracker extends MTEEnhancedMultiBlockBase<MTEOilCracker> impl
 
     public void setCoilLevel(HeatingCoilLevel aCoilLevel) {
         heatLevel = aCoilLevel;
+    }
+
+    public double getEuModifier() {
+        return 1.0F - Math.min(0.1F * (heatLevel.getTier() + 1), 0.5F);
     }
 
     private boolean addMiddleInputToMachineList(IGregTechTileEntity aTileEntity, int aBaseCasingIndex) {

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEPyrolyseOven.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEPyrolyseOven.java
@@ -21,8 +21,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import org.jetbrains.annotations.NotNull;
-
 import com.gtnewhorizon.structurelib.alignment.constructable.ISurvivalConstructable;
 import com.gtnewhorizon.structurelib.structure.IStructureDefinition;
 import com.gtnewhorizon.structurelib.structure.ISurvivalBuildEnvironment;
@@ -42,7 +40,6 @@ import gregtech.api.logic.ProcessingLogic;
 import gregtech.api.metatileentity.implementations.MTEExtendedPowerMultiBlockBase;
 import gregtech.api.recipe.RecipeMap;
 import gregtech.api.recipe.RecipeMaps;
-import gregtech.api.recipe.check.CheckRecipeResult;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.MultiblockTooltipBuilder;
 import gregtech.api.util.tooltip.TooltipTier;

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEPyrolyseOven.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEPyrolyseOven.java
@@ -162,15 +162,7 @@ public class MTEPyrolyseOven extends MTEExtendedPowerMultiBlockBase<MTEPyrolyseO
 
     @Override
     protected ProcessingLogic createProcessingLogic() {
-        return new ProcessingLogic() {
-
-            @NotNull
-            @Override
-            public CheckRecipeResult process() {
-                setSpeedBonus(2f / (1 + coilHeat.getTier()));
-                return super.process();
-            }
-        };
+        return new ProcessingLogic().setSpeedBonusSupplier(this::getSpeedBonus);
     }
 
     @Override
@@ -188,6 +180,10 @@ public class MTEPyrolyseOven extends MTEExtendedPowerMultiBlockBase<MTEPyrolyseO
 
     private void setCoilLevel(HeatingCoilLevel aCoilLevel) {
         coilHeat = aCoilLevel;
+    }
+
+    public double getSpeedBonus() {
+        return 2f / (1 + coilHeat.getTier());
     }
 
     @Override

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEPyrolyseOvenLegacy.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEPyrolyseOvenLegacy.java
@@ -155,15 +155,7 @@ public class MTEPyrolyseOvenLegacy extends MTEEnhancedMultiBlockBase<MTEPyrolyse
 
     @Override
     protected ProcessingLogic createProcessingLogic() {
-        return new ProcessingLogic() {
-
-            @NotNull
-            @Override
-            public CheckRecipeResult process() {
-                setSpeedBonus(2f / (1 + coilHeat.getTier()));
-                return super.process();
-            }
-        };
+        return new ProcessingLogic().setSpeedBonusSupplier(this::getSpeedBonus);
     }
 
     @Override
@@ -177,6 +169,10 @@ public class MTEPyrolyseOvenLegacy extends MTEEnhancedMultiBlockBase<MTEPyrolyse
 
     public HeatingCoilLevel getCoilLevel() {
         return coilHeat;
+    }
+
+    public double getSpeedBonus() {
+        return 2f / (1 + coilHeat.getTier());
     }
 
     private void setCoilLevel(HeatingCoilLevel aCoilLevel) {

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEPyrolyseOvenLegacy.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEPyrolyseOvenLegacy.java
@@ -21,8 +21,6 @@ import static gregtech.api.util.GTStructureUtility.ofCoil;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import org.jetbrains.annotations.NotNull;
-
 import com.gtnewhorizon.structurelib.alignment.constructable.ISurvivalConstructable;
 import com.gtnewhorizon.structurelib.structure.IStructureDefinition;
 import com.gtnewhorizon.structurelib.structure.ISurvivalBuildEnvironment;
@@ -42,7 +40,6 @@ import gregtech.api.logic.ProcessingLogic;
 import gregtech.api.metatileentity.implementations.MTEEnhancedMultiBlockBase;
 import gregtech.api.recipe.RecipeMap;
 import gregtech.api.recipe.RecipeMaps;
-import gregtech.api.recipe.check.CheckRecipeResult;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.MultiblockTooltipBuilder;
 import gregtech.api.util.tooltip.TooltipTier;

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTESpinmatron.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTESpinmatron.java
@@ -110,6 +110,8 @@ public class MTESpinmatron extends MTEExtendedPowerMultiBlockBase<MTESpinmatron>
         .customOptional("iconsets/TFFT_ACTIVE_GLOW");
     public ArrayList<MTEHatchTurbine> turbineRotorHatchList = new ArrayList<>();
 
+    private int ticker = 1; // just increments and drains (amountToDrain) of the given
+
     private boolean staticAnimations = false;
     // spotless:off
 
@@ -731,8 +733,6 @@ public class MTESpinmatron extends MTEExtendedPowerMultiBlockBase<MTESpinmatron>
         }
         return parallels > 0 ? parallels : 1; // if its 1, something messed up lol, just a failsafe in case i mess up
     }
-
-    private int ticker = 1; // just increments and drains (amountToDrain) of the given
 
     @Override
     public boolean onRunningTick(ItemStack aStack) {


### PR DESCRIPTION
Adds suppliers for EU/Speed like there exists for parallels for `ProcessingLogic` so they can be added in `createProcessingLogic` and `setupProcessingLogic` can be reserved for more complicated circumstances. Tested as working with the Large Fluid Extractor (1A UIV, Hypogen block recycling, ran 5 recipes (20% EU usage) at 280% speed (3.85 seconds from 10.8)).