### PR TITLE
Fix Better Jukebox looping vanilla music discs

### DIFF
--- a/src/main/resources/soundmeta/durations.json
+++ b/src/main/resources/soundmeta/durations.json
@@ -1,16 +1,16 @@
 {
   "soundDurationsMs": {
-    "minecraft:11": 71112,
-    "minecraft:13": 178086,
-    "minecraft:blocks": 345914,
-    "minecraft:cat": 185343,
-    "minecraft:chirp": 185584,
-    "minecraft:far": 174462,
-    "minecraft:mall": 197219,
-    "minecraft:mellohi": 96199,
-    "minecraft:stal": 150858,
-    "minecraft:strad": 188168,
-    "minecraft:wait": 237886,
-    "minecraft:ward": 251393
+    "minecraft:records.11": 71112,
+    "minecraft:records.13": 178086,
+    "minecraft:records.blocks": 345914,
+    "minecraft:records.cat": 185343,
+    "minecraft:records.chirp": 185584,
+    "minecraft:records.far": 174462,
+    "minecraft:records.mall": 197219,
+    "minecraft:records.mellohi": 96199,
+    "minecraft:records.stal": 150858,
+    "minecraft:records.strad": 188168,
+    "minecraft:records.wait": 237886,
+    "minecraft:records.ward": 251393
   }
 }


### PR DESCRIPTION
Vanilla music discs (13, cat, blocks, etc.) were being replayed repeatedly for about 500 seconds instead of playing once, while custom discs played normally.

The duration lookup keys in durations.json didn't match the ResourceLocation the game actually uses for vanilla records, so the lookup fell through to mismatched fallback durations on the client and server, which triggered the client to keep restarting the disc.