### PR TITLE
Fix incorrect lanthanide cauldron recipes in NEI

### DIFF
--- a/src/main/java/gregtech/GTMod.java
+++ b/src/main/java/gregtech/GTMod.java
@@ -135,6 +135,7 @@ import gregtech.loaders.preload.LoaderGTOreDictionary;
 import gregtech.loaders.preload.LoaderMetaPipeEntities;
 import gregtech.loaders.preload.LoaderMetaTileEntities;
 import gregtech.loaders.preload.LoaderOreProcessing;
+import gtnhlanth.loader.RecipeLoader;
 import ic2.api.recipe.IRecipeInput;
 import ic2.api.recipe.RecipeOutput;
 
@@ -567,6 +568,7 @@ public class GTMod {
 
         GTPostLoad.addSolidFakeLargeBoilerFuels();
         NaquadahReworkRecipeLoader.Remover();
+        RecipeLoader.registerCauldronRemaps();
         GTPostLoad.addCauldronRecipe();
         GTPostLoad.identifyAnySteam();
         GTPostLoad.processToolboxBans();

--- a/src/main/java/gtnhlanth/loader/RecipeLoader.java
+++ b/src/main/java/gtnhlanth/loader/RecipeLoader.java
@@ -4084,20 +4084,21 @@ public class RecipeLoader {
         removeCeriumDehydrator();
         removeCeriumChemicalBath();
 
-        // For Cauldron Wash
-        GTLog.out.println(Tags.MODID + ": processing cauldron washing recipes to replace cerium sources");
-        registerCauldronCleaningFor(Materials.Cerium, WerkstoffMaterialPool.CeriumRichMixture.getBridgeMaterial());
-        registerCauldronCleaningFor(
-            Materials.Samarium,
-            WerkstoffMaterialPool.SamariumOreConcentrate.getBridgeMaterial());
-        GTLog.out.println(Tags.MODID + ": processing cauldron washing recipes done!");
-
         // For Crafting Table
         GTLog.out.println(Tags.MODID + ": processing crafting recipes to replace cerium sources");
         CraftingManager.getInstance()
             .getRecipeList()
             .forEach(RecipeLoader::replaceInCraftTable);
         GTLog.out.println(Tags.MODID + ": processing crafting recipes done!");
+    }
+
+    public static void registerCauldronRemaps() {
+        GTLog.out.println(Tags.MODID + ": processing cauldron washing recipes to replace cerium sources");
+        registerCauldronCleaningFor(Materials.Cerium, WerkstoffMaterialPool.CeriumRichMixture.getBridgeMaterial());
+        registerCauldronCleaningFor(
+            Materials.Samarium,
+            WerkstoffMaterialPool.SamariumOreConcentrate.getBridgeMaterial());
+        GTLog.out.println(Tags.MODID + ": processing cauldron washing recipes done!");
     }
 
     public static void replaceInCraftTable(Object obj) {


### PR DESCRIPTION
## What changed

- Register the Cerium and Samarium cauldron cleaning remaps before NEI cauldron recipes are generated.
- Keep the remaining lanthanide recipe replacement work in the existing load-complete stage.

## Why

NEI generates and caches its cauldron recipes during GregTech post-init, while the Cerium and Samarium output remaps were previously registered later during GTNH Lanthanides load-complete.

As a result, the actual cauldron wash used the remapped output, but NEI still displayed the original material. Registering these remaps before the NEI recipes are generated keeps the displayed and actual outputs consistent.

Fixes GTNewHorizons/GT-New-Horizons-Modpack#25927

## Checklist

- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
