### PR TITLE
Fix steam multi gauge using wrong theme

### DIFF
--- a/src/main/java/gregtech/api/modularui2/GTGuiTextures.java
+++ b/src/main/java/gregtech/api/modularui2/GTGuiTextures.java
@@ -1195,9 +1195,16 @@ public final class GTGuiTextures {
         .location(GTPlusPlus.ID, "gui/progressbar/fluid_reactor")
         .build();
 
-    public static final UITexture STEAM_GAUGE_BG = UITexture.fullImage(GregTech.ID, "gui/background/steam_dial");
-    public static final UITexture STEAM_GAUGE_BG_STEEL = UITexture
-        .fullImage(GregTech.ID, "gui/background/steam_dial_steel");
+    public static final UITexture STEAM_GAUGE_BG = UITexture.builder()
+        .fullImage()
+        .location(GregTech.ID, "gui/background/steam_dial")
+        .name(GTTextureIds.PICTURE_STEAM_GAUGE)
+        .build();
+    public static final UITexture STEAM_GAUGE_BG_STEEL = UITexture.builder()
+        .fullImage()
+        .location(GregTech.ID, "gui/background/steam_dial_steel")
+        .name(GTTextureIds.PICTURE_STEAM_GAUGE_STEEL)
+        .build();
 
     public static final UITexture PROGRESSBAR_TESLA_TOWER_CURRENT = UITexture
         .fullImage(MODID, "gui/tesla_tower_current");

--- a/src/main/java/gregtech/api/modularui2/GTGuiThemes.java
+++ b/src/main/java/gregtech/api/modularui2/GTGuiThemes.java
@@ -222,6 +222,7 @@ public final class GTGuiThemes {
             GTTextureIds.BUTTON_COVER_TAB_DISABLED_STEEL)
         .themedTexture(GTWidgetThemes.PICTURE_CANISTER.getFullName(), GTTextureIds.OVERLAY_SLOT_CANISTER_STEEL)
         .themedTexture(GTWidgetThemes.PICTURE_LOGO.getFullName(), GTTextureIds.PICTURE_GT_LOGO_STEEL)
+        .themedTexture(GTWidgetThemes.STEAM_GAUGE.getFullName(), GTTextureIds.PICTURE_STEAM_GAUGE_STEEL)
         .themedColor(GTWidgetThemes.STEAM_GAUGE_NEEDLE.getFullName(), 0x3d3847)
         .build();
     public static final GTGuiTheme PRIMITIVE = GTGuiTheme.builder("gregtech:primitive")

--- a/src/main/java/gregtech/api/modularui2/GTTextureIds.java
+++ b/src/main/java/gregtech/api/modularui2/GTTextureIds.java
@@ -163,4 +163,7 @@ public final class GTTextureIds {
     public static final String PICTURE_WATER_PURIFICATION_ONLINE = "gregtech:picture_water_purification_online";
     public static final String PICTURE_WATER_PURIFICATION_IDLE = "gregtech:picture_water_purification_idle";
     public static final String PICTURE_WATER_PURIFICATION_OFFLINE = "gregtech:picture_water_purification_offline";
+    public static final String PICTURE_STEAM_GAUGE = "gregtech:steam_dial";
+    public static final String PICTURE_STEAM_GAUGE_STEEL = "gregtech:steam_dial_steel";
+
 }

--- a/src/main/java/gregtech/api/modularui2/GTWidgetThemes.java
+++ b/src/main/java/gregtech/api/modularui2/GTWidgetThemes.java
@@ -93,6 +93,11 @@ public final class GTWidgetThemes {
         .defaultTheme(new ProgressbarWidgetTheme(GTGuiTextures.PROGRESSBAR_FUEL_STANDARD, 14))
         .defaultHoverTheme(null)
         .register();
+    public static WidgetThemeKey<WidgetTheme> STEAM_GAUGE = themeApi
+        .widgetThemeKeyBuilder("steamGauge", WidgetTheme.class)
+        .defaultTheme(new WidgetTheme(0, 0, GTGuiTextures.STEAM_GAUGE_BG, Color.WHITE.main, Color.WHITE.main, false, 0))
+        .defaultHoverTheme(null)
+        .register();
     public static WidgetThemeKey<WidgetTheme> STEAM_GAUGE_NEEDLE = themeApi
         .widgetThemeKeyBuilder("steamGaugeNeedle", WidgetTheme.class)
         .defaultTheme(new WidgetTheme(0, 0, null, Color.BROWN.main, 0xFF404040, false, 0))

--- a/src/main/java/gregtech/common/gui/modularui/multiblock/base/MTESteamMultiBlockBaseGui.java
+++ b/src/main/java/gregtech/common/gui/modularui/multiblock/base/MTESteamMultiBlockBaseGui.java
@@ -1,13 +1,12 @@
 package gregtech.common.gui.modularui.multiblock.base;
 
-import com.cleanroommc.modularui.api.drawable.IDrawable;
 import com.cleanroommc.modularui.factory.PosGuiData;
 import com.cleanroommc.modularui.screen.ModularPanel;
 import com.cleanroommc.modularui.screen.UISettings;
 import com.cleanroommc.modularui.value.sync.IntSyncValue;
 import com.cleanroommc.modularui.value.sync.PanelSyncManager;
+import com.cleanroommc.modularui.widget.Widget;
 
-import gregtech.api.modularui2.GTGuiTextures;
 import gregtech.api.modularui2.GTWidgetThemes;
 import gregtech.common.gui.modularui.widget.CircularGaugeDrawable;
 import gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.base.MTESteamMultiBlockBase;
@@ -25,17 +24,16 @@ public class MTESteamMultiBlockBaseGui extends MTEMultiBlockBaseGui<MTESteamMult
         IntSyncValue maxSteamSyncer = new IntSyncValue(multiblock::getTotalSteamCapacity);
         syncManager.syncValue("maxSteam", maxSteamSyncer);
 
-        return super.build(guiData, syncManager, uiSettings).child(
-            IDrawable
-                .of(multiblock.getThemeTier() != 2 ? GTGuiTextures.STEAM_GAUGE_BG : GTGuiTextures.STEAM_GAUGE_BG_STEEL)
-                .asWidget()
-                .size(48, 42)
-                .left(-48)
-                .top(8)
-                .tooltipDynamic(
-                    t -> t.addLine(
-                        String.format("%s/%sL Steam", steamStoredSyncer.getValue(), maxSteamSyncer.getValue())))
-                .tooltipAutoUpdate(true))
+        return super.build(guiData, syncManager, uiSettings)
+            .child(
+                new Widget<>().widgetTheme(GTWidgetThemes.STEAM_GAUGE)
+                    .size(48, 42)
+                    .left(-48)
+                    .top(8)
+                    .tooltipDynamic(
+                        t -> t.addLine(
+                            String.format("%s/%sL Steam", steamStoredSyncer.getValue(), maxSteamSyncer.getValue())))
+                    .tooltipAutoUpdate(true))
             .child(
                 new CircularGaugeDrawable(() -> (float) steamStoredSyncer.getValue() / maxSteamSyncer.getValue())
                     .asWidget()

--- a/src/main/java/gregtech/common/tileentities/machines/multi/steam/MTESteamAlloySmelter.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/steam/MTESteamAlloySmelter.java
@@ -350,8 +350,4 @@ public class MTESteamAlloySmelter extends MTESteamMultiBlockBase<MTESteamAlloySm
         return SoundResource.IC2_MACHINES_INDUCTION_LOOP;
     }
 
-    @Override
-    public int getThemeTier() {
-        return tierMachineCasing;
-    }
 }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/steam/MTESteamCentrifuge.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/steam/MTESteamCentrifuge.java
@@ -401,9 +401,4 @@ public class MTESteamCentrifuge extends MTESteamMultiBlockBase<MTESteamCentrifug
         return SoundResource.GT_MACHINES_STEAM_CENTRIFUGE_LOOP;
     }
 
