### PR TITLE
Add missing MTE ID registration for industial farm

### DIFF
--- a/src/main/java/gregtech/api/enums/MetaTileEntityIDs.java
+++ b/src/main/java/gregtech/api/enums/MetaTileEntityIDs.java
@@ -1906,6 +1906,7 @@ public enum MetaTileEntityIDs {
     CropsNHCropSynthesizerUEV(28052),
     CropsNHCropSynthesizerUIV(28053),
     CropsNHCropSynthesizerUMV(28054),
+    CropsNHIndustrialFarm(28055),
     MAGLEV_PYLON_MV(29990),
     MAGLEV_PYLON_HV(29991),
     MAGLEV_PYLON_EV(29992),


### PR DESCRIPTION
Adds a missing MTE ID registration for CropsNH's Industrial farm.

proof of usage: https://github.com/GTNewHorizons/CropsNH/blob/89cf9d3c19d270c4325933f94a3ad3dbc3bf29f6/src/main/java/com/gtnewhorizon/cropsnh/loaders/MTELoader.java#L163