### PR TITLE
Sync HTGR reactor info text to client

### DIFF
--- a/src/main/java/kubatech/gui/modularui2/MTEHighTempGasCooledReactorGui.java
+++ b/src/main/java/kubatech/gui/modularui2/MTEHighTempGasCooledReactorGui.java
@@ -8,6 +8,7 @@ import com.cleanroommc.modularui.api.widget.IWidget;
 import com.cleanroommc.modularui.screen.ModularPanel;
 import com.cleanroommc.modularui.utils.Alignment;
 import com.cleanroommc.modularui.value.sync.PanelSyncManager;
+import com.cleanroommc.modularui.value.sync.StringSyncValue;
 import com.cleanroommc.modularui.widgets.ListWidget;
 
 import gregtech.api.interfaces.tileentity.IGregTechDeviceInformation;
@@ -16,8 +17,17 @@ import kubatech.tileentity.gregtech.multiblock.MTEHighTempGasCooledReactor;
 
 public class MTEHighTempGasCooledReactorGui extends KubaTechGTMultiBlockBaseGUI<MTEHighTempGasCooledReactor> {
 
+    private StringSyncValue reactorInfoSyncer;
+
     public MTEHighTempGasCooledReactorGui(MTEHighTempGasCooledReactor multiblock) {
         super(multiblock);
+    }
+
+    @Override
+    protected void registerSyncValues(PanelSyncManager syncManager) {
+        super.registerSyncValues(syncManager);
+        reactorInfoSyncer = new StringSyncValue(multiblock::getReactorInfoText);
+        syncManager.syncValue("htgrReactorInfo", reactorInfoSyncer);
     }
 
     @Override
@@ -25,7 +35,7 @@ public class MTEHighTempGasCooledReactorGui extends KubaTechGTMultiBlockBaseGUI<
         return super.createTerminalTextWidget(syncManager, parent).child(
             IKey.dynamic(
                 () -> Arrays.stream(
-                    multiblock.getReactorInfoText()
+                    reactorInfoSyncer.getStringValue()
                         .split("\n"))
                     .map(IGregTechDeviceInformation::decode)
                     .collect(Collectors.joining("\n")))


### PR DESCRIPTION
## Summary
Fill level, fuel properties, burned fuel, helium supply, coolant per tick and water per tick always showed 0 in the High Temperature Gas-cooled Reactor GUI while the reactor was running normally, even though the underlying values were correct (confirmed via NBT editor and the scanner tool).

The GUI widget read these fields directly off the client-side tile entity, but they are only ever updated server-side and were never networked to the client. Other multiblocks route this kind of live text through PanelSyncManager, so the reactor info text is now synced the same way.

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25737

## Checklist
- [X] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
