### PR TITLE
Read actual amperage instead of hardcoded constant in Target Chamber

### DIFF
--- a/src/main/java/gtnhlanth/common/tileentity/recipe/beamline/TargetChamberFrontend.java
+++ b/src/main/java/gtnhlanth/common/tileentity/recipe/beamline/TargetChamberFrontend.java
@@ -13,9 +13,6 @@ import gregtech.nei.RecipeDisplayInfo;
 
 public class TargetChamberFrontend extends RecipeMapFrontend {
 
-    // Target Chamber recipes are always single-amp, so Usage == Voltage; only the Usage line is shown.
-    private static final int AMPERAGE = 1;
-
     public TargetChamberFrontend(BasicUIPropertiesBuilder uiPropertiesBuilder,
         NEIRecipePropertiesBuilder neiPropertiesBuilder) {
         super(uiPropertiesBuilder, neiPropertiesBuilder);
@@ -36,37 +33,38 @@ public class TargetChamberFrontend extends RecipeMapFrontend {
 
         // recipeInfo.drawText(trans("152", "Total: ") + getTotalPowerString(recipeInfo.calculator));
 
-        recipeInfo.drawText(getEUtDisplay(recipeInfo.calculator));
-        if (AMPERAGE != 1) {
-            recipeInfo.drawText(getVoltageString(recipeInfo.calculator));
+        int amperage = recipeInfo.recipeMap.getAmperage();
+        recipeInfo.drawText(getEUtDisplay(recipeInfo.calculator, amperage));
+        if (amperage != 1) {
+            recipeInfo.drawText(getVoltageString(recipeInfo.calculator, amperage));
         }
-        recipeInfo.drawText(getAmperageString(recipeInfo.calculator));
+        recipeInfo.drawText(getAmperageString(amperage));
 
     }
 
     // todo: use an OverclockDescriber here
-    private String getEUtDisplay(OverclockCalculator calculator) {
-        String tier = AMPERAGE == 1
-            ? GTUtility.getTierNameWithParentheses(computeVoltageForEURate(calculator.getConsumption()))
+    private String getEUtDisplay(OverclockCalculator calculator, int amperage) {
+        String tier = amperage == 1
+            ? GTUtility.getTierNameWithParentheses(computeVoltageForEURate(calculator.getConsumption(), amperage))
             : "";
         return StatCollector
             .translateToLocalFormatted("GT5U.nei.display.usage", formatNumber(calculator.getConsumption()), tier);
     }
 
-    private String getVoltageString(OverclockCalculator calculator) {
-        long voltage = computeVoltageForEURate(calculator.getConsumption());
+    private String getVoltageString(OverclockCalculator calculator, int amperage) {
+        long voltage = computeVoltageForEURate(calculator.getConsumption(), amperage);
         return StatCollector.translateToLocalFormatted(
             "GT5U.nei.display.voltage",
             formatNumber(voltage),
             GTUtility.getTierNameWithParentheses(voltage));
     }
 
-    private long computeVoltageForEURate(long euPerTick) {
-        return euPerTick;
+    private long computeVoltageForEURate(long euPerTick, int amperage) {
+        return euPerTick / amperage;
     }
 
-    private String getAmperageString(OverclockCalculator calculator) {
-        return StatCollector.translateToLocalFormatted("GT5U.nei.display.amperage", formatNumber(AMPERAGE));
+    private String getAmperageString(int amperage) {
+        return StatCollector.translateToLocalFormatted("GT5U.nei.display.amperage", formatNumber(amperage));
     }
 
 }


### PR DESCRIPTION
## Summary
The previous fix ([#7590](https://github.com/GTNewHorizons/GT5-Unofficial/issues/7590)) introduced a private AMPERAGE constant hardcoded to 1 to decide whether the Voltage line should be shown, which is dead code since the constant can never be anything else. This reads the recipe map's actual amperage instead, so the check reflects real data and would keep working correctly if Target Chamber recipes ever used amperage other than 1. Also fixes computeVoltageForEURate, which previously returned EU/t unchanged instead of dividing by amperage.

## Checklist
- [X] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
