### PR TITLE
fix bw ingot freezer recipe autogen algorithm

### DIFF
--- a/src/main/java/bartworks/system/material/Werkstoff.java
+++ b/src/main/java/bartworks/system/material/Werkstoff.java
@@ -478,8 +478,10 @@ public class Werkstoff implements IColorModulationContainer, IOreMaterial {
             case COMPOUND:
             case MIXTURE:
             case BIOLOGICAL: {
-                for (int i = 0; i < this.CONTENTS.toArray().length; i++) {
-                    ret += (int) this.CONTENTS.toArray(new Pair[0])[i].getValue();
+                Pair<ISubTagContainer, Integer>[] tArray = this.CONTENTS.toArray(new Pair[0]);
+                int arrayLen = tArray.length;
+                for (int i = 0; i < arrayLen; i++) {
+                    ret += tArray[i].getValue();
                 }
                 break;
             }

--- a/src/main/java/bartworks/system/material/WerkstoffLoader.java
+++ b/src/main/java/bartworks/system/material/WerkstoffLoader.java
@@ -183,6 +183,7 @@ public class WerkstoffLoader {
         "Zirconium",
         "Zr",
         new Werkstoff.Stats().setProtons(40)
+            .setMass(91)
             .setBlastFurnace(true)
             .setMeltingPoint(2130)
             .setMeltingVoltage(480),

--- a/src/main/java/bartworks/system/material/werkstoff_loaders/recipe/DustLoader.java
+++ b/src/main/java/bartworks/system/material/werkstoff_loaders/recipe/DustLoader.java
@@ -207,7 +207,7 @@ public class DustLoader implements IWerkstoffRunnable {
                                 (int) Math.max(
                                     1L,
                                     Math.abs(
-                                        werkstoffStats.getProtons() / werkstoff.getContents()
+                                        werkstoffStats.getMass() / werkstoff.getContents()
                                             .getValue()
                                             .size())))
                             .eut(


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
in the past we had some recipes very weird, e.g. 1tick to freeze the zirconium

the root cause was, Q ~ M, but the original code wrongly defined the Q to relate with the Proton sum, which would cause the recipes to be ridiculously fast.

before:
<img width="520" height="435" alt="Screenshot 2026-08-13 at 21 04 20" src="https://github.com/user-attachments/assets/58132a11-1841-46c2-8564-12f7336896be" />

after:
<img width="358" height="308" alt="Screenshot 2026-08-13 at 20 54 39" src="https://github.com/user-attachments/assets/81a8b933-6ad2-4cdb-91e6-d4bfccf9afdd" />

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
