### PR TITLE
Fix BEC unable to validate casing count

### DIFF
--- a/src/main/java/tectech/thing/metaTileEntity/multi/base/MTEBECMultiblockBase.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/base/MTEBECMultiblockBase.java
@@ -131,6 +131,8 @@ public abstract class MTEBECMultiblockBase<TSelf extends MTEBECMultiblockBase<TS
     public void clearHatches() {
         super.clearHatches();
 
+        structureInstanceInfo.clearHatches();
+
         mPreviousBECHatches = new ArrayList<>(mBECHatches);
 
         mBECHatches.forEach(h -> h.removeController(this));


### PR DESCRIPTION
## Summary
Previously, BEC is unable to validate casing count, making it possible for it to work even with less than min casing
This fix that


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
