### PR TITLE
fix fluid tank duplication in waila for machines with only one fluid slot

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -103,6 +103,8 @@ dependencies {
     compileOnly('com.github.GTNewHorizons:Binnie:2.6.24:dev') {transitive = false}
     compileOnly('curse.maven:PlayerAPI-228969:2248928') {transitive=false}
     devOnlyNonPublishable('com.github.GTNewHorizons:BlockRenderer6343:1.4.12:dev'){transitive=false}
+    // for waila integration testing
+    // devOnlyNonPublishable('com.github.GTNewHorizons:WAILAPlugins:0.7.2:dev')
 
     compileOnly("com.google.auto.value:auto-value-annotations:1.10.1") { transitive = false }
     annotationProcessor("com.google.auto.value:auto-value:1.10.1")

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -103,6 +103,8 @@ dependencies {
     compileOnly('com.github.GTNewHorizons:Binnie:2.6.24:dev') {transitive = false}
     compileOnly('curse.maven:PlayerAPI-228969:2248928') {transitive=false}
     devOnlyNonPublishable('com.github.GTNewHorizons:BlockRenderer6343:1.4.11:dev'){transitive=false}
+    // for waila integration testing
+    // devOnlyNonPublishable('com.github.GTNewHorizons:WAILAPlugins:0.7.2:dev')
 
     compileOnly("com.google.auto.value:auto-value-annotations:1.10.1") { transitive = false }
     annotationProcessor("com.google.auto.value:auto-value:1.10.1")

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEBasicMachineBronze.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEBasicMachineBronze.java
@@ -18,6 +18,7 @@ import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.StatCollector;
 import net.minecraftforge.common.util.ForgeDirection;
+import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTankInfo;
 
 import com.gtnewhorizons.modularui.api.drawable.IDrawable;
@@ -28,7 +29,7 @@ import com.gtnewhorizons.modularui.common.widget.FluidSlotWidget;
 
 import gregtech.api.covers.CoverRegistry;
 import gregtech.api.enums.Dyes;
-import gregtech.api.enums.GTValues;
+import gregtech.api.enums.Materials;
 import gregtech.api.enums.ParticleFX;
 import gregtech.api.enums.SoundResource;
 import gregtech.api.enums.SteamVariant;
@@ -153,8 +154,10 @@ public abstract class MTEBasicMachineBronze extends MTEBasicMachine {
 
     @Override
     public FluidTankInfo[] getTankInfo(ForgeDirection side) {
-        // bronze machines don't have fluid slots
-        return GTValues.emptyFluidTankInfo;
+        int steamAmount = (int) getBaseMetaTileEntity().getStoredSteam() * 2;
+        int steamCapacity = (int) getBaseMetaTileEntity().getSteamCapacity() * 2;
+        FluidStack steam = Materials.Steam.getGas(steamAmount);
+        return new FluidTankInfo[] { new FluidTankInfo(steam, steamCapacity) };
     }
 
     @Override

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEBasicMachineBronze.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEBasicMachineBronze.java
@@ -11,7 +11,6 @@ import static gregtech.api.objects.XSTR.XSTR_INSTANCE;
 
 import java.util.Arrays;
 
-import gregtech.api.enums.GTValues;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -19,6 +18,7 @@ import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.StatCollector;
 import net.minecraftforge.common.util.ForgeDirection;
+import net.minecraftforge.fluids.FluidTankInfo;
 
 import com.gtnewhorizons.modularui.api.drawable.IDrawable;
 import com.gtnewhorizons.modularui.api.math.Pos2d;
@@ -28,6 +28,7 @@ import com.gtnewhorizons.modularui.common.widget.FluidSlotWidget;
 
 import gregtech.api.covers.CoverRegistry;
 import gregtech.api.enums.Dyes;
+import gregtech.api.enums.GTValues;
 import gregtech.api.enums.ParticleFX;
 import gregtech.api.enums.SoundResource;
 import gregtech.api.enums.SteamVariant;
@@ -41,7 +42,6 @@ import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GTRecipe;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.WorldSpawnedEventBuilder.ParticleEventBuilder;
-import net.minecraftforge.fluids.FluidTankInfo;
 
 /**
  * NEVER INCLUDE THIS FILE IN YOUR MOD!!!

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEBasicMachineBronze.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEBasicMachineBronze.java
@@ -11,6 +11,7 @@ import static gregtech.api.objects.XSTR.XSTR_INSTANCE;
 
 import java.util.Arrays;
 
+import gregtech.api.enums.GTValues;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -40,6 +41,7 @@ import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GTRecipe;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.WorldSpawnedEventBuilder.ParticleEventBuilder;
+import net.minecraftforge.fluids.FluidTankInfo;
 
 /**
  * NEVER INCLUDE THIS FILE IN YOUR MOD!!!
@@ -147,6 +149,12 @@ public abstract class MTEBasicMachineBronze extends MTEBasicMachine {
     @Override
     public boolean doesAutoOutput() {
         return false;
+    }
+
+    @Override
+    public FluidTankInfo[] getTankInfo(ForgeDirection side) {
+        // bronze machines don't have fluid slots
+        return GTValues.emptyFluidTankInfo;
     }
 
     @Override

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEBasicMachineWithRecipe.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEBasicMachineWithRecipe.java
@@ -15,6 +15,7 @@ import java.util.Locale;
 import net.minecraft.block.Block;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.common.util.ForgeDirection;
+import net.minecraftforge.fluids.FluidTankInfo;
 import net.minecraftforge.oredict.OreDictionary;
 
 import com.cleanroommc.modularui.factory.PosGuiData;
@@ -52,6 +53,8 @@ public class MTEBasicMachineWithRecipe extends MTEBasicMachine {
 
     private final RecipeMap<?> mRecipes;
     private final int mTankCapacity;
+    private final boolean hasInputFluidSlot;
+    private final boolean hasOutputFluidSlot;
     private final SpecialEffects mSpecialEffect;
     private final SoundResource mSoundResource;
     private FallbackableUITexture progressBarTexture;
@@ -61,8 +64,8 @@ public class MTEBasicMachineWithRecipe extends MTEBasicMachine {
      * Registers machine with multi-line descriptions, specific tank capacity, and sound specified by SoundResource.
      */
     public MTEBasicMachineWithRecipe(int aID, String aName, String aNameRegional, int aTier, String[] aDescription,
-        RecipeMap<?> aRecipes, int aInputSlots, int aOutputSlots, int aTankCapacity, SoundResource aSound,
-        SpecialEffects aSpecialEffect, String aOverlays, Object[] aRecipe) {
+        RecipeMap<?> aRecipes, int aInputSlots, int aOutputSlots, boolean hasInputFluidSlot, boolean hasOutputFluidSlot,
+        int aTankCapacity, SoundResource aSound, SpecialEffects aSpecialEffect, String aOverlays, Object[] aRecipe) {
         super(
             aID,
             aName,
@@ -153,6 +156,8 @@ public class MTEBasicMachineWithRecipe extends MTEBasicMachine {
                     .glow()
                     .build()));
         this.mTankCapacity = aTankCapacity;
+        this.hasInputFluidSlot = hasInputFluidSlot;
+        this.hasOutputFluidSlot = hasOutputFluidSlot;
         this.mSoundResource = aSound;
         this.mSpecialEffect = aSpecialEffect;
         this.mRecipes = aRecipes;
@@ -167,8 +172,8 @@ public class MTEBasicMachineWithRecipe extends MTEBasicMachine {
      * no recipe.
      */
     public MTEBasicMachineWithRecipe(int aID, String aName, String aNameRegional, int aTier, String[] aDescription,
-        RecipeMap<?> aRecipes, int aInputSlots, int aOutputSlots, boolean usesFluids, SoundResource aSound,
-        SpecialEffects aSpecialEffect, String aOverlays) {
+        RecipeMap<?> aRecipes, int aInputSlots, int aOutputSlots, boolean hasInputFluidSlot, boolean hasOutputFluidSlot,
+        SoundResource aSound, SpecialEffects aSpecialEffect, String aOverlays) {
         this(
             aID,
             aName,
@@ -178,7 +183,9 @@ public class MTEBasicMachineWithRecipe extends MTEBasicMachine {
             aRecipes,
             aInputSlots,
             aOutputSlots,
-            usesFluids ? getCapacityForTier(aTier) : 0,
+            hasInputFluidSlot,
+            hasOutputFluidSlot,
+            hasInputFluidSlot || hasOutputFluidSlot ? getCapacityForTier(aTier) : 0,
             aSound,
             aSpecialEffect,
             aOverlays,
@@ -190,8 +197,8 @@ public class MTEBasicMachineWithRecipe extends MTEBasicMachine {
      * no recipe.
      */
     public MTEBasicMachineWithRecipe(int aID, String aName, String aNameRegional, int aTier, String[] aDescription,
-        RecipeMap<?> aRecipes, int aInputSlots, int aOutputSlots, int aTankCapacity, SoundResource aSound,
-        SpecialEffects aSpecialEffect, String aOverlays) {
+        RecipeMap<?> aRecipes, int aInputSlots, int aOutputSlots, boolean hasInputFluidSlot, boolean hasOutputFluidSlot,
+        int aTankCapacity, SoundResource aSound, SpecialEffects aSpecialEffect, String aOverlays) {
         this(
             aID,
             aName,
@@ -201,6 +208,8 @@ public class MTEBasicMachineWithRecipe extends MTEBasicMachine {
             aRecipes,
             aInputSlots,
             aOutputSlots,
+            hasInputFluidSlot,
+            hasOutputFluidSlot,
             aTankCapacity,
             aSound,
             aSpecialEffect,
@@ -212,10 +221,12 @@ public class MTEBasicMachineWithRecipe extends MTEBasicMachine {
      * For {@link #newMetaEntity}.
      */
     public MTEBasicMachineWithRecipe(String aName, int aTier, String[] aDescription, RecipeMap<?> aRecipes,
-        int aInputSlots, int aOutputSlots, int aTankCapacity, int aAmperage, ITexture[][][] aTextures,
-        SoundResource aSound, SpecialEffects aSpecialEffect) {
+        int aInputSlots, int aOutputSlots, boolean hasInputFluidSlot, boolean hasOutputFluidSlot, int aTankCapacity,
+        int aAmperage, ITexture[][][] aTextures, SoundResource aSound, SpecialEffects aSpecialEffect) {
         super(aName, aTier, aAmperage, aDescription, aTextures, aInputSlots, aOutputSlots);
         this.mTankCapacity = aTankCapacity;
+        this.hasInputFluidSlot = hasInputFluidSlot;
+        this.hasOutputFluidSlot = hasOutputFluidSlot;
         this.mSpecialEffect = aSpecialEffect;
         this.mRecipes = aRecipes;
         this.mSoundResource = aSound;
@@ -230,6 +241,8 @@ public class MTEBasicMachineWithRecipe extends MTEBasicMachine {
             this.mRecipes,
             this.mInputSlotCount,
             this.mOutputItems == null ? 0 : this.mOutputItems.length,
+            this.hasInputFluidSlot,
+            this.hasOutputFluidSlot,
             this.mTankCapacity,
             this.mAmperage,
             this.mTextures,
@@ -442,6 +455,20 @@ public class MTEBasicMachineWithRecipe extends MTEBasicMachine {
         return this.mTankCapacity;
     }
 
+    @Override
+    public FluidTankInfo[] getTankInfo(ForgeDirection side) {
+        if (hasInputFluidSlot && hasOutputFluidSlot) {
+            return new FluidTankInfo[] { new FluidTankInfo(getFillableStack(), getCapacity()),
+                new FluidTankInfo(getDrainableStack(), getCapacity()) };
+        } else if (hasInputFluidSlot) {
+            return new FluidTankInfo[] { new FluidTankInfo(getFillableStack(), getCapacity()) };
+        } else if (hasOutputFluidSlot) {
+            return new FluidTankInfo[] { new FluidTankInfo(getDrainableStack(), getCapacity()) };
+        }
+
+        return super.getTankInfo(side);
+    }
+
     @SideOnly(Side.CLIENT)
     @Override
     protected SoundResource getActivitySoundLoop() {
@@ -451,6 +478,8 @@ public class MTEBasicMachineWithRecipe extends MTEBasicMachine {
     @Override
     protected BasicUIProperties getUIProperties() {
         return super.getUIProperties().toBuilder()
+            .maxFluidInputs(hasInputFluidSlot ? 1 : 0)
+            .maxFluidOutputs(hasOutputFluidSlot ? 1 : 0)
             .progressBarTexture(progressBarTexture)
             .build();
     }

--- a/src/main/java/gregtech/common/tileentities/machines/basic/MTEBasicMachineWithRecipeBuilder.java
+++ b/src/main/java/gregtech/common/tileentities/machines/basic/MTEBasicMachineWithRecipeBuilder.java
@@ -122,7 +122,8 @@ public final class MTEBasicMachineWithRecipeBuilder {
                     recipes,
                     inputSlotCount,
                     outputSlotCount,
-                    hasInputFluidSlot || hasOutputFluidSlot,
+                    hasInputFluidSlot,
+                    hasOutputFluidSlot,
                     sound,
                     specialEffect,
                     overlays);
@@ -137,6 +138,8 @@ public final class MTEBasicMachineWithRecipeBuilder {
                 recipes,
                 inputSlotCount,
                 outputSlotCount,
+                hasInputFluidSlot,
+                hasOutputFluidSlot,
                 fluidTankCapacityOverride,
                 sound,
                 specialEffect,


### PR DESCRIPTION
fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/23580

hasInputFluidSlot & hasOutputFluidSlot was set for every machine in https://github.com/GTNewHorizons/GT5-Unofficial/pull/5952, so we only need to wire everything up here

also now waila shows steam contents :letsfuckinggo:
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/611b8741-88e3-40cc-86b2-1795a32704b3" />

