### PR TITLE
Fix crash re-opening godforge exoticizer inputs panel

### DIFF
--- a/src/main/java/gregtech/common/gui/modularui/multiblock/godforge/panel/ExoticInputsListPanel.java
+++ b/src/main/java/gregtech/common/gui/modularui/multiblock/godforge/panel/ExoticInputsListPanel.java
@@ -2,7 +2,6 @@ package gregtech.common.gui.modularui.multiblock.godforge.panel;
 
 import static gregtech.api.metatileentity.BaseTileEntity.TOOLTIP_DELAY;
 import static net.minecraft.util.StatCollector.translateToLocal;
-import static tectech.thing.metaTileEntity.multi.godforge.MTEExoticModule.NUMBER_OF_INPUTS;
 import static tectech.thing.metaTileEntity.multi.godforge.MTEExoticModule.RECIPE_REFRESH_LIMIT;
 
 import net.minecraft.util.EnumChatFormatting;
@@ -11,8 +10,8 @@ import com.cleanroommc.modularui.api.IPanelHandler;
 import com.cleanroommc.modularui.api.drawable.IKey;
 import com.cleanroommc.modularui.screen.ModularPanel;
 import com.cleanroommc.modularui.utils.Alignment;
+import com.cleanroommc.modularui.value.sync.FluidSlotSyncHandler;
 import com.cleanroommc.modularui.value.sync.LongSyncValue;
-import com.cleanroommc.modularui.value.sync.SyncHandlers;
 import com.cleanroommc.modularui.widgets.ButtonWidget;
 import com.cleanroommc.modularui.widgets.SlotGroupWidget;
 import com.cleanroommc.modularui.widgets.layout.Flow;
@@ -57,7 +56,7 @@ public class ExoticInputsListPanel {
         // Create fluid slots
 
         // Panel rows
-        column.child(createFirstRow().marginTop(3));
+        column.child(createFirstRow(hypervisor).marginTop(3));
         column.child(createSecondRow(hypervisor));
         panel.child(column);
 
@@ -69,19 +68,9 @@ public class ExoticInputsListPanel {
 
         SyncActions.REFRESH_EXOTIC_RECIPE
             .registerFor(Modules.EXOTIC, Panels.EXOTIC_INPUTS_LIST, hypervisor, hypervisor.getModule(Modules.EXOTIC));
-
-        for (int i = 0; i < NUMBER_OF_INPUTS; i++) {
-            hypervisor.getSyncManager(Modules.EXOTIC, Panels.EXOTIC_INPUTS_LIST)
-                .syncValue(
-                    "exotic_fluid_tanks",
-                    i,
-                    SyncHandlers.fluidSlot(hypervisor.getModule(Modules.EXOTIC).tankHandler.getFluidTank(i))
-                        .canDrainSlot(false)
-                        .canFillSlot(false));
-        }
     }
 
-    private static Flow createFirstRow() {
+    private static Flow createFirstRow(SyncHypervisor hypervisor) {
         Flow row = Flow.row()
             .size(72, 18);
 
@@ -89,7 +78,12 @@ public class ExoticInputsListPanel {
         row.child(
             SlotGroupWidget.builder()
                 .matrix("SSSS")
-                .key('S', index -> new FluidSlot().syncHandler("exotic_fluid_tanks", index))
+                .key(
+                    'S',
+                    index -> new FluidSlot().syncHandler(
+                        new FluidSlotSyncHandler(hypervisor.getModule(Modules.EXOTIC).fluidTanks[index])
+                            .canFillSlot(false)
+                            .canDrainSlot(false)))
                 .build());
 
         return row;
@@ -136,7 +130,12 @@ public class ExoticInputsListPanel {
         row.child(
             SlotGroupWidget.builder()
                 .matrix("SSS")
-                .key('S', index -> new FluidSlot().syncHandler("exotic_fluid_tanks", index + 4))
+                .key(
+                    'S',
+                    index -> new FluidSlot().syncHandler(
+                        new FluidSlotSyncHandler(hypervisor.getModule(Modules.EXOTIC).fluidTanks[index])
+                            .canFillSlot(false)
+                            .canDrainSlot(false)))
                 .build());
 
         // All possible inputs panel button

--- a/src/main/java/gregtech/common/gui/modularui/multiblock/godforge/panel/ExoticInputsListPanel.java
+++ b/src/main/java/gregtech/common/gui/modularui/multiblock/godforge/panel/ExoticInputsListPanel.java
@@ -133,7 +133,7 @@ public class ExoticInputsListPanel {
                 .key(
                     'S',
                     index -> new FluidSlot().syncHandler(
-                        new FluidSlotSyncHandler(hypervisor.getModule(Modules.EXOTIC).fluidTanks[index])
+                        new FluidSlotSyncHandler(hypervisor.getModule(Modules.EXOTIC).fluidTanks[index + 4])
                             .canFillSlot(false)
                             .canDrainSlot(false)))
                 .build());

--- a/src/main/java/tectech/thing/metaTileEntity/multi/godforge/MTEExoticModule.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/godforge/MTEExoticModule.java
@@ -33,8 +33,7 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import com.cleanroommc.modularui.utils.fluid.FluidTanksHandler;
-import com.cleanroommc.modularui.utils.fluid.IFluidTanksHandler;
+import com.cleanroommc.modularui.utils.fluid.FluidStackTank;
 
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.Materials;
@@ -74,15 +73,25 @@ public class MTEExoticModule extends MTEBaseModule {
     private FluidStack[] randomizedFluidInput = GTValues.emptyFluidStackArray;
     private ItemStack[] randomizedItemInput = GTValues.emptyItemStackArray;
     private GTRecipe plasmaRecipe = null;
-    public final IFluidTanksHandler tankHandler = new FluidTanksHandler(NUMBER_OF_INPUTS, 128000);
+    private final FluidStack[] fluidStacks = new FluidStack[NUMBER_OF_INPUTS];
+    public final FluidStackTank[] fluidTanks = new FluidStackTank[NUMBER_OF_INPUTS];
     private BigInteger powerForRecipe = BigInteger.ZERO;
 
     public MTEExoticModule(int aID, String aName, String aNameRegional) {
         super(aID, aName, aNameRegional);
+        initialize();
     }
 
     public MTEExoticModule(String aName) {
         super(aName);
+        initialize();
+    }
+
+    private void initialize() {
+        for (int i = 0; i < fluidTanks.length; i++) {
+            final int ii = i;
+            fluidTanks[i] = new FluidStackTank(() -> fluidStacks[ii], val -> fluidStacks[ii] = val, 128000);
+        }
     }
 
     @Override
@@ -259,15 +268,15 @@ public class MTEExoticModule extends MTEBaseModule {
 
         for (int i = 0; i < NUMBER_OF_INPUTS; i++) {
             if (plasmaRecipe == null) {
-                tankHandler.setFluidInTank(i, null, 0);
+                fluidStacks[i] = null;
                 continue;
             }
 
             if (i < plasmaRecipe.mFluidInputs.length) {
                 FluidStack plasma = plasmaRecipe.mFluidInputs[i];
-                tankHandler.setFluidInTank(i, plasma.getFluid(), plasma.amount);
+                fluidStacks[i] = new FluidStack(plasma.getFluid(), plasma.amount);
             } else {
-                tankHandler.setFluidInTank(i, null, 0);
+                fluidStacks[i] = null;
             }
         }
     }


### PR DESCRIPTION
## Summary
Fixes a crash when trying to re-open the godforge's exotic inputs list panel after closing it


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
