### PR TITLE
Fix board processor restart problem

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/modules/MTEBoardProcessorModule.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/modules/MTEBoardProcessorModule.java
@@ -238,7 +238,6 @@ public class MTEBoardProcessorModule extends MTENanochipAssemblyModuleBase<MTEBo
 
     float euMultiplier = 1;
 
-    protected int fluidCapacity = 1000000;
     protected FluidStack storedFluidStack;
     protected int fluidAmount;
 
@@ -246,13 +245,11 @@ public class MTEBoardProcessorModule extends MTENanochipAssemblyModuleBase<MTEBo
 
     protected FluidStack impurityFluidStack;
     protected int impurityFluidAmount;
-    protected double impurityPercentage;
 
     private static final int IMPURITY_THRESHOLD = 1000;
     private static final int IMPURITY_INCREASE = 100;
 
     private int autoFlushPercentage = 100;
-    private double fillPercentage = 0;
 
     protected static final HashSet<Fluid> LEGAL_FLUIDS = new HashSet<>(
         Arrays.asList(
@@ -270,11 +267,11 @@ public class MTEBoardProcessorModule extends MTENanochipAssemblyModuleBase<MTEBo
             return CheckRecipeResultRegistry.NO_IMMERSION_FLUID;
         }
 
-        if (fillPercentage < 0.5) {
+        if (getFillPercentage() < 0.5) {
             return CheckRecipeResultRegistry.NO_IMMERSION_FLUID;
         }
 
-        if (impurityPercentage == 1) {
+        if (getImpurityPercentage() == 1) {
             return CheckRecipeResultRegistry.NO_IMMERSION_FLUID;
         }
 
@@ -297,10 +294,10 @@ public class MTEBoardProcessorModule extends MTENanochipAssemblyModuleBase<MTEBo
             return CheckRecipeResultRegistry.NO_RECIPE;
         }
 
-        if (impurityPercentage <= 0.15) {
-            euMultiplier = (float) (1 - 0.3 + impurityPercentage * 2);
-        } else if (impurityPercentage >= 0.65) {
-            euMultiplier = (float) (1 + 2 * (impurityPercentage - 0.65));
+        if (getImpurityPercentage() <= 0.15) {
+            euMultiplier = (float) (1 - 0.3 + getImpurityPercentage() * 2);
+        } else if (getImpurityPercentage() >= 0.65) {
+            euMultiplier = (float) (1 + 2 * (getImpurityPercentage() - 0.65));
         }
 
         return super.validateRecipe(recipe);
@@ -314,10 +311,9 @@ public class MTEBoardProcessorModule extends MTENanochipAssemblyModuleBase<MTEBo
                 while (processedItems >= IMPURITY_THRESHOLD) {
                     processedItems -= IMPURITY_THRESHOLD;
                     impurityFluidAmount += (int) Math.min(
-                        IMPURITY_INCREASE * (1 / Math.pow(fillPercentage, 1.5)),
+                        IMPURITY_INCREASE * (1 / Math.pow(getFillPercentage(), 1.5)),
                         fluidAmount - impurityFluidAmount);
                     impurityFluidStack.amount = impurityFluidAmount;
-                    impurityPercentage = (double) impurityFluidAmount / fluidAmount;
                 }
             }
         }
@@ -329,7 +325,7 @@ public class MTEBoardProcessorModule extends MTENanochipAssemblyModuleBase<MTEBo
 
         if (aTick % 20 == 0) {
 
-            if (impurityPercentage >= ((double) autoFlushPercentage / 100)) {
+            if (getImpurityPercentage() >= ((double) autoFlushPercentage / 100)) {
                 flushTank();
             }
 
@@ -345,10 +341,10 @@ public class MTEBoardProcessorModule extends MTENanochipAssemblyModuleBase<MTEBo
         for (FluidStack fluid : inputFluid) {
             if (LEGAL_FLUIDS.contains(fluid.getFluid())) {
                 if (storedFluidStack == null) {
-                    int depleted = depleteInputQuantity(new FluidStack(fluid, fluidCapacity), false);
-                    storedFluidStack = new FluidStack(fluid, Math.min(fluidCapacity, depleted));
+                    int depleted = depleteInputQuantity(new FluidStack(fluid, getCapacity()), false);
+                    storedFluidStack = new FluidStack(fluid, Math.min(getCapacity(), depleted));
                 } else if (storedFluidStack.isFluidEqual(fluid)) {
-                    int max = fluidCapacity - storedFluidStack.amount;
+                    int max = getCapacity() - storedFluidStack.amount;
                     // If we're already full don't cause a 0L drain.
                     if (max == 0) return;
                     int depleted = depleteInputQuantity(new FluidStack(fluid, max), false);
@@ -357,7 +353,6 @@ public class MTEBoardProcessorModule extends MTENanochipAssemblyModuleBase<MTEBo
 
                 if (storedFluidStack != null) {
                     fluidAmount = storedFluidStack.amount;
-                    fillPercentage = (double) fluidAmount / fluidCapacity;
                     if (storedFluidStack.isFluidEqual(Materials.IronIIIChloride.getFluid(0))) {
                         impurityFluidStack = GGMaterial.ferrousChloride.getFluidOrGas(0);
                     } else if (storedFluidStack.isFluidEqual(Materials.GrowthMediumSterilized.getFluid(0))) {
@@ -384,8 +379,6 @@ public class MTEBoardProcessorModule extends MTENanochipAssemblyModuleBase<MTEBo
             impurityFluidStack = null;
             fluidAmount = 0;
             impurityFluidAmount = 0;
-            impurityPercentage = 0;
-            fillPercentage = 0;
         }
     }
 
@@ -409,7 +402,11 @@ public class MTEBoardProcessorModule extends MTENanochipAssemblyModuleBase<MTEBo
 
     @Override
     public int getCapacity() {
-        return fluidCapacity;
+        return 1000000;
+    }
+
+    protected double getFillPercentage() {
+        return (double) fluidAmount / getCapacity();
     }
 
     public int getProcessedItems() {
@@ -425,7 +422,7 @@ public class MTEBoardProcessorModule extends MTENanochipAssemblyModuleBase<MTEBo
     }
 
     public double getImpurityPercentage() {
-        return impurityPercentage;
+        return (double) impurityFluidAmount / fluidAmount;
     }
 
     public float getEuMultiplier() {


### PR DESCRIPTION
## Summary
When server restart, the field fillPercentage is not populated properly. I'll just move these fields to be computed on the fly since it's just a division, and I don't want to go through the code yet again to find missed updates to the underlying field.


## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
