### PR TITLE
Small tooltip fixes

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTECokeOven.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTECokeOven.java
@@ -87,7 +87,7 @@ public class MTECokeOven extends MTEEnhancedMultiBlockBase<MTECokeOven>
             .addPollutionAmount(GTMod.proxy.mPollutionCokeOvenPerSecond)
             .beginStructureBlock(3, 3, 3, true)
             .addController("Front center")
-            .addCasing("0-26", "Coke Oven Casing", false)
+            .addCasing("0-26", "Coke Oven Bricks", false)
             .addMiscHatch("0+", StatCollector.translateToLocal("GT5U.MBTT.CokeOvenHatch"), "Any casing", 1)
             .addAir("Interior of the structure")
             .addStructureInfo("")

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTECokeOven.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTECokeOven.java
@@ -88,7 +88,7 @@ public class MTECokeOven extends MTEEnhancedMultiBlockBase<MTECokeOven>
             .beginStructureBlock(3, 3, 3, true)
             .addController("Front center")
             .addCasing("0-26", "Coke Oven Bricks", false)
-            .addMiscHatch("0+", StatCollector.translateToLocal("GT5U.MBTT.CokeOvenHatch"), "Any casing", 1)
+            .addMiscHatch("0+", StatCollector.translateToLocal("GT5U.MBTT.CokeOvenHatch"), "Any coke oven brick", 1)
             .addAir("Interior of the structure")
             .addStructureInfo("")
             .addStructureFooter("GregTech multiblocks may wallshare each of their sides")

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTENuclearReactor.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTENuclearReactor.java
@@ -108,10 +108,10 @@ public class MTENuclearReactor extends GTPPMultiBlockBase<MTENuclearReactor> imp
         tt.addMachineType(getMachineType())
             .addInfo("Controller Block for the Liquid Fluoride Thorium Reactor")
             .addInfo("Produces energy and new elements from Radioactive Beta Decay!")
-            .addInfo("Input LFTB and a molten salt as fuel, and match the 4 Buffered Dynamo Hatches:")
+            .addInfo("Input LFTB and a molten salt as fuel, and match the four 4A dynamo hatches:")
             .addInfo("LFTR Fuel 1 (4 EV Hatches), LFTR Fuel 2 (4 IV Hatches), LFTR Fuel 3 (4 LuV Hatches)")
-            .addInfo("If using better hatches for a worse fuel, only 1 hatch will output EU")
-            .addInfo("Outputs U233 every 10 seconds, on average, while the reactor is running")
+            .addInfo("If using better hatches for a worse fuel, only 1 hatch outputs EU")
+            .addInfo("Outputs U-233 every 10 seconds, on average, while the reactor is running")
             .addInfo("Check NEI to see the other 3 outputs - they differ between fuels")
             .addPollutionAmount(getPollutionPerSecond(null))
             .beginStructureBlock(7, 7, 4, true)
@@ -125,6 +125,7 @@ public class MTENuclearReactor extends GTPPMultiBlockBase<MTENuclearReactor> imp
             .addOutputHatch("4+", "Any edge casing (IV+)", 1)
             .addAir("Interior of the structure")
             .addStructureInfo("")
+            .addStructureFooter(StatCollector.translateToLocal("GT5U.MBTT.Structure.DynamoLimit"))
             .addStructureFooter("One ME output hatch can replace the four regular output hatches")
             .toolTipFinisher();
         return tt;

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTENuclearReactor.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTENuclearReactor.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.StatCollector;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.FluidStack;
 


### PR DESCRIPTION
## Summary
Rewords "Coke Oven Casings" to "Coke Oven Bricks" in its tooltip to match the actual name of the blocks
Replaces mention of buffered dynamo hatches with 4A dynamo hatches in LFTR tooltip


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
