### PR TITLE
Change Dilithium Dust to Unstable Dust in Shijima Dust recipes

### DIFF
--- a/src/main/java/gregtech/loaders/materials/MaterialsInit.java
+++ b/src/main/java/gregtech/loaders/materials/MaterialsInit.java
@@ -16575,7 +16575,7 @@ public class MaterialsInit {
             .setChemicalFormula(
                 "(" + Materials.NetherStar.getChemicalFormula()
                     + ")₈Tb₇Tc₄("
-                    + Materials.Dilithium.getChemicalFormula()
+                    + CustomGlyphs.FIXED_JAPANESE_OPENING_QUOTE + "Fe/C⌋"
                     + ")₄Fl₃If")
             .setIconSet(TextureSet.SET_SHINY)
             .setColor(Dyes.dyeWhite)

--- a/src/main/java/gregtech/loaders/materials/MaterialsInit.java
+++ b/src/main/java/gregtech/loaders/materials/MaterialsInit.java
@@ -16575,7 +16575,8 @@ public class MaterialsInit {
             .setChemicalFormula(
                 "(" + Materials.NetherStar.getChemicalFormula()
                     + ")₈Tb₇Tc₄("
-                    + CustomGlyphs.FIXED_JAPANESE_OPENING_QUOTE + "Fe/C⌋"
+                    + CustomGlyphs.FIXED_JAPANESE_OPENING_QUOTE
+                    + "Fe/C⌋"
                     + ")₄Fl₃If")
             .setIconSet(TextureSet.SET_SHINY)
             .setColor(Dyes.dyeWhite)

--- a/src/main/java/gregtech/loaders/postload/recipes/CentrifugeRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/CentrifugeRecipes.java
@@ -946,7 +946,7 @@ public class CentrifugeRecipes implements Runnable {
                 Materials.NetherStar.getDust(8),
                 Materials.Terbium.getDust(7),
                 MaterialsElements.getInstance().TECHNETIUM.getDust(4),
-                Materials.Dilithium.getDust(4),
+                Materials.Unstable.getDust(4),
                 Materials.Flerovium.getDust(3),
                 Materials.InfinityCatalyst.getDust(1))
             .duration(60 * SECONDS)

--- a/src/main/java/gregtech/loaders/postload/recipes/MixerRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/MixerRecipes.java
@@ -1653,7 +1653,7 @@ public class MixerRecipes implements Runnable {
                 Materials.NetherStar.getDust(8),
                 Materials.Terbium.getDust(7),
                 MaterialsElements.getInstance().TECHNETIUM.getDust(4),
-                Materials.Dilithium.getDust(4),
+                Materials.Unstable.getDust(4),
                 Materials.Flerovium.getDust(3),
                 Materials.InfinityCatalyst.getDust(1))
             .circuit(6)


### PR DESCRIPTION
does that, makes shijima no longer gated to post mothership, as shijima should be available sooner than churitsu anyway
(plus both dusts are free anyway lol)
unstable ingots can be crafted in beamcrafter without sigil in zpm, making this pr a non issue. (plus the planet stone)