### PR TITLE
Crafting recipe speedups

### DIFF
--- a/src/main/java/gregtech/GTMod.java
+++ b/src/main/java/gregtech/GTMod.java
@@ -85,7 +85,6 @@ import gregtech.api.util.GTOreDictUnificator;
 import gregtech.api.util.GTRecipe;
 import gregtech.api.util.GTRecipeRegistrator;
 import gregtech.api.util.GTUtility;
-import gregtech.api.util.RecipeChangeAudit;
 import gregtech.common.GTCapesLoader;
 import gregtech.common.GTClient;
 import gregtech.common.GTDummyWorld;
@@ -639,7 +638,6 @@ public class GTMod {
         }
         GregTechAPI.sGTCompleteLoad = null;
         GregTechAPI.sFullLoadFinished = true;
-        RecipeChangeAudit.dump("gt-load-complete", "GT load complete");
     }
 
     @Mod.EventHandler

--- a/src/main/java/gregtech/GTMod.java
+++ b/src/main/java/gregtech/GTMod.java
@@ -85,6 +85,7 @@ import gregtech.api.util.GTOreDictUnificator;
 import gregtech.api.util.GTRecipe;
 import gregtech.api.util.GTRecipeRegistrator;
 import gregtech.api.util.GTUtility;
+import gregtech.api.util.RecipeChangeAudit;
 import gregtech.common.GTCapesLoader;
 import gregtech.common.GTClient;
 import gregtech.common.GTDummyWorld;
@@ -638,6 +639,7 @@ public class GTMod {
         }
         GregTechAPI.sGTCompleteLoad = null;
         GregTechAPI.sFullLoadFinished = true;
+        RecipeChangeAudit.dump("gt-load-complete", "GT load complete");
     }
 
     @Mod.EventHandler

--- a/src/main/java/gregtech/api/util/GTModHandler.java
+++ b/src/main/java/gregtech/api/util/GTModHandler.java
@@ -80,6 +80,7 @@ import gregtech.api.recipe.RecipeCategories;
 import gregtech.common.items.ItemGTToolbox;
 import gregtech.common.items.toolbox.ToolboxDelegateInventory;
 import gregtech.common.items.toolbox.ToolboxUtil;
+import gregtech.mixin.interfaces.accessors.ShapedOreRecipeAccessor;
 import ic2.api.item.IBoxable;
 import ic2.api.item.IC2Items;
 import ic2.api.item.IElectricItem;
@@ -1686,6 +1687,10 @@ public class GTModHandler {
         return getRecipeOutput(false, false, shape);
     }
 
