### PR TITLE
Fix Energy in some Reworked Multis

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTELargeBoilerBase.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTELargeBoilerBase.java
@@ -278,7 +278,7 @@ public abstract class MTELargeBoilerBase extends MTEExtendedPowerMultiBlockBase<
                 // if any item is not in ALLOWED_SOLID_FUELS, operation cannot be allowed because it might still be
                 // consumed
                 this.mMaxProgresstime = 0;
-                this.mEUt = 0;
+                this.lEUt = 0;
                 return false;
             }
         }
@@ -321,7 +321,7 @@ public abstract class MTELargeBoilerBase extends MTEExtendedPowerMultiBlockBase<
                     if (depleteInput(tFluid)) {
                         this.mMaxProgresstime = adjustBurnTimeForConfig(runtimeBoost(tRecipe.mSpecialValue / 2));
                         this.mEfficiencyIncrease = this.mMaxProgresstime * getEfficiencyIncrease() * 4;
-                        this.mEUt = adjustEUtForConfig(getEUt());
+                        this.lEUt = adjustEUtForConfig(getEUt());
                         if (this.mEfficiencyIncrease > 5000) {
                             this.mEfficiencyIncrease = 0;
                             this.superEfficencyIncrease = 20;
@@ -338,7 +338,7 @@ public abstract class MTELargeBoilerBase extends MTEExtendedPowerMultiBlockBase<
                         this.mMaxProgresstime = adjustBurnTimeForConfig(
                             Math.max(1, runtimeBoost(tRecipe.mSpecialValue * 2)));
                         this.mEfficiencyIncrease = this.mMaxProgresstime * getEfficiencyIncrease();
-                        this.mEUt = adjustEUtForConfig(getEUt());
+                        this.lEUt = adjustEUtForConfig(getEUt());
                         if (this.mEfficiencyIncrease > 5000) {
                             this.mEfficiencyIncrease = 0;
                             this.superEfficencyIncrease = 20;
@@ -361,7 +361,7 @@ public abstract class MTELargeBoilerBase extends MTEExtendedPowerMultiBlockBase<
                             this.excessFuel %= 80;
                             this.mEfficiencyIncrease = this.mMaxProgresstime * getEfficiencyIncrease();
                             this.mMaxProgresstime = adjustBurnTimeForConfig(runtimeBoost(this.mMaxProgresstime));
-                            this.mEUt = adjustEUtForConfig(getEUt());
+                            this.lEUt = adjustEUtForConfig(getEUt());
                             this.mOutputItems = new ItemStack[] { GTUtility.getContainerItem(tInput, true) };
                             tInput.stackSize -= 1;
                             updateSlots();
@@ -387,7 +387,7 @@ public abstract class MTELargeBoilerBase extends MTEExtendedPowerMultiBlockBase<
                             this.mEfficiencyIncrease = this.mMaxProgresstime * getEfficiencyIncrease();
                             int burnTime = (int) (this.mMaxProgresstime * getLongBurntimeRatio(tInput));
                             this.mMaxProgresstime = adjustBurnTimeForConfig(runtimeBoost(burnTime));
-                            this.mEUt = adjustEUtForConfig(getEUt());
+                            this.lEUt = adjustEUtForConfig(getEUt());
                             this.mOutputItems = new ItemStack[] { GTUtility.getContainerItem(tInput, true) };
                             tInput.stackSize -= 1;
                             updateSlots();
@@ -402,7 +402,7 @@ public abstract class MTELargeBoilerBase extends MTEExtendedPowerMultiBlockBase<
             }
         }
         this.mMaxProgresstime = 0;
-        this.mEUt = 0;
+        this.lEUt = 0;
         return CheckRecipeResultRegistry.NO_FUEL_FOUND;
     }
 
