### PR TITLE
Fix energy infuser did not output charged draconium blocks to output bus

### DIFF
--- a/src/main/java/tectech/thing/metaTileEntity/multi/MTEEnergyInfuser.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/MTEEnergyInfuser.java
@@ -96,8 +96,9 @@ public class MTEEnergyInfuser extends TTMultiblockBase implements ISurvivalConst
             if (item instanceof IElectricItem) {
                 return ElectricItem.manager.getCharge(stack) >= ((IElectricItem) item).getMaxCharge(stack);
             } else if (Mods.COFHCore.isModLoaded() && item instanceof IEnergyContainerItem) {
-                return ((IEnergyContainerItem) item).getEnergyStored(stack)
-                    >= ((IEnergyContainerItem) item).getMaxEnergyStored(stack);
+                IEnergyContainerItem rfItem = (IEnergyContainerItem) item;
+                return rfItem.getEnergyStored(stack) >= rfItem.getMaxEnergyStored(stack)
+                    || rfItem.receiveEnergy(stack, 1, true) == 0;
             }
         }
         return true;


### PR DESCRIPTION
Cause: The old isItemStackFullyCharged() in MTEEnergyInfuser only checked getEnergyStored >= getMaxEnergyStored, which evaluates to 0 >= capacity = false. The machine then entered an infinite loop: "charging" the item (which now returns 0 for receiveEnergy since getItemDamage() != 0), never outputting it.

fix: For the transformed (damage=2) item, receiveEnergy(stack, 1, true) returns 0 immediately (the early-exit if (container.getItemDamage() != 0) return 0 in DraconiumItemBlock), so the check correctly identifies it as fully charged and moves it to the output bus.
This mirrors exactly the logic already used by DE's own TileEnergyInfuser.canExtractItem().

