### PR TITLE
Fix: prevent jetpack movement while in GUI

### DIFF
--- a/src/main/java/gregtech/api/enums/ItemList.java
+++ b/src/main/java/gregtech/api/enums/ItemList.java
@@ -2830,6 +2830,7 @@ public enum ItemList implements IItemContainer {
     Augment_SpaceSuit,
     Augment_ForceField,
     Augment_WaterBreathing,
+    Augment_MilkInfusion,
 
     CompressedOutputBusLuV,
     CompressedOutputBusZPM,

--- a/src/main/java/gregtech/api/items/armor/MechArmorAugmentRegistries.java
+++ b/src/main/java/gregtech/api/items/armor/MechArmorAugmentRegistries.java
@@ -3,7 +3,6 @@ package gregtech.api.items.armor;
 import java.util.Collection;
 import java.util.HashMap;
 
-import gregtech.api.items.armor.behaviors.*;
 import net.minecraft.item.EnumRarity;
 import net.minecraft.item.ItemStack;
 
@@ -16,6 +15,7 @@ import gregtech.api.items.ItemAugment;
 import gregtech.api.items.ItemAugmentCore;
 import gregtech.api.items.ItemAugmentFrame;
 import gregtech.api.items.armor.AugmentBuilder.AugmentCategory;
+import gregtech.api.items.armor.behaviors.*;
 
 public class MechArmorAugmentRegistries {
 
@@ -512,20 +512,20 @@ public class MechArmorAugmentRegistries {
             .setCategory(AugmentCategory.Movement)
             .setRarity(EnumRarity.rare)
         ),
+        WaterBreathing(ItemList.Augment_WaterBreathing, new AugmentBuilder()
+            .setId("WaterBreathing")
+            .setItemId("augmentwaterbreathing")
+            .fitsInto(ArmorType.Helmet)
+            .providesBehaviors(WaterBreathingBehavior.INSTANCE)
+            .setCategory(AugmentCategory.Utility)
+            .setRarity(EnumRarity.uncommon)
+        ),
         MilkInfusion(ItemList.Augment_MilkInfusion, new AugmentBuilder()
             .setId("MilkInfusion")
             .setItemId("augmentmilkinfusion")
             .fitsInto(ArmorType.Helmet)
             .providesBehaviors(MilkInfusionBehavior.INSTANCE)
             .setMinimumCore(1)
-            .setCategory(AugmentCategory.Utility)
-            .setRarity(EnumRarity.uncommon)
-        ),
-        WaterBreathing(ItemList.Augment_WaterBreathing, new AugmentBuilder()
-            .setId("WaterBreathing")
-            .setItemId("augmentwaterbreathing")
-            .fitsInto(ArmorType.Helmet)
-            .providesBehaviors(WaterBreathingBehavior.INSTANCE)
             .setCategory(AugmentCategory.Utility)
             .setRarity(EnumRarity.uncommon)
         );

--- a/src/main/java/gregtech/api/items/armor/MechArmorAugmentRegistries.java
+++ b/src/main/java/gregtech/api/items/armor/MechArmorAugmentRegistries.java
@@ -15,7 +15,31 @@ import gregtech.api.items.ItemAugment;
 import gregtech.api.items.ItemAugmentCore;
 import gregtech.api.items.ItemAugmentFrame;
 import gregtech.api.items.armor.AugmentBuilder.AugmentCategory;
-import gregtech.api.items.armor.behaviors.*;
+import gregtech.api.items.armor.behaviors.ApiaristBehavior;
+import gregtech.api.items.armor.behaviors.BehaviorName;
+import gregtech.api.items.armor.behaviors.CreativeFlightBehavior;
+import gregtech.api.items.armor.behaviors.FallProtectionBehavior;
+import gregtech.api.items.armor.behaviors.FireImmunityBehavior;
+import gregtech.api.items.armor.behaviors.ForceFieldBehavior;
+import gregtech.api.items.armor.behaviors.GogglesOfRevealingBehavior;
+import gregtech.api.items.armor.behaviors.HazmatBehavior;
+import gregtech.api.items.armor.behaviors.IArmorBehavior;
+import gregtech.api.items.armor.behaviors.InertiaCancelingBehavior;
+import gregtech.api.items.armor.behaviors.InfiniteEnergyBehavior;
+import gregtech.api.items.armor.behaviors.JetpackBehavior;
+import gregtech.api.items.armor.behaviors.JetpackHoverBehavior;
+import gregtech.api.items.armor.behaviors.JetpackPerfectHoverBehavior;
+import gregtech.api.items.armor.behaviors.JumpBoostBehavior;
+import gregtech.api.items.armor.behaviors.KnockbackResistBehavior;
+import gregtech.api.items.armor.behaviors.MilkInfusionBehavior;
+import gregtech.api.items.armor.behaviors.NightVisionBehavior;
+import gregtech.api.items.armor.behaviors.OmniMovementBehavior;
+import gregtech.api.items.armor.behaviors.SpaceSuitBehavior;
+import gregtech.api.items.armor.behaviors.SpeedBoostBehavior;
+import gregtech.api.items.armor.behaviors.StepAssistBehavior;
+import gregtech.api.items.armor.behaviors.SwimSpeedBehavior;
+import gregtech.api.items.armor.behaviors.VisDiscountBehavior;
+import gregtech.api.items.armor.behaviors.WaterBreathingBehavior;
 
 public class MechArmorAugmentRegistries {
 

--- a/src/main/java/gregtech/api/items/armor/MechArmorAugmentRegistries.java
+++ b/src/main/java/gregtech/api/items/armor/MechArmorAugmentRegistries.java
@@ -3,6 +3,7 @@ package gregtech.api.items.armor;
 import java.util.Collection;
 import java.util.HashMap;
 
+import gregtech.api.items.armor.behaviors.*;
 import net.minecraft.item.EnumRarity;
 import net.minecraft.item.ItemStack;
 
@@ -15,30 +16,6 @@ import gregtech.api.items.ItemAugment;
 import gregtech.api.items.ItemAugmentCore;
 import gregtech.api.items.ItemAugmentFrame;
 import gregtech.api.items.armor.AugmentBuilder.AugmentCategory;
-import gregtech.api.items.armor.behaviors.ApiaristBehavior;
-import gregtech.api.items.armor.behaviors.BehaviorName;
-import gregtech.api.items.armor.behaviors.CreativeFlightBehavior;
-import gregtech.api.items.armor.behaviors.FallProtectionBehavior;
-import gregtech.api.items.armor.behaviors.FireImmunityBehavior;
-import gregtech.api.items.armor.behaviors.ForceFieldBehavior;
-import gregtech.api.items.armor.behaviors.GogglesOfRevealingBehavior;
-import gregtech.api.items.armor.behaviors.HazmatBehavior;
-import gregtech.api.items.armor.behaviors.IArmorBehavior;
-import gregtech.api.items.armor.behaviors.InertiaCancelingBehavior;
-import gregtech.api.items.armor.behaviors.InfiniteEnergyBehavior;
-import gregtech.api.items.armor.behaviors.JetpackBehavior;
-import gregtech.api.items.armor.behaviors.JetpackHoverBehavior;
-import gregtech.api.items.armor.behaviors.JetpackPerfectHoverBehavior;
-import gregtech.api.items.armor.behaviors.JumpBoostBehavior;
-import gregtech.api.items.armor.behaviors.KnockbackResistBehavior;
-import gregtech.api.items.armor.behaviors.NightVisionBehavior;
-import gregtech.api.items.armor.behaviors.OmniMovementBehavior;
-import gregtech.api.items.armor.behaviors.SpaceSuitBehavior;
-import gregtech.api.items.armor.behaviors.SpeedBoostBehavior;
-import gregtech.api.items.armor.behaviors.StepAssistBehavior;
-import gregtech.api.items.armor.behaviors.SwimSpeedBehavior;
-import gregtech.api.items.armor.behaviors.VisDiscountBehavior;
-import gregtech.api.items.armor.behaviors.WaterBreathingBehavior;
 
 public class MechArmorAugmentRegistries {
 
@@ -534,6 +511,15 @@ public class MechArmorAugmentRegistries {
             .setMinimumCore(1)
             .setCategory(AugmentCategory.Movement)
             .setRarity(EnumRarity.rare)
+        ),
+        MilkInfusion(ItemList.Augment_MilkInfusion, new AugmentBuilder()
+            .setId("MilkInfusion")
+            .setItemId("augmentmilkinfusion")
+            .fitsInto(ArmorType.Helmet)
+            .providesBehaviors(MilkInfusionBehavior.INSTANCE)
+            .setMinimumCore(1)
+            .setCategory(AugmentCategory.Utility)
+            .setRarity(EnumRarity.uncommon)
         ),
         WaterBreathing(ItemList.Augment_WaterBreathing, new AugmentBuilder()
             .setId("WaterBreathing")

--- a/src/main/java/gregtech/api/items/armor/behaviors/BehaviorName.java
+++ b/src/main/java/gregtech/api/items/armor/behaviors/BehaviorName.java
@@ -32,6 +32,7 @@ public enum BehaviorName {
     WaterBreathing(EnumRarity.uncommon),
     VisDiscount(EnumRarity.uncommon),
     SpaceSuit(EnumRarity.rare),
+    MilkInfusion(EnumRarity.uncommon)
     //
     ;
 

--- a/src/main/java/gregtech/api/items/armor/behaviors/CreativeFlightBehavior.java
+++ b/src/main/java/gregtech/api/items/armor/behaviors/CreativeFlightBehavior.java
@@ -27,11 +27,13 @@ public class CreativeFlightBehavior implements IArmorBehavior {
 
     @Override
     public void onArmorTick(@NotNull ArmorContext context) {
-        if (!context.isRemote()) return;
-
         EntityPlayer player = context.getPlayer();
 
-        // Constantly re-check because alloyFlying is reset when you travel between dimensions
+        player.fallDistance = 0;
+
+        if (!context.isRemote()) return;
+
+        // Constantly re-check because allowFlying is reset when you travel between dimensions
         if (!player.capabilities.allowFlying) {
             player.capabilities.allowFlying = true;
             player.sendPlayerAbilities();

--- a/src/main/java/gregtech/api/items/armor/behaviors/CreativeFlightBehavior.java
+++ b/src/main/java/gregtech/api/items/armor/behaviors/CreativeFlightBehavior.java
@@ -29,7 +29,9 @@ public class CreativeFlightBehavior implements IArmorBehavior {
     public void onArmorTick(@NotNull ArmorContext context) {
         EntityPlayer player = context.getPlayer();
 
-        player.fallDistance = 0;
+        if (context.drainEnergy(75)) {
+            player.fallDistance = 0;
+        }
 
         if (!context.isRemote()) return;
 

--- a/src/main/java/gregtech/api/items/armor/behaviors/JetpackBehavior.java
+++ b/src/main/java/gregtech/api/items/armor/behaviors/JetpackBehavior.java
@@ -67,11 +67,13 @@ public class JetpackBehavior implements IArmorBehavior {
         double currentSpeedVertical = jetpackStats.getVerticalSpeed() * (player.isInWater() ? 0.4D : 1.0D);
         boolean ascend = ArmorKeybinds.VANILLA_JUMP.isKeyDown(player);
         boolean descend = ArmorKeybinds.VANILLA_SNEAK.isKeyDown(player);
+        boolean isHovering = context.isBehaviorActive(BehaviorName.JetpackHover);
+        boolean isGuiOpen = context.getPlayer().worldObj.isRemote && ClientGuiHelper.isGuiOpen();
 
-        if (ascend || context.isBehaviorActive(BehaviorName.JetpackHover) && !player.onGround) {
+        if (ascend || isHovering && !player.onGround) {
             if (!player.isInWater() && context.drainEnergy(20)) {
-                if (ascend) {
-                    if (!context.isBehaviorActive(BehaviorName.JetpackHover)) {
+                if (ascend && !isGuiOpen) {
+                    if (!isHovering) {
                         player.motionY = Math.min(player.motionY + currentAccel, currentSpeedVertical);
                     } else {
                         if (descend) player.motionY = Math
@@ -79,7 +81,7 @@ public class JetpackBehavior implements IArmorBehavior {
                         else player.motionY = Math
                             .min(player.motionY + currentAccel, jetpackStats.getVerticalHoverSpeed());
                     }
-                } else if (descend) {
+                } else if (descend && !isGuiOpen) {
                     player.motionY = Math.min(player.motionY + currentAccel, -jetpackStats.getVerticalHoverSpeed());
                 } else {
                     player.motionY = Math.min(
@@ -93,16 +95,30 @@ public class JetpackBehavior implements IArmorBehavior {
                     ? speedSideways * jetpackStats.getSprintSpeedModifier()
                     : speedSideways);
 
-                if (ArmorKeybinds.VANILLA_FORWARD.isKeyDown(player)) player.moveFlying(0, speedForward, speedForward);
-                if (ArmorKeybinds.VANILLA_BACK.isKeyDown(player))
-                    player.moveFlying(0, -speedSideways, speedSideways * 0.8f);
-                if (ArmorKeybinds.VANILLA_LEFT.isKeyDown(player)) player.moveFlying(speedSideways, 0, speedSideways);
-                if (ArmorKeybinds.VANILLA_RIGHT.isKeyDown(player)) player.moveFlying(-speedSideways, 0, speedSideways);
+                if (!isGuiOpen) {
+                    if (ArmorKeybinds.VANILLA_FORWARD.isKeyDown(player))
+                        player.moveFlying(0, speedForward, speedForward);
+                    if (ArmorKeybinds.VANILLA_BACK.isKeyDown(player))
+                        player.moveFlying(0, -speedSideways, speedSideways * 0.8f);
+                    if (ArmorKeybinds.VANILLA_LEFT.isKeyDown(player))
+                        player.moveFlying(speedSideways, 0, speedSideways);
+                    if (ArmorKeybinds.VANILLA_RIGHT.isKeyDown(player))
+                        player.moveFlying(-speedSideways, 0, speedSideways);
+                }
+
                 if (!player.getEntityWorld().isRemote) {
                     player.fallDistance = 0;
                 }
                 // spawnParticle(player.getEntityWorld(), player, jetpackStats.getParticle());
             }
         }
+    }
+}
+
+class ClientGuiHelper {
+
+    @cpw.mods.fml.relauncher.SideOnly(cpw.mods.fml.relauncher.Side.CLIENT)
+    static boolean isGuiOpen() {
+        return net.minecraft.client.Minecraft.getMinecraft().currentScreen != null;
     }
 }

--- a/src/main/java/gregtech/api/items/armor/behaviors/MilkInfusionBehavior.java
+++ b/src/main/java/gregtech/api/items/armor/behaviors/MilkInfusionBehavior.java
@@ -1,46 +1,57 @@
 package gregtech.api.items.armor.behaviors;
 
-import com.gtnewhorizon.gtnhlib.keybind.SyncedKeybind;
-import gregtech.api.items.armor.ArmorContext;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.potion.Potion;
 import net.minecraft.potion.PotionEffect;
+
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Collections;
-import java.util.Set;
-
-import static gregtech.api.items.armor.ArmorKeybinds.OMNI_MOVEMENT_KEYBIND;
+import gregtech.api.items.armor.ArmorContext;
 
 public class MilkInfusionBehavior implements IArmorBehavior {
 
     public static MilkInfusionBehavior INSTANCE = new MilkInfusionBehavior();
 
     @Override
-    public BehaviorName getName() { return BehaviorName.MilkInfusion; }
+    public BehaviorName getName() {
+        return BehaviorName.MilkInfusion;
+    }
 
     @Override
     public void onArmorTick(@NotNull ArmorContext context) {
         if (context.isRemote()) return;
-
         EntityPlayer player = context.getPlayer();
 
-        for (Object obj: player.getActivePotionEffects()){
-            if (obj instanceof PotionEffect effect) {
-                int effectID = effect.getPotionID();
+        if (player.ticksExisted % 10 != 0) {
+            return;
+        }
 
-                if (effectID >= 0 && effectID < Potion.potionTypes.length) {
-                    Potion potion = Potion.potionTypes[effectID];
+        Collection<PotionEffect> activeEffects = player.getActivePotionEffects();
+        if (activeEffects.isEmpty()) return;
 
-                    if (potion != null && potion.isBadEffect()) {
-                        if (context.drainEnergy(5000)) {
-                            player.removePotionEffect(effectID);
+        List<PotionEffect> effectsToProcess = new ArrayList<>(activeEffects);
+        boolean effectRemoved = false;
 
-                            player.worldObj.playSoundAtEntity(player, "random.drink", 1.0F, 1.1F);
-                        }
+        for (PotionEffect effect : effectsToProcess) {
+            int effectID = effect.getPotionID();
+
+            if (effectID >= 0 && effectID < Potion.potionTypes.length) {
+                Potion potion = Potion.potionTypes[effectID];
+
+                if (potion != null && potion.isBadEffect()) {
+                    if (context.drainEnergy(5000)) {
+                        player.removePotionEffect(effectID);
+                        effectRemoved = true;
                     }
                 }
             }
+        }
+        if (effectRemoved) {
+            player.worldObj.playSoundAtEntity(player, "random.drink", 1.0F, 1.1F);
         }
     }
 }

--- a/src/main/java/gregtech/api/items/armor/behaviors/MilkInfusionBehavior.java
+++ b/src/main/java/gregtech/api/items/armor/behaviors/MilkInfusionBehavior.java
@@ -1,0 +1,46 @@
+package gregtech.api.items.armor.behaviors;
+
+import com.gtnewhorizon.gtnhlib.keybind.SyncedKeybind;
+import gregtech.api.items.armor.ArmorContext;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.potion.Potion;
+import net.minecraft.potion.PotionEffect;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collections;
+import java.util.Set;
+
+import static gregtech.api.items.armor.ArmorKeybinds.OMNI_MOVEMENT_KEYBIND;
+
+public class MilkInfusionBehavior implements IArmorBehavior {
+
+    public static MilkInfusionBehavior INSTANCE = new MilkInfusionBehavior();
+
+    @Override
+    public BehaviorName getName() { return BehaviorName.MilkInfusion; }
+
+    @Override
+    public void onArmorTick(@NotNull ArmorContext context) {
+        if (context.isRemote()) return;
+
+        EntityPlayer player = context.getPlayer();
+
+        for (Object obj: player.getActivePotionEffects()){
+            if (obj instanceof PotionEffect effect) {
+                int effectID = effect.getPotionID();
+
+                if (effectID >= 0 && effectID < Potion.potionTypes.length) {
+                    Potion potion = Potion.potionTypes[effectID];
+
+                    if (potion != null && potion.isBadEffect()) {
+                        if (context.drainEnergy(5000)) {
+                            player.removePotionEffect(effectID);
+
+                            player.worldObj.playSoundAtEntity(player, "random.drink", 1.0F, 1.1F);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/resources/assets/gregtech/lang/en_US.lang
+++ b/src/main/resources/assets/gregtech/lang/en_US.lang
@@ -3391,6 +3391,7 @@ GT5U.armor.part.name.SpaceSuit=Augment: Astronaut's Equipment
 GT5U.armor.part.name.ForceField=Augment: Energy Grid Defense
 GT5U.armor.part.name.OmniMovement=Augment: Rotational Movement Adjusters
 GT5U.armor.part.name.WaterBreathing=Augment: Rebreather
+GT5U.armor.part.name.MilkInfusion=Augment: Milk Infusion
 
 GT5U.armor.part.tooltip.NightVision=Allows user to see clearly at night and in the dark
 GT5U.armor.part.tooltip.CreativeFlight=Grants the user creative flight
@@ -3411,6 +3412,7 @@ GT5U.armor.part.tooltip.SpaceSuit=Adds Spacesuit capability. Must be applied to 
 GT5U.armor.part.tooltip.ForceField=Allows user to deploy a powerful forcefield which will block any damage for huge amounts of eu
 GT5U.armor.part.tooltip.OmniMovement=Allows user to move at increased speed in all directions
 GT5U.armor.part.tooltip.WaterBreathing=Restore's the user's air if they run out underwater
+GT5U.armor.part.tooltip.MilkInfusion=Removes bad potion effects
 
 GT5U.armor.behavior.NightVision=Night Vision
 GT5U.armor.behavior.GogglesOfRevealing=Thaumic Sight
@@ -3434,6 +3436,7 @@ GT5U.armor.behavior.InfiniteEnergy=Infinite Energy
 GT5U.armor.behavior.ForceField=Force Field
 GT5U.armor.behavior.WaterBreathing=Water Breathing
 GT5U.armor.behavior.Teleporter=Personal Teleporter
+GT5U.armor.behavior.MilkInfusion=Milk Infusion
 
 GT5U.armor.message.enabled=%s Enabled
 GT5U.armor.message.disabled=%s Disabled


### PR DESCRIPTION
Bug Fix: Prevents jetpack movement while in GUI. Uses a helper class to ensure server compatibility.

Bug Fix: Added fall damage immunity to creative flight to fix a bug where you take fall damage while slowly descending with sneak.

Assumption: You should not take fall damage while wearing a chestplate with this module.