### PR TITLE
nerf raw silicon ebf recipe

### DIFF
--- a/src/main/java/gregtech/loaders/postload/recipes/BlastFurnaceRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/BlastFurnaceRecipes.java
@@ -234,7 +234,7 @@ public class BlastFurnaceRecipes implements Runnable {
             .itemOutputs(Materials.Silicon.getIngots(1), Materials.Ash.getDust(1))
             .outputChances(10000, 1111)
             .fluidOutputs(Materials.CarbonMonoxide.getGas(2_000))
-            .duration(4 * SECONDS)
+            .duration(20 * SECONDS)
             .eut((int) TierEU.RECIPE_MV)
             .metadata(COIL_HEAT, 1200)
             .addTo(blastFurnaceRecipes);


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
we had raw silicon recipe output the carbon monoxide which would cause net energy income.
<img width="651" height="519" alt="image png-2" src="https://github.com/user-attachments/assets/5b1f5619-4d76-478a-934e-2b5c294bbe0d" />
<img width="430" height="317" alt="image png-3" src="https://github.com/user-attachments/assets/e84d69a9-7171-47d7-b97d-4d68a7d39978" />

now this recipe time is nerfed to 20s, would not cause issues for it is not used in early stages, but just for orundum plate later and this effect is ignorable

## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
