### PR TITLE
Fix ghost mold dupe in Solidifier Hatch

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/MTEHatchSolidifier.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/MTEHatchSolidifier.java
@@ -138,7 +138,8 @@ public class MTEHatchSolidifier extends MTEHatchInput implements IConfigurationC
 
     @Override
     public boolean isValidSlot(int aIndex) {
-        return aIndex == moldSlot || super.isValidSlot(aIndex);
+        // the mold is a ghost item and the circuit is a configuration slot, neither may be dropped or picked up
+        return aIndex != moldSlot && aIndex != circuitSlot && super.isValidSlot(aIndex);
     }
 
     @Override


### PR DESCRIPTION
## Summary
The Solidifier Hatch marked its ghost mold slot as a valid slot, so a Matter Manipulator pickup handed out a real mold item. Regular breaking never showed it because onBlockDestroyed clears the slot first. The Extrusion Hatch already excludes its ghost shape slot, this brings the Solidifier Hatch in line.

The configuration circuit slot was affected the same way and is excluded as well.

## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge