### PR TITLE
Fix BEC casing texture indices

### DIFF
--- a/src/main/java/gregtech/api/casing/Casings.java
+++ b/src/main/java/gregtech/api/casing/Casings.java
@@ -602,11 +602,11 @@ public enum Casings implements ICasing {
 
     // BEC
     SuperconductivePlasmaEnergyConduit
-        (() -> GregTechAPI.sBlockCasingsBEC, 0, gt(16, 6, 0)),
+        (() -> GregTechAPI.sBlockCasingsBEC, 0, gt(17, 0, 0)),
     ElectromagneticallyIsolatedCasing
-        (() -> GregTechAPI.sBlockCasingsBEC, 1, gt(16, 6, 1)),
+        (() -> GregTechAPI.sBlockCasingsBEC, 1, gt(17, 0, 1)),
     FineStructureConstantManipulator
-        (() -> GregTechAPI.sBlockCasingsBEC, 2, gt(16, 6, 2)),
+        (() -> GregTechAPI.sBlockCasingsBEC, 2, gt(17, 0, 2)),
 
     // Block Glass 1
     ChemicalGradeGlass

--- a/src/main/java/gregtech/api/enums/Textures.java
+++ b/src/main/java/gregtech/api/enums/Textures.java
@@ -2562,6 +2562,7 @@ public class Textures {
             GTUtility.addTexturePage((byte) 2);
             GTUtility.addTexturePage((byte) 8);
             GTUtility.addTexturePage((byte) 16);
+            GTUtility.addTexturePage((byte) 17);
             setCasingTextureForId(ERROR_TEXTURE_INDEX, ERROR_RENDERING[0]);
         }
 

--- a/src/main/java/gregtech/common/blocks/BlockCasingsBEC.java
+++ b/src/main/java/gregtech/common/blocks/BlockCasingsBEC.java
@@ -21,7 +21,7 @@ public class BlockCasingsBEC extends BlockCasingsAbstract {
 
     @Override
     public int getTextureIndex(int aMeta) {
-        return (16 << 7) | (aMeta + 96);
+        return (17 << 7) | aMeta;
     }
 
     @Override


### PR DESCRIPTION
I had to add another texture page (17) since I'm pretty sure 16 is full, then I just shifted the numbers around to match. The BEC and LHC structures are correct after this.