### PR TITLE
Fix missing texture in block renderer

### DIFF
--- a/src/main/java/gregtech/common/blocks/BlockRenderer.java
+++ b/src/main/java/gregtech/common/blocks/BlockRenderer.java
@@ -95,4 +95,9 @@ public class BlockRenderer<T extends TileEntity> extends Block {
     public AxisAlignedBB getSelectedBoundingBoxFromPool(World worldIn, int x, int y, int z) {
         return null;
     }
+
+    @Override
+    public int getRenderType() {
+        return -1;
+    }
 }


### PR DESCRIPTION
Blocks using BlockRenderer have a custom render and don't have any block texture

Before:
<img width="856" height="512" alt="image" src="https://github.com/user-attachments/assets/034863b2-eac2-455b-ae7a-39bcda5e8d17" />

After:
<img width="856" height="512" alt="image" src="https://github.com/user-attachments/assets/b236ebaa-c7ec-4841-944b-8661891b964c" />
