### PR TITLE
fix extruder not forming with only cribs

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialExtruder.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialExtruder.java
@@ -134,13 +134,7 @@ public class MTEIndustrialExtruder extends MTEExtendedPowerMultiBlockBase<MTEInd
         casingAmountStainless = 0;
         return checkPiece(STRUCTURE_PIECE_MAIN, OFFSET_X, OFFSET_Y, OFFSET_Z) && casingAmountStainless >= 3
             && casingAmount >= 8
-            && checkHatch();
-    }
-
-    public boolean checkHatch() {
-        return mMufflerHatches.size() >= 1 && mInputBusses.size() >= 1
-            && mOutputBusses.size() >= 1
-            && mEnergyHatches.size() >= 1;
+            && !mMufflerHatches.isEmpty();
     }
 
     @Override


### PR DESCRIPTION
Apparently, mInputBusses does not include cribs...
changes it to similar checks as other multiblocks, will get reworked soon anyways