### PR TITLE
Fix Vacuum Freezer holo build + Move Pyro Hatch to HatchElement

### DIFF
--- a/src/main/java/gregtech/api/enums/HatchElement.java
+++ b/src/main/java/gregtech/api/enums/HatchElement.java
@@ -26,6 +26,7 @@ import gregtech.common.tileentities.machines.MTEHatchCraftingInputSlave;
 import gregtech.common.tileentities.machines.multi.purification.MTEHatchLensHousing;
 import gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.MTEHatchSteamBusInput;
 import gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.MTEHatchSteamBusOutput;
+import gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.base.MTEHatchCustomFluidBase;
 import gtnhlanth.common.hatch.MTEBusInputFocus;
 import gtnhlanth.common.hatch.MTEHatchInputBeamline;
 import gtnhlanth.common.hatch.MTEHatchOutputBeamline;
@@ -137,11 +138,21 @@ public enum HatchElement implements IHatchElement<MTEMultiBlockBase> {
                 .size();
         }
     },
-    CryotheumHatch("GT5U.MBTT.CryotheumHatch", MTEMultiBlockBase::addCryotheumHatchToMachineList) {
+    CryotheumHatch("GT5U.MBTT.CryotheumHatch", MTEMultiBlockBase::addCryotheumHatchToMachineList,
+        MTEHatchCustomFluidBase.class) {
 
         @Override
         public long count(MTEMultiBlockBase t) {
             return t.getCryotheumHatches()
+                .size();
+        }
+    },
+    PyrotheumHatch("GT5U.MBTT.PyrotheumHatch", MTEMultiBlockBase::addPyrotheumHatchToMachineList,
+        MTEHatchCustomFluidBase.class) {
+
+        @Override
+        public long count(MTEMultiBlockBase t) {
+            return t.getPyrotheumHatches()
                 .size();
         }
     },

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
@@ -250,6 +250,7 @@ public abstract class MTEMultiBlockBase extends MetaTileEntity
     protected List<MTEHatch> mExoticEnergyHatches = new ArrayList<>();
     protected List<MTEHatch> mExoticDynamoHatches = new ArrayList<>();
     protected List<MTEHatch> mCryotheumHatches = new ArrayList<>();
+    protected List<MTEHatch> mPyrotheumHatches = new ArrayList<>();
 
     protected final List<MTEHatchInputBeamline> mBeamlineInputHatches = new ArrayList<>();
     protected final List<MTEHatchOutputBeamline> mBeamlineOutputHatches = new ArrayList<>();
@@ -546,6 +547,7 @@ public abstract class MTEMultiBlockBase extends MetaTileEntity
         }
         mSmartInputHatches.clear();
         mCryotheumHatches.clear();
+        mPyrotheumHatches.clear();
         mBeamlineInputHatches.clear();
         mBeamlineOutputHatches.clear();
         mFocusInputBuses.clear();
@@ -2266,6 +2268,19 @@ public abstract class MTEMultiBlockBase extends MetaTileEntity
         return false;
     }
 
