### PR TITLE
Fix laser mirror race condition

### DIFF
--- a/src/main/java/tectech/thing/metaTileEntity/pipe/MTEPipeLaserMirror.java
+++ b/src/main/java/tectech/thing/metaTileEntity/pipe/MTEPipeLaserMirror.java
@@ -140,6 +140,12 @@ public class MTEPipeLaserMirror extends MTEPipeLaser {
 
         ForgeDirection a = connectedSides[0];
         ForgeDirection b = connectedSides[1];
+
+        // Race condition of updateNetwork() and onPostTick()
+        if (a == null || b == null) {
+            return null;
+        }
+
         if (dir == a) {
             chainedFrontFacing = b.getOpposite();
             return b;


### PR DESCRIPTION
## Summary
Fix an issue where Laser Vacuum Mirror is trying to retrieve connection from a null side
See https://discord.com/channels/181078474394566657/522098956491030558/1532962298061389976

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
