### PR TITLE
Add missing watchers for Cracker Multis

### DIFF
--- a/src/main/java/bartworks/common/tileentities/multis/mega/MTEMegaOilCrackerLegacy.java
+++ b/src/main/java/bartworks/common/tileentities/multis/mega/MTEMegaOilCrackerLegacy.java
@@ -358,6 +358,7 @@ public class MTEMegaOilCrackerLegacy extends MegaMultiBlockBase<MTEMegaOilCracke
             return false;
         }
         if (aMetaTileEntity instanceof MTEHatchInput tHatch) {
+            addIfSmartInput(aMetaTileEntity);
             tHatch.updateTexture(aBaseCasingIndex);
             tHatch.mRecipeMap = this.getRecipeMap();
             return this.mMiddleInputHatches.add(tHatch);

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEMegaOilCracker.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEMegaOilCracker.java
@@ -364,6 +364,7 @@ public class MTEMegaOilCracker extends MTEExtendedPowerMultiBlockBase<MTEMegaOil
             return false;
         }
         if (aMetaTileEntity instanceof MTEHatchInput tHatch) {
+            addIfSmartInput(aMetaTileEntity);
             tHatch.updateTexture(aBaseCasingIndex);
             tHatch.mRecipeMap = this.getRecipeMap();
             return this.mMiddleInputHatches.add(tHatch);

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEOilCracker.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEOilCracker.java
@@ -202,6 +202,7 @@ public class MTEOilCracker extends MTEEnhancedMultiBlockBase<MTEOilCracker>
         IMetaTileEntity aMetaTileEntity = aTileEntity.getMetaTileEntity();
         if (aMetaTileEntity == null) return false;
         if (aMetaTileEntity instanceof MTEHatchInput tHatch) {
+            addIfSmartInput(aMetaTileEntity);
             tHatch.updateTexture(aBaseCasingIndex);
             tHatch.mRecipeMap = getRecipeMap();
             return mMiddleInputHatches.add(tHatch);


### PR DESCRIPTION
## Summary
stumbled across this during testing, stocking input hatch wouldnt detect if a fluid was added to the me system and wouldnt start a new recipe check until controller gui was opened. tested these in dev env, and oil cracker now instantly runs the recipe with stocking hatch as soon as i put cracking fluid into the me system


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
