### PR TITLE
Fix CAL fluid recipe check

### DIFF
--- a/src/main/java/bartworks/common/tileentities/multis/MTECircuitAssemblyLine.java
+++ b/src/main/java/bartworks/common/tileentities/multis/MTECircuitAssemblyLine.java
@@ -450,6 +450,7 @@ public class MTECircuitAssemblyLine extends MTEEnhancedMultiBlockBase<MTECircuit
         if (!(aMetaTileEntity instanceof MTEHatchInput)) {
             return false;
         } else {
+            addIfSmartInput(aMetaTileEntity);
             ((MTEHatch) aMetaTileEntity).updateTexture(aBaseCasingIndex);
             ((MTEHatchInput) aMetaTileEntity).mRecipeMap = this.getRecipeMap();
             return this.mInputHatches.add((MTEHatchInput) aMetaTileEntity);


### PR DESCRIPTION
## Summary
Add watcher to the input hatch in CAL
Fixes GTNewHorizons/GT-New-Horizons-Modpack#25843


## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
