### PR TITLE
Fix Mega Apiary controller voiding bees when broken

### DIFF
--- a/src/main/java/kubatech/tileentity/gregtech/multiblock/MTEMegaIndustrialApiary.java
+++ b/src/main/java/kubatech/tileentity/gregtech/multiblock/MTEMegaIndustrialApiary.java
@@ -236,6 +236,7 @@ public class MTEMegaIndustrialApiary extends KubaTechGTMultiBlockBase<MTEMegaInd
                 bmte.getYCoord(),
                 bmte.getZCoord(),
                 s.queenStack);
+            item.delayBeforeCanPickup = 10;
             bmte.getWorld()
                 .spawnEntityInWorld(item);
         }

--- a/src/main/java/kubatech/tileentity/gregtech/multiblock/MTEMegaIndustrialApiary.java
+++ b/src/main/java/kubatech/tileentity/gregtech/multiblock/MTEMegaIndustrialApiary.java
@@ -51,6 +51,7 @@ import java.util.List;
 import java.util.Map;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
@@ -227,8 +228,17 @@ public class MTEMegaIndustrialApiary extends KubaTechGTMultiBlockBase<MTEMegaInd
     @Override
     public void onRemoval() {
         super.onRemoval();
-        if (getBaseMetaTileEntity().isServerSide())
-            tryOutputAll(mStorage, s -> Collections.singletonList(s.queenStack));
+        IGregTechTileEntity bmte = getBaseMetaTileEntity();
+        for (BeeSimulator s : mStorage) {
+            EntityItem item = new EntityItem(
+                bmte.getWorld(),
+                bmte.getXCoord(),
+                bmte.getYCoord(),
+                bmte.getZCoord(),
+                s.queenStack);
+            bmte.getWorld()
+                .spawnEntityInWorld(item);
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
This PR makes the mega apiary controller drop all of the queens stored inside of it when it is broken, same behaviour as the Extreme Industrial Greenhouse.

An alternative to this is moving the `super.onRemoval()` call down below the if statement in the original code. This fixes it not outputting the bees into the output bus, but it does mean that the queens get voided if the bus has no space for them.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/26060

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
