### PR TITLE
Allow Laser Hatches on LATEX

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTELatex.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTELatex.java
@@ -4,10 +4,10 @@ import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofBlock;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofBlocksTiered;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.onElementPass;
 import static gregtech.api.enums.HatchElement.Energy;
+import static gregtech.api.enums.HatchElement.ExoticEnergy;
 import static gregtech.api.enums.HatchElement.InputBus;
 import static gregtech.api.enums.HatchElement.InputHatch;
 import static gregtech.api.enums.HatchElement.Maintenance;
-import static gregtech.api.enums.HatchElement.MultiAmpEnergy;
 import static gregtech.api.enums.HatchElement.OutputBus;
 import static gregtech.api.enums.Mods.UniversalSingularities;
 import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_FRONT_MULTI_LATEX;
@@ -139,7 +139,7 @@ public class MTELatex extends MTEExtendedPowerMultiBlockBase<MTELatex> implement
         .addElement(
             'C',
             buildHatchAdder(MTELatex.class)
-                .atLeast(InputBus, InputHatch, OutputBus, Maintenance, Energy.or(MultiAmpEnergy))
+                .atLeast(InputBus, InputHatch, OutputBus, Maintenance, Energy.or(ExoticEnergy))
                 .casingIndex(CASING_INDEX)
                 .hint(1)
                 .buildAndChain(onElementPass(MTELatex::onCasingAdded, ofBlock(GregTechAPI.sBlockCasings8, 0))))
@@ -275,8 +275,8 @@ public class MTELatex extends MTEExtendedPowerMultiBlockBase<MTELatex> implement
             .addInfo(
                 TooltipHelper.parallelText("2x") + " parallels, +"
                     + TooltipHelper.coloredText("25%", DARK_GREEN)
-                    + " rubber discount, and the use of a singular "
-                    + TooltipHelper.coloredText("Multi-Amp energy hatch", GREEN))
+                    + " rubber discount, and the use of "
+                    + TooltipHelper.coloredText("Multi-Amp & Laser Energy Hatches", GREEN))
             .addSeparator()
             .addInfo(DARK_AQUA + "Make sure to cover up!")
             .beginStructureBlock(5, 8, 5, false)
@@ -319,14 +319,11 @@ public class MTELatex extends MTEExtendedPowerMultiBlockBase<MTELatex> implement
         clearHatches();
         if (!checkPiece(STRUCTURE_PIECE_MAIN, 2, 7, 0)) return false;
         ItemStack controllerStack = this.getControllerSlot();
-        boolean singularity_present = (controllerStack != null && controllerStack.isItemEqual(
+        boolean singularityPresent = controllerStack != null && controllerStack.isItemEqual(
             UniversalSingularities.isModLoaded()
                 ? getModItem(UniversalSingularities.ID, "universal.rubber.singularity", 1L, 5)
-                : ItemList.Tool_DataStick.get(1)));
-        if (!mExoticEnergyHatches.isEmpty()) {
-            if (!singularity_present) return false;
-            if (mExoticEnergyHatches.size() > 1) return false;
-        }
+                : ItemList.Tool_DataStick.get(1));
+        if (!mExoticEnergyHatches.isEmpty() && !singularityPresent) return false;
         return mCasingAmount >= 14;
     }
 


### PR DESCRIPTION
Still gates the usage of Multi & laser hatches to after the Elastic Singularity is put into the machine but removes the limit of one hatch and the limitation of just multi-amp hatches. 

Given that the Precise Assembler uses laser hatches it makes no sense that this shouldn't too considering it's the dedicated device.

Generously giving it the Affects Balance moniker.