### PR TITLE
[BEC] Clamp assembler nanites to 2048 * 15

### DIFF
--- a/src/main/java/tectech/thing/metaTileEntity/multi/bec/MTEBECAssembler.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/bec/MTEBECAssembler.java
@@ -23,6 +23,8 @@ import net.minecraftforge.fluids.Fluid;
 
 import org.jetbrains.annotations.NotNull;
 
+import com.google.common.collect.ImmutableMap;
+import com.gtnewhorizon.gtnhlib.util.numberformatting.NumberFormatUtil;
 import com.gtnewhorizon.structurelib.structure.IStructureDefinition;
 
 import appeng.api.storage.data.IAEFluidStack;
@@ -55,6 +57,8 @@ import tectech.thing.metaTileEntity.multi.structures.BECStructureDefinitions;
 
 @IMetaTileEntity.SkipGenerateDescription
 public class MTEBECAssembler extends MTEBECMultiblockBase<MTEBECAssembler> {
+
+    public static final int MAX_NANITES = 2048 * 15;
 
     private final List<MTEHatchLoS> losHatches = new ArrayList<>();
 
@@ -140,7 +144,9 @@ public class MTEBECAssembler extends MTEBECMultiblockBase<MTEBECAssembler> {
         StructureWrapperTooltipBuilder<MTEBECAssembler> tt = new StructureWrapperTooltipBuilder<>(structure);
 
         tt.addMachineType("BEC Assembler, Observation Array")
-            .addMarkdown(new ResourceLocation(Mods.ModIDs.GREG_TECH, "bec-assembler"))
+            .addMarkdown(
+                new ResourceLocation(Mods.ModIDs.GREG_TECH, "bec-assembler"),
+                ImmutableMap.of("max-nanites", NumberFormatUtil.formatNumber(MAX_NANITES)))
             .addSupportAny();
 
         tt.beginStructureBlock(61, 31, 31, true)
@@ -253,6 +259,8 @@ public class MTEBECAssembler extends MTEBECMultiblockBase<MTEBECAssembler> {
 
                 igte.setActive(!nodes.isEmpty());
             }
+
+            this.availableNanites = Math.min(MAX_NANITES, this.availableNanites);
 
             lEUt = 0;
 

--- a/src/main/resources/assets/gregtech/lang/en_US/tooltip/bec-assembler.md
+++ b/src/main/resources/assets/gregtech/lang/en_US/tooltip/bec-assembler.md
@@ -1,6 +1,7 @@
 Supplies nanites, power, and condensate to {gold:{item:gregtech:gt.blockmachines:15757}s}.
 Nanites must be stored in a {gold:{item:gregtech:gt.blockmachines:9415}}.
 Different types of nanites can be mixed, but the effective tier will be the {underline:lowest} of all provided nanites.
+Only {gold:{var:max-nanites}} nanites can be provided at once - any additional nanites will be ignored.
 {dark_gray:{hr}}
 {gold:{item:gregtech:gt.blockmachines:15757}s} will stall if they request more power than the observation array can provide.
 A recipe's condensate can be supplied at any time during its crafting.


### PR DESCRIPTION
## Summary
This limit was previously implicit, but with the addition of a bigger nanite hatch we need to make it explicit. This PR just clamps the nanite count to the max amount artificially, allowing higher amounts (although they will be ignored).

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
