### PR TITLE
fix(recipechk): add edge check to eliminate warning

### DIFF
--- a/src/main/java/gregtech/api/recipe/maps/ReplicatorBackend.java
+++ b/src/main/java/gregtech/api/recipe/maps/ReplicatorBackend.java
@@ -9,7 +9,6 @@ import java.util.Optional;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import gtPlusPlus.core.material.Material;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
@@ -87,20 +86,11 @@ public class ReplicatorBackend extends RecipeMapBackend {
             return null;
         }
         Materials foundMaterial = getMaterialFromDataOrb(specialSlot);
-        if (foundMaterial == null || fluids.length == 0) {
+        if (foundMaterial == null) {
             return null;
         }
         GTRecipe recipeFound = recipesByMaterial.getOrDefault(foundMaterial, null);
-        if (recipeFound == null) {
-            return null;
-        }
-        FluidStack recipeUUMInput = recipeFound.getRepresentativeFluidInput(0);
-        for (FluidStack fs : fluids) {
-            if (fs.isFluidEqual(recipeUUMInput) && fs.amount >= recipeUUMInput.amount) {
-                return recipeFound;
-            }
-        }
-        return null;
+        return recipeFound.maxParallelCalculatedByInputs(1, fluids, items) < 1 ? null : recipeFound;
     }
 
     @Nullable

--- a/src/main/java/gregtech/api/recipe/maps/ReplicatorBackend.java
+++ b/src/main/java/gregtech/api/recipe/maps/ReplicatorBackend.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import gtPlusPlus.core.material.Material;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
@@ -89,7 +90,17 @@ public class ReplicatorBackend extends RecipeMapBackend {
         if (foundMaterial == null || fluids.length == 0) {
             return null;
         }
-        return recipesByMaterial.getOrDefault(foundMaterial, null);
+        GTRecipe recipeFound = recipesByMaterial.getOrDefault(foundMaterial, null);
+        if (recipeFound == null) {
+            return null;
+        }
+        FluidStack recipeUUMInput = recipeFound.getRepresentativeFluidInput(0);
+        for (FluidStack fs : fluids) {
+            if (fs.isFluidEqual(recipeUUMInput) && fs.amount >= recipeUUMInput.amount) {
+                return recipeFound;
+            }
+        }
+        return null;
     }
 
     @Nullable

--- a/src/main/java/gregtech/api/recipe/maps/ReplicatorBackend.java
+++ b/src/main/java/gregtech/api/recipe/maps/ReplicatorBackend.java
@@ -86,7 +86,7 @@ public class ReplicatorBackend extends RecipeMapBackend {
             return null;
         }
         Materials foundMaterial = getMaterialFromDataOrb(specialSlot);
-        if (foundMaterial == null) {
+        if (foundMaterial == null || fluids.length == 0) {
             return null;
         }
         return recipesByMaterial.getOrDefault(foundMaterial, null);


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
before:
<img width="400" height="274" alt="Screenshot 2026-07-27 at 00 35 48" src="https://github.com/user-attachments/assets/30245bda-3773-4361-bfb4-2060abafb5bd" />
after:
<img width="419" height="257" alt="Screenshot 2026-07-27 at 15 16 39" src="https://github.com/user-attachments/assets/7bb3df32-8212-4aee-a4b3-9cd35cf2a371" />

cause:
with ME input hatch, regardless of the uum amount or even not marked with UUM, recipe check is always successful for the specific backend implementation and cause currentParallel to be 0 then cause internal err, which is confusing for players.

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
