### PR TITLE
Add wooden sword and spike assembler recipes

### DIFF
--- a/src/main/java/gregtech/loaders/postload/recipes/AssemblerRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/AssemblerRecipes.java
@@ -3421,7 +3421,7 @@ public class AssemblerRecipes implements Runnable {
             .itemOutputs(new ItemStack(Items.wooden_sword))
             .circuit(17)
             .duration(30 * SECONDS)
-            .eut(7)
+            .eut(TierEU.RECIPE_LV / 4)
             .addTo(assemblerRecipes);
     }
 

--- a/src/main/java/gregtech/loaders/postload/recipes/AssemblerRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/AssemblerRecipes.java
@@ -3421,7 +3421,7 @@ public class AssemblerRecipes implements Runnable {
             .itemOutputs(new ItemStack(Items.wooden_sword))
             .circuit(17)
             .duration(30 * SECONDS)
-            .eut(TierEU.RECIPE_LV)
+            .eut(7)
             .addTo(assemblerRecipes);
     }
 

--- a/src/main/java/gregtech/loaders/postload/recipes/AssemblerRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/AssemblerRecipes.java
@@ -3414,6 +3414,15 @@ public class AssemblerRecipes implements Runnable {
             .duration(4 * SECONDS)
             .eut(TierEU.RECIPE_MV)
             .addTo(assemblerRecipes);
+        GTValues.RA.stdBuilder()
+            .itemInputs(
+                new OreDictItemStack("plankWood", 2),
+                GTOreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1))
+            .itemOutputs(new ItemStack(Items.wooden_sword))
+            .circuit(2)
+            .duration(4 * SECONDS)
+            .eut(TierEU.RECIPE_MV)
+            .addTo(assemblerRecipes);
     }
 
     /**
@@ -3962,6 +3971,17 @@ public class AssemblerRecipes implements Runnable {
                     GTOreDictUnificator.get(OrePrefixes.screw, Materials.Iron, 2),
                     new ItemStack(Items.iron_sword, 1))
                 .itemOutputs(getModItem(ExtraUtilities.ID, "spike_base", 2L, 0))
+                .duration(5 * SECONDS)
+                .eut(TierEU.RECIPE_LV)
+                .addTo(assemblerRecipes);
+
+            GTValues.RA.stdBuilder()
+                .itemInputs(
+                    new OreDictItemStack("logWood", 1),
+                    GTOreDictUnificator.get(OrePrefixes.plate, Materials.Wood, 3),
+                    GTOreDictUnificator.get(OrePrefixes.screw, Materials.Wood, 2),
+                    new ItemStack(Items.wooden_sword, 1))
+                .itemOutputs(getModItem(ExtraUtilities.ID, "spike_base_wood", 2L, 0))
                 .duration(5 * SECONDS)
                 .eut(TierEU.RECIPE_LV)
                 .addTo(assemblerRecipes);

--- a/src/main/java/gregtech/loaders/postload/recipes/AssemblerRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/AssemblerRecipes.java
@@ -3389,8 +3389,8 @@ public class AssemblerRecipes implements Runnable {
 
         GTValues.RA.stdBuilder()
             .itemInputs(
-                GTOreDictUnificator.get(OrePrefixes.plate, Materials.Diamond, 2),
-                GTOreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1))
+                GTOreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1),
+                GTOreDictUnificator.get(OrePrefixes.plate, Materials.Diamond, 2))
             .itemOutputs(new ItemStack(Items.diamond_sword))
             .circuit(17)
             .duration(4 * SECONDS)
@@ -3398,8 +3398,8 @@ public class AssemblerRecipes implements Runnable {
             .addTo(assemblerRecipes);
         GTValues.RA.stdBuilder()
             .itemInputs(
-                GTOreDictUnificator.get(OrePrefixes.plate, Materials.Gold, 2),
-                GTOreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1))
+                GTOreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1),
+                GTOreDictUnificator.get(OrePrefixes.plate, Materials.Gold, 2))
             .itemOutputs(new ItemStack(Items.golden_sword))
             .circuit(17)
             .duration(4 * SECONDS)
@@ -3407,8 +3407,8 @@ public class AssemblerRecipes implements Runnable {
             .addTo(assemblerRecipes);
         GTValues.RA.stdBuilder()
             .itemInputs(
-                GTOreDictUnificator.get(OrePrefixes.plate, Materials.Iron, 2),
-                GTOreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1))
+                GTOreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1),
+                GTOreDictUnificator.get(OrePrefixes.plate, Materials.Iron, 2))
             .itemOutputs(new ItemStack(Items.iron_sword))
             .circuit(17)
             .duration(4 * SECONDS)
@@ -3416,12 +3416,12 @@ public class AssemblerRecipes implements Runnable {
             .addTo(assemblerRecipes);
         GTValues.RA.stdBuilder()
             .itemInputs(
-                new OreDictItemStack("plankWood", 2),
-                GTOreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1))
+                GTOreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1),
+                new OreDictItemStack("plankWood", 2))
             .itemOutputs(new ItemStack(Items.wooden_sword))
             .circuit(17)
-            .duration(4 * SECONDS)
-            .eut(TierEU.RECIPE_MV)
+            .duration(30 * SECONDS)
+            .eut(TierEU.RECIPE_LV)
             .addTo(assemblerRecipes);
     }
 

--- a/src/main/java/gregtech/loaders/postload/recipes/AssemblerRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/AssemblerRecipes.java
@@ -3392,7 +3392,7 @@ public class AssemblerRecipes implements Runnable {
                 GTOreDictUnificator.get(OrePrefixes.plate, Materials.Diamond, 2),
                 GTOreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1))
             .itemOutputs(new ItemStack(Items.diamond_sword))
-            .circuit(2)
+            .circuit(17)
             .duration(4 * SECONDS)
             .eut(TierEU.RECIPE_MV)
             .addTo(assemblerRecipes);
@@ -3401,7 +3401,7 @@ public class AssemblerRecipes implements Runnable {
                 GTOreDictUnificator.get(OrePrefixes.plate, Materials.Gold, 2),
                 GTOreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1))
             .itemOutputs(new ItemStack(Items.golden_sword))
-            .circuit(2)
+            .circuit(17)
             .duration(4 * SECONDS)
             .eut(TierEU.RECIPE_MV)
             .addTo(assemblerRecipes);
@@ -3410,7 +3410,7 @@ public class AssemblerRecipes implements Runnable {
                 GTOreDictUnificator.get(OrePrefixes.plate, Materials.Iron, 2),
                 GTOreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1))
             .itemOutputs(new ItemStack(Items.iron_sword))
-            .circuit(2)
+            .circuit(17)
             .duration(4 * SECONDS)
             .eut(TierEU.RECIPE_MV)
             .addTo(assemblerRecipes);
@@ -3419,7 +3419,7 @@ public class AssemblerRecipes implements Runnable {
                 new OreDictItemStack("plankWood", 2),
                 GTOreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1))
             .itemOutputs(new ItemStack(Items.wooden_sword))
-            .circuit(2)
+            .circuit(17)
             .duration(4 * SECONDS)
             .eut(TierEU.RECIPE_MV)
             .addTo(assemblerRecipes);


### PR DESCRIPTION
## Summary
This PR adds the assembler recipes to the wooden sword and the wooden spike. Additionally, I moved the metal sword recipes to circuit 17 and rearranged the inputs to match the existing recipe for the stone sword.

<img width="337" height="237" alt="image" src="https://github.com/user-attachments/assets/c99ab2ea-48b1-4703-87f4-65d0fb47831e" />
<img width="237" height="233" alt="image" src="https://github.com/user-attachments/assets/55bd6cfb-6e46-48e9-8770-5758595b9a32" />
<img width="238" height="232" alt="image" src="https://github.com/user-attachments/assets/d0d69c3e-fa43-40ea-81b8-86881fc2df98" />
<img width="247" height="237" alt="image" src="https://github.com/user-attachments/assets/652d9bd6-9183-46a5-9be6-226d8aa21355" />
<img width="255" height="245" alt="image" src="https://github.com/user-attachments/assets/abf56fc0-e1c9-44eb-bea4-ecf8ec88a459" />
<img width="246" height="238" alt="image" src="https://github.com/user-attachments/assets/88ee9f39-8669-4194-b2e8-1606530b07d1" />



## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [x] This PR requires another PR in order to merge (https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1893)