### PR TITLE
Implement event-based recipe check for TT Multiblock

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
@@ -211,17 +211,17 @@ public abstract class MTEMultiBlockBase extends MetaTileEntity
     protected boolean canBeMuffled = true;
     protected boolean debugEnergyPresent = false;
     /** A pending IMMEDIATE recipe-check push (new inputs, drained output, user/structure change); never throttled. */
-    private boolean recipeCheckImmediately = false;
+    protected boolean recipeCheckImmediately = false;
     /**
      * A pending THROTTLED recipe-check push (ME restock, power trickle); deferred while the fail cooldown is active.
      */
-    private boolean recipeCheckThrottled = false;
+    protected boolean recipeCheckThrottled = false;
     /**
      * While {@code mTotalRunTime < this}, THROTTLED rechecks are deferred (the push flag is kept until it expires).
      * Set after a failed check to {@code now + MachineStats.machines.recipeCheckFailCooldown}; 0 means no cooldown.
      * IMMEDIATE pushes ignore this entirely.
      */
-    private long recipeCheckCooldownUntil = 0;
+    protected long recipeCheckCooldownUntil = 0;
 
     protected static final String INPUT_SEPARATION_NBT_KEY = "inputSeparation";
     protected static final String VOID_EXCESS_NBT_KEY = "voidExcess";
@@ -239,7 +239,7 @@ public abstract class MTEMultiBlockBase extends MetaTileEntity
     public ArrayList<MTEHatchMuffler> mMufflerHatches = new ArrayList<>();
     public ArrayList<MTEHatchEnergy> mEnergyHatches = new ArrayList<>();
     public ArrayList<MTEHatchMaintenance> mMaintenanceHatches = new ArrayList<>();
