### PR TITLE
Skip nested inventory cache capture

### DIFF
--- a/src/main/java/gregtech/common/render/GTRendererBlock.java
+++ b/src/main/java/gregtech/common/render/GTRendererBlock.java
@@ -26,6 +26,7 @@ import net.minecraft.world.World;
 
 import org.lwjgl.opengl.GL11;
 
+import com.gtnewhorizon.gtnhlib.client.renderer.TessellatorManager;
 import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
@@ -209,7 +210,9 @@ public class GTRendererBlock implements ISimpleBlockRenderingHandler {
     @Override
     public void renderInventoryBlock(Block aBlock, int aMeta, int aModelID, RenderBlocks aRenderer) {
         final IMetaTileEntity imte = getMTE(aBlock, aMeta);
-        if (((TesselatorAccessor) Tessellator.instance).gt5u$isDrawing()) {
+        // Nested capture can cache an incomplete model; let the outer renderer own that render instead.
+        if (((TesselatorAccessor) Tessellator.instance).gt5u$isDrawing() || TessellatorManager.isCurrentlyCapturing()
+            || TessellatorManager.shouldInterceptDraw(Tessellator.instance)) {
             renderInventoryBlockImmediate(aBlock, aMeta, aModelID, aRenderer, imte);
             return;
         }


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
Before, the cache could accept invalid or partial captures, leading to some blocks having invisible textures on some sides. A config reload or F3+T would fix it. Now, invalid or partial captures cannot enter the cache anymore.
## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
