### PR TITLE
Fix IAF structure

### DIFF
--- a/src/main/java/kubatech/tileentity/gregtech/multiblock/MTEIndustrialArcFurnace.java
+++ b/src/main/java/kubatech/tileentity/gregtech/multiblock/MTEIndustrialArcFurnace.java
@@ -206,7 +206,7 @@ public class MTEIndustrialArcFurnace extends KubaTechGTMultiBlockBase<MTEIndustr
             buildHatchAdder(MTEIndustrialArcFurnace.class)
                 .atLeast(
                     ElectrodeDetectorHatch,
-                    InputBus.or(ElectrodeHatch),
+                    ElectrodeHatch.or(InputBus),
                     OutputBus,
                     InputHatch,
                     OutputHatch,


### PR DESCRIPTION
## Summary
IAF relies on custom adder, which needs the specific order. Rechecked all changes from previous PR and this is the only multiblock that uses a custom adder. The others include solidier, extruder which does not have custom adder, and LMA already use the correct order.

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/26556

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
