### PR TITLE
Fix MV rock cutter not being craftable

### DIFF
--- a/src/main/java/bartworks/common/loaders/recipes/CraftingRecipes.java
+++ b/src/main/java/bartworks/common/loaders/recipes/CraftingRecipes.java
@@ -90,7 +90,7 @@ public class CraftingRecipes implements Runnable {
             new Object[] { "DS ", "DP ", "DCB", 'D', GTOreDictUnificator.get(OrePrefixes.dust, Materials.Diamond, 1L),
                 'S', GTOreDictUnificator.get(OrePrefixes.stick, Materials.TungstenSteel, 1L), 'P',
                 GTOreDictUnificator.get(OrePrefixes.plate, Materials.TungstenSteel, 1L), 'C', "circuitGood", 'B',
-                ItemList.IC2_AdvBattery.get(1L) });
+                GTOreDictUnificator.get(OrePrefixes.battery, Materials.MV, 1L) });
 
         GTModHandler.addCraftingRecipe(
             new ItemStack(ItemRegistry.ROCKCUTTER_LV),
@@ -106,7 +106,7 @@ public class CraftingRecipes implements Runnable {
             new Object[] { "DS ", "DP ", "DCB", 'D', GTOreDictUnificator.get(OrePrefixes.dust, Materials.Diamond, 1L),
                 'S', GTOreDictUnificator.get(OrePrefixes.stick, Materials.Iridium, 1L), 'P',
                 GTOreDictUnificator.get(OrePrefixes.plate, Materials.Iridium, 1L), 'C', "circuitAdvanced", 'B',
-                ItemList.IC2_EnergyCrystal.get(1L) });
+                GTOreDictUnificator.get(OrePrefixes.battery, Materials.HV, 1L) });
 
         GTModHandler.addCraftingRecipe(
             new ItemStack(ItemRegistry.TESLASTAFF),


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24103

Make MV and HV recipe use oredict (only MV was broken).
<img width="566" height="265" alt="image" src="https://github.com/user-attachments/assets/0fd4ba5d-e983-4779-b271-79fde3f58a4d" />
<img width="623" height="255" alt="image" src="https://github.com/user-attachments/assets/e7d0286a-12ce-41c4-b353-07f24df924f1" />

Wanted to do same for LV since it works but only allow fully empty battery but it's same result with OreDict. Probably due to how weird this item seem to be.
