### PR TITLE
Add missing input watchers

### DIFF
--- a/src/main/java/goodgenerator/blocks/tileEntity/MTEExtremeHeatExchanger.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/MTEExtremeHeatExchanger.java
@@ -138,6 +138,7 @@ public class MTEExtremeHeatExchanger extends TTMultiblockBase implements ISurviv
         IMetaTileEntity aMetaTileEntity = aTileEntity.getMetaTileEntity();
         if (aMetaTileEntity == null) return false;
         if (aMetaTileEntity instanceof MTEHatchInput) {
+            addIfSmartInput(aMetaTileEntity);
             ((MTEHatch) aMetaTileEntity).updateTexture(aBaseCasingIndex);
             mHotFluidHatch = (MTEHatchInput) aMetaTileEntity;
             return true;

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEHatchNonConsumableBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEHatchNonConsumableBase.java
@@ -38,11 +38,12 @@ import gregtech.api.gui.modularui.GTUITextures;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.util.GTUtility;
+import gregtech.common.tileentities.machines.ISmartInputHatch;
 import gregtech.crossmod.ae2.IMEAwareItemInventory;
 import gregtech.crossmod.ae2.MEItemInventoryHandler;
 
 public abstract class MTEHatchNonConsumableBase extends MTEHatch
-    implements IMEMonitor<IAEItemStack>, IMEAwareItemInventory {
+    implements IMEMonitor<IAEItemStack>, IMEAwareItemInventory, ISmartInputHatch {
 
     private ItemStack itemStack = null;
     private int itemCount = 0;
@@ -286,7 +287,10 @@ public abstract class MTEHatchNonConsumableBase extends MTEHatch
             }
 
             meInventoryHandler.notifyListeners(count - savedCount, stack);
-            if (count != savedCount) getBaseMetaTileEntity().markDirty();
+            if (count != savedCount) {
+                getBaseMetaTileEntity().markDirty();
+                notifyWatchers();
+            }
         }
     }
 

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
@@ -2292,6 +2292,7 @@ public abstract class MTEMultiBlockBase extends MetaTileEntity
             && mteHatchCryotheum.mLockedFluid == TFFluids.fluidCryotheum) {
             mteHatchCryotheum.updateTexture(aBaseCasingIndex);
             mteHatchCryotheum.updateCraftingIcon(this.getMachineCraftingIcon());
+            addIfSmartInput(mteHatchCryotheum);
             return mCryotheumHatches.add(mteHatchCryotheum);
         }
         return false;
@@ -2305,6 +2306,7 @@ public abstract class MTEMultiBlockBase extends MetaTileEntity
             && mteHatchPyrotheum.mLockedFluid == TFFluids.fluidPyrotheum) {
             mteHatchPyrotheum.updateTexture(aBaseCasingIndex);
             mteHatchPyrotheum.updateCraftingIcon(this.getMachineCraftingIcon());
+            addIfSmartInput(mteHatchPyrotheum);
             return mPyrotheumHatches.add(mteHatchPyrotheum);
         }
         return false;

