### PR TITLE
Don't render CTM in inventory, use default IIcon

### DIFF
--- a/src/main/java/gregtech/common/render/GTCopiedBlockTextureRender.java
+++ b/src/main/java/gregtech/common/render/GTCopiedBlockTextureRender.java
@@ -35,7 +35,7 @@ public class GTCopiedBlockTextureRender extends GTTextureBase implements IBlockC
         else return ctx instanceof ISBRWorldContext ctxW
             ? CTMUtils
                 .getBlockIcon(icon, mBlock, ctxW.getBlockAccess(), ctxW.getX(), ctxW.getY(), ctxW.getZ(), ordinalSide)
-            : CTMUtils.getBlockIcon(icon, mBlock, ordinalSide);
+            : icon;
     }
 
     @Override


### PR DESCRIPTION
Fixes a BEC-casing related bug, but this is non-changing for any CTM block which also had a default IIcon (like NAC glass, probably all of them).

Fix is, just don't use CTM when you're in inventory (and can't have connected textures). This allows CTM blocks to use a different texture than CTM index 0 for their inventory renders (BEC casing does this because it looks much better).

Tested, BEC casing works, NAC glass works.