### PR TITLE
Make the inflection manager to support multi-level key, and add some built-in rules

### DIFF
--- a/src/main/java/gregtech/api/enums/OrePrefixes.java
+++ b/src/main/java/gregtech/api/enums/OrePrefixes.java
@@ -3255,6 +3255,12 @@ public class OrePrefixes {
         if (StatCollector.canTranslate(key)) {
             return StatCollector.translateToLocal(key);
         }
+        final String phraseKey = prefixKey + ".phrase";
+        if (StatCollector.canTranslate(phraseKey) && material.getLocalizedName()
+            .trim()
+            .split(" ").length > 1) {
+            return GTInflectionManager.formatInflection(phraseKey, material.getLocalizedNameKey());
+        }
         return GTInflectionManager.formatInflection(prefixKey, material.getLocalizedNameKey());
     }
 
@@ -3266,6 +3272,12 @@ public class OrePrefixes {
         final String key = prefixKey + "." + materialKey.toLowerCase();
         if (StatCollector.canTranslate(key)) {
             return StatCollector.translateToLocal(key);
+        }
+        final String phraseKey = prefixKey + ".phrase";
+        if (StatCollector.canTranslate(phraseKey) && StatCollector.translateToLocal(materialKey)
+            .trim()
+            .split(" ").length > 1) {
+            return GTInflectionManager.formatInflection(phraseKey, materialKey);
         }
         return GTInflectionManager.formatInflection(prefixKey, materialKey);
     }

