### PR TITLE
Fix NPE in singleblock GUIs caused by map corruption during sync handler initialization

### DIFF
--- a/src/main/java/gregtech/common/modularui2/sync/GhostCircuitSyncHandler.java
+++ b/src/main/java/gregtech/common/modularui2/sync/GhostCircuitSyncHandler.java
@@ -36,11 +36,6 @@ public class GhostCircuitSyncHandler extends PhantomItemSlotSH {
     public GhostCircuitSyncHandler(ModularSlot slot, IMetaTileEntity mte) {
         super(slot);
         this.mte = mte;
-    }
-
-    @Override
-    public void init(String key, PanelSyncManager syncHandler) {
-        super.init(key, syncHandler);
         if (mte instanceof IConfigurationCircuitSupport circuitEnabled && circuitEnabled.allowSelectCircuit()) {
             indexSync = new IntSyncValue(() -> {
                 ItemStack selectedItem = mte.getInventoryHandler()
@@ -61,13 +56,30 @@ public class GhostCircuitSyncHandler extends PhantomItemSlotSH {
                     mte.setInventorySlotContents(circuitEnabled.getCircuitSlot(), null);
                 }
             });
+        }
+    }
+
+    /**
+     * Registers the index sync value on the given sync manager. Must be called during widget construction,
+     * before {@link com.cleanroommc.modularui.value.sync.PanelSyncManager#initialize} runs, to avoid
+     * modifying the sync handler map during iteration.
+     */
+    public void registerIndexSync(PanelSyncManager syncManager, String key) {
+        if (indexSync != null) {
+            syncManager.syncValue(key, 0, indexSync);
+        }
+    }
+
+    @Override
+    public void init(String key, PanelSyncManager syncHandler) {
+        super.init(key, syncHandler);
+        if (indexSync != null) {
             indexSync.setChangeListener(() -> {
                 if (indexSync.getSyncManager()
                     .isClient()) return;
                 mte.getBaseMetaTileEntity()
                     .markInventoryBeenModified();
             });
-            syncHandler.syncValue(key, indexSync);
         }
     }
 

--- a/src/main/java/gregtech/common/modularui2/widget/GhostCircuitSlotWidget.java
+++ b/src/main/java/gregtech/common/modularui2/widget/GhostCircuitSlotWidget.java
@@ -80,6 +80,7 @@ public class GhostCircuitSlotWidget extends PhantomItemSlot {
     public PhantomItemSlot slot(ModularSlot slot) {
         circuitSyncHandler = new GhostCircuitSyncHandler(slot, mte);
         setSyncOrValue(circuitSyncHandler);
+        circuitSyncHandler.registerIndexSync(syncManager, "ghostCircuitIndex");
         return this;
     }
 

--- a/src/main/java/gregtech/common/modularui2/widget/GhostShapeSlotWidget.java
+++ b/src/main/java/gregtech/common/modularui2/widget/GhostShapeSlotWidget.java
@@ -75,6 +75,7 @@ public class GhostShapeSlotWidget extends PhantomItemSlot {
     public PhantomItemSlot slot(ModularSlot slot) {
         shapeSyncHandler = new GhostShapeSyncHandler(slot, hatch);
         setSyncOrValue(shapeSyncHandler);
+        shapeSyncHandler.registerIndexSync(syncManager, "ghostShapeIndex");
         return this;
     }
 

--- a/src/main/java/gregtech/common/modularui2/widget/GhostShapeSyncHandler.java
+++ b/src/main/java/gregtech/common/modularui2/widget/GhostShapeSyncHandler.java
@@ -21,11 +21,6 @@ public class GhostShapeSyncHandler extends PhantomItemSlotSH {
     public GhostShapeSyncHandler(ModularSlot slot, MTEHatchExtrusion hatch) {
         super(slot);
         this.hatch = hatch;
-    }
-
-    @Override
-    public void init(String key, PanelSyncManager syncHandler) {
-        super.init(key, syncHandler);
         indexSync = new IntSyncValue(() -> {
             ItemStack current = hatch.inventoryHandler.getStackInSlot(hatch.shapeSlot);
             return current != null ? hatch.findMatchingShapeIndex(current) : -1;
@@ -36,8 +31,22 @@ public class GhostShapeSyncHandler extends PhantomItemSlotSH {
                 hatch.setShape(null);
             }
         }).allowC2S();
+    }
 
-        syncHandler.syncValue(key, indexSync);
+    /**
+     * Registers the index sync value on the given sync manager. Must be called during widget construction,
+     * before {@link com.cleanroommc.modularui.value.sync.PanelSyncManager#initialize} runs, to avoid
+     * modifying the sync handler map during iteration.
+     */
+    public void registerIndexSync(PanelSyncManager syncManager, String key) {
+        if (indexSync != null) {
+            syncManager.syncValue(key, 0, indexSync);
+        }
+    }
+
+    @Override
+    public void init(String key, PanelSyncManager syncHandler) {
+        super.init(key, syncHandler);
     }
 
     @Override

--- a/src/main/java/gregtech/common/modularui2/widget/GhostShapeSyncHandler.java
+++ b/src/main/java/gregtech/common/modularui2/widget/GhostShapeSyncHandler.java
@@ -45,11 +45,6 @@ public class GhostShapeSyncHandler extends PhantomItemSlotSH {
     }
 
     @Override
-    public void init(String key, PanelSyncManager syncHandler) {
-        super.init(key, syncHandler);
-    }
-
-    @Override
     protected void phantomClick(MouseData mouseData, ItemStack cursorStack) {
         if (indexSync == null) return;
 


### PR DESCRIPTION
related to: https://github.com/GTNewHorizons/ModularUI2/pull/128