### PR TITLE
Configure watchers on other update sources

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchInputBusME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchInputBusME.java
@@ -532,6 +532,8 @@ public class MTEHatchInputBusME extends MTEHatchInputBus implements IRecipeProce
             for (int i = 0; i < stockingItems.tagCount(); i++) {
                 slots[i] = new Slot(GTUtility.loadItem(stockingItems.getCompoundTagAt(i)));
             }
+            // The writes above bypass setSlotConfig, so re-sync the AE stack watcher with the pasted config.
+            configureWatchers();
         }
 
         updateValidGridProxySides();
@@ -775,6 +777,9 @@ public class MTEHatchInputBusME extends MTEHatchInputBus implements IRecipeProce
 
     public void setSlotConfig(int index, ItemStack config) {
         slots[index] = config == null ? null : new Slot(config.copy());
+        // Keep the AE stack watcher in sync, or a bus configured after joining the grid never gets onStackChange for
+        // the new item and a machine idling on it never wakes when the network restocks.
+        configureWatchers();
     }
 
     /**
@@ -804,6 +809,7 @@ public class MTEHatchInputBusME extends MTEHatchInputBus implements IRecipeProce
 
     protected void clearSlotConfigs() {
         Arrays.fill(slots, null);
+        configureWatchers();
     }
 
     protected void clearExtractedStacks() {

--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchInputME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchInputME.java
@@ -619,6 +619,9 @@ public class MTEHatchInputME extends MTEHatchInput implements IPowerChannelState
 
     public void setSlotConfig(int index, FluidStack config) {
         slots[index] = config == null ? null : new Slot(config.copy());
+        // Keep the AE stack watcher in sync, or a hatch configured after joining the grid never gets onStackChange for
+        // the new fluid and a machine idling on it never wakes when the network restocks.
+        configureWatchers();
     }
 
     /**
@@ -649,6 +652,7 @@ public class MTEHatchInputME extends MTEHatchInput implements IPowerChannelState
 
     protected void clearSlotConfigs() {
         Arrays.fill(slots, null);
+        configureWatchers();
     }
 
     protected void clearExtractedStacks() {
@@ -857,6 +861,8 @@ public class MTEHatchInputME extends MTEHatchInput implements IPowerChannelState
                 if (fs == null) continue;
                 slots[i] = new Slot(fs);
             }
+            // The writes above bypass setSlotConfig, so re-sync the AE stack watcher with the pasted config.
+            configureWatchers();
         }
 
         updateValidGridProxySides();


### PR DESCRIPTION
Follow up to #7185 - fixes a bug caused by that PR where certain configuration sources never called `configureWatchers`, thus leading to ME buses/hatches never updating when the contents of the network changed.