### PR TITLE
Uptier bauxite comb processing to HV

### DIFF
--- a/src/main/java/gregtech/common/items/ItemComb.java
+++ b/src/main/java/gregtech/common/items/ItemComb.java
@@ -580,7 +580,7 @@ public class ItemComb extends Item implements IGT_ItemWithMaterialRenderer, IIte
             30 * 100);
 
         // Rare Metals Line
-        addProcessGT(CombType.BAUXITE, new Materials[] { Materials.Bauxite }, Voltage.LV);
+        addProcessGT(CombType.BAUXITE, new Materials[] { Materials.Bauxite }, Voltage.HV);
         addProcessGT(CombType.ALUMINIUM, new Materials[] { Materials.Aluminium }, Voltage.LV);
         addProcessGT(CombType.MANGANESE, new Materials[] { Materials.Manganese }, Voltage.LV);
         addProcessGT(CombType.TITANIUM, new Materials[] { Materials.Titanium }, Voltage.EV);


### PR DESCRIPTION
I asked Dream for his take on Bauxia since it allowed a fairly easy moon skip, as Bauxia and crops in general can generate quite a lot of resources/drops early on. We also talked about the bauxite comb processing recipe, and this PR is the result of that conversation.

The gist of it is that:
- Bauxite _ore_ generation shouldn't be possible before HV, _period_.
- Bauxite _dust_ generation pre-HV is mostly fine as it is, as it requires a lot more investment to get anything bauxite-related when using it.

With that goal in mind, this PR makes some changes to the bauxite comb recipe to better gate the generation of bauxite ore to HV:
- Bauxite ore production was moved from an MV recipe to an HV recipe
- This also changes the acid used from HCL (384L) to HF (1152L)

A similar PR has been made to CropsNH to _mostly_ mirror these changes (the recipe is EV instead of HV, since crops will drop a lot more things that can be turned into bauxite, making the skip a bit too easy): https://github.com/GTNewHorizons/CropsNH/pull/172

---

# Screenshots

<img width="519" height="531" alt="image" src="https://github.com/user-attachments/assets/1088237a-4da5-4ccf-95a3-e13aba78b758" />
