### PR TITLE
Downtier proton source recipe to ZPM

### DIFF
--- a/src/main/java/gtnhlanth/common/tileentity/recipe/beamline/BeamlineRecipeLoader.java
+++ b/src/main/java/gtnhlanth/common/tileentity/recipe/beamline/BeamlineRecipeLoader.java
@@ -155,7 +155,7 @@ public class BeamlineRecipeLoader {
                     .focus(99)
                     .build())
             .duration(20)
-            .eut(TierEU.RECIPE_UV)
+            .eut(TierEU.RECIPE_ZPM)
             .addTo(sourceChamberRecipes);
 
         /*


### PR DESCRIPTION
## Summary
Downtiers proton source chamber recipe to ZPM. Having it at UV pushes quantum anomalies and MM Mk3 back one tier compared to 2.8, which was unintended.

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/26663

## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
