### PR TITLE
Fix condensate detector hatch not updating when storage shuts down

### DIFF
--- a/src/main/java/tectech/thing/metaTileEntity/multi/bec/MTEBECStorage.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/bec/MTEBECStorage.java
@@ -221,6 +221,7 @@ public class MTEBECStorage extends MTEBECMultiblockBase<MTEBECStorage> implement
     @Override
     public void stopMachine(@Nonnull ShutDownReason reason) {
         super.stopMachine(reason);
+        contentsChanged = true;
         storedCondensate.clear();
     }
 
@@ -243,6 +244,7 @@ public class MTEBECStorage extends MTEBECMultiblockBase<MTEBECStorage> implement
     public void addCondensate(IAEFluidStack stack) {
         if (mMaxProgresstime <= 0) {
             // Should be cleared by stopMachine, but just to be sure let's do it again here
+            contentsChanged = true;
             storedCondensate.clear();
             return;
         }
@@ -257,6 +259,7 @@ public class MTEBECStorage extends MTEBECMultiblockBase<MTEBECStorage> implement
     public boolean removeCondensate(IAEFluidStack stack) {
         if (mMaxProgresstime <= 0) {
             // Should be cleared by stopMachine, but just to be sure let's do it again here
+            contentsChanged = true;
             storedCondensate.clear();
             return false;
         }


### PR DESCRIPTION
## Summary
Hatches are not notified when their containment field shuts down (which deletes all stored condensate). Wherever this takes place, I added `contentsChanged = true` so that the hatches are updated on the next tick.


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [ ] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
