### PR TITLE
Fix computation tooltip

### DIFF
--- a/src/main/java/gregtech/common/gui/modularui/multiblock/base/MTEMultiBlockBaseGui.java
+++ b/src/main/java/gregtech/common/gui/modularui/multiblock/base/MTEMultiBlockBaseGui.java
@@ -139,7 +139,7 @@ public class MTEMultiBlockBaseGui<T extends MTEMultiBlockBase> {
             EnumChatFormatting.DARK_RED + StatCollector.translateToLocal("GT5U.gui.hoverable.manualshutdown"));
         this.shutdownReasonTooltipMap.put(
             "computation_loss",
-            EnumChatFormatting.DARK_RED + StatCollector.translateToLocal("GT5U.gui.text.computation_loss"));
+            EnumChatFormatting.DARK_RED + StatCollector.translateToLocal("GT5U.gui.hoverable.computation_loss"));
     }
 
     public ModularPanel build(PosGuiData guiData, PanelSyncManager syncManager, UISettings uiSettings) {

--- a/src/main/resources/assets/gregtech/lang/en_US.lang
+++ b/src/main/resources/assets/gregtech/lang/en_US.lang
@@ -3220,7 +3220,7 @@ GT5U.gui.hoverable.incomplete=Structure incomplete.
 GT5U.gui.hoverable.powerloss=Lost Power.
 GT5U.gui.hoverable.norepair=Machine too damaged.
 GT5U.gui.hoverable.manualshutdown=Manual shutdown (get it?).
-GT5U.gui.hoverable.computation_loss=Lost computation.
+GT5U.gui.hoverable.computation_loss=Out of computation.
 GT5U.gui.hoverable.error=ERROR! REPORT ME!
 
 GT5U.gui.config.client=Client

--- a/src/main/resources/assets/gregtech/lang/en_US.lang
+++ b/src/main/resources/assets/gregtech/lang/en_US.lang
@@ -3220,6 +3220,7 @@ GT5U.gui.hoverable.incomplete=Structure incomplete.
 GT5U.gui.hoverable.powerloss=Lost Power.
 GT5U.gui.hoverable.norepair=Machine too damaged.
 GT5U.gui.hoverable.manualshutdown=Manual shutdown (get it?).
+GT5U.gui.hoverable.computation_loss=Lost computation.
 GT5U.gui.hoverable.error=ERROR! REPORT ME!
 
 GT5U.gui.config.client=Client


### PR DESCRIPTION
## Summary
Adds a tooltip for the computation_loss icon

- old key was not existent. Added new one, with corresponding naming.


Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/26182

## Checklist
- [X] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
