### PR TITLE
Drop trailing format codes left by format stack pops

### DIFF
--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -652,6 +652,12 @@ public class GTUtility {
             }
         }
 
+        // A format code at the very end has nothing left to format, so a pop that lands there only emits noise.
+        // Drop it, otherwise consumers that match whole lines (tooltip separators, for one) never see a clean line.
+        while (out.length() >= 2 && out.charAt(out.length() - 2) == FORMAT_ESCAPE) {
+            out.setLength(out.length() - 2);
+        }
+
         return out.toString();
     }
 

--- a/src/test/java/gregtech/api/util/GTUtilityTest.java
+++ b/src/test/java/gregtech/api/util/GTUtilityTest.java
@@ -185,4 +185,17 @@ public class GTUtilityTest {
         assertEquals(1L, GTUtility.getAmperageForTier(TierEU.UIV, (byte) VoltageIndex.UIV));
         assertEquals(274877906944L, GTUtility.getAmperageForTier(Long.MAX_VALUE, (byte) VoltageIndex.UIV));
     }
+
+    @Test
+    public void testProcessFormatStacks() {
+        // The example from the processFormatStacks javadoc
+        assertEquals("§a§lHello §eWorld§a§l!", GTUtility.processFormatStacks("§a§lHello §s§eWorld§t!"));
+
+        // A pop at the very end has nothing left to format and must not be emitted
+        assertEquals("§7§m---", GTUtility.processFormatStacks("§7§s§m---§t"));
+        assertEquals("§7§8§m---", GTUtility.processFormatStacks("§7§s§8§s§m---§t§t"));
+
+        // Text is untouched, and so are format codes that still have something after them
+        assertEquals("§7Liquid §aXP§7 per operation", GTUtility.processFormatStacks("§7Liquid §s§aXP§t per operation"));
+    }
 }


### PR DESCRIPTION
## Summary

When processFormatStacks pops the format stack at the very end of a line, it re-emits the restored format where there is nothing left to format. The codes are invisible, but they make the line unrecognisable to anything that matches whole lines.

Concretely, this is why markdown tooltip separators never turn into ChromaticTooltips dividers while the Java addSeparator() ones do: {gray:{hr}} ends up as §7§7§m----§7§7 instead of §7§7§m----. Affects every markdown tooltip, BEC included.

## Checklist
- [X] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge