### PR TITLE
Make the game blow up on null oredict recipes inputs

### DIFF
--- a/src/main/java/gregtech/api/util/GTRecipeBuilder.java
+++ b/src/main/java/gregtech/api/util/GTRecipeBuilder.java
@@ -377,15 +377,17 @@ public class GTRecipeBuilder {
             Object input = inputs[i];
             if (input instanceof ItemStack) {
                 alts[i] = new ItemStack[] { (ItemStack) input };
-            } else if (input instanceof ItemStack[]) {
-                alts[i] = ((ItemStack[]) input).clone();
+            } else if (input instanceof ItemStack[]inputArr) {
+                if (debugNull() && containsNull(inputArr)) handleNullRecipeComponents("itemInputs");
+                alts[i] = inputArr.clone();
             } else if (input instanceof OreDictItemStack ods) {
                 altOreIds[i] = OreDictionary.getOreID(ods.mOreName);
                 ArrayList<ItemStack> ores = GTOreDictUnificator.getOres(ods.mOreName);
                 if (ores.isEmpty()) {
+                    alts[i] = GTValues.emptyItemStackArray;
                     GTLog.err
                         .println("Warning: OreDict entry \"" + ods.mOreName + "\" is empty; recipe will be skipped.");
-                    alts[i] = GTValues.emptyItemStackArray;
+                    if (debugNull()) handleNullRecipeComponents("itemInputs empty ore dict");
                     continue;
                 }
                 ArrayList<ItemStack> list = new ArrayList<>(ores.size());
@@ -394,14 +396,16 @@ public class GTRecipeBuilder {
                     ItemStack itemStack = GTUtility.copyAmount(ods.mAmount, ores.get(j));
                     if (GTUtility.isStackValid(itemStack)) list.add(itemStack);
                 }
+                if (debugNull() && list.isEmpty()) handleNullRecipeComponents("itemInputs no valid ore dict item");
                 alts[i] = list.toArray(new ItemStack[0]);
             } else if (input instanceof Object[]arr) {
                 if (arr.length != 2) continue;
                 altOreIds[i] = OreDictionary.getOreID(arr[0].toString());
                 ArrayList<ItemStack> ores = GTOreDictUnificator.getOres(arr[0]);
                 if (ores.isEmpty()) {
-                    GTLog.err.println("Warning: OreDict entry \"" + arr[0] + "\" is empty; recipe will be skipped.");
                     alts[i] = GTValues.emptyItemStackArray;
+                    GTLog.err.println("Warning: OreDict entry \"" + arr[0] + "\" is empty; recipe will be skipped.");
+                    if (debugNull()) handleNullRecipeComponents("itemInputs empty ore dict");
                     continue;
                 }
                 int size = ((Number) arr[1]).intValue();
@@ -411,9 +415,10 @@ public class GTRecipeBuilder {
                     ItemStack itemStack = GTUtility.copyAmount(size, ores.get(j));
                     if (GTUtility.isStackValid(itemStack)) list.add(itemStack);
                 }
+                if (debugNull() && list.isEmpty()) handleNullRecipeComponents("itemInputs no valid ore dict item");
                 alts[i] = list.toArray(new ItemStack[0]);
             } else if (input == null) {
-                handleNullRecipeComponents("recipe oredict input");
+                if (debugNull()) handleNullRecipeComponents("recipe oredict input");
                 alts[i] = GTValues.emptyItemStackArray;
             } else {
                 throw new IllegalArgumentException("index " + i + ", unexpected type: " + input.getClass());

--- a/src/main/java/gregtech/loaders/postload/recipes/Pulverizer.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/Pulverizer.java
@@ -787,36 +787,6 @@ public class Pulverizer implements Runnable {
             .eut(2)
             .addTo(maceratorRecipes);
 
-        GTValues.RA.stdBuilder()
-            .itemInputs(new OreDictItemStack("stoneSoapstone", 1))
-            .itemOutputs(
-                GTOreDictUnificator.get(OrePrefixes.dustImpure, Materials.Talc, 1L),
-                GTOreDictUnificator.get(OrePrefixes.dustTiny, Materials.Chromite, 1L))
-            .outputChances(10000, 1000)
-            .duration(20 * SECONDS)
-            .eut(2)
-            .addTo(maceratorRecipes);
-
-        GTValues.RA.stdBuilder()
-            .itemInputs(new OreDictItemStack("stoneMigmatite", 1))
-            .itemOutputs(
-                GTOreDictUnificator.get(OrePrefixes.dust, Materials.SiliconDioxide, 1L),
-                GTOreDictUnificator.get(OrePrefixes.dustImpure, Materials.GraniteBlack, 1L))
-            .outputChances(10000, 5000)
-            .duration(20 * SECONDS)
-            .eut(2)
-            .addTo(maceratorRecipes);
-
-        GTValues.RA.stdBuilder()
-            .itemInputs(new OreDictItemStack("stoneQuartzite", 1))
-            .itemOutputs(
-                GTOreDictUnificator.get(OrePrefixes.dustImpure, Materials.Quartzite, 1L),
-                GTOreDictUnificator.get(OrePrefixes.dust, Materials.Quartzite, 1L))
-            .outputChances(10000, 1000)
-            .duration(20 * SECONDS)
-            .eut(2)
-            .addTo(maceratorRecipes);
-
         // Basalt falls through to the Quartzite macerator case in the original ProcessingStone
         GTValues.RA.stdBuilder()
             .itemInputs(new OreDictItemStack("stoneBasalt", 1))
@@ -824,16 +794,6 @@ public class Pulverizer implements Runnable {
                 GTOreDictUnificator.get(OrePrefixes.dustImpure, Materials.Basalt, 1L),
                 GTOreDictUnificator.get(OrePrefixes.dust, Materials.Basalt, 1L))
             .outputChances(10000, 1000)
-            .duration(20 * SECONDS)
-            .eut(2)
-            .addTo(maceratorRecipes);
-
-        GTValues.RA.stdBuilder()
-            .itemInputs(new OreDictItemStack("stoneFlint", 1))
-            .itemOutputs(
-                GTOreDictUnificator.get(OrePrefixes.dustImpure, Materials.Flint, 2L),
-                new ItemStack(Items.flint, 1))
-            .outputChances(10000, 5000)
             .duration(20 * SECONDS)
             .eut(2)
             .addTo(maceratorRecipes);


### PR DESCRIPTION
All the recipe input methods in the recipe builder will blow up when there is a null input but not the ore direct based methods, I changed it so now it does.
Also remove a few recipes that are null because the ore direct doesn't exist.

Tested in full pack daily 460, works as intended.