### PR TITLE
[Mechanical Armor] Fix wrong armor index check for rendering jetpack

### DIFF
--- a/src/main/java/gregtech/common/items/armor/MechArmorBase.java
+++ b/src/main/java/gregtech/common/items/armor/MechArmorBase.java
@@ -1,7 +1,6 @@
 package gregtech.common.items.armor;
 
 import static gregtech.api.enums.Mods.GregTech;
-import static gregtech.api.items.armor.ArmorHelper.SLOT_CHEST;
 import static gregtech.api.items.armor.ArmorHelper.SLOT_LEGS;
 import static gregtech.api.util.GTUtility.getOrCreateNbtCompound;
 
@@ -283,7 +282,7 @@ public class MechArmorBase extends ItemArmor implements IKeyPressedListener, ISp
 
         ArmorState state = ArmorState.load(itemStack);
 
-        model.jettank1.showModel = (armorSlot == SLOT_CHEST && state.hasBehavior(BehaviorName.Jetpack));
+        model.jettank1.showModel = (armorSlot == 1 && state.hasBehavior(BehaviorName.Jetpack));
 
         model.core1.showModel = false;
         model.core2.showModel = false;


### PR DESCRIPTION
Returns the beautiful jetpack model

<img width="187" height="234" alt="image" src="https://github.com/user-attachments/assets/4176ffed-f091-46fc-8635-996de54f36bf" />
