### PR TITLE
Fix steam multis being locked to void mode

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/MTESteamMultiBlockBase.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/MTESteamMultiBlockBase.java
@@ -460,6 +460,11 @@ public abstract class MTESteamMultiBlockBase<T extends MTESteamMultiBlockBase<T>
     }
 
     @Override
+    public boolean supportsVoidProtection() {
+        return true;
+    }
+
+    @Override
     public void clearHatches() {
         super.clearHatches();
         mInputHatches.clear();


### PR DESCRIPTION
Override supportsVoidProtection() to return true in MTESteamMultiBlockBase. Previously inherited from GTPPMultiBlockBase, but that inheritance was removed in #6160, causing steam multis to fall back to the false default.
Fixes GTNewHorizons/GT-New-Horizons-Modpack#24376
