### PR TITLE
Fix NAC splitter redstone input resets after reload

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/hatches/MTEHatchSplitterRedstone.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/hatches/MTEHatchSplitterRedstone.java
@@ -78,6 +78,18 @@ public class MTEHatchSplitterRedstone extends MTEHatch {
     }
 
     @Override
+    public void loadNBTData(NBTTagCompound aNBT) {
+        channel = aNBT.getInteger("mChannel");
+        super.loadNBTData(aNBT);
+    }
+
+    @Override
+    public void saveNBTData(NBTTagCompound aNBT) {
+        aNBT.setInteger("mChannel", channel);
+        super.saveNBTData(aNBT);
+    }
+
+    @Override
     public String[] getDescription() {
         return new String[] { translateToLocal("GT5U.tooltip.nac.hatch.splitter.body.1"),
             translateToLocal("GT5U.tooltip.nac.hatch.splitter.body.2"),


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
This PR made NAC splitter redstone input saves & loads channel data so that the channel set won't lost upon reload.
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24657


## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge