### PR TITLE
Unclamp assline recipe persistent hash

### DIFF
--- a/src/main/java/tectech/recipe/TTRecipeAdder.java
+++ b/src/main/java/tectech/recipe/TTRecipeAdder.java
@@ -216,8 +216,8 @@ public class TTRecipeAdder extends RecipeAdder {
         }
         researchAmperage = GTUtility.clamp(researchAmperage, 1, Short.MAX_VALUE);
         computationRequiredPerSec = GTUtility.clamp(computationRequiredPerSec, 1, (~0L) >>> 16);
-        tPersistentHash = GTUtility.safeInt(tPersistentHash * 31L + totalComputationRequired);
-        tPersistentHash = GTUtility.safeInt(tPersistentHash * 31L + computationRequiredPerSec);
+        tPersistentHash = (int) (tPersistentHash * 31L + totalComputationRequired);
+        tPersistentHash = (int) (tPersistentHash * 31L + computationRequiredPerSec);
         tPersistentHash = tPersistentHash * 31 + researchAmperage;
         tPersistentHash = tPersistentHash * 31 + researchEUt;
         tPersistentHash = tPersistentHash * 31 + assDuration;


### PR DESCRIPTION
## Summary
The persistent hash was clamped when it wasn't supposed to, we'll use naive casting instead


## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
