### PR TITLE
Fix flasks renderer

### DIFF
--- a/src/main/java/gregtech/common/render/FlaskRenderer.java
+++ b/src/main/java/gregtech/common/render/FlaskRenderer.java
@@ -33,8 +33,7 @@ public final class FlaskRenderer implements IItemRenderer {
     @Override
     public void renderItem(ItemRenderType type, ItemStack item, Object... data) {
         GL11.glPushAttrib(
-            GL11.GL_ENABLE_BIT
-                | GL11.GL_COLOR_BUFFER_BIT
+            GL11.GL_ENABLE_BIT | GL11.GL_COLOR_BUFFER_BIT
                 | GL11.GL_CURRENT_BIT
                 | GL11.GL_DEPTH_BUFFER_BIT
                 | GL11.GL_TEXTURE_BIT);

--- a/src/main/java/gregtech/common/render/FlaskRenderer.java
+++ b/src/main/java/gregtech/common/render/FlaskRenderer.java
@@ -32,11 +32,7 @@ public final class FlaskRenderer implements IItemRenderer {
 
     @Override
     public void renderItem(ItemRenderType type, ItemStack item, Object... data) {
-        GL11.glPushAttrib(
-            GL11.GL_ENABLE_BIT | GL11.GL_COLOR_BUFFER_BIT
-                | GL11.GL_CURRENT_BIT
-                | GL11.GL_DEPTH_BUFFER_BIT
-                | GL11.GL_TEXTURE_BIT);
+        GL11.glPushAttrib(GL11.GL_ENABLE_BIT | GL11.GL_COLOR_BUFFER_BIT | GL11.GL_CURRENT_BIT);
 
         try {
             ItemVolumetricFlask cell = (ItemVolumetricFlask) item.getItem();

--- a/src/main/java/gregtech/common/render/FlaskRenderer.java
+++ b/src/main/java/gregtech/common/render/FlaskRenderer.java
@@ -32,36 +32,47 @@ public final class FlaskRenderer implements IItemRenderer {
 
     @Override
     public void renderItem(ItemRenderType type, ItemStack item, Object... data) {
-        ItemVolumetricFlask cell = (ItemVolumetricFlask) item.getItem();
-        IIcon icon = item.getIconIndex();
-        GL11.glEnable(GL11.GL_BLEND);
-        GL11.glEnable(GL11.GL_ALPHA_TEST);
-        ItemRenderUtil.applyStandardItemTransform(type);
+        GL11.glPushAttrib(
+            GL11.GL_ENABLE_BIT
+                | GL11.GL_COLOR_BUFFER_BIT
+                | GL11.GL_CURRENT_BIT
+                | GL11.GL_DEPTH_BUFFER_BIT
+                | GL11.GL_TEXTURE_BIT);
 
-        FluidStack fs = cell != null ? cell.getFluid(item) : null;
-        if (fs != null) {
-            IIcon iconWindow = cell.iconWindow;
-            Fluid fluid = fs.getFluid();
-            IIcon fluidIcon = fluid.getIcon(fs);
-            int fluidColor = fluid.getColor(fs);
+        try {
+            ItemVolumetricFlask cell = (ItemVolumetricFlask) item.getItem();
+            IIcon icon = item.getIconIndex();
+
+            GL11.glEnable(GL11.GL_BLEND);
+            GL11.glEnable(GL11.GL_ALPHA_TEST);
+
+            ItemRenderUtil.applyStandardItemTransform(type);
+
+            FluidStack fs = cell != null ? cell.getFluid(item) : null;
+            if (fs != null) {
+                IIcon iconWindow = cell.iconWindow;
+                Fluid fluid = fs.getFluid();
+                IIcon fluidIcon = fluid.getIcon(fs);
+                int fluidColor = fluid.getColor(fs);
+
+                Minecraft.getMinecraft().renderEngine.bindTexture(TextureMap.locationItemsTexture);
+                GL11.glBlendFunc(GL11.GL_ZERO, GL11.GL_ONE);
+                ItemRenderUtil.renderItem(type, iconWindow);
+
+                Minecraft.getMinecraft().renderEngine.bindTexture(TextureMap.locationBlocksTexture);
+                GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
+                GL11.glDepthFunc(GL11.GL_EQUAL);
+                GL11.glColor3ub((byte) (fluidColor >> 16), (byte) (fluidColor >> 8), (byte) fluidColor);
+                ItemRenderUtil.renderItem(type, fluidIcon);
+                GL11.glColor3ub((byte) -1, (byte) -1, (byte) -1);
+                GL11.glDepthFunc(GL11.GL_LEQUAL);
+            }
 
             Minecraft.getMinecraft().renderEngine.bindTexture(TextureMap.locationItemsTexture);
-            GL11.glBlendFunc(GL11.GL_ZERO, GL11.GL_ONE);
-            ItemRenderUtil.renderItem(type, iconWindow);
-
-            Minecraft.getMinecraft().renderEngine.bindTexture(TextureMap.locationBlocksTexture);
             GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
-            GL11.glDepthFunc(GL11.GL_EQUAL);
-            GL11.glColor3ub((byte) (fluidColor >> 16), (byte) (fluidColor >> 8), (byte) fluidColor);
-            ItemRenderUtil.renderItem(type, fluidIcon);
-            GL11.glColor3ub((byte) -1, (byte) -1, (byte) -1);
-            GL11.glDepthFunc(GL11.GL_LEQUAL);
+            ItemRenderUtil.renderItem(type, icon);
+        } finally {
+            GL11.glPopAttrib();
         }
-
-        Minecraft.getMinecraft().renderEngine.bindTexture(TextureMap.locationItemsTexture);
-        GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
-        ItemRenderUtil.renderItem(type, icon);
-        GL11.glDisable(GL11.GL_ALPHA_TEST);
-        GL11.glDisable(GL11.GL_BLEND);
     }
 }


### PR DESCRIPTION
- fixes GTNewHorizons/GT-New-Horizons-Modpack#23127

| Before | After |
|---|---|
| <img width="330" height="300" src="https://github.com/user-attachments/assets/1fe46979-1694-402a-bce2-02f9e4f2c98d" /> | <img width="370" height="300" src="https://github.com/user-attachments/assets/640a5606-104a-4a97-a3ff-f75542c0ba0d" /> |
| <img width="330" height="300" src="https://github.com/user-attachments/assets/ba7700ef-4e6f-4dc9-b72c-3885060b8334" /> | <img width="370" height="300" src="https://github.com/user-attachments/assets/d9fc94ed-6104-4c6d-89c7-84ffaff966e7" /> |
| <img width="330" height="300" src="https://github.com/user-attachments/assets/913e5ae0-cced-469d-b1af-a4fa3bfdae6f" /> | <img width="370" height="300" src="https://github.com/user-attachments/assets/60b18726-b391-4067-b136-c505d91cc66c" /> |
| <img width="330" height="300" src="https://github.com/user-attachments/assets/16f07bb7-8db4-4103-96cb-8df00790fdf4" /> | <img width="370" height="300" src="https://github.com/user-attachments/assets/46d11628-2051-44fe-ab72-cc5ce9d901d1" /> |

FlaskRenderer leaked GL alpha/blend/depth/color state after rendering.
This could affect subsequent item renders, especially offhand items rendered by Backhand.
Preserve and restore GL state around the custom flask renderer.