### PR TITLE
increase durability of mutagenic frames

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/forestry/bees/items/MBFrameType.java
+++ b/src/main/java/gtPlusPlus/xmod/forestry/bees/items/MBFrameType.java
@@ -17,7 +17,7 @@ public enum MBFrameType implements IBeeModifier {
     // Name, FrameHP, territory (1f), Mutation rate, lifespan rate, production rate, genetic decay (1f)
     ACCELERATED("Accelerated", 175, 1f, 1.2f, 0.9f, 0.8f, 1f), // production was 1.8x, now +0.8
     VOID("Void", 20, 1f, 1f, 0.0001f, 9f, 1f), // production was 10x, now +9
-    MUTAGENIC("Mutagenic", 3, 1f, 5f, 0.0001f, 9f, 1f), // production was 10x, now +9
+    MUTAGENIC("Mutagenic", 20, 1f, 5f, 0.0001f, 9f, 1f), // production was 10x, now +9
     BUSY("Busy", 2000, 1f, 0f, 3f, 3f, 1f), // production was 4x, now +3
     USELESS("Useless", 100, 1f, 0f, 1f, 0f, 1f), // production was 1x, now +0
 


### PR DESCRIPTION
I passed the proposal (https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1786) through meta dev, and currently it seems most people that responded are inclined to remove the soulful wax and the magical frame from the bag (remove the rng).

Imo, this should come with a buff to the durability of the mutagenic frame, so it's not dogshit to use enmasse.

Gives people the option to:
1. find oblivion in stronghold (3 per world, so at least 1 is basically guaranteed)
2. Do bees raw (stone to lv/mv before they have power for a WA or two) until they can get either alveary or other frame to make cycles faster
3. wait until they have some tech, and then do bees with mutagenic frames (Which if dura is increased won't be bad. They currently only offer 3 uses, since they don't work on their last durability point.)

I think this works well enough for tech tiering? Stone to steam is raw, lv has WA and some of the magic bees frames, mv has alveary and elec stims, hv has BM frames, industrial apiary, and eyes of ender to find oblivion frames, ev has mutagenic (pain to get), and iv to luv make mutagenic more reasonable. Obv WA is applicable to every tier.

This, if nothing else, lines up with how tech tiering allows skips if you're sufficiently above the entry threshold for the mod. 


Another pr will be required to remove mentions of mutagenic having 3 durability, as well as removing soul combs and magic frames from qb bags. (https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/pull/25016)