### PR TITLE
Fix z-fighting issues for some blocks

### DIFF
--- a/src/main/java/gregtech/common/render/GTCopiedBlockTextureRender.java
+++ b/src/main/java/gregtech/common/render/GTCopiedBlockTextureRender.java
@@ -15,6 +15,8 @@ import gregtech.api.render.ISBRWorldContext;
 
 public class GTCopiedBlockTextureRender extends GTTextureBase implements IBlockContainer {
 
+    private static final double COMPACT_CTM_LAYER_OFFSET = 0.001D;
+
     private final Block mBlock;
     private final byte mSide;
     private final int mMeta;
@@ -42,6 +44,7 @@ public class GTCopiedBlockTextureRender extends GTTextureBase implements IBlockC
     public void renderXPos(ISBRContext ctx) {
         if (!ctx.canRenderInPass(mBlock::canRenderInPass)) return;
         final IIcon aIcon = getIcon(ForgeDirection.EAST.ordinal(), ctx);
+        boolean usesCompactCtm = usesCompactCtm(ctx);
         final RenderBlocks renderBlocks = ctx.getRenderBlocks();
         renderBlocks.field_152631_f = true;
         startDrawingQuads(renderBlocks, 1.0f, 0.0f, 0.0f);
@@ -49,6 +52,7 @@ public class GTCopiedBlockTextureRender extends GTTextureBase implements IBlockC
             .setupColor(ForgeDirection.EAST, 0xffffff);
         renderBlocks.renderFaceXPos(ctx.getBlock(), ctx.getX(), ctx.getY(), ctx.getZ(), aIcon);
         draw(renderBlocks);
+        if (usesCompactCtm) renderBlocks.renderMaxX += COMPACT_CTM_LAYER_OFFSET;
         renderBlocks.field_152631_f = false;
     }
 
@@ -58,10 +62,12 @@ public class GTCopiedBlockTextureRender extends GTTextureBase implements IBlockC
         final RenderBlocks renderBlocks = ctx.getRenderBlocks();
         startDrawingQuads(renderBlocks, -1.0f, 0.0f, 0.0f);
         final IIcon aIcon = getIcon(ForgeDirection.WEST.ordinal(), ctx);
+        boolean usesCompactCtm = usesCompactCtm(ctx);
         ctx.reset()
             .setupColor(ForgeDirection.WEST, 0xffffff);
         renderBlocks.renderFaceXNeg(ctx.getBlock(), ctx.getX(), ctx.getY(), ctx.getZ(), aIcon);
         draw(renderBlocks);
+        if (usesCompactCtm) renderBlocks.renderMinX -= COMPACT_CTM_LAYER_OFFSET;
     }
 
     @Override
@@ -70,10 +76,12 @@ public class GTCopiedBlockTextureRender extends GTTextureBase implements IBlockC
         final RenderBlocks renderBlocks = ctx.getRenderBlocks();
         startDrawingQuads(renderBlocks, 0.0f, 1.0f, 0.0f);
         final IIcon aIcon = getIcon(ForgeDirection.UP.ordinal(), ctx);
+        boolean usesCompactCtm = usesCompactCtm(ctx);
         ctx.reset()
             .setupColor(ForgeDirection.UP, 0xffffff);
         renderBlocks.renderFaceYPos(ctx.getBlock(), ctx.getX(), ctx.getY(), ctx.getZ(), aIcon);
         draw(renderBlocks);
+        if (usesCompactCtm) renderBlocks.renderMaxY += COMPACT_CTM_LAYER_OFFSET;
     }
 
     @Override
@@ -82,10 +90,12 @@ public class GTCopiedBlockTextureRender extends GTTextureBase implements IBlockC
         final RenderBlocks renderBlocks = ctx.getRenderBlocks();
         startDrawingQuads(renderBlocks, 0.0f, -1.0f, 0.0f);
         final IIcon aIcon = getIcon(ForgeDirection.DOWN.ordinal(), ctx);
+        boolean usesCompactCtm = usesCompactCtm(ctx);
         ctx.reset()
             .setupColor(ForgeDirection.DOWN, 0xffffff);
         renderBlocks.renderFaceYNeg(ctx.getBlock(), ctx.getX(), ctx.getY(), ctx.getZ(), aIcon);
         draw(renderBlocks);
+        if (usesCompactCtm) renderBlocks.renderMinY -= COMPACT_CTM_LAYER_OFFSET;
     }
 
     @Override
@@ -94,10 +104,12 @@ public class GTCopiedBlockTextureRender extends GTTextureBase implements IBlockC
         final RenderBlocks renderBlocks = ctx.getRenderBlocks();
         startDrawingQuads(renderBlocks, 0.0f, 0.0f, 1.0f);
         final IIcon aIcon = getIcon(ForgeDirection.SOUTH.ordinal(), ctx);
+        boolean usesCompactCtm = usesCompactCtm(ctx);
         ctx.reset()
             .setupColor(ForgeDirection.SOUTH, 0xffffff);
         renderBlocks.renderFaceZPos(ctx.getBlock(), ctx.getX(), ctx.getY(), ctx.getZ(), aIcon);
         draw(renderBlocks);
+        if (usesCompactCtm) renderBlocks.renderMaxZ += COMPACT_CTM_LAYER_OFFSET;
     }
 
     @Override
