### PR TITLE
NAC NBT QoL

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/MTENanochipAssemblyComplex.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/MTENanochipAssemblyComplex.java
@@ -685,6 +685,18 @@ public class MTENanochipAssemblyComplex extends MTEExtendedPowerMultiBlockBase<M
     }
 
     @Override
+    public void setItemNBT(NBTTagCompound nbt) {
+        super.setItemNBT(nbt);
+        NBTTagList history = new NBTTagList();
+        for (CircuitBatch batch : circuitHistory) {
+            history.appendTag(new NBTTagIntArray(batch.writeToIntArray()));
+        }
+        if (currentBlock != null) {
+            nbt.setIntArray("currentBlock", currentBlock.writeToIntArray());
+        }
+    }
+
+    @Override
     public void saveNBTData(NBTTagCompound aNBT) {
         super.saveNBTData(aNBT);
         NBTTagList history = new NBTTagList();

--- a/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/modules/MTESplitterModule.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/nanochip/modules/MTESplitterModule.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
@@ -25,11 +26,13 @@ import net.minecraftforge.common.util.Constants;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import com.gtnewhorizon.structurelib.structure.IStructureDefinition;
 
 import gregtech.api.casing.Casings;
 import gregtech.api.enums.Materials;
+import gregtech.api.interfaces.IDataCopyable;
 import gregtech.api.interfaces.IHatchElement;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
@@ -49,7 +52,7 @@ import gregtech.common.tileentities.machines.multi.nanochip.util.ModuleStructure
 import gregtech.common.tileentities.machines.multi.nanochip.util.ModuleTypes;
 import gregtech.common.tileentities.machines.multi.nanochip.util.SplitterRule;
 
-public class MTESplitterModule extends MTENanochipAssemblyModuleBase<MTESplitterModule> {
+public class MTESplitterModule extends MTENanochipAssemblyModuleBase<MTESplitterModule> implements IDataCopyable {
 
     protected static final String STRUCTURE_PIECE_MAIN = "main";
     protected static final int SPLITTER_OFFSET_X = 3;
@@ -299,6 +302,14 @@ public class MTESplitterModule extends MTENanochipAssemblyModuleBase<MTESplitter
     }
 
     @Override
+    public void setItemNBT(NBTTagCompound nbt) {
+        super.setItemNBT(nbt);
+        nbt.setByteArray("bufferSize", this.euBufferSize.toByteArray());
+        nbt.setByteArray("currentEU", this.currentEU.toByteArray());
+        nbt.setTag("rules", createRulesTagList());
+    }
+
+    @Override
     public void saveNBTData(NBTTagCompound aNBT) {
         super.saveNBTData(aNBT);
         aNBT.setTag("rules", createRulesTagList());
@@ -330,6 +341,28 @@ public class MTESplitterModule extends MTENanochipAssemblyModuleBase<MTESplitter
     @Override
     protected @NotNull MTEMultiBlockBaseGui<?> getGui() {
         return new MTESplitterModuleGui(this);
+    }
+
+    public static final String COPIED_DATA_IDENTIFIER = "nacSplitter";
+
+    @Override
+    public @Nullable NBTTagCompound getCopiedData(EntityPlayer player) {
+        NBTTagCompound tag = new NBTTagCompound();
+        tag.setString("type", COPIED_DATA_IDENTIFIER);
+        tag.setTag("rules", createRulesTagList());
+        return tag;
+    }
+
+    @Override
+    public boolean pasteCopiedData(EntityPlayer player, @Nullable NBTTagCompound nbt) {
+        if (nbt == null || !COPIED_DATA_IDENTIFIER.equals(nbt.getString("type"))) return false;
+        rules = loadRulesTagList(nbt.getTagList("rules", Constants.NBT.TAG_COMPOUND));
+        return true;
+    }
+
+    @Override
+    public String getCopiedDataIdentifier(EntityPlayer player) {
+        return COPIED_DATA_IDENTIFIER;
     }
 
     public static class RedstoneChannelInfo {


### PR DESCRIPTION
## Summary
adds the ability for NAC and splitter to keep their NBT in their item form, preserving circuit history and splitter rules respectively. Also allows for splitter to be MM-copyable if needed.


## Checklist
- [X] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
