### PR TITLE
Fix PseudoStar recipe null fluid

### DIFF
--- a/src/main/java/gregtech/loaders/postload/recipes/beamcrafter/BeamCrafterRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/beamcrafter/BeamCrafterRecipes.java
@@ -387,7 +387,7 @@ public class BeamCrafterRecipes implements Runnable {
 
         GTValues.RA.stdBuilder()
             .itemInputs(ItemList.PseudoStar.get(64L), Materials.TranscendentMetal.getNanite(2))
-            .fluidInputs(Materials.InactiveCosmicSolder.getFluid(160_000L), Materials.SpaceTime.getFluid(16 * INGOTS))
+            .fluidInputs(Materials.InactiveCosmicSolder.getFluid(160_000L), Materials.SpaceTime.getMolten(16 * INGOTS))
             .itemOutputs(Materials.TranscendentMetal.getNanite(2))
             .outputChances(8000)
             .fluidOutputs(Materials.BoundlessCosmicSolder.getFluid(160_000L))


### PR DESCRIPTION
Fixing an issue from https://github.com/GTNewHorizons/GT5-Unofficial/pull/6655 where `SpaceTime.getFluid` was called instead of `SpaceTime.getMolten` causing a null fluid to be used

<img width="519" height="342" alt="image" src="https://github.com/user-attachments/assets/a53f2e03-787e-4578-b05f-f287107bd6d4" />
