### PR TITLE
Fix Godforge beam shader compilation

### DIFF
--- a/src/main/resources/assets/tectech/shaders/gorgeBeam.vert.330.glsl
+++ b/src/main/resources/assets/tectech/shaders/gorgeBeam.vert.330.glsl
@@ -24,7 +24,7 @@ float getAngle(int quadID, int localID){
 void main() {
 
     int id = gl_VertexID;
-    const int segments = u_SegmentArray.length()-1;
+    int segments = u_SegmentArray.length()-1;
     int quads = int(u_SegmentQuads);
 
     int localID = id % 6; // Local id of the vertex within a face


### PR DESCRIPTION
## Summary

Saw this error at launch on full pack daily 717:
` [Client thread/ERROR] [gtnhlib/]: Could not compile shader shaders/gorgeBeam.vert.330.glsl: 0(27) : error C1059: non constant expression in initialization`

This fix it

## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
