### PR TITLE
fix gorge tt

### DIFF
--- a/src/main/java/gregtech/api/casing/Casings.java
+++ b/src/main/java/gregtech/api/casing/Casings.java
@@ -1043,23 +1043,23 @@ public enum Casings implements ICasing {
 
     // Godforge Casings
     SingularityReinforcedStellarShieldingCasing
-        (() -> TTCasingsContainer.TimeAccelerationFieldGenerator, 0, gt(7,64)),
+        (() -> TTCasingsContainer.GodforgeCasings, 0, gt(7,64)),
     CelestialMatterGuidanceCasing
-        (() -> TTCasingsContainer.TimeAccelerationFieldGenerator, 1, gt(7,65)),
+        (() -> TTCasingsContainer.GodforgeCasings, 1, gt(7,65)),
     BoundlessGravitationallySeveredStructureCasing
-        (() -> TTCasingsContainer.TimeAccelerationFieldGenerator, 2, gt(7,66)),
+        (() -> TTCasingsContainer.GodforgeCasings, 2, gt(7,66)),
     TranscendentallyAmplifiedMagneticConfinementCasing
-        (() -> TTCasingsContainer.TimeAccelerationFieldGenerator, 3, gt(7,67)),
+        (() -> TTCasingsContainer.GodforgeCasings, 3, gt(7,67)),
     StellarEnergySiphonCasing
-        (() -> TTCasingsContainer.TimeAccelerationFieldGenerator, 4, gt(7,68)),
+        (() -> TTCasingsContainer.GodforgeCasings, 4, gt(7,68)),
     RemoteGravitonFlowModulator
-        (() -> TTCasingsContainer.TimeAccelerationFieldGenerator, 5, gt(7,69)),
+        (() -> TTCasingsContainer.GodforgeCasings, 5, gt(7,69)),
     MedialGravitonFlowModulator
-        (() -> TTCasingsContainer.TimeAccelerationFieldGenerator, 6, gt(7,70)),
+        (() -> TTCasingsContainer.GodforgeCasings, 6, gt(7,70)),
     CentralGravitonFlowModulator
-        (() -> TTCasingsContainer.TimeAccelerationFieldGenerator, 7, gt(7,71)),
+        (() -> TTCasingsContainer.GodforgeCasings, 7, gt(7,71)),
     HarmonicPhononTransmissionConduit
-        (() -> TTCasingsContainer.TimeAccelerationFieldGenerator, 8, gt(7,72)),
+        (() -> TTCasingsContainer.GodforgeCasings, 8, gt(7,72)),
 
     QuantumGlass
         (() -> BlockQuantumGlass.INSTANCE, 0, -1),


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
the gorge tt is wrong according to CN translation team
![Image_1788694853926_342.png](https://github.com/user-attachments/assets/17876523-7d59-495f-88bd-9c428f992328)

the root cause of this issue was that #5931 wrongly introduced eoh structure blocks to the gorge enums, and the direct reason of this break was #7667 introduced the stuff into tooltip
now it is fixed
<img width="701" height="459" alt="屏幕截图 2026-09-06 200129" src="https://github.com/user-attachments/assets/d1e48e8f-e754-4d2a-b305-48dcb9f13beb" />


Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/26638


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
