### PR TITLE
Fix BioLabParts NBT iteration CME

### DIFF
--- a/src/main/java/gregtech/loaders/postload/PosteaTransformers.java
+++ b/src/main/java/gregtech/loaders/postload/PosteaTransformers.java
@@ -286,9 +286,8 @@ public class PosteaTransformers implements Runnable {
                 var tag = nbt.getCompoundTag("tag");
                 // skip special NEI recipe item for BioLab Clonal Cellular Synthesis
                 if (tag.hasKey("NEI")) return false;
-                for (String key : tag.func_150296_c()) {
-                    if (!key.equals("Name")) tag.removeTag(key);
-                }
+                tag.func_150296_c()
+                    .removeIf(key -> !key.equals("Name"));
             }
             return true;
         });


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
Basically since the 15th of july we have this issue, and it went unoticed because servers don't have enough quest profiles to trigger the issue. But when i tried to load zeta on daily 720 (136 quest profiles) it blew up. This PR has been tested live on zeta and the server now boots normally.

The error log:
```
[03:02:19] [Server thread/ERROR] [FML/]: Caught exception from betterquesting
java.util.ConcurrentModificationException
	at java.util.HashMap$HashIterator.nextNode(HashMap.java:1469) ~[?:1.8.0_482]
	at java.util.HashMap$KeyIterator.next(HashMap.java:1493) ~[?:1.8.0_482]
	at gregtech.loaders.postload.PosteaTransformers.lambda$registerBartworksLabPartTransformer$0(PosteaTransformers.java:289) ~[PosteaTransformers.class:?]
	at com.gtnewhorizons.postea.utility.TransformerRegistry.transformItem(TransformerRegistry.java:170) ~[TransformerRegistry.class:?]
	at net.minecraft.item.ItemStack.handler$bdh000$postea$onReadFromNBTReturn(ItemStack.java:4427) ~[add.class:?]
	at net.minecraft.item.ItemStack.func_77963_c(ItemStack.java) ~[add.class:?]
	at net.minecraft.item.ItemStack.func_77949_a(ItemStack.java:125) ~[add.class:?]
	at betterquesting.api.utils.BigItemStack.loadItemStackFromNBT(BigItemStack.java:172) ~[BigItemStack.class:?]
	at betterquesting.api.utils.JsonHelper.JsonToItemStack(JsonHelper.java:377) ~[JsonHelper.class:?]
	at bq_standard.tasks.TaskRetrieval.readFromNBT(TaskRetrieval.java:83) ~[TaskRetrieval.class:?]
	at bq_standard.tasks.TaskRetrieval.readFromNBT(TaskRetrieval.java:42) ~[TaskRetrieval.class:?]
	at betterquesting.questing.tasks.TaskStorage.readFromNBT(TaskStorage.java:61) ~[TaskStorage.class:?]
	at betterquesting.questing.QuestInstance.readFromNBT(QuestInstance.java:546) ~[QuestInstance.class:?]
	at betterquesting.questing.QuestInstance.readFromNBT(QuestInstance.java:53) ~[QuestInstance.class:?]
	at betterquesting.questing.QuestDatabase.readFromNBT(QuestDatabase.java:120) ~[QuestDatabase.class:?]
	at betterquesting.commands.admin.QuestCommandDefaults.loadLegacy(QuestCommandDefaults.java:495) ~[QuestCommandDefaults.class:?]
	at betterquesting.handlers.SaveLoadHandler.loadConfig(SaveLoadHandler.java:235) ~[SaveLoadHandler.class:?]
	at betterquesting.handlers.SaveLoadHandler.loadDatabases(SaveLoadHandler.java:103) ~[SaveLoadHandler.class:?]
	at betterquesting.core.proxies.CommonProxy.serverStarting(CommonProxy.java:59) ~[CommonProxy.class:?]
	at betterquesting.core.BetterQuesting.serverStarting(BetterQuesting.java:166) ~[BetterQuesting.class:?]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_482]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_482]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_482]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_482]
	at cpw.mods.fml.common.FMLModContainer.handleModStateEvent(FMLModContainer.java:532) ~[FMLModContainer.class:1.7.10-1614.UNOFFICIAL]
	at sun.reflect.GeneratedMethodAccessor10.invoke(Unknown Source) ~[?:?]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_482]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_482]
	at com.google.common.eventbus.EventSubscriber.handleEvent(EventSubscriber.java:74) ~[server-1.7.10.jar:?]
	at com.google.common.eventbus.SynchronizedEventSubscriber.handleEvent(SynchronizedEventSubscriber.java:47) ~[server-1.7.10.jar:?]
	at com.google.common.eventbus.EventBus.dispatch(EventBus.java:322) ~[server-1.7.10.jar:?]
	at com.google.common.eventbus.EventBus.dispatchQueuedEvents(EventBus.java:304) ~[server-1.7.10.jar:?]
	at com.google.common.eventbus.EventBus.post(EventBus.java:275) ~[server-1.7.10.jar:?]
	at cpw.mods.fml.common.LoadController.sendEventToModContainer(LoadController.java:212) ~[LoadController.class:1.7.10-1614.UNOFFICIAL]
	at cpw.mods.fml.common.LoadController.propogateStateMessage(LoadController.java:190) ~[LoadController.class:1.7.10-1614.UNOFFICIAL]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_482]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_482]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_482]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_482]
	at com.google.common.eventbus.EventSubscriber.handleEvent(EventSubscriber.java:74) ~[server-1.7.10.jar:?]
	at com.google.common.eventbus.SynchronizedEventSubscriber.handleEvent(SynchronizedEventSubscriber.java:47) ~[server-1.7.10.jar:?]
	at com.google.common.eventbus.EventBus.dispatch(EventBus.java:322) ~[server-1.7.10.jar:?]
	at com.google.common.eventbus.EventBus.dispatchQueuedEvents(EventBus.java:304) ~[server-1.7.10.jar:?]
	at com.google.common.eventbus.EventBus.post(EventBus.java:275) ~[server-1.7.10.jar:?]
	at cpw.mods.fml.common.LoadController.distributeStateMessage(LoadController.java:119) [LoadController.class:1.7.10-1614.UNOFFICIAL]
	at cpw.mods.fml.common.Loader.serverStarting(Loader.java:789) [Loader.class:1.7.10-1614.UNOFFICIAL]
	at cpw.mods.fml.common.FMLCommonHandler.handleServerStarting(FMLCommonHandler.java:283) [FMLCommonHandler.class:1.7.10-1614.UNOFFICIAL]
	at net.minecraft.server.dedicated.DedicatedServer.func_71197_b(DedicatedServer.java:368) [lt.class:?]
	at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:648) [MinecraftServer.class:?]
	at java.lang.Thread.run(Thread.java:750) [?:1.8.0_482]
[03:02:19] [Server thread/ERROR] [FML/]: A fatal exception occurred during the server starting event
java.util.ConcurrentModificationException
	at java.util.HashMap$HashIterator.nextNode(HashMap.java:1469) ~[?:1.8.0_482]
	at java.util.HashMap$KeyIterator.next(HashMap.java:1493) ~[?:1.8.0_482]
	at gregtech.loaders.postload.PosteaTransformers.lambda$registerBartworksLabPartTransformer$0(PosteaTransformers.java:289) ~[PosteaTransformers.class:?]
	at com.gtnewhorizons.postea.utility.TransformerRegistry.transformItem(TransformerRegistry.java:170) ~[TransformerRegistry.class:?]
	at net.minecraft.item.ItemStack.handler$bdh000$postea$onReadFromNBTReturn(ItemStack.java:4427) ~[add.class:?]
	at net.minecraft.item.ItemStack.func_77963_c(ItemStack.java) ~[add.class:?]
	at net.minecraft.item.ItemStack.func_77949_a(ItemStack.java:125) ~[add.class:?]
	at betterquesting.api.utils.BigItemStack.loadItemStackFromNBT(BigItemStack.java:172) ~[BigItemStack.class:?]
	at betterquesting.api.utils.JsonHelper.JsonToItemStack(JsonHelper.java:377) ~[JsonHelper.class:?]
	at bq_standard.tasks.TaskRetrieval.readFromNBT(TaskRetrieval.java:83) ~[TaskRetrieval.class:?]
	at bq_standard.tasks.TaskRetrieval.readFromNBT(TaskRetrieval.java:42) ~[TaskRetrieval.class:?]
	at betterquesting.questing.tasks.TaskStorage.readFromNBT(TaskStorage.java:61) ~[TaskStorage.class:?]
	at betterquesting.questing.QuestInstance.readFromNBT(QuestInstance.java:546) ~[QuestInstance.class:?]
	at betterquesting.questing.QuestInstance.readFromNBT(QuestInstance.java:53) ~[QuestInstance.class:?]
	at betterquesting.questing.QuestDatabase.readFromNBT(QuestDatabase.java:120) ~[QuestDatabase.class:?]
	at betterquesting.commands.admin.QuestCommandDefaults.loadLegacy(QuestCommandDefaults.java:495) ~[QuestCommandDefaults.class:?]
	at betterquesting.handlers.SaveLoadHandler.loadConfig(SaveLoadHandler.java:235) ~[SaveLoadHandler.class:?]
	at betterquesting.handlers.SaveLoadHandler.loadDatabases(SaveLoadHandler.java:103) ~[SaveLoadHandler.class:?]
	at betterquesting.core.proxies.CommonProxy.serverStarting(CommonProxy.java:59) ~[CommonProxy.class:?]
	at betterquesting.core.BetterQuesting.serverStarting(BetterQuesting.java:166) ~[BetterQuesting.class:?]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_482]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_482]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_482]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_482]
	at cpw.mods.fml.common.FMLModContainer.handleModStateEvent(FMLModContainer.java:532) ~[FMLModContainer.class:1.7.10-1614.UNOFFICIAL]
	at sun.reflect.GeneratedMethodAccessor10.invoke(Unknown Source) ~[?:?]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_482]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_482]
	at com.google.common.eventbus.EventSubscriber.handleEvent(EventSubscriber.java:74) ~[server-1.7.10.jar:?]
	at com.google.common.eventbus.SynchronizedEventSubscriber.handleEvent(SynchronizedEventSubscriber.java:47) ~[server-1.7.10.jar:?]
	at com.google.common.eventbus.EventBus.dispatch(EventBus.java:322) ~[server-1.7.10.jar:?]
	at com.google.common.eventbus.EventBus.dispatchQueuedEvents(EventBus.java:304) ~[server-1.7.10.jar:?]
	at com.google.common.eventbus.EventBus.post(EventBus.java:275) ~[server-1.7.10.jar:?]
	at cpw.mods.fml.common.LoadController.sendEventToModContainer(LoadController.java:212) ~[LoadController.class:1.7.10-1614.UNOFFICIAL]
	at cpw.mods.fml.common.LoadController.propogateStateMessage(LoadController.java:190) ~[LoadController.class:1.7.10-1614.UNOFFICIAL]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_482]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_482]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_482]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_482]
	at com.google.common.eventbus.EventSubscriber.handleEvent(EventSubscriber.java:74) ~[server-1.7.10.jar:?]
	at com.google.common.eventbus.SynchronizedEventSubscriber.handleEvent(SynchronizedEventSubscriber.java:47) ~[server-1.7.10.jar:?]
	at com.google.common.eventbus.EventBus.dispatch(EventBus.java:322) ~[server-1.7.10.jar:?]
	at com.google.common.eventbus.EventBus.dispatchQueuedEvents(EventBus.java:304) ~[server-1.7.10.jar:?]
	at com.google.common.eventbus.EventBus.post(EventBus.java:275) ~[server-1.7.10.jar:?]
	at cpw.mods.fml.common.LoadController.distributeStateMessage(LoadController.java:119) ~[LoadController.class:1.7.10-1614.UNOFFICIAL]
	at cpw.mods.fml.common.Loader.serverStarting(Loader.java:789) [Loader.class:1.7.10-1614.UNOFFICIAL]
	at cpw.mods.fml.common.FMLCommonHandler.handleServerStarting(FMLCommonHandler.java:283) [FMLCommonHandler.class:1.7.10-1614.UNOFFICIAL]
	at net.minecraft.server.dedicated.DedicatedServer.func_71197_b(DedicatedServer.java:368) [lt.class:?]
	at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:648) [MinecraftServer.class:?]
```	

## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
