### PR TITLE
fix beam mirror orientations once & for all hopefully

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/beamcrafting/MTEBeamMirror.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/beamcrafting/MTEBeamMirror.java
@@ -263,22 +263,10 @@ public class MTEBeamMirror extends MTEBeamMultiBase<MTEBeamMirror> implements IS
                 beamOutput.getBaseMetaTileEntity()
                     .setFrontFacing(getDirection());
             } else if (this.mTier == 1) {
-                // only flip orientation I could achieve during tests
-                boolean isFlipped = getFlip().isHorizontallyFlipped();
-                switch (getRotation()) {
-                    case NORMAL -> beamOutput.getBaseMetaTileEntity()
-                        .setFrontFacing(ForgeDirection.UP);
-                    case UPSIDE_DOWN -> beamOutput.getBaseMetaTileEntity()
-                        .setFrontFacing(ForgeDirection.DOWN);
-                    case CLOCKWISE -> beamOutput.getBaseMetaTileEntity()
-                        .setFrontFacing(
-                            getDirection().getRotation(isFlipped ? ForgeDirection.UP : ForgeDirection.DOWN));
-                    case COUNTER_CLOCKWISE -> beamOutput.getBaseMetaTileEntity()
-                        .setFrontFacing(
-                            getDirection().getRotation(isFlipped ? ForgeDirection.DOWN : ForgeDirection.UP));
-                    default -> beamOutput.getBaseMetaTileEntity()
-                        .setFrontFacing(getDirection().getRotation(ForgeDirection.UP));
-                }
+                beamOutput.getBaseMetaTileEntity()
+                    .setFrontFacing(
+                        this.getExtendedFacing()
+                            .getRelativeUpInWorld());
             }
         }
     }


### PR DESCRIPTION
i got pinged on discord, because downwards facing beam mirrors rotated outputs constantly down & never relatively up as intended, so i'm switching the logic to extended facing like it should have been from the beginning i believe.

I've tested all 4 down facing rotations, all 4 up facing rotations, and 4 rotations facing the same cardinal direction, but not all 4 cardinal directions