### PR TITLE
Fix machines being really quiet

### DIFF
--- a/src/main/java/gregtech/client/GTSoundLoop.java
+++ b/src/main/java/gregtech/client/GTSoundLoop.java
@@ -54,7 +54,6 @@ public class GTSoundLoop extends MovingSound {
         zPosF = soundZ;
         worldID = base.getWorld().provider.dimensionId;
         repeat = true;
-        targetVolume = VOLUME_RAMP;
         volume = VOLUME_RAMP;
     }
 


### PR DESCRIPTION
Got broken from https://github.com/GTNewHorizons/GT5-Unofficial/pull/6120

`targetVolume` defaults to 1 but was being overriden with `VOLUME_RAMP` which is `0.0625f`