### PR TITLE
Fix energy delivery through disconnected cables

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
@@ -34,6 +34,7 @@ import gregtech.api.covers.CoverRegistry;
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.SoundResource;
 import gregtech.api.enums.Textures;
+import gregtech.api.graphs.GenerateNodeMap;
 import gregtech.api.graphs.Lock;
 import gregtech.api.graphs.Node;
 import gregtech.api.graphs.paths.NodePath;
@@ -234,6 +235,9 @@ public class BaseMetaPipeEntity extends CommonBaseMetaTileEntity
             return;
         }
         mConnections = mMetaTileEntity.mConnections;
+        if (node != null) {
+            GenerateNodeMap.clearNodeMap(node, -1);
+        }
         GregTechAPI.causeCableUpdate(worldObj, xCoord, yCoord, zCoord);
     }
 

--- a/src/test/java/gregtech/api/metatileentity/BaseMetaPipeEntityTest.java
+++ b/src/test/java/gregtech/api/metatileentity/BaseMetaPipeEntityTest.java
@@ -1,0 +1,49 @@
+package gregtech.api.metatileentity;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import gregtech.api.GregTechAPI;
+import gregtech.api.graphs.PowerNode;
+
+class BaseMetaPipeEntityTest {
+
+    @Test
+    void connectionChangeClearsCachedPowerNode() {
+        final BaseMetaPipeEntity pipe = new BaseMetaPipeEntity();
+        final World world = mock(World.class);
+        pipe.setWorldObj(world);
+        pipe.xCoord = 10;
+        pipe.yCoord = 20;
+        pipe.zCoord = 30;
+        pipe.mConnections = (byte) (ForgeDirection.WEST.flag | ForgeDirection.EAST.flag);
+        pipe.mMetaTileEntity = mock(MetaPipeEntity.class);
+        pipe.mMetaTileEntity.mConnections = (byte) ForgeDirection.EAST.flag;
+
+        final MinecraftServer server = mock(MinecraftServer.class);
+        try (MockedStatic<MinecraftServer> minecraft = mockStatic(MinecraftServer.class);
+            MockedStatic<GregTechAPI> api = mockStatic(GregTechAPI.class)) {
+            minecraft.when(MinecraftServer::getServer)
+                .thenReturn(server);
+            when(server.getTickCounter()).thenReturn(1);
+            pipe.setNode(new PowerNode(0, pipe, new ArrayList<>()));
+
+            pipe.updateConnections();
+
+            assertNull(pipe.getNode());
+            api.verify(() -> GregTechAPI.causeCableUpdate(world, 10, 20, 30));
+            api.verifyNoMoreInteractions();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Clear the cached GT power graph immediately when a cable connection changes, preventing energy P2P tunnels from using stale consumers after a wire-cutter disconnect. Adds a focused regression test.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/26757

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge