### PR TITLE
Fix owner being set to null

### DIFF
--- a/src/main/java/gregtech/common/blocks/ItemMachines.java
+++ b/src/main/java/gregtech/common/blocks/ItemMachines.java
@@ -261,12 +261,12 @@ public class ItemMachines extends ItemBlock implements IFluidContainerItem {
             final IGregTechTileEntity tTileEntity = (IGregTechTileEntity) aWorld.getTileEntity(aX, aY, aZ);
             if (tTileEntity != null) {
                 tTileEntity.setInitialValuesAsNBT(tTileEntity.isServerSide() ? aStack.getTagCompound() : null, tDamage);
-                tTileEntity.setFrontFacing(
-                    BaseTileEntity.getSideForPlayerPlacing(aPlayer, ForgeDirection.UP, tTileEntity.getValidFacings()));
                 if (aPlayer != null) {
                     tTileEntity.setOwnerName(aPlayer.getDisplayName());
                     tTileEntity.setOwnerUuid(aPlayer.getUniqueID());
                 }
+                tTileEntity.setFrontFacing(
+                    BaseTileEntity.getSideForPlayerPlacing(aPlayer, ForgeDirection.UP, tTileEntity.getValidFacings()));
                 final ForgeDirection oppositeSide = side.getOpposite();
                 if (tTileEntity.getMetaTileEntity() instanceof IConnectable connectable) {
                     // If we're connectable, try connecting to whatever we're up against


### PR DESCRIPTION
setFrontFacing have triggered `getProxy` when owner is not yet set.

Caused by:
- #6758 

Supersedes:
- #6808

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24925
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24924
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24931
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24973