### PR TITLE
[README] Add credit for spacetime asset

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ the chance of strange errors.
 Some textures/ideas have been taken from future versions of GT and texture pack authors for GTNH. Credit goes to Jimbno for the UU-Tex texture pack and its contributions to the base pack here: https://github.com/Jimbno/UU-Tex.
 Many sound effects were backported from the GregTech Community Edition Unofficial / Modern team: https://github.com/GregTechCEu/
 
+Credit to [EtVitki](https://linktr.ee/ekvitki) for the Spacetime material textures, adapted from their [original work.](https://www.reddit.com/r/PixelArt/comments/e1j9yt/i_need_some_space/)
+
 ## Music duration metadata
 
 The electric jukebox requires duration metadata to specify how many milliseconds each disk plays for.


### PR DESCRIPTION
## Summary
Spacetime texture was stolen. I reached out to the original artist and got permission to continue using it, we must credit them where the asset is used. I also want to do a follow-up to GTNHCredits and make sure they are listed there ASAP.

<img width="1592" height="337" alt="image" src="https://github.com/user-attachments/assets/820fb200-9eff-4629-91ff-912de943c959" />

## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md) - Created with one billion Claude Mythos tokens through exclusive partnership with the U.S. Department of Defense
- [ ] This PR requires another PR in order to merge
