### PR TITLE
Fix Uncertainty MatrixElemet typo and refresh bugs

### DIFF
--- a/src/main/java/gregtech/common/gui/modularui/hatch/MTEHatchUncertaintyGui.java
+++ b/src/main/java/gregtech/common/gui/modularui/hatch/MTEHatchUncertaintyGui.java
@@ -200,7 +200,7 @@ public class MTEHatchUncertaintyGui extends MTEHatchBaseGui<MTEHatchUncertainty>
                 i -> syncManager.syncValue(
                     "matrix",
                     i,
-                    new ShortSyncValue(() -> hatch.getMatrixElement(i), val -> hatch.setMatrixElemet(val, i))));
+                    new ShortSyncValue(() -> hatch.getMatrixElement(i), val -> hatch.setMatrixElement(val, i))));
 
         syncManager.syncValue("selection", new ByteSyncValue(hatch::getSelection, hatch::setSelection));
         syncManager.syncValue("mode", new ByteSyncValue(hatch::getMode, hatch::setMode));

--- a/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchUncertainty.java
+++ b/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchUncertainty.java
@@ -59,6 +59,7 @@ public class MTEHatchUncertainty extends MTEHatch {
 
     public void setMatrixElemet(short matrixElement, int index) {
         matrix[index] = matrixElement;
+        compute();
     }
 
     public byte getSelection() {

--- a/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchUncertainty.java
+++ b/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchUncertainty.java
@@ -57,7 +57,7 @@ public class MTEHatchUncertainty extends MTEHatch {
         return matrix[index];
     }
 
-    public void setMatrixElemet(short matrixElement, int index) {
+    public void setMatrixElement(short matrixElement, int index) {
         matrix[index] = matrixElement;
         compute();
     }


### PR DESCRIPTION
So why is there a method called setMatrixElemet but the compilation does not report an error?

Also, the matrix refreshes once every 16 seconds — is that intentional or accidental?

After the fix, every time a position change within the matrix is triggered, it will be recalculated immediately, instead of waiting for the 16-second refresh (red/green status).