### PR TITLE
Enable Shift click on Item Holder covers

### DIFF
--- a/src/main/java/gregtech/common/gui/modularui/cover/CoverChestGui.java
+++ b/src/main/java/gregtech/common/gui/modularui/cover/CoverChestGui.java
@@ -17,6 +17,8 @@ import gregtech.common.gui.modularui.cover.base.CoverBaseGui;
 
 public class CoverChestGui extends CoverBaseGui<CoverChest> {
 
+    private static final String SLOT_GROUP_NAME = "cover_chest_items";
+
     /**
      * The side of the block this GUI is representing the cover for.
      */
@@ -40,11 +42,13 @@ public class CoverChestGui extends CoverBaseGui<CoverChest> {
 
         IItemHandlerModifiable handler = cover.getItems();
 
+        syncManager.registerSlotGroup(SLOT_GROUP_NAME, 3);
+
         column.horizontalCenter()
             .child(
                 SlotGroupWidget.builder()
                     .matrix(matrix)
-                    .key('x', i -> new ItemSlot().slot(new ModularSlot(handler, i)))
+                    .key('x', i -> new ItemSlot().slot(new ModularSlot(handler, i).slotGroup(SLOT_GROUP_NAME)))
                     .build());
     }
 

--- a/src/main/java/gregtech/common/gui/modularui/cover/CoverChestGui.java
+++ b/src/main/java/gregtech/common/gui/modularui/cover/CoverChestGui.java
@@ -42,7 +42,7 @@ public class CoverChestGui extends CoverBaseGui<CoverChest> {
 
         IItemHandlerModifiable handler = cover.getItems();
 
-        syncManager.registerSlotGroup(SLOT_GROUP_NAME, 3);
+        syncManager.registerSlotGroup(SLOT_GROUP_NAME, 3, 200);
 
         column.horizontalCenter()
             .child(


### PR DESCRIPTION
## Summary
Enables shift click priority to: Basic/Good/Advanced Item Holders

"Fixes": https://discord.com/channels/181078474394566657/522098956491030558/1536039595001651240

Example Chemical Reactor:
- Opened Chemical reactor gui -> If the cover is enabled (opened), and the two input slots are full, the next shift clicked item, will go into the cover
- Opened Cover gui (Shift click on the block - cover gui) - normal shift click works now


Reference:
https://github.com/GTNewHorizons/GT5-Unofficial/blob/c7c31279451486b61814dee46cfac1b28a379be7/src/main/java/gregtech/common/gui/modularui/singleblock/MTEBoilerGui.java#L40-L62

## Checklist
- [X] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
