### PR TITLE
Fix Toxic Everglades ore height range

### DIFF
--- a/src/main/java/gregtech/api/enums/OreMixes.java
+++ b/src/main/java/gregtech/api/enums/OreMixes.java
@@ -1138,7 +1138,7 @@ public enum OreMixes {
         .sporadic(MaterialsOres.AGARDITE_ND)),
 
     GTPP5(new OreMixBuilder().name("ore.mix.gtpp5")
-        .heightRange(30, 128)
+        .heightRange(15, 58)
         .weight(20)
         .density(2)
         .size(48)
@@ -1160,7 +1160,7 @@ public enum OreMixes {
         .sporadic(MaterialsOres.IRARSITE)),
 
     GTPP7(new OreMixBuilder().name("ore.mix.gtpp7")
-        .heightRange(40, 128)
+        .heightRange(20, 58)
         .weight(20)
         .density(2)
         .size(48)
@@ -1204,7 +1204,7 @@ public enum OreMixes {
         .sporadic(MaterialsOres.RADIOBARITE)),
 
     GTPP11(new OreMixBuilder().name("ore.mix.gtpp11")
-        .heightRange(30, 70)
+        .heightRange(18, 58)
         .weight(20)
         .density(1)
         .size(48)
@@ -1215,7 +1215,7 @@ public enum OreMixes {
         .sporadic(MaterialsOres.CRYOLITE)),
 
     GTPP12(new OreMixBuilder().name("ore.mix.gtpp12")
-        .heightRange(40, 80)
+        .heightRange(22, 58)
         .weight(20)
         .density(3)
         .size(32)


### PR DESCRIPTION
The Toxic Everglades dimension (227) have a mostly surface level around Y60 (actually a bit less since it's a swamp).
Yet the some of it's OreMixes have height range way outside of that. It causes useless rerolls and lower placement density due to it.

Actual rarity is already pretty heavily impacted by how this is the only dim set in `DimensionDef` with `.setOreVeinChance(66)` (1/3 chances of not getting a vein in a 3x3 spot).
