### PR TITLE
Optimize recipe loading by almost 4s

### DIFF
--- a/src/main/java/bartworks/common/loaders/recipes/CraftingRecipes.java
+++ b/src/main/java/bartworks/common/loaders/recipes/CraftingRecipes.java
@@ -79,14 +79,14 @@ public class CraftingRecipes implements Runnable {
 
         GTModHandler.addCraftingRecipe(
             new MTELESU(LESU.ID, "LESU", "L.E.S.U.").getStackForm(1L),
-            RecipeLoader.BITSD,
+            RecipeLoader.BITSD | GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "CDC", "SBS", "CFC", 'C', "circuitAdvanced", 'D', ItemList.Cover_Screen.get(1L), 'S',
                 GTOreDictUnificator.get(OrePrefixes.cableGt12, Materials.Platinum, 1L), 'B',
                 new ItemStack(ItemRegistry.BW_BLOCKS[1]), 'F', ItemList.Field_Generator_HV.get(1L) });
 
         GTModHandler.addCraftingRecipe(
             new ItemStack(ItemRegistry.ROCKCUTTER_MV),
-            RecipeLoader.BITSD,
+            RecipeLoader.BITSD | GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "DS ", "DP ", "DCB", 'D', GTOreDictUnificator.get(OrePrefixes.dust, Materials.Diamond, 1L),
                 'S', GTOreDictUnificator.get(OrePrefixes.stick, Materials.TungstenSteel, 1L), 'P',
                 GTOreDictUnificator.get(OrePrefixes.plate, Materials.TungstenSteel, 1L), 'C', "circuitGood", 'B',
@@ -94,7 +94,7 @@ public class CraftingRecipes implements Runnable {
 
         GTModHandler.addCraftingRecipe(
             new ItemStack(ItemRegistry.ROCKCUTTER_LV),
-            RecipeLoader.BITSD,
+            RecipeLoader.BITSD | GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "DS ", "DP ", "DCB", 'D', GTOreDictUnificator.get(OrePrefixes.dust, Materials.Diamond, 1L),
                 'S', GTOreDictUnificator.get(OrePrefixes.stick, Materials.Titanium, 1L), 'P',
                 GTOreDictUnificator.get(OrePrefixes.plate, Materials.Titanium, 1L), 'C', "circuitBasic", 'B',
@@ -102,7 +102,7 @@ public class CraftingRecipes implements Runnable {
 
         GTModHandler.addCraftingRecipe(
             new ItemStack(ItemRegistry.ROCKCUTTER_HV),
-            RecipeLoader.BITSD,
+            RecipeLoader.BITSD | GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "DS ", "DP ", "DCB", 'D', GTOreDictUnificator.get(OrePrefixes.dust, Materials.Diamond, 1L),
                 'S', GTOreDictUnificator.get(OrePrefixes.stick, Materials.Iridium, 1L), 'P',
                 GTOreDictUnificator.get(OrePrefixes.plate, Materials.Iridium, 1L), 'C', "circuitAdvanced", 'B',
@@ -110,18 +110,18 @@ public class CraftingRecipes implements Runnable {
 
         GTModHandler.addCraftingRecipe(
             new ItemStack(ItemRegistry.TESLASTAFF),
-            RecipeLoader.BITSD,
+            RecipeLoader.BITSD | GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "BO ", "OP ", "  P", 'O',
                 GTOreDictUnificator.get(OrePrefixes.wireGt16, Materials.SuperconductorUHV, 1L), 'B',
                 ItemList.Energy_LapotronicOrb.get(1L), 'P', "plateAlloyIridium", });
 
         GTModHandler.addCraftingRecipe(
             new ItemStack(ItemRegistry.PUMPPARTS, 1, 0), // tube
-            GTModHandler.RecipeBits.NOT_REMOVABLE,
+            GTModHandler.RecipeBits.NOT_REMOVABLE | GTModHandler.RecipeBits.BUFFERED,
             new Object[] { " fG", " G ", "G  ", 'G', ItemList.Circuit_Parts_Glass_Tube.get(1L) });
         GTModHandler.addCraftingRecipe(
             new ItemStack(ItemRegistry.PUMPPARTS, 1, 1), // motor
-            GTModHandler.RecipeBits.NOT_REMOVABLE,
+            GTModHandler.RecipeBits.NOT_REMOVABLE | GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "GLP", "LSd", "PfT", 'G',
                 GTOreDictUnificator.get(OrePrefixes.gearGtSmall, Materials.Steel, 1L), 'L',
                 GTOreDictUnificator.get(OrePrefixes.stickLong, Materials.Steel, 1L), 'S',
@@ -129,14 +129,14 @@ public class CraftingRecipes implements Runnable {
                 new ItemStack(ItemRegistry.PUMPPARTS, 1, 0) });
         GTModHandler.addCraftingRecipe(
             new ItemStack(ItemRegistry.PUMPBLOCK, 1, 0),
-            GTModHandler.RecipeBits.NOT_REMOVABLE,
+            GTModHandler.RecipeBits.NOT_REMOVABLE | GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "IPI", "PMP", "ISI", 'I', GTOreDictUnificator.get(OrePrefixes.plate, Materials.Iron, 1L),
                 'P', GTOreDictUnificator.get(OrePrefixes.pipeLarge, Materials.Wood, 1L), 'M',
                 new ItemStack(ItemRegistry.PUMPPARTS, 1, 1), 'S', "craftingBlastFurnace" });
 
         GTModHandler.addCraftingRecipe(
             new ItemStack(ItemRegistry.WINDMETER),
-            GTModHandler.RecipeBits.NOT_REMOVABLE,
+            GTModHandler.RecipeBits.NOT_REMOVABLE | GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "SWF", "Sf ", "Ss ", 'S', "stickWood", 'W', new ItemStack(Blocks.wool, 1, Short.MAX_VALUE),
                 'F', new ItemStack(Items.string), });
 
@@ -145,14 +145,14 @@ public class CraftingRecipes implements Runnable {
             ItemStack machinehull = ItemList.MACHINE_HULLS[i + 2].get(1L);
             GTModHandler.addCraftingRecipe(
                 ItemRegistry.acidGens[i],
-                RecipeLoader.BITSD,
+                RecipeLoader.BITSD | GTModHandler.RecipeBits.BUFFERED,
                 new Object[] { "HRH", "HCH", "HKH", 'H', bats[i], 'K',
                     GTOreDictUnificator.get(OrePrefixes.cableGt01, cable, 1L), 'C', machinehull, 'R', chreac[i] });
         }
 
         GTModHandler.addCraftingRecipe(
             ItemRegistry.acidGensLV,
-            RecipeLoader.BITSD,
+            RecipeLoader.BITSD | GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "HRH", "KCK", "HKH", 'H', ItemList.Battery_Hull_LV.get(1L), 'K',
                 GTOreDictUnificator.get(OrePrefixes.cableGt01, Materials.Tin, 1L), 'C', ItemList.Hull_LV.get(1L), 'R',
                 ItemList.Machine_LV_ChemicalReactor.get(1L), });
@@ -167,32 +167,32 @@ public class CraftingRecipes implements Runnable {
 
                 GTModHandler.addCraftingRecipe(
                     ItemRegistry.energyDistributor[i],
-                    RecipeLoader.BITSD,
+                    RecipeLoader.BITSD | GTModHandler.RecipeBits.BUFFERED,
                     new Object[] { "PWP", "WCW", "PWP", 'W', GTOreDictUnificator.get(OrePrefixes.wireGt16, cable, 1L),
                         'P', hull, 'C', machinehull });
                 GTModHandler.addCraftingRecipe(
                     ItemRegistry.diode12A[i],
-                    RecipeLoader.BITSD,
+                    RecipeLoader.BITSD | GTModHandler.RecipeBits.BUFFERED,
                     new Object[] { "WDW", "DCD", "PDP", 'D', OrePrefixes.componentCircuit.get(Materials.Diode), 'W',
                         GTOreDictUnificator.get(OrePrefixes.cableGt12, cable, 1L), 'P', hull, 'C', machinehull });
                 GTModHandler.addCraftingRecipe(
                     ItemRegistry.diode8A[i],
-                    RecipeLoader.BITSD,
+                    RecipeLoader.BITSD | GTModHandler.RecipeBits.BUFFERED,
                     new Object[] { "WDW", "DCD", "PDP", 'D', OrePrefixes.componentCircuit.get(Materials.Diode), 'W',
                         GTOreDictUnificator.get(OrePrefixes.cableGt08, cable, 1L), 'P', hull, 'C', machinehull });
                 GTModHandler.addCraftingRecipe(
                     ItemRegistry.diode4A[i],
-                    RecipeLoader.BITSD,
+                    RecipeLoader.BITSD | GTModHandler.RecipeBits.BUFFERED,
                     new Object[] { "WDW", "DCD", "PDP", 'D', OrePrefixes.componentCircuit.get(Materials.Diode), 'W',
                         GTOreDictUnificator.get(OrePrefixes.cableGt04, cable, 1L), 'P', hull, 'C', machinehull });
                 GTModHandler.addCraftingRecipe(
                     ItemRegistry.diode2A[i],
-                    RecipeLoader.BITSD,
+                    RecipeLoader.BITSD | GTModHandler.RecipeBits.BUFFERED,
                     new Object[] { "WDW", "DCD", "PDP", 'D', OrePrefixes.componentCircuit.get(Materials.Diode), 'W',
                         GTOreDictUnificator.get(OrePrefixes.cableGt02, cable, 1L), 'P', hull, 'C', machinehull });
                 GTModHandler.addCraftingRecipe(
                     ItemRegistry.diode16A[i],
-                    RecipeLoader.BITSD,
+                    RecipeLoader.BITSD | GTModHandler.RecipeBits.BUFFERED,
                     new Object[] { "WHW", "DCD", "PDP", 'H', OrePrefixes.componentCircuit.get(Materials.Inductor), 'D',
                         OrePrefixes.componentCircuit.get(Materials.Diode), 'W',
                         GTOreDictUnificator.get(OrePrefixes.wireGt16, cable, 1L), 'P', hull, 'C', machinehull });
@@ -209,26 +209,26 @@ public class CraftingRecipes implements Runnable {
             for (String stone : stones) {
                 GTModHandler.addCraftingRecipe(
                     new ItemStack(ItemRegistry.CRAFTING_PARTS, 1, 0),
-                    GTModHandler.RecipeBits.NOT_REMOVABLE,
+                    GTModHandler.RecipeBits.NOT_REMOVABLE | GTModHandler.RecipeBits.BUFFERED,
                     new Object[] { "SSS", "DfD", " h ", 'S', stone, 'D',
                         new ItemStack(GregTechAPI.sBlockGranites, 1, OreDictionary.WILDCARD_VALUE), });
                 GTModHandler.addCraftingRecipe(
                     new ItemStack(ItemRegistry.CRAFTING_PARTS, 1, 1),
-                    GTModHandler.RecipeBits.NOT_REMOVABLE,
+                    GTModHandler.RecipeBits.NOT_REMOVABLE | GTModHandler.RecipeBits.BUFFERED,
                     new Object[] { "hDf", "SSS", 'S', stone, 'D',
                         new ItemStack(GregTechAPI.sBlockGranites, 1, OreDictionary.WILDCARD_VALUE), });
                 GTModHandler.addCraftingRecipe(
                     new ItemStack(ItemRegistry.CRAFTING_PARTS, 1, 0),
-                    GTModHandler.RecipeBits.NOT_REMOVABLE,
+                    GTModHandler.RecipeBits.NOT_REMOVABLE | GTModHandler.RecipeBits.BUFFERED,
                     new Object[] { "SSS", "DfD", " h ", 'S', stone, 'D', granite, });
                 GTModHandler.addCraftingRecipe(
                     new ItemStack(ItemRegistry.CRAFTING_PARTS, 1, 1),
-                    GTModHandler.RecipeBits.NOT_REMOVABLE,
+                    GTModHandler.RecipeBits.NOT_REMOVABLE | GTModHandler.RecipeBits.BUFFERED,
                     new Object[] { "hDf", "SSS", 'S', stone, 'D', granite, });
             }
             GTModHandler.addCraftingRecipe(
                 new ItemStack(ItemRegistry.CRAFTING_PARTS, 1, 2),
-                GTModHandler.RecipeBits.NOT_REMOVABLE,
+                GTModHandler.RecipeBits.NOT_REMOVABLE | GTModHandler.RecipeBits.BUFFERED,
                 new Object[] { "STS", "h f", "SBS", 'S', granite, 'T', new ItemStack(ItemRegistry.CRAFTING_PARTS, 1, 0),
                     'B', new ItemStack(ItemRegistry.CRAFTING_PARTS, 1, 1), });
         }
@@ -236,109 +236,109 @@ public class CraftingRecipes implements Runnable {
         GTModHandler.addCraftingRecipe(
             new MTEManualTrafo(ManualTrafo.ID, "bw.manualtrafo", StatCollector.translateToLocal("tile.manutrafo.name"))
                 .getStackForm(1L),
-            RecipeLoader.BITSD,
+            RecipeLoader.BITSD | GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "SCS", "CHC", "ZCZ", 'S', GTOreDictUnificator.get(OrePrefixes.screw, Materials.Titanium, 1L),
                 'C', new ItemStack(ItemRegistry.BW_BLOCKS[2]), 'H', ItemList.Hull_HV.get(1L), 'Z', "circuitAdvanced" });
 
         GTModHandler.addCraftingRecipe(
             new MTEWindmill(Windmill.ID, "bw.windmill", StatCollector.translateToLocal("tile.bw.windmill.name"))
                 .getStackForm(1L),
-            RecipeLoader.BITSD,
+            RecipeLoader.BITSD | GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "BHB", "WGW", "BWB", 'B', new ItemStack(Blocks.brick_block), 'W',
                 GTOreDictUnificator.get(OrePrefixes.gearGt, Materials.Iron, 1L), 'H', new ItemStack(Blocks.hopper), 'G',
                 new ItemStack(ItemRegistry.CRAFTING_PARTS, 1, 2), });
 
         GTModHandler.addCraftingRecipe(
             new ItemStack(ItemRegistry.CRAFTING_PARTS, 1, 2),
-            GTModHandler.RecipeBits.NOT_REMOVABLE,
+            GTModHandler.RecipeBits.NOT_REMOVABLE | GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "STS", "h f", "SBS", 'S',
                 new ItemStack(GregTechAPI.sBlockGranites, 1, OreDictionary.WILDCARD_VALUE), 'T',
                 new ItemStack(ItemRegistry.CRAFTING_PARTS, 1, 0), 'B',
                 new ItemStack(ItemRegistry.CRAFTING_PARTS, 1, 1), });
         GTModHandler.addCraftingRecipe(
             new ItemStack(ItemRegistry.CRAFTING_PARTS, 1, 3),
-            GTModHandler.RecipeBits.NOT_REMOVABLE,
+            GTModHandler.RecipeBits.NOT_REMOVABLE | GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "WLs", "WLh", "WLf", 'L', new ItemStack(Items.leather), 'W', "logWood", });
         GTModHandler.addCraftingRecipe(
             new ItemStack(ItemRegistry.CRAFTING_PARTS, 1, 4),
-            GTModHandler.RecipeBits.NOT_REMOVABLE,
+            GTModHandler.RecipeBits.NOT_REMOVABLE | GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "WLs", "WLh", "WLf", 'L', new ItemStack(Blocks.carpet), 'W', "logWood", });
         GTModHandler.addCraftingRecipe(
             new ItemStack(ItemRegistry.CRAFTING_PARTS, 1, 5),
-            GTModHandler.RecipeBits.NOT_REMOVABLE,
+            GTModHandler.RecipeBits.NOT_REMOVABLE | GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "WLs", "WLh", "WLf", 'L', new ItemStack(Items.paper), 'W', "logWood", });
 
         GTModHandler.addCraftingRecipe(
             new ItemStack(ItemRegistry.CRAFTING_PARTS, 1, 6),
-            GTModHandler.RecipeBits.NOT_REMOVABLE,
+            GTModHandler.RecipeBits.NOT_REMOVABLE | GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "WEs", "WZh", "WDf", 'E', new ItemStack(ItemRegistry.CRAFTING_PARTS, 1, 3), 'Z',
                 new ItemStack(ItemRegistry.CRAFTING_PARTS, 1, 4), 'D', new ItemStack(ItemRegistry.CRAFTING_PARTS, 1, 5),
                 'W', "logWood", });
 
         GTModHandler.addCraftingRecipe(
             new ItemStack(ItemRegistry.CRAFTING_PARTS, 1, 6),
-            GTModHandler.RecipeBits.NOT_REMOVABLE,
+            GTModHandler.RecipeBits.NOT_REMOVABLE | GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "WEs", "WZh", "WDf", 'Z', new ItemStack(ItemRegistry.CRAFTING_PARTS, 1, 3), 'E',
                 new ItemStack(ItemRegistry.CRAFTING_PARTS, 1, 4), 'D', new ItemStack(ItemRegistry.CRAFTING_PARTS, 1, 5),
                 'W', "logWood", });
 
         GTModHandler.addCraftingRecipe(
             new ItemStack(ItemRegistry.CRAFTING_PARTS, 1, 6),
-            GTModHandler.RecipeBits.NOT_REMOVABLE,
+            GTModHandler.RecipeBits.NOT_REMOVABLE | GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "WEs", "WZh", "WDf", 'D', new ItemStack(ItemRegistry.CRAFTING_PARTS, 1, 3), 'Z',
                 new ItemStack(ItemRegistry.CRAFTING_PARTS, 1, 4), 'E', new ItemStack(ItemRegistry.CRAFTING_PARTS, 1, 5),
                 'W', "logWood", });
 
         GTModHandler.addCraftingRecipe(
             new ItemStack(ItemRegistry.CRAFTING_PARTS, 1, 6),
-            GTModHandler.RecipeBits.NOT_REMOVABLE,
+            GTModHandler.RecipeBits.NOT_REMOVABLE | GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "WEs", "WZh", "WDf", 'E', new ItemStack(ItemRegistry.CRAFTING_PARTS, 1, 3), 'D',
                 new ItemStack(ItemRegistry.CRAFTING_PARTS, 1, 4), 'Z', new ItemStack(ItemRegistry.CRAFTING_PARTS, 1, 5),
                 'W', "logWood", });
 
         GTModHandler.addCraftingRecipe(
             new ItemStack(ItemRegistry.CRAFTING_PARTS, 1, 6),
-            GTModHandler.RecipeBits.NOT_REMOVABLE,
+            GTModHandler.RecipeBits.NOT_REMOVABLE | GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "WEs", "WZh", "WDf", 'Z', new ItemStack(ItemRegistry.CRAFTING_PARTS, 1, 3), 'D',
                 new ItemStack(ItemRegistry.CRAFTING_PARTS, 1, 4), 'E', new ItemStack(ItemRegistry.CRAFTING_PARTS, 1, 5),
                 'W', "logWood", });
 
         GTModHandler.addCraftingRecipe(
             new ItemStack(ItemRegistry.LEATHER_ROTOR),
-            GTModHandler.RecipeBits.NOT_REMOVABLE,
+            GTModHandler.RecipeBits.NOT_REMOVABLE | GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "hPf", "PWP", "sPr", 'P', new ItemStack(ItemRegistry.CRAFTING_PARTS, 1, 3), 'W',
                 GTOreDictUnificator.get(OrePrefixes.gearGt, Materials.Iron, 1L), });
         GTModHandler.addCraftingRecipe(
             new ItemStack(ItemRegistry.WOOL_ROTOR),
-            GTModHandler.RecipeBits.NOT_REMOVABLE,
+            GTModHandler.RecipeBits.NOT_REMOVABLE | GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "hPf", "PWP", "sPr", 'P', new ItemStack(ItemRegistry.CRAFTING_PARTS, 1, 4), 'W',
                 GTOreDictUnificator.get(OrePrefixes.gearGt, Materials.Iron, 1L), });
         GTModHandler.addCraftingRecipe(
             new ItemStack(ItemRegistry.PAPER_ROTOR),
-            GTModHandler.RecipeBits.NOT_REMOVABLE,
+            GTModHandler.RecipeBits.NOT_REMOVABLE | GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "hPf", "PWP", "sPr", 'P', new ItemStack(ItemRegistry.CRAFTING_PARTS, 1, 5), 'W',
                 GTOreDictUnificator.get(OrePrefixes.gearGt, Materials.Iron, 1L), });
         GTModHandler.addCraftingRecipe(
             new ItemStack(ItemRegistry.COMBINED_ROTOR),
-            GTModHandler.RecipeBits.NOT_REMOVABLE,
+            GTModHandler.RecipeBits.NOT_REMOVABLE | GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "hPf", "PWP", "sPr", 'P', new ItemStack(ItemRegistry.CRAFTING_PARTS, 1, 6), 'W',
                 GTOreDictUnificator.get(OrePrefixes.gearGt, Materials.Iron, 1L), });
         GTModHandler.addCraftingRecipe(
             new ItemStack(ItemRegistry.ROTORBLOCK),
-            RecipeLoader.BITSD,
+            RecipeLoader.BITSD | GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "WRW", "RGR", "WRW", 'R', GTOreDictUnificator.get(OrePrefixes.ring, Materials.Iron, 1L), 'W',
                 "plankWood", 'G', GTOreDictUnificator.get(OrePrefixes.gearGt, Materials.Iron, 1L), });
 
         GTModHandler.addCraftingRecipe(
             ItemRegistry.THTR,
-            RecipeLoader.BITSD,
+            RecipeLoader.BITSD | GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "BZB", "BRB", "BZB", 'B', new ItemStack(GregTechAPI.sBlockCasings3, 1, 12), 'R',
                 GTModHandler.getModItem(IndustrialCraft2.ID, "blockGenerator", 1, 5), 'Z', "circuitUltimate" });
 
         // DNAExtractionModule
         GTModHandler.addCraftingRecipe(
             BioItemList.mBioLabParts[0],
-            RecipeLoader.BITSD,
+            RecipeLoader.BITSD | GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "TET", "CFC", "TST", 'T', GTOreDictUnificator.get(OrePrefixes.plate, Materials.Titanium, 1L),
                 'E', ItemList.Emitter_EV.get(1L), 'C',
                 GTOreDictUnificator.get(OrePrefixes.cableGt04, Materials.Aluminium, 1L), 'S',
@@ -347,7 +347,7 @@ public class CraftingRecipes implements Runnable {
         // PCRThermoclyclingModule
         GTModHandler.addCraftingRecipe(
             BioItemList.mBioLabParts[1],
-            RecipeLoader.BITSD,
+            RecipeLoader.BITSD | GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "NEN", "CFC", "NSN", 'N',
                 GTOreDictUnificator.get(OrePrefixes.wireGt04, Materials.Nichrome, 1L), 'E', ItemList.Emitter_EV.get(1L),
                 'C', GTOreDictUnificator.get(OrePrefixes.cableGt04, Materials.Aluminium, 1L), 'S',
@@ -356,7 +356,7 @@ public class CraftingRecipes implements Runnable {
         // PlasmidSynthesisModule
         GTModHandler.addCraftingRecipe(
             BioItemList.mBioLabParts[2],
-            RecipeLoader.BITSD,
+            RecipeLoader.BITSD | GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "SFE", "CPC", "NFN", 'N',
                 GTOreDictUnificator.get(OrePrefixes.wireGt04, Materials.Nichrome, 1L), 'C', "circuit" + Materials.EV,
                 'F', ItemList.Field_Generator_EV.get(1L), 'E', ItemList.Emitter_EV.get(1L), 'S',
@@ -364,7 +364,7 @@ public class CraftingRecipes implements Runnable {
         // TransformationModule
         GTModHandler.addCraftingRecipe(
             BioItemList.mBioLabParts[3],
-            RecipeLoader.BITSD,
+            RecipeLoader.BITSD | GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "SFE", "PCP", "NFN", 'N',
                 GTOreDictUnificator.get(OrePrefixes.wireGt04, Materials.Nichrome, 1L), 'C', "circuit" + Materials.EV,
                 'F', ItemList.Field_Generator_EV.get(1L), 'E', ItemList.Emitter_EV.get(1L), 'S',
@@ -373,7 +373,7 @@ public class CraftingRecipes implements Runnable {
         // ClonalCellularSynthesisModule
         GTModHandler.addCraftingRecipe(
             BioItemList.mBioLabParts[4],
-            RecipeLoader.BITSD,
+            RecipeLoader.BITSD | GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "FEF", "CPC", "FSF", 'N',
                 GTOreDictUnificator.get(OrePrefixes.wireGt04, Materials.Naquadah, 1L), 'C', "circuit" + Materials.LuV,
                 'F', ItemList.Field_Generator_LuV.get(1L), 'E', ItemList.Emitter_LuV.get(1L), 'S',
@@ -381,7 +381,7 @@ public class CraftingRecipes implements Runnable {
 
         GTModHandler.addCraftingRecipe(
             ItemRegistry.vat.copy(),
-            RecipeLoader.BITSD,
+            RecipeLoader.BITSD | GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "GCG", "KHK", "GCG", 'G', new ItemStack(ItemRegistry.bw_glasses[0], 1, 1), 'C',
                 "circuit" + Materials.EV, 'K', GTOreDictUnificator.get(OrePrefixes.wireGt08, Materials.Silver, 1L), 'H',
                 ItemList.MACHINE_HULLS[3].get(1L) });
@@ -390,7 +390,7 @@ public class CraftingRecipes implements Runnable {
         GTModHandler.addCraftingRecipe(
             new MTEBioLab(BioLab_HV.ID, "bw.biolabHV", StatCollector.translateToLocal("tile.biolab.name"), 3)
                 .getStackForm(1L),
-            RecipeLoader.BITSD,
+            RecipeLoader.BITSD | GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PFP", "WCW", "OGO", 'F',
                 GTOreDictUnificator.get(OrePrefixes.frameGt, Materials.StainlessSteel, 1L), 'W',
                 GTOreDictUnificator.get(OrePrefixes.wireGt01, Materials.Kanthal, 1L), 'P',
@@ -401,7 +401,7 @@ public class CraftingRecipes implements Runnable {
         GTModHandler.addCraftingRecipe(
             new MTEBioLab(BioLab_EV.ID, "bw.biolabEV", StatCollector.translateToLocal("tile.biolab.name"), 4)
                 .getStackForm(1L),
-            RecipeLoader.BITSD,
+            RecipeLoader.BITSD | GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PFP", "WCW", "OGO", 'F',
                 GTOreDictUnificator.get(OrePrefixes.frameGt, Materials.Titanium, 1L), 'W',
                 GTOreDictUnificator.get(OrePrefixes.wireGt01, Materials.Nichrome, 1L), 'P',
@@ -412,7 +412,7 @@ public class CraftingRecipes implements Runnable {
         GTModHandler.addCraftingRecipe(
             new MTEBioLab(BioLab_IV.ID, "bw.biolabIV", StatCollector.translateToLocal("tile.biolab.name"), 5)
                 .getStackForm(1L),
-            RecipeLoader.BITSD,
+            RecipeLoader.BITSD | GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PFP", "WCW", "OGO", 'F',
                 GTOreDictUnificator.get(OrePrefixes.frameGt, Materials.TungstenSteel, 1L), 'W',
                 GTOreDictUnificator.get(OrePrefixes.wireGt01, Materials.TPV, 1L), 'P',
@@ -423,7 +423,7 @@ public class CraftingRecipes implements Runnable {
         GTModHandler.addCraftingRecipe(
             new MTEBioLab(BioLab_LuV.ID, "bw.biolabLuV", StatCollector.translateToLocal("tile.biolab.name"), 6)
                 .getStackForm(1L),
-            RecipeLoader.BITSD,
+            RecipeLoader.BITSD | GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PFP", "WCW", "OGO", 'F', GTOreDictUnificator.get(OrePrefixes.frameGt, Materials.Chrome, 1L),
                 'W', GTOreDictUnificator.get(OrePrefixes.wireGt01, Materials.HSSG, 1L), 'P',
                 GTOreDictUnificator.get(OrePrefixes.plate, Materials.Polytetrafluoroethylene, 1L), 'O',
@@ -433,7 +433,7 @@ public class CraftingRecipes implements Runnable {
         GTModHandler.addCraftingRecipe(
             new MTEBioLab(BioLab_ZPM.ID, "bw.biolabZPM", StatCollector.translateToLocal("tile.biolab.name"), 7)
                 .getStackForm(1L),
-            RecipeLoader.BITSD,
+            RecipeLoader.BITSD | GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PFP", "WCW", "OGO", 'F',
                 GTOreDictUnificator.get(OrePrefixes.frameGt, Materials.Iridium, 1L), 'W',
                 GTOreDictUnificator.get(OrePrefixes.wireGt01, Materials.Naquadah, 1L), 'P',
@@ -444,7 +444,7 @@ public class CraftingRecipes implements Runnable {
         GTModHandler.addCraftingRecipe(
             new MTEBioLab(BioLab_UV.ID, "bw.biolabUV", StatCollector.translateToLocal("tile.biolab.name"), 8)
                 .getStackForm(1L),
-            RecipeLoader.BITSD,
+            RecipeLoader.BITSD | GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PFP", "WCW", "OGO", 'F', GTOreDictUnificator.get(OrePrefixes.frameGt, Materials.Osmium, 1L),
                 'W', GTOreDictUnificator.get(OrePrefixes.wireGt01, Materials.NaquadahAlloy, 1L), 'P',
                 GTOreDictUnificator.get(OrePrefixes.plate, Materials.Polytetrafluoroethylene, 1L), 'O',
@@ -454,7 +454,7 @@ public class CraftingRecipes implements Runnable {
         GTModHandler.addCraftingRecipe(
             new MTEBioLab(BioLab_UHV.ID, "bw.biolabUHV", StatCollector.translateToLocal("tile.biolab.name"), 9)
                 .getStackForm(1L),
-            RecipeLoader.BITSD,
+            RecipeLoader.BITSD | GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PFP", "WCW", "OGO", 'F',
                 GTOreDictUnificator.get(OrePrefixes.frameGt, Materials.Neutronium, 1L), 'W',
                 GTOreDictUnificator.get(OrePrefixes.wireGt01, Materials.ElectrumFlux, 1L), 'P',
@@ -465,7 +465,7 @@ public class CraftingRecipes implements Runnable {
         GTModHandler.addCraftingRecipe(
             new MTEBioLab(BioLab_UEV.ID, "bw.biolabUEV", StatCollector.translateToLocal("tile.biolab.name"), 10)
                 .getStackForm(1L),
-            RecipeLoader.BITSD,
+            RecipeLoader.BITSD | GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PFP", "WCW", "OGO", 'F',
                 GTOreDictUnificator.get(OrePrefixes.frameGt, Materials.Bedrockium, 1L), 'W',
                 GTOreDictUnificator.get(OrePrefixes.wireGt01, Materials.DraconiumAwakened, 1L), 'P',
@@ -476,7 +476,7 @@ public class CraftingRecipes implements Runnable {
         GTModHandler.addCraftingRecipe(
             new MTEBioLab(BioLab_UIV.ID, "bw.biolabUIV", StatCollector.translateToLocal("tile.biolab.name"), 11)
                 .getStackForm(1L),
-            RecipeLoader.BITSD,
+            RecipeLoader.BITSD | GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PFP", "WCW", "OGO", 'F',
                 GTOreDictUnificator.get(OrePrefixes.frameGt, Materials.TranscendentMetal, 1L), 'W',
                 GTOreDictUnificator.get(OrePrefixes.wireGt01, Materials.Infinity, 1L), 'P',
@@ -487,7 +487,7 @@ public class CraftingRecipes implements Runnable {
         GTModHandler.addCraftingRecipe(
             new MTEBioLab(BioLab_UMV.ID, "bw.biolabUMV", StatCollector.translateToLocal("tile.biolab.name"), 12)
                 .getStackForm(1L),
-            RecipeLoader.BITSD,
+            RecipeLoader.BITSD | GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PFP", "WCW", "OGO", 'F',
                 GTOreDictUnificator.get(OrePrefixes.frameGt, Materials.SpaceTime, 1L), 'W',
                 GTOreDictUnificator.get("wireGt01Hypogen", 1L), 'P',
@@ -502,7 +502,7 @@ public class CraftingRecipes implements Runnable {
                 "bw.radiohatchHV",
                 StatCollector.translateToLocal("tile.radiohatch.name"),
                 3).getStackForm(1L),
-            RecipeLoader.BITSD,
+            RecipeLoader.BITSD | GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "DPD", "DCD", "DKD", 'D',
                 GTOreDictUnificator.get(OrePrefixes.plateDense, Materials.Lead, 1L), 'C',
                 ItemList.MACHINE_HULLS[3].get(1L), 'K',
@@ -511,6 +511,7 @@ public class CraftingRecipes implements Runnable {
 
         GTModHandler.addCraftingRecipe(
             ItemList.Item_Power_Goggles.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "MPM", "LSL", "PRP", 'M', ItemList.Cover_Screen.get(1), 'P',
                 GTOreDictUnificator.get(OrePrefixes.plate, Materials.Polytetrafluoroethylene, 1L), 'L',
                 GTOreDictUnificator.get(OrePrefixes.lens, Materials.GarnetYellow, 1L), 'S', ItemList.Sensor_IV.get(1),
@@ -518,24 +519,28 @@ public class CraftingRecipes implements Runnable {
 
         GTModHandler.addCraftingRecipe(
             ItemList.Item_Redstone_Sniffer.get(1L),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { " M ", "STS", "dPw", 'M', ItemList.Cover_Screen.get(1L), 'S',
                 OrePrefixes.screw.get(Materials.Titanium), 'T', GregtechItemList.TransmissionComponent_EV.get(1), 'P',
                 OrePrefixes.plate.get(Materials.Titanium) });
 
         GTModHandler.addCraftingRecipe(
             ItemList.Tool_Vajra.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "RMR", "hCd", "EBE", 'R', OrePrefixes.lens.get(Materials.Amethyst), 'M',
                 ItemList.Magnetron.get(1), 'C', ItemList.Vajra_Core.get(1), 'E',
                 OrePrefixes.plateDense.get(Materials.Silver), 'B', OrePrefixes.battery.get(Materials.IV) });
 
         GTModHandler.addCraftingRecipe(
             ItemList.Magnetron.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "DCD", "PWP", "DCD", 'D', OrePrefixes.plateDense.get(Materials.NeodymiumMagnetic), 'C',
                 ItemList.HV_Coil, 'P', OrePrefixes.plate.get(Materials.Silver), 'W',
                 OrePrefixes.wireGt12.get(Materials.SuperconductorIV) });
 
         GTModHandler.addCraftingRecipe(
             ItemList.Vajra_Core.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "wEh", "ITI", "SRS", 'E', OrePrefixes.plate.get(Materials.Silver), 'I',
                 OrePrefixes.plateDense.get(Materials.Iridium), 'T', ItemList.Transformer_EV_HV.get(1), 'S',
                 OrePrefixes.wireGt12.get(Materials.SuperconductorIV), 'R', ItemList.Transformer_IV_EV.get(1) });

--- a/src/main/java/bartworks/system/material/werkstoff_loaders/recipe/CasingLoader.java
+++ b/src/main/java/bartworks/system/material/werkstoff_loaders/recipe/CasingLoader.java
@@ -52,6 +52,7 @@ public class CasingLoader implements IWerkstoffRunnable {
     private static void addCasingRecipes(Werkstoff werkstoff, OrePrefixes reboltedCasingsOuterStuff) {
         GTModHandler.addCraftingRecipe(
             werkstoff.get(blockCasing),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PSP", "PGP", "PSP", 'P', werkstoff.get(plate), 'S', werkstoff.get(screw), 'G',
                 werkstoff.get(gearGtSmall) });
 
@@ -64,6 +65,7 @@ public class CasingLoader implements IWerkstoffRunnable {
 
         GTModHandler.addCraftingRecipe(
             werkstoff.get(blockCasingAdvanced),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PSP", "PGP", "PSP", 'P', werkstoff.get(reboltedCasingsOuterStuff), 'S',
                 werkstoff.get(screw), 'G', werkstoff.get(gearGt) });
 

--- a/src/main/java/bartworks/system/material/werkstoff_loaders/recipe/CrushedLoader.java
+++ b/src/main/java/bartworks/system/material/werkstoff_loaders/recipe/CrushedLoader.java
@@ -68,13 +68,17 @@ public class CrushedLoader implements IWerkstoffRunnable {
             GTModHandler.addSmeltingRecipe(werkstoff.get(dust), werkstoff.get(ingot));
         }
 
-        GTModHandler
-            .addCraftingRecipe(werkstoff.get(dustImpure), new Object[] { "h  ", "W  ", 'W', werkstoff.get(crushed) });
+        GTModHandler.addCraftingRecipe(
+            werkstoff.get(dustImpure),
+            GTModHandler.RecipeBits.BUFFERED,
+            new Object[] { "h  ", "W  ", 'W', werkstoff.get(crushed) });
         GTModHandler.addCraftingRecipe(
             werkstoff.get(dustPure),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "h  ", "W  ", 'W', werkstoff.get(crushedPurified) });
         GTModHandler.addCraftingRecipe(
             werkstoff.get(dust),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "h  ", "W  ", 'W', werkstoff.get(crushedCentrifuged) });
 
         GTValues.RA.stdBuilder()

--- a/src/main/java/bartworks/system/material/werkstoff_loaders/recipe/DustLoader.java
+++ b/src/main/java/bartworks/system/material/werkstoff_loaders/recipe/DustLoader.java
@@ -306,15 +306,19 @@ public class DustLoader implements IWerkstoffRunnable {
 
             GTModHandler.addCraftingRecipe(
                 werkstoff.get(dust),
+                GTModHandler.RecipeBits.BUFFERED,
                 new Object[] { "TTT", "TTT", "TTT", 'T', werkstoff.get(dustTiny) });
             GTModHandler.addCraftingRecipe(
                 werkstoff.get(dust),
+                GTModHandler.RecipeBits.BUFFERED,
                 new Object[] { "TT ", "TT ", 'T', WerkstoffLoader.getCorrespondingItemStack(dustSmall, werkstoff) });
             GTModHandler.addCraftingRecipe(
                 WerkstoffLoader.getCorrespondingItemStack(dustSmall, werkstoff, 4),
+                GTModHandler.RecipeBits.BUFFERED,
                 new Object[] { " T ", 'T', werkstoff.get(dust) });
             GTModHandler.addCraftingRecipe(
                 WerkstoffLoader.getCorrespondingItemStack(dustTiny, werkstoff, 9),
+                GTModHandler.RecipeBits.BUFFERED,
                 new Object[] { "T  ", 'T', werkstoff.get(dust) });
 
             GTValues.RA.stdBuilder()

--- a/src/main/java/bartworks/system/material/werkstoff_loaders/recipe/GemLoader.java
+++ b/src/main/java/bartworks/system/material/werkstoff_loaders/recipe/GemLoader.java
@@ -87,19 +87,19 @@ public class GemLoader implements IWerkstoffRunnable {
 
             GTModHandler.addCraftingRecipe(
                 werkstoff.get(gemFlawless, 2),
-                0,
+                GTModHandler.RecipeBits.BUFFERED,
                 new Object[] { "h  ", "W  ", 'W', werkstoff.get(gemExquisite) });
             GTModHandler.addCraftingRecipe(
                 werkstoff.get(gem, 2),
-                0,
+                GTModHandler.RecipeBits.BUFFERED,
                 new Object[] { "h  ", "W  ", 'W', werkstoff.get(gemFlawless) });
             GTModHandler.addCraftingRecipe(
                 werkstoff.get(gemFlawed, 2),
-                0,
+                GTModHandler.RecipeBits.BUFFERED,
                 new Object[] { "h  ", "W  ", 'W', werkstoff.get(gem) });
             GTModHandler.addCraftingRecipe(
                 werkstoff.get(gemChipped, 2),
-                0,
+                GTModHandler.RecipeBits.BUFFERED,
                 new Object[] { "h  ", "W  ", 'W', werkstoff.get(gemFlawed) });
 
             GTValues.RA.stdBuilder()

--- a/src/main/java/ggfab/SingleUseToolRecipeLoader.java
+++ b/src/main/java/ggfab/SingleUseToolRecipeLoader.java
@@ -43,6 +43,7 @@ class SingleUseToolRecipeLoader implements Runnable {
         for (SingleUseTool singleUseTool : SingleUseTool.values()) {
             GTModHandler.addCraftingRecipe(
                 singleUseTool.mold.get(1L),
+                GTModHandler.RecipeBits.BUFFERED,
                 new Object[] { "h", "P", "I", 'P', ItemList.Shape_Empty, 'I', singleUseTool.toolDictName });
         }
     }

--- a/src/main/java/goodgenerator/loader/Loaders.java
+++ b/src/main/java/goodgenerator/loader/Loaders.java
@@ -536,30 +536,22 @@ public class Loaders {
 
     public static void initLoad() {
         GTMetaTileRegister();
-        initLoadRecipes();
-    }
-
-    public static void postInitLoad() {
-        postInitLoadRecipes();
-    }
-
-    public static void completeLoad() {
-        RecipeLoader2.FinishLoadRecipe();
-        MaterialFix.addRecipeForMultiItems();
-        ComponentAssemblyLineLoader.run();
-    }
-
-    public static void initLoadRecipes() {
         RecipeLoader.InitLoadRecipe();
         RecipeLoader2.InitLoadRecipe();
         FuelRecipeLoader.RegisterFuel();
         NaquadahReworkRecipeLoader.RecipeLoad();
     }
 
-    public static void postInitLoadRecipes() {
+    public static void postInitLoad() {
         RecipeLoader.RecipeLoad();
         RecipeLoader.Fixer();
         RecipeLoader2.RecipeLoad();
         NeutronActivatorLoader.NARecipeLoad();
+        MaterialFix.addRecipeForMultiItems();
+        ComponentAssemblyLineLoader.run();
+    }
+
+    public static void completeLoad() {
+        RecipeLoader2.FinishLoadRecipe();
     }
 }

--- a/src/main/java/goodgenerator/loader/RecipeLoader.java
+++ b/src/main/java/goodgenerator/loader/RecipeLoader.java
@@ -893,7 +893,8 @@ public class RecipeLoader {
 
         GTModHandler.addCraftingRecipe(
             ItemRefer.Raw_Cylinder.get(1),
-            GTModHandler.RecipeBits.DISMANTLEABLE | GTModHandler.RecipeBits.REVERSIBLE,
+            GTModHandler.RecipeBits.DISMANTLEABLE | GTModHandler.RecipeBits.REVERSIBLE
+                | GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PPP", "PFP", "PPP", 'P', ItemRefer.Special_Ceramics_Plate.get(1), 'F',
                 GTOreDictUnificator.get(OrePrefixes.frameGt, Materials.StainlessSteel, 1) });
 
@@ -950,7 +951,8 @@ public class RecipeLoader {
 
         GTModHandler.addCraftingRecipe(
             ItemList.UniversalChemicalFuelEngine.get(1),
-            GTModHandler.RecipeBits.DISMANTLEABLE | GTModHandler.RecipeBits.REVERSIBLE,
+            GTModHandler.RecipeBits.DISMANTLEABLE | GTModHandler.RecipeBits.REVERSIBLE
+                | GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "TZT", "ALB", "WGW", 'T',
                 GTOreDictUnificator.get(OrePrefixes.plateDense, Materials.Titanium, 1), 'Z', "circuitUltimate", 'A',
                 ItemList.LargeCombustionEngine.get(1), 'B', ItemList.ExtremeCombustionEngine.get(1), 'L',
@@ -982,6 +984,7 @@ public class RecipeLoader {
 
         GTModHandler.addCraftingRecipe(
             ItemRefer.Plastic_Case.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PCP", "CDC", "PCP", 'P',
                 GTOreDictUnificator.get(OrePrefixes.stick, Materials.PolyvinylChloride, 1), 'C',
                 GTOreDictUnificator.get(OrePrefixes.itemCasing, Materials.Polyethylene, 1), 'D', "dyeCyan" });
@@ -1104,7 +1107,8 @@ public class RecipeLoader {
         // Neutron Accelerator ULV
         GTModHandler.addCraftingRecipe(
             Loaders.NeutronAccelerators[0].copy(),
-            GTModHandler.RecipeBits.DISMANTLEABLE | GTModHandler.RecipeBits.REVERSIBLE,
+            GTModHandler.RecipeBits.DISMANTLEABLE | GTModHandler.RecipeBits.REVERSIBLE
+                | GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "WPM", "CHI", "WPM", 'W', GTOreDictUnificator.get(OrePrefixes.cableGt01, Materials.Lead, 1),
                 'P', GTOreDictUnificator.get(OrePrefixes.plate, Materials.Lead, 1), 'M',
                 GTOreDictUnificator.get(OrePrefixes.rotor, Materials.Lead, 1), 'C',
@@ -1114,7 +1118,8 @@ public class RecipeLoader {
         // Neutron Accelerator LV
         GTModHandler.addCraftingRecipe(
             Loaders.NeutronAccelerators[1].copy(),
-            GTModHandler.RecipeBits.DISMANTLEABLE | GTModHandler.RecipeBits.REVERSIBLE,
+            GTModHandler.RecipeBits.DISMANTLEABLE | GTModHandler.RecipeBits.REVERSIBLE
+                | GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "WPM", "CHI", "WPM", 'W',
                 GTOreDictUnificator.get(OrePrefixes.cableGt01, Materials.RedAlloy, 1), 'P',
                 GTOreDictUnificator.get(OrePrefixes.plateDouble, Materials.Lead, 1), 'M', ItemList.Electric_Motor_LV,
@@ -1341,7 +1346,8 @@ public class RecipeLoader {
 
         GTModHandler.addCraftingRecipe(
             ItemRefer.Neutron_Source.get(1),
-            GTModHandler.RecipeBits.DISMANTLEABLE | GTModHandler.RecipeBits.REVERSIBLE,
+            GTModHandler.RecipeBits.DISMANTLEABLE | GTModHandler.RecipeBits.REVERSIBLE
+                | GTModHandler.RecipeBits.BUFFERED,
             new Object[] { " P ", "PUP", " P ", 'P',
                 GTOreDictUnificator.get(OrePrefixes.plateDense, Materials.Steel, 1), 'U',
                 ItemRefer.High_Density_Uranium.get(1) });

--- a/src/main/java/goodgenerator/util/MaterialFix.java
+++ b/src/main/java/goodgenerator/util/MaterialFix.java
@@ -153,6 +153,7 @@ public class MaterialFix {
                     .addTo(benderRecipes);
                 GTModHandler.addCraftingRecipe(
                     tMaterial.get(OrePrefixes.plateDouble, 1),
+                    GTModHandler.RecipeBits.BUFFERED,
                     new Object[] { "P", "P", "h", 'P', tMaterial.get(OrePrefixes.plate, 1) });
             }
             if (tMaterial.hasItemType(OrePrefixes.plateTriple)) {
@@ -180,6 +181,7 @@ public class MaterialFix {
                     .addTo(benderRecipes);
                 GTModHandler.addCraftingRecipe(
                     tMaterial.get(OrePrefixes.plateTriple, 1),
+                    GTModHandler.RecipeBits.BUFFERED,
                     new Object[] { "B", "P", "h", 'P', tMaterial.get(OrePrefixes.plate, 1), 'B',
                         tMaterial.get(OrePrefixes.plateDouble, 1) });
             }
@@ -225,12 +227,14 @@ public class MaterialFix {
                 if (tMaterial.hasItemType(OrePrefixes.stick)) {
                     GTModHandler.addCraftingRecipe(
                         tMaterial.get(OrePrefixes.stickLong, 1),
+                        GTModHandler.RecipeBits.BUFFERED,
                         new Object[] { "PhP", 'P', tMaterial.get(OrePrefixes.stick, 1) });
                 }
             }
             if (tMaterial.hasItemType(OrePrefixes.spring)) {
                 GTModHandler.addCraftingRecipe(
                     tMaterial.get(OrePrefixes.spring, 1),
+                    GTModHandler.RecipeBits.BUFFERED,
                     new Object[] { " s ", "fPx", " P ", 'P', tMaterial.get(OrePrefixes.stickLong, 1) });
                 GTValues.RA.stdBuilder()
                     .itemInputs(tMaterial.get(OrePrefixes.stickLong, 1))
@@ -247,6 +251,7 @@ public class MaterialFix {
             if (tMaterial.hasItemType(OrePrefixes.springSmall)) {
                 GTModHandler.addCraftingRecipe(
                     tMaterial.get(OrePrefixes.springSmall, 1),
+                    GTModHandler.RecipeBits.BUFFERED,
                     new Object[] { " s ", "fPx", 'P', tMaterial.get(OrePrefixes.stick, 1) });
                 GTValues.RA.stdBuilder()
                     .itemInputs(tMaterial.get(OrePrefixes.stick, 1))

--- a/src/main/java/gregtech/common/GTProxy.java
+++ b/src/main/java/gregtech/common/GTProxy.java
@@ -1075,12 +1075,6 @@ public class GTProxy implements IFuelHandler {
         GTLanguageManager.writePlaceholderStrings();
     }
 
-    /**
-     * @deprecated use {@link gregtech.api.util.GTModHandler.RecipeBits#BITS_STD}
-     */
-    @Deprecated
-    public static long tBits = GTModHandler.RecipeBits.BITS_STD;
-
     public void onPostInitialization(FMLPostInitializationEvent event) {
         GTLog.out.println("GTMod: Beginning PostLoad-Phase.");
         GregTechAPI.sPostloadStarted = true;
@@ -1115,60 +1109,60 @@ public class GTProxy implements IFuelHandler {
                 if (!aMaterial.contains(SubTag.NO_ORE_PROCESSING)) {
                     GTModHandler.addCraftingRecipe(
                         GTOreDictUnificator.get(OrePrefixes.dust, aMaterial.mMacerateInto, 1L),
-                        tBits,
+                        GTModHandler.RecipeBits.BITS_STD,
                         new Object[] { "h", "X", 'X', OrePrefixes.crushedCentrifuged.get(aMaterial) });
                     GTModHandler.addCraftingRecipe(
                         GTOreDictUnificator.get(OrePrefixes.dust, aMaterial.mMacerateInto, 1L),
-                        tBits,
+                        GTModHandler.RecipeBits.BITS_STD,
                         new Object[] { "h", "X", 'X', OrePrefixes.crystalline.get(aMaterial) });
                     GTModHandler.addCraftingRecipe(
                         GTOreDictUnificator.get(OrePrefixes.dust, aMaterial.mMacerateInto, 1L),
-                        tBits,
+                        GTModHandler.RecipeBits.BITS_STD,
                         new Object[] { "h", "X", 'X', OrePrefixes.crystal.get(aMaterial) });
                     GTModHandler.addCraftingRecipe(
                         GTOreDictUnificator.get(OrePrefixes.dustPure, aMaterial.mMacerateInto, 1L),
-                        tBits,
+                        GTModHandler.RecipeBits.BITS_STD,
                         new Object[] { "h", "X", 'X', OrePrefixes.crushedPurified.get(aMaterial) });
                     GTModHandler.addCraftingRecipe(
                         GTOreDictUnificator.get(OrePrefixes.dustPure, aMaterial.mMacerateInto, 1L),
-                        tBits,
+                        GTModHandler.RecipeBits.BITS_STD,
                         new Object[] { "h", "X", 'X', OrePrefixes.cleanGravel.get(aMaterial) });
                     GTModHandler.addCraftingRecipe(
                         GTOreDictUnificator.get(OrePrefixes.dustPure, aMaterial.mMacerateInto, 1L),
-                        tBits,
+                        GTModHandler.RecipeBits.BITS_STD,
                         new Object[] { "h", "X", 'X', OrePrefixes.reduced.get(aMaterial) });
                     GTModHandler.addCraftingRecipe(
                         GTOreDictUnificator.get(OrePrefixes.dustImpure, aMaterial.mMacerateInto, 1L),
-                        tBits,
+                        GTModHandler.RecipeBits.BITS_STD,
                         new Object[] { "h", "X", 'X', OrePrefixes.clump.get(aMaterial) });
                     GTModHandler.addCraftingRecipe(
                         GTOreDictUnificator.get(OrePrefixes.dustImpure, aMaterial.mMacerateInto, 1L),
-                        tBits,
+                        GTModHandler.RecipeBits.BITS_STD,
                         new Object[] { "h", "X", 'X', OrePrefixes.shard.get(aMaterial) });
                     GTModHandler.addCraftingRecipe(
                         GTOreDictUnificator.get(OrePrefixes.dustImpure, aMaterial.mMacerateInto, 1L),
-                        tBits,
+                        GTModHandler.RecipeBits.BITS_STD,
                         new Object[] { "h", "X", 'X', OrePrefixes.crushed.get(aMaterial) });
                     GTModHandler.addCraftingRecipe(
                         GTOreDictUnificator.get(OrePrefixes.dustImpure, aMaterial.mMacerateInto, 1L),
-                        tBits,
+                        GTModHandler.RecipeBits.BITS_STD,
                         new Object[] { "h", "X", 'X', OrePrefixes.dirtyGravel.get(aMaterial) });
                 }
                 GTModHandler.addCraftingRecipe(
                     GTOreDictUnificator.get(OrePrefixes.dustSmall, aMaterial, 4L),
-                    tBits,
+                    GTModHandler.RecipeBits.BITS_STD,
                     new Object[] { " X ", "   ", "   ", 'X', OrePrefixes.dust.get(aMaterial) });
                 GTModHandler.addCraftingRecipe(
                     GTOreDictUnificator.get(OrePrefixes.dustTiny, aMaterial, 9L),
-                    tBits,
+                    GTModHandler.RecipeBits.BITS_STD,
                     new Object[] { "X  ", "   ", "   ", 'X', OrePrefixes.dust.get(aMaterial) });
                 GTModHandler.addCraftingRecipe(
                     GTOreDictUnificator.get(OrePrefixes.dust, aMaterial, 1L),
-                    tBits,
+                    GTModHandler.RecipeBits.BITS_STD,
                     new Object[] { "XX", "XX", 'X', OrePrefixes.dustSmall.get(aMaterial) });
                 GTModHandler.addCraftingRecipe(
                     GTOreDictUnificator.get(OrePrefixes.dust, aMaterial, 1L),
-                    tBits,
+                    GTModHandler.RecipeBits.BITS_STD,
                     new Object[] { "XXX", "XXX", "XXX", 'X', OrePrefixes.dustTiny.get(aMaterial) });
             }
         }

--- a/src/main/java/gregtech/loaders/load/MTERecipeLoader.java
+++ b/src/main/java/gregtech/loaders/load/MTERecipeLoader.java
@@ -1601,6 +1601,7 @@ public class MTERecipeLoader implements Runnable {
         // Industrial Centrifuge
         GTModHandler.addCraftingRecipe(
             ItemList.IndustrialCentrifuge.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "ABA", "CDC", "EFE", 'A', "circuitData", 'B',
                 OrePrefixes.pipeHuge.get(Materials.StainlessSteel), 'C', MaterialsAlloy.MARAGING250.getPlate(1), 'D',
                 ItemList.Machine_EV_Centrifuge, 'E', MaterialsAlloy.INCONEL_792.getPlate(1), 'F', ItemList.Casing_EV });
@@ -1608,18 +1609,21 @@ public class MTERecipeLoader implements Runnable {
         // Amazon Warehousing Depot
         GTModHandler.addCraftingRecipe(
             ItemList.IndustrialPackager.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "DCD", "PMP", "ODO", 'D', GregtechItemList.Casing_AmazonWarehouse, 'C', "circuitElite", 'P',
                 ItemList.Electric_Piston_IV, 'M', ItemList.Machine_IV_Boxinator, 'O', ItemList.Conveyor_Module_IV });
 
         // Industrial Wire Factory
         GTModHandler.addCraftingRecipe(
             ItemList.IndustrialWireFactory.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PHP", "CMC", "PHP", 'P', OrePrefixes.plate.get(Materials.BlueSteel), 'H',
                 ItemList.Casing_IV, 'C', "circuitElite", 'M', ItemList.Machine_IV_Wiremill });
 
         // Industrial Electrolyzer
         GTModHandler.addCraftingRecipe(
             ItemList.IndustrialElectrolyzer.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PCP", "HMH", "PRP", 'P', MaterialsAlloy.STELLITE.getPlate(1), 'C', "circuitElite", 'H',
                 ItemList.Casing_IV, 'M', ItemList.Machine_IV_Electrolyzer, 'R', MaterialsAlloy.STELLITE.getRotor(1) });
         // Mega Chemical Reactor
@@ -1635,12 +1639,14 @@ public class MTERecipeLoader implements Runnable {
         // Industrial Mixer
         GTModHandler.addCraftingRecipe(
             ItemList.IndustrialMixer.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PCP", "ZMZ", "PCP", 'P', MaterialsAlloy.MARAGING300.getPlate(1), 'C', "circuitElite", 'Z',
                 MaterialsAlloy.MARAGING250.getPlate(1), 'M', ItemList.Machine_IV_Mixer });
 
         // Mixer casing, move if there is a better place for it
         GTModHandler.addCraftingRecipe(
             ItemList.CasingMixer.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PhP", "SFS", "PwP", 'P', MaterialsAlloy.MARAGING300.getPlate(1), 'S',
                 MaterialsAlloy.MARAGING250.getPlate(1), 'F',
                 OrePrefixes.frameGt.get(Materials.Polytetrafluoroethylene) });
@@ -1648,6 +1654,7 @@ public class MTERecipeLoader implements Runnable {
         // Forming Core
         GTModHandler.addCraftingRecipe(
             ItemList.FormingCore.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PhP", "SFS", "PwP", 'P', OrePrefixes.plate.get(Materials.StainlessSteel), 'S',
                 OrePrefixes.plate.get(Materials.Steel), 'F', OrePrefixes.frameGt.get(Materials.StainlessSteel) });
     }

--- a/src/main/java/gtPlusPlus/core/recipe/RecipesBatteries.java
+++ b/src/main/java/gtPlusPlus/core/recipe/RecipesBatteries.java
@@ -20,6 +20,7 @@ public class RecipesBatteries {
     private static void addBatteryRecipe(ItemStack quad, ItemStack single) {
         GTModHandler.addCraftingRecipe(
             quad,
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "BWB", "CTC", "BWB", 'B', single, 'W',
                 GTOreDictUnificator.get(OrePrefixes.cableGt04, Materials.Gold, 1), 'C', "circuitAdvanced", 'T',
                 ItemList.Transformer_EV_HV.get(1) });

--- a/src/main/java/gtPlusPlus/core/recipe/RecipesGeneral.java
+++ b/src/main/java/gtPlusPlus/core/recipe/RecipesGeneral.java
@@ -79,37 +79,45 @@ public class RecipesGeneral {
         // Workbench Blueprint
         GTModHandler.addCraftingRecipe(
             GregtechItemList.BlueprintBase.get(2),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PL ", "PL ", "LL ", 'P', new ItemStack(Items.paper), 'L',
                 GTOreDictUnificator.get(OrePrefixes.dust, Materials.Lazurite, 1) });
 
         // Rainforest Oak Sapling
         GTModHandler.addCraftingRecipe(
             new ItemStack(BOPBlockRegistrator.sapling_Rainforest),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "SSS", "SPS", "SBS", 'S', "stickWood", 'P', "treeSapling", 'B', "dustBone" });
 
         // Potin
         GTModHandler.addShapelessCraftingRecipe(
             MaterialsAlloy.POTIN.getDust(5),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "dustLead", "dustBronze", "dustTin", "dustLead", "dustBronze" });
 
         // Tumbaga
         GTModHandler.addShapelessCraftingRecipe(
             GregtechItemList.TumbagaMixDust.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "dustGold", "dustGold", "dustCopper" });
         GTModHandler.addShapelessCraftingRecipe(
             MaterialsAlloy.TUMBAGA.getDust(10),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { GregtechItemList.TumbagaMixDust.get(1), GregtechItemList.TumbagaMixDust.get(1),
                 GregtechItemList.TumbagaMixDust.get(1), "dustGold" });
 
         // Basic Turbines
         GTModHandler.addCraftingRecipe(
             GregtechItemList.BasicIronTurbine.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "fPS", "PRP", "SPh", 'P', "plateIron", 'R', "ringIron", 'S', "stickIron" });
         GTModHandler.addCraftingRecipe(
             GregtechItemList.BasicBronzeTurbine.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "fPS", "PRP", "SPh", 'P', "plateBronze", 'R', "ringBronze", 'S', "stickBronze" });
         GTModHandler.addCraftingRecipe(
             GregtechItemList.BasicSteelTurbine.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "fPS", "PRP", "SPh", 'P', "plateSteel", 'R', "ringSteel", 'S', "stickSteel" });
 
         // Large Volumetric Flask
@@ -142,12 +150,14 @@ public class RecipesGeneral {
         // Mining Explosives
         GTModHandler.addCraftingRecipe(
             GregtechItemList.MiningExplosives.get(3),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "ITI", "TFT", "STS", 'I', Ic2Items.industrialTnt.copy(), 'T', new ItemStack(Blocks.tnt), 'F',
                 GTOreDictUnificator.get(OrePrefixes.frameGt, Materials.Iron, 1), 'S', "dustSulfur" });
 
         // Alkalus Disk
         GTModHandler.addCraftingRecipe(
             GregtechItemList.AlkalusDisk.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "ABC", "DEF", "GHI", 'A', "gemExquisiteRuby", 'B', "gemFlawlessDiamond", 'C',
                 "gemExquisiteDiamond", 'D', "gemFlawlessRuby", 'E', ItemList.Credit_Greg_Osmium.get(1), 'F',
                 "gemFlawlessSapphire", 'G', "gemExquisiteEmerald", 'H', "gemFlawlessEmerald", 'I',
@@ -156,6 +166,7 @@ public class RecipesGeneral {
         // Wither Cage
         GTModHandler.addCraftingRecipe(
             GregtechItemList.WitherGuard.get(32),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "SPS", "PWP", "SPS", 'S', "stickBlackSteel", 'P', "plateTungstenSteel", 'W',
                 new ItemStack(Items.nether_star) });
 

--- a/src/main/java/gtPlusPlus/core/recipe/RecipesMachines.java
+++ b/src/main/java/gtPlusPlus/core/recipe/RecipesMachines.java
@@ -108,18 +108,21 @@ public class RecipesMachines {
         // Tesseract Generator
         GTModHandler.addCraftingRecipe(
             GregtechItemList.GT4_Tesseract_Generator.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PCP", "CEC", "PXP", 'P', OrePrefixes.plate.get(Materials.Titanium), 'C', "circuitMaster",
                 'E', new ItemStack(Blocks.ender_chest), 'X', GregtechItemList.Gregtech_Computer_Cube });
 
         // Tesseract Terminal
         GTModHandler.addCraftingRecipe(
             GregtechItemList.GT4_Tesseract_Terminal.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PCP", "CEC", "PHP", 'P', OrePrefixes.plate.get(Materials.Titanium), 'C', "circuitElite",
                 'E', new ItemStack(Blocks.ender_chest), 'H', ItemList.Hull_EV });
 
         // Air Intake Hatch
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Hatch_Air_Intake.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PCP", "PRP", "IHI", 'P', OrePrefixes.plate.get(Materials.Redstone), 'C',
                 ItemList.Casing_Grate, 'R', ItemList.FluidRegulator_IV, 'I', "circuitElite", 'H',
                 ItemList.Hatch_Input_IV });
@@ -127,6 +130,7 @@ public class RecipesMachines {
         // Extreme Air Intake Hatch
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Hatch_Air_Intake_Extreme.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PCP", "PRP", "IHI", 'P', MaterialsAlloy.PIKYONIUM.getPlate(1), 'C',
                 GregtechItemList.Hatch_Air_Intake, 'R', ItemList.FluidRegulator_ZPM, 'I', "circuitUltimate", 'H',
                 ItemList.Hatch_Input_ZPM });
@@ -134,6 +138,7 @@ public class RecipesMachines {
         // Atmospheric Intake Hatch
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Hatch_Air_Intake_Atmospheric.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PCP", "PRP", "IHI", 'P', MaterialsAlloy.OCTIRON.getPlate(1), 'C',
                 GregtechItemList.Hatch_Air_Intake_Extreme, 'R', ItemList.FluidRegulator_UHV, 'I', "circuitInfinite",
                 'H', ItemList.Hatch_Input_UHV });
@@ -178,6 +183,7 @@ public class RecipesMachines {
         // Industrial Multi Tank Casing (unused but craftable)
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Casing_MultitankExterior.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "RPR", "PFP", "PPP", 'R', MaterialsAlloy.LEAGRISIUM.getRod(1), 'P',
                 MaterialsAlloy.LEAGRISIUM.getPlate(1), 'F', MaterialsAlloy.LEAGRISIUM.getFrameBox(1) });
 

--- a/src/main/java/gtPlusPlus/core/recipe/RecipesMachinesCustom.java
+++ b/src/main/java/gtPlusPlus/core/recipe/RecipesMachinesCustom.java
@@ -376,14 +376,14 @@ public class RecipesMachinesCustom {
         // Alloy Blast Smelter
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Industrial_AlloyBlastSmelter.get(1),
-                GTModHandler.RecipeBits.BUFFERED,
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PCP", "WMW", "PCP", 'P', MaterialsAlloy.ZIRCONIUM_CARBIDE.getPlate(1), 'C', "circuitElite",
                 'W', OrePrefixes.cableGt04.get(Materials.Tungsten), 'M', ItemList.Machine_IV_AlloySmelter });
 
         // Blast Smelter Casing Block
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Casing_BlastSmelter.get(1),
-                GTModHandler.RecipeBits.BUFFERED,
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PhP", "PFP", "PwP", 'P', MaterialsAlloy.ZIRCONIUM_CARBIDE.getPlate(1), 'F',
                 MaterialsAlloy.ZIRCONIUM_CARBIDE.getFrameBox(1) });
 
@@ -398,7 +398,7 @@ public class RecipesMachinesCustom {
         // Blast Smelter Heat Containment Coil
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Casing_Coil_BlastSmelter.get(1),
-                GTModHandler.RecipeBits.BUFFERED,
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PPP", "FCF", "PPP", 'P', MaterialsAlloy.STABALLOY.getPlate(1), 'F',
                 MaterialsAlloy.STABALLOY.getFrameBox(1), 'C', ItemList.Casing_Gearbox_Titanium });
 
@@ -450,7 +450,7 @@ public class RecipesMachinesCustom {
         // Tree Growth Simulator
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Industrial_TreeFarm.get(1),
-                GTModHandler.RecipeBits.BUFFERED,
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "FRF", "PHP", "FXF", 'F', ItemList.Field_Generator_IV, 'R',
                 MaterialsAlloy.INCOLOY_MA956.getRotor(1), 'P', MaterialsAlloy.NITINOL_60.getPlate(1), 'H',
                 GregtechItemList.GTPP_Casing_IV.get(1), 'X',
@@ -476,7 +476,7 @@ public class RecipesMachinesCustom {
         // Thorium Reactor [LFTR]
         GTModHandler.addCraftingRecipe(
             GregtechItemList.ThoriumReactor.get(1),
-                GTModHandler.RecipeBits.BUFFERED,
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "ABA", "CDC", "EFE", 'A', GregtechItemList.LFTRControlCircuit, 'B',
                 OrePrefixes.cableGt12.get(Materials.Naquadah), 'C', MaterialsAlloy.HASTELLOY_N.getPlateDouble(1), 'D',
                 GregtechItemList.Gregtech_Computer_Cube, 'E', MaterialsElements.getInstance().THORIUM232.getPlate(1),
@@ -485,7 +485,7 @@ public class RecipesMachinesCustom {
         // Reactor Shield Casing
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Casing_Reactor_II.get(1),
-                GTModHandler.RecipeBits.BUFFERED,
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PdP", "GFG", "PhP", 'P', MaterialsAlloy.HASTELLOY_C276.getPlateDouble(1), 'G',
                 MaterialsAlloy.TALONITE.getGear(1), 'F', ItemList.Field_Generator_LV });
 
@@ -502,7 +502,7 @@ public class RecipesMachinesCustom {
         // Hastelloy-N Reactor Casing
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Casing_Reactor_I.get(1),
-                GTModHandler.RecipeBits.BUFFERED,
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PIP", "IFI", "PIP", 'P', MaterialsAlloy.HASTELLOY_N.getPlateDouble(1), 'I',
                 getModItem(Mods.IndustrialCraft2.ID, "reactorPlatingHeat", 1), 'F',
                 MaterialsAlloy.HASTELLOY_C276.getFrameBox(1) });
@@ -520,7 +520,7 @@ public class RecipesMachinesCustom {
         // Reactor Fuel Processing Plant
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Industrial_FuelRefinery.get(1),
-                GTModHandler.RecipeBits.BUFFERED,
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "CiC", "PXP", "GHG", 'C', "circuitElite", 'P',
                 OrePrefixes.plateDense.get(Materials.TungstenSteel), 'X', GregtechItemList.Gregtech_Computer_Cube, 'G',
                 MaterialsAlloy.STELLITE.getGear(1), 'H', ItemList.Hull_IV });
@@ -528,7 +528,7 @@ public class RecipesMachinesCustom {
         // Incoloy-DS Fluid Containment Block
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Casing_Refinery_Internal.get(1),
-                GTModHandler.RecipeBits.BUFFERED,
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PHP", "GTG", "PHP", 'P', MaterialsAlloy.INCOLOY_DS.getPlate(1), 'H',
                 MaterialsAlloy.STABALLOY.getComponentByPrefix(OrePrefixes.pipeHuge, 1), 'G',
                 MaterialsAlloy.INCOLOY_DS.getGear(1), 'T', ItemList.Super_Tank_IV });
@@ -536,7 +536,7 @@ public class RecipesMachinesCustom {
         // Hastelloy-N Sealant Block
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Casing_Refinery_External.get(1),
-                GTModHandler.RecipeBits.BUFFERED,
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "ABA", "BFB", "ABA", 'A', MaterialsAlloy.INCOLOY_MA956.getPlate(1), 'B',
                 MaterialsAlloy.HASTELLOY_N.getPlate(1), 'F', MaterialsAlloy.HASTELLOY_C276.getFrameBox(1) });
 
@@ -553,7 +553,7 @@ public class RecipesMachinesCustom {
         // Hastelloy-X Structural Block
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Casing_Refinery_Structural.get(1),
-                GTModHandler.RecipeBits.BUFFERED,
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "RGP", "hFw", "PHR", 'R', MaterialsAlloy.INCONEL_792.getRing(1), 'G',
                 MaterialsAlloy.HASTELLOY_X.getGear(1), 'P', OrePrefixes.plate.get(Materials.Steel), 'F',
                 MaterialsAlloy.HASTELLOY_C276.getFrameBox(1), 'H', ItemList.Casing_EV });
@@ -561,7 +561,7 @@ public class RecipesMachinesCustom {
         // Cold Trap I
         GTModHandler.addCraftingRecipe(
             GregtechItemList.ColdTrap_IV.get(1),
-                GTModHandler.RecipeBits.BUFFERED,
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PDP", "PCP", "RFR", 'P', MaterialsAlloy.INCONEL_625.getPlate(1), 'D',
                 MaterialsAlloy.HASTELLOY_X.getPlateDouble(1), 'C', ItemList.Casing_IV, 'R', ItemList.Robot_Arm_IV, 'F',
                 ItemList.Casing_FrostProof });
@@ -569,7 +569,7 @@ public class RecipesMachinesCustom {
         // Cold Trap II
         GTModHandler.addCraftingRecipe(
             GregtechItemList.ColdTrap_ZPM.get(1),
-                GTModHandler.RecipeBits.BUFFERED,
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PDP", "PCP", "RFR", 'P', MaterialsAlloy.PIKYONIUM.getPlate(1), 'D',
                 MaterialsAlloy.HS188A.getPlateDouble(1), 'C', GregtechItemList.ColdTrap_IV, 'R', ItemList.Robot_Arm_ZPM,
                 'F', ItemList.Casing_FrostProof });
@@ -577,7 +577,7 @@ public class RecipesMachinesCustom {
         // Reactor Processing Unit I
         GTModHandler.addCraftingRecipe(
             GregtechItemList.ReactorProcessingUnit_IV.get(1),
-                GTModHandler.RecipeBits.BUFFERED,
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "FRP", "DCD", "PDF", 'F', ItemList.Field_Generator_HV, 'R', ItemList.Robot_Arm_IV, 'P',
                 MaterialsAlloy.INCONEL_625.getPlate(1), 'D', MaterialsAlloy.HASTELLOY_N.getPlateDouble(1), 'C',
                 ItemList.Machine_IV_ChemicalReactor });
@@ -585,7 +585,7 @@ public class RecipesMachinesCustom {
         // Reactor Processing Unit II
         GTModHandler.addCraftingRecipe(
             GregtechItemList.ReactorProcessingUnit_ZPM.get(1),
-                GTModHandler.RecipeBits.BUFFERED,
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "FRP", "DCD", "PDF", 'F', ItemList.Field_Generator_IV, 'R', ItemList.Robot_Arm_ZPM, 'P',
                 MaterialsAlloy.PIKYONIUM.getPlate(1), 'D', MaterialsAlloy.HS188A.getPlateDouble(1), 'C',
                 GregtechItemList.ReactorProcessingUnit_IV });
@@ -593,7 +593,7 @@ public class RecipesMachinesCustom {
         // Nuclear Salt Processing Plant
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Nuclear_Salt_Processing_Plant.get(1),
-                GTModHandler.RecipeBits.BUFFERED,
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "ABA", "CDC", "AEA", 'A', OrePrefixes.plate.get(Materials.Osmiridium), 'B',
                 GregtechItemList.ReactorProcessingUnit_IV, 'C', WerkstoffLoader.Ruridit.get(OrePrefixes.plate), 'D',
                 "circuitUltimate", 'E', GregtechItemList.ColdTrap_IV });
@@ -636,14 +636,14 @@ public class RecipesMachinesCustom {
         // Sub-Station External Casing
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Casing_Power_SubStation.get(1),
-                GTModHandler.RecipeBits.BUFFERED,
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "SPS", "PFP", "SPS", 'S', OrePrefixes.screw.get(Materials.Titanium), 'P',
                 MaterialsAlloy.INCOLOY_020.getPlate(1), 'F', MaterialsAlloy.INCOLOY_MA956.getFrameBox(1) });
 
         // Power Station Control Node
         GTModHandler.addCraftingRecipe(
             GregtechItemList.PowerSubStation.get(1),
-                GTModHandler.RecipeBits.BUFFERED,
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "ABA", "CDC", "EAE", 'A', MaterialsAlloy.INCOLOY_MA956.getPlate(1), 'B',
                 GregtechItemList.LFTRControlCircuit, 'C', GregtechItemList.Casing_Power_SubStation, 'D',
                 GregtechItemList.Casing_Vanadium_Redox, 'E', MaterialsAlloy.INCOLOY_020.getPlate(1) });
@@ -731,7 +731,7 @@ public class RecipesMachinesCustom {
         // Aquatic Casing
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Casing_FishPond.get(1),
-                GTModHandler.RecipeBits.BUFFERED,
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PhP", "EFE", "PwP", 'P', MaterialsAlloy.AQUATIC_STEEL.getPlate(1), 'E',
                 MaterialsAlloy.EGLIN_STEEL.getPlate(1), 'F', MaterialsAlloy.EGLIN_STEEL.getFrameBox(1) });
 
@@ -749,7 +749,7 @@ public class RecipesMachinesCustom {
         // Zhuhai - Fishing Port
         GTModHandler.addCraftingRecipe(
             ItemList.FishingPort.get(1),
-                GTModHandler.RecipeBits.BUFFERED,
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PCP", "WFW", "PCP", 'P', MaterialsAlloy.AQUATIC_STEEL.getPlate(1), 'C', "circuitElite", 'W',
                 OrePrefixes.wireFine.get(Materials.Electrum), 'F', GregtechItemList.FishTrap });
     }
@@ -1029,7 +1029,7 @@ public class RecipesMachinesCustom {
         // Thermal Boiler
         GTModHandler.addCraftingRecipe(
             GregtechItemList.GT4_Thermal_Boiler.get(1),
-                GTModHandler.RecipeBits.BUFFERED,
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "LCL", "GIG", "LCL", 'L', getModItem(RemoteIO.ID, "tile.machine", 1, 1), 'C',
                 ItemList.Machine_HV_Centrifuge, 'G', OrePrefixes.gearGt.get(Materials.TungstenSteel), 'I',
                 "circuitElite" });
@@ -1037,7 +1037,7 @@ public class RecipesMachinesCustom {
         // Thermal Containment Casing
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Casing_ThermalContainment.get(2),
-                GTModHandler.RecipeBits.BUFFERED,
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PSP", "CHC", "PPP", 'P', MaterialsAlloy.MARAGING350.getPlate(1), 'S',
                 OrePrefixes.plate.get(Materials.StainlessSteel), 'C', "circuitAdvanced", 'H', ItemList.Casing_HV });
 

--- a/src/main/java/gtPlusPlus/core/recipe/RecipesMachinesCustom.java
+++ b/src/main/java/gtPlusPlus/core/recipe/RecipesMachinesCustom.java
@@ -376,12 +376,14 @@ public class RecipesMachinesCustom {
         // Alloy Blast Smelter
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Industrial_AlloyBlastSmelter.get(1),
+                GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PCP", "WMW", "PCP", 'P', MaterialsAlloy.ZIRCONIUM_CARBIDE.getPlate(1), 'C', "circuitElite",
                 'W', OrePrefixes.cableGt04.get(Materials.Tungsten), 'M', ItemList.Machine_IV_AlloySmelter });
 
         // Blast Smelter Casing Block
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Casing_BlastSmelter.get(1),
+                GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PhP", "PFP", "PwP", 'P', MaterialsAlloy.ZIRCONIUM_CARBIDE.getPlate(1), 'F',
                 MaterialsAlloy.ZIRCONIUM_CARBIDE.getFrameBox(1) });
 
@@ -396,6 +398,7 @@ public class RecipesMachinesCustom {
         // Blast Smelter Heat Containment Coil
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Casing_Coil_BlastSmelter.get(1),
+                GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PPP", "FCF", "PPP", 'P', MaterialsAlloy.STABALLOY.getPlate(1), 'F',
                 MaterialsAlloy.STABALLOY.getFrameBox(1), 'C', ItemList.Casing_Gearbox_Titanium });
 
@@ -447,6 +450,7 @@ public class RecipesMachinesCustom {
         // Tree Growth Simulator
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Industrial_TreeFarm.get(1),
+                GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "FRF", "PHP", "FXF", 'F', ItemList.Field_Generator_IV, 'R',
                 MaterialsAlloy.INCOLOY_MA956.getRotor(1), 'P', MaterialsAlloy.NITINOL_60.getPlate(1), 'H',
                 GregtechItemList.GTPP_Casing_IV.get(1), 'X',
@@ -472,6 +476,7 @@ public class RecipesMachinesCustom {
         // Thorium Reactor [LFTR]
         GTModHandler.addCraftingRecipe(
             GregtechItemList.ThoriumReactor.get(1),
+                GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "ABA", "CDC", "EFE", 'A', GregtechItemList.LFTRControlCircuit, 'B',
                 OrePrefixes.cableGt12.get(Materials.Naquadah), 'C', MaterialsAlloy.HASTELLOY_N.getPlateDouble(1), 'D',
                 GregtechItemList.Gregtech_Computer_Cube, 'E', MaterialsElements.getInstance().THORIUM232.getPlate(1),
@@ -480,6 +485,7 @@ public class RecipesMachinesCustom {
         // Reactor Shield Casing
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Casing_Reactor_II.get(1),
+                GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PdP", "GFG", "PhP", 'P', MaterialsAlloy.HASTELLOY_C276.getPlateDouble(1), 'G',
                 MaterialsAlloy.TALONITE.getGear(1), 'F', ItemList.Field_Generator_LV });
 
@@ -496,6 +502,7 @@ public class RecipesMachinesCustom {
         // Hastelloy-N Reactor Casing
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Casing_Reactor_I.get(1),
+                GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PIP", "IFI", "PIP", 'P', MaterialsAlloy.HASTELLOY_N.getPlateDouble(1), 'I',
                 getModItem(Mods.IndustrialCraft2.ID, "reactorPlatingHeat", 1), 'F',
                 MaterialsAlloy.HASTELLOY_C276.getFrameBox(1) });
@@ -513,6 +520,7 @@ public class RecipesMachinesCustom {
         // Reactor Fuel Processing Plant
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Industrial_FuelRefinery.get(1),
+                GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "CiC", "PXP", "GHG", 'C', "circuitElite", 'P',
                 OrePrefixes.plateDense.get(Materials.TungstenSteel), 'X', GregtechItemList.Gregtech_Computer_Cube, 'G',
                 MaterialsAlloy.STELLITE.getGear(1), 'H', ItemList.Hull_IV });
@@ -520,6 +528,7 @@ public class RecipesMachinesCustom {
         // Incoloy-DS Fluid Containment Block
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Casing_Refinery_Internal.get(1),
+                GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PHP", "GTG", "PHP", 'P', MaterialsAlloy.INCOLOY_DS.getPlate(1), 'H',
                 MaterialsAlloy.STABALLOY.getComponentByPrefix(OrePrefixes.pipeHuge, 1), 'G',
                 MaterialsAlloy.INCOLOY_DS.getGear(1), 'T', ItemList.Super_Tank_IV });
@@ -527,6 +536,7 @@ public class RecipesMachinesCustom {
         // Hastelloy-N Sealant Block
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Casing_Refinery_External.get(1),
+                GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "ABA", "BFB", "ABA", 'A', MaterialsAlloy.INCOLOY_MA956.getPlate(1), 'B',
                 MaterialsAlloy.HASTELLOY_N.getPlate(1), 'F', MaterialsAlloy.HASTELLOY_C276.getFrameBox(1) });
 
@@ -543,6 +553,7 @@ public class RecipesMachinesCustom {
         // Hastelloy-X Structural Block
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Casing_Refinery_Structural.get(1),
+                GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "RGP", "hFw", "PHR", 'R', MaterialsAlloy.INCONEL_792.getRing(1), 'G',
                 MaterialsAlloy.HASTELLOY_X.getGear(1), 'P', OrePrefixes.plate.get(Materials.Steel), 'F',
                 MaterialsAlloy.HASTELLOY_C276.getFrameBox(1), 'H', ItemList.Casing_EV });
@@ -550,6 +561,7 @@ public class RecipesMachinesCustom {
         // Cold Trap I
         GTModHandler.addCraftingRecipe(
             GregtechItemList.ColdTrap_IV.get(1),
+                GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PDP", "PCP", "RFR", 'P', MaterialsAlloy.INCONEL_625.getPlate(1), 'D',
                 MaterialsAlloy.HASTELLOY_X.getPlateDouble(1), 'C', ItemList.Casing_IV, 'R', ItemList.Robot_Arm_IV, 'F',
                 ItemList.Casing_FrostProof });
@@ -557,6 +569,7 @@ public class RecipesMachinesCustom {
         // Cold Trap II
         GTModHandler.addCraftingRecipe(
             GregtechItemList.ColdTrap_ZPM.get(1),
+                GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PDP", "PCP", "RFR", 'P', MaterialsAlloy.PIKYONIUM.getPlate(1), 'D',
                 MaterialsAlloy.HS188A.getPlateDouble(1), 'C', GregtechItemList.ColdTrap_IV, 'R', ItemList.Robot_Arm_ZPM,
                 'F', ItemList.Casing_FrostProof });
@@ -564,6 +577,7 @@ public class RecipesMachinesCustom {
         // Reactor Processing Unit I
         GTModHandler.addCraftingRecipe(
             GregtechItemList.ReactorProcessingUnit_IV.get(1),
+                GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "FRP", "DCD", "PDF", 'F', ItemList.Field_Generator_HV, 'R', ItemList.Robot_Arm_IV, 'P',
                 MaterialsAlloy.INCONEL_625.getPlate(1), 'D', MaterialsAlloy.HASTELLOY_N.getPlateDouble(1), 'C',
                 ItemList.Machine_IV_ChemicalReactor });
@@ -571,6 +585,7 @@ public class RecipesMachinesCustom {
         // Reactor Processing Unit II
         GTModHandler.addCraftingRecipe(
             GregtechItemList.ReactorProcessingUnit_ZPM.get(1),
+                GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "FRP", "DCD", "PDF", 'F', ItemList.Field_Generator_IV, 'R', ItemList.Robot_Arm_ZPM, 'P',
                 MaterialsAlloy.PIKYONIUM.getPlate(1), 'D', MaterialsAlloy.HS188A.getPlateDouble(1), 'C',
                 GregtechItemList.ReactorProcessingUnit_IV });
@@ -578,6 +593,7 @@ public class RecipesMachinesCustom {
         // Nuclear Salt Processing Plant
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Nuclear_Salt_Processing_Plant.get(1),
+                GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "ABA", "CDC", "AEA", 'A', OrePrefixes.plate.get(Materials.Osmiridium), 'B',
                 GregtechItemList.ReactorProcessingUnit_IV, 'C', WerkstoffLoader.Ruridit.get(OrePrefixes.plate), 'D',
                 "circuitUltimate", 'E', GregtechItemList.ColdTrap_IV });
@@ -620,12 +636,14 @@ public class RecipesMachinesCustom {
         // Sub-Station External Casing
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Casing_Power_SubStation.get(1),
+                GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "SPS", "PFP", "SPS", 'S', OrePrefixes.screw.get(Materials.Titanium), 'P',
                 MaterialsAlloy.INCOLOY_020.getPlate(1), 'F', MaterialsAlloy.INCOLOY_MA956.getFrameBox(1) });
 
         // Power Station Control Node
         GTModHandler.addCraftingRecipe(
             GregtechItemList.PowerSubStation.get(1),
+                GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "ABA", "CDC", "EAE", 'A', MaterialsAlloy.INCOLOY_MA956.getPlate(1), 'B',
                 GregtechItemList.LFTRControlCircuit, 'C', GregtechItemList.Casing_Power_SubStation, 'D',
                 GregtechItemList.Casing_Vanadium_Redox, 'E', MaterialsAlloy.INCOLOY_020.getPlate(1) });
@@ -713,6 +731,7 @@ public class RecipesMachinesCustom {
         // Aquatic Casing
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Casing_FishPond.get(1),
+                GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PhP", "EFE", "PwP", 'P', MaterialsAlloy.AQUATIC_STEEL.getPlate(1), 'E',
                 MaterialsAlloy.EGLIN_STEEL.getPlate(1), 'F', MaterialsAlloy.EGLIN_STEEL.getFrameBox(1) });
 
@@ -730,6 +749,7 @@ public class RecipesMachinesCustom {
         // Zhuhai - Fishing Port
         GTModHandler.addCraftingRecipe(
             ItemList.FishingPort.get(1),
+                GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PCP", "WFW", "PCP", 'P', MaterialsAlloy.AQUATIC_STEEL.getPlate(1), 'C', "circuitElite", 'W',
                 OrePrefixes.wireFine.get(Materials.Electrum), 'F', GregtechItemList.FishTrap });
     }
@@ -1009,6 +1029,7 @@ public class RecipesMachinesCustom {
         // Thermal Boiler
         GTModHandler.addCraftingRecipe(
             GregtechItemList.GT4_Thermal_Boiler.get(1),
+                GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "LCL", "GIG", "LCL", 'L', getModItem(RemoteIO.ID, "tile.machine", 1, 1), 'C',
                 ItemList.Machine_HV_Centrifuge, 'G', OrePrefixes.gearGt.get(Materials.TungstenSteel), 'I',
                 "circuitElite" });
@@ -1016,6 +1037,7 @@ public class RecipesMachinesCustom {
         // Thermal Containment Casing
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Casing_ThermalContainment.get(2),
+                GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PSP", "CHC", "PPP", 'P', MaterialsAlloy.MARAGING350.getPlate(1), 'S',
                 OrePrefixes.plate.get(Materials.StainlessSteel), 'C', "circuitAdvanced", 'H', ItemList.Casing_HV });
 

--- a/src/main/java/gtPlusPlus/core/recipe/RecipesMachinesMulti.java
+++ b/src/main/java/gtPlusPlus/core/recipe/RecipesMachinesMulti.java
@@ -243,12 +243,14 @@ public class RecipesMachinesMulti {
         // Steam Grinder
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Controller_SteamMaceratorMulti.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "CDC", "PFP", "CDC", 'C', ItemList.Casing_BronzePlatedBricks, 'D', "gemDiamond", 'P',
                 OreDictNames.craftingPiston, 'F', MaterialsAlloy.TUMBAGA.getFrameBox(1) });
 
         // Steam Purifier
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Controller_SteamWasherMulti.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "CPC", "RFR", "CPC", 'C', ItemList.Casing_BronzePlatedBricks, 'P',
                 OrePrefixes.plate.get(Materials.WroughtIron), 'R', OrePrefixes.rotor.get(Materials.Tin), 'F',
                 MaterialsAlloy.TUMBAGA.getFrameBox(1), });
