### PR TITLE
Titanium Dust Based Titaniumtetrachloride Nerf

### DIFF
--- a/src/main/java/gregtech/loaders/postload/recipes/ChemicalRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/ChemicalRecipes.java
@@ -470,8 +470,8 @@ public class ChemicalRecipes implements Runnable {
             .itemInputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.Titanium, 1))
             .fluidInputs(Materials.Chlorine.getGas(4_000))
             .fluidOutputs(Materials.Titaniumtetrachloride.getFluid(1_000))
-            .duration(10 * SECONDS)
-            .eut(TierEU.RECIPE_HV)
+            .duration(60 * SECONDS)
+            .eut(TierEU.RECIPE_EV)
             .addTo(UniversalChemical);
 
         // 4Na + 2MgCl2 = 2Mg + 4NaCl


### PR DESCRIPTION
10s HV -> 60s EV

I know it seems harsh, but it's actually more than generous. This still places it as more efficient than using Helium in an EBF. It had absolutely no place being where it was. Reminder that tetra is a free loop and because there are multiple recipe steps they can be done concurrently for an even bigger time save than listed below.

Reminder on status quo (to hot ingot):
Titanium Dust EBF (No liquid): 112.5s EV
Titanium Dust EBF (W/ Helium): 81s EV
Pure Rutile Tetra EBF: 60s HV
Ilmenite -> Rutile Tetra EBF: 220s HV
Titanium Dust Tetra EBF (This recipe): 50s HV

Titanium Dust Tetra EBF (This recipe post-change): 60s EV + 40s HV

The numbers speak for themselves.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24232