### PR TITLE
Add blood orbs / TF Trophies / division sigil to AE2 blocking mode ignored items

### DIFF
--- a/src/main/java/gregtech/crossmod/ae2/AE2Compat.java
+++ b/src/main/java/gregtech/crossmod/ae2/AE2Compat.java
@@ -1,6 +1,12 @@
 package gregtech.crossmod.ae2;
 
+import static gregtech.api.enums.Mods.Avaritia;
+import static gregtech.api.enums.Mods.BloodArsenal;
+import static gregtech.api.enums.Mods.BloodMagic;
+import static gregtech.api.enums.Mods.ExtraUtilities;
+import static gregtech.api.enums.Mods.ForbiddenMagic;
 import static gregtech.api.enums.Mods.NewHorizonsCoreMod;
+import static gregtech.api.enums.Mods.TwilightForest;
 import static gregtech.api.util.GTModHandler.getModItem;
 import static gregtech.api.util.GTRecipeBuilder.WILDCARD;
 import static gtPlusPlus.xmod.gregtech.api.enums.GregtechItemList.Laser_Lens_Special;
@@ -112,5 +118,35 @@ public final class AE2Compat {
             registry.register(getModItem(NewHorizonsCoreMod.ID, "RadoxPolymerLens"));
             registry.register(getModItem(NewHorizonsCoreMod.ID, "ChromaticLens"));
         }
+
+        if (BloodMagic.isModLoaded()) {
+            registry.register(getModItem(BloodMagic.ID, "weakBloodOrb"));
+            registry.register(getModItem(BloodMagic.ID, "apprenticeBloodOrb"));
+            registry.register(getModItem(BloodMagic.ID, "magicianBloodOrb"));
+            registry.register(getModItem(BloodMagic.ID, "masterBloodOrb"));
+            registry.register(getModItem(BloodMagic.ID, "archmageBloodOrb"));
+            registry.register(getModItem(BloodMagic.ID, "transcendentBloodOrb"));
+        }
+
+        if (BloodArsenal.isModLoaded()) {
+            registry.register(getModItem(BloodArsenal.ID, "transparent_orb"));
+        }
+
+        if (ForbiddenMagic.isModLoaded()) {
+            registry.register(getModItem(ForbiddenMagic.ID, "EldritchOrb"));
+        }
+
+        if (Avaritia.isModLoaded()) {
+            registry.register(getModItem(Avaritia.ID, "Orb_Armok"));
+        }
+
+        if (TwilightForest.isModLoaded()) {
+            registry.register(getModItem(TwilightForest.ID, "item.trophy", 1, WILDCARD));
+        }
+
+        if (ExtraUtilities.isModLoaded()) {
+            registry.register(getModItem(ExtraUtilities.ID, "divisionSigil"));
+        }
+
     }
 }


### PR DESCRIPTION
## Summary
Make some "Not Consumed" items in assembler ignored by the blocking mode of an ME Interface.
Items:
- All current Blood Orbs (Week/Apprentice/Magician/Master/Archmage/Transcendent/Transparent/Eldritch/Armok)
- All TF Trophy
- Pseudo-Inversion Sigil


## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x ] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
