### PR TITLE
Change tooltipBuilder to have one error check (crash fix)

### DIFF
--- a/src/main/java/gregtech/common/gui/modularui/singleblock/base/MTEBasicMachineBaseGui.java
+++ b/src/main/java/gregtech/common/gui/modularui/singleblock/base/MTEBasicMachineBaseGui.java
@@ -331,15 +331,12 @@ public class MTEBasicMachineBaseGui<T extends MTEBasicMachine> extends MTETiered
             .widgetTheme(GTWidgetThemes.PICTURE_ERROR)
             .setEnabledIf(_ -> hasErrorSyncer.getBoolValue())
             .tooltipShowUpTimer(TOOLTIP_DELAY)
-            .tooltipBuilder(t -> {
-                if (hasErrorSyncer.getBoolValue()) addTooltipDataToRichTooltip(
-                    () -> errorMap.get(
-                        errorMap.keySet()
-                            .stream()
-                            .filter(BooleanSyncValue::getBoolValue)
-                            .findFirst()
-                            .get())).accept(t);
-            });
+            .tooltipBuilder(
+                t -> errorMap.keySet()
+                    .stream()
+                    .filter(BooleanSyncValue::getBoolValue)
+                    .findFirst()
+                    .ifPresent(key -> addTooltipDataToRichTooltip(() -> errorMap.get(key)).accept(t)));
     }
 
     protected ParentWidget<?> createItemInputSlots(ModularPanel panel, PanelSyncManager syncManager) {


### PR DESCRIPTION
## Summary
Alright, before the code change the `.tooltipBuilder` checked for error 2 times (2 separate times). Because of that the Ice Cream machine error flags (29 of them `initErrors()`) could flip (day reroll). So like first check said yes, then second check found nothing, then `.get()` on nothing just crashed. So change is that now there is one check instead of two. So check for error once then only show a tooltip when one was actually found. 

Crash report from discord user: https://mclo.gs/HoWIQGC

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
