### PR TITLE
Fix LHC turning off after server restart

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/beamcrafting/MTEBeamMultiBase.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/beamcrafting/MTEBeamMultiBase.java
@@ -39,6 +39,7 @@ public abstract class MTEBeamMultiBase<T extends MTEExtendedPowerMultiBlockBase<
         if (mte == null) return false;
 
         if (mte instanceof MTEHatchInputBeamline) {
+            this.addIfSmartInput(mte);
             return this.mInputBeamline.add((MTEHatchInputBeamline) mte);
         }
 


### PR DESCRIPTION
## Summary
This happens because the watcher were not set properly on beam input so recipe check were not triggered
Fixes GTNewHorizons/GT-New-Horizons-Modpack#25912

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
