### PR TITLE
Return laser plate texture directly

### DIFF
--- a/src/main/java/gregtech/common/blocks/BlockLaser.java
+++ b/src/main/java/gregtech/common/blocks/BlockLaser.java
@@ -63,13 +63,11 @@ public class BlockLaser extends Block implements ITileEntityProvider {
 
     @Override
     @SideOnly(Side.CLIENT)
-    public void registerBlockIcons(IIconRegister iconRegister) {
-        blockIcon = Textures.BlockIcons.LASER_PLATE.getIcon();
-    }
+    public void registerBlockIcons(IIconRegister iconRegister) {}
 
     @Override
     public IIcon getIcon(int side, int meta) {
-        return blockIcon;
+        return Textures.BlockIcons.LASER_PLATE.getIcon();
     }
 
     @Override


### PR DESCRIPTION
`BlockLaser` assumes a specific load order for icons. This PR removes that assumption.

Adds support for https://github.com/GTNewHorizons/Hodgepodge/pull/908