### PR TITLE
Fix YOT Hatch Sticky Mode blocking external AE fluid insertion

### DIFF
--- a/src/main/java/goodgenerator/blocks/tileEntity/GTMetaTileEntity/MTEYOTTAHatch.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/GTMetaTileEntity/MTEYOTTAHatch.java
@@ -514,10 +514,11 @@ public class MTEYOTTAHatch extends MTEHatch
 
     @Override
     public boolean canAccept(IAEFluidStack input) {
-        if (this.host == null) return false;
+        if (this.host == null || input == null) return false;
         FluidStack rInput = input.getFluidStack();
-        return (host.mLockedFluid != null && !host.mLockedFluid.isFluidEqual(rInput)) || host.mFluid == null
-            || host.mFluid.isFluidEqual(rInput);
+        if (rInput == null) return false;
+        return (this.host.mLockedFluid == null || this.host.mLockedFluid.isFluidEqual(rInput))
+            && (this.host.mFluid == null || this.host.mFluid.isFluidEqual(rInput));
     }
 
     @Override


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/21268

When lock the YOTTank to a fluid and enable Sticky Mode on the YOT Hatch, external fluid insertion into the AE network appears to break globally, not just for the YOT itself.

This issue is caused by `MTEYOTTAHatch.canAccept()` returning the wrong result for locked fluids. With Sticky Mode enabled, AE selects the YOT Hatch first, but the hatch later rejects the fluid in `fill()`, which breaks external fluid insertion routing for the network.

Have tested this fix in-game, now sticky mode works well with AE network.