### PR TITLE
Fixes an AL recipe NBT explosion fix.

### DIFF
--- a/src/functionalTest/java/gregtech/test/ALRecipeDataPacketTest.java
+++ b/src/functionalTest/java/gregtech/test/ALRecipeDataPacketTest.java
@@ -1,0 +1,96 @@
+package gregtech.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import gregtech.api.util.GTRecipe.RecipeAssemblyLine;
+import gregtech.api.util.GTUtility.ItemId;
+import tectech.mechanics.dataTransport.ALRecipeDataPacket;
+
+class ALRecipeDataPacketTest {
+
+    static Map<ItemId, List<RecipeAssemblyLine>> recipesByOutput;
+    static List<RecipeAssemblyLine> duplicateOutputGroup;
+    static RecipeAssemblyLine uniqueOutputRecipe;
+
+    @BeforeAll
+    static void findRecipeGroups() {
+        recipesByOutput = new HashMap<>();
+        for (RecipeAssemblyLine recipe : RecipeAssemblyLine.sAssemblylineRecipes) {
+            recipesByOutput.computeIfAbsent(ItemId.create(recipe.mOutput), id -> new ArrayList<>())
+                .add(recipe);
+        }
+        for (List<RecipeAssemblyLine> group : recipesByOutput.values()) {
+            if (duplicateOutputGroup == null && group.size() >= 2) duplicateOutputGroup = group;
+            if (uniqueOutputRecipe == null && group.size() == 1) uniqueOutputRecipe = group.get(0);
+        }
+    }
+
+    private static ALRecipeDataPacket roundTrip(ALRecipeDataPacket packet) {
+        return new ALRecipeDataPacket(packet.toNbt());
+    }
+
+    private static Set<RecipeAssemblyLine> asSet(RecipeAssemblyLine[] content) {
+        return new HashSet<>(Arrays.asList(content));
+    }
+
+    @Test
+    void duplicateOutputExists() {
+        assertNotNull(duplicateOutputGroup, "expected at least one output with multiple assembly line recipes");
+    }
+
+    @Test
+    void duplicateOutputReachesFixpoint() {
+        assertNotNull(duplicateOutputGroup);
+        ALRecipeDataPacket packet = new ALRecipeDataPacket(new RecipeAssemblyLine[] { duplicateOutputGroup.get(0) });
+
+        ALRecipeDataPacket once = roundTrip(packet);
+        assertEquals(duplicateOutputGroup.size(), once.getContent().length);
+        assertEquals(new HashSet<>(duplicateOutputGroup), asSet(once.getContent()));
+
+        ALRecipeDataPacket twice = roundTrip(once);
+        assertEquals(once.getContent().length, twice.getContent().length);
+        assertEquals(asSet(once.getContent()), asSet(twice.getContent()));
+    }
+
+    @Test
+    void bloatedPacketCollapses() {
+        assertNotNull(duplicateOutputGroup);
+        RecipeAssemblyLine[] bloated = new RecipeAssemblyLine[8];
+        Arrays.fill(bloated, duplicateOutputGroup.get(0));
+
+        ALRecipeDataPacket once = roundTrip(new ALRecipeDataPacket(bloated));
+        assertEquals(duplicateOutputGroup.size(), once.getContent().length);
+        assertEquals(new HashSet<>(duplicateOutputGroup), asSet(once.getContent()));
+    }
+
+    @Test
+    void uniqueOutputIsLossless() {
+        assertNotNull(uniqueOutputRecipe);
+        ALRecipeDataPacket once = roundTrip(new ALRecipeDataPacket(new RecipeAssemblyLine[] { uniqueOutputRecipe }));
+        assertEquals(1, once.getContent().length);
+        assertSame(uniqueOutputRecipe, once.getContent()[0]);
+    }
+
+    @Test
+    void allPacketsShrinkBelowRegisteredRecipeCount() {
+        int total = RecipeAssemblyLine.sAssemblylineRecipes.size();
+        assertTrue(total > 0);
+        RecipeAssemblyLine[] everything = RecipeAssemblyLine.sAssemblylineRecipes.toArray(new RecipeAssemblyLine[0]);
+        ALRecipeDataPacket once = roundTrip(new ALRecipeDataPacket(everything));
+        assertTrue(once.getContent().length <= total);
+    }
+}

