### PR TITLE
Remove Input Hatch for Mining Modules

### DIFF
--- a/src/main/java/gtnhintergalactic/tile/multi/elevatormodules/TileEntityModuleMiner.java
+++ b/src/main/java/gtnhintergalactic/tile/multi/elevatormodules/TileEntityModuleMiner.java
@@ -906,7 +906,6 @@ public abstract class TileEntityModuleMiner extends TileEntityModuleBase
         if (!errors.isEmpty()) return;
         checkHasInputBus(errors);
         checkHasOutputBus(errors);
-        checkHasInputHatch(errors);
         if (eInputData.isEmpty() && this.parent != null && !this.parent.hasDataHatches()) {
             errors.add(StructureErrorRegistry.MISSING_DATA_HATCH);
         }


### PR DESCRIPTION
Plasma is now sourced from the main structure so an input hatch is no longer required on SE mining modules. There can still be one if necessary but this just removes the hard requirement in the structure check.