### PR TITLE
Remove unnecessary Recipe Map registrations for AE2FC

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -36,74 +36,74 @@
 dependencies {
     api("com.github.GTNewHorizons:StructureLib:1.4.34:dev")
     api("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev")
-    api("com.github.GTNewHorizons:NotEnoughItems:2.8.93-GTNH:dev")
-    api("com.github.GTNewHorizons:GTNHLib:0.10.0:dev")
+    api("com.github.GTNewHorizons:NotEnoughItems:2.8.98-GTNH:dev")
+    api("com.github.GTNewHorizons:GTNHLib:0.10.2:dev")
     api("com.falsepattern:chunkapi-mc1.7.10:0.8.1:dev")
     api("com.falsepattern:endlessids-mc1.7.10:1.7.1:dev")
     api("com.github.GTNewHorizons:ModularUI:1.3.4:dev")
-    api("com.github.GTNewHorizons:ModularUI2:2.3.63-1.7.10:dev")
-    api("com.github.GTNewHorizons:waila:1.19.23:dev")
-    api("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-913-GTNH:dev")
-    api("com.github.GTNewHorizons:AE2FluidCraft-Rework:1.5.77-gtnh:dev")
+    api("com.github.GTNewHorizons:ModularUI2:2.3.65-1.7.10:dev")
+    api("com.github.GTNewHorizons:waila:1.19.28:dev")
+    api("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-945-GTNH:dev")
+    api("com.github.GTNewHorizons:AE2FluidCraft-Rework:1.5.85-gtnh:dev")
     api("com.github.GTNewHorizons:Postea:1.2.5:dev")
 
-    compileOnlyApi('com.github.GTNewHorizons:ThaumicTinkerer:2.12.20:dev')
-    compileOnlyApi("com.github.GTNewHorizons:Mobs-Info:0.5.12-GTNH:dev")
-    compileOnlyApi("com.github.GTNewHorizons:Navigator:1.1.2:dev")
-    implementation('com.github.GTNewHorizons:Baubles-Expanded:2.2.13-GTNH:dev') {transitive=false}
+    compileOnlyApi('com.github.GTNewHorizons:ThaumicTinkerer:2.12.22:dev')
+    compileOnlyApi("com.github.GTNewHorizons:Mobs-Info:0.5.14-GTNH:dev")
+    compileOnlyApi("com.github.GTNewHorizons:Navigator:1.1.3:dev")
+    implementation('com.github.GTNewHorizons:Baubles-Expanded:2.2.19-GTNH:dev') {transitive=false}
     // Required to prevent an older bauble api from Extra Utilities from loading first in the javac classpath
-    compileOnly('com.github.GTNewHorizons:Baubles-Expanded:2.2.13-GTNH:dev') {transitive=false}
+    compileOnly('com.github.GTNewHorizons:Baubles-Expanded:2.2.19-GTNH:dev') {transitive=false}
 
-    devOnlyNonPublishable("com.github.GTNewHorizons:Infernal-Mobs:1.10.4-GTNH:dev")
+    devOnlyNonPublishable("com.github.GTNewHorizons:Infernal-Mobs:1.10.5-GTNH:dev")
 
-    devOnlyNonPublishable("com.github.GTNewHorizons:Avaritia:1.96:dev")
+    devOnlyNonPublishable("com.github.GTNewHorizons:Avaritia:1.97:dev")
 
     compileOnlyApi("com.github.GTNewHorizons:AppleCore:3.3.10:dev") { transitive = false }
-    compileOnlyApi("com.github.GTNewHorizons:BuildCraft:7.1.57:dev") { transitive = false }
-    compileOnlyApi("com.github.GTNewHorizons:EnderIO:2.10.25:dev") { transitive = false }
-    compileOnlyApi("com.github.GTNewHorizons:ForestryMC:4.11.15:dev") { transitive = false }
-    compileOnlyApi("com.github.GTNewHorizons:Galacticraft:3.4.25-GTNH:dev") { transitive = false }
-    compileOnlyApi("com.github.GTNewHorizons:ProjectRed:4.12.33-GTNH:dev") { transitive = false }
+    compileOnlyApi("com.github.GTNewHorizons:BuildCraft:7.1.60:dev") { transitive = false }
+    compileOnlyApi("com.github.GTNewHorizons:EnderIO:2.10.27:dev") { transitive = false }
+    compileOnlyApi("com.github.GTNewHorizons:ForestryMC:4.11.23:dev") { transitive = false }
+    compileOnlyApi("com.github.GTNewHorizons:Galacticraft:3.4.28-GTNH:dev") { transitive = false }
+    compileOnlyApi("com.github.GTNewHorizons:ProjectRed:4.12.38-GTNH:dev") { transitive = false }
     compileOnlyApi("com.github.GTNewHorizons:Railcraft:9.17.26:dev") { transitive = false }
 
     // Required to use Blast Furnace and Smoker Recipe maps from EFR.
     compileOnlyApi("ganymedes01.etfuturum:Et-Futurum-Requiem:2.6.2.21-GTNH-daily") { transitive = false }
-    compileOnlyApi("com.github.GTNewHorizons:Backhand:1.8.8:dev") { transitive = false }
+    compileOnlyApi("com.github.GTNewHorizons:Backhand:1.8.10:dev") { transitive = false }
 
     compileOnly("TGregworks:TGregworks:1.7.10-GTNH-1.0.27:deobf") {transitive = false}
-    compileOnly("com.github.GTNewHorizons:ThaumicBases:1.9.12:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:EnderCore:0.5.13:dev") { transitive = false }
-    compileOnly('com.github.GTNewHorizons:VisualProspecting:1.5.20:dev') { transitive = false }
-    compileOnly("com.github.GTNewHorizons:Galaxy-Space-GTNH:1.1.136-GTNH:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:Hardcore-Ender-Expansion:1.12.21-GTNH:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:ThaumicBases:1.9.16:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:EnderCore:0.5.14:dev") { transitive = false }
+    compileOnly('com.github.GTNewHorizons:VisualProspecting:1.5.21:dev') { transitive = false }
+    compileOnly("com.github.GTNewHorizons:Galaxy-Space-GTNH:1.1.138-GTNH:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:Hardcore-Ender-Expansion:1.12.22-GTNH:dev") { transitive = false }
 
-    implementation("com.github.GTNewHorizons:TinkersConstruct:1.14.58-GTNH:dev")
-    compileOnly("com.github.GTNewHorizons:StorageDrawers:2.2.20-GTNH:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:ArchitectureCraft:1.12.10:dev") { transitive = false }
+    implementation("com.github.GTNewHorizons:TinkersConstruct:1.14.73-GTNH:dev")
+    compileOnly("com.github.GTNewHorizons:StorageDrawers:2.2.22-GTNH:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:ArchitectureCraft:1.12.11:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:Chisel:2.17.26-GTNH:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:Translocators:1.4.4:dev") { transitive = false }
     compileOnly rfg.deobf("curse.maven:cofh-core-69162:2388751")
     compileOnly("com.github.GTNewHorizons:Nuclear-Control:2.7.8:dev") { transitive = false }
     compileOnly("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev") { transitive = false }
-    implementation("com.github.GTNewHorizons:Hodgepodge:2.7.128:dev")
-    compileOnly('com.github.GTNewHorizons:Botania:1.13.16-GTNH:dev') { transitive = false }
-    compileOnly("com.github.GTNewHorizons:Natura:2.8.18:dev") { transitive = false }
-    compileOnly('com.github.GTNewHorizons:HoloInventory:2.5.12-GTNH:dev') { transitive = false }
+    implementation("com.github.GTNewHorizons:Hodgepodge:2.7.145:dev")
+    compileOnly('com.github.GTNewHorizons:Botania:1.13.19-GTNH:dev') { transitive = false }
+    compileOnly("com.github.GTNewHorizons:Natura:2.8.19:dev") { transitive = false }
+    compileOnly('com.github.GTNewHorizons:HoloInventory:2.5.13-GTNH:dev') { transitive = false }
     compileOnly rfg.deobf("curse.maven:extra-utilities-225561:2264384")
     compileOnly rfg.deobf('curse.maven:minefactory-reloaded-66672:2366150')
-    compileOnly("com.github.GTNewHorizons:OpenComputers:1.12.38-GTNH:dev") {transitive = false}
+    compileOnly("com.github.GTNewHorizons:OpenComputers:1.12.42-GTNH:dev") {transitive = false}
     // https://www.curseforge.com/minecraft/mc-mods/advancedsolarpanels
     compileOnlyApi rfg.deobf('curse.maven:advsolar-362768:2885953')
-    compileOnly('com.github.GTNewHorizons:ThaumicEnergistics:1.7.45-GTNH:dev') {transitive =  false}
-    compileOnly("com.github.GTNewHorizons:BloodMagic:1.8.14:dev") { transitive = false }
+    compileOnly('com.github.GTNewHorizons:ThaumicEnergistics:1.7.51-GTNH:dev') {transitive =  false}
+    compileOnly("com.github.GTNewHorizons:BloodMagic:1.9.3:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:CraftTweaker:3.4.7:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:BetterLoadingScreen:1.7.7-GTNH:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:BetterLoadingScreen:1.7.8-GTNH:dev") { transitive = false }
     compileOnly rfg.deobf("curse.maven:biomes-o-plenty-220318:2499612")
 
     compileOnly('com.github.GTNewHorizons:SC2:2.3.14:dev') {transitive=false}
-    compileOnly('com.github.GTNewHorizons:Binnie:2.6.24:dev') {transitive = false}
+    compileOnly('com.github.GTNewHorizons:Binnie:2.6.30:dev') {transitive = false}
     compileOnly('curse.maven:PlayerAPI-228969:2248928') {transitive=false}
-    devOnlyNonPublishable('com.github.GTNewHorizons:BlockRenderer6343:1.4.12:dev'){transitive=false}
+    devOnlyNonPublishable('com.github.GTNewHorizons:BlockRenderer6343:1.4.13:dev'){transitive=false}
     // for waila integration testing
     // devOnlyNonPublishable('com.github.GTNewHorizons:WAILAPlugins:0.7.2:dev')
 
@@ -111,20 +111,20 @@ dependencies {
     annotationProcessor("com.google.auto.value:auto-value:1.10.1")
 
     // For testing forestry integration (iApiary, combs, tree growth simulator)
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:ForestryMC:4.11.15:dev")
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:ForestryMC:4.11.23:dev")
     // runtimeOnlyNonPublishable('com.github.GTNewHorizons:neiaddons:1.18.1:dev')
-    // runtimeOnlyNonPublishable('com.github.GTNewHorizons:MagicBees:2.10.8-GTNH:dev')
-    // runtimeOnlyNonPublishable('com.github.GTNewHorizons:Binnie:2.6.24:dev')
+    // runtimeOnlyNonPublishable('com.github.GTNewHorizons:MagicBees:2.10.9-GTNH:dev')
+    // runtimeOnlyNonPublishable('com.github.GTNewHorizons:Binnie:2.6.30:dev')
 
     // For testing Galacticraft integration (GTNH intergalactic, Ross, etc)
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Galacticraft:3.4.25-GTNH:dev") {
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Galacticraft:3.4.28-GTNH:dev") {
     //     exclude group: "com.github.GTNewHorizons", module: "GT5-Unofficial"
     // }
 
     // For testing EEC multiblock
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:EnderIO:2.10.25:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:EnderIO:2.10.27:dev") { transitive = false }
     // runtimeOnlyNonPublishable rfg.deobf("curse.maven:extra-utilities-225561:2264384")
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Mobs-Info:0.5.12-GTNH:dev")
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Mobs-Info:0.5.14-GTNH:dev")
 
     testImplementation(platform('org.junit:junit-bom:5.14.1'))
     testImplementation('org.junit.jupiter:junit-jupiter')
@@ -133,7 +133,7 @@ dependencies {
     testImplementation("com.github.GTNewHorizons:Chisel:2.17.26-GTNH:dev") { transitive = false }
 
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:DuraDisplay:1.4.2:dev")
-    runtimeOnlyNonPublishable('com.github.GTNewHorizons:EnderIO:2.10.25:dev')
+    runtimeOnlyNonPublishable('com.github.GTNewHorizons:EnderIO:2.10.27:dev')
 
     // For testing
     //runtimeOnlyNonPublishable('com.github.GTNewHorizons:TCNEIAdditions:1.5.13:dev')
@@ -146,7 +146,7 @@ dependencies {
     runtimeOnlyNonPublishable('com.github.GTNewHorizons:Angelica:2.1.25:dev') { transitive = false }
 
     // Speeds up mod identification and loading in dev
-    runtimeOnlyNonPublishable(rfg.deobf("com.github.GTNewHorizons:CoreTweaks:0.3.4.2-GTNH"))
+    runtimeOnlyNonPublishable(rfg.deobf("com.github.GTNewHorizons:CoreTweaks:0.3.4.5-GTNH"))
 
     // For testing involving the quantum computer
     // runtimeOnlyNonPublishable(deobf('https://forum.industrial-craft.net/core/attachment/4519-gravisuite-1-7-10-2-0-3-jar'))

--- a/src/main/java/gregtech/common/GTClient.java
+++ b/src/main/java/gregtech/common/GTClient.java
@@ -43,8 +43,6 @@ import net.minecraftforge.oredict.OreDictionary;
 
 import org.lwjgl.input.Keyboard;
 
-import com.glodblock.github.nei.recipes.FluidRecipe;
-import com.glodblock.github.nei.recipes.extractor.GregTech5RecipeExtractor;
 import com.gtnewhorizons.navigator.api.NavigatorApi;
 
 import cpw.mods.fml.client.event.ConfigChangedEvent;
@@ -83,7 +81,6 @@ import gregtech.api.metatileentity.BaseMetaTileEntity;
 import gregtech.api.metatileentity.MetaPipeEntity;
 import gregtech.api.net.GTPacketClientPreference;
 import gregtech.api.net.cape.GTPacketSetCape;
-import gregtech.api.recipe.RecipeCategory;
 import gregtech.api.render.RenderOverlay;
 import gregtech.api.util.ColorsMetadataSection;
 import gregtech.api.util.ColorsMetadataSectionSerializer;
@@ -401,16 +398,7 @@ public class GTClient extends GTProxy {
     @Override
     public void onLoadComplete(FMLLoadCompleteEvent event) {
         super.onLoadComplete(event);
-        for (RecipeCategory category : RecipeCategory.ALL_RECIPE_CATEGORIES.values()) {
-            if (category.recipeMap.getFrontend()
-                .getNEIProperties().registerNEI) {
-                FluidRecipe.addRecipeMap(
-                    category.unlocalizedName,
-                    new GregTech5RecipeExtractor(
-                        category.unlocalizedName.equals("gt.recipe.scanner")
-                            || category.unlocalizedName.equals("gt.recipe.fakeAssemblylineProcess")));
-            }
-        }
+
         Textures.ItemIcons.cleanup();
         Textures.BlockIcons.cleanup();
     }


### PR DESCRIPTION
I removed FluidRecipe entirely in https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/434 because the RecipeExtractors added to it were unused.
NotEnoughEnergistics provides equivalent functionality.