--- a/src/main/java/ggfab/mte/MTEAdvAssLine.java
+++ b/src/main/java/ggfab/mte/MTEAdvAssLine.java
@@ -26,6 +26,7 @@ import static gregtech.api.util.GTUtility.validMTEList;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -437,12 +438,12 @@ public class MTEAdvAssLine extends MTEExtendedPowerMultiBlockBase<MTEAdvAssLine>
         RecipeAssemblyLine recipe = null;
 
         if (aNBT.hasKey(TAG_KEY_CURRENT_RECIPE, Constants.NBT.TAG_COMPOUND)) {
-            recipe = AssemblyLineUtils
-                .assertSingleRecipe(AssemblyLineUtils.loadRecipe(aNBT.getCompoundTag(TAG_KEY_CURRENT_RECIPE)));
+            recipe = selectRecipe(AssemblyLineUtils.loadRecipe(aNBT.getCompoundTag(TAG_KEY_CURRENT_RECIPE)), aNBT);
         } else if (aNBT.hasKey(TAG_KEY_CURRENT_STICK, Constants.NBT.TAG_COMPOUND)) {
-            recipe = AssemblyLineUtils.assertSingleRecipe(
+            recipe = selectRecipe(
                 AssemblyLineUtils.findALRecipeFromDataStick(
-                    ItemStack.loadItemStackFromNBT(aNBT.getCompoundTag(TAG_KEY_CURRENT_STICK))));
+                    ItemStack.loadItemStackFromNBT(aNBT.getCompoundTag(TAG_KEY_CURRENT_STICK))),
+                aNBT);
         }
 
         if (recipe != null) {
@@ -468,6 +469,20 @@ public class MTEAdvAssLine extends MTEExtendedPowerMultiBlockBase<MTEAdvAssLine>
         } else {
             setCurrentRecipe(recipe);
         }
