### PR TITLE
Reduce memory usage of the GTRecipeLookup data

### DIFF
--- a/src/main/java/gregtech/api/recipe/lookup/GTRecipeLookup.java
+++ b/src/main/java/gregtech/api/recipe/lookup/GTRecipeLookup.java
@@ -7,7 +7,6 @@ import java.util.Deque;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.NoSuchElementException;
 
 import javax.annotation.Nullable;
@@ -44,12 +43,11 @@ public final class GTRecipeLookup {
         GTRecipeLookupBranch branch, int index) {
         boolean lastIngredient = index == ingredients.size() - 1;
         for (GTRecipeLookupIngredient ingredient : ingredients.get(index)) {
-            Map<GTRecipeLookupIngredient, Node> nodes = branch.nodesFor(ingredient);
-            Node node = nodes.get(ingredient);
+            Node node = branch.getNode(ingredient);
 
             if (lastIngredient) {
                 if (node == null) {
-                    nodes.put(ingredient, Node.leaf(recipe));
+                    branch.putNode(ingredient, Node.leaf(recipe));
                     continue;
                 }
                 if (!node.containsRecipe(recipe)) {
@@ -61,7 +59,7 @@ public final class GTRecipeLookup {
             GTRecipeLookupBranch childBranch;
             if (node == null) {
                 childBranch = new GTRecipeLookupBranch();
-                nodes.put(ingredient, Node.branch(childBranch));
+                branch.putNode(ingredient, Node.branch(childBranch));
             } else if (node.branch != null) {
                 childBranch = node.branch;
             } else {

--- a/src/main/java/gregtech/api/recipe/lookup/GTRecipeLookup.java
+++ b/src/main/java/gregtech/api/recipe/lookup/GTRecipeLookup.java
@@ -8,6 +8,7 @@ import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -73,14 +74,13 @@ public final class GTRecipeLookup {
 
     static final class Node {
 
-        private @Nullable List<GTRecipe> recipes;
+        private @Nullable GTRecipe recipe;
+        private @Nullable List<GTRecipe> additionalRecipes;
         private @Nullable GTRecipeLookupBranch branch;
 
         static Node leaf(GTRecipe recipe) {
             Node node = new Node();
-            List<GTRecipe> recipes = new ArrayList<>(1);
-            recipes.add(recipe);
-            node.recipes = recipes;
+            node.recipe = recipe;
             return node;
         }
 
@@ -91,14 +91,19 @@ public final class GTRecipeLookup {
         }
 
         void addRecipe(GTRecipe recipe) {
-            if (recipes == null) {
-                recipes = new ArrayList<>(1);
+            if (this.recipe == null) {
+                this.recipe = recipe;
+                return;
             }
-            recipes.add(recipe);
+            if (additionalRecipes == null) {
+                additionalRecipes = new ArrayList<>(1);
+            }
+            additionalRecipes.add(recipe);
         }
 
         boolean containsRecipe(GTRecipe recipe) {
-            return recipes != null && recipes.contains(recipe);
+            return Objects.equals(recipe, this.recipe)
+                || additionalRecipes != null && additionalRecipes.contains(recipe);
         }
     }
 
@@ -172,8 +177,11 @@ public final class GTRecipeLookup {
                     stack.push(new SearchFrame(node.branch));
                 }
 
-                if (node.recipes != null && !node.recipes.isEmpty()) {
-                    leafIterator = node.recipes.iterator();
+                if (node.recipe != null) {
+                    if (node.additionalRecipes != null) {
+                        leafIterator = node.additionalRecipes.iterator();
+                    }
+                    return node.recipe;
                 }
             }
         }

--- a/src/main/java/gregtech/api/recipe/lookup/GTRecipeLookupBranch.java
+++ b/src/main/java/gregtech/api/recipe/lookup/GTRecipeLookupBranch.java
@@ -2,34 +2,66 @@ package gregtech.api.recipe.lookup;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 final class GTRecipeLookupBranch {
 
+    // Most branches have at most two entries, so store those entries inline.
+    private GTRecipeLookupIngredient ingredient1;
+    private GTRecipeLookup.Node node1;
+    private GTRecipeLookupIngredient ingredient2;
+    private GTRecipeLookup.Node node2;
     private Map<GTRecipeLookupIngredient, GTRecipeLookup.Node> nodes;
 
-    Map<GTRecipeLookupIngredient, GTRecipeLookup.Node> getNodes() {
-        if (nodes == null) {
-            nodes = new HashMap<>(2);
-        }
-        return nodes;
-    }
-
-    Map<GTRecipeLookupIngredient, GTRecipeLookup.Node> nodesFor(GTRecipeLookupIngredient ingredient) {
-        return getNodes();
-    }
-
     GTRecipeLookup.Node getNode(GTRecipeLookupIngredient ingredient) {
-        if (nodes == null) {
-            return null;
+        if (nodes != null) {
+            return nodes.get(ingredient);
         }
-        return nodes.get(ingredient);
+        if (node1 != null && Objects.equals(ingredient, ingredient1)) {
+            return node1;
+        }
+        if (node2 != null && Objects.equals(ingredient, ingredient2)) {
+            return node2;
+        }
+        return null;
+    }
+
+    void putNode(GTRecipeLookupIngredient ingredient, GTRecipeLookup.Node node) {
+        if (nodes != null) {
+            nodes.put(ingredient, node);
+            return;
+        }
+        if (node1 == null || Objects.equals(ingredient, ingredient1)) {
+            ingredient1 = ingredient;
+            node1 = node;
+            return;
+        }
+        if (node2 == null || Objects.equals(ingredient, ingredient2)) {
+            ingredient2 = ingredient;
+            node2 = node;
+            return;
+        }
+
+        Map<GTRecipeLookupIngredient, GTRecipeLookup.Node> promotedNodes = new HashMap<>(4);
+        promotedNodes.put(ingredient1, node1);
+        promotedNodes.put(ingredient2, node2);
+        promotedNodes.put(ingredient, node);
+        ingredient1 = null;
+        node1 = null;
+        ingredient2 = null;
+        node2 = null;
+        nodes = promotedNodes;
     }
 
     boolean isEmpty() {
-        return nodes == null || nodes.isEmpty();
+        return nodes == null ? node1 == null && node2 == null : nodes.isEmpty();
     }
 
     void clear() {
+        ingredient1 = null;
+        node1 = null;
+        ingredient2 = null;
+        node2 = null;
         nodes = null;
     }
 }

--- a/src/main/java/gregtech/api/recipe/lookup/GTRecipeLookupBranch.java
+++ b/src/main/java/gregtech/api/recipe/lookup/GTRecipeLookupBranch.java
@@ -1,6 +1,6 @@
 package gregtech.api.recipe.lookup;
 
-import java.util.LinkedHashMap;
+import java.util.HashMap;
 import java.util.Map;
 
 final class GTRecipeLookupBranch {
@@ -9,7 +9,7 @@ final class GTRecipeLookupBranch {
 
     Map<GTRecipeLookupIngredient, GTRecipeLookup.Node> getNodes() {
         if (nodes == null) {
-            nodes = new LinkedHashMap<>(2);
+            nodes = new HashMap<>(2);
         }
         return nodes;
     }


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
Turns out 95% of the GTRecipeLookupBranch object have less than 3 entries. So for these, we avoid the map init overheads. Then when it needs to store 3 or more entries, then we only create the maps, then null the inlined entries. Also, LinkedHashMap was replaced for a regular HashMap, because the previous code does not seem to use the conservative order property and that has more overhead than regular HashMap.

This alone saves ~70MB of RAM, which may not sound like a lot, but for targetted Mobile plateform where allocating more than 2GB can be tricky, it's huge. Tested on daily 717.

## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
