### PR TITLE
Add alternate nuclear star recipe

### DIFF
--- a/src/main/java/gregtech/loaders/postload/recipes/AutoclaveRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/AutoclaveRecipes.java
@@ -208,6 +208,14 @@ public class AutoclaveRecipes implements Runnable {
             .addTo(autoclaveRecipes);
 
         GTValues.RA.stdBuilder()
+            .itemInputs(GTOreDictUnificator.get(OrePrefixes.gem, Materials.NetherStar, 64))
+            .itemOutputs(ItemList.NuclearStar.get(1L))
+            .fluidInputs(Materials.Infinity.getPlasma(4 * INGOTS))
+            .duration(20 * TICKS)
+            .eut(TierEU.RECIPE_UIV)
+            .addTo(autoclaveRecipes);
+
+        GTValues.RA.stdBuilder()
             .itemInputs(Materials.SiliconDioxide.getDust(1))
             .itemOutputs(Materials.Quartzite.getGems(1))
             .outputChances(750)


### PR DESCRIPTION
## Summary
The big increase in nuclear star usage due to cosmic solder put a massive strain on autoclaves at endgame. This PR adds an alternate recipe tiered to t7 eoh that uses infinity plasma and makes the stars directly from base nether stars.

<img width="518" height="424" alt="image" src="https://github.com/user-attachments/assets/45d4d104-025f-4a0f-b20d-23d5b52a1781" />



## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
