### PR TITLE
Add null check for asteroidsAtDistance in the Space Mining Module UI

### DIFF
--- a/src/main/java/gregtech/common/gui/modularui/multiblock/TileEntityModuleMinerGui.java
+++ b/src/main/java/gregtech/common/gui/modularui/multiblock/TileEntityModuleMinerGui.java
@@ -437,14 +437,15 @@ public class TileEntityModuleMinerGui extends TileEntityModuleBaseGui<TileEntity
 
         Set<Integer> visited = new HashSet<>();
         for (int i = start; i <= end; i++) {
-            List<Pair<Integer, GTRecipe>> asteroidsAtDistance = asteroids.get(i)
-                .stream()
-                .filter(
-                    asteroid -> asteroid.second()
-                        .getMetadata(IGRecipeMaps.MODULE_TIER) <= multiblock.getModuleTier())
-                .toList();
-
-            for (Pair<Integer, GTRecipe> asteroid : asteroidsAtDistance) visited.add(asteroid.first());
+            List<Pair<Integer, GTRecipe>> asteroidsAtDistance = asteroids.get(i);
+            if (asteroidsAtDistance != null) {
+                asteroidsAtDistance.stream()
+                    .filter(
+                        asteroid -> asteroid.second()
+                            .getMetadata(IGRecipeMaps.MODULE_TIER) <= multiblock.getModuleTier())
+                    .toList();
+                for (Pair<Integer, GTRecipe> asteroid : asteroidsAtDistance) visited.add(asteroid.first());
+            }
         }
 
         Grid asteroidGrid = new Grid()


### PR DESCRIPTION
## Summary
This PR adds a null check for the `asteroids.get(i)` call for `generateAsteroidButtons()`, to prevent a crash if the `asteroids` map returns `null`.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/26690

## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
