### PR TITLE
add abyssal and octiron mixer recipes

### DIFF
--- a/src/main/java/gtPlusPlus/core/recipe/RecipesGregTech.java
+++ b/src/main/java/gtPlusPlus/core/recipe/RecipesGregTech.java
@@ -50,6 +50,7 @@ import static gregtech.api.util.GTRecipeConstants.UniversalChemical;
 import java.util.Arrays;
 import java.util.List;
 
+import gtPlusPlus.core.material.Material;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
@@ -58,6 +59,7 @@ import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 
 import bartworks.system.material.WerkstoffLoader;
+import gtnhlanth.common.register.WerkstoffMaterialPool;
 import goodgenerator.items.GGMaterial;
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.ItemList;
@@ -1665,6 +1667,35 @@ public class RecipesGregTech {
             .itemOutputs(MaterialsAlloy.MARAGING250.getDust(24))
             .duration(1 * MINUTES)
             .eut(TierEU.RECIPE_EV)
+            .addTo(mixerRecipes);
+
+        GTValues.RA.stdBuilder()
+            .itemInputs(
+                Materials.StainlessSteel.getDust(10),
+                Materials.TungstenCarbide.getDust(10),
+                Materials.Nichrome.getDust(10),
+                Materials.Bronze.getDust(10),
+                MaterialsAlloy.INCOLOY_MA956.getDust(10),
+                WerkstoffMaterialPool.Iodine.get(OrePrefixes.dust, 2),
+                MaterialsElements.getInstance().GERMANIUM.getDust(2))
+            .fluidInputs(Materials.Radon.getFluid(2000L))
+            .circuit(8)
+            .itemOutputs(MaterialsAlloy.ABYSSAL.getDust(56))
+            .duration(5 * MINUTES + 36 * SECONDS)
+            .eut(TierEU.RECIPE_UHV)
+            .addTo(mixerRecipes);
+
+        GTValues.RA.stdBuilder()
+            .itemInputs(
+                MaterialsAlloy.ARCANITE.getDust(6),
+                MaterialsAlloy.TITANSTEEL.getDust(6),
+                MaterialsAlloy.ENERGYCRYSTAL.getDust(1),
+                Materials.BlackSteel.getDust(2),
+                Materials.Thaumium.getDust(5))
+            .circuit(5)
+            .itemOutputs(MaterialsAlloy.OCTIRON.getDust(20))
+            .duration(2 * MINUTES)
+            .eut(TierEU.RECIPE_UHV)
             .addTo(mixerRecipes);
     }
 

--- a/src/main/java/gtPlusPlus/core/recipe/RecipesGregTech.java
+++ b/src/main/java/gtPlusPlus/core/recipe/RecipesGregTech.java
@@ -1678,7 +1678,7 @@ public class RecipesGregTech {
                 MaterialsAlloy.INCOLOY_MA956.getDust(10),
                 WerkstoffMaterialPool.Iodine.get(OrePrefixes.dust, 2),
                 MaterialsElements.getInstance().GERMANIUM.getDust(2))
-            .fluidInputs(Materials.Radon.getFluid(2000L))
+            .fluidInputs(Materials.Radon.getGas(2000L))
             .circuit(8)
             .itemOutputs(MaterialsAlloy.ABYSSAL.getDust(56))
             .duration(5 * MINUTES + 36 * SECONDS)

--- a/src/main/java/gtPlusPlus/core/recipe/RecipesGregTech.java
+++ b/src/main/java/gtPlusPlus/core/recipe/RecipesGregTech.java
@@ -50,7 +50,6 @@ import static gregtech.api.util.GTRecipeConstants.UniversalChemical;
 import java.util.Arrays;
 import java.util.List;
 
-import gtPlusPlus.core.material.Material;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
@@ -59,7 +58,6 @@ import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 
 import bartworks.system.material.WerkstoffLoader;
-import gtnhlanth.common.register.WerkstoffMaterialPool;
 import goodgenerator.items.GGMaterial;
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.ItemList;
@@ -89,6 +87,7 @@ import gtPlusPlus.core.util.minecraft.MaterialUtils;
 import gtPlusPlus.xmod.bop.blocks.BOPBlockRegistrator;
 import gtPlusPlus.xmod.gregtech.api.enums.GregtechItemList;
 import gtPlusPlus.xmod.thermalfoundation.fluid.TFFluids;
+import gtnhlanth.common.register.WerkstoffMaterialPool;
 import ic2.core.Ic2Items;
 
 public class RecipesGregTech {


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
this pr would add abyssal and octiron dust recipes for mixer
these recipes will provide another option to make these 2 alloys.

Abyssal Alloy:
<img width="326" height="308" alt="Screenshot 2026-08-29 at 12 03 56" src="https://github.com/user-attachments/assets/dd5d6bac-ea4f-4806-b2c4-93df9b1390e6" />

Octiron:
<img width="347" height="339" alt="Screenshot 2026-08-29 at 12 04 25" src="https://github.com/user-attachments/assets/68ea7fd0-e669-4cce-8061-884259ab592f" />


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
