### PR TITLE
Fix processingLogic overflow for spinmatron

### DIFF
--- a/src/main/java/gregtech/api/util/ParallelHelper.java
+++ b/src/main/java/gregtech/api/util/ParallelHelper.java
@@ -396,7 +396,7 @@ public class ParallelHelper {
 
         double heatDiscountMultiplier = calculator.calculateHeatDiscountMultiplier();
 
-        final int tRecipeEUt = (int) Math.ceil(recipe.mEUt * eutModifier * heatDiscountMultiplier);
+        final long tRecipeEUt = (long) Math.ceil(recipe.mEUt * eutModifier * heatDiscountMultiplier);
         if (availableEUt < tRecipeEUt) {
             result = CheckRecipeResultRegistry.insufficientPower(tRecipeEUt);
             return;


### PR DESCRIPTION
This PR fixes a bug where the spinmatron could powerfail in heavy mode when trying to run the spacetime separation recipe, due to an int overflow in processingLogic, caused by the 16x power increase of heavy mode.