### PR TITLE
fix thermal boilers water consumption

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEThermalBoiler.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEThermalBoiler.java
@@ -133,10 +133,11 @@ public class MTEThermalBoiler extends MTEExtendedPowerMultiBlockBase<MTEThermalB
             protected ParallelHelper createParallelHelper(@Nonnull GTRecipe recipe) {
                 GTRecipe adjustedRecipe = recipe.copy();
 
-                for (FluidStack inputFluid : adjustedRecipe.mFluidInputs) {
+                for (int i = 0; i < adjustedRecipe.mFluidInputs.length; i++) {
+                    FluidStack inputFluid = adjustedRecipe.mFluidInputs[i];
                     if (inputFluid != null
                         && (inputFluid.getFluid() == fluidWater || inputFluid.getFluid() == fluidDistilledWater)) {
-                        inputFluid.amount = 0;
+                        adjustedRecipe.mFluidInputs[i] = null;
                     }
                 }
 

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTEThermalBoilerLegacy.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTEThermalBoilerLegacy.java
@@ -148,10 +148,11 @@ public class MTEThermalBoilerLegacy extends GTPPMultiBlockBase<MTEThermalBoilerL
                 GTRecipe adjustedRecipe = recipe.copy();
 
                 // Hack the recipe logic to not consume water, so that we can explode.
-                for (FluidStack inputFluid : adjustedRecipe.mFluidInputs) {
+                for (int i = 0; i < adjustedRecipe.mFluidInputs.length; i++) {
+                    FluidStack inputFluid = adjustedRecipe.mFluidInputs[i];
                     if (inputFluid != null
                         && (inputFluid.getFluid() == fluidWater || inputFluid.getFluid() == fluidDistilledWater)) {
-                        inputFluid.amount = 0;
+                        adjustedRecipe.mFluidInputs[i] = null;
                     }
                 }
 


### PR DESCRIPTION
got broken by the changes to GTRecipe in https://github.com/GTNewHorizons/GT5-Unofficial/pull/6661
Before that PR, GTRecipe.maxParallelCalculatedByInputs grouped fluid costs by fluid and skipped zero-cost entries, so the earlier hack for the boilers worked.
After this PR, fluid inputs are checked per input slot to support substitute fluids. A zero-amount water slot now still counts as a required fluid slot, but it can never choose a valid alternative because alt.amount > 0 is false. That makes parallel calculation return 0 and led to the internal error.
fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24858

Working in dev env:
<img width="577" height="609" alt="image" src="https://github.com/user-attachments/assets/df4676ef-5fef-415b-8d2b-df4a50765ffb" />
