### PR TITLE
fix(uncertainty-hatch): Fix red/green status light hints

### DIFF
--- a/src/main/java/gregtech/common/gui/modularui/hatch/MTEHatchUncertaintyGui.java
+++ b/src/main/java/gregtech/common/gui/modularui/hatch/MTEHatchUncertaintyGui.java
@@ -118,27 +118,27 @@ public class MTEHatchUncertaintyGui extends MTEHatchBaseGui<MTEHatchUncertainty>
                 case 1: // ooo oxo ooo
                     if (index == 4) return status == 0 ? valid : invalid;
                     break;
-                case 2: // ooo xox ooo
-                    if (index == 3) return (status & 1) == 0 ? valid : invalid;
-                    if (index == 5) return (status & 2) == 0 ? valid : invalid;
+                case 2: // oxo ooo oxo
+                    if (index == 1) return (status & 1) == 0 ? valid : invalid;
+                    if (index == 7) return (status & 2) == 0 ? valid : invalid;
                     break;
                 case 3: // oxo xox oxo
-                    if (index == 1) return (status & 1) == 0 ? valid : invalid;
-                    if (index == 3) return (status & 2) == 0 ? valid : invalid;
-                    if (index == 5) return (status & 4) == 0 ? valid : invalid;
-                    if (index == 7) return (status & 8) == 0 ? valid : invalid;
+                    if (index == 3) return (status & 1) == 0 ? valid : invalid;
+                    if (index == 1) return (status & 2) == 0 ? valid : invalid;
+                    if (index == 7) return (status & 4) == 0 ? valid : invalid;
+                    if (index == 5) return (status & 8) == 0 ? valid : invalid;
                     break;
                 case 4: // xox ooo xox
                     if (index == 0) return (status & 1) == 0 ? valid : invalid;
-                    if (index == 2) return (status & 2) == 0 ? valid : invalid;
-                    if (index == 6) return (status & 4) == 0 ? valid : invalid;
+                    if (index == 6) return (status & 2) == 0 ? valid : invalid;
+                    if (index == 2) return (status & 4) == 0 ? valid : invalid;
                     if (index == 8) return (status & 8) == 0 ? valid : invalid;
                     break;
                 case 5: // xox oxo xox
                     if (index == 0) return (status & 1) == 0 ? valid : invalid;
-                    if (index == 2) return (status & 2) == 0 ? valid : invalid;
+                    if (index == 6) return (status & 2) == 0 ? valid : invalid;
                     if (index == 4) return (status & 4) == 0 ? valid : invalid;
-                    if (index == 6) return (status & 8) == 0 ? valid : invalid;
+                    if (index == 2) return (status & 8) == 0 ? valid : invalid;
                     if (index == 8) return (status & 16) == 0 ? valid : invalid;
                     break;
             }


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->

The color green/red color marker were wrong in 4 of the 5 puzzle mode. They reported the wrong section that needed balancing which created confusion and misunderstanding of what was actually required. That's the main reason why people were saying this puzzle was random.

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
