### PR TITLE
Don't show macerator recipe when right-clicking arrow in any crafting table handler

### DIFF
--- a/src/main/java/gregtech/nei/GTNEIMacerationStackConversion.java
+++ b/src/main/java/gregtech/nei/GTNEIMacerationStackConversion.java
@@ -42,15 +42,6 @@ public class GTNEIMacerationStackConversion extends ShapelessRecipeHandler {
     }
 
     @Override
-    public void loadUsageRecipes(String inputId, Object... ingredients) {
-        if (inputId.equals("crafting") || inputId.equals(getOverlayIdentifier())) {
-            loadAllRecipes();
-        } else {
-            super.loadUsageRecipes(inputId, ingredients);
-        }
-    }
-
-    @Override
     public void loadCraftingRecipes(ItemStack result) {
         if (!isNewMacerationStack(result)) return;
         loadRecipeForTier(result);


### PR DESCRIPTION
No other crafting table handler uses this for some reason so I just removed it