### PR TITLE
Fix BEC voiding on server restart

### DIFF
--- a/src/main/java/tectech/thing/metaTileEntity/multi/base/TTMultiblockBase.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/base/TTMultiblockBase.java
@@ -566,9 +566,7 @@ public abstract class TTMultiblockBase extends MTEExtendedPowerMultiBlockBase<TT
             aNBT.setInteger("mOutputItemsLength", mOutputItems.length);
             for (int i = 0; i < mOutputItems.length; i++) {
                 if (mOutputItems[i] != null) {
-                    NBTTagCompound tNBT = new NBTTagCompound();
-                    mOutputItems[i].writeToNBT(tNBT);
-                    aNBT.setTag("mOutputItem" + i, tNBT);
+                    GTUtility.saveItem(aNBT, "mOutputItem" + i, mOutputItems[i]);
                 }
             }
         }


### PR DESCRIPTION
## Summary
Use utility function to save item in NBT in TTMultiblockBase, similar to the one used in MTEMultiblockBase
It had a problem of not saving it correctly if it was outputting more than 64 items

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
