### PR TITLE
Fixes crash on opening inventory of a fresh toolbox

### DIFF
--- a/src/main/java/gregtech/common/items/ItemGTToolbox.java
+++ b/src/main/java/gregtech/common/items/ItemGTToolbox.java
@@ -364,7 +364,7 @@ public class ItemGTToolbox extends GTGenericItem implements IGuiHolder<PlayerInv
         final int slot = data.getSlotIndex();
         final ItemStack candidate = data.getUsedItemStack();
 
-        if (candidate == null || !(candidate.getItem() instanceof ItemGTToolbox) || !candidate.hasTagCompound()) {
+        if (candidate == null || !(candidate.getItem() instanceof ItemGTToolbox)) {
             throw new RuntimeException(
                 String.format("Toolbox was expected in slot %d but was either not found or not a toolbox", slot));
         }


### PR DESCRIPTION
This PR fixes a crash that happens when the user opens the inventory of a toolbox when it has no NBT data. Previously, some unknown side effect was making it so all toolboxes had *some* NBT data, which satisfied the check the GUI code was doing. But, since the optimizations in #6335, this was no longer the case, making the overzealous sanity check crash the game. Removing the check fixes the problem.