### PR TITLE
Add circuit 2 lubricant recipe from Oil in Distillation Tower

### DIFF
--- a/src/main/java/gregtech/loaders/postload/recipes/DistilleryRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/DistilleryRecipes.java
@@ -389,7 +389,7 @@ public class DistilleryRecipes implements Runnable {
 
         GTValues.RA.stdBuilder()
             .circuit(2)
-            .fluidInputs(Materials.Oil.getFluid(1000))
+            .fluidInputs(Materials.Oil.getFluid(1_000))
             .fluidOutputs(Materials.Lubricant.getFluid(500))
             .duration(20 * SECONDS)
             .eut(TierEU.RECIPE_MV)

--- a/src/main/java/gregtech/loaders/postload/recipes/DistilleryRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/DistilleryRecipes.java
@@ -389,6 +389,14 @@ public class DistilleryRecipes implements Runnable {
 
         GTValues.RA.stdBuilder()
             .circuit(2)
+            .fluidInputs(Materials.Oil.getFluid(1000))
+            .fluidOutputs(Materials.Lubricant.getFluid(500))
+            .duration(20 * SECONDS)
+            .eut(TierEU.RECIPE_MV)
+            .addTo(distillationTowerRecipes);
+
+        GTValues.RA.stdBuilder()
+            .circuit(2)
             .fluidInputs(Materials.OilLight.getFluid(1_000))
             .fluidOutputs(Materials.Lubricant.getFluid(250))
             .duration(20 * SECONDS)


### PR DESCRIPTION
## Summary
This PR adds a Distillation Tower recipe for making lubricant out of regular Oil, as a counterpart to both the distillery recipe and the rest of the DT Oil -> Lubricant recipes.

<img width="337" height="227" alt="image" src="https://github.com/user-attachments/assets/25928c2a-c67f-4ad2-a305-3208b214db22" />


Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/26379, closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/23493

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
