### PR TITLE
Armor: Added a way to configure vertical flight speed

### DIFF
--- a/src/main/java/gregtech/api/items/armor/ArmorActionManager.java
+++ b/src/main/java/gregtech/api/items/armor/ArmorActionManager.java
@@ -134,6 +134,22 @@ public class ArmorActionManager {
                 SyncedKeybind.createConfigurable("key.gt.toggle_levitation_mode", "Gregtech Armor", Keyboard.KEY_NONE),
                 BehaviorName.Levitation));
 
+        register(
+            new ArmorAction(
+                "vertical_speed_increase",
+                "Increase vertical speed",
+                false,
+                SyncedKeybind.createConfigurable("key.gt.vertical_speed_increase", "Gregtech Armor", Keyboard.KEY_NONE),
+                BehaviorName.SpeedBoost));
+
+        register(
+            new ArmorAction(
+                "vertical_speed_decrease",
+                "Decrease vertical speed",
+                false,
+                SyncedKeybind.createConfigurable("key.gt.vertical_speed_decrease", "Gregtech Armor", Keyboard.KEY_NONE),
+                BehaviorName.SpeedBoost));
+
         // Keybinds
 
         register(

--- a/src/main/java/gregtech/api/items/armor/ArmorState.java
+++ b/src/main/java/gregtech/api/items/armor/ArmorState.java
@@ -56,7 +56,7 @@ public class ArmorState {
 
     public int visDiscount;
     public float manaDiscount;
-    public float speedBoostMulti, jumpBoostMulti;
+    public float speedBoostMulti, verticalSpeedBoostMulti, jumpBoostMulti;
 
     public void addArmorInformation(ArmorContext context, List<String> tooltip) {
         boolean showAllInfo = ArmorHelper.isShiftPressed();

--- a/src/main/java/gregtech/api/items/armor/behaviors/SpeedBoostBehavior.java
+++ b/src/main/java/gregtech/api/items/armor/behaviors/SpeedBoostBehavior.java
@@ -21,13 +21,11 @@ public class SpeedBoostBehavior implements IArmorBehavior {
 
     public static final SpeedBoostBehavior MECH_ARMOR_INSTANCE = new SpeedBoostBehavior(2.0F);
 
-    /// Somewhat arbitrary multiplier to make vertical flight speed comparable to horizontal flight speed
-    private static final double VERTICAL_SPEED_MULT = 2.5;
+    private static final float VERTICAL_SPEED_MULTI_INCREMENT = 0.5F;
+    private static final float VERTICAL_SPEED_MAX = 5.0F;
 
     public static final float SPEED_INCREMENT = 0.25F;
-
     private final float speedMaxMulti;
-
     private final float BASE_SPEED = 0.127F;
 
     public SpeedBoostBehavior(float speedUp) {
@@ -45,20 +43,44 @@ public class SpeedBoostBehavior implements IArmorBehavior {
 
         ArmorState state = context.getArmorState();
 
+        String messageKey = null;
+        double displayValue = 0;
+
         if (keyPressed == ArmorActionManager.getAction("speed_increase")
             .getKeybind()) {
             state.speedBoostMulti += SPEED_INCREMENT;
+            state.speedBoostMulti = MathUtils.clamp(state.speedBoostMulti, 1, speedMaxMulti);
+            messageKey = "GT5U.armor.message.speed_set";
+            displayValue = state.speedBoostMulti;
+
         } else if (keyPressed == ArmorActionManager.getAction("speed_decrease")
             .getKeybind()) {
                 state.speedBoostMulti -= SPEED_INCREMENT;
-            }
+                state.speedBoostMulti = MathUtils.clamp(state.speedBoostMulti, 1, speedMaxMulti);
+                messageKey = "GT5U.armor.message.speed_set";
+                displayValue = state.speedBoostMulti;
 
-        state.speedBoostMulti = MathUtils.clamp(state.speedBoostMulti, 1, speedMaxMulti);
+            } else if (keyPressed == ArmorActionManager.getAction("vertical_speed_increase")
+                .getKeybind()) {
+                    state.verticalSpeedBoostMulti += VERTICAL_SPEED_MULTI_INCREMENT;
+                    state.verticalSpeedBoostMulti = MathUtils
+                        .clamp(state.verticalSpeedBoostMulti, 0.5F, VERTICAL_SPEED_MAX);
+                    messageKey = "GT5U.armor.message.vertical_speed_set";
+                    displayValue = state.verticalSpeedBoostMulti;
 
-        if (context.getPlayer() instanceof EntityPlayerMP playerMP) {
+                } else if (keyPressed == ArmorActionManager.getAction("vertical_speed_decrease")
+                    .getKeybind()) {
+                        state.verticalSpeedBoostMulti -= VERTICAL_SPEED_MULTI_INCREMENT;
+                        state.verticalSpeedBoostMulti = MathUtils
+                            .clamp(state.verticalSpeedBoostMulti, 0.5F, VERTICAL_SPEED_MAX);
+                        messageKey = "GT5U.armor.message.vertical_speed_set";
+                        displayValue = state.verticalSpeedBoostMulti;
+                    }
+
+        if (messageKey != null && context.getPlayer() instanceof EntityPlayerMP playerMP) {
             ChatComponentTranslation chatComponent = new ChatComponentTranslation(
-                "GT5U.armor.message.speed_set",
-                "§f" + state.speedBoostMulti + "x§r");
+                messageKey,
+                "§f" + displayValue + "x§r");
             GTNHLib.proxy.sendMessageAboveHotbar(playerMP, chatComponent, 60, true, true);
         }
     }
@@ -67,11 +89,15 @@ public class SpeedBoostBehavior implements IArmorBehavior {
     public void configureArmorState(@NotNull ArmorContext context, @NotNull NBTTagCompound stackTag) {
         float savedBoost = stackTag.getFloat("speedBoostMulti");
         context.getArmorState().speedBoostMulti = Math.max(savedBoost, 1.0F);
+
+        float savedVerticalBoost = stackTag.getFloat("verticalSpeedBoostMulti");
+        context.getArmorState().verticalSpeedBoostMulti = Math.max(savedVerticalBoost, 0.5F);
     }
 
     @Override
     public void saveArmorState(@NotNull ArmorContext context, @NotNull NBTTagCompound stackTag) {
         stackTag.setFloat("speedBoostMulti", context.getArmorState().speedBoostMulti);
+        stackTag.setFloat("verticalSpeedBoostMulti", context.getArmorState().verticalSpeedBoostMulti);
     }
 
     @Override
@@ -88,8 +114,9 @@ public class SpeedBoostBehavior implements IArmorBehavior {
     @Override
     public void onArmorTick(@NotNull ArmorContext context) {
         EntityPlayer player = context.getPlayer();
+        ArmorState state = context.getArmorState();
 
-        float speed = (context.getArmorState().speedBoostMulti - 1.0F) * BASE_SPEED;
+        float speed = (state.speedBoostMulti - 1.0F) * BASE_SPEED;
         if (speed <= 0) return;
 
         if (player.capabilities.isFlying) {
@@ -123,7 +150,7 @@ public class SpeedBoostBehavior implements IArmorBehavior {
             if (player.moveStrafing < 0F) player.moveFlying(-1F, 0F, currentSpeed);
 
             if (player.capabilities.isFlying) {
-                float verticalSpeed = (float) (speed * VERTICAL_SPEED_MULT);
+                float verticalSpeed = (speed * state.verticalSpeedBoostMulti * 1.5F);
 
                 if (player.isSneaking()) {
                     player.moveEntity(0, -verticalSpeed, 0);

--- a/src/main/resources/assets/gregtech/lang/en_US.lang
+++ b/src/main/resources/assets/gregtech/lang/en_US.lang
@@ -3857,6 +3857,7 @@ GT5U.armor.message.disabled=%s §cDisabled§r
 GT5U.armor.message.installed=%s Installed
 GT5U.armor.message.systems_online=Armor Systems Online... Active keybindings:
 GT5U.armor.message.speed_set=§6New speed:§r %s
+GT5U.armor.message.vertical_speed_set=§6New vertical speed:§r %s
 GT5U.armor.message.jump_boost_set=§6New jump boost:§r %s
 
 GT5U.armor.tooltip.hold_shift=Hold Shift for more info
@@ -7169,6 +7170,8 @@ key.gt.jump_decrease=Decrease Jump Boost
 key.gt.force_field=Toggle Force Field
 key.gt.toggle_levitation_mode=Toggle Levitation Mode
 key.gt.open_radial_menu=Open Radial Menu
+key.gt.vertical_speed_increase=Increase vertical speed
+key.gt.vertical_speed_decrease=Decrease vertical speed
 
 # Tooltips for GT Tools
 gt.softmallet.tooltip=Activates and Deactivates Machines


### PR DESCRIPTION
## Summary
Two new armor actions now allow players to increase/decrease vertical flight speed.

May need user feedback for balancing.

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
