### PR TITLE
chore: bump Horizon-QA to 0.14.1

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -161,7 +161,7 @@ dependencies {
     // For testing involving the quantum computer
     // runtimeOnlyNonPublishable(deobf('https://forum.industrial-craft.net/core/attachment/4519-gravisuite-1-7-10-2-0-3-jar'))
 
-    devOnlyNonPublishable("com.github.GTNewHorizons:Horizon-QA:0.14.0:dev")
+    devOnlyNonPublishable("com.github.GTNewHorizons:Horizon-QA:0.14.1:dev")
     // jvmDowngrader
     compileOnly 'javax.xml.bind:jaxb-api:2.3.1'
 


### PR DESCRIPTION
## Summary
Bump the Horizon-QA development dependency from 0.14.0 to 0.14.1.

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge