### PR TITLE
make the rocketdyne tooltip readable

### DIFF
--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTELargeRocketEngine.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTELargeRocketEngine.java
@@ -21,6 +21,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
+import net.minecraft.util.EnumChatFormatting;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -99,22 +100,24 @@ public class MTELargeRocketEngine extends GTPPMultiBlockBase<MTELargeRocketEngin
     protected MultiblockTooltipBuilder createTooltip() {
         MultiblockTooltipBuilder tt = new MultiblockTooltipBuilder();
         tt.addMachineType(getMachineType())
-            .addInfo("Generating Power from Rocket Fuels")
-            .addInfo("Supply GT++ Rocket Fuels and 1000L of " + mLubricantName + " per hour")
-            .addInfo("Produces as much energy as you put fuel in, with optional boosting")
-            .addInfo("This multi doesn't accept fluids if not enabled - enable it first!")
-            .addInfo("Consumes 2000L/s of air and pollutes 1500 gibbl/s per 16384 eu/t produced")
-            .addInfo("Place 1-8 Air Intake Hatches on the sides to maintain Air input")
-            .addInfo("If it runs out of air, it will shut down and have to be manually restarted")
-            .addInfo("Supply 3L of " + mCoolantName + " per second, per 1000 EU/t to boost")
-            .addInfo("Takes 3x the amount of " + mLubricantName + " and maintains efficiency")
-            .addInfo("Fuel efficiency starts at ~160%, falls more slowly at higher EU/t if boosted")
-            .addInfo("If producing more than 30k EU/t, fuel efficiency will be lower:")
-            .addInfo("(These thresholds are 3x higher when boosted, boosted values displayed second)")
-            .addInfo("- 75% of max fuel efficiency at 53k or 159k EU/t output energy")
-            .addInfo("- 50% of max fuel efficiency at 69k or 207k EU/t output energy")
-            .addInfo("- 25% of max fuel efficiency at 98k or 294k EU/t output energy")
-            .addInfo("formula: x = input of energy (30000^(1/3)/ x^(1/3)) * (80000^(1/3)/ x^(1/3))")
+            .addInfo("Generates power from rocket fuels")
+            .addInfo("No hard limit on EU/t output - scales with fuel input")
+            .addInfo(
+                EnumChatFormatting.YELLOW
+                    + "Do not insert rocket fuel while disabled - it will be voided when enabled!"
+                    + EnumChatFormatting.GRAY)
+            .addInfo("Consumes 1% of current EU/t in Air per second")
+            .addInfo("Air is supplied only through Air Intake Hatches")
+            .addInfo("If air runs out, it shuts down and requires manual restart")
+            .addInfo("Minimum fuel input: 5 L/s")
+            .addSeparator()
+            .addInfo("Consumes 1000 L of " + EnumChatFormatting.GOLD + mLubricantName + EnumChatFormatting.GRAY + " per hour")
+            .addInfo("Takes 90 seconds to warm up to full efficiency")
+            .addSeparator()
+            .addInfo("Optional boost: supply 0.3% of current EU/t in " + EnumChatFormatting.GOLD + mCoolantName + EnumChatFormatting.GRAY + " per second")
+            .addInfo("Boosting triples the soft caps and " + EnumChatFormatting.GOLD + mLubricantName + EnumChatFormatting.GRAY + " consumption")
+            .addInfo("Fuel efficiency decreases after the soft caps below")
+            .addInfo("Soft caps: " + EnumChatFormatting.RED + "49k EU/t" + EnumChatFormatting.GRAY + " and " + EnumChatFormatting.RED + "94k EU/t" + EnumChatFormatting.GRAY + " (unboosted)")
             .addSupportAny()
             .beginStructureBlock(3, 3, 10, false)
             .addController("Front center, 2nd layer")

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTELargeRocketEngine.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTELargeRocketEngine.java
@@ -104,7 +104,7 @@ public class MTELargeRocketEngine extends GTPPMultiBlockBase<MTELargeRocketEngin
             .addInfo("No hard limit on EU/t output - scales with fuel input")
             .addInfo(
                 EnumChatFormatting.YELLOW
-                    + "Do not insert rocket fuel while disabled - it will be voided when enabled!"
+                    + "Do not insert rocket fuel while disabled - it will be consumed when enabled!"
                     + EnumChatFormatting.GRAY)
             .addInfo("Consumes 1% of current EU/t in Air per tick")
             .addInfo("Air is supplied only through Air Intake Hatches")

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTELargeRocketEngine.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTELargeRocketEngine.java
@@ -1,5 +1,7 @@
 package gtPlusPlus.xmod.gregtech.common.tileentities.machines.multi.production;
 
+import static com.gtnewhorizon.gtnhlib.util.numberformatting.NumberFormatUtil.formatFluid;
+import static com.gtnewhorizon.gtnhlib.util.numberformatting.NumberFormatUtil.formatNumber;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofBlock;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.onElementPass;
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.transpose;
@@ -19,9 +21,9 @@ import java.util.List;
 import net.minecraft.block.Block;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.EnumChatFormatting;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
-import net.minecraft.util.EnumChatFormatting;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -66,6 +68,14 @@ public class MTELargeRocketEngine extends GTPPMultiBlockBase<MTELargeRocketEngin
     public static final String mCasingName = "Turbodyne Casing";
     public static final String mGearboxName = "Inconel Reinforced Casing";
 
+    private static final int LUBRICANT_CONSUMPTION_PER_HOUR = 1000;
+    private static final int MIN_FUEL_INPUT_PER_SECOND = 5;
+    private static final int COOLANT_BOOST_PERCENT = 3;
+    private static final int WARMUP_TICKS = 2000;
+    private static final int AIR_PERCENT = 1;
+    private static final int SOFT_CAP_1 = 49_000;
+    private static final int SOFT_CAP_2 = 94_000;
+
     private static Fluid sAirFluid = null;
     private static FluidStack sAirFluidStack = null;
 
@@ -104,20 +114,46 @@ public class MTELargeRocketEngine extends GTPPMultiBlockBase<MTELargeRocketEngin
             .addInfo("No hard limit on EU/t output - scales with fuel input")
             .addInfo(
                 EnumChatFormatting.YELLOW
-                    + "Do not insert rocket fuel while disabled - it will be consumed when enabled!"
+                    + "Do not insert rocket fuel while disabled - it will be buffered and consumed all at once when enabled!"
                     + EnumChatFormatting.GRAY)
-            .addInfo("Consumes 1% of current EU/t in Air per tick")
+            .addInfo("Consumes " + AIR_PERCENT + "% of current EU/t in Air per tick")
             .addInfo("Air is supplied only through Air Intake Hatches")
             .addInfo("If air runs out, it shuts down and requires manual restart")
-            .addInfo("Minimum fuel input: 5 L/s")
+            .addInfo("Minimum fuel input: " + formatFluid(MIN_FUEL_INPUT_PER_SECOND) + "/s")
             .addSeparator()
-            .addInfo("Consumes 1000 L of " + EnumChatFormatting.GOLD + mLubricantName + EnumChatFormatting.GRAY + " per hour")
-            .addInfo("Takes 100 seconds to warm up to full efficiency")
+            .addInfo(
+                "Consumes " + formatFluid(LUBRICANT_CONSUMPTION_PER_HOUR)
+                    + " of "
+                    + EnumChatFormatting.GOLD
+                    + mLubricantName
+                    + EnumChatFormatting.GRAY
+                    + " per hour")
+            .addInfo("Takes " + WARMUP_TICKS / 20 + " seconds to warm up to full efficiency")
             .addSeparator()
-            .addInfo("Optional boost: supply 0.3% of current EU/t in " + EnumChatFormatting.GOLD + mCoolantName + EnumChatFormatting.GRAY + " per tick")
-            .addInfo("Boosting triples the soft caps and " + EnumChatFormatting.GOLD + mLubricantName + EnumChatFormatting.GRAY + " consumption")
+            .addInfo(
+                "Optional boost: supply " + formatFluid(COOLANT_BOOST_PERCENT)
+                    + " of "
+                    + EnumChatFormatting.GOLD
+                    + mCoolantName
+                    + EnumChatFormatting.GRAY
+                    + " per 1000 EU/t output")
+            .addInfo(
+                "Boosting triples the soft caps and " + EnumChatFormatting.GOLD
+                    + mLubricantName
+                    + EnumChatFormatting.GRAY
+                    + " consumption")
             .addInfo("Fuel efficiency decreases after the soft caps below")
-            .addInfo("Soft caps: " + EnumChatFormatting.RED + "49k EU/t" + EnumChatFormatting.GRAY + " and " + EnumChatFormatting.RED + "94k EU/t" + EnumChatFormatting.GRAY + " (unboosted)")
+            .addInfo(
+                "Soft caps: " + EnumChatFormatting.RED
+                    + formatNumber(SOFT_CAP_1)
+                    + " EU/t"
+                    + EnumChatFormatting.GRAY
+                    + " and "
+                    + EnumChatFormatting.RED
+                    + formatNumber(SOFT_CAP_2)
+                    + " EU/t"
+                    + EnumChatFormatting.GRAY
+                    + " (unboosted)")
             .addSupportAny()
             .beginStructureBlock(3, 3, 10, false)
             .addController("Front center, 2nd layer")

--- a/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTELargeRocketEngine.java
+++ b/src/main/java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/production/MTELargeRocketEngine.java
@@ -106,15 +106,15 @@ public class MTELargeRocketEngine extends GTPPMultiBlockBase<MTELargeRocketEngin
                 EnumChatFormatting.YELLOW
                     + "Do not insert rocket fuel while disabled - it will be voided when enabled!"
                     + EnumChatFormatting.GRAY)
