### PR TITLE
Re-add putting max tier at end of glass list

### DIFF
--- a/src/main/java/gregtech/api/util/GlassTier.java
+++ b/src/main/java/gregtech/api/util/GlassTier.java
@@ -131,6 +131,8 @@ public class GlassTier {
                     .registerAsIndicator(new ItemStack(glass.getLeft(), 1, glass.getRight()), ctr);
                 ctr++;
             }
+            // Re-add the highest tier borosilicate to the end of the list so the max slider value is maximum tier glass
+            glassList.add(mainGlass.getLast());
         }
         return glassList;
     }


### PR DESCRIPTION
This was removed in https://github.com/GTNewHorizons/GT5-Unofficial/pull/7025. Re-added with a comment.