### PR TITLE
Fix AAL not auto-detect new data sticks

### DIFF
--- a/src/main/java/ggfab/mte/MTEAdvAssLine.java
+++ b/src/main/java/ggfab/mte/MTEAdvAssLine.java
@@ -221,6 +221,7 @@ public class MTEAdvAssLine extends MTEExtendedPowerMultiBlockBase<MTEAdvAssLine>
         IMetaTileEntity aMetaTileEntity = aTileEntity.getMetaTileEntity();
         if (aMetaTileEntity == null) return false;
         if (aMetaTileEntity instanceof MTEHatchDataAccess) {
+            addIfSmartInput(aMetaTileEntity);
             ((MTEHatch) aMetaTileEntity).updateTexture(aBaseCasingIndex);
             return mDataAccessHatches.add((MTEHatchDataAccess) aMetaTileEntity);
         }

--- a/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchWirelessDataItemsInput.java
+++ b/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchWirelessDataItemsInput.java
@@ -6,6 +6,7 @@ import static tectech.thing.metaTileEntity.hatch.MTEHatchDataConnector.EM_D_ACTI
 import static tectech.thing.metaTileEntity.hatch.MTEHatchDataConnector.EM_D_CONN;
 import static tectech.thing.metaTileEntity.hatch.MTEHatchDataConnector.EM_D_SIDES;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -110,7 +111,7 @@ public class MTEHatchWirelessDataItemsInput extends MTEHatchDataAccess {
             if (aTick % WirelessDataStore.IO_TICK_RATE == WirelessDataStore.DOWNLOAD_TICK_OFFSET) {
                 WirelessDataStore wirelessDataStore = WirelessDataStore
                     .getWirelessDataSticks(getBaseMetaTileEntity().getOwnerUuid());
-                List<RecipeAssemblyLine> oldRecipes = recipes;
+                List<RecipeAssemblyLine> oldRecipes = recipes != null ? new ArrayList<>(recipes) : null;
                 this.recipes = wirelessDataStore.downloadData(aTick);
                 // Only notify when the available recipe set changed (by content, not count, so a same-size swap of
                 // wireless data sticks still fires), to avoid re-checking every download cycle.


### PR DESCRIPTION
## Summary
Add watcher for data stick hatch in AdvAssLine
also fix an issue where wireless data hatch doesn't trigger a recipe check

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
