### PR TITLE
Remove alternate BEC recipes

### DIFF
--- a/src/main/java/gregtech/api/enums/CondensateType.java
+++ b/src/main/java/gregtech/api/enums/CondensateType.java
@@ -81,52 +81,52 @@ public enum CondensateType {
         "phononmedium",
         () -> Materials.PhononMedium,
         1000,
-        () -> Materials.PhononMedium.getFluid(1000), 60 * SECONDS, 4 * TierEU.RECIPE_UXV),
+        () -> Materials.PhononMedium.getFluid(1000), 90 * SECONDS, TierEU.RECIPE_UMV),
     QuarkGluonPlasma(
         "quarkgluonplasma",
         () -> Materials.QuarkGluonPlasma,
         1000,
-        () -> Materials.QuarkGluonPlasma.getFluid(1000), 120 * SECONDS, 4 * TierEU.RECIPE_UXV),
+        () -> Materials.QuarkGluonPlasma.getFluid(1000), 120 * SECONDS, TierEU.RECIPE_UMV),
     SpaceTime(
         "spacetime",
         () -> Materials.SpaceTime,
         144,
-        () -> Materials.SpaceTime.getMolten(144), 90 * SECONDS, 16 * TierEU.RECIPE_UXV),
+        () -> Materials.SpaceTime.getMolten(144), 120 * SECONDS, TierEU.RECIPE_UXV),
     Time(
         "time",
         () -> Materials.Time,
         144,
-        () -> Materials.Time.getMolten(144), 90 * SECONDS, 16 * TierEU.RECIPE_UXV),
+        () -> Materials.Time.getMolten(144), 120 * SECONDS, TierEU.RECIPE_UXV),
     Space(
         "space",
         () -> Materials.Space,
         144,
-        () -> Materials.Space.getMolten(144), 90 * SECONDS, 16 * TierEU.RECIPE_UXV),
+        () -> Materials.Space.getMolten(144), 120 * SECONDS, TierEU.RECIPE_UXV),
     BoundlessCosmicSolder(
         "cosmicsolder",
         () -> Materials.BoundlessCosmicSolder,
         1000,
-        () -> Materials.BoundlessCosmicSolder.getFluid(1000), 120 * SECONDS, 16 * TierEU.RECIPE_UXV),
+        () -> Materials.BoundlessCosmicSolder.getFluid(1000), 120 * SECONDS, TierEU.RECIPE_UXV),
     MHDCSM(
         "mhdcsm",
         () -> Materials.MHDCSM,
         144,
-        () -> Materials.MHDCSM.getMolten(144), 120 * SECONDS, 64 * TierEU.RECIPE_UXV),
+        () -> Materials.MHDCSM.getMolten(144), 180 * SECONDS, 4 * TierEU.RECIPE_UXV),
     MagMatter(
         "magmatter",
         () -> Materials.MagMatter,
         144,
-        () -> Materials.MagMatter.getMolten(144), 120 * SECONDS, 64 * TierEU.RECIPE_UXV),
+        () -> Materials.MagMatter.getMolten(144), 180 * SECONDS, 4 * TierEU.RECIPE_UXV),
     Universium(
         "universium",
         () -> Materials.Universium,
         144,
-        () -> Materials.Universium.getMolten(144), 120 * SECONDS, 64 * TierEU.RECIPE_UXV),
+        () -> Materials.Universium.getMolten(144), 180 * SECONDS, 4 * TierEU.RECIPE_UXV),
     Eternity(
         "eternity",
         () -> Materials.Eternity,
         144,
-        () -> Materials.Eternity.getMolten(144), 120 * SECONDS, 64 * TierEU.RECIPE_UXV),
+        () -> Materials.Eternity.getMolten(144), 180 * SECONDS, 4 * TierEU.RECIPE_UXV),
     // spotless:on
     ;
 

