### PR TITLE
Remove invalid item fuel acceptance from semi-fluid generator

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/generators/MTESemiFluidGenerator.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/generators/MTESemiFluidGenerator.java
@@ -5,8 +5,6 @@ import net.minecraftforge.common.util.ForgeDirection;
 
 import org.apache.commons.lang3.ArrayUtils;
 
-import cpw.mods.fml.common.registry.GameRegistry;
-import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Textures;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
@@ -14,8 +12,6 @@ import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.implementations.MTEBasicGenerator;
 import gregtech.api.recipe.RecipeMap;
 import gregtech.api.render.TextureFactory;
-import gregtech.api.util.GTModHandler;
-import gregtech.api.util.GTUtility;
 import gregtech.common.pollution.PollutionConfig;
 import gtPlusPlus.api.recipe.GTPPRecipeMaps;
 import gtPlusPlus.core.lib.GTPPCore;
@@ -72,18 +68,6 @@ public class MTESemiFluidGenerator extends MTEBasicGenerator {
             return true;
         }
         return super.allowCoverOnSide(side, coverItem);
-    }
-
-    @Override
-    public int getFuelValue(ItemStack aStack) {
-        if (GTUtility.isStackInvalid(aStack)) {
-            return 0;
-        }
-        int rValue = Math.max(GTModHandler.getFuelValue(aStack) * 6 / 5, super.getFuelValue(aStack));
-        if (ItemList.Fuel_Can_Plastic_Filled.isStackEqual(aStack, false, true)) {
-            rValue = Math.max(rValue, GameRegistry.getFuelValue(aStack) * 3);
-        }
-        return rValue;
     }
 
     @Override


### PR DESCRIPTION
The Semi-Fluid Generator allowed every single burnable item because GTModHandler.getFuelValue(aStack) always returns a value for items that are burnable.

A side effect of allowing everything that burns to be converted into EU, it allowed strange things like this with Block of Quintuple Compressed Coal: 
<img width="1000" height="239" alt="image" src="https://github.com/user-attachments/assets/f550a782-676f-4d0b-a600-36872c11c1b7" />

now this is no longer possible. 