### PR TITLE
Re-add chili powder macerator recipe

### DIFF
--- a/src/main/java/gregtech/loaders/postload/recipes/Pulverizer.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/Pulverizer.java
@@ -139,8 +139,7 @@ public class Pulverizer implements Runnable {
         GTValues.RA.stdBuilder()
             .itemInputs(new OreDictItemStack("cropChilipepper", 1))
             .itemOutputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.Chili, 1))
-            .duration(20 * SECONDS)
-            .eut(TierEU.RECIPE_ULV)
+            .duration(2 * SECONDS)
             .eut(2)
             .addTo(maceratorRecipes);
 

--- a/src/main/java/gregtech/loaders/postload/recipes/Pulverizer.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/Pulverizer.java
@@ -137,6 +137,14 @@ public class Pulverizer implements Runnable {
             .addTo(maceratorRecipes);
 
         GTValues.RA.stdBuilder()
+            .itemInputs(new OreDictItemStack("cropChilipepper", 1))
+            .itemOutputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.Chili, 1))
+            .duration(20 * SECONDS)
+            .eut(TierEU.RECIPE_ULV)
+            .eut(2)
+            .addTo(maceratorRecipes);
+
+        GTValues.RA.stdBuilder()
             .itemInputs(ItemList.Casing_Coil_Cupronickel.get(1))
             .itemOutputs(
                 GTOreDictUnificator.get(OrePrefixes.dust, Materials.Cupronickel, 8),


### PR DESCRIPTION
Fixes: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25318

2.8.4 recipe:
<img width="349" height="292" alt="image" src="https://github.com/user-attachments/assets/9f1b8844-0f56-4123-aa2c-31745bd09d3a" />

This PR:
<img width="551" height="444" alt="image" src="https://github.com/user-attachments/assets/65a9c72f-5e9e-4c2e-a9a8-a5ed9a41ee5a" />
Note: it show LV now but it is properly listed in bronze macerator:
<img width="669" height="455" alt="image" src="https://github.com/user-attachments/assets/d06e5d04-0c22-4439-b40a-dbf57511d0e0" />
