### PR TITLE
Always allow proxy to function as input hatch

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEEnhancedMultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEEnhancedMultiBlockBase.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import javax.annotation.Nonnegative;
 
-import gregtech.common.tileentities.machines.MTEHatchCraftingInputSlave;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
@@ -47,7 +46,7 @@ import gregtech.api.util.GTUtility;
 import gregtech.api.util.shutdown.ShutDownReasonRegistry;
 import gregtech.client.GTSoundLoop;
 import gregtech.client.volumetric.ISoundPosition;
-import gregtech.common.tileentities.machines.IDualInputHatch;
+import gregtech.common.tileentities.machines.MTEHatchCraftingInputSlave;
 
 /**
  * Enhanced multiblock base class, featuring following improvement over {@link MTEMultiBlockBase}

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEEnhancedMultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEEnhancedMultiBlockBase.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import javax.annotation.Nonnegative;
 
+import gregtech.common.tileentities.machines.MTEHatchCraftingInputSlave;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
@@ -628,8 +629,9 @@ public abstract class MTEEnhancedMultiBlockBase<T extends MTEEnhancedMultiBlockB
     // Most of the time it's what you want. If you don't want such inputs,
     // you can omit InputBus in your structure or roll your own checks
     protected final void checkHasInputHatch(List<StructureError> errors) {
+        // Due to update delay, slave is sometimes not recognized. We always allow slave to substitute as input hatch
         long count = mInputHatches.size() + mDualInputHatches.stream()
-            .filter(IDualInputHatch::supportsFluids)
+            .filter(hatch -> hatch.supportsFluids() || hatch instanceof MTEHatchCraftingInputSlave)
             .count();
         if (count == 0) {
             errors.add(StructureErrors.hatchCount(ErrorType.TOO_FEW, HatchElement.InputHatch, 0, 1));


### PR DESCRIPTION
There is a slight start-up time when proxy connects to crafting input buffer. This fixes it by always treating proxy to support fluid.

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25275