### PR TITLE
Add null check for EHE hot fluid input hatch explosion

### DIFF
--- a/src/main/java/goodgenerator/blocks/tileEntity/MTEExtremeHeatExchanger.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/MTEExtremeHeatExchanger.java
@@ -335,9 +335,11 @@ public class MTEExtremeHeatExchanger extends TTMultiblockBase implements ISurviv
                 }
                 addOutput(new FluidStack(tReadySteam, steamToOutput));
             } else {
-                GTLog.writeExplosionLog(this, "had no more distilled water!");
-                mHotFluidHatch.getBaseMetaTileEntity()
-                    .doExplosion(V[8]);
+                if (mHotFluidHatch.getBaseMetaTileEntity() != null) {
+                    GTLog.writeExplosionLog(this, "had no more distilled water!");
+                    mHotFluidHatch.getBaseMetaTileEntity()
+                        .doExplosion(V[8]);
+                }
                 return false;
             }
         }

--- a/src/main/java/goodgenerator/blocks/tileEntity/MTEExtremeHeatExchanger.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/MTEExtremeHeatExchanger.java
@@ -335,10 +335,10 @@ public class MTEExtremeHeatExchanger extends TTMultiblockBase implements ISurviv
                 }
                 addOutput(new FluidStack(tReadySteam, steamToOutput));
             } else {
-                if (mHotFluidHatch.getBaseMetaTileEntity() != null) {
+                IGregTechTileEntity hotFluidHatchBMTE = mHotFluidHatch.getBaseMetaTileEntity();
+                if (hotFluidHatchBMTE != null) {
                     GTLog.writeExplosionLog(this, "had no more distilled water!");
-                    mHotFluidHatch.getBaseMetaTileEntity()
-                        .doExplosion(V[8]);
+                    hotFluidHatchBMTE.doExplosion(V[8]);
                 }
                 return false;
             }


### PR DESCRIPTION
## Summary
When the EHE tries to explode the hot fluid input hatch if it runs out of water, if the hatch explosion does not destroy the controller, the controller will keep trying to access the now-exploded input hatch to try and blow it up every tick, spamming the log with Null Pointer Exceptions. I've added a null check to prevent this.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25964

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
