### PR TITLE
Fix vajra ghost block

### DIFF
--- a/src/main/java/gregtech/common/tools/ToolVajra.java
+++ b/src/main/java/gregtech/common/tools/ToolVajra.java
@@ -180,7 +180,7 @@ public class ToolVajra extends ItemTool implements IElectricItem {
         stack.getTagCompound()
             .setBoolean("harvested", true); // prevent onItemRightClick from going through
         ElectricItem.manager.use(stack, baseCost, player);
-        return super.onItemUse(stack, player, world, x, y, z, side, hitX, hitY, hitZ);
+        return true;
     }
 
     private boolean isHarvestableOwned(TileEntity tileEntity, EntityPlayer player) {


### PR DESCRIPTION
In the picture, the 1x superconducter LUV wire has actually been destroyed by using Vajra right click (it doesn't exist, but other players can still stand on it), but right-clicking it once makes it disappear
<img width="1004" height="719" alt="image" src="https://github.com/user-attachments/assets/f5a80b23-18e0-4bc5-b6d7-40fdc8060347" />
When using right click with Vajra, the other player does not sync the breaking, causing ghost blocks

In Forge 1.7.10, when PlayerControllerMP.processRightClickBlock returns false from onItemUse, it means the C08PacketPlayerBlockPlacement packet will not be sent to the server. As a result:

Client side: Executes onPlayerDestroyBlock → removes the block client-side → onItemUse returns false.

Since false is returned, no packet is sent.

Server side: Never receives the packet → never calls onItemUse → never calls removedByPlayer → the block still exists.

Ghost block phenomenon: The breaker sees the block disappear, but other players still see the block and can stand on it. The block only disappears when right-clicked (which triggers a server state sync).

The fix: Only one line was changed – at the end of ToolVajra.onItemUse, return super.onItemUse(...) was changed to return true.

This causes the client to send the packet to the server. The server then calls onItemUse → removedByPlayer removes the block → a S23PacketBlockChange packet notifies all clients → the ghost block issue is resolved.