+    public boolean addPyrotheumHatchToMachineList(IGregTechTileEntity aTileEntity, int aBaseCasingIndex) {
+        if (aTileEntity == null) return false;
+        IMetaTileEntity aMetaTileEntity = aTileEntity.getMetaTileEntity();
+        if (aMetaTileEntity == null) return false;
+        if (aMetaTileEntity instanceof MTEHatchCustomFluidBase mteHatchPyrotheum
+            && mteHatchPyrotheum.mLockedFluid == TFFluids.fluidPyrotheum) {
+            mteHatchPyrotheum.updateTexture(aBaseCasingIndex);
+            mteHatchPyrotheum.updateCraftingIcon(this.getMachineCraftingIcon());
+            return mPyrotheumHatches.add(mteHatchPyrotheum);
+        }
+        return false;
+    }
+
     public boolean addBeamlineInputToMachineList(IGregTechTileEntity aTileEntity, int aBaseCasingIndex) {
         if (aTileEntity == null) return false;
         IMetaTileEntity aMetaTileEntity = aTileEntity.getMetaTileEntity();
@@ -2847,6 +2862,10 @@ public abstract class MTEMultiBlockBase extends MetaTileEntity
 
     public List<MTEHatch> getCryotheumHatches() {
         return mCryotheumHatches;
+    }
+
+    public List<MTEHatch> getPyrotheumHatches() {
+        return mPyrotheumHatches;
     }
 
     public List<MTEHatchInputBeamline> getBeamlineInputHatches() {

--- a/src/main/java/gtPlusPlus/core/recipe/RecipesMachinesMulti.java
+++ b/src/main/java/gtPlusPlus/core/recipe/RecipesMachinesMulti.java
@@ -842,7 +842,7 @@ public class RecipesMachinesMulti {
                 ItemList.Robot_Arm_IV, 'X', GregtechItemList.Casing_Adv_BlastFurnace, 'P',
                 MaterialsAlloy.HASTELLOY_N.getPlateDouble(1), 'Z', GregtechItemList.Gregtech_Computer_Cube });
 
-        // Pyrotheum Heating Vent
+        // Pyrotheum Heating Hatch
         GTModHandler.addCraftingRecipe(
             GregtechItemList.Hatch_Input_Pyrotheum.get(1L),
             GTModHandler.RecipeBits.BUFFERED,

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/advanced/MTEAdvEBF.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/processing/advanced/MTEAdvEBF.java
@@ -12,12 +12,12 @@ import static gregtech.api.enums.HatchElement.Maintenance;
 import static gregtech.api.enums.HatchElement.Muffler;
 import static gregtech.api.enums.HatchElement.OutputBus;
 import static gregtech.api.enums.HatchElement.OutputHatch;
+import static gregtech.api.enums.HatchElement.PyrotheumHatch;
 import static gregtech.api.util.GTStructureUtility.activeCoils;
 import static gregtech.api.util.GTStructureUtility.buildHatchAdder;
 import static gregtech.api.util.GTStructureUtility.ofCoil;
 import static gregtech.api.util.GTUtility.validMTEList;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import net.minecraft.entity.player.EntityPlayer;
@@ -48,13 +48,13 @@ import gregtech.api.interfaces.IIconContainer;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.logic.ProcessingLogic;
+import gregtech.api.metatileentity.implementations.MTEHatch;
 import gregtech.api.recipe.RecipeMap;
 import gregtech.api.recipe.RecipeMaps;
 import gregtech.api.recipe.check.CheckRecipeResult;
 import gregtech.api.recipe.check.CheckRecipeResultRegistry;
 import gregtech.api.structure.error.StructureError;
 import gregtech.api.structure.error.StructureErrorRegistry;
-import gregtech.api.structure.error.StructureErrors;
 import gregtech.api.util.GTRecipe;
 import gregtech.api.util.MultiblockTooltipBuilder;
 import gregtech.api.util.OverclockCalculator;
@@ -63,7 +63,6 @@ import gregtech.api.util.tooltip.TooltipHelper;
 import gregtech.common.misc.GTStructureChannels;
 import gregtech.common.pollution.PollutionConfig;
 import gtPlusPlus.core.block.ModBlocks;
-import gtPlusPlus.xmod.gregtech.api.enums.GregtechItemList;
 import gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.base.GTPPMultiBlockBase;
 import gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.base.MTEHatchCustomFluidBase;
 import gtPlusPlus.xmod.gregtech.common.blocks.textures.TexturesGtBlock;
@@ -79,7 +78,6 @@ public class MTEAdvEBF extends GTPPMultiBlockBase<MTEAdvEBF> implements ISurviva
     public static String mHatchName = "Pyrotheum Hatch";
     private static IStructureDefinition<MTEAdvEBF> STRUCTURE_DEFINITION = null;
     private int mCasing;
-    private final ArrayList<MTEHatchCustomFluidBase> mPyrotheumHatches = new ArrayList<>();
 
     private HeatingCoilLevel mHeatingCapacity = HeatingCoilLevel.None;
 
@@ -161,14 +159,16 @@ public class MTEAdvEBF extends GTPPMultiBlockBase<MTEAdvEBF> implements ISurviva
                 .addElement(
                     'C',
                     ofChain(
-                        buildHatchAdder(MTEAdvEBF.class).adder(MTEAdvEBF::addPyrotheumHatch)
-                            .hatchId(968)
-                            .shouldReject(x -> !x.mPyrotheumHatches.isEmpty())
-                            .casingIndex(CASING_TEXTURE_ID)
-                            .hint(1)
-                            .build(),
                         buildHatchAdder(MTEAdvEBF.class)
-                            .atLeast(InputBus, OutputBus, Maintenance, Energy, Muffler, InputHatch, OutputHatch)
+                            .atLeast(
+                                PyrotheumHatch,
+                                InputBus,
+                                OutputBus,
+                                Maintenance,
+                                Energy,
+                                Muffler,
+                                InputHatch,
+                                OutputHatch)
                             .casingIndex(CASING_TEXTURE_ID)
                             .hint(1)
                             .build(),
@@ -196,7 +196,6 @@ public class MTEAdvEBF extends GTPPMultiBlockBase<MTEAdvEBF> implements ISurviva
     @Override
     public void checkMachine(IGregTechTileEntity aBaseMetaTileEntity, ItemStack aStack, List<StructureError> errors) {
         mCasing = 0;
-        mPyrotheumHatches.clear();
         setCoilLevel(HeatingCoilLevel.None);
         if (!checkPiece(mName, 1, 3, 0, errors)) return;
         checkCasingMin(errors, mCasing, 6);
@@ -205,34 +204,13 @@ public class MTEAdvEBF extends GTPPMultiBlockBase<MTEAdvEBF> implements ISurviva
             errors.add(StructureErrorRegistry.COIL_LEVEL_NOT_ENOUGH);
         }
 
-        if (mPyrotheumHatches.isEmpty()) {
-            errors.add(StructureErrors.missingHatch(GregtechItemList.Hatch_Input_Pyrotheum.get(1)));
-        }
+        checkHatchMin(errors, PyrotheumHatch, 1);
 
         checkHasEnergyHatch(errors);
         checkHasMaintenanceHatch(errors);
         checkHasMufflerHatch(errors);
         checkHasAnyInput(errors);
         checkHasAnyOutput(errors);
-    }
-
-    private boolean addPyrotheumHatch(IGregTechTileEntity aTileEntity, int aBaseCasingIndex) {
-        if (aTileEntity == null) {
-            return false;
-        } else {
-            IMetaTileEntity aMetaTileEntity = aTileEntity.getMetaTileEntity();
-            if (aMetaTileEntity instanceof MTEHatchCustomFluidBase hatch && aMetaTileEntity.getBaseMetaTileEntity()
-                .getMetaTileID() == 968) {
-                return addToMachineListInternal(mPyrotheumHatches, hatch, aBaseCasingIndex);
-            }
-        }
-        return false;
-    }
-
-    @Override
-    public void updateSlots() {
-        for (MTEHatchCustomFluidBase tHatch : validMTEList(mPyrotheumHatches)) tHatch.updateSlots();
-        super.updateSlots();
     }
 
     @Override
@@ -308,7 +286,7 @@ public class MTEAdvEBF extends GTPPMultiBlockBase<MTEAdvEBF> implements ISurviva
                 .hasWorkJustBeenEnabled()) {
                 if (aTick % 20 == 0 || this.getBaseMetaTileEntity()
                     .hasWorkJustBeenEnabled()) {
-                    if (!this.depleteInputFromRestrictedHatches(this.mPyrotheumHatches, 10)) {
+                    if (!drainPyrotheum(10)) {
                         this.causeMaintenanceIssue();
                         this.stopMachine(
                             ShutDownReasonRegistry.outOfFluid(new FluidStack(TFFluids.fluidPyrotheum, 10)));
@@ -316,6 +294,19 @@ public class MTEAdvEBF extends GTPPMultiBlockBase<MTEAdvEBF> implements ISurviva
                 }
             }
         }
+    }
+
+    private boolean drainPyrotheum(int amount) {
+        FluidStack toDrain = new FluidStack(TFFluids.fluidPyrotheum, amount);
+        for (MTEHatch hatch : validMTEList(mPyrotheumHatches)) {
+            if (!(hatch instanceof MTEHatchCustomFluidBase pyroHatch)) continue;
+            if (pyroHatch.getBaseMetaTileEntity() == null) continue;
+            FluidStack drained = pyroHatch.drain(ForgeDirection.UNKNOWN, toDrain, true);
+            if (drained != null && drained.amount >= amount) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechCustomHatches.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechCustomHatches.java
@@ -99,7 +99,7 @@ public class GregtechCustomHatches {
                 128000, // Capacity
                 Hatch_Input_Pyrotheum.ID, // ID
                 "hatch.pyrotheum.input.tier.00", // unlocal name
-                "Pyrotheum Heating Vent", // Local name
+                "Pyrotheum Heating Hatch", // Local name
                 5 // Casing texture
             ).getStackForm(1L));
 

--- a/src/main/resources/assets/gregtech/lang/en_US.lang
+++ b/src/main/resources/assets/gregtech/lang/en_US.lang
@@ -1832,6 +1832,7 @@ GT5U.MBTT.subchannel=Subchannel §b%s§7 determines §b%s
 
 GT5U.MBTT.CokeOvenHatch=Coke Oven Hatch
 GT5U.MBTT.CryotheumHatch=Cryotheum Cooling Hatch
+GT5U.MBTT.PyrotheumHatch=Pyrotheum Heating Hatch
 
 GT5U.cracker.io_side=Input/Output Hatches must be on opposite sides!
 GT5U.gui.text.structure_error.cracker_missing_middle_input_hatch=Missing Input Hatch for cracking fluid


### PR DESCRIPTION
## Summary
- rename Pyrotheum Heating Vent -> Pyrotheum Heating Hatch
- move it to HatchElements, like i did with Cryo Hatch
- fix holo projector whining about cryo hatch when building cryo freezer

closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/26017
## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
