### PR TITLE
Change Mega Chemical Reactor recipe to match LuV Megas

### DIFF
--- a/src/main/java/gregtech/loaders/load/MTERecipeLoader.java
+++ b/src/main/java/gregtech/loaders/load/MTERecipeLoader.java
@@ -10,11 +10,9 @@ import static gregtech.api.enums.Mods.Thaumcraft;
 import static gregtech.api.recipe.RecipeMaps.assemblerRecipes;
 import static gregtech.api.util.GTModHandler.RecipeBits.BUFFERED;
 import static gregtech.api.util.GTModHandler.RecipeBits.NOT_REMOVABLE;
-import static gregtech.api.util.GTRecipeBuilder.HOURS;
 import static gregtech.api.util.GTRecipeBuilder.INGOTS;
 import static gregtech.api.util.GTRecipeBuilder.MINUTES;
 import static gregtech.api.util.GTRecipeBuilder.SECONDS;
-import static gregtech.api.util.GTRecipeBuilder.STACKS;
 import static gregtech.api.util.GTRecipeBuilder.TICKS;
 import static gregtech.api.util.GTRecipeBuilder.WILDCARD;
 
@@ -1627,15 +1625,6 @@ public class MTERecipeLoader implements Runnable {
             BUFFERED,
             new Object[] { "PCP", "HMH", "PRP", 'P', MaterialsAlloy.STELLITE.getPlate(1), 'C', "circuitElite", 'H',
                 ItemList.Casing_IV, 'M', ItemList.Machine_IV_Electrolyzer, 'R', MaterialsAlloy.STELLITE.getRotor(1) });
-        // Mega Chemical Reactor
-        // todo: tweak this recipe
-        GTValues.RA.stdBuilder()
-            .itemInputs(ItemList.Machine_Multi_LargeChemicalReactor.get(64))
-            .itemOutputs(ItemList.MegaChemicalReactor.get(1))
-            .fluidInputs(Materials.SolderingAlloy.getMolten(1 * STACKS))
-            .duration(1 * HOURS)
-            .eut(TierEU.RECIPE_HV)
-            .addTo(assemblerRecipes);
 
         // Industrial Mixer
         GTModHandler.addCraftingRecipe(

--- a/src/main/java/gregtech/loaders/postload/recipes/AssemblyLineRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/AssemblyLineRecipes.java
@@ -952,6 +952,7 @@ public class AssemblyLineRecipes implements Runnable {
             .eut(TierEU.RECIPE_ZPM / 2)
             .duration(1 * MINUTES)
             .addTo(AssemblyLine);
+
         // Exothermic Hearth
         GTValues.RA.stdBuilder()
             .metadata(RESEARCH_ITEM, ItemList.Machine_Multi_BlastFurnace.get(1))
@@ -977,6 +978,7 @@ public class AssemblyLineRecipes implements Runnable {
             .duration(1 * MINUTES)
             .addTo(AssemblyLine);
 
+        // Mega Chemical Reactor
         GTValues.RA.stdBuilder()
             .metadata(RESEARCH_ITEM, ItemList.Machine_Multi_LargeChemicalReactor.get(1))
             .metadata(SCANNING, new Scanning(1 * MINUTES, TierEU.RECIPE_LuV))

--- a/src/main/java/gregtech/loaders/postload/recipes/AssemblyLineRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/AssemblyLineRecipes.java
@@ -976,5 +976,26 @@ public class AssemblyLineRecipes implements Runnable {
             .eut(TierEU.RECIPE_ZPM / 2)
             .duration(1 * MINUTES)
             .addTo(AssemblyLine);
+
+        GTValues.RA.stdBuilder()
+            .metadata(RESEARCH_ITEM, ItemList.Machine_Multi_LargeChemicalReactor.get(1))
+            .metadata(SCANNING, new Scanning(1 * MINUTES, TierEU.RECIPE_LuV))
+            .itemInputs(
+                ItemList.Machine_Multi_LargeChemicalReactor.get(64),
+                GregtechItemList.ChemicalPlant_Controller.get(4),
+                new Object[] { OrePrefixes.circuit.get(Materials.LuV), 4 },
+                ItemList.Casing_Chemically_Inert.get(8),
+                ItemList.Electric_Pump_LuV.get(4),
+                ItemList.FluidRegulator_LuV.get(4),
+                ItemList.Machine_IV_ChemicalReactor.get(2),
+                GTOreDictUnificator.get(OrePrefixes.wireGt02, Materials.SuperconductorLuV, 16))
+            .fluidInputs(
+                Materials.Lubricant.getFluid(16_000),
+                MaterialsAlloy.INDALLOY_140.getFluidStack(10 * INGOTS),
+                Materials.Naquadah.getMolten(4 * INGOTS))
+            .itemOutputs(ItemList.MegaChemicalReactor.get(1))
+            .eut(TierEU.RECIPE_LuV / 2)
+            .duration(1 * MINUTES)
+            .addTo(AssemblyLine);
     }
 }


### PR DESCRIPTION
Changes the MCR recipe, to make it more in line with the [Mega Distillation Tower](https://github.com/GTNewHorizons/GT5-Unofficial/pull/6868), and eventually the Mega Oil Cracker.

<img width="515" height="495" alt="image" src="https://github.com/user-attachments/assets/af812a27-cf97-4643-86b4-fcadcfb38df1" />

Simple recipe really. All 3 of these megas will have similar luv themed recipes, as they are a trio of some sorts (idk)