### PR TITLE
Fix oob and missing me output hatch check in DT

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
@@ -3044,7 +3044,11 @@ public abstract class MTEMultiBlockBase extends MetaTileEntity
 
     protected boolean canDumpFluidToMEByLayer(List<GTUtility.FluidId> outputs,
         List<List<MTEHatchOutput>> hatchesByLayer) {
-        for (int i = 0; i < hatchesByLayer.size(); i++) {
+        for (int i = 0; i < outputs.size(); i++) {
+            if (i >= hatchesByLayer.size()) {
+                // Less layer than recipe size
+                return false;
+            }
             List<MTEHatchOutputME> hatches = GTUtility.getMTEsOfType(hatchesByLayer.get(i), MTEHatchOutputME.class);
             GTUtility.FluidId output = outputs.get(i);
             boolean handled = false;

--- a/src/main/java/gregtech/api/util/FluidEjectionHelper.java
+++ b/src/main/java/gregtech/api/util/FluidEjectionHelper.java
@@ -103,7 +103,8 @@ public class FluidEjectionHelper {
 
                 if (ofType == null) continue;
 
-                GTDataUtils.addAllFiltered(ofType, transactions, t -> !t.isFiltered() || t.isFilteredToFluid(parallelData.id));
+                GTDataUtils
+                    .addAllFiltered(ofType, transactions, t -> !t.isFiltered() || t.isFilteredToFluid(parallelData.id));
             }
 
             parallelData.outputs = Iterators.peekingIterator(transactions.iterator());

--- a/src/main/java/gregtech/api/util/FluidEjectionHelper.java
+++ b/src/main/java/gregtech/api/util/FluidEjectionHelper.java
@@ -103,11 +103,7 @@ public class FluidEjectionHelper {
 
                 if (ofType == null) continue;
 
-                if (hatchType.isFiltered()) {
-                    GTDataUtils.addAllFiltered(ofType, transactions, t -> t.isFilteredToFluid(parallelData.id));
-                } else {
-                    transactions.addAll(ofType);
-                }
+                GTDataUtils.addAllFiltered(ofType, transactions, t -> !t.isFiltered() || t.isFilteredToFluid(parallelData.id));
             }
 
             parallelData.outputs = Iterators.peekingIterator(transactions.iterator());

--- a/src/main/java/gregtech/api/util/OutputHatchWrapper.java
+++ b/src/main/java/gregtech/api/util/OutputHatchWrapper.java
@@ -2,7 +2,6 @@ package gregtech.api.util;
 
 import java.util.function.Predicate;
 
-import appeng.api.AEApi;
 import net.minecraftforge.fluids.FluidStack;
 
 import org.jetbrains.annotations.NotNull;
@@ -55,7 +54,8 @@ public class OutputHatchWrapper implements IOutputHatch {
         return new FilteredTransactionWrapper();
     }
 
-    public class FilteredTransactionWrapper implements IOutputHatchTransaction, IOutputHatchTransaction.IRecipeCheckAware {
+    public class FilteredTransactionWrapper
+        implements IOutputHatchTransaction, IOutputHatchTransaction.IRecipeCheckAware {
 
         private final OutputHatchWrapper hatch = OutputHatchWrapper.this;
         private final IOutputHatchTransaction transaction = OutputHatchWrapper.this.outputHatch.createTransaction();

--- a/src/main/java/gregtech/api/util/OutputHatchWrapper.java
+++ b/src/main/java/gregtech/api/util/OutputHatchWrapper.java
@@ -2,6 +2,7 @@ package gregtech.api.util;
 
 import java.util.function.Predicate;
 
+import appeng.api.AEApi;
 import net.minecraftforge.fluids.FluidStack;
 
 import org.jetbrains.annotations.NotNull;
@@ -54,7 +55,7 @@ public class OutputHatchWrapper implements IOutputHatch {
         return new FilteredTransactionWrapper();
     }
 
-    public class FilteredTransactionWrapper implements IOutputHatchTransaction {
+    public class FilteredTransactionWrapper implements IOutputHatchTransaction, IOutputHatchTransaction.IRecipeCheckAware {
 
         private final OutputHatchWrapper hatch = OutputHatchWrapper.this;
         private final IOutputHatchTransaction transaction = OutputHatchWrapper.this.outputHatch.createTransaction();
@@ -62,6 +63,13 @@ public class OutputHatchWrapper implements IOutputHatch {
         @Override
         public IOutputHatch getHatch() {
             return hatch;
+        }
+
+        @Override
+        public void setRecipeCheck(boolean isRecipeCheck) {
+            if (transaction instanceof IOutputHatchTransaction.IRecipeCheckAware rt) {
+                rt.setRecipeCheck(isRecipeCheck);
+            }
         }
 
         @Override


### PR DESCRIPTION
Fix bug where if the recipe contain fewer output than the height of the dt it will crash. Fix bug where recipeCheck is not passed to the underlying me hatch, causing non-stop production even me hatch is full.