### PR TITLE
Register blockAluminum as an OreDict alias for the Aluminium block

### DIFF
--- a/src/main/java/gregtech/common/blocks/BlockMetal.java
+++ b/src/main/java/gregtech/common/blocks/BlockMetal.java
@@ -7,6 +7,7 @@ import net.minecraft.block.material.Material;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.World;
+import net.minecraftforge.oredict.OreDictionary;
 
 import gregtech.api.GregTechAPI;
 import gregtech.api.enums.Materials;
@@ -39,6 +40,11 @@ public class BlockMetal extends BlockStorage {
                     GTOreDictUnificator.set(aPrefix, materials, new ItemStack(this, 1, i));
                 } else {
                     GTOreDictUnificator.registerOre(aPrefix.get(materials), new ItemStack(this, 1, i));
+                }
+                if (aPrefix == OrePrefixes.block && materials == Materials.Aluminium) {
+                    // Some addons (e.g. MagicBees) still look up the American spelling in the
+                    // OreDictionary, so register it as an alias alongside blockAluminium.
+                    OreDictionary.registerOre("blockAluminum", new ItemStack(this, 1, i));
                 }
             }
         }


### PR DESCRIPTION
## Summary
- GT's Aluminium storage block is only ever registered in the OreDictionary as `blockAluminium` (British spelling).
- Some addons (e.g. MagicBees, whose "Aluminum" bee mutation calls `requireResource("blockAluminum")`) check for the American spelling instead, so they never recognize GT's block even though the material is the same.
- This registers `blockAluminum` as an additional OreDict alias alongside the existing `blockAluminium`, in `BlockMetal`'s block registration loop. Purely additive — existing `blockAluminium` behavior is untouched, and no other material is affected.

## Test plan
- [ ] Build and confirm `OreDictionary.getOres("blockAluminum")` returns the Aluminium storage block
- [ ] Confirm `blockAluminium`-based recipes/behavior are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)