### PR TITLE
Fix NAC splitter rule scroll wheel being interrupted by item slots

### DIFF
--- a/src/main/java/gregtech/common/gui/modularui/multiblock/MTESplitterModuleGui.java
+++ b/src/main/java/gregtech/common/gui/modularui/multiblock/MTESplitterModuleGui.java
@@ -16,6 +16,7 @@ import org.jetbrains.annotations.NotNull;
 import org.lwjgl.input.Keyboard;
 
 import com.cleanroommc.modularui.api.IPanelHandler;
+import com.cleanroommc.modularui.api.UpOrDown;
 import com.cleanroommc.modularui.api.drawable.IIcon;
 import com.cleanroommc.modularui.api.drawable.IKey;
 import com.cleanroommc.modularui.api.widget.IWidget;
@@ -346,6 +347,11 @@ public class MTESplitterModuleGui extends MTENanochipAssemblyModuleBaseGui<MTESp
                         return Result.SUCCESS;
                     }
                     return super.onMousePressed(mouseButton);
+                }
+
+                @Override
+                public boolean onMouseScroll(UpOrDown scrollDirection, int amount) {
+                    return false;
                 }
             }.syncHandler(
                 syncManager.getOrCreateSyncHandler(


### PR DESCRIPTION
## Summary
Fixes using scroll wheel over a splitter rule item slot not scrolling the rules list


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
