### PR TITLE
Fixes toolbox's inappropriate durability use on PR gates

### DIFF
--- a/src/main/java/gregtech/common/items/toolbox/ToolboxUtil.java
+++ b/src/main/java/gregtech/common/items/toolbox/ToolboxUtil.java
@@ -180,7 +180,7 @@ public class ToolboxUtil {
             final ToolboxItemStackHandler handler = new ToolboxItemStackHandler(toolbox);
             handler.mutateCurrentTool(toolStack -> {
                 if (toolStack.getItem() instanceof final MetaGeneratedTool toolItem) {
-                    toolItem.doDamageToItem(toolStack, toolItem.getToolStats(toolStack).getToolDamagePerEntityAttack());
+                    toolItem.doDamage(toolStack, toolItem.getToolStats(toolStack).getToolDamagePerEntityAttack());
                 }
             });
         }


### PR DESCRIPTION
The toolbox was using excessive durability when rotating ProjectRed gates. This PR returns the durability use back to expected levels. Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24610 .

Root cause: the toolbox was using `MetaGeneratedTool#doDamageToItem`, which expects a vanilla damage amount. I was passing in the Greg-ified damage amount; 200 times what the vanilla damage would be. Switching the routine to use `MetaGeneratedTool#doDamage` fixes the problem, as it does not perform any additional multiplication.