### PR TITLE
Ice Cream machine ghost block/explosion fixes

### DIFF
--- a/src/main/java/gregtech/api/GregTechAPI.java
+++ b/src/main/java/gregtech/api/GregTechAPI.java
@@ -189,6 +189,7 @@ public class GregTechAPI {
     public static Block sBlackholeRender;
     public static Block sSpaceElevatorCable;
     public static Block nanoForgeRender;
+    public static Block sBlockGhostSpace;
     /**
      * Getting assigned by the Config
      */

--- a/src/main/java/gregtech/api/GregTechAPI.java
+++ b/src/main/java/gregtech/api/GregTechAPI.java
@@ -30,6 +30,7 @@ import goodgenerator.loader.Loaders;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
 import gregtech.api.interfaces.IDamagableItem;
+import gregtech.api.interfaces.internal.IDraconicCompat;
 import gregtech.api.interfaces.internal.IThaumcraftCompat;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.IMachineBlockUpdateable;
@@ -142,6 +143,10 @@ public class GregTechAPI {
      * Registers Aspects to Thaumcraft. This Object might be {@code null} if Thaumcraft isn't installed.
      */
     public static IThaumcraftCompat sThaumcraftCompat;
+    /**
+     * Draconic Evolution compat. This Object might be {@code null} if Draconic Evolution isn't installed.
+     */
+    public static IDraconicCompat sDraconicCompat;
     /**
      * The Lists below are executed at their respective timings. Useful to do things at a particular moment in time. The
      * Lists are not Threaded - a native Java interface is used for their execution. Add your "commands" in the

--- a/src/main/java/gregtech/api/interfaces/internal/IDraconicCompat.java
+++ b/src/main/java/gregtech/api/interfaces/internal/IDraconicCompat.java
@@ -1,0 +1,12 @@
+package gregtech.api.interfaces.internal;
+
+import net.minecraft.world.World;
+
+public interface IDraconicCompat {
+
+    /**
+     * Triggers a Draconic Evolution reactor-style spherical explosion at the given position, blocking until it
+     * finishes. The power scale matches DE's reactor meltdown power, not vanilla explosion strength.
+     */
+    void createReactorExplosion(World world, int x, int y, int z, float power);
+}

--- a/src/main/java/gregtech/api/util/GTFoodStat.java
+++ b/src/main/java/gregtech/api/util/GTFoodStat.java
@@ -6,8 +6,7 @@ import net.minecraft.item.EnumAction;
 import net.minecraft.item.ItemStack;
 import net.minecraft.potion.PotionEffect;
 
-import com.brandon3055.draconicevolution.common.tileentities.multiblocktiles.reactor.ReactorExplosion;
-
+import gregtech.api.GregTechAPI;
 import gregtech.api.damagesources.GTDamageSources;
 import gregtech.api.enums.SoundResource;
 import gregtech.api.interfaces.IFoodStat;
@@ -104,15 +103,22 @@ public class GTFoodStat implements IFoodStat {
             if (mExplosive) {
                 final boolean dealDamage = Gregtech.general.explosiveFoodDamage;
                 if (dealDamage) {
-                    // Draconic Evolution's reactor explosion
-                    final ReactorExplosion explosion = new ReactorExplosion(
-                        aPlayer.worldObj,
-                        (int) aPlayer.posX,
-                        (int) aPlayer.posY,
-                        (int) aPlayer.posZ,
-                        mExplosionStrength);
-                    while (!explosion.isDead()) {
-                        explosion.updateProcess();
+                    if (GregTechAPI.sDraconicCompat != null) {
+                        // Draconic Evolution's reactor explosion
+                        GregTechAPI.sDraconicCompat.createReactorExplosion(
+                            aPlayer.worldObj,
+                            (int) aPlayer.posX,
+                            (int) aPlayer.posY,
+                            (int) aPlayer.posZ,
+                            mExplosionStrength);
+                    } else {
+                        new WorldSpawnedEventBuilder.ExplosionEffectEventBuilder().setSmoking(true)
+                            .setFlaming(true)
+                            .setStrength(mExplosionStrength)
+                            .setPosition(aPlayer.posX, aPlayer.posY, aPlayer.posZ)
+                            .setEntity(aPlayer)
+                            .setWorld(aPlayer.worldObj)
+                            .run();
                     }
                     aPlayer.attackEntityFrom(GTDamageSources.getExplodingDamage(), Float.MAX_VALUE);
                 } else {

--- a/src/main/java/gregtech/api/util/GTFoodStat.java
+++ b/src/main/java/gregtech/api/util/GTFoodStat.java
@@ -6,6 +6,8 @@ import net.minecraft.item.EnumAction;
 import net.minecraft.item.ItemStack;
 import net.minecraft.potion.PotionEffect;
 
+import com.brandon3055.draconicevolution.common.tileentities.multiblocktiles.reactor.ReactorExplosion;
+
 import gregtech.api.damagesources.GTDamageSources;
 import gregtech.api.enums.SoundResource;
 import gregtech.api.interfaces.IFoodStat;
@@ -101,15 +103,26 @@ public class GTFoodStat implements IFoodStat {
             }
             if (mExplosive) {
                 final boolean dealDamage = Gregtech.general.explosiveFoodDamage;
-                new WorldSpawnedEventBuilder.ExplosionEffectEventBuilder().setSmoking(true)
-                    .setFlaming(true)
-                    .setStrength(dealDamage ? mExplosionStrength : 0f)
-                    .setPosition(aPlayer.posX, aPlayer.posY, aPlayer.posZ)
-                    .setEntity(aPlayer)
-                    .setWorld(aPlayer.worldObj)
-                    .run();
                 if (dealDamage) {
+                    // Draconic Evolution's reactor explosion
+                    final ReactorExplosion explosion = new ReactorExplosion(
+                        aPlayer.worldObj,
+                        (int) aPlayer.posX,
+                        (int) aPlayer.posY,
+                        (int) aPlayer.posZ,
+                        mExplosionStrength);
+                    while (!explosion.isDead()) {
+                        explosion.updateProcess();
+                    }
                     aPlayer.attackEntityFrom(GTDamageSources.getExplodingDamage(), Float.MAX_VALUE);
+                } else {
+                    new WorldSpawnedEventBuilder.ExplosionEffectEventBuilder().setSmoking(true)
+                        .setFlaming(true)
+                        .setStrength(0f)
+                        .setPosition(aPlayer.posX, aPlayer.posY, aPlayer.posZ)
+                        .setEntity(aPlayer)
+                        .setWorld(aPlayer.worldObj)
+                        .run();
                 }
             }
         }

--- a/src/main/java/gregtech/common/GTDraconicCompat.java
+++ b/src/main/java/gregtech/common/GTDraconicCompat.java
@@ -1,0 +1,24 @@
+package gregtech.common;
+
+import net.minecraft.world.World;
+
+import com.brandon3055.draconicevolution.common.tileentities.multiblocktiles.reactor.ReactorExplosion;
+
+import gregtech.api.interfaces.internal.IDraconicCompat;
+
+/**
+ * The only place in the codebase allowed to touch Draconic Evolution's internal {@code common} package - everything
+ * else should go through {@link IDraconicCompat} so a future DE refactor only breaks this one file.
+ */
+public class GTDraconicCompat implements IDraconicCompat {
+
+    @Override
+    public void createReactorExplosion(World world, int x, int y, int z, float power) {
+        // IProcess is normally driven by DE's own tick handler - run it to completion synchronously here since
+        // we're triggering it standalone.
+        final ReactorExplosion explosion = new ReactorExplosion(world, x, y, z, power);
+        while (!explosion.isDead()) {
+            explosion.updateProcess();
+        }
+    }
+}

--- a/src/main/java/gregtech/common/GTProxy.java
+++ b/src/main/java/gregtech/common/GTProxy.java
@@ -835,6 +835,9 @@ public class GTProxy implements IFuelHandler {
         if (Thaumcraft.isModLoaded()) {
             GregTechAPI.sThaumcraftCompat = new GTThaumcraftCompat();
         }
+        if (Mods.DraconicEvolution.isModLoaded()) {
+            GregTechAPI.sDraconicCompat = new GTDraconicCompat();
+        }
         GregTechAPI.sPreloadStarted = true;
         this.mIgnoreTcon = OPStuff.ignoreTinkerConstruct;
         this.replicatorExponent = OPStuff.replicatorExponent;

--- a/src/main/java/gregtech/common/blocks/BlockGhostSpace.java
+++ b/src/main/java/gregtech/common/blocks/BlockGhostSpace.java
@@ -21,11 +21,20 @@ import mcp.mobius.waila.api.IWailaConfigHandler;
 import mcp.mobius.waila.api.IWailaDataAccessor;
 
 /**
- * Invisible block that reserves extra space for a machine whose model is taller than one block. Any MTE can use
- * the shared instance ({@code GregTechAPI.sBlockGhostSpace}): on placement, place it in the extra space and forward
- * clicks to the real block. When either this block or the GT machine directly below it is destroyed by any means,
- * the other is destroyed too. Has no identity of its own - WAILA icon/name are derived live from whatever block is
- * below it.
+ * Invisible block that reserves one extra cell of space for a machine whose model doesn't fit in a single block.
+ * Any MTE can use the shared instance ({@code GregTechAPI.sBlockGhostSpace}): on placement, put it in the extra
+ * cell directly above the machine, and forward clicks to the real block. When either this block or the GT machine
+ * below it is destroyed by any means, the other is destroyed too. Has no identity of its own - WAILA icon/name are
+ * derived live from whatever block owns it.
+ * <p>
+ * Restrictions:
+ * <ul>
+ * <li>The owning machine is always looked up directly below this block ({@code y - 1}). A machine that can be
+ * rotated so its extra space ends up somewhere other than "above me" (e.g. upside-down, or extending sideways) is
+ * not supported without changing this lookup.</li>
+ * <li>Only a single adjacent cell is reserved. A machine needing more than one extra cell (e.g. spanning 3+ blocks)
+ * is not supported - there is no chaining through multiple ghost blocks.</li>
+ * </ul>
  */
 public class BlockGhostSpace extends Block implements IGregtechWailaProvider {
 

--- a/src/main/java/gregtech/common/blocks/BlockGhostSpace.java
+++ b/src/main/java/gregtech/common/blocks/BlockGhostSpace.java
@@ -3,23 +3,31 @@ package gregtech.common.blocks;
 import java.util.Random;
 
 import net.minecraft.block.Block;
+import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
+import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.IIcon;
+import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
 import cpw.mods.fml.common.registry.GameRegistry;
+import gregtech.api.enums.HarvestTool;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
+import gregtech.api.interfaces.tileentity.IGregtechWailaProvider;
+import mcp.mobius.waila.api.IWailaConfigHandler;
+import mcp.mobius.waila.api.IWailaDataAccessor;
 
 /**
  * Invisible block that reserves extra space for a machine whose model is taller than one block. Any MTE can use
- * the shared instance ({@code GregTechAPI.sBlockGhostSpace}): on placement, place it in the extra space (and forward
- * clicks to the real block); when either this block or the GT machine directly below it is destroyed by any means,
- * the other is destroyed too.
+ * the shared instance ({@code GregTechAPI.sBlockGhostSpace}): on placement, place it in the extra space and forward
+ * clicks to the real block. When either this block or the GT machine directly below it is destroyed by any means,
+ * the other is destroyed too. Has no identity of its own - WAILA icon/name are derived live from whatever block is
+ * below it.
  */
-public class BlockGhostSpace extends Block {
+public class BlockGhostSpace extends Block implements IGregtechWailaProvider {
 
     public BlockGhostSpace() {
         super(new MaterialMachines());
@@ -62,6 +70,30 @@ public class BlockGhostSpace extends Block {
     }
 
     @Override
+    public String getHarvestTool(int meta) {
+        return HarvestTool.PickaxeLevel0.getHarvestTool();
+    }
+
+    @Override
+    public int getHarvestLevel(int meta) {
+        return HarvestTool.PickaxeLevel0.getHarvestLevel();
+    }
+
+    @Override
+    public ItemStack getWailaStack(IWailaDataAccessor accessor, IWailaConfigHandler config) {
+        return getParentPickBlock(accessor.getWorld(), accessor.getPosition());
+    }
+
+    /** Whatever block sits directly below this one - used to show WAILA icon/name. */
+    public static ItemStack getParentPickBlock(World world, MovingObjectPosition pos) {
+        final int x = pos.blockX;
+        final int y = pos.blockY - 1;
+        final int z = pos.blockZ;
+        return world.getBlock(x, y, z)
+            .getPickBlock(null, world, x, y, z);
+    }
+
+    @Override
     public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float hitX,
         float hitY, float hitZ) {
         return world.getBlock(x, y - 1, z)
@@ -71,9 +103,16 @@ public class BlockGhostSpace extends Block {
     @Override
     public void breakBlock(World world, int x, int y, int z, Block block, int meta) {
         super.breakBlock(world, x, y, z, block, meta);
-        if (isGTMachine(world, x, y - 1, z)) {
-            world.func_147480_a(x, y - 1, z, true);
+        final int mx = x, my = y - 1, mz = z;
+        if (!isGTMachine(world, mx, my, mz)) return;
+
+        // Drop and remove the machine silently
+        final Block machineBlock = world.getBlock(mx, my, mz);
+        final int machineMeta = world.getBlockMetadata(mx, my, mz);
+        for (ItemStack drop : machineBlock.getDrops(world, mx, my, mz, machineMeta, 0)) {
+            world.spawnEntityInWorld(new EntityItem(world, mx + 0.5, my + 0.5, mz + 0.5, drop));
         }
+        world.setBlockToAir(mx, my, mz);
     }
 
     private static boolean isGTMachine(World world, int x, int y, int z) {

--- a/src/main/java/gregtech/common/blocks/BlockGhostSpace.java
+++ b/src/main/java/gregtech/common/blocks/BlockGhostSpace.java
@@ -1,0 +1,83 @@
+package gregtech.common.blocks;
+
+import java.util.Random;
+
+import net.minecraft.block.Block;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.Blocks;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.IIcon;
+import net.minecraft.world.IBlockAccess;
+import net.minecraft.world.World;
+
+import cpw.mods.fml.common.registry.GameRegistry;
+import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
+
+/**
+ * Invisible block that reserves extra space for a machine whose model is taller than one block. Any MTE can use
+ * the shared instance ({@code GregTechAPI.sBlockGhostSpace}): on placement, place it in the extra space (and forward
+ * clicks to the real block); when either this block or the GT machine directly below it is destroyed by any means,
+ * the other is destroyed too.
+ */
+public class BlockGhostSpace extends Block {
+
+    public BlockGhostSpace() {
+        super(new MaterialMachines());
+        setBlockName("gt.ghostspace");
+        setHardness(1.0F);
+        setResistance(10.0F);
+        setStepSound(soundTypeMetal);
+        setCreativeTab(null);
+        GameRegistry.registerBlock(this, getUnlocalizedName());
+    }
+
+    @Override
+    public boolean isReplaceable(IBlockAccess world, int x, int y, int z) {
+        return false;
+    }
+
+    @Override
+    public int quantityDropped(Random random) {
+        return 0;
+    }
+
+    @Override
+    public boolean renderAsNormalBlock() {
+        return false;
+    }
+
+    @Override
+    public boolean isOpaqueCube() {
+        return false;
+    }
+
+    @Override
+    public int getRenderType() {
+        return -1;
+    }
+
+    @Override
+    public IIcon getIcon(int side, int meta) {
+        return Blocks.iron_block.getIcon(side, meta);
+    }
+
+    @Override
+    public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float hitX,
+        float hitY, float hitZ) {
+        return world.getBlock(x, y - 1, z)
+            .onBlockActivated(world, x, y - 1, z, player, side, hitX, hitY, hitZ);
+    }
+
+    @Override
+    public void breakBlock(World world, int x, int y, int z, Block block, int meta) {
+        super.breakBlock(world, x, y, z, block, meta);
+        if (isGTMachine(world, x, y - 1, z)) {
+            world.func_147480_a(x, y - 1, z, true);
+        }
+    }
+
+    private static boolean isGTMachine(World world, int x, int y, int z) {
+        final TileEntity te = world.getTileEntity(x, y, z);
+        return te instanceof IGregTechTileEntity gtte && gtte.getMetaTileEntity() != null;
+    }
+}

--- a/src/main/java/gregtech/common/items/MetaGeneratedItem02.java
+++ b/src/main/java/gregtech/common/items/MetaGeneratedItem02.java
@@ -2593,7 +2593,7 @@ public class MetaGeneratedItem02 extends MetaGeneratedItemX32 {
                 Food_IceCream_Explosive.ID,
                 "gt.item.food.icecream_explosive.name",
                 "gt.item.food.icecream_explosive.tooltip",
-                new GTFoodStat(2, 0.1F, EnumAction.eat, null, false, true, false).setExplosive(150f),
+                new GTFoodStat(2, 0.1F, EnumAction.eat, null, false, true, false).setExplosive(5f),
                 new TCAspects.TC_AspectStack(TCAspects.GELUM, 1L)));
         ItemList.Ice_Cream_Trophy.set(
             addItemWithLocalizationKeys(

--- a/src/main/java/gregtech/common/tileentities/machines/basic/MTEIceCreamMachine.java
+++ b/src/main/java/gregtech/common/tileentities/machines/basic/MTEIceCreamMachine.java
@@ -12,6 +12,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.StatCollector;
+import net.minecraft.world.World;
 import net.minecraftforge.client.IItemRenderer;
 import net.minecraftforge.common.util.ForgeDirection;
 
@@ -34,6 +35,7 @@ import com.gtnewhorizon.gtnhlib.client.renderer.vao.IVertexArrayObject;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import gregtech.api.GregTechAPI;
 import gregtech.api.enums.HarvestTool;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
@@ -130,6 +132,39 @@ public class MTEIceCreamMachine extends MTEBasicMachine implements IMTERenderer,
     public boolean allowPullStack(IGregTechTileEntity aBaseMetaTileEntity, int aIndex, ForgeDirection side,
         ItemStack aStack) {
         return false;
+    }
+
+    // Ghost block 
+    @Override
+    public void onFirstTick(IGregTechTileEntity aBaseMetaTileEntity) {
+        super.onFirstTick(aBaseMetaTileEntity);
+        if (!aBaseMetaTileEntity.isServerSide()) return;
+
+        final World world = aBaseMetaTileEntity.getWorld();
+        final int x = aBaseMetaTileEntity.getXCoord();
+        final int y = aBaseMetaTileEntity.getYCoord();
+        final int z = aBaseMetaTileEntity.getZCoord();
+        if (!world.getBlock(x, y + 1, z)
+            .isReplaceable(world, x, y + 1, z)) {
+            world.func_147480_a(x, y, z, true);
+            return;
+        }
+        world.setBlock(x, y + 1, z, GregTechAPI.sBlockGhostSpace);
+    }
+
+    @Override
+    public void onRemoval() {
+        super.onRemoval();
+        final IGregTechTileEntity base = getBaseMetaTileEntity();
+        if (!base.isServerSide()) return;
+
+        final World world = base.getWorld();
+        final int x = base.getXCoord();
+        final int y = base.getYCoord();
+        final int z = base.getZCoord();
+        if (world.getBlock(x, y + 1, z) == GregTechAPI.sBlockGhostSpace) {
+            world.func_147480_a(x, y + 1, z, false);
+        }
     }
 
     /** Chance out of 100 that the machine works on that day */

--- a/src/main/java/gregtech/common/tileentities/machines/basic/MTEIceCreamMachine.java
+++ b/src/main/java/gregtech/common/tileentities/machines/basic/MTEIceCreamMachine.java
@@ -134,7 +134,7 @@ public class MTEIceCreamMachine extends MTEBasicMachine implements IMTERenderer,
         return false;
     }
 
-    // Ghost block 
+    // Ghost block
     @Override
     public void onFirstTick(IGregTechTileEntity aBaseMetaTileEntity) {
         super.onFirstTick(aBaseMetaTileEntity);
@@ -162,8 +162,9 @@ public class MTEIceCreamMachine extends MTEBasicMachine implements IMTERenderer,
         final int x = base.getXCoord();
         final int y = base.getYCoord();
         final int z = base.getZCoord();
+        // Silent removal
         if (world.getBlock(x, y + 1, z) == GregTechAPI.sBlockGhostSpace) {
-            world.func_147480_a(x, y + 1, z, false);
+            world.setBlockToAir(x, y + 1, z);
         }
     }
 

--- a/src/main/java/gregtech/common/tileentities/machines/basic/MTEIceCreamMachine.java
+++ b/src/main/java/gregtech/common/tileentities/machines/basic/MTEIceCreamMachine.java
@@ -144,6 +144,7 @@ public class MTEIceCreamMachine extends MTEBasicMachine implements IMTERenderer,
         final int x = aBaseMetaTileEntity.getXCoord();
         final int y = aBaseMetaTileEntity.getYCoord();
         final int z = aBaseMetaTileEntity.getZCoord();
+        if (world.getBlock(x, y + 1, z) == GregTechAPI.sBlockGhostSpace) return;
         if (!world.getBlock(x, y + 1, z)
             .isReplaceable(world, x, y + 1, z)) {
             world.func_147480_a(x, y, z, true);

--- a/src/main/java/gregtech/crossmod/waila/GregtechBlockWailaDataProvider.java
+++ b/src/main/java/gregtech/crossmod/waila/GregtechBlockWailaDataProvider.java
@@ -7,9 +7,11 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.world.World;
 
 import gregtech.api.interfaces.tileentity.IGregtechWailaProvider;
+import gregtech.common.blocks.BlockGhostSpace;
 import mcp.mobius.waila.api.IWailaConfigHandler;
 import mcp.mobius.waila.api.IWailaDataAccessor;
 import mcp.mobius.waila.api.IWailaDataProvider;
@@ -30,6 +32,11 @@ public class GregtechBlockWailaDataProvider implements IWailaDataProvider {
     @Override
     public List<String> getWailaHead(ItemStack itemStack, List<String> currenttip, IWailaDataAccessor accessor,
         IWailaConfigHandler config) {
+        // Ghost space blocks have no meaningful name of their own - show whatever block is below it instead
+        if (accessor.getBlock() instanceof BlockGhostSpace && !currenttip.isEmpty()) {
+            final ItemStack parent = BlockGhostSpace.getParentPickBlock(accessor.getWorld(), accessor.getPosition());
+            if (parent != null) currenttip.set(0, EnumChatFormatting.WHITE + parent.getDisplayName());
+        }
         return currenttip;
     }
 

--- a/src/main/java/gregtech/crossmod/waila/Waila.java
+++ b/src/main/java/gregtech/crossmod/waila/Waila.java
@@ -5,6 +5,7 @@ import gregtech.api.enums.Mods;
 import gregtech.api.metatileentity.BaseMetaPipeEntity;
 import gregtech.api.metatileentity.BaseMetaTileEntity;
 import gregtech.common.blocks.BlockCasings5;
+import gregtech.common.blocks.BlockGhostSpace;
 import mcp.mobius.waila.api.IWailaDataProvider;
 import mcp.mobius.waila.api.IWailaRegistrar;
 
@@ -25,6 +26,8 @@ public class Waila {
         final IWailaDataProvider blockProvider = new GregtechBlockWailaDataProvider();
 
         register.registerStackProvider(blockProvider, BlockCasings5.class);
+        register.registerStackProvider(blockProvider, BlockGhostSpace.class);
+        register.registerHeadProvider(blockProvider, BlockGhostSpace.class);
     }
 
     public static void init() {

--- a/src/main/java/gregtech/loaders/preload/LoaderGTBlockFluid.java
+++ b/src/main/java/gregtech/loaders/preload/LoaderGTBlockFluid.java
@@ -75,6 +75,7 @@ import gregtech.common.blocks.BlockCyclotronCoils;
 import gregtech.common.blocks.BlockDecorativeFrame;
 import gregtech.common.blocks.BlockFenceMetal;
 import gregtech.common.blocks.BlockFrameBox;
+import gregtech.common.blocks.BlockGhostSpace;
 import gregtech.common.blocks.BlockGlass1;
 import gregtech.common.blocks.BlockGranites;
 import gregtech.common.blocks.BlockLaser;
@@ -760,6 +761,7 @@ public class LoaderGTBlockFluid implements Runnable {
         GregTechAPI.sBlockGlass1 = new BlockGlass1();
         GregTechAPI.sBlockTintedGlass = new BlockTintedIndustrialGlass();
         GregTechAPI.sLaserRender = new BlockLaser();
+        GregTechAPI.sBlockGhostSpace = new BlockGhostSpace();
         GT_FML_LOGGER.debug("GTMod: Adding Renderer Blocks.");
         GregTechAPI.sWormholeRender = new BlockRenderer<>("wormholerenderer", RenderingTileEntityWormhole::new);
         GregTechAPI.sBlackholeRender = new BlockRenderer<>("blackholerenderer", RenderingTileEntityBlackhole::new);


### PR DESCRIPTION
## Summary
- Added Ghost block to be placed above the Ice Cream machine (in-game works as intended if you ask me
   - Waila - Icon and texture synced
- Explosion changed from stupid vanilla raycast makers to Draconic Evolution reactor explosion

Ghost block applied
| Before | After |
| - | - |
|  <img width="1324" height="971" alt="Pre" src="https://github.com/user-attachments/assets/c59f46e7-fa0a-4ead-b121-4adccd1567e7" /> |  <img width="1799" height="899" alt="Post" src="https://github.com/user-attachments/assets/1b30b8a0-8efd-4e24-8a74-333b04a83c06" /> |

Waila
| Bottom | Top |
| - | - |
|  <img width="445" height="868" alt="1" src="https://github.com/user-attachments/assets/c17c2355-f7f9-4c57-bae0-b0f143b656dd" /> | <img width="482" height="1119" alt="2" src="https://github.com/user-attachments/assets/41b4d52c-8707-476b-b67a-e36f35d6cdb5" /> |

Explosion
| Before | After |
| - | - |
| <img width="2024" height="1231" alt="pre" src="https://github.com/user-attachments/assets/12bb0589-307c-477a-b58b-65d55553bc5d" /> |  <img width="1867" height="874" alt="Post" src="https://github.com/user-attachments/assets/f4958c60-c4a6-4bd0-af35-8d03e6bd0049" /> |

TODO:
- [ ] Remove the ghost block from the NEI in core mod `tile.gt.ghostspace.name`

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
