### PR TITLE
Move Materials.Air init to loadDegree2Compounds()

### DIFF
--- a/src/main/java/gregtech/loaders/materials/MaterialsInit.java
+++ b/src/main/java/gregtech/loaders/materials/MaterialsInit.java
@@ -5406,7 +5406,6 @@ public class MaterialsInit {
     private static void loadDegree1Compounds() {
         Materials.AceticAcid = loadAceticAcid();
         Materials.Acetone = loadAcetone();
-        Materials.Air = loadAir();
         Materials.AllylChloride = loadAllylChloride();
         Materials.Almandine = loadAlmandine();
         Materials.Ammonia = loadAmmonia();
@@ -9641,6 +9640,7 @@ public class MaterialsInit {
     }
 
     private static void loadDegree2Compounds() {
+        Materials.Air = loadAir();
         Materials.Aluminiumhydroxide = loadAluminiumHydroxide();
         Materials.Aluminiumoxide = loadAluminiumoxide();
         Materials.Alumite = loadAlumite();


### PR DESCRIPTION
Air was previously initialized before noble gasses. Moved it to degree 2 compounds similar to liquid air so it gets initialized after noble gasses.

Did a check for all the other materials as well and none of the other materials had a null material component, only air.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25389