### PR TITLE
Remove Dragon Blood from GTPP custom material rendering

### DIFF
--- a/src/main/java/gtPlusPlus/core/material/MaterialsElements.java
+++ b/src/main/java/gtPlusPlus/core/material/MaterialsElements.java
@@ -616,7 +616,7 @@ public final class MaterialsElements {
             "Dragonblood",
             MaterialState.SOLID,
             TextureSet.SET_HYPOGEN,
-            new short[] { 220, 40, 20, 2 },
+            new short[] { 220, 40, 20 },
             10160,
             17850,
             96,


### PR DESCRIPTION
Dragon blood was updated alongside Hypogen to have a custom animation, instead of the GTPP flashing animation (like Astral Titanium / Celestial Tungsten). This removes dragon blood from the animation system (which GTPP gates using the RGBA alpha value, for reasons).

Confirmed works fine in-game.