### PR TITLE
Fix BEC route traversal latency

### DIFF
--- a/src/main/java/gregtech/api/factory/GraphRouteTracker.java
+++ b/src/main/java/gregtech/api/factory/GraphRouteTracker.java
@@ -98,6 +98,9 @@ public class GraphRouteTracker<TElement extends IFactoryElement<TElement, TNetwo
         return EMPTY_NODE_ARRAY;
     }
 
+    /**
+     * Visits each node at most once; alternate paths to an already visited node are not exposed to the visitor.
+     */
     public void iterateNetworkBFS(TNotable start, NetworkVisitor<TNotable, TRouteInfo> visitor) {
         updateEdgesIfNeeded();
 

--- a/src/main/java/gregtech/api/factory/GraphRouteTracker.java
+++ b/src/main/java/gregtech/api/factory/GraphRouteTracker.java
@@ -102,19 +102,22 @@ public class GraphRouteTracker<TElement extends IFactoryElement<TElement, TNetwo
         updateEdgesIfNeeded();
 
         StepQueue<TNotable, TRouteInfo> queue = new StepQueue<>();
+        Set<TNotable> visited = new HashSet<>();
 
         queue.add(new NetworkStep<>(start, zero, null));
 
         NetworkStep<TNotable, TRouteInfo> step;
 
         while ((step = queue.takeFront()) != null) {
+            if (!visited.add(step.node())) continue;
+
             VisitorResult result = visitor.visit(step);
 
             if (result == VisitorResult.Break) break;
             if (result == VisitorResult.SkipNode) continue;
 
             for (var edge : edges.getOrDefault(step.node(), emptyNodeArray())) {
-                if (!step.contains(edge.element())) {
+                if (!visited.contains(edge.element())) {
                     queue.add(
                         new NetworkStep<>(
                             edge.element(),

--- a/src/main/java/gregtech/api/factory/routing/NetworkStepList.java
+++ b/src/main/java/gregtech/api/factory/routing/NetworkStepList.java
@@ -1,10 +1,10 @@
 package gregtech.api.factory.routing;
 
+import java.util.ArrayDeque;
+
 import com.github.bsideup.jabel.Desugar;
 
-import it.unimi.dsi.fastutil.objects.ObjectArrayList;
-
 @Desugar
-public record NetworkStepList<N, R> (ObjectArrayList<NetworkStep<N, R>> steps) implements StepLike {
+public record NetworkStepList<N, R> (ArrayDeque<NetworkStep<N, R>> steps) implements StepLike {
 
 }

--- a/src/main/java/gregtech/api/factory/routing/StepQueue.java
+++ b/src/main/java/gregtech/api/factory/routing/StepQueue.java
@@ -1,8 +1,9 @@
 package gregtech.api.factory.routing;
 
+import java.util.ArrayDeque;
+
 import gregtech.api.factory.IRouteInfo;
 import it.unimi.dsi.fastutil.objects.Object2ObjectRBTreeMap;
-import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 
 @SuppressWarnings("unchecked")
 public class StepQueue<N, R extends IRouteInfo<R>> extends Object2ObjectRBTreeMap<R, StepLike> {
@@ -20,11 +21,8 @@ public class StepQueue<N, R extends IRouteInfo<R>> extends Object2ObjectRBTreeMa
             return step;
         } else if (front instanceof NetworkStepList) {
             NetworkStepList<N, R> list = (NetworkStepList<N, R>) front;
-            // Remove the front and shift all later elements down one.
-            // This is more correct than removing the last element and the chances of a NetworkStepList existing are
-            // very low.
             NetworkStep<N, R> step = list.steps()
-                .remove(0);
+                .removeFirst();
 
             if (list.steps()
                 .isEmpty()) {
@@ -43,16 +41,16 @@ public class StepQueue<N, R extends IRouteInfo<R>> extends Object2ObjectRBTreeMa
         if (existing instanceof NetworkStep) {
             NetworkStep<N, R> existingStep = (NetworkStep<N, R>) existing;
 
-            ObjectArrayList<NetworkStep<N, R>> steps = new ObjectArrayList<>();
+            ArrayDeque<NetworkStep<N, R>> steps = new ArrayDeque<>();
 
-            steps.add(existingStep);
-            steps.add(step);
+            steps.addLast(existingStep);
+            steps.addLast(step);
 
             this.put(step.route(), new NetworkStepList<>(steps));
         } else if (existing instanceof NetworkStepList) {
             NetworkStepList<N, R> list = (NetworkStepList<N, R>) existing;
             list.steps()
-                .add(step);
+                .addLast(step);
 
             this.put(step.route(), list);
         } else {

--- a/src/test/java/tectech/mechanics/boseEinsteinCondensate/BECFactoryNetworkTest.java
+++ b/src/test/java/tectech/mechanics/boseEinsteinCondensate/BECFactoryNetworkTest.java
@@ -405,22 +405,23 @@ class BECFactoryNetworkTest {
     }
 
     @Test
-    void differentFiltersOnConvergingPathsRemainReachable() {
+    void differentFiltersOnConvergingPathsRemainReachableFromDownstreamView() {
         Fluid fluidA = mock(Fluid.class);
         Fluid fluidB = mock(Fluid.class);
+        StubGenerator downstreamViewer = new StubGenerator();
         StubFilter pathA = new StubFilter(fluidA);
         StubFilter pathB = new StubFilter(fluidB);
-        generator.routedNeighbors = List.of(pathA, pathB);
+        downstreamViewer.routedNeighbors = List.of(pathA, pathB);
         pathA.routedNeighbors = List.of(storage);
         pathB.routedNeighbors = List.of(storage);
         storage.contents.put(fluidA, 300L);
         storage.contents.put(fluidB, 500L);
-        network.addElement(generator);
+        network.addElement(downstreamViewer);
         network.addElement(pathA);
         network.addElement(pathB);
         network.addElement(storage);
 
-        CondensateList result = network.getStoredCondensate(generator);
+        CondensateList result = network.getStoredCondensate(downstreamViewer);
 
         assertEquals(300L, result.getLong(fluidA));
         assertEquals(500L, result.getLong(fluidB));

--- a/src/test/java/tectech/mechanics/boseEinsteinCondensate/BECFactoryNetworkTest.java
+++ b/src/test/java/tectech/mechanics/boseEinsteinCondensate/BECFactoryNetworkTest.java
@@ -6,7 +6,9 @@ import static org.mockito.Mockito.*;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.Fluid;
@@ -16,6 +18,7 @@ import org.junit.jupiter.api.Test;
 
 import appeng.api.storage.data.IAEFluidStack;
 import gregtech.api.factory.RoutedNode;
+import gregtech.api.factory.routing.VisitorResult;
 import it.unimi.dsi.fastutil.Pair;
 
 class BECFactoryNetworkTest {
@@ -364,6 +367,27 @@ class BECFactoryNetworkTest {
         assertDoesNotThrow(() -> network.injectCondensate(generator, fluidStack));
         // No BECInventory reachable → inventories empty → early return → stack unchanged
         assertEquals(100L, fluidStack.getStackSize(), "no storage in cycle → condensate should be unchanged");
+    }
+
+    @Test
+    void routeTraversalVisitsEachNodeOnceAcrossConvergingPaths() {
+        StubGenerator left = new StubGenerator();
+        StubGenerator right = new StubGenerator();
+        generator.routedNeighbors = List.of(left, right);
+        left.routedNeighbors = List.of(storage);
+        right.routedNeighbors = List.of(storage);
+        network.addElement(generator);
+        network.addElement(left);
+        network.addElement(right);
+        network.addElement(storage);
+
+        Set<NotableBECFactoryElement> visited = new HashSet<>();
+        network.routeTracker.iterateNetworkBFS(generator, step -> {
+            assertTrue(visited.add(step.node()), "a converging route must not visit the same node twice");
+            return VisitorResult.Continue;
+        });
+
+        assertEquals(4, visited.size());
     }
 
     @Test

--- a/src/test/java/tectech/mechanics/boseEinsteinCondensate/BECFactoryNetworkTest.java
+++ b/src/test/java/tectech/mechanics/boseEinsteinCondensate/BECFactoryNetworkTest.java
@@ -59,6 +59,20 @@ class BECFactoryNetworkTest {
         }
     }
 
+    static class StubFilter extends StubGenerator {
+
+        private final Fluid allowed;
+
+        StubFilter(Fluid allowed) {
+            this.allowed = allowed;
+        }
+
+        @Override
+        public boolean allowsCondensateThrough(Fluid condensate) {
+            return condensate == allowed;
+        }
+    }
+
     /** Storage stub: BECFactoryElement + NotableBECFactoryElement + BECInventory. */
     static class StubStorage implements BECFactoryElement, NotableBECFactoryElement, BECInventory {
 
@@ -388,6 +402,28 @@ class BECFactoryNetworkTest {
         });
 
         assertEquals(4, visited.size());
+    }
+
+    @Test
+    void differentFiltersOnConvergingPathsRemainReachable() {
+        Fluid fluidA = mock(Fluid.class);
+        Fluid fluidB = mock(Fluid.class);
+        StubFilter pathA = new StubFilter(fluidA);
+        StubFilter pathB = new StubFilter(fluidB);
+        generator.routedNeighbors = List.of(pathA, pathB);
+        pathA.routedNeighbors = List.of(storage);
+        pathB.routedNeighbors = List.of(storage);
+        storage.contents.put(fluidA, 300L);
+        storage.contents.put(fluidB, 500L);
+        network.addElement(generator);
+        network.addElement(pathA);
+        network.addElement(pathB);
+        network.addElement(storage);
+
+        CondensateList result = network.getStoredCondensate(generator);
+
+        assertEquals(300L, result.getLong(fluidA));
+        assertEquals(500L, result.getLong(fluidB));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Prevents BEC route traversal from enumerating every simple path through networks with converging routes.

- Tracks visited nodes so each notable network element is processed once.
- Uses an `ArrayDeque` for equal-distance route steps, preserving FIFO ordering without costly array shifts.
- Adds a regression test for converging routes.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/26730

Validation:
- `./gradlew test --tests tectech.mechanics.boseEinsteinCondensate.BECFactoryNetworkTest`
- `./gradlew spotlessJavaCheck`
- Tested in cherry pick in 2.9.0 beta 3


## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge