### PR TITLE
Fix index out of bounds error when no slots are available for SMM filter

### DIFF
--- a/src/main/java/gregtech/common/gui/modularui/multiblock/TileEntityModuleMinerGui.java
+++ b/src/main/java/gregtech/common/gui/modularui/multiblock/TileEntityModuleMinerGui.java
@@ -518,6 +518,8 @@ public class TileEntityModuleMinerGui extends TileEntityModuleBaseGui<TileEntity
                 : GTOreDictUnificator.get(data.orePrefixes, data.output[i], 1);
             if (!filterContainsOre(ore)) {
                 int j = findFirstEmptySlot(visited);
+                if (j == -1) return;
+
                 filterModularSlots[j].putStack(ore);
                 filterSlots[j].getSyncHandler()
                     .updateFromClient(ore, 0);


### PR DESCRIPTION
## Summary
When you click on the asteroid in the GUI when no free slots for filters exist, the index is set to -1, but there is no check for it before accessing the array.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/26684

## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
