### PR TITLE
Make the list of molds that the solidifier uses modifiable

### DIFF
--- a/src/main/java/gregtech/common/modularui2/widget/GhostMoldSlotWidget.java
+++ b/src/main/java/gregtech/common/modularui2/widget/GhostMoldSlotWidget.java
@@ -1,7 +1,5 @@
 package gregtech.common.modularui2.widget;
 
-import java.util.Arrays;
-
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.StatCollector;
 
@@ -107,7 +105,7 @@ public class GhostMoldSlotWidget extends PhantomItemSlot {
     private IPanelHandler buildSelectorPanel() {
         return syncManager.syncedPanel("moldSlotPanel", true, (mainPanel, player) -> {
             ModularPanel panel = GTGuis.createPopUpPanel(GUI_ID);
-            return new SelectItemGuiBuilder(panel, Arrays.asList(MTEHatchSolidifier.solidifierMolds))
+            return new SelectItemGuiBuilder(panel, MTEHatchSolidifier.solidifierMolds)
                 .setHeaderItem(hatch.getStackForm(1))
                 .setTitle(IKey.lang("GT5U.machines.select_mold"))
                 .setSelectedSyncHandler(moldSyncHandler.getIndexSync())

--- a/src/main/java/gregtech/common/modularui2/widget/GhostMoldSyncHandler.java
+++ b/src/main/java/gregtech/common/modularui2/widget/GhostMoldSyncHandler.java
@@ -25,8 +25,8 @@ public class GhostMoldSyncHandler extends PhantomItemSlotSH {
             ItemStack current = hatch.inventoryHandler.getStackInSlot(MTEHatchSolidifier.moldSlot);
             return current != null ? hatch.findMatchingMoldIndex(current) : -1;
         }, index -> {
-            if (index >= 0 && index < MTEHatchSolidifier.solidifierMolds.length) {
-                hatch.setMold(MTEHatchSolidifier.solidifierMolds[index]);
+            if (index >= 0 && index < MTEHatchSolidifier.solidifierMolds.size()) {
+                hatch.setMold(MTEHatchSolidifier.solidifierMolds.get(index));
             } else {
                 hatch.setMold(null);
             }
@@ -72,8 +72,8 @@ public class GhostMoldSyncHandler extends PhantomItemSlotSH {
 
     private int getNextMoldConfig(int delta) {
         int newIndex = getSelectedIndex() + delta;
-        if (newIndex < -1) newIndex = MTEHatchSolidifier.solidifierMolds.length - 1;
-        if (newIndex >= MTEHatchSolidifier.solidifierMolds.length) newIndex = -1;
+        if (newIndex < -1) newIndex = MTEHatchSolidifier.solidifierMolds.size() - 1;
+        if (newIndex >= MTEHatchSolidifier.solidifierMolds.size()) newIndex = -1;
         return newIndex;
     }
 

--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/MTEHatchSolidifier.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/MTEHatchSolidifier.java
@@ -32,7 +32,7 @@ public class MTEHatchSolidifier extends MTEHatchInput implements IConfigurationC
     public static final int moldSlot = 2;
     public static final int circuitSlot = 3;
 
-    public static ArrayList<ItemStack> solidifierMolds = new ArrayList<>(
+    public static final ArrayList<ItemStack> solidifierMolds = new ArrayList<>(
         Arrays.asList(
             ItemList.Shape_Mold_Bottle.get(1),
             ItemList.Shape_Mold_Plate.get(1),

--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/MTEHatchSolidifier.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/MTEHatchSolidifier.java
@@ -3,6 +3,7 @@ package gtPlusPlus.xmod.gregtech.api.metatileentity.implementations;
 import static com.gtnewhorizon.gtnhlib.util.numberformatting.NumberFormatUtil.formatNumber;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import net.minecraft.item.ItemStack;
@@ -31,21 +32,43 @@ public class MTEHatchSolidifier extends MTEHatchInput implements IConfigurationC
     public static final int moldSlot = 2;
     public static final int circuitSlot = 3;
 
-    public static final ItemStack[] solidifierMolds = { ItemList.Shape_Mold_Bottle.get(1),
-        ItemList.Shape_Mold_Plate.get(1), ItemList.Shape_Mold_Ingot.get(1), ItemList.Shape_Mold_Casing.get(1),
-        ItemList.Shape_Mold_Gear.get(1), ItemList.Shape_Mold_Gear_Small.get(1), ItemList.Shape_Mold_Credit.get(1),
-        ItemList.Shape_Mold_Nugget.get(1), ItemList.Shape_Mold_Block.get(1), ItemList.Shape_Mold_Ball.get(1),
-        ItemList.Shape_Mold_Cylinder.get(1), ItemList.Shape_Mold_Anvil.get(1), ItemList.Shape_Mold_Arrow.get(1),
-        ItemList.Shape_Mold_Rod.get(1), ItemList.Shape_Mold_Bolt.get(1), ItemList.Shape_Mold_Round.get(1),
-        ItemList.Shape_Mold_Screw.get(1), ItemList.Shape_Mold_Ring.get(1), ItemList.Shape_Mold_Rod_Long.get(1),
-        ItemList.Shape_Mold_Rotor.get(1), ItemList.Shape_Mold_Turbine_Blade.get(1),
-        ItemList.Shape_Mold_Pipe_Tiny.get(1), ItemList.Shape_Mold_Pipe_Small.get(1),
-        ItemList.Shape_Mold_Pipe_Medium.get(1), ItemList.Shape_Mold_Pipe_Large.get(1),
-        ItemList.Shape_Mold_Pipe_Huge.get(1), ItemList.Shape_Mold_ToolHeadDrill.get(1),
-        GGItemList.SingleUseFileMold.get(1), GGItemList.SingleUseWrenchMold.get(1),
-        GGItemList.SingleUseCrowbarMold.get(1), GGItemList.SingleUseWireCutterMold.get(1),
-        GGItemList.SingleUseHardHammerMold.get(1), GGItemList.SingleUseSoftMalletMold.get(1),
-        GGItemList.SingleUseScrewdriverMold.get(1), GGItemList.SingleUseSawMold.get(1) };
+    public static ArrayList<ItemStack> solidifierMolds = new ArrayList<>(
+        Arrays.asList(
+            ItemList.Shape_Mold_Bottle.get(1),
+            ItemList.Shape_Mold_Plate.get(1),
+            ItemList.Shape_Mold_Ingot.get(1),
+            ItemList.Shape_Mold_Casing.get(1),
+            ItemList.Shape_Mold_Gear.get(1),
+            ItemList.Shape_Mold_Gear_Small.get(1),
+            ItemList.Shape_Mold_Credit.get(1),
+            ItemList.Shape_Mold_Nugget.get(1),
+            ItemList.Shape_Mold_Block.get(1),
+            ItemList.Shape_Mold_Ball.get(1),
+            ItemList.Shape_Mold_Cylinder.get(1),
+            ItemList.Shape_Mold_Anvil.get(1),
+            ItemList.Shape_Mold_Arrow.get(1),
+            ItemList.Shape_Mold_Rod.get(1),
+            ItemList.Shape_Mold_Bolt.get(1),
+            ItemList.Shape_Mold_Round.get(1),
+            ItemList.Shape_Mold_Screw.get(1),
+            ItemList.Shape_Mold_Ring.get(1),
+            ItemList.Shape_Mold_Rod_Long.get(1),
+            ItemList.Shape_Mold_Rotor.get(1),
+            ItemList.Shape_Mold_Turbine_Blade.get(1),
+            ItemList.Shape_Mold_Pipe_Tiny.get(1),
+            ItemList.Shape_Mold_Pipe_Small.get(1),
+            ItemList.Shape_Mold_Pipe_Medium.get(1),
+            ItemList.Shape_Mold_Pipe_Large.get(1),
+            ItemList.Shape_Mold_Pipe_Huge.get(1),
+            ItemList.Shape_Mold_ToolHeadDrill.get(1),
+            GGItemList.SingleUseFileMold.get(1),
+            GGItemList.SingleUseWrenchMold.get(1),
+            GGItemList.SingleUseCrowbarMold.get(1),
+            GGItemList.SingleUseWireCutterMold.get(1),
+            GGItemList.SingleUseHardHammerMold.get(1),
+            GGItemList.SingleUseSoftMalletMold.get(1),
+            GGItemList.SingleUseScrewdriverMold.get(1),
+            GGItemList.SingleUseSawMold.get(1)));
 
     public MTEHatchSolidifier(int aID, String aName, String aNameRegional, int aTier) {
         super(aID, aName, aNameRegional, aTier);
@@ -101,8 +124,8 @@ public class MTEHatchSolidifier extends MTEHatchInput implements IConfigurationC
     }
 
     public int findMatchingMoldIndex(ItemStack stack) {
-        for (int i = 0; i < solidifierMolds.length; i++) {
-            if (GTUtility.areStacksEqual(solidifierMolds[i], stack, true)) return i;
+        for (int i = 0; i < solidifierMolds.size(); i++) {
+            if (GTUtility.areStacksEqual(solidifierMolds.get(i), stack, true)) return i;
         }
         return -1;
     }


### PR DESCRIPTION
This PR changes `MTEHatchSolidifier.solidifierMolds` into an ArrayList and makes it not final, so it is able to be modified later on by other mods that is not in the scope of GT. Specifically this was made so that the armor molds in NHCM can be added to the list.

Please merge before (https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1839), as it depends on this PR.