### PR TITLE
Remove step up/down string from distributor WAILA tooltip

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/MTETransformer.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/MTETransformer.java
@@ -274,17 +274,19 @@ public class MTETransformer extends MTETieredMachineBlock {
         final byte inputTier = GTUtility.getTier(tag.getLong("maxEUInput"));
         final byte outputTier = GTUtility.getTier(tag.getLong("maxEUOutput"));
 
-        currenttip.add(
-            String.format(
-                "%s %s(%dA) -> %s(%dA)",
-                (allowedToWork ? (GREEN + StatCollector.translateToLocal("GT5U.waila.transformer.step_down"))
-                    : (RED + StatCollector.translateToLocal("GT5U.waila.transformer.step_up"))) + RESET,
-                GTMod.proxy.mWailaTransformerVoltageTier ? GTUtility.getColoredTierNameFromTier(inputTier)
-                    : tag.getLong("maxEUInput"),
-                tag.getLong("displayedAmperesIn"),
-                GTMod.proxy.mWailaTransformerVoltageTier ? GTUtility.getColoredTierNameFromTier(outputTier)
-                    : tag.getLong("maxEUOutput"),
-                tag.getLong("maxAmperesOut")));
+        if (maxEUInput() != maxEUOutput()) {
+            currenttip.add(
+                String.format(
+                    "%s %s(%dA) -> %s(%dA)",
+                    (allowedToWork ? (GREEN + StatCollector.translateToLocal("GT5U.waila.transformer.step_down"))
+                        : (RED + StatCollector.translateToLocal("GT5U.waila.transformer.step_up"))) + RESET,
+                    GTMod.proxy.mWailaTransformerVoltageTier ? GTUtility.getColoredTierNameFromTier(inputTier)
+                        : tag.getLong("maxEUInput"),
+                    tag.getLong("displayedAmperesIn"),
+                    GTMod.proxy.mWailaTransformerVoltageTier ? GTUtility.getColoredTierNameFromTier(outputTier)
+                        : tag.getLong("maxEUOutput"),
+                    tag.getLong("maxAmperesOut")));
+        }
 
         if ((side == facing && allowedToWork) || (side != facing && !allowedToWork)) {
             currenttip.add(


### PR DESCRIPTION
## Summary
This PR removes the Step Up/Step Down string from the WAILA tooltip of the energy distributor by checking if the EU input and output tiers are the same. Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/26497

<img width="486" height="626" alt="Screenshot 2026-08-27 163339" src="https://github.com/user-attachments/assets/62f3d3cf-e7c0-4a80-ba80-7a10d4f4be2f" />

<img width="431" height="692" alt="Screenshot 2026-08-27 163401" src="https://github.com/user-attachments/assets/087cb255-4d17-4fb2-94f0-128763c64cbc" />

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
