### PR TITLE
Add instant recipe checks to normal input busses/hatches

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEHatch.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEHatch.java
@@ -39,6 +39,19 @@ public abstract class MTEHatch extends MTEBasicTank implements ICasingTexturePro
 
     private ItemStack ae2CraftingIcon;
 
+    /**
+     * Latched flag indicating new ingredients arrived since the controller last polled it. Lets a multiblock run a
+     * recipe check the moment new ingredients arrive instead of waiting for its periodic poll. Consumed (and reset) by
+     * {@link #justUpdated()}.
+     */
+    private boolean justUpdated = false;
+
+    /**
+     * Total contents seen on the previous tick, used by {@link #detectInventoryChange()} to distinguish ingredients
+     * being inserted (which may enable a new recipe) from ingredients being consumed (which never can).
+     */
+    private long lastContentAmount = 0;
+
     public MTEHatch(int aID, String aName, String aNameRegional, int aTier, int aInvSlotCount, String aDescription,
         ITexture... aTextures) {
         super(aID, aName, aNameRegional, aTier, aInvSlotCount, aDescription, aTextures);
@@ -55,6 +68,54 @@ public abstract class MTEHatch extends MTEBasicTank implements ICasingTexturePro
 
     public static int getSlots(int aTier) {
         return (aTier + 1) * (aTier + 1);
+    }
+
+    /**
+     * Latches a signal if this hatch gained contents since last tick. Input hatches and busses should call this from
+     * {@code onPostTick}. Only a net <em>increase</em> latches: consuming ingredients lowers the tracked amount without
+     * triggering, so the controller never runs an expensive recipe check on consumption alone. The signal is latched
+     * (rather than read live) so it survives the arbitrary tile-entity tick ordering between this hatch and its
+     * controlling multiblock.
+     */
+    protected void detectInventoryChange() {
+        long amount = getContentAmount();
+        if (amount > lastContentAmount) {
+            justUpdated = true;
+        }
+        lastContentAmount = amount;
+    }
+
+    /**
+     * @return a monotonic measure of this hatch's stored contents (summed item stack sizes plus stored fluid). Only its
+     *         direction of change matters, not its absolute value. Subclasses holding fluids or non-standard storage
+     *         should override to include those amounts.
+     */
+    protected long getContentAmount() {
+        long amount = 0;
+        if (mInventory != null) {
+            for (ItemStack stack : mInventory) {
+                if (stack != null) amount += stack.stackSize;
+            }
+        }
+        return amount;
+    }
+
+    /**
+     * Forces the next controller poll to run a recipe check. Use for changes that aren't a monotonic increase in stored
+     * contents (e.g. a configuration circuit being changed), which {@link #detectInventoryChange()} cannot see.
+     */
+    protected void markJustUpdated() {
+        justUpdated = true;
+    }
+
+    /**
+     * @return {@code true} if new items and/or fluids were inserted since the last call, which triggers an immediate
+     *         recipe check on the controlling multiblock. Resets the flag.
+     */
+    public boolean justUpdated() {
+        boolean ret = justUpdated;
+        justUpdated = false;
+        return ret;
     }
 
     private int getOffsetTier() {

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEHatchInput.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEHatchInput.java
@@ -157,6 +157,21 @@ public class MTEHatchInput extends MTEHatch {
         return true;
     }
 
+    @Override
+    public void onPostTick(IGregTechTileEntity aBaseMetaTileEntity, long aTimer) {
+        super.onPostTick(aBaseMetaTileEntity, aTimer);
+        if (aBaseMetaTileEntity.isServerSide()) {
+            detectInventoryChange();
+        }
+    }
+
+    @Override
+    protected long getContentAmount() {
+        long amount = super.getContentAmount();
+        if (mFluid != null) amount += mFluid.amount;
+        return amount;
+    }
+
     public void updateSlots() {
         if (mInventory[getInputSlot()] != null && mInventory[getInputSlot()].stackSize <= 0)
             mInventory[getInputSlot()] = null;

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEHatchInputBus.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEHatchInputBus.java
@@ -144,10 +144,30 @@ public class MTEHatchInputBus extends MTEHatch implements IConfigurationCircuitS
         }
     }
 
+    /** Configuration circuit setting seen last tick; -1 means no circuit. Detects ghost-circuit changes. */
+    private int lastCircuitConfig = Integer.MIN_VALUE;
+
     @Override
     public void onPostTick(IGregTechTileEntity aBaseMetaTileEntity, long aTimer) {
         if (aBaseMetaTileEntity.isServerSide()) {
+            detectInventoryChange();
+            detectCircuitChange();
             updateSlots();
+        }
+    }
+
+    /**
+     * Latches a recipe-check signal when the configuration circuit changes. A ghost circuit is stored with stack size 0
+     * and only its damage encodes the setting, so {@link #detectInventoryChange()} cannot see it. Any change (in either
+     * direction) can select a different recipe, so this is not gated on an increase.
+     */
+    private void detectCircuitChange() {
+        int slot = getCircuitSlot();
+        ItemStack circuit = (slot >= 0 && slot < mInventory.length) ? mInventory[slot] : null;
+        int config = circuit == null ? -1 : circuit.getItemDamage();
+        if (config != lastCircuitConfig) {
+            lastCircuitConfig = config;
+            markJustUpdated();
         }
     }
 

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEHatchMultiInput.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEHatchMultiInput.java
@@ -83,6 +83,17 @@ public class MTEHatchMultiInput extends MTEHatchInput {
         return mStoredFluid;
     }
 
+    @Override
+    protected long getContentAmount() {
+        long amount = super.getContentAmount();
+        if (mStoredFluid != null) {
+            for (FluidStack fluid : mStoredFluid) {
+                if (fluid != null) amount += fluid.amount;
+            }
+        }
+        return amount;
+    }
+
     public FluidStackTank[] getFluidTanks() {
         return fluidTanks;
     }

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
@@ -715,6 +715,15 @@ public abstract class MTEMultiBlockBase extends MetaTileEntity
             shouldCheck |= smartInputHatch.justUpdated();
         }
         if (shouldCheck) return true;
+        // And for regular input busses/hatches, so freshly inserted ingredients trigger an immediate check
+        // instead of waiting for the periodic poll below.
+        for (MTEHatchInputBus inputBus : validMTEList(mInputBusses)) {
+            shouldCheck |= inputBus.justUpdated();
+        }
+        for (MTEHatchInput inputHatch : validMTEList(mInputHatches)) {
+            shouldCheck |= inputHatch.justUpdated();
+        }
+        if (shouldCheck) return true;
 
         // Perform more frequent recipe change after the machine just shuts down.
         long timeElapsed = mTotalRunTime - mLastWorkingTick;


### PR DESCRIPTION
This PR adds instant recipe checks similarly to how ME Input Bus/Hatches do it currently to regular input bus/hatches.

It achieves this by basically keeping an aggregate of the contents of the hatches and then using that aggregate to easily determine if the contents have increased, and if they have, it will fire a recipe check. The reason for this is that if we just watched for the contents _changing_, we'd end up with two recipe checks per cycle because the recipe starting would also fire off another recipe check once the machine was idle again.

Ghost circuit changes are handled separately since a ghost circuit is stored with stack size 0 and only its damage encodes the setting, so the content aggregate can't see it. Instead, it tracks the circuit's setting and fires a check on any change (in either direction), since switching circuits should trigger a recipe check just the same as changing items/fluids should.