### PR TITLE
Fix ME Output Bus/Hatch WAILA content names using server locale

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/outputme/base/MTEHatchOutputMEBase.java
+++ b/src/main/java/gregtech/common/tileentities/machines/outputme/base/MTEHatchOutputMEBase.java
@@ -27,6 +27,7 @@ import net.minecraft.util.IChatComponent;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
+import net.minecraftforge.fluids.FluidStack;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -727,7 +728,6 @@ public abstract class MTEHatchOutputMEBase<T extends IAEStack<T>> {
             .forEach(stack -> {
                 NBTTagCompound stackTag = new NBTTagCompound();
                 stack.writeToNBT(stackTag);
-                stackTag.setString("Name", stack.getDisplayName());
                 stackTag.setLong("Amount", stack.getStackSize());
                 tagList.appendTag(stackTag);
             });
@@ -798,6 +798,16 @@ public abstract class MTEHatchOutputMEBase<T extends IAEStack<T>> {
     @SideOnly(Side.CLIENT)
     public static class WailaHelper {
 
+        @Nullable
+        private static String getLocalizedName(String prefix, NBTTagCompound stackTag) {
+            if ("fluid".equals(prefix)) {
+                FluidStack fluid = FluidStack.loadFluidStackFromNBT(stackTag);
+                return fluid == null ? null : fluid.getLocalizedName();
+            }
+            ItemStack stack = ItemStack.loadItemStackFromNBT(stackTag);
+            return stack == null ? null : stack.getDisplayName();
+        }
+
         private static void processWailaAdvancedBody(String prefix, List<String> ss, String listKey, String countKey,
             NBTTagCompound tag) {
             NBTTagList stacks = tag.getTagList(listKey, 10);
@@ -815,11 +825,14 @@ public abstract class MTEHatchOutputMEBase<T extends IAEStack<T>> {
 
             for (int i = 0; i < stacks.tagCount(); i++) {
                 NBTTagCompound stackTag = stacks.getCompoundTagAt(i);
+                // Names must be resolved client-side, otherwise a dedicated server sends its own localization
+                String name = getLocalizedName(prefix, stackTag);
+                if (name == null) continue;
 
                 ss.add(
                     String.format(
                         "%s: %s%s%s",
-                        stackTag.getString("Name"),
+                        name,
                         EnumChatFormatting.GOLD,
                         formatNumber(stackTag.getLong("Amount")),
                         EnumChatFormatting.RESET));


### PR DESCRIPTION
## Summary
The WAILA cache list wrote the already localized display name into the NBT on the server side, so on a dedicated server every client saw the server locale instead of its own. Names are now resolved on the client from the stack NBT that was being sent anyway, and entries the client cannot resolve are skipped.

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
