### PR TITLE
Fix modular armor landing gear not absorbing low fall damage due to distance mismatch

### DIFF
--- a/src/main/java/gregtech/api/items/armor/ArmorEventHandlers.java
+++ b/src/main/java/gregtech/api/items/armor/ArmorEventHandlers.java
@@ -167,7 +167,7 @@ public class ArmorEventHandlers {
                 }
             }
 
-            if (event.distance < 3.2f) {
+            if (player.fallDistance < 3.2f) {
                 return;
             }
             ItemStack boots = player.getCurrentArmor(SLOT_BOOTS);


### PR DESCRIPTION
## Summary
This was a pain to debug, but from what I can tell, the reason why the landing gear augment didn't protect from low fall damage was due to a mismatch between the event distance and the `fallDistance` of the player. In very specific circumstances, you could get the event distance inside the armor's `onLivingFall` event handler to be just below 3.2, while player fall distance would be just above (in testing I got about 3.06 for the event distance and about 4.06 for the player fall distance). This caused the armor's event handler to exit early, while minecraft's fall damage handler would then end up getting the higher value and doing fall damage. 

Changing the condition to use player fall distance instead seems to fix it.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/26309

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
