### PR TITLE
Fix LHC calculator giving wrong values if LHC is not doing a recipe

### DIFF
--- a/src/main/java/gregtech/common/gui/modularui/multiblock/MTELargeHadronColliderGui.java
+++ b/src/main/java/gregtech/common/gui/modularui/multiblock/MTELargeHadronColliderGui.java
@@ -1,6 +1,7 @@
 package gregtech.common.gui.modularui.multiblock;
 
 import static gregtech.api.enums.Mods.GregTech;
+import static gregtech.api.enums.TickTime.SECOND;
 import static gregtech.api.metatileentity.BaseTileEntity.TOOLTIP_DELAY;
 
 import java.text.DecimalFormat;
@@ -440,7 +441,7 @@ public class MTELargeHadronColliderGui extends MTEMultiBlockBaseGui<MTELargeHadr
             inputRate,
             targetEnergyeV / 1000.0,
             numCycles,
-            multiblock.mMaxProgresstime);
+            1 * SECOND); // relies on all LHC "recipes" being 20t long
         double finalBeamEnergyKeV = result[0];
         int finalRate = (int) result[1];
         long finalEUt = (long) result[2];


### PR DESCRIPTION
## Summary

Fixes LHC calculator not working correctly unless a recipe was active.

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/26440


## Checklist
- [ x ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [ x ] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
