### PR TITLE
Fix WAILA display for steam singleblocks usage

### DIFF
--- a/src/main/resources/assets/gregtech/lang/en_US.lang
+++ b/src/main/resources/assets/gregtech/lang/en_US.lang
@@ -6251,7 +6251,7 @@ GT5U.waila.machine.input=§6Input:
 GT5U.waila.machine.output=§bOutput: §e%s
 GT5U.waila.machine.render_item=§a%s§7x %s
 GT5U.waila.machine.more_items=And %s more...
-GT5U.waila.machine.use_steam=Using §e%s Steam L/t
+GT5U.waila.machine.use_steam=Using §e%s L/s Steam
 GT5U.waila.machine.eu_bar=Stored energy: %s%%
 
 GT5U.waila.multiblock.status.incomplete=** INCOMPLETE STRUCTURE **


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
Matches steam singleblock WAILA steam usage text to that of the steam mutliblocks.

Closes: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/26565

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
