### PR TITLE
Add modern chest connection compat for mallet + wrench

### DIFF
--- a/src/main/java/gregtech/api/util/GTUtil.java
+++ b/src/main/java/gregtech/api/util/GTUtil.java
@@ -15,6 +15,7 @@ import net.minecraft.nbt.NBTBase;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.tileentity.TileEntityChest;
 import net.minecraft.util.ChunkCoordinates;
 import net.minecraft.util.Tuple;
 import net.minecraft.world.World;
@@ -365,7 +366,7 @@ public class GTUtil {
     }
 
     /**
-     * Set the direction of a vanilla large chest. return false when the new direction is invalid
+     * Set the direction of a vanilla chest. return false when the new direction is invalid
      *
      * @param dryRun pass in true to prevent actually setting block metadata
      */
@@ -374,26 +375,49 @@ public class GTUtil {
         ForgeDirection newDirection = ForgeDirection.getOrientation(newSide);
         if (newDirection.offsetY != 0) return false; // cannot face up/down
         if (currentBlock == null) currentBlock = world.getBlock(x, y, z);
-        if (world.getBlock(x + newDirection.offsetX, y + newDirection.offsetY, z + newDirection.offsetZ) == currentBlock
-            || world.getBlock(x - newDirection.offsetX, y - newDirection.offsetY, z - newDirection.offsetZ)
-                == currentBlock) {
-            // new direction would face towards/away from another chest. not good
-            return false;
-        }
+
+        TileEntity tile = world.getTileEntity(x, y, z);
+        if (!(tile instanceof TileEntityChest tileChest)) return false;
+
+        tileChest.checkForAdjacentChests();
+        // new direction would face towards/away from a connected chest. not good
+        if (isChestConnectedInDir(world, x, y, z, currentBlock, tileChest, newDirection)) return false;
+        if (isChestConnectedInDir(world, x, y, z, currentBlock, tileChest, newDirection.getOpposite())) return false;
+
         if (dryRun) return true;
-        ForgeDirection sideway = ForgeDirection
-            .getOrientation(ForgeDirection.ROTATION_MATRIX[ForgeDirection.UP.ordinal()][newSide]);
-        boolean result = true;
-        if (world.getBlock(x + sideway.offsetX, y + sideway.offsetY, z + sideway.offsetZ) == currentBlock) {
-            result &= world
-                .setBlockMetadataWithNotify(x + sideway.offsetX, y + sideway.offsetY, z + sideway.offsetZ, newSide, 3);
-        } else if (world.getBlock(x - sideway.offsetX, y - sideway.offsetY, z - sideway.offsetZ) == currentBlock) {
-            result &= world
-                .setBlockMetadataWithNotify(x - sideway.offsetX, y - sideway.offsetY, z - sideway.offsetZ, newSide, 3);
+
+        // if connected, rotate connected chest first
+        ForgeDirection right = newDirection.getRotation(ForgeDirection.UP);
+        ForgeDirection left = right.getOpposite();
+        if (isChestConnectedInDir(world, x, y, z, currentBlock, tileChest, right)) {
+            if (!setChestDirMeta(world, x + right.offsetX, y + right.offsetY, z + right.offsetZ, newDirection))
+                return false;
+        } else if (isChestConnectedInDir(world, x, y, z, currentBlock, tileChest, left)) {
+            if (!setChestDirMeta(world, x + left.offsetX, y + left.offsetY, z + left.offsetZ, newDirection))
+                return false;
         }
-        if (!result) {
-            return false;
-        }
-        return world.setBlockMetadataWithNotify(x, y, z, newSide, 3);
+
+        return setChestDirMeta(world, x, y, z, newDirection);
+    }
+
+    private static boolean isChestConnectedInDir(World world, int x, int y, int z, Block block, TileEntityChest tile,
+        ForgeDirection dir) {
+        boolean tileConnected = switch (dir) {
+            case NORTH -> tile.adjacentChestZNeg != null;
+            case SOUTH -> tile.adjacentChestZPos != null;
+            case WEST -> tile.adjacentChestXNeg != null;
+            case EAST -> tile.adjacentChestXPos != null;
+            default -> false;
+        };
+        if (!tileConnected) return false;
+
+        Block other = world.getBlock(x + dir.offsetX, y + dir.offsetY, z + dir.offsetZ);
+        return block == other;
+    }
+
+    private static boolean setChestDirMeta(World world, int x, int y, int z, ForgeDirection dir) {
+        int prevMeta = world.getBlockMetadata(x, y, z);
+        int newMeta = (prevMeta & ~0b111) | (dir.ordinal() & 0b111); // only change rotation bits
+        return world.setBlockMetadataWithNotify(x, y, z, newMeta, 3);
     }
 }

--- a/src/main/java/gregtech/client/BlockOverlayRenderer.java
+++ b/src/main/java/gregtech/client/BlockOverlayRenderer.java
@@ -282,7 +282,7 @@ public class BlockOverlayRenderer {
         } else if (tTile instanceof IWrenchable wrenchable) {
             tConnections |= ForgeDirection.getOrientation(wrenchable.getFacing()).flag;
         } else if (ROTATABLE_VANILLA_BLOCKS.contains(block)) {
-            tConnections |= ForgeDirection.getOrientation(meta).flag;
+            tConnections |= ForgeDirection.getOrientation(meta & 0b111).flag;
         } else if (tTile instanceof TileInterface tileInterface) tConnections |= tileInterface.getUp()
             .getOpposite().flag;
 


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
Changes the way mallet/wrench rotate vanilla chests. 
The connection check is now based on the TileEntity connection state, as it's correct in both vanilla and with modern chest connections (https://github.com/GTNewHorizons/Et-Futurum-Requiem/pull/118).
It now only reads/writes the actual rotation bits of the chest meta, instead of the whole meta value.
This shouldn't change the vanilla behaviour at all, but makes it compatible with the modern chest connections.

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
