### PR TITLE
Give singleblock compressors a fluid slot

### DIFF
--- a/src/main/java/gregtech/loaders/preload/LoaderMetaTileEntities.java
+++ b/src/main/java/gregtech/loaders/preload/LoaderMetaTileEntities.java
@@ -3846,6 +3846,7 @@ public class LoaderMetaTileEntities implements Runnable { // TODO CHECK CIRCUIT 
                 .setSlotsCount(1, 1)
                 .setSound(SoundResource.GTCEU_LOOP_COMPRESSOR)
                 .setOverlays("COMPRESSOR")
+                .setFluidSlots(true, false)
                 .build()
                 .getStackForm(1L));
 
@@ -3858,6 +3859,7 @@ public class LoaderMetaTileEntities implements Runnable { // TODO CHECK CIRCUIT 
                 .setSlotsCount(1, 1)
                 .setSound(SoundResource.GTCEU_LOOP_COMPRESSOR)
                 .setOverlays("COMPRESSOR")
+                .setFluidSlots(true, false)
                 .build()
                 .getStackForm(1L));
 
@@ -3870,6 +3872,7 @@ public class LoaderMetaTileEntities implements Runnable { // TODO CHECK CIRCUIT 
                 .setSlotsCount(1, 1)
                 .setSound(SoundResource.GTCEU_LOOP_COMPRESSOR)
                 .setOverlays("COMPRESSOR")
+                .setFluidSlots(true, false)
                 .build()
                 .getStackForm(1L));
 
@@ -3882,6 +3885,7 @@ public class LoaderMetaTileEntities implements Runnable { // TODO CHECK CIRCUIT 
                 .setSlotsCount(1, 1)
                 .setSound(SoundResource.GTCEU_LOOP_COMPRESSOR)
                 .setOverlays("COMPRESSOR")
+                .setFluidSlots(true, false)
                 .build()
                 .getStackForm(1L));
 
@@ -3894,6 +3898,7 @@ public class LoaderMetaTileEntities implements Runnable { // TODO CHECK CIRCUIT 
                 .setSlotsCount(1, 1)
                 .setSound(SoundResource.GTCEU_LOOP_COMPRESSOR)
                 .setOverlays("COMPRESSOR")
+                .setFluidSlots(true, false)
                 .build()
                 .getStackForm(1L));
 
@@ -3906,6 +3911,7 @@ public class LoaderMetaTileEntities implements Runnable { // TODO CHECK CIRCUIT 
                 .setSlotsCount(1, 1)
                 .setSound(SoundResource.GTCEU_LOOP_COMPRESSOR)
                 .setOverlays("COMPRESSOR")
+                .setFluidSlots(true, false)
                 .build()
                 .getStackForm(1L));
 
@@ -3918,6 +3924,7 @@ public class LoaderMetaTileEntities implements Runnable { // TODO CHECK CIRCUIT 
                 .setSlotsCount(1, 1)
                 .setSound(SoundResource.GTCEU_LOOP_COMPRESSOR)
                 .setOverlays("COMPRESSOR")
+                .setFluidSlots(true, false)
                 .build()
                 .getStackForm(1L));
 
@@ -3930,6 +3937,7 @@ public class LoaderMetaTileEntities implements Runnable { // TODO CHECK CIRCUIT 
                 .setSlotsCount(1, 1)
                 .setSound(SoundResource.GTCEU_LOOP_COMPRESSOR)
                 .setOverlays("COMPRESSOR")
+                .setFluidSlots(true, false)
                 .build()
                 .getStackForm(1L));
 
@@ -3942,6 +3950,7 @@ public class LoaderMetaTileEntities implements Runnable { // TODO CHECK CIRCUIT 
                 .setSlotsCount(1, 1)
                 .setSound(SoundResource.GTCEU_LOOP_COMPRESSOR)
                 .setOverlays("COMPRESSOR")
+                .setFluidSlots(true, false)
                 .build()
                 .getStackForm(1L));
 
@@ -3954,6 +3963,7 @@ public class LoaderMetaTileEntities implements Runnable { // TODO CHECK CIRCUIT 
                 .setSlotsCount(1, 1)
                 .setSound(SoundResource.GTCEU_LOOP_COMPRESSOR)
                 .setOverlays("COMPRESSOR")
+                .setFluidSlots(true, false)
                 .build()
                 .getStackForm(1L));
 
@@ -3966,6 +3976,7 @@ public class LoaderMetaTileEntities implements Runnable { // TODO CHECK CIRCUIT 
                 .setSlotsCount(1, 1)
                 .setSound(SoundResource.GTCEU_LOOP_COMPRESSOR)
                 .setOverlays("COMPRESSOR")
+                .setFluidSlots(true, false)
                 .build()
                 .getStackForm(1L));
 
@@ -3978,6 +3989,7 @@ public class LoaderMetaTileEntities implements Runnable { // TODO CHECK CIRCUIT 
                 .setSlotsCount(1, 1)
                 .setSound(SoundResource.GTCEU_LOOP_COMPRESSOR)
                 .setOverlays("COMPRESSOR")
+                .setFluidSlots(true, false)
                 .build()
                 .getStackForm(1L));
 


### PR DESCRIPTION
## Summary
Recipemap now has fluids, so allow singleblocks to perform those recipes too
<img width="894" height="850" alt="image" src="https://github.com/user-attachments/assets/fb2d122f-891c-4536-afe2-43d0c5544016" />

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/21129

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