@@ -106,12 +118,19 @@ public class GTCopiedBlockTextureRender extends GTTextureBase implements IBlockC
         final RenderBlocks renderBlocks = ctx.getRenderBlocks();
         startDrawingQuads(renderBlocks, 0.0f, 0.0f, -1.0f);
         final IIcon aIcon = getIcon(ForgeDirection.NORTH.ordinal(), ctx);
+        boolean usesCompactCtm = usesCompactCtm(ctx);
         renderBlocks.field_152631_f = true;
         ctx.reset()
             .setupColor(ForgeDirection.NORTH, 0xffffff);
         renderBlocks.renderFaceZNeg(ctx.getBlock(), ctx.getX(), ctx.getY(), ctx.getZ(), aIcon);
         draw(renderBlocks);
         renderBlocks.field_152631_f = false;
+        if (usesCompactCtm) renderBlocks.renderMinZ -= COMPACT_CTM_LAYER_OFFSET;
+    }
+
+    private static boolean usesCompactCtm(ISBRContext ctx) {
+        if (!Angelica.isModLoaded()) return false;
+        return ctx instanceof ISBRWorldContext && CTMUtils.getCurrentCompact() != null;
     }
 
     @Override

--- a/src/main/java/gregtech/common/render/SBRWorldContext.java
+++ b/src/main/java/gregtech/common/render/SBRWorldContext.java
@@ -49,8 +49,6 @@ public final class SBRWorldContext extends SBRContextBase implements ISBRWorldCo
      */
     private static final double FLUSH_MAX = 0.999D;
 
-    private static final double LAYER_OFFSET = 0.001D;
-
     /**
      * Mixed Brightness cache
      * <p>
@@ -218,8 +216,8 @@ public final class SBRWorldContext extends SBRContextBase implements ISBRWorldCo
         final double origMinY = renderBlocks.renderMinY;
         for (ITexture layer : tex) {
             if (layer == null || !layer.isValidTexture()) continue;
+            renderBlocks.renderMinY = Math.nextDown(renderBlocks.renderMinY);
             layer.renderYNeg(this);
-            renderBlocks.renderMinY -= LAYER_OFFSET;
         }
         renderBlocks.renderMinY = origMinY;
     }
@@ -233,8 +231,8 @@ public final class SBRWorldContext extends SBRContextBase implements ISBRWorldCo
         final double origMaxY = renderBlocks.renderMaxY;
         for (ITexture layer : tex) {
             if (layer == null || !layer.isValidTexture()) continue;
+            renderBlocks.renderMaxY = Math.nextUp(renderBlocks.renderMaxY);
             layer.renderYPos(this);
-            renderBlocks.renderMaxY += LAYER_OFFSET;
         }
         renderBlocks.renderMaxY = origMaxY;
     }
@@ -248,8 +246,8 @@ public final class SBRWorldContext extends SBRContextBase implements ISBRWorldCo
         final double origMinZ = renderBlocks.renderMinZ;
         for (ITexture layer : tex) {
             if (layer == null || !layer.isValidTexture()) continue;
+            renderBlocks.renderMinZ = Math.nextDown(renderBlocks.renderMinZ);
             layer.renderZNeg(this);
-            renderBlocks.renderMinZ -= LAYER_OFFSET;
         }
         renderBlocks.renderMinZ = origMinZ;
     }
@@ -263,8 +261,8 @@ public final class SBRWorldContext extends SBRContextBase implements ISBRWorldCo
         final double origMaxZ = renderBlocks.renderMaxZ;
         for (ITexture layer : tex) {
             if (layer == null || !layer.isValidTexture()) continue;
+            renderBlocks.renderMaxZ = Math.nextUp(renderBlocks.renderMaxZ);
             layer.renderZPos(this);
-            renderBlocks.renderMaxZ += LAYER_OFFSET;
         }
         renderBlocks.renderMaxZ = origMaxZ;
     }
@@ -278,8 +276,8 @@ public final class SBRWorldContext extends SBRContextBase implements ISBRWorldCo
         final double origMinX = renderBlocks.renderMinX;
         for (ITexture layer : tex) {
             if (layer == null || !layer.isValidTexture()) continue;
+            renderBlocks.renderMinX = Math.nextDown(renderBlocks.renderMinX);
             layer.renderXNeg(this);
-            renderBlocks.renderMinX -= LAYER_OFFSET;
         }
         renderBlocks.renderMinX = origMinX;
     }
@@ -293,8 +291,8 @@ public final class SBRWorldContext extends SBRContextBase implements ISBRWorldCo
         final double origMaxX = renderBlocks.renderMaxX;
         for (ITexture layer : tex) {
             if (layer == null || !layer.isValidTexture()) continue;
+            renderBlocks.renderMaxX = Math.nextUp(renderBlocks.renderMaxX);
             layer.renderXPos(this);
-            renderBlocks.renderMaxX += LAYER_OFFSET;
         }
         renderBlocks.renderMaxX = origMaxX;
     }


### PR DESCRIPTION
Reverts the z-fighting fix in https://github.com/GTNewHorizons/GT5-Unofficial/pull/7019 and only does that fix if compact CTM is used. 

The reason why compact CTM is different is because compact CTM draws quads using quadrants which causes z-fighting issues with anything drawn on top. 

The compact CTM state is created in the `getIcon` call and cleared in the `renderFace...` call which is why the bool is split like it is 