### PR TITLE
Fix new mixer multiamp restrictions

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialMixer.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialMixer.java
@@ -265,7 +265,10 @@ public class MTEIndustrialMixer extends MTEExtendedPowerMultiBlockBase<MTEIndust
         if (!checkPiece(STRUCTURE_PIECE_MAIN, OFFSET_X, OFFSET_Y, OFFSET_Z)) return false;
         if (!(casingAmount >= 5)) return false;
         if (mMufflerHatches.isEmpty()) return false;
-        if (mExoticEnergyHatches.size() == 1) return glassTier >= VoltageIndex.UIV;
+        if (!mExoticEnergyHatches.isEmpty()) {
+            if (!mEnergyHatches.isEmpty()) return false;
+            return (mExoticEnergyHatches.size() == 1) && glassTier >= VoltageIndex.UIV;
+        }
         return true;
     }
 


### PR DESCRIPTION
- actually only lets you place 1 multiamp hatch
- only lets you place multiamp if no other energy hatches are present