### PR TITLE
fix beam crafter tooltip

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/beamcrafting/MTEBeamCrafter.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/beamcrafting/MTEBeamCrafter.java
@@ -310,7 +310,7 @@ public class MTEBeamCrafter extends MTEBeamMultiBase<MTEBeamCrafter> implements 
             .addController("Front center, 3rd layer")
             .addCasing(
                 "224-227",
-                StatCollector.translateToLocal("gt.blockmachines.multimachine.beamcrafting.ttcasing"),
+                StatCollector.translateToLocal("gt.blockmachines.multimachine.beamcrafting.ttshieldacccasing"),
                 false)
             .addCasing("26", "Any Tiered Glass", false)
             .addCasing(


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
beam crafter does not use collider casing
before:
<img width="544" height="350" alt="Screenshot 2026-08-10 at 19 22 16" src="https://github.com/user-attachments/assets/0892dd41-e299-4127-9893-e32ee6002ccb" />
after:
<img width="620" height="331" alt="Screenshot 2026-08-10 at 19 29 40" src="https://github.com/user-attachments/assets/0d109baa-44ef-4ecc-9458-0e147a3ad7b1" />

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
