### PR TITLE
fix(FluidEjectionHelper): ensure fair fluid ejection

### DIFF
--- a/src/main/java/gregtech/api/util/FluidEjectionHelper.java
+++ b/src/main/java/gregtech/api/util/FluidEjectionHelper.java
@@ -131,19 +131,11 @@ public class FluidEjectionHelper {
                     continue;
                 }
 
-                boolean insertAnything = false;
-                while (output.remainingAmount > 0) {
-                    int amount = (int) Math.min(output.remainingAmount, Integer.MAX_VALUE);
-                    FluidStack tmp = output.id.getFluidStack(amount);
-                    transaction.storePartial(output.id, tmp);
-                    long actuallyInsert = amount - tmp.amount;
-                    output.remainingAmount -= actuallyInsert;
-                    if (actuallyInsert > 0) insertAnything = true;
-                    if (tmp.amount > 0) break;
-                }
+                int amount = (int) Math.min(output.remainingAmount, Integer.MAX_VALUE);
+                FluidStack tmp = output.id.getFluidStack(amount);
 
                 // Fill at most one slot with the remaining fluids
-                if (insertAnything) {
+                if (transaction.storePartial(output.id, tmp)) {
                     break;
                 } else {
                     // If we couldn't insert anything into the hatch, go to the next one


### PR DESCRIPTION
## Summary
This PR fixes an issue where the fair scheduling loop dumps the same fluid into multiple slots when exceeding Integer.MAX_VALUE, which reduces parallels.
Sorry for my mistake.

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
