### PR TITLE
Show physical circuits and non-consumed items in AE2 interface name for single blocks and hatches

### DIFF
--- a/src/main/java/gregtech/api/interfaces/INonConsumedItemDisplay.java
+++ b/src/main/java/gregtech/api/interfaces/INonConsumedItemDisplay.java
@@ -2,7 +2,12 @@ package gregtech.api.interfaces;
 
 import java.util.List;
 
+import javax.annotation.Nullable;
+
 import net.minecraft.item.ItemStack;
+
+import gregtech.api.recipe.RecipeMap;
+import gregtech.api.util.GTUtility;
 
 /**
  * Implement on a MetaTileEntity to expose non-consumed recipe inputs (e.g. molds in the Extruder)
@@ -15,4 +20,14 @@ public interface INonConsumedItemDisplay {
      * in the recipe definition). Returns an empty list if no recipe has been run yet or none exist.
      */
     List<ItemStack> getNonConsumedInputDisplayItems();
+
+    /**
+     * @return Whether the given stack should be displayed as a non-consumed item of the given recipemap. Integrated
+     *         Circuits are excluded because they are shown by the ghost circuit suffix instead.
+     */
+    static boolean isDisplayableItem(@Nullable RecipeMap<?> recipeMap, @Nullable ItemStack stack) {
+        if (recipeMap == null || stack == null || GTUtility.isAnyIntegratedCircuit(stack)) return false;
+        return recipeMap.getNonConsumedInputItemIds()
+            .contains(GTUtility.ItemId.create(stack));
+    }
 }

--- a/src/main/java/gregtech/api/interfaces/IPhysicalCircuitDisplay.java
+++ b/src/main/java/gregtech/api/interfaces/IPhysicalCircuitDisplay.java
@@ -1,6 +1,12 @@
 package gregtech.api.interfaces;
 
+import java.util.ArrayList;
 import java.util.List;
+
+import net.minecraft.item.ItemStack;
+
+import gregtech.api.metatileentity.MetaTileEntity;
+import gregtech.api.util.GTUtility;
 
 /**
  * Implement on a MetaTileEntity to expose physical Integrated Circuit item(s) present alongside a ghost circuit
@@ -14,4 +20,21 @@ public interface IPhysicalCircuitDisplay {
      * ghost circuit slot itself. Returns an empty list if none are present.
      */
     List<Integer> getPhysicalCircuitNumbers();
+
+    /**
+     * Collects the configuration numbers of the Integrated Circuits found in the given slot range.
+     *
+     * @param skipSlot Slot to ignore, usually the ghost circuit slot.
+     */
+    static List<Integer> collectCircuitNumbers(MetaTileEntity machine, int fromSlot, int toSlot, int skipSlot) {
+        List<Integer> numbers = new ArrayList<>();
+        for (int i = fromSlot; i < toSlot; i++) {
+            if (i == skipSlot) continue;
+            ItemStack stack = machine.getStackInSlot(i);
+            if (GTUtility.isAnyIntegratedCircuit(stack)) {
+                numbers.add(stack.getItemDamage());
+            }
+        }
+        return numbers;
+    }
 }

--- a/src/main/java/gregtech/api/metatileentity/CommonBaseMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/CommonBaseMetaTileEntity.java
@@ -618,7 +618,7 @@ public abstract class CommonBaseMetaTileEntity extends CoverableTileEntity
             List<ItemStack> items = provider.getNonConsumedInputDisplayItems();
             if (!items.isEmpty()) {
                 String joined = items.stream()
-                    .map(ItemStack::getDisplayName)
+                    .map(CommonBaseMetaTileEntity::getShortItemDisplayName)
                     .collect(Collectors.joining(", "));
                 try {
                     suffix.append(String.format(Gregtech.machines.itemSlotsSuffixFormat, joined));
@@ -627,6 +627,20 @@ public abstract class CommonBaseMetaTileEntity extends CoverableTileEntity
         }
 
         return !suffix.isEmpty() ? suffix.toString() : null;
+    }
+
+    /**
+     * Shortens item names like "Mold (Ingot)" to just "Ingot", so the interface name stays readable. Names without a
+     * trailing parenthesised part are returned unchanged.
+     */
+    private static String getShortItemDisplayName(ItemStack stack) {
+        String name = stack.getDisplayName();
+        if (!name.endsWith(")")) return name;
+        int open = name.lastIndexOf('(');
+        if (open < 0) return name;
+        String inner = name.substring(open + 1, name.length() - 1)
+            .trim();
+        return inner.isEmpty() ? name : inner;
     }
 
     @Override

