### PR TITLE
Extreme Industrial Greenhouse no longer outputs seeds

### DIFF
--- a/src/main/java/kubatech/tileentity/gregtech/multiblock/eigbuckets/EIGSeedBucket.java
+++ b/src/main/java/kubatech/tileentity/gregtech/multiblock/eigbuckets/EIGSeedBucket.java
@@ -1,6 +1,7 @@
 package kubatech.tileentity.gregtech.multiblock.eigbuckets;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
@@ -22,6 +23,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.DamageSource;
 import net.minecraft.world.World;
 import net.minecraftforge.common.IPlantable;
+import net.minecraftforge.oredict.OreDictionary;
 
 import com.mitchej123.hodgepodge.mixins.interfaces.INetherSeed;
 
@@ -164,7 +166,10 @@ public class EIGSeedBucket extends EIGBucket {
         seedSafe.stackSize = 1;
         // first check if we dropped an item identical to our seed item.
         int inputSeedDropCountAfterRemoval = (int) Math.round(drops.getItemAmount(seedSafe)) - seedsToConsume;
-        if (inputSeedDropCountAfterRemoval > 0) {
+        // true seeds should be removed entirely, potatos/carrots should only be reduced.
+        boolean isTrueSeed = Arrays.stream(OreDictionary.getOreIDs(seedSafe))
+            .anyMatch(id -> id == OreDictionary.getOreID("listAllseed"));
+        if (inputSeedDropCountAfterRemoval > 0 && !isTrueSeed) {
             drops.setItemAmount(seedSafe, inputSeedDropCountAfterRemoval);
         } else {
             drops.removeItem(seedSafe);


### PR DESCRIPTION
Bugfix for GTNewHorizons/GT-New-Horizons-Modpack#19078

Any output with oredict "listAllSeed" is removed from drop table. This affects things like wheat/cotton, but not potatos/carrots.

Results of testing:
- Vanilla, Witchery, Natura, Pam's seeds do not generate seeds as output.
- Potatoes and carrots still operate as normal. 


Spotted a few prexisting issues, such as barley not allowing to be input and it saving the history of output items in the processing gui. 