+    public static ItemStack getRecipeOutputFrom(List<IRecipe> recipes, ItemStack... shape) {
+        return getRecipeOutputFrom(recipes, false, false, shape);
+    }
+
     /**
      * Gives you a copy of the Output from a Crafting Recipe Used for Recipe Detection. If available, will choose a
      * recipe that wasn't auto generated during OreDictionary registration. The OreDict recipe is still chosen if it is
@@ -1700,6 +1705,10 @@ public class GTModHandler {
         return getRecipeOutput(false, true, shape);
     }
 
+    public static ItemStack getRecipeOutputPreferNonOreDictFrom(List<IRecipe> recipes, ItemStack... shape) {
+        return getRecipeOutputFrom(recipes, false, true, shape);
+    }
+
     public static ItemStack getRecipeOutput(boolean aUncopiedStack, ItemStack... shape) {
         return getRecipeOutput(aUncopiedStack, false, shape);
     }
@@ -1708,6 +1717,16 @@ public class GTModHandler {
      * Gives you a copy of the Output from a Crafting Recipe Used for Recipe Detection.
      */
     public static ItemStack getRecipeOutput(boolean aUncopiedStack, boolean aPreferNonOreDict, ItemStack... shape) {
+        return getRecipeOutputFrom(
+            CraftingManager.getInstance()
+                .getRecipeList(),
+            aUncopiedStack,
+            aPreferNonOreDict,
+            shape);
+    }
+
+    private static ItemStack getRecipeOutputFrom(List<IRecipe> recipes, boolean aUncopiedStack,
+        boolean aPreferNonOreDict, ItemStack... shape) {
         if (shape == null || isAllNulls(shape)) return null;
 
         InventoryCrafting craftMatrix = new InventoryCrafting(new Container() {
@@ -1721,9 +1740,6 @@ public class GTModHandler {
         for (int i = 0; i < 9 && i < shape.length; i++) {
             craftMatrix.setInventorySlotContents(i, shape[i]);
         }
-
-        ArrayList<IRecipe> recipes = (ArrayList<IRecipe>) CraftingManager.getInstance()
-            .getRecipeList();
 
         boolean tOreDictRecipeFound = false;
         ItemStack tOreDictOutput = null;
@@ -1761,6 +1777,73 @@ public class GTModHandler {
 
         if (aUncopiedStack) return tOreDictOutput;
         return GTUtility.copyOrNull(tOreDictOutput);
+    }
+
+    public static List<IRecipe> getRecipeCandidates(ItemStack... shape) {
+        if (shape == null) return new ArrayList<>();
+
+        int occupiedSlots = 0;
+        for (int i = 0; i < 9 && i < shape.length; i++) {
+            if (shape[i] != null) occupiedSlots |= 1 << i;
+        }
+
+        List<IRecipe> recipes = CraftingManager.getInstance()
+            .getRecipeList();
+        List<IRecipe> candidates = new ArrayList<>(recipes.size());
+        for (IRecipe recipe : recipes) {
+            if (canMatchRecipeShape(recipe, occupiedSlots)) candidates.add(recipe);
+        }
+        return candidates;
+    }
+
+    private static boolean canMatchRecipeShape(IRecipe recipe, int occupiedSlots) {
+        Class<?> recipeClass = recipe.getClass();
+        if (recipeClass == ShapedRecipes.class) {
+            ShapedRecipes shaped = (ShapedRecipes) recipe;
+            return canMatchShapedRecipe(shaped.recipeItems, shaped.recipeWidth, shaped.recipeHeight, occupiedSlots);
+        }
+        if (recipeClass == ShapedOreRecipe.class || recipeClass == GTShapedRecipe.class) {
+            ShapedOreRecipe shaped = (ShapedOreRecipe) recipe;
+            ShapedOreRecipeAccessor accessor = (ShapedOreRecipeAccessor) shaped;
+            return canMatchShapedRecipe(
+                shaped.getInput(),
+                accessor.gt5u$getWidth(),
+                accessor.gt5u$getHeight(),
+                occupiedSlots);
+        }
+
+        int occupiedSlotCount = Integer.bitCount(occupiedSlots);
+        if (recipeClass == ShapelessRecipes.class) {
+            return ((ShapelessRecipes) recipe).recipeItems.size() == occupiedSlotCount;
+        }
+        if (recipeClass == ShapelessOreRecipe.class || recipeClass == GTShapelessRecipe.class) {
+            return ((ShapelessOreRecipe) recipe).getInput()
+                .size() == occupiedSlotCount;
+        }
+
+        // Unknown recipes may implement arbitrary matching rules.
+        return true;
+    }
+
+    private static boolean canMatchShapedRecipe(Object[] input, int width, int height, int occupiedSlots) {
+        if (input == null || width <= 0 || height <= 0 || input.length < width * height) return true;
+        if (width > 3 || height > 3) return false;
+
+        for (int offsetY = 0; offsetY <= 3 - height; offsetY++) {
+            for (int offsetX = 0; offsetX <= 3 - width; offsetX++) {
+                int normalSlots = 0;
+                int mirroredSlots = 0;
+                for (int y = 0; y < height; y++) {
+                    for (int x = 0; x < width; x++) {
+                        if (input[x + y * width] == null) continue;
+                        normalSlots |= 1 << (offsetX + x + (offsetY + y) * 3);
+                        mirroredSlots |= 1 << (offsetX + width - x - 1 + (offsetY + y) * 3);
+                    }
+                }
+                if (occupiedSlots == normalSlots || occupiedSlots == mirroredSlots) return true;
+            }
+        }
+        return false;
     }
 
     private static List<IRecipe> bufferedRecipes = null;

--- a/src/main/java/gregtech/common/GTCapesLoader.java
+++ b/src/main/java/gregtech/common/GTCapesLoader.java
@@ -110,7 +110,7 @@ public class GTCapesLoader implements Runnable {
                 }
             }
         } catch (Exception e) {
-            GT_FML_LOGGER.error(e);
+            GT_FML_LOGGER.error("Could not download cape list from {}", url, e);
         }
     }
 
@@ -121,7 +121,7 @@ public class GTCapesLoader implements Runnable {
                 putName(scanner.nextLine());
             }
         } catch (Exception e) {
-            GT_FML_LOGGER.error(e);
+            GT_FML_LOGGER.error("Could not download cape list from {}", url, e);
         }
     }
 
