### PR TITLE
Call the cover's onBaseTEDestroyed when breaking a BlockFrameBox

### DIFF
--- a/src/main/java/gregtech/common/blocks/BlockFrameBox.java
+++ b/src/main/java/gregtech/common/blocks/BlockFrameBox.java
@@ -39,7 +39,6 @@ import gregtech.api.metatileentity.BaseTileEntity;
 import gregtech.api.metatileentity.CoverableTileEntity;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GTLanguageManager;
-import gregtech.common.covers.Cover;
 import gregtech.common.render.GTRendererBlock;
 
 public class BlockFrameBox extends BlockContainer implements IBlockWithTextures {
@@ -414,7 +413,7 @@ public class BlockFrameBox extends BlockContainer implements IBlockWithTextures 
         // If there is one, grab all attached covers and drop them
         if (tempTe != null) {
             for (ForgeDirection side : ForgeDirection.VALID_DIRECTIONS) {
-                if(tempTe.hasCoverAtSide(side)) tempTe.dropCover(side, side);
+                if (tempTe.hasCoverAtSide(side)) tempTe.dropCover(side, side);
             }
         }
         // Make sure to clear the temporary TE

--- a/src/main/java/gregtech/common/blocks/BlockFrameBox.java
+++ b/src/main/java/gregtech/common/blocks/BlockFrameBox.java
@@ -413,12 +413,8 @@ public class BlockFrameBox extends BlockContainer implements IBlockWithTextures 
         drops.add(getStackForm(1, metadata & MATERIAL_MASK));
         // If there is one, grab all attached covers and drop them
         if (tempTe != null) {
-            for (ForgeDirection direction : ForgeDirection.VALID_DIRECTIONS) {
-                ItemStack coverItem = tempTe.getCoverItemAtSide(direction);
-                Cover cover = tempTe.getCoverAtSide(direction);
-
-                if (coverItem != null) drops.add(coverItem);
-                if (cover.isValid()) cover.onBaseTEDestroyed();
+            for (ForgeDirection side : ForgeDirection.VALID_DIRECTIONS) {
+                if(tempTe.hasCoverAtSide(side)) tempTe.dropCover(side, side);
             }
         }
         // Make sure to clear the temporary TE

--- a/src/main/java/gregtech/common/blocks/BlockFrameBox.java
+++ b/src/main/java/gregtech/common/blocks/BlockFrameBox.java
@@ -39,6 +39,7 @@ import gregtech.api.metatileentity.BaseTileEntity;
 import gregtech.api.metatileentity.CoverableTileEntity;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GTLanguageManager;
+import gregtech.common.covers.Cover;
 import gregtech.common.render.GTRendererBlock;
 
 public class BlockFrameBox extends BlockContainer implements IBlockWithTextures {
@@ -413,8 +414,11 @@ public class BlockFrameBox extends BlockContainer implements IBlockWithTextures 
         // If there is one, grab all attached covers and drop them
         if (tempTe != null) {
             for (ForgeDirection direction : ForgeDirection.VALID_DIRECTIONS) {
-                ItemStack cover = tempTe.getCoverItemAtSide(direction);
-                if (cover != null) drops.add(cover);
+                ItemStack coverItem = tempTe.getCoverItemAtSide(direction);
+                Cover cover = tempTe.getCoverAtSide(direction);
+
+                if (coverItem != null) drops.add(coverItem);
+                if (cover.isValid()) cover.onBaseTEDestroyed();
             }
         }
         // Make sure to clear the temporary TE


### PR DESCRIPTION
## Summary
When breaking a frame box, it wouldn't call onBaseTEDestroyed of the cover that it was dropping, which meant that the data for the location and frequency of the (advanced) redstone transmitter cover would stay after the block and the cover were dropped

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/26236

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
