### PR TITLE
Log useless remove recipe removals

### DIFF
--- a/src/main/java/gregtech/GTLoggers.java
+++ b/src/main/java/gregtech/GTLoggers.java
@@ -11,6 +11,8 @@ public final class GTLoggers {
     public static final Logger GT_EXPLOSION_LOGGER = GTLog.conditionalLogger("GregTech Explosions");
     public static final Logger GT_ICON_LOGGER = GTLog.conditionalLogger("GregTech Icons");
     public static final Logger GT_ORE_DICT_LOGGER = GTLog.conditionalLogger("GregTech Ore Dictionary");
+    public static final boolean GT_RECIPE_REMOVAL_LOGGER_ENABLED = Boolean.getBoolean("gt.recipe.remove_delayed.debug");
+    public static final Logger GT_RECIPE_REMOVAL_LOGGER = GTLog.conditionalLogger("GregTech Useless Recipe Removals");
     public static final Logger GT_SHADER_LOGGER = LogManager.getLogger("ShaderAPI");
 
     private GTLoggers() {}

--- a/src/main/java/gregtech/GTMod.java
+++ b/src/main/java/gregtech/GTMod.java
@@ -229,6 +229,11 @@ public class GTMod {
         } catch (RuntimeException e) {
             GT_FML_LOGGER.error("Failed to configure icon logger", e);
         }
+        try {
+            GTLog.configureRecipeRemovalLogger(minecraftHome);
+        } catch (RuntimeException e) {
+            GT_FML_LOGGER.error("Failed to configure recipe removal logger", e);
+        }
     }
 
     public static final int NBT_VERSION = calculateTotalGTVersion(VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH);

--- a/src/main/java/gregtech/api/util/GTLog.java
+++ b/src/main/java/gregtech/api/util/GTLog.java
@@ -3,6 +3,8 @@ package gregtech.api.util;
 import static gregtech.GTLoggers.GT_EXPLOSION_LOGGER;
 import static gregtech.GTLoggers.GT_ICON_LOGGER;
 import static gregtech.GTLoggers.GT_ORE_DICT_LOGGER;
+import static gregtech.GTLoggers.GT_RECIPE_REMOVAL_LOGGER;
+import static gregtech.GTLoggers.GT_RECIPE_REMOVAL_LOGGER_ENABLED;
 
 import java.io.File;
 
