### PR TITLE
Remove sawing unstable ingots to nuggets

### DIFF
--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingNugget.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingNugget.java
@@ -81,7 +81,7 @@ public class ProcessingNugget implements gregtech.api.interfaces.IOreRecipeRegis
                 .eut(calculateRecipeEU(aMaterial, 1))
                 .recipeCategory(RecipeCategories.alloySmelterMolding)
                 .addTo(alloySmelterRecipes);
-            if (aMaterial.getProcessingMaterialTierEU() < TierEU.IV) {
+            if (aMaterial.getProcessingMaterialTierEU() < TierEU.IV && aMaterial != Materials.Unstable) {
                 GTModHandler.addCraftingRecipe(
                     GTOreDictUnificator.get(OrePrefixes.nugget, aMaterial, 8L),
                     GTModHandler.RecipeBits.BUFFERED,


### PR DESCRIPTION
## Summary
Disable sawing unstable ingots into 8 nuggets. This bypasses the intended mechanic of unstable ingots (You either craft full ingots for 1 diamond or you craft 9 nuggets for 9 diamonds and 9x the sigil durability). Obviously adding these hacky material checks sucks but they are already everywhere in autogen code anyways.

Doesn't affect any tiering, you can still make stable ingots with the basic sigil, etc. Just it is now at the intended cost instead of 8x cheaper.

## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
