### PR TITLE
LHC - fix small RNG bug for blacklisted particles

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/beamcrafting/MTELargeHadronCollider.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/beamcrafting/MTELargeHadronCollider.java
@@ -639,8 +639,9 @@ public class MTELargeHadronCollider extends MTEBeamMultiBase<MTELargeHadronColli
         for (int i = 0; i < n; i++) {
             Particle p = Particle.getParticleFromId(i);
 
-            // filter module-incompatible particles
-            if (acceptedInputMap == null || !acceptedInputMap.getOrDefault(p, false)) {
+            // filter module-incompatible particles -- keep blacklisted particles in the pool but output nothing if
+            // rolled
+            if (acceptedInputMap == null || !acceptedInputMap.containsKey(p)) {
                 weights[i] = 0.0;
                 continue;
             }
@@ -687,6 +688,14 @@ public class MTELargeHadronCollider extends MTEBeamMultiBase<MTELargeHadronColli
                 o.dataPacket = null;
                 continue;
             }
+
+            // void blacklisted particles
+            Particle rolled = Particle.getParticleFromId(rolledId);
+            if (!o.acceptedInputMap.getOrDefault(rolled, false)) {
+                o.dataPacket = null;
+                continue;
+            }
+
             o.dataPacket = new BeamLinePacket(new BeamInformation(this.outputEnergy, rate, rolledId, this.outputFocus));
         }
     }


### PR DESCRIPTION
This change makes the LHC roll and void blacklisted particles. 

Previously, blacklisted particles were not rolled at all, allowing the player to have 100% generation rate of rare particles when unintended by blacklisting everything but the target particle.

Tested in dev