### PR TITLE
Show insufficient voltage error in CAL assembler mode

### DIFF
--- a/src/main/java/bartworks/common/tileentities/multis/MTECircuitAssemblyLine.java
+++ b/src/main/java/bartworks/common/tileentities/multis/MTECircuitAssemblyLine.java
@@ -366,7 +366,7 @@ public class MTECircuitAssemblyLine extends MTEEnhancedMultiBlockBase<MTECircuit
                 // limit CA mode recipes to hatch tier - 1
                 if (machineMode == MACHINEMODE_ASSEMBLER
                     && recipe.mEUt > MTECircuitAssemblyLine.this.getMaxInputVoltage() / 4) {
-                    return CheckRecipeResultRegistry.NO_RECIPE;
+                    return CheckRecipeResultRegistry.insufficientVoltage(recipe.mEUt * 4L);
                 }
                 if (machineMode == MACHINEMODE_CAL) {
                     if (mInputBusses.size() < recipe.mInputs.length) {


### PR DESCRIPTION
## Summary
Show `Insufficient voltage` instead of `No recipe found`

<img width="221" height="197" alt="image" src="https://github.com/user-attachments/assets/e7435141-bc6b-42be-8ae2-ccf2ee4dab70" />

<img width="327" height="160" alt="image" src="https://github.com/user-attachments/assets/6153fe94-196f-4c72-b31f-4fdc840ab604" />

## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
