### PR TITLE
Rename "Bio Ethanol" to "Ethanol"

### DIFF
--- a/src/main/java/gregtech/loaders/preload/LoaderGTBlockFluid.java
+++ b/src/main/java/gregtech/loaders/preload/LoaderGTBlockFluid.java
@@ -1422,7 +1422,7 @@ public class LoaderGTBlockFluid implements Runnable {
                 GTOreDictUnificator.get(OrePrefixes.cell, Materials.Biomass, 1L),
                 ItemList.Cell_Empty.get(1L));
         GTFluidFactory.builder("bioethanol")
-            .withDefaultLocalName("Bio Ethanol")
+            .withDefaultLocalName("Ethanol")
             .withStateAndTemperature(LIQUID, 295)
             .buildAndRegister()
             .configureMaterials(Materials.Ethanol)

--- a/src/main/resources/assets/gregtech/lang/en_US.lang
+++ b/src/main/resources/assets/gregtech/lang/en_US.lang
@@ -6634,7 +6634,7 @@ entity.gregtech.GT_Entity_Arrow.name= a GregTech arrow
 
 # Fluids
 fluid.aniline=Aniline
-fluid.bioethanol=Bio Ethanol
+fluid.bioethanol=Ethanol
 fluid.biomass=Biomass
 fluid.boricacid=Boric Acid
 fluid.butanol=Butanol


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
[Forestry's lang file](https://github.com/GTNewHorizons/ForestryMC/blob/704861b666fad9f5d7a05b8e74e0c8b82b6d1bf3/src/main/resources/assets/forestry/lang/en_US.lang#L89) calls bioethanol "Ethanol", so rename GT's bioethanol to "Ethanol" as well.

<img width="241" height="47" alt="image" src="https://github.com/user-attachments/assets/62f0b94f-b9d1-472f-b8ba-e8ffc7895dc3" />

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
