### PR TITLE
Allow for looting mechanic to work in EEC for the staballoy construct

### DIFF
--- a/src/main/java/gtPlusPlus/core/entity/monster/EntityStaballoyConstruct.java
+++ b/src/main/java/gtPlusPlus/core/entity/monster/EntityStaballoyConstruct.java
@@ -62,7 +62,7 @@ public class EntityStaballoyConstruct extends EntityIronGolem {
     protected void dropFewItems(boolean p_70628_1_, int p_70628_2_) {
         int flowers = this.rand.nextInt(3);
         int ingots = this.rand.nextInt(3);
-        int lootingLevel = Math.min(p_70628_2_, 3); // hard capping it to 3
+        int lootingLevel = Math.min(p_70628_2_, 4); // hard capping it to 4
 
         for (int i = 0; i < lootingLevel; i++) {
             ingots += this.rand.nextInt(0, 2);

--- a/src/main/java/gtPlusPlus/core/entity/monster/EntityStaballoyConstruct.java
+++ b/src/main/java/gtPlusPlus/core/entity/monster/EntityStaballoyConstruct.java
@@ -62,6 +62,11 @@ public class EntityStaballoyConstruct extends EntityIronGolem {
     protected void dropFewItems(boolean p_70628_1_, int p_70628_2_) {
         int flowers = this.rand.nextInt(3);
         int ingots = this.rand.nextInt(3);
+        int lootingLevel = Math.min(p_70628_2_, 3); // hard capping it to 3
+
+        for (int i = 0; i < lootingLevel; i++) {
+            ingots += this.rand.nextInt(0, 2);
+        }
 
         if (flowers > 0) {
             this.func_145778_a(Item.getItemFromBlock(Blocks.yellow_flower), flowers, 0.0F);


### PR DESCRIPTION
We wanted to nerf the staballoy to avoid the looting mechanic, but i have done some testing on D545, and it's 15.6 seconds per cycle, given the loot allowed between 0 and 2 ingots per kill, that's 3231 ingots for 14h on average, which corresponds to 323 titanium and 2908 uranium. This is a tad too low, given we do not explain everywhere that looting III does not work in the EEC.

I suggest instead to cap the looting at level 3 in the code, so we still avoid the looting spike exploit to abuse it, and that way we make it compatible again with the looting mechanic of the EEC and people have another way to buff a bit their production than EEC spam. I added a 50% chance to pull a new ingot per looting level, so the average per kill goes from 1 with 0 looting to 3 with looting IV. To compare with the same duration i used in my play through, that would shift from 3231 to 9693 staballoy ingots, and from 323 to 969 titanium dusts. That seems more honest.