### PR TITLE
Fix crash in cell loader if cellEmpty is positive

### DIFF
--- a/src/main/java/bartworks/system/material/werkstoff_loaders/recipe/CellLoader.java
+++ b/src/main/java/bartworks/system/material/werkstoff_loaders/recipe/CellLoader.java
@@ -161,7 +161,9 @@ public class CellLoader implements IWerkstoffRunnable {
 
                 int cellEmpty = cells - 1;
 
-                stOutputs.add(Materials.Empty.getCells(-cellEmpty));
+                if (cellEmpty < 0) {
+                    stOutputs.add(Materials.Empty.getCells(-cellEmpty));
+                }
                 if (werkstoff.getStats()
                     .isElektrolysis())
                     GTValues.RA.stdBuilder()


### PR DESCRIPTION
Crash was caused due to null ItemStack in output