### PR TITLE
Fix iapiary basic automation not moving princesses

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/basic/MTEIndustrialApiary.java
+++ b/src/main/java/gregtech/common/tileentities/machines/basic/MTEIndustrialApiary.java
@@ -620,7 +620,8 @@ public class MTEIndustrialApiary extends MTEBasicMachine
                                     if (aBaseMetaTileEntity.addStackToSlot(drone, mOutputItems[i])) break;
                             } else if (mAutoQueen && i == 0
                                 && j == 0
-                                && beeRoot.isMember(mOutputItems[0], EnumBeeType.QUEEN.ordinal())
+                                && (beeRoot.isMember(mOutputItems[0], EnumBeeType.QUEEN.ordinal())
+                                    || beeRoot.isMember(mOutputItems[0], EnumBeeType.PRINCESS.ordinal()))
                                 && aBaseMetaTileEntity.addStackToSlot(queen, mOutputItems[0])) break;
                             if (aBaseMetaTileEntity
                                 .addStackToSlot(getOutputSlot() + ((j + i) % mOutputItems.length), mOutputItems[i]))


### PR DESCRIPTION
## Summary
This PR makes the industrial apiary basic automation toggle move princesses into their slot upon finishing a recipe.

Looking at the code, my assumption is that the automation upgrade is supposed to move both the princess and the drones into their respective slots, while the basic automation is supposed to only move the princess. The original code for the basic automation only checked for a queen, and not for a princess, when deciding whether or not to move the item into the queen slot. Since the iapiary outputs princesses, not queens, that meant the toggle did nothing.

I assume this closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25546 if I understood the issue correctly.


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