@@ -256,6 +258,7 @@ public class RecipesMachinesMulti {
         // Steam Blender
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Controller_SteamMixerMulti.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "CRC", "OFO", "CRC", 'C', ItemList.Casing_BronzePlatedBricks, 'R',
                 MaterialsAlloy.TUMBAGA.getRing(1), 'O', MaterialsAlloy.TUMBAGA.getRotor(1), 'F',
                 MaterialsAlloy.TUMBAGA.getFrameBox(1) });
@@ -263,12 +266,14 @@ public class RecipesMachinesMulti {
         // Water Pump
         GTModHandler.addCraftingRecipe(
             GregtechItemList.WaterPump.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "FFF", "FGF", "CCC", 'F', OrePrefixes.frameGt.get(Materials.Bronze), 'G',
                 OrePrefixes.gearGt.get(Materials.Bronze), 'C', ItemList.WoodenCasing });
 
         // Steam Separator
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Controller_SteamCentrifugeMulti.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "CPC", "GFG", "CPC", 'C', ItemList.Casing_BronzePlatedBricks, 'P',
                 OrePrefixes.plate.get(Materials.WroughtIron), 'G', OrePrefixes.gearGt.get(Materials.Bronze), 'F',
                 MaterialsAlloy.TUMBAGA.getFrameBox(1) });
