### PR TITLE
Restore Voltage in machine tier names

### DIFF
--- a/src/main/resources/assets/gregtech/lang/en_US.lang
+++ b/src/main/resources/assets/gregtech/lang/en_US.lang
@@ -8039,21 +8039,21 @@ GT5U.infodata.super_tank.name=§9Super Tank§r
 GT5U.word_accelerator.mode.blocks=Blocks
 GT5U.word_accelerator.mode.tile_entities=TileEntities
 
-GT5U.voltage_names.ultra_low_voltage=Ultra Low
-GT5U.voltage_names.low_voltage=Low
-GT5U.voltage_names.medium_voltage=Medium
-GT5U.voltage_names.high_voltage=High
-GT5U.voltage_names.extreme_voltage=Extreme
-GT5U.voltage_names.insane_voltage=Insane
-GT5U.voltage_names.ludicrous_voltage=Ludicrous
-GT5U.voltage_names.zpm_voltage=ZPM
-GT5U.voltage_names.ultimate_voltage=Ultimate
-GT5U.voltage_names.ultimate_high_voltage=Highly Ultimate
-GT5U.voltage_names.ultimate_extreme_voltage=Extremely Ultimate
-GT5U.voltage_names.ultimate_insane_voltage=Insanely Ultimate
-GT5U.voltage_names.ultimate_mega_voltage=Mega Ultimate
-GT5U.voltage_names.ultimate_extended_mega_voltage=Extended Mega Ultimate
-GT5U.voltage_names.maximum_voltage=Maximum
+GT5U.voltage_names.ultra_low_voltage=Ultra Low Voltage
+GT5U.voltage_names.low_voltage=Low Voltage
+GT5U.voltage_names.medium_voltage=Medium Voltage
+GT5U.voltage_names.high_voltage=High Voltage
+GT5U.voltage_names.extreme_voltage=Extreme Voltage
+GT5U.voltage_names.insane_voltage=Insane Voltage
+GT5U.voltage_names.ludicrous_voltage=Ludicrous Voltage
+GT5U.voltage_names.zpm_voltage=ZPM Voltage
+GT5U.voltage_names.ultimate_voltage=Ultimate Voltage
+GT5U.voltage_names.ultimate_high_voltage=Highly Ultimate Voltage
+GT5U.voltage_names.ultimate_extreme_voltage=Extremely Ultimate Voltage
+GT5U.voltage_names.ultimate_insane_voltage=Insanely Ultimate Voltage
+GT5U.voltage_names.ultimate_mega_voltage=Mega Ultimate Voltage
+GT5U.voltage_names.ultimate_extended_mega_voltage=Extended Mega Ultimate Voltage
+GT5U.voltage_names.maximum_voltage=Maximum Voltage
 GT5U.voltage_names.error_voltage_report_this=Error Voltage, report this
 
 


### PR DESCRIPTION
## Summary
PR #7895 started formatting machine names from GT5U.voltage_names.*, and those values spell the tier without the word Voltage. Low Voltage Transformer turned into Low Transformer. The same drop hits Chest Buffer, Filter, Regulator, Item Distributor, Charger, Energy Buffer, Locker and the tier line in GT++ tooltips.

The values carry Voltage again. Hi-Amp Transformers and Fluid Tanks keep the short tier. Discussion: https://discord.com/channels/181078474394566657/939305179524792340/1546777898877452319

I changed no code, so GTValues.VOLTAGE_NAMES and the literal comparison in MTEPowerSubStation.getMaxHatchTier still work as before. I diffed an NEI item dump against a pre-#7895 one: the transformer, power transformer, battery buffer and battery charger families gain Voltage, and no other name changes.

## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [ ] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge