### PR TITLE
fix 2 slots of shijima screws in BEC casing

### DIFF
--- a/src/main/java/tectech/loader/recipe/ResearchStationAssemblyLine.java
+++ b/src/main/java/tectech/loader/recipe/ResearchStationAssemblyLine.java
@@ -2322,7 +2322,7 @@ public class ResearchStationAssemblyLine implements Runnable {
                 GTModHandler.getModItem(Railcraft.ID, "machine.eta", 6, 8),
                 GTOreDictUnificator.get(OrePrefixes.ring, Materials.ProtoHalkonite, 12),
                 GTOreDictUnificator.get(OrePrefixes.gearGtSmall, Materials.Churitsu, 6),
-                GTOreDictUnificator.get(OrePrefixes.screw, Materials.Shijima, 48), ItemList.Sensor_UIV.get(2),
+                GTOreDictUnificator.get(OrePrefixes.bolt, Materials.Shijima, 48), ItemList.Sensor_UIV.get(2),
                 ItemList.Emitter_UIV.get(2) },
             new FluidStack[] { CHRONOMATIC_GLASS.getFluidStack(384 * INGOTS), Materials.Infinity.getMolten(48 * INGOTS),
                 MaterialsElements.STANDALONE.CELESTIAL_TUNGSTEN.getFluidStack(48 * INGOTS),


### PR DESCRIPTION
## Summary
Fix situation as the pic showed by changing the second slot of shijima screw to bolt
<img width="684" height="673" alt="image" src="https://github.com/user-attachments/assets/f67b38d8-4224-4570-a5f7-1d382e958d53" />
<img width="82" height="163" alt="image" src="https://github.com/user-attachments/assets/d8ee3830-5f38-4219-a056-795a5ed1cf69" />


## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
