### PR TITLE
Increasing the height of the DTPF recipe window

### DIFF
--- a/src/main/java/gregtech/api/recipe/RecipeMaps.java
+++ b/src/main/java/gregtech/api/recipe/RecipeMaps.java
@@ -846,7 +846,7 @@ public final class RecipeMaps {
         .neiSpecialInfoFormatter(HeatingCoilSpecialValueFormatter.INSTANCE)
         .neiHandlerInfo(
             builder -> builder.setShiftY(8)
-                .setHeight(156))
+                .setHeight(166))
         .frontend(LargeNEIFrontend::new)
         .build();
     public static final RecipeMap<RecipeMapBackend> transcendentPlasmaMixerRecipes = RecipeMapBuilder


### PR DESCRIPTION
## Summary
Enlarging the prescription window after adding a line to https://github.com/GTNewHorizons/GT5-Unofficial/pull/7463

|Before|After|
|-|-|
|<img width="427" height="830" alt="image" src="https://github.com/user-attachments/assets/88c912c5-6bf7-4534-8de2-a0f0936955c8" />|<img width="435" height="826" alt="image" src="https://github.com/user-attachments/assets/b844b587-ca9d-4353-9812-fc013ac0c037" />| 


## Checklist
- [ ] I have tested this PR in DevEnv
- [X] I have tested this PR in Fullpack
- [ ] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
