### PR TITLE
Fix multiblock preview not showing hatches

### DIFF
--- a/src/main/java/gregtech/api/util/HatchElementBuilder.java
+++ b/src/main/java/gregtech/api/util/HatchElementBuilder.java
@@ -491,8 +491,9 @@ public class HatchElementBuilder<T> {
     public final IStructureElementChain<T> buildAndChain(IStructureElement<T>... elements) {
         // just in case
         mExclusive = false;
-        List<IStructureElement<T>> l = new ArrayList<>(Arrays.asList(elements));
+        List<IStructureElement<T>> l = new ArrayList<>();
         l.add(build());
+        l.addAll(Arrays.asList(elements));
         IStructureElement<T>[] array = l.toArray(new IStructureElement[0]);
         return () -> array;
     }


### PR DESCRIPTION
In #6780 we changed the order of casing and hatches. This turns out to cause the multiblock preview to not show any hatch (and survival autobuild will always build casing first, making gt_hatch=1 useless).