### PR TITLE
fix ruthenium tetroxide solidifier recipe

### DIFF
--- a/src/main/java/bartworks/system/material/WerkstoffLoader.java
+++ b/src/main/java/bartworks/system/material/WerkstoffLoader.java
@@ -1063,7 +1063,8 @@ public class WerkstoffLoader {
         new short[] { 0xc7, 0xc7, 0xc7 },
         "Ruthenium Tetroxide",
         subscriptNumbers("Ru?O?") + "??",
-        new Werkstoff.Stats().setMeltingPoint(313),
+        new Werkstoff.Stats().setMeltingPoint(313)
+            .setMass(165),
         Werkstoff.Types.COMPOUND,
         new Werkstoff.GenerationFeatures().disable()
             .onlyDust()


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
RuO4 solidifier recipe is smh broken.
in 2.8 we had autogen recipe: 
<img width="290" height="237" alt="Screenshot 2026-08-11 at 22 13 36" src="https://github.com/user-attachments/assets/50ba239d-867c-4b65-95a3-03faa0992d90" />

before this change, we had this recipe broken:
<img width="593" height="276" alt="Screenshot 2026-08-11 at 22 10 50" src="https://github.com/user-attachments/assets/5daca631-29ab-41d4-909c-c29ffe429071" />
the root of this issue was that we did not specify the mass of this stuff, and werkstoff could not infer the mass from its formula as it is actually not set.

after change (autogen):
<img width="334" height="304" alt="Screenshot 2026-08-11 at 22 42 14" src="https://github.com/user-attachments/assets/032fe7e5-d928-4934-9e68-6a89e6f2bbb5" />

its recipe is smh more in line with its properties tbh

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