-            .addInfo("Consumes 1% of current EU/t in Air per second")
+            .addInfo("Consumes 1% of current EU/t in Air per tick")
             .addInfo("Air is supplied only through Air Intake Hatches")
             .addInfo("If air runs out, it shuts down and requires manual restart")
             .addInfo("Minimum fuel input: 5 L/s")
             .addSeparator()
             .addInfo("Consumes 1000 L of " + EnumChatFormatting.GOLD + mLubricantName + EnumChatFormatting.GRAY + " per hour")
-            .addInfo("Takes 90 seconds to warm up to full efficiency")
+            .addInfo("Takes 100 seconds to warm up to full efficiency")
             .addSeparator()
-            .addInfo("Optional boost: supply 0.3% of current EU/t in " + EnumChatFormatting.GOLD + mCoolantName + EnumChatFormatting.GRAY + " per second")
+            .addInfo("Optional boost: supply 0.3% of current EU/t in " + EnumChatFormatting.GOLD + mCoolantName + EnumChatFormatting.GRAY + " per tick")
             .addInfo("Boosting triples the soft caps and " + EnumChatFormatting.GOLD + mLubricantName + EnumChatFormatting.GRAY + " consumption")
             .addInfo("Fuel efficiency decreases after the soft caps below")
             .addInfo("Soft caps: " + EnumChatFormatting.RED + "49k EU/t" + EnumChatFormatting.GRAY + " and " + EnumChatFormatting.RED + "94k EU/t" + EnumChatFormatting.GRAY + " (unboosted)")
@@ -128,6 +128,7 @@ public class MTELargeRocketEngine extends GTPPMultiBlockBase<MTELargeRocketEngin
             .addMaintenanceHatch("1", "Any center casing", 1, 2)
             .addMufflerHatch("1", "Back center casing", 3)
             .addInputHatch("1+", "Any side or bottom center casing", 1)
+            .addPollutionAmount(getPollutionPerSecond(null))
             .toolTipFinisher();
         return tt;
     }


### PR DESCRIPTION
before, the rocketdyne multi tooltip was borederline unbearable
this pr makes it understandable

before
<img width="1282" height="691" alt="image" src="https://github.com/user-attachments/assets/6f76d2f9-dfca-4128-a4cc-9ff9f723ec63" />

after
<img width="977" height="580" alt="image" src="https://github.com/user-attachments/assets/8f11b9dc-62d1-4021-8168-1d40103fb8e2" />


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
