### PR TITLE
Fix spinmatron auto rotation

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTESpinmatron.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTESpinmatron.java
@@ -39,6 +39,7 @@ import org.jetbrains.annotations.NotNull;
 
 import com.cleanroommc.modularui.utils.item.LimitingItemStackHandler;
 import com.gtnewhorizon.structurelib.alignment.constructable.ISurvivalConstructable;
+import com.gtnewhorizon.structurelib.alignment.enumerable.ExtendedFacing;
 import com.gtnewhorizon.structurelib.structure.IStructureDefinition;
 import com.gtnewhorizon.structurelib.structure.ISurvivalBuildEnvironment;
 import com.gtnewhorizon.structurelib.structure.StructureDefinition;
@@ -296,7 +297,7 @@ public class MTESpinmatron extends MTEExtendedPowerMultiBlockBase<MTESpinmatron>
         for (int i = 0; i < turbineRotorHatchList.size(); i++) {
             if (turbineRotorHatchList.get(i) == null) continue;
             MTEHatchTurbine turbine = turbineRotorHatchList.get(i);
-            ForgeDirection direction = this.getDirection();
+            ExtendedFacing direction = getExtendedFacing();
             IGregTechTileEntity te = turbine.getBaseMetaTileEntity();
             // 0, 1 = front top, front bottom
             // 2, 4 = left top, left bottom
@@ -304,16 +305,16 @@ public class MTESpinmatron extends MTEExtendedPowerMultiBlockBase<MTESpinmatron>
             // 6, 7 = back top, back bottom (all in theory)
             switch (i) {
                 case 0, 1 -> {
-                    te.setFrontFacing(direction);
+                    te.setFrontFacing(direction.getRelativeForwardInWorld());
                 }
                 case 2, 4 -> {
-                    te.setFrontFacing(direction.getRotation(ForgeDirection.EAST));
+                    te.setFrontFacing(direction.getRelativeRightInWorld());
                 }
                 case 3, 5 -> {
-                    te.setFrontFacing(direction.getRotation(ForgeDirection.WEST));
+                    te.setFrontFacing(direction.getRelativeLeftInWorld());
                 }
                 case 6, 7 -> {
-                    te.setFrontFacing(direction.getOpposite());
+                    te.setFrontFacing(direction.getRelativeBackInWorld());
                 }
             }
         }


### PR DESCRIPTION
## Summary
The original calculation is completely wrong for the left and right side. This fixes it now using ExtendedFacing which also respect flip and rotation of the multiblock controller itself.


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
