### PR TITLE
Fix Electrode Tooltips

### DIFF
--- a/src/main/java/kubatech/loaders/ArcFurnaceElectrode.java
+++ b/src/main/java/kubatech/loaders/ArcFurnaceElectrode.java
@@ -190,7 +190,7 @@ public enum ArcFurnaceElectrode {
         tooltip.add(
             StatCollector.translateToLocalFormatted(
                 "item.arc_furnace_electrode.tip.speed",
-                getModifierFormatted(this.speedModifier)));
+                getModifierFormatted((int) (this.speedModifier * 100), false, 50d, 100d, 200d, "", "%")));
         tooltip.add(
             StatCollector.translateToLocalFormatted(
                 "item.arc_furnace_electrode.tip.parallel_limit",
@@ -200,9 +200,9 @@ public enum ArcFurnaceElectrode {
         tooltip.add(
             StatCollector.translateToLocalFormatted(
                 "item.arc_furnace_electrode.tip.oc",
-                getModifierFormatted(this.OCSpeedFactor, false, 1d, 2d, 4d, "", "") + EnumChatFormatting.GRAY
+                getModifierFormatted(this.OCPowerFactor, false, 2d, 4d, 6d, "", "") + EnumChatFormatting.GRAY
                     + "/"
-                    + getModifierFormatted(this.OCPowerFactor, true, 0.25d, 0.5d, 1d, "", ""),
+                    + getModifierFormatted(this.OCSpeedFactor, false, 1d, 2d, 4d, "", ""),
                 ""));
         tooltip.add(
             StatCollector.translateToLocalFormatted(
@@ -240,10 +240,6 @@ public enum ArcFurnaceElectrode {
             color = EnumChatFormatting.AQUA; // "great" stat
         }
         return color.toString() + value;
-    }
-
-    private static String getModifierFormatted(double value) {
-        return getModifierFormatted(value, false, 0.5d, 1.0d, 2.0d, "x", "");
     }
 
     private static String getModifierFormatted(double value, boolean undesireable, double lo_threshold,

--- a/src/main/resources/assets/kubatech/lang/en_US.lang
+++ b/src/main/resources/assets/kubatech/lang/en_US.lang
@@ -237,11 +237,11 @@ item.arc_furnace_electrode.UniversiumNaniteElectrode.name=Universium Nanite Elec
 
 item.arc_furnace_electrode.tip.durability=Durability: %s/%s
 item.arc_furnace_electrode.tip.speed=Speed: %s
-item.arc_furnace_electrode.tip.parallel_limit=Parallel: %s
+item.arc_furnace_electrode.tip.parallel_limit=Parallels: %s
 item.arc_furnace_electrode.tip.parallel_limit_none=None
 item.arc_furnace_electrode.tip.oc=OC: %s%s
 item.arc_furnace_electrode.tip.amperage_per_parallel=Amp/Parallel: %s
-item.arc_furnace_electrode.tip.startup_surge=Startup Surge: %s
+item.arc_furnace_electrode.tip.startup_surge=Surge Power: %s
 
 item.arc_furnace_electrode.tip.special_effect.GraphiteElectrode=§6§lBread and Butter§r§6: No startup surge penalty
 item.arc_furnace_electrode.tip.special_effect.GrapheneElectrode=§6§lBread and Butter§r§6: No startup surge penalty

--- a/src/main/resources/assets/kubatech/lang/en_US.lang
+++ b/src/main/resources/assets/kubatech/lang/en_US.lang
@@ -240,7 +240,7 @@ item.arc_furnace_electrode.tip.speed=Speed: %s
 item.arc_furnace_electrode.tip.parallel_limit=Parallels: %s
 item.arc_furnace_electrode.tip.parallel_limit_none=None
 item.arc_furnace_electrode.tip.oc=OC: %s%s
-item.arc_furnace_electrode.tip.amperage_per_parallel=Amp/Parallel: %s
+item.arc_furnace_electrode.tip.amperage_per_parallel=Amps/Parallel: %s
 item.arc_furnace_electrode.tip.startup_surge=Surge Power: %s
 
 item.arc_furnace_electrode.tip.special_effect.GraphiteElectrode=§6§lBread and Butter§r§6: No startup surge penalty


### PR DESCRIPTION
Small cosmetic changes to the Industrial Arc Furnace electrode tooltips to align them with the rest of the game's tooltips, and the questbook/wiki/GuideNH.

- Processing speed is always represented as a percent (not a multiplier)
- Overclock Factor on all current documentation is power/speed instead of speed/power
- The x4 power cost for overclocks is not "bad" or "low" so changed it's color from red to orange because it is extremely average.
- "Surge Power" is more encompassing than "Startup Surge" because surges may occur randomly if the electrode durability is low enough, not just at startup. Also is more clear as to what it affects, the power cost.

Before:
<img width="741" height="368" alt="2026-06-10_23 23 47" src="https://github.com/user-attachments/assets/149a2f0e-9968-48b4-a9ae-434034a23cdf" />

After:
<img width="739" height="323" alt="2026-06-10_23 22 46" src="https://github.com/user-attachments/assets/d1597554-246a-4602-8006-8b3c69e627b6" />

Oh and removed an extremely redundant function that was only ever called once and had the same name as two other functions.