### PR TITLE
Beamcrafter hatch priority fixes and disallow CRIBs

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/beamcrafting/MTEBeamCrafter.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/beamcrafting/MTEBeamCrafter.java
@@ -419,6 +419,11 @@ public class MTEBeamCrafter extends MTEBeamMultiBase<MTEBeamCrafter> implements 
     }
 
     @Override
+    public boolean supportsCraftingMEBuffer() {
+        return false;
+    }
+
+    @Override
     public @NotNull CheckRecipeResult checkProcessing() {
         this.currentRecipeMaxAmountA = 0;
         this.currentRecipeMaxAmountB = 0;

--- a/src/main/java/gregtech/common/tileentities/machines/multi/beamcrafting/MTEBeamCrafter.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/beamcrafting/MTEBeamCrafter.java
@@ -438,7 +438,6 @@ public class MTEBeamCrafter extends MTEBeamMultiBase<MTEBeamCrafter> implements 
             .fluids(inputFluids)
             .voltage(tVoltageActual)
             .filter((GTRecipe recipe) -> (recipe.getMetadata(BEAMCRAFTER_METADATA) != null))
-            .cachedRecipe(this.lastRecipe)
             .find();
         if (tRecipe == null) return CheckRecipeResultRegistry.NO_RECIPE;
 


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24780

This change allows the beamcrafter to passively do one recipe and then switch to another recipe on demand by using hatch colour priority by removing lastRecipe caching

Also disable CRIBs as part of the structure because I don't know how to make it work :( someone else is welcome to pick this up or teach me lol
