### PR TITLE
fix deps to work with a computronics patch

### DIFF
--- a/src/main/java/gregtech/GTMod.java
+++ b/src/main/java/gregtech/GTMod.java
@@ -183,7 +183,8 @@ import ic2.api.recipe.RecipeOutput;
         + "after:UndergroundBiomes;"
         + "after:TConstruct;"
         + "after:Translocator;"
-        + "after:gendustry;")
+        + "after:gendustry;"
+        + "before:computronics;")
 public class GTMod {
 
     static {


### PR DESCRIPTION
computronics had an after:gregtech dep which breaks with gt6 so i moved it to before:computronics here
https://github.com/GTNewHorizons/Computronics/pull/42