### PR TITLE
previous pr accidentally nerfed sandline

### DIFF
--- a/src/main/java/gtPlusPlus/core/recipe/RecipesGregTech.java
+++ b/src/main/java/gtPlusPlus/core/recipe/RecipesGregTech.java
@@ -166,10 +166,8 @@ public class RecipesGregTech {
                 new ItemStack(Blocks.sandstone, 64))
             .circuit(17)
             .itemOutputs(
-                MaterialsFluorides.FLUORITE.getOre(8),
-                MaterialsFluorides.FLUORITE.getOre(4),
-                MaterialsFluorides.FLUORITE.getOre(4),
-                MaterialsFluorides.FLUORITE.getOre(4))
+                MaterialsFluorides.FLUORITE.getOre(64),
+                MaterialsFluorides.FLUORITE.getOre(16))
             .fluidInputs(Materials.NitricAcid.getFluid(4_000), Materials.Air.getGas(8_000))
             .duration(10 * SECONDS)
             .eut(TierEU.RECIPE_EV / 2)
@@ -184,10 +182,7 @@ public class RecipesGregTech {
                 new ItemStack(Blocks.sand, 64))
             .circuit(17)
             .itemOutputs(
-                MaterialsFluorides.FLUORITE.getOre(4),
-                MaterialsFluorides.FLUORITE.getOre(2),
-                MaterialsFluorides.FLUORITE.getOre(2),
-                MaterialsFluorides.FLUORITE.getOre(2))
+                MaterialsFluorides.FLUORITE.getOre(40))
             .fluidInputs(Materials.NitricAcid.getFluid(5_000), Materials.Air.getGas(12_000))
             .duration(10 * SECONDS)
             .eut(TierEU.RECIPE_EV / 2)


### PR DESCRIPTION
do not push this one until the other pr is pushed

https://github.com/GTNewHorizons/GT5-Unofficial/pull/7305 this pr accidentally nerfed sandline by around 4x, this fixes it by 4xing the ores gained from exxon. it also fixes the random stacking in the output