@@ -276,6 +281,7 @@ public class RecipesMachinesMulti {
         // Steam Presser
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Controller_SteamForgeHammerMulti.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "CPC", "PAP", "CFC", 'C', ItemList.Casing_BronzePlatedBricks, 'P',
                 OrePrefixes.plate.get(Materials.WroughtIron), 'A', OreDictNames.craftingAnvil, 'F',
                 MaterialsAlloy.TUMBAGA.getFrameBox(1) });
@@ -283,6 +289,7 @@ public class RecipesMachinesMulti {
         // Steam Squasher
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Controller_SteamCompressorMulti.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "CPC", "GFG", "CPC", 'C', ItemList.Casing_BronzePlatedBricks, 'P',
                 OreDictNames.craftingPiston, 'G', MaterialsAlloy.TUMBAGA.getGear(1), 'F',
                 MaterialsAlloy.TUMBAGA.getFrameBox(1) });
@@ -291,6 +298,7 @@ public class RecipesMachinesMulti {
             // Steam Fuser
             GTModHandler.addCraftingRecipe(
                 GregtechItemList.Controller_SteamAlloySmelterMulti.get(1),
+                GTModHandler.RecipeBits.BUFFERED,
                 new Object[] { "BTB", "FUF", "BLB", 'B', ItemList.Casing_BronzePlatedBricks.get(1L), 'T',
                     GTOreDictUnificator.get(OrePrefixes.pipeTiny, Materials.Bronze, 1L), 'F',
                     getModItem(EtFuturumRequiem.ID, "blast_furnace", 1, 0), 'U', MaterialsAlloy.TUMBAGA.getFrameBox(1),
@@ -299,6 +307,7 @@ public class RecipesMachinesMulti {
             // Steam Hearth
             GTModHandler.addCraftingRecipe(
                 GregtechItemList.Controller_SteamFurnaceMulti.get(1),
+                GTModHandler.RecipeBits.BUFFERED,
                 new Object[] { "RGR", "YBZ", "WFW", 'R', OrePrefixes.plateDouble.get(Materials.Bronze), 'G',
                     MaterialsAlloy.TUMBAGA.getGear(1), 'Y', getModItem(EtFuturumRequiem.ID, "blast_furnace", 1, 0), 'B',
                     ItemList.Machine_HP_Furnace, 'Z', getModItem(EtFuturumRequiem.ID, "smoker", 1, 0), 'W',
@@ -308,12 +317,14 @@ public class RecipesMachinesMulti {
         // Steam Hatch
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Hatch_Input_Steam.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PBP", "PTP", "PBP", 'P', OrePrefixes.plate.get(Materials.Bronze), 'B',
                 OrePrefixes.pipeMedium.get(Materials.Bronze), 'T', GregtechItemList.GTFluidTank_ULV.get(1) });
 
         // Steam Input Bus
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Hatch_Input_Bus_Steam.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "BTB", "SHS", "BTB", 'B', OrePrefixes.plate.get(Materials.Bronze), 'T',
                 MaterialsAlloy.TUMBAGA.getPlate(1), 'S', OrePrefixes.plate.get(Materials.Tin), 'H',
                 new ItemStack(Blocks.hopper) });
@@ -321,6 +332,7 @@ public class RecipesMachinesMulti {
         // Steam Output Bus
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Hatch_Output_Bus_Steam.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "BSB", "THT", "BSB", 'B', OrePrefixes.plate.get(Materials.Bronze), 'T',
                 MaterialsAlloy.TUMBAGA.getPlate(1), 'S', OrePrefixes.plate.get(Materials.Tin), 'H',
                 new ItemStack(Blocks.hopper) });
@@ -331,6 +343,7 @@ public class RecipesMachinesMulti {
         // Centrifuge Casing
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Casing_Centrifuge1.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "ABA", "CBC", "ABA", 'A', MaterialsAlloy.MARAGING250.getPlate(1), 'B',
                 MaterialsAlloy.TUMBAGA.getRod(1), 'C', MaterialsAlloy.INCONEL_792.getPlate(1) });
 
@@ -350,12 +363,14 @@ public class RecipesMachinesMulti {
         // Industrial Coke Oven
         GTModHandler.addCraftingRecipe(
             ItemList.IndustrialCokeOven.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PCP", "HOH", "PCP", 'P', MaterialsAlloy.TANTALLOY_61.getPlate(1), 'C', "circuitData", 'H',
                 ItemList.Casing_EV, 'O', ItemList.CokeOvenController });
 
         // Structural Coke Oven Casing
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Casing_CokeOven.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PRP", "RFR", "PRP", 'P', MaterialsAlloy.TANTALLOY_61.getPlate(1), 'R',
                 MaterialsAlloy.TANTALLOY_61.getRod(1), 'F', MaterialsAlloy.TANTALLOY_61.getFrameBox(1) });
 
