### PR TITLE
Allow Crib and Proxy as valid Input Hatches

### DIFF
--- a/src/main/java/gregtech/api/enums/HatchElement.java
+++ b/src/main/java/gregtech/api/enums/HatchElement.java
@@ -20,6 +20,8 @@ import gregtech.api.metatileentity.implementations.MTEMultiBlockBase;
 import gregtech.api.util.ExoticEnergyInputHelper;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.IGTHatchAdder;
+import gregtech.common.tileentities.machines.MTEHatchCraftingInputME;
+import gregtech.common.tileentities.machines.MTEHatchCraftingInputSlave;
 import gregtech.common.tileentities.machines.multi.purification.MTEHatchLensHousing;
 import gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.MTEHatchSteamBusInput;
 import gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.MTEHatchSteamBusOutput;
@@ -50,6 +52,11 @@ public enum HatchElement implements IHatchElement<MTEMultiBlockBase> {
         @Override
         public long count(MTEMultiBlockBase t) {
             return t.mInputHatches.size();
+        }
+
+        @Override
+        public List<? extends Class<? extends IMetaTileEntity>> mteClasses() {
+            return ImmutableList.of(MTEHatchInput.class, MTEHatchCraftingInputME.class, MTEHatchCraftingInputSlave.class);
         }
     },
     InputBus("GT5U.MBTT.InputBus", MTEMultiBlockBase::addInputBusToMachineList, MTEHatchInputBus.class) {

--- a/src/main/java/gregtech/api/enums/HatchElement.java
+++ b/src/main/java/gregtech/api/enums/HatchElement.java
@@ -51,12 +51,15 @@ public enum HatchElement implements IHatchElement<MTEMultiBlockBase> {
 
         @Override
         public long count(MTEMultiBlockBase t) {
-            return t.mInputHatches.size();
+            return t.mInputHatches.size() + t.mDualInputHatches.stream()
+                .filter(hatch -> hatch.supportsFluids() || hatch instanceof MTEHatchCraftingInputSlave)
+                .count();
         }
 
         @Override
         public List<? extends Class<? extends IMetaTileEntity>> mteClasses() {
-            return ImmutableList.of(MTEHatchInput.class, MTEHatchCraftingInputME.class, MTEHatchCraftingInputSlave.class);
+            return ImmutableList
+                .of(MTEHatchInput.class, MTEHatchCraftingInputME.class, MTEHatchCraftingInputSlave.class);
         }
     },
     InputBus("GT5U.MBTT.InputBus", MTEMultiBlockBase::addInputBusToMachineList, MTEHatchInputBus.class) {

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEEnhancedMultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEEnhancedMultiBlockBase.java
@@ -46,7 +46,6 @@ import gregtech.api.util.GTUtility;
 import gregtech.api.util.shutdown.ShutDownReasonRegistry;
 import gregtech.client.GTSoundLoop;
 import gregtech.client.volumetric.ISoundPosition;
-import gregtech.common.tileentities.machines.MTEHatchCraftingInputSlave;
 
 /**
  * Enhanced multiblock base class, featuring following improvement over {@link MTEMultiBlockBase}

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEEnhancedMultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEEnhancedMultiBlockBase.java
@@ -624,9 +624,6 @@ public abstract class MTEEnhancedMultiBlockBase<T extends MTEEnhancedMultiBlockB
         checkHatchMin(errors, HatchElement.OutputBus, 1);
     }
 
-    // NOTE: Despite the name, this also allow crafting inputs, if they support fluids
-    // Most of the time it's what you want. If you don't want such inputs,
-    // you can omit InputBus in your structure or roll your own checks
     protected final void checkHasInputHatch(List<StructureError> errors) {
         checkHatchMin(errors, HatchElement.InputHatch, 1);
     }

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEEnhancedMultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEEnhancedMultiBlockBase.java
@@ -628,13 +628,7 @@ public abstract class MTEEnhancedMultiBlockBase<T extends MTEEnhancedMultiBlockB
     // Most of the time it's what you want. If you don't want such inputs,
     // you can omit InputBus in your structure or roll your own checks
     protected final void checkHasInputHatch(List<StructureError> errors) {
-        // Due to update delay, slave is sometimes not recognized. We always allow slave to substitute as input hatch
-        long count = mInputHatches.size() + mDualInputHatches.stream()
-            .filter(hatch -> hatch.supportsFluids() || hatch instanceof MTEHatchCraftingInputSlave)
-            .count();
-        if (count == 0) {
-            errors.add(StructureErrors.hatchCount(ErrorType.TOO_FEW, HatchElement.InputHatch, 0, 1));
-        }
+        checkHatchMin(errors, HatchElement.InputHatch, 1);
     }
 
     protected final void checkHasOutputHatch(List<StructureError> errors) {

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
@@ -143,6 +143,7 @@ import gregtech.common.tileentities.machines.IHatchWatcher;
 import gregtech.common.tileentities.machines.IRecipeProcessingAwareHatch;
 import gregtech.common.tileentities.machines.ISmartInputHatch;
 import gregtech.common.tileentities.machines.MTEHatchCraftingInputME;
+import gregtech.common.tileentities.machines.MTEHatchCraftingInputSlave;
 import gregtech.common.tileentities.machines.MTEHatchInputBusME;
 import gregtech.common.tileentities.machines.MTEHatchInputME;
 import gregtech.common.tileentities.machines.multi.MTELargeTurbineLegacy;
@@ -2342,6 +2343,15 @@ public abstract class MTEMultiBlockBase extends MetaTileEntity
         IMetaTileEntity aMetaTileEntity = aTileEntity.getMetaTileEntity();
         if (aMetaTileEntity == null) return false;
         addIfSmartInput(aMetaTileEntity);
+        if (aMetaTileEntity instanceof IDualInputHatch hatch
+            && (hatch.supportsFluids() || aMetaTileEntity instanceof MTEHatchCraftingInputSlave)) {
+            hatch.updateTexture(aBaseCasingIndex);
+            hatch.updateCraftingIcon(this.getMachineCraftingIcon());
+            if (!mDualInputHatches.contains(hatch)) {
+                mDualInputHatches.add(hatch);
+            }
+            return true;
+        }
         if (aMetaTileEntity instanceof MTEHatchInput hatch) {
             hatch.updateTexture(aBaseCasingIndex);
             hatch.updateCraftingIcon(this.getMachineCraftingIcon());


### PR DESCRIPTION
Unsure if this breaks anything, but i hope it doesnt. Cribs and proxys now count towards input hatches and are allowed in their position.
tested on MDT and works.
Before: (Crib doesnt let MDT form and is not accepted as Input Hatch)
<img width="3024" height="1964" alt="image" src="https://github.com/user-attachments/assets/8895b95c-ee6a-4284-a758-0b2a5f3bf5f4" />

after:
<img width="374" height="263" alt="image" src="https://github.com/user-attachments/assets/ac179083-b044-48e8-a713-cba645aabbf7" />

