### PR TITLE
Fix bad copy / paste leading to null GMI calls

### DIFF
--- a/src/main/java/gregtech/api/util/GTModHandler.java
+++ b/src/main/java/gregtech/api/util/GTModHandler.java
@@ -398,11 +398,9 @@ public class GTModHandler {
                 + "\" has returned null because "
                 + reason;
             if (PANIC_MODE_NULL) {
-                GT_FML_LOGGER.fatal(log_message);
-                GT_FML_LOGGER.fatal(new Exception());
+                GT_FML_LOGGER.fatal(log_message, new Exception());
             } else {
-                GT_FML_LOGGER.info(log_message);
-                GT_FML_LOGGER.info(new Exception());
+                GT_FML_LOGGER.info(log_message, new Exception());
             }
         }
         return result;

--- a/src/main/java/gregtech/loaders/postload/ScannerHandlerLoader.java
+++ b/src/main/java/gregtech/loaders/postload/ScannerHandlerLoader.java
@@ -65,15 +65,15 @@ public class ScannerHandlerLoader {
         }
         if (Mods.GalaxySpace.isModLoaded()) {
             GALACTICRAFT_SCHEMATIC_LOOKUP
-                .put(GTModHandler.getModItem(Mods.GalacticraftMars.ID, "item.SchematicTier4", 1L, 0), (short) 4);
+                .put(GTModHandler.getModItem(Mods.GalaxySpace.ID, "item.SchematicTier4", 1L, 0), (short) 4);
             GALACTICRAFT_SCHEMATIC_LOOKUP
-                .put(GTModHandler.getModItem(Mods.GalacticraftMars.ID, "item.SchematicTier5", 1L, 0), (short) 5);
+                .put(GTModHandler.getModItem(Mods.GalaxySpace.ID, "item.SchematicTier5", 1L, 0), (short) 5);
             GALACTICRAFT_SCHEMATIC_LOOKUP
-                .put(GTModHandler.getModItem(Mods.GalacticraftMars.ID, "item.SchematicTier6", 1L, 0), (short) 6);
+                .put(GTModHandler.getModItem(Mods.GalaxySpace.ID, "item.SchematicTier6", 1L, 0), (short) 6);
             GALACTICRAFT_SCHEMATIC_LOOKUP
-                .put(GTModHandler.getModItem(Mods.GalacticraftMars.ID, "item.SchematicTier7", 1L, 0), (short) 7);
+                .put(GTModHandler.getModItem(Mods.GalaxySpace.ID, "item.SchematicTier7", 1L, 0), (short) 7);
             GALACTICRAFT_SCHEMATIC_LOOKUP
-                .put(GTModHandler.getModItem(Mods.GalacticraftMars.ID, "item.SchematicTier8", 1L, 0), (short) 8);
+                .put(GTModHandler.getModItem(Mods.GalaxySpace.ID, "item.SchematicTier8", 1L, 0), (short) 8);
         }
         if (Mods.GalacticraftAmunRa.isModLoaded()) {
             // shuttle, doesn't have a dream craft chip, consider removal or implementation of chip


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
Finally got around to fix these in the log:
`[Client thread/FATAL] [GregTech GTNH]: getModItem call: object "item.SchematicTier5" with mod id "GalacticraftMars" has returned null because the item was not found in the game registry`

## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
