### PR TITLE
Fix the SSASS renderer

### DIFF
--- a/src/main/java/goodgenerator/blocks/regularBlock/AntimatterRenderBlock.java
+++ b/src/main/java/goodgenerator/blocks/regularBlock/AntimatterRenderBlock.java
@@ -81,4 +81,9 @@ public class AntimatterRenderBlock extends Block {
     public AxisAlignedBB getSelectedBoundingBoxFromPool(World worldIn, int x, int y, int z) {
         return null;
     }
+
+    @Override
+    public int getRenderType() {
+        return -1;
+    }
 }

--- a/src/main/java/goodgenerator/blocks/regularBlock/AntimatterRenderBlock.java
+++ b/src/main/java/goodgenerator/blocks/regularBlock/AntimatterRenderBlock.java
@@ -28,7 +28,7 @@ public class AntimatterRenderBlock extends Block {
     @Override
     @SideOnly(Side.CLIENT)
     public void registerBlockIcons(IIconRegister iconRegister) {
-        blockIcon = iconRegister.registerIcon("gregtech:iconsets/TRANSPARENT");
+        // Rendered by TESR; no block-atlas sprite required.
     }
 
     @Override

--- a/src/main/java/goodgenerator/blocks/tileEntity/render/TileAntimatter.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/render/TileAntimatter.java
@@ -30,7 +30,7 @@ public class TileAntimatter extends TileEntity {
     public float coreScale = 1f;
     public float coreScaleSnapshot = 1f;
     public final float coreScaleTransitionTime = 2.5f;
-    public float timeSnapshot;
+    public long timeSnapshot;
     public float spikeFactor = .01f;
 
     // Protomatter Settings
@@ -46,7 +46,7 @@ public class TileAntimatter extends TileEntity {
         super.writeToNBT(compound);
         compound.setFloat("coreScale", coreScale);
         compound.setFloat("coreScaleSnapshot", coreScaleSnapshot);
-        compound.setFloat("currentTime", timeSnapshot);
+        compound.setLong("currentTime", timeSnapshot);
         compound.setFloat("spikeFactor", spikeFactor);
         compound.setBoolean("protomatterRender", protomatterRender);
 
@@ -61,7 +61,7 @@ public class TileAntimatter extends TileEntity {
         super.readFromNBT(compound);
         coreScale = compound.getFloat("coreScale");
         coreScaleSnapshot = compound.getFloat("coreScaleSnapshot");
-        timeSnapshot = compound.getFloat("currentTime");
+        timeSnapshot = compound.getLong("currentTime");
         spikeFactor = compound.getFloat("spikeFactor");
         protomatterRender = compound.getBoolean("protomatterRender");
 

--- a/src/main/java/goodgenerator/client/render/AntimatterRenderer.java
+++ b/src/main/java/goodgenerator/client/render/AntimatterRenderer.java
@@ -29,7 +29,7 @@ public class AntimatterRenderer extends TileEntitySpecialRenderer {
 
     // Antimatter 'Blob'
     private static final ShaderRecipe ANTIMATTER = ShaderRecipe.of(GoodGenerator.resourceDomain, "antimatter")
-        .required("u_Scale", "u_ScaleSnapshot", "u_Time", "u_TimeSnapshot")
+        .required("u_Scale", "u_ScaleSnapshot", "u_Time", "u_TransitionProgress")
         .constant("u_ColorCore", TileAntimatter.coreR, TileAntimatter.coreG, TileAntimatter.coreB)
         .constant("u_ColorSpike", TileAntimatter.spikeR, TileAntimatter.spikeG, TileAntimatter.spikeB)
         .constant("u_Opacity", 1f)
@@ -39,7 +39,7 @@ public class AntimatterRenderer extends TileEntitySpecialRenderer {
     private static final Uniform AM_SCALE = ANTIMATTER.uniform("u_Scale");
     private static final Uniform AM_SCALE_SNAPSHOT = ANTIMATTER.uniform("u_ScaleSnapshot");
     private static final Uniform AM_TIME = ANTIMATTER.uniform("u_Time");
-    private static final Uniform AM_TIME_SNAPSHOT = ANTIMATTER.uniform("u_TimeSnapshot");
+    private static final Uniform AM_TRANSITION_PROGRESS = ANTIMATTER.uniform("u_TransitionProgress");
 
     private static ShaderHandle antimatterShader;
 
@@ -171,14 +171,14 @@ public class AntimatterRenderer extends TileEntitySpecialRenderer {
         return null;
     }
 
-    private void renderAntimatter(TileAntimatter tile, double x, double y, double z, float timer) {
+    private void renderAntimatter(TileAntimatter tile, double x, double y, double z, double timer) {
         antimatterShader.use();
 
-        float angle = ((timer) % (20 * 60 * 60)) * tile.rotationSpeedMultiplier;
+        double angle = (timer % (20 * 60 * 60)) * tile.rotationSpeedMultiplier;
 
         modelMatrix.translation((float) x, (float) y, (float) z)
-            .rotateY(angle / 180f * (float) Math.PI)
-            .rotateX(angle / 8f / 180f * (float) Math.PI);
+            .rotateY((float) Math.toRadians(angle % 360))
+            .rotateX((float) Math.toRadians((angle / 8) % 360));
 
         float snapshotSize = tile.coreScaleSnapshot;
         snapshotSize *= modelNormalize;
@@ -187,11 +187,13 @@ public class AntimatterRenderer extends TileEntitySpecialRenderer {
         targetSize *= modelNormalize;
         float coreSize = Math.min(targetSize, TileAntimatter.maximalRadius / (1 + tile.spikeFactor));
 
-        float realTime = timer / 20;
-        float snapTime = tile.timeSnapshot / 20;
+        // Wrap before float conversion to preserve sub-tick precision.
+        float realTime = (float) ((timer % 80) / 20);
+        float transitionProgress = (float) Math
+            .max(0, Math.min(1, (timer - tile.timeSnapshot) / (20.0 * tile.coreScaleTransitionTime)));
 
         GL20.glUniform1f(antimatterShader.loc(AM_TIME), realTime);
-        GL20.glUniform1f(antimatterShader.loc(AM_TIME_SNAPSHOT), snapTime);
+        GL20.glUniform1f(antimatterShader.loc(AM_TRANSITION_PROGRESS), transitionProgress);
         GL20.glUniform1f(antimatterShader.loc(AM_SCALE), coreSize);
         GL20.glUniform1f(antimatterShader.loc(AM_SCALE_SNAPSHOT), coreSizeSnapshot);
         final boolean cullWas = GL11.glGetBoolean(GL11.GL_CULL_FACE);
@@ -212,10 +214,11 @@ public class AntimatterRenderer extends TileEntitySpecialRenderer {
         RenderState.restore(GL11.GL_CULL_FACE, cullWas);
     }
 
-    private void renderProtomatterBeam(TileAntimatter tile, double x, double y, double z, float timer) {
+    private void renderProtomatterBeam(TileAntimatter tile, double x, double y, double z, double timer) {
         protomatterShader.use();
 
-        GL20.glUniform1f(protomatterShader.loc(PM_TIME), timer);
+        // Wrap before float conversion to preserve sub-tick precision.
+        GL20.glUniform1f(protomatterShader.loc(PM_TIME), (float) (timer % 100));
         GL20.glUniform1f(protomatterShader.loc(PM_SCALE), tile.protomatterScale);
         GL20.glUniform3f(
             protomatterShader.loc(PM_COLOR),
@@ -231,7 +234,7 @@ public class AntimatterRenderer extends TileEntitySpecialRenderer {
         ShaderProgram.clear();
     }
 
-    public void renderRing(TileAntimatter tile, double x, double y, double z, float timer) {
+    public void renderRing(TileAntimatter tile, double x, double y, double z) {
         tileRotation(tile, x, y, z);
 
         solidShader.use();
@@ -261,7 +264,7 @@ public class AntimatterRenderer extends TileEntitySpecialRenderer {
         float ty = (float) y + 0.5f;
         float tz = (float) z + 0.5f;
 
-        float timer = tile.getWorldObj()
+        double timer = (double) tile.getWorldObj()
             .getWorldInfo()
             .getWorldTotalTime() + timeSinceLastTick;
         renderAntimatter(Antimatter, tx, ty, tz, timer);
@@ -269,6 +272,6 @@ public class AntimatterRenderer extends TileEntitySpecialRenderer {
         if (!Antimatter.protomatterRender) return;
         renderProtomatterBeam(Antimatter, tx, ty, tz, timer);
 
-        renderRing(Antimatter, tx, ty, tz, timer);
+        renderRing(Antimatter, tx, ty, tz);
     }
 }

--- a/src/main/java/gregtech/common/blocks/BlockRenderer.java
+++ b/src/main/java/gregtech/common/blocks/BlockRenderer.java
@@ -34,7 +34,7 @@ public class BlockRenderer<T extends TileEntity> extends Block {
     @Override
     @SideOnly(Side.CLIENT)
     public void registerBlockIcons(IIconRegister iconRegister) {
-        blockIcon = iconRegister.registerIcon("gregtech:iconsets/TRANSPARENT");
+        // Rendered by TESR; no block-atlas sprite required.
     }
 
     /**

--- a/src/main/java/tectech/thing/block/BlockEOHRender.java
+++ b/src/main/java/tectech/thing/block/BlockEOHRender.java
@@ -31,7 +31,7 @@ public class BlockEOHRender extends Block {
     @Override
     @SideOnly(Side.CLIENT)
     public void registerBlockIcons(IIconRegister iconRegister) {
-        blockIcon = iconRegister.registerIcon("gregtech:iconsets/TRANSPARENT");
+        // Rendered by TESR; no block-atlas sprite required.
     }
 
     @Override

--- a/src/main/java/tectech/thing/block/BlockForgeOfGods.java
+++ b/src/main/java/tectech/thing/block/BlockForgeOfGods.java
@@ -31,7 +31,7 @@ public class BlockForgeOfGods extends Block {
     @Override
     @SideOnly(Side.CLIENT)
     public void registerBlockIcons(IIconRegister iconRegister) {
-        blockIcon = iconRegister.registerIcon("gregtech:iconsets/TRANSPARENT");
+        // Rendered by TESR; no block-atlas sprite required.
     }
 
     @Override

--- a/src/main/resources/assets/goodgenerator/shaders/antimatter.vert.330.glsl
+++ b/src/main/resources/assets/goodgenerator/shaders/antimatter.vert.330.glsl
@@ -11,7 +11,7 @@ uniform float u_ScaleSnapshot;
 uniform vec3 u_ColorCore;
 uniform vec3 u_ColorSpike;
 uniform float u_Time;
-uniform float u_TimeSnapshot;
+uniform float u_TransitionProgress;
 
 float lazyHash(vec3 toHash){
     vec3 v = fract(toHash*1.23456 + 3.1456);
@@ -27,8 +27,7 @@ void main() {
     vec3 currentCoreColor = mix(u_ColorCore,u_ColorSpike,triangle(mod((u_Time/4.0 + lazyHash(a_Position)/2.0),1.0)));
     v_Color = currentCoreColor;
 
-    float timelerp = clamp((u_Time-u_TimeSnapshot)/2.5,0.0,1.0);
-    float scale = mix(u_ScaleSnapshot,u_Scale,timelerp);
+    float scale = mix(u_ScaleSnapshot,u_Scale,u_TransitionProgress);
     mat4 mScale = mat4(
         scale,0,0,0,
         0,scale,0,0,

--- a/src/main/resources/assets/goodgenerator/shaders/antimatter.vert.glsl
+++ b/src/main/resources/assets/goodgenerator/shaders/antimatter.vert.glsl
@@ -9,7 +9,7 @@ uniform float u_ScaleSnapshot;
 uniform vec3 u_ColorCore;
 uniform vec3 u_ColorSpike;
 uniform float u_Time;
-uniform float u_TimeSnapshot;
+uniform float u_TransitionProgress;
 uniform mat4 u_ModelMatrix;
 
 float lazyHash(vec3 toHash){
@@ -28,8 +28,7 @@ void main() {
     vec3 currentCoreColor = mix(u_ColorCore,u_ColorSpike,triangle(mod((u_Time/4.0 + lazyHash(pos)/2.0),1.0)));
     v_Color = currentCoreColor;
 
-    float timelerp = clamp((u_Time-u_TimeSnapshot)/2.5,0.0,1.0);
-    float scale = mix(u_ScaleSnapshot,u_Scale,timelerp);
+    float scale = mix(u_ScaleSnapshot,u_Scale,u_TransitionProgress);
     mat4 mScale = mat4(
         scale,0,0,0,
         0,scale,0,0,


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
Before:
<img width="1047" height="808" alt="image" src="https://github.com/user-attachments/assets/ecdbfcb6-3a70-454d-b866-b3c20425b1aa" />

After:
<img width="1920" height="1017" alt="2026-09-05_19 20 26" src="https://github.com/user-attachments/assets/7d7a8ccd-dee2-454c-b887-ef43e2e0be91" />

Also you can find a comparison before/after of the rendering here: https://discord.com/channels/181078474394566657/939305179524792340/1545846429589835787 (too heavy to post here)

I also removed the references to transparent texture, it's gone since march apparently and wasn't used outside of the SSASS.

tested in daily 720

## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
