### PR TITLE
Fix scanner custom info showing raw translation keys

### DIFF
--- a/src/main/java/gregtech/api/util/scanner/ScannerHelper.java
+++ b/src/main/java/gregtech/api/util/scanner/ScannerHelper.java
@@ -335,7 +335,7 @@ public class ScannerHelper {
                 if (resultList.isEmpty()) return;
 
                 list.add(addTitleComp("title_custom_info"));
-                for (String s : resultList) list.add(new ChatComponentText(s));
+                for (String s : resultList) list.add(IGregTechDeviceInformation.toComponent(s));
             }
         } catch (Exception e) {
             list.add(transComp("error_custom_info").setChatStyle(new ChatStyle().setColor(EnumChatFormatting.RED)));


### PR DESCRIPTION
The scanner HUD showed raw translation keys like GT5U.EBF.heat.s\2,001 in the Custom Info section because addCustomInfoComp wrapped the encoded strings in a plain ChatComponentText instead of decoding them. addMachineInfoComp already does this right via toComponent, so I use the same call. Regression from #7090.
