### PR TITLE
fix(outputme): fix output bus me void items when multipie transactions occur in 1t.

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/outputme/MTEHatchOutputBusME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/outputme/MTEHatchOutputBusME.java
@@ -207,10 +207,6 @@ public class MTEHatchOutputBusME extends MTEHatchOutputBus
 
         @Override
         public boolean hasAvailableSpace() {
-            // There's really no reason for the tick counter, it's just more accurate to the real bus's behaviour.
-            // Transactions should never be kept around long enough for it to matter, but in case someone does something
-            // stupid it's here to make sure nothing breaks.
-            // This condition should always return true unless this transaction is kept around for more than one tick.
             return cache.getTotal() < availableSpace || provider.getTickCounter() == tick;
         }
 
@@ -243,7 +239,7 @@ public class MTEHatchOutputBusME extends MTEHatchOutputBus
         public void commit() {
             cache.iterateAll(
                 (id, amount) -> {
-                    provider.addToCache(
+                    provider.storeToCache(
                         provider.getFilter()
                             .fromNative(id.getItemStack())
                             .setStackSize(amount));

--- a/src/main/java/gregtech/common/tileentities/machines/outputme/base/MTEHatchOutputMEBase.java
+++ b/src/main/java/gregtech/common/tileentities/machines/outputme/base/MTEHatchOutputMEBase.java
@@ -512,24 +512,32 @@ public abstract class MTEHatchOutputMEBase<T extends IAEStack<T>, F extends MEFi
         return hasAvailableSpace() && filter.isAllowed(stack);
     }
 
-    public void addToCache(I stack) {
+    public void addToCache(@NotNull I stack) {
         addToCache(filter.fromNative(stack));
     }
 
-    public void addToCache(T stack) {
+    public void addToCache(@NotNull T stack) {
         if (!isVoidCell) {
             cache.insert(stack, stack.getStackSize());
-            env.dispatchMarkDirty();
         }
     }
 
-    public boolean storePartial(I stack, boolean simulate) {
+    public void storeToCache(@NotNull T stack) {
+        addToCache(stack);
+        lastInputTick = tickCounter;
+    }
+
+    public void storeToCache(@NotNull I stack) {
+        storeToCache(filter.fromNative(stack));
+    }
+
+    public boolean storePartial(@NotNull I stack, boolean simulate) {
         if (lastInputTick != tickCounter && !canStore(stack)) {
             return false;
         }
         if (!simulate) {
-            addToCache(stack);
-            lastInputTick = tickCounter;
+            storeToCache(stack);
+            env.dispatchMarkDirty();
         }
         return true;
     }


### PR DESCRIPTION
It turns out the tick checks is necessary now cause transcations can occur more the once per tick.
I also moved markDirty to storePartial to reduce redundant calls and improve consistency.
fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24652