### PR TITLE
Add some recipes to make dimlock GotG possible

### DIFF
--- a/src/main/java/gregtech/loaders/postload/chains/NetheriteRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/chains/NetheriteRecipes.java
@@ -234,6 +234,29 @@ public class NetheriteRecipes {
                 .addTo(formingPressRecipes);
         }
 
+        // recipes for GotG nether air
+        GTValues.RA.stdBuilder()
+            .itemInputs(
+                GTOreDictUnificator.get(OrePrefixes.dust, Materials.Netherrack, 64L),
+                GTOreDictUnificator.get(OrePrefixes.dust, Materials.HellishMetal, 64L))
+            .fluidInputs(Materials.Air.getGas(10_000))
+            .fluidOutputs(Materials.NetherAir.getFluid(1_000))
+            .duration(2 * SECONDS)
+            .eut(TierEU.RECIPE_LuV)
+            .metadata(COIL_HEAT, 8600)
+            .addTo(blastFurnaceRecipes);
+
+        GTValues.RA.stdBuilder()
+            .itemInputs(
+                GTOreDictUnificator.get(OrePrefixes.dust, Materials.Netherrack, 16L),
+                getModItem(ThaumicTinkerer.ID, "kamiResource", 16, 6))
+            .fluidInputs(Materials.Air.getGas(10_000))
+            .fluidOutputs(Materials.NetherAir.getFluid(10_000))
+            .duration(1 * SECONDS)
+            .eut(TierEU.RECIPE_ZPM)
+            .metadata(COIL_HEAT, 10800)
+            .addTo(blastFurnaceRecipes);
+
         GTValues.RA.stdBuilder()
             .fluidInputs(Materials.NetherAir.getFluid(10_000))
             .fluidOutputs(

--- a/src/main/java/gregtech/loaders/postload/recipes/AssemblerRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/AssemblerRecipes.java
@@ -3,6 +3,7 @@ package gregtech.loaders.postload.recipes;
 import static gregtech.api.enums.Mods.AppliedEnergistics2;
 import static gregtech.api.enums.Mods.AvaritiaAddons;
 import static gregtech.api.enums.Mods.BuildCraftFactory;
+import static gregtech.api.enums.Mods.DraconicEvolution;
 import static gregtech.api.enums.Mods.ExtraUtilities;
 import static gregtech.api.enums.Mods.Forestry;
 import static gregtech.api.enums.Mods.GalacticraftCore;
@@ -14,6 +15,7 @@ import static gregtech.api.enums.Mods.NewHorizonsCoreMod;
 import static gregtech.api.enums.Mods.OpenComputers;
 import static gregtech.api.enums.Mods.Railcraft;
 import static gregtech.api.enums.Mods.TwilightForest;
+import static gregtech.api.enums.Mods.UniversalSingularities;
 import static gregtech.api.recipe.RecipeMaps.assemblerRecipes;
 import static gregtech.api.util.GTModHandler.getModItem;
 import static gregtech.api.util.GTRecipeBuilder.EIGHTH_INGOTS;
@@ -3423,6 +3425,19 @@ public class AssemblerRecipes implements Runnable {
             .duration(30 * SECONDS)
             .eut(TierEU.RECIPE_LV / 4)
             .addTo(assemblerRecipes);
+
+        // expensive recipe for chaos shard
+        if (DraconicEvolution.isModLoaded() && UniversalSingularities.isModLoaded()) {
+            GTValues.RA.stdBuilder()
+                .itemInputs(
+                    ItemList.ChaosLocator.get(1),
+                    // Awakened Draconium Singularity
+                    getModItem(UniversalSingularities.ID, "universal.draconicEvolution.singularity", 1, 1))
+                .itemOutputs(getModItem(DraconicEvolution.ID, "chaosShard", 1, 0))
+                .duration(100 * SECONDS)
+                .eut(TierEU.RECIPE_UMV)
+                .addTo(assemblerRecipes);
+        }
     }
 
     /**

--- a/src/main/java/gregtech/loaders/postload/recipes/CentrifugeRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/CentrifugeRecipes.java
@@ -20,6 +20,7 @@ import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 
+import bartworks.common.loaders.ItemRegistry;
 import bartworks.system.material.WerkstoffLoader;
 import goodgenerator.items.GGMaterial;
 import gregtech.api.enums.GTValues;
@@ -31,6 +32,7 @@ import gregtech.api.enums.TierEU;
 import gregtech.api.objects.OreDictItemStack;
 import gregtech.api.recipe.metadata.CentrifugeRecipeKey;
 import gregtech.api.util.GTOreDictUnificator;
+import gregtech.api.util.GTUtility;
 import gtPlusPlus.core.material.MaterialsAlloy;
 import gtPlusPlus.core.material.MaterialsElements;
 import gtPlusPlus.xmod.gregtech.api.enums.GregtechItemList;
@@ -927,6 +929,21 @@ public class CentrifugeRecipes implements Runnable {
             .fluidOutputs(Materials.Space.getMolten(10 * INGOTS), Materials.Time.getMolten(10 * INGOTS))
             .metadata(CentrifugeRecipeKey.INSTANCE, true)
             .duration(10 * SECONDS)
+            .eut(TierEU.RECIPE_UXV)
+            .addTo(centrifugeNonCellRecipes);
+
+        // dd Iron + forcicium + forcillium
+        GTValues.RA.stdBuilder()
+            .itemInputs(
+                GTUtility.copyAmount(0, ItemRegistry.voidminer[2]),
+                getModItem(ExtraUtilities.ID, "dark_portal", 1, 0))
+            .fluidInputs(WerkstoffLoader.Oganesson.getFluidOrGas(2000))
+            .itemOutputs(
+                GTOreDictUnificator.get(OrePrefixes.dust, Materials.DarkIron, 64),
+                GTOreDictUnificator.get(OrePrefixes.dust, Materials.Forcicium, 64),
+                GTOreDictUnificator.get(OrePrefixes.dust, Materials.Forcillium, 64))
+            .metadata(CentrifugeRecipeKey.INSTANCE, true)
+            .duration(1000 * SECONDS)
             .eut(TierEU.RECIPE_UXV)
             .addTo(centrifugeNonCellRecipes);
 

--- a/src/main/java/gregtech/loaders/postload/recipes/ChemicalRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/ChemicalRecipes.java
@@ -3,6 +3,8 @@ package gregtech.loaders.postload.recipes;
 import static gregtech.api.enums.Mods.Forestry;
 import static gregtech.api.enums.Mods.GalaxySpace;
 import static gregtech.api.enums.Mods.Railcraft;
+import static gregtech.api.enums.Mods.RandomThings;
+import static gregtech.api.enums.Mods.TwilightForest;
 import static gregtech.api.recipe.RecipeMaps.chemicalReactorRecipes;
 import static gregtech.api.recipe.RecipeMaps.multiblockChemicalReactorRecipes;
 import static gregtech.api.util.GTModHandler.getModItem;
@@ -6168,6 +6170,19 @@ public class ChemicalRecipes implements Runnable {
             .itemOutputs(GTOreDictUnificator.get(OrePrefixes.gemFlawless, Materials.Amalgatite, 1))
             .duration(120 * SECONDS)
             .eut(TierEU.RECIPE_MAX)
+            .addTo(multiblockChemicalReactorRecipes);
+
+        // Barnarda C sapling
+        GTValues.RA.stdBuilder()
+            .itemInputs(
+                getModItem(RandomThings.ID, "spectreKey", 0, 0),
+                // Tree of Transformation sapling
+                getModItem(TwilightForest.ID, "tile.TFSapling", 1, 6),
+                GTBees.combs.getStackForType(CombType.BARNARDA, 64))
+            .itemOutputs(getModItem(GalaxySpace.ID, "barnardaCsapling", 1, 0))
+            .outputChances(100)
+            .duration(60 * SECONDS)
+            .eut(TierEU.RECIPE_UEV)
             .addTo(multiblockChemicalReactorRecipes);
     }
 }


### PR DESCRIPTION
## Summary
All recipes here are so expensive that only players who are playing GotG would use them, so these make little influence on game balance.
nether air:
recipe unlocks in LuV with quite low efficiency (64 netherrack + 64 hellish metal -> 1000L nether air), and requires a ZPM-voltage naq-alloy coiled EBF to reach the heat. Later a better recipe is unlocked with flux coiled hearth or awakened coiled EBF for lategame usage.(16 netherrack + 16 nether shard -> 10000L nether air)
<img width="677" height="665" alt="ddf8ea6e625617300ffdeb1741ae30e0" src="https://github.com/user-attachments/assets/89f63a42-01fe-4db9-8a91-dd26c82ee17c" />
<img width="688" height="667" alt="fec94791d12785522241cba1790908d0" src="https://github.com/user-attachments/assets/4de5b007-abfc-4a83-b8dd-205528cc3023" />
chaos shard:
requires chaos locator + awakened draconium singularity and is available only in UIV+. players will need about 40 zero point modules from space miner mk3 for a chaos locator, then get more chaos shards from draconium reactor.
<img width="670" height="574" alt="6513eb5cf3715027a9ae411b7be5a2e7" src="https://github.com/user-attachments/assets/959befc7-575a-4ca9-9ece-32678ed97e19" />
barnarda C sapling:
A simulation for things really happening in rocketless players' spectre. Bedrock dimension is unavailable since no bedrock generated in GotG, but other magical dimensions may be added later. Spectre is the easiest one to get among them.
<img width="680" height="573" alt="79930e5a07df0c4c8ecc28798f7300e2" src="https://github.com/user-attachments/assets/a364cc45-b643-4121-b340-10e7a2addb50" />
DD ores:
Including deep dark iron, forcicium and forcillium, all necessary for UXV. Added a recipe by 'mining' in DD portal with void miner and then centrifuging products to these dusts.
<img width="680" height="617" alt="b85fa1c1dc4caa7af88ed4d48a9592ab" src="https://github.com/user-attachments/assets/d37b0636-37df-46b3-81c5-3eaad905f61f" />


## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
