### PR TITLE
Disable the GUI from opening for the Wireless Assembly Line Reception Connector and the Assembly Line Reception Connector

### DIFF
--- a/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchDataItemsInput.java
+++ b/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchDataItemsInput.java
@@ -11,6 +11,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumChatFormatting;
@@ -59,6 +60,11 @@ public class MTEHatchDataItemsInput extends MTEHatchDataAccess implements IConne
     @Override
     public MetaTileEntity newMetaEntity(IGregTechTileEntity aTileEntity) {
         return new MTEHatchDataItemsInput(this.mName, this.mTier, mDescriptionArray, this.mTextures);
+    }
+
+    @Override
+    public boolean onRightclick(IGregTechTileEntity aBaseMetaTileEntity, EntityPlayer aPlayer) {
+        return true;
     }
 
     @Override

--- a/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchWirelessDataItemsInput.java
+++ b/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchWirelessDataItemsInput.java
@@ -9,6 +9,7 @@ import static tectech.thing.metaTileEntity.hatch.MTEHatchDataConnector.EM_D_SIDE
 import java.util.Collections;
 import java.util.List;
 
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.server.MinecraftServer;
 import net.minecraftforge.common.util.ForgeDirection;
@@ -53,6 +54,11 @@ public class MTEHatchWirelessDataItemsInput extends MTEHatchDataAccess {
             TextureFactory
                 .of(EM_D_SIDES, Dyes.getModulation(getBaseMetaTileEntity().getColorization(), MACHINE_METAL.getRGBA())),
             TextureFactory.of(EM_D_CONN) };
+    }
+
+    @Override
+    public boolean onRightclick(IGregTechTileEntity aBaseMetaTileEntity, EntityPlayer aPlayer) {
+        return true;
     }
 
     @Override


### PR DESCRIPTION
They shouldn’t be openable in the first place, since the inventory size is 0