### PR TITLE
Fix Forestry fruit stack size being rounded to zero by TGS

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTETreeFarm.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTETreeFarm.java
@@ -725,7 +725,7 @@ public class MTETreeFarm extends MTEExtendedPowerMultiBlockBase<MTETreeFarm>
                 .getYield() * 10;
 
             fruit = fruit.copy();
-            fruit.stackSize = (int) (fruit.stackSize * yield);
+            fruit.stackSize = Math.max(1, (int) (fruit.stackSize * yield));
             adjustedMap.put(Mode.FRUIT, fruit);
         }
 

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTETreeFarmLegacy.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTETreeFarmLegacy.java
@@ -644,7 +644,7 @@ public class MTETreeFarmLegacy extends GTPPMultiBlockBase<MTETreeFarmLegacy> imp
                 .getYield() * 10;
 
             fruit = fruit.copy();
-            fruit.stackSize = (int) (fruit.stackSize * yield);
+            fruit.stackSize = Math.max(1, (int) (fruit.stackSize * yield));
             adjustedMap.put(Mode.FRUIT, fruit);
         }
 


### PR DESCRIPTION
## Summary
The int type coersion used to adjust the fruit stack size rounds off values below 1 to zero, making the TGS not produce any fruit if the forestry sappling's yield is lower than 0.1. I've switched it to use Math.max instead. This does still make Lowest and Lower have the same yield of 1, same as Low, but it's better than them yielding 0.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25772

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
