### PR TITLE
Localize bee frame tooltips via GTUtility.translate()

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/forestry/bees/items/FRItemRegistry.java
+++ b/src/main/java/gtPlusPlus/xmod/forestry/bees/items/FRItemRegistry.java
@@ -16,14 +16,13 @@ public class FRItemRegistry {
         GregtechItemList.HiveFrameVoid
             .set(new MBItemFrame(MBFrameType.USELESS, EnumRarity.common, "gtpp.tooltip.frame.void"));
 
-        GregtechItemList.HiveFrameAccelerated.set(
-            new MBItemFrame(MBFrameType.ACCELERATED, "gtpp.tooltip.frame.accelerated"));
+        GregtechItemList.HiveFrameAccelerated
+            .set(new MBItemFrame(MBFrameType.ACCELERATED, "gtpp.tooltip.frame.accelerated"));
 
-        GregtechItemList.HiveFrameMutagenic.set(
-            new MBItemFrame(MBFrameType.MUTAGENIC, EnumRarity.epic, "gtpp.tooltip.frame.mutagenic"));
+        GregtechItemList.HiveFrameMutagenic
+            .set(new MBItemFrame(MBFrameType.MUTAGENIC, EnumRarity.epic, "gtpp.tooltip.frame.mutagenic"));
 
-        GregtechItemList.HiveFrameBusy
-            .set(new MBItemFrame(MBFrameType.BUSY, "gtpp.tooltip.frame.busy"));
+        GregtechItemList.HiveFrameBusy.set(new MBItemFrame(MBFrameType.BUSY, "gtpp.tooltip.frame.busy"));
 
         GregtechItemList.HiveFrameDecay
             .set(new MBItemFrame(MBFrameType.DECAYING, EnumRarity.uncommon, "gtpp.tooltip.frame.decaying"));
@@ -31,8 +30,8 @@ public class FRItemRegistry {
         GregtechItemList.HiveFrameSlow
             .set(new MBItemFrame(MBFrameType.SLOWING, EnumRarity.common, "gtpp.tooltip.frame.slowing"));
 
-        GregtechItemList.HiveFrameStabilize.set(
-            new MBItemFrame(MBFrameType.STABILIZING, EnumRarity.rare, "gtpp.tooltip.frame.stabilizing"));
+        GregtechItemList.HiveFrameStabilize
+            .set(new MBItemFrame(MBFrameType.STABILIZING, EnumRarity.rare, "gtpp.tooltip.frame.stabilizing"));
 
         GregtechItemList.HiveFrameArborist
             .set(new MBItemFrame(MBFrameType.ARBORISTS, EnumRarity.common, "gtpp.tooltip.frame.arborists"));

--- a/src/main/java/gtPlusPlus/xmod/forestry/bees/items/FRItemRegistry.java
+++ b/src/main/java/gtPlusPlus/xmod/forestry/bees/items/FRItemRegistry.java
@@ -14,30 +14,28 @@ public class FRItemRegistry {
     public static void Register() {
 
         GregtechItemList.HiveFrameVoid
-            .set(new MBItemFrame(MBFrameType.USELESS, EnumRarity.common, "No more cheaty frames for GTNH players."));
+            .set(new MBItemFrame(MBFrameType.USELESS, EnumRarity.common, "gtpp.tooltip.frame.void"));
 
         GregtechItemList.HiveFrameAccelerated.set(
-            new MBItemFrame(
-                MBFrameType.ACCELERATED,
-                "Longevity for bees isn't very common, especially if they're working harder."));
+            new MBItemFrame(MBFrameType.ACCELERATED, "gtpp.tooltip.frame.accelerated"));
 
         GregtechItemList.HiveFrameMutagenic.set(
-            new MBItemFrame(MBFrameType.MUTAGENIC, EnumRarity.epic, "Evolution of the fittest, finest and fastest."));
+            new MBItemFrame(MBFrameType.MUTAGENIC, EnumRarity.epic, "gtpp.tooltip.frame.mutagenic"));
 
         GregtechItemList.HiveFrameBusy
-            .set(new MBItemFrame(MBFrameType.BUSY, "Your bee will work harder and longer than you expected."));
+            .set(new MBItemFrame(MBFrameType.BUSY, "gtpp.tooltip.frame.busy"));
 
         GregtechItemList.HiveFrameDecay
-            .set(new MBItemFrame(MBFrameType.DECAYING, EnumRarity.uncommon, "Who really needs stable genetics?"));
+            .set(new MBItemFrame(MBFrameType.DECAYING, EnumRarity.uncommon, "gtpp.tooltip.frame.decaying"));
 
         GregtechItemList.HiveFrameSlow
-            .set(new MBItemFrame(MBFrameType.SLOWING, EnumRarity.common, "The journey is its own reward."));
+            .set(new MBItemFrame(MBFrameType.SLOWING, EnumRarity.common, "gtpp.tooltip.frame.slowing"));
 
         GregtechItemList.HiveFrameStabilize.set(
-            new MBItemFrame(MBFrameType.STABILIZING, EnumRarity.rare, "If you wish your bees to keep their form."));
+            new MBItemFrame(MBFrameType.STABILIZING, EnumRarity.rare, "gtpp.tooltip.frame.stabilizing"));
 
         GregtechItemList.HiveFrameArborist
-            .set(new MBItemFrame(MBFrameType.ARBORISTS, EnumRarity.common, "Who need Bees when you can have Trees?"));
+            .set(new MBItemFrame(MBFrameType.ARBORISTS, EnumRarity.common, "gtpp.tooltip.frame.arborists"));
 
         ChestGenHooks.addItem(
             ChestGenHooks.STRONGHOLD_CORRIDOR,

--- a/src/main/java/gtPlusPlus/xmod/forestry/bees/items/MBItemFrame.java
+++ b/src/main/java/gtPlusPlus/xmod/forestry/bees/items/MBItemFrame.java
@@ -18,33 +18,34 @@ import forestry.api.apiculture.IBee;
 import forestry.api.apiculture.IBeeHousing;
 import forestry.api.apiculture.IBeeModifier;
 import forestry.api.apiculture.IHiveFrame;
+import gregtech.api.util.GTUtility;
 import gtPlusPlus.core.creative.AddToCreativeTab;
 
 public class MBItemFrame extends Item implements IHiveFrame {
 
     private final MBFrameType type;
     private final EnumRarity rarity_value;
-    private final String toolTip;
+    private final String toolTipKey;
 
-    public MBItemFrame(final MBFrameType frameType, final String description) {
-        this(frameType, EnumRarity.uncommon, description);
+    public MBItemFrame(final MBFrameType frameType, final String tooltipKey) {
+        this(frameType, EnumRarity.uncommon, tooltipKey);
     }
 
-    public MBItemFrame(final MBFrameType frameType, final EnumRarity rarity, final String description) {
+    public MBItemFrame(final MBFrameType frameType, final EnumRarity rarity, final String tooltipKey) {
         this.type = frameType;
         this.setMaxDamage(this.type.maxDamage);
         this.setMaxStackSize(1);
         this.setCreativeTab(AddToCreativeTab.tabMisc);
         this.setUnlocalizedName("frame" + frameType.getName());
         this.rarity_value = rarity;
-        this.toolTip = description;
+        this.toolTipKey = tooltipKey;
         GameRegistry.registerItem(this, "frame" + frameType.getName());
     }
 
     @Override
     public void addInformation(final ItemStack stack, final EntityPlayer aPlayer, final List list, final boolean bool) {
-        if (!this.toolTip.isEmpty()) {
-            list.add(EnumChatFormatting.GRAY + this.toolTip);
+        if (!this.toolTipKey.isEmpty()) {
+            list.add(EnumChatFormatting.GRAY + GTUtility.translate(this.toolTipKey));
         }
         super.addInformation(stack, aPlayer, list, bool);
     }

--- a/src/main/resources/assets/miscutils/lang/en_US.lang
+++ b/src/main/resources/assets/miscutils/lang/en_US.lang
@@ -4260,6 +4260,15 @@ gtplusplus.blocktieredcasings.1.1.name=Integral Encasement II
 gtplusplus.blocktieredcasings.1.2.name=Integral Encasement III
 gtplusplus.blocktieredcasings.1.3.name=Integral Encasement IV
 gtplusplus.blocktieredcasings.1.4.name=Integral Encasement V
+gtpp.tooltip.frame.void=No more cheaty frames for GTNH players.
+gtpp.tooltip.frame.accelerated=Longevity for bees isn't very common, especially if they're working harder.
+gtpp.tooltip.frame.mutagenic=Evolution of the fittest, finest and fastest.
+gtpp.tooltip.frame.busy=Your bee will work harder and longer than you expected.
+gtpp.tooltip.frame.decaying=Who really needs stable genetics?
+gtpp.tooltip.frame.slowing=The journey is its own reward.
+gtpp.tooltip.frame.stabilizing=If you wish your bees to keep their form.
+gtpp.tooltip.frame.arborists=Who need Bees when you can have Trees?
+
 gtplusplus.blocktieredcasings.1.5.name=Integral Framework I
 gtplusplus.blocktieredcasings.1.6.name=Integral Framework II
 gtplusplus.blocktieredcasings.1.7.name=Integral Framework III

--- a/src/main/resources/assets/miscutils/lang/ru_RU.lang
+++ b/src/main/resources/assets/miscutils/lang/ru_RU.lang
@@ -4050,3 +4050,12 @@ gtpp.chat.wireless_charger.lock=Locked to owner
 gtpp.chat.wireless_charger.unlock=Разблокировано
 gtpp.chat.wireless_charger.enter=Вы вошли в радиус зарядки. [%s м - %s]
 gtpp.chat.wireless_charger.leave=Вы покинули радиус зарядки. [%s м - %s]
+
+gtpp.tooltip.frame.void=Никаких читерских рамок для игроков GTNH.
+gtpp.tooltip.frame.accelerated=Долголетие пчёл — редкость, особенно когда они работают усерднее.
+gtpp.tooltip.frame.mutagenic=Эволюция самых приспособленных, лучших и быстрых.
+gtpp.tooltip.frame.busy=Ваша пчела будет работать усерднее и дольше, чем вы ожидали.
+gtpp.tooltip.frame.decaying=Кому нужна стабильная генетика?
+gtpp.tooltip.frame.slowing=Сам путь и есть награда.
+gtpp.tooltip.frame.stabilizing=Если вы хотите, чтобы ваши пчёлы сохранили свою форму.
+gtpp.tooltip.frame.arborists=Зачем нужны пчёлы, если есть деревья?


### PR DESCRIPTION
Localize bee frame tooltips

- Replace hardcoded tooltip strings in `MBItemFrame` with localization keys
- Use `GTUtility.translate()` in `addInformation` for live language switching without client restart
- Add `gtpp.tooltip.frame.*` keys to `miscutils` en_US and ru_RU lang files