### PR TITLE
Use the default of 1000K if no temperature was set for molten fluid

### DIFF
--- a/src/main/java/gregtech/common/GTProxy.java
+++ b/src/main/java/gregtech/common/GTProxy.java
@@ -2292,7 +2292,7 @@ public class GTProxy implements IFuelHandler {
             .withDefaultLocalName("Molten " + aMaterial.mDefaultLocalName)
             .withTextureName(fluidTexture)
             .withColorRGBA(aMaterial.mMoltenRGBa)
-            .withStateAndTemperature(MOLTEN, aMaterial.mMeltingPoint < 0 ? 1000 : aMaterial.mMeltingPoint)
+            .withStateAndTemperature(MOLTEN, aMaterial.mMeltingPoint <= 0 ? 1000 : aMaterial.mMeltingPoint)
             .buildAndRegister()
             .configureMaterials(aMaterial)
             .addLocalizedName(aMaterial)


### PR DESCRIPTION
1000K is more reasonable than 0K.