### PR TITLE
show progress when active even if working is disabled

### DIFF
--- a/src/main/java/gregtech/api/util/GTWaila.java
+++ b/src/main/java/gregtech/api/util/GTWaila.java
@@ -22,9 +22,10 @@ public abstract class GTWaila {
     public static String getMachineProgressString(boolean isActive, boolean isAllowedToWork, long maxProgresstime,
         long progresstime) {
 
-        if (!isAllowedToWork) return StatCollector.translateToLocal("GT5U.waila.machine.working_disabled");
+        if (!isAllowedToWork && !isActive) return StatCollector.translateToLocal("GT5U.waila.machine.working_disabled");
         if (!isActive) return StatCollector.translateToLocal("GT5U.waila.machine.idle");
 
-        return SpecialChars.getRenderString("waila.gt.progress", progresstime + "", maxProgresstime + "");
+        return SpecialChars
+            .getRenderString("waila.gt.progress", progresstime + "", maxProgresstime + "", isAllowedToWork + "");
     }
 }

--- a/src/main/java/gregtech/client/renderer/waila/TTRenderGTProgressBar.java
+++ b/src/main/java/gregtech/client/renderer/waila/TTRenderGTProgressBar.java
@@ -20,7 +20,11 @@ public class TTRenderGTProgressBar implements IWailaVariableWidthTooltipRenderer
 
     @Override
     public Dimension getSize(String[] params, IWailaCommonAccessor accessor) {
-        return new Dimension(width, 12);
+        int height = 12;
+        if (!Boolean.parseBoolean(params[2])) {
+            height += 10;
+        }
+        return new Dimension(width, height);
     }
 
     @Override
@@ -36,6 +40,8 @@ public class TTRenderGTProgressBar implements IWailaVariableWidthTooltipRenderer
             -1);
         int progresstime = Integer.parseInt(params[0]);
         int maxProgresstime = Integer.parseInt(params[1]);
+        boolean isAllowedToWork = Boolean.parseBoolean(params[2]);
+
         double ratio = maxProgresstime != 0 ? (double) progresstime / maxProgresstime : 0.0;
         ratio = Math.clamp(ratio, 0.0, 1.0);
         int progress = (int) ((maxStringW - 1) * ratio);
@@ -53,6 +59,14 @@ public class TTRenderGTProgressBar implements IWailaVariableWidthTooltipRenderer
             2,
             OverlayConfig.fontcolor,
             true);
+        if (!isAllowedToWork) {
+            DisplayUtil.drawString(
+                StatCollector.translateToLocal("GT5U.waila.machine.working_disabled"),
+                0,
+                14,
+                OverlayConfig.fontcolor,
+                true);
+        }
     }
 
     public static void drawThickBeveledBox(int x1, int y1, int x2, int y2, int thickness, int topleftcolor,


### PR DESCRIPTION
## Summary
Show progress when active even if working is disabled. The information about time remaining is still useful, especially in steam age when no information inside the machine.

<img width="1268" height="858" alt="image" src="https://github.com/user-attachments/assets/814a4829-f9e2-41fe-9e32-e052d6fa4806" />

https://github.com/user-attachments/assets/887fa36c-f1fc-4523-a1a8-d3180e00efc6


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