@@ -373,12 +388,14 @@ public class RecipesMachinesMulti {
         // Heat Resistant Coke Oven Casing
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Casing_CokeOven_Coil1.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PPP", "FCF", "PPP", 'P', OrePrefixes.plate.get(Materials.Bronze), 'F',
                 OrePrefixes.frameGt.get(Materials.TPV), 'C', ItemList.Casing_Gearbox_Bronze });
 
         // Heat Proof Coke Oven Casing
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Casing_CokeOven_Coil2.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PPP", "FCF", "PPP", 'P', OrePrefixes.plate.get(Materials.Steel), 'F',
                 OrePrefixes.frameGt.get(Materials.HSSS), 'C', ItemList.Casing_Gearbox_Steel });
     }
@@ -387,6 +404,7 @@ public class RecipesMachinesMulti {
         // Electrolyzer Casing
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Casing_Electrolyzer.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PCP", "RFR", "PRP", 'P', MaterialsAlloy.POTIN.getPlate(1), 'C',
                 OrePrefixes.stickLong.get(Materials.Chrome), 'R', MaterialsAlloy.POTIN.getLongRod(1), 'F',
                 MaterialsAlloy.POTIN.getFrameBox(1) });
@@ -408,6 +426,7 @@ public class RecipesMachinesMulti {
         // Material Press Machine Casing
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Casing_MaterialPress.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PBP", "TFT", "PBP", 'P', OrePrefixes.plate.get(Materials.Titanium), 'B',
                 MaterialsAlloy.TUMBAGA.getLongRod(1), 'T', MaterialsAlloy.TANTALLOY_60.getRod(1), 'F',
                 MaterialsAlloy.TUMBAGA.getFrameBox(1) });
