### PR TITLE
Fix wireless charger bypassing tier requirements

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/basic/MTEWirelessCharger.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/basic/MTEWirelessCharger.java
@@ -618,7 +618,7 @@ public class MTEWirelessCharger extends MTETieredMachineBlock implements IWirele
                         continue;
                     }
 
-                    final int charged = Math.max(0, (int)manager.charge(stack, chargeableEU, Integer.MAX_VALUE, true, false));
+                    final int charged = Math.max(0, (int)manager.charge(stack, chargeableEU, this.mTier, true, false));
                     chargedEU += charged;
                 }
             }


### PR DESCRIPTION
## Summary
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/22101

Replaces `Integer.MAX_VALUE` with `mTier` when calling `manager.charge()`
Use the wireless charger's actual machine tier when charging items, ensuring IC2 charging tier restrictions are properly enforced

## Checklist
- [X] I have tested this PR in DevEnv
- [X] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
