### PR TITLE
Revert previous boiler fix

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEThermalBoiler.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEThermalBoiler.java
@@ -133,11 +133,10 @@ public class MTEThermalBoiler extends MTEExtendedPowerMultiBlockBase<MTEThermalB
             protected ParallelHelper createParallelHelper(@Nonnull GTRecipe recipe) {
                 GTRecipe adjustedRecipe = recipe.copy();
 
-                for (int i = 0; i < adjustedRecipe.mFluidInputs.length; i++) {
-                    FluidStack inputFluid = adjustedRecipe.mFluidInputs[i];
+                for (FluidStack inputFluid : adjustedRecipe.mFluidInputs) {
                     if (inputFluid != null
                         && (inputFluid.getFluid() == fluidWater || inputFluid.getFluid() == fluidDistilledWater)) {
-                        adjustedRecipe.mFluidInputs[i] = null;
+                        inputFluid.amount = 0;
                     }
                 }
 

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTEThermalBoilerLegacy.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTEThermalBoilerLegacy.java
@@ -148,11 +148,10 @@ public class MTEThermalBoilerLegacy extends GTPPMultiBlockBase<MTEThermalBoilerL
                 GTRecipe adjustedRecipe = recipe.copy();
 
                 // Hack the recipe logic to not consume water, so that we can explode.
-                for (int i = 0; i < adjustedRecipe.mFluidInputs.length; i++) {
-                    FluidStack inputFluid = adjustedRecipe.mFluidInputs[i];
+                for (FluidStack inputFluid : adjustedRecipe.mFluidInputs) {
                     if (inputFluid != null
                         && (inputFluid.getFluid() == fluidWater || inputFluid.getFluid() == fluidDistilledWater)) {
-                        adjustedRecipe.mFluidInputs[i] = null;
+                        inputFluid.amount = 0;
                     }
                 }
 


### PR DESCRIPTION
reverts https://github.com/GTNewHorizons/GT5-Unofficial/pull/6798 , due to changes made in https://github.com/GTNewHorizons/GT5-Unofficial/pull/6836
this broke the new boiler logic now, so reverted to the old one, which now works
(yes, confusing)
tested in dev env, and they work again