### PR TITLE
Add Transparent Glass to SLAM

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -104,7 +104,7 @@ dependencies {
     compileOnly('com.github.GTNewHorizons:SC2:2.3.14:dev') {transitive=false}
     compileOnly('com.github.GTNewHorizons:Binnie:2.6.34:dev') {transitive = false}
     compileOnly('curse.maven:PlayerAPI-228969:2248928') {transitive=false}
-    devOnlyNonPublishable('com.github.GTNewHorizons:BlockRenderer6343:1.4.16:dev'){transitive=false}
+    devOnlyNonPublishable('com.github.GTNewHorizons:BlockRenderer6343:1.4.20:dev'){transitive=false}
     // for waila integration testing
     // devOnlyNonPublishable('com.github.GTNewHorizons:WAILAPlugins:0.7.2:dev')
 

--- a/src/main/java/goodgenerator/blocks/tileEntity/AntimatterForge.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/AntimatterForge.java
@@ -11,7 +11,6 @@ import java.util.Random;
 
 import javax.annotation.Nonnull;
 
-import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
@@ -118,10 +117,10 @@ public class AntimatterForge extends MTEExtendedPowerMultiBlockBase<AntimatterFo
         protected IStructureDefinition<AntimatterForge> computeValue(Class<?> type) {
             return StructureDefinition.<AntimatterForge>builder()
                 .addShape(MAIN_NAME, AntimatterStructures.ANTIMATTER_FORGE)
-                .addElement('A', lazy(x -> ofBlock(x.getFrameBlock(), x.getFrameMeta())))
-                .addElement('B', lazy(x -> ofBlock(x.getCoilBlock(), x.getCoilMeta())))
-                .addElement('C', lazy(x -> ofBlock(x.getCasingBlock(2), x.getCasingMeta(2))))
-                .addElement('D', lazy(x -> ofBlock(x.getCasingBlock(1), x.getCasingMeta(1))))
+                .addElement('A', lazy(() -> ofBlock(Loaders.antimatterContainmentCasing, 0)))
+                .addElement('B', lazy(() -> ofBlock(Loaders.protomatterActivationCoil, 0)))
+                .addElement('C', lazy(() -> ofBlock(Loaders.gravityStabilizationCasing, 0)))
+                .addElement('D', lazy(() -> ofBlock(Loaders.magneticFluxCasing, 0)))
                 .addElement(
                     'F',
                     lazy(
@@ -130,7 +129,7 @@ public class AntimatterForge extends MTEExtendedPowerMultiBlockBase<AntimatterFo
                             .adder(AntimatterForge::addFluidIO)
                             .casingIndex(x.textureIndex(2))
                             .hint(1)
-                            .buildAndChain(x.getCasingBlock(2), x.getCasingMeta(2))))
+                            .buildAndChain(ofBlock(Loaders.gravityStabilizationCasing, 0))))
                 .addElement(
                     'E',
                     lazy(
@@ -149,7 +148,7 @@ public class AntimatterForge extends MTEExtendedPowerMultiBlockBase<AntimatterFo
                             .adder(AntimatterForge::addEnergyInjector)
                             .casingIndex(x.textureIndex(2))
                             .hint(2)
-                            .buildAndChain(x.getCasingBlock(2), x.getCasingMeta(2))))
+                            .buildAndChain(ofBlock(Loaders.gravityStabilizationCasing, 0))))
                 .build();
         }
     };
