### PR TITLE
Change ulv input hatch to use same amount of material as output hatch

### DIFF
--- a/src/main/java/gregtech/loaders/load/MTERecipeLoader.java
+++ b/src/main/java/gregtech/loaders/load/MTERecipeLoader.java
@@ -2327,7 +2327,7 @@ public class MTERecipeLoader implements Runnable {
             GTModHandler.RecipeBits.BITS,
             new Object[] { "ASA", "AFA", "APA", 'S', GTModHandler.getModItem(BuildCraftFactory.ID, "tankBlock", 1L, 0),
                 'F', ItemList.Hull_ULV.get(1L), 'A', OrePrefixes.plate.get(Materials.Rubber), 'P',
-                OrePrefixes.screw.get(Materials.Rubber) });
+                OrePrefixes.plate.get(Materials.Rubber) });
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_Firebox_Steel.get(1L),
             GTModHandler.RecipeBits.BITS,

--- a/src/main/java/gregtech/loaders/load/MTERecipeLoader.java
+++ b/src/main/java/gregtech/loaders/load/MTERecipeLoader.java
@@ -2327,7 +2327,7 @@ public class MTERecipeLoader implements Runnable {
             GTModHandler.RecipeBits.BITS,
             new Object[] { "ASA", "AFA", "APA", 'S', GTModHandler.getModItem(BuildCraftFactory.ID, "tankBlock", 1L, 0),
                 'F', ItemList.Hull_ULV.get(1L), 'A', OrePrefixes.plate.get(Materials.Rubber), 'P',
-                OrePrefixes.gear.get(Materials.Rubber) });
+                OrePrefixes.screw.get(Materials.Rubber) });
         GTModHandler.addCraftingRecipe(
             ItemList.Casing_Firebox_Steel.get(1L),
             GTModHandler.RecipeBits.BITS,


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->

change ulv input hatch to use same amount of material as output hatch. The two have a conversion recipe between each other, so the recipes should have little material difference (for steam age)

previous was 1 ingot to 8 ingots:
<img width="299" height="309" alt="image" src="https://github.com/user-attachments/assets/bbf5da12-a564-4c10-aac3-bea62b795c54" />


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
