### PR TITLE
add sodium nitrate neutralization recipe

### DIFF
--- a/src/main/java/bartworks/system/material/gtenhancement/PlatinumSludgeRecipes.java
+++ b/src/main/java/bartworks/system/material/gtenhancement/PlatinumSludgeRecipes.java
@@ -639,6 +639,17 @@ public final class PlatinumSludgeRecipes {
             .duration(8 * TICKS)
             .eut(TierEU.RECIPE_MV / 2)
             .addTo(UniversalChemical);
+        // NaOH + HNO3 = NaNO3 + H2O
+        GTValues.RA.stdBuilder()
+            .itemInputs(Materials.SodiumHydroxide.getDust(3))
+            .itemOutputs(SodiumNitrate.get(dust, 5))
+            .fluidInputs(Materials.NitricAcid.getFluid(1_000))
+            .fluidOutputs(Materials.Water.getFluid(1_000))
+            .circuit(7)
+            .duration(1 * SECONDS)
+            .eut(TierEU.RECIPE_MV)
+            .addTo(UniversalChemical);
+
         GTValues.RA.stdBuilder()
             .itemInputs(RHNitrate.get(dust))
             .itemOutputs(


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
currently, if we want to make NaNO3, we only have 2 good ways
one is Na2CO3 + HNO3 -> NaNO3 + CO2 + H2O(eliminated)
<img width="332" height="240" alt="Screenshot 2026-08-12 at 19 52 46" src="https://github.com/user-attachments/assets/8a18f11c-5f8b-4211-8aea-17d59fd2f7e2" />

another is Na + HNO3 -> NaNO3 + H
<img width="337" height="244" alt="Screenshot 2026-08-12 at 19 52 53" src="https://github.com/user-attachments/assets/1a53c042-9fb9-44ab-afde-462f3998ff17" />


but the base + the acid neutralizing recipe is gone
so I am now adding that recipe to make the behaviour more in line with what it is irl.
<img width="344" height="299" alt="Screenshot 2026-08-12 at 19 46 01" src="https://github.com/user-attachments/assets/2a85521b-dbb7-4cef-8d5e-aa9d77ac600b" />

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