@@ -427,6 +446,7 @@ public class RecipesMachinesMulti {
         // Industrial Bending Machine
         GTModHandler.addCraftingRecipe(
             ItemList.IndustrialBendingMachine.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PGP", "MFM", "PRP", 'P', OrePrefixes.plate.get(Materials.Titanium), 'G',
                 OrePrefixes.gearGt.get(Materials.Titanium), 'R', MaterialsAlloy.TANTALLOY_60.getGear(1), 'M',
                 OrePrefixes.stick.get(Materials.Titanium), 'F', ItemList.Machine_EV_Bender });
@@ -434,6 +454,7 @@ public class RecipesMachinesMulti {
         // Industrial Forming Press
         GTModHandler.addCraftingRecipe(
             ItemList.IndustrialFormingPress.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PGP", "MFM", "PRP", 'P', OrePrefixes.plate.get(Materials.Titanium), 'G',
                 OrePrefixes.gearGt.get(Materials.Titanium), 'R', MaterialsAlloy.TANTALLOY_60.getGear(1), 'M',
                 OrePrefixes.stick.get(Materials.Titanium), 'F', ItemList.Machine_EV_Press });
@@ -443,6 +464,7 @@ public class RecipesMachinesMulti {
         // Maceration Stack Casing
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Casing_MacerationStack.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PPP", "RFR", "PXP", 'P', OrePrefixes.plate.get(Materials.Palladium), 'R',
                 OrePrefixes.stick.get(Materials.Platinum), 'F', MaterialsAlloy.INCONEL_625.getFrameBox(1), 'X',
                 OrePrefixes.stickLong.get(Materials.Palladium) });
