### PR TITLE
Check Industrial Arc Furnace outputs before ignition

### DIFF
--- a/src/main/java/kubatech/tileentity/gregtech/multiblock/MTEIndustrialArcFurnace.java
+++ b/src/main/java/kubatech/tileentity/gregtech/multiblock/MTEIndustrialArcFurnace.java
@@ -980,6 +980,10 @@ public class MTEIndustrialArcFurnace extends KubaTechGTMultiBlockBase<MTEIndustr
                 // check if we can even process anything
                 if (this.availableVoltage < recipe.mEUt)
                     return CheckRecipeResultRegistry.insufficientPower(recipe.mEUt);
+                if (phase == ArcFurnacePhase.Standby && !canOutputAll(recipe.mOutputs))
+                    return CheckRecipeResultRegistry.ITEM_OUTPUT_FULL;
+                if (phase == ArcFurnacePhase.Standby && !canOutputAll(recipe.mFluidOutputs))
+                    return CheckRecipeResultRegistry.FLUID_OUTPUT_FULL;
                 return result;
             }
 


### PR DESCRIPTION
## What changed

- Check item and fluid output availability while the Industrial Arc Furnace is still in standby.
- Return the appropriate output-full result before arc ignition starts.

## Why
<img width="805" height="382" alt="acab2d98aea50b53979aacabea2391e6" src="https://github.com/user-attachments/assets/8a75a2b4-86e1-4ac6-8cbb-e12e62c97024" />

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25816

The furnace previously used its outputless ignition recipe before validating the real recipe outputs. If the required output bus or hatch was unavailable, ignition completed first, processing then failed, and the machine entered a repeated ignition/shutdown cycle.

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
