### PR TITLE
Add ABS mode to Melting Core

### DIFF
--- a/src/main/java/bartworks/MainMod.java
+++ b/src/main/java/bartworks/MainMod.java
@@ -235,7 +235,10 @@ public final class MainMod {
                     .reInit());
 
         // because the above code runs so late that I couldn't find anywhere else to call this
-        if (!recipesAdded) Godforge.initMoltenModuleRecipes();
+        if (!recipesAdded) {
+            Godforge.initMoltenModuleRecipes();
+            Godforge.initAlloyModuleRecipes();
+        }
 
         recipesAdded = true;
     }

--- a/src/main/java/gregtech/common/gui/modularui/multiblock/godforge/MTEMoltenModuleGui.java
+++ b/src/main/java/gregtech/common/gui/modularui/multiblock/godforge/MTEMoltenModuleGui.java
@@ -1,6 +1,22 @@
 package gregtech.common.gui.modularui.multiblock.godforge;
 
+import static gregtech.api.metatileentity.BaseTileEntity.TOOLTIP_DELAY;
+import static net.minecraft.util.StatCollector.translateToLocal;
+
+import net.minecraft.util.EnumChatFormatting;
+
+import com.cleanroommc.modularui.api.widget.IWidget;
+import com.cleanroommc.modularui.drawable.DynamicDrawable;
+import com.cleanroommc.modularui.drawable.ItemDrawable;
+import com.cleanroommc.modularui.value.sync.BooleanSyncValue;
+import com.cleanroommc.modularui.value.sync.PanelSyncManager;
+import com.cleanroommc.modularui.widgets.ButtonWidget;
+
+import gregtech.api.enums.ItemList;
+import gregtech.api.modularui2.GTGuiTextures;
 import gregtech.common.gui.modularui.multiblock.godforge.sync.Modules;
