### PR TITLE
Fix GT++ Textures in GTNH CoreMod Dev Env

### DIFF
--- a/src/main/java/gregtech/api/enums/Textures.java
+++ b/src/main/java/gregtech/api/enums/Textures.java
@@ -2643,7 +2643,12 @@ public class Textures {
          * @return The {@link IIconContainer} instance
          */
         public static @NotNull IIconContainer textureSet(@NotNull String setName, @NotNull String prefix) {
-            return GTTextureSetBlockIconContainer.create(setName, prefix);
+            return GTTextureSetBlockIconContainer.create(setName, prefix, null);
+        }
+
+        public static @NotNull IIconContainer textureSetWithRegister(@NotNull String setName, @NotNull String prefix,
+            IIconRegister register) {
+            return GTTextureSetBlockIconContainer.create(setName, prefix, register);
         }
 
         private static @NotNull IIconContainer create(@NotNull String name) {
@@ -2737,7 +2742,12 @@ public class Textures {
          * @return The {@link IIconContainer} instance
          */
         public static @NotNull IIconContainer textureSet(@NotNull String setName, @NotNull String prefix) {
-            return GTTextureSetItemIconContainer.create(setName, prefix);
+            return GTTextureSetItemIconContainer.create(setName, prefix, null);
+        }
+
+        public static @NotNull IIconContainer textureSetWithRegister(@NotNull String setName, @NotNull String prefix,
+            IIconRegister register) {
+            return GTTextureSetItemIconContainer.create(setName, prefix, register);
         }
 
         private static @NotNull IIconContainer create(@NotNull String name) {

--- a/src/main/java/gregtech/client/iconContainers/blocks/GTTextureSetBlockIconContainer.java
+++ b/src/main/java/gregtech/client/iconContainers/blocks/GTTextureSetBlockIconContainer.java
@@ -8,11 +8,13 @@ import static gregtech.client.iconContainers.items.GTTextureSetItemIconContainer
 import java.util.HashMap;
 import java.util.Map;
 
+import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.util.IIcon;
 import net.minecraft.util.ResourceLocation;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import gregtech.api.GregTechAPI;
 import gregtech.api.interfaces.IIconContainer;
@@ -32,10 +34,11 @@ public class GTTextureSetBlockIconContainer extends AbstractBlockIconContainer i
     protected ResourceLocation iconOverlayResource, iconOverlayFallbackResource;
 
     private GTTextureSetBlockIconContainer(@NotNull Pair<String, String> pair) {
-        this(pair.getLeft(), pair.getRight());
+        this(pair.getLeft(), pair.getRight(), null);
     }
 
-    private GTTextureSetBlockIconContainer(@NotNull String setName, @NotNull String prefix) {
+    private GTTextureSetBlockIconContainer(@NotNull String setName, @NotNull String prefix,
+        @Nullable IIconRegister override) {
         this.iconName = createIconName(setName, prefix);
         this.fallbackIconName = createIconName(TextureSetFallback, prefix);
         iconResource = ResourceUtils.getCompleteBlockTextureResourceLocation(iconName);
@@ -46,14 +49,22 @@ public class GTTextureSetBlockIconContainer extends AbstractBlockIconContainer i
         iconOverlayResource = ResourceUtils.getCompleteBlockTextureResourceLocation(iconOverlayName);
         iconOverlayFallbackResource = ResourceUtils.getCompleteBlockTextureResourceLocation(fallbackIconOverlayName);
 
-        GregTechAPI.sGTBlockIconload.add(this);
+        if (override != null) {
+            run(override);
+        } else {
+            GregTechAPI.sGTBlockIconload.add(this);
+        }
         if (Gregtech.debug.logRegisterIcons) logRegisterIcons();
     }
 
     // 2026-13-05: Counted 1782 unique Block TextureSetIcons, so 2.5K will avoid resize until 1920 entries
     private static Map<Pair<String, String>, IIconContainer> INSTANCES = new HashMap<>(2520);
 
-    public static @NotNull IIconContainer create(@NotNull String setName, String prefix) {
+    public static @NotNull IIconContainer create(@NotNull String setName, @NotNull String prefix,
+        IIconRegister override) {
+        if (override != null) {
+            return new GTTextureSetBlockIconContainer(setName, prefix, override);
+        }
         return INSTANCES.computeIfAbsent(Pair.of(setName, prefix), GTTextureSetBlockIconContainer::new);
     }
 
@@ -78,18 +89,22 @@ public class GTTextureSetBlockIconContainer extends AbstractBlockIconContainer i
 
     @Override
     public void run() {
+        run(GregTechAPI.sBlockIcons);
+    }
+
+    private void run(IIconRegister register) {
         Pair<IIcon, TextureSetIconType> iconPair = registerResourceOrFallback(
             iconResource,
             iconName,
             iconFallbackResource,
             fallbackIconName,
-            GregTechAPI.sBlockIcons);
+            register);
         Pair<IIcon, TextureSetIconType> overlayPair = registerResourceOrFallback(
             iconOverlayResource,
             iconOverlayName,
             iconOverlayFallbackResource,
             fallbackIconOverlayName,
-            GregTechAPI.sBlockIcons);
+            register);
         mIcon = iconPair.getRight() == TextureSetIconType.INVISIBLE ? GregTechAPI.sBlockIcons.registerIcon(iconName)
             : iconPair.getLeft();
         if (iconPair.getRight() == overlayPair.getRight() && overlayPair.getRight() != TextureSetIconType.INVISIBLE) {

--- a/src/main/java/gregtech/client/iconContainers/items/GTTextureSetItemIconContainer.java
+++ b/src/main/java/gregtech/client/iconContainers/items/GTTextureSetItemIconContainer.java
@@ -14,6 +14,7 @@ import net.minecraft.util.ResourceLocation;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import gregtech.api.GregTechAPI;
 import gregtech.api.enums.Textures;
@@ -34,10 +35,11 @@ public class GTTextureSetItemIconContainer extends AbstractItemIconContainer imp
     protected ResourceLocation iconOverlayResource, iconOverlayFallbackResource;
 
     private GTTextureSetItemIconContainer(@NotNull Pair<String, String> pair) {
-        this(pair.getLeft(), pair.getRight());
+        this(pair.getLeft(), pair.getRight(), null);
     }
 
-    private GTTextureSetItemIconContainer(@NotNull String setName, @NotNull String prefix) {
+    private GTTextureSetItemIconContainer(@NotNull String setName, @NotNull String prefix,
+        @Nullable IIconRegister override) {
         this.iconName = createIconName(setName, prefix);
         this.fallbackIconName = createIconName(TextureSetFallback, prefix);
         iconResource = ResourceUtils.getCompleteItemTextureResourceLocation(iconName);
@@ -48,7 +50,11 @@ public class GTTextureSetItemIconContainer extends AbstractItemIconContainer imp
         iconOverlayResource = ResourceUtils.getCompleteItemTextureResourceLocation(iconOverlayName);
         iconOverlayFallbackResource = ResourceUtils.getCompleteItemTextureResourceLocation(fallbackIconOverlayName);
 
-        GregTechAPI.sGTItemIconload.add(this);
+        if (override != null) {
+            run(override);
+        } else {
+            GregTechAPI.sGTItemIconload.add(this);
+        }
         if (Gregtech.debug.logRegisterIcons) logRegisterIcons();
     }
 
@@ -60,7 +66,11 @@ public class GTTextureSetItemIconContainer extends AbstractItemIconContainer imp
     // 2026-13-05: Counted 7371 unique Item TextureSetIcons, so 9.4K will avoid resize until 7500 entries
     private static Map<Pair<String, String>, IIconContainer> INSTANCES = new HashMap<>(9375);
 
-    public static @NotNull IIconContainer create(@NotNull String setName, @NotNull String prefix) {
+    public static @NotNull IIconContainer create(@NotNull String setName, @NotNull String prefix,
+        IIconRegister override) {
+        if (override != null) {
+            return new GTTextureSetItemIconContainer(setName, prefix, override);
+        }
         return INSTANCES.computeIfAbsent(Pair.of(setName, prefix), GTTextureSetItemIconContainer::new);
     }
 
@@ -85,18 +95,22 @@ public class GTTextureSetItemIconContainer extends AbstractItemIconContainer imp
 
     @Override
     public void run() {
+        run(GregTechAPI.sItemIcons);
+    }
+
+    private void run(IIconRegister register) {
         Pair<IIcon, TextureSetIconType> iconPair = registerResourceOrFallback(
             iconResource,
             iconName,
             iconFallbackResource,
             fallbackIconName,
-            GregTechAPI.sItemIcons);
+            register);
         Pair<IIcon, TextureSetIconType> overlayPair = registerResourceOrFallback(
             iconOverlayResource,
             iconOverlayName,
             iconOverlayFallbackResource,
             fallbackIconOverlayName,
-            GregTechAPI.sItemIcons);
+            register);
 
         mIcon = iconPair.getLeft();
         mOverlay = overlayPair.getLeft();

--- a/src/main/java/gtPlusPlus/core/block/base/BlockBaseModular.java
+++ b/src/main/java/gtPlusPlus/core/block/base/BlockBaseModular.java
@@ -20,7 +20,6 @@ import gregtech.api.enums.Dyes;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.enums.TextureSet;
 import gregtech.api.enums.Textures;
-import gregtech.api.interfaces.IIconContainer;
 import gregtech.api.util.GTOreDictUnificator;
 import gregtech.api.util.StringUtils;
 import gtPlusPlus.core.item.base.itemblock.ItemBlockGtBlock;
@@ -35,7 +34,7 @@ public class BlockBaseModular extends BasicBlock {
     protected String materialName;
 
     @SideOnly(Side.CLIENT)
-    private IIconContainer iconContainer;
+    private IIcon blockIcon;
 
     private static final HashMap<String, Block> BLOCK_CACHE = new HashMap<>();
 
@@ -173,13 +172,14 @@ public class BlockBaseModular extends BasicBlock {
         metType = (metType == null ? "METALLIC" : metType);
         int tier = this.material.vTier;
         String aType = (this.blockType == BlockTypes.FRAME) ? "frameGt" : (tier <= 4 ? "block1" : "block5");
-        iconContainer = Textures.BlockIcons.textureSet(metType, "/" + aType);
+        blockIcon = Textures.BlockIcons.textureSetWithRegister(metType, "/" + aType, iIcon)
+            .getIcon();
     }
 
     @Override
     @SideOnly(Side.CLIENT)
     public IIcon getIcon(int side, int meta) {
-        return iconContainer.getIcon();
+        return blockIcon;
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/core/item/base/BaseItemComponent.java
+++ b/src/main/java/gtPlusPlus/core/item/base/BaseItemComponent.java
@@ -48,7 +48,9 @@ public class BaseItemComponent extends Item {
     public short[] extraData;
 
     @SideOnly(Side.CLIENT)
-    protected IIconContainer iconContainer;
+    protected IIcon iconBase;
+    @SideOnly(Side.CLIENT)
+    protected IIcon iconOverlay;
 
     public BaseItemComponent(final Material material, final ComponentTypes componentType) {
         this.componentMaterial = material;
@@ -262,9 +264,9 @@ public class BaseItemComponent extends Item {
     @SideOnly(Side.CLIENT)
     public IIcon getIconFromDamageForRenderPass(final int damage, final int pass) {
         if (pass == 0) {
-            return this.iconContainer.getIcon();
+            return iconBase;
         }
-        return this.iconContainer.getOverlayIcon();
+        return iconOverlay;
     }
 
     @Override
@@ -278,7 +280,10 @@ public class BaseItemComponent extends Item {
             }
         }
         metType = (metType == null ? "METALLIC" : metType);
-        iconContainer = Textures.ItemIcons.textureSet(metType, "/" + this.componentType.getOreDictName());
+        IIconContainer container = Textures.ItemIcons
+            .textureSetWithRegister(metType, "/" + this.componentType.getOreDictName(), i);
+        iconBase = container.getIcon();
+        iconOverlay = container.getOverlayIcon();
     }
 
     public enum ComponentTypes {

--- a/src/main/java/gtPlusPlus/core/item/base/ingots/BaseItemIngotHot.java
+++ b/src/main/java/gtPlusPlus/core/item/base/ingots/BaseItemIngotHot.java
@@ -8,7 +8,6 @@ import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.IIcon;
 import net.minecraft.world.World;
 
 import cpw.mods.fml.relauncher.Side;
@@ -24,9 +23,6 @@ import gtPlusPlus.core.util.Utils;
 public class BaseItemIngotHot extends BaseItemIngot {
 
     private final ItemStack outputIngot;
-
-    @SideOnly(Side.CLIENT)
-    private IIconContainer iconContainer;
 
     public BaseItemIngotHot(final Material material) {
         super(material, ComponentTypes.HOTINGOT);
@@ -74,15 +70,9 @@ public class BaseItemIngotHot extends BaseItemIngot {
     @Override
     @SideOnly(Side.CLIENT)
     public void registerIcons(final IIconRegister i) {
-        iconContainer = Textures.ItemIcons.textureSet("METALLIC", "/" + OrePrefixes.ingotHot.getName());
-    }
-
-    @Override
-    @SideOnly(Side.CLIENT)
-    public IIcon getIconFromDamageForRenderPass(final int damage, final int pass) {
-        if (pass == 0) {
-            return this.iconContainer.getIcon();
-        }
-        return this.iconContainer.getOverlayIcon();
+        IIconContainer container = Textures.ItemIcons
+            .textureSetWithRegister("METALLIC", "/" + OrePrefixes.ingotHot.getName(), i);
+        iconBase = container.getIcon();
+        iconOverlay = container.getOverlayIcon();
     }
 }

--- a/src/main/java/gtPlusPlus/core/item/base/ore/BaseOreComponent.java
+++ b/src/main/java/gtPlusPlus/core/item/base/ore/BaseOreComponent.java
@@ -31,7 +31,9 @@ import gtPlusPlus.core.util.minecraft.EntityUtils;
 public class BaseOreComponent extends Item {
 
     @SideOnly(Side.CLIENT)
-    private IIconContainer iconContainer;
+    private IIcon iconBase;
+    @SideOnly(Side.CLIENT)
+    private IIcon iconOverlay;
 
     public final Material componentMaterial;
     public final String materialName;
@@ -141,9 +143,16 @@ public class BaseOreComponent extends Item {
     @SideOnly(Side.CLIENT)
     public void registerIcons(final IIconRegister par1IconRegister) {
         if (this.componentType == ComponentTypes.MILLED) {
-            iconContainer = Textures.ItemIcons.custom(GTPlusPlus.ID + ":processing/MilledOre/milled");
+            this.iconBase = par1IconRegister.registerIcon(GTPlusPlus.ID + ":" + "processing/MilledOre/milled");
+            if (this.componentType.hasOverlay()) {
+                this.iconOverlay = par1IconRegister
+                    .registerIcon(GTPlusPlus.ID + ":" + "processing/MilledOre/milled_OVERLAY");
+            }
         } else {
-            iconContainer = Textures.ItemIcons.textureSet("METALLIC", "/" + this.componentType.COMPONENT_NAME);
+            IIconContainer container = Textures.ItemIcons
+                .textureSetWithRegister("METALLIC", "/" + this.componentType.COMPONENT_NAME, par1IconRegister);
+            iconBase = container.getIcon();
+            iconOverlay = container.getOverlayIcon();
         }
     }
 
@@ -165,9 +174,9 @@ public class BaseOreComponent extends Item {
     @SideOnly(Side.CLIENT)
     public IIcon getIconFromDamageForRenderPass(final int damage, final int pass) {
         if (pass == 0) {
-            return this.iconContainer.getIcon();
+            return iconBase;
         }
-        return this.iconContainer.getOverlayIcon();
+        return iconOverlay;
     }
 
     public enum ComponentTypes {


### PR DESCRIPTION
For some reason, GT++ textures break specifically in the dev env for the core mod. They are fine in both the gt dev env and in the full pack.

https://github.com/GTNewHorizons/GT5-Unofficial/pull/6687 relied on GT++ texture icons to be processed before GT's own texture icons were processed. This PR semi-reverts the other one and instead has the GT++ texture icons processed entirely independently of GT

This PR was tested in:
- GT Dev Env
- CoreMod Dev Env
- Full Pack
- 
and I noticed no texture issues