--- a/src/main/java/gregtech/api/enums/OrePrefixes.java
+++ b/src/main/java/gregtech/api/enums/OrePrefixes.java
@@ -3258,7 +3258,7 @@ public class OrePrefixes {
         final String phraseKey = prefixKey + ".phrase";
         if (StatCollector.canTranslate(phraseKey) && material.getLocalizedName()
             .trim()
-            .split(" ").length > 1) {
+            .indexOf(' ') != -1) {
             return GTInflectionManager.formatInflection(phraseKey, material.getLocalizedNameKey());
         }
         return GTInflectionManager.formatInflection(prefixKey, material.getLocalizedNameKey());
@@ -3276,7 +3276,7 @@ public class OrePrefixes {
         final String phraseKey = prefixKey + ".phrase";
         if (StatCollector.canTranslate(phraseKey) && StatCollector.translateToLocal(materialKey)
             .trim()
-            .split(" ").length > 1) {
+            .indexOf(' ') != -1) {
             return GTInflectionManager.formatInflection(phraseKey, materialKey);
         }
         return GTInflectionManager.formatInflection(prefixKey, materialKey);

--- a/src/main/java/gregtech/api/util/GTInflectionManager.java
+++ b/src/main/java/gregtech/api/util/GTInflectionManager.java
@@ -11,6 +11,7 @@ import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.IllegalFormatException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -124,19 +125,16 @@ public final class GTInflectionManager {
      */
     public static String formatInflection(String inputKey, String... formatterKey) {
         final String input = StatCollector.translateToLocal(inputKey);
-        if (!input.contains("s{")) {
-            return String.format(
-                unescape(input),
-                Arrays.stream(formatterKey)
-                    .map(StatCollector::translateToLocal)
-                    .toArray(Object[]::new));
-        }
-        if (IS_SERVER) {
-            return String.format(
-                unescape(input),
-                Arrays.stream(formatterKey)
-                    .map(StatCollector::translateToLocal)
-                    .toArray(Object[]::new));
+        if (!input.contains("s{") || IS_SERVER) {
+            try {
+                return String.format(
+                    unescape(input),
+                    Arrays.stream(formatterKey)
+                        .map(StatCollector::translateToLocal)
+                        .toArray(Object[]::new));
+            } catch (IllegalFormatException e) {
+                return "Format Error: " + input;
+            }
         }
 
         Matcher matcher = PLACEHOLDER_PATTERN.matcher(input);

--- a/src/main/java/gregtech/api/util/GTInflectionManager.java
+++ b/src/main/java/gregtech/api/util/GTInflectionManager.java
@@ -113,7 +113,7 @@ public final class GTInflectionManager {
      * {@code part1/part2/part3} will execute the {@code part1} rule, {@code part2} rule, and {@code part3} rule in
      * sequence.<br>
      * See ({@code assets/gregtech/inflection/en_US.example.json} for an example JSON format.<br>
-     * See also: {@link <a href="https://gist.github.com/iouter/efcfb45dbc337e5c45f1c177df3cbaa0">document in gist</a>}
+     * See also: {@link <a href="https://wiki.gtnewhorizons.com/wiki/Inflection_Manager">document in wiki</a>}
      * <p>
      * On the client side, words are replaced according to the inflection rules; on the server side, inflection markers
      * are automatically removed (no inflection applied).<br>

--- a/src/main/java/gregtech/api/util/GTInflectionManager.java
+++ b/src/main/java/gregtech/api/util/GTInflectionManager.java
@@ -11,7 +11,6 @@ import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.IllegalFormatException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -140,7 +139,6 @@ public final class GTInflectionManager {
                     .toArray(Object[]::new));
         }
 
-        List<String> params = new ArrayList<>();
         Matcher matcher = PLACEHOLDER_PATTERN.matcher(input);
         boolean hasImplicit = false;
         boolean hasExplicit = false;
@@ -168,18 +166,10 @@ public final class GTInflectionManager {
                 return "Inflection Format Error: " + input;
             }
 
-            params.add(getInflection(formatterKey[targetPos], inflectionKey));
-            matcher.appendReplacement(sb, "%s");
+            matcher.appendReplacement(sb, getInflection(formatterKey[targetPos], inflectionKey));
         }
         matcher.appendTail(sb);
-        Object[] formattedArgs = params.toArray();
-
-        String cleanedPattern = unescape(sb.toString());
-        try {
-            return String.format(cleanedPattern, formattedArgs);
-        } catch (IllegalFormatException e) {
-            return "Illegal Format in Inflection: " + input;
-        }
+        return sb.toString();
     }
 
     private static String getInflection(String formatterKey, String key) {
@@ -239,6 +229,7 @@ public final class GTInflectionManager {
                     .matcher(word);
                 if (m.matches()) {
                     word = m.replaceFirst(rule.replacement());
+                    break;
                 }
             }
         }

--- a/src/main/java/gregtech/api/util/GTInflectionManager.java
+++ b/src/main/java/gregtech/api/util/GTInflectionManager.java
@@ -37,6 +37,7 @@ public final class GTInflectionManager {
     private static final boolean IS_SERVER = FMLCommonHandler.instance()
         .getEffectiveSide()
         .isServer();
+    private static final Pattern CAPITALIZE_WORDS_PATTERN = Pattern.compile("\\p{L}+");
 
     private GTInflectionManager() {}
 
@@ -211,9 +212,26 @@ public final class GTInflectionManager {
                     word = word.toUpperCase(LOCALE);
                     continue;
                 }
-                case "capitalize" -> {
+                case "capitalize_first" -> {
                     word = word.substring(0, 1)
-                        .toUpperCase(LOCALE) + word.substring(1);
+                        .toUpperCase(LOCALE)
+                        + word.substring(1)
+                            .toLowerCase(LOCALE);
+                    continue;
+                }
+                case "capitalize_words" -> {
+                    Matcher matcher = CAPITALIZE_WORDS_PATTERN.matcher(word);
+                    StringBuilder sb = new StringBuilder(word.length());
+                    while (matcher.find()) {
+                        String matchedWord = matcher.group();
+                        String capitalized = matchedWord.substring(0, 1)
+                            .toUpperCase(LOCALE)
+                            + matchedWord.substring(1)
+                                .toLowerCase(LOCALE);
+                        matcher.appendReplacement(sb, Matcher.quoteReplacement(capitalized));
+                    }
+                    matcher.appendTail(sb);
+                    word = sb.toString();
                     continue;
                 }
             }

--- a/src/main/java/gregtech/api/util/GTInflectionManager.java
+++ b/src/main/java/gregtech/api/util/GTInflectionManager.java
@@ -221,7 +221,7 @@ public final class GTInflectionManager {
                 }
                 case "capitalize_words" -> {
                     Matcher matcher = CAPITALIZE_WORDS_PATTERN.matcher(word);
-                    StringBuilder sb = new StringBuilder(word.length());
+                    StringBuffer sb = new StringBuffer(word.length());
                     while (matcher.find()) {
                         String matchedWord = matcher.group();
                         String capitalized = matchedWord.substring(0, 1)

--- a/src/main/java/gregtech/api/util/GTInflectionManager.java
+++ b/src/main/java/gregtech/api/util/GTInflectionManager.java
@@ -88,7 +88,7 @@ public final class GTInflectionManager {
         } catch (IOException e) {
             GT_FML_LOGGER.warn("Failed to load inflection file: {}", json, e);
         } catch (JsonParseException e) {
-            GT_FML_LOGGER.warn("Successfully found the file: {}, but an error occurred.", json, e);
+            GT_FML_LOGGER.warn("Successfully found the inflection file: {}, but an error occurred.", json, e);
         }
     }
 

--- a/src/main/java/gregtech/api/util/GTInflectionManager.java
+++ b/src/main/java/gregtech/api/util/GTInflectionManager.java
@@ -24,6 +24,7 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.StatCollector;
 
 import com.github.bsideup.jabel.Desugar;
+import com.google.common.base.Splitter;
 import com.google.gson.Gson;
 import com.google.gson.JsonParseException;
 import com.google.gson.reflect.TypeToken;
@@ -176,11 +177,9 @@ public final class GTInflectionManager {
             return word;
         }
         String specialCaseKey = formatterKey;
-        final String[] targetRules = key.split("/");
-        for (String targetRule : targetRules) {
-            if (targetRule.isEmpty()) {
-                GT_FML_LOGGER.warn("A rule key is empty, full rule key: {}", key);
-            }
+        for (String targetRule : Splitter.on("/")
+            .omitEmptyStrings()
+            .split(key)) {
             specialCaseKey += "." + targetRule;
             if (StatCollector.canTranslate(specialCaseKey)) {
                 word = StatCollector.translateToLocal(specialCaseKey);

--- a/src/main/java/gregtech/api/util/GTInflectionManager.java
+++ b/src/main/java/gregtech/api/util/GTInflectionManager.java
@@ -1,6 +1,7 @@
 package gregtech.api.util;
 
 import static gregtech.GTMod.GT_FML_LOGGER;
+import static gregtech.api.util.GTLanguageManager.LOCALE;
 
 import java.io.BufferedReader;
 import java.io.FileNotFoundException;
@@ -11,6 +12,7 @@ import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
@@ -199,6 +201,20 @@ public final class GTInflectionManager {
             if (StatCollector.canTranslate(specialCaseKey)) {
                 word = StatCollector.translateToLocal(specialCaseKey);
                 continue;
+            }
+            switch (rule) {
+                case "lowercase" -> {
+                    word = word.toLowerCase(LOCALE);
+                    continue;
+                }
+                case "uppercase" -> {
+                    word = word.toUpperCase(LOCALE);
+                    continue;
+                }
+                case "capitalize" -> {
+                    word = word.substring(0, 1).toUpperCase(LOCALE) + word.substring(1);
+                    continue;
+                }
             }
             LinkedHashMap<Pattern, String> ruleMap = INFLECTION_MAP.get(rule);
             if (ruleMap == null || ruleMap.isEmpty()) {

--- a/src/main/java/gregtech/api/util/GTInflectionManager.java
+++ b/src/main/java/gregtech/api/util/GTInflectionManager.java
@@ -128,7 +128,7 @@ public final class GTInflectionManager {
      */
     public static String formatInflection(String inputKey, String... formatterKey) {
         final String input = StatCollector.translateToLocal(inputKey);
-        if (!input.contains("s{") || IS_SERVER) {
+        if (IS_SERVER || !input.contains("s{")) {
             try {
                 return String.format(
                     unescape(input),
@@ -186,21 +186,12 @@ public final class GTInflectionManager {
                 continue;
             }
             switch (targetRule) {
-                case "lowercase" -> {
-                    word = word.toLowerCase(LOCALE);
-                    continue;
-                }
-                case "uppercase" -> {
-                    word = word.toUpperCase(LOCALE);
-                    continue;
-                }
-                case "capitalize_first" -> {
-                    word = word.substring(0, 1)
-                        .toUpperCase(LOCALE)
-                        + word.substring(1)
-                            .toLowerCase(LOCALE);
-                    continue;
-                }
+                case "lowercase" -> word = word.toLowerCase(LOCALE);
+                case "uppercase" -> word = word.toUpperCase(LOCALE);
+                case "capitalize_first" -> word = word.substring(0, 1)
+                    .toUpperCase(LOCALE)
+                    + word.substring(1)
+                        .toLowerCase(LOCALE);
                 case "capitalize_words" -> {
                     Matcher matcher = CAPITALIZE_WORDS_PATTERN.matcher(word);
                     StringBuffer sb = new StringBuffer(word.length());
@@ -214,19 +205,20 @@ public final class GTInflectionManager {
                     }
                     matcher.appendTail(sb);
                     word = sb.toString();
-                    continue;
                 }
-            }
-            List<Rule> rules = INFLECTION_MAP.get(targetRule);
-            if (rules == null || rules.isEmpty()) {
-                continue;
-            }
-            for (Rule rule : rules) {
-                Matcher m = rule.pattern()
-                    .matcher(word);
-                if (m.matches()) {
-                    word = m.replaceFirst(rule.replacement());
-                    break;
+                default -> {
+                    List<Rule> rules = INFLECTION_MAP.get(targetRule);
+                    if (rules == null || rules.isEmpty()) {
+                        continue;
+                    }
+                    for (Rule rule : rules) {
+                        Matcher m = rule.pattern()
+                            .matcher(word);
+                        if (m.matches()) {
+                            word = m.replaceFirst(rule.replacement());
+                            break;
+                        }
+                    }
                 }
             }
         }

--- a/src/main/java/gregtech/api/util/GTInflectionManager.java
+++ b/src/main/java/gregtech/api/util/GTInflectionManager.java
@@ -48,9 +48,6 @@ public final class GTInflectionManager {
     private GTInflectionManager() {}
 
     public static void loadInflectionJson(String userLang) {
-        if (IS_SERVER) {
-            return;
-        }
         Minecraft minecraft = Minecraft.getMinecraft();
         final ResourceLocation json = new ResourceLocation(Mods.GregTech.ID, "inflection/" + userLang + ".json");
         try (BufferedReader reader = new BufferedReader(
@@ -128,7 +125,7 @@ public final class GTInflectionManager {
      */
     public static String formatInflection(String inputKey, String... formatterKey) {
         final String input = StatCollector.translateToLocal(inputKey);
-        if (IS_SERVER || !input.contains("s{")) {
+        if (!input.contains("s{")) {
             try {
                 return String.format(
                     unescape(input),
@@ -175,7 +172,7 @@ public final class GTInflectionManager {
 
     private static String getInflection(String formatterKey, String key) {
         String word = StatCollector.translateToLocal(formatterKey);
-        if (key == null || key.isEmpty()) {
+        if (IS_SERVER || key == null || key.isEmpty()) {
             return word;
         }
         String specialCaseKey = formatterKey;

--- a/src/main/java/gregtech/api/util/GTInflectionManager.java
+++ b/src/main/java/gregtech/api/util/GTInflectionManager.java
@@ -42,6 +42,8 @@ public final class GTInflectionManager {
         .getEffectiveSide()
         .isServer();
     private static final Pattern CAPITALIZE_WORDS_PATTERN = Pattern.compile("\\p{L}+");
+    private static final Splitter SPLITTER = Splitter.on('/')
+        .omitEmptyStrings();
 
     private GTInflectionManager() {}
 
@@ -177,9 +179,7 @@ public final class GTInflectionManager {
             return word;
         }
         String specialCaseKey = formatterKey;
-        for (String targetRule : Splitter.on("/")
-            .omitEmptyStrings()
-            .split(key)) {
+        for (String targetRule : SPLITTER.split(key)) {
             specialCaseKey += "." + targetRule;
             if (StatCollector.canTranslate(specialCaseKey)) {
                 word = StatCollector.translateToLocal(specialCaseKey);

--- a/src/main/java/gregtech/api/util/GTInflectionManager.java
+++ b/src/main/java/gregtech/api/util/GTInflectionManager.java
@@ -178,7 +178,6 @@ public final class GTInflectionManager {
         try {
             return String.format(cleanedPattern, formattedArgs);
         } catch (IllegalFormatException e) {
-            GT_FML_LOGGER.warn("Illegal Format in Inflection: {}", input, e);
             return "Illegal Format in Inflection: " + input;
         }
     }

--- a/src/main/java/gregtech/api/util/GTInflectionManager.java
+++ b/src/main/java/gregtech/api/util/GTInflectionManager.java
@@ -102,7 +102,8 @@ public final class GTInflectionManager {
      * Special cases can be defined via the localization key <code>formatterKey.key</code> to override the default
      * inflection result.<br>
      * Supports a slash ({@code /}) in {@code rule key} for multiple replacement:<br>
-     * {@code part1/part2/part3} will execute the {@code part1} rule, {@code part2} rule, and {@code part3} rule in sequence.<br>
+     * {@code part1/part2/part3} will execute the {@code part1} rule, {@code part2} rule, and {@code part3} rule in
+     * sequence.<br>
      * See ({@code assets/gregtech/inflection/en_US.example.json} for an example JSON format.<br>
      * See also: {@link <a href="https://gist.github.com/iouter/efcfb45dbc337e5c45f1c177df3cbaa0">document in gist</a>}
      * <p>

--- a/src/main/java/gregtech/api/util/GTInflectionManager.java
+++ b/src/main/java/gregtech/api/util/GTInflectionManager.java
@@ -91,7 +91,7 @@ public final class GTInflectionManager {
         }
     }
 
-    private static String unEscape(String input) {
+    private static String unescape(String input) {
         return input.replace("\\{", "{")
             .replace("\\}", "}");
     }
@@ -126,14 +126,14 @@ public final class GTInflectionManager {
         final String input = StatCollector.translateToLocal(inputKey);
         if (!input.contains("s{")) {
             return String.format(
-                unEscape(input),
+                unescape(input),
                 Arrays.stream(formatterKey)
                     .map(StatCollector::translateToLocal)
                     .toArray(Object[]::new));
         }
         if (IS_SERVER) {
             return String.format(
-                unEscape(input),
+                unescape(input),
                 Arrays.stream(formatterKey)
                     .map(StatCollector::translateToLocal)
                     .toArray(Object[]::new));
@@ -173,7 +173,7 @@ public final class GTInflectionManager {
         matcher.appendTail(sb);
         Object[] formattedArgs = params.toArray();
 
-        String cleanedPattern = unEscape(sb.toString());
+        String cleanedPattern = unescape(sb.toString());
         return String.format(cleanedPattern, formattedArgs);
     }
 

--- a/src/main/java/gregtech/api/util/GTInflectionManager.java
+++ b/src/main/java/gregtech/api/util/GTInflectionManager.java
@@ -11,6 +11,7 @@ import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.IllegalFormatException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -174,7 +175,12 @@ public final class GTInflectionManager {
         Object[] formattedArgs = params.toArray();
 
         String cleanedPattern = unescape(sb.toString());
-        return String.format(cleanedPattern, formattedArgs);
+        try {
+            return String.format(cleanedPattern, formattedArgs);
+        } catch (IllegalFormatException e) {
+            GT_FML_LOGGER.warn("Illegal Format in Inflection: {}", input, e);
+            return "Illegal Format in Inflection: " + input;
+        }
     }
 
     private static String getInflection(String formatterKey, String key) {

--- a/src/main/java/gregtech/api/util/GTInflectionManager.java
+++ b/src/main/java/gregtech/api/util/GTInflectionManager.java
@@ -12,6 +12,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -58,12 +59,12 @@ public final class GTInflectionManager {
 
             Map<String, LinkedHashMap<Pattern, String>> inflectionTempMap = new ConcurrentHashMap<>();
 
-            for (Map.Entry<String, LinkedHashMap<String, String>> entry : fileData.entrySet()) {
+            for (Entry<String, LinkedHashMap<String, String>> entry : fileData.entrySet()) {
                 String typeKey = entry.getKey();
                 LinkedHashMap<String, String> stringRules = entry.getValue();
                 LinkedHashMap<Pattern, String> compiledRules = new LinkedHashMap<>();
 
-                for (Map.Entry<String, String> rule : stringRules.entrySet()) {
+                for (Entry<String, String> rule : stringRules.entrySet()) {
                     try {
                         String pattern = rule.getKey();
                         if (!pattern.startsWith("^")) pattern = "^" + pattern;
@@ -98,10 +99,10 @@ public final class GTInflectionManager {
      * and replacement.<br>
      * Special cases can be defined via the localization key <code>formatterKey.key</code> to override the default
      * inflection result.<br>
-     * Supports a slash ({@code /}) in {@code key} for secondary replacement:<br>
-     * {@code "prefix/rest"} first attempts to translate {@code formatterKey.prefix} as the base word, then applies the
-     * {@code rest} inflection rule.<br>
-     * See <code>assets/gregtech/inflection/en_US.example.json</code> for an example JSON format.
+     * Supports a slash ({@code /}) in {@code rule key} for multiple replacement:<br>
+     * {@code part1/part2/part3} will execute the {@code part1} rule, {@code part2} rule, and {@code part3} rule in sequence.<br>
+     * See ({@code assets/gregtech/inflection/en_US.example.json} for an example JSON format.<br>
+     * See also: {@link <a href="https://gist.github.com/iouter/efcfb45dbc337e5c45f1c177df3cbaa0">document in gist</a>}
      * <p>
      * On the client side, words are replaced according to the inflection rules; on the server side, inflection markers
      * are automatically removed (no inflection applied).<br>
@@ -188,36 +189,27 @@ public final class GTInflectionManager {
         if (key == null || key.isEmpty()) {
             return word;
         }
-        if (key.contains("/")) {
-            String[] temp = key.split("/", 2);
-            String secondaryKey = formatterKey + "." + temp[0];
-            key = temp[1];
-            if (key.isEmpty()) {
-                GT_FML_LOGGER.warn("Rule key is empty");
-                return word;
+        String specialCaseKey = formatterKey;
+        final String[] rules = key.split("/");
+        for (String rule : rules) {
+            if (rule.isEmpty()) {
+                GT_FML_LOGGER.warn("A rule key is empty, full rule key: {}", key);
             }
-            if (StatCollector.canTranslate(secondaryKey)) {
-                word = StatCollector.translateToLocal(secondaryKey);
-            } else {
-                GT_FML_LOGGER
-                    .warn("Set key '{}', but unable to translate key '{}', using base word", temp[0], secondaryKey);
+            specialCaseKey += "." + rule;
+            if (StatCollector.canTranslate(specialCaseKey)) {
+                word = StatCollector.translateToLocal(specialCaseKey);
+                continue;
             }
-        }
-        String specialCaseKey = formatterKey + "." + key;
-        if (StatCollector.canTranslate(specialCaseKey)) {
-            return StatCollector.translateToLocal(specialCaseKey);
-        }
-
-        LinkedHashMap<Pattern, String> rules = INFLECTION_MAP.get(key);
-        if (rules == null || rules.isEmpty()) {
-            return word;
-        }
-
-        for (Map.Entry<Pattern, String> rule : rules.entrySet()) {
-            Matcher m = rule.getKey()
-                .matcher(word);
-            if (m.matches()) {
-                return m.replaceFirst(rule.getValue());
+            LinkedHashMap<Pattern, String> ruleMap = INFLECTION_MAP.get(rule);
+            if (ruleMap == null || ruleMap.isEmpty()) {
+                continue;
+            }
+            for (Entry<Pattern, String> ruleEntry : ruleMap.entrySet()) {
+                Matcher m = ruleEntry.getKey()
+                    .matcher(word);
+                if (m.matches()) {
+                    word = m.replaceFirst(ruleEntry.getValue());
+                }
             }
         }
         return word;

--- a/src/main/java/gregtech/api/util/GTInflectionManager.java
+++ b/src/main/java/gregtech/api/util/GTInflectionManager.java
@@ -12,7 +12,6 @@ import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
@@ -213,7 +212,8 @@ public final class GTInflectionManager {
                     continue;
                 }
                 case "capitalize" -> {
-                    word = word.substring(0, 1).toUpperCase(LOCALE) + word.substring(1);
+                    word = word.substring(0, 1)
+                        .toUpperCase(LOCALE) + word.substring(1);
                     continue;
                 }
             }

--- a/src/main/java/gregtech/api/util/GTInflectionManager.java
+++ b/src/main/java/gregtech/api/util/GTInflectionManager.java
@@ -8,13 +8,13 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -22,7 +22,9 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.StatCollector;
 
+import com.github.bsideup.jabel.Desugar;
 import com.google.gson.Gson;
+import com.google.gson.JsonParseException;
 import com.google.gson.reflect.TypeToken;
 
 import cpw.mods.fml.common.FMLCommonHandler;
@@ -31,9 +33,9 @@ import gregtech.api.enums.Mods;
 public final class GTInflectionManager {
 
     private static final Type MAP_TYPE = new TypeToken<Map<String, LinkedHashMap<String, String>>>() {}.getType();
-    private static final Pattern PLACEHOLDER_PATTERN = Pattern.compile("(?<!%)%(\\d+\\$)?s(?:\\{([^}]+)})?");
+    private static final Pattern PLACEHOLDER_PATTERN = Pattern.compile("(?<!%)%(?:(\\d+)\\$)?s(?:\\{([^}]+)})?");
     private static final Gson GSON = new Gson();
-    private static volatile Map<String, LinkedHashMap<Pattern, String>> INFLECTION_MAP = new ConcurrentHashMap<>();
+    private static volatile Map<String, List<Rule>> INFLECTION_MAP = new HashMap<>();
     private static final boolean IS_SERVER = FMLCommonHandler.instance()
         .getEffectiveSide()
         .isServer();
@@ -59,19 +61,19 @@ public final class GTInflectionManager {
                 return;
             }
 
-            Map<String, LinkedHashMap<Pattern, String>> inflectionTempMap = new ConcurrentHashMap<>();
+            Map<String, List<Rule>> inflectionTempMap = new HashMap<>();
 
             for (Entry<String, LinkedHashMap<String, String>> entry : fileData.entrySet()) {
                 String typeKey = entry.getKey();
                 LinkedHashMap<String, String> stringRules = entry.getValue();
-                LinkedHashMap<Pattern, String> compiledRules = new LinkedHashMap<>();
+                List<Rule> compiledRules = new ArrayList<>();
 
                 for (Entry<String, String> rule : stringRules.entrySet()) {
                     try {
                         String pattern = rule.getKey();
                         if (!pattern.startsWith("^")) pattern = "^" + pattern;
                         if (!pattern.endsWith("$")) pattern = pattern + "$";
-                        compiledRules.put(Pattern.compile(pattern), rule.getValue());
+                        compiledRules.add(new Rule(Pattern.compile(pattern), rule.getValue()));
                     } catch (Exception e) {
                         GT_FML_LOGGER.warn("Invalid regex pattern '{}' for type '{}'", rule.getKey(), typeKey, e);
                     }
@@ -84,10 +86,12 @@ public final class GTInflectionManager {
 
         } catch (IOException e) {
             GT_FML_LOGGER.warn("Failed to load inflection file: {}", json, e);
+        } catch (JsonParseException e) {
+            GT_FML_LOGGER.warn("Successfully found the file: {}, but an error occurred.", json, e);
         }
     }
 
-    private static String escape(String input) {
+    private static String unEscape(String input) {
         return input.replace("\\{", "{")
             .replace("\\}", "}");
     }
@@ -122,24 +126,25 @@ public final class GTInflectionManager {
         final String input = StatCollector.translateToLocal(inputKey);
         if (!input.contains("s{")) {
             return String.format(
-                escape(input),
+                unEscape(input),
                 Arrays.stream(formatterKey)
                     .map(StatCollector::translateToLocal)
                     .toArray(Object[]::new));
         }
         if (IS_SERVER) {
             return String.format(
-                escape(input.replaceAll(PLACEHOLDER_PATTERN.pattern(), "%$1s")),
+                unEscape(input),
                 Arrays.stream(formatterKey)
                     .map(StatCollector::translateToLocal)
                     .toArray(Object[]::new));
         }
 
-        List<String> params = new LinkedList<>();
+        List<String> params = new ArrayList<>();
         Matcher matcher = PLACEHOLDER_PATTERN.matcher(input);
         boolean hasImplicit = false;
         boolean hasExplicit = false;
         int sequentialPos = 0;
+        StringBuffer sb = new StringBuffer();
 
         while (matcher.find()) {
             String indexPart = matcher.group(1);
@@ -147,43 +152,28 @@ public final class GTInflectionManager {
 
             int targetPos;
             if (indexPart != null) {
-                targetPos = Integer.parseInt(indexPart.substring(0, indexPart.length() - 1)) - 1;
+                try {
+                    targetPos = Integer.parseInt(indexPart) - 1;
+                } catch (NumberFormatException e) {
+                    return "Inflection Format Error: " + input;
+                }
                 hasExplicit = true;
             } else {
                 targetPos = sequentialPos++;
                 hasImplicit = true;
             }
 
-            if (targetPos >= formatterKey.length) {
-                GT_FML_LOGGER.warn(
-                    "Inflection Format Error: Placeholder index {} out of bounds for inputKey '{}' (only {} arguments provided)",
-                    targetPos + 1,
-                    inputKey,
-                    formatterKey.length);
-                return String.format(
-                    escape(input),
-                    Arrays.stream(formatterKey)
-                        .map(StatCollector::translateToLocal)
-                        .toArray(Object[]::new));
-            }
-
-            if (hasImplicit && hasExplicit) {
-                GT_FML_LOGGER.warn(
-                    "Inflection Format Error: Mixed implicit (%s) and explicit (%2$s) placeholders in inflection string: '{}'",
-                    inputKey);
-                return String.format(
-                    escape(input),
-                    Arrays.stream(formatterKey)
-                        .map(StatCollector::translateToLocal)
-                        .toArray(Object[]::new));
+            if (targetPos >= formatterKey.length || (hasImplicit && hasExplicit)) {
+                return "Inflection Format Error: " + input;
             }
 
             params.add(getInflection(formatterKey[targetPos], inflectionKey));
+            matcher.appendReplacement(sb, "%s");
         }
-
+        matcher.appendTail(sb);
         Object[] formattedArgs = params.toArray();
 
-        String cleanedPattern = escape(input.replaceAll(PLACEHOLDER_PATTERN.pattern(), "%s"));
+        String cleanedPattern = unEscape(sb.toString());
         return String.format(cleanedPattern, formattedArgs);
     }
 
@@ -193,17 +183,17 @@ public final class GTInflectionManager {
             return word;
         }
         String specialCaseKey = formatterKey;
-        final String[] rules = key.split("/");
-        for (String rule : rules) {
-            if (rule.isEmpty()) {
+        final String[] targetRules = key.split("/");
+        for (String targetRule : targetRules) {
+            if (targetRule.isEmpty()) {
                 GT_FML_LOGGER.warn("A rule key is empty, full rule key: {}", key);
             }
-            specialCaseKey += "." + rule;
+            specialCaseKey += "." + targetRule;
             if (StatCollector.canTranslate(specialCaseKey)) {
                 word = StatCollector.translateToLocal(specialCaseKey);
                 continue;
             }
-            switch (rule) {
+            switch (targetRule) {
                 case "lowercase" -> {
                     word = word.toLowerCase(LOCALE);
                     continue;
@@ -235,18 +225,21 @@ public final class GTInflectionManager {
                     continue;
                 }
             }
-            LinkedHashMap<Pattern, String> ruleMap = INFLECTION_MAP.get(rule);
-            if (ruleMap == null || ruleMap.isEmpty()) {
+            List<Rule> rules = INFLECTION_MAP.get(targetRule);
+            if (rules == null || rules.isEmpty()) {
                 continue;
             }
-            for (Entry<Pattern, String> ruleEntry : ruleMap.entrySet()) {
-                Matcher m = ruleEntry.getKey()
+            for (Rule rule : rules) {
+                Matcher m = rule.pattern()
                     .matcher(word);
                 if (m.matches()) {
-                    word = m.replaceFirst(ruleEntry.getValue());
+                    word = m.replaceFirst(rule.replacement());
                 }
             }
         }
         return word;
     }
+
+    @Desugar
+    private record Rule(Pattern pattern, String replacement) {}
 }

--- a/src/main/java/gregtech/api/util/GTLanguageManager.java
+++ b/src/main/java/gregtech/api/util/GTLanguageManager.java
@@ -6,6 +6,7 @@ import static gregtech.api.util.GTRecipeBuilder.WILDCARD;
 import java.io.File;
 import java.lang.reflect.Field;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -74,6 +75,7 @@ public class GTLanguageManager {
     private static final Map<String, String> stringTranslateLanguageList;
     private static final Map<String, String> stringTranslateLanguageListFallBack;
     public static String LanguageCode = "en_US";
+    public static Locale LOCALE;
 
     static {
         try {

--- a/src/main/resources/assets/gregtech/inflection/en_US.example.json
+++ b/src/main/resources/assets/gregtech/inflection/en_US.example.json
@@ -1,7 +1,7 @@
 {
     "type1": {
         "regex pattern": "regex replace pattern",
-        "check the link": "https://gist.github.com/iouter/efcfb45dbc337e5c45f1c177df3cbaa0",
+        "check the link": "https://wiki.gtnewhorizons.com/wiki/Inflection_Manager",
         "pattern3": "replace3"
     },
     "type2": {

--- a/src/mixin/java/gregtech/mixin/mixins/early/minecraft/LanguageRegistryMixin.java
+++ b/src/mixin/java/gregtech/mixin/mixins/early/minecraft/LanguageRegistryMixin.java
@@ -1,13 +1,13 @@
 package gregtech.mixin.mixins.early.minecraft;
 
-import java.util.Locale;
 import java.util.Map;
 
-import com.ibm.icu.impl.LocaleUtility;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.ibm.icu.impl.LocaleUtility;
 
 import cpw.mods.fml.common.ModContainer;
 import cpw.mods.fml.common.registry.LanguageRegistry;

--- a/src/mixin/java/gregtech/mixin/mixins/early/minecraft/LanguageRegistryMixin.java
+++ b/src/mixin/java/gregtech/mixin/mixins/early/minecraft/LanguageRegistryMixin.java
@@ -1,7 +1,9 @@
 package gregtech.mixin.mixins.early.minecraft;
 
+import java.util.Locale;
 import java.util.Map;
 
+import com.ibm.icu.impl.LocaleUtility;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -29,6 +31,7 @@ public class LanguageRegistryMixin {
 
     @Inject(method = "mergeLanguageTable", at = @At(value = "HEAD"), remap = false)
     private void gt5u$mergeLanguageTable(Map field_135032_a, String lang, CallbackInfo ci) {
+        GTLanguageManager.LOCALE = LocaleUtility.getLocaleFromName(lang);
         GTInflectionManager.loadInflectionJson(lang);
         GTLanguageManager.reloadLanguage(field_135032_a);
     }


### PR DESCRIPTION
Now it can perform multiple replacements.

```json
{
    "part2": {
        "(.*)el": "$1test"
    },
    "part3": {
        "(.*)test": "$1tesssssst"
    }
}
```

```
gt.oreprefix.material_plate=%s{part1/part2/part3} Plate
Material.steel.part1=Steeeeeeeeeeeeel
```

In Game:
<img width="926" height="143" alt="image" src="https://github.com/user-attachments/assets/1b9e76cf-0b64-495d-95d6-f0c539ef753a" />

Some built-in rules have also been added, including lowercase, uppercase, and capitalize

Phrase Key: when there is more than one word in the material translation name, a special oreprefix key can be used for translation.