@@ -70,6 +72,15 @@ public class GTLog {
         GT_ICON_LOGGER.info("* First column R|O tells if resource is (Required or Optional)  *");
         GT_ICON_LOGGER.info("* Second column is the resource path                            *");
         GT_ICON_LOGGER.info("*****************************************************************");
+    }
+
+    public static void configureRecipeRemovalLogger(File parentFile) {
+        configureRollingLogger(
+            GT_RECIPE_REMOVAL_LOGGER,
+            GT_RECIPE_REMOVAL_LOGGER_ENABLED,
+            new File(parentFile, "logs/UselessRecipeRemovals.log"),
+            new File(parentFile, "logs/UselessRecipeRemovals-%i.log"),
+            "GregTechUselessRecipeRemovalsFile");
     }
 
     private static void configureLogger(Logger apiLogger, boolean enabled) {

--- a/src/main/java/gregtech/api/util/GTModHandler.java
+++ b/src/main/java/gregtech/api/util/GTModHandler.java
@@ -1,6 +1,8 @@
 package gregtech.api.util;
 
 import static gregtech.GTLoggers.GT_FML_LOGGER;
+import static gregtech.GTLoggers.GT_RECIPE_REMOVAL_LOGGER;
+import static gregtech.GTLoggers.GT_RECIPE_REMOVAL_LOGGER_ENABLED;
 import static gregtech.api.enums.GTValues.B;
 import static gregtech.api.enums.GTValues.D1;
 import static gregtech.api.enums.GTValues.DW;
@@ -114,8 +116,6 @@ public class GTModHandler {
     private static final int DELAYED_REMOVAL_ONLY_REMOVE_NATIVE = 2;
 
     private static final List<InventoryCrafting> delayedRemovalByRecipe = new ArrayList<>();
-    private static final boolean DEBUG_USELESS_DELAYED_RECIPE_REMOVALS = Boolean
-        .getBoolean("gt.recipe.remove_delayed.debug");
     private static final List<Exception> delayedRemovalCallsites = new ArrayList<>();
 
     public static Collection<String> sNativeRecipeClasses = new HashSet<>();
@@ -1389,7 +1389,7 @@ public class GTModHandler {
         }
 
         delayedRemovalByRecipe.add(craftMatrix);
-        if (DEBUG_USELESS_DELAYED_RECIPE_REMOVALS) {
+        if (GT_RECIPE_REMOVAL_LOGGER_ENABLED) {
             delayedRemovalCallsites.add(new Exception("removeRecipeDelayed shape: " + Arrays.toString(shape)));
         }
     }
@@ -1400,7 +1400,7 @@ public class GTModHandler {
         GT_FML_LOGGER
             .info("BulkRemoveByRecipe: allRecipes: {}; toRemove: {}", allRecipes.size(), delayedRemovalByRecipe.size());
 
-        AtomicIntegerArray matchedDelayedRemovals = DEBUG_USELESS_DELAYED_RECIPE_REMOVALS
+        AtomicIntegerArray matchedDelayedRemovals = GT_RECIPE_REMOVAL_LOGGER_ENABLED
             ? new AtomicIntegerArray(delayedRemovalByRecipe.size())
             : null;
         Set<IRecipe> listToRemove = allRecipes.parallelStream()
@@ -1423,7 +1423,7 @@ public class GTModHandler {
         if (matchedDelayedRemovals != null) {
             for (int i = 0; i < matchedDelayedRemovals.length(); i++) {
                 if (matchedDelayedRemovals.get(i) == 0) {
-                    GT_FML_LOGGER
+                    GT_RECIPE_REMOVAL_LOGGER
                         .warn("removeRecipeDelayed call matched no removable recipe", delayedRemovalCallsites.get(i));
                 }
             }

--- a/src/main/java/gregtech/api/util/GTModHandler.java
+++ b/src/main/java/gregtech/api/util/GTModHandler.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicIntegerArray;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -113,6 +114,9 @@ public class GTModHandler {
     private static final int DELAYED_REMOVAL_ONLY_REMOVE_NATIVE = 2;
 
     private static final List<InventoryCrafting> delayedRemovalByRecipe = new ArrayList<>();
+    private static final boolean DEBUG_USELESS_DELAYED_RECIPE_REMOVALS = Boolean
+        .getBoolean("gt.recipe.remove_delayed.debug");
+    private static final List<Exception> delayedRemovalCallsites = new ArrayList<>();
 
     public static Collection<String> sNativeRecipeClasses = new HashSet<>();
     public static Collection<String> sSpecialRecipeClasses = new HashSet<>();
@@ -552,6 +556,7 @@ public class GTModHandler {
         delayedRemovalByOutput.clear();
         delayedRemovalByOutputFlags.clear();
         delayedRemovalByRecipe.clear();
+        delayedRemovalCallsites.clear();
         sBufferRecipeList.clear();
     }
 
@@ -1384,6 +1389,9 @@ public class GTModHandler {
         }
 
         delayedRemovalByRecipe.add(craftMatrix);
+        if (DEBUG_USELESS_DELAYED_RECIPE_REMOVALS) {
+            delayedRemovalCallsites.add(new Exception("removeRecipeDelayed shape: " + Arrays.toString(shape)));
+        }
     }
 
     private static void bulkRemoveByRecipe() {
@@ -1392,13 +1400,17 @@ public class GTModHandler {
         GT_FML_LOGGER
             .info("BulkRemoveByRecipe: allRecipes: {}; toRemove: {}", allRecipes.size(), delayedRemovalByRecipe.size());
 
+        AtomicIntegerArray matchedDelayedRemovals = DEBUG_USELESS_DELAYED_RECIPE_REMOVALS
+            ? new AtomicIntegerArray(delayedRemovalByRecipe.size())
+            : null;
         Set<IRecipe> listToRemove = allRecipes.parallelStream()
             .filter(recipe -> {
                 if (recipe instanceof IGTCraftingRecipe craftingRecipe && !craftingRecipe.isRemovable()) {
                     return false;
                 }
-                for (InventoryCrafting crafting : delayedRemovalByRecipe) {
-                    if (recipe.matches(crafting, DW)) {
+                for (int i = 0; i < delayedRemovalByRecipe.size(); i++) {
+                    if (recipe.matches(delayedRemovalByRecipe.get(i), DW)) {
+                        if (matchedDelayedRemovals != null) matchedDelayedRemovals.set(i, 1);
                         return true;
                     }
                 }
@@ -1407,6 +1419,15 @@ public class GTModHandler {
             .collect(Collectors.toSet());
 
         allRecipes.removeIf(listToRemove::contains);
+
+        if (matchedDelayedRemovals != null) {
+            for (int i = 0; i < matchedDelayedRemovals.length(); i++) {
+                if (matchedDelayedRemovals.get(i) == 0) {
+                    GT_FML_LOGGER
+                        .warn("removeRecipeDelayed call matched no removable recipe", delayedRemovalCallsites.get(i));
+                }
+            }
+        }
     }
 
     public static boolean removeRecipeByOutputDelayed(ItemStack aOutput) {

--- a/src/main/java/gregtech/api/util/GTModHandler.java
+++ b/src/main/java/gregtech/api/util/GTModHandler.java
@@ -1368,13 +1368,19 @@ public class GTModHandler {
     }
 
     public static void removeRecipeDelayed(ItemStack... shape) {
+        if (shape == null || isAllNulls(shape)) {
+            if (GT_RECIPE_REMOVAL_LOGGER_ENABLED) {
+                GT_RECIPE_REMOVAL_LOGGER.error(
+                    "removeRecipeDelayed rejected empty or null-only crafting inputs; call site follows",
+                    new Exception("Rejected crafting inputs: " + Arrays.toString(shape)));
+            }
+            return;
+        }
+
         if (!sBufferCraftingRecipes) {
             removeRecipe(shape);
             return;
         }
-
-        if (shape == null) return;
-        if (isAllNulls(shape)) return;
 
         InventoryCrafting craftMatrix = new InventoryCrafting(new Container() {
 

--- a/src/main/java/gregtech/api/util/GTModHandler.java
+++ b/src/main/java/gregtech/api/util/GTModHandler.java
@@ -1390,7 +1390,8 @@ public class GTModHandler {
 
         delayedRemovalByRecipe.add(craftMatrix);
         if (GT_RECIPE_REMOVAL_LOGGER_ENABLED) {
-            delayedRemovalCallsites.add(new Exception("removeRecipeDelayed shape: " + Arrays.toString(shape)));
+            delayedRemovalCallsites
+                .add(new Exception("Queued crafting inputs (not an existing recipe): " + Arrays.toString(shape)));
         }
     }
 
@@ -1423,8 +1424,9 @@ public class GTModHandler {
         if (matchedDelayedRemovals != null) {
             for (int i = 0; i < matchedDelayedRemovals.length(); i++) {
                 if (matchedDelayedRemovals.get(i) == 0) {
-                    GT_RECIPE_REMOVAL_LOGGER
-                        .warn("removeRecipeDelayed call matched no removable recipe", delayedRemovalCallsites.get(i));
+                    GT_RECIPE_REMOVAL_LOGGER.warn(
+                        "No existing removable crafting recipe matched these queued inputs; removal call site follows",
+                        delayedRemovalCallsites.get(i));
                 }
             }
         }


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
I was curious to see if the heavy step of batch removing recipes was doing unecessary work by trying to remove stuff that does not exist. So here is the tooling for this. I made a new conditional logger for this, that logs everything in `UselessRecipeRemovals.log` if `-Dgt.recipe.remove_delayed.debug=true` is added as a jvm argument. Tested on daily 677.

Guess who got a 48.2MB log to process now? 😂 

## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