--- a/src/main/java/gregtech/api/metatileentity/CommonBaseMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/CommonBaseMetaTileEntity.java
@@ -633,7 +633,7 @@ public abstract class CommonBaseMetaTileEntity extends CoverableTileEntity
      * Shortens item names like "Mold (Ingot)" to just "Ingot", so the interface name stays readable. Names without a
      * trailing parenthesised part are returned unchanged.
      */
-    private static String getShortItemDisplayName(ItemStack stack) {
+    public static String getShortItemDisplayName(ItemStack stack) {
         String name = stack.getDisplayName();
         if (!name.endsWith(")")) return name;
         int open = name.lastIndexOf('(');

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEBasicMachine.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEBasicMachine.java
@@ -30,7 +30,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Set;
 
 import javax.annotation.Nonnull;
 
@@ -78,6 +78,7 @@ import gregtech.api.gui.modularui.SteamTexture;
 import gregtech.api.interfaces.ICleanroom;
 import gregtech.api.interfaces.IConfigurationCircuitSupport;
 import gregtech.api.interfaces.INonConsumedItemDisplay;
+import gregtech.api.interfaces.IPhysicalCircuitDisplay;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.modularui.IAddGregtechLogo;
 import gregtech.api.interfaces.tileentity.IGregTechDeviceInformation;
@@ -114,7 +115,7 @@ import mcp.mobius.waila.overlay.tooltiprenderers.TTRenderStack;
  * Machine
  */
 public abstract class MTEBasicMachine extends MTEBasicTank implements RecipeMapWorkable, IConfigurationCircuitSupport,
-    IOverclockDescriptionProvider, IAddGregtechLogo, INonConsumedItemDisplay {
+    IOverclockDescriptionProvider, IAddGregtechLogo, INonConsumedItemDisplay, IPhysicalCircuitDisplay {
 
     /**
      * return values for checkRecipe()
@@ -383,10 +384,32 @@ public abstract class MTEBasicMachine extends MTEBasicTank implements RecipeMapW
 
     @Override
     public List<ItemStack> getNonConsumedInputDisplayItems() {
-        if (mLastRecipe == null || mLastRecipe.mInputs == null) return Collections.emptyList();
-        return Arrays.stream(mLastRecipe.mInputs)
-            .filter(s -> s != null && s.stackSize == 0)
-            .collect(Collectors.toList());
+        RecipeMap<?> recipeMap = getRecipeMap();
+        if (recipeMap == null) return Collections.emptyList();
+        Set<GTUtility.ItemId> nonConsumedIds = recipeMap.getNonConsumedInputItemIds();
+        if (nonConsumedIds.isEmpty()) return Collections.emptyList();
+
+        List<ItemStack> result = new ArrayList<>();
+        for (int i = getInputSlot(), j = i + mInputSlotCount; i < j; i++) {
+            ItemStack stack = getStackInSlot(i);
+            if (stack == null || GTUtility.isAnyIntegratedCircuit(stack)) continue;
+            if (nonConsumedIds.contains(GTUtility.ItemId.create(stack))) {
+                result.add(stack);
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public List<Integer> getPhysicalCircuitNumbers() {
+        List<Integer> numbers = new ArrayList<>();
+        for (int i = getInputSlot(), j = i + mInputSlotCount; i < j; i++) {
+            ItemStack stack = getStackInSlot(i);
+            if (GTUtility.isAnyIntegratedCircuit(stack)) {
+                numbers.add(stack.getItemDamage());
+            }
+        }
+        return numbers;
     }
 
     @Override

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEBasicMachine.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEBasicMachine.java
@@ -30,7 +30,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Set;
 
 import javax.annotation.Nonnull;
 
@@ -384,16 +383,10 @@ public abstract class MTEBasicMachine extends MTEBasicTank implements RecipeMapW
 
     @Override
     public List<ItemStack> getNonConsumedInputDisplayItems() {
-        RecipeMap<?> recipeMap = getRecipeMap();
-        if (recipeMap == null) return Collections.emptyList();
-        Set<GTUtility.ItemId> nonConsumedIds = recipeMap.getNonConsumedInputItemIds();
-        if (nonConsumedIds.isEmpty()) return Collections.emptyList();
-
         List<ItemStack> result = new ArrayList<>();
         for (int i = getInputSlot(), j = i + mInputSlotCount; i < j; i++) {
             ItemStack stack = getStackInSlot(i);
-            if (stack == null || GTUtility.isAnyIntegratedCircuit(stack)) continue;
-            if (nonConsumedIds.contains(GTUtility.ItemId.create(stack))) {
+            if (INonConsumedItemDisplay.isDisplayableItem(getRecipeMap(), stack)) {
                 result.add(stack);
             }
         }
@@ -402,14 +395,8 @@ public abstract class MTEBasicMachine extends MTEBasicTank implements RecipeMapW
 
     @Override
     public List<Integer> getPhysicalCircuitNumbers() {
-        List<Integer> numbers = new ArrayList<>();
-        for (int i = getInputSlot(), j = i + mInputSlotCount; i < j; i++) {
-            ItemStack stack = getStackInSlot(i);
-            if (GTUtility.isAnyIntegratedCircuit(stack)) {
-                numbers.add(stack.getItemDamage());
-            }
-        }
-        return numbers;
+        return IPhysicalCircuitDisplay
+            .collectCircuitNumbers(this, getInputSlot(), getInputSlot() + mInputSlotCount, getCircuitSlot());
     }
 
     @Override

--- a/src/main/java/gregtech/api/metatileentity/implementations/MTEHatchInputBus.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTEHatchInputBus.java
@@ -7,9 +7,7 @@ import static gregtech.api.metatileentity.BaseTileEntity.TOOLTIP_DELAY;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -268,29 +266,16 @@ public class MTEHatchInputBus extends MTEHatch
 
     @Override
     public List<Integer> getPhysicalCircuitNumbers() {
-        List<Integer> numbers = new ArrayList<>();
-        for (int i = 0; i < getSizeInventory(); i++) {
-            if (i == getCircuitSlot()) continue;
-            ItemStack stack = getStackInSlot(i);
-            if (GTUtility.isAnyIntegratedCircuit(stack)) {
-                numbers.add(stack.getItemDamage());
-            }
-        }
-        return numbers;
+        return IPhysicalCircuitDisplay.collectCircuitNumbers(this, 0, getSizeInventory(), getCircuitSlot());
     }
 
     @Override
     public List<ItemStack> getNonConsumedInputDisplayItems() {
-        if (mRecipeMap == null) return Collections.emptyList();
-        Set<GTUtility.ItemId> nonConsumedIds = mRecipeMap.getNonConsumedInputItemIds();
-        if (nonConsumedIds.isEmpty()) return Collections.emptyList();
-
         List<ItemStack> result = new ArrayList<>();
         for (int i = 0; i < getSizeInventory(); i++) {
             if (i == getCircuitSlot()) continue;
             ItemStack stack = getStackInSlot(i);
-            if (stack == null || GTUtility.isAnyIntegratedCircuit(stack)) continue;
-            if (nonConsumedIds.contains(GTUtility.ItemId.create(stack))) {
+            if (INonConsumedItemDisplay.isDisplayableItem(mRecipeMap, stack)) {
                 result.add(stack);
             }
         }

--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchCraftingInputME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchCraftingInputME.java
@@ -1172,11 +1172,11 @@ public class MTEHatchCraftingInputME extends MTEHatchInputBus implements IPowerC
         lines.appendTag(new NBTTagString(head));
 
         for (ItemStack item : getNonConsumedInputDisplayItems()) {
-            lines.appendTag(new NBTTagString(item.getDisplayName()));
+            lines.appendTag(new NBTTagString(CommonBaseMetaTileEntity.getShortItemDisplayName(item)));
         }
         for (int i = SLOT_MANUAL_START; i < SLOT_MANUAL_START + SLOT_MANUAL_SIZE; i++) {
             if (mInventory[i] != null) {
-                lines.appendTag(new NBTTagString(mInventory[i].getDisplayName()));
+                lines.appendTag(new NBTTagString(CommonBaseMetaTileEntity.getShortItemDisplayName(mInventory[i])));
             }
         }
         return lines;

--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchCraftingInputME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchCraftingInputME.java
@@ -115,6 +115,7 @@ import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.IGregTechDeviceInformation;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
+import gregtech.api.metatileentity.CommonBaseMetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.implementations.MTEHatchInputBus;
 import gregtech.api.objects.GTDualInputPattern;
@@ -724,7 +725,7 @@ public class MTEHatchCraftingInputME extends MTEHatchInputBus implements IPowerC
         StringJoiner manualSlots = new StringJoiner(", ");
         for (int i = SLOT_MANUAL_START; i < SLOT_MANUAL_START + SLOT_MANUAL_SIZE; i++) {
             if (mInventory[i] != null) {
-                manualSlots.add(mInventory[i].getDisplayName());
+                manualSlots.add(CommonBaseMetaTileEntity.getShortItemDisplayName(mInventory[i]));
             }
         }
         if (manualSlots.length() > 0) {

--- a/src/main/java/gregtech/common/tileentities/machines/MTEHatchInputBusME.java
+++ b/src/main/java/gregtech/common/tileentities/machines/MTEHatchInputBusME.java
@@ -8,12 +8,10 @@ import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_ME_INPUT_HATCH_ACTI
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 
 import javax.annotation.Nullable;
 
@@ -66,6 +64,7 @@ import gregtech.api.enums.Dyes;
 import gregtech.api.enums.ItemList;
 import gregtech.api.interfaces.IDataCopyable;
 import gregtech.api.interfaces.IMEConnectable;
+import gregtech.api.interfaces.INonConsumedItemDisplay;
 import gregtech.api.interfaces.IPhysicalCircuitDisplay;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
@@ -602,14 +601,10 @@ public class MTEHatchInputBusME extends MTEHatchInputBus implements IRecipeProce
 
     @Override
     public List<ItemStack> getNonConsumedInputDisplayItems() {
-        if (mRecipeMap == null) return Collections.emptyList();
-        Set<GTUtility.ItemId> nonConsumedIds = mRecipeMap.getNonConsumedInputItemIds();
-        if (nonConsumedIds.isEmpty()) return Collections.emptyList();
-
         List<ItemStack> result = new ArrayList<>();
         for (Slot slot : slots) {
-            if (slot == null || slot.config == null || GTUtility.isAnyIntegratedCircuit(slot.config)) continue;
-            if (nonConsumedIds.contains(GTUtility.ItemId.create(slot.config))) {
+            if (slot == null) continue;
+            if (INonConsumedItemDisplay.isDisplayableItem(mRecipeMap, slot.config)) {
                 result.add(slot.config);
             }
         }

--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/MTEHatchSolidifier.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/MTEHatchSolidifier.java
@@ -4,6 +4,7 @@ import static com.gtnewhorizon.gtnhlib.util.numberformatting.NumberFormatUtil.fo
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import net.minecraft.item.ItemStack;
@@ -17,6 +18,7 @@ import ggfab.GGItemList;
 import gregtech.api.enums.GTAuthors;
 import gregtech.api.enums.ItemList;
 import gregtech.api.interfaces.IConfigurationCircuitSupport;
+import gregtech.api.interfaces.INonConsumedItemDisplay;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
@@ -27,7 +29,7 @@ import gregtech.common.gui.modularui.hatch.MTEHatchSolidifierGui;
 import gtPlusPlus.core.util.Utils;
 
 @IMetaTileEntity.SkipGenerateDescription
-public class MTEHatchSolidifier extends MTEHatchInput implements IConfigurationCircuitSupport {
+public class MTEHatchSolidifier extends MTEHatchInput implements IConfigurationCircuitSupport, INonConsumedItemDisplay {
 
     public static final int moldSlot = 2;
     public static final int circuitSlot = 3;
@@ -103,6 +105,16 @@ public class MTEHatchSolidifier extends MTEHatchInput implements IConfigurationC
     @Override
     public MetaTileEntity newMetaEntity(IGregTechTileEntity aTileEntity) {
         return new MTEHatchSolidifier(mName, mTier, mDescriptionArray, mTextures);
+    }
+
+    @Override
+    public List<ItemStack> getNonConsumedInputDisplayItems() {
+        // the circuit is already shown by the ghost circuit suffix
+        ItemStack mold = getStackInSlot(moldSlot);
+        if (mold == null || mRecipeMap == null) return Collections.emptyList();
+        if (!mRecipeMap.getNonConsumedInputItemIds()
+            .contains(GTUtility.ItemId.create(mold))) return Collections.emptyList();
+        return Collections.singletonList(mold);
     }
 
     public List<ItemStack> getNonConsumableItems() {

--- a/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/MTEHatchSolidifier.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/MTEHatchSolidifier.java
@@ -111,10 +111,8 @@ public class MTEHatchSolidifier extends MTEHatchInput implements IConfigurationC
     public List<ItemStack> getNonConsumedInputDisplayItems() {
         // the circuit is already shown by the ghost circuit suffix
         ItemStack mold = getStackInSlot(moldSlot);
-        if (mold == null || mRecipeMap == null) return Collections.emptyList();
-        if (!mRecipeMap.getNonConsumedInputItemIds()
-            .contains(GTUtility.ItemId.create(mold))) return Collections.emptyList();
-        return Collections.singletonList(mold);
+        return INonConsumedItemDisplay.isDisplayableItem(mRecipeMap, mold) ? Collections.singletonList(mold)
+            : Collections.emptyList();
     }
 
     public List<ItemStack> getNonConsumableItems() {


### PR DESCRIPTION
## Summary
Follow-up to #7546, which only covered input buses. Single block machines now expose physical Integrated Circuits sitting in their input slots, and their non-consumed items are detected by scanning the input slots against the recipemap instead of relying on the last run recipe, so a mold shows up immediately without waiting for the first craft. The Solidifier Hatch does the same for its mold slot, while the Extrusion Bus needed no change since it inherits the scan from the input bus.

Non-consumed item names are also shortened to their parenthesised part, so "Extruder Shape (Rod)" reads as "Rod". This applies to input buses, single blocks and the manual slots of the Crafting Input Buffer, which previously listed the full name of every shape.

The rules behind both suffixes are now single helpers next to their interfaces, since the same slot scan had been copied into four classes by now.

Note that on a dedicated server the item names in the suffix are still English, because the suffix is built server side and AE2 appends it to the name without translating it. Fixing that needs an AE2 side change and will be a separate PR.

### Fluid Solidifier
<img width="430" height="228" alt="image" src="https://github.com/user-attachments/assets/48fdfbdd-c8e2-475b-8ff6-f1788a3ea80e" />
<img width="405" height="80" alt="image" src="https://github.com/user-attachments/assets/11ee00f5-3263-47bf-8698-43c026dacfe9" />

### Solidifier Hatch
<img width="574" height="209" alt="image" src="https://github.com/user-attachments/assets/344dfd65-69ce-46ee-ae34-4e468434b82f" />
<img width="389" height="74" alt="image" src="https://github.com/user-attachments/assets/ae30b6a7-c594-4856-86b6-9acce68d1a49" />

### Extrusion Bus
<img width="375" height="326" alt="image" src="https://github.com/user-attachments/assets/7ecd49b8-144d-4958-8205-5a47b2868cee" />
<img width="391" height="98" alt="image" src="https://github.com/user-attachments/assets/d63cf74a-6dae-4d3b-b94c-b4ca0fda1c5c" />

### Crafting Input Bus/Bufer
|Before|After|
|-|-|
<img width="445" height="601" alt="image" src="https://github.com/user-attachments/assets/6cbd23a2-5207-45b6-822b-a7df0b7d40a4" />|<img width="380" height="448" alt="image" src="https://github.com/user-attachments/assets/54d8ea7c-fb91-425e-a696-a64620a6af23" />| 

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
