### PR TITLE
Double waterline radius

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/purification/MTEPurificationPlant.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/purification/MTEPurificationPlant.java
@@ -67,7 +67,7 @@ public class MTEPurificationPlant extends MTEExtendedPowerMultiBlockBase<MTEPuri
      * Maximum distance in each axis between the purification plant main controller and the controller blocks of the
      * purification plant units.
      */
-    public static final int MAX_UNIT_DISTANCE = 32;
+    public static final int MAX_UNIT_DISTANCE = 64;
 
     /**
      * Time in ticks for a full processing cycle to complete.


### PR DESCRIPTION
It's a little cramped rn especially when the last couple modules get put in. For aesthetic purposes doubling it would be nice, so people don't have to construct multiple waterline controllers, or stack the modules on top of each other. Let me know what you think.