### PR TITLE
Remove redundant Dense Tairitsu Plate recipe

### DIFF
--- a/src/main/java/gregtech/loaders/postload/recipes/BenderRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/BenderRecipes.java
@@ -8,7 +8,6 @@ import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.oredict.OreDictionary;
 
-import goodgenerator.items.GGMaterial;
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
@@ -284,14 +283,6 @@ public class BenderRecipes implements Runnable {
             .itemOutputs(ItemList.IC2_Fuel_Rod_Empty.get(1))
             .duration(5 * SECONDS)
             .eut(TierEU.RECIPE_ULV)
-            .addTo(benderRecipes);
-
-        GTValues.RA.stdBuilder()
-            .itemInputs(GGMaterial.tairitsu.get(OrePrefixes.ingot, 9))
-            .circuit(9)
-            .itemOutputs(GGMaterial.tairitsu.get(OrePrefixes.plateDense, 1))
-            .duration(5 * SECONDS)
-            .eut(TierEU.RECIPE_ZPM)
             .addTo(benderRecipes);
 
         if (GTOreDictUnificator.get(OrePrefixes.itemCasing, Materials.Tin, 1L) != null) {


### PR DESCRIPTION
## Summary
Fixes GTNewHorizons/GT-New-Horizons-Modpack/issues/25607


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
