### PR TITLE
Fix broken GT++ textures

### DIFF
--- a/src/main/java/gtPlusPlus/core/block/base/BlockBaseModular.java
+++ b/src/main/java/gtPlusPlus/core/block/base/BlockBaseModular.java
@@ -1,7 +1,6 @@
 package gtPlusPlus.core.block.base;
 
 import static gregtech.api.enums.Mods.GTPlusPlus;
-import static gregtech.api.enums.Mods.GregTech;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -9,6 +8,7 @@ import java.util.Map;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 
 import org.jetbrains.annotations.NotNull;
@@ -19,6 +19,8 @@ import cpw.mods.fml.relauncher.SideOnly;
 import gregtech.api.enums.Dyes;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.enums.TextureSet;
+import gregtech.api.enums.Textures;
+import gregtech.api.interfaces.IIconContainer;
 import gregtech.api.util.GTOreDictUnificator;
 import gregtech.api.util.StringUtils;
 import gtPlusPlus.core.item.base.itemblock.ItemBlockGtBlock;
@@ -31,6 +33,9 @@ public class BlockBaseModular extends BasicBlock {
     protected int blockColour;
     public BlockTypes blockType;
     protected String materialName;
+
+    @SideOnly(Side.CLIENT)
+    private IIconContainer iconContainer;
 
     private static final HashMap<String, Block> BLOCK_CACHE = new HashMap<>();
 
@@ -168,7 +173,13 @@ public class BlockBaseModular extends BasicBlock {
         metType = (metType == null ? "METALLIC" : metType);
         int tier = this.material.vTier;
         String aType = (this.blockType == BlockTypes.FRAME) ? "frameGt" : (tier <= 4 ? "block1" : "block5");
-        this.blockIcon = iIcon.registerIcon(GregTech.ID + ":" + "materialicons/" + metType + "/" + aType);
+        iconContainer = Textures.BlockIcons.textureSet(metType, "/" + aType);
+    }
+
+    @Override
+    @SideOnly(Side.CLIENT)
+    public IIcon getIcon(int side, int meta) {
+        return iconContainer.getIcon();
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/core/item/base/BaseItemComponent.java
+++ b/src/main/java/gtPlusPlus/core/item/base/BaseItemComponent.java
@@ -1,8 +1,6 @@
 package gtPlusPlus.core.item.base;
 
 import static gregtech.api.enums.Mods.GTPlusPlus;
-import static gregtech.api.enums.Mods.GregTech;
-import static gregtech.api.enums.Textures.GlobalIcons.RENDERING_ERROR;
 
 import java.awt.Color;
 import java.util.HashMap;
@@ -17,7 +15,6 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.IIcon;
-import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 import net.minecraftforge.fluids.Fluid;
@@ -29,10 +26,10 @@ import gregtech.api.covers.CoverRegistry;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.enums.TextureSet;
 import gregtech.api.enums.Textures;
+import gregtech.api.interfaces.IIconContainer;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GTOreDictUnificator;
 import gregtech.api.util.StringUtils;
-import gregtech.api.util.client.ResourceUtils;
 import gregtech.common.config.Client;
 import gtPlusPlus.core.creative.AddToCreativeTab;
 import gtPlusPlus.core.material.Material;
@@ -50,8 +47,8 @@ public class BaseItemComponent extends Item {
     public final int componentColour;
     public short[] extraData;
 
-    protected IIcon base;
-    protected IIcon overlay;
+    @SideOnly(Side.CLIENT)
+    protected IIconContainer iconContainer;
 
     public BaseItemComponent(final Material material, final ComponentTypes componentType) {
         this.componentMaterial = material;
@@ -131,18 +128,6 @@ public class BaseItemComponent extends Item {
         } else {
             return false;
         }
-    }
-
-    public String getCorrectTextures() {
-        String metType = null;
-        if (this.componentMaterial != null) {
-            TextureSet u = this.componentMaterial.getTextureSet();
-            if (u != null) {
-                metType = u.mSetName;
-            }
-        }
-        metType = (metType == null ? "METALLIC" : metType);
-        return GregTech.ID + ":" + "materialicons/" + metType + "/" + this.componentType.getOreDictName();
     }
 
     public final String getMaterialName() {
@@ -274,23 +259,26 @@ public class BaseItemComponent extends Item {
     }
 
     @Override
+    @SideOnly(Side.CLIENT)
     public IIcon getIconFromDamageForRenderPass(final int damage, final int pass) {
         if (pass == 0) {
-            return this.base;
+            return this.iconContainer.getIcon();
         }
-        return this.overlay;
+        return this.iconContainer.getOverlayIcon();
     }
 
     @Override
+    @SideOnly(Side.CLIENT)
     public void registerIcons(final IIconRegister i) {
-        final String iconPath = getCorrectTextures();
-        final ResourceLocation iconResource = ResourceUtils.getCompleteItemTextureResourceLocation(iconPath);
-        this.base = ResourceUtils.resourceExists(iconResource) ? i.registerIcon(iconPath) : RENDERING_ERROR.getIcon();;
-
-        final String overlayPath = getCorrectTextures() + "_OVERLAY";
-        final ResourceLocation overlayResource = ResourceUtils.getCompleteItemTextureResourceLocation(overlayPath);
-        this.overlay = ResourceUtils.resourceExists(overlayResource) ? i.registerIcon(overlayPath)
-            : Textures.InvisibleIcon.INVISIBLE_ICON;
+        String metType = null;
+        if (this.componentMaterial != null) {
+            TextureSet u = this.componentMaterial.getTextureSet();
+            if (u != null) {
+                metType = u.mSetName;
+            }
+        }
+        metType = (metType == null ? "METALLIC" : metType);
+        iconContainer = Textures.ItemIcons.textureSet(metType, "/" + this.componentType.getOreDictName());
     }
 
     public enum ComponentTypes {

--- a/src/main/java/gtPlusPlus/core/item/base/cell/BaseItemCell.java
+++ b/src/main/java/gtPlusPlus/core/item/base/cell/BaseItemCell.java
@@ -1,6 +1,5 @@
 package gtPlusPlus.core.item.base.cell;
 
-import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.item.ItemStack;
 
 import gtPlusPlus.core.item.base.BaseItemComponent;
@@ -11,12 +10,6 @@ public class BaseItemCell extends BaseItemComponent {
 
     public BaseItemCell(final Material material) {
         super(material, BaseItemComponent.ComponentTypes.CELL);
-    }
-
-    @Override
-    public void registerIcons(final IIconRegister i) {
-        this.base = i.registerIcon(getCorrectTextures());
-        this.overlay = i.registerIcon(getCorrectTextures() + "_OVERLAY");
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/core/item/base/cell/BaseItemPlasmaCell.java
+++ b/src/main/java/gtPlusPlus/core/item/base/cell/BaseItemPlasmaCell.java
@@ -1,10 +1,8 @@
 package gtPlusPlus.core.item.base.cell;
 
-import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.Entity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.DamageSource;
-import net.minecraft.util.IIcon;
 import net.minecraft.world.World;
 
 import cpw.mods.fml.relauncher.Side;
@@ -15,8 +13,6 @@ import gtPlusPlus.core.util.Utils;
 
 public class BaseItemPlasmaCell extends BaseItemComponent {
 
-    private IIcon base;
-    private IIcon overlay;
     private int tickCounter = 0;
 
     public BaseItemPlasmaCell(final Material material) {
@@ -30,25 +26,11 @@ public class BaseItemPlasmaCell extends BaseItemComponent {
     }
 
     @Override
-    public void registerIcons(final IIconRegister i) {
-        this.base = i.registerIcon(getCorrectTextures());
-        this.overlay = i.registerIcon(getCorrectTextures() + "_OVERLAY");
-    }
-
-    @Override
     public int getColorFromItemStack(final ItemStack stack, final int renderPass) {
         if (renderPass == 1) {
             return Utils.rgbtoHexValue(255, 255, 255);
         }
         return this.componentColour;
-    }
-
-    @Override
-    public IIcon getIconFromDamageForRenderPass(final int damage, final int pass) {
-        if (pass == 0) {
-            return this.base;
-        }
-        return this.overlay;
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/core/item/base/ingots/BaseItemIngotHot.java
+++ b/src/main/java/gtPlusPlus/core/item/base/ingots/BaseItemIngotHot.java
@@ -1,7 +1,6 @@
 package gtPlusPlus.core.item.base.ingots;
 
 import static gregtech.api.enums.Mods.GTPlusPlus;
-import static gregtech.api.enums.Mods.GregTech;
 import static gregtech.api.recipe.RecipeMaps.vacuumFreezerRecipes;
 import static gregtech.api.util.GTRecipeBuilder.TICKS;
 
@@ -15,6 +14,9 @@ import net.minecraft.world.World;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import gregtech.api.enums.GTValues;
+import gregtech.api.enums.OrePrefixes;
+import gregtech.api.enums.Textures;
+import gregtech.api.interfaces.IIconContainer;
 import gregtech.api.util.GTUtility;
 import gtPlusPlus.core.material.Material;
 import gtPlusPlus.core.util.Utils;
@@ -23,8 +25,8 @@ public class BaseItemIngotHot extends BaseItemIngot {
 
     private final ItemStack outputIngot;
 
-    private IIcon base;
-    private IIcon overlay;
+    @SideOnly(Side.CLIENT)
+    private IIconContainer iconContainer;
 
     public BaseItemIngotHot(final Material material) {
         super(material, ComponentTypes.HOTINGOT);
@@ -70,19 +72,17 @@ public class BaseItemIngotHot extends BaseItemIngot {
     }
 
     @Override
+    @SideOnly(Side.CLIENT)
     public void registerIcons(final IIconRegister i) {
-        this.base = i.registerIcon(GregTech.ID + ":" + "materialicons/METALLIC/" + "ingotHot");
-        this.overlay = i.registerIcon(GregTech.ID + ":" + "materialicons/METALLIC/" + "ingotHot_OVERLAY");
+        iconContainer = Textures.ItemIcons.textureSet("METALLIC", "/" + OrePrefixes.ingotHot.getName());
     }
 
     @Override
+    @SideOnly(Side.CLIENT)
     public IIcon getIconFromDamageForRenderPass(final int damage, final int pass) {
         if (pass == 0) {
-            return this.base;
-        } else if (pass == 1) {
-            return this.overlay;
-        } else {
-            return this.overlay;
+            return this.iconContainer.getIcon();
         }
+        return this.iconContainer.getOverlayIcon();
     }
 }

--- a/src/main/java/gtPlusPlus/core/item/base/ore/BaseOreComponent.java
+++ b/src/main/java/gtPlusPlus/core/item/base/ore/BaseOreComponent.java
@@ -1,7 +1,6 @@
 package gtPlusPlus.core.item.base.ore;
 
 import static gregtech.api.enums.Mods.GTPlusPlus;
-import static gregtech.api.enums.Mods.GregTech;
 
 import java.util.HashMap;
 import java.util.List;
@@ -13,7 +12,6 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
-import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 
 import cpw.mods.fml.common.registry.GameRegistry;
@@ -21,9 +19,9 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.enums.Textures;
+import gregtech.api.interfaces.IIconContainer;
 import gregtech.api.util.GTOreDictUnificator;
 import gregtech.api.util.StringUtils;
-import gregtech.api.util.client.ResourceUtils;
 import gregtech.common.config.Client;
 import gtPlusPlus.core.creative.AddToCreativeTab;
 import gtPlusPlus.core.material.Material;
@@ -33,10 +31,7 @@ import gtPlusPlus.core.util.minecraft.EntityUtils;
 public class BaseOreComponent extends Item {
 
     @SideOnly(Side.CLIENT)
-    private IIcon base;
-
-    @SideOnly(Side.CLIENT)
-    private IIcon overlay;
+    private IIconContainer iconContainer;
 
     public final Material componentMaterial;
     public final String materialName;
@@ -146,26 +141,9 @@ public class BaseOreComponent extends Item {
     @SideOnly(Side.CLIENT)
     public void registerIcons(final IIconRegister par1IconRegister) {
         if (this.componentType == ComponentTypes.MILLED) {
-            this.base = par1IconRegister.registerIcon(GTPlusPlus.ID + ":" + "processing/MilledOre/milled");
-            if (this.componentType.hasOverlay()) {
-                this.overlay = par1IconRegister
-                    .registerIcon(GTPlusPlus.ID + ":" + "processing/MilledOre/milled_OVERLAY");
-            }
+            iconContainer = Textures.ItemIcons.custom(GTPlusPlus.ID + ":processing/MilledOre/milled");
         } else {
-            this.base = par1IconRegister
-                .registerIcon(GregTech.ID + ":" + "materialicons/METALLIC/" + this.componentType.COMPONENT_NAME);
-            if (this.componentType.hasOverlay()) {
-                final String overlayPath = GregTech.ID + ":"
-                    + "materialicons/METALLIC/"
-                    + this.componentType.COMPONENT_NAME
-                    + "_OVERLAY";
-                final ResourceLocation overlayResource = ResourceUtils
-                    .getCompleteItemTextureResourceLocation(overlayPath);
-
-                this.overlay = ResourceUtils.resourceExists(overlayResource)
-                    ? par1IconRegister.registerIcon(overlayPath)
-                    : Textures.InvisibleIcon.INVISIBLE_ICON;
-            }
+            iconContainer = Textures.ItemIcons.textureSet("METALLIC", "/" + this.componentType.COMPONENT_NAME);
         }
     }
 
@@ -184,11 +162,12 @@ public class BaseOreComponent extends Item {
     }
 
     @Override
+    @SideOnly(Side.CLIENT)
     public IIcon getIconFromDamageForRenderPass(final int damage, final int pass) {
         if (pass == 0) {
-            return this.base;
+            return this.iconContainer.getIcon();
         }
-        return this.overlay;
+        return this.iconContainer.getOverlayIcon();
     }
 
     public enum ComponentTypes {


### PR DESCRIPTION
https://github.com/GTNewHorizons/GT5-Unofficial/pull/6681 broke some GT++ textures as GT++ had hardcoded paths for many of its items/blocks. This PR changes them to use GT's `IIconContainer` so that GT++'s material textures can fallback the same way GT's do