### PR TITLE
Hide redundant Voltage line in Target Chamber NEI tooltip

### DIFF
--- a/src/main/java/gtnhlanth/common/tileentity/recipe/beamline/TargetChamberFrontend.java
+++ b/src/main/java/gtnhlanth/common/tileentity/recipe/beamline/TargetChamberFrontend.java
@@ -13,6 +13,9 @@ import gregtech.nei.RecipeDisplayInfo;
 
 public class TargetChamberFrontend extends RecipeMapFrontend {
 
+    // Target Chamber recipes are always single-amp, so Usage == Voltage; only the Usage line is shown.
+    private static final int AMPERAGE = 1;
+
     public TargetChamberFrontend(BasicUIPropertiesBuilder uiPropertiesBuilder,
         NEIRecipePropertiesBuilder neiPropertiesBuilder) {
         super(uiPropertiesBuilder, neiPropertiesBuilder);
@@ -34,15 +37,20 @@ public class TargetChamberFrontend extends RecipeMapFrontend {
         // recipeInfo.drawText(trans("152", "Total: ") + getTotalPowerString(recipeInfo.calculator));
 
         recipeInfo.drawText(getEUtDisplay(recipeInfo.calculator));
-        recipeInfo.drawText(getVoltageString(recipeInfo.calculator));
+        if (AMPERAGE != 1) {
+            recipeInfo.drawText(getVoltageString(recipeInfo.calculator));
+        }
         recipeInfo.drawText(getAmperageString(recipeInfo.calculator));
 
     }
 
     // todo: use an OverclockDescriber here
     private String getEUtDisplay(OverclockCalculator calculator) {
+        String tier = AMPERAGE == 1
+            ? GTUtility.getTierNameWithParentheses(computeVoltageForEURate(calculator.getConsumption()))
+            : "";
         return StatCollector
-            .translateToLocalFormatted("GT5U.nei.display.usage", formatNumber(calculator.getConsumption()), "");
+            .translateToLocalFormatted("GT5U.nei.display.usage", formatNumber(calculator.getConsumption()), tier);
     }
 
     private String getVoltageString(OverclockCalculator calculator) {
@@ -58,7 +66,7 @@ public class TargetChamberFrontend extends RecipeMapFrontend {
     }
 
     private String getAmperageString(OverclockCalculator calculator) {
-        return StatCollector.translateToLocalFormatted("GT5U.nei.display.amperage", formatNumber(1));
+        return StatCollector.translateToLocalFormatted("GT5U.nei.display.amperage", formatNumber(AMPERAGE));
     }
 
 }


### PR DESCRIPTION
## Summary
Target Chamber recipes are single-amp, so Voltage duplicated Usage and the tier was shown on the wrong line compared to every other recipe map. The Voltage line is now only shown when amperage differs from 1, and the tier moved onto the Usage line for the single-amp case, matching the rest of GT5U.

|Before|After|
|-|-|
|<img width="421" height="813" alt="image" src="https://github.com/user-attachments/assets/fecd66aa-18ed-4d31-80b0-676fbd02b69c" />|<img width="435" height="829" alt="image" src="https://github.com/user-attachments/assets/c8ff4039-54b6-4625-8bbb-fbdcec5c2975" />| 

## Checklist
- [X] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
