### PR TITLE
Fix splitter rule item slot indices

### DIFF
--- a/src/main/java/gregtech/common/gui/modularui/multiblock/MTESplitterModuleGui.java
+++ b/src/main/java/gregtech/common/gui/modularui/multiblock/MTESplitterModuleGui.java
@@ -350,7 +350,7 @@ public class MTESplitterModuleGui extends MTENanochipAssemblyModuleBaseGui<MTESp
             }.syncHandler(
                 syncManager.getOrCreateSyncHandler(
                     "items",
-                    (index * 9) + i,
+                    (index * 16) + i,
                     PhantomItemSlotSH.class,
                     () -> new PhantomItemSlotSH(
                         new ModularSlot(rule.filterStacks, i).accessibility(true, false)


### PR DESCRIPTION
## Summary
Fix a typo in splitter item filter so you can now actually use all 16 slots


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
