### PR TITLE
Fix accidental Angelica dep, and turn off the runtime dep

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -145,7 +145,7 @@ dependencies {
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Electro-Magic-Tools:1.7.21:dev") { transitive = false }
 
     // For testing ctm
-    runtimeOnlyNonPublishable('com.github.GTNewHorizons:Angelica:2.1.33:dev') { transitive = false }
+    // runtimeOnlyNonPublishable('com.github.GTNewHorizons:Angelica:2.1.33:dev') { transitive = false }
 
     // Speeds up mod identification and loading in dev
     runtimeOnlyNonPublishable(rfg.deobf("com.github.GTNewHorizons:CoreTweaks:0.3.4.6-GTNH"))

--- a/src/main/java/gtPlusPlus/core/proxy/ClientProxy.java
+++ b/src/main/java/gtPlusPlus/core/proxy/ClientProxy.java
@@ -1,5 +1,7 @@
 package gtPlusPlus.core.proxy;
 
+import static gregtech.api.enums.Mods.Angelica;
+
 import java.util.ArrayList;
 
 import net.minecraft.client.Minecraft;
@@ -50,12 +52,14 @@ public class ClientProxy extends CommonProxy {
         RenderingRegistry.registerBlockHandler(new MachineBlockRenderer());
         new FlaskRenderer();
         MinecraftForge.EVENT_BUS.register(PowerGogglesHudHandler.getInstance());
-        AnimatedBlockTextureHandler animatedBlockTextureHandler = new AnimatedBlockTextureHandler();
-        FMLCommonHandler.instance()
-            .bus()
-            .register(animatedBlockTextureHandler);
-        ((IReloadableResourceManager) Minecraft.getMinecraft()
-            .getResourceManager()).registerReloadListener(animatedBlockTextureHandler);
+        if (Angelica.isModLoaded()) {
+            AnimatedBlockTextureHandler animatedBlockTextureHandler = new AnimatedBlockTextureHandler();
+            FMLCommonHandler.instance()
+                .bus()
+                .register(animatedBlockTextureHandler);
+            ((IReloadableResourceManager) Minecraft.getMinecraft()
+                .getResourceManager()).registerReloadListener(animatedBlockTextureHandler);
+        }
         PowerGogglesKeybindHandler.init();
         if (Mods.AdvancedSolarPanel.isModLoaded()) {
             MinecraftForge.EVENT_BUS.register(new MolecularTransformerTooltipNotice());


### PR DESCRIPTION
https://github.com/GTNewHorizons/GT5-Unofficial/pull/6810 needed an Angelica-specific workaround for animations, which accidentally added a runtime dep to GT5. This PR locks that behind an isModLoaded check, and also turns off the Angelica runtime dep to prevent future accidents (like with others, it can be toggled on or off as needed).

Tested with the dep off and confirmed it launched + loaded in world + animations cycled (but way less pretty).