### PR TITLE
Fix identical tooltips of identical named machines but GTLanguageManager

### DIFF
--- a/src/main/java/gregtech/api/util/GTLanguageManager.java
+++ b/src/main/java/gregtech/api/util/GTLanguageManager.java
@@ -460,4 +460,8 @@ public class GTLanguageManager {
             LANGMAP.put(key, english);
         }
     }
+
+    public static boolean canTranslatedGT(final String key) {
+        return LANGMAP.containsKey(key);
+    }
 }

--- a/src/main/java/gregtech/api/util/GTLanguageManager.java
+++ b/src/main/java/gregtech/api/util/GTLanguageManager.java
@@ -461,7 +461,7 @@ public class GTLanguageManager {
         }
     }
 
-    public static boolean canTranslatedGT(final String key) {
+    public static boolean hasGTLocalizationKey(final String key) {
         return LANGMAP.containsKey(key);
     }
 }

--- a/src/main/java/gregtech/common/blocks/ItemMachines.java
+++ b/src/main/java/gregtech/common/blocks/ItemMachines.java
@@ -194,7 +194,7 @@ public class ItemMachines extends ItemBlock implements IFluidContainerItem {
         if (tDescription.contains("%%%")) {
             tDescription = tDescription.replaceAll("%%%.*?%%%", "%s");
         }
-        if (StatCollector.canTranslate(key)) {
+        if (GTLanguageManager.canTranslatedGT(key)) {
             GTLanguageManager.addStringLocalization(key + "." + damage, tDescription);
             return;
         }

--- a/src/main/java/gregtech/common/blocks/ItemMachines.java
+++ b/src/main/java/gregtech/common/blocks/ItemMachines.java
@@ -194,7 +194,7 @@ public class ItemMachines extends ItemBlock implements IFluidContainerItem {
         if (tDescription.contains("%%%")) {
             tDescription = tDescription.replaceAll("%%%.*?%%%", "%s");
         }
-        if (GTLanguageManager.canTranslatedGT(key)) {
+        if (GTLanguageManager.hasGTLocalizationKey(key)) {
             GTLanguageManager.addStringLocalization(key + "." + damage, tDescription);
             return;
         }


### PR DESCRIPTION
https://github.com/GTNewHorizons/GT5-Unofficial/pull/6572#issuecomment-4496735858
Fortunately, I had a sample to test with this time.
[GregTech.txt](https://github.com/user-attachments/files/28051508/GregTech.txt)
when this lang file exists, tooltips cannot be generated properly in the original code, while this pr code can.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24756