@@ -462,12 +484,14 @@ public class RecipesMachinesMulti {
         // Industrial Maceration Stack
         GTModHandler.addCraftingRecipe(
             ItemList.MacerationStack.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PMP", "MCM", "PMP", 'P', OrePrefixes.plate.get(Materials.Titanium), 'M',
                 ItemList.Machine_EV_Macerator, 'C', "circuitData" });
 
         // Maceration Upgrade Chip
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Maceration_Upgrade_Chip.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PMP", "MCM", "PMP", 'P', OrePrefixes.plate.get(Materials.TungstenCarbide), 'M',
                 ItemList.Machine_IV_Macerator, 'C', "circuitUltimate" });
     }
@@ -476,6 +500,7 @@ public class RecipesMachinesMulti {
         // Wire Factory Casing
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Casing_WireFactory.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PRP", "RFR", "PRP", 'P', OrePrefixes.plate.get(Materials.BlueSteel), 'R',
                 OrePrefixes.stick.get(Materials.BlueSteel), 'F', OrePrefixes.frameGt.get(Materials.BlueSteel), });
 
@@ -496,6 +521,7 @@ public class RecipesMachinesMulti {
         // Matter Fabricator CPU
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Industrial_MassFab.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PCP", "WHW", "PCP", 'P', MaterialsElements.STANDALONE.ADVANCED_NITINOL.getPlate(1), 'C',
                 "circuitSuperconductor", 'W', OrePrefixes.cableGt04.get(Materials.NaquadahAlloy), 'H',
                 ItemList.Casing_UV });
@@ -503,6 +529,7 @@ public class RecipesMachinesMulti {
         // Matter Fabricator Casing
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Casing_MatterFab.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PRP", "RFR", "PRP", 'P', MaterialsAlloy.NIOBIUM_CARBIDE.getPlate(1), 'R',
                 MaterialsAlloy.INCONEL_792.getRod(1), 'F', MaterialsAlloy.INCONEL_690.getFrameBox(1) });
 
@@ -519,6 +546,7 @@ public class RecipesMachinesMulti {
         // Matter Generation Coil
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Casing_MatterGen.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PRP", "FHF", "PRP", 'P', MaterialsAlloy.ZERON_100.getPlate(1), 'R',
                 MaterialsAlloy.PIKYONIUM.getPlate(1), 'F', MaterialsAlloy.STELLITE.getFrameBox(1), 'H',
                 ItemList.Casing_UV });
@@ -580,12 +608,14 @@ public class RecipesMachinesMulti {
         // Large Sifter Control Block
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Industrial_Sifter.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PCP", "WMW", "PCP", 'P', MaterialsAlloy.EGLIN_STEEL.getPlate(1), 'C', "circuitAdvanced",
                 'W', OrePrefixes.cableGt04.get(Materials.Gold), 'M', ItemList.Machine_HV_Sifter });
 
         // Industrial Sieve Casing
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Casing_Sifter.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PPP", "PFP", "PPP", 'P', MaterialsAlloy.EGLIN_STEEL.getPlate(1), 'F',
                 MaterialsAlloy.TUMBAGA.getFrameBox(1) });
 
@@ -600,6 +630,7 @@ public class RecipesMachinesMulti {
         // Industrial Sieve Grate
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Casing_SifterGrate.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "FWF", "WWW", "FWF", 'F', MaterialsAlloy.EGLIN_STEEL.getFrameBox(1), 'W',
                 OrePrefixes.wireFine.get(Materials.Steel) });
 
@@ -618,6 +649,7 @@ public class RecipesMachinesMulti {
         // Thermal Processing Casing
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Casing_ThermalCentrifuge.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PhP", "PFP", "PwP", 'P', OrePrefixes.plate.get(Materials.RedSteel), 'F',
                 OrePrefixes.frameGt.get(Materials.BlackSteel) });
 
@@ -634,6 +666,7 @@ public class RecipesMachinesMulti {
         // Large Thermal Refinery
         GTModHandler.addCraftingRecipe(
             ItemList.LargeThermalRefinery.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PCP", "RMR", "PGP", 'P', OrePrefixes.plate.get(Materials.RedSteel), 'C', "circuitData", 'R',
                 MaterialsAlloy.TALONITE.getRod(1), 'M', ItemList.Machine_EV_ThermalCentrifuge, 'G',
                 MaterialsAlloy.TALONITE.getGear(1) });
@@ -643,6 +676,7 @@ public class RecipesMachinesMulti {
         // Wash Plant Casing
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Casing_WashPlant.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PhP", "TFT", "PwP", 'P', MaterialsAlloy.LEAGRISIUM.getPlate(1), 'T',
                 MaterialsAlloy.TALONITE.getPlate(1), 'F', MaterialsAlloy.LEAGRISIUM.getFrameBox(1) });
 
@@ -660,12 +694,14 @@ public class RecipesMachinesMulti {
         // Ore Washing Plant
         GTModHandler.addCraftingRecipe(
             ItemList.OreWashingPlant.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PPP", "TCT", "PAP", 'P', MaterialsAlloy.LEAGRISIUM.getPlate(1), 'A',
                 ItemList.Machine_EV_OreWasher, 'T', MaterialsAlloy.TALONITE.getPlate(1), 'C', "circuitData" });
 
         // Industrial Chemical Plant
         GTModHandler.addCraftingRecipe(
             ItemList.IndustrialChemicalBath.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PPP", "TCT", "PBP", 'P', MaterialsAlloy.LEAGRISIUM.getPlate(1), 'T',
                 MaterialsAlloy.TALONITE.getPlate(1), 'C', "circuitData", 'B', ItemList.Machine_EV_ChemicalBath });
     }
@@ -674,6 +710,7 @@ public class RecipesMachinesMulti {
         // Cutting Factory Frame
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Casing_CuttingFactoryFrame.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PhP", "SFS", "PwP", 'P', MaterialsAlloy.MARAGING300.getPlate(1), 'S',
                 MaterialsAlloy.STELLITE.getPlate(1), 'F', MaterialsAlloy.TALONITE.getFrameBox(1) });
 
@@ -691,6 +728,7 @@ public class RecipesMachinesMulti {
         // Industrial Cutting Factory
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Industrial_CuttingFactoryController.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PCP", "WMW", "PCP", 'P', MaterialsAlloy.MARAGING300.getPlate(1), 'C', "circuitData", 'W',
                 OrePrefixes.wireFine.get(Materials.Platinum), 'M', ItemList.Machine_IV_Cutter });
     }
@@ -699,6 +737,7 @@ public class RecipesMachinesMulti {
         // Inconel Reinforced Casing
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Casing_Extruder.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PhP", "TFT", "PwP", 'P', MaterialsAlloy.INCONEL_690.getPlate(1), 'T',
                 MaterialsAlloy.TALONITE.getPlate(1), 'F', MaterialsAlloy.STABALLOY.getFrameBox(1) });
 
@@ -716,6 +755,7 @@ public class RecipesMachinesMulti {
         // Industrial Extrusion Machine
         GTModHandler.addCraftingRecipe(
             ItemList.IndustrialExtruder.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PCP", "IMI", "PCP", 'P', MaterialsAlloy.INCONEL_690.getPlate(1), 'C', "circuitElite", 'I',
                 ItemList.Electric_Piston_IV, 'M', ItemList.Machine_IV_Extruder });
     }
@@ -724,6 +764,7 @@ public class RecipesMachinesMulti {
         // Advanced Cryogenic Casing
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Casing_AdvancedVacuum.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PGP", "AFB", "PGP", 'P', MaterialsAlloy.LEAGRISIUM.getPlateDouble(1), 'G',
                 MaterialsAlloy.INCOLOY_MA956.getGear(1), 'A', ItemList.Reactor_Coolant_He_6, 'F',
                 MaterialsAlloy.NITINOL_60.getFrameBox(1), 'B', ItemList.Reactor_Coolant_NaK_6.get(1) });
@@ -731,6 +772,7 @@ public class RecipesMachinesMulti {
         // Cryogenic Freezer
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Industrial_Cryogenic_Freezer.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "GCG", "PXP", "DOD", 'G', MaterialsAlloy.INCOLOY_MA956.getGear(1), 'C', "circuitMaster", 'P',
                 ItemList.Electric_Piston_IV, 'X', GregtechItemList.Casing_AdvancedVacuum, 'D',
                 MaterialsAlloy.LEAGRISIUM.getPlateDouble(1), 'O', GregtechItemList.Gregtech_Computer_Cube });