+    }
+
+    // Outputs aren't unique so pick by hash; on a miss return the first candidate so the
+    // caller's hash check fails loudly instead of null silently clearing the recipe.
+    private static RecipeAssemblyLine selectRecipe(Collection<RecipeAssemblyLine> candidates, NBTTagCompound aNBT) {
+        if (candidates.isEmpty()) return null;
+        if (aNBT.hasKey(TAG_KEY_RECIPE_HASH, Constants.NBT.TAG_INT)) {
+            int hash = aNBT.getInteger(TAG_KEY_RECIPE_HASH);
+            for (RecipeAssemblyLine candidate : candidates) {
+                if (candidate.getPersistentHash() == hash) return candidate;
+            }
+        }
+        return candidates.iterator()
+            .next();
     }
 
     /**

--- a/src/main/java/gregtech/api/util/AssemblyLineUtils.java
+++ b/src/main/java/gregtech/api/util/AssemblyLineUtils.java
@@ -3,10 +3,7 @@ package gregtech.api.util;
 import java.util.Collection;
 import java.util.Collections;
 
-import javax.annotation.Nullable;
-
 import net.minecraft.item.ItemStack;
-import net.minecraft.launchwrapper.Launch;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.nbt.NBTTagString;
@@ -17,7 +14,6 @@ import com.google.common.collect.MultimapBuilder;
 import com.gtnewhorizon.gtnhlib.item.ItemStackNBT;
 
 import cpw.mods.fml.common.FMLCommonHandler;
-import gregtech.GTMod;
 import gregtech.api.enums.ItemList;
 import gregtech.api.util.GTRecipe.RecipeAssemblyLine;
 import gregtech.api.util.GTUtility.ItemId;
@@ -71,26 +67,6 @@ public class AssemblyLineUtils {
         ItemStack output = ItemStack.loadItemStackFromNBT(tag);
 
         return findALRecipeByOutput(output);
-    }
-
-    public static @Nullable RecipeAssemblyLine assertSingleRecipe(Collection<RecipeAssemblyLine> recipes) {
-        if (recipes.isEmpty()) return null;
-
-        if (recipes.size() > 1) {
-            if ((boolean) Launch.blackboard.get("fml.deobfuscatedEnvironment")) {
-                throw new RuntimeException(
-                    "found too many assembly line recipes for output: '" + recipes.iterator()
-                        .next().mOutput.getDisplayName() + "', this method assumes this cannot happen");
-            } else {
-                GTMod.GT_FML_LOGGER.error(
-                    "found too many assembly line recipes for output: '" + recipes.iterator()
-                        .next().mOutput.getDisplayName() + "', this method assumes this cannot happen",
-                    new Exception());
-            }
-        }
-
-        return recipes.iterator()
-            .next();
     }
 
     /**

--- a/src/main/java/gregtech/api/util/GTRecipe.java
+++ b/src/main/java/gregtech/api/util/GTRecipe.java
@@ -1169,6 +1169,18 @@ public class GTRecipe implements Comparable<GTRecipe> {
         }
 
         @Override
+        public int hashCode() {
+            return mPersistentHash != 0 ? mPersistentHash : super.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) return true;
+            if (!(obj instanceof RecipeAssemblyLine other)) return false;
+            return mPersistentHash != 0 && mPersistentHash == other.mPersistentHash;
+        }
+
+        @Override
         public String toString() {
             return "GTRecipe_AssemblyLine{" + "mResearchItem="
                 + mResearchItem

--- a/src/main/java/tectech/mechanics/dataTransport/ALRecipeDataPacket.java
+++ b/src/main/java/tectech/mechanics/dataTransport/ALRecipeDataPacket.java
@@ -1,6 +1,6 @@
 package tectech.mechanics.dataTransport;
 
-import java.util.ArrayList;
+import java.util.LinkedHashSet;
 
 import net.minecraft.nbt.NBTTagCompound;
 
@@ -22,7 +22,8 @@ public class ALRecipeDataPacket extends DataPacket<RecipeAssemblyLine[]> {
         int count = nbt.getInteger("count");
 
         if (count > 0) {
-            ArrayList<RecipeAssemblyLine> recipes = new ArrayList<>();
+            // loadRecipe returns every recipe sharing the saved output and lists don't dedupe
+            LinkedHashSet<RecipeAssemblyLine> recipes = new LinkedHashSet<>();
 
             for (int i = 0; i < count; i++) {
                 recipes.addAll(AssemblyLineUtils.loadRecipe(nbt.getCompoundTag(Integer.toString(i))));

--- a/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchDataItemsInput.java
+++ b/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchDataItemsInput.java
@@ -9,6 +9,7 @@ import static tectech.thing.metaTileEntity.hatch.MTEHatchDataConnector.EM_D_SIDE
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 
 import net.minecraft.entity.player.EntityPlayer;
@@ -157,13 +158,13 @@ public class MTEHatchDataItemsInput extends MTEHatchDataAccess implements IConne
         NBTTagCompound stacksTag = aNBT.getCompoundTag("data_stacks");
         int count = stacksTag.getInteger("count");
         if (count > 0) {
-            recipes = new ArrayList<>();
+            LinkedHashSet<RecipeAssemblyLine> loaded = new LinkedHashSet<>();
 
             for (int i = 0; i < count; i++) {
-                recipes.addAll(AssemblyLineUtils.loadRecipe(stacksTag.getCompoundTag(Integer.toString(i))));
+                loaded.addAll(AssemblyLineUtils.loadRecipe(stacksTag.getCompoundTag(Integer.toString(i))));
             }
 
-            if (recipes.isEmpty()) recipes = null;
+            recipes = loaded.isEmpty() ? null : new ArrayList<>(loaded);
         }
     }
 


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->

Ran into this locally repeatedly loading a gateworld in SP for Angelica Testing

```
[20:54:56] [Client thread/INFO] [STDOUT/]: [net.minecraft.client.Minecraft:func_71377_b:349]: ---- Minecraft Crash Report ----
// On the bright side, I bought you a teddy bear!

Time: 7/23/26, 8:54 PM
Description: Exception in server tick loop

java.lang.OutOfMemoryError: Java heap space
	at Launch//net.minecraft.nbt.NBTTagCompound.<init>(NBTTagCompound.java:20)
	at Launch//gregtech.api.util.AssemblyLineUtils.saveRecipe(AssemblyLineUtils.java:67)
	at Launch//tectech.mechanics.dataTransport.ALRecipeDataPacket.contentToNBT(ALRecipeDataPacket.java:45)
	at Launch//tectech.mechanics.dataTransport.DataPacket.toNbt(DataPacket.java:34)
	at Launch//tectech.thing.metaTileEntity.hatch.MTEHatchWirelessDataItemsOutput.saveNBTData(MTEHatchWirelessDataItemsOutput.java:91)
	at Launch//gregtech.api.metatileentity.CommonBaseMetaTileEntity.saveMetaTileNBT(CommonBaseMetaTileEntity.java:302)
	at Launch//gregtech.api.metatileentity.BaseMetaTileEntity.func_145841_b(BaseMetaTileEntity.java:156)
	at Launch//net.minecraft.world.chunk.storage.AnvilChunkLoader.writeEntities(AnvilChunkLoader.java:1241)
	at Launch//net.minecraft.world.chunk.storage.AnvilChunkLoader.handler$bco000$chunkapi$writeChunkToNBT(AnvilChunkLoader.java:1141)
	at Launch//net.minecraft.world.chunk.storage.AnvilChunkLoader.func_75820_a(AnvilChunkLoader.java)
	at Launch//net.minecraft.world.chunk.storage.AnvilChunkLoader.func_75816_a(AnvilChunkLoader.java:197)
	at Launch//net.minecraft.world.gen.ChunkProviderServer.func_73242_b(ChunkProviderServer.java:256)
	at Launch//net.minecraft.world.gen.ChunkProviderServer.func_73151_a(ChunkProviderServer.java:302)
	at Launch//net.minecraft.world.WorldServer.func_73044_a(WorldServer.java:809)
	at Launch//net.minecraft.server.MinecraftServer.func_71267_a(MinecraftServer.java:318)
	at Launch//net.minecraft.server.integrated.IntegratedServer.func_71217_p(IntegratedServer.java:106)
	at Launch//net.minecraft.server.MinecraftServer.run(MinecraftServer.java:427)
	at Launch//net.minecraft.server.MinecraftServer$2.run(MinecraftServer.java:685)

```

## Checklist
- [X] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge



