### PR TITLE
[MUI2] Moved charger slot creation from MTEBasicMachineWithRecipeBaseGui to parent class

### DIFF
--- a/src/main/java/gregtech/common/gui/modularui/singleblock/base/MTEBasicMachineWithRecipeBaseGui.java
+++ b/src/main/java/gregtech/common/gui/modularui/singleblock/base/MTEBasicMachineWithRecipeBaseGui.java
@@ -7,7 +7,6 @@ import java.util.Arrays;
 import com.cleanroommc.modularui.api.drawable.IDrawable;
 import com.cleanroommc.modularui.drawable.UITexture;
 import com.cleanroommc.modularui.screen.ModularPanel;
-import com.cleanroommc.modularui.screen.RichTooltip;
 import com.cleanroommc.modularui.utils.Alignment;
 import com.cleanroommc.modularui.value.sync.BooleanSyncValue;
 import com.cleanroommc.modularui.value.sync.DoubleSyncValue;
@@ -158,28 +157,6 @@ public class MTEBasicMachineWithRecipeBaseGui extends MTETieredMachineBlockBaseG
                 t -> t.addLine(GTUtility.translate(tooltipKeys[0]))
                     .addLine(GTUtility.translate(tooltipKeys[1])))
             .tooltipShowUpTimer(TOOLTIP_DELAY);
-    }
-
-    protected ItemSlot createChargerSlot() {
-
-        return new ItemSlot()
-            .slot(
-                new ModularSlot(machine.inventoryHandler, machine.rechargerSlotStartIndex()).changeListener(
-                    (newItem, onlyAmountChanged, client, init) -> {
-                        if (!client && !init) machine.getBaseMetaTileEntity()
-                            .markInventoryBeenModified();
-                    }))
-            .background(GTGuiTextures.SLOT_ITEM_STANDARD, GTGuiTextures.OVERLAY_SLOT_CHARGER)
-            .tooltip(this::createTooltipForChargerSlot)
-            .tooltipShowUpTimer(TOOLTIP_DELAY);
-    }
-
-    private void createTooltipForChargerSlot(RichTooltip tooltip) {
-        final byte machineTier = machine.mTier;
-        String tierName = GTUtility.getColoredTierNameFromTier(machineTier);
-        tooltip.addLine(GTUtility.translate("GT5U.machines.battery_slot.tooltip"))
-            .addLine(GTUtility.translate("GT5U.machines.battery_slot.tooltip.1", tierName))
-            .addLine(GTUtility.translate("GT5U.machines.battery_slot.tooltip.2", tierName));
     }
 
     protected ProgressWidget createProgressBar() {

--- a/src/main/java/gregtech/common/gui/modularui/singleblock/base/MTETieredMachineBlockBaseGui.java
+++ b/src/main/java/gregtech/common/gui/modularui/singleblock/base/MTETieredMachineBlockBaseGui.java
@@ -7,6 +7,7 @@ import com.cleanroommc.modularui.api.widget.IWidget;
 import com.cleanroommc.modularui.drawable.UITexture;
 import com.cleanroommc.modularui.factory.PosGuiData;
 import com.cleanroommc.modularui.screen.ModularPanel;
+import com.cleanroommc.modularui.screen.RichTooltip;
 import com.cleanroommc.modularui.screen.UISettings;
 import com.cleanroommc.modularui.utils.Alignment;
 import com.cleanroommc.modularui.value.sync.BooleanSyncValue;
@@ -17,12 +18,15 @@ import com.cleanroommc.modularui.widgets.SlotGroupWidget;
 import com.cleanroommc.modularui.widgets.ToggleButton;
 import com.cleanroommc.modularui.widgets.layout.Flow;
 import com.cleanroommc.modularui.widgets.layout.Row;
+import com.cleanroommc.modularui.widgets.slot.ItemSlot;
+import com.cleanroommc.modularui.widgets.slot.ModularSlot;
 
 import gregtech.api.gui.widgets.CommonWidgets;
 import gregtech.api.interfaces.IConfigurationCircuitSupport;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.implementations.MTETieredMachineBlock;
 import gregtech.api.modularui2.GTGuiTextures;
+import gregtech.api.util.GTUtility;
 import gregtech.common.modularui2.factory.GTBaseGuiBuilder;
 
 // For singleblock MUI2 guis.
@@ -216,4 +220,25 @@ public class MTETieredMachineBlockBaseGui<T extends MTETieredMachineBlock> {
             .tooltipShowUpTimer(TOOLTIP_DELAY);
     }
 
+    protected ItemSlot createChargerSlot() {
+
+        return new ItemSlot()
+            .slot(
+                new ModularSlot(machine.inventoryHandler, machine.rechargerSlotStartIndex()).changeListener(
+                    (newItem, onlyAmountChanged, client, init) -> {
+                        if (!client && !init) machine.getBaseMetaTileEntity()
+                            .markInventoryBeenModified();
+                    }))
+            .background(GTGuiTextures.SLOT_ITEM_STANDARD, GTGuiTextures.OVERLAY_SLOT_CHARGER)
+            .tooltip(this::createTooltipForChargerSlot)
+            .tooltipShowUpTimer(TOOLTIP_DELAY);
+    }
+
+    protected void createTooltipForChargerSlot(RichTooltip tooltip) {
+        final byte machineTier = machine.mTier;
+        String tierName = GTUtility.getColoredTierNameFromTier(machineTier);
+        tooltip.addLine(GTUtility.translate("GT5U.machines.battery_slot.tooltip"))
+            .addLine(GTUtility.translate("GT5U.machines.battery_slot.tooltip.1", tierName))
+            .addLine(GTUtility.translate("GT5U.machines.battery_slot.tooltip.2", tierName));
+    }
 }


### PR DESCRIPTION
This will be needed for upcoming ports of MTEBuffer subclasses. Only change of substance is the createTooltip() method has protected visibility instead of private for consistency.