### PR TITLE
Add isGTRenderer

### DIFF
--- a/src/main/java/gregtech/api/GregTechAPI.java
+++ b/src/main/java/gregtech/api/GregTechAPI.java
@@ -22,8 +22,10 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 
+import bartworks.common.loaders.FluidLoader;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import goodgenerator.loader.Loaders;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
 import gregtech.api.interfaces.IDamagableItem;
@@ -44,6 +46,7 @@ import gregtech.api.util.GTUtility;
 import gregtech.api.world.GTWorldgen;
 import gregtech.common.GTDummyWorld;
 import gregtech.common.covers.CoverPosition;
+import tectech.thing.casing.TTCasingsContainer;
 
 /**
  * Please do not include this File in your Mod-download as it ruins compatibility, like with the IC2-API You may just
@@ -318,6 +321,19 @@ public class GregTechAPI {
                 return (id & B[aMeta]) != 0;
             }
         }
+        return false;
+    }
+
+    /**
+     * if this Block is a TESR Render Block
+     */
+    public static boolean isGTRenderer(Block block) {
+        if (block == GregTechAPI.sWormholeRender) return true;
+        if (block == GregTechAPI.sBlackholeRender) return true;
+        if (block == TTCasingsContainer.eyeOfHarmonyRenderBlock) return true;
+        if (block == TTCasingsContainer.forgeOfGodsRenderBlock) return true;
+        if (block == FluidLoader.bioFluidBlock) return true;
+        if (block == Loaders.antimatterRenderBlock) return true;
         return false;
     }
 


### PR DESCRIPTION
Some mods like [MatterManipulator](https://github.com/GTNewHorizons/MatterManipulator) need to [identify GT render block](https://github.com/GTNewHorizons/MatterManipulator/blob/87d7bc2b58957ade11e37a5ee82b29e80add86bb/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/InteropConstants.java#L70), but we are switching to IMTERenderer. It's annoying to have to update other mods every time a render block disappears, so i make a method here.