### PR TITLE
Remove equals and hashCode override to use implementation from Object

### DIFF
--- a/src/main/java/gregtech/api/util/GTRecipe.java
+++ b/src/main/java/gregtech/api/util/GTRecipe.java
@@ -1169,18 +1169,6 @@ public class GTRecipe implements Comparable<GTRecipe> {
         }
 
         @Override
-        public int hashCode() {
-            return mPersistentHash != 0 ? mPersistentHash : super.hashCode();
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            if (this == obj) return true;
-            if (!(obj instanceof RecipeAssemblyLine other)) return false;
-            return mPersistentHash != 0 && mPersistentHash == other.mPersistentHash;
-        }
-
-        @Override
         public String toString() {
             return "GTRecipe_AssemblyLine{" + "mResearchItem="
                 + mResearchItem


### PR DESCRIPTION
## Summary
This PR https://github.com/GTNewHorizons/GT5-Unofficial/pull/7555 added override for HashSet efficiency. This is wrong since GTRecipe equals already use Object.hashCode and Object.equals (compare by identity) which is already the most efficient possible. Revert this part of the PR as the hash may collide.

## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
