### PR TITLE
Fix c2s sync

### DIFF
--- a/src/main/java/gregtech/common/gui/modularui/multiblock/MTEBeamStabilizerGui.java
+++ b/src/main/java/gregtech/common/gui/modularui/multiblock/MTEBeamStabilizerGui.java
@@ -32,7 +32,8 @@ public class MTEBeamStabilizerGui extends MTEMultiBlockBaseGui<MTEBeamStabilizer
         super.registerSyncValues(syncManager);
         syncManager.syncValue(
             "playerTargetBeamRate",
-            new IntSyncValue(() -> multiblock.playerTargetBeamRate, i -> multiblock.playerTargetBeamRate = i));
+            new IntSyncValue(() -> multiblock.playerTargetBeamRate, i -> multiblock.playerTargetBeamRate = i)
+                .allowC2S());
         syncManager.syncValue("inputBeamRate", new IntSyncValue(multiblock::getCachedBeamRate));
     }
 

--- a/src/main/java/gregtech/common/gui/modularui/multiblock/MTELargeHadronColliderGui.java
+++ b/src/main/java/gregtech/common/gui/modularui/multiblock/MTELargeHadronColliderGui.java
@@ -52,12 +52,12 @@ public class MTELargeHadronColliderGui extends MTEMultiBlockBaseGui<MTELargeHadr
             "playerTargetBeamEnergyeV",
             new DoubleSyncValue(
                 () -> multiblock.playerTargetBeamEnergyeV,
-                dub -> multiblock.playerTargetBeamEnergyeV = dub));
+                dub -> multiblock.playerTargetBeamEnergyeV = dub).allowC2S());
         syncManager.syncValue(
             "playerTargetAccelerationCycles",
             new IntSyncValue(
                 () -> multiblock.playerTargetAccelerationCycles,
-                i -> multiblock.playerTargetAccelerationCycles = i));
+                i -> multiblock.playerTargetAccelerationCycles = i).allowC2S());
         syncManager.syncValue("cachedOutputBeamEnergy", new DoubleSyncValue(multiblock::getCachedBeamEnergy));
         syncManager.syncValue("cachedOutputBeamRate", new IntSyncValue(multiblock::getCachedBeamRate));
         syncManager

--- a/src/main/java/gregtech/common/gui/modularui/multiblock/base/MTEMultiBlockBaseGui.java
+++ b/src/main/java/gregtech/common/gui/modularui/multiblock/base/MTEMultiBlockBaseGui.java
@@ -1311,6 +1311,7 @@ public class MTEMultiBlockBaseGui<T extends MTEMultiBlockBase> {
             .setter(baseMetaTileEntity::setShutDownReason)
             .adapter(new ShutdownReasonAdapter())
             .build();
+        shutdownReasonSyncer.allowC2S();
         syncManager.syncValue("shutdownReason", shutdownReasonSyncer);
 
         syncManager.syncValue(


### PR DESCRIPTION
mainly fix c2s sync warns for https://github.com/GTNewHorizons/ModularUI2/pull/121
MTEMultiBlockBaseGui.java — shutdownReasonSyncer missing .allowC2S()
Triggered from the log error: clicking the power switch called shutdownReasonSyncer.setValue() from the client, which threw SecurityException.

MTEBeamStabilizerGui.java — playerTargetBeamRate missing .allowC2S()
This IntSyncValue is bound to a TextFieldWidget, so typing into the beam rate field would fail silently or throw an exception.

MTELargeHadronColliderGui.java — playerTargetBeamEnergyeV and playerTargetAccelerationCycles missing .allowC2S()
Both are bound to TextFieldWidgets in the LHC's stats panel popup, preventing players from configuring beam energy target and acceleration