### PR TITLE
fix: add inventory stack limit to MTEHatchPatternProvider and MTEHatchCraftingInputME

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchCraftingInputME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchCraftingInputME.java
@@ -1440,8 +1440,7 @@ public class MTEHatchCraftingInputME extends MTEHatchInputBus implements IPowerC
     }
 
     @Override
-    public int getInventoryStackLimit()
-    {
+    public int getInventoryStackLimit() {
         return 1;
     }
 }

--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchCraftingInputME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchCraftingInputME.java
@@ -1438,4 +1438,10 @@ public class MTEHatchCraftingInputME extends MTEHatchInputBus implements IPowerC
         }
         return super.isItemValidForSlot(index, itemStack);
     }
+
+    @Override
+    public int getInventoryStackLimit()
+    {
+        return 1;
+    }
 }

--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchPatternProvider.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchPatternProvider.java
@@ -104,4 +104,10 @@ public class MTEHatchPatternProvider extends MTEHatchInputBus {
             default -> 9; // should be unreachable
         };
     }
+
+    @Override
+    public int getInventoryStackLimit()
+    {
+        return 1;
+    }
 }

--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchPatternProvider.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchPatternProvider.java
@@ -106,8 +106,7 @@ public class MTEHatchPatternProvider extends MTEHatchInputBus {
     }
 
     @Override
-    public int getInventoryStackLimit()
-    {
+    public int getInventoryStackLimit() {
         return 1;
     }
 }


### PR DESCRIPTION
## Summary
This PR adds inventory stack limit to MTEHatchPatternProvider and MTEHatchCraftingInputME to be consistent with the me interface.
fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25827

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
