### PR TITLE
fix high pressure steam sb progression tt

### DIFF
--- a/src/main/java/gregtech/common/gui/modularui/singleblock/MTEBasicMachineBronzeGui.java
+++ b/src/main/java/gregtech/common/gui/modularui/singleblock/MTEBasicMachineBronzeGui.java
@@ -2,10 +2,6 @@ package gregtech.common.gui.modularui.singleblock;
 
 import static gregtech.api.metatileentity.BaseTileEntity.TOOLTIP_DELAY;
 
-import com.cleanroommc.modularui.value.sync.DoubleSyncValue;
-import com.cleanroommc.modularui.widgets.ProgressWidget;
-import gregtech.api.util.GTUtility;
-import gregtech.common.modularui2.widget.GTProgressWidget;
 import net.minecraft.util.StatCollector;
 
 import com.cleanroommc.modularui.api.drawable.IDrawable;
@@ -20,6 +16,7 @@ import com.cleanroommc.modularui.widgets.slot.ModularSlot;
 
 import gregtech.api.metatileentity.implementations.MTEBasicMachineBronze;
 import gregtech.api.recipe.BasicUIProperties;
+import gregtech.api.util.GTUtility;
 import gregtech.common.gui.modularui.singleblock.base.MTEBasicMachineBaseGui;
 import gregtech.common.gui.modularui.widget.SteamGaugeWidget;
 

--- a/src/main/java/gregtech/common/gui/modularui/singleblock/MTEBasicMachineBronzeGui.java
+++ b/src/main/java/gregtech/common/gui/modularui/singleblock/MTEBasicMachineBronzeGui.java
@@ -85,8 +85,7 @@ public class MTEBasicMachineBronzeGui extends MTEBasicMachineBaseGui<MTEBasicMac
 
     @Override
     protected String createTooltipForProgressBar() {
-        byte machineTier = 1;
-        String tierName = GTUtility.getColoredTierNameFromTier(machineTier);
+        String tierName = GTUtility.getColoredTierNameFromTier(1);
         return StatCollector.translateToLocalFormatted("GT5U.machines.nei_transfer.voltage.tooltip", tierName);
     }
 }

--- a/src/main/java/gregtech/common/gui/modularui/singleblock/MTEBasicMachineBronzeGui.java
+++ b/src/main/java/gregtech/common/gui/modularui/singleblock/MTEBasicMachineBronzeGui.java
@@ -85,7 +85,7 @@ public class MTEBasicMachineBronzeGui extends MTEBasicMachineBaseGui<MTEBasicMac
 
     @Override
     protected String createTooltipForProgressBar() {
-        String tierName = GTUtility.getColoredTierNameFromTier(1);
+        String tierName = GTUtility.getColoredTierNameFromTier((byte) 1);
         return StatCollector.translateToLocalFormatted("GT5U.machines.nei_transfer.voltage.tooltip", tierName);
     }
 }

--- a/src/main/java/gregtech/common/gui/modularui/singleblock/MTEBasicMachineBronzeGui.java
+++ b/src/main/java/gregtech/common/gui/modularui/singleblock/MTEBasicMachineBronzeGui.java
@@ -2,6 +2,10 @@ package gregtech.common.gui.modularui.singleblock;
 
 import static gregtech.api.metatileentity.BaseTileEntity.TOOLTIP_DELAY;
 
+import com.cleanroommc.modularui.value.sync.DoubleSyncValue;
+import com.cleanroommc.modularui.widgets.ProgressWidget;
+import gregtech.api.util.GTUtility;
+import gregtech.common.modularui2.widget.GTProgressWidget;
 import net.minecraft.util.StatCollector;
 
 import com.cleanroommc.modularui.api.drawable.IDrawable;
@@ -80,5 +84,12 @@ public class MTEBasicMachineBronzeGui extends MTEBasicMachineBaseGui<MTEBasicMac
         BooleanSyncValue ventingSyncer = new BooleanSyncValue(machine::needsSteamVenting);
         syncManager.syncValue("venting", ventingSyncer);
         errorMap.put(ventingSyncer, machine.mTooltipCache.getData("GT5U.machines.stalled_vent.tooltip"));
+    }
+
+    @Override
+    protected String createTooltipForProgressBar() {
+        byte machineTier = 1;
+        String tierName = GTUtility.getColoredTierNameFromTier(machineTier);
+        return StatCollector.translateToLocalFormatted("GT5U.machines.nei_transfer.voltage.tooltip", tierName);
     }
 }

--- a/src/main/java/gregtech/common/gui/modularui/singleblock/base/MTEBasicMachineBaseGui.java
+++ b/src/main/java/gregtech/common/gui/modularui/singleblock/base/MTEBasicMachineBaseGui.java
@@ -311,7 +311,7 @@ public class MTEBasicMachineBaseGui<T extends MTEBasicMachine> extends MTETiered
             .tooltipShowUpTimer(TOOLTIP_DELAY);
     }
 
-    private String createTooltipForProgressBar() {
+    protected String createTooltipForProgressBar() {
         final byte machineTier = machine.mTier;
         String tierName = GTUtility.getColoredTierNameFromTier(machineTier);
         return StatCollector.translateToLocalFormatted("GT5U.machines.nei_transfer.voltage.tooltip", tierName);


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
fixes: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/26669
the root cause of this issue was from #5478 failed to notice that the steel tier steam sbs' mTier values are 2.
now it is fixed:
<img width="856" height="512" alt="屏幕截图 2026-09-07 170221" src="https://github.com/user-attachments/assets/d06ca9cb-8ebf-4a1a-a54f-ffb04f738da3" />


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
