### PR TITLE
Changed MessageFormat inside ME bus/hatch

### DIFF
--- a/src/main/java/gregtech/common/gui/modularui/hatch/MTEHatchInputBusMEGui.java
+++ b/src/main/java/gregtech/common/gui/modularui/hatch/MTEHatchInputBusMEGui.java
@@ -36,6 +36,7 @@ import com.cleanroommc.modularui.widgets.textfield.TextFieldWidget;
 import appeng.core.localization.WailaText;
 import appeng.me.GridAccessException;
 import gregtech.api.modularui2.GTGuiTextures;
+import gregtech.api.modularui2.GTWidgetThemes;
 import gregtech.api.util.GTDataUtils;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.StringUtils;
@@ -337,16 +338,16 @@ public class MTEHatchInputBusMEGui extends MTEHatchBaseGui<MTEHatchInputBusME> {
 
             if (isActive && isPowered) {
                 return MessageFormat.format(
-                    "{0}{1}§f ({2})",
-                    EnumChatFormatting.GREEN,
-                    state,
+                    "{0} ({1})",
+                    EnumChatFormatting.GREEN + state + EnumChatFormatting.RESET,
                     translateToLocal(
                         isAllowedToWorkSyncer.getBoolValue() ? "GT5U.gui.text.enabled" : "GT5U.gui.text.disabled"));
             } else {
-                return EnumChatFormatting.DARK_RED + state;
+                return EnumChatFormatting.DARK_RED + state + EnumChatFormatting.RESET;
             }
         })
-            .asWidget();
+            .asWidget()
+            .widgetTheme(GTWidgetThemes.DISPLAY_TEXT);
 
         return super.createLeftCornerFlow(panel, syncManager).child(status);
     }

--- a/src/main/java/gregtech/common/gui/modularui/hatch/MTEHatchInputMEGui.java
+++ b/src/main/java/gregtech/common/gui/modularui/hatch/MTEHatchInputMEGui.java
@@ -42,6 +42,7 @@ import com.cleanroommc.modularui.widgets.textfield.TextFieldWidget;
 import appeng.core.localization.WailaText;
 import appeng.me.GridAccessException;
 import gregtech.api.modularui2.GTGuiTextures;
+import gregtech.api.modularui2.GTWidgetThemes;
 import gregtech.api.util.GTDataUtils;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.StringUtils;
@@ -337,16 +338,16 @@ public class MTEHatchInputMEGui extends MTEHatchBaseGui<MTEHatchInputME> {
 
             if (isActive && isPowered) {
                 return MessageFormat.format(
-                    "{0}{1}§f ({2})",
-                    EnumChatFormatting.GREEN,
-                    state,
+                    "{0} ({1})",
+                    EnumChatFormatting.GREEN + state + EnumChatFormatting.RESET,
                     IKey.lang(
                         isAllowedToWorkSyncer.getBoolValue() ? "GT5U.gui.text.enabled" : "GT5U.gui.text.disabled"));
             } else {
-                return EnumChatFormatting.DARK_RED + state;
+                return EnumChatFormatting.DARK_RED + state + EnumChatFormatting.RESET;
             }
         })
-            .asWidget();
+            .asWidget()
+            .widgetTheme(GTWidgetThemes.DISPLAY_TEXT);
 
         return super.createLeftCornerFlow(panel, syncManager).child(status);
     }


### PR DESCRIPTION
Corrected Device offline, online text inside ME bus and hatch.

It uses the ae2 waila keys:
`waila.appliedenergistics2.DeviceOnline=Device Online`
`waila.appliedenergistics2.DeviceOffline=Device Offline`
but it was kinda messed up with the resource packs. 

That's why the simpler solution was to add a reset here and not inside the ae2.
Also added the widget theme (Brackets - still white)

Practically nothing changed in-game.

Another point to use EnumChatFormatting rather that colored lang keys ;v
