### PR TITLE
Fix Structurelib mixing Pyro and Cryo Hatch due to same base class

### DIFF
--- a/src/main/java/gregtech/api/enums/HatchElement.java
+++ b/src/main/java/gregtech/api/enums/HatchElement.java
@@ -27,6 +27,7 @@ import gregtech.common.tileentities.machines.multi.purification.MTEHatchLensHous
 import gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.MTEHatchSteamBusInput;
 import gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.MTEHatchSteamBusOutput;
 import gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.base.MTEHatchCustomFluidBase;
+import gtPlusPlus.xmod.thermalfoundation.fluid.TFFluids;
 import gtnhlanth.common.hatch.MTEBusInputFocus;
 import gtnhlanth.common.hatch.MTEHatchInputBeamline;
 import gtnhlanth.common.hatch.MTEHatchOutputBeamline;
@@ -146,6 +147,11 @@ public enum HatchElement implements IHatchElement<MTEMultiBlockBase> {
             return t.getCryotheumHatches()
                 .size();
         }
+
+        @Override
+        public boolean matchesHatch(IMetaTileEntity mte) {
+            return mte instanceof MTEHatchCustomFluidBase f && f.mLockedFluid == TFFluids.fluidCryotheum;
+        }
     },
     PyrotheumHatch("GT5U.MBTT.PyrotheumHatch", MTEMultiBlockBase::addPyrotheumHatchToMachineList,
         MTEHatchCustomFluidBase.class) {
@@ -154,6 +160,11 @@ public enum HatchElement implements IHatchElement<MTEMultiBlockBase> {
         public long count(MTEMultiBlockBase t) {
             return t.getPyrotheumHatches()
                 .size();
+        }
+
+        @Override
+        public boolean matchesHatch(IMetaTileEntity mte) {
+            return mte instanceof MTEHatchCustomFluidBase f && f.mLockedFluid == TFFluids.fluidPyrotheum;
         }
     },
     LaserSource("GT5U.MBTT.LaserSourceHatch", MTEMultiBlockBase::addLaserSourceToMachineList,

--- a/src/main/java/gregtech/api/interfaces/IHatchElement.java
+++ b/src/main/java/gregtech/api/interfaces/IHatchElement.java
@@ -211,6 +211,11 @@ class HatchElementEither<T> implements IHatchElement<T> {
     public long count(T t) {
         return first.count(t) + second.count(t);
     }
+
+    @Override
+    public boolean matchesHatch(IMetaTileEntity mte) {
+        return first.matchesHatch(mte) || second.matchesHatch(mte);
+    }
 }
 
 class HatchElement<T> implements IHatchElement<T> {
@@ -259,6 +264,11 @@ class HatchElement<T> implements IHatchElement<T> {
     @Override
     public long count(T t) {
         return mCount == null ? mBacking.count(t) : mCount.applyAsLong(t);
+    }
+
+    @Override
+    public boolean matchesHatch(IMetaTileEntity mte) {
+        return mBacking.matchesHatch(mte);
     }
 
     @Override

--- a/src/main/java/gregtech/api/interfaces/IHatchElement.java
+++ b/src/main/java/gregtech/api/interfaces/IHatchElement.java
@@ -44,6 +44,11 @@ public interface IHatchElement<T> {
 
     long count(T t);
 
+    default boolean matchesHatch(IMetaTileEntity mte) {
+        return mteClasses().stream()
+            .anyMatch(c -> c.isInstance(mte));
+    }
+
     default <T2 extends T> IHatchElement<T2> withMteClass(Class<? extends IMetaTileEntity> aClass) {
         if (aClass == null) throw new IllegalArgumentException();
         return withMteClasses(Collections.singletonList(aClass));

--- a/src/main/java/gregtech/api/util/GTStructureUtility.java
+++ b/src/main/java/gregtech/api/util/GTStructureUtility.java
@@ -1356,5 +1356,10 @@ public class GTStructureUtility {
         public long count(T t) {
             return proxiedHatch.count(t);
         }
+
+        @Override
+        public boolean matchesHatch(IMetaTileEntity mte) {
+            return proxiedHatch.matchesHatch(mte);
+        }
     }
 }

--- a/src/main/java/gregtech/api/util/HatchElementBuilder.java
+++ b/src/main/java/gregtech/api/util/HatchElementBuilder.java
@@ -87,17 +87,17 @@ public class HatchElementBuilder<T> {
                 e -> e.getDescriptionLangKeys()
                     .stream())
             .collect(Collectors.toList());
-        List<? extends Class<? extends IMetaTileEntity>> mteClasses = Arrays.stream(elements)
-            .map(IHatchElement::mteClasses)
-            .flatMap(Collection::stream)
-            .collect(Collectors.toList());
         return adder(
             Arrays.stream(elements)
                 .map(
                     e -> e.adder()
                         .rebrand())
                 .reduce(IGTHatchAdder::orElse)
-                .get()).hatchItemFilter(obj -> GTStructureUtility.filterByMTEClass(mteClasses))
+                .get()).hatchItemFilter(obj -> is -> {
+                    IMetaTileEntity tile = ItemMachines.getMetaTileEntity(is);
+                    return tile != null && Arrays.stream(elements)
+                        .anyMatch(e -> e.matchesHatch(tile));
+                })
                     .shouldSkip(
                         (BiPredicate<? super T, ? super IGregTechTileEntity> & Builtin) (c,
                             t) -> t != null && Arrays.stream(elements)

--- a/src/main/java/gregtech/api/util/HatchElementBuilder.java
+++ b/src/main/java/gregtech/api/util/HatchElementBuilder.java
@@ -100,8 +100,8 @@ public class HatchElementBuilder<T> {
                 .get()).hatchItemFilter(obj -> GTStructureUtility.filterByMTEClass(mteClasses))
                     .shouldSkip(
                         (BiPredicate<? super T, ? super IGregTechTileEntity> & Builtin) (c,
-                            t) -> t != null && mteClasses.stream()
-                                .anyMatch(clazz -> clazz.isInstance(t.getMetaTileEntity())))
+                            t) -> t != null && Arrays.stream(elements)
+                                .anyMatch(e -> e.matchesHatch(t.getMetaTileEntity())))
                     .cacheHint(
                         () -> Arrays.stream(elements)
                             .map(IHatchElement::getDisplayName)
@@ -161,11 +161,6 @@ public class HatchElementBuilder<T> {
             .flatMap(Collection::stream)
             .collect(Collectors.toList());
 
-        List<Class<? extends IMetaTileEntity>> list = elements.keySet()
-            .stream()
-            .map(IHatchElement::mteClasses)
-            .flatMap(Collection::stream)
-            .collect(Collectors.toList());
         // map cannot be null or empty, so assert Optional isPresent
         return adder(
             elements.keySet()
@@ -174,22 +169,23 @@ public class HatchElementBuilder<T> {
                     e -> e.adder()
                         .rebrand())
                 .reduce(IGTHatchAdder::orElse)
-                .orElseThrow(AssertionError::new))
-                    .hatchItemFilter(
-                        obj -> GTStructureUtility.filterByMTEClassWithBlacklist(
-                            elements.entrySet()
-                                .stream()
-                                .filter(
-                                    entry -> entry.getKey()
-                                        .count(obj)
-                                        < entry.getValue()
-                                            .longValue())
-                                .flatMap(
-                                    entry -> entry.getKey()
-                                        .mteClasses()
-                                        .stream())
-                                .collect(Collectors.toList()),
-                            blacklist))
+                .orElseThrow(AssertionError::new)).hatchItemFilter(obj -> {
+                    List<IHatchElement<? super T>> neededElements = elements.entrySet()
+                        .stream()
+                        .filter(
+                            entry -> entry.getKey()
+                                .count(obj)
+                                < entry.getValue()
+                                    .longValue())
+                        .map(Map.Entry::getKey)
+                        .collect(Collectors.toList());
+                    return is -> {
+                        IMetaTileEntity tile = ItemMachines.getMetaTileEntity(is);
+                        return tile != null && !blacklist.contains(tile.getClass())
+                            && neededElements.stream()
+                                .anyMatch(e -> e.matchesHatch(tile));
+                    };
+                })
                     .shouldReject(
                         obj -> elements.entrySet()
                             .stream()
@@ -200,8 +196,9 @@ public class HatchElementBuilder<T> {
                                         .longValue()))
                     .shouldSkip(
                         (BiPredicate<? super T, ? super IGregTechTileEntity> & Builtin) (c,
-                            t) -> t != null && list.stream()
-                                .anyMatch(clazz -> clazz.isInstance(t.getMetaTileEntity())))
+                            t) -> t != null && elements.keySet()
+                                .stream()
+                                .anyMatch(e -> e.matchesHatch(t.getMetaTileEntity())))
                     .cacheHint(
                         () -> elements.keySet()
                             .stream()


### PR DESCRIPTION
## Summary
both hatches share the same MTEHatchCustomFluidBase class, causing structurelib to get confused and corrupting volcanus preview and sometimes cryo preview:
<img width="981" height="964" alt="image" src="https://github.com/user-attachments/assets/35902db0-0394-410c-b3f2-cd33e246a317" />

<img width="627" height="327" alt="image" src="https://github.com/user-attachments/assets/65e5b5ca-0a1c-419d-b711-534174941fc2" />

because of this, i added  matchesHatch hook to allow matching beyond class-based isInstance, which is then overridden in both cryo and pyro hatch
devenv seems fine now:

<img width="399" height="472" alt="image" src="https://github.com/user-attachments/assets/f24888db-a9b2-4587-97e9-958684168f4b" />

<img width="696" height="414" alt="image" src="https://github.com/user-attachments/assets/cdfaae0f-f1f0-47a6-ae5c-22801aef3b65" />

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
