### PR TITLE
Fix beam particle pattern transfer

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -146,6 +146,7 @@ dependencies {
 
     // For testing
     //runtimeOnlyNonPublishable('com.github.GTNewHorizons:TCNEIAdditions:1.5.13:dev')
+    // runtimeOnlyNonPublishable('com.github.GTNewHorizons:NotEnoughEnergistics:1.7.41:dev')
 
     // For Magical Maintenance Hatch Testing
     // runtimeOnlyNonPublishable("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev") { transitive = false }

--- a/src/main/java/gregtech/api/recipe/RecipeMaps.java
+++ b/src/main/java/gregtech/api/recipe/RecipeMaps.java
@@ -1796,8 +1796,8 @@ public final class RecipeMaps {
         .neiItemInputsGetter(recipe -> {
             BeamCrafterMetadata metadata = recipe.getMetadata(BEAMCRAFTER_METADATA);
             if (metadata == null) return GTValues.emptyItemStackArray;
-            ItemStack particleStack_A = new ItemStack(LanthItemList.PARTICLE_ITEM, 1, metadata.particleID_A);
-            ItemStack particleStack_B = new ItemStack(LanthItemList.PARTICLE_ITEM, 1, metadata.particleID_B);
+            ItemStack particleStack_A = new ItemStack(LanthItemList.PARTICLE_ITEM, 0, metadata.particleID_A);
+            ItemStack particleStack_B = new ItemStack(LanthItemList.PARTICLE_ITEM, 0, metadata.particleID_B);
 
             List<ItemStack> ret = new ArrayList<>();
             ret.addAll(Arrays.asList(recipe.mInputs));

--- a/src/main/java/gtnhlanth/api/recipe/LanthanidesRecipeMaps.java
+++ b/src/main/java/gtnhlanth/api/recipe/LanthanidesRecipeMaps.java
@@ -111,7 +111,7 @@ public class LanthanidesRecipeMaps {
         .neiItemInputsGetter(recipe -> {
             TargetChamberMetadata metadata = recipe.getMetadata(TARGET_CHAMBER_METADATA);
             if (metadata == null) return GTValues.emptyItemStackArray;
-            ItemStack particleStack = new ItemStack(LanthItemList.PARTICLE_ITEM, 1, metadata.particleID);
+            ItemStack particleStack = new ItemStack(LanthItemList.PARTICLE_ITEM, 0, metadata.particleID);
             List<ItemStack> ret = new ArrayList<>();
             ret.add(particleStack);
             ret.addAll(Arrays.asList(recipe.mInputs));


### PR DESCRIPTION
## Summary
Mark the Target Chamber photon and Beam Crafter particles as non-consumable so they remain visible in NEI without being added to AE2 processing patterns.

Asked by Fox in #meta-dev https://discord.com/channels/181078474394566657/939305179524792340/1548252240953999360

## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge