### PR TITLE
[BEC] Allow for one extra condensate detector hatch on containment field

### DIFF
--- a/src/main/java/tectech/thing/metaTileEntity/multi/bec/MTEBECStorage.java
+++ b/src/main/java/tectech/thing/metaTileEntity/multi/bec/MTEBECStorage.java
@@ -100,7 +100,7 @@ public class MTEBECStorage extends MTEBECMultiblockBase<MTEBECStorage> implement
     public IStructureDefinition<MTEBECStorage> compile(String[][] definition) {
         structure.addCasing('A', CoherencePreservingPlasmaConduit);
         structure.addCasing('B', ElectromagneticallyIsolatedCasing)
-            .withHatches(1, 20, Arrays.asList(Energy, ExoticEnergy, DetectorHatchElement.INSTANCE));
+            .withHatches(1, 21, Arrays.asList(Energy, ExoticEnergy, DetectorHatchElement.INSTANCE));
         structure.addCasing('C', FineStructureConstantManipulator);
         structure.addCasing('D', ConflictInducementCasing);
         structure.addCasing('E', PeaceEnforcementCasing);
@@ -156,7 +156,7 @@ public class MTEBECStorage extends MTEBECMultiblockBase<MTEBECStorage> implement
             .addCasing("568", PeaceEnforcementCasing.getLocalizedName(), false)
             .addCasing("508", CondensateGuidanceCoil.getLocalizedName(), false)
             .addCasing("439-442", FineStructureConstantManipulator.getLocalizedName(), false)
-            .addCasing("324-343", ElectromagneticallyIsolatedCasing.getLocalizedName(), false)
+            .addCasing("322-343", ElectromagneticallyIsolatedCasing.getLocalizedName(), false)
             .addCasing("292", CondensateTransformativeCoil.getLocalizedName(), false)
             .addEnergyHatch("1+", StatCollector.translateToLocal("GT5U.tooltip.bec-storage.hatch-pos"), 1)
             .addMiscHatch("1-4", "Bose-Einstein Condensate Hatch", StatCollector.translateToLocal("GT5U.tooltip.bec-storage.bec-hatch-pos"), 2)


### PR DESCRIPTION
## Summary
21 total means 1 energy hatch, 1 detector for overall condensate, and 19 for the 19 condensate types.

## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
