### PR TITLE
[Fix] actually update last working tick of water line after cycle ends

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/purification/MTEPurificationPlant.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/purification/MTEPurificationPlant.java
@@ -403,6 +403,7 @@ public class MTEPurificationPlant extends MTEExtendedPowerMultiBlockBase<MTEPuri
             }
             unit.setActive(false);
         }
+        mLastWorkingTick = mTotalRunTime;
     }
 
     /**


### PR DESCRIPTION
## Summary
fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25857
somehow the powerSwitchSyncer of the MTEMultiBlockBaseGui is unreliable for shutting the controller correctly down after the cycle ends and only does call `stopMachine` on the second time you open the UI for updating the last working tick.
this fix just gives the UI a better approximation.

This behavior could be related to what i already observed with the parallels synchronization https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25973

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
