### PR TITLE
Remove mention of output hatch requirement from the Source Chamber

### DIFF
--- a/src/main/java/gtnhlanth/common/tileentity/MTESourceChamber.java
+++ b/src/main/java/gtnhlanth/common/tileentity/MTESourceChamber.java
@@ -151,7 +151,7 @@ public class MTESourceChamber extends MTEEnhancedMultiBlockBase<MTESourceChamber
             .addEnergyHatch("1", StatCollector.translateToLocal("gt.mbtt.structure.any_front_bottom_casing"), 3)
             .addMaintenanceHatch("1", StatCollector.translateToLocal("gt.mbtt.structure.any_front_bottom_casing"), 3)
             .addInputAny("1", StatCollector.translateToLocal("gt.mbtt.structure.front_center_casing"), 1)
-            .addOutputAny("1", StatCollector.translateToLocal("gtnhlanth.tt.sc.structure.output_pos"), 2)
+            .addOutputBus("1", StatCollector.translateToLocal("gtnhlanth.tt.sc.structure.output_pos"), 2)
             .addAir(StatCollector.translateToLocal("gt.mbtt.structure.interior"))
             .toolTipFinisher();
         // spotless:on


### PR DESCRIPTION
## Summary
Title, there are no recipes that output a fluid.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/26474

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
