### PR TITLE
Fix Dense Plate Min EU for GT++ Materials

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/RecipeGenPlates.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/RecipeGenPlates.java
@@ -112,7 +112,7 @@ public class RecipeGenPlates extends RecipeGenBase {
                 .circuit(2)
                 .itemOutputs(plate_Double)
                 .duration(Math.max(material.getMass() * 2L, 1L))
-                .eut(material.voltageMultiplier)
+                .eut(Math.max(TierEU.RECIPE_MV, material.voltageMultiplier))
                 .addTo(benderRecipes);
         }
 
@@ -122,7 +122,7 @@ public class RecipeGenPlates extends RecipeGenBase {
                 .circuit(2)
                 .itemOutputs(plate_Double)
                 .duration(Math.max(material.getMass() * 2L, 1L))
-                .eut(material.voltageMultiplier)
+                .eut(Math.max(TierEU.RECIPE_MV, material.voltageMultiplier))
                 .addTo(benderRecipes);
         }
 

--- a/src/main/java/gtPlusPlus/xmod/gregtech/loaders/RecipeGenPlates.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/loaders/RecipeGenPlates.java
@@ -148,7 +148,7 @@ public class RecipeGenPlates extends RecipeGenBase {
                 .circuit(9)
                 .itemOutputs(plate_Dense)
                 .duration(Math.max(material.getMass() * 2L, 1L))
-                .eut(material.voltageMultiplier)
+                .eut(Math.max(TierEU.RECIPE_MV, material.voltageMultiplier))
                 .addTo(benderRecipes);
         }
 
@@ -158,7 +158,7 @@ public class RecipeGenPlates extends RecipeGenBase {
                 .circuit(9)
                 .itemOutputs(plate_Dense)
                 .duration(Math.max(material.getMass() * 2L, 1L))
-                .eut(material.voltageMultiplier)
+                .eut(Math.max(TierEU.RECIPE_MV, material.voltageMultiplier))
                 .addTo(benderRecipes);
 
         }


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
Dense plates are hard locked to MV Bender+. The GT++ recipes were allowing LV tiered materials to have LV Dense plate bender recipes. This simply puts a minimum on it as a catch all until our material system improves. 

Problem found by GlacialVitality: https://discord.com/channels/181078474394566657/1536609020822028378/1536609020822028378

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
