### PR TITLE
Reset fluid lock when shift-breaking an empty digital tank

### DIFF
--- a/src/main/java/gregtech/common/blocks/BlockMachines.java
+++ b/src/main/java/gregtech/common/blocks/BlockMachines.java
@@ -61,6 +61,7 @@ import gregtech.api.util.GTUtility;
 import gregtech.common.covers.Cover;
 import gregtech.common.render.GTRendererBlock;
 import gregtech.common.render.IIconTexture;
+import gregtech.common.tileentities.storage.MTEDigitalTankBase;
 import gregtech.common.tileentities.storage.MTEQuantumChest;
 import gtPlusPlus.xmod.gregtech.common.tileentities.redstone.MTERedstoneLamp;
 
@@ -532,6 +533,11 @@ public class BlockMachines extends GTGenericBlock implements IDebugableBlock, IT
 
             if (tTileEntity instanceof BaseMetaTileEntity baseTE) {
                 baseTE.setColorization((byte) -1);
+            }
+
+            if (tTileEntity instanceof IGregTechTileEntity gtTE
+                && gtTE.getMetaTileEntity() instanceof MTEDigitalTankBase tankMTE) {
+                tankMTE.resetFluidLockOnShiftBreak();
             }
         }
         // This delays deletion of the block until after getDrops

--- a/src/main/java/gregtech/common/tileentities/storage/MTEDigitalTankBase.java
+++ b/src/main/java/gregtech/common/tileentities/storage/MTEDigitalTankBase.java
@@ -264,6 +264,12 @@ public abstract class MTEDigitalTankBase extends MTEBasicTank
             .equals(fluid);
     }
 
+    public void resetFluidLockOnShiftBreak() {
+        if (mLockFluid && getFluidAmount() == 0) {
+            lockFluid(false);
+        }
+    }
+
     public boolean isOutputFluid() {
         return mOutputFluid;
     }


### PR DESCRIPTION
## Summary
Shift-breaking a machine already drops covers and clears colorization, but Digital/Super/Quantum Tanks kept their fluid lock regardless, so the lock silently carried over into the item's NBT even after the tank was emptied out.

Keeping the lock while fluid is still present avoids losing that binding when a tank is just being relocated.

## Checklist
- [X] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
