### PR TITLE
Fix Miniature Wormhole Generator transfer interval

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEWormholeGenerator.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEWormholeGenerator.java
@@ -517,7 +517,7 @@ public class MTEWormholeGenerator extends MTEEnhancedMultiBlockBase<MTEWormholeG
     protected void runMachine(IGregTechTileEntity aBaseMetaTileEntity, long aTick) {
         checkFrequency();
 
-        mMaxProgresstime = 20;
+        mMaxProgresstime = 1;
         mEfficiency = Math.max(0, getMaxEfficiency(mInventory[1]) - ((getIdealStatus() - getRepairStatus()) * 1000));
 
         if (doRandomMaintenanceDamage()) {


### PR DESCRIPTION
The Miniature Wormhole Generator transferred energy only once every 20 ticks, while its energy hatches can store approximately four ticks of power. This limited continuous power transfer to about 20% of the configured amperage.

Processing the transfer every tick allows the hatches to continuously receive and output energy instead of remaining full or empty between one-second transfer cycles.

Fixes GTNewHorizons/GT-New-Horizons-Modpack#26231

## Checklist

- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
