### PR TITLE
Schedule recipe check when sievert has changed

### DIFF
--- a/src/main/java/bartworks/common/tileentities/multis/MTEBioVat.java
+++ b/src/main/java/bartworks/common/tileentities/multis/MTEBioVat.java
@@ -344,6 +344,7 @@ public class MTEBioVat extends MTEEnhancedMultiBlockBase<MTEBioVat>
         if (!(aMetaTileEntity instanceof MTERadioHatch radioHatch)) {
             return false;
         } else {
+            addIfSmartInput(radioHatch);
             radioHatch.updateTexture(CasingIndex);
             return this.mRadHatches.add(radioHatch);
         }
@@ -639,9 +640,6 @@ public class MTEBioVat extends MTEEnhancedMultiBlockBase<MTEBioVat>
 
     @Override
     public void onPostTick(IGregTechTileEntity aBaseMetaTileEntity, long aTick) {
-        super.onPostTick(aBaseMetaTileEntity, aTick);
-        if (this.height != this.reCalculateHeight()) this.needsVisualUpdate = true;
-        this.doAllVisualThings();
         if (aBaseMetaTileEntity.isServerSide()) {
             if (this.mRadHatches.size() == 1) {
                 this.mSievert = this.mRadHatches.get(0)
@@ -655,6 +653,10 @@ public class MTEBioVat extends MTEEnhancedMultiBlockBase<MTEBioVat>
                 this.mMaxProgresstime = 0;
             }
         }
+
+        super.onPostTick(aBaseMetaTileEntity, aTick);
+        if (this.height != this.reCalculateHeight()) this.needsVisualUpdate = true;
+        this.doAllVisualThings();
     }
 
     @Override

--- a/src/main/java/bartworks/common/tileentities/tiered/MTERadioHatch.java
+++ b/src/main/java/bartworks/common/tileentities/tiered/MTERadioHatch.java
@@ -49,8 +49,9 @@ import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GTOreDictUnificator;
 import gregtech.api.util.GTUtility;
 import gregtech.common.gui.modularui.hatch.MTERadioHatchGui;
+import gregtech.common.tileentities.machines.ISmartInputHatch;
 
-public class MTERadioHatch extends MTEHatch implements RecipeMapWorkable {
+public class MTERadioHatch extends MTEHatch implements RecipeMapWorkable, ISmartInputHatch {
 
     public int sievert;
     private long timer = 1;
@@ -153,6 +154,8 @@ public class MTERadioHatch extends MTEHatch implements RecipeMapWorkable {
             return;
         }
 
+        int oldSievert = this.sievert;
+
         if (this.mass > 0) {
             ++this.timer;
             if (this.decayTime == 0 || this.decayTime > 0 && this.timer % this.decayTime == 0) {
@@ -233,6 +236,8 @@ public class MTERadioHatch extends MTEHatch implements RecipeMapWorkable {
                 }
             }
         }
+
+        if (oldSievert != this.sievert) notifyWatchers();
     }
 
     @Override


### PR DESCRIPTION
## Summary
Make it so that radio hatch will schedule recipe check when the sievert has changed in Bacterial Vat


## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
