### PR TITLE
Dragonblood Recipe Adjustments

### DIFF
--- a/src/main/java/kubatech/loaders/DEFCRecipes.java
+++ b/src/main/java/kubatech/loaders/DEFCRecipes.java
@@ -60,7 +60,7 @@ public class DEFCRecipes {
             .itemOutputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.Ash, 8L))
             .fluidOutputs(new FluidStack(FluidRegistry.getFluid("molten.dragonblood"), 288))
             .eut(TierEU.RECIPE_UHV)
-            .duration(14_000)
+            .duration(2100 * SECONDS)
             .addTo(mixerRecipes);
 
         // Casings
@@ -282,7 +282,7 @@ public class DEFCRecipes {
             .fluidOutputs(new FluidStack(FluidRegistry.getFluid("molten.dragonblood"), 288))
             .eut(TierEU.RECIPE_UHV)
             .duration(4200)
-            .metadata(DEFC_CASING_TIER, 3)
+            .metadata(DEFC_CASING_TIER, 2)
             .addTo(fusionCraftingRecipes);
 
         if (Witchery.isModLoaded()) {
@@ -295,7 +295,7 @@ public class DEFCRecipes {
                 .fluidOutputs(new FluidStack(FluidRegistry.getFluid("molten.dragonblood"), 432))
                 .eut(TierEU.RECIPE_UHV)
                 .duration(3600)
-                .metadata(DEFC_CASING_TIER, 3)
+                .metadata(DEFC_CASING_TIER, 2)
                 .addTo(fusionCraftingRecipes);
         }
 
@@ -308,7 +308,7 @@ public class DEFCRecipes {
             .fluidOutputs(new FluidStack(FluidRegistry.getFluid("molten.dragonblood"), 432))
             .eut(TierEU.RECIPE_UHV)
             .duration(2800)
-            .metadata(DEFC_CASING_TIER, 3)
+            .metadata(DEFC_CASING_TIER, 2)
             .addTo(fusionCraftingRecipes);
 
         if (Witchery.isModLoaded()) {
@@ -321,7 +321,7 @@ public class DEFCRecipes {
                 .fluidOutputs(new FluidStack(FluidRegistry.getFluid("molten.dragonblood"), 648))
                 .eut(TierEU.RECIPE_UHV)
                 .duration(2400)
-                .metadata(DEFC_CASING_TIER, 3)
+                .metadata(DEFC_CASING_TIER, 2)
                 .addTo(fusionCraftingRecipes);
         }
     }


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
TLDR, this adjusts the Dragonblood recipes in both the Mixer and the DEFC. The balance was thrown off with the OP Mixer adjustments (I still think the mixer was given too much power, but that's a 2.10 problem at this point).

The exact changes are increasing the duration of the mixer recipe 3x to 2100s and decreasing the coil tier on the DEFC recipes from T3 to T2. 

Also I had GPT turn this into markdown charts from excel, so numbers should be correct, however the formatting may be a little odd.

## DB Throughput Comparison:

### Calculation Assumptions

- ** Using the BEST DEFC recipe & circumstances (Req. Bees & Witchery)**
  - 648 L output
  - 120-second duration
  - UHV tier
  - Using T3 casings at UHV, T4 at UEV, T5 at UIV
  - DEFC always receives 16 A
- **Legacy Mixer**
  - 3.5× maximum speed
  - 8 parallels per voltage tier
  - Standard energy hatches only
  - 16 A maximum
- **Reworked Mixer**
  - 9× maximum speed
  - 8 parallels per voltage tier
  - 16 A through standard energy hatches
  - 64 A multiamp available at UIV+


> [!NOTE]
> The primary comparison uses throughput-optimized Mixer parallel settings. At UIV+, this means manually disabling “always max parallel” and setting the parallel cap to 68. The wiki’s 72/80/88/96/104 figures remain the correct structural maximum parallels.

---

## 1. Legacy 350% Mixer versus the current T3 DEFC

This is the pre-rework baseline: a 700-second Mixer recipe, 3.5× speed, and 16 A maximum.

| Voltage | DEFC 16 A | Legacy Mixer, default max-parallel | Legacy Mixer, throughput-tuned | Fastest tuned machine |
|---|---:|---:|---:|---|
| UHV | 21.600 L/s | **24.480 L/s** — 17p/0 OC | **24.480 L/s** — 17p/0 OC | Mixer by 13.3% |
| UEV | 86.400 L/s | **97.920 L/s** — 68p/0 OC | **97.920 L/s** — 68p/0 OC | Mixer by 13.3% |
| UIV | **350.270 L/s** | 126.720 L/s — 88p/0 OC | 195.840 L/s — 68p/1 OC | DEFC by 78.9% |
| UMV | **720.000 L/s** | 276.480 L/s — 96p/1 OC | 391.680 L/s — 68p/2 OC | DEFC by 83.8% |
| UXV | **1,440.000 L/s** | 599.040 L/s — 104p/2 OC | 783.360 L/s — 68p/3 OC | DEFC by 83.8% |

The legacy Mixer was slightly faster at UHV and UEV. Once T5 DEFC casings became available at UIV, the DEFC overtook it and reached approximately **1.84×** the legacy Mixer's tuned throughput at UMV and UXV.

---

## 2. Reworked 900% Mixer with the current 700-second recipe

This shows the reworked Mixer at maximum 9× speed without changing either recipe.

| Voltage | DEFC 16 A, T3 recipe | Reworked Mixer 16 A | Reworked Mixer 64 A | Fastest |
|---|---:|---:|---:|---|
| UHV | 21.600 L/s | **62.971 L/s** | — | Mixer 16 A by 2.92× |
| UEV | 86.400 L/s | **251.884 L/s** | — | Mixer 16 A by 2.92× |
| UIV | 350.270 L/s | 504.093 L/s | **1,009.485 L/s** | Mixer 64 A by 2.88× |
| UMV | 720.000 L/s | 1,009.485 L/s | **2,018.969 L/s** | Mixer 64 A by 2.80× |
| UXV | 1,440.000 L/s | 2,018.969 L/s | **4,037.938 L/s** | Mixer 64 A by 2.80× |

At the same 16 A, the 9× Mixer produces approximately **2.57×** the throughput of the legacy 3.5× Mixer.

At UIV+, 64 A provides one additional OC and approximately doubles the tuned 16 A output.

---

## 3. Reworked Mixer with the recipe increased to 2,100 seconds

This keeps the current T3 DEFC recipe requirement but triples the Mixer recipe duration from 700 to 2,100 seconds.

| Voltage | DEFC 16 A, T3 recipe | Reworked Mixer 16 A | Reworked Mixer 64 A | Fastest |
|---|---:|---:|---:|---|
| UHV | **21.600 L/s** | 20.986 L/s | — | DEFC by 2.9% |
| UEV | **86.400 L/s** | 83.943 L/s | — | DEFC by 2.9% |
| UIV | **350.270 L/s** | 167.887 L/s | 335.918 L/s | DEFC by 4.3% |
| UMV | **720.000 L/s** | 335.918 L/s | 671.835 L/s | DEFC by 7.2% |
| UXV | **1,440.000 L/s** | 671.835 L/s | 1,345.979 L/s | DEFC by 7.0% |

Tripling the Mixer duration makes maximum sustained output very close to the current T3 DEFC.

Across the compared voltage tiers, the DEFC remains approximately **3–7% faster**, including against the 64 A Mixer at UIV+.

---

## 4. Reworked Mixer at 2,100 seconds and DEFC requirement lowered to T2

This combines the 2,100-second Mixer recipe with lowering the DEFC recipe casing requirement from T3 to T2.

The DEFC consequently receives one additional perfect OC at every casing tier.

| Voltage | DEFC 16 A, T2 recipe | Reworked Mixer 16 A | Reworked Mixer 64 A | Fastest |
|---|---:|---:|---:|---|
| UHV | **43.200 L/s** | 20.986 L/s | — | DEFC by 2.06× |
| UEV | **172.800 L/s** | 83.943 L/s | — | DEFC by 2.06× |
| UIV | **720.000 L/s** | 167.887 L/s | 335.918 L/s | DEFC by 2.14× |
| UMV | **1,440.000 L/s** | 335.918 L/s | 671.835 L/s | DEFC by 2.14× |
| UXV | **3,240.000 L/s** | 671.835 L/s | 1,345.979 L/s | DEFC by 2.41× |

This combination strongly favors the DEFC. At UXV, the DEFC produces approximately **2.41×** the output of the tuned 64 A Mixer.

---

## In Summation

| Configuration | UHV–UEV result | UIV–UXV result |
|---|---|---|
| Legacy 3.5× Mixer, 700 s, DEFC T3 | Mixer is 13.3% faster | DEFC is approximately 1.79–1.84× faster |
| Reworked 9× Mixer, 700 s, DEFC T3 | Mixer is 2.92× faster | 64 A Mixer is approximately 2.80–2.88× faster |
| Reworked 9× Mixer, 2,100 s, DEFC T3 | DEFC is 2.9% faster | DEFC is approximately 4–7% faster |
| Reworked 9× Mixer, 2,100 s, DEFC T2 | DEFC is 2.06× faster | DEFC is approximately 2.14–2.41× faster |

The 2,100-second Mixer recipe with the existing T3 DEFC requirement produces the closest balance between the machines, but that's not the intended goal. The investment required to make the DEFC must give it a notable advantage, thus the reason for the proposed buff of the recipe to T2 casings. 

---

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
