### PR TITLE
Fix CRIB proxy AIOOBE

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEHatchInputBus.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEHatchInputBus.java
@@ -160,7 +160,10 @@ public class MTEHatchInputBus extends MTEHatch implements IConfigurationCircuitS
     }
 
     protected void fillStacksIntoFirstSlots() {
-        GTUtility.compactInventory(Arrays.asList(mInventory), 0, mInventory.length - 1);
+        // Don't compact busses with fewer than 2 slots since there's no point
+        if (mInventory.length > 1) {
+            GTUtility.compactInventory(Arrays.asList(mInventory), 0, mInventory.length - 1);
+        }
     }
 
     @Override


### PR DESCRIPTION
## Summary
It seems like some unpaired CRIB proxies can cause ArrayIndexOutOfBoundsExceptions each tick, because the compacting code is getting called with a zero-sized mInventory array. This PR changes it to only compact busses with 2 or more slots, since there's no point for slotless or single-slot busses.

Normally this code isn't hit, since CRIB proxies only tick when unpaired.

```
[12:57:43] [Server thread/ERROR] [GregTech GTNH]: Error ticking meta tile entity 2716 at (-29, 81, -40) in world 217
java.lang.IllegalArgumentException: fromIndex(0) > toIndex(-1)
	at java.base/java.util.AbstractList.subListRangeCheck(AbstractList.java:511) ~[?:?]
	at java.base/java.util.AbstractList.subList(AbstractList.java:499) ~[?:?]
	at Launch//gregtech.api.util.GTUtility.compactInventory(GTUtility.java:755) ~[GTUtility.class:?]
	at Launch//gregtech.api.metatileentity.implementations.MTEHatchInputBus.fillStacksIntoFirstSlots(MTEHatchInputBus.java:163) ~[MTEHatchInputBus.class:?]
	at Launch//gregtech.api.metatileentity.implementations.MTEHatchInputBus.updateSlots(MTEHatchInputBus.java:159) ~[MTEHatchInputBus.class:?]
	at Launch//gregtech.api.metatileentity.implementations.MTEHatchInputBus.onPostTick(MTEHatchInputBus.java:152) ~[MTEHatchInputBus.class:?]
	at Launch//gregtech.common.tileentities.machines.MTEHatchCraftingInputSlave.onPostTick(MTEHatchCraftingInputSlave.java:86) ~[MTEHatchCraftingInputSlave.class:?]
	at Launch//gregtech.api.metatileentity.BaseMetaTileEntity.doPostTick(BaseMetaTileEntity.java:368) ~[BaseMetaTileEntity.class:?]
	at Launch//gregtech.api.metatileentity.BaseMetaTileEntity.updateEntityProfiled(BaseMetaTileEntity.java:327) ~[BaseMetaTileEntity.class:?]
	at Launch//gregtech.api.metatileentity.CommonBaseMetaTileEntity.func_145845_h(CommonBaseMetaTileEntity.java:153) [CommonBaseMetaTileEntity.class:?]
	at Launch//net.minecraft.world.World.func_72939_s(World.java:1939) [ahb.class:?]
	at Launch//net.minecraft.world.WorldServer.func_72939_s(WorldServer.java:489) [mt.class:?]
	at Launch//net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:636) [MinecraftServer.class:?]
	at Launch//net.minecraft.server.dedicated.DedicatedServer.func_71190_q(DedicatedServer.java:334) [lt.class:?]
	at Launch//net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:547) [MinecraftServer.class:?]
	at Launch//net.minecraft.server.MinecraftServer.run(MinecraftServer.java:427) [MinecraftServer.class:?]
	at Launch//net.minecraft.server.MinecraftServer$2.run(MinecraftServer.java:685) [li.class:?]
```

https://discord.com/channels/181078474394566657/522098956491030558/1534273327227732201

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
