### PR TITLE
Fix GT language early mixin load GTMod.class too early 

### DIFF
--- a/src/main/java/gregtech/api/util/GTInflectionManager.java
+++ b/src/main/java/gregtech/api/util/GTInflectionManager.java
@@ -1,6 +1,5 @@
 package gregtech.api.util;
 
-import static gregtech.GTMod.GT_FML_LOGGER;
 import static gregtech.api.util.GTLanguageManager.LOCALE;
 
 import java.io.BufferedReader;
@@ -33,7 +32,7 @@ import cpw.mods.fml.common.FMLCommonHandler;
 import gregtech.api.enums.Mods;
 
 public final class GTInflectionManager {
-
+    public static final Logger LOGGER = LogManager.getLogger("GT Inflection Manager");
     private static final Type MAP_TYPE = new TypeToken<Map<String, LinkedHashMap<String, String>>>() {}.getType();
     private static final Pattern PLACEHOLDER_PATTERN = Pattern.compile("(?<!%)%(?:(\\d+)\\$)?s(?:\\{([^}]+)})?");
     private static final Gson GSON = new Gson();
@@ -58,7 +57,7 @@ public final class GTInflectionManager {
             Map<String, LinkedHashMap<String, String>> fileData = GSON.fromJson(reader, MAP_TYPE);
 
             if (fileData == null || fileData.isEmpty()) {
-                GT_FML_LOGGER.warn("Inflection file is empty or does not conform to the format");
+                LOGGER.warn("Inflection file is empty or does not conform to the format");
                 return;
             }
 
@@ -76,19 +75,19 @@ public final class GTInflectionManager {
                         if (!pattern.endsWith("$")) pattern = pattern + "$";
                         compiledRules.add(new Rule(Pattern.compile(pattern), rule.getValue()));
                     } catch (Exception e) {
-                        GT_FML_LOGGER.warn("Invalid regex pattern '{}' for type '{}'", rule.getKey(), typeKey, e);
+                        LOGGER.warn("Invalid regex pattern '{}' for type '{}'", rule.getKey(), typeKey, e);
                     }
                 }
                 inflectionTempMap.put(typeKey, compiledRules);
             }
             INFLECTION_MAP = inflectionTempMap;
-            GT_FML_LOGGER.info("Loaded inflection rules for language: {}", userLang);
+            LOGGER.info("Loaded inflection rules for language: {}", userLang);
         } catch (FileNotFoundException ignored) {
 
         } catch (IOException e) {
-            GT_FML_LOGGER.warn("Failed to load inflection file: {}", json, e);
+            LOGGER.warn("Failed to load inflection file: {}", json, e);
         } catch (JsonParseException e) {
-            GT_FML_LOGGER.warn("Successfully found the inflection file: {}, but an error occurred.", json, e);
+            LOGGER.warn("Successfully found the inflection file: {}, but an error occurred.", json, e);
         }
     }
 

--- a/src/main/java/gregtech/api/util/GTInflectionManager.java
+++ b/src/main/java/gregtech/api/util/GTInflectionManager.java
@@ -22,6 +22,9 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.StatCollector;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import com.github.bsideup.jabel.Desugar;
 import com.google.common.base.Splitter;
 import com.google.gson.Gson;