--- a/src/main/java/gregtech/loaders/postload/recipes/BECMetaMaterialRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/BECMetaMaterialRecipes.java
@@ -184,13 +184,9 @@ public class BECMetaMaterialRecipes implements Runnable {
         final int[] becAmounts;
         if (t == 0) {
             becCondensates = new CondensateType[] { CondensateType.ChromaticGlass, CondensateType.Infinity,
-                CondensateType.TranscendentMetal };
-            final CondensateType[] becCondensates2 = new CondensateType[] { CondensateType.ChromaticGlass,
-                CondensateType.Infinity, CondensateType.BoundlessCosmicSolder };
+                CondensateType.TranscendentMetal };;
             becAmounts = new int[] { chromatic4TierAmts[t], infinity4TierAmts[t], 2 };
-            final int[] becAmounts2 = new int[] { chromatic4TierAmts[t], infinity4TierAmts[t], 1 };
             addBec(outputs[t].get(1), inputs, nanites, becCondensates, becAmounts, baseDuration, euts[t]);
-            addBec(outputs[t].get(1), inputs, nanites, becCondensates2, becAmounts2, baseDuration, euts[t]);
         } else {
             becCondensates = new CondensateType[] { CondensateType.ChromaticGlass, CondensateType.Infinity,
                 CondensateType.BoundlessCosmicSolder };

--- a/src/main/java/gregtech/loaders/postload/recipes/BECMetaMaterialRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/BECMetaMaterialRecipes.java
@@ -184,7 +184,7 @@ public class BECMetaMaterialRecipes implements Runnable {
         final int[] becAmounts;
         if (t == 0) {
             becCondensates = new CondensateType[] { CondensateType.ChromaticGlass, CondensateType.Infinity,
-                CondensateType.TranscendentMetal };;
+                CondensateType.TranscendentMetal };
             becAmounts = new int[] { chromatic4TierAmts[t], infinity4TierAmts[t], 2 };
             addBec(outputs[t].get(1), inputs, nanites, becCondensates, becAmounts, baseDuration, euts[t]);
         } else {

--- a/src/main/java/gregtech/loaders/postload/recipes/BECRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/BECRecipes.java
@@ -113,8 +113,8 @@ public class BECRecipes implements Runnable {
                 GTOreDictUnificator.get(OrePrefixes.circuit, Materials.UIV, 16),
                 ItemList.MetaMaterial_Shielding1.get(64), ItemList.MetaMaterial_EnergyConduit1.get(64) },
             nanites(1, 1, 3, 3, 3, 2, 2, 1, 4, 4, 2, 2),
-            new FluidStack[] { CondensateType.TranscendentMetal.getEntangled(32 * INGOTS),
-                CondensateType.Space.getEntangled(24 * INGOTS), CondensateType.SpaceTime.getEntangled(12 * INGOTS),
+            new FluidStack[] { CondensateType.Space.getEntangled(24 * INGOTS),
+                CondensateType.SpaceTime.getEntangled(12 * INGOTS),
                 CondensateType.DimensionallyShiftedSuperfluid.getEntangled(10_000) },
             600 * SECONDS,
             TierEU.RECIPE_UMV);
@@ -247,24 +247,6 @@ public class BECRecipes implements Runnable {
             new FluidStack[] { CondensateType.ChromaticGlass.getEntangled(64 * INGOTS),
                 CondensateType.Infinity.getEntangled(32 * INGOTS),
                 CondensateType.TranscendentMetal.getEntangled(32 * INGOTS), },
-            300 * SECONDS,
-            TierEU.RECIPE_UMV);
-        addBec(
-            CustomItemList.Godforge_GravitonFlowModulatorTier2.get(1),
-            new ItemStack[] { CustomItemList.Godforge_MagneticConfinementCasing.get(1),
-                ItemRefer.Field_Restriction_Coil_T4.get(1),
-                GTOreDictUnificator.get(OrePrefixes.plateDense, Materials.Creon, 8),
-                GTOreDictUnificator.get(OrePrefixes.gearGt, Materials.Mellion, 4),
-                GTOreDictUnificator.get(OrePrefixes.frameGt, Materials.SuperconductorUIVBase, 32),
-                GregtechItemList.Battery_Gem_4.get(4), GregtechItemList.Laser_Lens_Special.get(8),
-                ItemList.Emitter_UMV.get(4), GTOreDictUnificator.get(OrePrefixes.circuit, Materials.UMV, 8),
-                GTOreDictUnificator.get(OrePrefixes.nanite, Materials.Silver, 2),
-                GTOreDictUnificator.get(OrePrefixes.nanite, Materials.Gold, 2),
-                ItemList.MetaMaterial_Waveguide1.get(4) },
-            nanites(1, 1, 1, 1, 1, 2, 3, 3, 3, 2, 2, 4),
-            new FluidStack[] { CondensateType.ChromaticGlass.getEntangled(64 * INGOTS),
-                CondensateType.Infinity.getEntangled(32 * INGOTS),
-                CondensateType.BoundlessCosmicSolder.getEntangled(2_000), },
             300 * SECONDS,
             TierEU.RECIPE_UMV);
 

--- a/src/main/java/gregtech/loaders/postload/recipes/BECRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/BECRecipes.java
@@ -55,6 +55,9 @@ import tectech.thing.block.BlockQuantumGlass;
 /// | Family 3 | Phononic Medium, Universium, MHDCSM, QGP, MagMatter, Cosmic Solder, Eternity |
 /// | Family 4 | Phononic Medium, Celestial Tungsten, Infinity, Neutronium, Cosmic Neutronium, Hypogen, Bedrockium |
 /// | Family 5 | SpaceTime, Space, MHDCSM, QGP, DSS, Cosmic Solder, Eternity |
+///
+/// Presently, recipes cannot be alternatives that diverge only in condensates. The BEC recipe check only acknowledges
+/// items, then checks condensates present against the _selected_ recipe.
 public class BECRecipes implements Runnable {
 
     private static final NaniteTier[] TIER_TO_NANITE = { NaniteTier.Carbon, NaniteTier.Silver, NaniteTier.Gold,


### PR DESCRIPTION
## Summary
I realized, on review, that recipes which diverge in condensates in BEC *do not work*. So, this removes some of the alternate recipes added in https://github.com/GTNewHorizons/GT5-Unofficial/pull/7824. Most weren't necessary for the groupings I identified.

One wasn't added in the first place (supposed to be for UMV CoAL). I removed the (trivial) transcendent metal off of it. I don't think cosmic solder gating it makes sense. QGP would fit cleanly, and I think makes a lot of sense for when exotic circuits exist. For now, it is empty, which actually looks kind of clean.
<img width="221" height="89" alt="image" src="https://github.com/user-attachments/assets/db205fe4-6023-401b-8c05-7b4a4957a160" />


## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
