### PR TITLE
Hide CRIB suffixes when using custom names

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchCraftingInputME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchCraftingInputME.java
@@ -702,6 +702,8 @@ public class MTEHatchCraftingInputME extends MTEHatchInputBus implements IPowerC
 
     @Override
     public String getNameSuffix() {
+        if (hasCustomName()) return "";
+
         StringBuilder suffix = new StringBuilder();
 
         IGregTechTileEntity base = getBaseMetaTileEntity();


### PR DESCRIPTION
## What changed

- Stop appending ghost circuit and manual-slot item suffixes in the Interface Terminal when a Crafting Input Bus (ME) or Crafting Input Buffer (ME) has a custom name.
- Preserve the existing generated suffixes when no custom name is set.

## Why

The Interface Terminal requests the generated name suffix separately, so renamed crafting input buses and buffers still displayed their circuit and every item from their manual slots. With several identical items, this produced a long, repetitive entry even though the player had provided a custom name.

Renamed entries now display only the chosen custom name, while unnamed entries retain the existing detailed information.

## Checklist

- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge

Automated checks: `spotlessCheck` and `test` pass.