### PR TITLE
fix client world leaks in NAC and BEC

### DIFF
--- a/src/main/java/gregtech/common/GTClient.java
+++ b/src/main/java/gregtech/common/GTClient.java
@@ -132,6 +132,7 @@ import gregtech.common.render.items.MechanicalArmorRenderer;
 import gregtech.common.render.items.MetaGeneratedItemRenderer;
 import gregtech.common.render.items.ToolboxRenderer;
 import gregtech.common.tileentities.debug.MTEDebugStructureWriter;
+import gregtech.common.tileentities.machines.multi.nanochip.factory.VacuumFactoryGrid;
 import gregtech.common.tileentities.render.RenderingTileEntityBlackhole;
 import gregtech.common.tileentities.render.RenderingTileEntityLaser;
 import gregtech.common.tileentities.render.RenderingTileEntityNanoForge;
@@ -145,6 +146,7 @@ import gtPlusPlus.xmod.gregtech.api.enums.GregtechItemList;
 import mcp.mobius.waila.api.impl.ModuleRegistrar;
 import paulscode.sound.SoundSystemConfig;
 import paulscode.sound.SoundSystemException;
+import tectech.mechanics.boseEinsteinCondensate.BECFactoryGrid;
 
 public class GTClient extends GTProxy {
 
@@ -618,6 +620,12 @@ public class GTClient extends GTProxy {
     public void onWorldUnload(WorldEvent.Unload event) {
         super.onWorldUnload(event);
         RenderOverlay.onWorldUnload(event.world);
+    }
+
+    @SubscribeEvent
+    public void onClientDisconnect(FMLNetworkEvent.ClientDisconnectionFromServerEvent event){
+        VacuumFactoryGrid.clearAll();
+        BECFactoryGrid.clearAll();
     }
 
     @SubscribeEvent

--- a/src/main/java/gregtech/common/GTClient.java
+++ b/src/main/java/gregtech/common/GTClient.java
@@ -623,7 +623,7 @@ public class GTClient extends GTProxy {
     }
 
     @SubscribeEvent
-    public void onClientDisconnect(FMLNetworkEvent.ClientDisconnectionFromServerEvent event){
+    public void onClientDisconnect(FMLNetworkEvent.ClientDisconnectionFromServerEvent event) {
         VacuumFactoryGrid.clearAll();
         BECFactoryGrid.clearAll();
     }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/factory/VacuumFactoryGrid.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/factory/VacuumFactoryGrid.java
@@ -25,7 +25,10 @@ public class VacuumFactoryGrid
         }
 
         // Make sure everything is unloaded, even if something didn't remove itself properly
+        clearAll();
+    }
 
+    public static void clearAll() {
         INSTANCE.networks.forEach(network -> {
             network.elements.forEach(element -> { element.setNetwork(null); });
 

--- a/src/main/java/tectech/mechanics/boseEinsteinCondensate/BECFactoryGrid.java
+++ b/src/main/java/tectech/mechanics/boseEinsteinCondensate/BECFactoryGrid.java
@@ -24,7 +24,11 @@ public class BECFactoryGrid extends StandardFactoryGrid<BECFactoryGrid, BECFacto
         }
 
         // Make sure everything is unloaded, even if something didn't remove itself properly
+        clearAll();
+    }
 
+
+    public static void clearAll() {
         INSTANCE.networks.forEach(network -> {
             network.elements.forEach(element -> { element.setNetwork(null); });
 

--- a/src/main/java/tectech/mechanics/boseEinsteinCondensate/BECFactoryGrid.java
+++ b/src/main/java/tectech/mechanics/boseEinsteinCondensate/BECFactoryGrid.java
@@ -27,7 +27,6 @@ public class BECFactoryGrid extends StandardFactoryGrid<BECFactoryGrid, BECFacto
         clearAll();
     }
 
-
     public static void clearAll() {
         INSTANCE.networks.forEach(network -> {
             network.elements.forEach(element -> { element.setNetwork(null); });


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
NAC was trying to avoid client world leaks but did so slightly incorrectly because the unloading was done in a server sided event only, which was working only in SP because the jvm has both sides. Made it so it also unloads correctly when a client disconnect from a dedicated server. BEC also had that flaw, so i fixed both.

Tested for the NAC in daily 658, it works.

## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
