### PR TITLE
Trigger structure check from main structure

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/MTENanochipAssemblyComplex.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/MTENanochipAssemblyComplex.java
@@ -312,7 +312,8 @@ public class MTENanochipAssemblyComplex extends MTEExtendedPowerMultiBlockBase<M
         IMetaTileEntity aMetaTileEntity = aTileEntity.getMetaTileEntity();
         if (aMetaTileEntity instanceof MTENanochipAssemblyModuleBase<?>module) {
             module.connect(this);
-            // whenever main structure check happens, trigger module structure check immediately.
+            // immediate recheck to prevent module from using outdated hatch during recipe check
+            // delay is already done by the main structure, this does not cause immediate recheck.
             module.checkStructure(true, aTileEntity);
             return modules.add(module);
         }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/MTENanochipAssemblyComplex.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/MTENanochipAssemblyComplex.java
@@ -312,6 +312,8 @@ public class MTENanochipAssemblyComplex extends MTEExtendedPowerMultiBlockBase<M
         IMetaTileEntity aMetaTileEntity = aTileEntity.getMetaTileEntity();
         if (aMetaTileEntity instanceof MTENanochipAssemblyModuleBase<?>module) {
             module.connect(this);
+            // whenever main structure check happens, trigger module structure check immediately.
+            module.checkStructure(true, aTileEntity);
             return modules.add(module);
         }
         return false;


### PR DESCRIPTION
## Summary
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25592

If the module is disconnected, `onPostTick` will never be run. As a result, the module check is delayed by 50 ticks. This can cause issue when the structure just wake up from the main structure forming and try to start a recipe with old hatches if mStartupCheck is already passed.


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
