### PR TITLE
Fix color swatch tooltip only showing on 1px border

### DIFF
--- a/src/main/java/gregtech/api/modularui2/common/CommonWidgets.java
+++ b/src/main/java/gregtech/api/modularui2/common/CommonWidgets.java
@@ -98,14 +98,14 @@ public final class CommonWidgets {
                     new ParentWidget<>().size(swatchOuterSize, swatchOuterSize)
                         .marginTop(swatchMarginTop)
                         .widgetTheme(GTWidgetThemes.BACKGROUND_COLOR_SWATCH)
-                        .tooltip(
-                            tooltip -> tooltip.add(
-                                Dyes.get(colorization)
-                                    .getLocalizedDyeName()))
                         .child(
                             new Widget<>().size(swatchSize, swatchSize)
                                 .pos(1, 1)
-                                .background(new Rectangle().color(Color.withAlpha(mte.getGUIColorization(), 255)))));
+                                .background(new Rectangle().color(Color.withAlpha(mte.getGUIColorization(), 255)))
+                                .tooltip(
+                                    tooltip -> tooltip.add(
+                                        Dyes.get(colorization)
+                                            .getLocalizedDyeName()))));
             }
 
             int textMarginTop = (rowContentHeight - height) / 2;


### PR DESCRIPTION
The tooltip was attached to the outer 9x9 wrapper widget instead of the inner 7x7 colored fill widget, so hovering the actual color square did not show the dye name, only the 1px border ring around it did.

Follow-up to #7500.