### PR TITLE
Deprecate Buffered Dynamo and allow 4A TT Hatches

### DIFF
--- a/src/main/java/gregtech/api/enums/MetaTileEntityIDs.java
+++ b/src/main/java/gregtech/api/enums/MetaTileEntityIDs.java
@@ -1658,6 +1658,7 @@ public enum MetaTileEntityIDs {
     UIV256AtLaserSourceHatch(15236),
     UMV256AtLaserSourceHatch(15237),
     UXV256AtLaserSourceHatch(15238),
+    HV4ADynamoHatch(15239),
     LuV1024AtLaserSourceHatch(15241),
     ZPM1024AtLaserSourceHatch(15242),
     UV1024AtLaserSourceHatch(15243),

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
@@ -2132,7 +2132,7 @@ public abstract class MTEMultiBlockBase extends MetaTileEntity
         if (aTileEntity == null) return false;
         IMetaTileEntity aMetaTileEntity = aTileEntity.getMetaTileEntity();
         if (aMetaTileEntity == null) return false;
-        if (aMetaTileEntity instanceof MTEHatchDynamo hatch) {
+        if (aMetaTileEntity instanceof MTEHatchDynamo hatch && hatch.maxAmperesOut() <= 4) {
             hatch.updateTexture(aBaseCasingIndex);
             hatch.updateCraftingIcon(this.getMachineCraftingIcon());
             return mDynamoHatches.add(hatch);

--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/MTEHatchDynamoBuffer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/MTEHatchDynamoBuffer.java
@@ -1,5 +1,9 @@
 package gtPlusPlus.xmod.gregtech.api.metatileentity.implementations;
 
+import net.minecraft.util.StatCollector;
+
+import org.apache.commons.lang3.ArrayUtils;
+
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.Textures;
 import gregtech.api.interfaces.ITexture;
@@ -8,8 +12,6 @@ import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.implementations.MTEHatchDynamo;
 import gtPlusPlus.core.util.Utils;
-import net.minecraft.util.StatCollector;
-import org.apache.commons.lang3.ArrayUtils;
 
 @IMetaTileEntity.SkipGenerateDescription
 @Deprecated // Remove in 2.10
@@ -51,10 +53,12 @@ public class MTEHatchDynamoBuffer extends MTEHatchDynamo {
 
     @Override
     public String[] getDescription() {
-        return ArrayUtils.addAll(Utils.splitLocalizedFormattedWithAlkalus(
-            "gt.blockmachines.dynamo_hatch_buffer.desc",
-            this.maxEUOutput() * this.maxAmperesIn()),
-            StatCollector.translateToLocalFormatted("GT5U.MBTT.Deprecated",
+        return ArrayUtils.addAll(
+            Utils.splitLocalizedFormattedWithAlkalus(
+                "gt.blockmachines.dynamo_hatch_buffer.desc",
+                this.maxEUOutput() * this.maxAmperesIn()),
+            StatCollector.translateToLocalFormatted(
+                "GT5U.MBTT.Deprecated",
                 StatCollector.translateToLocal("GT5U.MBTT.Deprecated.RemovalMachine")));
     }
 

--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/MTEHatchDynamoBuffer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/MTEHatchDynamoBuffer.java
@@ -8,8 +8,11 @@ import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.implementations.MTEHatchDynamo;
 import gtPlusPlus.core.util.Utils;
+import net.minecraft.util.StatCollector;
+import org.apache.commons.lang3.ArrayUtils;
 
 @IMetaTileEntity.SkipGenerateDescription
+@Deprecated // Remove in 2.10
 public class MTEHatchDynamoBuffer extends MTEHatchDynamo {
 
     public MTEHatchDynamoBuffer(final int aID, final String aName, final String aNameRegional, final int aTier) {
@@ -48,9 +51,11 @@ public class MTEHatchDynamoBuffer extends MTEHatchDynamo {
 
     @Override
     public String[] getDescription() {
-        return Utils.splitLocalizedFormattedWithAlkalus(
+        return ArrayUtils.addAll(Utils.splitLocalizedFormattedWithAlkalus(
             "gt.blockmachines.dynamo_hatch_buffer.desc",
-            this.maxEUOutput() * this.maxAmperesIn());
+            this.maxEUOutput() * this.maxAmperesIn()),
+            StatCollector.translateToLocalFormatted("GT5U.MBTT.Deprecated",
+                StatCollector.translateToLocal("GT5U.MBTT.Deprecated.RemovalMachine")));
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechBufferDynamos.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechBufferDynamos.java
@@ -10,12 +10,7 @@ import static gregtech.api.enums.MetaTileEntityIDs.Hatch_Buffer_Dynamo_MV;
 import static gregtech.api.enums.MetaTileEntityIDs.Hatch_Buffer_Dynamo_ULV;
 import static gregtech.api.enums.MetaTileEntityIDs.Hatch_Buffer_Dynamo_UV;
 import static gregtech.api.enums.MetaTileEntityIDs.Hatch_Buffer_Dynamo_ZPM;
-import static gregtech.api.util.GTModHandler.RecipeBits.BITS;
-import static gregtech.api.util.GTModHandler.RecipeBits.BITSD;
 
-import gregtech.api.enums.ItemList;
-import gregtech.api.enums.Materials;
-import gregtech.api.enums.OrePrefixes;
 import gregtech.api.util.GTModHandler;
 import gtPlusPlus.xmod.gregtech.api.enums.GregtechItemList;
 import gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.MTEHatchDynamoBuffer;
@@ -91,21 +86,21 @@ public class GregtechBufferDynamos {
         // Conversion Recipes, to be removed in 2.10 (alongside this whole class).
         GTModHandler.addShapelessCraftingRecipe(
             CustomItemList.eM_dynamoMulti4_HV.get(1L),
-            new Object[] {GregtechItemList.Hatch_Buffer_Dynamo_HV.get(1L)});
+            new Object[] { GregtechItemList.Hatch_Buffer_Dynamo_HV.get(1L) });
         GTModHandler.addShapelessCraftingRecipe(
             CustomItemList.eM_dynamoMulti4_EV.get(1L),
-            new Object[] {GregtechItemList.Hatch_Buffer_Dynamo_EV.get(1L)});
+            new Object[] { GregtechItemList.Hatch_Buffer_Dynamo_EV.get(1L) });
         GTModHandler.addShapelessCraftingRecipe(
             CustomItemList.eM_dynamoMulti4_IV.get(1L),
-            new Object[] {GregtechItemList.Hatch_Buffer_Dynamo_IV.get(1L)});
+            new Object[] { GregtechItemList.Hatch_Buffer_Dynamo_IV.get(1L) });
         GTModHandler.addShapelessCraftingRecipe(
             CustomItemList.eM_dynamoMulti4_LuV.get(1L),
-            new Object[] {GregtechItemList.Hatch_Buffer_Dynamo_LuV.get(1L)});
+            new Object[] { GregtechItemList.Hatch_Buffer_Dynamo_LuV.get(1L) });
         GTModHandler.addShapelessCraftingRecipe(
             CustomItemList.eM_dynamoMulti4_ZPM.get(1L),
-            new Object[] {GregtechItemList.Hatch_Buffer_Dynamo_ZPM.get(1L)});
+            new Object[] { GregtechItemList.Hatch_Buffer_Dynamo_ZPM.get(1L) });
         GTModHandler.addShapelessCraftingRecipe(
             CustomItemList.eM_dynamoMulti4_UV.get(1L),
-            new Object[] {GregtechItemList.Hatch_Buffer_Dynamo_UV.get(1L)});
+            new Object[] { GregtechItemList.Hatch_Buffer_Dynamo_UV.get(1L) });
     }
 }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechBufferDynamos.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechBufferDynamos.java
@@ -10,6 +10,7 @@ import static gregtech.api.enums.MetaTileEntityIDs.Hatch_Buffer_Dynamo_MV;
 import static gregtech.api.enums.MetaTileEntityIDs.Hatch_Buffer_Dynamo_ULV;
 import static gregtech.api.enums.MetaTileEntityIDs.Hatch_Buffer_Dynamo_UV;
 import static gregtech.api.enums.MetaTileEntityIDs.Hatch_Buffer_Dynamo_ZPM;
+import static gregtech.api.util.GTModHandler.RecipeBits.BITS;
 import static gregtech.api.util.GTModHandler.RecipeBits.BITSD;
 
 import gregtech.api.enums.ItemList;
@@ -18,6 +19,7 @@ import gregtech.api.enums.OrePrefixes;
 import gregtech.api.util.GTModHandler;
 import gtPlusPlus.xmod.gregtech.api.enums.GregtechItemList;
 import gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.MTEHatchDynamoBuffer;
+import tectech.thing.CustomItemList;
 
 public class GregtechBufferDynamos {
 
@@ -86,55 +88,24 @@ public class GregtechBufferDynamos {
                 "hatch.dynamo.buffer.tier.09",
                 "UHV Dynamo Hatch [Buffered]",
                 9).getStackForm(1L));
-        GTModHandler.addCraftingRecipe(
-            GregtechItemList.Hatch_Buffer_Dynamo_ULV.get(1L),
-            BITSD,
-            new Object[] { "TMC", 'M', ItemList.Hatch_Dynamo_ULV, 'T', "circuitPrimitive", 'C',
-                OrePrefixes.cableGt04.get(Materials.Lead) });
-        GTModHandler.addCraftingRecipe(
-            GregtechItemList.Hatch_Buffer_Dynamo_LV.get(1L),
-            BITSD,
-            new Object[] { "TMC", 'M', ItemList.Hatch_Dynamo_LV, 'T', "circuitBasic", 'C',
-                OrePrefixes.cableGt04.get(Materials.Tin) });
-        GTModHandler.addCraftingRecipe(
-            GregtechItemList.Hatch_Buffer_Dynamo_MV.get(1L),
-            BITSD,
-            new Object[] { "TMC", 'M', ItemList.Hatch_Dynamo_MV, 'T', "circuitGood", 'C',
-                OrePrefixes.cableGt04.get(Materials.AnyCopper) });
-        GTModHandler.addCraftingRecipe(
-            GregtechItemList.Hatch_Buffer_Dynamo_HV.get(1L),
-            BITSD,
-            new Object[] { "TMC", 'M', ItemList.Hatch_Dynamo_HV, 'T', "circuitAdvanced", 'C',
-                OrePrefixes.cableGt04.get(Materials.Gold) });
-        GTModHandler.addCraftingRecipe(
-            GregtechItemList.Hatch_Buffer_Dynamo_EV.get(1L),
-            BITSD,
-            new Object[] { "TMC", 'M', ItemList.Hatch_Dynamo_EV, 'T', "circuitData", 'C',
-                OrePrefixes.cableGt04.get(Materials.Aluminium) });
-        GTModHandler.addCraftingRecipe(
-            GregtechItemList.Hatch_Buffer_Dynamo_IV.get(1L),
-            BITSD,
-            new Object[] { "TMC", 'M', ItemList.Hatch_Dynamo_IV, 'T', "circuitElite", 'C',
-                OrePrefixes.cableGt04.get(Materials.Tungsten) });
-        GTModHandler.addCraftingRecipe(
-            GregtechItemList.Hatch_Buffer_Dynamo_LuV.get(1L),
-            BITSD,
-            new Object[] { "TMC", 'M', ItemList.Hatch_Dynamo_LuV, 'T', "circuitMaster", 'C',
-                OrePrefixes.cableGt04.get(Materials.VanadiumGallium) });
-        GTModHandler.addCraftingRecipe(
-            GregtechItemList.Hatch_Buffer_Dynamo_ZPM.get(1L),
-            BITSD,
-            new Object[] { "TMC", 'M', ItemList.Hatch_Dynamo_ZPM, 'T', "circuitUltimate", 'C',
-                OrePrefixes.cableGt04.get(Materials.Naquadah) });
-        GTModHandler.addCraftingRecipe(
-            GregtechItemList.Hatch_Buffer_Dynamo_UV.get(1L),
-            BITSD,
-            new Object[] { "TMC", 'M', ItemList.Hatch_Dynamo_UV, 'T', "circuitSuperconductor", 'C',
-                OrePrefixes.wireGt12.get(Materials.NaquadahAlloy) });
-        GTModHandler.addCraftingRecipe(
-            GregtechItemList.Hatch_Buffer_Dynamo_MAX.get(1L),
-            BITSD,
-            new Object[] { "TMC", 'M', ItemList.Hatch_Dynamo_UHV, 'T', "circuitInfinite", 'C',
-                OrePrefixes.wireGt04.get(Materials.SuperconductorUHV) });
+        // Conversion Recipes, to be removed in 2.10 (alongside this whole class).
+        GTModHandler.addShapelessCraftingRecipe(
+            CustomItemList.eM_dynamoMulti4_HV.get(1L),
+            new Object[] {GregtechItemList.Hatch_Buffer_Dynamo_HV.get(1L)});
+        GTModHandler.addShapelessCraftingRecipe(
+            CustomItemList.eM_dynamoMulti4_EV.get(1L),
+            new Object[] {GregtechItemList.Hatch_Buffer_Dynamo_EV.get(1L)});
+        GTModHandler.addShapelessCraftingRecipe(
+            CustomItemList.eM_dynamoMulti4_IV.get(1L),
+            new Object[] {GregtechItemList.Hatch_Buffer_Dynamo_IV.get(1L)});
+        GTModHandler.addShapelessCraftingRecipe(
+            CustomItemList.eM_dynamoMulti4_LuV.get(1L),
+            new Object[] {GregtechItemList.Hatch_Buffer_Dynamo_LuV.get(1L)});
+        GTModHandler.addShapelessCraftingRecipe(
+            CustomItemList.eM_dynamoMulti4_ZPM.get(1L),
+            new Object[] {GregtechItemList.Hatch_Buffer_Dynamo_ZPM.get(1L)});
+        GTModHandler.addShapelessCraftingRecipe(
+            CustomItemList.eM_dynamoMulti4_UV.get(1L),
+            new Object[] {GregtechItemList.Hatch_Buffer_Dynamo_UV.get(1L)});
     }
 }

--- a/src/main/java/tectech/loader/recipe/Assembler.java
+++ b/src/main/java/tectech/loader/recipe/Assembler.java
@@ -230,6 +230,17 @@ public class Assembler implements Runnable {
         {
             // Dynamo Hatches 4A
             {
+                // Dynamo HV 4A
+                GTValues.RA.stdBuilder()
+                    .itemInputs(
+                        ItemList.Hatch_Dynamo_HV.get(1),
+                        GTOreDictUnificator.get(OrePrefixes.wireGt04, Materials.Gold, 2),
+                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.StainlessSteel, 2))
+                    .itemOutputs(CustomItemList.eM_dynamoMulti4_HV.get(1))
+                    .fluidInputs(Materials.Kanthal.getMolten(1 * INGOTS))
+                    .duration(5 * SECONDS)
+                    .eut(TierEU.RECIPE_MV)
+                    .addTo(assemblerRecipes);
                 // Dynamo EV 4A
                 GTValues.RA.stdBuilder()
                     .itemInputs(

--- a/src/main/java/tectech/loader/thing/MachineLoader.java
+++ b/src/main/java/tectech/loader/thing/MachineLoader.java
@@ -1343,7 +1343,7 @@ public class MachineLoader implements Runnable {
         // Multi AMP Power OUTPUTS
         // ===================================================================================================
         eM_dynamoMulti4_HV.set(
-            new MTEHatchDynamoMulti(HV4ADynamoHatch.ID, "hatch.dynamomulti04.tier.03", "HV 4A Dynamo Hatch", 4, 4)
+            new MTEHatchDynamoMulti(HV4ADynamoHatch.ID, "hatch.dynamomulti04.tier.03", "HV 4A Dynamo Hatch", 3, 4)
                 .getStackForm(1L));
         eM_dynamoMulti4_EV.set(
             new MTEHatchDynamoMulti(EV4ADynamoHatch.ID, "hatch.dynamomulti04.tier.04", "EV 4A Dynamo Hatch", 4, 4)

--- a/src/main/java/tectech/loader/thing/MachineLoader.java
+++ b/src/main/java/tectech/loader/thing/MachineLoader.java
@@ -40,6 +40,7 @@ import static gregtech.api.enums.MetaTileEntityIDs.ExtendedMegaUltimateBuckConve
 import static gregtech.api.enums.MetaTileEntityIDs.ExtremelyUltimateBuckConverter;
 import static gregtech.api.enums.MetaTileEntityIDs.EyeofHarmony;
 import static gregtech.api.enums.MetaTileEntityIDs.ForgeoftheGods;
+import static gregtech.api.enums.MetaTileEntityIDs.HV4ADynamoHatch;
 import static gregtech.api.enums.MetaTileEntityIDs.HelioflarePowerForge;
 import static gregtech.api.enums.MetaTileEntityIDs.HeliofluxMeltingCore;
 import static gregtech.api.enums.MetaTileEntityIDs.HeliofusionExoticizer;
@@ -347,6 +348,7 @@ import static tectech.thing.CustomItemList.eM_dynamoMulti256_UMV;
 import static tectech.thing.CustomItemList.eM_dynamoMulti256_UV;
 import static tectech.thing.CustomItemList.eM_dynamoMulti256_UXV;
 import static tectech.thing.CustomItemList.eM_dynamoMulti4_EV;
+import static tectech.thing.CustomItemList.eM_dynamoMulti4_HV;
 import static tectech.thing.CustomItemList.eM_dynamoMulti4_IV;
 import static tectech.thing.CustomItemList.eM_dynamoMulti4_LuV;
 import static tectech.thing.CustomItemList.eM_dynamoMulti4_UEV;
@@ -1340,6 +1342,9 @@ public class MachineLoader implements Runnable {
         // ===================================================================================================
         // Multi AMP Power OUTPUTS
         // ===================================================================================================
+        eM_dynamoMulti4_HV.set(
+            new MTEHatchDynamoMulti(HV4ADynamoHatch.ID, "hatch.dynamomulti04.tier.03", "HV 4A Dynamo Hatch", 4, 4)
+                .getStackForm(1L));
         eM_dynamoMulti4_EV.set(
             new MTEHatchDynamoMulti(EV4ADynamoHatch.ID, "hatch.dynamomulti04.tier.04", "EV 4A Dynamo Hatch", 4, 4)
                 .getStackForm(1L));

--- a/src/main/java/tectech/loader/thing/MachineLoader.java
+++ b/src/main/java/tectech/loader/thing/MachineLoader.java
@@ -539,15 +539,13 @@ import static tectech.thing.CustomItemList.hatch_CreativeUncertainty;
 import static tectech.thing.CustomItemList.holder_Hatch;
 import static tectech.thing.CustomItemList.rack_Hatch;
 
-import gregtech.api.enums.GTValues;
-import gregtech.api.enums.VoltageIndex;
-import gregtech.client.GTTooltipHandler;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.launchwrapper.Launch;
 
 import gregtech.api.enums.GTAuthors;
 import gregtech.api.enums.MetaTileEntityIDs;
+import gregtech.api.enums.VoltageIndex;
 import gregtech.api.factory.test.TestFactoryHatch;
 import gregtech.api.factory.test.TestFactoryPipe;
 import tectech.thing.metaTileEntity.hatch.MTEHatchCapacitor;
@@ -1346,53 +1344,117 @@ public class MachineLoader implements Runnable {
         // Multi AMP Power OUTPUTS
         // ===================================================================================================
         eM_dynamoMulti4_HV.set(
-            new MTEHatchDynamoMulti(HV4ADynamoHatch.ID, "hatch.dynamomulti04.tier.03", "HV 4A Dynamo Hatch", VoltageIndex.HV, 4)
-                .getStackForm(1L));
+            new MTEHatchDynamoMulti(
+                HV4ADynamoHatch.ID,
+                "hatch.dynamomulti04.tier.03",
+                "HV 4A Dynamo Hatch",
+                VoltageIndex.HV,
+                4).getStackForm(1L));
         eM_dynamoMulti4_EV.set(
-            new MTEHatchDynamoMulti(EV4ADynamoHatch.ID, "hatch.dynamomulti04.tier.04", "EV 4A Dynamo Hatch", VoltageIndex.EV, 4)
-                .getStackForm(1L));
+            new MTEHatchDynamoMulti(
+                EV4ADynamoHatch.ID,
+                "hatch.dynamomulti04.tier.04",
+                "EV 4A Dynamo Hatch",
+                VoltageIndex.EV,
+                4).getStackForm(1L));
         eM_dynamoMulti16_EV.set(
-            new MTEHatchDynamoMulti(EV16ADynamoHatch.ID, "hatch.dynamomulti16.tier.04", "EV 16A Dynamo Hatch", VoltageIndex.EV, 16)
-                .getStackForm(1L));
+            new MTEHatchDynamoMulti(
+                EV16ADynamoHatch.ID,
+                "hatch.dynamomulti16.tier.04",
+                "EV 16A Dynamo Hatch",
+                VoltageIndex.EV,
+                16).getStackForm(1L));
         eM_dynamoMulti64_EV.set(
-            new MTEHatchDynamoMulti(EV64ADynamoHatch.ID, "hatch.dynamomulti64.tier.04", "EV 64A Dynamo Hatch", VoltageIndex.EV, 64)
-                .getStackForm(1L));
+            new MTEHatchDynamoMulti(
+                EV64ADynamoHatch.ID,
+                "hatch.dynamomulti64.tier.04",
+                "EV 64A Dynamo Hatch",
+                VoltageIndex.EV,
+                64).getStackForm(1L));
         eM_dynamoMulti4_IV.set(
-            new MTEHatchDynamoMulti(IV4ADynamoHatch.ID, "hatch.dynamomulti04.tier.05", "IV 4A Dynamo Hatch", VoltageIndex.IV, 4)
-                .getStackForm(1L));
+            new MTEHatchDynamoMulti(
+                IV4ADynamoHatch.ID,
+                "hatch.dynamomulti04.tier.05",
+                "IV 4A Dynamo Hatch",
+                VoltageIndex.IV,
+                4).getStackForm(1L));
         eM_dynamoMulti16_IV.set(
-            new MTEHatchDynamoMulti(IV16ADynamoHatch.ID, "hatch.dynamomulti16.tier.05", "IV 16A Dynamo Hatch", VoltageIndex.IV, 16)
-                .getStackForm(1L));
+            new MTEHatchDynamoMulti(
+                IV16ADynamoHatch.ID,
+                "hatch.dynamomulti16.tier.05",
+                "IV 16A Dynamo Hatch",
+                VoltageIndex.IV,
+                16).getStackForm(1L));
         eM_dynamoMulti64_IV.set(
-            new MTEHatchDynamoMulti(IV64ADynamoHatch.ID, "hatch.dynamomulti64.tier.05", "IV 64A Dynamo Hatch", VoltageIndex.IV, 64)
-                .getStackForm(1L));
+            new MTEHatchDynamoMulti(
+                IV64ADynamoHatch.ID,
+                "hatch.dynamomulti64.tier.05",
+                "IV 64A Dynamo Hatch",
+                VoltageIndex.IV,
+                64).getStackForm(1L));
         eM_dynamoMulti4_LuV.set(
-            new MTEHatchDynamoMulti(LuV4ADynamoHatch.ID, "hatch.dynamomulti04.tier.06", "LuV 4A Dynamo Hatch", VoltageIndex.LuV, 4)
-                .getStackForm(1L));
+            new MTEHatchDynamoMulti(
+                LuV4ADynamoHatch.ID,
+                "hatch.dynamomulti04.tier.06",
+                "LuV 4A Dynamo Hatch",
+                VoltageIndex.LuV,
+                4).getStackForm(1L));
         eM_dynamoMulti16_LuV.set(
-            new MTEHatchDynamoMulti(LuV16ADynamoHatch.ID, "hatch.dynamomulti16.tier.06", "LuV 16A Dynamo Hatch", VoltageIndex.LuV, 16)
-                .getStackForm(1L));
+            new MTEHatchDynamoMulti(
+                LuV16ADynamoHatch.ID,
+                "hatch.dynamomulti16.tier.06",
+                "LuV 16A Dynamo Hatch",
+                VoltageIndex.LuV,
+                16).getStackForm(1L));
         eM_dynamoMulti64_LuV.set(
-            new MTEHatchDynamoMulti(LuV64ADynamoHatch.ID, "hatch.dynamomulti64.tier.06", "LuV 64A Dynamo Hatch", VoltageIndex.LuV, 64)
-                .getStackForm(1L));
+            new MTEHatchDynamoMulti(
+                LuV64ADynamoHatch.ID,
+                "hatch.dynamomulti64.tier.06",
+                "LuV 64A Dynamo Hatch",
+                VoltageIndex.LuV,
+                64).getStackForm(1L));
         eM_dynamoMulti4_ZPM.set(
-            new MTEHatchDynamoMulti(ZPM4ADynamoHatch.ID, "hatch.dynamomulti04.tier.07", "ZPM 4A Dynamo Hatch", VoltageIndex.ZPM, 4)
-                .getStackForm(1L));
+            new MTEHatchDynamoMulti(
+                ZPM4ADynamoHatch.ID,
+                "hatch.dynamomulti04.tier.07",
+                "ZPM 4A Dynamo Hatch",
+                VoltageIndex.ZPM,
+                4).getStackForm(1L));
         eM_dynamoMulti16_ZPM.set(
-            new MTEHatchDynamoMulti(ZPM16ADynamoHatch.ID, "hatch.dynamomulti16.tier.07", "ZPM 16A Dynamo Hatch", VoltageIndex.ZPM, 16)
-                .getStackForm(1L));
+            new MTEHatchDynamoMulti(
+                ZPM16ADynamoHatch.ID,
+                "hatch.dynamomulti16.tier.07",
+                "ZPM 16A Dynamo Hatch",
+                VoltageIndex.ZPM,
+                16).getStackForm(1L));
         eM_dynamoMulti64_ZPM.set(
-            new MTEHatchDynamoMulti(ZPM64ADynamoHatch.ID, "hatch.dynamomulti64.tier.07", "ZPM 64A Dynamo Hatch", VoltageIndex.ZPM, 64)
-                .getStackForm(1L));
+            new MTEHatchDynamoMulti(
+                ZPM64ADynamoHatch.ID,
+                "hatch.dynamomulti64.tier.07",
+                "ZPM 64A Dynamo Hatch",
+                VoltageIndex.ZPM,
+                64).getStackForm(1L));
         eM_dynamoMulti4_UV.set(
-            new MTEHatchDynamoMulti(UV4ADynamoHatch.ID, "hatch.dynamomulti04.tier.08", "UV 4A Dynamo Hatch", VoltageIndex.UV, 4)
-                .getStackForm(1L));
+            new MTEHatchDynamoMulti(
+                UV4ADynamoHatch.ID,
+                "hatch.dynamomulti04.tier.08",
+                "UV 4A Dynamo Hatch",
+                VoltageIndex.UV,
+                4).getStackForm(1L));
         eM_dynamoMulti16_UV.set(
-            new MTEHatchDynamoMulti(UV16ADynamoHatch.ID, "hatch.dynamomulti16.tier.08", "UV 16A Dynamo Hatch", VoltageIndex.UV, 16)
-                .getStackForm(1L));
+            new MTEHatchDynamoMulti(
+                UV16ADynamoHatch.ID,
+                "hatch.dynamomulti16.tier.08",
+                "UV 16A Dynamo Hatch",
+                VoltageIndex.UV,
+                16).getStackForm(1L));
         eM_dynamoMulti64_UV.set(
-            new MTEHatchDynamoMulti(UV64ADynamoHatch.ID, "hatch.dynamomulti64.tier.08", "UV 64A Dynamo Hatch", VoltageIndex.UV, 64)
-                .getStackForm(1L));
+            new MTEHatchDynamoMulti(
+                UV64ADynamoHatch.ID,
+                "hatch.dynamomulti64.tier.08",
+                "UV 64A Dynamo Hatch",
+                VoltageIndex.UV,
+                64).getStackForm(1L));
         eM_dynamoMulti256_UV.set(
             new MTEHatchDynamoMulti(
                 UV256ADynamoHatch.ID,
@@ -1401,14 +1463,26 @@ public class MachineLoader implements Runnable {
                 VoltageIndex.UV,
                 256).getStackForm(1L));
         eM_dynamoMulti4_UHV.set(
-            new MTEHatchDynamoMulti(UHV4ADynamoHatch.ID, "hatch.dynamomulti04.tier.09", "UHV 4A Dynamo Hatch", VoltageIndex.UHV, 4)
-                .getStackForm(1L));
+            new MTEHatchDynamoMulti(
+                UHV4ADynamoHatch.ID,
+                "hatch.dynamomulti04.tier.09",
+                "UHV 4A Dynamo Hatch",
+                VoltageIndex.UHV,
+                4).getStackForm(1L));
         eM_dynamoMulti16_UHV.set(
-            new MTEHatchDynamoMulti(UHV16ADynamoHatch.ID, "hatch.dynamomulti16.tier.09", "UHV 16A Dynamo Hatch", VoltageIndex.UHV, 16)
-                .getStackForm(1L));
+            new MTEHatchDynamoMulti(
+                UHV16ADynamoHatch.ID,
+                "hatch.dynamomulti16.tier.09",
+                "UHV 16A Dynamo Hatch",
+                VoltageIndex.UHV,
+                16).getStackForm(1L));
         eM_dynamoMulti64_UHV.set(
-            new MTEHatchDynamoMulti(UHV64ADynamoHatch.ID, "hatch.dynamomulti64.tier.09", "UHV 64A Dynamo Hatch", VoltageIndex.UHV, 64)
-                .getStackForm(1L));
+            new MTEHatchDynamoMulti(
+                UHV64ADynamoHatch.ID,
+                "hatch.dynamomulti64.tier.09",
+                "UHV 64A Dynamo Hatch",
+                VoltageIndex.UHV,
+                64).getStackForm(1L));
         eM_dynamoMulti256_UHV.set(
             new MTEHatchDynamoMulti(
                 UHV256ADynamoHatch.ID,
@@ -1417,14 +1491,26 @@ public class MachineLoader implements Runnable {
                 VoltageIndex.UHV,
                 256).getStackForm(1L));
         eM_dynamoMulti4_UEV.set(
-            new MTEHatchDynamoMulti(UEV4ADynamoHatch.ID, "hatch.dynamomulti04.tier.10", "UEV 4A Dynamo Hatch", VoltageIndex.UEV, 4)
-                .getStackForm(1L));
+            new MTEHatchDynamoMulti(
+                UEV4ADynamoHatch.ID,
+                "hatch.dynamomulti04.tier.10",
+                "UEV 4A Dynamo Hatch",
+                VoltageIndex.UEV,
+                4).getStackForm(1L));
         eM_dynamoMulti16_UEV.set(
-            new MTEHatchDynamoMulti(UEV16ADynamoHatch.ID, "hatch.dynamomulti16.tier.10", "UEV 16A Dynamo Hatch", VoltageIndex.UEV, 16)
-                .getStackForm(1L));
+            new MTEHatchDynamoMulti(
+                UEV16ADynamoHatch.ID,
+                "hatch.dynamomulti16.tier.10",
+                "UEV 16A Dynamo Hatch",
+                VoltageIndex.UEV,
+                16).getStackForm(1L));
         eM_dynamoMulti64_UEV.set(
-            new MTEHatchDynamoMulti(UEV64ADynamoHatch.ID, "hatch.dynamomulti64.tier.10", "UEV 64A Dynamo Hatch", VoltageIndex.UEV, 64)
-                .getStackForm(1L));
+            new MTEHatchDynamoMulti(
+                UEV64ADynamoHatch.ID,
+                "hatch.dynamomulti64.tier.10",
+                "UEV 64A Dynamo Hatch",
+                VoltageIndex.UEV,
+                64).getStackForm(1L));
         eM_dynamoMulti256_UEV.set(
             new MTEHatchDynamoMulti(
                 UEV256ADynamoHatch.ID,
@@ -1433,14 +1519,26 @@ public class MachineLoader implements Runnable {
                 VoltageIndex.UEV,
                 256).getStackForm(1L));
         eM_dynamoMulti4_UIV.set(
-            new MTEHatchDynamoMulti(UIV4ADynamoHatch.ID, "hatch.dynamomulti04.tier.11", "UIV 4A Dynamo Hatch", VoltageIndex.UIV, 4)
-                .getStackForm(1L));
+            new MTEHatchDynamoMulti(
+                UIV4ADynamoHatch.ID,
+                "hatch.dynamomulti04.tier.11",
+                "UIV 4A Dynamo Hatch",
+                VoltageIndex.UIV,
+                4).getStackForm(1L));
         eM_dynamoMulti16_UIV.set(
-            new MTEHatchDynamoMulti(UIV16ADynamoHatch.ID, "hatch.dynamomulti16.tier.11", "UIV 16A Dynamo Hatch", VoltageIndex.UIV, 16)
-                .getStackForm(1L));
+            new MTEHatchDynamoMulti(
+                UIV16ADynamoHatch.ID,
+                "hatch.dynamomulti16.tier.11",
+                "UIV 16A Dynamo Hatch",
+                VoltageIndex.UIV,
+                16).getStackForm(1L));
         eM_dynamoMulti64_UIV.set(
-            new MTEHatchDynamoMulti(UIV64ADynamoHatch.ID, "hatch.dynamomulti64.tier.11", "UIV 64A Dynamo Hatch", VoltageIndex.UIV, 64)
-                .getStackForm(1L));
+            new MTEHatchDynamoMulti(
+                UIV64ADynamoHatch.ID,
+                "hatch.dynamomulti64.tier.11",
+                "UIV 64A Dynamo Hatch",
+                VoltageIndex.UIV,
+                64).getStackForm(1L));
         eM_dynamoMulti256_UIV.set(
             new MTEHatchDynamoMulti(
                 UIV256ADynamoHatch.ID,
@@ -1449,14 +1547,26 @@ public class MachineLoader implements Runnable {
                 VoltageIndex.UIV,
                 256).getStackForm(1L));
         eM_dynamoMulti4_UMV.set(
-            new MTEHatchDynamoMulti(UMV4ADynamoHatch.ID, "hatch.dynamomulti04.tier.12", "UMV 4A Dynamo Hatch", VoltageIndex.UMV, 4)
-                .getStackForm(1L));
+            new MTEHatchDynamoMulti(
+                UMV4ADynamoHatch.ID,
+                "hatch.dynamomulti04.tier.12",
+                "UMV 4A Dynamo Hatch",
+                VoltageIndex.UMV,
+                4).getStackForm(1L));
         eM_dynamoMulti16_UMV.set(
-            new MTEHatchDynamoMulti(UMV16ADynamoHatch.ID, "hatch.dynamomulti16.tier.12", "UMV 16A Dynamo Hatch", VoltageIndex.UMV, 16)
-                .getStackForm(1L));
+            new MTEHatchDynamoMulti(
+                UMV16ADynamoHatch.ID,
+                "hatch.dynamomulti16.tier.12",
+                "UMV 16A Dynamo Hatch",
+                VoltageIndex.UMV,
+                16).getStackForm(1L));
         eM_dynamoMulti64_UMV.set(
-            new MTEHatchDynamoMulti(UMV64ADynamoHatch.ID, "hatch.dynamomulti64.tier.12", "UMV 64A Dynamo Hatch", VoltageIndex.UMV, 64)
-                .getStackForm(1L));
+            new MTEHatchDynamoMulti(
+                UMV64ADynamoHatch.ID,
+                "hatch.dynamomulti64.tier.12",
+                "UMV 64A Dynamo Hatch",
+                VoltageIndex.UMV,
+                64).getStackForm(1L));
         eM_dynamoMulti256_UMV.set(
             new MTEHatchDynamoMulti(
                 UMV256ADynamoHatch.ID,
@@ -1465,14 +1575,26 @@ public class MachineLoader implements Runnable {
                 VoltageIndex.UMV,
                 256).getStackForm(1L));
         eM_dynamoMulti4_UXV.set(
-            new MTEHatchDynamoMulti(UXV4ADynamoHatch.ID, "hatch.dynamomulti04.tier.13", "UXV 4A Dynamo Hatch", VoltageIndex.UXV, 4)
-                .getStackForm(1L));
+            new MTEHatchDynamoMulti(
+                UXV4ADynamoHatch.ID,
+                "hatch.dynamomulti04.tier.13",
+                "UXV 4A Dynamo Hatch",
+                VoltageIndex.UXV,
+                4).getStackForm(1L));
         eM_dynamoMulti16_UXV.set(
-            new MTEHatchDynamoMulti(UXV16ADynamoHatch.ID, "hatch.dynamomulti16.tier.13", "UXV 16A Dynamo Hatch", VoltageIndex.UXV, 16)
-                .getStackForm(1L));
+            new MTEHatchDynamoMulti(
+                UXV16ADynamoHatch.ID,
+                "hatch.dynamomulti16.tier.13",
+                "UXV 16A Dynamo Hatch",
+                VoltageIndex.UXV,
+                16).getStackForm(1L));
         eM_dynamoMulti64_UXV.set(
-            new MTEHatchDynamoMulti(UXV64ADynamoHatch.ID, "hatch.dynamomulti64.tier.13", "UXV 64A Dynamo Hatch", VoltageIndex.UXV, 64)
-                .getStackForm(1L));
+            new MTEHatchDynamoMulti(
+                UXV64ADynamoHatch.ID,
+                "hatch.dynamomulti64.tier.13",
+                "UXV 64A Dynamo Hatch",
+                VoltageIndex.UXV,
+                64).getStackForm(1L));
         eM_dynamoMulti256_UXV.set(
             new MTEHatchDynamoMulti(
                 UXV256ADynamoHatch.ID,

--- a/src/main/java/tectech/loader/thing/MachineLoader.java
+++ b/src/main/java/tectech/loader/thing/MachineLoader.java
@@ -539,6 +539,9 @@ import static tectech.thing.CustomItemList.hatch_CreativeUncertainty;
 import static tectech.thing.CustomItemList.holder_Hatch;
 import static tectech.thing.CustomItemList.rack_Hatch;
 
+import gregtech.api.enums.GTValues;
+import gregtech.api.enums.VoltageIndex;
+import gregtech.client.GTTooltipHandler;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.launchwrapper.Launch;
@@ -1343,139 +1346,139 @@ public class MachineLoader implements Runnable {
         // Multi AMP Power OUTPUTS
         // ===================================================================================================
         eM_dynamoMulti4_HV.set(
-            new MTEHatchDynamoMulti(HV4ADynamoHatch.ID, "hatch.dynamomulti04.tier.03", "HV 4A Dynamo Hatch", 3, 4)
+            new MTEHatchDynamoMulti(HV4ADynamoHatch.ID, "hatch.dynamomulti04.tier.03", "HV 4A Dynamo Hatch", VoltageIndex.HV, 4)
                 .getStackForm(1L));
         eM_dynamoMulti4_EV.set(
-            new MTEHatchDynamoMulti(EV4ADynamoHatch.ID, "hatch.dynamomulti04.tier.04", "EV 4A Dynamo Hatch", 4, 4)
+            new MTEHatchDynamoMulti(EV4ADynamoHatch.ID, "hatch.dynamomulti04.tier.04", "EV 4A Dynamo Hatch", VoltageIndex.EV, 4)
                 .getStackForm(1L));
         eM_dynamoMulti16_EV.set(
-            new MTEHatchDynamoMulti(EV16ADynamoHatch.ID, "hatch.dynamomulti16.tier.04", "EV 16A Dynamo Hatch", 4, 16)
+            new MTEHatchDynamoMulti(EV16ADynamoHatch.ID, "hatch.dynamomulti16.tier.04", "EV 16A Dynamo Hatch", VoltageIndex.EV, 16)
                 .getStackForm(1L));
         eM_dynamoMulti64_EV.set(
-            new MTEHatchDynamoMulti(EV64ADynamoHatch.ID, "hatch.dynamomulti64.tier.04", "EV 64A Dynamo Hatch", 4, 64)
+            new MTEHatchDynamoMulti(EV64ADynamoHatch.ID, "hatch.dynamomulti64.tier.04", "EV 64A Dynamo Hatch", VoltageIndex.EV, 64)
                 .getStackForm(1L));
         eM_dynamoMulti4_IV.set(
-            new MTEHatchDynamoMulti(IV4ADynamoHatch.ID, "hatch.dynamomulti04.tier.05", "IV 4A Dynamo Hatch", 5, 4)
+            new MTEHatchDynamoMulti(IV4ADynamoHatch.ID, "hatch.dynamomulti04.tier.05", "IV 4A Dynamo Hatch", VoltageIndex.IV, 4)
                 .getStackForm(1L));
         eM_dynamoMulti16_IV.set(
-            new MTEHatchDynamoMulti(IV16ADynamoHatch.ID, "hatch.dynamomulti16.tier.05", "IV 16A Dynamo Hatch", 5, 16)
+            new MTEHatchDynamoMulti(IV16ADynamoHatch.ID, "hatch.dynamomulti16.tier.05", "IV 16A Dynamo Hatch", VoltageIndex.IV, 16)
                 .getStackForm(1L));
         eM_dynamoMulti64_IV.set(
-            new MTEHatchDynamoMulti(IV64ADynamoHatch.ID, "hatch.dynamomulti64.tier.05", "IV 64A Dynamo Hatch", 5, 64)
+            new MTEHatchDynamoMulti(IV64ADynamoHatch.ID, "hatch.dynamomulti64.tier.05", "IV 64A Dynamo Hatch", VoltageIndex.IV, 64)
                 .getStackForm(1L));
         eM_dynamoMulti4_LuV.set(
-            new MTEHatchDynamoMulti(LuV4ADynamoHatch.ID, "hatch.dynamomulti04.tier.06", "LuV 4A Dynamo Hatch", 6, 4)
+            new MTEHatchDynamoMulti(LuV4ADynamoHatch.ID, "hatch.dynamomulti04.tier.06", "LuV 4A Dynamo Hatch", VoltageIndex.LuV, 4)
                 .getStackForm(1L));
         eM_dynamoMulti16_LuV.set(
-            new MTEHatchDynamoMulti(LuV16ADynamoHatch.ID, "hatch.dynamomulti16.tier.06", "LuV 16A Dynamo Hatch", 6, 16)
+            new MTEHatchDynamoMulti(LuV16ADynamoHatch.ID, "hatch.dynamomulti16.tier.06", "LuV 16A Dynamo Hatch", VoltageIndex.LuV, 16)
                 .getStackForm(1L));
         eM_dynamoMulti64_LuV.set(
-            new MTEHatchDynamoMulti(LuV64ADynamoHatch.ID, "hatch.dynamomulti64.tier.06", "LuV 64A Dynamo Hatch", 6, 64)
+            new MTEHatchDynamoMulti(LuV64ADynamoHatch.ID, "hatch.dynamomulti64.tier.06", "LuV 64A Dynamo Hatch", VoltageIndex.LuV, 64)
                 .getStackForm(1L));
         eM_dynamoMulti4_ZPM.set(
-            new MTEHatchDynamoMulti(ZPM4ADynamoHatch.ID, "hatch.dynamomulti04.tier.07", "ZPM 4A Dynamo Hatch", 7, 4)
+            new MTEHatchDynamoMulti(ZPM4ADynamoHatch.ID, "hatch.dynamomulti04.tier.07", "ZPM 4A Dynamo Hatch", VoltageIndex.ZPM, 4)
                 .getStackForm(1L));
         eM_dynamoMulti16_ZPM.set(
-            new MTEHatchDynamoMulti(ZPM16ADynamoHatch.ID, "hatch.dynamomulti16.tier.07", "ZPM 16A Dynamo Hatch", 7, 16)
+            new MTEHatchDynamoMulti(ZPM16ADynamoHatch.ID, "hatch.dynamomulti16.tier.07", "ZPM 16A Dynamo Hatch", VoltageIndex.ZPM, 16)
                 .getStackForm(1L));
         eM_dynamoMulti64_ZPM.set(
-            new MTEHatchDynamoMulti(ZPM64ADynamoHatch.ID, "hatch.dynamomulti64.tier.07", "ZPM 64A Dynamo Hatch", 7, 64)
+            new MTEHatchDynamoMulti(ZPM64ADynamoHatch.ID, "hatch.dynamomulti64.tier.07", "ZPM 64A Dynamo Hatch", VoltageIndex.ZPM, 64)
                 .getStackForm(1L));
         eM_dynamoMulti4_UV.set(
-            new MTEHatchDynamoMulti(UV4ADynamoHatch.ID, "hatch.dynamomulti04.tier.08", "UV 4A Dynamo Hatch", 8, 4)
+            new MTEHatchDynamoMulti(UV4ADynamoHatch.ID, "hatch.dynamomulti04.tier.08", "UV 4A Dynamo Hatch", VoltageIndex.UV, 4)
                 .getStackForm(1L));
         eM_dynamoMulti16_UV.set(
-            new MTEHatchDynamoMulti(UV16ADynamoHatch.ID, "hatch.dynamomulti16.tier.08", "UV 16A Dynamo Hatch", 8, 16)
+            new MTEHatchDynamoMulti(UV16ADynamoHatch.ID, "hatch.dynamomulti16.tier.08", "UV 16A Dynamo Hatch", VoltageIndex.UV, 16)
                 .getStackForm(1L));
         eM_dynamoMulti64_UV.set(
-            new MTEHatchDynamoMulti(UV64ADynamoHatch.ID, "hatch.dynamomulti64.tier.08", "UV 64A Dynamo Hatch", 8, 64)
+            new MTEHatchDynamoMulti(UV64ADynamoHatch.ID, "hatch.dynamomulti64.tier.08", "UV 64A Dynamo Hatch", VoltageIndex.UV, 64)
                 .getStackForm(1L));
         eM_dynamoMulti256_UV.set(
             new MTEHatchDynamoMulti(
                 UV256ADynamoHatch.ID,
                 "hatch.dynamomulti256.tier.08",
                 "UV 256A Dynamo Hatch",
-                8,
+                VoltageIndex.UV,
                 256).getStackForm(1L));
         eM_dynamoMulti4_UHV.set(
-            new MTEHatchDynamoMulti(UHV4ADynamoHatch.ID, "hatch.dynamomulti04.tier.09", "UHV 4A Dynamo Hatch", 9, 4)
+            new MTEHatchDynamoMulti(UHV4ADynamoHatch.ID, "hatch.dynamomulti04.tier.09", "UHV 4A Dynamo Hatch", VoltageIndex.UHV, 4)
                 .getStackForm(1L));
         eM_dynamoMulti16_UHV.set(
-            new MTEHatchDynamoMulti(UHV16ADynamoHatch.ID, "hatch.dynamomulti16.tier.09", "UHV 16A Dynamo Hatch", 9, 16)
+            new MTEHatchDynamoMulti(UHV16ADynamoHatch.ID, "hatch.dynamomulti16.tier.09", "UHV 16A Dynamo Hatch", VoltageIndex.UHV, 16)
                 .getStackForm(1L));
         eM_dynamoMulti64_UHV.set(
-            new MTEHatchDynamoMulti(UHV64ADynamoHatch.ID, "hatch.dynamomulti64.tier.09", "UHV 64A Dynamo Hatch", 9, 64)
+            new MTEHatchDynamoMulti(UHV64ADynamoHatch.ID, "hatch.dynamomulti64.tier.09", "UHV 64A Dynamo Hatch", VoltageIndex.UHV, 64)
                 .getStackForm(1L));
         eM_dynamoMulti256_UHV.set(
             new MTEHatchDynamoMulti(
                 UHV256ADynamoHatch.ID,
                 "hatch.dynamomulti256.tier.09",
                 "UHV 256A Dynamo Hatch",
-                9,
+                VoltageIndex.UHV,
                 256).getStackForm(1L));
         eM_dynamoMulti4_UEV.set(
-            new MTEHatchDynamoMulti(UEV4ADynamoHatch.ID, "hatch.dynamomulti04.tier.10", "UEV 4A Dynamo Hatch", 10, 4)
+            new MTEHatchDynamoMulti(UEV4ADynamoHatch.ID, "hatch.dynamomulti04.tier.10", "UEV 4A Dynamo Hatch", VoltageIndex.UEV, 4)
                 .getStackForm(1L));
         eM_dynamoMulti16_UEV.set(
-            new MTEHatchDynamoMulti(UEV16ADynamoHatch.ID, "hatch.dynamomulti16.tier.10", "UEV 16A Dynamo Hatch", 10, 16)
+            new MTEHatchDynamoMulti(UEV16ADynamoHatch.ID, "hatch.dynamomulti16.tier.10", "UEV 16A Dynamo Hatch", VoltageIndex.UEV, 16)
                 .getStackForm(1L));
         eM_dynamoMulti64_UEV.set(
-            new MTEHatchDynamoMulti(UEV64ADynamoHatch.ID, "hatch.dynamomulti64.tier.10", "UEV 64A Dynamo Hatch", 10, 64)
+            new MTEHatchDynamoMulti(UEV64ADynamoHatch.ID, "hatch.dynamomulti64.tier.10", "UEV 64A Dynamo Hatch", VoltageIndex.UEV, 64)
                 .getStackForm(1L));
         eM_dynamoMulti256_UEV.set(
             new MTEHatchDynamoMulti(
                 UEV256ADynamoHatch.ID,
                 "hatch.dynamomulti256.tier.10",
                 "UEV 256A Dynamo Hatch",
-                10,
+                VoltageIndex.UEV,
                 256).getStackForm(1L));
         eM_dynamoMulti4_UIV.set(
-            new MTEHatchDynamoMulti(UIV4ADynamoHatch.ID, "hatch.dynamomulti04.tier.11", "UIV 4A Dynamo Hatch", 11, 4)
+            new MTEHatchDynamoMulti(UIV4ADynamoHatch.ID, "hatch.dynamomulti04.tier.11", "UIV 4A Dynamo Hatch", VoltageIndex.UIV, 4)
                 .getStackForm(1L));
         eM_dynamoMulti16_UIV.set(
-            new MTEHatchDynamoMulti(UIV16ADynamoHatch.ID, "hatch.dynamomulti16.tier.11", "UIV 16A Dynamo Hatch", 11, 16)
+            new MTEHatchDynamoMulti(UIV16ADynamoHatch.ID, "hatch.dynamomulti16.tier.11", "UIV 16A Dynamo Hatch", VoltageIndex.UIV, 16)
                 .getStackForm(1L));
         eM_dynamoMulti64_UIV.set(
-            new MTEHatchDynamoMulti(UIV64ADynamoHatch.ID, "hatch.dynamomulti64.tier.11", "UIV 64A Dynamo Hatch", 11, 64)
+            new MTEHatchDynamoMulti(UIV64ADynamoHatch.ID, "hatch.dynamomulti64.tier.11", "UIV 64A Dynamo Hatch", VoltageIndex.UIV, 64)
                 .getStackForm(1L));
         eM_dynamoMulti256_UIV.set(
             new MTEHatchDynamoMulti(
                 UIV256ADynamoHatch.ID,
                 "hatch.dynamomulti256.tier.11",
                 "UIV 256A Dynamo Hatch",
-                11,
+                VoltageIndex.UIV,
                 256).getStackForm(1L));
         eM_dynamoMulti4_UMV.set(
-            new MTEHatchDynamoMulti(UMV4ADynamoHatch.ID, "hatch.dynamomulti04.tier.12", "UMV 4A Dynamo Hatch", 12, 4)
+            new MTEHatchDynamoMulti(UMV4ADynamoHatch.ID, "hatch.dynamomulti04.tier.12", "UMV 4A Dynamo Hatch", VoltageIndex.UMV, 4)
                 .getStackForm(1L));
         eM_dynamoMulti16_UMV.set(
-            new MTEHatchDynamoMulti(UMV16ADynamoHatch.ID, "hatch.dynamomulti16.tier.12", "UMV 16A Dynamo Hatch", 12, 16)
+            new MTEHatchDynamoMulti(UMV16ADynamoHatch.ID, "hatch.dynamomulti16.tier.12", "UMV 16A Dynamo Hatch", VoltageIndex.UMV, 16)
                 .getStackForm(1L));
         eM_dynamoMulti64_UMV.set(
-            new MTEHatchDynamoMulti(UMV64ADynamoHatch.ID, "hatch.dynamomulti64.tier.12", "UMV 64A Dynamo Hatch", 12, 64)
+            new MTEHatchDynamoMulti(UMV64ADynamoHatch.ID, "hatch.dynamomulti64.tier.12", "UMV 64A Dynamo Hatch", VoltageIndex.UMV, 64)
                 .getStackForm(1L));
         eM_dynamoMulti256_UMV.set(
             new MTEHatchDynamoMulti(
                 UMV256ADynamoHatch.ID,
                 "hatch.dynamomulti256.tier.12",
                 "UMV 256A Dynamo Hatch",
-                12,
+                VoltageIndex.UMV,
                 256).getStackForm(1L));
         eM_dynamoMulti4_UXV.set(
-            new MTEHatchDynamoMulti(UXV4ADynamoHatch.ID, "hatch.dynamomulti04.tier.13", "UXV 4A Dynamo Hatch", 13, 4)
+            new MTEHatchDynamoMulti(UXV4ADynamoHatch.ID, "hatch.dynamomulti04.tier.13", "UXV 4A Dynamo Hatch", VoltageIndex.UXV, 4)
                 .getStackForm(1L));
         eM_dynamoMulti16_UXV.set(
-            new MTEHatchDynamoMulti(UXV16ADynamoHatch.ID, "hatch.dynamomulti16.tier.13", "UXV 16A Dynamo Hatch", 13, 16)
+            new MTEHatchDynamoMulti(UXV16ADynamoHatch.ID, "hatch.dynamomulti16.tier.13", "UXV 16A Dynamo Hatch", VoltageIndex.UXV, 16)
                 .getStackForm(1L));
         eM_dynamoMulti64_UXV.set(
-            new MTEHatchDynamoMulti(UXV64ADynamoHatch.ID, "hatch.dynamomulti64.tier.13", "UXV 64A Dynamo Hatch", 13, 64)
+            new MTEHatchDynamoMulti(UXV64ADynamoHatch.ID, "hatch.dynamomulti64.tier.13", "UXV 64A Dynamo Hatch", VoltageIndex.UXV, 64)
                 .getStackForm(1L));
         eM_dynamoMulti256_UXV.set(
             new MTEHatchDynamoMulti(
                 UXV256ADynamoHatch.ID,
                 "hatch.dynamomulti256.tier.13",
                 "UXV 256A Dynamo Hatch",
-                13,
+                VoltageIndex.UXV,
                 256).getStackForm(1L));
 
         // ===================================================================================================

--- a/src/main/java/tectech/thing/CustomItemList.java
+++ b/src/main/java/tectech/thing/CustomItemList.java
@@ -37,6 +37,7 @@ public enum CustomItemList implements IItemContainer {
     holder_Hatch,
     capacitor_Hatch,
 
+    eM_dynamoMulti4_HV,
     eM_dynamoMulti4_EV,
     eM_dynamoMulti16_EV,
     eM_dynamoMulti64_EV,

--- a/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchDynamoMulti.java
+++ b/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchDynamoMulti.java
@@ -5,7 +5,6 @@ import static gregtech.api.enums.GTValues.V;
 
 import java.util.List;
 
-import gregtech.api.metatileentity.implementations.MTEHatchDynamo;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -20,6 +19,7 @@ import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.implementations.MTEHatch;
+import gregtech.api.metatileentity.implementations.MTEHatchDynamo;
 import gregtech.api.util.GTUtility;
 import mcp.mobius.waila.api.IWailaConfigHandler;
 import mcp.mobius.waila.api.IWailaDataAccessor;
@@ -39,7 +39,7 @@ public class MTEHatchDynamoMulti extends MTEHatchDynamo implements IHideTooltipE
     }
 
     public MTEHatchDynamoMulti(int aID, String aName, String aNameRegional, int aTier, int i, String[] description,
-                               int aAmp) {
+        int aAmp) {
         super(aID, aName, aNameRegional, aTier, description);
         Amperes = maxAmperes = aAmp;
     }

--- a/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchDynamoMulti.java
+++ b/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchDynamoMulti.java
@@ -12,7 +12,6 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.world.World;
-import net.minecraftforge.common.util.ForgeDirection;
 
 import gregtech.api.enums.Textures;
 import gregtech.api.interfaces.IHideTooltipEnergyInfo;
@@ -96,33 +95,8 @@ public class MTEHatchDynamoMulti extends MTEHatchDynamo implements IHideTooltipE
     }
 
     @Override
-    public boolean isFacingValid(ForgeDirection facing) {
-        return true;
-    }
-
-    @Override
-    public boolean isEnetOutput() {
-        return true;
-    }
-
-    @Override
-    public boolean isOutputFacing(ForgeDirection side) {
-        return side == getBaseMetaTileEntity().getFrontFacing();
-    }
-
-    @Override
-    public boolean isValidSlot(int aIndex) {
-        return false;
-    }
-
-    @Override
     public long getMinimumStoredEU() {
         return 128L * Amperes;
-    }
-
-    @Override
-    public long maxEUOutput() {
-        return V[mTier];
     }
 
     @Override
@@ -171,18 +145,6 @@ public class MTEHatchDynamoMulti extends MTEHatchDynamo implements IHideTooltipE
     @Override
     public MetaTileEntity newMetaEntity(IGregTechTileEntity aTileEntity) {
         return new MTEHatchDynamoMulti(mName, mTier, Amperes, mDescriptionArray, mTextures);
-    }
-
-    @Override
-    public boolean allowPullStack(IGregTechTileEntity aBaseMetaTileEntity, int aIndex, ForgeDirection side,
-        ItemStack aStack) {
-        return false;
-    }
-
-    @Override
-    public boolean allowPutStack(IGregTechTileEntity aBaseMetaTileEntity, int aIndex, ForgeDirection side,
-        ItemStack aStack) {
-        return false;
     }
 
     @Override

--- a/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchDynamoMulti.java
+++ b/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchDynamoMulti.java
@@ -5,6 +5,7 @@ import static gregtech.api.enums.GTValues.V;
 
 import java.util.List;
 
+import gregtech.api.metatileentity.implementations.MTEHatchDynamo;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -28,24 +29,24 @@ import mcp.mobius.waila.api.IWailaDataAccessor;
  * Created by danie_000 on 16.12.2016.
  */
 @IMetaTileEntity.SkipGenerateDescription
-public class MTEHatchDynamoMulti extends MTEHatch implements IHideTooltipEnergyInfo {
+public class MTEHatchDynamoMulti extends MTEHatchDynamo implements IHideTooltipEnergyInfo {
 
     public final int maxAmperes;
     public int Amperes;
 
     public MTEHatchDynamoMulti(int aID, String aName, String aNameRegional, int aTier, int aAmp) {
-        super(aID, aName, aNameRegional, aTier, 0, (String) null);
-        Amperes = maxAmperes = aAmp;
-    }
-
-    public MTEHatchDynamoMulti(String aName, int aTier, int aAmp, String[] aDescription, ITexture[][][] aTextures) {
-        super(aName, aTier, 0, aDescription, aTextures);
+        super(aID, aName, aNameRegional, aTier);
         Amperes = maxAmperes = aAmp;
     }
 
     public MTEHatchDynamoMulti(int aID, String aName, String aNameRegional, int aTier, int i, String[] description,
-        int aAmp) {
-        super(aID, aName, aNameRegional, aTier, 0, description);
+                               int aAmp) {
+        super(aID, aName, aNameRegional, aTier, description);
+        Amperes = maxAmperes = aAmp;
+    }
+
+    public MTEHatchDynamoMulti(String aName, int aTier, int aAmp, String[] aDescription, ITexture[][][] aTextures) {
+        super(aName, aTier, aDescription, aTextures);
         Amperes = maxAmperes = aAmp;
     }
 

--- a/src/main/resources/assets/gregtech/lang/en_US.lang
+++ b/src/main/resources/assets/gregtech/lang/en_US.lang
@@ -1678,6 +1678,7 @@ GT5U.MBTT.ConfigMenu=Configuration Menu
 GT5U.MBTT.PerfectOC=Machine does not lose efficiency when overclocked
 GT5U.MBTT.Deprecated=§4DEPRECATED - %s
 GT5U.MBTT.Deprecated.Removal=Controller will be removed in next major update!
+GT5U.MBTT.Deprecated.RemovalMachine=Machine will be removed in next major update!
 GT5U.MBTT.Deprecated.NEI=§4Check NEI for new Controller and conversion recipe
 GT5U.MBTT.PCB.Tier=PCB Factory Tier
 GT5U.MBTT.PCB.Bio=Biochamber


### PR DESCRIPTION
Buffered dynamos are silly and redundant; this PR deprecates them in favor of the TecTech 4A Dynamo.

To accomplish this, this PR makes the following changes:
- Flags Buffered Dynamos as deprecated with 2.10 removal TODO, adding relevant tooltip
- Changes the Multi-Amp dynamo class to extend MTEHatchDynamo, which it should've anyways. The dynamo list then just checks for amperage <= 4 for adding to the non-exotic dynamo list.
- Adds a 4A HV dynamo with recipe (tested in full pack). Recipe follows the pattern of other dynamos.

Tested to confirm:
- Recipe exists
- HV 4A Dynamo exists
- 4A TT dynamos are valid for the ECE
- 64A ZPM dynamo was invalid for the ECE

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18687