### PR TITLE
Fix useInventoryTint not being properly reset

### DIFF
--- a/src/main/java/gregtech/common/render/GTRendererBlock.java
+++ b/src/main/java/gregtech/common/render/GTRendererBlock.java
@@ -232,7 +232,6 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
         aRenderer.setRenderBoundsFromBlock(aBlock);
 
         GL11.glTranslatef(0.5F, 0.5F, 0.5F);
-        aRenderer.useInventoryTint = false;
         ctx.doCleanup();
     }
 

--- a/src/main/java/gregtech/common/render/GTRendererCasing.java
+++ b/src/main/java/gregtech/common/render/GTRendererCasing.java
@@ -62,7 +62,6 @@ public class GTRendererCasing implements ISimpleBlockRenderingHandler {
         aRenderer.setRenderBoundsFromBlock(aBlock);
 
         GL11.glTranslatef(0.5F, 0.5F, 0.5F);
-        aRenderer.useInventoryTint = false;
         ctx.doCleanup();
     }
 
@@ -118,7 +117,7 @@ public class GTRendererCasing implements ISimpleBlockRenderingHandler {
         ctx.renderPositiveXFacing(textureArray[SIDE_EAST]);
         ctx.doCleanup();
         // spotless:on
-
+        aRenderer.useInventoryTint = true;
         return tessAccess.gt5u$hasVertices();
     }
 

--- a/src/main/java/gregtech/common/render/SBRWorldContext.java
+++ b/src/main/java/gregtech/common/render/SBRWorldContext.java
@@ -202,6 +202,7 @@ public final class SBRWorldContext extends SBRContextBase implements ISBRWorldCo
 
     @Override
     public void doCleanup() {
+        this.renderBlocks.useInventoryTint = true;
         super.doCleanup();
         this.blockAccess = null;
     }


### PR DESCRIPTION
`useInventoryTint = true` is the default state. There are a few places in GT where its not being properly reset back to true causing things like grass to not render with a color when held in the hand.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24132