### PR TITLE
Expose a single oregenPattern and not make mods guess

### DIFF
--- a/src/main/java/gregtech/common/GTWorldgenerator.java
+++ b/src/main/java/gregtech/common/GTWorldgenerator.java
@@ -216,6 +216,7 @@ public class GTWorldgenerator implements IWorldGenerator {
                 instance = new OregenPatternSavedData(NAME);
                 world.mapStorage.setData(OregenPatternSavedData.NAME, instance);
             }
+            clientOregenPattern = oregenPattern;
             instance.markDirty();
             loadedWorld = new WeakReference<>(world);
         }

--- a/src/main/java/gregtech/common/GTWorldgenerator.java
+++ b/src/main/java/gregtech/common/GTWorldgenerator.java
@@ -31,7 +31,6 @@ import cpw.mods.fml.common.IWorldGenerator;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.PlayerEvent;
 import cpw.mods.fml.common.registry.GameRegistry;
-import cpw.mods.fml.relauncher.Side;
 import galacticgreg.api.ModDimensionDef;
 import galacticgreg.api.enums.DimensionDef;
 import gregtech.GTMod;
@@ -76,29 +75,30 @@ public class GTWorldgenerator implements IWorldGenerator {
     public static Long2ObjectOpenHashMap<CachedOreVein> validOreveins = new Long2ObjectOpenHashMap<>(1024);
     public boolean mIsGenerating = false;
     private static OregenPattern oregenPattern = OregenPattern.AXISSYMMETRICAL;
-    private static OregenPattern clientOregenPattern = OregenPattern.AXISSYMMETRICAL;
 
-    /** Returns the oregen pattern for the current physical or logical server, or the connected client. */
+    /** Returns the oregen pattern used by the current world. */
     public static OregenPattern getOregenPattern() {
-        FMLCommonHandler fml = FMLCommonHandler.instance();
-        boolean server = fml.getSide() == Side.SERVER || fml.getEffectiveSide() == Side.SERVER;
-        return server ? oregenPattern : clientOregenPattern;
+        return oregenPattern;
     }
 
     /** @deprecated Use {@link #getOregenPattern()}. */
     @Deprecated
     public static OregenPattern getClientOregenPattern() {
-        return clientOregenPattern;
+        return getOregenPattern();
     }
 
     /** @deprecated Use {@link #getOregenPattern()}. */
     @Deprecated
     public static OregenPattern getServerOregenPattern() {
-        return oregenPattern;
+        return getOregenPattern();
     }
 
+    /** Called when the server syncs its pattern to the client; no-op when a local server is authoritative. */
     public static void setClientOregenPattern(OregenPattern pattern) {
-        clientOregenPattern = pattern;
+        if (FMLCommonHandler.instance()
+            .getMinecraftServerInstance() == null) {
+            oregenPattern = pattern;
+        }
     }
 
     public GTWorldgenerator() {
@@ -216,7 +216,6 @@ public class GTWorldgenerator implements IWorldGenerator {
                 instance = new OregenPatternSavedData(NAME);
                 world.mapStorage.setData(OregenPatternSavedData.NAME, instance);
             }
-            clientOregenPattern = oregenPattern;
             instance.markDirty();
             loadedWorld = new WeakReference<>(world);
         }

--- a/src/main/java/gregtech/common/GTWorldgenerator.java
+++ b/src/main/java/gregtech/common/GTWorldgenerator.java
@@ -26,10 +26,12 @@ import org.jetbrains.annotations.Nullable;
 
 import com.gtnewhorizon.gtnhlib.hash.Fnv1a64;
 
+import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.IWorldGenerator;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.PlayerEvent;
 import cpw.mods.fml.common.registry.GameRegistry;
+import cpw.mods.fml.relauncher.Side;
 import galacticgreg.api.ModDimensionDef;
 import galacticgreg.api.enums.DimensionDef;
 import gregtech.GTMod;
@@ -76,12 +78,21 @@ public class GTWorldgenerator implements IWorldGenerator {
     private static OregenPattern oregenPattern = OregenPattern.AXISSYMMETRICAL;
     private static OregenPattern clientOregenPattern = OregenPattern.AXISSYMMETRICAL;
 
-    // Used in VisualProspecting
+    /** Returns the oregen pattern for the current physical or logical server, or the connected client. */
+    public static OregenPattern getOregenPattern() {
+        FMLCommonHandler fml = FMLCommonHandler.instance();
+        boolean server = fml.getSide() == Side.SERVER || fml.getEffectiveSide() == Side.SERVER;
+        return server ? oregenPattern : clientOregenPattern;
+    }
+
+    /** @deprecated Use {@link #getOregenPattern()}. */
+    @Deprecated
     public static OregenPattern getClientOregenPattern() {
         return clientOregenPattern;
     }
 
-    // Used in VisualProspecting
+    /** @deprecated Use {@link #getOregenPattern()}. */
+    @Deprecated
     public static OregenPattern getServerOregenPattern() {
         return oregenPattern;
     }
@@ -162,7 +173,7 @@ public class GTWorldgenerator implements IWorldGenerator {
     }
 
     public static boolean isOreChunk(int chunkX, int chunkZ) {
-        if (getServerOregenPattern() == OregenPattern.EQUAL_SPACING) {
+        if (getOregenPattern() == OregenPattern.EQUAL_SPACING) {
             return Math.floorMod(chunkX, 3) == 1 && Math.floorMod(chunkZ, 3) == 1;
         }
         // add next if statement here or convert to switch when expanding OregenPattern enum


### PR DESCRIPTION
## Summary
#7215 introduced a split getClientOregenPattern() / getServerOregenPattern() to get oregen pattern.
It's making mods need to figure out which one they need, and in some contexts can be a bit unstable depending on which thread query it.

Instead I'm introducing a single getOregenPattern() that will give mods which patterns is currently in use. A bit like it was before.

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)