### PR TITLE
fix connected blocks checker

### DIFF
--- a/src/main/java/bartworks/util/ConnectedBlocksChecker.java
+++ b/src/main/java/bartworks/util/ConnectedBlocksChecker.java
@@ -56,6 +56,12 @@ public class ConnectedBlocksChecker {
 
         int wID = w.provider.dimensionId;
 
+        if (this.hashset.contains(new Coords(x, y, z, wID))) {
+            return ret;
+        }
+
+        this.hashset.add(new Coords(x, y, z, wID));
+
         byte sides = this.check_sourroundings(w, x, y, z, b);
 
         if ((sides | 0b111011) == 0b111111 && !this.hashset.contains(new Coords(x + 1, y, z, wID))) {
@@ -95,10 +101,6 @@ public class ConnectedBlocksChecker {
 
         byte ret = 0;
         int wID = w.provider.dimensionId;
-
-        if (this.hashset.contains(new Coords(x, y, z, wID))) return ret;
-
-        this.hashset.add(new Coords(x, y, z, wID));
 
         if (w.getBlock(x + 1, y, z)
             .equals(b)) ret = (byte) (ret | 0b000100);

--- a/src/main/java/bartworks/util/ConnectedBlocksChecker.java
+++ b/src/main/java/bartworks/util/ConnectedBlocksChecker.java
@@ -13,7 +13,9 @@
 
 package bartworks.util;
 
+import java.util.ArrayDeque;
 import java.util.HashSet;
+import java.util.Queue;
 
 import net.minecraft.block.Block;
 import net.minecraft.world.World;
@@ -56,42 +58,35 @@ public class ConnectedBlocksChecker {
 
         int wID = w.provider.dimensionId;
 
-        if (this.hashset.contains(new Coords(x, y, z, wID))) {
-            return ret;
-        }
-
-        this.hashset.add(new Coords(x, y, z, wID));
-
-        byte sides = this.check_sourroundings(w, x, y, z, b);
-
-        if ((sides | 0b111011) == 0b111111 && !this.hashset.contains(new Coords(x + 1, y, z, wID))) {
+        // BFS starting node
+        Queue<Coords> toVisit = new ArrayDeque<>();
+        toVisit.add(new Coords(x, y, z, wID));
+        while (!toVisit.isEmpty()) {
+            Coords curr = toVisit.poll();
+            if (this.hashset.contains(curr)) {
+                continue;
+            }
+            this.hashset.add(curr);
             ret++;
-            ret += this.get_connected(w, x + 1, y, z, b);
-        }
-
-        if ((sides | 0b110111) == 0b111111 && !this.hashset.contains(new Coords(x - 1, y, z, wID))) {
-            ret++;
-            ret += this.get_connected(w, x - 1, y, z, b);
-        }
-
-        if ((sides | 0b101111) == 0b111111 && !this.hashset.contains(new Coords(x, y, z + 1, wID))) {
-            ret++;
-            ret += this.get_connected(w, x, y, z + 1, b);
-        }
-
-        if ((sides | 0b011111) == 0b111111 && !this.hashset.contains(new Coords(x, y, z - 1, wID))) {
-            ret++;
-            ret += this.get_connected(w, x, y, z - 1, b);
-        }
-
-        if ((sides | 0b111110) == 0b111111 && !this.hashset.contains(new Coords(x, y + 1, z, wID))) {
-            ret++;
-            ret += this.get_connected(w, x, y + 1, z, b);
-        }
-
-        if ((sides | 0b111101) == 0b111111 && !this.hashset.contains(new Coords(x, y - 1, z, wID))) {
-            ret++;
-            ret += this.get_connected(w, x, y - 1, z, b);
+            byte res = check_sourroundings(w, curr.x, curr.y, curr.z, b);
+            if ((res | 0b111011) == 0b111111) {
+                toVisit.add(new Coords(curr.x + 1, curr.y, curr.z, curr.wID));
+            }
+            if ((res | 0b110111) == 0b111111) {
+                toVisit.add(new Coords(curr.x - 1, curr.y, curr.z, curr.wID));
+            }
+            if ((res | 0b101111) == 0b111111) {
+                toVisit.add(new Coords(curr.x, curr.y, curr.z + 1, curr.wID));
+            }
+            if ((res | 0b011111) == 0b111111) {
+                toVisit.add(new Coords(curr.x, curr.y, curr.z - 1, curr.wID));
+            }
+            if ((res | 0b111110) == 0b111111) {
+                toVisit.add(new Coords(curr.x, curr.y + 1, curr.z, curr.wID));
+            }
+            if ((res | 0b111101) == 0b111111) {
+                toVisit.add(new Coords(curr.x, curr.y - 1, curr.z, curr.wID));
+            }
         }
 
         return ret;


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
Closes: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/26284
the root cause was the recursive DFS algorithm would be limited by the stack size and cause SOF then crash.
now switched to non-recursive BFS and will never cause this issue.
<img width="1708" height="960" alt="2026-08-14_08 27 10" src="https://github.com/user-attachments/assets/90c36e15-80ea-4b71-89d9-872c1dd97cc3" />


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
