### PR TITLE
Add another pass of buffering for delayed removals

### DIFF
--- a/src/main/java/gregtech/GTMod.java
+++ b/src/main/java/gregtech/GTMod.java
@@ -6,6 +6,7 @@ import static gregtech.GT_Version.VERSION_MAJOR;
 import static gregtech.GT_Version.VERSION_MINOR;
 import static gregtech.GT_Version.VERSION_PATCH;
 import static gregtech.api.enums.Mods.Forestry;
+import static gregtech.api.enums.Mods.NewHorizonsCoreMod;
 import static gregtech.api.util.GTRecipe.setItemStacks;
 
 import java.io.File;
@@ -573,6 +574,9 @@ public class GTMod {
         // noinspection UnstableApiUsage// Stable enough for this project
         GT_FML_LOGGER.info("Executed delayed Crafting Recipes ({}). Have a Cake.", stopwatch.stop());
 
+        GT_FML_LOGGER.debug("restarting recipe removal buffering for NHCore...");
+        GTModHandler.restartBufferingCraftingRecipe();
+
         GT_FML_LOGGER.debug("GTMod: Saving Lang File.");
         new MachineTooltipsLoader().run();
         GTLanguageManager.sEnglishFile.save();
@@ -620,6 +624,17 @@ public class GTMod {
         new BECRecipes().runLateRecipes();
         for (Runnable tRunnable : GregTechAPI.sGTCompleteLoad) {
             tRunnable.run();
+        }
+
+        if (!NewHorizonsCoreMod.isModLoaded()) {
+            GT_FML_LOGGER.debug("stopping second buffering pass, likely a dev env.");
+            @SuppressWarnings("UnstableApiUsage") // Stable enough for this project
+            Stopwatch stopwatch = Stopwatch.createStarted();
+            GT_FML_LOGGER.debug("GTMod: Adding 2nd pass of buffered Recipes.");
+            GTModHandler.stopBufferingCraftingRecipes();
+            // noinspection UnstableApiUsage// Stable enough for this project
+            GT_FML_LOGGER
+                .info("Executed 2nd pass of delayed Crafting Recipes ({}). Have another Cake.", stopwatch.stop());
         }
         GregTechAPI.sGTCompleteLoad = null;
         GregTechAPI.sFullLoadFinished = true;

--- a/src/main/java/gregtech/api/util/GTModHandler.java
+++ b/src/main/java/gregtech/api/util/GTModHandler.java
@@ -550,6 +550,11 @@ public class GTModHandler {
         return sBufferCraftingRecipes;
     }
 
+    /**
+     * This was supposed to be called once, but since now there is a second buffering pass, this will now called too
+     * at the end of GT5U's load complete if NHCore isn't present, otherwise NHCore will call it in its own load
+     * complete phase, as it runs after GT5U and has delayed removals.
+     */
     public static void stopBufferingCraftingRecipes() {
         sBufferCraftingRecipes = false;
 
@@ -562,6 +567,17 @@ public class GTModHandler {
         delayedRemovalByRecipe.clear();
         delayedRemovalCallsites.clear();
         sBufferRecipeList.clear();
+    }
+
+    /**
+     * This is simply allowed because who knows what side effects there are if we just switch the
+     * {@link #stopBufferingCraftingRecipes()} from end of preinit to end of load complete. So to
+     * play safe, we restart the buffer to catch all the calls to delayed removals happening after
+     * GT5U's post init. If later it is proven that it is safe to move the {@link #stopBufferingCraftingRecipes()}
+     * to load complete, then feel free to remove this dirty hack.
+     */
+    public static void restartBufferingCraftingRecipe() {
+        sBufferCraftingRecipes = true;
     }
 
     /**

--- a/src/main/java/gregtech/api/util/GTModHandler.java
+++ b/src/main/java/gregtech/api/util/GTModHandler.java
@@ -551,7 +551,7 @@ public class GTModHandler {
     }
 
     /**
-     * This was supposed to be called once, but since now there is a second buffering pass, this will now called too
+     * This was supposed to be called once, but since now there is a second buffering pass, this will now be called too
      * at the end of GT5U's load complete if NHCore isn't present, otherwise NHCore will call it in its own load
      * complete phase, as it runs after GT5U and has delayed removals.
      */
@@ -571,7 +571,7 @@ public class GTModHandler {
 
     /**
      * This is simply allowed because who knows what side effects there are if we just switch the
-     * {@link #stopBufferingCraftingRecipes()} from end of preinit to end of load complete. So to
+     * {@link #stopBufferingCraftingRecipes()} from end of postinit to end of load complete. So to
      * play safe, we restart the buffer to catch all the calls to delayed removals happening after
      * GT5U's post init. If later it is proven that it is safe to move the {@link #stopBufferingCraftingRecipes()}
      * to load complete, then feel free to remove this dirty hack.


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
Basically, I was investigating why NHCore was taking 1.2s to do its load complete phase. Turns out it spends a ton of time going through `addCraftingRecipe`, which does buffer recipes removals when the `BUFFERED` bitmask is passed, but only until GT5U's post init. @mitchej123 told me that when he originally implemented it he did not think about moving it to a later stage.

Because i don't know well the code base about recipe management, i'm playing it safe by redoing another pass of buffering instead of moving the initial stop of the buffering stage to a later event. This would have to be when server starts because on load complete is also used by NHCore to load its scripts, and NHCore runs after GT5U. So when NHCore isn't present i put the stop of the 2nd recipe buffering pass at the end of GT5U's load complete phase, and when NHCore is present, it will be NHCore which will call the stop of the second pass in its load complete phase, right after the script loading. (see: https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1913).

## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
