### PR TITLE
Fix SSASS tooltip markdown to use the new name for naqfuel

### DIFF
--- a/src/main/resources/assets/gregtech/lang/en_US/tooltip/antimatter-forge.md
+++ b/src/main/resources/assets/gregtech/lang/en_US/tooltip/antimatter-forge.md
@@ -28,5 +28,5 @@ Each stabilization can only use one of the fluids at a time
 1. {fluid:molten.shirabon} = {gold:0.05}
 2. {fluid:molten.magnetohydrodynamicallyconstrainedstarmatter} = {gold:0.10}
 {aqua:{bold:{underline:A}}}{aqua:ctivation Stabilization} (Consumes {dark_aqua:Antimatter}^(1/3) L of fluid per cycle)
-1. {fluid:naquadah based liquid fuel mk-v (depleted)} = {aqua:0.05}
-2. {fluid:naquadah based liquid fuel mk-vi (depleted)} = {aqua:0.10}
+1. {fluid:naquadah based liquid fuel mkv (depleted)} = {aqua:0.05}
+2. {fluid:naquadah based liquid fuel mkvi (depleted)} = {aqua:0.10}


### PR DESCRIPTION
## Summary
Title. Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/26671
<img width="890" height="772" alt="image" src="https://github.com/user-attachments/assets/8a40a9b4-a346-4260-9a4e-66d06a7b4cf4" />



## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
