### PR TITLE
Increase Chemical Bath NEI Item Outputs to 6

### DIFF
--- a/src/main/java/gregtech/api/recipe/RecipeMaps.java
+++ b/src/main/java/gregtech/api/recipe/RecipeMaps.java
@@ -552,7 +552,7 @@ public final class RecipeMaps {
         .neiHandlerInfo(builder -> builder.setDisplayStack(ItemList.Machine_LV_Macerator.get(1)))
         .build();
     public static final RecipeMap<RecipeMapBackend> chemicalBathRecipes = RecipeMapBuilder.of("gt.recipe.chemicalbath")
-        .maxIO(2, 3, 2, 2)
+        .maxIO(2, 6, 2, 2)
         .minInputs(1, 1)
         .progressBar(GTUITextures.PROGRESSBAR_BATH, ProgressBar.Direction.CIRCULAR_CW)
         .progressBarMUI2(GTGuiTextures.PROGRESSBAR_BATH, ProgressWidget.Direction.CIRCULAR_CW)


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25456

Gives chem bath 6 item output slots, single block hv already had this capacity, so its just for nei.

made it 6 instead of 4, so that it keeps the old 3 output recipes from looking weird

example image, salty root is not in gt5u

<img width="512" height="341" alt="image" src="https://github.com/user-attachments/assets/db933d23-77c3-4e5a-b2ae-53a17c2857ac" />
