### PR TITLE
Allow Jackhammer to Perform Hardhammer Maintenance

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEHatchMaintenance.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEHatchMaintenance.java
@@ -389,7 +389,8 @@ public class MTEHatchMaintenance extends MTEHatch implements IAlignment {
             mSoftMallet = true;
             setMaintenanceSound(SoundResource.GTCEU_OP_SOFT_HAMMER, 1.0F, 1.0F);
         }
-        if (GTUtility.isStackInList(aStack, GregTechAPI.sHardHammerList) && !mHardHammer
+        if ((GTUtility.isStackInList(aStack, GregTechAPI.sHardHammerList)
+            || GTUtility.isStackInList(aStack, GregTechAPI.sJackhammerList)) && !mHardHammer
             && GTModHandler.damageOrDechargeItem(aStack, 1, 1000, aPlayer)) {
             mHardHammer = true;
             setMaintenanceSound(SoundResource.GTCEU_LOOP_FORGE_HAMMER, 1.0F, 1.0F);


### PR DESCRIPTION
As title states. The two are functionally equivalent already this was really just an oversight from the tool revamp.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24922