### PR TITLE
Improve BEC NEI Handler

### DIFF
--- a/src/main/java/gregtech/api/recipe/RecipeMapFrontend.java
+++ b/src/main/java/gregtech/api/recipe/RecipeMapFrontend.java
@@ -26,7 +26,9 @@ import com.gtnewhorizons.modularui.common.widget.DrawableWidget;
 import com.gtnewhorizons.modularui.common.widget.ProgressBar;
 import com.gtnewhorizons.modularui.common.widget.SlotWidget;
 
+import codechicken.nei.NEIClientUtils;
 import codechicken.nei.PositionedStack;
+import codechicken.nei.recipe.GuiRecipe;
 import gregtech.api.enums.TieredVariant;
 import gregtech.api.gui.GUIColorOverride;
 import gregtech.api.gui.modularui.GTUITextures;
@@ -35,6 +37,7 @@ import gregtech.api.util.GTRecipe;
 import gregtech.api.util.MethodsReturnNonnullByDefault;
 import gregtech.common.gui.modularui.UIHelper;
 import gregtech.nei.GTNEIDefaultHandler;
+import gregtech.nei.GTNEIDefaultHandler.FixedPositionedStack;
 import gregtech.nei.RecipeDisplayInfo;
 
 /**
@@ -281,23 +284,31 @@ public class RecipeMapFrontend {
 
     public List<String> handleNEIItemTooltip(ItemStack stack, List<String> currentTip,
         GTNEIDefaultHandler.CachedDefaultRecipe neiCachedRecipe) {
-        for (PositionedStack pStack : neiCachedRecipe.mInputs) {
-            if (pStack.containsWithNBT(stack)) {
-                if (pStack instanceof GTNEIDefaultHandler.FixedPositionedStack fixed) {
-                    currentTip = handleNEIItemInputTooltip(currentTip, fixed);
-                }
-                break;
-            }
-        }
-        for (PositionedStack pStack : neiCachedRecipe.mOutputs) {
-            if (pStack.containsWithNBT(stack)) {
-                if (pStack instanceof GTNEIDefaultHandler.FixedPositionedStack fixed) {
-                    currentTip = handleNEIItemOutputTooltip(currentTip, fixed);
-                }
-                break;
-            }
-        }
+        GuiRecipe<?> gui = NEIClientUtils.getGuiContainer() instanceof GuiRecipe<?>g ? g : null;
+
+        FixedPositionedStack input = pickHoveredStack(gui, neiCachedRecipe.mInputs, stack);
+        if (input != null) currentTip = handleNEIItemInputTooltip(currentTip, input);
+
+        FixedPositionedStack output = pickHoveredStack(gui, neiCachedRecipe.mOutputs, stack);
+        if (output != null) currentTip = handleNEIItemOutputTooltip(currentTip, output);
+
         return currentTip;
+    }
+
+    /**
+     * Prefer the slot the mouse is actually over so duplicate items in different slots resolve to the correct
+     * slot (e.g. BEC per-slot nanite tiers); fall back to the first match when no slot is under the mouse. The
+     * `0` passed to {@link GuiRecipe#isMouseOver} is its unused `refIndex` argument.
+     */
+    private static FixedPositionedStack pickHoveredStack(GuiRecipe<?> gui, List<PositionedStack> stacks,
+        ItemStack stack) {
+        FixedPositionedStack firstMatch = null;
+        for (PositionedStack pStack : stacks) {
+            if (!(pStack instanceof FixedPositionedStack fixed) || !fixed.containsWithNBT(stack)) continue;
+            if (gui != null && gui.isMouseOver(fixed, 0)) return fixed;
+            if (firstMatch == null) firstMatch = fixed;
+        }
+        return firstMatch;
     }
 
     protected List<String> handleNEIItemInputTooltip(List<String> currentTip,

--- a/src/main/java/tectech/recipe/BECAssemblyFrontend.java
+++ b/src/main/java/tectech/recipe/BECAssemblyFrontend.java
@@ -1,5 +1,6 @@
 package tectech.recipe;
 
+import static com.gtnewhorizon.gtnhlib.util.AnimatedTooltipHandler.AQUA;
 import static com.gtnewhorizon.gtnhlib.util.AnimatedTooltipHandler.GRAY;
 
 import java.util.List;
@@ -36,7 +37,7 @@ public class BECAssemblyFrontend extends AssemblyLineFrontend {
             .getIndexSafe(pStack.recipe.mRecipe.getMetadata(GTRecipeConstants.NANITE_TIERS), slot);
 
         if (tier != null) {
-            currentTip.add(GRAY + GTUtility.translate("gt.tooltip.nanite-tier", tier.describe()));
+            currentTip.add(AQUA + GTUtility.translate("gt.tooltip.nanite-tier", tier.describe()) + GRAY);
         }
 
         return currentTip;

--- a/src/main/java/tectech/recipe/BECAssemblyFrontend.java
+++ b/src/main/java/tectech/recipe/BECAssemblyFrontend.java
@@ -56,7 +56,8 @@ public class BECAssemblyFrontend extends AssemblyLineFrontend {
                 if (tier.tier > maxTier.tier) maxTier = tier;
             }
 
-            recipeInfo.drawText(GTUtility.translate("gt.tooltip.max-nanite", maxTier.describe()));
+            recipeInfo.drawText(GTUtility.translate("gt.tooltip.max-nanite"));
+            recipeInfo.drawText(maxTier.describe());
         }
     }
 }

--- a/src/main/resources/assets/gregtech/lang/en_US.lang
+++ b/src/main/resources/assets/gregtech/lang/en_US.lang
@@ -8873,7 +8873,7 @@ GT5U.gui.text.bec-speed-divisor=Speed Divisor
 
 # Misc BEC Tooltips
 gt.tooltip.nanite-tier=Nanite Tier: %s
-gt.tooltip.max-nanite=Max Nanite Tier: %s
+gt.tooltip.max-nanite=Max Nanite Tier:
 GT5U.gui.text.pause-immediately.tooltip=The I/O Node will stop processing when it receives a redstone signal
 GT5U.gui.text.pause-next-step.tooltip=The I/O Node will stop upon transitioning into a new input step when it receives a redstone signal
 

--- a/src/main/resources/assets/gregtech/lang/ru_RU.lang
+++ b/src/main/resources/assets/gregtech/lang/ru_RU.lang
@@ -8794,7 +8794,7 @@ GT5U.gui.text.bec-speed-divisor=Speed Divisor
 
 # Misc BEC Tooltips
 gt.tooltip.nanite-tier=Тир нанита: %s
-gt.tooltip.max-nanite=Макс. тир нанита: %s
+gt.tooltip.max-nanite=Макс. тир нанита:
 GT5U.gui.text.pause-immediately.tooltip=The I/O Node will stop processing when it receives a redstone signal
 GT5U.gui.text.pause-next-step.tooltip=The I/O Node will stop upon transitioning into a new input step when it receives a redstone signal
 


### PR DESCRIPTION
Makes a couple improvements and a bug fix for the BEC NEI handler:
- The tooltip on hovering each item now shows the correct nanite tier, and uses teal to make it more visible
- The Max Nanite Tier value is after a line break so that it stops overflowing the box
<img width="479" height="284" alt="image" src="https://github.com/user-attachments/assets/02891089-f354-48ef-a208-0411bd33e742" />
