### PR TITLE
Fix CeLUAG Base Amounts

### DIFF
--- a/src/main/java/gtnhlanth/common/item/MaskList.java
+++ b/src/main/java/gtnhlanth/common/item/MaskList.java
@@ -140,17 +140,17 @@ public enum MaskList {
         ItemStack tcTargetItem, ItemList... forbiddenWafers) {
         this.name = name;
         this.englishName = englishName;
-        this.spectrum = spectrum;
         this.maxUses = maxUses;
+        this.spectrum = spectrum;
         this.precursor = precursor;
         this.lensColour = lensColour;
         this.engraverEUt = engraverEUt;
-        this.minFocus = minFocus;
         this.minEnergy = minEnergy;
         this.maxEnergy = maxEnergy;
+        this.minFocus = minFocus;
         this.baselineAmount = baselineAmount;
-        this.tcTargetItem = tcTargetItem;
         this.producedItem = producedItem;
+        this.tcTargetItem = tcTargetItem;
         this.forbiddenWafers = forbiddenWafers;
     }
 
@@ -162,12 +162,12 @@ public enum MaskList {
         return this.englishName;
     }
 
-    public String getSpectrum() {
-        return this.spectrum;
-    }
-
     public int getMaxUses() {
         return this.maxUses;
+    }
+
+    public String getSpectrum() {
+        return this.spectrum;
     }
 
     public MaskList getPrecursor() {
@@ -198,16 +198,15 @@ public enum MaskList {
         return this.baselineAmount;
     }
 
-    public ItemStack getTCTargetItem() {
-        return this.tcTargetItem;
-    }
-
     public ItemStack getProducedItem() {
         return this.producedItem;
+    }
+
+    public ItemStack getTCTargetItem() {
+        return this.tcTargetItem;
     }
 
     public ItemList[] getForbiddenWafers() {
         return this.forbiddenWafers;
     }
-
 }

--- a/src/main/java/gtnhlanth/common/tileentity/recipe/beamline/BeamlineRecipeLoader.java
+++ b/src/main/java/gtnhlanth/common/tileentity/recipe/beamline/BeamlineRecipeLoader.java
@@ -263,7 +263,7 @@ public class BeamlineRecipeLoader {
                 TARGET_CHAMBER_METADATA,
                 TargetChamberMetadata.builder(focusItem)
                     .particleID(PHOTON.getId())
-                    .amount(24)
+                    .amount(MaskList.CSOC.getBaselineAmount() * MaskList.CSOC.getMaxUses() * 3)
                     .energy(5, 12, 1)
                     .minFocus(60)
                     .build())
@@ -284,7 +284,7 @@ public class BeamlineRecipeLoader {
                 TARGET_CHAMBER_METADATA,
                 TargetChamberMetadata.builder(focusItem)
                     .particleID(PHOTON.getId())
-                    .amount(36)
+                    .amount(MaskList.ACC.getBaselineAmount() * MaskList.ACC.getMaxUses() * 3)
                     .energy(6, 14, 1)
                     .minFocus(70)
                     .build())


### PR DESCRIPTION
## Summary
https://github.com/GTNewHorizons/GT5-Unofficial/pull/7468 changed how masks and wafers worked in the Beamline but mistakenly forgot to scale the base amounts for the two CeLUAG recipes. This PR fixes that and reorders some of the methods in MaskList because it was out of order with the arguments.

- Crystal SoC CeLUAG Base Amount 24 --> 2,400
- Raw Adv Crystal CeLUAG Base Amount 36 --> 3,600

I think it also unintentionally increased the ratio of CeLUAG to crystal socs from 1:64 to 1:100 based on the variables its calling but GTUtility.copyAmountUnsafe() seems to be clamping it. Not sure how to fix that one if we even want to fix it. https://github.com/GTNewHorizons/GT5-Unofficial/blob/56eff58ec005b7ae10c1d4832bce24941c9294dd/src/main/java/gtnhlanth/common/tileentity/recipe/beamline/BeamlineRecipeLoader.java#L278

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
