### PR TITLE
Fix OreInteractEvent not firing from simple left click interaction

### DIFF
--- a/src/main/java/gregtech/common/blocks/GTBlockOre.java
+++ b/src/main/java/gregtech/common/blocks/GTBlockOre.java
@@ -390,6 +390,14 @@ public class GTBlockOre extends GTGenericBlock implements IBlockWithTextures, IB
     }
 
     @Override
+    public void onBlockClicked(World world, int x, int y, int z, EntityPlayer player) {
+        super.onBlockClicked(world, x, y, z, player);
+
+        MinecraftForge.EVENT_BUS
+            .post(new OreInteractEvent(world, x, y, z, this, world.getBlockMetadata(x, y, z), player));
+    }
+
+    @Override
     public void onBlockHarvested(World world, int x, int y, int z, int meta, EntityPlayer player) {
         super.onBlockHarvested(world, x, y, z, meta, player);
 


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25136
Regression caused by https://github.com/GTNewHorizons/VisualProspecting/pull/65

I did a search and doesn't seem to be used by anything else right now so should be fairly safe:
https://github.com/search?q=org%3AGTNewHorizons%20OreInteractEvent&type=code

Will also automatically fix VP side: 
https://github.com/GTNewHorizons/VisualProspecting/blob/master/src/main/java/com/sinthoras/visualprospecting/database/ClientCache.java#L149
