### PR TITLE
Override IOreMaterial#getPart for GT++ materials

### DIFF
--- a/src/main/java/gtPlusPlus/core/material/Material.java
+++ b/src/main/java/gtPlusPlus/core/material/Material.java
@@ -811,6 +811,11 @@ public class Material implements IOreMaterial {
         return this.usesBlastFurnace;
     }
 
+    @Override
+    public ItemStack getPart(OrePrefixes prefix, int amount) {
+        return getComponentByPrefix(prefix, amount);
+    }
+
     public final ItemStack getComponentByPrefix(OrePrefixes aPrefix, int stacksize) {
         String aKey = aPrefix.getName();
         Map<String, ItemStack> g = mComponentMap.get(this.unlocalizedName);


### PR DESCRIPTION
## Summary
Will need this in another PR on a different repo


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
