### PR TITLE
Add config toggle for machine energy capacity tooltip

### DIFF
--- a/src/main/java/gregtech/common/blocks/ItemMachines.java
+++ b/src/main/java/gregtech/common/blocks/ItemMachines.java
@@ -62,6 +62,7 @@ import gregtech.api.util.GTModHandler;
 import gregtech.api.util.GTSplit;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.tooltip.TooltipHelper;
+import gregtech.common.config.Client;
 import gregtech.common.tileentities.storage.MTESuperChest;
 import gregtech.common.tileentities.storage.MTESuperTank;
 import gregtech.crossmod.backhand.Backhand;
@@ -119,10 +120,12 @@ public class ItemMachines extends ItemBlock implements IFluidContainerItem {
                                     TooltipHelper.ampText(gtTileEntity.getOutputAmperage())));
                         }
                     }
-                    aList.add(
-                        translateToLocalFormatted(
-                            "gt.tileentity.eup_store",
-                            TooltipHelper.euCapacityText(gtTileEntity.getEUCapacity())));
+                    if (Client.tooltip.showEnergyCapacity) {
+                        aList.add(
+                            translateToLocalFormatted(
+                                "gt.tileentity.eup_store",
+                                TooltipHelper.euCapacityText(gtTileEntity.getEUCapacity())));
+                    }
                 }
             }
             final NBTTagCompound aNBT = aStack.getTagCompound();

--- a/src/main/java/gregtech/common/config/Client.java
+++ b/src/main/java/gregtech/common/config/Client.java
@@ -423,6 +423,11 @@ public class Client {
     @Config.LangKey("GT5U.gui.config.client.tooltip")
     public static class Tooltip {
 
+        @Config.Comment("Enabled show energy capacity of machines")
+        @Config.DefaultBoolean(true)
+        @Config.Name("Show Energy Capacity")
+        public boolean showEnergyCapacity;
+
         @Config.Comment("Enabled show Formula")
         @Config.DefaultBoolean(true)
         @Config.Name("Show Formula")


### PR DESCRIPTION
## Summary
The Capacity line in machine item tooltips is useful for energy storage, transformers and throughput blocks, but noise on everything else. Adds a client config option (Tooltip section, Show Energy Capacity) so it can be turned off, enabled by default so nothing changes for existing players.

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
