### PR TITLE
Fix GT++ hot ingots not having tint

### DIFF
--- a/src/main/java/gtPlusPlus/core/item/base/ingots/BaseItemIngotHot.java
+++ b/src/main/java/gtPlusPlus/core/item/base/ingots/BaseItemIngotHot.java
@@ -18,7 +18,6 @@ import gregtech.api.enums.Textures;
 import gregtech.api.interfaces.IIconContainer;
 import gregtech.api.util.GTUtility;
 import gtPlusPlus.core.material.Material;
-import gtPlusPlus.core.util.Utils;
 
 public class BaseItemIngotHot extends BaseItemIngot {
 
@@ -29,17 +28,6 @@ public class BaseItemIngotHot extends BaseItemIngot {
         this.setTextureName(GTPlusPlus.ID + ":" + "itemIngotHot");
         this.outputIngot = material.getIngot(1);
         this.generateRecipe();
-    }
-
-    @Override
-    public String getItemStackDisplayName(final ItemStack p_77653_1_) {
-        return super.getItemStackDisplayName(p_77653_1_);
-        // return ("Hot "+this.materialName+ " Ingot");
-    }
-
-    @Override
-    public int getColorFromItemStack(final ItemStack stack, final int HEX_OxFFFFFF) {
-        return Utils.rgbtoHexValue(225, 225, 225);
     }
 
     private void generateRecipe() {


### PR DESCRIPTION
## Summary
Sometimes less code is better

Before (after the multiblock controller):
<img width="667" height="440" alt="image" src="https://github.com/user-attachments/assets/904b0e9e-87c0-4a91-bd21-bb0ae5f5f004" />

After:
<img width="982" height="267" alt="image" src="https://github.com/user-attachments/assets/d665cf60-039a-4d3b-be04-7d3b49e92286" />

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
