### PR TITLE
fix Fr line chrome recycle possibility

### DIFF
--- a/src/main/java/gregtech/loaders/postload/chains/AcidRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/chains/AcidRecipes.java
@@ -48,7 +48,7 @@ public class AcidRecipes {
         GTValues.RA.stdBuilder()
             .fluidInputs(Materials.ThoriumElutionAdsorbent.getFluid(8000L))
             .itemOutputs(Materials.Chrome.getDust(4))
-            .outputChances(5500)
+            .outputChances(4500)
             .fluidOutputs(Materials.ImpureFranciumSolution.getFluid(4500L), Materials.Ammonia.getGas(3500L))
             .eut(TierEU.RECIPE_LuV)
             .duration(30 * SECONDS)


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
in the past we had the amount of the chrome in Fr line increases as net effect
<img width="271" height="149" alt="Screenshot 2026-08-26 at 22 23 07" src="https://github.com/user-attachments/assets/426bad69-b924-4108-9a53-f89bd191a0b6" />
8CrO3 ~ 0.55 * 4 Cr -> +0.2 Cr every cycle, which is confirmed to be not intended

now it is fixed

## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
