### PR TITLE
Fix vajra ghost block

### DIFF
--- a/src/main/java/gregtech/common/tools/ToolVajra.java
+++ b/src/main/java/gregtech/common/tools/ToolVajra.java
@@ -180,7 +180,7 @@ public class ToolVajra extends ItemTool implements IElectricItem {
         stack.getTagCompound()
             .setBoolean("harvested", true); // prevent onItemRightClick from going through
         ElectricItem.manager.use(stack, baseCost, player);
-        return super.onItemUse(stack, player, world, x, y, z, side, hitX, hitY, hitZ);
+        return true;
     }
 
     private boolean isHarvestableOwned(TileEntity tileEntity, EntityPlayer player) {


### PR DESCRIPTION
In the picture, the 1x superconducter LUV wire has actually been destroyed by using Vajra right click (it doesn't exist, but other players can still stand on it), but right-clicking it once makes it disappear
<img width="1004" height="719" alt="image" src="https://github.com/user-attachments/assets/f5a80b23-18e0-4bc5-b6d7-40fdc8060347" />
When using right click with Vajra, the other player does not sync the breaking, causing ghost blocks
