### PR TITLE
Fix sheetmetal icon getting material incorrectly

### DIFF
--- a/src/main/java/gregtech/common/blocks/BlockSheetMetal.java
+++ b/src/main/java/gregtech/common/blocks/BlockSheetMetal.java
@@ -138,9 +138,9 @@ public class BlockSheetMetal extends BlockStorage implements IBlockWithTextures,
     @SideOnly(Side.CLIENT)
     @Override
     public IIcon getIcon(int ordinalSide, int aMeta) {
-        Materials material = GregTechAPI.sGeneratedMaterials[aMeta];
+        IOreMaterial material = materials.get(aMeta);
         if (material == null) return null;
-        return material.mIconSet.mTextures[OrePrefixes.sheetmetal.getTextureIndex()].getIcon();
+        return material.getTextureSet().mTextures[OrePrefixes.sheetmetal.getTextureIndex()].getIcon();
     }
 
     public void registerRecipes() {


### PR DESCRIPTION
oops (caused by https://github.com/GTNewHorizons/GT5-Unofficial/pull/6790)

Everything else in the class uses the `materials` field