### PR TITLE
Fix crash when making chum in a mixer

### DIFF
--- a/src/main/java/toxiceverglades/block/BlockDarkWorldSludgeFluid.java
+++ b/src/main/java/toxiceverglades/block/BlockDarkWorldSludgeFluid.java
@@ -1,11 +1,15 @@
 package toxiceverglades.block;
 
+import static gregtech.api.enums.Mods.GTPlusPlus;
+
 import net.minecraft.block.material.MapColor;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.material.MaterialLiquid;
 import net.minecraftforge.fluids.Fluid;
 
-public class BlockDarkWorldSludgeFluid extends Fluid {
+import gregtech.api.GregTechAPI;
+
+public class BlockDarkWorldSludgeFluid extends Fluid implements Runnable {
 
     public static final Material SLUDGE = new MaterialLiquid(MapColor.dirtColor);
 
@@ -25,6 +29,16 @@ public class BlockDarkWorldSludgeFluid extends Fluid {
         } else {
             setAlpha(0);
         }
+        if (GregTechAPI.sGTBlockIconload != null) {
+            GregTechAPI.sGTBlockIconload.add(this);
+        }
+    }
+
+    @Override
+    public void run() {
+        this.setIcons(
+            GregTechAPI.sBlockIcons.registerIcon(GTPlusPlus.ID + ":fluid/Fluid_Sludge_Still"),
+            GregTechAPI.sBlockIcons.registerIcon(GTPlusPlus.ID + ":fluid/Fluid_Sludge_Flow"));
     }
 
     @Override


### PR DESCRIPTION
## Summary
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25688

Adds a block icon for ToxicEverglades `sludge`.

The original crash was caused by WAILA attempting to render the contents of the HV mixer. As `sludge` is a output of the chum recipe and does not have a block icon, WAILA fails to retrieve the block icon and crashes the game.

<img width="362" height="368" alt="image" src="https://github.com/user-attachments/assets/fee684de-596c-46f0-9a39-c42acce7984b" />

<img width="303" height="231" alt="image" src="https://github.com/user-attachments/assets/7fd08ede-4730-4d45-871b-27ae84a1a441" />

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