-    @Override
-    public int getThemeTier() {
-        return tierMachineCasing;
-    }
-
 }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/steam/MTESteamCompressor.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/steam/MTESteamCompressor.java
@@ -436,8 +436,4 @@ public class MTESteamCompressor extends MTESteamMultiBlockBase<MTESteamCompresso
         return SoundResource.GTCEU_LOOP_COMPRESSOR;
     }
 
-    @Override
-    public int getThemeTier() {
-        return tierMachine;
-    }
 }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/steam/MTESteamForgeHammer.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/steam/MTESteamForgeHammer.java
@@ -400,9 +400,4 @@ public class MTESteamForgeHammer extends MTESteamMultiBlockBase<MTESteamForgeHam
         tierMachineCasing = aNBT.getInteger("tierMachineCasing");
     }
 
-    @Override
-    public int getThemeTier() {
-        return tierMachineCasing;
-    }
-
 }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/steam/MTESteamFurnaceMulti.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/steam/MTESteamFurnaceMulti.java
@@ -553,9 +553,4 @@ public class MTESteamFurnaceMulti extends MTESteamMultiBlockBase<MTESteamFurnace
         return SoundResource.GTCEU_LOOP_FURNACE;
     }
 
-    @Override
-    public int getThemeTier() {
-        return tierMachineCasing;
-    }
-
 }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/steam/MTESteamMacerator.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/steam/MTESteamMacerator.java
