### PR TITLE
attempt to fix nac voiding on server start

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/hatches/MTEHatchVacuumConveyor.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/hatches/MTEHatchVacuumConveyor.java
@@ -109,6 +109,7 @@ public abstract class MTEHatchVacuumConveyor extends MTEHatch implements VacuumF
     public void unifyPacket(CircuitComponentPacket packet) {
         if (contents == null) contents = packet;
         else contents.unifyWith(packet);
+        this.markDirty();
         // Components are fake items kept outside mInventory, so the inventory-dirty flag never fires for them. Push a
         // recipe check directly so a module waiting on these inputs restarts the moment a component arrives.
         if (packet != null && !packet.isEmpty()) {

--- a/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/hatches/MTEHatchVacuumConveyorOutput.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/hatches/MTEHatchVacuumConveyorOutput.java
@@ -76,6 +76,7 @@ public class MTEHatchVacuumConveyorOutput extends MTEHatchVacuumConveyor impleme
     public CircuitComponentPacket extractPacket() {
         CircuitComponentPacket outputPacket = this.contents;
         this.contents = null;
+        this.markDirty();
         return outputPacket;
     }
 


### PR DESCRIPTION
## Summary
NAC sometimes voids contents of circuit components on server close. i could not consistently reproduce this during testing but I did have it happen sporadically. As i can't figure out the root cause I would imagine marking dirty when the contents are transferred from input to output (or from NAC to output) may hopefully fix this bug.

my commit said duping, i meant voiding oops.
## Checklist
- [X] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