-    private boolean doPeriodicChecks = false;
+    protected boolean doPeriodicChecks = false;
 
     /**
      * The list of coils in this multi's structure. Use
@@ -756,7 +756,7 @@ public abstract class MTEMultiBlockBase extends MetaTileEntity
         }
     }
 
-    private boolean shouldCheckRecipeThisTick(long aTick) {
+    protected boolean shouldCheckRecipeThisTick(long aTick) {
         // Recipe checks are purely event-driven: hatches and config changes push via scheduleRecipeCheck(reason)
         // instead of being polled on a periodic timer.
         if (recipeCheckImmediately) {

--- a/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchObjectHolder.java
+++ b/src/main/java/tectech/thing/metaTileEntity/hatch/MTEHatchObjectHolder.java
@@ -129,4 +129,12 @@ public class MTEHatchObjectHolder extends MTEHatch implements ISmartInputHatch {
     public GTGuiTheme getGuiTheme() {
         return GTGuiThemes.TECTECH_STANDARD;
     }
+
+    @Override
+    public void onPostTick(IGregTechTileEntity baseMetaTileEntity, long tick) {
+        super.onPostTick(baseMetaTileEntity, tick);
+        if (baseMetaTileEntity.isServerSide()) {
+            detectInventoryChange();
+        }
+    }
 }

--- a/src/main/java/tectech/thing/metaTileEntity/hatch/bec/MTEHatchLoS.java
+++ b/src/main/java/tectech/thing/metaTileEntity/hatch/bec/MTEHatchLoS.java
@@ -34,10 +34,11 @@ import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.tooltip.MarkdownTooltipLoader;
 import gregtech.common.render.IMTERenderer;
+import gregtech.common.tileentities.machines.ISmartInputHatch;
 import tectech.thing.metaTileEntity.hatch.MTEBaseFactoryHatch;
 
 /// Line of sight connector hatch for observation arrays + teleportation nodes
-public class MTEHatchLoS extends MTEBaseFactoryHatch implements IMTERenderer {
+public class MTEHatchLoS extends MTEBaseFactoryHatch implements IMTERenderer, ISmartInputHatch {
 
     private static final int SCAN_DIST = 128;
     private static final ResourceLocation BEAM_TEXTURE = new ResourceLocation("textures/entity/beacon_beam.png");
@@ -112,6 +113,7 @@ public class MTEHatchLoS extends MTEBaseFactoryHatch implements IMTERenderer {
             .setActive(true);
         this.getBaseMetaTileEntity()
             .issueTileUpdate();
+        notifyWatchers();
     }
 
     public boolean hasOwner() {

--- a/src/main/java/tectech/thing/metaTileEntity/multi/MTEEyeOfHarmony.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/MTEEyeOfHarmony.java
@@ -80,6 +80,7 @@ import gregtech.api.util.MultiblockTooltipBuilder;
 import gregtech.api.util.shutdown.ShutDownReason;
 import gregtech.common.misc.GTStructureChannels;
 import gregtech.common.tileentities.machines.MTEHatchInputBusME;
+import gregtech.common.tileentities.machines.RecipeCheckReason;
 import gtPlusPlus.core.util.minecraft.ItemUtils;
 import gtneioreplugin.plugin.block.BlockDimensionDisplay;
 import gtneioreplugin.plugin.block.ModBlocks;
@@ -1146,11 +1147,8 @@ public class MTEEyeOfHarmony extends TTMultiblockBase implements ISurvivalConstr
 
     private EyeOfHarmonyRecipe currentRecipe;
 
-    // Counter for lag prevention.
-    private long lagPreventer = 0;
-
-    // Check for recipe every recipeCheckInterval ticks.
-    private static final long RECIPE_CHECK_INTERVAL = 3 * 20;
+    private boolean shouldDrainHatches = true;
+    private boolean justDrainedHatches = false;
     private long currentCircuitMultiplier = 0;
     private long astralArrayAmount = 0;
     private long parallelAmount = 1;
@@ -1161,6 +1159,14 @@ public class MTEEyeOfHarmony extends TTMultiblockBase implements ISurvivalConstr
     private FluidStackLong starMatter;
 
     @Override
+    public void scheduleRecipeCheck(RecipeCheckReason reason) {
+        super.scheduleRecipeCheck(reason);
+        // Input hatch sends a recipe check schedule
+        // we will reschedule again when the fluids are drained from the hatches
+        shouldDrainHatches = true;
+    }
+
+    @Override
     @NotNull
     protected CheckRecipeResult checkProcessing_EM() {
         ItemStack controllerStack = getControllerSlot();
@@ -1168,20 +1174,20 @@ public class MTEEyeOfHarmony extends TTMultiblockBase implements ISurvivalConstr
             return SimpleCheckRecipeResult.ofFailure("no_planet_block");
         }
 
-        lagPreventer++;
-        if (lagPreventer < RECIPE_CHECK_INTERVAL) {
-            lagPreventer = 0;
-            // No item in multi gui slot.
-
-            currentRecipe = TecTech.eyeOfHarmonyRecipeStorage.recipeLookUp(controllerStack);
-            if (currentRecipe == null) {
-                return CheckRecipeResultRegistry.NO_RECIPE;
-            }
-            CheckRecipeResult result = processRecipe(currentRecipe);
-            if (!result.wasSuccessful()) currentRecipe = null;
-            return result;
+        // Delay recipe-check until hatches are drained
+        if (!justDrainedHatches) {
+            return checkRecipeResult;
         }
-        return CheckRecipeResultRegistry.NO_RECIPE;
+
+        justDrainedHatches = false;
+
+        currentRecipe = TecTech.eyeOfHarmonyRecipeStorage.recipeLookUp(controllerStack);
+        if (currentRecipe == null) {
+            return CheckRecipeResultRegistry.NO_RECIPE;
+        }
+        CheckRecipeResult result = processRecipe(currentRecipe);
+        if (!result.wasSuccessful()) currentRecipe = null;
+        return result;
     }
 
     private long getHydrogenStored() {
@@ -1482,6 +1488,9 @@ public class MTEEyeOfHarmony extends TTMultiblockBase implements ISurvivalConstr
 
         // Do other stuff from TT superclasses. E.g. outputting fluids.
         super.outputAfterRecipe_EM();
+
+        // Schedule drain after output
+        shouldDrainHatches = true;
     }
 
     @Override
@@ -1494,8 +1503,11 @@ public class MTEEyeOfHarmony extends TTMultiblockBase implements ISurvivalConstr
         }
 
         if (!recipeRunning && mMachine) {
-            if ((aTick % TICKS_BETWEEN_HATCH_DRAIN) == 0) {
+            if ((aTick % TICKS_BETWEEN_HATCH_DRAIN) == 0 && shouldDrainHatches) {
                 drainFluidFromHatchesAndStoreInternally();
+                scheduleRecipeCheckImmediate();
+                shouldDrainHatches = false;
+                justDrainedHatches = true;
             }
         }
     }

--- a/src/main/java/tectech/thing/metaTileEntity/multi/base/TTMultiblockBase.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/base/TTMultiblockBase.java
@@ -775,6 +775,28 @@ public abstract class TTMultiblockBase extends MTEExtendedPowerMultiBlockBase<TT
         return result;
     }
 
+    @Override
+    protected boolean shouldCheckRecipeThisTick(long aTick) {
+        // Recipe checks are purely event-driven: hatches and config changes push via scheduleRecipeCheck(reason)
+        // instead of being polled on a periodic timer.
+        if (recipeCheckImmediately) {
+            // An immediate push (new inputs, drained output, user/structure change) always runs, and covers any
+            // pending throttled push too.
+            recipeCheckImmediately = false;
+            recipeCheckThrottled = false;
+            return true;
+        }
+        if (recipeCheckThrottled && mTotalRunTime >= recipeCheckCooldownUntil) {
+            // A throttleable push (ME restock, power trickle) runs once the post-failure cooldown has expired.
+            recipeCheckThrottled = false;
+            return true;
+        }
+        if (doPeriodicChecks) {
+            return CommonValues.RECIPE_AT == aTick % 20;
+        }
+        return false;
+    }
+
     @NotNull
     @Override
     public final CheckRecipeResult checkProcessing() {
@@ -908,6 +930,8 @@ public abstract class TTMultiblockBase extends MTEExtendedPowerMultiBlockBase<TT
                     if (getEUVar() > maxEUStore()) {
                         setEUVar(maxEUStore());
                     }
+
+                    scheduleRecipeCheckImmediate();
                 } else {
                     maxEUinputMin = 0;
                     maxEUinputMax = 0;
@@ -980,8 +1004,10 @@ public abstract class TTMultiblockBase extends MTEExtendedPowerMultiBlockBase<TT
                             } // else {//failed to consume power/resources - inside on running tick
                               // stopMachine();
                               // }
-                        } else if (CommonValues.RECIPE_AT == Tick || aBaseMetaTileEntity.hasWorkJustBeenEnabled()) {
-                            if (aBaseMetaTileEntity.isAllowedToWork()) {
+                        } else if (aBaseMetaTileEntity.isAllowedToWork()) {
+                            if (aBaseMetaTileEntity.hasWorkJustBeenEnabled()
+                                || aBaseMetaTileEntity.hasInventoryBeenModified()
+                                || shouldCheckRecipeThisTick(aTick)) {
                                 if (checkRecipe()) {
                                     mEfficiency = Math.max(
                                         0,
@@ -993,7 +1019,7 @@ public abstract class TTMultiblockBase extends MTEExtendedPowerMultiBlockBase<TT
                                     afterRecipeCheckFailed();
                                 }
                                 updateSlots();
-                            } // else notAllowedToWork_stopMachine_EM(); //it is already stopped here
+                            }
                         }
                     } else if (aBaseMetaTileEntity.isAllowedToWork()) { // not repaired
                         stopMachine(ShutDownReasonRegistry.NO_REPAIR);

--- a/src/main/java/tectech/thing/metaTileEntity/multi/bec/MTEBECIONode.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/bec/MTEBECIONode.java
@@ -1058,6 +1058,7 @@ public class MTEBECIONode extends MTEBECMultiblockBase<MTEBECIONode> implements 
                     hatch.updateCraftingIcon(self.getMachineCraftingIcon());
                     hatch.setOwner(self);
 
+                    self.addIfSmartInput(hatch);
                     self.losHatch = hatch;
 
                     return true;


### PR DESCRIPTION
## Summary
Event-based recipe checks were already implemented for MTEMultiblockBase, but TTMultiblockBase was still doing periodic recipe checks because it has its own running implementation. This PR makes it so that it also does event-based recipe check instead of periodic ones

Also fix input watchers on some special hatches


## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
