### PR TITLE
Cache enum `.values()`

### DIFF
--- a/src/main/java/gregtech/api/enums/CondensateType.java
+++ b/src/main/java/gregtech/api/enums/CondensateType.java
@@ -126,6 +126,7 @@ public enum CondensateType {
     // spotless:on
     ;
 
+    public static final CondensateType[] VALUES = values();
     private final String id;
     private final Lazy<IOreMaterial> material;
     private final int unit;
@@ -171,7 +172,7 @@ public enum CondensateType {
     }
 
     public static void registerFluids() {
-        for (CondensateType type : values()) {
+        for (CondensateType type : VALUES) {
             IOreMaterial material = type.getMaterial();
             IGTFluidBuilder builder = GTFluidFactory.builder("entangled_" + type.id)
                 .withColorRGBA(material.getRGBA())
@@ -204,7 +205,7 @@ public enum CondensateType {
     }
 
     public static void registerRecipes() {
-        for (CondensateType type : values()) {
+        for (CondensateType type : VALUES) {
             GTValues.RA.stdBuilder()
                 .fluidInputs(type.source.get())
                 .fluidOutputs(new FluidStack(type.entangledFluid, type.unit))
@@ -215,7 +216,7 @@ public enum CondensateType {
     }
 
     public static CondensateType getCondensateType(Fluid fluid) {
-        for (CondensateType type : values()) {
+        for (CondensateType type : VALUES) {
             if (fluid == type.entangledFluid) {
                 return type;
             }

--- a/src/main/java/gregtech/api/enums/MaterialIconRegistry.java
+++ b/src/main/java/gregtech/api/enums/MaterialIconRegistry.java
@@ -204,6 +204,7 @@ public class MaterialIconRegistry {
         ;
         // spotless:on
 
+        public static final IconType[] VALUES = values();
         public final String suffix;
         public final TextureType texture;
 

--- a/src/main/java/gregtech/api/enums/TextureSet.java
+++ b/src/main/java/gregtech/api/enums/TextureSet.java
@@ -67,14 +67,14 @@ public class TextureSet {
         SET_ASTRAL_TITANIUM = new TextureSet("astraltitanium", true),
         SET_CELESTIAL_TUNGSTEN = new TextureSet("celestialtungsten", true);
 
-    public final IIconContainer[] mTextures = new IIconContainer[MaterialIconRegistry.IconType.values().length];
+    public final IIconContainer[] mTextures = new IIconContainer[MaterialIconRegistry.IconType.VALUES.length];
     public final String mSetName;
     private IIconContainer[][] mStoneOreTextures;
     private String mStoneOreTextureSetName;
 
     public TextureSet(String aSetName) {
         mSetName = aSetName;
-        for (MaterialIconRegistry.IconType type : MaterialIconRegistry.IconType.values()) {
+        for (MaterialIconRegistry.IconType type : MaterialIconRegistry.IconType.VALUES) {
             switch (type.texture) {
                 case BLOCK:
                     mTextures[type.ordinal()] = Textures.BlockIcons.textureSet(aSetName, type.suffix);
@@ -112,7 +112,7 @@ public class TextureSet {
             GregTechAPI.sGTBlockIconload.add(this::initStoneOreTextures);
         }
 
-        for (MaterialIconRegistry.IconType type : MaterialIconRegistry.IconType.values()) {
+        for (MaterialIconRegistry.IconType type : MaterialIconRegistry.IconType.VALUES) {
             if (overrides.contains(type)) {
                 // Override this specific icon
                 switch (type.texture) {

--- a/src/main/java/gregtech/api/enums/ToolboxSlot.java
+++ b/src/main/java/gregtech/api/enums/ToolboxSlot.java
@@ -63,6 +63,7 @@ public enum ToolboxSlot {
     // merge conflict defeater comment
     ;
 
+    public static final ToolboxSlot[] VALUES = values();
     public static final ImmutableList<ToolboxSlot> GENERIC_SLOTS = ImmutableList
         .of(GENERIC_SLOT0, GENERIC_SLOT1, GENERIC_SLOT2, GENERIC_SLOT3, GENERIC_SLOT4, GENERIC_SLOT5);
     public static final ImmutableList<ToolboxSlot> TOOL_SLOTS = ImmutableList
@@ -70,7 +71,7 @@ public enum ToolboxSlot {
     public static final int ROW_WIDTH = 7;
 
     private static final ImmutableMap<Integer, ToolboxSlot> LOOKUP = Maps
-        .uniqueIndex(Arrays.asList(values()), ToolboxSlot::getSlotID);
+        .uniqueIndex(Arrays.asList(VALUES), ToolboxSlot::getSlotID);
 
     private static final ImmutableSet<Class<? extends IToolStats>> BANNED_TOOLS = ImmutableSet.copyOf(
         Arrays.asList(

--- a/src/main/java/gregtech/api/items/armor/ArmorState.java
+++ b/src/main/java/gregtech/api/items/armor/ArmorState.java
@@ -243,7 +243,7 @@ public class ArmorState {
 
         NBTTagCompound augmentTag = tag.getCompoundTag("augments");
 
-        for (AugmentCategory category : AugmentCategory.values()) {
+        for (AugmentCategory category : AugmentCategory.VALUES) {
             NBTTagCompound categoryTag = augmentTag.getCompoundTag(Integer.toString(category.ordinal()));
 
             for (Map.Entry<String, NBTBase> e : ((Map<String, NBTBase>) categoryTag.tagMap).entrySet()) {
@@ -326,7 +326,7 @@ public class ArmorState {
         NBTTagCompound augmentTag = new NBTTagCompound();
         tag.setTag("augments", augmentTag);
 
-        for (AugmentCategory category : AugmentCategory.values()) {
+        for (AugmentCategory category : AugmentCategory.VALUES) {
             augmentTag.setTag(Integer.toString(category.ordinal()), new NBTTagCompound());
         }
 

--- a/src/main/java/gregtech/api/items/armor/AugmentBuilder.java
+++ b/src/main/java/gregtech/api/items/armor/AugmentBuilder.java
@@ -10,11 +10,13 @@ import gregtech.api.items.armor.MechArmorAugmentRegistries.ArmorType;
 public class AugmentBuilder extends ArmorPartBuilder<AugmentBuilder> {
 
     public enum AugmentCategory {
+
         // Order sensitive - do not rearrange
         Protection,
         Movement,
         Utility,
         Prismatic;
+
         public static final AugmentCategory[] VALUES = values();
     }
 

--- a/src/main/java/gregtech/api/items/armor/AugmentBuilder.java
+++ b/src/main/java/gregtech/api/items/armor/AugmentBuilder.java
@@ -14,7 +14,8 @@ public class AugmentBuilder extends ArmorPartBuilder<AugmentBuilder> {
         Protection,
         Movement,
         Utility,
-        Prismatic
+        Prismatic;
+        public static final AugmentCategory[] VALUES = values();
     }
 
     private AugmentCategory category = AugmentCategory.Protection;

--- a/src/main/java/gregtech/common/gui/modularui/item/ToolboxInventoryGui.java
+++ b/src/main/java/gregtech/common/gui/modularui/item/ToolboxInventoryGui.java
@@ -99,7 +99,7 @@ public class ToolboxInventoryGui {
         final int genericSlotSize = ToolboxSlot.GENERIC_SLOTS.size();
         final SlotGroup toolGroup = new SlotGroup(
             "gt5:toolbox:tools",
-            ToolboxSlot.values().length - genericSlotSize,
+            ToolboxSlot.VALUES.length - genericSlotSize,
             0,
             true);
         final SlotGroup genericGroup = new SlotGroup("gt5:toolbox:generic", genericSlotSize, 100, true);
@@ -107,7 +107,7 @@ public class ToolboxInventoryGui {
         syncManager.registerSlotGroup(toolGroup);
         syncManager.registerSlotGroup(genericGroup);
 
-        for (final ToolboxSlot slot : ToolboxSlot.values()) {
+        for (final ToolboxSlot slot : ToolboxSlot.VALUES) {
 
             final ItemSlot itemSlot = new CustomItemSlot(() -> itemHandler, slot).slot(
                 new ModularSlot(itemHandler, slot.getSlotID()).slotGroup(slot.isGeneric() ? genericGroup : toolGroup))
@@ -123,7 +123,7 @@ public class ToolboxInventoryGui {
 
         slotGroupWidget.size(
             ToolboxSlot.ROW_WIDTH * SLOT_DRAW_SIZE + GAP_SIZE,
-            (int) (Math.ceil((double) ToolboxSlot.values().length / (double) ToolboxSlot.ROW_WIDTH)) * SLOT_DRAW_SIZE);
+            (int) (Math.ceil((double) ToolboxSlot.VALUES.length / (double) ToolboxSlot.ROW_WIDTH)) * SLOT_DRAW_SIZE);
         column.child(slotGroupWidget);
 
         panel.child(column);

--- a/src/main/java/gregtech/common/gui/modularui/multiblock/MTEBeamCrafterGui.java
+++ b/src/main/java/gregtech/common/gui/modularui/multiblock/MTEBeamCrafterGui.java
@@ -142,7 +142,7 @@ public class MTEBeamCrafterGui extends MTEMultiBlockBaseGui<MTEBeamCrafter> {
     }
 
     private Grid createParticleButtonGrid(PanelSyncManager syncManager) {
-        Particle[] particles = Particle.values();
+        Particle[] particles = Particle.VALUES;
 
         return new Grid()
             .gridOfWidthElements(

--- a/src/main/java/gregtech/common/items/CombType.java
+++ b/src/main/java/gregtech/common/items/CombType.java
@@ -235,6 +235,7 @@ public enum CombType {
     // ALWAYS KEEP _NULL AT THE BOTTOM
     _NULL(-1, "INVALIDCOMB", false, Materials._NULL, 0, 0, 0);
 
+    public static final CombType[] VALUES = values();
     public boolean showInList;
     public final ItemComb.Voltage voltage;
     public final Materials material;
@@ -287,13 +288,13 @@ public enum CombType {
         private static final CombType[] VALUES;
 
         static {
-            int biggestId = Arrays.stream(CombType.values())
+            int biggestId = Arrays.stream(CombType.VALUES)
                 .mapToInt(CombType::getId)
                 .max()
                 .getAsInt();
             VALUES = new CombType[biggestId + 1];
             Arrays.fill(VALUES, _NULL);
-            for (CombType type : CombType.values()) {
+            for (CombType type : CombType.VALUES) {
                 if (type != _NULL) VALUES[type.getId()] = type;
             }
         }

--- a/src/main/java/gregtech/common/items/DropType.java
+++ b/src/main/java/gregtech/common/items/DropType.java
@@ -19,6 +19,8 @@ public enum DropType {
     LAPIS("lapis coolant", true),
     ENDERGOO("ender goo", true);
 
+    public static final DropType[] VALUES = values();
+
     private static final int[][] colours = new int[][] { { 0x19191B, 0x303032 }, { 0xffc100, 0x00ff11 },
         { 0x144F5A, 0x2494A2 }, { 0xC11F1F, 0xEBB9B9 }, { 0x872836, 0xB8132C }, { 0xD02001, 0x9C0018 },
         { 0x003366, 0x0066BB }, { 0x1727b1, 0x008ce3 }, { 0xA005E7, 0x161616 }, };

--- a/src/main/java/gregtech/common/items/ItemComb.java
+++ b/src/main/java/gregtech/common/items/ItemComb.java
@@ -95,7 +95,7 @@ public class ItemComb extends Item implements IGT_ItemWithMaterialRenderer, IIte
     @Override
     @SideOnly(Side.CLIENT)
     public void getSubItems(Item item, CreativeTabs tabs, List<ItemStack> list) {
-        for (CombType type : CombType.values()) {
+        for (CombType type : CombType.VALUES) {
             if (type.showInList) {
                 list.add(this.getStackForType(type));
             }
@@ -1146,7 +1146,7 @@ public class ItemComb extends Item implements IGT_ItemWithMaterialRenderer, IIte
     }
 
     public void registerOreDict() {
-        for (CombType comb : CombType.values()) {
+        for (CombType comb : CombType.VALUES) {
             ItemStack tComb = getStackForType(comb);
             GTOreDictUnificator.registerOre(OrePrefixes.beeComb.getName(), tComb);
             OrePrefixes.beeComb.add(tComb);

--- a/src/main/java/gregtech/common/items/ItemDrop.java
+++ b/src/main/java/gregtech/common/items/ItemDrop.java
@@ -55,7 +55,7 @@ public class ItemDrop extends Item {
     @Override
     @SideOnly(Side.CLIENT)
     public void getSubItems(Item item, CreativeTabs tabs, List<ItemStack> list) {
-        for (DropType type : DropType.values()) {
+        for (DropType type : DropType.VALUES) {
             if (type.showInList) {
                 list.add(this.getStackForType(type));
             }
@@ -88,11 +88,11 @@ public class ItemDrop extends Item {
     @Override
     @SideOnly(Side.CLIENT)
     public int getColorFromItemStack(ItemStack stack, int pass) {
-        int meta = Math.max(0, Math.min(DropType.values().length - 1, stack.getItemDamage()));
-        int colour = DropType.values()[meta].getColours()[0];
+        int meta = Math.max(0, Math.min(DropType.VALUES.length - 1, stack.getItemDamage()));
+        int colour = DropType.VALUES[meta].getColours()[0];
 
         if (pass >= 1) {
-            colour = DropType.values()[meta].getColours()[1];
+            colour = DropType.VALUES[meta].getColours()[1];
         }
 
         return colour;
@@ -100,7 +100,7 @@ public class ItemDrop extends Item {
 
     @Override
     public String getItemStackDisplayName(ItemStack stack) {
-        return DropType.values()[stack.getItemDamage()].getLocalizedName();
+        return DropType.VALUES[stack.getItemDamage()].getLocalizedName();
     }
 
     public void initDropsRecipes() {

--- a/src/main/java/gregtech/common/items/ItemGTToolbox.java
+++ b/src/main/java/gregtech/common/items/ItemGTToolbox.java
@@ -147,7 +147,7 @@ public class ItemGTToolbox extends GTGenericItem implements IGuiHolder<PlayerInv
                             true
                         );
 
-                        for (final ToolboxSlot slot : ToolboxSlot.values()) {
+                        for (final ToolboxSlot slot : ToolboxSlot.VALUES) {
                             if (slot == ToolboxSlot.BATTERY) {
                                 continue;
                             }

--- a/src/main/java/gregtech/common/items/ItemPropolis.java
+++ b/src/main/java/gregtech/common/items/ItemPropolis.java
@@ -51,7 +51,7 @@ public class ItemPropolis extends Item {
     @Override
     @SideOnly(Side.CLIENT)
     public void getSubItems(Item item, CreativeTabs tabs, List<ItemStack> list) {
-        for (PropolisType type : PropolisType.values()) {
+        for (PropolisType type : PropolisType.VALUES) {
             if (type.showInList) {
                 list.add(this.getStackForType(type));
             }
@@ -72,13 +72,13 @@ public class ItemPropolis extends Item {
     @Override
     @SideOnly(Side.CLIENT)
     public int getColorFromItemStack(ItemStack stack, int pass) {
-        int meta = Math.max(0, Math.min(PropolisType.values().length - 1, stack.getItemDamage()));
-        return PropolisType.values()[meta].getColours();
+        int meta = Math.max(0, Math.min(PropolisType.VALUES.length - 1, stack.getItemDamage()));
+        return PropolisType.VALUES[meta].getColours();
     }
 
     @Override
     public String getItemStackDisplayName(ItemStack stack) {
-        return PropolisType.values()[stack.getItemDamage()].getLocalizedName();
+        return PropolisType.VALUES[stack.getItemDamage()].getLocalizedName();
     }
 
     public void initPropolisRecipes() {

--- a/src/main/java/gregtech/common/items/PropolisType.java
+++ b/src/main/java/gregtech/common/items/PropolisType.java
@@ -17,6 +17,7 @@ public enum PropolisType {
     Endium("Endium", true),
     Fireessence("Fireessence", true);
 
+    public static final PropolisType[] VALUES = values();
     private static final int[] colours = new int[] { 0xCC00FA, 0xDCB0E5, 0x9010AD, 0xFFFF00, 0x911ECE, 0x161616,
         0xEE053D, 0xa0ffff, 0xD41238 };
 

--- a/src/main/java/gregtech/common/items/toolbox/ToolboxItemStackHandler.java
+++ b/src/main/java/gregtech/common/items/toolbox/ToolboxItemStackHandler.java
@@ -22,7 +22,7 @@ public class ToolboxItemStackHandler extends ItemStackHandler {
     private final ItemStack toolboxStack;
 
     public ToolboxItemStackHandler(final ItemStack toolbox) {
-        super(ToolboxSlot.values().length);
+        super(ToolboxSlot.VALUES.length);
         this.toolboxStack = toolbox;
         int currentTool = ItemGTToolbox.NO_TOOL_SELECTED;
 

--- a/src/main/java/gregtech/common/tileentities/machines/basic/MTEModificationTable.java
+++ b/src/main/java/gregtech/common/tileentities/machines/basic/MTEModificationTable.java
@@ -51,7 +51,7 @@ import it.unimi.dsi.fastutil.objects.ObjectIntPair;
 
 public class MTEModificationTable extends MetaTileEntity {
 
-    public static final int AUGMENT_CATEGORY_COUNT = AugmentCategory.values().length;
+    public static final int AUGMENT_CATEGORY_COUNT = AugmentCategory.VALUES.length;
     // Update this integer if you add a frame with more slots in a single category than the previous highest
     public static final int LARGEST_FRAME = 5;
     private static final int AUGMENT_SLOTS_COUNT = LARGEST_FRAME * AUGMENT_CATEGORY_COUNT;

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTETreeFarm.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTETreeFarm.java
@@ -350,6 +350,7 @@ public class MTETreeFarm extends MTEExtendedPowerMultiBlockBase<MTETreeFarm>
      * Valid processing modes (types of output) for the Tree Growth Simulator.
      */
     public enum Mode {
+
         LOG,
         SAPLING,
         LEAVES,

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTETreeFarm.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTETreeFarm.java
@@ -353,7 +353,9 @@ public class MTETreeFarm extends MTEExtendedPowerMultiBlockBase<MTETreeFarm>
         LOG,
         SAPLING,
         LEAVES,
-        FRUIT
+        FRUIT;
+
+        public static final Mode[] VALUES = values();
     }
 
     /**
@@ -853,11 +855,11 @@ public class MTETreeFarm extends MTEExtendedPowerMultiBlockBase<MTETreeFarm>
          * the mode multiplier, but not tool/tier multipliers as those can change dynamically. If the sapling has an
          * output in this mode, also add the tools usable for this mode as inputs.
          */
-        final Mode[] MODE_VALUES = Mode.values();
-        ItemStack[][] inputStacks = new ItemStack[MODE_VALUES.length][];
-        ItemStack[] outputStacks = new ItemStack[MODE_VALUES.length];
 
-        for (Mode mode : MODE_VALUES) {
+        ItemStack[][] inputStacks = new ItemStack[Mode.VALUES.length][];
+        ItemStack[] outputStacks = new ItemStack[Mode.VALUES.length];
+
+        for (Mode mode : Mode.VALUES) {
             ItemStack output = switch (mode) {
                 case LOG -> log;
                 case SAPLING -> saplingOut;

--- a/src/main/java/gtnhintergalactic/tile/TileEntitySpaceElevatorCable.java
+++ b/src/main/java/gtnhintergalactic/tile/TileEntitySpaceElevatorCable.java
@@ -19,6 +19,7 @@ import micdoodle8.mods.galacticraft.core.util.Annotations;
 public class TileEntitySpaceElevatorCable extends TileEntityAdvanced {
 
     public enum ClimberAnimation {
+
         /** Let the climber sit on its spot */
         NO_ANIMATION,
         /** Animation that drives the climber into orbit, pauses a bit and then drives down */

--- a/src/main/java/gtnhintergalactic/tile/TileEntitySpaceElevatorCable.java
+++ b/src/main/java/gtnhintergalactic/tile/TileEntitySpaceElevatorCable.java
@@ -24,7 +24,9 @@ public class TileEntitySpaceElevatorCable extends TileEntityAdvanced {
         /** Animation that drives the climber into orbit, pauses a bit and then drives down */
         DELIVER_ANIMATION,
         /** Animation that spawns the climber in orbit and then drives it down */
-        FORMATION_ANIMATION,
+        FORMATION_ANIMATION;
+
+        public static final ClimberAnimation[] VALUES = values();
     }
 
     /** Vertical movement speed of the climber */
@@ -206,8 +208,8 @@ public class TileEntitySpaceElevatorCable extends TileEntityAdvanced {
     public void readExtraNetworkedData(ByteBuf dataStream) {
         if (worldObj.isRemote) {
             int animationOrdinal = dataStream.readInt();
-            if (animationOrdinal < ClimberAnimation.values().length) {
-                animation = ClimberAnimation.values()[animationOrdinal];
+            if (animationOrdinal < ClimberAnimation.VALUES.length) {
+                animation = ClimberAnimation.VALUES[animationOrdinal];
             } else {
                 animation = ClimberAnimation.NO_ANIMATION;
             }

--- a/src/main/java/gtnhlanth/common/beamline/BeamInformation.java
+++ b/src/main/java/gtnhlanth/common/beamline/BeamInformation.java
@@ -14,10 +14,10 @@ public class BeamInformation {
         this.energy = energy;
         this.rate = rate;
         this.particleId = particleId;
-        if (particleId >= Particle.values().length || particleId < 0) {
+        if (particleId >= Particle.VALUES.length || particleId < 0) {
             throw new IllegalArgumentException("Invalid particleId");
         }
-        this.particle = Particle.values()[particleId];
+        this.particle = Particle.VALUES[particleId];
         this.focus = focus;
     }
 

--- a/src/main/java/gtnhlanth/common/item/ItemParticle.java
+++ b/src/main/java/gtnhlanth/common/item/ItemParticle.java
@@ -18,12 +18,12 @@ import gtnhlanth.common.beamline.Particle;
 
 public class ItemParticle extends Item {
 
-    public static final int NUMBER_OF_SUBTYPES = Particle.values().length;
+    public static final int NUMBER_OF_SUBTYPES = Particle.VALUES.length;
     private static final String[] names = new String[NUMBER_OF_SUBTYPES];
 
     static {
         for (int i = 0; i < NUMBER_OF_SUBTYPES; i++) {
-            Particle particle = Particle.values()[i];
+            Particle particle = Particle.VALUES[i];
             names[i] = particle.getName();
         }
     }
@@ -71,7 +71,7 @@ public class ItemParticle extends Item {
     @Override
     public String getItemStackDisplayName(ItemStack stack) {
         int i = MathHelper.clamp_int(stack.getItemDamage(), 0, NUMBER_OF_SUBTYPES - 1);
-        Particle particle = Particle.values()[i];
+        Particle particle = Particle.VALUES[i];
         return particle.getLocalisedName();
 
     }
@@ -80,7 +80,7 @@ public class ItemParticle extends Item {
     @Override
     public void addInformation(ItemStack stack, EntityPlayer player, List list, boolean bool) {
         int i = MathHelper.clamp_int(stack.getItemDamage(), 0, NUMBER_OF_SUBTYPES - 1);
-        Particle particle = Particle.values()[i];
+        Particle particle = Particle.VALUES[i];
         float restMass = particle.getMass();
         float charge = particle.getCharge();
         String chargeSpecial = particle.getChargeSpecial();

--- a/src/test/java/gregtech/common/items/CombTypeTest.java
+++ b/src/test/java/gregtech/common/items/CombTypeTest.java
@@ -13,14 +13,14 @@ class CombTypeTest {
     @Test
     void noDuplicateID() {
         Set<Integer> seen = new HashSet<>();
-        for (CombType value : CombType.values()) {
+        for (CombType value : CombType.VALUES) {
             assertTrue(seen.add(value.getId()), "Comb type must not have duplicate ID");
         }
     }
 
     @Test
     void noNegativeID() {
-        for (CombType value : CombType.values()) {
+        for (CombType value : CombType.VALUES) {
             if (value == CombType._NULL) assertTrue(value.getId() <= 0, "Comb type ID must be negative for _NULL");
             else assertTrue(value.getId() >= 0, "Comb type ID must not be negative");
         }
@@ -34,7 +34,7 @@ class CombTypeTest {
 
     @Test
     void validIDCorrectComb() {
-        for (CombType value : CombType.values()) {
+        for (CombType value : CombType.VALUES) {
             if (value != CombType._NULL)
                 assertEquals(CombType.valueOf(value.getId()), value, "Valid ID Lookup should result in correct output");
         }


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
caching enum values() calls that got called more than 500 times during my little playtest.

## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
