### PR TITLE
Fix target chamber progress time calculation

### DIFF
--- a/src/main/java/gtnhlanth/common/tileentity/MTETargetChamber.java
+++ b/src/main/java/gtnhlanth/common/tileentity/MTETargetChamber.java
@@ -360,7 +360,7 @@ public class MTETargetChamber extends MTEEnhancedMultiBlockBase<MTETargetChamber
         this.lastTCRecipeRate = inputRate;
 
         // 5 seconds per integer multiple over the rate
-        float progressTime = metadata.amount / inputRate * 5 * TickTime.SECOND;
+        float progressTime = calculateProgressTime(metadata.amount, inputRate);
         int batchAmount = 1;
         if (progressTime < 1) { // Subticking
             batchAmount = (int) Math.round(1.0 / progressTime);
@@ -416,6 +416,10 @@ public class MTETargetChamber extends MTEEnhancedMultiBlockBase<MTETargetChamber
         this.updateSlots();
 
         return CheckRecipeResultRegistry.SUCCESSFUL;
+    }
+
+    private static float calculateProgressTime(int particleAmount, int particleRate) {
+        return (float) particleAmount / particleRate * 5 * TickTime.SECOND;
     }
 
     @Nullable


### PR DESCRIPTION
## Summary
Fix target chamber progress time calculation introduced in #7753, losing the float cast


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
