### PR TITLE
Revert "Optimize performance"

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
@@ -96,7 +96,6 @@ public class BaseMetaTileEntity extends CommonBaseMetaTileEntity implements IAct
 
     private final boolean[] mActiveEUInputs = new boolean[] { false, false, false, false, false, false };
     private final boolean[] mActiveEUOutputs = new boolean[] { false, false, false, false, false, false };
-    private boolean mEnergyConnectionsDirty = true;
     public long mLastSoundTick = 0;
     public boolean mWasShutdown = false;
     public @Nonnull ShutDownReason lastShutDownReason = ShutDownReasonRegistry.NONE;
@@ -419,7 +418,6 @@ public class BaseMetaTileEntity extends CommonBaseMetaTileEntity implements IAct
         oldFacing = mFacing;
         checkDropCover();
         issueBlockUpdate();
-        mEnergyConnectionsDirty = true;
     }
 
     /**
@@ -442,10 +440,6 @@ public class BaseMetaTileEntity extends CommonBaseMetaTileEntity implements IAct
      * Updates which faces are active for EU I/O
      */
     private void updateActiveEUIOFaces() {
-        if (!mEnergyConnectionsDirty) {
-            return;
-        }
-        mEnergyConnectionsDirty = false;
         if (!mMetaTileEntity.isEnetOutput() && !mMetaTileEntity.isEnetInput()) {
             return;
         }
@@ -1196,11 +1190,7 @@ public class BaseMetaTileEntity extends CommonBaseMetaTileEntity implements IAct
 
     @Override
     public long getStoredEU() {
-        if (canAccessData()) {
-            final long cap = mMetaTileEntity.maxEUStore();
-            final long stored = mMetaTileEntity.getEUVar();
-            return stored > cap ? cap : stored;
-        }
+        if (canAccessData()) return Math.min(mMetaTileEntity.getEUVar(), getEUCapacity());
         return 0;
     }
 
@@ -1257,12 +1247,6 @@ public class BaseMetaTileEntity extends CommonBaseMetaTileEntity implements IAct
                 return mMetaTileEntity.isOutputFacing(side);
         }
         return false;
-    }
-
-    @Override
-    public void issueCoverUpdate(ForgeDirection side) {
-        super.issueCoverUpdate(side);
-        mEnergyConnectionsDirty = true;
     }
 
     @Override
@@ -1852,24 +1836,21 @@ public class BaseMetaTileEntity extends CommonBaseMetaTileEntity implements IAct
             || !inputEnergyFrom(side)
             || aAmperage <= 0
             || aVoltage <= 0
+            || getStoredEU() >= getEUCapacity()
             || mMetaTileEntity.maxAmperesIn() <= mAcceptedAmperes) return 0;
-        final long euCapacity = mMetaTileEntity.maxEUStore();
-        final long storedEU = mMetaTileEntity.getEUVar();
-        if (storedEU >= euCapacity) return 0;
-        if (aVoltage > mMetaTileEntity.maxEUInput()) {
+        if (aVoltage > getInputVoltage()) {
             GTLog.writeExplosionLog(
                 this.mMetaTileEntity,
-                "Energy Explosion, injected " + aVoltage
-                    + "EU/t in a "
-                    + mMetaTileEntity.maxEUInput()
-                    + "EU/t Machine!");
+                "Energy Explosion, injected " + aVoltage + "EU/t in a " + getInputVoltage() + "EU/t Machine!");
             doExplosion(aVoltage);
             return 0;
         }
         if (increaseStoredEnergyUnits(
             aVoltage * (aAmperage = Math.min(
                 aAmperage,
-                Math.min(mMetaTileEntity.maxAmperesIn() - mAcceptedAmperes, 1 + ((euCapacity - storedEU) / aVoltage)))),
+                Math.min(
+                    mMetaTileEntity.maxAmperesIn() - mAcceptedAmperes,
+                    1 + ((getEUCapacity() - getStoredEU()) / aVoltage)))),
             true)) {
             mAverageEUInput[mAverageEUInputIndex] += aVoltage * aAmperage;
             mAcceptedAmperes += aAmperage;

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEBasicTank.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEBasicTank.java
@@ -149,9 +149,6 @@ public abstract class MTEBasicTank extends MTETieredMachineBlock implements IAdd
 
             final int inputSlot = getInputSlot();
 
-            // Early exit if no item in input slot - nothing to fill or empty
-            if (inputSlot >= mInventory.length || mInventory[inputSlot] == null) return;
-
             if (doesEmptyContainers()) {
                 FluidStack tFluid = GTUtility.getFluidForFilledItem(mInventory[inputSlot], true);
                 if (tFluid != null && isFluidInputAllowed(tFluid)) {

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEHatchInputBus.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEHatchInputBus.java
@@ -147,9 +147,7 @@ public class MTEHatchInputBus extends MTEHatch implements IConfigurationCircuitS
     @Override
     public void onPostTick(IGregTechTileEntity aBaseMetaTileEntity, long aTimer) {
         if (aBaseMetaTileEntity.isServerSide()) {
-            if (aBaseMetaTileEntity.hasInventoryBeenModified()) {
-                updateSlots();
-            }
+            updateSlots();
         }
     }
 
@@ -216,7 +214,6 @@ public class MTEHatchInputBus extends MTEHatch implements IConfigurationCircuitS
                     disableLimited = true;
                 }
             }
-            updateSlots();
             GTUtility.sendChatComp(
                 aPlayer,
                 new ChatComponentTranslation("GT5U.hatch.disableSort." + disableSort).appendText("   ")
@@ -280,10 +277,12 @@ public class MTEHatchInputBus extends MTEHatch implements IConfigurationCircuitS
     }
 
     protected void addSortStacksButton(ModularWindow.Builder builder) {
-        builder.widget(createToggleButton(() -> !disableSort, val -> {
-            disableSort = !val;
-            updateSlots();
-        }, GTUITextures.OVERLAY_BUTTON_SORTING_MODE, () -> mTooltipCache.getData(SORTING_MODE_TOOLTIP)));
+        builder.widget(
+            createToggleButton(
+                () -> !disableSort,
+                val -> disableSort = !val,
+                GTUITextures.OVERLAY_BUTTON_SORTING_MODE,
+                () -> mTooltipCache.getData(SORTING_MODE_TOOLTIP)));
     }
 
     protected void addOneStackLimitButton(ModularWindow.Builder builder) {


### PR DESCRIPTION
Reverts GTNewHorizons/GT5-Unofficial#6751
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24844

There are blocks that potentially change the EU facing without rotation. MTETransformer is an example. We also got cases of MTEBasicMachine where output face can be rotated in a way that turn an input face into not an input face.