### PR TITLE
Use real tank capacity for fluid gauge when void mode is enabled

### DIFF
--- a/src/main/java/gregtech/common/gui/modularui/singleblock/base/MTEMachineWithFluidScreenBaseGui.java
+++ b/src/main/java/gregtech/common/gui/modularui/singleblock/base/MTEMachineWithFluidScreenBaseGui.java
@@ -6,6 +6,7 @@ import static net.minecraft.util.StatCollector.translateToLocal;
 import java.util.function.Predicate;
 
 import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.FluidTankInfo;
 import net.minecraftforge.fluids.IFluidTank;
 
 import com.cleanroommc.modularui.api.drawable.IKey;
@@ -89,11 +90,12 @@ public class MTEMachineWithFluidScreenBaseGui<T extends MTETieredMachineBlock> e
             .fullHeight()
             .mainAxisAlignment(Alignment.MainAxis.SPACE_BETWEEN);
 
+        RealCapacityFluidTank realCapacityFluidTank = new RealCapacityFluidTank(fluidTank, machine.getRealCapacity());
         ioColumn.child(createInputSlot(panel, syncManager, inputSlot));
         ioColumn.child(
             new FluidSlot().size(16)
                 .syncHandler(
-                    new FluidSlotSyncHandler(fluidTank).controlsAmount(false)
+                    new FluidSlotSyncHandler(realCapacityFluidTank).controlsAmount(false)
                         .canDrainSlot(false)
                         .canFillSlot(false))
                 .alwaysShowFull(false)
@@ -158,5 +160,46 @@ public class MTEMachineWithFluidScreenBaseGui<T extends MTETieredMachineBlock> e
                 .background(GTGuiTextures.SLOT_FLUID_TANK));
 
         return screen;
+    }
+
+    private static class RealCapacityFluidTank implements IFluidTank {
+
+        private final IFluidTank wrappedTank;
+        private final int capacity;
+
+        private RealCapacityFluidTank(IFluidTank fluidTank, int capacity) {
+            this.wrappedTank = fluidTank;
+            this.capacity = capacity;
+        }
+
+        @Override
+        public FluidStack getFluid() {
+            return wrappedTank.getFluid();
+        }
+
+        @Override
+        public int getFluidAmount() {
+            return wrappedTank.getFluidAmount();
+        }
+
+        @Override
+        public int getCapacity() {
+            return capacity;
+        }
+
+        @Override
+        public FluidTankInfo getInfo() {
+            return wrappedTank.getInfo();
+        }
+
+        @Override
+        public int fill(FluidStack resource, boolean doFill) {
+            return 0;
+        }
+
+        @Override
+        public FluidStack drain(int maxDrain, boolean doDrain) {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
## Summary
Activating void mode no longer affects  the fluid gauge capacity or "fullness".


### Before
<img width="921" height="664" alt="image" src="https://github.com/user-attachments/assets/be04d47b-7783-4840-8034-392a281007e6" />

### After
<img width="789" height="575" alt="image" src="https://github.com/user-attachments/assets/5ce7da41-7ac9-4b13-ace1-f665af2b2556" />

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
