### PR TITLE
Fix Mixer Multi controller tooltip to use correct casing name

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialMixer.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEIndustrialMixer.java
@@ -196,7 +196,7 @@ public class MTEIndustrialMixer extends MTEExtendedPowerMultiBlockBase<MTEIndust
             .addPollutionAmount(getPollutionPerSecond(null))
             .beginStructureBlock(5, 7, 5, false)
             .addController("Front center, 2nd layer")
-            .addCasingInfoMin("Mixer Containment Casing", 5, false)
+            .addCasingInfoMin("Mixer Casing", 5, false)
             .addCasingInfoExactly("Titanium Turbine Casing", 5, false)
             .addCasingInfoExactly("Any Tiered Glass", 30, false)
             .addCasingInfoExactly("Tungsten Sheetmetal", 24, false)


### PR DESCRIPTION
This PR changes the name of Mixer Containment Casings in the tooltip of the Mixer Multi controller to match the actual name of the used casing, which is just Mixer Casing.