### PR TITLE
Clean up some structurelib log spam

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTENanoForge.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTENanoForge.java
@@ -1,5 +1,6 @@
 package gregtech.common.tileentities.machines.multi;
 
+import static com.gtnewhorizon.structurelib.structure.StructureUtility.isAir;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofBlock;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.onElementPass;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.transpose;
@@ -24,7 +25,6 @@ import java.util.List;
 import javax.annotation.Nonnull;
 
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
@@ -350,7 +350,7 @@ public class MTENanoForge extends MTEExtendedPowerMultiBlockBase<MTENanoForge>
         .addElement('W', ofBlock(GregTechAPI.nanoForgeRender, 0))
         .addElement('X', ofBlock(GregTechAPI.sBlockCasings8, 7))
         .addElement('Y', ofBlock(GregTechAPI.sBlockCasings8, 10))
-        .addElement('Z', ofBlock(Blocks.air, 0))
+        .addElement('Z', isAir())
         .build();
     private byte mSpecialTier = 0;
     private boolean renderActive = false;

--- a/src/main/java/tectech/thing/metaTileEntity/multi/godforge/MTEForgeOfGods.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/godforge/MTEForgeOfGods.java
@@ -1,5 +1,6 @@
 package tectech.thing.metaTileEntity.multi.godforge;
 
+import static com.gtnewhorizon.structurelib.structure.StructureUtility.isAir;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofBlock;
 import static gregtech.api.enums.HatchElement.InputBus;
 import static gregtech.api.enums.HatchElement.InputHatch;
@@ -201,7 +202,7 @@ public class MTEForgeOfGods extends TTMultiblockBase implements ISurvivalConstru
                 .hint(2)
                 .buildAndChain(GodforgeCasings, 0))
         .addElement('K', ofBlock(GodforgeCasings, 6))
-        .addElement('L', ofBlock(Blocks.air, 0))
+        .addElement('L', isAir())
         .build();
 
     public MTEForgeOfGods(int aID, String aName, String aNameRegional) {


### PR DESCRIPTION
Removes the "ofBlock() does not accept air. use isAir() instead" from the log for these structures