### PR TITLE
Use watcher to add instant-on to regular buses and hatches

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -540,10 +540,13 @@ public abstract class MetaTileEntity extends CommonMetaTileEntity implements ICr
 
     /**
      * Called when a slot is changed. Note: {@link #setInventorySlotContents} is not called when the player interacts
-     * with a {@link gregtech.api.interfaces.modularui.IAddInventorySlots} slot.
+     * with a {@link gregtech.api.interfaces.modularui.IAddInventorySlots} slot, nor when items are inserted/extracted
+     * through {@link #getInventoryHandler()} (the path used by the GUI and AE). Marking the tile dirty here makes
+     * {@link IGregTechTileEntity#hasInventoryBeenModified()} reliable across all of those paths, which input hatches
+     * rely on to trigger instant recipe checks.
      */
     public void onContentsChanged(int slot) {
-
+        markDirty();
     }
 
     /**

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEHatch.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEHatch.java
@@ -41,16 +41,10 @@ public abstract class MTEHatch extends MTEBasicTank {
     private ItemStack ae2CraftingIcon;
 
     /**
-     * Controllers watching this hatch for new ingredients (see {@link ISmartInputHatch}). When new contents arrive we
-     * notify them so they can run an immediate recipe check instead of waiting for their periodic poll.
+     * Controllers watching this hatch for new ingredients (see {@link ISmartInputHatch}). When this hatch's contents
+     * change we notify them so they can run an immediate recipe check instead of waiting for their periodic poll.
      */
     private final List<IHatchWatcher> watchers = new ArrayList<>();
