### PR TITLE
Fix crash when accessing a TileEntity in a GTDummyWorld

### DIFF
--- a/src/main/java/gregtech/common/GTDummyWorld.java
+++ b/src/main/java/gregtech/common/GTDummyWorld.java
@@ -8,6 +8,7 @@ import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.profiler.Profiler;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldProvider;
 import net.minecraft.world.WorldSettings;
@@ -134,5 +135,10 @@ public class GTDummyWorld extends World {
     @Override
     protected int func_152379_p() {
         return 0;
+    }
+
+    @Override
+    public TileEntity getTileEntity(int x, int y, int z) {
+        return null;
     }
 }


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/23998

Note: This doesn't make infused seeds usable in the EIG. Just stops the crash