### PR TITLE
Fix Coke Oven Hatch texture not updating on screwdriver right-click

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEHatchCokeOven.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEHatchCokeOven.java
@@ -156,6 +156,10 @@ public class MTEHatchCokeOven extends MTEHatch {
     @Override
     public void onDescriptionPacket(NBTTagCompound data) {
         mode = Mode.loadNBTData(data);
+        IGregTechTileEntity base = getBaseMetaTileEntity();
+        if (base != null) {
+            base.issueTextureUpdate();
+        }
     }
 
     @Override


### PR DESCRIPTION
Calls `issueTextureUpdate()` when mode is updated

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24621