@@ -415,12 +415,12 @@ public abstract class MTELargeBoilerBase extends MTEExtendedPowerMultiBlockBase<
 
     @Override
     public boolean onRunningTick(ItemStack aStack) {
-        if (this.mEUt > 0) {
+        if (this.lEUt > 0) {
             int maxEff = getCorrectedMaxEfficiency(mInventory[1]);
             if (this.superEfficencyIncrease > 0 && mEfficiency < maxEff) {
                 mEfficiency = Math.max(0, Math.min(mEfficiency + superEfficencyIncrease, maxEff));
             }
-            int tGeneratedEU = (int) (this.mEUt * 2L * this.mEfficiency / 10000L);
+            int tGeneratedEU = (int) (this.lEUt * 2L * this.mEfficiency / 10000L);
             if (tGeneratedEU > 0) {
                 long amount = (tGeneratedEU + STEAM_PER_WATER) / STEAM_PER_WATER;
                 excessWater += amount * STEAM_PER_WATER - tGeneratedEU;

--- a/src/main/java/gregtech/common/tileentities/machines/multi/turbines/MTELargeTurbineBase.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/turbines/MTELargeTurbineBase.java
@@ -237,11 +237,9 @@ public abstract class MTELargeTurbineBase extends MTEExtendedPowerMultiBlockBase
         } else {
             this.lEUt = newPower;
         }
-        this.mEUt = GTUtility.safeInt(this.lEUt);
 
         if (this.lEUt <= 0) {
             this.lEUt = 0;
-            this.mEUt = 0;
             this.mEfficiency = 0;
             return CheckRecipeResultRegistry.NO_FUEL_FOUND;
         } else {
@@ -395,7 +393,7 @@ public abstract class MTELargeTurbineBase extends MTEExtendedPowerMultiBlockBase
         }
 
         return new String[] {
-            tRunning + ": " + EnumChatFormatting.RED + formatNumber(mEUt) + EnumChatFormatting.RESET + " EU/t",
+            tRunning + ": " + EnumChatFormatting.RED + formatNumber(lEUt) + EnumChatFormatting.RESET + " EU/t",
             tMaintainance,
             StatCollector.translateToLocal("GT5U.turbine.efficiency") + ": "
                 + EnumChatFormatting.YELLOW

--- a/src/main/java/gtnhintergalactic/tile/multi/MTEPlanetaryGasSiphon.java
+++ b/src/main/java/gtnhintergalactic/tile/multi/MTEPlanetaryGasSiphon.java
@@ -375,11 +375,11 @@ public class MTEPlanetaryGasSiphon extends MTEExtendedPowerMultiBlockBase<MTEPla
         fluid = recipeFluid.copy();
 
         if (ocLevel == 0) {
-            mEUt = -recipeEUt;
+            lEUt = -recipeEUt;
         } else {
             ocLevel--;
             fluid.amount *= 2 << ocLevel;
-            mEUt = -recipeEUt * (4 << (2 * ocLevel));
+            lEUt = -recipeEUt * (4 << (2 * ocLevel));
         }
 
         int processTime = (int) (20 * speedBoost(getCoilTier()));
@@ -449,7 +449,7 @@ public class MTEPlanetaryGasSiphon extends MTEExtendedPowerMultiBlockBase<MTEPla
     }
 
     private void resetMachine() {
-        mEUt = 0;
+        lEUt = 0;
         mEfficiency = 0;
     }
 
@@ -481,7 +481,7 @@ public class MTEPlanetaryGasSiphon extends MTEExtendedPowerMultiBlockBase<MTEPla
                 + EnumChatFormatting.BLUE
                 + fluid.getLocalizedName()
                 + EnumChatFormatting.RESET,
-            "EU/t required: " + EnumChatFormatting.YELLOW + formatNumber(-mEUt) + EnumChatFormatting.RESET + " EU/t",
+            "EU/t required: " + EnumChatFormatting.YELLOW + formatNumber(-lEUt) + EnumChatFormatting.RESET + " EU/t",
             "Maintenance Status: " + (getRepairStatus() == getIdealStatus()
                 ? EnumChatFormatting.GREEN + "Working perfectly" + EnumChatFormatting.RESET
                 : EnumChatFormatting.RED + "Has problems" + EnumChatFormatting.RESET),


### PR DESCRIPTION
`lEUt != mEUt`.
The MTELargeTubineBase change is just cleanup, the other two actual fixes. This should be all, did a regex search for `extends MTEExtendedPowerMultiBlockBase[\w\W]*meut` and checked all results.