### PR TITLE
Remove mention of Explosion Hazard Blocks on Implo Comp

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEImplosionCompressor.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEImplosionCompressor.java
@@ -108,7 +108,6 @@ public class MTEImplosionCompressor extends MTEExtendedPowerMultiBlockBase<MTEIm
             .beginStructureBlock(3, 3, 3, true)
             .addController("Front center")
             .addCasingInfoRange("Solid Steel Machine Casing", 16, 24, false)
-            .addStructureInfo("Casings can be replaced with Explosion Hazard Signs")
             .addEnergyHatch("Any Casing", 1)
             .addMaintenanceHatch("Any Casing", 1)
             .addMufflerHatch("Any Casing", 1)


### PR DESCRIPTION
was intentionally removed in https://github.com/GTNewHorizons/GT5-Unofficial/commit/4ee367fcc8fcd1312552970a79fcd46bcae73503#diff-f4146b90ee0dea5b09478a3e5f251ede40e9f545d90b6c05068ecf1372b90029 
closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25410