### PR TITLE
Fix MUI1 Text disappearance

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
@@ -1784,7 +1784,7 @@ public abstract class MTEMultiBlockBase extends MetaTileEntity
 
     /**
      * Returns the amount that is actually drained
-     * 
+     *
      * @param aLiquid  The liquid to drain, will not be modified.
      * @param simulate Whether to perform the draining
      * @return The amount that is drained
@@ -3645,15 +3645,13 @@ public abstract class MTEMultiBlockBase extends MetaTileEntity
                                     .setSize(8, 8)
                                     .setPos(0, 0))
                         .addChild(
-                            TextWidget
-                                .dynamicString(
-                                    () -> translateToLocalFormatted(
-                                        "GT5U.gui.text.item_amount_display",
-                                        truncatedItemName,
-                                        shortenedCount) + rateShort)
-                                .setTextAlignment(Alignment.CenterLeft)
-                                .addTooltip(lineTooltip)
-                                .setPos(10, 1)));
+                            new TextWidget(
+                                translateToLocalFormatted(
+                                    "GT5U.gui.text.item_amount_display",
+                                    truncatedItemName,
+                                    shortenedCount) + rateShort).setTextAlignment(Alignment.CenterLeft)
+                                        .addTooltip(lineTooltip)
+                                        .setPos(10, 1)));
             }
         }
         if (mOutputFluids != null) {
@@ -3694,15 +3692,14 @@ public abstract class MTEMultiBlockBase extends MetaTileEntity
                             .setSize(8, 8)
                             .setPos(0, 0))
                         .addChild(
-                            TextWidget
-                                .dynamicString(
-                                    () -> translateToLocalFormatted(
-                                        "GT5U.gui.text.fluid_amount_display",
-                                        truncatedFluidName,
-                                        shortenedCount) + rateShort)
-                                .setTextAlignment(Alignment.CenterLeft)
-                                .addTooltip(lineTooltip)
-                                .setPos(10, 1)));
+                            new TextWidget(
+                                translateToLocalFormatted(
+                                    "GT5U.gui.text.fluid_amount_display",
+                                    truncatedFluidName,
+                                    shortenedCount) + rateShort).setTextAlignment(Alignment.CenterLeft)
+                                        .addTooltip(lineTooltip)
+                                        .setSize(100, 8)
+                                        .setPos(10, 1)));
 
             }
         }

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
@@ -3798,7 +3798,8 @@ public abstract class MTEMultiBlockBase extends MetaTileEntity
 
         if (supportsMachineModeSwitch()) {
             screenElements.widget(
-                new TextWidget(translateToLocalFormatted("gt.interact.desc.mb.mode", getMachineModeName()))
+                TextWidget
+                    .dynamicString(() -> translateToLocalFormatted("gt.interact.desc.mb.mode", getMachineModeName()))
                     .setTextAlignment(Alignment.CenterLeft));
         }
         screenElements

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEMultiBlockBase.java
@@ -3698,7 +3698,6 @@ public abstract class MTEMultiBlockBase extends MetaTileEntity
                                     truncatedFluidName,
                                     shortenedCount) + rateShort).setTextAlignment(Alignment.CenterLeft)
                                         .addTooltip(lineTooltip)
-                                        .setSize(100, 8)
                                         .setPos(10, 1)));
 
             }
@@ -3799,8 +3798,7 @@ public abstract class MTEMultiBlockBase extends MetaTileEntity
 
         if (supportsMachineModeSwitch()) {
             screenElements.widget(
-                TextWidget
-                    .dynamicString(() -> translateToLocalFormatted("gt.interact.desc.mb.mode", getMachineModeName()))
+                new TextWidget(translateToLocalFormatted("gt.interact.desc.mb.mode", getMachineModeName()))
                     .setTextAlignment(Alignment.CenterLeft));
         }
         screenElements


### PR DESCRIPTION
## Summary
`DynamicTextWidget` (or equivalently, TextWidget.dynamicString) should only be used when the text is computed server side and needs to be synced server to client. Since the widget logic computes it on the client side, there is no point to sync from server as the real underlying data is mOutputItems which are synced separately and the widget is redrawn separately.

Broken by:
- https://github.com/GTNewHorizons/GT5-Unofficial/pull/7149

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/26267

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
