### PR TITLE
Fix pipe oddity in recipe registration

### DIFF
--- a/src/main/java/gregtech/GTMod.java
+++ b/src/main/java/gregtech/GTMod.java
@@ -16,7 +16,6 @@ import java.util.Arrays;
 import java.util.Locale;
 import java.util.Map;
 
-import gregtech.api.util.RecipeChangeAudit;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;

--- a/src/main/java/gregtech/GTMod.java
+++ b/src/main/java/gregtech/GTMod.java
@@ -785,7 +785,6 @@ public class GTMod {
                 .bus()
                 .register(new RecipeLookupValidationServerTickHandler());
         }
-        RecipeChangeAudit.run("pipes", "pipe recipe checking", () -> {});
     }
 
     public static final class RecipeLookupValidationServerTickHandler {

--- a/src/main/java/gregtech/GTMod.java
+++ b/src/main/java/gregtech/GTMod.java
@@ -16,6 +16,7 @@ import java.util.Arrays;
 import java.util.Locale;
 import java.util.Map;
 
+import gregtech.api.util.RecipeChangeAudit;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
@@ -784,6 +785,7 @@ public class GTMod {
                 .bus()
                 .register(new RecipeLookupValidationServerTickHandler());
         }
+        RecipeChangeAudit.run("pipes", "pipe recipe checking", () -> {});
     }
 
     public static final class RecipeLookupValidationServerTickHandler {

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingPipe.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingPipe.java
@@ -59,7 +59,7 @@ public class ProcessingPipe implements gregtech.api.interfaces.IOreRecipeRegistr
                             aMaterial.contains(SubTag.WOOD) ? ToolDictNames.craftingToolSoftMallet
                                 : ToolDictNames.craftingToolHardHammer,
                             'W', aMaterial.contains(SubTag.WOOD) ? ToolDictNames.craftingToolSaw
-                            : ToolDictNames.craftingToolWrench });
+                                : ToolDictNames.craftingToolWrench });
                 }
             }
             case "pipeMedium" -> {
@@ -74,7 +74,7 @@ public class ProcessingPipe implements gregtech.api.interfaces.IOreRecipeRegistr
                             aMaterial.contains(SubTag.WOOD) ? ToolDictNames.craftingToolSoftMallet
                                 : ToolDictNames.craftingToolHardHammer,
                             'W', aMaterial.contains(SubTag.WOOD) ? ToolDictNames.craftingToolSaw
-                            : ToolDictNames.craftingToolWrench });
+                                : ToolDictNames.craftingToolWrench });
                 }
             }
             case "pipeSmall" -> {
@@ -89,7 +89,7 @@ public class ProcessingPipe implements gregtech.api.interfaces.IOreRecipeRegistr
                             aMaterial.contains(SubTag.WOOD) ? ToolDictNames.craftingToolSoftMallet
                                 : ToolDictNames.craftingToolHardHammer,
                             'W', aMaterial.contains(SubTag.WOOD) ? ToolDictNames.craftingToolSaw
-                            : ToolDictNames.craftingToolWrench });
+                                : ToolDictNames.craftingToolWrench });
                 }
             }
             case "pipeTiny" -> {

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingPipe.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingPipe.java
@@ -39,35 +39,16 @@ public class ProcessingPipe implements gregtech.api.interfaces.IOreRecipeRegistr
     public void registerOre(OrePrefixes aPrefix, Materials aMaterial, String aOreDictName, String aModName,
         ItemStack aStack) {
         switch (aPrefix.getName()) {
-            case "pipeHuge", "pipeLarge", "pipeMedium", "pipeSmall", "pipeTiny" -> {
+            case "pipeHuge" -> {
                 if (aMaterial.getProcessingMaterialTierEU() < TierEU.IV) {
-
                     GTModHandler.addCraftingRecipe(
-                        GTOreDictUnificator.get(OrePrefixes.pipeTiny, aMaterial, 8L),
+                        GTOreDictUnificator.get(OrePrefixes.pipeHuge, aMaterial, 1L),
                         GTModHandler.RecipeBits.BUFFERED,
-                        new Object[] { "PPP", "h w", "PPP", 'P', OrePrefixes.plate.get(aMaterial) });
-                    GTModHandler.addCraftingRecipe(
-                        GTOreDictUnificator.get(OrePrefixes.pipeSmall, aMaterial, 6L),
-                        GTModHandler.RecipeBits.BUFFERED,
-                        new Object[] { "PWP", "P P", "PHP", 'P',
-                            aMaterial == Materials.Wood ? OrePrefixes.plank.get(aMaterial)
-                                : OrePrefixes.plate.get(aMaterial),
-                            'H',
-                            aMaterial.contains(SubTag.WOOD) ? ToolDictNames.craftingToolSoftMallet
-                                : ToolDictNames.craftingToolHardHammer,
-                            'W', aMaterial.contains(SubTag.WOOD) ? ToolDictNames.craftingToolSaw
-                                : ToolDictNames.craftingToolWrench });
-                    GTModHandler.addCraftingRecipe(
-                        GTOreDictUnificator.get(OrePrefixes.pipeMedium, aMaterial, 2L),
-                        GTModHandler.RecipeBits.BUFFERED,
-                        new Object[] { "PPP", "W H", "PPP", 'P',
-                            aMaterial == Materials.Wood ? OrePrefixes.plank.get(aMaterial)
-                                : OrePrefixes.plate.get(aMaterial),
-                            'H',
-                            aMaterial.contains(SubTag.WOOD) ? ToolDictNames.craftingToolSoftMallet
-                                : ToolDictNames.craftingToolHardHammer,
-                            'W', aMaterial.contains(SubTag.WOOD) ? ToolDictNames.craftingToolSaw
-                                : ToolDictNames.craftingToolWrench });
+                        new Object[] { "DhD", "D D", "DwD", 'D', OrePrefixes.plateDouble.get(aMaterial) });
+                }
+            }
+            case "pipeLarge" -> {
+                if (aMaterial.getProcessingMaterialTierEU() < TierEU.IV) {
                     GTModHandler.addCraftingRecipe(
                         GTOreDictUnificator.get(OrePrefixes.pipeLarge, aMaterial, 1L),
                         GTModHandler.RecipeBits.BUFFERED,
@@ -78,11 +59,45 @@ public class ProcessingPipe implements gregtech.api.interfaces.IOreRecipeRegistr
                             aMaterial.contains(SubTag.WOOD) ? ToolDictNames.craftingToolSoftMallet
                                 : ToolDictNames.craftingToolHardHammer,
                             'W', aMaterial.contains(SubTag.WOOD) ? ToolDictNames.craftingToolSaw
-                                : ToolDictNames.craftingToolWrench });
+                            : ToolDictNames.craftingToolWrench });
+                }
+            }
+            case "pipeMedium" -> {
+                if (aMaterial.getProcessingMaterialTierEU() < TierEU.IV) {
                     GTModHandler.addCraftingRecipe(
-                        GTOreDictUnificator.get(OrePrefixes.pipeHuge, aMaterial, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.pipeMedium, aMaterial, 2L),
                         GTModHandler.RecipeBits.BUFFERED,
-                        new Object[] { "DhD", "D D", "DwD", 'D', OrePrefixes.plateDouble.get(aMaterial) });
+                        new Object[] { "PPP", "W H", "PPP", 'P',
+                            aMaterial == Materials.Wood ? OrePrefixes.plank.get(aMaterial)
+                                : OrePrefixes.plate.get(aMaterial),
+                            'H',
+                            aMaterial.contains(SubTag.WOOD) ? ToolDictNames.craftingToolSoftMallet
+                                : ToolDictNames.craftingToolHardHammer,
+                            'W', aMaterial.contains(SubTag.WOOD) ? ToolDictNames.craftingToolSaw
+                            : ToolDictNames.craftingToolWrench });
+                }
+            }
+            case "pipeSmall" -> {
+                if (aMaterial.getProcessingMaterialTierEU() < TierEU.IV) {
+                    GTModHandler.addCraftingRecipe(
+                        GTOreDictUnificator.get(OrePrefixes.pipeSmall, aMaterial, 6L),
+                        GTModHandler.RecipeBits.BUFFERED,
+                        new Object[] { "PWP", "P P", "PHP", 'P',
+                            aMaterial == Materials.Wood ? OrePrefixes.plank.get(aMaterial)
+                                : OrePrefixes.plate.get(aMaterial),
+                            'H',
+                            aMaterial.contains(SubTag.WOOD) ? ToolDictNames.craftingToolSoftMallet
+                                : ToolDictNames.craftingToolHardHammer,
+                            'W', aMaterial.contains(SubTag.WOOD) ? ToolDictNames.craftingToolSaw
+                            : ToolDictNames.craftingToolWrench });
+                }
+            }
+            case "pipeTiny" -> {
+                if (aMaterial.getProcessingMaterialTierEU() < TierEU.IV) {
+                    GTModHandler.addCraftingRecipe(
+                        GTOreDictUnificator.get(OrePrefixes.pipeTiny, aMaterial, 8L),
+                        GTModHandler.RecipeBits.BUFFERED,
+                        new Object[] { "PPP", "h w", "PPP", 'P', OrePrefixes.plate.get(aMaterial) });
                 }
             }
             case "pipeRestrictiveHuge", "pipeRestrictiveLarge", "pipeRestrictiveMedium", "pipeRestrictiveSmall", "pipeRestrictiveTiny" -> {


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
I was investigating misses in recipe removals in https://github.com/GTNewHorizons/GT5-Unofficial/pull/7773 and apparently since 2016, GT5U registers recipes for all the pipes if one of the oredict gets registered for the material. This causes the game to register 5 times the recipes for 163 materials, and 3 times for 15 materials, resulting in 682 recipe duplicates.

Now this PR dedupes the recipes without removing a single pipe recipe from the game. Idk why this was coded like this, but let's fix it.

tested in daily 677.

## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
