### PR TITLE
Fix off-thread chunk loading in machine block update threads

### DIFF
--- a/src/main/java/gregtech/api/threads/RunnableCableUpdate.java
+++ b/src/main/java/gregtech/api/threads/RunnableCableUpdate.java
@@ -35,15 +35,15 @@ public class RunnableCableUpdate extends RunnableMachineUpdate {
 
                 final TileEntity tTileEntity;
 
+                // Check chunk availability without holding TICK_LOCK so the server thread can
+                // create the chunk map snapshot if needed (same fix as RunnableMachineUpdate)
+                if (!world.blockExists(posX, posY, posZ)) {
+                    continue;
+                }
+
                 GTMod.proxy.TICK_LOCK.lock();
                 try {
-                    // we dont want to go over cables that are in unloaded chunks
-                    // keeping the lock just to make sure no CME happens
-                    if (world.blockExists(posX, posY, posZ)) {
-                        tTileEntity = world.getTileEntity(posX, posY, posZ);
-                    } else {
-                        tTileEntity = null;
-                    }
+                    tTileEntity = world.getTileEntity(posX, posY, posZ);
                 } finally {
                     GTMod.proxy.TICK_LOCK.unlock();
                 }

--- a/src/main/java/gregtech/api/threads/RunnableMachineUpdate.java
+++ b/src/main/java/gregtech/api/threads/RunnableMachineUpdate.java
@@ -174,6 +174,14 @@ public class RunnableMachineUpdate implements Runnable {
                 final TileEntity tTileEntity;
                 final boolean isMachineBlock;
 
+                // Check chunk availability WITHOUT holding TICK_LOCK. blockExists() only checks the
+                // chunk hash map (snapshot for off-thread callers) and never triggers chunk loading.
+                // This prevents provideChunk() from calling loadChunk() on this background thread,
+                // which would corrupt shared data structures and fire events from the wrong thread.
+                if (!world.blockExists(posX, posY, posZ)) {
+                    continue;
+                }
+
                 // This might load a chunk... which might load a TileEntity... which might get added to
                 // `loadedTileEntityList`... which might be in the process
                 // of being iterated over during `UpdateEntities()`... which might cause a


### PR DESCRIPTION
- Placing a machine block like a long-distance pipe triggers a connected block search on a background thread  
- The thread uses a chunk map snapshot from Hodgepodge, refreshed roughly once per second  
- Chunks loaded after the snapshot was taken aren’t visible to the thread  
- When the search reaches a block in a missing chunk, EntityGuard calls `loadChunk()` because the chunk exists on disk  
- Since the snapshot is still stale, the next block in that same chunk triggers another `loadChunk()`  
- Each `loadChunk()` causes disk I/O, creates entities, fires `ChunkEvent.Load`, and runs mod event handlers that assume they’re on the server thread  
- With ~200 pipes, this can happen hundreds of times, the log grows to hundreds of MB, and eventually leads to an OOM crash  
- Fix: check `blockExists()` before accessing block data, and skip blocks in missing chunks instead of loading them