### PR TITLE
optimize removeFurnaceSmelting

### DIFF
--- a/src/main/java/gregtech/api/util/GTModHandler.java
+++ b/src/main/java/gregtech/api/util/GTModHandler.java
@@ -1279,20 +1279,13 @@ public class GTModHandler {
     /**
      * Removes a Smelting Recipe
      */
-    public static boolean removeFurnaceSmelting(ItemStack aInput) {
-        if (aInput != null) {
-            for (ItemStack tInput : FurnaceRecipes.smelting()
-                .getSmeltingList()
-                .keySet()) {
-                if (GTUtility.areStacksEqual(aInput, tInput, true)) {
-                    FurnaceRecipes.smelting()
-                        .getSmeltingList()
-                        .remove(tInput);
-                    return true;
-                }
-            }
-        }
-        return false;
+    public static boolean removeFurnaceSmelting(ItemStack input) {
+        if (input == null) return false;
+
+        // smelting list was optimized to allow fast operations like that, see MixinFurnaceRecipes.java in Hodgepodge
+        return FurnaceRecipes.smelting()
+            .getSmeltingList()
+            .remove(input) != null;
     }
 
     /**


### PR DESCRIPTION
`removeFurnaceSmelting` was taking 10% of GT loading time, and now it takes only 0.01%. It saved ~1.4s on my M1 macbook

All thanks to the [MixinFurnaceRecipes](https://github.com/GTNewHorizons/Hodgepodge/blob/master/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinFurnaceRecipes.java) mixin though

Before:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/520439a0-22b0-4a56-841f-bf4cc17ea43f" />

After:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f893d380-7d33-44ef-b2a9-b65d335c2f8e" />

Compared successful recipe deletions in dev env and they all match:
| Before | After |
| - | - |
| <img width="1029" height="185" alt="image" src="https://github.com/user-attachments/assets/c02af688-269b-4a21-8a92-8f7863414821" /> | <img width="940" height="188" alt="image" src="https://github.com/user-attachments/assets/88f66724-dee7-41bf-9e52-b7e1b5d22dfe" /> |
