### PR TITLE
Fix incorrect support bools for ZFP, TGS and IMS

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialFishingPond.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialFishingPond.java
@@ -150,6 +150,16 @@ public class MTEIndustrialFishingPond extends MTEExtendedPowerMultiBlockBase<MTE
     }
 
     @Override
+    public boolean supportsVoidProtection() {
+        return true;
+    }
+
+    @Override
+    public boolean supportsBatchMode() {
+        return true;
+    }
+
+    @Override
     public int survivalConstruct(ItemStack stackSize, int elementBudget, ISurvivalBuildEnvironment env) {
         if (mMachine) return -1;
         return survivalBuildPiece(mName, stackSize, OFFSET_X, OFFSET_Y, OFFSET_Z, elementBudget, env, false, true);

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialMacerator.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialMacerator.java
@@ -348,6 +348,16 @@ public class MTEIndustrialMacerator extends MTEExtendedPowerMultiBlockBase<MTEIn
     }
 
     @Override
+    public boolean supportsVoidProtection() {
+        return true;
+    }
+
+    @Override
+    public boolean supportsBatchMode() {
+        return true;
+    }
+
+    @Override
     public void saveNBTData(NBTTagCompound aNBT) {
         super.saveNBTData(aNBT);
         aNBT.setByte("mTier", (byte) controllerTier);

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTETreeFarm.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTETreeFarm.java
@@ -269,6 +269,11 @@ public class MTETreeFarm extends MTEExtendedPowerMultiBlockBase<MTETreeFarm> imp
     }
 
     @Override
+    public boolean supportsVoidProtection() {
+        return true;
+    }
+
+    @Override
     public boolean supportsBatchMode() {
         // Batch mode would not do anything, processing time is fixed at 100 ticks.
         return false;


### PR DESCRIPTION
Updated some bools to match their pre-rework value

Zhuhai Fishing Port (ZFP):
- supportsVoidProtection → true
- supportsBatchMode → true

Tree Growth Simulator (TGS):
- supportsVoidProtection → true

Industrial Maceration Stack (IMS):
- supportsVoidProtection → true
- supportsBatchMode → true

I checked most but not all reworked structures