@@ -738,6 +780,7 @@ public class RecipesMachinesMulti {
         // Cryotheum Cooling Hatch
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Hatch_Input_Cryotheum.get(1L),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "MGM", "CBC", "PHP", 'M', MaterialsAlloy.MARAGING250.getPlate(1), 'G',
                 MaterialsAlloy.MARAGING250.getGear(1), 'C', "circuitData", 'B',
                 GregtechItemList.Casing_AdvancedVacuum.get(1), 'P', Materials.Aluminium.getPlates(1), 'H',
@@ -748,6 +791,7 @@ public class RecipesMachinesMulti {
         // Volcanus Casing
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Casing_Adv_BlastFurnace.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PAP", "BFC", "PGP", 'P', MaterialsAlloy.HASTELLOY_N.getPlateDouble(1), 'A',
                 getModItem(Mods.IndustrialCraft2.ID, "reactorHeatSwitchDiamond", 1, 1), 'B',
                 getModItem(Mods.IndustrialCraft2.ID, "reactorVentGold", 1, 1), 'C',
@@ -771,6 +815,7 @@ public class RecipesMachinesMulti {
         // Volcanus
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Machine_Adv_BlastFurnace.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "GCG", "RXR", "PZP", 'G', MaterialsAlloy.HASTELLOY_W.getGear(1), 'C', "circuitMaster", 'R',
                 ItemList.Robot_Arm_IV, 'X', GregtechItemList.Casing_Adv_BlastFurnace, 'P',
                 MaterialsAlloy.HASTELLOY_N.getPlateDouble(1), 'Z', GregtechItemList.Gregtech_Computer_Cube });
@@ -778,6 +823,7 @@ public class RecipesMachinesMulti {
         // Pyrotheum Heating Vent
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Hatch_Input_Pyrotheum.get(1L),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "MGM", "CBC", "MHM", 'M', MaterialsAlloy.MARAGING250.getPlate(1), 'G',
                 MaterialsAlloy.MARAGING300.getGear(1), 'C', "circuitElite", 'B',
                 GregtechItemList.Casing_Adv_BlastFurnace.get(1), 'H', ItemList.Hatch_Input_IV.get(1) });
@@ -800,6 +846,7 @@ public class RecipesMachinesMulti {
         // Density^2
         GTModHandler.addCraftingRecipe(
             ItemList.AdvancedImplosionCompressor.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "GCG", "FHR", "IXI", 'G', MaterialsAlloy.LEAGRISIUM.getGear(1), 'C', "circuitMaster", 'F',
                 ItemList.Field_Generator_IV, 'H', ItemList.Hull_ZPM, 'R', ItemList.Robot_Arm_IV, 'I',
                 "plateAlloyIridium", 'X', GregtechItemList.Gregtech_Computer_Cube });
@@ -809,6 +856,7 @@ public class RecipesMachinesMulti {
         // Supply Depot Casing
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Casing_AmazonWarehouse.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PMP", "wFh", "PCP", 'P', MaterialsAlloy.HASTELLOY_C276.getPlateDouble(1), 'M',
                 ItemList.Electric_Motor_HV, 'F', MaterialsAlloy.TUNGSTEN_CARBIDE.getFrameBox(1), 'C',
                 ItemList.Conveyor_Module_HV, });
@@ -830,6 +878,7 @@ public class RecipesMachinesMulti {
         // Multi-Use Casing
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Casing_Multi_Use.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PhP", "SFS", "PwP", 'P', MaterialsAlloy.STABALLOY.getPlate(1), 'S',
                 OrePrefixes.plate.get(Materials.StainlessSteel), 'F',
                 MaterialsAlloy.ZIRCONIUM_CARBIDE.getFrameBox(1) });

--- a/src/main/java/gtPlusPlus/core/recipe/RecipesMachinesTiered.java
+++ b/src/main/java/gtPlusPlus/core/recipe/RecipesMachinesTiered.java
@@ -700,24 +700,28 @@ public class RecipesMachinesTiered {
         // Modulator I
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Modulator_I.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "CPC", "PHP", "CPC", 'C', "circuitData", 'P', MaterialsAlloy.INCOLOY_DS.getPlate(1), 'H',
                 ItemList.Casing_EV });
 
         // Modulator II
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Modulator_II.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "CPC", "PHP", "CPC", 'C', "circuitElite", 'P', MaterialsAlloy.INCONEL_625.getPlate(1), 'H',
                 ItemList.Casing_IV });
 
         // Modulator III
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Modulator_III.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "CPC", "PHP", "CPC", 'C', "circuitMaster", 'P', MaterialsAlloy.ZERON_100.getPlate(1), 'H',
                 ItemList.Casing_LuV });
 
         // Modulator IV
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Modulator_IV.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "CPC", "PHP", "CPC", 'C', "circuitUltimate", 'P', MaterialsAlloy.PIKYONIUM.getPlate(1), 'H',
                 ItemList.Casing_ZPM });
     }
@@ -726,24 +730,28 @@ public class RecipesMachinesTiered {
         // Resonance Chamber I
         GTModHandler.addCraftingRecipe(
             GregtechItemList.ResonanceChamber_I.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PFP", "FHF", "PFP", 'P', MaterialsAlloy.INCOLOY_DS.getPlateDouble(1), 'F',
                 ItemList.Field_Generator_LV, 'H', ItemList.Casing_EV });
 
         // Resonance Chamber II
         GTModHandler.addCraftingRecipe(
             GregtechItemList.ResonanceChamber_II.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PFP", "FHF", "PFP", 'P', MaterialsAlloy.INCONEL_625.getPlateDouble(1), 'F',
                 ItemList.Field_Generator_MV, 'H', ItemList.Casing_IV });
 
         // Resonance Chamber III
         GTModHandler.addCraftingRecipe(
             GregtechItemList.ResonanceChamber_III.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PFP", "FHF", "PFP", 'P', MaterialsAlloy.ZERON_100.getPlateDouble(1), 'F',
                 ItemList.Field_Generator_HV, 'H', ItemList.Casing_LuV });
 
         // Resonance Chamber IV
         GTModHandler.addCraftingRecipe(
             GregtechItemList.ResonanceChamber_IV.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PFP", "FHF", "PFP", 'P', MaterialsAlloy.PIKYONIUM.getPlateDouble(1), 'F',
                 ItemList.Field_Generator_EV, 'H', ItemList.Casing_ZPM });
     }
@@ -752,6 +760,7 @@ public class RecipesMachinesTiered {
         // LV
         GTModHandler.addCraftingRecipe(
             GregtechItemList.GT4_Electric_Auto_Workbench_LV.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PCP", "IHI", "PRP", 'P', OrePrefixes.plate.get(Materials.Steel), 'C',
                 new ItemStack(Blocks.crafting_table), 'I', OrePrefixes.circuit.get(Materials.LV), 'H', ItemList.Hull_LV,
                 'R', ItemList.Robot_Arm_LV });
@@ -759,6 +768,7 @@ public class RecipesMachinesTiered {
         // MV
         GTModHandler.addCraftingRecipe(
             GregtechItemList.GT4_Electric_Auto_Workbench_MV.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PCP", "IHI", "PRP", 'P', OrePrefixes.plate.get(Materials.Aluminium), 'C',
                 new ItemStack(Blocks.crafting_table), 'I', OrePrefixes.circuit.get(Materials.MV), 'H', ItemList.Hull_MV,
                 'R', ItemList.Robot_Arm_MV });
@@ -766,6 +776,7 @@ public class RecipesMachinesTiered {
         // HV
         GTModHandler.addCraftingRecipe(
             GregtechItemList.GT4_Electric_Auto_Workbench_HV.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PCP", "IHI", "PRP", 'P', OrePrefixes.plate.get(Materials.StainlessSteel), 'C',
                 new ItemStack(Blocks.crafting_table), 'I', OrePrefixes.circuit.get(Materials.HV), 'H', ItemList.Hull_HV,
                 'R', ItemList.Robot_Arm_HV });
@@ -773,6 +784,7 @@ public class RecipesMachinesTiered {
         // EV
         GTModHandler.addCraftingRecipe(
             GregtechItemList.GT4_Electric_Auto_Workbench_EV.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PCP", "IHI", "PRP", 'P', OrePrefixes.plate.get(Materials.Titanium), 'C',
                 new ItemStack(Blocks.crafting_table), 'I', OrePrefixes.circuit.get(Materials.EV), 'H', ItemList.Hull_EV,
                 'R', ItemList.Robot_Arm_EV });
@@ -780,6 +792,7 @@ public class RecipesMachinesTiered {
         // IV
         GTModHandler.addCraftingRecipe(
             GregtechItemList.GT4_Electric_Auto_Workbench_IV.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PCP", "IHI", "PRP", 'P', OrePrefixes.plate.get(Materials.TungstenSteel), 'C',
                 new ItemStack(Blocks.crafting_table), 'I', OrePrefixes.circuit.get(Materials.IV), 'H', ItemList.Hull_IV,
                 'R', ItemList.Robot_Arm_IV });
@@ -787,6 +800,7 @@ public class RecipesMachinesTiered {
         // LuV
         GTModHandler.addCraftingRecipe(
             GregtechItemList.GT4_Electric_Auto_Workbench_LuV.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PCP", "IHI", "PRP", 'P', OrePrefixes.plate.get(Materials.Chrome), 'C',
                 new ItemStack(Blocks.crafting_table), 'I', OrePrefixes.circuit.get(Materials.LuV), 'H',
                 ItemList.Hull_LuV, 'R', ItemList.Robot_Arm_LuV });
@@ -794,6 +808,7 @@ public class RecipesMachinesTiered {
         // ZPM
         GTModHandler.addCraftingRecipe(
             GregtechItemList.GT4_Electric_Auto_Workbench_ZPM.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PCP", "IHI", "PRP", 'P', OrePrefixes.plate.get(Materials.Iridium), 'C',
                 new ItemStack(Blocks.crafting_table), 'I', OrePrefixes.circuit.get(Materials.ZPM), 'H',
                 ItemList.Hull_ZPM, 'R', ItemList.Robot_Arm_ZPM });
@@ -801,6 +816,7 @@ public class RecipesMachinesTiered {
         // UV
         GTModHandler.addCraftingRecipe(
             GregtechItemList.GT4_Electric_Auto_Workbench_UV.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PCP", "IHI", "PRP", 'P', OrePrefixes.plate.get(Materials.Osmium), 'C',
                 new ItemStack(Blocks.crafting_table), 'I', OrePrefixes.circuit.get(Materials.UV), 'H', ItemList.Hull_UV,
                 'R', ItemList.Robot_Arm_UV });
@@ -1277,18 +1293,21 @@ public class RecipesMachinesTiered {
         // Air Filter [Tier 1]
         GTModHandler.addCraftingRecipe(
             GregtechItemList.AirFilter_Tier1.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PPP", "DDD", "PPP", 'P', OrePrefixes.plate.get(Materials.Carbon), 'D',
                 OrePrefixes.dust.get(Materials.Carbon) });
 
         // Air Filter [Tier 2]
         GTModHandler.addCraftingRecipe(
             GregtechItemList.AirFilter_Tier2.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PPP", "CDC", "PPP", 'P', OrePrefixes.plate.get(Materials.Carbon), 'C',
                 "cellLithiumPeroxide", 'D', OrePrefixes.dust.get(Materials.Carbon) });
 
         // Pollution Detection Device
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Pollution_Detector.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PSP", "PMP", "CHC", 'P', OrePrefixes.plate.get(Materials.Steel), 'S', ItemList.Sensor_LV,
                 'M', ItemList.Electric_Motor_LV, 'C', "circuitBasic", 'H', ItemList.Hull_LV });
 
@@ -1296,6 +1315,7 @@ public class RecipesMachinesTiered {
         // LV
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Pollution_Cleaner_LV.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PFP", "PMP", "CHC", 'P', GregtechItemList.AirFilter_Tier1, 'F',
                 OrePrefixes.plate.get(Materials.Tin), 'M', ItemList.Electric_Motor_LV, 'C', "circuitBasic", 'H',
                 ItemList.Hull_LV });
@@ -1303,6 +1323,7 @@ public class RecipesMachinesTiered {
         // MV
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Pollution_Cleaner_MV.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PFP", "PMP", "CHC", 'P', GregtechItemList.AirFilter_Tier1, 'F',
                 OrePrefixes.plate.get(Materials.Copper), 'M', ItemList.Electric_Motor_MV, 'C', "circuitGood", 'H',
                 ItemList.Hull_MV });
@@ -1310,6 +1331,7 @@ public class RecipesMachinesTiered {
         // HV
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Pollution_Cleaner_HV.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PFP", "PMP", "CHC", 'P', GregtechItemList.AirFilter_Tier1, 'F',
                 OrePrefixes.plate.get(Materials.Bronze), 'M', ItemList.Electric_Motor_HV, 'C', "circuitAdvanced", 'H',
                 ItemList.Hull_HV });
@@ -1317,6 +1339,7 @@ public class RecipesMachinesTiered {
         // EV
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Pollution_Cleaner_EV.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PFP", "PMP", "CHC", 'P', GregtechItemList.AirFilter_Tier1, 'F',
                 OrePrefixes.plate.get(Materials.Iron), 'M', ItemList.Electric_Motor_EV, 'C', "circuitData", 'H',
                 ItemList.Hull_EV });
@@ -1324,6 +1347,7 @@ public class RecipesMachinesTiered {
         // IV
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Pollution_Cleaner_IV.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PFP", "PMP", "CHC", 'P', GregtechItemList.AirFilter_Tier2, 'F',
                 OrePrefixes.plate.get(Materials.Steel), 'M', ItemList.Electric_Motor_IV, 'C', "circuitElite", 'H',
                 ItemList.Hull_IV });
@@ -1331,6 +1355,7 @@ public class RecipesMachinesTiered {
         // LuV
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Pollution_Cleaner_LuV.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PFP", "PMP", "CHC", 'P', GregtechItemList.AirFilter_Tier2, 'F',
                 OrePrefixes.plate.get(Materials.Redstone), 'M', ItemList.Electric_Motor_LuV, 'C', "circuitMaster", 'H',
                 ItemList.Hull_LuV });
@@ -1338,6 +1363,7 @@ public class RecipesMachinesTiered {
         // ZPM
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Pollution_Cleaner_ZPM.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PFP", "PMP", "CHC", 'P', GregtechItemList.AirFilter_Tier2, 'F',
                 OrePrefixes.plate.get(Materials.Aluminium), 'M', ItemList.Electric_Motor_ZPM, 'C', "circuitUltimate",
                 'H', ItemList.Hull_ZPM });
@@ -1345,6 +1371,7 @@ public class RecipesMachinesTiered {
         // UV
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Pollution_Cleaner_UV.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PFP", "PMP", "CHC", 'P', GregtechItemList.AirFilter_Tier2, 'F',
                 OrePrefixes.plate.get(Materials.DarkSteel), 'M', ItemList.Electric_Motor_UV, 'C',
                 "circuitSuperconductor", 'H', ItemList.Hull_UV });
@@ -1352,6 +1379,7 @@ public class RecipesMachinesTiered {
         // UHV
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Pollution_Cleaner_MAX.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PFP", "PMP", "CHC", 'P', GregtechItemList.AirFilter_Tier2, 'F',
                 MaterialsAlloy.ZERON_100.getPlate(1), 'M', ItemList.Electric_Motor_UHV, 'C', "circuitInfinite", 'H',
                 ItemList.Hull_MAX });
@@ -1361,20 +1389,25 @@ public class RecipesMachinesTiered {
         // Allows clearing stored fluids
         GTModHandler.addShapelessCraftingRecipe(
             GregtechItemList.GTFluidTank_ULV.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { GregtechItemList.GTFluidTank_ULV.get(1) });
         GTModHandler.addShapelessCraftingRecipe(
             GregtechItemList.GTFluidTank_LV.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { GregtechItemList.GTFluidTank_LV.get(1) });
         GTModHandler.addShapelessCraftingRecipe(
             GregtechItemList.GTFluidTank_MV.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { GregtechItemList.GTFluidTank_MV.get(1) });
         GTModHandler.addShapelessCraftingRecipe(
             GregtechItemList.GTFluidTank_HV.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { GregtechItemList.GTFluidTank_HV.get(1) });
 
         // ULV Fluid Tank
         GTModHandler.addCraftingRecipe(
             GregtechItemList.GTFluidTank_ULV.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "TST", "IPI", "IBI", 'T', OrePrefixes.plate.get(Materials.Tin), 'S',
                 OrePrefixes.plate.get(Materials.Steel), 'I', OrePrefixes.plate.get(Materials.Iron), 'P',
                 OrePrefixes.pipeLarge.get(Materials.Clay), 'B', new ItemStack(Items.water_bucket) });
@@ -1382,6 +1415,7 @@ public class RecipesMachinesTiered {
         // LV Fluid Tank
         GTModHandler.addCraftingRecipe(
             GregtechItemList.GTFluidTank_LV.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "SIS", "BPB", "BUB", 'S', OrePrefixes.plate.get(Materials.Steel), 'I',
                 OrePrefixes.plate.get(Materials.Iron), 'B', OrePrefixes.plate.get(Materials.Bronze), 'P',
                 OrePrefixes.pipeHuge.get(Materials.Clay), 'U', ItemList.Electric_Pump_LV });
@@ -1389,6 +1423,7 @@ public class RecipesMachinesTiered {
         // MV Fluid Tank
         GTModHandler.addCraftingRecipe(
             GregtechItemList.GTFluidTank_MV.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "DBD", "SPS", "SUS", 'D', OrePrefixes.plate.get(Materials.DarkSteel), 'B',
                 OrePrefixes.plate.get(Materials.Bronze), 'S', OrePrefixes.plate.get(Materials.Steel), 'P',
                 OrePrefixes.pipeMedium.get(Materials.Bronze), 'U', ItemList.Electric_Pump_LV });
@@ -1396,6 +1431,7 @@ public class RecipesMachinesTiered {
         // HV Fluid Tank
         GTModHandler.addCraftingRecipe(
             GregtechItemList.GTFluidTank_HV.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "CAC", "DPD", "CUC", 'C', "circuitPrimitive", 'A',
                 OrePrefixes.plate.get(Materials.Aluminium), 'D', OrePrefixes.plate.get(Materials.DarkSteel), 'P',
                 OrePrefixes.pipeMedium.get(Materials.Steel), 'U', ItemList.Electric_Pump_MV });

--- a/src/main/java/gtPlusPlus/core/util/minecraft/ItemUtils.java
+++ b/src/main/java/gtPlusPlus/core/util/minecraft/ItemUtils.java
@@ -129,15 +129,23 @@ public class ItemUtils {
             .addTo(packagerRecipes);
 
         // Tiny Dusts
-        GTModHandler.addCraftingRecipe(normalDust, new Object[] { "TTT", "TTT", "TTT", 'T', tinyDust });
+        GTModHandler.addCraftingRecipe(
+            normalDust,
+            GTModHandler.RecipeBits.BUFFERED,
+            new Object[] { "TTT", "TTT", "TTT", 'T', tinyDust });
         GTModHandler.addCraftingRecipe(
             GTUtility.copyAmount(9, tinyDust),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "D  ", "   ", "   ", 'D', normalDust });
 
         // Small Dusts
