### PR TITLE
Allow GT++ materials to work with familiar prefix lookup

### DIFF
--- a/src/main/java/gregtech/nei/GTNEIDefaultHandler.java
+++ b/src/main/java/gregtech/nei/GTNEIDefaultHandler.java
@@ -259,7 +259,10 @@ public class GTNEIDefaultHandler extends TemplateRecipeHandler {
             Material material = bic.componentMaterial;
             if (prefix != null && material != null && !prefix.mFamiliarPrefixes.isEmpty()) {
                 for (OrePrefixes tPrefix : prefix.mFamiliarPrefixes) {
-                    tResults.add(material.getComponentByPrefix(tPrefix, 1));
+                    ItemStack stack = material.getComponentByPrefix(tPrefix, 1);
+                    if (stack != null) {
+                        tResults.add(stack);
+                    }
                 }
             }
         }

--- a/src/main/java/gregtech/nei/GTNEIDefaultHandler.java
+++ b/src/main/java/gregtech/nei/GTNEIDefaultHandler.java
@@ -72,6 +72,8 @@ import gregtech.api.util.OverclockCalculator;
 import gregtech.common.blocks.ItemMachines;
 import gregtech.common.gui.modularui.UIHelper;
 import gregtech.common.tileentities.machines.multi.nanochip.util.CCNEIRepresentation;
+import gtPlusPlus.core.item.base.BaseItemComponent;
+import gtPlusPlus.core.material.Material;
 
 public class GTNEIDefaultHandler extends TemplateRecipeHandler {
 
@@ -238,17 +240,30 @@ public class GTNEIDefaultHandler extends TemplateRecipeHandler {
 
     @Override
     public void loadCraftingRecipes(ItemStack aResult) {
-        ItemData tPrefixMaterial = GTOreDictUnificator.getAssociation(aResult);
-
         ArrayList<ItemStack> tResults = new ArrayList<>();
         tResults.add(aResult);
         tResults.add(GTOreDictUnificator.get(true, aResult));
+
+        // Handle familiar prefixes for GT items
+        ItemData tPrefixMaterial = GTOreDictUnificator.getAssociation(aResult);
         if ((tPrefixMaterial != null) && (!tPrefixMaterial.mBlackListed)
             && (!tPrefixMaterial.mPrefix.mFamiliarPrefixes.isEmpty())) {
             for (OrePrefixes tPrefix : tPrefixMaterial.mPrefix.mFamiliarPrefixes) {
                 tResults.add(GTOreDictUnificator.get(tPrefix, tPrefixMaterial.mMaterial.mMaterial, 1L));
             }
         }
+
+        // Handle familiar prefixes for GT++ items
+        if (aResult != null && aResult.getItem() instanceof BaseItemComponent bic) {
+            OrePrefixes prefix = bic.componentType.getGtOrePrefix();
+            Material material = bic.componentMaterial;
+            if (prefix != null && material != null && !prefix.mFamiliarPrefixes.isEmpty()) {
+                for (OrePrefixes tPrefix : prefix.mFamiliarPrefixes) {
+                    tResults.add(material.getComponentByPrefix(tPrefix, 1));
+                }
+            }
+        }
+
         if (aResult != null) {
             List<ItemStack> ccRepresentations = CCNEIRepresentation.NEI_RECIPE_ASSOCIATIONS.get(aResult);
             if (ccRepresentations != null) {


### PR DESCRIPTION
## Summary
Allows GT++ material items to work with NEI familiar prefix lookup like GT and BW, i.e., if you press U or R on a nugget for example, you also get results for ingots, as well as dusts + small dusts + tiny dusts, and other similar behaviors

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