+import gregtech.common.gui.modularui.multiblock.godforge.sync.SyncValues;
+import gtPlusPlus.xmod.gregtech.api.enums.GregtechItemList;
 import tectech.thing.metaTileEntity.multi.godforge.MTEMoltenModule;
 
 public class MTEMoltenModuleGui extends MTEBaseModuleGui<MTEMoltenModule> {
@@ -12,5 +28,54 @@ public class MTEMoltenModuleGui extends MTEBaseModuleGui<MTEMoltenModule> {
     @Override
     public Modules<MTEMoltenModule> getModuleType() {
         return Modules.MOLTEN;
+    }
+
+    @Override
+    protected void registerSyncValues(PanelSyncManager syncManager) {
+        super.registerSyncValues(syncManager);
+
+        SyncValues.ALLOY_CAPABLE.registerFor(getModuleType(), getMainPanel(), hypervisor);
+        SyncValues.ALLOY_MODE.registerFor(getModuleType(), getMainPanel(), hypervisor);
+    }
+
+    @Override
+    protected boolean usesExtraButton() {
+        return true;
+    }
+
+    @Override
+    protected IWidget createExtraButton() {
+        BooleanSyncValue alloyCapable = SyncValues.ALLOY_CAPABLE
+            .lookupFrom(getModuleType(), getMainPanel(), hypervisor);
+        BooleanSyncValue alloyMode = SyncValues.ALLOY_MODE.lookupFrom(getModuleType(), getMainPanel(), hypervisor);
+
+        return new ButtonWidget<>().size(16)
+            .background(GTGuiTextures.TT_BUTTON_CELESTIAL_32x32)
+            .overlay(new DynamicDrawable(() -> {
+                if (alloyMode.getBoolValue()) {
+                    return new ItemDrawable(GregtechItemList.Mega_AlloyBlastSmelter.get(1));
+                }
+                return new ItemDrawable(ItemList.Machine_Multi_BlastFurnace.get(1));
+            }))
+            .onMousePressed(d -> {
+                if (alloyCapable.getBoolValue()) {
+                    alloyMode.setBoolValue(!alloyMode.getBoolValue());
+                }
+                return true;
+            })
+            .tooltipDynamic(t -> {
+                if (!alloyMode.getBoolValue()) {
+                    t.addLine(translateToLocal("fog.button.alloymode.tooltip.01"));
+                }
+                if (alloyCapable.getBoolValue() && alloyMode.getBoolValue()) {
+                    t.addLine(translateToLocal("fog.button.alloymode.tooltip.02"));
+                }
+                if (!alloyCapable.getBoolValue()) {
+                    t.addLine(EnumChatFormatting.GRAY + translateToLocal("fog.button.alloymode.tooltip.03"));
+                }
+            })
+            .tooltipAutoUpdate(true)
+            .tooltipShowUpTimer(TOOLTIP_DELAY)
+            .clickSound(ForgeOfGodsGuiUtil.getButtonSound());
     }
 }

--- a/src/main/java/gregtech/common/gui/modularui/multiblock/godforge/panel/UpgradeTreePanel.java
+++ b/src/main/java/gregtech/common/gui/modularui/multiblock/godforge/panel/UpgradeTreePanel.java
@@ -82,6 +82,7 @@ public class UpgradeTreePanel {
             .child(createConnectorLine(UpgradeColor.BLUE, REC, QGPIU, hypervisor))
             .child(createConnectorLine(UpgradeColor.BLUE, CTCDD, QGPIU, hypervisor))
             .child(createConnectorLine(UpgradeColor.ORANGE, QGPIU, TCT, hypervisor))
+            .child(createConnectorLine(UpgradeColor.ORANGE, TCT, MAS, hypervisor))
             .child(createConnectorLine(UpgradeColor.ORANGE, TCT, EPEC, hypervisor))
             .child(createConnectorLine(UpgradeColor.ORANGE, EPEC, POS, hypervisor))
             .child(createConnectorLine(UpgradeColor.ORANGE, POS, NGMS, hypervisor))

--- a/src/main/java/gregtech/common/gui/modularui/multiblock/godforge/sync/SyncValues.java
+++ b/src/main/java/gregtech/common/gui/modularui/multiblock/godforge/sync/SyncValues.java
@@ -20,6 +20,7 @@ import gregtech.common.gui.modularui.multiblock.godforge.sync.SyncValue.HybridSy
 import gregtech.common.gui.modularui.multiblock.godforge.sync.SyncValue.ModuleSyncValue;
 import tectech.thing.metaTileEntity.multi.godforge.MTEBaseModule;
 import tectech.thing.metaTileEntity.multi.godforge.MTEExoticModule;
+import tectech.thing.metaTileEntity.multi.godforge.MTEMoltenModule;
 import tectech.thing.metaTileEntity.multi.godforge.MTEPlasmaModule;
 import tectech.thing.metaTileEntity.multi.godforge.MTESmeltingModule;
 import tectech.thing.metaTileEntity.multi.godforge.color.ForgeOfGodsStarColor;
@@ -240,6 +241,14 @@ public class SyncValues {
     public static final ModuleSyncValue<BooleanSyncValue, MTESmeltingModule> SMELTING_MODE = new ModuleSyncValue<>(
         "fog.sync.smelting_mode",
         module -> new BooleanSyncValue(module::isFurnaceModeOn, module::setFurnaceMode));
+
+    public static final ModuleSyncValue<BooleanSyncValue, MTEMoltenModule> ALLOY_CAPABLE = new ModuleSyncValue<>(
+        "fog.sync.alloy_capable",
+        module -> new BooleanSyncValue(module::isAlloyCapable, module::setAlloyCapable));
+
+    public static final ModuleSyncValue<BooleanSyncValue, MTEMoltenModule> ALLOY_MODE = new ModuleSyncValue<>(
+        "fog.sync.alloy_mode",
+        module -> new BooleanSyncValue(module::isAlloyModeOn, module::setAlloyMode));
 
     public static final ModuleSyncValue<IntSyncValue, MTEPlasmaModule> DEBUG_PLASMA_PARALLEL = new ModuleSyncValue<>(
         "fog.sync.debug_plasma_parallel",

--- a/src/main/java/tectech/loader/recipe/Godforge.java
+++ b/src/main/java/tectech/loader/recipe/Godforge.java
@@ -737,6 +737,15 @@ public class Godforge implements Runnable {
                 ItemList.ZPM6.get(2),
                 ItemList.Field_Generator_UMV.get(32));
 
+            ForgeOfGodsUpgrade.MAS.addExtraCost(
+                GregtechItemList.Mega_AlloyBlastSmelter.get(64L),
+                ItemList.Casing_Coil_Eternal.get(32L),
+                CustomItemList.Godforge_HarmonicPhononTransmissionConduit.get(32L),
+                getModItem(EternalSingularity.ID, "eternal_singularity", 16L),
+                ItemRefer.Field_Restriction_Coil_T4.get(32),
+                ItemList.Robot_Arm_UMV.get(32L),
+                ItemList.Field_Generator_UIV.get(64L));
+
             ForgeOfGodsUpgrade.EE.addExtraCost(
                 GTOreDictUnificator.get(OrePrefixes.frameGt, Materials.WhiteDwarfMatter, 64),
                 GTOreDictUnificator.get(OrePrefixes.frameGt, Materials.BlackDwarfMatter, 64),
@@ -779,6 +788,7 @@ public class Godforge implements Runnable {
         ForgeOfGodsUpgrade.CD.addExtraCost(new ItemStack(Blocks.cobblestone, 32));
         ForgeOfGodsUpgrade.EE.addExtraCost(new ItemStack(Blocks.cobblestone, 48));
         ForgeOfGodsUpgrade.END.addExtraCost(new ItemStack(Blocks.cobblestone, 64));
+        ForgeOfGodsUpgrade.MAS.addExtraCost(new ItemStack(Blocks.cobblestone, 24));
     }
 
     public static void addFakeUpgradeCostRecipes() {
@@ -815,6 +825,14 @@ public class Godforge implements Runnable {
             .duration(1)
             .eut(1)
             .metadata(FOG_UPGRADE_NAME_SHORT, translateToLocal(ForgeOfGodsUpgrade.QGPIU.getShortNameKey()))
+            .fake()
+            .addTo(TecTechRecipeMaps.godforgeFakeUpgradeCostRecipes);
+        GTValues.RA.stdBuilder()
+            .itemInputs(ForgeOfGodsUpgrade.MAS.getExtraCostNoNulls())
+            .itemOutputs(CustomItemList.Machine_Multi_MoltenModule.get(1))
+            .duration(1)
+            .eut(1)
+            .metadata(FOG_UPGRADE_NAME_SHORT, translateToLocal(ForgeOfGodsUpgrade.MAS.getShortNameKey()))
             .fake()
             .addTo(TecTechRecipeMaps.godforgeFakeUpgradeCostRecipes);
         GTValues.RA.stdBuilder()
@@ -895,6 +913,31 @@ public class Godforge implements Runnable {
             .eut(TierEU.RECIPE_UXV)
             .metadata(COIL_HEAT, 50000)
             .addTo(TecTechRecipeMaps.godforgeMoltenRecipes);
+    }
+
+    public static void initAlloyModuleRecipes() {
+        for (GTRecipe recipe : RecipeMaps.alloyBlastSmelterRecipes.getAllRecipes()) {
+            // The ABS ignores mSpecialValue, so a synthetic heat requirement is derived from the
+            // recipe's voltage tier instead. This eats into the module's perfect-overclock headroom
+            // the same way high-heat recipes do in the molten module, so high tier alloys don't get
+            // their entire overclock stack for free. Always below the module's minimum heat of
+            // ~12600, so no recipe is ever locked out.
+            int heat = 900 * Math.max(0, GTUtility.getTier(recipe.mEUt) - 1);
+
+            GTRecipeBuilder builder = GTValues.RA.stdBuilder()
+                .duration(recipe.mDuration)
+                .eut(recipe.mEUt)
+                .specialValue(heat);
+
+            if (recipe.mInputs != null) builder.itemInputs(recipe.mInputs);
+            if (recipe.mFluidInputs != null) builder.fluidInputs(recipe.mFluidInputs);
+            if (recipe.mOutputs != null) builder.itemOutputs(recipe.mOutputs);
+            if (recipe.mFluidOutputs != null) builder.fluidOutputs(recipe.mFluidOutputs);
+            if (recipe.mOutputChances != null && recipe.mOutputChances.length > 0)
+                builder.outputChances(recipe.mOutputChances);
+
+            builder.addTo(TecTechRecipeMaps.godforgeAlloyRecipes);
+        }
     }
 
     private static FluidStack convertToMolten(ItemStack stack) {

--- a/src/main/java/tectech/recipe/TecTechRecipeMaps.java
+++ b/src/main/java/tectech/recipe/TecTechRecipeMaps.java
@@ -17,6 +17,7 @@ import gregtech.api.recipe.RecipeMap;
 import gregtech.api.recipe.RecipeMapBackend;
 import gregtech.api.recipe.RecipeMapBuilder;
 import gregtech.api.recipe.maps.BECCreationFrontend;
+import gregtech.api.recipe.maps.LargeNEIFrontend;
 import gregtech.api.util.GTRecipe;
 import gregtech.api.util.GTRecipeConstants;
 import gregtech.nei.formatter.HeatingCoilSpecialValueFormatter;
@@ -125,6 +126,13 @@ public class TecTechRecipeMaps {
         .logo(TecTechUITextures.PICTURE_GODFORGE_LOGO)
         .logoSize(18, 18)
         .logoPos(151, 63)
+        .build();
+
+    public static final RecipeMap<RecipeMapBackend> godforgeAlloyRecipes = RecipeMapBuilder.of("gt.recipe.fog_alloy")
+        .maxIO(9, 9, 3, 3)
+        .minInputs(1, 0)
+        .neiSpecialInfoFormatter(HeatingCoilSpecialValueFormatter.INSTANCE)
+        .frontend(LargeNEIFrontend::new)
         .build();
 
     public static final RecipeMap<RecipeMapBackend> godforgeFakeUpgradeCostRecipes = RecipeMapBuilder

--- a/src/main/java/tectech/thing/metaTileEntity/multi/godforge/MTEMoltenModule.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/godforge/MTEMoltenModule.java
@@ -10,7 +10,10 @@ import static net.minecraft.util.EnumChatFormatting.YELLOW;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.StatCollector;
 
@@ -37,6 +40,8 @@ public class MTEMoltenModule extends MTEBaseModule {
 
     private long EUt = 0;
     private int currentParallel = 0;
+    private boolean alloyMode = false;
+    private boolean alloyCapable = false;
 
     public MTEMoltenModule(int aID, String aName, String aNameRegional) {
         super(aID, aName, aNameRegional);
@@ -124,7 +129,44 @@ public class MTEMoltenModule extends MTEBaseModule {
 
     @Override
     public RecipeMap<?> getRecipeMap() {
-        return TecTechRecipeMaps.godforgeMoltenRecipes;
+        return alloyMode ? TecTechRecipeMaps.godforgeAlloyRecipes : TecTechRecipeMaps.godforgeMoltenRecipes;
+    }
+
+    @NotNull
+    @Override
+    public Collection<RecipeMap<?>> getAvailableRecipeMaps() {
+        return Arrays.asList(TecTechRecipeMaps.godforgeMoltenRecipes, TecTechRecipeMaps.godforgeAlloyRecipes);
+    }
+
+    public boolean isAlloyModeOn() {
+        return alloyMode;
+    }
+
+    public void setAlloyMode(boolean enabled) {
+        alloyMode = enabled;
+        // The machine is using a different recipemap now
+        // Clear the cached recipe
+        setSingleRecipeCheck(null);
+    }
+
+    public boolean isAlloyCapable() {
+        return alloyCapable;
+    }
+
+    public void setAlloyCapable(boolean capable) {
+        alloyCapable = capable;
+    }
+
+    @Override
+    public void saveNBTData(NBTTagCompound NBT) {
+        NBT.setBoolean("alloyMode", alloyMode);
+        super.saveNBTData(NBT);
+    }
+
+    @Override
+    public void loadNBTData(final NBTTagCompound NBT) {
+        alloyMode = NBT.getBoolean("alloyMode");
+        super.loadNBTData(NBT);
     }
 
     @Override

--- a/src/main/java/tectech/thing/metaTileEntity/multi/godforge/upgrade/ForgeOfGodsUpgrade.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/godforge/upgrade/ForgeOfGodsUpgrade.java
@@ -54,6 +54,8 @@ public enum ForgeOfGodsUpgrade {
     TBF,
     EE,
     END,
+    // Appended after END so existing ordinal-keyed NBT and lang entries stay stable
+    MAS,
 
     ;
 
@@ -253,6 +255,12 @@ public enum ForgeOfGodsUpgrade {
             .background(BLUE, COMPOSITION)
             .panelSize(LARGE)
             .treePos(126, 798));
+
+        MAS.build(b -> b
+            .prereqs(TCT)
+            .cost(3)
+            .background(ORANGE, COMPOSITION)
+            .treePos(156, 506));
 
         // spotless:on
 

--- a/src/main/java/tectech/thing/metaTileEntity/multi/godforge/util/GodforgeMath.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/godforge/util/GodforgeMath.java
@@ -291,6 +291,10 @@ public class GodforgeMath {
             }
         }
 
+        if (module instanceof MTEMoltenModule molten) {
+            molten.setAlloyCapable(data.isUpgradeActive(MAS));
+        }
+
         module.setUpgrade83(data.isUpgradeActive(IMKG));
         module.setMultiStepPlasma(data.isUpgradeActive(TPTP));
         module.setPlasmaTier(plasmaTier);
@@ -301,8 +305,9 @@ public class GodforgeMath {
 
     public static boolean allowModuleConnection(MTEBaseModule module, ForgeOfGodsData data) {
 
-        if (module instanceof MTEMoltenModule && data.isUpgradeActive(FDIM)) {
-            return true;
+        if (module instanceof MTEMoltenModule molten && data.isUpgradeActive(FDIM)) {
+            // Alloy smelting mode additionally requires its dedicated upgrade
+            return !molten.isAlloyModeOn() || data.isUpgradeActive(MAS);
         }
 
         if (module instanceof MTEPlasmaModule && data.isUpgradeActive(GPCI)) {

--- a/src/main/resources/assets/gregtech/lang/en_US.lang
+++ b/src/main/resources/assets/gregtech/lang/en_US.lang
@@ -1752,7 +1752,7 @@ gt.mbtt.structure.no_air_gaps_fluid_cells_different_tiers=No air gaps allowed, b
 # Generic machine types
 gt.mbtt.machine_type.spacetime_manipulator=Spacetime Manipulator, EOH
 gt.mbtt.machine_type.exotic_matter_producer=Exotic Matter Producer
-gt.mbtt.machine_type.blast_smelter=Blast Smelter
+gt.mbtt.machine_type.blast_smelter=Blast Smelter, ABS
 gt.mbtt.machine_type.blast_furnace=Blast Furnace, Furnace
 gt.mbtt.machine_type.plasma_fabricator=Plasma Fabricator
 gt.mbtt.machine_type.stellar_forge=Stellar Forge

--- a/src/main/resources/assets/gregtech/lang/en_US/tooltip/godforge-molten-module.md
+++ b/src/main/resources/assets/gregtech/lang/en_US/tooltip/godforge-molten-module.md
@@ -5,4 +5,8 @@ Used for high temperature material liquefaction
 The second module of the Godforge, this module melts materials directly into
 their liquid form. If an output material does not have a liquid form, it will be output
 as a regular solid instead
+With the Multiphasic Alloy Synthesis upgrade, it can be switched into Alloy
+Smelting mode to run Alloy Blast Smelter recipes directly. Alloy recipes carry
+a heat requirement based on their voltage tier, so higher tier alloys benefit
+less from heat overclocking
 This module is specialized towards parallel processing

--- a/src/main/resources/assets/tectech/lang/en_US.lang
+++ b/src/main/resources/assets/tectech/lang/en_US.lang
@@ -862,6 +862,7 @@ fog.upgrade.tt.27=Transfinite Stellar Existence
 fog.upgrade.tt.28=The Boundless Flow
 fog.upgrade.tt.29=Effortless Existence
 fog.upgrade.tt.30=Orion’s Arm Genesis Schema
+fog.upgrade.tt.31=Multiphasic Alloy Synthesis
 fog.upgrade.tt.secret=Secret Upgrade
 
 fog.upgrade.tt.short.0=START
@@ -895,6 +896,7 @@ fog.upgrade.tt.short.27=TSE
 fog.upgrade.tt.short.28=TBF
 fog.upgrade.tt.short.29=EE
 fog.upgrade.tt.short.30=END
+fog.upgrade.tt.short.31=MAS
 fog.upgrade.tt.short.secret=SECRET
 
 fog.upgrade.lore.0=The Forge of the Gods is an immensely powerful structure constructed around a stabilized neutron star – it is so advanced that its full capabilities are not yet understood. However, through continued use, one can slowly upgrade and expand the range of abilities of the Forge, and learn the power hidden in the most extreme parts of the universe: graviton shards. This esoteric material can only be found where conventional matter and degenerate neutronium crust matter on the surface of a neutron star meet. At this point in space, gravitons are far more common and irradiate this material mixture to create highly unstable graviton shards, which can be used to internally upgrade the Forge. While these shards cannot yet exist outside the extreme conditions of the Forge, with continued research and utilization it may be possible to eventually isolate and extract them outside the Forge – but for what purpose?
@@ -928,6 +930,7 @@ fog.upgrade.lore.27=A huge development in the capabilities of the Forge has been
 fog.upgrade.lore.28=The usage of graviton shards in electrical systems to create localised miniature energy wormholes has allowed for such efficient power transfer that effectively unlimited electricity may be utilized by the Forge. More power means faster processing, quicker material movement, and better utilization of graviton shard related upgrades.
 fog.upgrade.lore.29=Further enrichment of the extreme spaces within the Plasma Fabricator & Exoticizer allows for the production of the most exotic plasmas beyond merely periodic elements and facilitates the creation of completely new kinds of subatomic particles, resulting in the creation of magmatter, a form of matter made entirely of magnetic monopoles with density and stability billions of times that of conventional bosonic matter.
 fog.upgrade.lore.30=With the construction of the third and final ring, total mastery of the Forge of the Gods has been achieved and it is now possible to quantize and extract graviton shards for use outside the Forge in powerful new technological endeavours. It is with this development you realise that the completion of the Forge was not the end goal, but merely a stepping stone to universal transcendence.
+fog.upgrade.lore.31=Transfinite construction principles applied to the melting core allow multiple material phases to be smelted and converged in a single operation. 
 
 fog.upgrade.text.0=Unlocks the base functionality of the Forge of the Gods, meaning 8 module slots, 1 ring, the Helioflare Power Forge module, 2 billion EU/t processing voltage and 15,000K heat bonus cap.
 fog.upgrade.text.1=Unlocks a recipe time reduction multiplier based on the current heat the multi is running at. This bonus is calculated via following formula: Multiplier = 1 / (Heat^0.01)
@@ -960,6 +963,7 @@ fog.upgrade.text.27=Uncaps maximum fuel consumption, but fuel consumption used i
 fog.upgrade.text.28=Uncaps maximum processing voltage. Voltage can be set in each module's GUI.
 fog.upgrade.text.29=Unlocks Magmatter production in the Heliofusion Exoticizer and creation of exotic plasmas in the Heliothermal Plasma Fabricator.
 fog.upgrade.text.30=Allows construction of the third ring, adds 4 module slots and unlocks Graviton Shard ejection & injection.
+fog.upgrade.text.31=Unlocks the Alloy Smelting mode of the Helioflux Melting Core, allowing it to run Alloy Blast Smelter recipes.
 
 fog.debug.resetbutton.text=Reset
 fog.debug.resetbutton.tooltip=Resets all upgrades to zero
@@ -973,6 +977,9 @@ fog.button.furnacemode.tooltip.02=Furnace Mode
 fog.button.magmattermode.tooltip.01=Quark-Gluon Plasma Mode
 fog.button.magmattermode.tooltip.02=Magmatter Mode
 fog.button.magmattermode.tooltip.03=Magmatter Mode locked, missing upgrade
+fog.button.alloymode.tooltip.01=Melting Mode
+fog.button.alloymode.tooltip.02=Alloy Smelting Mode
+fog.button.alloymode.tooltip.03=Alloy Smelting Mode locked, missing upgrade
 fog.button.battery.tooltip.01=Toggle Battery Charging
 fog.button.battery.tooltip.02=Right click to open configuration menu (if unlocked)
 fog.button.voltageconfig.tooltip.01=Open voltage config
@@ -1329,6 +1336,7 @@ gt.recipe.researchStation=Research Station
 gt.recipe.fog_plasma=Heliothermal Plasma Fabricator
 gt.recipe.fog_exotic=Heliofusion Exoticizer
 gt.recipe.fog_molten=Helioflux Melting Core
+gt.recipe.fog_alloy=Helioflux Melting Core (ABS)
 gt.recipe.upgrade_costs=Godforge Upgrades
 gt.recipe.condensate=Bose-Einstein Condensate
 


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
At present, the ABS feels extremely lacking compared to other multis of the sort, and there doesn't seem to be a good alternative available. The Forge of the Gods feels like a natural place for the upgrade to it to land, as it's already melting things and blasting them, so why not alloying them too?

This PR adds the ABS mode to the Helioflux Melting Core for the Forge of the Gods. The upgrade is branched off of the middle split of "The Split", adding some intriguing gameplay choices for the player who may want this upgrade but may not have the second ring yet, so they must choose between the plasma fabricator and the ABS core, or wait for the second ring.

The upgrade cost is in line with most other module costs, and I followed the gating that magmatter uses for the Exoticizer in terms of how the switching works and the unlock mechanics.

<img width="355" height="228" alt="Screenshot From 2026-08-31 23-28-41" src="https://github.com/user-attachments/assets/f6599d8c-20f3-44a6-a35d-2d7d4d8028ce" />
<img width="1107" height="600" alt="image" src="https://github.com/user-attachments/assets/2e6a48da-7fc8-4268-a865-3ab3de65ec2b" />


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
