### PR TITLE
Make item slots on fluid tank to be the same slot group

### DIFF
--- a/src/main/java/gregtech/common/gui/modularui/singleblock/base/MTEMachineWithFluidScreenBaseGui.java
+++ b/src/main/java/gregtech/common/gui/modularui/singleblock/base/MTEMachineWithFluidScreenBaseGui.java
@@ -38,6 +38,12 @@ public class MTEMachineWithFluidScreenBaseGui<T extends MTETieredMachineBlock> e
         super(machine);
     }
 
+    @Override
+    protected void registerSyncValues(PanelSyncManager syncManager) {
+        super.registerSyncValues(syncManager);
+        syncManager.registerSlotGroup("fluid_inv", 1);
+    }
+
     protected boolean supportsFluidScreen() {
         return true;
     }
@@ -108,12 +114,14 @@ public class MTEMachineWithFluidScreenBaseGui<T extends MTETieredMachineBlock> e
     }
 
     protected ItemSlot createInputSlot(ModularPanel panel, PanelSyncManager syncManager, int inputSlot) {
-        return new ItemSlot().slot(new ModularSlot(machine.inventoryHandler, inputSlot).singletonSlotGroup())
+        return new ItemSlot().slot(new ModularSlot(machine.inventoryHandler, inputSlot).slotGroup("fluid_inv"))
             .backgroundOverlay(GTGuiTextures.OVERLAY_SLOT_IN_STANDARD);
     }
 
     protected ItemSlot createOutputSlot(ModularPanel panel, PanelSyncManager syncManager, int outputSlot) {
-        return new ItemSlot().slot(new ModularSlot(machine.inventoryHandler, outputSlot).canPut(false))
+        return new ItemSlot().slot(
+            new ModularSlot(machine.inventoryHandler, outputSlot).slotGroup("fluid_inv")
+                .canPut(false))
             .backgroundOverlay(GTGuiTextures.OVERLAY_SLOT_OUT_STANDARD);
     }
 


### PR DESCRIPTION
## Summary
Similar to https://github.com/GTNewHorizons/GT5-Unofficial/pull/7693. `singletonSlotGroup` shouldn't be used on a GUI that both has input and output solts.


## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
