### PR TITLE
Remove LINAC chat spam from BlockRenderer

### DIFF
--- a/src/main/java/gtnhlanth/common/tileentity/MTELINAC.java
+++ b/src/main/java/gtnhlanth/common/tileentity/MTELINAC.java
@@ -368,8 +368,6 @@ public class MTELINAC extends MTEEnhancedMultiBlockBase<MTELINAC>
         }
 
         buildPiece(STRUCTURE_PIECE_END, stackSize, hintsOnly, 3, 6, -(lLength + 2));
-
-        StructureLib.addClientSideChatMessages("Length: " + (11 + lLength) + " blocks.");
     }
 
     @Override

--- a/src/main/java/gtnhlanth/common/tileentity/MTELINAC.java
+++ b/src/main/java/gtnhlanth/common/tileentity/MTELINAC.java
@@ -32,7 +32,6 @@ import net.minecraftforge.fluids.FluidStack;
 
 import org.jetbrains.annotations.NotNull;
 
-import com.gtnewhorizon.structurelib.StructureLib;
 import com.gtnewhorizon.structurelib.alignment.constructable.ISurvivalConstructable;
 import com.gtnewhorizon.structurelib.structure.IStructureDefinition;
 import com.gtnewhorizon.structurelib.structure.ISurvivalBuildEnvironment;


### PR DESCRIPTION
## Summary
Due to [new change](https://github.com/GTNewHorizons/BlockRenderer6343/pull/58) in BlockRenderer, `MTELINAC#construct` is called on the client to determine the length now. This PR remove the chat spam so that player won't see the message on launch.


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