@@ -429,8 +429,4 @@ public class MTESteamMacerator extends MTESteamMultiBlockBase<MTESteamMacerator>
         return SoundResource.GTCEU_LOOP_MACERATOR;
     }
 
-    @Override
-    public int getThemeTier() {
-        return tierMachine;
-    }
 }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/steam/MTESteamMixer.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/steam/MTESteamMixer.java
@@ -470,9 +470,4 @@ public class MTESteamMixer extends MTESteamMultiBlockBase<MTESteamMixer> impleme
         return SoundResource.GT_MACHINES_STEAM_CENTRIFUGE_LOOP;
     }
 
-    @Override
-    public int getThemeTier() {
-        return tierMachineCasing;
-    }
-
 }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/steam/MTESteamWasher.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/steam/MTESteamWasher.java
@@ -561,8 +561,4 @@ public class MTESteamWasher extends MTESteamMultiBlockBase<MTESteamWasher> imple
             GTGuiTextures.OVERLAY_BUTTON_MACHINEMODE_SIMPLEWASHER);
     }
 
-    @Override
-    public int getThemeTier() {
-        return tierMachineCasing;
-    }
 }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/steam/MTESteamWaterPump.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/steam/MTESteamWaterPump.java
@@ -377,8 +377,4 @@ public class MTESteamWaterPump extends MTESteamMultiBlockBase<MTESteamWaterPump>
         return false;
     }
 
-    @Override
-    public int getThemeTier() {
-        return mSetTier;
-    }
 }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/MTESteamMultiBlockBase.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/MTESteamMultiBlockBase.java
@@ -188,9 +188,6 @@ public abstract class MTESteamMultiBlockBase<T extends MTESteamMultiBlockBase<T>
         for (MTEHatch h : mOutputHatches) h.updateTexture(id);
     }
 
