### PR TITLE
feat(ITextureBuilder): add glow(boolean) overload

### DIFF
--- a/src/main/java/gregtech/api/interfaces/ITextureBuilder.java
+++ b/src/main/java/gregtech/api/interfaces/ITextureBuilder.java
@@ -52,6 +52,12 @@ public interface ITextureBuilder {
      * Texture always render with full brightness to glow in the dark
      *
      * @return {@link ITextureBuilder} for chaining
+     *
+     * @implSpec Must be overridden to actually do something
      */
+    default ITextureBuilder glow(boolean glow) {
+        return this;
+    }
+
     ITextureBuilder glow();
 }

--- a/src/main/java/gregtech/common/blocks/GTBlockOre.java
+++ b/src/main/java/gregtech/common/blocks/GTBlockOre.java
@@ -209,29 +209,25 @@ public class GTBlockOre extends GTGenericBlock implements IBlockWithTextures, IB
         Materials mat = getMaterial(metadata);
         boolean small = isSmallOre(metadata);
 
-        ITexture[] textures;
-
-        if (stoneType == null) stoneType = StoneType.Stone;
+        final ITextureBuilder fgBuilder;
 
         if (mat != null) {
-            ITextureBuilder builder = TextureFactory.builder()
+            fgBuilder = TextureFactory.builder()
                 .addIcon(
                     mat.mIconSet.mTextures[small ? OrePrefixes.oreSmall.getTextureIndex()
                         : OrePrefixes.ore.getTextureIndex()])
                 .setRGBA(mat.mRGBa)
-                .stdOrient();
-            if (mat.hasGlowingOre()) {
-                builder = builder.glow();
-            }
-            ITexture iTexture = builder.build();
-
-            textures = new ITexture[] { stoneType.getTexture(0), iTexture };
+                .glow(mat.hasGlowingOre());
         } else {
-            textures = new ITexture[] { stoneType.getTexture(0), TextureFactory.builder()
-                .addIcon(TextureSet.SET_NONE.mTextures[OrePrefixes.ore.getTextureIndex()])
-                .stdOrient()
-                .build() };
+            fgBuilder = TextureFactory.builder()
+                .addIcon(TextureSet.SET_NONE.mTextures[OrePrefixes.ore.getTextureIndex()]);
         }
+
+        final ITexture bg = (stoneType == null ? StoneType.Stone : stoneType).getTexture(0);
+        final ITexture fg = fgBuilder.stdOrient()
+            .build();
+
+        final ITexture[] textures = new ITexture[] { bg, fg };
 
         return new ITexture[][] { textures, textures, textures, textures, textures, textures };
     }

--- a/src/main/java/gregtech/common/render/GTTextureBuilder.java
+++ b/src/main/java/gregtech/common/render/GTTextureBuilder.java
@@ -47,7 +47,12 @@ public final class GTTextureBuilder implements ITextureBuilder {
 
     @Override
     public ITextureBuilder glow() {
-        glow = true;
+        return glow(true);
+    }
+
+    @Override
+    public ITextureBuilder glow(boolean glow) {
+        this.glow = glow;
         return this;
     }
 


### PR DESCRIPTION
This lets `GTBlockOre` set the glow flag inline in the builder.

See: [#7225 Glowing GT Ores & New Infused Stone texture](#7225)