### PR TITLE
remove explosion tooltips on multis that dont explode

### DIFF
--- a/src/main/java/goodgenerator/blocks/tileEntity/MTENeutronActivator.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/MTENeutronActivator.java
@@ -15,7 +15,6 @@ import java.util.List;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.StatCollector;
 import net.minecraftforge.common.util.ForgeDirection;
 
@@ -199,11 +198,6 @@ public class MTENeutronActivator extends TTMultiblockBase implements ISurvivalCo
             .addInfo("It will output correct products with Specific Neutron Kinetic Energy")
             .addInfo("Otherwise it will output trash")
             .addInfo("The Neutron Kinetic Energy will decrease 72KeV/s when no Neutron Accelerator is running")
-            .addInfo(
-                "It will explode when the Neutron Kinetic Energy is over" + EnumChatFormatting.RED
-                    + " 1200MeV"
-                    + EnumChatFormatting.GRAY
-                    + ".")
             .addInfo("Inputting Graphite/Beryllium dust can reduce 10MeV per dust immediately.")
             .addController("Front bottom center")
             .addCasingInfoRange("Clean Stainless Steel Machine Casing", 7, 31, false)

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTELargeNaquadahReactor.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTELargeNaquadahReactor.java
@@ -379,11 +379,6 @@ public class MTELargeNaquadahReactor extends TTMultiblockBase implements ISurviv
                     EnumChatFormatting.AQUA,
                     LiquidAirConsumptionPerSecond,
                     EnumChatFormatting.GRAY))
-            .addInfo(
-                "The reactor will explode when there is more than" + EnumChatFormatting.RED
-                    + " ONE"
-                    + EnumChatFormatting.GRAY
-                    + " type of fuel in hatches!")
             .addInfo("Input liquid nuclear fuel or liquid naquadah fuel")
             .addSeparator()
             .addInfo(


### PR DESCRIPTION
large naquadah reactor and neutron activator tooltips claim they explode, the multis cannot explode via the way the tooltip states