@@ -32,6 +35,7 @@ import cpw.mods.fml.common.FMLCommonHandler;
 import gregtech.api.enums.Mods;
 
 public final class GTInflectionManager {
+
     public static final Logger LOGGER = LogManager.getLogger("GT Inflection Manager");
     private static final Type MAP_TYPE = new TypeToken<Map<String, LinkedHashMap<String, String>>>() {}.getType();
     private static final Pattern PLACEHOLDER_PATTERN = Pattern.compile("(?<!%)%(?:(\\d+)\\$)?s(?:\\{([^}]+)})?");


### PR DESCRIPTION
Using static field gregtech.GTMod.GT_FML_LOGGER triggers the initialization of GTMod, and lots of GT classes.
This will break late mixins that targets those GT classes.
So create a new LOGGER than using the one from GTMod.
<img width="2963" height="1315" alt="8896d0a4-1595-43dc-9f95-91a0a159df88" src="https://github.com/user-attachments/assets/0cb718b5-2c1c-44fa-b90e-871efc41aefc" />

This bug will not be triggered if you are not using inflection.

`-Xlog:class+load=info:stdout` outputs:
As you can see, GTMod is loaded too early, and load many GT classes
<details>
  <summary>Click to expand</summary>


```
[15:19:52] [Client thread/INFO]: Reloading ResourceManager: Default, FMLFileResourcePack:Better Loading Screen GTNH, TX Loader Resources, TX Loader Forced Resources
[14.892s][info   ][class,load] com.gtnewhorizon.gtnhlib.client.model.loading.BackingResourceManager source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/instances/GT_New_Horizons_2.9.0-beta-1_Java_17-25/.minecraft/mods/gtnhlib-0.11.9.jar!/com/gtnewhorizon/gtnhlib/client/model/loading/BackingResourceManager.class
[14.892s][info   ][class,load] com.gtnewhorizon.gtnhlib.mixins.early.models.FRMAccessor source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/instances/GT_New_Horizons_2.9.0-beta-1_Java_17-25/.minecraft/mods/gtnhlib-0.11.9.jar!/com/gtnewhorizon/gtnhlib/mixins/early/models/FRMAccessor.class
[14.892s][info   ][class,load] com.hfstudio.guidenh.mixins.early.minecraft.AccessorFallbackResourceManager source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/instances/GT_New_Horizons_2.9.0-beta-1_Java_17-25/.minecraft/mods/guidenh-1.3.5.jar!/com/hfstudio/guidenh/mixins/early/minecraft/AccessorFallbackResourceManager.class
[14.892s][info   ][class,load] net.minecraft.client.resources.FallbackResourceManager source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/libraries/com/mojang/minecraft/1.7.10/minecraft-1.7.10-client.jar!/bqq.class
[14.892s][info   ][class,load] net.minecraft.client.resources.IResource source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/libraries/com/mojang/minecraft/1.7.10/minecraft-1.7.10-client.jar!/bqw.class
[14.893s][info   ][class,load] glowredman.txloader.progress.ProgressBarProxy source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/instances/GT_New_Horizons_2.9.0-beta-1_Java_17-25/.minecraft/mods/txloader-1.8.11.jar!/glowredman/txloader/progress/ProgressBarProxy.class
[14.893s][info   ][class,load] glowredman.txloader.progress.IProgressBar source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/instances/GT_New_Horizons_2.9.0-beta-1_Java_17-25/.minecraft/mods/txloader-1.8.11.jar!/glowredman/txloader/progress/IProgressBar.class
[14.894s][info   ][class,load] glowredman.txloader.progress.FMLProgressBar source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/instances/GT_New_Horizons_2.9.0-beta-1_Java_17-25/.minecraft/mods/txloader-1.8.11.jar!/glowredman/txloader/progress/FMLProgressBar.class
[15:19:52] [Client thread/INFO] [TX Loader]: Successfully added 0 assets. (0 skipped, 0 failed)
[14.894s][info   ][class,load] glowredman.txloader.TXResourcePack$$Lambda/0x0000000085922d28 source: glowredman.txloader.TXResourcePack
[14.894s][info   ][class,load] glowredman.txloader.TXResourcePack$$Lambda/0x0000000085922f80 source: glowredman.txloader.TXResourcePack
[15:19:52] [Client thread/INFO] [TX Loader]: Successfully added 0 assets. (0 skipped, 0 failed)
[14.946s][info   ][class,load] com.prupe.mcpatcher.mal.resource.ResourceList source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/instances/GT_New_Horizons_2.9.0-beta-1_Java_17-25/.minecraft/mods/angelica-2.1.32.jar!/META-INF/versions/17/com/prupe/mcpatcher/mal/resource/ResourceList.class
[15:19:52] [Client thread/INFO] [MCPatcherForge]: [Texture Pack/INFO]: refreshing Tilesheet API (pre)...
[15:19:52] [Client thread/INFO] [MCPatcherForge]: [Texture Pack/INFO]: refreshing Connected Textures (pre)...
[14.947s][info   ][class,load] com.prupe.mcpatcher.renderpass.RenderPassMap source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/instances/GT_New_Horizons_2.9.0-beta-1_Java_17-25/.minecraft/mods/angelica-2.1.32.jar!/com/prupe/mcpatcher/renderpass/RenderPassMap.class
[14.948s][info   ][class,load] com.prupe.mcpatcher.ctm.GlassPaneRenderer source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/instances/GT_New_Horizons_2.9.0-beta-1_Java_17-25/.minecraft/mods/angelica-2.1.32.jar!/com/prupe/mcpatcher/ctm/GlassPaneRenderer.class
[14.948s][info   ][class,load] com.prupe.mcpatcher.mal.block.RenderBlocksUtils source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/instances/GT_New_Horizons_2.9.0-beta-1_Java_17-25/.minecraft/mods/angelica-2.1.32.jar!/com/prupe/mcpatcher/mal/block/RenderBlocksUtils.class
[14.949s][info   ][class,load] com.prupe.mcpatcher.mal.resource.PropertiesFile source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/instances/GT_New_Horizons_2.9.0-beta-1_Java_17-25/.minecraft/mods/angelica-2.1.32.jar!/META-INF/versions/17/com/prupe/mcpatcher/mal/resource/PropertiesFile.class
[14.950s][info   ][class,load] makamys.coretweaks.optimization.PrefixedClasspathResourceAccelerator source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/instances/GT_New_Horizons_2.9.0-beta-1_Java_17-25/.minecraft/mods/coretweaks-0.3.4.6-GTNH.jar!/makamys/coretweaks/optimization/PrefixedClasspathResourceAccelerator.class
[14.950s][info   ][class,load] makamys.coretweaks.util.DefaultLibraries source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/instances/GT_New_Horizons_2.9.0-beta-1_Java_17-25/.minecraft/mods/coretweaks-0.3.4.6-GTNH.jar!/makamys/coretweaks/util/DefaultLibraries.class
[14.951s][info   ][class,load] makamys.coretweaks.optimization.PrefixedClasspathResourceAccelerator$Index source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/instances/GT_New_Horizons_2.9.0-beta-1_Java_17-25/.minecraft/mods/coretweaks-0.3.4.6-GTNH.jar!/makamys/coretweaks/optimization/PrefixedClasspathResourceAccelerator$Index.class
[14.951s][info   ][class,load] makamys.coretweaks.optimization.PrefixedClasspathResourceAccelerator$JarIndex source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/instances/GT_New_Horizons_2.9.0-beta-1_Java_17-25/.minecraft/mods/coretweaks-0.3.4.6-GTNH.jar!/makamys/coretweaks/optimization/PrefixedClasspathResourceAccelerator$JarIndex.class
[15:19:52] [Client thread/INFO] [MCPatcherForge]: [CTM/INFO]: loading CTM overrides
[15.015s][info   ][class,load] com.prupe.mcpatcher.mal.resource.ResourceLocationWithSource$Comparator1 source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/instances/GT_New_Horizons_2.9.0-beta-1_Java_17-25/.minecraft/mods/angelica-2.1.32.jar!/META-INF/versions/17/com/prupe/mcpatcher/mal/resource/ResourceLocationWithSource$Comparator1.class
[15.114s][info   ][class,load] com.cleanroommc.modularui.core.mixins.early.minecraft.SimpleResourceAccessor source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/instances/GT_New_Horizons_2.9.0-beta-1_Java_17-25/.minecraft/mods/modularui2-2.3.73-1.7.10.jar!/com/cleanroommc/modularui/core/mixins/early/minecraft/SimpleResourceAccessor.class
[15.114s][info   ][class,load] net.minecraft.client.resources.SimpleResource source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/libraries/com/mojang/minecraft/1.7.10/minecraft-1.7.10-client.jar!/bri.class
[15:19:52] [Client thread/INFO] [MCPatcherForge]: [Texture Pack/INFO]: refreshing Better Glass (pre)...
[15.299s][info   ][class,load] sun.security.ssl.Alert source: jrt:/java.base
[15.300s][info   ][class,load] sun.security.ssl.Alert$AlertConsumer source: jrt:/java.base
[15.300s][info   ][class,load] sun.security.ssl.Alert$Level source: jrt:/java.base
[15.302s][info   ][class,load] java.io.InterruptedIOException source: jrt:/java.base
[15.302s][info   ][class,load] java.net.SocketTimeoutException source: jrt:/java.base
[15.456s][info   ][class,load] gregtech.GTMod source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/instances/GT_New_Horizons_2.9.0-beta-1_Java_17-25/.minecraft/mods/gregtech-5.09.52.594.jar!/META-INF/versions/17/gregtech/GTMod.class
[15.457s][info   ][class,load] gregtech.api.net.IGT_NetworkHandler source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/instances/GT_New_Horizons_2.9.0-beta-1_Java_17-25/.minecraft/mods/gregtech-5.09.52.594.jar!/gregtech/api/net/IGT_NetworkHandler.class
[15.457s][info   ][class,load] gregtech.api.interfaces.internal.IGTRecipeAdder source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/instances/GT_New_Horizons_2.9.0-beta-1_Java_17-25/.minecraft/mods/gregtech-5.09.52.594.jar!/gregtech/api/interfaces/internal/IGTRecipeAdder.class
[15.460s][info   ][class,load] gregtech.api.interfaces.modularui.IAddGregtechLogo source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/instances/GT_New_Horizons_2.9.0-beta-1_Java_17-25/.minecraft/mods/gregtech-5.09.52.594.jar!/gregtech/api/interfaces/modularui/IAddGregtechLogo.class
[15.460s][info   ][class,load] gregtech.api.interfaces.tileentity.IIC2Enet source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/instances/GT_New_Horizons_2.9.0-beta-1_Java_17-25/.minecraft/mods/gregtech-5.09.52.594.jar!/gregtech/api/interfaces/tileentity/IIC2Enet.class
[15.460s][info   ][class,load] com.gtnewhorizons.modularui.api.screen.ITileWithModularUI source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/instances/GT_New_Horizons_2.9.0-beta-1_Java_17-25/.minecraft/mods/modularui-1.3.4.jar!/com/gtnewhorizons/modularui/api/screen/ITileWithModularUI.class
[15.460s][info   ][class,load] gregtech.api.interfaces.modularui.IAddInventorySlots source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/instances/GT_New_Horizons_2.9.0-beta-1_Java_17-25/.minecraft/mods/gregtech-5.09.52.594.jar!/gregtech/api/interfaces/modularui/IAddInventorySlots.class
[15.461s][info   ][class,load] gregtech.api.interfaces.tileentity.IHasWorldObjectAndCoords source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/instances/GT_New_Horizons_2.9.0-beta-1_Java_17-25/.minecraft/mods/gregtech-5.09.52.594.jar!/gregtech/api/interfaces/tileentity/IHasWorldObjectAndCoords.class
[15.461s][info   ][class,load] gregtech.api.interfaces.tileentity.IGTEnet source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/instances/GT_New_Horizons_2.9.0-beta-1_Java_17-25/.minecraft/mods/gregtech-5.09.52.594.jar!/gregtech/api/interfaces/tileentity/IGTEnet.class
[15.462s][info   ][class,load] gregtech.api.metatileentity.BaseTileEntity source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/instances/GT_New_Horizons_2.9.0-beta-1_Java_17-25/.minecraft/mods/gregtech-5.09.52.594.jar!/META-INF/versions/17/gregtech/api/metatileentity/BaseTileEntity.class
[15.464s][info   ][class,load] gregtech.api.interfaces.tileentity.IRedstoneEmitter source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/instances/GT_New_Horizons_2.9.0-beta-1_Java_17-25/.minecraft/mods/gregtech-5.09.52.594.jar!/gregtech/api/interfaces/tileentity/IRedstoneEmitter.class
[15.464s][info   ][class,load] gregtech.api.interfaces.tileentity.IRedstoneReceiver source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/instances/GT_New_Horizons_2.9.0-beta-1_Java_17-25/.minecraft/mods/gregtech-5.09.52.594.jar!/gregtech/api/interfaces/tileentity/IRedstoneReceiver.class
[15.464s][info   ][class,load] gregtech.api.interfaces.tileentity.IRedstoneTileEntity source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/instances/GT_New_Horizons_2.9.0-beta-1_Java_17-25/.minecraft/mods/gregtech-5.09.52.594.jar!/gregtech/api/interfaces/tileentity/IRedstoneTileEntity.class
[15.465s][info   ][class,load] gregtech.api.interfaces.tileentity.IHasInventory source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/instances/GT_New_Horizons_2.9.0-beta-1_Java_17-25/.minecraft/mods/gregtech-5.09.52.594.jar!/gregtech/api/interfaces/tileentity/IHasInventory.class
[15.465s][info   ][class,load] gregtech.api.interfaces.tileentity.IColoredTileEntity source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/instances/GT_New_Horizons_2.9.0-beta-1_Java_17-25/.minecraft/mods/gregtech-5.09.52.594.jar!/gregtech/api/interfaces/tileentity/IColoredTileEntity.class
[15.465s][info   ][class,load] gregtech.api.interfaces.tileentity.IEnergyConnected source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/instances/GT_New_Horizons_2.9.0-beta-1_Java_17-25/.minecraft/mods/gregtech-5.09.52.594.jar!/META-INF/versions/17/gregtech/api/interfaces/tileentity/IEnergyConnected.class
[15.465s][info   ][class,load] gregtech.api.interfaces.tileentity.IBasicEnergyContainer source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/instances/GT_New_Horizons_2.9.0-beta-1_Java_17-25/.minecraft/mods/gregtech-5.09.52.594.jar!/gregtech/api/interfaces/tileentity/IBasicEnergyContainer.class
[15.466s][info   ][class,load] gregtech.api.interfaces.tileentity.ICoverable source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/instances/GT_New_Horizons_2.9.0-beta-1_Java_17-25/.minecraft/mods/gregtech-5.09.52.594.jar!/gregtech/api/interfaces/tileentity/ICoverable.class
[15.466s][info   ][class,load] gregtech.api.metatileentity.CoverableTileEntity source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/instances/GT_New_Horizons_2.9.0-beta-1_Java_17-25/.minecraft/mods/gregtech-5.09.52.594.jar!/META-INF/versions/17/gregtech/api/metatileentity/CoverableTileEntity.class
[15.468s][info   ][class,load] appeng.api.interfaces.IInterfaceNameProvider source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/instances/GT_New_Horizons_2.9.0-beta-1_Java_17-25/.minecraft/mods/appliedenergistics2-rv3-beta-977-GTNH.jar!/appeng/api/interfaces/IInterfaceNameProvider.class
[15.469s][info   ][class,load] gregtech.api.interfaces.tileentity.ITexturedTileEntity source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/instances/GT_New_Horizons_2.9.0-beta-1_Java_17-25/.minecraft/mods/gregtech-5.09.52.594.jar!/gregtech/api/interfaces/tileentity/ITexturedTileEntity.class
[15.469s][info   ][class,load] gregtech.api.interfaces.tileentity.ITurnable source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/instances/GT_New_Horizons_2.9.0-beta-1_Java_17-25/.minecraft/mods/gregtech-5.09.52.594.jar!/gregtech/api/interfaces/tileentity/ITurnable.class
[15.470s][info   ][class,load] gregtech.api.interfaces.tileentity.IMachineProgress source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/instances/GT_New_Horizons_2.9.0-beta-1_Java_17-25/.minecraft/mods/gregtech-5.09.52.594.jar!/gregtech/api/interfaces/tileentity/IMachineProgress.class
[15.470s][info   ][class,load] gregtech.api.interfaces.tileentity.IUpgradableMachine source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/instances/GT_New_Horizons_2.9.0-beta-1_Java_17-25/.minecraft/mods/gregtech-5.09.52.594.jar!/gregtech/api/interfaces/tileentity/IUpgradableMachine.class
[15.470s][info   ][class,load] gregtech.api.interfaces.tileentity.IDigitalChest source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/instances/GT_New_Horizons_2.9.0-beta-1_Java_17-25/.minecraft/mods/gregtech-5.09.52.594.jar!/gregtech/api/interfaces/tileentity/IDigitalChest.class
[15.470s][info   ][class,load] gregtech.api.interfaces.IDescribable source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/instances/GT_New_Horizons_2.9.0-beta-1_Java_17-25/.minecraft/mods/gregtech-5.09.52.594.jar!/gregtech/api/interfaces/IDescribable.class
[15.471s][info   ][class,load] gregtech.api.interfaces.tileentity.IGregTechTileEntity source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/instances/GT_New_Horizons_2.9.0-beta-1_Java_17-25/.minecraft/mods/gregtech-5.09.52.594.jar!/gregtech/api/interfaces/tileentity/IGregTechTileEntity.class
[15.472s][info   ][class,load] gregtech.api.metatileentity.CommonBaseMetaTileEntity source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/instances/GT_New_Horizons_2.9.0-beta-1_Java_17-25/.minecraft/mods/gregtech-5.09.52.594.jar!/META-INF/versions/17/gregtech/api/metatileentity/CommonBaseMetaTileEntity.class
[15.474s][info   ][class,load] com.gtnewhorizon.structurelib.alignment.IAlignmentProvider source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/instances/GT_New_Horizons_2.9.0-beta-1_Java_17-25/.minecraft/mods/structurelib-1.4.38.jar!/com/gtnewhorizon/structurelib/alignment/IAlignmentProvider.class
[15.474s][info   ][class,load] appeng.api.networking.IGridHost source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/instances/GT_New_Horizons_2.9.0-beta-1_Java_17-25/.minecraft/mods/appliedenergistics2-rv3-beta-977-GTNH.jar!/appeng/api/networking/IGridHost.class
[15.474s][info   ][class,load] appeng.api.networking.security.IActionHost source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/instances/GT_New_Horizons_2.9.0-beta-1_Java_17-25/.minecraft/mods/appliedenergistics2-rv3-beta-977-GTNH.jar!/appeng/api/networking/security/IActionHost.class
[15.474s][info   ][class,load] gregtech.api.interfaces.tileentity.IDebugableTileEntity source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/instances/GT_New_Horizons_2.9.0-beta-1_Java_17-25/.minecraft/mods/gregtech-5.09.52.594.jar!/gregtech/api/interfaces/tileentity/IDebugableTileEntity.class
[15.474s][info   ][class,load] appeng.helpers.ICustomNameObject source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/instances/GT_New_Horizons_2.9.0-beta-1_Java_17-25/.minecraft/mods/appliedenergistics2-rv3-beta-977-GTNH.jar!/appeng/helpers/ICustomNameObject.class
[15.475s][info   ][class,load] com.gtnewhorizon.structurelib.alignment.constructable.IConstructableProvider source: jar:file:/D:/application/minecraft/PrismLauncher-Windows-MinGW-w64-Portable-9.2/instances/GT_New_Horizons_2.9.0-beta-1_Java_17-25/.minecraft/mods/structurelib-1.4.38.jar!/com/gtnewhorizon/structurelib/alignment/constructable/IConstructableProvider.class

```
</details>