### PR TITLE
Jade autoclave recipe

### DIFF
--- a/src/main/java/gregtech/loaders/materials/MaterialsInit.java
+++ b/src/main/java/gregtech/loaders/materials/MaterialsInit.java
@@ -3843,6 +3843,8 @@ public class MaterialsInit {
             .addMaterial(Materials.Oxygen, 6)
             .addAspect(TCAspects.LUCRUM, 6)
             .addAspect(TCAspects.VITREUS, 3)
+            .addSubTag(SubTag.CRYSTAL)
+            .addSubTag(SubTag.CRYSTALLISABLE)
             .removeOrePrefix(OrePrefixes.lens)
             .constructMaterial();
     }


### PR DESCRIPTION
## Summary
jade gem is used in amalgatite in stargate. Although EoH produces jade dust, there's no way turning the dust into gem so u still need to build voidminers in twilight forest, causing unnecessary cpu stress. This PR added autoclave recipe for jade like other gems with no variants (dilithium orundum etc) do.
<img width="694" height="710" alt="image" src="https://github.com/user-attachments/assets/03095784-a2d3-4c08-a296-6c5e56ec4c1f" />


## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
