### PR TITLE
Fix debug ehatch and glass tier

### DIFF
--- a/src/main/java/bartworks/common/tileentities/multis/mega/MTEMegaBlastFurnaceLegacy.java
+++ b/src/main/java/bartworks/common/tileentities/multis/mega/MTEMegaBlastFurnaceLegacy.java
@@ -356,7 +356,7 @@ public class MTEMegaBlastFurnaceLegacy extends MegaMultiBlockBase<MTEMegaBlastFu
             }
         }
         for (MTEHatch mEnergyHatch : this.getExoticAndNormalEnergyHatchList()) {
-            if (this.glassTier < mEnergyHatch.mTier) {
+            if (this.glassTier < mEnergyHatch.getTierForStructure()) {
                 errors.add(StructureErrorRegistry.ENERGY_TIER_EXCEED_GLASS);
                 break;
             }

--- a/src/main/java/bartworks/common/tileentities/multis/mega/MTEMegaChemicalReactorLegacy.java
+++ b/src/main/java/bartworks/common/tileentities/multis/mega/MTEMegaChemicalReactorLegacy.java
@@ -199,7 +199,7 @@ public class MTEMegaChemicalReactorLegacy extends MegaMultiBlockBase<MTEMegaChem
             }
         }
         for (MTEHatch mEnergyHatch : this.getExoticAndNormalEnergyHatchList()) {
-            if (this.glassTier < mEnergyHatch.mTier) {
+            if (this.glassTier < mEnergyHatch.getTierForStructure()) {
                 errors.add(StructureErrorRegistry.ENERGY_TIER_EXCEED_GLASS);
                 break;
             }

--- a/src/main/java/bartworks/common/tileentities/multis/mega/MTEMegaOilCrackerLegacy.java
+++ b/src/main/java/bartworks/common/tileentities/multis/mega/MTEMegaOilCrackerLegacy.java
@@ -279,7 +279,7 @@ public class MTEMegaOilCrackerLegacy extends MegaMultiBlockBase<MTEMegaOilCracke
             }
         }
         for (MTEHatch mEnergyHatch : this.getExoticAndNormalEnergyHatchList()) {
-            if (this.glassTier < mEnergyHatch.mTier) {
+            if (this.glassTier < mEnergyHatch.getTierForStructure()) {
                 errors.add(StructureErrorRegistry.ENERGY_TIER_EXCEED_GLASS);
                 break;
             }

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEHatchEnergyDebug.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEHatchEnergyDebug.java
@@ -37,6 +37,11 @@ public class MTEHatchEnergyDebug extends MTEHatchEnergy {
     }
 
     @Override
+    public byte getTierForStructure() {
+        return (byte) voltageTier;
+    }
+
+    @Override
     public ITexture[] getTexturesActive(ITexture aBaseTexture) {
         return new ITexture[] { aBaseTexture, TextureFactory.of(Textures.BlockIcons.OVERLAY_ENERGY_IN_DEBUG) };
     }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEExothermicHearth.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEExothermicHearth.java
@@ -536,7 +536,7 @@ public class MTEExothermicHearth extends MTEExtendedPowerMultiBlockBase<MTEExoth
             }
         }
         for (MTEHatch mEnergyHatch : this.getExoticAndNormalEnergyHatchList()) {
-            if (this.glassTier < mEnergyHatch.mTier) {
+            if (this.glassTier < mEnergyHatch.getTierForStructure()) {
                 errors.add(StructureErrorRegistry.ENERGY_TIER_EXCEED_GLASS);
                 break;
             }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEMegaChemicalReactor.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEMegaChemicalReactor.java
@@ -226,7 +226,7 @@ public class MTEMegaChemicalReactor extends MTEExtendedPowerMultiBlockBase<MTEMe
             }
         }
         for (MTEHatch energyHatch : this.getExoticAndNormalEnergyHatchList()) {
-            if (this.glassTier < energyHatch.mTier) {
+            if (this.glassTier < energyHatch.getTierForStructure()) {
                 errors.add(StructureErrorRegistry.ENERGY_TIER_EXCEED_GLASS);
                 return;
             }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEMegaOilCracker.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEMegaOilCracker.java
@@ -304,7 +304,7 @@ public class MTEMegaOilCracker extends MTEExtendedPowerMultiBlockBase<MTEMegaOil
             }
         }
         for (MTEHatch mEnergyHatch : this.getExoticAndNormalEnergyHatchList()) {
-            if (this.glassTier < mEnergyHatch.mTier) {
+            if (this.glassTier < mEnergyHatch.getTierForStructure()) {
                 errors.add(StructureErrorRegistry.ENERGY_TIER_EXCEED_GLASS);
                 break;
             }

--- a/src/main/java/kubatech/tileentity/gregtech/multiblock/MTEExtremeIndustrialGreenhouse.java
+++ b/src/main/java/kubatech/tileentity/gregtech/multiblock/MTEExtremeIndustrialGreenhouse.java
@@ -328,7 +328,7 @@ public class MTEExtremeIndustrialGreenhouse extends KubaTechGTMultiBlockBase<MTE
         }
 
         for (MTEHatchEnergy hatchEnergy : this.mEnergyHatches) {
-            if (this.glassTier < hatchEnergy.mTier) {
+            if (this.glassTier < hatchEnergy.getTierForStructure()) {
                 errors.add(StructureErrors.glassTierNotEnough(hatchEnergy.mTier));
                 break;
             }

--- a/src/main/java/kubatech/tileentity/gregtech/multiblock/MTEMegaIndustrialApiary.java
+++ b/src/main/java/kubatech/tileentity/gregtech/multiblock/MTEMegaIndustrialApiary.java
@@ -660,7 +660,7 @@ public class MTEMegaIndustrialApiary extends KubaTechGTMultiBlockBase<MTEMegaInd
         mCasing = 0;
         if (!checkPiece(STRUCTURE_PIECE_MAIN, 7, 8, 0, errors)) return;
         for (MTEHatchEnergy hatchEnergy : this.mEnergyHatches) {
-            if (this.glassTier < hatchEnergy.mTier) {
+            if (this.glassTier < hatchEnergy.getTierForStructure()) {
                 errors.add(StructureErrors.glassTierNotEnough(hatchEnergy.mTier));
                 break;
             }


### PR DESCRIPTION
Stop checking mTier on multi checkMachine, use the dedicated method getTierForStructure which was written for this purpose. 