### PR TITLE
Fix the issue where the NBT of the crafted milling ball is inconsistent with that marked in the container.

### DIFF
--- a/src/main/java/gtPlusPlus/core/item/chemistry/RecipeLoaderGenericChem.java
+++ b/src/main/java/gtPlusPlus/core/item/chemistry/RecipeLoaderGenericChem.java
@@ -27,6 +27,7 @@ import gregtech.api.util.GTModHandler;
 import gregtech.api.util.GTOreDictUnificator;
 import gregtech.api.util.GTRecipeConstants;
 import gtPlusPlus.core.fluids.GTPPFluids;
+import gtPlusPlus.core.item.chemistry.general.ItemGenericChemBase;
 import gtPlusPlus.core.material.MaterialMisc;
 import gtPlusPlus.core.util.minecraft.ItemUtils;
 import gtPlusPlus.xmod.gregtech.api.enums.GregtechItemList;
@@ -179,10 +180,12 @@ public class RecipeLoaderGenericChem {
     }
 
     private static void recipeGrindingBallAlumina() {
+        ItemStack aluminaBallOutput = GregtechItemList.Milling_Ball_Alumina.get(8);
+        ItemGenericChemBase.createMillingBallNBT(aluminaBallOutput);
         GTValues.RA.stdBuilder()
             .itemInputs(WerkstoffLoader.Alumina.get(OrePrefixes.dust, 64))
             .circuit(10)
-            .itemOutputs(GregtechItemList.Milling_Ball_Alumina.get(8))
+            .itemOutputs(aluminaBallOutput)
             .fluidInputs(new FluidStack(GTPPFluids.Aniline, 4_000))
             .duration(3 * MINUTES)
             .eut(TierEU.RECIPE_HV)
@@ -190,10 +193,12 @@ public class RecipeLoaderGenericChem {
     }
 
     private static void recipeGrindingBallSoapstone() {
+        ItemStack soapstoneBallOutput = GregtechItemList.Milling_Ball_Soapstone.get(8);
+        ItemGenericChemBase.createMillingBallNBT(soapstoneBallOutput);
         GTValues.RA.stdBuilder()
             .itemInputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.Soapstone, 32))
             .circuit(10)
-            .itemOutputs(GregtechItemList.Milling_Ball_Soapstone.get(8))
+            .itemOutputs(soapstoneBallOutput)
             .fluidInputs(new FluidStack(GTPPFluids.LiquidResin, 2_500))
             .duration(2 * MINUTES)
             .eut(TierEU.RECIPE_HV)


### PR DESCRIPTION
crafted milling ball
<img width="1201" height="568" alt="image" src="https://github.com/user-attachments/assets/33c72f8c-bd59-46af-8bc8-24438e3d7cec" />

the marked milling ball directly dragged from NEI
<img width="1677" height="752" alt="image" src="https://github.com/user-attachments/assets/921ee8e9-cdc8-40f1-8d40-e50695f4e73a" />
which it had a spec tags

after fixes:
<img width="1415" height="936" alt="image" src="https://github.com/user-attachments/assets/8d6849bc-a597-4989-bb50-ea544439c1d1" />

Now the crafted milling ball also comes with its own NBT.