### PR TITLE
Fix log spam of gl error

### DIFF
--- a/src/main/java/gregtech/client/GTPowerfailRenderer.java
+++ b/src/main/java/gregtech/client/GTPowerfailRenderer.java
@@ -76,7 +76,7 @@ public class GTPowerfailRenderer {
         GL11.glPushAttrib(GL11.GL_ENABLE_BIT);
 
         GL11.glDisable(GL11.GL_DEPTH_TEST);
-        GL11.glEnable(GL11.GL_ALPHA);
+        GL11.glEnable(GL11.GL_ALPHA_TEST);
         GL11.glEnable(GL11.GL_BLEND);
         GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
 


### PR DESCRIPTION
There is a log spam of gl error whenever a machine power fail and the rendering code is invoked.

<img width="2417" height="380" alt="image" src="https://github.com/user-attachments/assets/94aa7994-b250-47cd-a2e9-a4bd6070ca37" />

GL_ALPHA is invalid, changed to GL_ALPHA_TEST.