### PR TITLE
Skip generate description for BEC multis

### DIFF
--- a/src/main/java/tectech/thing/metaTileEntity/multi/bec/MTEBECAssembler.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/bec/MTEBECAssembler.java
@@ -52,6 +52,7 @@ import tectech.thing.metaTileEntity.hatch.bec.MTEHatchLoS;
 import tectech.thing.metaTileEntity.multi.base.MTEBECMultiblockBase;
 import tectech.thing.metaTileEntity.multi.structures.BECStructureDefinitions;
 
+@IMetaTileEntity.SkipGenerateDescription
 public class MTEBECAssembler extends MTEBECMultiblockBase<MTEBECAssembler> {
 
     private final List<MTEHatchLoS> losHatches = new ArrayList<>();

--- a/src/main/java/tectech/thing/metaTileEntity/multi/bec/MTEBECDiode.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/bec/MTEBECDiode.java
@@ -50,6 +50,7 @@ import tectech.thing.metaTileEntity.multi.base.parameter.IParametrized;
 import tectech.thing.metaTileEntity.multi.base.parameter.Parameter;
 import tectech.thing.metaTileEntity.multi.structures.BECStructureDefinitions;
 
+@IMetaTileEntity.SkipGenerateDescription
 public class MTEBECDiode extends MTEBECMultiblockBase<MTEBECDiode> implements IParametrized {
 
     private MTEHatchBEC inputHatch;

--- a/src/main/java/tectech/thing/metaTileEntity/multi/bec/MTEBECGenerator.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/bec/MTEBECGenerator.java
@@ -47,6 +47,7 @@ import tectech.recipe.TecTechRecipeMaps;
 import tectech.thing.metaTileEntity.multi.base.MTEBECMultiblockBase;
 import tectech.thing.metaTileEntity.multi.structures.BECStructureDefinitions;
 
+@IMetaTileEntity.SkipGenerateDescription
 public class MTEBECGenerator extends MTEBECMultiblockBase<MTEBECGenerator> {
 
     public MTEBECGenerator(int aID, String aName) {

--- a/src/main/java/tectech/thing/metaTileEntity/multi/bec/MTEBECIONode.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/bec/MTEBECIONode.java
@@ -86,6 +86,7 @@ import tectech.thing.metaTileEntity.multi.base.parameter.IntegerParameter;
 import tectech.thing.metaTileEntity.multi.base.parameter.Parameter;
 import tectech.thing.metaTileEntity.multi.structures.BECStructureDefinitions;
 
+@IMetaTileEntity.SkipGenerateDescription
 public class MTEBECIONode extends MTEBECMultiblockBase<MTEBECIONode> implements IParametrized {
 
     private @Nullable NaniteTier[] requiredNanites;

--- a/src/main/java/tectech/thing/metaTileEntity/multi/bec/MTEBECStorage.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/bec/MTEBECStorage.java
@@ -64,6 +64,7 @@ import tectech.thing.metaTileEntity.multi.base.parameter.LongParameter;
 import tectech.thing.metaTileEntity.multi.base.parameter.Parameter;
 import tectech.thing.metaTileEntity.multi.structures.BECStructureDefinitions;
 
+@IMetaTileEntity.SkipGenerateDescription
 public class MTEBECStorage extends MTEBECMultiblockBase<MTEBECStorage> implements BECInventory, IParametrized {
 
     private final CondensateList storedCondensate = new CondensateList();


### PR DESCRIPTION
## Summary
Since we manage it via MarkDown, do not generate description. This allows the description to reload when resource pack reload / language change.


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
