### PR TITLE
Fix a mismatch between buffered recipe removal and unbuffered recipe removal

### DIFF
--- a/src/main/java/gregtech/api/util/GTModHandler.java
+++ b/src/main/java/gregtech/api/util/GTModHandler.java
@@ -1187,7 +1187,11 @@ public class GTModHandler {
                 !aRemoveAllOthersWithSameOutputIfTheyHaveSameNBT,
                 aRemoveAllOtherShapedsWithSameOutput,
                 aRemoveAllOtherNativeRecipes) || tThereWasARecipe;
-            else removeRecipeByOutputDelayed(aResult);
+            else removeRecipeByOutputDelayed(
+                aResult,
+                !aRemoveAllOthersWithSameOutputIfTheyHaveSameNBT,
+                aRemoveAllOtherShapedsWithSameOutput,
+                aRemoveAllOtherNativeRecipes);
         }
 
         if (aOnlyAddIfThereIsAnyRecipeOutputtingThis && !tDoWeCareIfThereWasARecipe && !tThereWasARecipe) {


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
Basically this happened when i added the second buffering pass fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/26405

This affects a very small bunch of recipes but mainly the AE2FC cell housing recipes

## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
