### PR TITLE
Rename inputs and outputs where they are not always inputs and outputs

### DIFF
--- a/src/main/java/bartworks/system/material/werkstoff_loaders/recipe/CellLoader.java
+++ b/src/main/java/bartworks/system/material/werkstoff_loaders/recipe/CellLoader.java
@@ -156,8 +156,8 @@ public class CellLoader implements IWerkstoffRunnable {
                         }
                     }
                 }
-                ItemStack input = werkstoff.get(cell);
-                input.stackSize = 1;
+                ItemStack werkstoffCell = werkstoff.get(cell);
+                werkstoffCell.stackSize = 1;
 
                 int cellEmpty = cells - 1;
 
@@ -168,8 +168,8 @@ public class CellLoader implements IWerkstoffRunnable {
                     .isElektrolysis())
                     GTValues.RA.stdBuilder()
                         .itemInputs(
-                            cellEmpty > 0 ? new ItemStack[] { input, Materials.Empty.getCells(cellEmpty) }
-                                : new ItemStack[] { input })
+                            cellEmpty > 0 ? new ItemStack[] { werkstoffCell, Materials.Empty.getCells(cellEmpty) }
+                                : new ItemStack[] { werkstoffCell })
                         .itemOutputs(stOutputs.toArray(new ItemStack[0]))
                         .fluidOutputs(flOutputs.isEmpty() ? new FluidStack[0] : new FluidStack[] { flOutputs.get(0) })
                         .duration(
@@ -195,8 +195,8 @@ public class CellLoader implements IWerkstoffRunnable {
                     .isCentrifuge())
                     GTValues.RA.stdBuilder()
                         .itemInputs(
-                            cellEmpty > 0 ? new ItemStack[] { input, Materials.Empty.getCells(cellEmpty) }
-                                : new ItemStack[] { input })
+                            cellEmpty > 0 ? new ItemStack[] { werkstoffCell, Materials.Empty.getCells(cellEmpty) }
+                                : new ItemStack[] { werkstoffCell })
                         .itemOutputs(stOutputs.toArray(new ItemStack[0]))
                         .fluidOutputs(flOutputs.isEmpty() ? new FluidStack[0] : new FluidStack[] { flOutputs.get(0) })
                         .duration(

--- a/src/main/java/bartworks/system/material/werkstoff_loaders/recipe/DustLoader.java
+++ b/src/main/java/bartworks/system/material/werkstoff_loaders/recipe/DustLoader.java
@@ -62,8 +62,8 @@ public class DustLoader implements IWerkstoffRunnable {
     @SuppressWarnings("unchecked")
     public void run(Werkstoff werkstoff) {
         if (werkstoff.hasItemType(dust)) {
-            List<FluidStack> flOutputs = new ArrayList<>();
-            List<ItemStack> stOutputs = new ArrayList<>();
+            List<FluidStack> fluidComponents = new ArrayList<>();
+            List<ItemStack> itemComponents = new ArrayList<>();
             HashMap<ISubTagContainer, Pair<Integer, Integer>> tracker = new HashMap<>();
 
             Werkstoff.Stats werkstoffStats = werkstoff.getStats();
@@ -92,17 +92,17 @@ public class DustLoader implements IWerkstoffRunnable {
                                 if (tmpFl == null || tmpFl.getFluid() == null) {
                                     tmpFl = materialKey.getFluid(1000L * value);
                                 }
-                                flOutputs.add(tmpFl);
-                                if (flOutputs.size() > 1) {
+                                fluidComponents.add(tmpFl);
+                                if (fluidComponents.size() > 1) {
                                     if (!tracker.containsKey(key)) {
-                                        stOutputs.add(materialKey.getCells(value));
-                                        tracker.put(key, Pair.of(value, stOutputs.size() - 1));
+                                        itemComponents.add(materialKey.getCells(value));
+                                        tracker.put(key, Pair.of(value, itemComponents.size() - 1));
                                     } else {
-                                        stOutputs.add(
+                                        itemComponents.add(
                                             materialKey.getCells(
                                                 tracker.get(key)
                                                     .getKey() + value));
-                                        stOutputs.remove(
+                                        itemComponents.remove(
                                             tracker.get(key)
                                                 .getValue() + 1);
                                     }
@@ -117,17 +117,17 @@ public class DustLoader implements IWerkstoffRunnable {
                                     if (tmpFl == null || tmpFl.getFluid() == null) {
                                         tmpFl = materialKey.getSolid(1000L * value);
                                     }
-                                    flOutputs.add(tmpFl);
-                                    if (flOutputs.size() > 1) {
+                                    fluidComponents.add(tmpFl);
+                                    if (fluidComponents.size() > 1) {
                                         if (!tracker.containsKey(key)) {
-                                            stOutputs.add(materialKey.getCells(value));
-                                            tracker.put(key, Pair.of(value, stOutputs.size() - 1));
+                                            itemComponents.add(materialKey.getCells(value));
+                                            tracker.put(key, Pair.of(value, itemComponents.size() - 1));
                                         } else {
-                                            stOutputs.add(
+                                            itemComponents.add(
                                                 materialKey.getCells(
                                                     tracker.get(key)
                                                         .getKey() + value));
-                                            stOutputs.remove(
+                                            itemComponents.remove(
                                                 tracker.get(key)
                                                     .getValue() + 1);
                                         }
@@ -135,14 +135,14 @@ public class DustLoader implements IWerkstoffRunnable {
                                     }
                                 }
                                 if (!tracker.containsKey(key)) {
-                                    stOutputs.add(materialKey.getDust(value));
-                                    tracker.put(key, Pair.of(value, stOutputs.size() - 1));
+                                    itemComponents.add(materialKey.getDust(value));
+                                    tracker.put(key, Pair.of(value, itemComponents.size() - 1));
                                 } else {
-                                    stOutputs.add(
+                                    itemComponents.add(
                                         materialKey.getDust(
                                             tracker.get(key)
                                                 .getKey() + value));
-                                    stOutputs.remove(
+                                    itemComponents.remove(
                                         tracker.get(key)
                                             .getValue() + 1);
                                 }
@@ -154,18 +154,18 @@ public class DustLoader implements IWerkstoffRunnable {
                                 if (tmpFl == null || tmpFl.getFluid() == null) {
                                     tmpFl = werkstoffKey.getFluidOrGas(1000 * value);
                                 }
-                                flOutputs.add(tmpFl);
-                                if (flOutputs.size() > 1) {
+                                fluidComponents.add(tmpFl);
+                                if (fluidComponents.size() > 1) {
                                     if (!tracker.containsKey(key)) {
-                                        stOutputs.add(werkstoffKey.get(cell, value));
-                                        tracker.put(key, Pair.of(value, stOutputs.size() - 1));
+                                        itemComponents.add(werkstoffKey.get(cell, value));
+                                        tracker.put(key, Pair.of(value, itemComponents.size() - 1));
                                     } else {
-                                        stOutputs.add(
+                                        itemComponents.add(
                                             werkstoffKey.get(
                                                 cell,
                                                 tracker.get(key)
                                                     .getKey() + value));
-                                        stOutputs.remove(
+                                        itemComponents.remove(
                                             tracker.get(key)
                                                 .getValue() + 1);
                                     }
@@ -174,15 +174,15 @@ public class DustLoader implements IWerkstoffRunnable {
                             } else {
                                 if (!werkstoffKey.hasItemType(dust)) continue;
                                 if (!tracker.containsKey(key)) {
-                                    stOutputs.add(werkstoffKey.get(dust, value));
-                                    tracker.put(key, Pair.of(value, stOutputs.size() - 1));
+                                    itemComponents.add(werkstoffKey.get(dust, value));
+                                    tracker.put(key, Pair.of(value, itemComponents.size() - 1));
                                 } else {
-                                    stOutputs.add(
+                                    itemComponents.add(
                                         werkstoffKey.get(
                                             dust,
                                             tracker.get(key)
                                                 .getKey() + value));
-                                    stOutputs.remove(
+                                    itemComponents.remove(
                                         tracker.get(key)
                                             .getValue() + 1);
                                 }
@@ -197,9 +197,10 @@ public class DustLoader implements IWerkstoffRunnable {
                             .itemInputs(
                                 cells > 0 ? new ItemStack[] { werkstoffDust, Materials.Empty.getCells(cells) }
                                     : new ItemStack[] { werkstoffDust })
-                            .itemOutputs(stOutputs.toArray(new ItemStack[0]))
+                            .itemOutputs(itemComponents.toArray(new ItemStack[0]))
                             .fluidOutputs(
-                                flOutputs.isEmpty() ? new FluidStack[0] : new FluidStack[] { flOutputs.get(0) })
+                                fluidComponents.isEmpty() ? new FluidStack[0]
+                                    : new FluidStack[] { fluidComponents.get(0) })
                             .duration(
                                 (int) Math.max(
                                     1L,
@@ -223,9 +224,10 @@ public class DustLoader implements IWerkstoffRunnable {
                             .itemInputs(
                                 cells > 0 ? new ItemStack[] { werkstoffDust, Materials.Empty.getCells(cells) }
                                     : new ItemStack[] { werkstoffDust })
-                            .itemOutputs(stOutputs.toArray(new ItemStack[0]))
+                            .itemOutputs(itemComponents.toArray(new ItemStack[0]))
                             .fluidOutputs(
-                                flOutputs.isEmpty() ? new FluidStack[0] : new FluidStack[] { flOutputs.get(0) })
+                                fluidComponents.isEmpty() ? new FluidStack[0]
+                                    : new FluidStack[] { fluidComponents.get(0) })
                             .duration(
                                 (int) Math.max(
                                     1L,
@@ -246,11 +248,11 @@ public class DustLoader implements IWerkstoffRunnable {
                     }
                     if (werkstoff.getGenerationFeatures()
                         .hasChemicalRecipes()) {
-                        if (cells > 0) stOutputs.add(Materials.Empty.getCells(cells));
+                        if (cells > 0) itemComponents.add(Materials.Empty.getCells(cells));
                         GTValues.RA.stdBuilder()
-                            .itemInputs(stOutputs.toArray(new ItemStack[0]))
+                            .itemInputs(itemComponents.toArray(new ItemStack[0]))
                             .itemOutputs(werkstoffDust)
-                            .fluidInputs(flOutputs.toArray(new FluidStack[0]))
+                            .fluidInputs(fluidComponents.toArray(new FluidStack[0]))
                             .duration(
                                 (int) Math.max(
                                     1L,
@@ -271,15 +273,16 @@ public class DustLoader implements IWerkstoffRunnable {
                     }
                     if (werkstoff.getGenerationFeatures()
                         .hasMixerRecipes()) {
-                        if (cells > 0) stOutputs.add(Materials.Empty.getCells(cells));
+                        if (cells > 0) itemComponents.add(Materials.Empty.getCells(cells));
                         short circuitID = werkstoff.getMixCircuit();
                         ItemStack circuit = circuitID == -1 ? null : GTUtility.getIntegratedCircuit(circuitID);
-                        if (circuit != null) stOutputs.add(circuit);
+                        if (circuit != null) itemComponents.add(circuit);
                         GTValues.RA.stdBuilder()
-                            .itemInputs(stOutputs.toArray(new ItemStack[0]))
+                            .itemInputs(itemComponents.toArray(new ItemStack[0]))
                             .itemOutputs(werkstoffDust)
                             .fluidInputs(
-                                flOutputs.isEmpty() ? new FluidStack[0] : new FluidStack[] { flOutputs.get(0) })
+                                fluidComponents.isEmpty() ? new FluidStack[0]
+                                    : new FluidStack[] { fluidComponents.get(0) })
                             .duration(
                                 (int) Math.max(
                                     1L,

--- a/src/main/java/bartworks/system/material/werkstoff_loaders/recipe/DustLoader.java
+++ b/src/main/java/bartworks/system/material/werkstoff_loaders/recipe/DustLoader.java
@@ -189,14 +189,14 @@ public class DustLoader implements IWerkstoffRunnable {
                             }
                         }
                     }
-                    ItemStack input = werkstoff.get(dust);
-                    input.stackSize = werkstoff.getContents()
+                    ItemStack werkstoffDust = werkstoff.get(dust);
+                    werkstoffDust.stackSize = werkstoff.getContents()
                         .getKey();
                     if (werkstoffStats.isElektrolysis()) {
                         GTValues.RA.stdBuilder()
                             .itemInputs(
-                                cells > 0 ? new ItemStack[] { input, Materials.Empty.getCells(cells) }
-                                    : new ItemStack[] { input })
+                                cells > 0 ? new ItemStack[] { werkstoffDust, Materials.Empty.getCells(cells) }
+                                    : new ItemStack[] { werkstoffDust })
                             .itemOutputs(stOutputs.toArray(new ItemStack[0]))
                             .fluidOutputs(
                                 flOutputs.isEmpty() ? new FluidStack[0] : new FluidStack[] { flOutputs.get(0) })
@@ -221,8 +221,8 @@ public class DustLoader implements IWerkstoffRunnable {
                     if (werkstoffStats.isCentrifuge()) {
                         GTValues.RA.stdBuilder()
                             .itemInputs(
-                                cells > 0 ? new ItemStack[] { input, Materials.Empty.getCells(cells) }
-                                    : new ItemStack[] { input })
+                                cells > 0 ? new ItemStack[] { werkstoffDust, Materials.Empty.getCells(cells) }
+                                    : new ItemStack[] { werkstoffDust })
                             .itemOutputs(stOutputs.toArray(new ItemStack[0]))
                             .fluidOutputs(
                                 flOutputs.isEmpty() ? new FluidStack[0] : new FluidStack[] { flOutputs.get(0) })
@@ -249,7 +249,7 @@ public class DustLoader implements IWerkstoffRunnable {
                         if (cells > 0) stOutputs.add(Materials.Empty.getCells(cells));
                         GTValues.RA.stdBuilder()
                             .itemInputs(stOutputs.toArray(new ItemStack[0]))
-                            .itemOutputs(input)
+                            .itemOutputs(werkstoffDust)
                             .fluidInputs(flOutputs.toArray(new FluidStack[0]))
                             .duration(
                                 (int) Math.max(
@@ -277,7 +277,7 @@ public class DustLoader implements IWerkstoffRunnable {
                         if (circuit != null) stOutputs.add(circuit);
                         GTValues.RA.stdBuilder()
                             .itemInputs(stOutputs.toArray(new ItemStack[0]))
-                            .itemOutputs(input)
+                            .itemOutputs(werkstoffDust)
                             .fluidInputs(
                                 flOutputs.isEmpty() ? new FluidStack[0] : new FluidStack[] { flOutputs.get(0) })
                             .duration(


### PR DESCRIPTION
Very minor refactor after https://github.com/GTNewHorizons/GT5-Unofficial/pull/7170.

Renamed `input` to `werkstoffX`, and where the outputs are mixed renamed them to `itemComponents` and `fluidComponents`.