### PR TITLE
Fix Mega Apiary input mode lag

### DIFF
--- a/src/main/java/kubatech/tileentity/gregtech/multiblock/MTEMegaIndustrialApiary.java
+++ b/src/main/java/kubatech/tileentity/gregtech/multiblock/MTEMegaIndustrialApiary.java
@@ -518,15 +518,19 @@ public class MTEMegaIndustrialApiary extends KubaTechGTMultiBlockBase<MTEMegaInd
                 World w = getBaseMetaTileEntity().getWorld();
                 float t = (float) getVoltageTierExact();
                 ArrayList<ItemStack> inputs = getStoredInputs();
+                boolean storageChanged = false;
                 for (ItemStack input : inputs) {
                     if (beeRoot.getType(input) == EnumBeeType.QUEEN) {
                         BeeSimulator bs = new BeeSimulator(input, w, t);
                         if (bs.isValid) {
                             mStorage.add(bs);
-                            onStorageContentChanged(false);
+                            storageChanged = true;
                         }
                     }
                     if (mStorage.size() >= mMaxSlots) break;
+                }
+                if (storageChanged) {
+                    onStorageContentChanged(false);
                 }
                 updateSlots();
             } else if (mPrimaryMode == MODE_PRIMARY_OUTPUT && !mStorage.isEmpty()) { // output mode


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
Mega apiary was doing redundant checks on the full apiary storage for each bee input, causing moderate lag. This fixes the issue by consolidating it into one check per cycle.

## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
