### PR TITLE
Revert "Fix vajra ghost block (#6402)"

### DIFF
--- a/src/main/java/gregtech/common/tools/ToolVajra.java
+++ b/src/main/java/gregtech/common/tools/ToolVajra.java
@@ -180,7 +180,7 @@ public class ToolVajra extends ItemTool implements IElectricItem {
         stack.getTagCompound()
             .setBoolean("harvested", true); // prevent onItemRightClick from going through
         ElectricItem.manager.use(stack, baseCost, player);
-        return true;
+        return super.onItemUse(stack, player, world, x, y, z, side, hitX, hitY, hitZ);
     }
 
     private boolean isHarvestableOwned(TileEntity tileEntity, EntityPlayer player) {


### PR DESCRIPTION
Because of this commit now if you sneak + right click a tile entity, it won't drop and it gets desync between the client and server