### PR TITLE
Ignore collision for space miner

### DIFF
--- a/src/main/java/gtnhintergalactic/recipe/IG_RecipeAdder.java
+++ b/src/main/java/gtnhintergalactic/recipe/IG_RecipeAdder.java
@@ -217,6 +217,7 @@ public class IG_RecipeAdder extends RecipeAdder {
             .metadata(IGRecipeMaps.SPACE_MINING_DATA, miningData)
             .duration(duration)
             .eut(EUt)
+            .ignoreCollision()
             .addTo(IGRecipeMaps.spaceMiningRecipes);
 
         return true;


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24426

The space mining recipes have exactly the same input, and the recipe collision checker removes them.