### PR TITLE
Add CTM support for BlockMachines

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -144,7 +144,7 @@ dependencies {
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Electro-Magic-Tools:1.7.21:dev") { transitive = false }
 
     // For testing ctm
-    runtimeOnlyNonPublishable('com.github.GTNewHorizons:Angelica:2.1.26:dev') { transitive = false }
+    runtimeOnlyNonPublishable('com.github.GTNewHorizons:Angelica:2.1.33:dev') { transitive = false }
 
     // Speeds up mod identification and loading in dev
     runtimeOnlyNonPublishable(rfg.deobf("com.github.GTNewHorizons:CoreTweaks:0.3.4.6-GTNH"))

--- a/src/main/java/gregtech/api/interfaces/tileentity/ICasingTextureProvider.java
+++ b/src/main/java/gregtech/api/interfaces/tileentity/ICasingTextureProvider.java
@@ -1,0 +1,9 @@
+package gregtech.api.interfaces.tileentity;
+
+import gregtech.api.interfaces.ITexture;
+
+public interface ICasingTextureProvider {
+
+    ITexture getCasingTexture();
+
+}

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEHatch.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEHatch.java
@@ -17,6 +17,7 @@ import gregtech.api.enums.GTAuthors;
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.Textures;
 import gregtech.api.interfaces.ITexture;
+import gregtech.api.interfaces.tileentity.ICasingTextureProvider;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.util.GTSplit;
 import gregtech.api.util.GTUtility;
@@ -25,7 +26,7 @@ import gregtech.api.util.tooltip.TooltipHelper;
 /**
  * Handles texture changes internally. No special calls are necessary other than updateTexture in add***ToMachineList.
  */
-public abstract class MTEHatch extends MTEBasicTank {
+public abstract class MTEHatch extends MTEBasicTank implements ICasingTextureProvider {
 
     public enum ConnectionType {
         CABLE,
@@ -82,11 +83,9 @@ public abstract class MTEHatch extends MTEBasicTank {
         int colorIndex, boolean aActive, boolean redstoneLevel) {
 
         try {
-            ITexture background;
+            ITexture background = getCasingTexture();
 
-            if (texturePage > 0 || textureIndex > 0) {
-                background = Textures.BlockIcons.casingTexturePages[texturePage][textureIndex];
-            } else {
+            if (background == null) {
                 background = Textures.BlockIcons.MACHINE_CASINGS[mTier][colorIndex + 1];
             }
 
@@ -102,6 +101,14 @@ public abstract class MTEHatch extends MTEBasicTank {
         } catch (NullPointerException npe) {
             return new ITexture[] { Textures.BlockIcons.MACHINE_CASINGS[0][0] };
         }
+    }
+
+    @Override
+    public ITexture getCasingTexture() {
+        if (texturePage > 0 || textureIndex > 0) {
+            return Textures.BlockIcons.casingTexturePages[texturePage][textureIndex];
+        }
+        return null;
     }
 
     @Override

--- a/src/main/java/gregtech/common/blocks/BlockMachines.java
+++ b/src/main/java/gregtech/common/blocks/BlockMachines.java
@@ -44,6 +44,7 @@ import gregtech.api.interfaces.IDebugableBlock;
 import gregtech.api.interfaces.IIconContainer;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
+import gregtech.api.interfaces.tileentity.ICasingTextureProvider;
 import gregtech.api.interfaces.tileentity.IColoredTileEntity;
 import gregtech.api.interfaces.tileentity.ICoverable;
 import gregtech.api.interfaces.tileentity.IDebugableTileEntity;
@@ -57,6 +58,7 @@ import gregtech.api.metatileentity.CoverableTileEntity;
 import gregtech.api.util.GTLog;
 import gregtech.api.util.GTUtility;
 import gregtech.common.covers.Cover;
+import gregtech.common.render.GTCopiedBlockTextureRender;
 import gregtech.common.render.GTRendererBlock;
 import gregtech.common.tileentities.storage.MTEQuantumChest;
 import gtPlusPlus.xmod.gregtech.common.tileentities.redstone.MTERedstoneLamp;
@@ -255,7 +257,15 @@ public class BlockMachines extends GTGenericBlock implements IDebugableBlock, IT
 
     @SideOnly(Side.CLIENT)
     @Override
-    public IIcon getIcon(IBlockAccess aIBlockAccess, int aX, int aY, int aZ, int ordinalSide) {
+    public IIcon getIcon(IBlockAccess blockAccess, int x, int y, int z, int ordinalSide) {
+        final TileEntity tTileEntity = blockAccess.getTileEntity(x, y, z);
+        if (tTileEntity instanceof BaseMetaTileEntity tile) {
+            if (tile.getMetaTileEntity() instanceof ICasingTextureProvider textureProvider) {
+                if (textureProvider.getCasingTexture() instanceof GTCopiedBlockTextureRender tex) {
+                    return tex.getIcon(ordinalSide, null);
+                }
+            }
+        }
         return Textures.BlockIcons.MACHINE_LV_SIDE.getIcon();
     }
 

--- a/src/main/java/gregtech/common/render/GTCopiedBlockTextureRender.java
+++ b/src/main/java/gregtech/common/render/GTCopiedBlockTextureRender.java
@@ -27,7 +27,7 @@ public class GTCopiedBlockTextureRender extends GTTextureBase implements IBlockC
         mMeta = aMeta;
     }
 
-    private IIcon getIcon(int ordinalSide, ISBRContext ctx) {
+    public IIcon getIcon(int ordinalSide, ISBRContext ctx) {
         final IIcon icon;
         if (mSide == 6) icon = mBlock.getIcon(ordinalSide, mMeta);
         else icon = mBlock.getIcon(mSide, mMeta);

--- a/src/main/java/gregtech/common/render/SBRWorldContext.java
+++ b/src/main/java/gregtech/common/render/SBRWorldContext.java
@@ -49,6 +49,8 @@ public final class SBRWorldContext extends SBRContextBase implements ISBRWorldCo
      */
     private static final double FLUSH_MAX = 0.999D;
 
+    private static final double LAYER_OFFSET = 0.001D;
+
     /**
      * Mixed Brightness cache
      * <p>
@@ -216,8 +218,8 @@ public final class SBRWorldContext extends SBRContextBase implements ISBRWorldCo
         final double origMinY = renderBlocks.renderMinY;
         for (ITexture layer : tex) {
             if (layer == null || !layer.isValidTexture()) continue;
-            renderBlocks.renderMinY = Math.nextDown(renderBlocks.renderMinY);
             layer.renderYNeg(this);
+            renderBlocks.renderMinY -= LAYER_OFFSET;
         }
         renderBlocks.renderMinY = origMinY;
     }
@@ -231,8 +233,8 @@ public final class SBRWorldContext extends SBRContextBase implements ISBRWorldCo
         final double origMaxY = renderBlocks.renderMaxY;
         for (ITexture layer : tex) {
             if (layer == null || !layer.isValidTexture()) continue;
-            renderBlocks.renderMaxY = Math.nextUp(renderBlocks.renderMaxY);
             layer.renderYPos(this);
+            renderBlocks.renderMaxY += LAYER_OFFSET;
         }
         renderBlocks.renderMaxY = origMaxY;
     }
@@ -246,8 +248,8 @@ public final class SBRWorldContext extends SBRContextBase implements ISBRWorldCo
         final double origMinZ = renderBlocks.renderMinZ;
         for (ITexture layer : tex) {
             if (layer == null || !layer.isValidTexture()) continue;
-            renderBlocks.renderMinZ = Math.nextDown(renderBlocks.renderMinZ);
             layer.renderZNeg(this);
+            renderBlocks.renderMinZ -= LAYER_OFFSET;
         }
         renderBlocks.renderMinZ = origMinZ;
     }
@@ -261,8 +263,8 @@ public final class SBRWorldContext extends SBRContextBase implements ISBRWorldCo
         final double origMaxZ = renderBlocks.renderMaxZ;
         for (ITexture layer : tex) {
             if (layer == null || !layer.isValidTexture()) continue;
-            renderBlocks.renderMaxZ = Math.nextUp(renderBlocks.renderMaxZ);
             layer.renderZPos(this);
+            renderBlocks.renderMaxZ += LAYER_OFFSET;
         }
         renderBlocks.renderMaxZ = origMaxZ;
     }
@@ -276,8 +278,8 @@ public final class SBRWorldContext extends SBRContextBase implements ISBRWorldCo
         final double origMinX = renderBlocks.renderMinX;
         for (ITexture layer : tex) {
             if (layer == null || !layer.isValidTexture()) continue;
-            renderBlocks.renderMinX = Math.nextDown(renderBlocks.renderMinX);
             layer.renderXNeg(this);
+            renderBlocks.renderMinX -= LAYER_OFFSET;
         }
         renderBlocks.renderMinX = origMinX;
     }
@@ -291,8 +293,8 @@ public final class SBRWorldContext extends SBRContextBase implements ISBRWorldCo
         final double origMaxX = renderBlocks.renderMaxX;
         for (ITexture layer : tex) {
             if (layer == null || !layer.isValidTexture()) continue;
-            renderBlocks.renderMaxX = Math.nextUp(renderBlocks.renderMaxX);
             layer.renderXPos(this);
+            renderBlocks.renderMaxX += LAYER_OFFSET;
         }
         renderBlocks.renderMaxX = origMaxX;
     }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEAlgaePond.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEAlgaePond.java
@@ -41,6 +41,7 @@ import gregtech.api.enums.SoundResource;
 import gregtech.api.enums.VoltageIndex;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
+import gregtech.api.interfaces.tileentity.ICasingTextureProvider;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.logic.ProcessingLogic;
 import gregtech.api.metatileentity.implementations.MTEExtendedPowerMultiBlockBase;
@@ -62,7 +63,8 @@ import gtPlusPlus.api.recipe.GTPPRecipeMaps;
 import gtPlusPlus.xmod.gregtech.api.enums.GregtechItemList;
 import gtPlusPlus.xmod.gregtech.common.blocks.textures.TexturesGtBlock;
 
-public class MTEAlgaePond extends MTEExtendedPowerMultiBlockBase<MTEAlgaePond> implements ISurvivalConstructable {
+public class MTEAlgaePond extends MTEExtendedPowerMultiBlockBase<MTEAlgaePond>
+    implements ISurvivalConstructable, ICasingTextureProvider {
 
     private static final int OFFSET_X = 1;
     private static final int OFFSET_Y = 3;
@@ -216,7 +218,7 @@ public class MTEAlgaePond extends MTEExtendedPowerMultiBlockBase<MTEAlgaePond> i
     public ITexture[] getTexture(IGregTechTileEntity aBaseMetaTileEntity, ForgeDirection side, ForgeDirection aFacing,
         int colorIndex, boolean aActive, boolean redstoneLevel) {
         if (side == aFacing) {
-            if (aActive) return new ITexture[] { Casings.AlgaeCasing.getCasingTexture(), TextureFactory.builder()
+            if (aActive) return new ITexture[] { getCasingTexture(), TextureFactory.builder()
                 .addIcon(TexturesGtBlock.oMCDAlgaePondBaseActive)
                 .extFacing()
                 .build(),
@@ -225,7 +227,7 @@ public class MTEAlgaePond extends MTEExtendedPowerMultiBlockBase<MTEAlgaePond> i
                     .extFacing()
                     .glow()
                     .build() };
-            return new ITexture[] { Casings.AlgaeCasing.getCasingTexture(), TextureFactory.builder()
+            return new ITexture[] { getCasingTexture(), TextureFactory.builder()
                 .addIcon(TexturesGtBlock.oMCDAlgaePondBase)
                 .extFacing()
                 .build(),
@@ -235,7 +237,12 @@ public class MTEAlgaePond extends MTEExtendedPowerMultiBlockBase<MTEAlgaePond> i
                     .glow()
                     .build() };
         }
-        return new ITexture[] { Casings.AlgaeCasing.getCasingTexture() };
+        return new ITexture[] { getCasingTexture() };
+    }
+
+    @Override
+    public ITexture getCasingTexture() {
+        return Casings.AlgaeCasing.getCasingTexture();
     }
 
     @Override

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEEndothermicFridge.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEEndothermicFridge.java
@@ -57,6 +57,7 @@ import gregtech.api.enums.SoundResource;
 import gregtech.api.enums.Textures;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
+import gregtech.api.interfaces.tileentity.ICasingTextureProvider;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.logic.ProcessingLogic;
 import gregtech.api.metatileentity.implementations.MTEExtendedPowerMultiBlockBase;
@@ -79,7 +80,7 @@ import mcp.mobius.waila.api.IWailaConfigHandler;
 import mcp.mobius.waila.api.IWailaDataAccessor;
 
 public class MTEEndothermicFridge extends MTEExtendedPowerMultiBlockBase<MTEEndothermicFridge>
-    implements ISurvivalConstructable {
+    implements ISurvivalConstructable, ICasingTextureProvider {
 
     private static final String STRUCTURE_PIECE_MAIN = "main";
     private static final int HORIZONTAL_OFFSET = 11;
@@ -553,22 +554,20 @@ public class MTEEndothermicFridge extends MTEExtendedPowerMultiBlockBase<MTEEndo
         ITexture[] rTexture;
         if (side == aFacing) {
             if (aActive) {
-                rTexture = new ITexture[] { Textures.BlockIcons.getCasingTextureForId(TEXTURE_ID),
-                    TextureFactory.builder()
-                        .addIcon(OVERLAY_FRONT_FRIDGE_ACTIVE)
-                        .extFacing()
-                        .build(),
+                rTexture = new ITexture[] { getCasingTexture(), TextureFactory.builder()
+                    .addIcon(OVERLAY_FRONT_FRIDGE_ACTIVE)
+                    .extFacing()
+                    .build(),
                     TextureFactory.builder()
                         .addIcon(OVERLAY_FRONT_FRIDGE_ACTIVE_GLOW)
                         .extFacing()
                         .glow()
                         .build() };
             } else {
-                rTexture = new ITexture[] { Textures.BlockIcons.getCasingTextureForId(TEXTURE_ID),
-                    TextureFactory.builder()
-                        .addIcon(OVERLAY_FRONT_FRIDGE)
-                        .extFacing()
-                        .build(),
+                rTexture = new ITexture[] { getCasingTexture(), TextureFactory.builder()
+                    .addIcon(OVERLAY_FRONT_FRIDGE)
+                    .extFacing()
+                    .build(),
                     TextureFactory.builder()
                         .addIcon(OVERLAY_FRONT_FRIDGE_GLOW)
                         .extFacing()
@@ -576,9 +575,14 @@ public class MTEEndothermicFridge extends MTEExtendedPowerMultiBlockBase<MTEEndo
                         .build() };
             }
         } else {
-            rTexture = new ITexture[] { Textures.BlockIcons.getCasingTextureForId(TEXTURE_ID) };
+            rTexture = new ITexture[] { getCasingTexture() };
         }
         return rTexture;
+    }
+
+    @Override
+    public ITexture getCasingTexture() {
+        return Textures.BlockIcons.getCasingTextureForId(TEXTURE_ID);
     }
 
     @SideOnly(Side.CLIENT)

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEExothermicHearth.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEExothermicHearth.java
@@ -55,6 +55,7 @@ import gregtech.api.enums.Textures;
 import gregtech.api.enums.VoltageIndex;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
+import gregtech.api.interfaces.tileentity.ICasingTextureProvider;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.logic.ProcessingLogic;
 import gregtech.api.metatileentity.implementations.MTEExtendedPowerMultiBlockBase;
@@ -83,7 +84,7 @@ import mcp.mobius.waila.api.IWailaConfigHandler;
 import mcp.mobius.waila.api.IWailaDataAccessor;
 
 public class MTEExothermicHearth extends MTEExtendedPowerMultiBlockBase<MTEExothermicHearth>
-    implements ISurvivalConstructable {
+    implements ISurvivalConstructable, ICasingTextureProvider {
 
     private static final String STRUCTURE_PIECE_MAIN = "main";
     private static final int VERTICAL_OFFSET = 39;
@@ -443,24 +444,20 @@ public class MTEExothermicHearth extends MTEExtendedPowerMultiBlockBase<MTEExoth
         ITexture[] rTexture;
         if (side == aFacing) {
             if (aActive) {
-                rTexture = new ITexture[] {
-                    Textures.BlockIcons.getCasingTextureForId(Casings.HearthCasing.getTextureId()),
-                    TextureFactory.builder()
-                        .addIcon(OVERLAY_FRONT_HEARTH_ACTIVE)
-                        .extFacing()
-                        .build(),
+                rTexture = new ITexture[] { getCasingTexture(), TextureFactory.builder()
+                    .addIcon(OVERLAY_FRONT_HEARTH_ACTIVE)
+                    .extFacing()
+                    .build(),
                     TextureFactory.builder()
                         .addIcon(OVERLAY_FRONT_HEARTH_ACTIVE_GLOW)
                         .extFacing()
                         .glow()
                         .build() };
             } else {
-                rTexture = new ITexture[] {
-                    Textures.BlockIcons.getCasingTextureForId(Casings.HearthCasing.getTextureId()),
-                    TextureFactory.builder()
-                        .addIcon(OVERLAY_FRONT_HEARTH)
-                        .extFacing()
-                        .build(),
+                rTexture = new ITexture[] { getCasingTexture(), TextureFactory.builder()
+                    .addIcon(OVERLAY_FRONT_HEARTH)
+                    .extFacing()
+                    .build(),
                     TextureFactory.builder()
                         .addIcon(OVERLAY_FRONT_HEARTH_GLOW)
                         .extFacing()
@@ -468,10 +465,14 @@ public class MTEExothermicHearth extends MTEExtendedPowerMultiBlockBase<MTEExoth
                         .build() };
             }
         } else {
-            rTexture = new ITexture[] {
-                Textures.BlockIcons.getCasingTextureForId(Casings.HearthCasing.getTextureId()) };
+            rTexture = new ITexture[] { getCasingTexture() };
         }
         return rTexture;
+    }
+
+    @Override
+    public ITexture getCasingTexture() {
+        return Textures.BlockIcons.getCasingTextureForId(Casings.HearthCasing.getTextureId());
     }
 
     int casingAmount = 0;

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialLaserEngraver.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialLaserEngraver.java
@@ -40,6 +40,7 @@ import gregtech.api.enums.Textures;
 import gregtech.api.enums.VoltageIndex;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
+import gregtech.api.interfaces.tileentity.ICasingTextureProvider;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.logic.ProcessingLogic;
 import gregtech.api.metatileentity.implementations.MTEExtendedPowerMultiBlockBase;
@@ -65,7 +66,7 @@ import mcp.mobius.waila.api.IWailaDataAccessor;
 import tectech.thing.metaTileEntity.hatch.MTEHatchDynamoTunnel;
 
 public class MTEIndustrialLaserEngraver extends MTEExtendedPowerMultiBlockBase<MTEIndustrialLaserEngraver>
-    implements ISurvivalConstructable {
+    implements ISurvivalConstructable, ICasingTextureProvider {
 
     private static final String STRUCTURE_PIECE_MAIN = "main";
     private static final IStructureDefinition<MTEIndustrialLaserEngraver> STRUCTURE_DEFINITION = StructureDefinition
@@ -154,26 +155,20 @@ public class MTEIndustrialLaserEngraver extends MTEExtendedPowerMultiBlockBase<M
         ITexture[] rTexture;
         if (side == aFacing) {
             if (aActive) {
-                rTexture = new ITexture[] {
-                    Textures.BlockIcons
-                        .getCasingTextureForId(GTUtility.getCasingTextureIndex(GregTechAPI.sBlockCasings10, 1)),
-                    TextureFactory.builder()
-                        .addIcon(OVERLAY_FRONT_ENGRAVER_ACTIVE)
-                        .extFacing()
-                        .build(),
+                rTexture = new ITexture[] { getCasingTexture(), TextureFactory.builder()
+                    .addIcon(OVERLAY_FRONT_ENGRAVER_ACTIVE)
+                    .extFacing()
+                    .build(),
                     TextureFactory.builder()
                         .addIcon(OVERLAY_FRONT_ENGRAVER_ACTIVE_GLOW)
                         .extFacing()
                         .glow()
                         .build() };
             } else {
-                rTexture = new ITexture[] {
-                    Textures.BlockIcons
-                        .getCasingTextureForId(GTUtility.getCasingTextureIndex(GregTechAPI.sBlockCasings10, 1)),
-                    TextureFactory.builder()
-                        .addIcon(OVERLAY_FRONT_ENGRAVER)
-                        .extFacing()
-                        .build(),
+                rTexture = new ITexture[] { getCasingTexture(), TextureFactory.builder()
+                    .addIcon(OVERLAY_FRONT_ENGRAVER)
+                    .extFacing()
+                    .build(),
                     TextureFactory.builder()
                         .addIcon(OVERLAY_FRONT_ENGRAVER_GLOW)
                         .extFacing()
@@ -181,10 +176,15 @@ public class MTEIndustrialLaserEngraver extends MTEExtendedPowerMultiBlockBase<M
                         .build() };
             }
         } else {
-            rTexture = new ITexture[] { Textures.BlockIcons
-                .getCasingTextureForId(GTUtility.getCasingTextureIndex(GregTechAPI.sBlockCasings10, 1)) };
+            rTexture = new ITexture[] { getCasingTexture() };
         }
         return rTexture;
+    }
+
+    @Override
+    public ITexture getCasingTexture() {
+        return Textures.BlockIcons
+            .getCasingTextureForId(GTUtility.getCasingTextureIndex(GregTechAPI.sBlockCasings10, 1));
     }
 
     private boolean stopAllRendering = false;

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEMegaDistillationTower.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEMegaDistillationTower.java
@@ -47,6 +47,7 @@ import gregtech.api.interfaces.IHatchElement;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.fluid.IFluidStore;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
+import gregtech.api.interfaces.tileentity.ICasingTextureProvider;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.logic.ProcessingLogic;
 import gregtech.api.metatileentity.implementations.MTEExtendedPowerMultiBlockBase;
@@ -64,7 +65,7 @@ import gregtech.common.misc.GTStructureChannels;
 import gregtech.common.tileentities.machines.outputme.MTEHatchOutputME;
 
 public class MTEMegaDistillationTower extends MTEExtendedPowerMultiBlockBase<MTEMegaDistillationTower>
-    implements ISurvivalConstructable {
+    implements ISurvivalConstructable, ICasingTextureProvider {
 
     private static final int MACHINEMODE_TOWER = 0;
     private static final int MACHINEMODE_DISTILLERY = 1;
@@ -624,31 +625,30 @@ public class MTEMegaDistillationTower extends MTEExtendedPowerMultiBlockBase<MTE
     public ITexture[] getTexture(IGregTechTileEntity aBaseMetaTileEntity, ForgeDirection side, ForgeDirection facing,
         int aColorIndex, boolean aActive, boolean aRedstone) {
         if (side == facing) {
-            if (aActive) return new ITexture[] {
-                Textures.BlockIcons.getCasingTextureForId(Casings.NaquadahReinforcedDistillationCasing.getTextureId()),
-                TextureFactory.builder()
-                    .addIcon(OVERLAY_FRONT_MEGA_DISTILLATION_TOWER_ACTIVE)
-                    .extFacing()
-                    .build(),
+            if (aActive) return new ITexture[] { getCasingTexture(), TextureFactory.builder()
+                .addIcon(OVERLAY_FRONT_MEGA_DISTILLATION_TOWER_ACTIVE)
+                .extFacing()
+                .build(),
                 TextureFactory.builder()
                     .addIcon(OVERLAY_FRONT_MEGA_DISTILLATION_TOWER_ACTIVE_GLOW)
                     .extFacing()
                     .glow()
                     .build() };
-            return new ITexture[] {
-                Textures.BlockIcons.getCasingTextureForId(Casings.NaquadahReinforcedDistillationCasing.getTextureId()),
-                TextureFactory.builder()
-                    .addIcon(OVERLAY_FRONT_MEGA_DISTILLATION_TOWER)
-                    .extFacing()
-                    .build(),
+            return new ITexture[] { getCasingTexture(), TextureFactory.builder()
+                .addIcon(OVERLAY_FRONT_MEGA_DISTILLATION_TOWER)
+                .extFacing()
+                .build(),
                 TextureFactory.builder()
                     .addIcon(OVERLAY_FRONT_MEGA_DISTILLATION_TOWER_GLOW)
                     .extFacing()
                     .glow()
                     .build() };
         }
-        return new ITexture[] {
-            Textures.BlockIcons.getCasingTextureForId(Casings.NaquadahReinforcedDistillationCasing.getTextureId()) };
+        return new ITexture[] { getCasingTexture() };
     }
 
+    @Override
+    public ITexture getCasingTexture() {
+        return Textures.BlockIcons.getCasingTextureForId(Casings.NaquadahReinforcedDistillationCasing.getTextureId());
+    }
 }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTETreeFarm.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTETreeFarm.java
@@ -63,6 +63,7 @@ import gregtech.api.enums.Materials;
 import gregtech.api.enums.Mods;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
+import gregtech.api.interfaces.tileentity.ICasingTextureProvider;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.items.MetaGeneratedTool;
 import gregtech.api.logic.ProcessingLogic;
@@ -88,7 +89,8 @@ import gtPlusPlus.api.recipe.GTPPRecipeMaps;
 import gtPlusPlus.xmod.gregtech.common.blocks.textures.TexturesGtBlock;
 import gtPlusPlus.xmod.gregtech.loaders.recipe.RecipeLoaderTreeFarm;
 
-public class MTETreeFarm extends MTEExtendedPowerMultiBlockBase<MTETreeFarm> implements ISurvivalConstructable {
+public class MTETreeFarm extends MTEExtendedPowerMultiBlockBase<MTETreeFarm>
+    implements ISurvivalConstructable, ICasingTextureProvider {
 
     private static final int TICKS_PER_OPERATION = 100;
     private static final int TOOL_DAMAGE_PER_OPERATION = 1;
@@ -165,7 +167,7 @@ public class MTETreeFarm extends MTEExtendedPowerMultiBlockBase<MTETreeFarm> imp
     public ITexture[] getTexture(IGregTechTileEntity aBaseMetaTileEntity, ForgeDirection side, ForgeDirection aFacing,
         int colorIndex, boolean aActive, boolean redstoneLevel) {
         if (side == aFacing) {
-            if (aActive) return new ITexture[] { Casings.SterileFarmCasing.getCasingTexture(), TextureFactory.builder()
+            if (aActive) return new ITexture[] { getCasingTexture(), TextureFactory.builder()
                 .addIcon(TexturesGtBlock.oMCATreeFarmActive)
                 .extFacing()
                 .build(),
@@ -174,7 +176,7 @@ public class MTETreeFarm extends MTEExtendedPowerMultiBlockBase<MTETreeFarm> imp
                     .extFacing()
                     .glow()
                     .build() };
-            return new ITexture[] { Casings.SterileFarmCasing.getCasingTexture(), TextureFactory.builder()
+            return new ITexture[] { getCasingTexture(), TextureFactory.builder()
                 .addIcon(TexturesGtBlock.oMCATreeFarm)
                 .extFacing()
                 .extFacing()
@@ -185,7 +187,12 @@ public class MTETreeFarm extends MTEExtendedPowerMultiBlockBase<MTETreeFarm> imp
                     .glow()
                     .build() };
         }
-        return new ITexture[] { Casings.SterileFarmCasing.getCasingTexture() };
+        return new ITexture[] { getCasingTexture() };
+    }
+
+    @Override
+    public ITexture getCasingTexture() {
+        return Casings.SterileFarmCasing.getCasingTexture();
     }
 
     @Override

--- a/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/MTENanochipAssemblyModuleBase.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/MTENanochipAssemblyModuleBase.java
@@ -40,6 +40,7 @@ import gregtech.api.enums.Textures;
 import gregtech.api.interfaces.IHatchElement;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
+import gregtech.api.interfaces.tileentity.ICasingTextureProvider;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.logic.ProcessingLogic;
 import gregtech.api.metatileentity.implementations.MTEExtendedPowerMultiBlockBase;
@@ -75,8 +76,8 @@ import gregtech.common.tileentities.machines.multi.nanochip.util.VacuumConveyorH
 import mcp.mobius.waila.api.IWailaConfigHandler;
 import mcp.mobius.waila.api.IWailaDataAccessor;
 
-public abstract class MTENanochipAssemblyModuleBase<T extends MTEExtendedPowerMultiBlockBase<T>>
-    extends MTEExtendedPowerMultiBlockBase<T> implements ISurvivalConstructable, NanochipTooltipValues {
+public abstract class MTENanochipAssemblyModuleBase<T extends MTEExtendedPowerMultiBlockBase<T>> extends
+    MTEExtendedPowerMultiBlockBase<T> implements ISurvivalConstructable, NanochipTooltipValues, ICasingTextureProvider {
 
     protected static final String STRUCTURE_PIECE_BASE = "base";
     protected static final String[][] base_structure = new String[][] { { " VV~VV ", "       ", " VVVVV " },
@@ -741,21 +742,19 @@ public abstract class MTENanochipAssemblyModuleBase<T extends MTEExtendedPowerMu
     public ITexture[] getTexture(IGregTechTileEntity aBaseMetaTileEntity, ForgeDirection side, ForgeDirection aFacing,
         int colorIndex, boolean aActive, boolean redstoneLevel) {
         if (side == aFacing) {
-            if (aActive) return new ITexture[] { Textures.BlockIcons.getCasingTextureForId(CASING_INDEX_WHITE),
-                TextureFactory.builder()
-                    .addIcon(OVERLAY_FRONT_DISTILLATION_TOWER_ACTIVE)
-                    .extFacing()
-                    .build(),
+            if (aActive) return new ITexture[] { getCasingTexture(), TextureFactory.builder()
+                .addIcon(OVERLAY_FRONT_DISTILLATION_TOWER_ACTIVE)
+                .extFacing()
+                .build(),
                 TextureFactory.builder()
                     .addIcon(OVERLAY_FRONT_DISTILLATION_TOWER_ACTIVE_GLOW)
                     .extFacing()
                     .glow()
                     .build() };
-            return new ITexture[] { Textures.BlockIcons.getCasingTextureForId(CASING_INDEX_WHITE),
-                TextureFactory.builder()
-                    .addIcon(OVERLAY_FRONT_DISTILLATION_TOWER)
-                    .extFacing()
-                    .build(),
+            return new ITexture[] { getCasingTexture(), TextureFactory.builder()
+                .addIcon(OVERLAY_FRONT_DISTILLATION_TOWER)
+                .extFacing()
+                .build(),
                 TextureFactory.builder()
                     .addIcon(OVERLAY_FRONT_DISTILLATION_TOWER_GLOW)
                     .extFacing()
@@ -763,6 +762,11 @@ public abstract class MTENanochipAssemblyModuleBase<T extends MTEExtendedPowerMu
                     .build() };
         }
         return new ITexture[] { Textures.BlockIcons.getCasingTextureForId(CASING_INDEX_WHITE) };
+    }
+
+    @Override
+    public ITexture getCasingTexture() {
+        return Textures.BlockIcons.getCasingTextureForId(CASING_INDEX_WHITE);
     }
 
     @Override

--- a/src/main/java/kubatech/tileentity/gregtech/multiblock/MTEExtremeIndustrialGreenhouse.java
+++ b/src/main/java/kubatech/tileentity/gregtech/multiblock/MTEExtremeIndustrialGreenhouse.java
@@ -119,6 +119,7 @@ import gregtech.api.enums.VoltageIndex;
 import gregtech.api.gui.modularui.GTUITextures;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
+import gregtech.api.interfaces.tileentity.ICasingTextureProvider;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.GregTechTileClientEvents;
 import gregtech.api.metatileentity.implementations.MTEHatchEnergy;
@@ -146,7 +147,7 @@ import kubatech.tileentity.gregtech.multiblock.eigbuckets.EIGIC2Bucket;
 
 @SuppressWarnings("unused")
 public class MTEExtremeIndustrialGreenhouse extends KubaTechGTMultiBlockBase<MTEExtremeIndustrialGreenhouse>
-    implements ISurvivalConstructable {
+    implements ISurvivalConstructable, ICasingTextureProvider {
 
     /***
      * BALANCE OF THE IC2 MODE: (let T = EIG_BALANCE_IC2_ACCELERATOR_TIER) All IC2 crops are simulated and all drops are
@@ -1461,7 +1462,7 @@ public class MTEExtremeIndustrialGreenhouse extends KubaTechGTMultiBlockBase<MTE
     @Override
     public ITexture[] getTexture(IGregTechTileEntity aBaseMetaTileEntity, ForgeDirection side, ForgeDirection facing,
         int colorIndex, boolean aActive, boolean aRedstone) {
-        final ITexture casingTexture = isOldStructure ? CASING_OLD.getCasingTexture() : CASING.getCasingTexture();
+        final ITexture casingTexture = getCasingTexture();
         if (side == facing) {
             if (aActive) return new ITexture[] { casingTexture, TextureFactory.builder()
                 .addIcon(OVERLAY_FRONT_DISTILLATION_TOWER_ACTIVE)
@@ -1483,6 +1484,11 @@ public class MTEExtremeIndustrialGreenhouse extends KubaTechGTMultiBlockBase<MTE
                     .build() };
         }
         return new ITexture[] { casingTexture };
+    }
+
+    @Override
+    public ITexture getCasingTexture() {
+        return isOldStructure ? CASING_OLD.getCasingTexture() : CASING.getCasingTexture();
     }
 
     @Override

--- a/src/main/resources/assets/gregtech/mcpatcher/ctm/algaecasing/algaecasing.properties
+++ b/src/main/resources/assets/gregtech/mcpatcher/ctm/algaecasing/algaecasing.properties
@@ -1,6 +1,5 @@
-matchBlocks=gregtech:gt.blockcasings12
-metadata=15
+matchTiles=gregtech:iconsets/ALGAE_CASING
 method=compact
 faces=all
 tiles=0-4
-connect=block
+connect=tile

--- a/src/main/resources/assets/gregtech/mcpatcher/ctm/blockcasings14/fridgecasing/fridgecasing.properties
+++ b/src/main/resources/assets/gregtech/mcpatcher/ctm/blockcasings14/fridgecasing/fridgecasing.properties
@@ -1,6 +1,5 @@
-matchBlocks=gregtech:gt.blockcasings14
-metadata=4
+matchTiles=gregtech:iconsets/MACHINE_CASING_FRIDGE_SIDE
 method=compact
 faces=sides
 tiles=0-4
-connect=block
+connect=tile

--- a/src/main/resources/assets/gregtech/mcpatcher/ctm/blockcasings14/hearthcasing/hearthcasing.properties
+++ b/src/main/resources/assets/gregtech/mcpatcher/ctm/blockcasings14/hearthcasing/hearthcasing.properties
@@ -1,6 +1,5 @@
-matchBlocks=gregtech:gt.blockcasings14
-metadata=3
+matchTiles=gregtech:iconsets/MACHINE_CASING_HEARTH_SIDE
 method=compact
 faces=sides
 tiles=0-4
-connect=block
+connect=tile

--- a/src/main/resources/assets/gregtech/mcpatcher/ctm/blockcasings14/naquadahdistillationcasing/naquadahdistillationcasing.properties
+++ b/src/main/resources/assets/gregtech/mcpatcher/ctm/blockcasings14/naquadahdistillationcasing/naquadahdistillationcasing.properties
@@ -1,6 +1,5 @@
-matchBlocks=gregtech:gt.blockcasings14
-metadata=5
+matchTiles=gregtech:iconsets/MACHINE_CASING_NAQUADAH_REINFORCED_DISTILLATION
 method=compact
 faces=all
 tiles=0-4
-connect=block
+connect=tile

--- a/src/main/resources/assets/gregtech/mcpatcher/ctm/lasercasing/laserCasing.properties
+++ b/src/main/resources/assets/gregtech/mcpatcher/ctm/lasercasing/laserCasing.properties
@@ -1,6 +1,5 @@
-matchBlocks=gregtech:gt.blockcasings10
-metadata=1
+matchTiles=gregtech:iconsets/MACHINE_CASING_LASER
 method=compact
 faces=all
 tiles=0-4
-connect=block
+connect=tile

--- a/src/main/resources/assets/gregtech/mcpatcher/ctm/sterilecasing/sterileCasing.properties
+++ b/src/main/resources/assets/gregtech/mcpatcher/ctm/sterilecasing/sterileCasing.properties
@@ -1,6 +1,5 @@
-matchBlocks=miscutils:gtplusplus.blockcasings.2
-metadata=15
+matchTiles=miscutils:TileEntities/sterileCasing
 method=compact
 faces=all
 tiles=0-4
-connect=block
+connect=tile

--- a/src/main/resources/assets/minecraft/mcpatcher/ctm/nanochipmeshinterfacecasing/nanochipmeshinterfacecasing.properties
+++ b/src/main/resources/assets/minecraft/mcpatcher/ctm/nanochipmeshinterfacecasing/nanochipmeshinterfacecasing.properties
@@ -1,6 +1,5 @@
-matchBlocks=gregtech:gt.blockcasings12
-metadata=1
+matchTiles=gregtech:iconsets/NANOCHIP_MESH_INTERFACE_CASING
 method=ctm
 faces=all
 tiles=0-46
-connect=block
+connect=tile


### PR DESCRIPTION
- Adds a new interface `ICasingTextureProvider` which is used in `BlockMachines#getIcon` to return the current background texture
- Changed relevant casing CTMs to connect based on texture rather than block so that hatches and controllers can connect to their casing
- In `SBRWorldContext`, nextUp/nextDown calls were changed to instead add/subtract `LAYER_OFFSET`. This is to fix a z-fighting issue with compact CTM. I noticed no negative side-effects from this change.


<img width="240" height="242" alt="image" src="https://github.com/user-attachments/assets/dafe4579-e2b1-4acb-8be2-e061369d7ae1" />
