### PR TITLE
clarify ability to split ccs in splitter tooltip

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/modules/MTESplitterModule.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/modules/MTESplitterModule.java
@@ -154,6 +154,12 @@ public class MTESplitterModule extends MTENanochipAssemblyModuleBase<MTESplitter
             .addInfo(translateToLocal("GT5U.tooltip.nac.module.splitter.body.2"))
             .addInfo(translateToLocalFormatted("GT5U.tooltip.nac.module.splitter.body.3", TOOLTIP_COLOR, TOOLTIP_COLOR))
             .addInfo(translateToLocalFormatted("GT5U.tooltip.nac.module.splitter.body.4", TOOLTIP_CCs))
+            .addInfo(
+                translateToLocalFormatted(
+                    "GT5U.tooltip.nac.module.splitter.body.5",
+                    TOOLTIP_COLORED,
+                    TOOLTIP_VCOs,
+                    TOOLTIP_CCs))
             .addSeparator()
             .addInfo(tooltipFlavorText(translateToLocal("GT5U.tooltip.nac.module.splitter.flavor.1")))
             .beginStructureBlock(7, 5, 7, false)

--- a/src/main/resources/assets/gregtech/lang/en_US.lang
+++ b/src/main/resources/assets/gregtech/lang/en_US.lang
@@ -3461,6 +3461,7 @@ GT5U.tooltip.nac.module.splitter.body.1=By default, splits same %s inputs evenly
 GT5U.tooltip.nac.module.splitter.body.2=Behavior can be overwritten by creating §2'Rules'§7 to follow in the GUI
 GT5U.tooltip.nac.module.splitter.body.3=§2Rules§7 can be set by input %s(§5s§7), output %s(§5s§7), supplied redstone signal, and item filters
 GT5U.tooltip.nac.module.splitter.body.4=%s will be transferred after all conditions of a §2Rule§7 are met
+GT5U.tooltip.nac.module.splitter.body.5=If multiple same-%s %s are present, will try and evenly split input %s among them
 GT5U.tooltip.nac.module.splitter.redstone_hatch= Any top mesh interface casing
 GT5U.tooltip.nac.module.superconductor_splitter.name=Superconductor Splitter
 GT5U.tooltip.nac.module.superconductor_splitter.flavor.1=Where there are superconductors, there is coolant!


### PR DESCRIPTION
## Summary
title, this is important info as the nac power rebalance makes use of this heavily.


## Checklist
- [X] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
