### PR TITLE
Fix Thermal Boiler Still Requiring Pollution

### DIFF
--- a/src/main/java/gregtech/common/pollution/PollutionConfig.java
+++ b/src/main/java/gregtech/common/pollution/PollutionConfig.java
@@ -343,14 +343,9 @@ public class PollutionConfig {
     @Config.Comment("pollution rate in gibbl/s for the Multiblock Molecular Transformer")
     @Config.DefaultInt(1_000)
     public static int pollutionPerSecondMultiMolecularTransformer;
-
     @Config.Comment("pollution rate in gibbl/s for the Elemental Duplicator")
     @Config.DefaultInt(1_000)
     public static int pollutionPerSecondElementalDuplicator;
-
-    @Config.Comment("pollution rate in gibbl/s for the Thermal boiler")
-    @Config.DefaultInt(700)
-    public static int pollutionPerSecondMultiThermalBoiler;
     @Config.Comment("pollution rate in gibbl/s for the Algae farm")
     @Config.DefaultInt(0)
     public static int pollutionPerSecondMultiAlgaePond;

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTEThermalBoilerLegacy.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTEThermalBoilerLegacy.java
@@ -48,7 +48,6 @@ import gregtech.api.util.GTRecipe;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.MultiblockTooltipBuilder;
 import gregtech.api.util.ParallelHelper;
-import gregtech.common.pollution.PollutionConfig;
 import gtPlusPlus.api.recipe.GTPPRecipeMaps;
 import gtPlusPlus.core.block.ModBlocks;
 import gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.base.GTPPMultiBlockBase;
@@ -272,11 +271,6 @@ public class MTEThermalBoilerLegacy extends GTPPMultiBlockBase<MTEThermalBoilerL
     }
 
     @Override
-    public int getPollutionPerSecond(ItemStack aStack) {
-        return PollutionConfig.pollutionPerSecondMultiThermalBoiler;
-    }
-
-    @Override
     protected MultiblockTooltipBuilder createTooltip() {
         MultiblockTooltipBuilder tt = new MultiblockTooltipBuilder();
         tt.addMachineType(getMachineType())
@@ -285,7 +279,6 @@ public class MTEThermalBoilerLegacy extends GTPPMultiBlockBase<MTEThermalBoilerL
             .addInfo(GTUtility.translate("gt.multiblock.ThermalBoiler.desc2"))
             .addInfo(GTUtility.translate("gt.multiblock.ThermalBoiler.desc3"))
             .addInfo(GTUtility.translate("gt.multiblock.ThermalBoiler.desc4"))
-            .addPollutionAmount(getPollutionPerSecond(null))
             .beginStructureBlock(3, 3, 3, true)
             .addController("Front center")
             .addCasingInfoMin("Thermal Containment Casing", 10, false)


### PR DESCRIPTION
The Thermal Boiler is only a heat exchanger so it should not be producing any pollution. This should be my last fix to have it work properly without a muffler hatch. Here's a short timeline:

- Remove Muffler Hatch Requirement for Thermal Boiler (https://github.com/GTNewHorizons/GT5-Unofficial/pull/6855)
- Remove Pollution from Tooltip and MTEThermalBoiler (https://github.com/GTNewHorizons/GT5-Unofficial/pull/7197)
- Remove Pollution from Config and MTEThermalBoilerLegacy (This PR)

Going to make another PR on the GTNH repo to remove the setting from pollution.cfg but can confirm the Thermal Boiler now works as intended without any pollution.

fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25572