### PR TITLE
Fix Fluid Ejection Infinite Loop

### DIFF
--- a/src/main/java/gregtech/api/util/FluidEjectionHelper.java
+++ b/src/main/java/gregtech/api/util/FluidEjectionHelper.java
@@ -133,9 +133,12 @@ public class FluidEjectionHelper {
 
                 int amount = (int) Math.min(output.remainingAmount, Integer.MAX_VALUE);
                 FluidStack tmp = output.id.getFluidStack(amount);
+                boolean stored = transaction.storePartial(output.id, tmp);
+                // Drained = Amount - Remaining
+                output.remainingAmount -= amount - tmp.amount;
 
                 // Fill at most one slot with the remaining fluids
-                if (transaction.storePartial(output.id, tmp)) {
+                if (stored) {
                     break;
                 } else {
                     // If we couldn't insert anything into the hatch, go to the next one


### PR DESCRIPTION
## Summary
The previous pr #7389 introduces an infinite loop on fluid ejection because the remainingAmount is not subtracted properly
This should fix it

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