-    // tierMachine isn't synced to client - getThemeTier() it is instead of a syncHandler
-    public abstract int getThemeTier();
-
     @Override
     protected GTGuiTheme getGuiTheme() {
         return isHighPressure() ? GTGuiThemes.STEEL : GTGuiThemes.BRONZE;

--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/MTESteamMultiBlockBase.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/MTESteamMultiBlockBase.java
@@ -2,13 +2,11 @@ package gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.base;
 
 import static com.gtnewhorizon.gtnhlib.util.numberformatting.NumberFormatUtil.formatNumber;
 import static gregtech.api.enums.GTValues.V;
-import static gregtech.api.metatileentity.BaseTileEntity.TOOLTIP_DELAY;
 import static gregtech.api.util.GTStructureUtility.buildHatchAdder;
 import static gregtech.api.util.GTUtility.validMTEList;
 import static mcp.mobius.waila.api.SpecialChars.GREEN;
 import static mcp.mobius.waila.api.SpecialChars.RED;
 import static mcp.mobius.waila.api.SpecialChars.RESET;
-import static net.minecraft.util.StatCollector.translateToLocalFormatted;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -26,17 +24,10 @@ import net.minecraftforge.fluids.FluidStack;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import com.gtnewhorizons.modularui.api.screen.ModularWindow;
-import com.gtnewhorizons.modularui.api.screen.UIBuildContext;
-import com.gtnewhorizons.modularui.common.widget.DrawableWidget;
-import com.gtnewhorizons.modularui.common.widget.FakeSyncWidget;
-
 import gregtech.GTMod;
 import gregtech.api.casing.Casings;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.SteamVariant;
-import gregtech.api.gui.modularui.CircularGaugeDrawable;
-import gregtech.api.gui.modularui.GTUITextures;
 import gregtech.api.interfaces.IHatchElement;
 import gregtech.api.interfaces.IIconContainer;
 import gregtech.api.interfaces.IOutputBus;
@@ -45,7 +36,6 @@ import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.interfaces.tileentity.IOverclockDescriptionProvider;
 import gregtech.api.logic.ProcessingLogic;
-import gregtech.api.metatileentity.implementations.MTEBasicMachine;
 import gregtech.api.metatileentity.implementations.MTEExtendedPowerMultiBlockBase;
 import gregtech.api.metatileentity.implementations.MTEHatch;
 import gregtech.api.metatileentity.implementations.MTEHatchInput;
@@ -482,36 +472,13 @@ public abstract class MTESteamMultiBlockBase<T extends MTESteamMultiBlockBase<T>
     }
 
     @Override
-    protected @NotNull MTEMultiBlockBaseGui<?> getGui() {
-        return new MTESteamMultiBlockBaseGui(this);
+    protected boolean forceUseMui2() {
+        return true;
     }
 
-    private int uiSteamStored = 0;
-    private int uiSteamCapacity = 0;
-
     @Override
-    public void addUIWidgets(ModularWindow.Builder builder, UIBuildContext buildContext) {
-        super.addUIWidgets(builder, buildContext);
-        builder.widget(new FakeSyncWidget.IntegerSyncer(this::getTotalSteamCapacity, val -> uiSteamCapacity = val));
-        builder.widget(new FakeSyncWidget.IntegerSyncer(this::getTotalSteamStored, val -> uiSteamStored = val));
-
-        builder.widget(
-            new DrawableWidget().setDrawable(GTUITextures.STEAM_GAUGE_BG_STEEL)
-                .dynamicTooltip(
-                    () -> Collections.singletonList(
-                        translateToLocalFormatted(
-                            MTEBasicMachine.STEAM_AMOUNT_LANGKEY,
-                            numberFormat.format(uiSteamStored),
-                            numberFormat.format(uiSteamCapacity))))
-                .setTooltipShowUpDelay(TOOLTIP_DELAY)
-                .setUpdateTooltipEveryTick(true)
-                .setSize(48, 42)
-                .setPos(-48, -8));
-
-        builder.widget(
-            new DrawableWidget().setDrawable(new CircularGaugeDrawable(() -> (float) uiSteamStored / uiSteamCapacity))
-                .setPos(-48 + 21, -8 + 21)
-                .setSize(18, 4));
+    protected @NotNull MTEMultiBlockBaseGui<?> getGui() {
+        return new MTESteamMultiBlockBaseGui(this);
     }
 
     @Override


### PR DESCRIPTION
We weren't using a properly synced value to determine the gauge picture to use. It has been made into a theme element so it change with the rest of the theme.

# Before
<img width="559" height="438" alt="image" src="https://github.com/user-attachments/assets/093fd564-1158-433d-a112-fc0b2d9e6f98" />


# After

<img width="540" height="441" alt="image" src="https://github.com/user-attachments/assets/002178ba-69e6-4d26-998c-a2e7d497b86e" />
