### PR TITLE
 Fix iApiary info tooltip not updating on upgrades change

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/basic/MTEIndustrialApiary.java
+++ b/src/main/java/gregtech/common/tileentities/machines/basic/MTEIndustrialApiary.java
@@ -1293,6 +1293,26 @@ public class MTEIndustrialApiary extends MTEBasicMachine
                         new FakeSyncWidget.ItemStackSyncer(() -> usedQueen, val -> usedQueen = val),
                         builder,
                         (widget, val) -> widget.notifyTooltipChange())
+                    .attachSyncer(
+                        new FakeSyncWidget.IntegerSyncer(() -> mSpeed, val -> {}),
+                        builder,
+                        (widget, val) -> widget.notifyTooltipChange())
+                    .attachSyncer(
+                        new FakeSyncWidget.ItemStackSyncer(() -> getStackInSlot(upgradeSlot), val -> {}),
+                        builder,
+                        (widget, val) -> widget.notifyTooltipChange())
+                    .attachSyncer(
+                        new FakeSyncWidget.ItemStackSyncer(() -> getStackInSlot(upgradeSlot + 1), val -> {}),
+                        builder,
+                        (widget, val) -> widget.notifyTooltipChange())
+                    .attachSyncer(
+                        new FakeSyncWidget.ItemStackSyncer(() -> getStackInSlot(upgradeSlot + 2), val -> {}),
+                        builder,
+                        (widget, val) -> widget.notifyTooltipChange())
+                    .attachSyncer(
+                        new FakeSyncWidget.ItemStackSyncer(() -> getStackInSlot(upgradeSlot + 3), val -> {}),
+                        builder,
+                        (widget, val) -> widget.notifyTooltipChange())
                     .setPos(163, 19)
                     .setSize(7, 18))
             .widget(new ButtonWidget().setOnClick((clickData, widget) -> {


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
Add syncers for speed toggle and each of the four upgrade slots so the tooltip refreshes

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25573

https://github.com/user-attachments/assets/eed5629f-07fa-462f-bae7-159e69319a37


## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
