### PR TITLE
Scanner formatting fixes

### DIFF
--- a/src/main/java/detrav/items/DetravMetaGeneratedTool01.java
+++ b/src/main/java/detrav/items/DetravMetaGeneratedTool01.java
@@ -1,5 +1,6 @@
 package detrav.items;
 
+import static com.gtnewhorizon.gtnhlib.util.numberformatting.NumberFormatUtil.formatNumber;
 import static detrav.enums.IDDetraveMetaGeneratedTool01.ElectricProspectorScannerLuV;
 import static detrav.enums.IDDetraveMetaGeneratedTool01.ElectricProspectorScannerUHV;
 import static detrav.enums.IDDetraveMetaGeneratedTool01.ElectricProspectorScannerUV;
@@ -48,7 +49,7 @@ public class DetravMetaGeneratedTool01 extends MetaGeneratedTool {
         INSTANCE = this;
         addTool(
             ProspectorScannerLV.ID,
-            "Prospector's Scanner(LV)",
+            "Prospector's Scanner (LV)",
             "",
             new DetravProspector(1),
             DetravToolDictNames.craftingToolProspector.toString(),
@@ -57,7 +58,7 @@ public class DetravMetaGeneratedTool01 extends MetaGeneratedTool {
             new TCAspects.TC_AspectStack(TCAspects.PERFODIO, 4L));
         addTool(
             ProspectorScannerMV.ID,
-            "Prospector's Scanner(MV)",
+            "Prospector's Scanner (MV)",
             "",
             new DetravProspector(2),
             DetravToolDictNames.craftingToolProspector.toString(),
@@ -66,7 +67,7 @@ public class DetravMetaGeneratedTool01 extends MetaGeneratedTool {
             new TCAspects.TC_AspectStack(TCAspects.PERFODIO, 4L));
         addTool(
             ProspectorScannerHV.ID,
-            "Prospector's Scanner(HV)",
+            "Prospector's Scanner (HV)",
             "",
             new DetravProspector(3),
             DetravToolDictNames.craftingToolProspector.toString(),
@@ -75,7 +76,7 @@ public class DetravMetaGeneratedTool01 extends MetaGeneratedTool {
             new TCAspects.TC_AspectStack(TCAspects.PERFODIO, 4L));
         addTool(
             ProspectorScannerEV.ID,
-            "Prospector's Scanner(EV)",
+            "Prospector's Scanner (EV)",
             "",
             new DetravProspector(4),
             DetravToolDictNames.craftingToolProspector.toString(),
@@ -84,7 +85,7 @@ public class DetravMetaGeneratedTool01 extends MetaGeneratedTool {
             new TCAspects.TC_AspectStack(TCAspects.PERFODIO, 4L));
         addTool(
             ProspectorScannerIV.ID,
-            "Prospector's Scanner(IV)",
+            "Prospector's Scanner (IV)",
             "",
             new DetravProspector(5),
             DetravToolDictNames.craftingToolProspector.toString(),
@@ -93,7 +94,7 @@ public class DetravMetaGeneratedTool01 extends MetaGeneratedTool {
             new TCAspects.TC_AspectStack(TCAspects.PERFODIO, 4L));
         addTool(
             ProspectorScannerLuV.ID,
-            "Prospector's Scanner(LuV)",
+            "Prospector's Scanner (LuV)",
             "",
             new DetravProspector(6),
             DetravToolDictNames.craftingToolProspector.toString(),
@@ -102,7 +103,7 @@ public class DetravMetaGeneratedTool01 extends MetaGeneratedTool {
             new TCAspects.TC_AspectStack(TCAspects.PERFODIO, 4L));
         addTool(
             ProspectorScannerZPM.ID,
-            "Prospector's Scanner(ZPM)",
+            "Prospector's Scanner (ZPM)",
             "",
             new DetravProspector(7),
             DetravToolDictNames.craftingToolProspector.toString(),
@@ -111,7 +112,7 @@ public class DetravMetaGeneratedTool01 extends MetaGeneratedTool {
             new TCAspects.TC_AspectStack(TCAspects.PERFODIO, 4L));
         addTool(
             ProspectorScannerUV.ID,
-            "Prospector's Scanner(UV)",
+            "Prospector's Scanner (UV)",
             "",
             new DetravProspector(8),
             DetravToolDictNames.craftingToolProspector.toString(),
@@ -120,7 +121,7 @@ public class DetravMetaGeneratedTool01 extends MetaGeneratedTool {
             new TCAspects.TC_AspectStack(TCAspects.PERFODIO, 4L));
         addTool(
             ProspectorScannerUHV.ID,
-            "Prospector's Scanner(UHV)",
+            "Prospector's Scanner (UHV)",
             "",
             new DetravProspector(9),
             DetravToolDictNames.craftingToolProspector.toString(),
@@ -186,19 +187,19 @@ public class DetravMetaGeneratedTool01 extends MetaGeneratedTool {
         if (meta < 100) {
             aList.add(
                 tOffset,
-                EnumChatFormatting.WHITE + StatCollector.translateToLocal("tooltip.detrav.scanner.durability")
-                    + EnumChatFormatting.GREEN
-                    + (tMaxDamage - getToolDamage(aStack))
-                    + " / "
-                    + tMaxDamage
-                    + EnumChatFormatting.GRAY);
+                EnumChatFormatting.GREEN + StatCollector.translateToLocalFormatted(
+                    "tooltip.detrav.scanner.durability",
+                    formatNumber(tMaxDamage - getToolDamage(aStack)),
+                    formatNumber(tMaxDamage)));
             aList.add(
                 tOffset + 1,
                 EnumChatFormatting.WHITE + tMaterial.getLocalizedNameForItem("%material") + EnumChatFormatting.GRAY);
             aList.add(
                 tOffset + 2,
-                EnumChatFormatting.WHITE + StatCollector
-                    .translateToLocal("tooltip.detrav.scanner.range") + range + "x" + range + EnumChatFormatting.GRAY);
+                EnumChatFormatting.WHITE + StatCollector.translateToLocalFormatted(
+                    "tooltip.detrav.scanner.range",
+                    formatNumber(range),
+                    formatNumber(range)));
             aList.add(
                 tOffset + 3,
                 EnumChatFormatting.ITALIC + StatCollector.translateToLocal("tooltip.detrav.scanner.usage.0")
@@ -209,11 +210,11 @@ public class DetravMetaGeneratedTool01 extends MetaGeneratedTool {
                     + EnumChatFormatting.GRAY);
             aList.add(
                 tOffset + 5,
-                EnumChatFormatting.ITALIC + StatCollector.translateToLocal("tooltip.detrav.scanner.success.chance")
-                    + EnumChatFormatting.RESET
-                    + (Math.min(((1 + meta) * 8), 100))
-                    + EnumChatFormatting.GRAY
-                    + "%");
+                EnumChatFormatting.GRAY + ""
+                    + EnumChatFormatting.ITALIC
+                    + StatCollector.translateToLocalFormatted(
+                        "tooltip.detrav.scanner.success.chance",
+                        EnumChatFormatting.RESET + formatNumber(Math.min(((1 + meta) * 8), 100))));
             aList.add(
                 tOffset + 6,
                 EnumChatFormatting.ITALIC + StatCollector.translateToLocal("tooltip.detrav.scanner.distance.0"));
@@ -221,29 +222,22 @@ public class DetravMetaGeneratedTool01 extends MetaGeneratedTool {
                 tOffset + 7,
                 EnumChatFormatting.ITALIC + StatCollector.translateToLocal("tooltip.detrav.scanner.distance.1"));
             return;
-
         }
 
         // from here, it's for the electric prospector scanners
         aList.add(
-            tOffset + 0,
-            EnumChatFormatting.WHITE + StatCollector.translateToLocal("tooltip.detrav.scanner.durability")
-                + EnumChatFormatting.GREEN
-                + (tMaxDamage - getToolDamage(aStack))
-                + " / "
-                + tMaxDamage
-                + EnumChatFormatting.GRAY);
+            tOffset,
+            EnumChatFormatting.GREEN + StatCollector.translateToLocalFormatted(
+                "tooltip.detrav.scanner.durability",
+                formatNumber(tMaxDamage - getToolDamage(aStack)),
+                formatNumber(tMaxDamage)));
         aList.add(
             tOffset + 1,
             EnumChatFormatting.WHITE + tMaterial.getLocalizedNameForItem("%material") + EnumChatFormatting.GRAY);
         aList.add(
             tOffset + 2,
-            EnumChatFormatting.WHITE + StatCollector.translateToLocal("tooltip.detrav.scanner.range")
-                + EnumChatFormatting.YELLOW
-                + (getHarvestLevel(aStack, "") * 2 + 1)
-                + "x"
-                + (getHarvestLevel(aStack, "") * 2 + 1)
-                + EnumChatFormatting.GRAY);
+            EnumChatFormatting.WHITE + StatCollector
+                .translateToLocalFormatted("tooltip.detrav.scanner.range", formatNumber(range), formatNumber(range)));
         aList.add(
             tOffset + 3,
             EnumChatFormatting.ITALIC + StatCollector.translateToLocal("tooltip.detrav.scanner.usage.0"));

--- a/src/main/resources/assets/detravscannermod/lang/en_US.lang
+++ b/src/main/resources/assets/detravscannermod/lang/en_US.lang
@@ -26,14 +26,14 @@ detrav.scanner.fail=Failed on %badluck chunks. Better luck next time!
 
 detrav.scanner.prospecting=Prospecting at
 
-tooltip.detrav.scanner.durability=Durability:
-tooltip.detrav.scanner.range=Chunks:
+tooltip.detrav.scanner.durability=Durability: %s / %s
+tooltip.detrav.scanner.range=Chunks: %s x %s
 tooltip.detrav.scanner.usage.0=Right click on rock for prospecting current chunk!
 tooltip.detrav.scanner.usage.1=Right click on bedrock for prospecting fluids!
 tooltip.detrav.scanner.usage.2=Right click on air for scanning!
 tooltip.detrav.scanner.usage.3=Shift + Right click on air to switch modes!
 tooltip.detrav.scanner.usage.4=Double click any entry to invert the background color!
-tooltip.detrav.scanner.success.chance=Chance of a successful scan:
+tooltip.detrav.scanner.success.chance=Chance of a successful scan: %s%%
 tooltip.detrav.scanner.distance.0=next to you (0 chunks away), close to you (1-2)
 tooltip.detrav.scanner.distance.1=at medium range (3-5), at long range (6-8), far away (9+)
 

--- a/src/main/resources/assets/detravscannermod/lang/ru_RU.lang
+++ b/src/main/resources/assets/detravscannermod/lang/ru_RU.lang
@@ -33,7 +33,7 @@ tooltip.detrav.scanner.usage.1=ПКМ по бедроку для поиска ж
 tooltip.detrav.scanner.usage.2=ПКМ по воздуху для сканирования!
 tooltip.detrav.scanner.usage.3=Shift+ПКМ по воздуху для переключения режимов!
 tooltip.detrav.scanner.usage.4=Двойной клик по любой записи для инвертирования фонового цвета!
-tooltip.detrav.scanner.success.chance=Шанс успешного сканирования:
+tooltip.detrav.scanner.success.chance=Шанс успешного сканирования: %s%%
 tooltip.detrav.scanner.distance.0=рядом с тобой (0 чанков отсюда), близко к тебе (1-2)
 tooltip.detrav.scanner.distance.1=на среднем расстоянии (3-5), на большом расстоянии (6-8), далеко (9+)
 

--- a/src/main/resources/assets/detravscannermod/lang/zh_CN.lang
+++ b/src/main/resources/assets/detravscannermod/lang/zh_CN.lang
@@ -26,14 +26,14 @@ detrav.scanner.fail=%badluck区块勘探失败，祝你下次好运！
 
 detrav.scanner.prospecting=正在勘探
 
-tooltip.detrav.scanner.durability=耐久：
-tooltip.detrav.scanner.range=勘探范围(区块)：
+tooltip.detrav.scanner.durability=耐久： %s / %s
+tooltip.detrav.scanner.range=勘探范围(区块)： %s x %s
 tooltip.detrav.scanner.usage.0=右键岩石方块以勘探当前区块!
 tooltip.detrav.scanner.usage.1=右键基岩以勘探地下流体!
 tooltip.detrav.scanner.usage.2=右键空气进行全范围扫描!
 tooltip.detrav.scanner.usage.3=Shift+右键空气更换扫描模式!
 tooltip.detrav.scanner.usage.4=双击任何条目以反转背景颜色!
-tooltip.detrav.scanner.success.chance=扫描成功几率：
+tooltip.detrav.scanner.success.chance=扫描成功几率： %s%%
 tooltip.detrav.scanner.distance.0=在你旁边(距离0区块), 离你很近(1-2)
 tooltip.detrav.scanner.distance.1=中等距离(3-5), 长距离(6-8), 很远(9+)
 


### PR DESCRIPTION
## Summary
Cleans up the tooltip for the scanner to be in line with other tools.

Old:
<img width="1307" height="597" alt="image" src="https://github.com/user-attachments/assets/172e0787-e5cd-4585-99d8-8cf3323bf07f" />

New:
<img width="1505" height="534" alt="image" src="https://github.com/user-attachments/assets/f5166598-7289-4341-bd37-1623bbfb7054" />



## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
