### PR TITLE
Fix vein names having duplicate ores

### DIFF
--- a/src/main/java/gregtech/api/enums/OreMixes.java
+++ b/src/main/java/gregtech/api/enums/OreMixes.java
@@ -485,7 +485,7 @@ public enum OreMixes {
         .secondary(Materials.InfusedFire)
         .inBetween(Materials.Amber)
         .sporadic(Materials.Cinnabar)
-        .setLocalizedName(Materials.InfusedWater, Materials.InfusedFire, Materials.Amber)),
+        .setLocalizedName(Materials.InfusedFire, Materials.Amber)),
 
     TerraAer(new OreMixBuilder().name("ore.mix.terraaer")
         .heightRange(5, 20)
@@ -498,7 +498,7 @@ public enum OreMixes {
         .secondary(Materials.InfusedAir)
         .inBetween(Materials.Amber)
         .sporadic(Materials.Cinnabar)
-        .setLocalizedName(Materials.InfusedEarth, Materials.InfusedAir)),
+        .setLocalizedName(Materials.InfusedAir)),
 
     PerditioOrdo(new OreMixBuilder().name("ore.mix.perditioordo")
         .heightRange(5, 20)
@@ -511,7 +511,7 @@ public enum OreMixes {
         .secondary(Materials.InfusedOrder)
         .inBetween(Materials.Amber)
         .sporadic(Materials.Cinnabar)
-        .setLocalizedName(Materials.InfusedEntropy, Materials.InfusedOrder)),
+        .setLocalizedName(Materials.InfusedOrder)),
 
     CopperTin(new OreMixBuilder().name("ore.mix.coppertin")
         .heightRange(80, 200)


### PR DESCRIPTION
The primary ore is already added to the vein name so adding them in `setLocalizedName` makes that ore appear twice.

Before:
<img width="358" height="331" alt="image" src="https://github.com/user-attachments/assets/e78b98e6-f2c8-450c-996f-57b262d40e49" />
After:
<img width="353" height="313" alt="image" src="https://github.com/user-attachments/assets/ac340968-468a-4c54-a492-7fb80d1f6c72" />
