### PR TITLE
Cap mining speed presentation to 2 decimal places

### DIFF
--- a/src/main/java/gregtech/api/items/MetaGeneratedTool.java
+++ b/src/main/java/gregtech/api/items/MetaGeneratedTool.java
@@ -635,17 +635,17 @@ public abstract class MetaGeneratedTool extends MetaBaseItem
                     EnumChatFormatting.WHITE
                         + translateToLocalFormatted(
                             "gt.item.desc.damage",
-                            "" + EnumChatFormatting.BLUE + getToolCombatDamage(aStack))
+                            EnumChatFormatting.BLUE + formatNumber(getToolCombatDamage(aStack)))
                         + EnumChatFormatting.GRAY);
                 aList.add(
                     tOffset + 3,
                     EnumChatFormatting.WHITE
                         + translateToLocalFormatted(
                             "gt.item.desc.mine_speed",
-                            "" + EnumChatFormatting.GOLD
-                                + Math.max(
+                            EnumChatFormatting.GOLD + formatNumber(
+                                Math.max(
                                     Float.MIN_NORMAL,
-                                    tStats.getSpeedMultiplier() * getPrimaryMaterial(aStack).mToolSpeed))
+                                    tStats.getSpeedMultiplier() * getPrimaryMaterial(aStack).mToolSpeed)))
                         + EnumChatFormatting.GRAY);
                 final NBTTagCompound nbt = aStack.getTagCompound();
                 if (nbt != null) {


### PR DESCRIPTION
## Summary
Caps mining speed presentation to 2 decimal places.

Old:
<img width="840" height="521" alt="image" src="https://github.com/user-attachments/assets/5acb6b9c-24f5-4394-85dc-bdcd23494cc5" />

New:
<img width="1038" height="671" alt="image" src="https://github.com/user-attachments/assets/f079c89a-0c32-4cd4-a9cb-3d850f89b8c1" />



## Checklist
- [X] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