-        GTModHandler.addCraftingRecipe(normalDust, new Object[] { "SS ", "SS ", "   ", 'S', smallDust });
+        GTModHandler.addCraftingRecipe(
+            normalDust,
+            GTModHandler.RecipeBits.BUFFERED,
+            new Object[] { "SS ", "SS ", "   ", 'S', smallDust });
         GTModHandler.addCraftingRecipe(
             GTUtility.copyAmount(4, smallDust),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { " D ", "   ", "   ", 'D', normalDust });
 
         return output;

--- a/src/main/java/gtPlusPlus/recipes/RecipeRemovals.java
+++ b/src/main/java/gtPlusPlus/recipes/RecipeRemovals.java
@@ -10,7 +10,7 @@ public class RecipeRemovals {
 
     public static void postInit() {
         if (Mods.AdvancedSolarPanel.isModLoaded()) {
-            GTModHandler.removeRecipeByOutput(new ItemStack(AdvancedSolarPanel.blockMolecularTransformer));
+            GTModHandler.removeRecipeByOutputDelayed(new ItemStack(AdvancedSolarPanel.blockMolecularTransformer));
         }
     }
 }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/RecipeGenDustGeneration.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/RecipeGenDustGeneration.java
@@ -44,13 +44,25 @@ public class RecipeGenDustGeneration extends RecipeGenBase {
         final ItemStack smallDust = M.getSmallDust(1);
         final ItemStack tinyDust = M.getTinyDust(1);
         if (tinyDust != null && normalDust != null) {
-            GTModHandler.addCraftingRecipe(normalDust, new Object[] { "TTT", "TTT", "TTT", 'T', tinyDust });
-            GTModHandler.addCraftingRecipe(M.getTinyDust(9), new Object[] { "D  ", "   ", "   ", 'D', normalDust });
+            GTModHandler.addCraftingRecipe(
+                normalDust,
+                GTModHandler.RecipeBits.BUFFERED,
+                new Object[] { "TTT", "TTT", "TTT", 'T', tinyDust });
+            GTModHandler.addCraftingRecipe(
+                M.getTinyDust(9),
+                GTModHandler.RecipeBits.BUFFERED,
+                new Object[] { "D  ", "   ", "   ", 'D', normalDust });
         }
 
         if (smallDust != null && normalDust != null) {
-            GTModHandler.addCraftingRecipe(normalDust, new Object[] { "SS ", "SS ", "   ", 'S', smallDust });
-            GTModHandler.addCraftingRecipe(M.getSmallDust(4), new Object[] { " D ", "   ", "   ", 'D', normalDust });
+            GTModHandler.addCraftingRecipe(
+                normalDust,
+                GTModHandler.RecipeBits.BUFFERED,
+                new Object[] { "SS ", "SS ", "   ", 'S', smallDust });
+            GTModHandler.addCraftingRecipe(
+                M.getSmallDust(4),
+                GTModHandler.RecipeBits.BUFFERED,
+                new Object[] { " D ", "   ", "   ", 'D', normalDust });
         }
     }
 

--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/RecipeGenFluorite.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/RecipeGenFluorite.java
@@ -37,25 +37,40 @@ public class RecipeGenFluorite extends RecipeGenBase {
 
         GTModHandler.addCraftingRecipe(
             material.getDustPurified(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "h  ", "P  ", "   ", 'P', material.getCrushedPurified(1) });
 
         GTModHandler.addCraftingRecipe(
             material.getDustImpure(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "h  ", "C  ", "   ", 'C', material.getCrushed(1) });
 
         GTModHandler.addCraftingRecipe(
             material.getDust(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "h  ", "C  ", "   ", 'C', material.getCrushedCentrifuged(1) });
 
         final ItemStack normalDust = material.getDust(1);
         final ItemStack smallDust = material.getSmallDust(1);
         final ItemStack tinyDust = material.getTinyDust(1);
 
-        GTModHandler.addCraftingRecipe(normalDust, new Object[] { "TTT", "TTT", "TTT", 'T', tinyDust });
-        GTModHandler.addCraftingRecipe(material.getTinyDust(9), new Object[] { "D  ", "   ", "   ", 'D', normalDust });
+        GTModHandler.addCraftingRecipe(
+            normalDust,
+            GTModHandler.RecipeBits.BUFFERED,
+            new Object[] { "TTT", "TTT", "TTT", 'T', tinyDust });
+        GTModHandler.addCraftingRecipe(
+            material.getTinyDust(9),
+            GTModHandler.RecipeBits.BUFFERED,
+            new Object[] { "D  ", "   ", "   ", 'D', normalDust });
 
-        GTModHandler.addCraftingRecipe(normalDust, new Object[] { "SS ", "SS ", "   ", 'S', smallDust });
-        GTModHandler.addCraftingRecipe(material.getSmallDust(4), new Object[] { " D ", "   ", "   ", 'D', normalDust });
+        GTModHandler.addCraftingRecipe(
+            normalDust,
+            GTModHandler.RecipeBits.BUFFERED,
+            new Object[] { "SS ", "SS ", "   ", 'S', smallDust });
+        GTModHandler.addCraftingRecipe(
+            material.getSmallDust(4),
+            GTModHandler.RecipeBits.BUFFERED,
+            new Object[] { " D ", "   ", "   ", 'D', normalDust });
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/RecipeGenOre.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/RecipeGenOre.java
@@ -469,27 +469,42 @@ public class RecipeGenOre extends RecipeGenBase {
 
         GTModHandler.addCraftingRecipe(
             material.getDustPurified(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "h  ", "P  ", "   ", 'P', material.getCrushedPurified(1) });
 
         GTModHandler.addCraftingRecipe(
             material.getDustImpure(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "h  ", "C  ", "   ", 'C', material.getCrushed(1) });
 
-        GTModHandler
-            .addCraftingRecipe(matDust, new Object[] { "h  ", "C  ", "   ", 'C', material.getCrushedCentrifuged(1) });
+        GTModHandler.addCraftingRecipe(
+            matDust,
+            GTModHandler.RecipeBits.BUFFERED,
+            new Object[] { "h  ", "C  ", "   ", 'C', material.getCrushedCentrifuged(1) });
 
         final ItemStack smallDust = material.getSmallDust(1);
         final ItemStack tinyDust = material.getTinyDust(1);
 
         if (tinyDust != null) {
-            GTModHandler.addCraftingRecipe(matDust, new Object[] { "TTT", "TTT", "TTT", 'T', tinyDust });
-            GTModHandler.addCraftingRecipe(material.getTinyDust(9), new Object[] { "D  ", "   ", "   ", 'D', matDust });
+            GTModHandler.addCraftingRecipe(
+                matDust,
+                GTModHandler.RecipeBits.BUFFERED,
+                new Object[] { "TTT", "TTT", "TTT", 'T', tinyDust });
+            GTModHandler.addCraftingRecipe(
+                material.getTinyDust(9),
+                GTModHandler.RecipeBits.BUFFERED,
+                new Object[] { "D  ", "   ", "   ", 'D', matDust });
         }
 
         if (smallDust != null) {
-            GTModHandler.addCraftingRecipe(matDust, new Object[] { "SS ", "SS ", "   ", 'S', smallDust });
-            GTModHandler
-                .addCraftingRecipe(material.getSmallDust(4), new Object[] { " D ", "   ", "   ", 'D', matDust });
+            GTModHandler.addCraftingRecipe(
+                matDust,
+                GTModHandler.RecipeBits.BUFFERED,
+                new Object[] { "SS ", "SS ", "   ", 'S', smallDust });
+            GTModHandler.addCraftingRecipe(
+                material.getSmallDust(4),
+                GTModHandler.RecipeBits.BUFFERED,
+                new Object[] { " D ", "   ", "   ", 'D', matDust });
         }
     }
 

--- a/src/main/java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechConduits.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechConduits.java
@@ -708,6 +708,7 @@ public class GregtechConduits {
             if (pipePlateDouble != null) {
                 GTModHandler.addCraftingRecipe(
                     ItemUtils.getItemStackOfAmountFromOreDict("pipe" + "Huge" + output, 1),
+                    GTModHandler.RecipeBits.BUFFERED,
                     new Object[] { "DhD", "D D", "DwD", 'D', pipePlateDouble.copy() });
             }
         }
@@ -791,7 +792,10 @@ public class GregtechConduits {
         // Adds manual crafting recipe
         if (ItemUtils.checkForInvalidItems(new ItemStack[] { aPlate, aWire01 })
             && aMaterial.vVoltageMultiplier < 7680) {
-            GTModHandler.addCraftingRecipe(aWire01, new Object[] { "Px ", "   ", "   ", 'P', aPlate });
+            GTModHandler.addCraftingRecipe(
+                aWire01,
+                GTModHandler.RecipeBits.BUFFERED,
+                new Object[] { "Px ", "   ", "   ", 'P', aPlate });
         }
 
         // Wire mill
@@ -944,68 +948,105 @@ public class GregtechConduits {
         // Shapeless Down-Crafting
         // 2x
         if (ItemUtils.checkForInvalidItems(new ItemStack[] { aWire01, aWire02 })) {
-            GTModHandler.addShapelessCraftingRecipe(aMaterial.getWire01(2), new ItemStack[] { aWire02 });
+            GTModHandler.addShapelessCraftingRecipe(
+                aMaterial.getWire01(2),
+                GTModHandler.RecipeBits.BUFFERED,
+                new ItemStack[] { aWire02 });
         }
 
         // 4x
         if (ItemUtils.checkForInvalidItems(new ItemStack[] { aWire01, aWire04 })) {
-            GTModHandler.addShapelessCraftingRecipe(aMaterial.getWire01(4), new ItemStack[] { aWire04 });
+            GTModHandler.addShapelessCraftingRecipe(
+                aMaterial.getWire01(4),
+                GTModHandler.RecipeBits.BUFFERED,
+                new ItemStack[] { aWire04 });
         }
 
         // 8x
         if (ItemUtils.checkForInvalidItems(new ItemStack[] { aWire01, aWire08 })) {
-            GTModHandler.addShapelessCraftingRecipe(aMaterial.getWire01(8), new ItemStack[] { aWire08 });
+            GTModHandler.addShapelessCraftingRecipe(
+                aMaterial.getWire01(8),
+                GTModHandler.RecipeBits.BUFFERED,
+                new ItemStack[] { aWire08 });
         }
 
         // 12x
         if (ItemUtils.checkForInvalidItems(new ItemStack[] { aWire01, aWire12 })) {
-            GTModHandler.addShapelessCraftingRecipe(aMaterial.getWire01(12), new ItemStack[] { aWire12 });
+            GTModHandler.addShapelessCraftingRecipe(
+                aMaterial.getWire01(12),
+                GTModHandler.RecipeBits.BUFFERED,
+                new ItemStack[] { aWire12 });
         }
 
         // 16x
         if (ItemUtils.checkForInvalidItems(new ItemStack[] { aWire01, aWire16 })) {
-            GTModHandler.addShapelessCraftingRecipe(aMaterial.getWire01(16), new ItemStack[] { aWire16 });
+            GTModHandler.addShapelessCraftingRecipe(
+                aMaterial.getWire01(16),
+                GTModHandler.RecipeBits.BUFFERED,
+                new ItemStack[] { aWire16 });
         }
 
         // 1x -> 2x
         if (ItemUtils.checkForInvalidItems(new ItemStack[] { aWire01, aWire02 })) {
-            GTModHandler.addShapelessCraftingRecipe(aWire02, new ItemStack[] { aWire01, aWire01 });
+            GTModHandler.addShapelessCraftingRecipe(
+                aWire02,
+                GTModHandler.RecipeBits.BUFFERED,
+                new ItemStack[] { aWire01, aWire01 });
         }
 
         // 2x -> 4x
         if (ItemUtils.checkForInvalidItems(new ItemStack[] { aWire02, aWire04 })) {
-            GTModHandler.addShapelessCraftingRecipe(aWire04, new ItemStack[] { aWire02, aWire02 });
+            GTModHandler.addShapelessCraftingRecipe(
+                aWire04,
+                GTModHandler.RecipeBits.BUFFERED,
+                new ItemStack[] { aWire02, aWire02 });
         }
 
         // 4x -> 8x
         if (ItemUtils.checkForInvalidItems(new ItemStack[] { aWire04, aWire08 })) {
-            GTModHandler.addShapelessCraftingRecipe(aWire08, new ItemStack[] { aWire04, aWire04 });
+            GTModHandler.addShapelessCraftingRecipe(
+                aWire08,
+                GTModHandler.RecipeBits.BUFFERED,
+                new ItemStack[] { aWire04, aWire04 });
         }
 
         // 8x -> 12x
         if (ItemUtils.checkForInvalidItems(new ItemStack[] { aWire04, aWire08, aWire12 })) {
-            GTModHandler.addShapelessCraftingRecipe(aWire12, new ItemStack[] { aWire04, aWire08 });
+            GTModHandler.addShapelessCraftingRecipe(
+                aWire12,
+                GTModHandler.RecipeBits.BUFFERED,
+                new ItemStack[] { aWire04, aWire08 });
         }
 
         // 12x -> 16x
         if (ItemUtils.checkForInvalidItems(new ItemStack[] { aWire04, aWire12, aWire16 })) {
-            GTModHandler.addShapelessCraftingRecipe(aWire16, new ItemStack[] { aWire04, aWire12 });
+            GTModHandler.addShapelessCraftingRecipe(
+                aWire16,
+                GTModHandler.RecipeBits.BUFFERED,
+                new ItemStack[] { aWire04, aWire12 });
         }
 
         // 8x -> 16x
         if (ItemUtils.checkForInvalidItems(new ItemStack[] { aWire08, aWire16 })) {
-            GTModHandler.addShapelessCraftingRecipe(aWire16, new ItemStack[] { aWire08, aWire08 });
+            GTModHandler.addShapelessCraftingRecipe(
+                aWire16,
+                GTModHandler.RecipeBits.BUFFERED,
+                new ItemStack[] { aWire08, aWire08 });
         }
 
         // 1x -> 4x
         if (ItemUtils.checkForInvalidItems(new ItemStack[] { aWire01, aWire04 })) {
-            GTModHandler.addShapelessCraftingRecipe(aWire04, new ItemStack[] { aWire01, aWire01, aWire01, aWire01 });
+            GTModHandler.addShapelessCraftingRecipe(
+                aWire04,
+                GTModHandler.RecipeBits.BUFFERED,
+                new ItemStack[] { aWire01, aWire01, aWire01, aWire01 });
         }
 
         // 1x -> 8x
         if (ItemUtils.checkForInvalidItems(new ItemStack[] { aWire01, aWire08 })) {
             GTModHandler.addShapelessCraftingRecipe(
                 aWire08,
+                GTModHandler.RecipeBits.BUFFERED,
                 new ItemStack[] { aWire01, aWire01, aWire01, aWire01, aWire01, aWire01, aWire01, aWire01 });
         }
 

--- a/src/main/java/gtPlusPlus/xmod/ic2/recipe/RecipeIC2.java
+++ b/src/main/java/gtPlusPlus/xmod/ic2/recipe/RecipeIC2.java
@@ -28,15 +28,19 @@ public class RecipeIC2 {
         // Rotor Blades
         GTModHandler.addCraftingRecipe(
             GregtechItemList.EnergeticAlloyRotorBlade.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PPP", "PRP", "PPP", 'P', "plateEnergeticAlloy", 'R', "ringStainlessSteel" });
         GTModHandler.addCraftingRecipe(
             GregtechItemList.TungstenSteelRotorBlade.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PPP", "PRP", "PPP", 'P', "plateTungstenSteel", 'R', "ringTungstenSteel" });
         GTModHandler.addCraftingRecipe(
             GregtechItemList.VibrantAlloyRotorBlade.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PPP", "PRP", "PPP", 'P', "plateVibrantAlloy", 'R', "ringChrome" });
         GTModHandler.addCraftingRecipe(
             GregtechItemList.IridiumRotorBlade.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "PPP", "PRP", "PPP", 'P', "plateAlloyIridium", 'R', "ringOsmiridium" });
 
         // Shaft Extruder Shape
@@ -131,18 +135,22 @@ public class RecipeIC2 {
         // Gearbox Rotors
         GTModHandler.addCraftingRecipe(
             GregtechItemList.EnergeticAlloyRotor.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "SBh", "BRB", "wBS", 'B', GregtechItemList.EnergeticAlloyRotorBlade.get(1), 'R',
                 "ringStainlessSteel", 'S', GregtechItemList.EnergeticAlloyShaft.get(1) });
         GTModHandler.addCraftingRecipe(
             GregtechItemList.TungstenSteelRotor.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "SBh", "BRB", "wBS", 'B', GregtechItemList.TungstenSteelRotorBlade.get(1), 'R',
                 "ringTungstenSteel", 'S', GregtechItemList.TungstenSteelShaft.get(1) });
         GTModHandler.addCraftingRecipe(
             GregtechItemList.VibrantAlloyRotor.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "SBh", "BRB", "wBS", 'B', GregtechItemList.VibrantAlloyRotorBlade.get(1), 'R', "ringChrome",
                 'S', GregtechItemList.VibrantAlloyShaft.get(1) });
         GTModHandler.addCraftingRecipe(
             GregtechItemList.IridiumRotor.get(1),
+            GTModHandler.RecipeBits.BUFFERED,
             new Object[] { "SBh", "BRB", "wBS", 'B', GregtechItemList.IridiumRotorBlade.get(1), 'R', "ringOsmiridium",
                 'S', GregtechItemList.IridiumShaft.get(1) });
     }


### PR DESCRIPTION
Buffered every recipe and compared recipe dumps after every commit

There is a tiny regression: these 4 dusts now have duplicate recipes for small and tiny piles
`AmmoniumNitrate`, `AncientGranite`, `Runite`, `SodiumNitrate`
and `Huge Clay Fluid Pipe` got 6th duplicate recipe (there were only 5 before)

Fair cost for faster loading i'd say