@@ -138,7 +138,7 @@ public class GTCapesLoader implements Runnable {
                 }
             }
         } catch (Exception e) {
-            GT_FML_LOGGER.error(e);
+            GT_FML_LOGGER.error("Could not download cape list from {}", url, e);
         }
     }
 
@@ -155,7 +155,7 @@ public class GTCapesLoader implements Runnable {
                 }
             }
         } catch (Exception e) {
-            GT_FML_LOGGER.error(e);
+            GT_FML_LOGGER.error("Could not download cape list from {}", url, e);
         }
     }
 

--- a/src/main/java/gregtech/common/GTCapesLoader.java
+++ b/src/main/java/gregtech/common/GTCapesLoader.java
@@ -49,7 +49,7 @@ public class GTCapesLoader implements Runnable {
             downloadGalacticraftCapes();
         }
         if (Mods.GalaxySpace.isModLoaded()) {
-            downloadGalaxySpaceCapes();
+            addGalaxySpaceCapes();
         }
         addHarcodedCapes();
     }
@@ -142,21 +142,19 @@ public class GTCapesLoader implements Runnable {
         }
     }
 
-    private static void downloadGalaxySpaceCapes() {
-        String url = "https://demigods.at.ua/capes.txt";
-        try (final Scanner scanner = new Scanner(new URL(url).openStream())) {
-            while (scanner.hasNextLine()) {
-                String line = scanner.nextLine();
-                String[] parts = line.split(":");
-                if (parts.length == 2) {
-                    putName(parts[0], parts[1] + "GS");
-                } else {
-                    GT_FML_LOGGER.error("Invalid cape mapping: {}", line);
-                }
-            }
-        } catch (Exception e) {
-            GT_FML_LOGGER.error("Could not download cape list from {}", url, e);
-        }
+    private static void addGalaxySpaceCapes() {
+        // From https://demigods.at.ua/capes.txt. Hardcoded because it was failing a lot since weeks now
+        putName("BlesseNtumble", "capeDevGS");
+        putName("BlesseNumble", "capeGrayCGS");
+        putName("MEGADesantnic", "capeBlueGS");
+        putName("izlow", "capeCyanGS");
+        putName("AlexSocol", "capeGrayCGS");
+        putName("Bagomot", "capeDarkGreenGS");
+        putName("juh9870", "capeRedGS");
+        putName("FriendlyDevil", "capeLightBlueGS");
+        putName("KETZALCOATL", "capeLightBlueGS");
+        putName("Dixil", "capeBlueGS");
+        putName("Pashok123321", "capeBlueGS");
     }
 
     private static void addHarcodedCapes() {

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingLog.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingLog.java
@@ -3,8 +3,11 @@ package gregtech.loaders.oreprocessing;
 import static gregtech.api.recipe.RecipeMaps.cutterRecipes;
 import static gregtech.api.util.GTRecipeBuilder.SECONDS;
 
+import java.util.List;
+
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.IRecipe;
 
 import gregtech.GTMod;
 import gregtech.api.enums.GTValues;
@@ -28,6 +31,7 @@ public class ProcessingLog implements gregtech.api.interfaces.IOreRecipeRegistra
         short aMeta = (short) aStack.getItemDamage();
 
         if (aMeta == Short.MAX_VALUE) {
+            List<IRecipe> recipeCandidates = GTModHandler.getRecipeCandidates(aStack);
             if ((GTUtility.areStacksEqual(
                 GTModHandler.getSmeltingOutput(GTUtility.copyAmount(1, aStack), false, null),
                 new ItemStack(Items.coal, 1, 1)))) {
@@ -39,7 +43,8 @@ public class ProcessingLog implements gregtech.api.interfaces.IOreRecipeRegistra
                     new ItemStack(Items.coal, 1, 1)))) {
                     GTModHandler.removeFurnaceSmelting(new ItemStack(aStack.getItem(), 1, i));
                 }
-                ItemStack tStack = GTModHandler.getRecipeOutput(new ItemStack(aStack.getItem(), 1, i));
+                ItemStack tStack = GTModHandler
+                    .getRecipeOutputFrom(recipeCandidates, new ItemStack(aStack.getItem(), 1, i));
                 if (tStack == null) {
                     if (i >= 16) {
                         break;

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingPlank.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingPlank.java
@@ -5,11 +5,13 @@ import static gregtech.api.util.GTRecipeBuilder.TICKS;
 import static gregtech.loaders.oreprocessing.ProcessingUtils.itemStackKey;
 
 import java.util.HashSet;
+import java.util.List;
 
 import net.minecraft.init.Blocks;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemMultiTexture;
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.IRecipe;
 import net.minecraftforge.oredict.OreDictionary;
 
 import com.github.bsideup.jabel.Desugar;
@@ -120,13 +122,14 @@ public class ProcessingPlank implements gregtech.api.interfaces.IOreRecipeRegist
     private void processWildcardPlank(ItemStack aStack, String tHashPrefix, int metaCount) {
         boolean anyOwnSlabRecipe = false;
         boolean anyOakSlabFallback = false;
+        List<IRecipe> recipeCandidates = GTModHandler.getRecipeCandidates(aStack, aStack, aStack);
 
         for (byte i = 0; i < metaCount; i = (byte) (i + 1)) {
             ItemStack tStack = GTUtility.copyMetaData(i, aStack);
             if ((tStack == null) && (i >= 16)) break;
             if (!sProcessedPlanks.add(tHashPrefix + ":" + i)) continue;
 
-            switch (convertSlabRecipe(tStack)) {
+            switch (convertSlabRecipe(tStack, recipeCandidates)) {
                 case CREATED -> anyOwnSlabRecipe = true;
                 case OAK_SLAB_FALLBACK -> anyOakSlabFallback = true;
                 default -> {}
@@ -146,6 +149,10 @@ public class ProcessingPlank implements gregtech.api.interfaces.IOreRecipeRegist
     }
 
     private SlabRecipeResult convertSlabRecipe(ItemStack aStack) {
+        return convertSlabRecipe(aStack, null);
+    }
+
+    private SlabRecipeResult convertSlabRecipe(ItemStack aStack, List<IRecipe> recipeCandidates) {
         SpecialSlabConversionResult tSpecialResult = trySpecialSlabConversion(aStack);
 
         boolean tSkipRecipeCreation = tSpecialResult.isSpecialConversion && tSpecialResult.resultingSlab == null;
@@ -154,7 +161,8 @@ public class ProcessingPlank implements gregtech.api.interfaces.IOreRecipeRegist
         if (tOutput == null) {
             // https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19535
             // Prefer the mod's own slab recipe over the oredict "plankWood -> Oak Slab" fallback.
-            tOutput = GTModHandler.getRecipeOutputPreferNonOreDict(aStack, aStack, aStack);
+            tOutput = recipeCandidates == null ? GTModHandler.getRecipeOutputPreferNonOreDict(aStack, aStack, aStack)
+                : GTModHandler.getRecipeOutputPreferNonOreDictFrom(recipeCandidates, aStack, aStack, aStack);
         }
 
         if (tOutput == null || tOutput.stackSize < 3) {


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
This PR speeds up wildcard wood recipe processing by building an ordered snapshot of recipes compatible with the crafting-grid layout and reusing it across metadata variants. Known recipes are filtered by shape or ingredient count, while unknown recipes remain candidates and still use normal matching logic.

Tested on the daily 684, compared dumps of before/after are identical. Saves ~3s on my old laptop.

Unrelated to this but still in this PR, i converted the galaxyspace capes into hardcoded ones because my game have been reporting me that the url is failing for a solid week now.

## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