--- a/src/main/java/gregtech/common/tileentities/machines/multi/foundry/MTEExoFoundry.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/foundry/MTEExoFoundry.java
@@ -641,6 +641,7 @@ public class MTEExoFoundry extends MTEExtendedPowerMultiBlockBase<MTEExoFoundry>
         IMetaTileEntity aMetaTileEntity = aTileEntity.getMetaTileEntity();
         if (aMetaTileEntity == null) return false;
         if (aMetaTileEntity instanceof MTEHatchInput inp) {
+            addIfSmartInput(inp);
             inp.updateTexture(aBaseCasingIndex);
             coolantHatches.add(inp);
             return true;

--- a/src/main/java/gregtech/common/tileentities/machines/multi/pcb/MTEPCBCoolingTower.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/pcb/MTEPCBCoolingTower.java
@@ -113,6 +113,7 @@ public class MTEPCBCoolingTower extends MTEPCBUpgradeBase<MTEPCBCoolingTower>
         IMetaTileEntity aMetaTileEntity = aTileEntity.getMetaTileEntity();
         if (aMetaTileEntity == null) return false;
         if (aMetaTileEntity instanceof MTEHatchInput) {
+            addIfSmartInput(aMetaTileEntity);
             ((MTEHatch) aMetaTileEntity).updateTexture(aBaseCasingIndex);
             ((MTEHatchInput) aMetaTileEntity).mRecipeMap = null;
             mCoolantInputHatch = (MTEHatchInput) aMetaTileEntity;

--- a/src/main/java/gregtech/common/tileentities/machines/multi/pcb/MTEPCBFactory.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/pcb/MTEPCBFactory.java
@@ -902,6 +902,7 @@ public class MTEPCBFactory extends MTEExtendedPowerMultiBlockBase<MTEPCBFactory>
             IMetaTileEntity aMetaTileEntity = aTileEntity.getMetaTileEntity();
             if (aMetaTileEntity == null) return false;
             if (aMetaTileEntity instanceof MTEHatchInput) {
+                addIfSmartInput(aMetaTileEntity);
                 ((MTEHatch) aMetaTileEntity).updateTexture(aBaseCasingIndex);
                 ((MTEHatchInput) aMetaTileEntity).mRecipeMap = null;
                 compatMode.coolantHatch = (MTEHatchInput) aMetaTileEntity;
@@ -920,6 +921,7 @@ public class MTEPCBFactory extends MTEExtendedPowerMultiBlockBase<MTEPCBFactory>
         if (tileEntity == null) return false;
         IMetaTileEntity metaTileEntity = tileEntity.getMetaTileEntity();
         if (metaTileEntity instanceof MTEHatchNanite naniteBus) {
+            addIfSmartInput(naniteBus);
             naniteBus.updateTexture(baseCasingIndex);
             this.naniteBuses.add(naniteBus);
             return true;

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTEQuantumForceTransformer.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTEQuantumForceTransformer.java
@@ -642,6 +642,7 @@ public class MTEQuantumForceTransformer extends MTEExtendedPowerMultiBlockBase<M
         if (tileEntity == null) return false;
         IMetaTileEntity metaTileEntity = tileEntity.getMetaTileEntity();
         if (metaTileEntity instanceof MTEHatchBulkCatalystHousing catalystHousing) {
+            addIfSmartInput(catalystHousing);
             catalystHousing.updateTexture(baseCasingIndex);
             this.catalystHousings.add(catalystHousing);
             return true;

--- a/src/main/java/kubatech/tileentity/gregtech/multiblock/MTEHighTempGasCooledReactor.java
+++ b/src/main/java/kubatech/tileentity/gregtech/multiblock/MTEHighTempGasCooledReactor.java
@@ -233,6 +233,7 @@ public class MTEHighTempGasCooledReactor extends KubaTechGTMultiBlockBase<MTEHig
         IMetaTileEntity aMetaTileEntity = aTileEntity.getMetaTileEntity();
         if (aMetaTileEntity == null) return false;
         if (aMetaTileEntity instanceof MTEHatchInput hatch) {
+            addIfSmartInput(hatch);
             hatch.updateTexture(aBaseCasingIndex);
             hatch.updateCraftingIcon(this.getMachineCraftingIcon());
             setHatchRecipeMap(hatch);
@@ -249,6 +250,7 @@ public class MTEHighTempGasCooledReactor extends KubaTechGTMultiBlockBase<MTEHig
         IMetaTileEntity aMetaTileEntity = aTileEntity.getMetaTileEntity();
         if (aMetaTileEntity == null) return false;
         if (aMetaTileEntity instanceof MTEHatchInput hatch) {
+            addIfSmartInput(hatch);
             hatch.updateTexture(aBaseCasingIndex);
             hatch.updateCraftingIcon(this.getMachineCraftingIcon());
             setHatchRecipeMap(hatch);
@@ -280,6 +282,7 @@ public class MTEHighTempGasCooledReactor extends KubaTechGTMultiBlockBase<MTEHig
         IMetaTileEntity aMetaTileEntity = aTileEntity.getMetaTileEntity();
         if (aMetaTileEntity == null) return false;
         if (aMetaTileEntity instanceof MTEHatchInput hatch) {
+            addIfSmartInput(hatch);
             hatch.updateTexture(aBaseCasingIndex);
             hatch.updateCraftingIcon(this.getMachineCraftingIcon());
             waterInputHatch = hatch;

--- a/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchDataInput.java
+++ b/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchDataInput.java
@@ -16,6 +16,7 @@ import net.minecraftforge.common.util.ForgeDirection;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
+import gregtech.common.tileentities.machines.ISmartInputHatch;
 import mcp.mobius.waila.api.IWailaConfigHandler;
 import mcp.mobius.waila.api.IWailaDataAccessor;
 import tectech.mechanics.dataTransport.QuantumDataPacket;
@@ -25,7 +26,7 @@ import tectech.util.CommonValues;
 /**
  * Created by danie_000 on 27.10.2016.
  */
-public class MTEHatchDataInput extends MTEHatchDataConnector<QuantumDataPacket> {
+public class MTEHatchDataInput extends MTEHatchDataConnector<QuantumDataPacket> implements ISmartInputHatch {
 
     private boolean delDelay = true;
 
@@ -81,6 +82,8 @@ public class MTEHatchDataInput extends MTEHatchDataConnector<QuantumDataPacket> 
     }
 
     public void setContents(QuantumDataPacket qIn) {
+        Long old = this.q == null ? null : this.q.getContent();
+
         if (qIn == null) {
             this.q = null;
         } else {
@@ -93,6 +96,9 @@ public class MTEHatchDataInput extends MTEHatchDataConnector<QuantumDataPacket> 
 
             history = q == null ? 0 : q.getContent();
         }
+
+        Long now = this.q == null ? null : this.q.getContent();
+        if (now != null && !now.equals(old)) notifyWatchers();
     }
 
     @Override

--- a/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchObjectHolder.java
+++ b/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchObjectHolder.java
@@ -25,12 +25,13 @@ import gregtech.api.modularui2.GTGuiTheme;
 import gregtech.api.modularui2.GTGuiThemes;
 import gregtech.api.render.TextureFactory;
 import gregtech.common.gui.modularui.hatch.MTEHatchObjectHolderGui;
+import gregtech.common.tileentities.machines.ISmartInputHatch;
 import tectech.util.CommonValues;
 
 /**
  * Created by Tec on 03.04.2017.
  */
-public class MTEHatchObjectHolder extends MTEHatch {
+public class MTEHatchObjectHolder extends MTEHatch implements ISmartInputHatch {
 
     private static IIconContainer EM_H;
     private static IIconContainer EM_H_ACTIVE;

--- a/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchUncertainty.java
+++ b/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchUncertainty.java
@@ -28,6 +28,7 @@ import gregtech.api.modularui2.GTGuiTheme;
 import gregtech.api.modularui2.GTGuiThemes;
 import gregtech.api.render.TextureFactory;
 import gregtech.common.gui.modularui.hatch.MTEHatchUncertaintyGui;
+import gregtech.common.tileentities.machines.ISmartInputHatch;
 import gregtech.mixin.interfaces.accessors.EntityPlayerMPAccessor;
 import tectech.TecTech;
 import tectech.util.CommonValues;
@@ -35,7 +36,7 @@ import tectech.util.CommonValues;
 /**
  * Created by danie_000 on 15.12.2016.
  */
-public class MTEHatchUncertainty extends MTEHatch {
+public class MTEHatchUncertainty extends MTEHatch implements ISmartInputHatch {
 
     private static IIconContainer ScreenON;
     private static IIconContainer ScreenOFF;
@@ -118,6 +119,8 @@ public class MTEHatchUncertainty extends MTEHatch {
                 if (!stopChecking) { // No point in making calculations if the entire matrix has faded to 0
                     shift();
                     compute();
+
+                    if (stopChecking) notifyWatchers();
                 }
             }
         }

--- a/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchUncertainty.java
+++ b/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchUncertainty.java
@@ -116,12 +116,15 @@ public class MTEHatchUncertainty extends MTEHatch implements ISmartInputHatch {
                 status = (byte) 0b11111111;
             } else {
                 aBaseMetaTileEntity.setActive(true);
+
+                int oldStatus = status;
+
                 if (!stopChecking) { // No point in making calculations if the entire matrix has faded to 0
                     shift();
                     compute();
-
-                    if (stopChecking) notifyWatchers();
                 }
+
+                if (status == 0 && oldStatus != status) notifyWatchers();
             }
         }
     }

--- a/src/main/java/tectech/thing/metaTileEntity/multi/MTEResearchStation.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/MTEResearchStation.java
@@ -152,6 +152,7 @@ public class MTEResearchStation extends TTMultiblockBase implements ISurvivalCon
             return false;
         }
         if (aMetaTileEntity instanceof MTEHatchObjectHolder) {
+            addIfSmartInput(aMetaTileEntity);
             ((MTEHatch) aMetaTileEntity).updateTexture(aBaseCasingIndex);
             return eHolders.add((MTEHatchObjectHolder) aMetaTileEntity);
         }

--- a/src/main/java/tectech/thing/metaTileEntity/multi/base/TTMultiblockBase.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/base/TTMultiblockBase.java
@@ -1780,6 +1780,7 @@ public abstract class TTMultiblockBase extends MTEExtendedPowerMultiBlockBase<TT
             return false;
         }
         if (aMetaTileEntity instanceof MTEHatchUncertainty hatch) {
+            addIfSmartInput(hatch);
             hatch.updateTexture(aBaseCasingIndex);
             hatch.updateCraftingIcon(this.getMachineCraftingIcon());
             return eUncertainHatches.add(hatch);
@@ -1839,6 +1840,7 @@ public abstract class TTMultiblockBase extends MTEExtendedPowerMultiBlockBase<TT
             return false;
         }
         if (aMetaTileEntity instanceof MTEHatchDataInput hatch) {
+            addIfSmartInput(hatch);
             hatch.updateTexture(aBaseCasingIndex);
             hatch.updateCraftingIcon(this.getMachineCraftingIcon());
             return eInputData.add(hatch);


### PR DESCRIPTION
## Summary
Add missing smart input adder for some multiblocks special hatches
and add missing watcher notifier for some hatches

If i still have missed something, do let me know!

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
