### PR TITLE
Increase FrOH Recipe EU/t to LV so it appears later, reduce recipe time

### DIFF
--- a/src/main/java/gregtech/loaders/postload/chains/AcidRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/chains/AcidRecipes.java
@@ -74,8 +74,8 @@ public class AcidRecipes {
             .itemOutputs(Materials.FranciumHydroxide.getDust(3))
             .fluidInputs(Materials.Water.getFluid(1000L))
             .fluidOutputs(Materials.Hydrogen.getGas(1000L))
-            .duration(5 * SECONDS)
-            .eut(TierEU.RECIPE_ULV)
+            .duration(2 * SECONDS)
+            .eut(TierEU.RECIPE_LV)
             .addTo(UniversalChemical);
         // Chlorosulfonic Acid Line
         GTValues.RA.stdBuilder()


### PR DESCRIPTION
## Summary
This PR increases the FrOH recipe eu/t to 30 EU/t to make it more in line with the other hydroxide recipes and make it appear first. Accordingly, the recipe time has been reduced to 2 seconds (since it is the most volatile it should have the fastest recipe). Affects balance but is minimal since the main power usage is from the electrolyzer recipe. 

<img width="688" height="580" alt="Screenshot 2026-07-16 at 11 08 01 AM" src="https://github.com/user-attachments/assets/8dcd3ba8-79b5-4a72-939e-59f60678b5bc" />

Fixes https://discord.com/channels/181078474394566657/522098956491030558/1526716191761105036.

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
