### PR TITLE
Fix small bugs for debug writer helper

### DIFF
--- a/src/main/java/gregtech/api/util/DebugWriterHelper.java
+++ b/src/main/java/gregtech/api/util/DebugWriterHelper.java
@@ -55,7 +55,7 @@ public class DebugWriterHelper {
         registerBlockAssociation((block, meta, symbol) -> {
             String name = VANILLA_BLOCK_NAMES.get(block);
             if (name != null) {
-                return symbol + "-> " + "addElement('" + symbol + "', ofBlocks(Blocks." + name + ", " + meta + ")";
+                return symbol + "-> " + "addElement('" + symbol + "', ofBlock(Blocks." + name + ", " + meta + ")";
             }
             return null;
         });


### PR DESCRIPTION
## Summary
There is a mistake of ofBlocks(actually ofBlock,not include "s")


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