-
-    /**
-     * Total contents seen on the previous tick, used by {@link #detectInventoryChange()} to distinguish ingredients
-     * being inserted (which may enable a new recipe) from ingredients being consumed (which never can).
-     */
-    private long lastContentAmount = 0;
 
     public MTEHatch(int aID, String aName, String aNameRegional, int aTier, int aInvSlotCount, String aDescription,
         ITexture... aTextures) {
@@ -92,33 +86,18 @@ public abstract class MTEHatch extends MTEBasicTank {
     }
 
     /**
-     * Notifies watchers when this hatch's stored contents have grown since last tick. Only a net <em>increase</em>
-     * fires: consuming ingredients lowers the tracked amount without notifying, so the controller never runs an
-     * expensive recipe check on consumption alone. We compare the actual contents rather than relying on
-     * {@code hasInventoryBeenModified()}, because automation/pipe/cover inserts don't reliably set that flag. Input
-     * hatches/busses should call this from {@code onPostTick}.
+     * Notifies watchers when this hatch's inventory or tank changed this tick. Relies on
+     * {@link IGregTechTileEntity#hasInventoryBeenModified()}, which every relevant insertion path sets (item slots via
+     * {@code setInventorySlotContents}/{@code decrStackSize}, the GUI/AE handler via
+     * {@link MetaTileEntity#onContentsChanged(int)}, and fluids via {@code fill}). Consuming ingredients also sets the
+     * flag, but that only ever costs a single redundant idle check at the tail of a run. Input hatches/busses should
+     * call this from {@code onPostTick}.
      */
     protected void detectInventoryChange() {
-        long amount = getContentAmount();
-        if (amount > lastContentAmount) {
+        IGregTechTileEntity base = getBaseMetaTileEntity();
+        if (base != null && base.hasInventoryBeenModified()) {
             notifyWatchers();
         }
-        lastContentAmount = amount;
-    }
-
-    /**
-     * @return a monotonic measure of this hatch's stored contents (summed item stack sizes plus stored fluid). Only its
-     *         direction of change matters, not its absolute value. Subclasses holding fluids or non-standard storage
-     *         should override to include those amounts.
-     */
-    protected long getContentAmount() {
-        long amount = 0;
-        if (mInventory != null) {
-            for (ItemStack stack : mInventory) {
-                if (stack != null) amount += stack.stackSize;
-            }
-        }
-        return amount;
     }
 
     private int getOffsetTier() {

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEHatch.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEHatch.java
@@ -2,6 +2,7 @@ package gregtech.api.metatileentity.implementations;
 
 import static com.gtnewhorizon.gtnhlib.util.numberformatting.NumberFormatUtil.formatNumber;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -21,6 +22,7 @@ import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.util.GTSplit;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.tooltip.TooltipHelper;
+import gregtech.common.tileentities.machines.IHatchWatcher;
 
 /**
  * Handles texture changes internally. No special calls are necessary other than updateTexture in add***ToMachineList.
@@ -38,6 +40,18 @@ public abstract class MTEHatch extends MTEBasicTank {
 
     private ItemStack ae2CraftingIcon;
 
+    /**
+     * Controllers watching this hatch for new ingredients (see {@link ISmartInputHatch}). When new contents arrive we
+     * notify them so they can run an immediate recipe check instead of waiting for their periodic poll.
+     */
+    private final List<IHatchWatcher> watchers = new ArrayList<>();
+
+    /**
+     * Total contents seen on the previous tick, used by {@link #detectInventoryChange()} to distinguish ingredients
+     * being inserted (which may enable a new recipe) from ingredients being consumed (which never can).
+     */
+    private long lastContentAmount = 0;
+
     public MTEHatch(int aID, String aName, String aNameRegional, int aTier, int aInvSlotCount, String aDescription,
         ITexture... aTextures) {
         super(aID, aName, aNameRegional, aTier, aInvSlotCount, aDescription, aTextures);
@@ -54,6 +68,57 @@ public abstract class MTEHatch extends MTEBasicTank {
 
     public static int getSlots(int aTier) {
         return (aTier + 1) * (aTier + 1);
+    }
+
+    /**
+     * Registers a controller to be notified when this hatch gains new ingredients. Input hatches/busses implement
+     * {@link ISmartInputHatch} so the controller registers itself here during structure assembly; the inherited
+     * implementation satisfies that interface.
+     */
+    public void addWatcher(IHatchWatcher watcher) {
+        watchers.add(watcher);
+    }
+
+    public void removeWatcher(IHatchWatcher watcher) {
+        watchers.remove(watcher);
+    }
+
+    /** Asks every registered controller to run a recipe check on its next tick. */
+    protected void notifyWatchers() {
+        for (int i = 0; i < watchers.size(); i++) {
+            watchers.get(i)
+                .scheduleRecipeCheckImmediate();
+        }
+    }
+
+    /**
+     * Notifies watchers when this hatch's stored contents have grown since last tick. Only a net <em>increase</em>
+     * fires: consuming ingredients lowers the tracked amount without notifying, so the controller never runs an
+     * expensive recipe check on consumption alone. We compare the actual contents rather than relying on
+     * {@code hasInventoryBeenModified()}, because automation/pipe/cover inserts don't reliably set that flag. Input
+     * hatches/busses should call this from {@code onPostTick}.
+     */
+    protected void detectInventoryChange() {
+        long amount = getContentAmount();
+        if (amount > lastContentAmount) {
+            notifyWatchers();
+        }
+        lastContentAmount = amount;
+    }
+
+    /**
+     * @return a monotonic measure of this hatch's stored contents (summed item stack sizes plus stored fluid). Only its
+     *         direction of change matters, not its absolute value. Subclasses holding fluids or non-standard storage
+     *         should override to include those amounts.
+     */
+    protected long getContentAmount() {
+        long amount = 0;
+        if (mInventory != null) {
+            for (ItemStack stack : mInventory) {
+                if (stack != null) amount += stack.stackSize;
+            }
+        }
+        return amount;
     }
 
     private int getOffsetTier() {

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEHatchInput.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEHatchInput.java
@@ -26,11 +26,12 @@ import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GTClientPreference;
 import gregtech.api.util.GTSplit;
 import gregtech.api.util.GTUtility;
+import gregtech.common.tileentities.machines.ISmartInputHatch;
 import mcp.mobius.waila.api.IWailaConfigHandler;
 import mcp.mobius.waila.api.IWailaDataAccessor;
 
 @IMetaTileEntity.SkipGenerateDescription
-public class MTEHatchInput extends MTEHatch {
+public class MTEHatchInput extends MTEHatch implements ISmartInputHatch {
 
     // hatch filter is disabled by default, meaning any fluid can be inserted when in structure.
     public boolean disableFilter = true;
@@ -155,6 +156,21 @@ public class MTEHatchInput extends MTEHatch {
     @Override
     public boolean canTankBeEmptied() {
         return true;
+    }
+
+    @Override
+    public void onPostTick(IGregTechTileEntity aBaseMetaTileEntity, long aTimer) {
+        super.onPostTick(aBaseMetaTileEntity, aTimer);
+        if (aBaseMetaTileEntity.isServerSide()) {
+            detectInventoryChange();
+        }
+    }
+
+    @Override
+    protected long getContentAmount() {
+        long amount = super.getContentAmount();
+        if (mFluid != null) amount += mFluid.amount;
+        return amount;
     }
 
     public void updateSlots() {

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEHatchInput.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEHatchInput.java
@@ -166,13 +166,6 @@ public class MTEHatchInput extends MTEHatch implements ISmartInputHatch {
         }
     }
 
-    @Override
-    protected long getContentAmount() {
-        long amount = super.getContentAmount();
-        if (mFluid != null) amount += mFluid.amount;
-        return amount;
-    }
-
     public void updateSlots() {
         if (mInventory[getInputSlot()] != null && mInventory[getInputSlot()].stackSize <= 0)
             mInventory[getInputSlot()] = null;

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEHatchInputBus.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEHatchInputBus.java
@@ -43,11 +43,12 @@ import gregtech.api.util.GTSplit;
 import gregtech.api.util.GTTooltipDataCache;
 import gregtech.api.util.GTUtility;
 import gregtech.common.gui.modularui.hatch.MTEHatchInputBusGui;
+import gregtech.common.tileentities.machines.ISmartInputHatch;
 import mcp.mobius.waila.api.IWailaConfigHandler;
 import mcp.mobius.waila.api.IWailaDataAccessor;
 
 @IMetaTileEntity.SkipGenerateDescription
-public class MTEHatchInputBus extends MTEHatch implements IConfigurationCircuitSupport {
+public class MTEHatchInputBus extends MTEHatch implements IConfigurationCircuitSupport, ISmartInputHatch {
 
     private static final String SORTING_MODE_TOOLTIP = "GT5U.machines.sorting_mode.tooltip";
     private static final String ONE_STACK_LIMIT_TOOLTIP = "GT5U.machines.one_stack_limit.tooltip";
@@ -144,10 +145,30 @@ public class MTEHatchInputBus extends MTEHatch implements IConfigurationCircuitS
         }
     }
 
+    /** Configuration circuit setting seen last tick; -1 means no circuit. Detects ghost-circuit changes. */
+    private int lastCircuitConfig = Integer.MIN_VALUE;
+
     @Override
     public void onPostTick(IGregTechTileEntity aBaseMetaTileEntity, long aTimer) {
         if (aBaseMetaTileEntity.isServerSide()) {
+            detectInventoryChange();
+            detectCircuitChange();
             updateSlots();
+        }
+    }
+
+    /**
+     * Notifies watchers when the configuration circuit changes. A ghost circuit is stored with stack size 0 and only
+     * its damage encodes the setting, so {@link #detectInventoryChange()} cannot see it. Any change (in either
+     * direction) can select a different recipe, so this is not gated on an increase.
+     */
+    private void detectCircuitChange() {
+        int slot = getCircuitSlot();
+        ItemStack circuit = (slot >= 0 && slot < mInventory.length) ? mInventory[slot] : null;
+        int config = circuit == null ? -1 : circuit.getItemDamage();
+        if (config != lastCircuitConfig) {
+            lastCircuitConfig = config;
+            notifyWatchers();
         }
     }
 

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEHatchInputBus.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEHatchInputBus.java
@@ -145,30 +145,11 @@ public class MTEHatchInputBus extends MTEHatch implements IConfigurationCircuitS
         }
     }
 
-    /** Configuration circuit setting seen last tick; -1 means no circuit. Detects ghost-circuit changes. */
-    private int lastCircuitConfig = Integer.MIN_VALUE;
-
     @Override
     public void onPostTick(IGregTechTileEntity aBaseMetaTileEntity, long aTimer) {
         if (aBaseMetaTileEntity.isServerSide()) {
             detectInventoryChange();
-            detectCircuitChange();
             updateSlots();
-        }
-    }
-
-    /**
-     * Notifies watchers when the configuration circuit changes. A ghost circuit is stored with stack size 0 and only
-     * its damage encodes the setting, so {@link #detectInventoryChange()} cannot see it. Any change (in either
-     * direction) can select a different recipe, so this is not gated on an increase.
-     */
-    private void detectCircuitChange() {
-        int slot = getCircuitSlot();
-        ItemStack circuit = (slot >= 0 && slot < mInventory.length) ? mInventory[slot] : null;
-        int config = circuit == null ? -1 : circuit.getItemDamage();
-        if (config != lastCircuitConfig) {
-            lastCircuitConfig = config;
-            notifyWatchers();
         }
     }
 

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEHatchMultiInput.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEHatchMultiInput.java
@@ -83,6 +83,17 @@ public class MTEHatchMultiInput extends MTEHatchInput {
         return mStoredFluid;
     }
 
+    @Override
+    protected long getContentAmount() {
+        long amount = super.getContentAmount();
+        if (mStoredFluid != null) {
+            for (FluidStack fluid : mStoredFluid) {
+                if (fluid != null) amount += fluid.amount;
+            }
+        }
+        return amount;
+    }
+
     public FluidStackTank[] getFluidTanks() {
         return fluidTanks;
     }

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEHatchMultiInput.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEHatchMultiInput.java
@@ -83,17 +83,6 @@ public class MTEHatchMultiInput extends MTEHatchInput {
         return mStoredFluid;
     }
 
-    @Override
-    protected long getContentAmount() {
-        long amount = super.getContentAmount();
-        if (mStoredFluid != null) {
-            for (FluidStack fluid : mStoredFluid) {
-                if (fluid != null) amount += fluid.amount;
-            }
-        }
-        return amount;
-    }
-
     public FluidStackTank[] getFluidTanks() {
         return fluidTanks;
     }


### PR DESCRIPTION
This uses the watcher API added via #6893 to add instant-on to multiblocks when items/fluid are added to regular hatches, similarly to how ME hatches can trigger recipe checks.

It achieves this by basically keeping an aggregate of the contents of the hatches and then using that aggregate to easily determine if the contents have increased, and if they have, it will fire a recipe check. The reason for this is that if we just watched for the contents changing, we'd end up with two recipe checks per cycle because the recipe starting would also fire off another recipe check once the machine was idle again.

Ghost circuit changes are handled separately since a ghost circuit is stored with stack size 0 and only its damage encodes the setting, so the content aggregate can't see it. Instead, it tracks the circuit's setting and fires a check on any change (in either direction), since switching circuits should trigger a recipe check just the same as changing items/fluids should.