### PR TITLE
PlatinumSludgeOverHaul cleanup & optimization

### DIFF
--- a/src/main/java/bartworks/system/material/gtenhancement/PlatinumSludgeOverHaul.java
+++ b/src/main/java/bartworks/system/material/gtenhancement/PlatinumSludgeOverHaul.java
@@ -824,12 +824,11 @@ public class PlatinumSludgeOverHaul {
     }
 
     public static void replacePureElements() {
-        // Cache the ItemList.values() call
-        final ItemList[] values = ItemList.values();
-        final ArrayList<ItemStack> ITEMLIST_VALUES = new ArrayList<>(values.length);
-        for (ItemList e : values) {
-            if (e.hasBeenSet()) {
-                ITEMLIST_VALUES.add(e.get(1));
+        final ItemList[] itemList = ItemList.values();
+        final ArrayList<ItemStack> availableItemList = new ArrayList<>(itemList.length);
+        for (ItemList item : itemList) {
+            if (item.hasBeenSet()) {
+                availableItemList.add(item.get(1));
             }
         }
 
@@ -857,7 +856,7 @@ public class PlatinumSludgeOverHaul {
 
             Werkstoff mat = (ass.mMaterial.mMaterial.equals(Materials.Platinum)) ? PTMetallicPowder : PDMetallicPowder;
 
-            if (PlatinumSludgeOverHaul.isInBlackList((ItemStack) entry.getKey(), ITEMLIST_VALUES)) continue;
+            if (PlatinumSludgeOverHaul.isInBlackList((ItemStack) entry.getKey(), availableItemList)) continue;
             entry.setValue(mat.get(prefix, stack.stackSize * 2));
         }
         // vanilla crafting
@@ -911,7 +910,7 @@ public class PlatinumSludgeOverHaul {
                         || BWUtil.areStacksEqualOrNull(Ruthenium.get(dustPure), recipe.mOutputs[i]))
                         && !BWUtil.areStacksEqualOrNull(Ruthenium.get(ingot), recipe.mInputs[0])) {
                         for (ItemStack mInput : recipe.mInputs)
-                            if (PlatinumSludgeOverHaul.isInBlackList(mInput, ITEMLIST_VALUES)) continue recipeloop;
+                            if (PlatinumSludgeOverHaul.isInBlackList(mInput, availableItemList)) continue recipeloop;
                         int amount = recipe.mOutputs[i].stackSize * 2;
                         GTLog.err.println("Recipe edited: " + displayRecipe(recipe));
                         recipe.mOutputs[i] = LeachResidue.get(dust, amount);
@@ -922,7 +921,7 @@ public class PlatinumSludgeOverHaul {
                         || BWUtil.areStacksEqualOrNull(Rhodium.get(dustPure), recipe.mOutputs[i]))
                         && !BWUtil.areStacksEqualOrNull(Rhodium.get(ingot), recipe.mInputs[0])) {
                         for (ItemStack mInput : recipe.mInputs)
-                            if (PlatinumSludgeOverHaul.isInBlackList(mInput, ITEMLIST_VALUES)) continue recipeloop;
+                            if (PlatinumSludgeOverHaul.isInBlackList(mInput, availableItemList)) continue recipeloop;
                         int amount = recipe.mOutputs[i].stackSize * 2;
                         GTLog.err.println("Recipe edited: " + displayRecipe(recipe));
                         recipe.mOutputs[i] = CrudeRhMetall.get(dust, amount);
@@ -933,7 +932,7 @@ public class PlatinumSludgeOverHaul {
                     if (GTOreDictUnificator.getAssociation(recipe.mOutputs[i]).mMaterial.mMaterial
                         .equals(Materials.Platinum)) {
                         for (ItemStack mInput : recipe.mInputs) {
-                            if (PlatinumSludgeOverHaul.isInBlackList(mInput, ITEMLIST_VALUES)) continue recipeloop;
+                            if (PlatinumSludgeOverHaul.isInBlackList(mInput, availableItemList)) continue recipeloop;
                         }
                         if (dust.equals(GTOreDictUnificator.getAssociation(recipe.mOutputs[i]).mPrefix)
                             || dustImpure.equals(GTOreDictUnificator.getAssociation(recipe.mOutputs[i]).mPrefix)
@@ -956,7 +955,7 @@ public class PlatinumSludgeOverHaul {
                     } else if (GTOreDictUnificator.getAssociation(recipe.mOutputs[i]).mMaterial.mMaterial
                         .equals(Materials.Palladium)) {
                             for (ItemStack mInput : recipe.mInputs) {
-                                if (PlatinumSludgeOverHaul.isInBlackList(mInput, ITEMLIST_VALUES)) continue recipeloop;
+                                if (PlatinumSludgeOverHaul.isInBlackList(mInput, availableItemList)) continue recipeloop;
                             }
                             if (dust.equals(GTOreDictUnificator.getAssociation(recipe.mOutputs[i]).mPrefix)
                                 || dustImpure.equals(GTOreDictUnificator.getAssociation(recipe.mOutputs[i]).mPrefix)
@@ -983,7 +982,7 @@ public class PlatinumSludgeOverHaul {
                         } else if (GTOreDictUnificator.getAssociation(recipe.mOutputs[i]).mMaterial.mMaterial
                             .equals(Materials.Osmium)) {
                                 for (ItemStack mInput : recipe.mInputs) {
-                                    if (PlatinumSludgeOverHaul.isInBlackList(mInput, ITEMLIST_VALUES))
+                                    if (PlatinumSludgeOverHaul.isInBlackList(mInput, availableItemList))
                                         continue recipeloop;
                                 }
                                 if (dust.equals(GTOreDictUnificator.getAssociation(recipe.mOutputs[i]).mPrefix)
@@ -1012,7 +1011,7 @@ public class PlatinumSludgeOverHaul {
                             } else if (GTOreDictUnificator.getAssociation(recipe.mOutputs[i]).mMaterial.mMaterial
                                 .equals(Materials.Iridium)) {
                                     for (ItemStack mInput : recipe.mInputs) {
-                                        if (PlatinumSludgeOverHaul.isInBlackList(mInput, ITEMLIST_VALUES))
+                                        if (PlatinumSludgeOverHaul.isInBlackList(mInput, availableItemList))
                                             continue recipeloop;
                                     }
                                     if (dust.equals(GTOreDictUnificator.getAssociation(recipe.mOutputs[i]).mPrefix)
@@ -1142,7 +1141,7 @@ public class PlatinumSludgeOverHaul {
         return false;
     }
 
-    private static boolean isInBlackList(ItemStack stack, List<ItemStack> ITEMLIST_VALUES) {
+    private static boolean isInBlackList(ItemStack stack, List<ItemStack> availableItemList) {
         if (stack == null || stack.getItem() instanceof BWMetaGeneratedItems
             || MainMod.MOD_ID.equals(GameRegistry.findUniqueIdentifierFor(stack.getItem()).modId)
             || BartWorksCrossmod.MOD_ID.equals(GameRegistry.findUniqueIdentifierFor(stack.getItem()).modId))
@@ -1158,7 +1157,7 @@ public class PlatinumSludgeOverHaul {
         if (Block.getBlockFromItem(stack.getItem()) instanceof GTGenericBlock
             && !(Block.getBlockFromItem(stack.getItem()) instanceof GTBlockOre)) return true;
 
-        for (ItemStack itemStack : ITEMLIST_VALUES) {
+        for (ItemStack itemStack : availableItemList) {
             if (!BWUtil.checkStackAndPrefix(stack) && GTUtility.areStacksEqual(itemStack, stack, true)) {
                 return true;
             }

--- a/src/main/java/bartworks/system/material/gtenhancement/PlatinumSludgeOverHaul.java
+++ b/src/main/java/bartworks/system/material/gtenhancement/PlatinumSludgeOverHaul.java
@@ -109,6 +109,7 @@ import java.util.List;
 import java.util.Set;
 
 import net.minecraft.block.Block;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.CraftingManager;
 import net.minecraft.item.crafting.FurnaceRecipes;
@@ -955,7 +956,8 @@ public class PlatinumSludgeOverHaul {
                     } else if (GTOreDictUnificator.getAssociation(recipe.mOutputs[i]).mMaterial.mMaterial
                         .equals(Materials.Palladium)) {
                             for (ItemStack mInput : recipe.mInputs) {
-                                if (PlatinumSludgeOverHaul.isInBlackList(mInput, availableItemList)) continue recipeloop;
+                                if (PlatinumSludgeOverHaul.isInBlackList(mInput, availableItemList))
+                                    continue recipeloop;
                             }
                             if (dust.equals(GTOreDictUnificator.getAssociation(recipe.mOutputs[i]).mPrefix)
                                 || dustImpure.equals(GTOreDictUnificator.getAssociation(recipe.mOutputs[i]).mPrefix)
@@ -1142,20 +1144,21 @@ public class PlatinumSludgeOverHaul {
     }
 
     private static boolean isInBlackList(ItemStack stack, List<ItemStack> availableItemList) {
-        if (stack == null || stack.getItem() instanceof BWMetaGeneratedItems
-            || MainMod.MOD_ID.equals(GameRegistry.findUniqueIdentifierFor(stack.getItem()).modId)
-            || BartWorksCrossmod.MOD_ID.equals(GameRegistry.findUniqueIdentifierFor(stack.getItem()).modId))
-            return true;
+        if (stack == null) return true;
 
-        if (GameRegistry.findUniqueIdentifierFor(stack.getItem()).modId.equals(NewHorizonsCoreMod.ID)
-            && !stack.getUnlocalizedName()
-                .contains("dust")
-            && !stack.getUnlocalizedName()
-                .contains("Dust"))
-            return true;
+        final Item item = stack.getItem();
+        if (item == null) return true;
+        if (item instanceof BWMetaGeneratedItems) return true;
 
-        if (Block.getBlockFromItem(stack.getItem()) instanceof GTGenericBlock
-            && !(Block.getBlockFromItem(stack.getItem()) instanceof GTBlockOre)) return true;
+        final String itemModId = GameRegistry.findUniqueIdentifierFor(item).modId;
+        if (MainMod.MOD_ID.equals(itemModId) || BartWorksCrossmod.MOD_ID.equals(itemModId)) return true;
+
+        final String stackUnlocalizedName = stack.getUnlocalizedName();
+        if (NewHorizonsCoreMod.ID.equals(itemModId) && !stackUnlocalizedName.contains("dust")
+            && !stackUnlocalizedName.contains("Dust")) return true;
+
+        Block block = Block.getBlockFromItem(item);
+        if (block instanceof GTGenericBlock && !(block instanceof GTBlockOre)) return true;
 
         for (ItemStack itemStack : availableItemList) {
             if (!BWUtil.checkStackAndPrefix(stack) && GTUtility.areStacksEqual(itemStack, stack, true)) {
@@ -1163,7 +1166,7 @@ public class PlatinumSludgeOverHaul {
             }
         }
 
-        if (stack.getItem() instanceof GTGenericItem) {
+        if (item instanceof GTGenericItem) {
             if (!BWUtil.checkStackAndPrefix(stack)) return false;
             if (GTOreDictUnificator.getAssociation(stack).mPrefix != rawOre) {
                 return !Arrays.asList(PlatinumSludgeOverHaul.OPBLACKLIST)
@@ -1173,47 +1176,43 @@ public class PlatinumSludgeOverHaul {
             }
         }
 
-        if (stack.getItem() instanceof BaseItemComponent && !stack.getUnlocalizedName()
-            .contains("dust")
-            && !stack.getUnlocalizedName()
-                .contains("Dust")) {
+        if (item instanceof BaseItemComponent && !stackUnlocalizedName.contains("dust")
+            && !stackUnlocalizedName.contains("Dust")) {
             return true;
         }
-        if (Block.getBlockFromItem(stack.getItem()) instanceof BlockBaseModular) {
+        if (block instanceof BlockBaseModular) {
             return true;
         }
-        if (Block.getBlockFromItem(stack.getItem()) instanceof BlockFrameBox) {
+        if (block instanceof BlockFrameBox) {
             return true;
         }
-        if (stack.getItem() == HELICOPTER.getDust(1)
+        if (item == HELICOPTER.getDust(1)
             .getItem()) {
             return true;
         }
-        if (stack.getItem() == HTGRItem.BURNED_TRISO) {
+        if (item == HTGRItem.BURNED_TRISO) {
             return true;
         }
-        if (stack.getItem() == WHITE_METAL.getDust(1)
+        if (item == WHITE_METAL.getDust(1)
             .getItem()) {
             return true;
         }
         if (Railcraft.isModLoaded()) {
-            if (Block.getBlockFromItem(stack.getItem())
-                .getUnlocalizedName()
+            if (block.getUnlocalizedName()
                 .equals("tile.railcraft.machine.zeta")
-                || Block.getBlockFromItem(stack.getItem())
-                    .getUnlocalizedName()
+                || block.getUnlocalizedName()
                     .equals("tile.railcraft.machine.eta")) {
                 return true;
             }
         }
         if (GalaxySpace.isModLoaded()) {
-            if (stack.getItem() == GTModHandler.getModItem(GalaxySpace.ID, "metalsblock", 1L, 7)
+            if (item == GTModHandler.getModItem(GalaxySpace.ID, "metalsblock", 1L, 7)
                 .getItem()) {
                 return true;
             }
         }
         if (NewHorizonsCoreMod.isModLoaded()) {
-            if (stack.getItem() == GTModHandler.getModItem(NewHorizonsCoreMod.ID, "IndustryFrame", 1L)
+            if (item == GTModHandler.getModItem(NewHorizonsCoreMod.ID, "IndustryFrame", 1L)
                 .getItem()) {
                 return true;
             }

--- a/src/main/java/bartworks/system/material/gtenhancement/PlatinumSludgeOverHaul.java
+++ b/src/main/java/bartworks/system/material/gtenhancement/PlatinumSludgeOverHaul.java
@@ -146,11 +146,25 @@ import kubatech.loaders.item.htgritem.HTGRItem;
 
 public class PlatinumSludgeOverHaul {
 
-    private static final Materials[] BLACKLIST = { Materials.HSSS, Materials.EnderiumBase, Materials.Osmiridium,
-        Materials.TPV, Materials.get("Uraniumtriplatinid"), Materials.get("Tetranaquadahdiindiumhexaplatiumosminid"),
-        Materials.get("Longasssuperconductornameforuvwire"), };
-    private static final OrePrefixes[] OPBLACKLIST = { crushedCentrifuged, crushed, crushedPurified, dustPure,
-        dustImpure, dustRefined, dust, dustTiny, dustSmall };
+    private static final List<Materials> MATERIALS_BLACKLIST = Arrays.asList(
+        Materials.HSSS,
+        Materials.EnderiumBase,
+        Materials.Osmiridium,
+        Materials.TPV,
+        Materials.SuperconductorEVBase,
+        Materials.SuperconductorZPMBase,
+        Materials.SuperconductorUVBase);
+
+    private static final List<OrePrefixes> ORE_PREFIXES_BLACKLIST = Arrays.asList(
+        crushedCentrifuged,
+        crushed,
+        crushedPurified,
+        dustPure,
+        dustImpure,
+        dustRefined,
+        dust,
+        dustTiny,
+        dustSmall);
 
     private PlatinumSludgeOverHaul() {}
 
@@ -184,6 +198,7 @@ public class PlatinumSludgeOverHaul {
             .duration(1 * SECONDS + 10 * TICKS)
             .eut(TierEU.RECIPE_LV)
             .addTo(mixerRecipes);
+
         // FormicAcid
         // CO + NaOH = CHO2Na
         GTValues.RA.stdBuilder()
@@ -192,8 +207,8 @@ public class PlatinumSludgeOverHaul {
             .duration(15 * TICKS)
             .eut(TierEU.RECIPE_LV)
             .addTo(UniversalChemical);
-        // H2SO4 + 2CHO2Na = 2CH2O2 + Na2SO4
 
+        // H2SO4 + 2CHO2Na = 2CH2O2 + Na2SO4
         GTValues.RA.stdBuilder()
             .itemInputs(Sodiumformate.get(cell, 2))
             .circuit(1)
@@ -253,7 +268,6 @@ public class PlatinumSludgeOverHaul {
 
         // AmmoniumChloride
         // NH3 + HCl = NH4Cl
-
         GTValues.RA.stdBuilder()
             .itemInputs(Materials.Ammonia.getCells(1))
             .circuit(1)
@@ -282,11 +296,12 @@ public class PlatinumSludgeOverHaul {
             .addTo(multiblockChemicalReactorRecipes);
 
         // base solution
-        for (Werkstoff w : Werkstoff.werkstoffHashSet) if (w.containsStuff(Materials.Sulfur)
-            && (w.containsStuff(Materials.Copper) || w.containsStuff(Materials.Nickel))) {
+        for (Werkstoff werkstoff : Werkstoff.werkstoffHashSet) {
+            if (werkstoff.containsStuff(Materials.Sulfur)
+                && (werkstoff.containsStuff(Materials.Copper) || werkstoff.containsStuff(Materials.Nickel))) {
 
                 GTValues.RA.stdBuilder()
-                    .itemInputs(w.get(crushedPurified))
+                    .itemInputs(werkstoff.get(crushedPurified))
                     .circuit(1)
                     .fluidInputs(AquaRegia.getFluidOrGas(300))
                     .fluidOutputs(PTConcentrate.getFluidOrGas(300))
@@ -295,7 +310,7 @@ public class PlatinumSludgeOverHaul {
                     .addTo(UniversalChemical);
 
                 GTValues.RA.stdBuilder()
-                    .itemInputs(w.get(crushedPurified, 9))
+                    .itemInputs(werkstoff.get(crushedPurified, 9))
                     .circuit(9)
                     .fluidInputs(AquaRegia.getFluidOrGas(2_700))
                     .fluidOutputs(PTConcentrate.getFluidOrGas(2_700))
@@ -304,7 +319,40 @@ public class PlatinumSludgeOverHaul {
                     .addTo(UniversalChemical);
 
                 GTValues.RA.stdBuilder()
-                    .itemInputs(w.get(crushedPurified, 9), PTMetallicPowder.get(dust, 9))
+                    .itemInputs(werkstoff.get(crushedPurified, 9), PTMetallicPowder.get(dust, 9))
+                    .itemOutputs(PTResidue.get(dust))
+                    .fluidInputs(AquaRegia.getFluidOrGas(20_700))
+                    .fluidOutputs(PTConcentrate.getFluidOrGas(20_700))
+                    .duration(1 * MINUTES + 52 * SECONDS + 10 * TICKS)
+                    .eut(TierEU.RECIPE_LV)
+                    .addTo(UniversalChemical);
+            }
+        }
+
+        for (Materials material : Materials.values()) {
+            if (materialsContains(material, Materials.Sulfur)
+                && (materialsContains(material, Materials.Copper) || materialsContains(material, Materials.Nickel))) {
+
+                GTValues.RA.stdBuilder()
+                    .itemInputs(GTOreDictUnificator.get(crushedPurified, material, 1))
+                    .circuit(1)
+                    .fluidInputs(AquaRegia.getFluidOrGas(300))
+                    .fluidOutputs(PTConcentrate.getFluidOrGas(300))
+                    .duration(12 * SECONDS + 10 * TICKS)
+                    .eut(TierEU.RECIPE_LV)
+                    .addTo(UniversalChemical);
+
+                GTValues.RA.stdBuilder()
+                    .itemInputs(GTOreDictUnificator.get(crushedPurified, material, 9))
+                    .circuit(9)
+                    .fluidInputs(AquaRegia.getFluidOrGas(2_700))
+                    .fluidOutputs(PTConcentrate.getFluidOrGas(2_700))
+                    .duration(1 * MINUTES + 52 * SECONDS + 10 * TICKS)
+                    .eut(TierEU.RECIPE_LV)
+                    .addTo(UniversalChemical);
+
+                GTValues.RA.stdBuilder()
+                    .itemInputs(GTOreDictUnificator.get(crushedPurified, material, 9), PTMetallicPowder.get(dust, 9))
                     .itemOutputs(PTResidue.get(dust))
                     .fluidInputs(AquaRegia.getFluidOrGas(20_700))
                     .fluidOutputs(PTConcentrate.getFluidOrGas(20_700))
@@ -313,38 +361,8 @@ public class PlatinumSludgeOverHaul {
                     .addTo(UniversalChemical);
 
             }
-        for (Materials m : Materials.values()) if (PlatinumSludgeOverHaul.materialsContains(m, Materials.Sulfur)
-            && (PlatinumSludgeOverHaul.materialsContains(m, Materials.Copper)
-                || PlatinumSludgeOverHaul.materialsContains(m, Materials.Nickel))) {
+        }
 
-                    GTValues.RA.stdBuilder()
-                        .itemInputs(GTOreDictUnificator.get(crushedPurified, m, 1))
-                        .circuit(1)
-                        .fluidInputs(AquaRegia.getFluidOrGas(300))
-                        .fluidOutputs(PTConcentrate.getFluidOrGas(300))
-                        .duration(12 * SECONDS + 10 * TICKS)
-                        .eut(TierEU.RECIPE_LV)
-                        .addTo(UniversalChemical);
-
-                    GTValues.RA.stdBuilder()
-                        .itemInputs(GTOreDictUnificator.get(crushedPurified, m, 9))
-                        .circuit(9)
-                        .fluidInputs(AquaRegia.getFluidOrGas(2_700))
-                        .fluidOutputs(PTConcentrate.getFluidOrGas(2_700))
-                        .duration(1 * MINUTES + 52 * SECONDS + 10 * TICKS)
-                        .eut(TierEU.RECIPE_LV)
-                        .addTo(UniversalChemical);
-
-                    GTValues.RA.stdBuilder()
-                        .itemInputs(GTOreDictUnificator.get(crushedPurified, m, 9), PTMetallicPowder.get(dust, 9))
-                        .itemOutputs(PTResidue.get(dust))
-                        .fluidInputs(AquaRegia.getFluidOrGas(20_700))
-                        .fluidOutputs(PTConcentrate.getFluidOrGas(20_700))
-                        .duration(1 * MINUTES + 52 * SECONDS + 10 * TICKS)
-                        .eut(TierEU.RECIPE_LV)
-                        .addTo(UniversalChemical);
-
-                }
         // Pt
         GTValues.RA.stdBuilder()
             .itemInputs(PTMetallicPowder.get(dust, 3))
@@ -440,7 +458,6 @@ public class PlatinumSludgeOverHaul {
             .addTo(blastFurnaceRecipes);
 
         // 2PtCl + Ca = 2Pt + CaCl2
-
         GTValues.RA.stdBuilder()
             .itemInputs(PTRawPowder.get(dust, 4), Materials.Calcium.getDust(1))
             .itemOutputs(Materials.Platinum.getDust(2), CalciumChloride.get(dust, 3))
@@ -449,7 +466,6 @@ public class PlatinumSludgeOverHaul {
             .addTo(UniversalChemical);
 
         // Pd
-
         GTValues.RA.stdBuilder()
             .itemInputs(PDMetallicPowder.get(dust))
             .circuit(1)
@@ -524,7 +540,6 @@ public class PlatinumSludgeOverHaul {
             .addTo(multiblockChemicalReactorRecipes);
 
         // Na2SO4 + 2H = 2Na + H2SO4
-
         GTValues.RA.stdBuilder()
             .itemInputs(Sodiumsulfate.get(dust, 7), Materials.Hydrogen.getCells(2))
             .itemOutputs(Materials.Sodium.getDust(2), Materials.Empty.getCells(2))
@@ -647,8 +662,8 @@ public class PlatinumSludgeOverHaul {
             .duration(15 * SECONDS)
             .eut(TierEU.RECIPE_EV)
             .addTo(UniversalChemical);
-        // Rh
 
+        // Rh
         GTValues.RA.stdBuilder()
             .itemInputs(RHSulfate.get(cell, 11))
             .circuit(1)
@@ -701,8 +716,8 @@ public class PlatinumSludgeOverHaul {
             .duration(15 * SECONDS)
             .eut(TierEU.RECIPE_LV)
             .addTo(UniversalChemical);
-        // Na + HNO3 = NaNO3 + H
 
+        // Na + HNO3 = NaNO3 + H
         GTValues.RA.stdBuilder()
             .itemInputs(Materials.Sodium.getDust(1))
             .itemOutputs(SodiumNitrate.get(dust, 5))
@@ -758,7 +773,7 @@ public class PlatinumSludgeOverHaul {
 
     private static boolean materialsContains(Materials one, ISubTagContainer other) {
         if (one == null || one.mMaterialList == null || one.mMaterialList.isEmpty()) return false;
-        for (MaterialStack stack : one.mMaterialList) if (stack.mMaterial.equals(other)) return true;
+        for (MaterialStack stack : one.mMaterialList) if (stack.mMaterial == other) return true;
         return false;
     }
 
@@ -1012,11 +1027,14 @@ public class PlatinumSludgeOverHaul {
             if (BWUtil.checkStackAndPrefix(recipe.mOutputs[0])) {
                 for (int i = 0; i < recipe.mInputs.length; i++) {
                     ItemStack stack = recipe.mInputs[i];
-                    ItemData ass = GTOreDictUnificator.getAssociation(stack);
-                    if (BWUtil.checkStackAndPrefix(stack) && ass.mMaterial.mMaterial.equals(Materials.Platinum)) {
-                        recipe.mInputs[i] = GTOreDictUnificator.get(ass.mPrefix, Materials.BlueAlloy, stack.stackSize);
-                        GTLog.out.println("Recipe edited: " + displayRecipe(recipe));
+                    ItemData association = GTOreDictUnificator.getAssociation(stack);
+                    if (!BWUtil.checkStackAndPrefix(association)) continue;
+
+                    if (association.mMaterial.mMaterial.equals(Materials.Platinum)) {
+                        recipe.mInputs[i] = GTOreDictUnificator
+                            .get(association.mPrefix, Materials.BlueAlloy, stack.stackSize);
                         recipe.reloadOwner();
+                        GTLog.out.println("Recipe edited: " + displayRecipe(recipe));
                     }
                 }
             }
@@ -1136,9 +1154,8 @@ public class PlatinumSludgeOverHaul {
         if (item instanceof GTGenericItem) {
             if (!isAssociationValid) return false;
             if (association.mPrefix != rawOre) {
-                return !Arrays.asList(PlatinumSludgeOverHaul.OPBLACKLIST)
-                    .contains(association.mPrefix) || Arrays.asList(PlatinumSludgeOverHaul.BLACKLIST)
-                        .contains(association.mMaterial.mMaterial);
+                return !ORE_PREFIXES_BLACKLIST.contains(association.mPrefix)
+                    || MATERIALS_BLACKLIST.contains(association.mMaterial.mMaterial);
             }
         }
 
@@ -1186,7 +1203,6 @@ public class PlatinumSludgeOverHaul {
         if (!isAssociationValid) {
             return false;
         }
-        return Arrays.asList(PlatinumSludgeOverHaul.BLACKLIST)
-            .contains(association.mMaterial.mMaterial);
+        return MATERIALS_BLACKLIST.contains(association.mMaterial.mMaterial);
     }
 }

--- a/src/main/java/bartworks/system/material/gtenhancement/PlatinumSludgeOverHaul.java
+++ b/src/main/java/bartworks/system/material/gtenhancement/PlatinumSludgeOverHaul.java
@@ -838,35 +838,47 @@ public class PlatinumSludgeOverHaul {
         for (Map.Entry<ItemStack, ItemStack> entry : FurnaceRecipes.smelting()
             .getSmeltingList()
             .entrySet()) {
-            if (!GTUtility.isStackValid(entry.getKey())) continue;
-            if (!BWUtil.checkStackAndPrefix(entry.getKey())) continue;
+            ItemStack input = entry.getKey();
+            ItemStack output = entry.getValue();
 
-            ItemData association = GTOreDictUnificator.getAssociation(entry.getKey());
-            boolean isDust = dust.equals(association.mPrefix) || dustTiny.equals(association.mPrefix);
-            ItemStack stack = entry.getValue();
-            if (isDust && association.mMaterial.mMaterial.equals(Materials.Platinum)) continue;
+            if (!GTUtility.isStackValid(input)) continue;
+            if (!GTUtility.isStackValid(output)) continue;
 
-            if (!GTUtility.isStackValid(stack)) continue;
-            if (!BWUtil.checkStackAndPrefix(stack)) continue;
+            ItemData inputAssociation = GTOreDictUnificator.getAssociation(input);
+            if (!BWUtil.checkStackAndPrefix(inputAssociation)) continue;
 
-            ItemData ass = GTOreDictUnificator.getAssociation(stack);
-            OrePrefixes prefix = ass.mPrefix == nugget ? dustTiny : dust;
-            boolean isPlatinumOrPalladium = ass.mMaterial.mMaterial.equals(Materials.Platinum)
-                || ass.mMaterial.mMaterial.equals(Materials.Palladium);
+            if (inputAssociation.mMaterial.mMaterial == Materials.Platinum) {
+                if (inputAssociation.mPrefix.equals(dust) || inputAssociation.mPrefix.equals(dustTiny)) {
+                    continue;
+                }
+            }
 
-            if (!isPlatinumOrPalladium) continue;
+            ItemData outputAssociation = GTOreDictUnificator.getAssociation(output);
+            if (!BWUtil.checkStackAndPrefix(outputAssociation)) continue;
 
-            Werkstoff mat = (ass.mMaterial.mMaterial.equals(Materials.Platinum)) ? PTMetallicPowder : PDMetallicPowder;
+            final Werkstoff newOutput;
+            if (outputAssociation.mMaterial.mMaterial == Materials.Platinum) {
+                newOutput = PTMetallicPowder;
+            } else if (outputAssociation.mMaterial.mMaterial == Materials.Palladium) {
+                newOutput = PDMetallicPowder;
+            } else {
+                continue;
+            }
 
-            if (PlatinumSludgeOverHaul.isInBlackList(entry.getKey(), availableItemList)) continue;
-            entry.setValue(mat.get(prefix, stack.stackSize * 2));
+            if (PlatinumSludgeOverHaul.isInBlackList(input, availableItemList)) continue;
+
+            OrePrefixes prefix = outputAssociation.mPrefix == nugget ? dustTiny : dust;
+            entry.setValue(newOutput.get(prefix, output.stackSize * 2));
         }
+
         // vanilla crafting
         CraftingManager.getInstance()
             .getRecipeList()
             .forEach(PlatinumSludgeOverHaul::setnewMaterialInRecipe);
+
         // gt crafting
         GTModHandler.sBufferRecipeList.forEach(PlatinumSludgeOverHaul::setnewMaterialInRecipe);
+
         // gt machines
         maploop: for (RecipeMap<?> map : RecipeMap.ALL_RECIPE_MAPS.values()) {
             GTLog.err.println("Processing recipmap: " + map.unlocalizedName);

--- a/src/main/java/bartworks/system/material/gtenhancement/PlatinumSludgeOverHaul.java
+++ b/src/main/java/bartworks/system/material/gtenhancement/PlatinumSludgeOverHaul.java
@@ -104,6 +104,7 @@ import static tectech.recipe.TecTechRecipeMaps.eyeOfHarmonyRecipes;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -1120,39 +1121,62 @@ public class PlatinumSludgeOverHaul {
         }
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
-    public static boolean checkRecipe(Object input, Materials mat) {
-        if (input instanceof List || input instanceof Object[]) {
-            Set lists = new HashSet(), stacks = new HashSet();
-            List ip = input instanceof List ? (List) input : new ArrayList();
-            Object[] ip2 = input instanceof Object[] ? (Object[]) input : GTValues.emptyObjectArray;
-
-            for (Object o : ip) {
-                if (o instanceof List) lists.add(o);
-                else if (o instanceof ItemStack) stacks.add(o);
-            }
-            for (Object o : ip2) {
-                if (o instanceof List) lists.add(o);
-                else if (o instanceof ItemStack) stacks.add(o);
-            }
-
-            for (Object o : lists) {
-                if (!((List) o).isEmpty()) stacks.add(((List) o).get(0));
-            }
-
-            boolean allSame = false;
-            for (Object stack : stacks) {
-                if (!(stack instanceof ItemStack)) {
-                    allSame = false;
-                    break;
-                }
-                allSame = BWUtil.checkStackAndPrefix((ItemStack) stack)
-                    && GTOreDictUnificator.getAssociation((ItemStack) stack).mMaterial.mMaterial.equals(mat);
-                if (!allSame) break;
-            }
-            return allSame;
+    public static boolean checkRecipe(Object input, Materials material) {
+        if (!(input instanceof List<?>) && !(input instanceof Object[])) {
+            return false;
         }
-        return false;
+
+        Set<List<?>> lists = new HashSet<>();
+        Set<ItemStack> stacks = new HashSet<>();
+
+        List<?> listInput = input instanceof List<?> ? (List<?>) input : Collections.emptyList();
+        Object[] arrayInput = input instanceof Object[] ? (Object[]) input : GTValues.emptyObjectArray;
+
+        for (Object entry : listInput) {
+            if (entry instanceof List<?>list) {
+                lists.add(list);
+            } else if (entry instanceof ItemStack stack) {
+                stacks.add(stack);
+            }
+        }
+
+        for (Object entry : arrayInput) {
+            if (entry instanceof List<?>list) {
+                lists.add(list);
+            } else if (entry instanceof ItemStack stack) {
+                stacks.add(stack);
+            }
+        }
+
+        for (List<?> list : lists) {
+            if (list.isEmpty()) {
+                continue;
+            }
+
+            Object first = list.get(0);
+            if (!(first instanceof ItemStack stack)) {
+                return false;
+            }
+
+            stacks.add(stack);
+        }
+
+        if (stacks.isEmpty()) {
+            return false;
+        }
+
+        for (ItemStack stack : stacks) {
+            ItemData association = GTOreDictUnificator.getAssociation(stack);
+            if (!BWUtil.checkStackAndPrefix(association)) {
+                return false;
+            }
+
+            if (association.mMaterial.mMaterial != material) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private static boolean isInBlackList(ItemStack stack, List<ItemStack> availableItemList) {

--- a/src/main/java/bartworks/system/material/gtenhancement/PlatinumSludgeOverHaul.java
+++ b/src/main/java/bartworks/system/material/gtenhancement/PlatinumSludgeOverHaul.java
@@ -106,6 +106,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import net.minecraft.block.Block;
@@ -834,7 +835,7 @@ public class PlatinumSludgeOverHaul {
         }
 
         // furnace
-        for (var entry : FurnaceRecipes.smelting()
+        for (Map.Entry<ItemStack, ItemStack> entry : FurnaceRecipes.smelting()
             .getSmeltingList()
             .entrySet()) {
             if (!GTUtility.isStackValid(entry.getKey())) continue;
@@ -857,7 +858,7 @@ public class PlatinumSludgeOverHaul {
 
             Werkstoff mat = (ass.mMaterial.mMaterial.equals(Materials.Platinum)) ? PTMetallicPowder : PDMetallicPowder;
 
-            if (PlatinumSludgeOverHaul.isInBlackList((ItemStack) entry.getKey(), availableItemList)) continue;
+            if (PlatinumSludgeOverHaul.isInBlackList(entry.getKey(), availableItemList)) continue;
             entry.setValue(mat.get(prefix, stack.stackSize * 2));
         }
         // vanilla crafting

--- a/src/main/java/bartworks/system/material/gtenhancement/PlatinumSludgeOverHaul.java
+++ b/src/main/java/bartworks/system/material/gtenhancement/PlatinumSludgeOverHaul.java
@@ -874,10 +874,10 @@ public class PlatinumSludgeOverHaul {
         // vanilla crafting
         CraftingManager.getInstance()
             .getRecipeList()
-            .forEach(PlatinumSludgeOverHaul::setnewMaterialInRecipe);
+            .forEach(PlatinumSludgeOverHaul::setNewMaterialInRecipe);
 
         // gt crafting
-        GTModHandler.sBufferRecipeList.forEach(PlatinumSludgeOverHaul::setnewMaterialInRecipe);
+        GTModHandler.sBufferRecipeList.forEach(PlatinumSludgeOverHaul::setNewMaterialInRecipe);
 
         // gt machines
         maploop: for (RecipeMap<?> map : RecipeMap.ALL_RECIPE_MAPS.values()) {
@@ -1093,31 +1093,30 @@ public class PlatinumSludgeOverHaul {
         }
     }
 
-    private static void setnewMaterialInRecipe(IRecipe recipe) {
-        ItemStack otpt = recipe.getRecipeOutput();
-
+    private static void setNewMaterialInRecipe(IRecipe recipe) {
         if (!(recipe instanceof IRecipeMutableAccess mutableRecipe)) {
             return;
         }
 
         Object input = mutableRecipe.gt5u$getRecipeInputs();
-
         if (input == null) {
             return;
         }
 
-        if (GTUtility.areStacksEqual(otpt, Materials.Platinum.getDust(1), true)) {
+        ItemStack output = recipe.getRecipeOutput();
+
+        if (GTUtility.areStacksEqual(output, Materials.Platinum.getDust(1), true)) {
             if (PlatinumSludgeOverHaul.checkRecipe(input, Materials.Platinum)) return;
-            mutableRecipe.gt5u$setRecipeOutputItem(PTMetallicPowder.get(dust, otpt.stackSize * 2));
-        } else if (GTUtility.areStacksEqual(otpt, Materials.Palladium.getDust(1), true)) {
+            mutableRecipe.gt5u$setRecipeOutputItem(PTMetallicPowder.get(dust, output.stackSize * 2));
+        } else if (GTUtility.areStacksEqual(output, Materials.Palladium.getDust(1), true)) {
             if (PlatinumSludgeOverHaul.checkRecipe(input, Materials.Palladium)) return;
-            mutableRecipe.gt5u$setRecipeOutputItem(PDMetallicPowder.get(dust, otpt.stackSize * 2));
-        } else if (GTUtility.areStacksEqual(otpt, Materials.Iridium.getDust(1), true)) {
+            mutableRecipe.gt5u$setRecipeOutputItem(PDMetallicPowder.get(dust, output.stackSize * 2));
+        } else if (GTUtility.areStacksEqual(output, Materials.Iridium.getDust(1), true)) {
             if (PlatinumSludgeOverHaul.checkRecipe(input, Materials.Iridium)) return;
-            mutableRecipe.gt5u$setRecipeOutputItem(IrLeachResidue.get(dust, otpt.stackSize));
-        } else if (GTUtility.areStacksEqual(otpt, Materials.Osmium.getDust(1), true)) {
+            mutableRecipe.gt5u$setRecipeOutputItem(IrLeachResidue.get(dust, output.stackSize));
+        } else if (GTUtility.areStacksEqual(output, Materials.Osmium.getDust(1), true)) {
             if (PlatinumSludgeOverHaul.checkRecipe(input, Materials.Osmium)) return;
-            mutableRecipe.gt5u$setRecipeOutputItem(IrOsLeachResidue.get(dust, otpt.stackSize));
+            mutableRecipe.gt5u$setRecipeOutputItem(IrOsLeachResidue.get(dust, output.stackSize));
         }
     }
 

--- a/src/main/java/bartworks/system/material/gtenhancement/PlatinumSludgeOverHaul.java
+++ b/src/main/java/bartworks/system/material/gtenhancement/PlatinumSludgeOverHaul.java
@@ -844,15 +844,6 @@ public class PlatinumSludgeOverHaul {
             if (!GTUtility.isStackValid(input)) continue;
             if (!GTUtility.isStackValid(output)) continue;
 
-            ItemData inputAssociation = GTOreDictUnificator.getAssociation(input);
-            if (!BWUtil.checkStackAndPrefix(inputAssociation)) continue;
-
-            if (inputAssociation.mMaterial.mMaterial == Materials.Platinum) {
-                if (inputAssociation.mPrefix.equals(dust) || inputAssociation.mPrefix.equals(dustTiny)) {
-                    continue;
-                }
-            }
-
             ItemData outputAssociation = GTOreDictUnificator.getAssociation(output);
             if (!BWUtil.checkStackAndPrefix(outputAssociation)) continue;
 
@@ -863,6 +854,15 @@ public class PlatinumSludgeOverHaul {
                 newOutput = PDMetallicPowder;
             } else {
                 continue;
+            }
+
+            ItemData inputAssociation = GTOreDictUnificator.getAssociation(input);
+            if (!BWUtil.checkStackAndPrefix(inputAssociation)) continue;
+
+            if (inputAssociation.mMaterial.mMaterial == Materials.Platinum) {
+                if (inputAssociation.mPrefix.equals(dust) || inputAssociation.mPrefix.equals(dustTiny)) {
+                    continue;
+                }
             }
 
             if (PlatinumSludgeOverHaul.isInBlackList(input, availableItemList)) continue;

--- a/src/main/java/bartworks/system/material/gtenhancement/PlatinumSludgeOverHaul.java
+++ b/src/main/java/bartworks/system/material/gtenhancement/PlatinumSludgeOverHaul.java
@@ -104,11 +104,9 @@ import static tectech.recipe.TecTechRecipeMaps.eyeOfHarmonyRecipes;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import net.minecraft.block.Block;
 import net.minecraft.item.Item;
@@ -1126,25 +1124,24 @@ public class PlatinumSludgeOverHaul {
             return false;
         }
 
-        Set<List<?>> lists = new HashSet<>();
-        Set<ItemStack> stacks = new HashSet<>();
+        ArrayList<List<?>> lists = new ArrayList<>();
+        ArrayList<ItemStack> stacks = new ArrayList<>();
 
-        List<?> listInput = input instanceof List<?> ? (List<?>) input : Collections.emptyList();
-        Object[] arrayInput = input instanceof Object[] ? (Object[]) input : GTValues.emptyObjectArray;
-
-        for (Object entry : listInput) {
-            if (entry instanceof List<?>list) {
-                lists.add(list);
-            } else if (entry instanceof ItemStack stack) {
-                stacks.add(stack);
+        if (input instanceof List<?>listInput) {
+            for (Object entry : listInput) {
+                if (entry instanceof List<?>list) {
+                    lists.add(list);
+                } else if (entry instanceof ItemStack stack) {
+                    stacks.add(stack);
+                }
             }
-        }
-
-        for (Object entry : arrayInput) {
-            if (entry instanceof List<?>list) {
-                lists.add(list);
-            } else if (entry instanceof ItemStack stack) {
-                stacks.add(stack);
+        } else if (input instanceof Object[]arrayInput) {
+            for (Object entry : arrayInput) {
+                if (entry instanceof List<?>list) {
+                    lists.add(list);
+                } else if (entry instanceof ItemStack stack) {
+                    stacks.add(stack);
+                }
             }
         }
 

--- a/src/main/java/bartworks/system/material/gtenhancement/PlatinumSludgeOverHaul.java
+++ b/src/main/java/bartworks/system/material/gtenhancement/PlatinumSludgeOverHaul.java
@@ -104,7 +104,6 @@ import static tectech.recipe.TecTechRecipeMaps.eyeOfHarmonyRecipes;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -880,183 +879,166 @@ public class PlatinumSludgeOverHaul {
 
         // gt machines
         maploop: for (RecipeMap<?> map : RecipeMap.ALL_RECIPE_MAPS.values()) {
-            GTLog.err.println("Processing recipmap: " + map.unlocalizedName);
             if (isMapIgnored(map)) continue;
 
-            HashSet<GTRecipe> toDel = new HashSet<>();
+            GTLog.out.println("Processing recipe map: " + map.unlocalizedName);
+
+            ArrayList<GTRecipe> toDelete = new ArrayList<>();
 
             recipeloop: for (GTRecipe recipe : map.getAllRecipes()) {
                 if (recipe.mFakeRecipe) continue maploop;
+
                 for (int i = 0; i < recipe.mFluidOutputs.length; i++) {
-                    if (map.equals(multiblockChemicalReactorRecipes) || map.equals(chemicalReactorRecipes)) {
+                    if (map == multiblockChemicalReactorRecipes || map == chemicalReactorRecipes) {
                         if (GTUtility.areFluidsEqual(Ruthenium.getMolten(1), recipe.mFluidOutputs[i])
                             || GTUtility.areFluidsEqual(Rhodium.getMolten(1), recipe.mFluidOutputs[i])) {
-                            toDel.add(recipe);
-                            GTLog.err.println("Recipe marked for deletion: " + displayRecipe(recipe));
+                            toDelete.add(recipe);
+                            GTLog.out.println("Recipe marked for deletion: " + displayRecipe(recipe));
                         } else if (GTUtility.areFluidsEqual(Materials.Iridium.getMolten(1), recipe.mFluidOutputs[i])) {
                             recipe.mFluidOutputs[i] = AcidicIridiumSolution.getFluidOrGas(1_000);
                             recipe.reloadOwner();
-                            GTLog.err.println("Recipe edited: " + displayRecipe(recipe));
+                            GTLog.out.println("Recipe edited: " + displayRecipe(recipe));
                         } else if (GTUtility.areFluidsEqual(Materials.Platinum.getMolten(1), recipe.mFluidOutputs[i])) {
                             recipe.mFluidOutputs[i] = PTConcentrate.getFluidOrGas(2_000);
                             recipe.reloadOwner();
-                            GTLog.err.println("Recipe edited: " + displayRecipe(recipe));
+                            GTLog.out.println("Recipe edited: " + displayRecipe(recipe));
                         } else if (GTUtility.areFluidsEqual(Materials.Osmium.getMolten(1), recipe.mFluidOutputs[i])) {
                             recipe.mFluidOutputs[i] = AcidicOsmiumSolution.getFluidOrGas(1_000);
                             recipe.reloadOwner();
-                            GTLog.err.println("Recipe edited: " + displayRecipe(recipe));
+                            GTLog.out.println("Recipe edited: " + displayRecipe(recipe));
                         }
                     } else if (GTUtility.areFluidsEqual(Ruthenium.getMolten(1), recipe.mFluidOutputs[i])
                         || GTUtility.areFluidsEqual(Rhodium.getMolten(1), recipe.mFluidOutputs[i])
                         || GTUtility.areFluidsEqual(Materials.Iridium.getMolten(1), recipe.mFluidOutputs[i])
                         || GTUtility.areFluidsEqual(Materials.Platinum.getMolten(1), recipe.mFluidOutputs[i])
                         || GTUtility.areFluidsEqual(Materials.Osmium.getMolten(1), recipe.mFluidOutputs[i])) {
-                            GTLog.err.println("Recipe marked for deletion: " + displayRecipe(recipe));
-                            toDel.add(recipe);
+                            toDelete.add(recipe);
+                            GTLog.out.println("Recipe marked for deletion: " + displayRecipe(recipe));
                         }
                 }
+
                 for (int i = 0; i < recipe.mOutputs.length; i++) {
                     if (!GTUtility.isStackValid(recipe.mOutputs[i])) continue;
 
-                    if ((BWUtil.areStacksEqualOrNull(Ruthenium.get(dust), recipe.mOutputs[i])
-                        || BWUtil.areStacksEqualOrNull(Ruthenium.get(dustImpure), recipe.mOutputs[i])
-                        || BWUtil.areStacksEqualOrNull(Ruthenium.get(dustPure), recipe.mOutputs[i]))
-                        && !BWUtil.areStacksEqualOrNull(Ruthenium.get(ingot), recipe.mInputs[0])) {
-                        for (ItemStack mInput : recipe.mInputs)
-                            if (PlatinumSludgeOverHaul.isInBlackList(mInput, availableItemList)) continue recipeloop;
-                        int amount = recipe.mOutputs[i].stackSize * 2;
-                        GTLog.err.println("Recipe edited: " + displayRecipe(recipe));
-                        recipe.mOutputs[i] = LeachResidue.get(dust, amount);
-                        recipe.reloadOwner();
-                    }
-                    if ((BWUtil.areStacksEqualOrNull(Rhodium.get(dust), recipe.mOutputs[i])
-                        || BWUtil.areStacksEqualOrNull(Rhodium.get(dustImpure), recipe.mOutputs[i])
-                        || BWUtil.areStacksEqualOrNull(Rhodium.get(dustPure), recipe.mOutputs[i]))
-                        && !BWUtil.areStacksEqualOrNull(Rhodium.get(ingot), recipe.mInputs[0])) {
-                        for (ItemStack mInput : recipe.mInputs)
-                            if (PlatinumSludgeOverHaul.isInBlackList(mInput, availableItemList)) continue recipeloop;
-                        int amount = recipe.mOutputs[i].stackSize * 2;
-                        GTLog.err.println("Recipe edited: " + displayRecipe(recipe));
-                        recipe.mOutputs[i] = CrudeRhMetall.get(dust, amount);
-                        recipe.reloadOwner();
-                    }
-                    if (!BWUtil.checkStackAndPrefix(recipe.mOutputs[i])) continue;
-                    // Pt
-                    if (GTOreDictUnificator.getAssociation(recipe.mOutputs[i]).mMaterial.mMaterial
-                        .equals(Materials.Platinum)) {
+                    if ((GTUtility.areStacksEqual(Ruthenium.get(dust), recipe.mOutputs[i])
+                        || GTUtility.areStacksEqual(Ruthenium.get(dustImpure), recipe.mOutputs[i])
+                        || GTUtility.areStacksEqual(Ruthenium.get(dustPure), recipe.mOutputs[i]))
+                        && !GTUtility.areStacksEqual(Ruthenium.get(ingot), recipe.mInputs[0])) {
                         for (ItemStack mInput : recipe.mInputs) {
                             if (PlatinumSludgeOverHaul.isInBlackList(mInput, availableItemList)) continue recipeloop;
                         }
-                        if (dust.equals(GTOreDictUnificator.getAssociation(recipe.mOutputs[i]).mPrefix)
-                            || dustImpure.equals(GTOreDictUnificator.getAssociation(recipe.mOutputs[i]).mPrefix)
-                            || dustPure.equals(GTOreDictUnificator.getAssociation(recipe.mOutputs[i]).mPrefix)) {
+                        int amount = recipe.mOutputs[i].stackSize * 2;
+                        recipe.mOutputs[i] = LeachResidue.get(dust, amount);
+                        recipe.reloadOwner();
+                        GTLog.out.println("Recipe edited: " + displayRecipe(recipe));
+                    }
+
+                    if ((GTUtility.areStacksEqual(Rhodium.get(dust), recipe.mOutputs[i])
+                        || GTUtility.areStacksEqual(Rhodium.get(dustImpure), recipe.mOutputs[i])
+                        || GTUtility.areStacksEqual(Rhodium.get(dustPure), recipe.mOutputs[i]))
+                        && !GTUtility.areStacksEqual(Rhodium.get(ingot), recipe.mInputs[0])) {
+                        for (ItemStack mInput : recipe.mInputs) {
+                            if (PlatinumSludgeOverHaul.isInBlackList(mInput, availableItemList)) continue recipeloop;
+                        }
+                        int amount = recipe.mOutputs[i].stackSize * 2;
+                        recipe.mOutputs[i] = CrudeRhMetall.get(dust, amount);
+                        recipe.reloadOwner();
+                        GTLog.out.println("Recipe edited: " + displayRecipe(recipe));
+                    }
+
+                    ItemData association = GTOreDictUnificator.getAssociation(recipe.mOutputs[i]);
+                    if (!BWUtil.checkStackAndPrefix(association)) continue;
+
+                    // Pt
+                    if (association.mMaterial.mMaterial.equals(Materials.Platinum)) {
+                        for (ItemStack mInput : recipe.mInputs) {
+                            if (PlatinumSludgeOverHaul.isInBlackList(mInput, availableItemList)) continue recipeloop;
+                        }
+                        if (dust.equals(association.mPrefix) || dustImpure.equals(association.mPrefix)
+                            || dustPure.equals(association.mPrefix)) {
                             int amount = recipe.mOutputs[i].stackSize;
-                            GTLog.err.println("Recipe edited: " + displayRecipe(recipe));
                             recipe.mOutputs[i] = BWUtil.setStackSize(PTMetallicPowder.get(dust), amount * 2);
                             recipe.reloadOwner();
-                        } else if (dustSmall.equals(GTOreDictUnificator.getAssociation(recipe.mOutputs[i]).mPrefix)) {
+                            GTLog.out.println("Recipe edited: " + displayRecipe(recipe));
+                        } else if (dustSmall.equals(association.mPrefix)) {
                             int amount = recipe.mOutputs[i].stackSize;
-                            GTLog.err.println("Recipe edited: " + displayRecipe(recipe));
                             recipe.mOutputs[i] = BWUtil.setStackSize(PTMetallicPowder.get(dustSmall), amount * 2);
                             recipe.reloadOwner();
-                        } else if (dustTiny.equals(GTOreDictUnificator.getAssociation(recipe.mOutputs[i]).mPrefix)) {
+                            GTLog.out.println("Recipe edited: " + displayRecipe(recipe));
+                        } else if (dustTiny.equals(association.mPrefix)) {
                             int amount = recipe.mOutputs[i].stackSize;
-                            GTLog.err.println("Recipe edited: " + displayRecipe(recipe));
                             recipe.mOutputs[i] = BWUtil.setStackSize(PTMetallicPowder.get(dustTiny), amount * 2);
                             recipe.reloadOwner();
+                            GTLog.out.println("Recipe edited: " + displayRecipe(recipe));
                         }
-                    } else if (GTOreDictUnificator.getAssociation(recipe.mOutputs[i]).mMaterial.mMaterial
-                        .equals(Materials.Palladium)) {
-                            for (ItemStack mInput : recipe.mInputs) {
-                                if (PlatinumSludgeOverHaul.isInBlackList(mInput, availableItemList))
-                                    continue recipeloop;
-                            }
-                            if (dust.equals(GTOreDictUnificator.getAssociation(recipe.mOutputs[i]).mPrefix)
-                                || dustImpure.equals(GTOreDictUnificator.getAssociation(recipe.mOutputs[i]).mPrefix)
-                                || dustPure.equals(GTOreDictUnificator.getAssociation(recipe.mOutputs[i]).mPrefix)) {
-                                int amount = recipe.mOutputs[i].stackSize;
-                                GTLog.err.println("Recipe edited: " + displayRecipe(recipe));
-                                recipe.mOutputs[i] = BWUtil.setStackSize(PDMetallicPowder.get(dust), amount * 4);
-                                recipe.reloadOwner();
-                            } else
-                                if (dustSmall.equals(GTOreDictUnificator.getAssociation(recipe.mOutputs[i]).mPrefix)) {
-                                    int amount = recipe.mOutputs[i].stackSize;
-                                    GTLog.err.println("Recipe edited: " + displayRecipe(recipe));
-                                    recipe.mOutputs[i] = BWUtil
-                                        .setStackSize(PDMetallicPowder.get(dustSmall), amount * 4);
-                                    recipe.reloadOwner();
-                                } else if (dustTiny
-                                    .equals(GTOreDictUnificator.getAssociation(recipe.mOutputs[i]).mPrefix)) {
-                                        int amount = recipe.mOutputs[i].stackSize;
-                                        GTLog.err.println("Recipe edited: " + displayRecipe(recipe));
-                                        recipe.mOutputs[i] = BWUtil
-                                            .setStackSize(PDMetallicPowder.get(dustTiny), amount * 4);
-                                        recipe.reloadOwner();
-                                    }
-                        } else if (GTOreDictUnificator.getAssociation(recipe.mOutputs[i]).mMaterial.mMaterial
-                            .equals(Materials.Osmium)) {
-                                for (ItemStack mInput : recipe.mInputs) {
-                                    if (PlatinumSludgeOverHaul.isInBlackList(mInput, availableItemList))
-                                        continue recipeloop;
-                                }
-                                if (dust.equals(GTOreDictUnificator.getAssociation(recipe.mOutputs[i]).mPrefix)
-                                    || dustImpure.equals(GTOreDictUnificator.getAssociation(recipe.mOutputs[i]).mPrefix)
-                                    || dustPure
-                                        .equals(GTOreDictUnificator.getAssociation(recipe.mOutputs[i]).mPrefix)) {
-                                    int amount = recipe.mOutputs[i].stackSize;
-                                    GTLog.err.println("Recipe edited: " + displayRecipe(recipe));
-                                    recipe.mOutputs[i] = BWUtil.setStackSize(IrOsLeachResidue.get(dust), amount);
-                                    recipe.reloadOwner();
-                                } else if (dustSmall
-                                    .equals(GTOreDictUnificator.getAssociation(recipe.mOutputs[i]).mPrefix)) {
-                                        int amount = recipe.mOutputs[i].stackSize;
-                                        GTLog.err.println("Recipe edited: " + displayRecipe(recipe));
-                                        recipe.mOutputs[i] = BWUtil
-                                            .setStackSize(IrOsLeachResidue.get(dustSmall), amount);
-                                        recipe.reloadOwner();
-                                    } else if (dustTiny
-                                        .equals(GTOreDictUnificator.getAssociation(recipe.mOutputs[i]).mPrefix)) {
-                                            GTLog.err.println("Recipe edited: " + displayRecipe(recipe));
-                                            int amount = recipe.mOutputs[i].stackSize;
-                                            recipe.mOutputs[i] = BWUtil
-                                                .setStackSize(IrOsLeachResidue.get(dustTiny), amount);
-                                            recipe.reloadOwner();
-                                        }
-                            } else if (GTOreDictUnificator.getAssociation(recipe.mOutputs[i]).mMaterial.mMaterial
-                                .equals(Materials.Iridium)) {
-                                    for (ItemStack mInput : recipe.mInputs) {
-                                        if (PlatinumSludgeOverHaul.isInBlackList(mInput, availableItemList))
-                                            continue recipeloop;
-                                    }
-                                    if (dust.equals(GTOreDictUnificator.getAssociation(recipe.mOutputs[i]).mPrefix)
-                                        || dustImpure
-                                            .equals(GTOreDictUnificator.getAssociation(recipe.mOutputs[i]).mPrefix)
-                                        || dustPure
-                                            .equals(GTOreDictUnificator.getAssociation(recipe.mOutputs[i]).mPrefix)) {
-                                        int amount = recipe.mOutputs[i].stackSize;
-                                        recipe.mOutputs[i] = BWUtil.setStackSize(IrLeachResidue.get(dust), amount);
-                                        GTLog.err.println("Recipe edited: " + displayRecipe(recipe));
-                                        recipe.reloadOwner();
-                                    } else if (dustSmall
-                                        .equals(GTOreDictUnificator.getAssociation(recipe.mOutputs[i]).mPrefix)) {
-                                            int amount = recipe.mOutputs[i].stackSize;
-                                            recipe.mOutputs[i] = BWUtil
-                                                .setStackSize(IrLeachResidue.get(dustSmall), amount);
-                                            GTLog.err.println("Recipe edited: " + displayRecipe(recipe));
-                                            recipe.reloadOwner();
-                                        } else if (dustTiny
-                                            .equals(GTOreDictUnificator.getAssociation(recipe.mOutputs[i]).mPrefix)) {
-                                                int amount = recipe.mOutputs[i].stackSize;
-                                                recipe.mOutputs[i] = BWUtil
-                                                    .setStackSize(IrLeachResidue.get(dustTiny), amount);
-                                                GTLog.err.println("Recipe edited: " + displayRecipe(recipe));
-                                                recipe.reloadOwner();
-                                            }
-                                }
+                    } else if (association.mMaterial.mMaterial.equals(Materials.Palladium)) {
+                        for (ItemStack mInput : recipe.mInputs) {
+                            if (PlatinumSludgeOverHaul.isInBlackList(mInput, availableItemList)) continue recipeloop;
+                        }
+                        if (dust.equals(association.mPrefix) || dustImpure.equals(association.mPrefix)
+                            || dustPure.equals(association.mPrefix)) {
+                            int amount = recipe.mOutputs[i].stackSize;
+                            recipe.mOutputs[i] = BWUtil.setStackSize(PDMetallicPowder.get(dust), amount * 4);
+                            recipe.reloadOwner();
+                            GTLog.out.println("Recipe edited: " + displayRecipe(recipe));
+                        } else if (dustSmall.equals(association.mPrefix)) {
+                            int amount = recipe.mOutputs[i].stackSize;
+                            recipe.mOutputs[i] = BWUtil.setStackSize(PDMetallicPowder.get(dustSmall), amount * 4);
+                            recipe.reloadOwner();
+                            GTLog.out.println("Recipe edited: " + displayRecipe(recipe));
+                        } else if (dustTiny.equals(association.mPrefix)) {
+                            int amount = recipe.mOutputs[i].stackSize;
+                            recipe.mOutputs[i] = BWUtil.setStackSize(PDMetallicPowder.get(dustTiny), amount * 4);
+                            recipe.reloadOwner();
+                            GTLog.out.println("Recipe edited: " + displayRecipe(recipe));
+                        }
+                    } else if (association.mMaterial.mMaterial.equals(Materials.Osmium)) {
+                        for (ItemStack mInput : recipe.mInputs) {
+                            if (PlatinumSludgeOverHaul.isInBlackList(mInput, availableItemList)) continue recipeloop;
+                        }
+                        if (dust.equals(association.mPrefix) || dustImpure.equals(association.mPrefix)
+                            || dustPure.equals(association.mPrefix)) {
+                            int amount = recipe.mOutputs[i].stackSize;
+                            recipe.mOutputs[i] = BWUtil.setStackSize(IrOsLeachResidue.get(dust), amount);
+                            recipe.reloadOwner();
+                            GTLog.out.println("Recipe edited: " + displayRecipe(recipe));
+                        } else if (dustSmall.equals(association.mPrefix)) {
+                            int amount = recipe.mOutputs[i].stackSize;
+                            recipe.mOutputs[i] = BWUtil.setStackSize(IrOsLeachResidue.get(dustSmall), amount);
+                            recipe.reloadOwner();
+                            GTLog.out.println("Recipe edited: " + displayRecipe(recipe));
+                        } else if (dustTiny.equals(association.mPrefix)) {
+                            int amount = recipe.mOutputs[i].stackSize;
+                            recipe.mOutputs[i] = BWUtil.setStackSize(IrOsLeachResidue.get(dustTiny), amount);
+                            recipe.reloadOwner();
+                            GTLog.out.println("Recipe edited: " + displayRecipe(recipe));
+                        }
+                    } else if (association.mMaterial.mMaterial.equals(Materials.Iridium)) {
+                        for (ItemStack mInput : recipe.mInputs) {
+                            if (PlatinumSludgeOverHaul.isInBlackList(mInput, availableItemList)) continue recipeloop;
+                        }
+                        if (dust.equals(association.mPrefix) || dustImpure.equals(association.mPrefix)
+                            || dustPure.equals(association.mPrefix)) {
+                            int amount = recipe.mOutputs[i].stackSize;
+                            recipe.mOutputs[i] = BWUtil.setStackSize(IrLeachResidue.get(dust), amount);
+                            recipe.reloadOwner();
+                            GTLog.out.println("Recipe edited: " + displayRecipe(recipe));
+                        } else if (dustSmall.equals(association.mPrefix)) {
+                            int amount = recipe.mOutputs[i].stackSize;
+                            recipe.mOutputs[i] = BWUtil.setStackSize(IrLeachResidue.get(dustSmall), amount);
+                            recipe.reloadOwner();
+                            GTLog.out.println("Recipe edited: " + displayRecipe(recipe));
+                        } else if (dustTiny.equals(association.mPrefix)) {
+                            int amount = recipe.mOutputs[i].stackSize;
+                            recipe.mOutputs[i] = BWUtil.setStackSize(IrLeachResidue.get(dustTiny), amount);
+                            recipe.reloadOwner();
+                            GTLog.out.println("Recipe edited: " + displayRecipe(recipe));
+                        }
+                    }
                 }
             }
             map.getBackend()
-                .removeRecipes(toDel);
+                .removeRecipes(toDelete);
         }
         // TODO: remove EnderIO recipes
 
@@ -1075,7 +1057,7 @@ public class PlatinumSludgeOverHaul {
             .eut(TierEU.RECIPE_MV)
             .addTo(mixerRecipes);
 
-        GTLog.err.println("Processing hv circuit materials (circuit assembler map)");
+        GTLog.out.println("Processing hv circuit materials (circuit assembler map)");
         for (GTRecipe recipe : circuitAssemblerRecipes.getAllRecipes()) {
             if (recipe.mEUt > 512) continue;
             if (BWUtil.checkStackAndPrefix(recipe.mOutputs[0])) {
@@ -1084,7 +1066,7 @@ public class PlatinumSludgeOverHaul {
                     ItemData ass = GTOreDictUnificator.getAssociation(stack);
                     if (BWUtil.checkStackAndPrefix(stack) && ass.mMaterial.mMaterial.equals(Materials.Platinum)) {
                         recipe.mInputs[i] = GTOreDictUnificator.get(ass.mPrefix, Materials.BlueAlloy, stack.stackSize);
-                        GTLog.err.println("Recipe edited: " + displayRecipe(recipe));
+                        GTLog.out.println("Recipe edited: " + displayRecipe(recipe));
                         recipe.reloadOwner();
                     }
                 }

--- a/src/main/java/bartworks/system/material/gtenhancement/PlatinumSludgeOverHaul.java
+++ b/src/main/java/bartworks/system/material/gtenhancement/PlatinumSludgeOverHaul.java
@@ -858,7 +858,7 @@ public class PlatinumSludgeOverHaul {
             if (!BWUtil.checkStackAndPrefix(inputAssociation)) continue;
 
             if (inputAssociation.mMaterial.mMaterial == Materials.Platinum) {
-                if (inputAssociation.mPrefix.equals(dust) || inputAssociation.mPrefix.equals(dustTiny)) {
+                if (inputAssociation.mPrefix == dust || inputAssociation.mPrefix == dustTiny) {
                     continue;
                 }
             }
@@ -949,94 +949,43 @@ public class PlatinumSludgeOverHaul {
                     ItemData association = GTOreDictUnificator.getAssociation(recipe.mOutputs[i]);
                     if (!BWUtil.checkStackAndPrefix(association)) continue;
 
-                    // Pt
-                    if (association.mMaterial.mMaterial.equals(Materials.Platinum)) {
-                        for (ItemStack mInput : recipe.mInputs) {
-                            if (PlatinumSludgeOverHaul.isInBlackList(mInput, availableItemList)) continue recipeloop;
-                        }
-                        if (dust.equals(association.mPrefix) || dustImpure.equals(association.mPrefix)
-                            || dustPure.equals(association.mPrefix)) {
-                            int amount = recipe.mOutputs[i].stackSize;
-                            recipe.mOutputs[i] = BWUtil.setStackSize(PTMetallicPowder.get(dust), amount * 2);
-                            recipe.reloadOwner();
-                            GTLog.out.println("Recipe edited: " + displayRecipe(recipe));
-                        } else if (dustSmall.equals(association.mPrefix)) {
-                            int amount = recipe.mOutputs[i].stackSize;
-                            recipe.mOutputs[i] = BWUtil.setStackSize(PTMetallicPowder.get(dustSmall), amount * 2);
-                            recipe.reloadOwner();
-                            GTLog.out.println("Recipe edited: " + displayRecipe(recipe));
-                        } else if (dustTiny.equals(association.mPrefix)) {
-                            int amount = recipe.mOutputs[i].stackSize;
-                            recipe.mOutputs[i] = BWUtil.setStackSize(PTMetallicPowder.get(dustTiny), amount * 2);
-                            recipe.reloadOwner();
-                            GTLog.out.println("Recipe edited: " + displayRecipe(recipe));
-                        }
-                    } else if (association.mMaterial.mMaterial.equals(Materials.Palladium)) {
-                        for (ItemStack mInput : recipe.mInputs) {
-                            if (PlatinumSludgeOverHaul.isInBlackList(mInput, availableItemList)) continue recipeloop;
-                        }
-                        if (dust.equals(association.mPrefix) || dustImpure.equals(association.mPrefix)
-                            || dustPure.equals(association.mPrefix)) {
-                            int amount = recipe.mOutputs[i].stackSize;
-                            recipe.mOutputs[i] = BWUtil.setStackSize(PDMetallicPowder.get(dust), amount * 4);
-                            recipe.reloadOwner();
-                            GTLog.out.println("Recipe edited: " + displayRecipe(recipe));
-                        } else if (dustSmall.equals(association.mPrefix)) {
-                            int amount = recipe.mOutputs[i].stackSize;
-                            recipe.mOutputs[i] = BWUtil.setStackSize(PDMetallicPowder.get(dustSmall), amount * 4);
-                            recipe.reloadOwner();
-                            GTLog.out.println("Recipe edited: " + displayRecipe(recipe));
-                        } else if (dustTiny.equals(association.mPrefix)) {
-                            int amount = recipe.mOutputs[i].stackSize;
-                            recipe.mOutputs[i] = BWUtil.setStackSize(PDMetallicPowder.get(dustTiny), amount * 4);
-                            recipe.reloadOwner();
-                            GTLog.out.println("Recipe edited: " + displayRecipe(recipe));
-                        }
-                    } else if (association.mMaterial.mMaterial.equals(Materials.Osmium)) {
-                        for (ItemStack mInput : recipe.mInputs) {
-                            if (PlatinumSludgeOverHaul.isInBlackList(mInput, availableItemList)) continue recipeloop;
-                        }
-                        if (dust.equals(association.mPrefix) || dustImpure.equals(association.mPrefix)
-                            || dustPure.equals(association.mPrefix)) {
-                            int amount = recipe.mOutputs[i].stackSize;
-                            recipe.mOutputs[i] = BWUtil.setStackSize(IrOsLeachResidue.get(dust), amount);
-                            recipe.reloadOwner();
-                            GTLog.out.println("Recipe edited: " + displayRecipe(recipe));
-                        } else if (dustSmall.equals(association.mPrefix)) {
-                            int amount = recipe.mOutputs[i].stackSize;
-                            recipe.mOutputs[i] = BWUtil.setStackSize(IrOsLeachResidue.get(dustSmall), amount);
-                            recipe.reloadOwner();
-                            GTLog.out.println("Recipe edited: " + displayRecipe(recipe));
-                        } else if (dustTiny.equals(association.mPrefix)) {
-                            int amount = recipe.mOutputs[i].stackSize;
-                            recipe.mOutputs[i] = BWUtil.setStackSize(IrOsLeachResidue.get(dustTiny), amount);
-                            recipe.reloadOwner();
-                            GTLog.out.println("Recipe edited: " + displayRecipe(recipe));
-                        }
-                    } else if (association.mMaterial.mMaterial.equals(Materials.Iridium)) {
-                        for (ItemStack mInput : recipe.mInputs) {
-                            if (PlatinumSludgeOverHaul.isInBlackList(mInput, availableItemList)) continue recipeloop;
-                        }
-                        if (dust.equals(association.mPrefix) || dustImpure.equals(association.mPrefix)
-                            || dustPure.equals(association.mPrefix)) {
-                            int amount = recipe.mOutputs[i].stackSize;
-                            recipe.mOutputs[i] = BWUtil.setStackSize(IrLeachResidue.get(dust), amount);
-                            recipe.reloadOwner();
-                            GTLog.out.println("Recipe edited: " + displayRecipe(recipe));
-                        } else if (dustSmall.equals(association.mPrefix)) {
-                            int amount = recipe.mOutputs[i].stackSize;
-                            recipe.mOutputs[i] = BWUtil.setStackSize(IrLeachResidue.get(dustSmall), amount);
-                            recipe.reloadOwner();
-                            GTLog.out.println("Recipe edited: " + displayRecipe(recipe));
-                        } else if (dustTiny.equals(association.mPrefix)) {
-                            int amount = recipe.mOutputs[i].stackSize;
-                            recipe.mOutputs[i] = BWUtil.setStackSize(IrLeachResidue.get(dustTiny), amount);
-                            recipe.reloadOwner();
-                            GTLog.out.println("Recipe edited: " + displayRecipe(recipe));
-                        }
+                    final Werkstoff replacementMaterial;
+                    if (association.mMaterial.mMaterial == Materials.Platinum) {
+                        replacementMaterial = PTMetallicPowder;
+                    } else if (association.mMaterial.mMaterial == Materials.Palladium) {
+                        replacementMaterial = PDMetallicPowder;
+                    } else if (association.mMaterial.mMaterial == Materials.Osmium) {
+                        replacementMaterial = IrOsLeachResidue;
+                    } else if (association.mMaterial.mMaterial == Materials.Iridium) {
+                        replacementMaterial = IrLeachResidue;
+                    } else {
+                        continue;
+                    }
+
+                    for (ItemStack mInput : recipe.mInputs) {
+                        if (PlatinumSludgeOverHaul.isInBlackList(mInput, availableItemList)) continue recipeloop;
+                    }
+
+                    if (association.mPrefix == dust || association.mPrefix == dustImpure
+                        || association.mPrefix == dustPure) {
+                        int amount = recipe.mOutputs[i].stackSize;
+                        recipe.mOutputs[i] = BWUtil.setStackSize(replacementMaterial.get(dust), amount * 2);
+                        recipe.reloadOwner();
+                        GTLog.out.println("Recipe edited: " + displayRecipe(recipe));
+                    } else if (association.mPrefix == dustSmall) {
+                        int amount = recipe.mOutputs[i].stackSize;
+                        recipe.mOutputs[i] = BWUtil.setStackSize(replacementMaterial.get(dustSmall), amount * 2);
+                        recipe.reloadOwner();
+                        GTLog.out.println("Recipe edited: " + displayRecipe(recipe));
+                    } else if (association.mPrefix == dustTiny) {
+                        int amount = recipe.mOutputs[i].stackSize;
+                        recipe.mOutputs[i] = BWUtil.setStackSize(replacementMaterial.get(dustTiny), amount * 2);
+                        recipe.reloadOwner();
+                        GTLog.out.println("Recipe edited: " + displayRecipe(recipe));
                     }
                 }
             }
+
             map.getBackend()
                 .removeRecipes(toDelete);
         }

--- a/src/main/java/bartworks/system/material/gtenhancement/PlatinumSludgeOverHaul.java
+++ b/src/main/java/bartworks/system/material/gtenhancement/PlatinumSludgeOverHaul.java
@@ -1160,19 +1160,21 @@ public class PlatinumSludgeOverHaul {
         Block block = Block.getBlockFromItem(item);
         if (block instanceof GTGenericBlock && !(block instanceof GTBlockOre)) return true;
 
+        ItemData association = GTOreDictUnificator.getAssociation(stack);
+        boolean isAssociationValid = BWUtil.checkStackAndPrefix(association);
+
         for (ItemStack itemStack : availableItemList) {
-            if (!BWUtil.checkStackAndPrefix(stack) && GTUtility.areStacksEqual(itemStack, stack, true)) {
+            if (!isAssociationValid && GTUtility.areStacksEqual(itemStack, stack, true)) {
                 return true;
             }
         }
 
         if (item instanceof GTGenericItem) {
-            if (!BWUtil.checkStackAndPrefix(stack)) return false;
-            if (GTOreDictUnificator.getAssociation(stack).mPrefix != rawOre) {
+            if (!isAssociationValid) return false;
+            if (association.mPrefix != rawOre) {
                 return !Arrays.asList(PlatinumSludgeOverHaul.OPBLACKLIST)
-                    .contains(GTOreDictUnificator.getAssociation(stack).mPrefix)
-                    || Arrays.asList(PlatinumSludgeOverHaul.BLACKLIST)
-                        .contains(GTOreDictUnificator.getAssociation(stack).mMaterial.mMaterial);
+                    .contains(association.mPrefix) || Arrays.asList(PlatinumSludgeOverHaul.BLACKLIST)
+                        .contains(association.mMaterial.mMaterial);
             }
         }
 
@@ -1217,10 +1219,10 @@ public class PlatinumSludgeOverHaul {
                 return true;
             }
         }
-        if (!BWUtil.checkStackAndPrefix(stack)) {
+        if (!isAssociationValid) {
             return false;
         }
         return Arrays.asList(PlatinumSludgeOverHaul.BLACKLIST)
-            .contains(GTOreDictUnificator.getAssociation(stack).mMaterial.mMaterial);
+            .contains(association.mMaterial.mMaterial);
     }
 }

--- a/src/main/java/bartworks/system/material/gtenhancement/PlatinumSludgeOverHaul.java
+++ b/src/main/java/bartworks/system/material/gtenhancement/PlatinumSludgeOverHaul.java
@@ -1145,9 +1145,11 @@ public class PlatinumSludgeOverHaul {
         ItemData association = GTOreDictUnificator.getAssociation(stack);
         boolean isAssociationValid = BWUtil.checkStackAndPrefix(association);
 
-        for (ItemStack itemStack : availableItemList) {
-            if (!isAssociationValid && GTUtility.areStacksEqual(itemStack, stack, true)) {
-                return true;
+        if (!isAssociationValid) {
+            for (ItemStack itemStack : availableItemList) {
+                if (GTUtility.areStacksEqual(itemStack, stack, true)) {
+                    return true;
+                }
             }
         }
 

--- a/src/main/java/bartworks/util/BWUtil.java
+++ b/src/main/java/bartworks/util/BWUtil.java
@@ -167,10 +167,13 @@ public class BWUtil {
     }
 
     public static boolean checkStackAndPrefix(ItemStack itemStack) {
-        return itemStack != null && GTOreDictUnificator.getAssociation(itemStack) != null
-            && GTOreDictUnificator.getAssociation(itemStack).mPrefix != null
-            && GTOreDictUnificator.getAssociation(itemStack).mMaterial != null
-            && GTOreDictUnificator.getAssociation(itemStack).mMaterial.mMaterial != null;
+        return checkStackAndPrefix(GTOreDictUnificator.getAssociation(itemStack));
+    }
+
+    public static boolean checkStackAndPrefix(ItemData association) {
+        return association != null && association.mPrefix != null
+            && association.mMaterial != null
+            && association.mMaterial.mMaterial != null;
     }
 
     @Deprecated


### PR DESCRIPTION
Not a rework, all logic is kept as is, but made the code more readable, with less copy-pasted code and much faster just by extracting method call results in variables and a bit of call order reorganization

All changes can be easily followed up commit by commit

Before: 228.5ms (0.75% of game loading time)
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/7dcbc75f-c4a9-49ed-8dcf-3fa9ac26ebc4" />

After: 83.5ms (0.25%)
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/18edb304-23cd-4663-b938-711e829b1c9b" />

