### PR TITLE
Unify all circuit recipes in LATEX to use c24

### DIFF
--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingWire.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingWire.java
@@ -259,7 +259,7 @@ public class ProcessingWire implements gregtech.api.interfaces.IOreRecipeRegistr
                     if (GTOreDictUnificator.get(correspondingCable, aMaterial, 1L) != null) {
                         GTValues.RA.stdBuilder()
                             .itemInputs(aStack)
-                            .circuit(1)
+                            .circuit(24)
                             .itemOutputs(GTOreDictUnificator.get(correspondingCable, aMaterial, 1L))
                             .fluidInputs(Materials.Rubber.getMolten((long) costMultiplier * INGOTS))
                             .duration(5 * SECONDS)
@@ -267,7 +267,7 @@ public class ProcessingWire implements gregtech.api.interfaces.IOreRecipeRegistr
                             .addTo(cableRecipes);
                         GTValues.RA.stdBuilder()
                             .itemInputs(aStack)
-                            .circuit(1)
+                            .circuit(24)
                             .itemOutputs(GTOreDictUnificator.get(correspondingCable, aMaterial, 1L))
                             .fluidInputs(
                                 Materials.StyreneButadieneRubber.getMolten((long) costMultiplier * 3 * QUARTER_INGOTS))
@@ -276,7 +276,7 @@ public class ProcessingWire implements gregtech.api.interfaces.IOreRecipeRegistr
                             .addTo(cableRecipes);
                         GTValues.RA.stdBuilder()
                             .itemInputs(aStack)
-                            .circuit(1)
+                            .circuit(24)
                             .itemOutputs(GTOreDictUnificator.get(correspondingCable, aMaterial, 1L))
                             .fluidInputs(Materials.RubberSilicone.getMolten((long) costMultiplier * HALF_INGOTS))
                             .duration(5 * SECONDS)
@@ -285,7 +285,7 @@ public class ProcessingWire implements gregtech.api.interfaces.IOreRecipeRegistr
 
                         GTValues.RA.stdBuilder()
                             .itemInputs(aStack)
-                            .circuit(1)
+                            .circuit(24)
                             .itemOutputs(GTOreDictUnificator.get(correspondingCable, aMaterial, 1L))
                             .fluidInputs(Materials.RubberSilicone.getMolten((long) costMultiplier * HALF_INGOTS))
                             .duration(5 * SECONDS)
@@ -345,8 +345,6 @@ public class ProcessingWire implements gregtech.api.interfaces.IOreRecipeRegistr
                                     .eut(TierEU.RECIPE_ULV)
                                     .addTo(cableRecipes);
 
-                                // Assembler Recipes to be removed in the next Major Update
-
                                 GTValues.RA.stdBuilder()
                                     .itemInputs(GTUtility.copyAmount(4, aStack), dielectric.getDust(costMultiplier))
                                     .itemOutputs(GTOreDictUnificator.get(correspondingCable, aMaterial, 4L))
@@ -405,7 +403,7 @@ public class ProcessingWire implements gregtech.api.interfaces.IOreRecipeRegistr
                 // Cable recipes
                 GTValues.RA.stdBuilder()
                     .itemInputs(aStack)
-                    .circuit(1)
+                    .circuit(24)
                     .itemOutputs(GTOreDictUnificator.get(correspondingCable, aMaterial, 1L))
                     .fluidInputs(Materials.Rubber.getMolten(costMultiplier * INGOTS))
                     .duration(5 * SECONDS)
@@ -414,7 +412,7 @@ public class ProcessingWire implements gregtech.api.interfaces.IOreRecipeRegistr
 
                 GTValues.RA.stdBuilder()
                     .itemInputs(aStack)
-                    .circuit(1)
+                    .circuit(24)
                     .itemOutputs(GTOreDictUnificator.get(correspondingCable, aMaterial, 1L))
                     .fluidInputs(Materials.StyreneButadieneRubber.getMolten(costMultiplier * 3 * QUARTER_INGOTS))
                     .duration(5 * SECONDS)
@@ -423,14 +421,12 @@ public class ProcessingWire implements gregtech.api.interfaces.IOreRecipeRegistr
 
                 GTValues.RA.stdBuilder()
                     .itemInputs(aStack)
-                    .circuit(1)
+                    .circuit(24)
                     .itemOutputs(GTOreDictUnificator.get(correspondingCable, aMaterial, 1L))
                     .fluidInputs(Materials.RubberSilicone.getMolten(costMultiplier * HALF_INGOTS))
                     .duration(5 * SECONDS)
                     .eut(TierEU.RECIPE_ULV)
                     .addTo(cableRecipes);
-
-                // Assembler Recipes to be removed in the next Major Update
 
                 GTValues.RA.stdBuilder()
                     .itemInputs(aStack)
@@ -476,8 +472,6 @@ public class ProcessingWire implements gregtech.api.interfaces.IOreRecipeRegistr
                             .duration(5 * SECONDS)
                             .eut(TierEU.RECIPE_ULV)
                             .addTo(cableRecipes);
-
-                        // Assembler Recipes to be removed in the next Major Update
 
                         GTValues.RA.stdBuilder()
                             .itemInputs(GTUtility.copyAmount(4, aStack), dielectric.getDust(costMultiplier))
@@ -516,7 +510,6 @@ public class ProcessingWire implements gregtech.api.interfaces.IOreRecipeRegistr
                     .eut(calculateRecipeEU(aMaterial, 8))
                     .addTo(cableRecipes);
 
-                // Assembler Recipes to be removed in the next Major Update
                 GTValues.RA.stdBuilder()
                     .itemInputs(
                         aStack,
@@ -552,8 +545,6 @@ public class ProcessingWire implements gregtech.api.interfaces.IOreRecipeRegistr
                             .duration(5 * SECONDS)
                             .eut(calculateRecipeEU(aMaterial, 8))
                             .addTo(cableRecipes);
-
-                        // Assembler Recipes to be removed in the next Major Update
 
                         GTValues.RA.stdBuilder()
                             .itemInputs(


### PR DESCRIPTION
Previously they were split between 1 and 24 by mistake. This unifies them all to use 24, like in the assembler.
<img width="577" height="601" alt="image" src="https://github.com/user-attachments/assets/96f2ae4c-1b4a-458a-aab7-d417b6147531" />
<img width="575" height="531" alt="image" src="https://github.com/user-attachments/assets/e17e2ccd-105b-4397-bb8a-097f9fb665b2" />

Assembler for reference:
<img width="513" height="439" alt="image" src="https://github.com/user-attachments/assets/a4ae60c5-c349-4dde-9f80-f3fb5310a0ba" />

Also remove those "Assembler Recipes to be removed in the next Major Update" comments. I believe they were written before the cable coater SB machines got scrapped and were never removed.