### PR TITLE
Add Missing Recipes For GT++ Small Gears

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/RecipeGenExtruder.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/RecipeGenExtruder.java
@@ -36,10 +36,12 @@ public class RecipeGenExtruder extends RecipeGenBase {
         final ItemStack itemIngot = material.getIngot(1);
         final ItemStack itemPlate = material.getPlate(1);
         final ItemStack itemGear = material.getGear(1);
+        final ItemStack itemGearSmall = material.getGearSmall(1);
 
         final ItemStack shape_Plate = ItemList.Shape_Extruder_Plate.get(0);
         final ItemStack shape_Ring = ItemList.Shape_Extruder_Ring.get(0);
         final ItemStack shape_Gear = ItemList.Shape_Extruder_Gear.get(0);
+        final ItemStack shape_GearSmall = ItemList.Shape_Extruder_Small_Gear.get(0);
         final ItemStack shape_Rod = ItemList.Shape_Extruder_Rod.get(0);
         final ItemStack shape_Bolt = ItemList.Shape_Extruder_Bolt.get(0);
         final ItemStack shape_Block = ItemList.Shape_Extruder_Block.get(0);
@@ -91,6 +93,16 @@ public class RecipeGenExtruder extends RecipeGenBase {
                 .itemInputs(material.getIngot(4), shape_Gear)
                 .itemOutputs(itemGear)
                 .duration((int) Math.max(material.getMass() * 5L, 1))
+                .eut(material.vVoltageMultiplier)
+                .addTo(extruderRecipes);
+        }
+
+        // Small Gear Recipe
+        if (material.getIngot(1) != null && material.getGearSmall(1) != null && !material.isRadioactive) {
+            GTValues.RA.stdBuilder()
+                .itemInputs(material.getIngot(1), shape_GearSmall)
+                .itemOutputs(itemGearSmall)
+                .duration((int) Math.max(material.getMass() * 2L, 1))
                 .eut(material.vVoltageMultiplier)
                 .addTo(extruderRecipes);
         }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/RecipeGenFluids.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/RecipeGenFluids.java
@@ -89,7 +89,7 @@ public class RecipeGenFluids extends RecipeGenBase {
             }
 
             // Small Gear
-            if (material.getGear(1) != null) {
+            if (material.getGearSmall(1) != null) {
                 GTValues.RA.stdBuilder()
                     .itemInputs(ItemList.Shape_Mold_Gear_Small.get(0))
                     .itemOutputs(material.getGearSmall(1))

--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/RecipeGenFluids.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/RecipeGenFluids.java
@@ -77,7 +77,7 @@ public class RecipeGenFluids extends RecipeGenBase {
                     .addTo(fluidSolidifierRecipes);
             }
 
-            // Gears
+            // Gear
             if (material.getGear(1) != null) {
                 GTValues.RA.stdBuilder()
                     .itemInputs(ItemList.Shape_Mold_Gear.get(0))
@@ -88,7 +88,18 @@ public class RecipeGenFluids extends RecipeGenBase {
                     .addTo(fluidSolidifierRecipes);
             }
 
-            // Blocks
+            // Small Gear
+            if (material.getGear(1) != null) {
+                GTValues.RA.stdBuilder()
+                    .itemInputs(ItemList.Shape_Mold_Gear_Small.get(0))
+                    .itemOutputs(material.getGearSmall(1))
+                    .fluidInputs(material.getFluidStack(144))
+                    .duration(3 * SECONDS)
+                    .eut(material.vVoltageMultiplier)
+                    .addTo(fluidSolidifierRecipes);
+            }
+
+            // Block
             if (material.getBlock(1) != null) {
                 GTValues.RA.stdBuilder()
                     .itemInputs(ItemList.Shape_Mold_Block.get(0))


### PR DESCRIPTION
was never added, since hypogen small gear is the first. it happens

Fluid solidifer is 3 seconds, the same time as plate and ingot, other 144 fluid recipes

Extruder has "material.getMass() * 2L * 1, 1", used for other 1 ingot -> part extruder recipes. making it identical to bolts, rods, rings, ingots, and.. blocks? i blame alk

<img width="506" height="431" alt="image" src="https://github.com/user-attachments/assets/f4b72d11-f771-4d39-92f2-fe0b4e875933" />

<img width="503" height="436" alt="image" src="https://github.com/user-attachments/assets/34f7ef41-f362-4279-b6e4-31e8014adb3c" />
