### PR TITLE
Fix crash with offhand wrench and fluid pipes

### DIFF
--- a/src/main/java/gregtech/common/blocks/ItemMachines.java
+++ b/src/main/java/gregtech/common/blocks/ItemMachines.java
@@ -25,6 +25,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.potion.Potion;
 import net.minecraft.potion.PotionEffect;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.Constants;
@@ -303,9 +304,10 @@ public class ItemMachines extends ItemBlock implements IFluidContainerItem {
         if ((GTUtility.isStackInList(offHand, GregTechAPI.sWrenchList))) {
             ForgeDirection oppositeSide = side.getOpposite();
             if (player.isSneaking()) {
-                IGregTechTileEntity adjTile = (IGregTechTileEntity) pipe.getBaseMetaTileEntity()
+                TileEntity adjTile = pipe.getBaseMetaTileEntity()
                     .getTileEntityAtSide(oppositeSide);
-                if (adjTile.getMetaTileEntity() instanceof MTEFluidPipe adjPipe) {
+                if (adjTile instanceof IGregTechTileEntity adjGTile
+                    && adjGTile.getMetaTileEntity() instanceof MTEFluidPipe adjPipe) {
                     adjPipe.mDisableInput |= (byte) side.flag;
                 }
             } else {


### PR DESCRIPTION
fix crash caused by trying to cast non gregtech tile entity to a gregtech tile entity by first casting it to a regular tile entity