### PR TITLE
fix(outputme): prevent voiding extra fluids when multiple output overflow

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/outputme/MTEHatchOutputME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/outputme/MTEHatchOutputME.java
@@ -132,7 +132,8 @@ public class MTEHatchOutputME extends MTEHatchOutput
 
     @Override
     public boolean canStoreFluid(@NotNull FluidStack fluidStack) {
-        return provider.canStore(fluidStack);
+        return provider.getFilter()
+            .isAllowed(fluidStack);
     }
 
     @Override


### PR DESCRIPTION
fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24384
fixed https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24617

prevent fluid voiding by correctly using `isAllowed` to check instead of `canStore`.
I was confused by the function name. Sorry for my mistake.