@@ -341,33 +340,6 @@ public class AntimatterForge extends MTEExtendedPowerMultiBlockBase<AntimatterFo
     @Override
     public boolean supportsPowerPanel() {
         return false;
-    }
-
-    public Block getCasingBlock(int type) {
-        if (type == 2) {
-            return Loaders.gravityStabilizationCasing;
-        }
-        return Loaders.magneticFluxCasing;
-    }
-
-    public int getCasingMeta(int type) {
-        return 0;
-    }
-
-    public Block getCoilBlock() {
-        return Loaders.protomatterActivationCoil;
-    }
-
-    public int getCoilMeta() {
-        return 0;
-    }
-
-    public Block getFrameBlock() {
-        return Loaders.antimatterContainmentCasing;
-    }
-
-    public int getFrameMeta() {
-        return 0;
     }
 
     public int textureIndex(int type) {

--- a/src/main/java/goodgenerator/blocks/tileEntity/AntimatterGenerator.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/AntimatterGenerator.java
@@ -3,6 +3,7 @@ package goodgenerator.blocks.tileEntity;
 import static com.gtnewhorizon.gtnhlib.util.numberformatting.NumberFormatUtil.formatNumber;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.lazy;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofBlock;
+import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofChain;
 import static gregtech.api.enums.Textures.BlockIcons.*;
 import static gregtech.api.util.GTStructureUtility.buildHatchAdder;
 import static gregtech.api.util.GTStructureUtility.ofFrame;
@@ -13,7 +14,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -74,13 +74,13 @@ public class AntimatterGenerator extends MTEExtendedPowerMultiBlockBase<Antimatt
         protected IStructureDefinition<AntimatterGenerator> computeValue(@NotNull Class<?> type) {
             return StructureDefinition.<AntimatterGenerator>builder()
                 .addShape(MAIN_NAME, AntimatterStructures.ANTIMATTER_GENERATOR)
-                .addElement('F', lazy(x -> ofFrame(Materials.Naquadria))) // Naquadria Frame Box
-                .addElement('D', lazy(x -> ofBlock(x.getCasingBlock(1), x.getCasingMeta(1)))) // Black Casing
-                .addElement('G', lazy(x -> ofBlock(x.getCoilBlock(1), x.getCoilMeta(1)))) // Annihilation Coil
-                .addElement('B', lazy(x -> ofBlock(x.getCoilBlock(2), x.getCoilMeta(2)))) // Containment Coil
-                .addElement('C', lazy(x -> ofBlock(x.getCasingBlock(2), x.getCasingMeta(2)))) // White Casing
-                .addElement('A', lazy(x -> ofBlock(x.getGlassBlock(), x.getGlassMeta()))) // Glass
-                .addElement('E', lazy(x -> ofBlock(GregTechAPI.sBlockCasings9, 1))) // Filter Casing
+                .addElement('F', ofFrame(Materials.Naquadria)) // Naquadria Frame Box
+                .addElement('D', lazy(() -> ofBlock(Loaders.magneticFluxCasing, 0))) // Black Casing
+                .addElement('G', lazy(() -> ofBlock(Loaders.antimatterAnnihilationMatrix, 0))) // Annihilation Coil
+                .addElement('B', lazy(() -> ofBlock(Loaders.protomatterActivationCoil, 0))) // Containment Coil
+                .addElement('C', lazy(() -> ofBlock(Loaders.gravityStabilizationCasing, 0))) // White Casing
+                .addElement('A', ofChain(ofBlock(ItemRegistry.bw_realglas, 8), ofBlock(ItemRegistry.bw_realglas2, 3))) // Glass
+                .addElement('E', ofBlock(GregTechAPI.sBlockCasings9, 1)) // Filter Casing
                 .addElement(
                     'H',
                     lazy(
@@ -88,14 +88,14 @@ public class AntimatterGenerator extends MTEExtendedPowerMultiBlockBase<Antimatt
                             .anyOf(HatchElement.ExoticDynamo)
                             .casingIndex(x.textureIndex(2))
                             .hint(2)
-                            .buildAndChain(x.getCasingBlock(2), x.getCasingMeta(2))))
+                            .buildAndChain(Loaders.gravityStabilizationCasing, 0)))
                 .addElement(
                     'I',
                     lazy(
                         x -> buildHatchAdder(AntimatterGenerator.class).atLeast(HatchElement.InputHatch)
                             .casingIndex(x.textureIndex(1))
                             .hint(1)
-                            .buildAndChain(x.getCasingBlock(1), x.getCasingMeta(1))))
+                            .buildAndChain(Loaders.magneticFluxCasing, 0)))
                 .build();
         }
     };
@@ -380,7 +380,7 @@ public class AntimatterGenerator extends MTEExtendedPowerMultiBlockBase<Antimatt
             .addController("Front center, 2nd layer")
             .addCasing("4127-4128", "Magnetic Flux Casing", false)
             .addCasing("2481-2544", "Gravity Stabilization Casing", false)
-            .addCasing("1008", "Transcendentally Reinforced Borosilicate Glass Block", false)
+            .addCasing("1008", "Any Transcendentally Reinforced Borosilicate Glass Block", false)
             .addCasing("600", "Antimatter Annihilation Matrix", false)
             .addCasing("292", "Naquadria Frame Box", false)
             .addCasing("209", "Advanced Filter Casing", false)
@@ -500,42 +500,6 @@ public class AntimatterGenerator extends MTEExtendedPowerMultiBlockBase<Antimatt
             .addIcon(MACHINE_CASING_ANTIMATTER)
             .extFacing()
             .build() };
-    }
-
-    public Block getCoilBlock(int type) {
-        if (type == 2) {
-            return Loaders.protomatterActivationCoil;
-        }
-        return Loaders.antimatterAnnihilationMatrix;
-    }
-
-    public int getCoilMeta(int type) {
-        return 0;
-    }
-
-    public Block getCasingBlock(int type) {
-        if (type == 2) return Loaders.gravityStabilizationCasing;
-        return Loaders.magneticFluxCasing;
-    }
-
-    public int getCasingMeta(int type) {
-        return 0;
-    }
-
-    public Block getFrameBlock() {
-        return Loaders.antimatterContainmentCasing;
-    }
-
-    public int getFrameMeta() {
-        return 0;
-    }
-
-    public Block getGlassBlock() {
-        return ItemRegistry.bw_realglas;
-    }
-
-    public int getGlassMeta() {
-        return 8;
     }
 
     public int textureIndex(int type) {


### PR DESCRIPTION
## Summary
Lets the SLAM optionally use Transparent Transmetal glass in its structure, instead of forced foggy transmetal.
Cleans up the SLAM and SSASS structure defs to be less lazy :)
Dep bump on BlockRenderer (for more glass channels)

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
