### PR TITLE
Prevent unsafe cast to interfere OC calculator

### DIFF
--- a/src/main/java/gregtech/api/util/OverclockCalculator.java
+++ b/src/main/java/gregtech/api/util/OverclockCalculator.java
@@ -340,7 +340,7 @@ public class OverclockCalculator {
         // Treat ULV (tier 0) as LV (tier 1) for overclocking calculations.
         double recipePower = recipeEUt * parallel * eutModifier * calculateHeatDiscountMultiplier();
         double machinePower = machineVoltage * (amperageOC ? machineAmperage : Math.min(machineAmperage, parallel));
-        int tiersAbove = (int) GTUtility.log4((long) machinePower / Math.max((long) recipePower, 32));
+        int tiersAbove = (int) GTUtility.log4((long) machinePower / Math.max((long) Math.ceil(recipePower), 32));
 
         // If overclocking is disabled, use the base values and return.
         if (noOverclock) {


### PR DESCRIPTION
Fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24686
<img width="1920" height="1017" alt="2026-05-13_14 31 27" src="https://github.com/user-attachments/assets/c46b3f31-86d5-4beb-a8ba-256e01a52c17" />
Now it will not cause any problems.