### PR TITLE
fix assline ignoring gt_hatch

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEAssemblyLine.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEAssemblyLine.java
@@ -95,6 +95,7 @@ public class MTEAssemblyLine extends MTEExtendedPowerMultiBlockBase<MTEAssemblyL
                 buildHatchAdder(MTEAssemblyLine.class).atLeast(Energy)
                     .casingIndex(16)
                     .hint(4)
+                    .allowOnly(ForgeDirection.UP, ForgeDirection.NORTH, ForgeDirection.SOUTH)
                     .continueIfSuccess()
                     .build(),
                 ofBlock(GregTechAPI.sBlockCasings2, 0)))

--- a/src/main/java/gregtech/common/tileentities/machines/multi/MTEAssemblyLine.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/MTEAssemblyLine.java
@@ -92,7 +92,11 @@ public class MTEAssemblyLine extends MTEExtendedPowerMultiBlockBase<MTEAssemblyL
         .addElement(
             'e',
             ofChain(
-                Energy.newAny(16, 4, ForgeDirection.UP, ForgeDirection.NORTH, ForgeDirection.SOUTH),
+                buildHatchAdder(MTEAssemblyLine.class).atLeast(Energy)
+                    .casingIndex(16)
+                    .hint(4)
+                    .continueIfSuccess()
+                    .build(),
                 ofBlock(GregTechAPI.sBlockCasings2, 0)))
         .addElement(
             'd',


### PR DESCRIPTION
closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/26482

stops the assline automatically placing 16 ehatches whether its gt_hatch 1 or not
one thing to note is that with gt_hatch 1 it only places 1 ehatch

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
